### PR TITLE
fix(ebpf): LSM emit path wrote pre-MonitorEvent 520-byte records; attach-smoke now fails on ABI skew

### DIFF
--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -42,13 +42,23 @@ jobs:
         # smoke run mislook like an assay monitor attach bug.
         run: |
           scripts/ci/install-ebpf-toolchain.sh
+          # Force a real recompile on this persistent runner. A cached/no-op build lets xtask's
+          # artifact resolution hand back a stale object out of a weeks-old target/ dir, which is
+          # exactly the got=520/need=552 skew #1575 chased: the smoke then loads an object that is
+          # NOT the product of this checkout while looking canonical. Deleting the copied .o and
+          # cleaning the crate makes "built from this commit" true by construction.
+          rm -f target/assay-ebpf.o
+          cargo clean -p assay-ebpf 2>/dev/null || true
           cargo xtask build-ebpf --release --no-docker
           # Build provenance, so the canonical eBPF build path is self-documenting in the run log and
           # nobody has to reconstruct in three months why this path is the right one (see #1570).
+          # The object hash + mtime pin WHICH artifact the smoke below will load (see #1575).
           {
             echo "ebpf_build_mode=release"
             echo "ebpf_build_path=xtask --release --no-docker"
             echo "toolchain_install=present"
+            echo "ebpf_object_sha256=$(sha256sum target/assay-ebpf.o | cut -d' ' -f1)"
+            echo "ebpf_object_mtime=$(stat -c %y target/assay-ebpf.o)"
           } | tee "$RUNNER_TEMP/ebpf-build-provenance.txt"
 
       - name: Smoke - assay monitor must attach its observation probes
@@ -75,3 +85,19 @@ jobs:
             exit 1
           fi
           echo "SMOKE PASS: assay monitor attached its observation probes."
+
+      - name: ABI skew check - loaded object must emit the pinned MonitorEvent size
+        # Separate step so the attach proof above stays a pure attach proof. This is the
+        # mechanical close condition of #1575: a canonical same-commit build that still emits
+        # size-mismatched records means the loaded object was stale, and that must FAIL the run
+        # instead of sitting quietly in the log (which is how run 28666638414 went green while
+        # carrying got=520/need=552).
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/monitor-smoke.log"
+          if grep -q "monitor event size mismatch" "$OUT"; then
+            echo "ABI SKEW FAIL: the loaded eBPF object emitted records that do not match the pinned MonitorEvent size (see #1575)."
+            grep -m1 "invalid event size" "$OUT" || true
+            exit 1
+          fi
+          echo "ABI SKEW PASS: no MonitorEvent size mismatch observed."

--- a/crates/assay-ebpf/src/lsm.rs
+++ b/crates/assay-ebpf/src/lsm.rs
@@ -3,8 +3,8 @@ use crate::{
     inc_stat, CONFIG, DENY_INO, LSM_BYPASS, LSM_DENY, LSM_EVENTS, LSM_HIT, MONITORED_CGROUPS,
 };
 use assay_common::{
-    KEY_EMIT_INODE_RESOLVED, KEY_MONITOR_ALL, MONITOR_STAT_LSM_EVENTS_EMITTED,
-    MONITOR_STAT_LSM_RINGBUF_DROPPED,
+    MonitorEvent, DATA_LEN, KEY_EMIT_INODE_RESOLVED, KEY_MONITOR_ALL,
+    MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
 };
 use aya_ebpf::{
     helpers::{bpf_get_current_cgroup_id, bpf_get_current_pid_tgid, bpf_probe_read_kernel},
@@ -45,22 +45,28 @@ fn emit_event(
     data: &[u8],
     _path_len: u32,
 ) {
-    if let Some(mut entry) = LSM_EVENTS.reserve::<[u8; 520]>(0) {
-        let buf = entry.as_mut_ptr() as *mut u8;
-        // SAFETY: `buf` points to a reserved LSM event ring-buffer entry. The
-        // fixed header and bounded payload bytes are initialized before submit.
+    // Reserve the shared MonitorEvent type, never a size literal: this path used to reserve
+    // `[u8; 520]` (an 8-byte pid+event_type header with data at offset 8), which predates the
+    // 40-byte MonitorEvent header and silently diverged when the shared struct grew. The
+    // userspace decoder rejects any record != size_of::<MonitorEvent>() fail-closed, so every
+    // LSM event was dropped as "invalid event size (got=520, need=552)" (#1575).
+    if let Some(mut entry) = LSM_EVENTS.reserve::<MonitorEvent>(0) {
+        let ev = entry.as_mut_ptr();
+        // SAFETY: `ev` points to a reserved `MonitorEvent` ring-buffer entry. The fixed
+        // header and bounded payload bytes are initialized before submit.
         unsafe {
-            // Write PID
             let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-            *(buf as *mut u32) = pid;
+            // Initializes the full 40-byte header and zeros the payload.
+            crate::write_event_header(ev, pid, event_id);
 
-            // Write Event Type
-            *(buf.add(4) as *mut u32) = event_id;
-
-            // Write Data
-            let data_ptr = buf.add(8);
-            let len = if data.len() > 512 { 512 } else { data.len() };
-            core::ptr::write_bytes(data_ptr, 0, 512);
+            // Write Data (byte layout within `data` unchanged; userspace decodes
+            // EVENT_FILE_BLOCKED payloads from the `data` field at the same offsets).
+            let data_ptr = (*ev).data.as_mut_ptr();
+            let len = if data.len() > DATA_LEN {
+                DATA_LEN
+            } else {
+                data.len()
+            };
             core::ptr::copy_nonoverlapping(data.as_ptr(), data_ptr, len);
 
             if event_id == assay_common::EVENT_FILE_BLOCKED && len >= FILE_BLOCKED_INO_OFFSET + 8 {


### PR DESCRIPTION
Chases #1575 to its actual root cause and closes the loop mechanically.

**Root cause (source, not staleness):** `emit_event` in `crates/assay-ebpf/src/lsm.rs` reserved a hardcoded `[u8; 520]` — an 8-byte pid+event_type header with data at offset 8, an ABI that predates the 40-byte MonitorEvent header. The userspace decoder rejects any record ≠ `size_of::<MonitorEvent>()` fail-closed, so **every LSM event on a bpf-lsm host was dropped** as `invalid event size (got=520, need=552)`: an observation gap on exactly the enforcement path. The compile-time 552 assert in assay-common could not catch it because the size literal never referenced the shared type.

**How it was found:** the verification run for #1575 (28666638414) went green while carrying the mismatch in its log; this branch's run 28667103298 then rebuilt with a forced-clean, sha256-pinned object and STILL emitted 520 — falsifying the stale-object thesis and pointing at the source.

**Changes:**
- `lsm.rs`: reserve `MonitorEvent` (never a size literal), initialize via `write_event_header`, size caps via `DATA_LEN`. Payload byte layout within `data` unchanged; existing `EVENT_FILE_BLOCKED` decode applies as-is.
- `monitor-attach-smoke.yml`: force a real recompile (`rm -f` + `cargo clean -p assay-ebpf`), pin `ebpf_object_sha256` + mtime in build provenance, and a separate **ABI skew check** step that fails the run on any size-mismatch — making #1575's close condition mechanical instead of forensic.

Dispatching the smoke on this branch: green = attach proven AND fresh object emits 552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)