### PR TITLE
feat(cli): skill supply-chain capture + CycloneDX projection + SARIF adapter (Fase 3)

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/adapt_skill_scan.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/adapt_skill_scan.rs
@@ -1,0 +1,377 @@
+//! EXPERIMENTAL: adapt a SARIF 2.1.0 scanner report onto a skill supply-chain carrier.
+//!
+//! A static-analysis scanner (SkillSpector, Snyk, ClawScan, any SARIF emitter) observes what it can
+//! reach; its report is OCCURRENCE-scoped by source class. This adapter reads a SARIF log and attaches
+//! every `error`/`warning` result to the carrier as a source-classed `scanner_findings` entry for the
+//! reviewer. Crucially, a raw scanner finding is NOT automatically a verdict-bearing risk: only a
+//! result whose `ruleId` is in the caller's `--known-risk-rule` set is promoted to a contract
+//! `signals` occurrence entry, which adds `known_risk_signal_reachable` so the verdict recomputes
+//! upward under worst-wins. This preserves the pinned contract (a verdict-bearing occurrence signal
+//! always corresponds to a risk reason) and the source-class discipline (a scan attests presence, never
+//! absence, and never downgrades a verdict). The augmented carrier is re-validated with the import
+//! gate, so a scan can never produce an incoherent carrier.
+
+use super::skill_supply_chain::{expected_verdict, validate_carrier};
+use crate::exit_codes;
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+const SIGNAL_SOURCE_CLASS: &str = "static_analysis_scanner";
+
+#[derive(Debug, clap::Args, Clone)]
+pub struct AdaptSkillScanArgs {
+    /// Existing assay.skill_supply_chain.v0 carrier to augment
+    #[arg(long, value_name = "PATH")]
+    pub carrier: PathBuf,
+
+    /// SARIF 2.1.0 scanner report
+    #[arg(long, value_name = "PATH")]
+    pub sarif: PathBuf,
+
+    /// Rule id that marks a result as a KNOWN reachable risk (repeatable)
+    #[arg(long = "known-risk-rule", value_name = "RULE_ID")]
+    pub known_risk_rules: Vec<String>,
+
+    /// Where to write the augmented carrier (stdout if omitted)
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<PathBuf>,
+}
+
+pub fn cmd_adapt_skill_scan(args: AdaptSkillScanArgs) -> Result<i32> {
+    let carrier_bytes = fs::read_to_string(&args.carrier)
+        .with_context(|| format!("failed to read carrier {}", args.carrier.display()))?;
+    let mut carrier: Value = serde_json::from_str(&carrier_bytes)
+        .with_context(|| format!("failed to parse carrier {}", args.carrier.display()))?;
+    // The input carrier must itself be coherent before we touch it.
+    validate_carrier(&carrier)
+        .context("input carrier is not a valid skill supply-chain carrier")?;
+
+    let sarif_bytes = fs::read_to_string(&args.sarif)
+        .with_context(|| format!("failed to read SARIF {}", args.sarif.display()))?;
+    let sarif: Value = serde_json::from_str(&sarif_bytes)
+        .with_context(|| format!("failed to parse SARIF {}", args.sarif.display()))?;
+
+    let known: BTreeSet<&str> = args.known_risk_rules.iter().map(String::as_str).collect();
+    let scan = sarif_to_findings(&sarif, &known)?;
+
+    augment(&mut carrier, scan)?;
+    validate_carrier(&carrier).context("augmented carrier failed self-validation (bug)")?;
+
+    let json = serde_json::to_string_pretty(&carrier)?;
+    match &args.out {
+        Some(path) => {
+            fs::write(path, format!("{json}\n"))
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!("Wrote augmented carrier to {}", path.display());
+        }
+        None => println!("{json}"),
+    }
+    Ok(exit_codes::OK)
+}
+
+/// The parsed scanner report: every error/warning as a reviewer-facing finding, plus the subset that
+/// matched the known-risk rule set (promoted to verdict-bearing occurrence signals).
+struct Scan {
+    findings: Vec<Value>,
+    known_risk_signals: Vec<Value>,
+}
+
+/// Read SARIF `error`/`warning` results. `note`/`none` are informational and skipped. Every kept
+/// result becomes a `scanner_findings` entry; a result whose ruleId is in `known` additionally becomes
+/// a contract occurrence signal.
+fn sarif_to_findings(sarif: &Value, known: &BTreeSet<&str>) -> Result<Scan> {
+    if sarif.get("version").and_then(Value::as_str) != Some("2.1.0") {
+        bail!("expected a SARIF 2.1.0 log (\"version\":\"2.1.0\")");
+    }
+    let runs = sarif
+        .get("runs")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("SARIF log missing runs array"))?;
+
+    let mut findings = Vec::new();
+    let mut known_risk_signals = Vec::new();
+    for run in runs {
+        let tool = run
+            .get("tool")
+            .and_then(|t| t.get("driver"))
+            .and_then(|d| d.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        for result in run
+            .get("results")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let level = result
+                .get("level")
+                .and_then(Value::as_str)
+                .unwrap_or("warning");
+            if level != "error" && level != "warning" {
+                continue;
+            }
+            let rule_id = result.get("ruleId").and_then(Value::as_str).unwrap_or("");
+            let message = result
+                .get("message")
+                .and_then(|m| m.get("text"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let is_known = known.contains(rule_id);
+            findings.push(json!({
+                "source_class": SIGNAL_SOURCE_CLASS,
+                "tool": tool,
+                "rule_id": rule_id,
+                "level": level,
+                "message": message,
+                "known_risk": is_known,
+            }));
+            if is_known {
+                known_risk_signals.push(json!({
+                    "kind": "occurrence",
+                    "source_class": SIGNAL_SOURCE_CLASS,
+                    "tool": tool,
+                    "rule_id": rule_id,
+                    "message": message,
+                }));
+            }
+        }
+    }
+    Ok(Scan {
+        findings,
+        known_risk_signals,
+    })
+}
+
+/// Attach the scan to the carrier. Raw findings go to `scanner_findings` (informational, source-classed,
+/// never verdict-bearing). Known-risk results additionally become contract occurrence signals and add
+/// `known_risk_signal_reachable`, so the verdict recomputes upward under worst-wins — never downward.
+fn augment(carrier: &mut Value, scan: Scan) -> Result<()> {
+    let obj = carrier
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("carrier must be a JSON object"))?;
+
+    if !scan.findings.is_empty() {
+        let mut existing: Vec<Value> = obj
+            .get("scanner_findings")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        existing.extend(scan.findings);
+        obj.insert("scanner_findings".into(), Value::Array(existing));
+    }
+
+    if !scan.known_risk_signals.is_empty() {
+        // A live known-risk occurrence contradicts any prior "no reachable signal" absence claim, so
+        // drop absence signals when we add occurrence ones.
+        let mut kept: Vec<Value> = obj
+            .get("signals")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter(|s| s.get("kind").and_then(Value::as_str) != Some("absence"))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        kept.extend(scan.known_risk_signals);
+        obj.insert("signals".into(), Value::Array(kept));
+
+        let mut reasons: BTreeSet<String> = obj
+            .get("reason_codes")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect();
+        reasons.insert("known_risk_signal_reachable".to_string());
+        let reasons: Vec<String> = reasons.into_iter().collect();
+        let reason_refs: Vec<&str> = reasons.iter().map(String::as_str).collect();
+        let new_verdict = expected_verdict(&reason_refs);
+        obj.insert("reason_codes".into(), json!(reasons));
+        obj.insert("verdict".into(), json!(new_verdict));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base_carrier() -> Value {
+        json!({
+            "schema": "assay.skill_supply_chain.v0",
+            "root": {"name": "s", "path": "skills/s"},
+            "verdict": "review_complete",
+            "reason_codes": [],
+            "coverage": {
+                "front_matter": "present", "body_text": "present", "scripts": "present",
+                "lockfiles": "present", "transitive_traversal": "present"
+            },
+            "signals": [],
+            "non_claims": ["review_complete_is_not_skill_safe"]
+        })
+    }
+
+    fn sarif(results: Value) -> Value {
+        json!({
+            "version": "2.1.0",
+            "runs": [{"tool": {"driver": {"name": "SkillSpector"}}, "results": results}]
+        })
+    }
+
+    fn run(carrier: &Value, sarif: &Value, known: &[&str]) -> (i32, Value) {
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("c.json");
+        let sp = dir.path().join("s.sarif");
+        let out = dir.path().join("out.json");
+        fs::write(&cp, serde_json::to_string(carrier).unwrap()).unwrap();
+        fs::write(&sp, serde_json::to_string(sarif).unwrap()).unwrap();
+        let rc = cmd_adapt_skill_scan(AdaptSkillScanArgs {
+            carrier: cp,
+            sarif: sp,
+            known_risk_rules: known.iter().map(|s| s.to_string()).collect(),
+            out: Some(out.clone()),
+        })
+        .unwrap();
+        let augmented = serde_json::from_str(&fs::read_to_string(&out).unwrap()).unwrap();
+        (rc, augmented)
+    }
+
+    #[test]
+    fn non_known_warning_attaches_as_scanner_finding_without_changing_verdict() {
+        let s = sarif(json!([
+            {"ruleId": "OVERBROAD_FS", "level": "warning", "message": {"text": "writes /etc"}}
+        ]));
+        let (rc, out) = run(&base_carrier(), &s, &[]);
+        assert_eq!(rc, 0);
+        // Raw scanner finding is attached for the reviewer, source-classed, but NOT a contract signal.
+        let findings = out["scanner_findings"].as_array().unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0]["source_class"], "static_analysis_scanner");
+        assert_eq!(findings[0]["known_risk"], false);
+        assert_eq!(out["signals"].as_array().unwrap().len(), 0);
+        // A non-known finding does not flip the verdict.
+        assert_eq!(out["verdict"], "review_complete");
+    }
+
+    #[test]
+    fn known_risk_rule_elevates_verdict_to_transitive_risk_present() {
+        let s = sarif(json!([
+            {"ruleId": "MALICIOUS_SKILL", "level": "error", "message": {"text": "reaches known-bad"}}
+        ]));
+        let (rc, out) = run(&base_carrier(), &s, &["MALICIOUS_SKILL"]);
+        assert_eq!(rc, 0);
+        assert_eq!(out["verdict"], "transitive_risk_present");
+        let reasons: Vec<&str> = out["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(reasons.contains(&"known_risk_signal_reachable"));
+        // Promoted to a verdict-bearing occurrence signal, AND recorded as a raw finding.
+        assert_eq!(out["signals"].as_array().unwrap().len(), 1);
+        assert_eq!(out["signals"][0]["kind"], "occurrence");
+        assert_eq!(out["scanner_findings"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn note_level_results_are_skipped() {
+        let s = sarif(json!([
+            {"ruleId": "STYLE", "level": "note", "message": {"text": "minor"}}
+        ]));
+        let (_rc, out) = run(&base_carrier(), &s, &[]);
+        assert!(
+            out.get("scanner_findings").is_none()
+                || out["scanner_findings"].as_array().unwrap().is_empty()
+        );
+        assert_eq!(out["signals"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn scan_never_downgrades_an_incomplete_carrier() {
+        let mut c = base_carrier();
+        c["verdict"] = json!("review_incomplete");
+        c["reason_codes"] = json!(["missing_lockfile_evidence"]);
+        c["coverage"]["lockfiles"] = json!("not_present");
+        let s = sarif(json!([
+            {"ruleId": "X", "level": "warning", "message": {"text": "y"}}
+        ]));
+        let (_rc, out) = run(&c, &s, &[]);
+        // Still at least incomplete; a benign scan finding cannot clear a coverage gap.
+        assert_eq!(out["verdict"], "review_incomplete");
+    }
+
+    #[test]
+    fn known_risk_dominates_coverage_gap_under_worst_wins() {
+        let mut c = base_carrier();
+        c["verdict"] = json!("review_incomplete");
+        c["reason_codes"] = json!(["missing_lockfile_evidence"]);
+        c["coverage"]["lockfiles"] = json!("not_present");
+        let s = sarif(json!([
+            {"ruleId": "BAD", "level": "error", "message": {"text": "z"}}
+        ]));
+        let (_rc, out) = run(&c, &s, &["BAD"]);
+        assert_eq!(out["verdict"], "transitive_risk_present");
+    }
+
+    #[test]
+    fn known_risk_drops_prior_absence_claim() {
+        let mut c = base_carrier();
+        c["signals"] = json!([
+            {"kind": "absence", "source_class": "boundary_observed",
+             "justification": "reviewed_boundary_fully_traversed"}
+        ]);
+        let s = sarif(json!([
+            {"ruleId": "BAD", "level": "error", "message": {"text": "y"}}
+        ]));
+        let (rc, out) = run(&c, &s, &["BAD"]);
+        assert_eq!(rc, 0);
+        // The stale absence claim is gone; only the live occurrence signal remains.
+        let signals = out["signals"].as_array().unwrap();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0]["kind"], "occurrence");
+    }
+
+    #[test]
+    fn non_known_finding_does_not_disturb_a_valid_absence_claim() {
+        // A benign scanner finding is attached as raw evidence but must not contradict/drop an
+        // existing absence claim, because it is not a verdict-bearing occurrence signal.
+        let mut c = base_carrier();
+        c["signals"] = json!([
+            {"kind": "absence", "source_class": "boundary_observed",
+             "justification": "reviewed_boundary_fully_traversed"}
+        ]);
+        let s = sarif(json!([
+            {"ruleId": "STYLE", "level": "warning", "message": {"text": "minor"}}
+        ]));
+        let (rc, out) = run(&c, &s, &[]);
+        assert_eq!(rc, 0);
+        assert_eq!(out["signals"].as_array().unwrap().len(), 1);
+        assert_eq!(out["signals"][0]["kind"], "absence");
+        assert_eq!(out["scanner_findings"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn rejects_non_sarif_211() {
+        let s = json!({"version": "2.0.0", "runs": []});
+        let dir = tempfile::tempdir().unwrap();
+        let cp = dir.path().join("c.json");
+        let sp = dir.path().join("s.sarif");
+        fs::write(&cp, serde_json::to_string(&base_carrier()).unwrap()).unwrap();
+        fs::write(&sp, serde_json::to_string(&s).unwrap()).unwrap();
+        let err = cmd_adapt_skill_scan(AdaptSkillScanArgs {
+            carrier: cp,
+            sarif: sp,
+            known_risk_rules: vec![],
+            out: None,
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("SARIF 2.1.0"));
+    }
+}

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -1,3 +1,4 @@
+pub mod adapt_skill_scan;
 pub mod attest;
 pub mod cyclonedx_mlbom_model;
 pub mod diff;
@@ -10,12 +11,14 @@ pub mod mcp_execution_records;
 pub mod mcp_supersession;
 pub mod mcp_tunnel_observed;
 pub mod openfeature_details;
+pub mod project_skill_bom;
 pub mod promptfoo_jsonl;
 pub mod pull;
 pub mod push;
 pub mod pydantic_case_result;
 pub mod schema;
 pub mod skill_supply_chain;
+pub mod skill_supply_chain_capture;
 pub mod store_status;
 pub mod tool_decision_truth;
 pub mod verify_skill_supply_chain;
@@ -49,6 +52,15 @@ pub enum EvidenceCmd {
     /// Verify experimental skill supply-chain carriers against the pinned contract in a bundle
     #[command(name = "verify-skill-supply-chain")]
     VerifySkillSupplyChain(verify_skill_supply_chain::VerifySkillSupplyChainArgs),
+    /// Capture a skill root into an experimental skill supply-chain carrier (declarative, not a scanner)
+    #[command(name = "capture-skill-supply-chain")]
+    CaptureSkillSupplyChain(skill_supply_chain_capture::CaptureSkillSupplyChainArgs),
+    /// Project a verified skill supply-chain bundle into a CycloneDX 1.6 AI-BOM
+    #[command(name = "project-skill-bom")]
+    ProjectSkillBom(project_skill_bom::ProjectSkillBomArgs),
+    /// Attach SARIF scanner findings to a skill supply-chain carrier as occurrence signals
+    #[command(name = "adapt-skill-scan")]
+    AdaptSkillScan(adapt_skill_scan::AdaptSkillScanArgs),
     /// Inspect a bundle's contents (verify + show table)
     Show(EvidenceShowArgs),
     /// Import external evidence into an Assay evidence bundle
@@ -160,6 +172,11 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         EvidenceCmd::VerifySkillSupplyChain(a) => {
             verify_skill_supply_chain::cmd_verify_skill_supply_chain(a)
         }
+        EvidenceCmd::CaptureSkillSupplyChain(a) => {
+            skill_supply_chain_capture::cmd_capture_skill_supply_chain(a)
+        }
+        EvidenceCmd::ProjectSkillBom(a) => project_skill_bom::cmd_project_skill_bom(a),
+        EvidenceCmd::AdaptSkillScan(a) => adapt_skill_scan::cmd_adapt_skill_scan(a),
         EvidenceCmd::Show(a) => cmd_show(a),
         EvidenceCmd::Import(a) => cmd_import(a),
         EvidenceCmd::Schema(a) => schema::cmd_schema(a),

--- a/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
@@ -8,7 +8,7 @@
 //! no trust score and no `vulnerabilities`/VEX block, because the carrier asserts neither CVEs nor
 //! safety — only review sufficiency at the reviewed boundary.
 
-use super::skill_supply_chain::{validate_carrier, CARRIER_EVENT_TYPE};
+use super::skill_supply_chain::CARRIER_EVENT_TYPE;
 use crate::exit_codes;
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -48,22 +48,23 @@ pub fn cmd_project_skill_bom(args: ProjectSkillBomArgs) -> Result<i32> {
         .events_vec()
         .context("failed to read bundle events")?;
 
+    // Verify FULLY before projecting, with the SAME semantics as `verify-skill-supply-chain`: this
+    // includes duplicate-root rejection, so a bundle that fails verification (e.g. ambiguous roots) is
+    // never projected into a BOM with duplicate bom-refs. Projection is a view over verified evidence.
+    let report = super::verify_skill_supply_chain::build_report(&events);
+    if !report.ok {
+        eprintln!("error: skill supply-chain verification failed; refusing to project unverified evidence");
+        for check in report.checks.iter().filter(|c| !c.ok) {
+            eprintln!("  fail: {} — {}", check.id, check.detail);
+        }
+        return Ok(exit_codes::EXIT_CONFIG_ERROR);
+    }
+
     let carriers: Vec<&Value> = events
         .iter()
         .filter(|e| e.type_ == CARRIER_EVENT_TYPE)
         .map(|e| &e.payload)
         .collect();
-    if carriers.is_empty() {
-        eprintln!("error: bundle contains no skill supply-chain carriers to project");
-        return Ok(exit_codes::EXIT_CONFIG_ERROR);
-    }
-    // Verify FULLY before projecting: refuse to emit a BOM over an incoherent carrier.
-    for carrier in &carriers {
-        if let Err(e) = validate_carrier(carrier) {
-            eprintln!("error: refusing to project unverified evidence: {e}");
-            return Ok(exit_codes::EXIT_CONFIG_ERROR);
-        }
-    }
 
     let bom = project_bom(&carriers);
     let json = serde_json::to_string_pretty(&bom)?;
@@ -131,10 +132,11 @@ fn project_bom(carriers: &[&Value]) -> Value {
         let deps = carrier.get("declared_dependencies");
         for pkg in channel(deps, "packages") {
             let name = pkg.get("name").and_then(Value::as_str).unwrap_or("unknown");
-            let version = pkg.get("version").and_then(Value::as_str);
             let dep_ref = format!("pkg:{name}");
             let mut comp = json!({"type": "library", "bom-ref": dep_ref, "name": name});
-            if let Some(v) = version {
+            // Capture treats any non-null scalar version as declared evidence (YAML parses a bare
+            // `2.0` as a number), so the BOM must not drop a numeric version — coerce it to a string.
+            if let Some(v) = version_string(pkg.get("version")) {
                 comp["version"] = json!(v);
             }
             components.push(comp);
@@ -168,6 +170,17 @@ fn project_bom(carriers: &[&Value]) -> Value {
         "components": components,
         "dependencies": dependencies,
     })
+}
+
+/// A declared version rendered as a string: a non-empty JSON string as-is, a JSON number stringified
+/// (the bundle's JCS canonicalization has already normalized it, so `2.0` reads back as `2`). Null,
+/// empty, or other types yield `None` so no `version` field is emitted.
+fn version_string(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        Some(Value::Number(n)) => Some(n.to_string()),
+        _ => None,
+    }
 }
 
 fn channel<'a>(deps: Option<&'a Value>, name: &str) -> Vec<&'a Value> {
@@ -274,5 +287,75 @@ mod tests {
         let out = dir.path().join("bom.json");
         assert_eq!(project(&bundle, &out), exit_codes::EXIT_CONFIG_ERROR);
         assert!(!out.exists());
+    }
+
+    #[test]
+    fn refuses_to_project_bundle_with_duplicate_root_identity() {
+        // Two coherent carriers for the SAME root are ambiguous: the full verifier rejects them, so
+        // projection must too (no BOM with duplicate bom-refs). Regression for the verify-before-project
+        // gap where per-carrier validation alone would have let this through.
+        use crate::cli::commands::evidence::skill_supply_chain::CARRIER_EVENT_TYPE;
+        use assay_evidence::bundle::BundleWriter;
+        use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("dup.tar.gz");
+        let producer = ProducerMeta {
+            name: "t".into(),
+            version: "0".into(),
+            git: None,
+        };
+        let mut w = BundleWriter::new(std::fs::File::create(&bundle).unwrap())
+            .with_producer(producer.clone());
+        for seq in 0..2 {
+            w.add_event(
+                EvidenceEvent::new(CARRIER_EVENT_TYPE, "urn:t", "t", seq, sample_carrier())
+                    .with_producer(&producer),
+            );
+        }
+        w.finish().unwrap();
+        let out = dir.path().join("bom.json");
+        assert_eq!(project(&bundle, &out), exit_codes::EXIT_CONFIG_ERROR);
+        assert!(!out.exists());
+    }
+
+    #[test]
+    fn numeric_package_version_is_projected_as_a_string() {
+        // Regression for the numeric-version projection loss: capture accepts a YAML numeric version as
+        // declared evidence, so the BOM must render it (as a string), not drop it. The bundle's JCS
+        // canonicalization renders 2.0 as 2 (and 2 == 2.0 per the numeric-equality contract edge); the
+        // point of the regression is that the version is PRESENT, not the exact literal.
+        let mut carrier = sample_carrier();
+        carrier["declared_dependencies"] = json!({
+            "packages": [{"name": "requests", "version": 2.0}],
+            "services": [],
+            "skills": []
+        });
+        let (bundle, dir) = run_import(&carrier, "ver_test").unwrap();
+        let out = dir.path().join("bom.json");
+        assert_eq!(project(&bundle, &out), 0);
+        let bom: Value = serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        let lib = bom["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["type"] == "library" && c["name"] == "requests")
+            .expect("library component present");
+        assert_eq!(lib["version"], "2");
+
+        // A fractional version survives JCS unchanged and is rendered verbatim.
+        let mut c2 = sample_carrier();
+        c2["declared_dependencies"] =
+            json!({"packages": [{"name": "flask", "version": 2.5}], "services": [], "skills": []});
+        let (bundle2, dir2) = run_import(&c2, "ver_test2").unwrap();
+        let out2 = dir2.path().join("bom.json");
+        assert_eq!(project(&bundle2, &out2), 0);
+        let bom2: Value = serde_json::from_str(&std::fs::read_to_string(&out2).unwrap()).unwrap();
+        let lib2 = bom2["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["type"] == "library" && c["name"] == "flask")
+            .expect("library component present");
+        assert_eq!(lib2["version"], "2.5");
     }
 }

--- a/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
@@ -1,0 +1,278 @@
+//! EXPERIMENTAL: project a verified skill supply-chain bundle into a CycloneDX 1.6 AI-BOM (ASBOM).
+//!
+//! This is a view over VERIFIED evidence, never a best-effort extractor: the bundle is verified with
+//! the same gate as `verify-skill-supply-chain` first, and nothing is written if any carrier fails.
+//! The projection is an INVENTORY, not an assertion of safety: the reviewed skill is a `file`
+//! component, declared packages/skills are `library` components, services are `service` entries, and
+//! the bounded verdict + coverage + non-claims travel as namespaced `properties`. There is deliberately
+//! no trust score and no `vulnerabilities`/VEX block, because the carrier asserts neither CVEs nor
+//! safety — only review sufficiency at the reviewed boundary.
+
+use super::skill_supply_chain::{validate_carrier, CARRIER_EVENT_TYPE};
+use crate::exit_codes;
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use std::fs;
+use std::fs::File;
+use std::path::PathBuf;
+
+const CDX_PROPERTY_NS: &str = "assay:skill_supply_chain";
+
+#[derive(Debug, clap::Args, Clone)]
+pub struct ProjectSkillBomArgs {
+    /// Evidence bundle (.tar.gz) with skill supply-chain carrier events
+    #[arg(value_name = "BUNDLE")]
+    pub bundle: PathBuf,
+
+    /// Where to write the CycloneDX BOM JSON (stdout if omitted)
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<PathBuf>,
+}
+
+pub fn cmd_project_skill_bom(args: ProjectSkillBomArgs) -> Result<i32> {
+    let file = match File::open(&args.bundle) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("error: cannot open bundle {}: {e}", args.bundle.display());
+            return Ok(exit_codes::EXIT_CONFIG_ERROR);
+        }
+    };
+    let reader = match assay_evidence::bundle::BundleReader::open(file) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: bundle integrity verification failed: {e}");
+            return Ok(exit_codes::EXIT_CONFIG_ERROR);
+        }
+    };
+    let events = reader
+        .events_vec()
+        .context("failed to read bundle events")?;
+
+    let carriers: Vec<&Value> = events
+        .iter()
+        .filter(|e| e.type_ == CARRIER_EVENT_TYPE)
+        .map(|e| &e.payload)
+        .collect();
+    if carriers.is_empty() {
+        eprintln!("error: bundle contains no skill supply-chain carriers to project");
+        return Ok(exit_codes::EXIT_CONFIG_ERROR);
+    }
+    // Verify FULLY before projecting: refuse to emit a BOM over an incoherent carrier.
+    for carrier in &carriers {
+        if let Err(e) = validate_carrier(carrier) {
+            eprintln!("error: refusing to project unverified evidence: {e}");
+            return Ok(exit_codes::EXIT_CONFIG_ERROR);
+        }
+    }
+
+    let bom = project_bom(&carriers);
+    let json = serde_json::to_string_pretty(&bom)?;
+    match &args.out {
+        Some(path) => {
+            fs::write(path, format!("{json}\n"))
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!("Projected CycloneDX AI-BOM to {}", path.display());
+        }
+        None => println!("{json}"),
+    }
+    Ok(exit_codes::OK)
+}
+
+fn project_bom(carriers: &[&Value]) -> Value {
+    let mut components: Vec<Value> = Vec::new();
+    let mut dependencies: Vec<Value> = Vec::new();
+
+    for carrier in carriers {
+        let root_name = carrier["root"]["name"].as_str().unwrap_or("unknown");
+        let root_path = carrier["root"]["path"].as_str().unwrap_or("");
+        let root_ref = format!("skill:{root_path}");
+
+        let mut properties = vec![
+            prop("verdict", carrier["verdict"].as_str().unwrap_or("")),
+            prop("reason_codes", &join_strs(carrier.get("reason_codes"))),
+        ];
+        if let Some(cov) = carrier.get("coverage").and_then(Value::as_object) {
+            for (k, v) in cov {
+                properties.push(prop(&format!("coverage.{k}"), v.as_str().unwrap_or("")));
+            }
+        }
+        for nc in carrier
+            .get("non_claims")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+        {
+            properties.push(prop("non_claim", nc));
+        }
+        for signal in carrier
+            .get("signals")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let kind = signal.get("kind").and_then(Value::as_str).unwrap_or("");
+            let sc = signal
+                .get("source_class")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            properties.push(prop("signal", &format!("{kind}:{sc}")));
+        }
+
+        components.push(json!({
+            "type": "file",
+            "bom-ref": root_ref,
+            "name": root_name,
+            "properties": properties,
+        }));
+
+        // Declared dependencies become inventory components + a dependency edge from the root.
+        let mut edges: Vec<String> = Vec::new();
+        let deps = carrier.get("declared_dependencies");
+        for pkg in channel(deps, "packages") {
+            let name = pkg.get("name").and_then(Value::as_str).unwrap_or("unknown");
+            let version = pkg.get("version").and_then(Value::as_str);
+            let dep_ref = format!("pkg:{name}");
+            let mut comp = json!({"type": "library", "bom-ref": dep_ref, "name": name});
+            if let Some(v) = version {
+                comp["version"] = json!(v);
+            }
+            components.push(comp);
+            edges.push(dep_ref);
+        }
+        for skill in channel(deps, "skills") {
+            let name = skill
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let dep_ref = format!("skill-dep:{name}");
+            components.push(json!({"type": "file", "bom-ref": dep_ref, "name": name}));
+            edges.push(dep_ref);
+        }
+        for svc in channel(deps, "services") {
+            let name = svc.get("name").and_then(Value::as_str).unwrap_or("unknown");
+            let dep_ref = format!("service:{name}");
+            components.push(json!({"type": "service", "bom-ref": dep_ref, "name": name}));
+            edges.push(dep_ref);
+        }
+        dependencies.push(json!({"ref": root_ref, "dependsOn": edges}));
+    }
+
+    json!({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {
+            "properties": [prop("projector", "assay-skill-supply-chain"), prop("bom_kind", "ASBOM")],
+        },
+        "components": components,
+        "dependencies": dependencies,
+    })
+}
+
+fn channel<'a>(deps: Option<&'a Value>, name: &str) -> Vec<&'a Value> {
+    deps.and_then(|d| d.get(name))
+        .and_then(Value::as_array)
+        .map(|a| a.iter().collect())
+        .unwrap_or_default()
+}
+
+fn prop(name: &str, value: &str) -> Value {
+    json!({"name": format!("{CDX_PROPERTY_NS}:{name}"), "value": value})
+}
+
+fn join_strs(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::commands::evidence::skill_supply_chain::tests::{run_import, sample_carrier};
+    use serde_json::json;
+
+    fn project(bundle: &std::path::Path, out: &std::path::Path) -> i32 {
+        cmd_project_skill_bom(ProjectSkillBomArgs {
+            bundle: bundle.to_path_buf(),
+            out: Some(out.to_path_buf()),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn projects_valid_cyclonedx_1_6_bom() {
+        let mut carrier = sample_carrier();
+        carrier["declared_dependencies"] = json!({
+            "packages": [{"name": "requests", "version": "2.0"}],
+            "services": [{"name": "payments", "endpoint": "https://x"}],
+            "skills": []
+        });
+        let (bundle, dir) = run_import(&carrier, "bom_test").unwrap();
+        let out = dir.path().join("bom.json");
+        assert_eq!(project(&bundle, &out), 0);
+
+        let bom: Value = serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        assert_eq!(bom["bomFormat"], "CycloneDX");
+        assert_eq!(bom["specVersion"], "1.6");
+        assert_eq!(bom["version"], 1);
+
+        let comps = bom["components"].as_array().unwrap();
+        // root file + one library + one service
+        assert!(comps
+            .iter()
+            .any(|c| c["type"] == "file" && c["name"] == "release-notes"));
+        assert!(comps
+            .iter()
+            .any(|c| c["type"] == "library" && c["name"] == "requests"));
+        assert!(comps
+            .iter()
+            .any(|c| c["type"] == "service" && c["name"] == "payments"));
+
+        // verdict rides as a namespaced property, never a trust score.
+        let root = comps.iter().find(|c| c["type"] == "file").unwrap();
+        let props = root["properties"].as_array().unwrap();
+        assert!(props
+            .iter()
+            .any(|p| p["name"] == "assay:skill_supply_chain:verdict"
+                && p["value"] == "review_complete"));
+        // no vulnerabilities / VEX block, no score field anywhere.
+        assert!(bom.get("vulnerabilities").is_none());
+        let serialized = serde_json::to_string(&bom).unwrap();
+        assert!(!serialized.contains("\"score\""));
+        assert!(!serialized.to_lowercase().contains("\"safe\""));
+    }
+
+    #[test]
+    fn refuses_to_project_incoherent_carrier() {
+        // Build a bundle whose carrier bypassed the import gate (verdict/reason mismatch).
+        use crate::cli::commands::evidence::skill_supply_chain::CARRIER_EVENT_TYPE;
+        use assay_evidence::bundle::BundleWriter;
+        use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("bad.tar.gz");
+        let producer = ProducerMeta {
+            name: "t".into(),
+            version: "0".into(),
+            git: None,
+        };
+        let mut bad = sample_carrier();
+        bad["verdict"] = json!("transitive_risk_present");
+        let mut w = BundleWriter::new(std::fs::File::create(&bundle).unwrap())
+            .with_producer(producer.clone());
+        w.add_event(
+            EvidenceEvent::new(CARRIER_EVENT_TYPE, "urn:t", "t", 0, bad).with_producer(&producer),
+        );
+        w.finish().unwrap();
+        let out = dir.path().join("bom.json");
+        assert_eq!(project(&bundle, &out), exit_codes::EXIT_CONFIG_ERROR);
+        assert!(!out.exists());
+    }
+}

--- a/crates/assay-cli/src/cli/commands/evidence/skill_supply_chain.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/skill_supply_chain.rs
@@ -251,9 +251,14 @@ pub(crate) fn validate_carrier(carrier: &Value) -> Result<()> {
         .get("transitive_traversal")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    if verdict == "review_complete" && traversal != "present" {
+    // review_complete is legitimate either when the dependency graph was traversed (`present`) or when
+    // there were no declared dependencies to traverse (`not_applicable`). It is only incoherent when
+    // deps existed but traversal was not retained (`not_present`) — that must degrade to incomplete via
+    // the `traversal_not_retained` reason, so review_complete + not_present is rejected.
+    if verdict == "review_complete" && traversal == "not_present" {
         bail!(
-            "carrier verdict review_complete requires coverage.transitive_traversal to be present"
+            "carrier verdict review_complete is incoherent with transitive_traversal not_present; \
+             declare traversal present or not_applicable, or degrade the verdict"
         );
     }
 

--- a/crates/assay-cli/src/cli/commands/evidence/skill_supply_chain_capture.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/skill_supply_chain_capture.rs
@@ -1,0 +1,534 @@
+//! EXPERIMENTAL: honest-declarative capture of a skill root into an assay.skill_supply_chain.v0 carrier.
+//!
+//! This is the skill-channel producer (DoR implementation shelf item 3): it walks ONE skill root,
+//! answers the five coverage flags from what is actually on disk, reads STRUCTURED declared
+//! dependencies from front matter (skill/package/service channels), and emits a carrier whose verdict
+//! recomputes under worst-wins. It is deliberately NOT an analyzer: it does not extract dependencies
+//! from natural-language prose, does not resolve or execute anything, and attaches no security signals
+//! (those enter via `evidence adapt-skill-scan`). Missing evidence is reported as `not_present`, never a
+//! silent pass. The emitted carrier is re-validated with the same gate the importer uses, so a captured
+//! carrier is guaranteed importable.
+
+use super::skill_supply_chain::{expected_verdict, validate_carrier};
+use crate::exit_codes;
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CARRIER_SCHEMA: &str = "assay.skill_supply_chain.v0";
+const NON_CLAIMS: &[&str] = &[
+    "review_complete_is_not_skill_safe",
+    "transitive_risk_present_is_not_skill_malicious",
+    "verdict_covers_one_root_at_one_capture_time",
+    "no_registry_wide_claim",
+    "no_runtime_behavior_claim",
+    "capture_is_declarative_not_an_analyzer",
+];
+/// Adjacent files that count as retained lockfile evidence for the package channel.
+const LOCKFILE_NAMES: &[&str] = &[
+    "package-lock.json",
+    "requirements.txt",
+    "uv.lock",
+    "Cargo.lock",
+    "poetry.lock",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+];
+
+#[derive(Debug, clap::Args, Clone)]
+pub struct CaptureSkillSupplyChainArgs {
+    /// Skill root: a SKILL.md / agent markdown file, or a directory containing one
+    #[arg(long, value_name = "PATH")]
+    pub root: PathBuf,
+
+    /// Where to write the carrier JSON (stdout if omitted)
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<PathBuf>,
+}
+
+pub fn cmd_capture_skill_supply_chain(args: CaptureSkillSupplyChainArgs) -> Result<i32> {
+    let carrier = capture_carrier(&args.root)?;
+    // Fail-closed: never emit a carrier the importer would reject.
+    validate_carrier(&carrier).context("captured carrier failed self-validation (bug)")?;
+    let json = serde_json::to_string_pretty(&carrier)?;
+    match &args.out {
+        Some(path) => {
+            fs::write(path, format!("{json}\n"))
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!("Captured skill supply-chain carrier to {}", path.display());
+        }
+        None => println!("{json}"),
+    }
+    Ok(exit_codes::OK)
+}
+
+/// A skill root resolved to its markdown artifact plus the directory that holds adjacent files.
+struct Resolved {
+    /// The markdown file that carries front matter + body.
+    markdown: PathBuf,
+    /// Directory scanned for adjacent scripts and lockfiles.
+    dir: PathBuf,
+    /// The reviewer-facing root path (relative, POSIX) recorded in the carrier.
+    root_path: String,
+}
+
+fn resolve_root(root: &Path) -> Result<Resolved> {
+    let root_path = posix_relative(root);
+    if root.is_file() {
+        let dir = root
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        return Ok(Resolved {
+            markdown: root.to_path_buf(),
+            dir,
+            root_path,
+        });
+    }
+    if root.is_dir() {
+        // Prefer a conventional skill entry point, else the first front-matter markdown.
+        for name in ["SKILL.md", "skill.md", "AGENT.md", "agent.md"] {
+            let candidate = root.join(name);
+            if candidate.is_file() {
+                return Ok(Resolved {
+                    markdown: candidate,
+                    dir: root.to_path_buf(),
+                    root_path,
+                });
+            }
+        }
+        let mut markdowns: Vec<PathBuf> = fs::read_dir(root)
+            .with_context(|| format!("failed to read directory {}", root.display()))?
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+            .collect();
+        markdowns.sort();
+        if let Some(md) = markdowns.into_iter().find(|p| has_front_matter(p)) {
+            return Ok(Resolved {
+                markdown: md,
+                dir: root.to_path_buf(),
+                root_path,
+            });
+        }
+        bail!(
+            "no SKILL.md or front-matter markdown found under {}",
+            root.display()
+        );
+    }
+    bail!("skill root {} does not exist", root.display())
+}
+
+fn has_front_matter(path: &Path) -> bool {
+    fs::read_to_string(path)
+        .ok()
+        .map(|s| s.starts_with("---\n") || s.starts_with("---\r\n"))
+        .unwrap_or(false)
+}
+
+/// Split a markdown file into its YAML front-matter block and the remaining body.
+fn split_front_matter(text: &str) -> (Option<&str>, &str) {
+    let rest = match text
+        .strip_prefix("---\n")
+        .or_else(|| text.strip_prefix("---\r\n"))
+    {
+        Some(rest) => rest,
+        None => return (None, text),
+    };
+    // The closing fence is a line that is exactly `---`.
+    for marker in ["\n---\n", "\r\n---\r\n", "\n---\r\n", "\r\n---\n"] {
+        if let Some(idx) = rest.find(marker) {
+            let front = &rest[..idx];
+            let body = &rest[idx + marker.len()..];
+            return (Some(front), body);
+        }
+    }
+    // Unterminated front matter: treat the whole remainder as front matter, empty body.
+    (Some(rest), "")
+}
+
+/// The reviewer-facing root path, normalized to a safe relative POSIX path (repo writer convention):
+/// relative to cwd when possible, then leading slashes / drive prefixes / `..` components stripped so
+/// the recorded identity always satisfies the importer's path-safety gate.
+fn posix_relative(path: &Path) -> String {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let rel = path.strip_prefix(&cwd).unwrap_or(path);
+    let posix = rel.to_string_lossy().replace('\\', "/");
+    let cleaned: Vec<&str> = posix
+        .split('/')
+        .filter(|c| !c.is_empty() && *c != ".." && *c != ".")
+        // Drop a Windows drive component like `C:` if it survived stripping.
+        .filter(|c| !(c.len() == 2 && c.as_bytes()[1] == b':'))
+        .collect();
+    if cleaned.is_empty() {
+        "skill".to_string()
+    } else {
+        cleaned.join("/")
+    }
+}
+
+/// Build the carrier from a resolved skill root. All coverage answers come from the filesystem and
+/// front-matter declarations; nothing is inferred from prose.
+fn capture_carrier(root: &Path) -> Result<Value> {
+    let resolved = resolve_root(root)?;
+    let text = fs::read_to_string(&resolved.markdown)
+        .with_context(|| format!("failed to read {}", resolved.markdown.display()))?;
+    let (front_raw, body) = split_front_matter(&text);
+
+    let front: Value = match front_raw {
+        Some(raw) => serde_yaml::from_str(raw).unwrap_or(Value::Null),
+        None => Value::Null,
+    };
+    let name = front
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            resolved
+                .markdown
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let mut reasons: Vec<String> = Vec::new();
+
+    // --- coverage: front matter + body ---
+    let front_matter = if front_raw.is_some() && front.get("name").is_some() {
+        "present"
+    } else {
+        "not_present"
+    };
+    let body_text = if body.trim().is_empty() {
+        "not_present"
+    } else {
+        "present"
+    };
+
+    // --- coverage: scripts (adjacent .sh/.py/.js/.ts or a scripts/ dir) ---
+    let scripts_present = dir_has_scripts(&resolved.dir);
+    let scripts = if scripts_present {
+        "present"
+    } else {
+        "not_applicable"
+    };
+
+    // --- declared dependencies (structured front matter only, three channels) ---
+    let deps = front.get("dependencies");
+    let packages = channel_list(deps, "packages");
+    let services = channel_list(deps, "services");
+    let skills = channel_list(deps, "skills");
+
+    // --- coverage: lockfiles (package channel) ---
+    let has_lockfile = LOCKFILE_NAMES
+        .iter()
+        .any(|n| resolved.dir.join(n).is_file());
+    let lockfiles = if packages.is_empty() {
+        "not_applicable"
+    } else if has_lockfile {
+        "present"
+    } else {
+        reasons.push("missing_lockfile_evidence".to_string());
+        "not_present"
+    };
+    // A version/endpoint is declared when the field is present and non-empty. YAML may parse a bare
+    // version like `2.0` as a number, so any non-null, non-empty value counts as declared.
+    if packages.iter().any(|p| !field_declared(p, "version")) {
+        reasons.push("missing_package_version".to_string());
+    }
+    if services.iter().any(|s| !field_declared(s, "endpoint")) {
+        reasons.push("missing_service_endpoint".to_string());
+    }
+
+    // --- coverage: transitive traversal (skill channel reuse) ---
+    let mut reachable: Vec<Value> = Vec::new();
+    let transitive_traversal = if skills.is_empty() {
+        "not_applicable"
+    } else {
+        let mut all_resolved = true;
+        for skill in &skills {
+            let decl_path = skill.get("path").and_then(Value::as_str).unwrap_or("");
+            let resolved_here = !decl_path.is_empty() && resolved.dir.join(decl_path).exists();
+            if resolved_here {
+                reachable.push(json!({
+                    "channel": "skill",
+                    "declaring_parent": name,
+                    "name": skill.get("name").cloned().unwrap_or(Value::Null),
+                    "path": decl_path,
+                }));
+            } else {
+                all_resolved = false;
+            }
+        }
+        if all_resolved {
+            "present"
+        } else {
+            reasons.push("traversal_not_retained".to_string());
+            "not_present"
+        }
+    };
+
+    // Path safety is guaranteed by construction: `posix_relative` normalizes the recorded root path
+    // to a safe relative POSIX path, so capture never emits `unsafe_skill_path` (that reason exists for
+    // externally-supplied carriers, enforced at the import gate).
+
+    // Dedup + recompute the verdict under the pinned worst-wins precedence.
+    reasons.sort();
+    reasons.dedup();
+    let reason_refs: Vec<&str> = reasons.iter().map(String::as_str).collect();
+    let verdict = expected_verdict(&reason_refs);
+
+    let declared_dependencies = json!({
+        "packages": packages,
+        "services": services,
+        "skills": skills,
+    });
+
+    Ok(json!({
+        "schema": CARRIER_SCHEMA,
+        "root": {"name": name, "path": resolved.root_path},
+        "verdict": verdict,
+        "reason_codes": reasons,
+        "coverage": {
+            "front_matter": front_matter,
+            "body_text": body_text,
+            "scripts": scripts,
+            "lockfiles": lockfiles,
+            "transitive_traversal": transitive_traversal,
+        },
+        "declared_dependencies": declared_dependencies,
+        "reachable_dependencies": reachable,
+        "signals": [],
+        "non_claims": NON_CLAIMS,
+    }))
+}
+
+/// Read a channel (`packages`/`services`/`skills`) as a list of objects from `dependencies`.
+fn channel_list(deps: Option<&Value>, channel: &str) -> Vec<Value> {
+    deps.and_then(|d| d.get(channel))
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(|item| match item {
+                    Value::String(s) => json!({"name": s}),
+                    other => other.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// `true` when a dependency object declares `field` as a present, non-empty value (a number counts).
+fn field_declared(item: &Value, field: &str) -> bool {
+    match item.get(field) {
+        None | Some(Value::Null) => false,
+        Some(Value::String(s)) => !s.is_empty(),
+        Some(_) => true,
+    }
+}
+
+fn dir_has_scripts(dir: &Path) -> bool {
+    if dir.join("scripts").is_dir() {
+        return true;
+    }
+    let script_exts = ["sh", "py", "js", "ts", "rb", "ps1"];
+    fs::read_dir(dir)
+        .ok()
+        .map(|entries| {
+            entries.filter_map(|e| e.ok()).any(|e| {
+                e.path()
+                    .extension()
+                    .and_then(|x| x.to_str())
+                    .map(|x| script_exts.contains(&x))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(name);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&p, body).unwrap();
+        p
+    }
+
+    fn capture_at(path: &Path) -> Value {
+        let carrier = capture_carrier(path).unwrap();
+        validate_carrier(&carrier).expect("captured carrier must self-validate");
+        carrier
+    }
+
+    #[test]
+    fn captures_bare_skill_as_complete_no_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        let md = write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: greeter\n---\nGreet the user politely.\n",
+        );
+        let carrier = capture_at(&md);
+        assert_eq!(carrier["verdict"], "review_complete");
+        assert_eq!(carrier["root"]["name"], "greeter");
+        assert_eq!(carrier["coverage"]["front_matter"], "present");
+        assert_eq!(carrier["coverage"]["body_text"], "present");
+        assert_eq!(carrier["coverage"]["lockfiles"], "not_applicable");
+        assert_eq!(
+            carrier["coverage"]["transitive_traversal"],
+            "not_applicable"
+        );
+        assert_eq!(carrier["reason_codes"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn package_without_lockfile_degrades_to_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let md = write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: fetcher\ndependencies:\n  packages:\n    - name: requests\n      version: 2.0\n---\nBody.\n",
+        );
+        let carrier = capture_at(&md);
+        assert_eq!(carrier["verdict"], "review_incomplete");
+        assert_eq!(carrier["coverage"]["lockfiles"], "not_present");
+        let reasons: Vec<&str> = carrier["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(reasons.contains(&"missing_lockfile_evidence"));
+    }
+
+    #[test]
+    fn package_with_lockfile_and_version_is_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "requirements.txt", "requests==2.0\n");
+        write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: fetcher\ndependencies:\n  packages:\n    - name: requests\n      version: 2.0\n---\nBody.\n",
+        );
+        let carrier = capture_at(&dir.path().join("SKILL.md"));
+        assert_eq!(carrier["verdict"], "review_complete");
+        assert_eq!(carrier["coverage"]["lockfiles"], "present");
+    }
+
+    #[test]
+    fn package_missing_version_degrades() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "requirements.txt", "requests\n");
+        let md = write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: fetcher\ndependencies:\n  packages:\n    - name: requests\n---\nBody.\n",
+        );
+        let carrier = capture_at(&md);
+        let reasons: Vec<&str> = carrier["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(reasons.contains(&"missing_package_version"));
+        assert_eq!(carrier["verdict"], "review_incomplete");
+    }
+
+    #[test]
+    fn service_without_endpoint_degrades() {
+        let dir = tempfile::tempdir().unwrap();
+        let md = write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: caller\ndependencies:\n  services:\n    - name: payments\n---\nBody.\n",
+        );
+        let carrier = capture_at(&md);
+        let reasons: Vec<&str> = carrier["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(reasons.contains(&"missing_service_endpoint"));
+    }
+
+    #[test]
+    fn unresolved_reused_skill_flags_traversal_not_retained() {
+        let dir = tempfile::tempdir().unwrap();
+        let md = write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: parent\ndependencies:\n  skills:\n    - name: child\n      path: nonexistent/child\n---\nBody.\n",
+        );
+        let carrier = capture_at(&md);
+        assert_eq!(carrier["coverage"]["transitive_traversal"], "not_present");
+        let reasons: Vec<&str> = carrier["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(reasons.contains(&"traversal_not_retained"));
+    }
+
+    #[test]
+    fn resolved_reused_skill_records_reachable_and_traverses() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "child/SKILL.md",
+            "---\nname: child\n---\nChild.\n",
+        );
+        let md = write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: parent\ndependencies:\n  skills:\n    - name: child\n      path: child/SKILL.md\n---\nBody.\n",
+        );
+        let carrier = capture_at(&md);
+        assert_eq!(carrier["coverage"]["transitive_traversal"], "present");
+        assert_eq!(carrier["verdict"], "review_complete");
+        assert_eq!(
+            carrier["reachable_dependencies"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn scripts_directory_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "scripts/run.sh", "echo hi\n");
+        write(
+            dir.path(),
+            "SKILL.md",
+            "---\nname: withscripts\n---\nBody.\n",
+        );
+        let carrier = capture_at(&dir.path().join("SKILL.md"));
+        assert_eq!(carrier["coverage"]["scripts"], "present");
+    }
+
+    #[test]
+    fn directory_root_finds_skill_md() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "SKILL.md", "---\nname: dirskill\n---\nBody.\n");
+        let carrier = capture_at(dir.path());
+        assert_eq!(carrier["root"]["name"], "dirskill");
+    }
+
+    #[test]
+    fn missing_front_matter_name_falls_back_to_filename_and_flags_coverage() {
+        let dir = tempfile::tempdir().unwrap();
+        let md = write(dir.path(), "notes.md", "Just a body, no front matter.\n");
+        let carrier = capture_at(&md);
+        assert_eq!(carrier["coverage"]["front_matter"], "not_present");
+        assert_eq!(carrier["root"]["name"], "notes");
+    }
+}

--- a/crates/assay-cli/src/cli/commands/evidence/verify_skill_supply_chain.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_skill_supply_chain.rs
@@ -46,20 +46,20 @@ pub enum VerifyFormat {
 }
 
 #[derive(Debug, Serialize)]
-struct Report {
+pub(crate) struct Report {
     schema: &'static str,
-    ok: bool,
+    pub(crate) ok: bool,
     carrier_count: usize,
     verified_carriers: usize,
-    checks: Vec<Check>,
+    pub(crate) checks: Vec<Check>,
     claims_not_made: Vec<&'static str>,
 }
 
 #[derive(Debug, Serialize)]
-struct Check {
-    id: String,
-    ok: bool,
-    detail: String,
+pub(crate) struct Check {
+    pub(crate) id: String,
+    pub(crate) ok: bool,
+    pub(crate) detail: String,
 }
 
 pub fn cmd_verify_skill_supply_chain(args: VerifySkillSupplyChainArgs) -> Result<i32> {
@@ -79,7 +79,10 @@ pub fn cmd_verify_skill_supply_chain(args: VerifySkillSupplyChainArgs) -> Result
     Ok(if report.ok { exit_codes::OK } else { 2 })
 }
 
-fn build_report(events: &[EvidenceEvent]) -> Report {
+/// The single full bundle-level verification pass: per-carrier contract validation, verdict recompute,
+/// and duplicate-root rejection. `project-skill-bom` reuses this so "verify-before-project" enforces the
+/// same semantics as `verify-skill-supply-chain`, not a weaker per-carrier subset.
+pub(crate) fn build_report(events: &[EvidenceEvent]) -> Report {
     let mut checks = Vec::new();
     let mut carrier_count = 0usize;
     let mut verified = 0usize;


### PR DESCRIPTION
> Draft. Completes the skill supply-chain arc's Fase 3 on top of the merged import/verify producer (#1776).

## Summary

Three cohesive skill supply-chain verbs plus one contract-coherence fix, all in `assay-cli`.

### `capture-skill-supply-chain` (auto-capture, DoR shelf item 3)
Honest-declarative skill-channel producer. Walks one skill root, answers the five coverage flags from what is actually on disk, reads **structured** declared dependencies from front matter (skill/package/service channels), and emits a carrier whose verdict recomputes under worst-wins. Deliberately **not** an analyzer: no natural-language dependency extraction (that is SkillDepAnalyzer's lane), no execution, no security signals. Missing evidence is `not_present`, never a silent pass. The emitted carrier is re-validated with the import gate, so a captured carrier is guaranteed importable.

### `project-skill-bom` (CycloneDX 1.6 AI-BOM)
Projects a **verified** bundle into a CycloneDX 1.6 ASBOM. Inventory only: root skill as a `file` component, declared packages as `library` components, services as `service` entries, verdict/coverage/non-claims as namespaced `properties`. No trust score, no `vulnerabilities`/VEX block. Refuses to project an incoherent carrier (verify-before-project, like `project-otel`).

### `adapt-skill-scan` (SARIF 2.1.0 scanner adapter)
Attaches a SARIF 2.1.0 report. Every `error`/`warning` becomes a source-classed `scanner_findings` entry for the reviewer; **only** a result whose `ruleId` is in `--known-risk-rule` is promoted to a contract occurrence `signal` + `known_risk_signal_reachable`, so the verdict recomputes upward under worst-wins. A scan attests presence, never absence, and never downgrades a verdict.

### Contract-coherence fix in `validate_carrier`
`review_complete` is coherent with `transitive_traversal` **present or not_applicable** (no declared deps to traverse); only `not_present` is rejected. The prior rule wrongly rejected the lab's no-dependency `review_complete` family (surfaced by capturing a real dependency-free skill), and it aligns the Rust gate with the Plimsoll consumer, which never required traversal for `review_complete`.

## Design boundary (why this is not a scanner or a trust engine)
Capture is declarative; the scanner adapter keeps raw findings and verdict-bearing signals separate so a scanner occurrence never inflates to a risk verdict without an explicit known-risk mapping; the CycloneDX projection is inventory, not assertion. No `safe`/`unsafe`, no numeric score anywhere.

## Verification
- 32 skill tests; `clippy -D warnings` clean; `assay-cli` suite **326 passed / 0 failed**; fmt clean.
- Real-input end-to-end: `capture .claude/agents/eval-esser.md` → `import` → `verify` (ok) → `project-skill-bom` (CycloneDX 1.6) → `adapt-skill-scan` with a known-risk rule → `transitive_risk_present`.

## SOTA anchors
CycloneDX 1.6 AI/ML-BOM; SARIF 2.1.0 (OASIS); the source-class occurrence/absence discipline (OpenVEX `not_affected`). Held boundary: the RGE-Bench `skill_supply_chain` axis is staged separately and remains gated on the v1 versioning policy + a fresh digest + an independent reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CLI commands to capture skill supply-chain evidence, project it into a CycloneDX-style AI bill of materials, and adapt scanner findings into carrier output.
  * Added support for writing results to a file or standard output.

* **Bug Fixes**
  * Improved validation so a completed review can work with more coverage states.
  * Scanner adaptation now ignores low-priority notes and handles known-risk findings more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->