### PR TITLE
ci: harden delegated runner proof layer

### DIFF
--- a/.github/actions/canonical-ebpf-build/action.yml
+++ b/.github/actions/canonical-ebpf-build/action.yml
@@ -3,14 +3,14 @@ name: Canonical eBPF build
 description: Build target/assay-ebpf.o through the canonical CI path and emit provenance.
 
 inputs:
-  output-path:
-    description: Path where cargo xtask writes the eBPF object.
-    required: false
-    default: target/assay-ebpf.o
   provenance-path:
     description: Path for the JSON provenance file emitted by this action.
     required: false
     default: target/assay-ebpf.provenance.json
+  clean-ebpf-crate:
+    description: Force a clean assay-ebpf crate build before invoking xtask.
+    required: false
+    default: "false"
 
 outputs:
   object-path:
@@ -37,14 +37,18 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        if [ "${{ inputs.clean-ebpf-crate }}" = "true" ]; then
+          rm -f target/assay-ebpf.o
+          cargo clean -p assay-ebpf 2>/dev/null || true
+        fi
         cargo xtask build-ebpf --release --no-docker
-        test -f "${{ inputs.output-path }}"
+        test -f target/assay-ebpf.o
 
     - name: Emit eBPF build provenance
       id: provenance
       shell: bash
       env:
-        ASSAY_EBPF_OBJECT: ${{ inputs.output-path }}
+        ASSAY_EBPF_OBJECT: target/assay-ebpf.o
         ASSAY_EBPF_PROVENANCE: ${{ inputs.provenance-path }}
       run: |
         set -euo pipefail
@@ -62,10 +66,7 @@ runs:
             raise SystemExit(f"missing eBPF object: {obj}")
 
         def git_output(*args):
-            try:
-                return subprocess.check_output(["git", *args], text=True, stderr=subprocess.DEVNULL).strip()
-            except subprocess.CalledProcessError:
-                return None
+            return subprocess.check_output(["git", *args], text=True, stderr=subprocess.PIPE).strip()
 
         def sha256_file(path: Path) -> str:
             digest = hashlib.sha256()
@@ -75,16 +76,17 @@ runs:
             return digest.hexdigest()
 
         stat = obj.stat()
+        manifest = json.loads(Path("scripts/ci/assay_runner_gated_paths.json").read_text(encoding="utf-8"))
         path_trees = {}
-        for path in (
-            "crates/assay-ebpf",
-            "crates/assay-monitor",
-            "crates/assay-xtask",
-            "scripts/ci",
-        ):
-            tree = git_output("rev-parse", f"HEAD:{path}")
-            if tree:
-                path_trees[path] = tree
+        missing_trees = []
+        for path in manifest["content_provenance_paths"]:
+            entry = {"oid": None, "error": None}
+            try:
+                entry["oid"] = git_output("rev-parse", f"HEAD:{path}")
+            except subprocess.CalledProcessError as exc:
+                entry["error"] = (exc.stderr or "").strip() or "missing_at_head"
+                missing_trees.append(path)
+            path_trees[path] = entry
 
         document = {
             "schema": "assay.ci.ebpf_build_provenance.v0",
@@ -115,6 +117,9 @@ runs:
 
         provenance.parent.mkdir(parents=True, exist_ok=True)
         provenance.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        if missing_trees:
+            raise SystemExit("missing required provenance tree(s): " + ", ".join(missing_trees))
 
         github_output = os.environ.get("GITHUB_OUTPUT")
         if github_output:

--- a/.github/actions/canonical-ebpf-build/action.yml
+++ b/.github/actions/canonical-ebpf-build/action.yml
@@ -1,0 +1,126 @@
+name: Canonical eBPF build
+
+description: Build target/assay-ebpf.o through the canonical CI path and emit provenance.
+
+inputs:
+  output-path:
+    description: Path where cargo xtask writes the eBPF object.
+    required: false
+    default: target/assay-ebpf.o
+  provenance-path:
+    description: Path for the JSON provenance file emitted by this action.
+    required: false
+    default: target/assay-ebpf.provenance.json
+
+outputs:
+  object-path:
+    description: Built eBPF object path.
+    value: ${{ steps.provenance.outputs.object-path }}
+  object-sha256:
+    description: SHA-256 digest of the built eBPF object.
+    value: ${{ steps.provenance.outputs.object-sha256 }}
+  object-size-bytes:
+    description: Size of the built eBPF object in bytes.
+    value: ${{ steps.provenance.outputs.object-size-bytes }}
+  provenance-path:
+    description: Path to the JSON provenance file.
+    value: ${{ steps.provenance.outputs.provenance-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install eBPF toolchain
+      shell: bash
+      run: scripts/ci/install-ebpf-toolchain.sh
+
+    - name: Build eBPF object
+      shell: bash
+      run: |
+        set -euo pipefail
+        cargo xtask build-ebpf --release --no-docker
+        test -f "${{ inputs.output-path }}"
+
+    - name: Emit eBPF build provenance
+      id: provenance
+      shell: bash
+      env:
+        ASSAY_EBPF_OBJECT: ${{ inputs.output-path }}
+        ASSAY_EBPF_PROVENANCE: ${{ inputs.provenance-path }}
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import hashlib
+        import json
+        import os
+        import subprocess
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        obj = Path(os.environ["ASSAY_EBPF_OBJECT"])
+        provenance = Path(os.environ["ASSAY_EBPF_PROVENANCE"])
+        if not obj.is_file():
+            raise SystemExit(f"missing eBPF object: {obj}")
+
+        def git_output(*args):
+            try:
+                return subprocess.check_output(["git", *args], text=True, stderr=subprocess.DEVNULL).strip()
+            except subprocess.CalledProcessError:
+                return None
+
+        def sha256_file(path: Path) -> str:
+            digest = hashlib.sha256()
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            return digest.hexdigest()
+
+        stat = obj.stat()
+        path_trees = {}
+        for path in (
+            "crates/assay-ebpf",
+            "crates/assay-monitor",
+            "crates/assay-xtask",
+            "scripts/ci",
+        ):
+            tree = git_output("rev-parse", f"HEAD:{path}")
+            if tree:
+                path_trees[path] = tree
+
+        document = {
+            "schema": "assay.ci.ebpf_build_provenance.v0",
+            "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "object": {
+                "path": str(obj),
+                "sha256": sha256_file(obj),
+                "size_bytes": stat.st_size,
+                "mtime_epoch": int(stat.st_mtime),
+                "mtime_utc": datetime.fromtimestamp(stat.st_mtime, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            },
+            "source": {
+                "head_sha": os.environ.get("GITHUB_SHA", ""),
+                "ref": os.environ.get("GITHUB_REF", ""),
+                "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+                "workflow": os.environ.get("GITHUB_WORKFLOW", ""),
+                "workflow_sha": os.environ.get("GITHUB_WORKFLOW_SHA", ""),
+                "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+                "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+                "path_trees": path_trees,
+            },
+            "build": {
+                "command": "cargo xtask build-ebpf --release --no-docker",
+                "toolchain_installer": "scripts/ci/install-ebpf-toolchain.sh",
+                "claim_ceiling": "build_provenance_only_not_runtime_behavior",
+            },
+        }
+
+        provenance.parent.mkdir(parents=True, exist_ok=True)
+        provenance.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        github_output = os.environ.get("GITHUB_OUTPUT")
+        if github_output:
+            with open(github_output, "a", encoding="utf-8") as handle:
+                handle.write(f"object-path={obj}\n")
+                handle.write(f"object-sha256={document['object']['sha256']}\n")
+                handle.write(f"object-size-bytes={document['object']['size_bytes']}\n")
+                handle.write(f"provenance-path={provenance}\n")
+        PY

--- a/.github/workflows/assay-runner-lane-check.yml
+++ b/.github/workflows/assay-runner-lane-check.yml
@@ -3,6 +3,9 @@ name: Assay-Runner Lane Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
+  workflow_run:
+    workflows: ["Runner Spike Delegated"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -16,6 +19,7 @@ jobs:
   lane-check:
     name: lane-check
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.event == 'workflow_dispatch'
     permissions:
       actions: read
       contents: read
@@ -48,10 +52,88 @@ jobs:
         shell: bash
         run: python3 scripts/ci/assay_runner_lane_check.py --self-test
 
-      - name: Check PR delegated lane proof
+      - name: Resolve PR number
+        id: pr
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          event_name = os.environ["GITHUB_EVENT_NAME"]
+          event_path = os.environ["GITHUB_EVENT_PATH"]
+          with open(event_path, encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          if event_name == "pull_request":
+              print(f"pr_number={event['pull_request']['number']}")
+              raise SystemExit(0)
+
+          if event_name == "workflow_dispatch":
+              value = event.get("inputs", {}).get("pr_number", "")
+              if not value:
+                  print("workflow_dispatch did not include pr_number", file=sys.stderr)
+                  raise SystemExit(1)
+              print(f"pr_number={value}")
+              raise SystemExit(0)
+
+          if event_name != "workflow_run":
+              print(f"unsupported event: {event_name}", file=sys.stderr)
+              raise SystemExit(1)
+
+          workflow_run = event.get("workflow_run") or {}
+          pull_requests = workflow_run.get("pull_requests") or []
+          if pull_requests:
+              print(f"pr_number={pull_requests[0]['number']}")
+              raise SystemExit(0)
+
+          # Manual workflow_dispatch runs can omit workflow_run.pull_requests.
+          # Fall back to GitHub's commit-associated PR endpoint for the run SHA.
+          head_sha = workflow_run.get("head_sha") or ""
+          if not head_sha:
+              print("pr_number=")
+              raise SystemExit(0)
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/commits/{head_sha}/pulls",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "Authorization": f"Bearer {token}",
+              },
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  pulls = json.loads(response.read().decode("utf-8"))
+          except Exception as exc:
+              print(f"warning: could not resolve PR for delegated run: {exc}", file=sys.stderr)
+              print("pr_number=")
+              raise SystemExit(0)
+
+          if pulls:
+              print(f"pr_number={pulls[0]['number']}")
+          else:
+              print("pr_number=")
+          PY
+
+      - name: Check PR delegated lane proof
+        if: steps.pr.outputs.pr_number != ''
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: python3 scripts/ci/assay_runner_lane_check.py --comment
+
+      - name: No associated PR for delegated run
+        if: github.event_name == 'workflow_run' && steps.pr.outputs.pr_number == ''
+        shell: bash
+        run: echo "No associated pull request found for delegated workflow_run; nothing to refresh."

--- a/.github/workflows/assay-runner-lane-check.yml
+++ b/.github/workflows/assay-runner-lane-check.yml
@@ -24,25 +24,14 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
+      statuses: write
     steps:
       - name: Checkout base helper
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
-
-      - name: Bootstrap helper for first same-repo rollout
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -f scripts/ci/assay_runner_lane_check.py ]; then
-            exit 0
-          fi
-          echo "::warning::Base helper is missing; bootstrapping lane-check helper from same-repo PR head."
-          git fetch --depth=1 origin "${{ github.event.pull_request.head.sha }}"
-          git checkout FETCH_HEAD -- scripts/ci/assay_runner_lane_check.py
 
       - name: Verify lane-check helper exists
         shell: bash
@@ -60,69 +49,20 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import json
-          import os
-          import sys
-          import urllib.request
-
-          event_name = os.environ["GITHUB_EVENT_NAME"]
-          event_path = os.environ["GITHUB_EVENT_PATH"]
-          with open(event_path, encoding="utf-8") as handle:
-              event = json.load(handle)
-
-          if event_name == "pull_request":
-              print(f"pr_number={event['pull_request']['number']}")
-              raise SystemExit(0)
-
-          if event_name == "workflow_dispatch":
-              value = event.get("inputs", {}).get("pr_number", "")
-              if not value:
-                  print("workflow_dispatch did not include pr_number", file=sys.stderr)
-                  raise SystemExit(1)
-              print(f"pr_number={value}")
-              raise SystemExit(0)
-
-          if event_name != "workflow_run":
-              print(f"unsupported event: {event_name}", file=sys.stderr)
-              raise SystemExit(1)
-
-          workflow_run = event.get("workflow_run") or {}
-          pull_requests = workflow_run.get("pull_requests") or []
-          if pull_requests:
-              print(f"pr_number={pull_requests[0]['number']}")
-              raise SystemExit(0)
-
-          # Manual workflow_dispatch runs can omit workflow_run.pull_requests.
-          # Fall back to GitHub's commit-associated PR endpoint for the run SHA.
-          head_sha = workflow_run.get("head_sha") or ""
-          if not head_sha:
-              print("pr_number=")
-              raise SystemExit(0)
-
-          repo = os.environ["GITHUB_REPOSITORY"]
-          token = os.environ["GITHUB_TOKEN"]
-          request = urllib.request.Request(
-              f"https://api.github.com/repos/{repo}/commits/{head_sha}/pulls",
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "X-GitHub-Api-Version": "2022-11-28",
-                  "Authorization": f"Bearer {token}",
-              },
-          )
-          try:
-              with urllib.request.urlopen(request, timeout=30) as response:
-                  pulls = json.loads(response.read().decode("utf-8"))
-          except Exception as exc:
-              print(f"warning: could not resolve PR for delegated run: {exc}", file=sys.stderr)
-              print("pr_number=")
-              raise SystemExit(0)
-
-          if pulls:
-              print(f"pr_number={pulls[0]['number']}")
-          else:
-              print("pr_number=")
-          PY
+          case "${{ github.event_name }}" in
+            pull_request)
+              echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+              ;;
+            workflow_dispatch)
+              echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+              ;;
+            workflow_run)
+              python3 scripts/ci/assay_runner_lane_check.py --resolve-pr-from-event >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "pr_number=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
       - name: Check PR delegated lane proof
         if: steps.pr.outputs.pr_number != ''
@@ -131,7 +71,13 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        run: python3 scripts/ci/assay_runner_lane_check.py --comment
+        run: |
+          set -euo pipefail
+          args=(--comment)
+          if python3 scripts/ci/assay_runner_lane_check.py --help | grep -q -- "--status"; then
+            args+=(--status)
+          fi
+          python3 scripts/ci/assay_runner_lane_check.py "${args[@]}"
 
       - name: No associated PR for delegated run
         if: github.event_name == 'workflow_run' && steps.pr.outputs.pr_number == ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,8 +514,8 @@ jobs:
     runs-on: [self-hosted, linux, assay-bpf-runner]
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-ebpf-smoke-self-hosted
-      cancel-in-progress: true
+      group: assay-bpf-runner-host
+      cancel-in-progress: false
     permissions:
       contents: read
     # Self-hosted runner has Rust in /opt/rust; jobs run with --noprofile so PATH can be minimal.

--- a/.github/workflows/host-capability-proof.yml
+++ b/.github/workflows/host-capability-proof.yml
@@ -22,6 +22,13 @@ permissions:
   contents: read
   actions: read
 
+concurrency:
+  # Shares the same singleton self-hosted VM as Runner Spike Delegated.
+  # Keep trusted proof producers serialized across refs until the host is
+  # moved to an ephemeral runner model.
+  group: assay-bpf-runner-host
+  cancel-in-progress: false
+
 jobs:
   proof:
     name: Produce host-capability proof

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -290,8 +290,8 @@ jobs:
     runs-on: [self-hosted, linux, assay-bpf-runner]
     timeout-minutes: 5
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-cleanup-runner
-      cancel-in-progress: true
+      group: assay-bpf-runner-host
+      cancel-in-progress: false
     steps:
       - name: Nuke _actions cache (force fresh download for next job)
         shell: bash
@@ -339,8 +339,8 @@ jobs:
     runs-on: [self-hosted, linux, assay-bpf-runner]
     timeout-minutes: 10
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ matrix.kernel }}
-      cancel-in-progress: true
+      group: assay-bpf-runner-host
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: monitor-attach-smoke-${{ github.ref }}
+  group: assay-bpf-runner-host
   cancel-in-progress: false
 
 jobs:
@@ -35,31 +35,19 @@ jobs:
         run: cargo build -p assay-cli --release
 
       - name: Build eBPF object
+        id: canonical-ebpf
         if: ${{ github.event.inputs.build_ebpf != 'false' }}
         # Build the eBPF object exactly like the delegated runner-spike gate: install the eBPF
         # toolchain and build in release with --no-docker. A debug-mode build produces programs the
         # verifier rejects (empty / "last insn is not an exit or jmp"), which is what made an earlier
         # smoke run mislook like an assay monitor attach bug.
-        run: |
-          scripts/ci/install-ebpf-toolchain.sh
-          # Force a real recompile on this persistent runner. A cached/no-op build lets xtask's
-          # artifact resolution hand back a stale object out of a weeks-old target/ dir, which is
-          # exactly the got=520/need=552 skew #1575 chased: the smoke then loads an object that is
-          # NOT the product of this checkout while looking canonical. Deleting the copied .o and
-          # cleaning the crate makes "built from this commit" true by construction.
-          rm -f target/assay-ebpf.o
-          cargo clean -p assay-ebpf 2>/dev/null || true
-          cargo xtask build-ebpf --release --no-docker
-          # Build provenance, so the canonical eBPF build path is self-documenting in the run log and
-          # nobody has to reconstruct in three months why this path is the right one (see #1570).
-          # The object hash + mtime pin WHICH artifact the smoke below will load (see #1575).
-          {
-            echo "ebpf_build_mode=release"
-            echo "ebpf_build_path=xtask --release --no-docker"
-            echo "toolchain_install=present"
-            echo "ebpf_object_sha256=$(sha256sum target/assay-ebpf.o | cut -d' ' -f1)"
-            echo "ebpf_object_mtime=$(stat -c %y target/assay-ebpf.o)"
-          } | tee "$RUNNER_TEMP/ebpf-build-provenance.txt"
+        uses: ./.github/actions/canonical-ebpf-build
+        with:
+          clean-ebpf-crate: "true"
+
+      - name: Show eBPF build provenance
+        if: ${{ github.event.inputs.build_ebpf != 'false' }}
+        run: python3 -m json.tool "${{ steps.canonical-ebpf.outputs.provenance-path }}"
 
       - name: Smoke - assay monitor must attach its observation probes
         run: |

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -183,9 +183,13 @@ jobs:
             exit 1
           fi
           ls -lh target/assay-ebpf.o target/debug/assay
-          if [ -f target/assay-ebpf.provenance.json ]; then
+          ebpf_provenance="${{ steps.canonical-ebpf.outputs.provenance-path }}"
+          if [ -z "$ebpf_provenance" ]; then
+            ebpf_provenance="target/assay-ebpf.provenance.json"
+          fi
+          if [ -f "$ebpf_provenance" ]; then
             echo "eBPF build provenance:"
-            python3 -m json.tool target/assay-ebpf.provenance.json
+            python3 -m json.tool "$ebpf_provenance"
           fi
 
       - name: Run delegated Phase 1 gates
@@ -270,6 +274,10 @@ jobs:
           set -euo pipefail
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           workflow_sha="${GITHUB_WORKFLOW_SHA:-$GITHUB_SHA}"
+          ebpf_provenance="${{ steps.canonical-ebpf.outputs.provenance-path }}"
+          if [ -z "$ebpf_provenance" ]; then
+            ebpf_provenance="target/assay-ebpf.provenance.json"
+          fi
           python3 scripts/ci/assay_runner_delegated_proof_pack.py \
             --proof-root "$ASSAY_RUNNER_DELEGATED_PROOF_ROOT" \
             --output-dir "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD" \
@@ -282,7 +290,7 @@ jobs:
             --head-sha "$GITHUB_SHA" \
             --workflow-sha "$workflow_sha" \
             --workflow-name "$GITHUB_WORKFLOW" \
-            --ebpf-provenance target/assay-ebpf.provenance.json \
+            --ebpf-provenance "$ebpf_provenance" \
             --retention-days 365
           {
             echo "### Delegated proof pack"

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -23,7 +23,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: runner-spike-delegated-${{ github.ref }}
+  # The assay-bpf-runner host is a singleton for delegated kernel/eBPF
+  # validation. Serialize all delegated runs across refs so workspace and
+  # downloaded-action cache state cannot race between back-to-back dispatches.
+  group: assay-bpf-runner-host
   cancel-in-progress: false
 
 jobs:
@@ -166,13 +169,9 @@ jobs:
           cargo build -p assay-cli --no-default-features --features runner
 
       - name: Build eBPF artifact
+        id: canonical-ebpf
         if: inputs.build_ebpf
-        shell: bash
-        run: |
-          set -euo pipefail
-          scripts/ci/install-ebpf-toolchain.sh
-          cargo xtask build-ebpf --release --no-docker
-          test -f target/assay-ebpf.o
+        uses: ./.github/actions/canonical-ebpf-build
 
       - name: Verify eBPF artifact
         shell: bash
@@ -184,6 +183,10 @@ jobs:
             exit 1
           fi
           ls -lh target/assay-ebpf.o target/debug/assay
+          if [ -f target/assay-ebpf.provenance.json ]; then
+            echo "eBPF build provenance:"
+            python3 -m json.tool target/assay-ebpf.provenance.json
+          fi
 
       - name: Run delegated Phase 1 gates
         shell: bash
@@ -279,6 +282,7 @@ jobs:
             --head-sha "$GITHUB_SHA" \
             --workflow-sha "$workflow_sha" \
             --workflow-name "$GITHUB_WORKFLOW" \
+            --ebpf-provenance target/assay-ebpf.provenance.json \
             --retention-days 365
           {
             echo "### Delegated proof pack"

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -79,6 +79,14 @@ machine-visible path classification and delegated proof check for this
 contract. To make the contract hard-blocking, repository branch protection must
 mark that check as required.
 
+When a completed delegated workflow refreshes proof from a `workflow_run`
+context, the workflow also writes a PR-head commit status named
+`lane-check/proof`. That status is intentionally distinct from the Actions job
+named `lane-check` so checks-API and statuses-API results do not collide under
+the same display name. If maintainers want the refresh path itself to satisfy
+branch protection without manually rerunning the pull-request job, require the
+`lane-check/proof` status.
+
 The executable path mapping lives in
 `scripts/ci/assay_runner_lane_check.py` and must mirror the decision table on
 this page. Changes to this contract and changes to the classifier must land in

--- a/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
+++ b/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
@@ -1,0 +1,63 @@
+# Runner delegated proof hardening plan
+
+Date: 2026-07-03
+
+## Context
+
+The Runner delegated lane currently proves success through a manually recorded workflow URL, gate value, and commit SHA. That worked for the first phase, but the July 2026 incidents exposed three avoidable failure classes:
+
+- concurrent jobs can share the same `assay-bpf-runner` host even when they target different refs;
+- the eBPF build/provenance steps are duplicated across workflows and can drift;
+- lane-check proof is bound to a commit SHA and a comment, not to the content that the delegated host actually built and exercised.
+
+This plan keeps the first implementation narrow. It hardens the host and build/provenance surface without changing branch protection semantics or replacing the existing comment contract in one step.
+
+## Layer 1: immediate hardening
+
+Ship as the first PR.
+
+1. Serialize `assay-bpf-runner` work with a host-global concurrency group on the trusted delegated workflows. This avoids `_actions` cache and workspace races across branches.
+2. Add `.github/actions/canonical-ebpf-build`, a local composite action that is the only Runner delegated eBPF build entrypoint.
+3. Have the action produce `target/assay-ebpf.provenance.json` with object path, SHA-256, size, mtime, head SHA, workflow metadata, and key tree OIDs for future content-addressed validation.
+4. Copy the provenance file into the delegated proof-pack upload directory so the existing artifact already carries the eBPF build facts.
+5. Add a `workflow_run` trigger to lane-check so a completed delegated run can refresh the lane result from a default-branch context.
+
+Non-goals for Layer 1:
+
+- no GitHub artifact attestations yet;
+- no tree-OID proof acceptance yet;
+- no merge queue enablement;
+- no Assay evidence-bundle dogfood path;
+- no broad rewrite of all experimental self-hosted workflows.
+
+## Layer 2: attested, content-addressed proof
+
+Follow-up PR.
+
+- Generate build provenance attestations for the proof pack and `target/assay-ebpf.o` using GitHub artifact attestations.
+- Teach lane-check to verify attestations and read workflow identity, source SHA, and gate inputs from the attestation/proof pack rather than from comments.
+- Keep comment parsing as a temporary fallback.
+- Accept a proof across rebases when the tree OIDs for gated paths match the attested/proven path trees.
+
+## Layer 3: runner platform
+
+Operational change, not a normal code-only PR.
+
+- Move the bpf host to an ephemeral self-hosted runner model.
+- Keep reusable compiler/cache state outside `GITHUB_WORKSPACE`; do not persist workspace or downloaded actions between jobs.
+- Document the systemd registration/cleanup process and runner minimum version requirements.
+
+## Layer 4: merge queue and dogfood
+
+After Layer 2.
+
+- Add `merge_group` coverage for required checks before enabling merge queue.
+- Let the heavy delegated proof run once during PR review; let merge queue perform only cheap content-addressed proof validation.
+- Optionally make the proof pack an Assay evidence bundle chained to the GitHub attestation.
+
+## Verification for Layer 1
+
+- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
+- `python3 scripts/ci/assay_runner_delegated_proof_pack.py --self-test`
+- workflow syntax lint for the touched workflows/actions
+- review the produced diff for branch-protection compatibility: required checks still run on PRs, no path-filter skip introduced.

--- a/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
+++ b/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
@@ -17,10 +17,10 @@ This plan keeps the first implementation narrow. It hardens the host and build/p
 Ship as the first PR.
 
 1. Serialize `assay-bpf-runner` work with a host-global concurrency group on the trusted delegated workflows. This avoids `_actions` cache and workspace races across branches.
-2. Add `.github/actions/canonical-ebpf-build`, a local composite action that is the only Runner delegated eBPF build entrypoint.
-3. Have the action produce `target/assay-ebpf.provenance.json` with object path, SHA-256, size, mtime, head SHA, workflow metadata, and key tree OIDs for future content-addressed validation.
+2. Add `.github/actions/canonical-ebpf-build`, a local composite action that is the canonical eBPF build entrypoint for the delegated runner lane and the monitor attach smoke.
+3. Have the action produce `target/assay-ebpf.provenance.json` with object path, SHA-256, size, mtime, head SHA, workflow metadata, and key tree OIDs from the shared runner gated-path manifest for future content-addressed validation.
 4. Copy the provenance file into the delegated proof-pack upload directory so the existing artifact already carries the eBPF build facts.
-5. Add a `workflow_run` trigger to lane-check so a completed delegated run can refresh the lane result from a default-branch context.
+5. Add a `workflow_run` trigger to lane-check so a completed delegated run can refresh the PR comment and the PR-head commit status from a default-branch context.
 
 Non-goals for Layer 1:
 

--- a/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
+++ b/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
@@ -22,6 +22,11 @@ Ship as the first PR.
 4. Copy the provenance file into the delegated proof-pack upload directory so the existing artifact already carries the eBPF build facts.
 5. Add a `workflow_run` trigger to lane-check so a completed delegated run can refresh the PR comment and the PR-head commit status from a default-branch context.
 
+Known Layer 1 semantics:
+
+- The commit-status context emitted by lane-check is `lane-check/proof`, deliberately separate from the Actions job named `lane-check`. If the refresh path should satisfy branch protection without manually rerunning the pull-request check, `lane-check/proof` must be configured as the required status.
+- GitHub Actions concurrency keeps at most one running and one pending run per group. A third `assay-bpf-runner-host` run can evict the pending run even with `cancel-in-progress: false`. That is acceptable for Layer 1 because the host is a singleton and a canceled proof can be re-dispatched, but it is another reason Layer 3 should move the host to an ephemeral-runner model and keep the heavy proof path content-addressed.
+
 Non-goals for Layer 1:
 
 - no GitHub artifact attestations yet;

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -64,6 +64,12 @@ def copy_payload_file(source: Path, output_root: Path, relative: Path) -> dict[s
     }
 
 
+def copy_optional_payload_file(source: Path | None, output_root: Path, relative: Path) -> dict[str, Any] | None:
+    if source is None or not source.exists():
+        return None
+    return copy_payload_file(source, output_root, relative)
+
+
 def pass_lines(log_path: Path) -> list[str]:
     if not log_path.exists():
         return []
@@ -169,6 +175,11 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
     output_root.mkdir(parents=True)
 
     gates = [collect_gate(gate, proof_root, output_root) for gate in selected_gates]
+    ebpf_provenance = copy_optional_payload_file(
+        args.ebpf_provenance,
+        output_root,
+        Path("build") / "assay-ebpf.provenance.json",
+    )
     manifest = {
         "schema": SCHEMA,
         "kind": KIND,
@@ -199,6 +210,9 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
             "separate_from_normalized_runner_evidence": True,
             "not_a_runner_emitted_artifact": True,
         },
+        "build_provenance": {
+            "ebpf": ebpf_provenance,
+        },
         "gates": gates,
         "payload_files": [],
         "pack_size_bytes": 0,
@@ -222,6 +236,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--head-sha", default="", help="workflow head SHA")
     parser.add_argument("--workflow-sha", default="", help="workflow definition SHA")
     parser.add_argument("--workflow-name", default="Runner Spike Delegated")
+    parser.add_argument("--ebpf-provenance", type=Path, help="optional canonical eBPF build provenance JSON")
     parser.add_argument("--retention-days", type=int, default=365)
     parser.add_argument("--soft-cap-bytes", type=int, default=50 * 1024 * 1024)
     return parser.parse_args(argv)
@@ -231,6 +246,8 @@ def self_test() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         proof_root = root / "proof"
+        ebpf_provenance = root / "assay-ebpf.provenance.json"
+        ebpf_provenance.write_text('{"schema":"assay.ci.ebpf_build_provenance.v0"}\n', encoding="utf-8")
         gate_dir = proof_root / "gates" / "kernel-only" / "run-1" / "extract"
         gate_dir.mkdir(parents=True)
         (proof_root / "gates" / "kernel-only" / "status.txt").write_text("passed\n", encoding="utf-8")
@@ -253,6 +270,7 @@ def self_test() -> None:
             head_sha="abc",
             workflow_sha="def",
             workflow_name="Runner Spike Delegated",
+            ebpf_provenance=ebpf_provenance,
             retention_days=365,
             soft_cap_bytes=50 * 1024 * 1024,
         )
@@ -271,6 +289,8 @@ def self_test() -> None:
             raise ProofPackError(f"self-test gate status mismatch: {statuses}")
         if not manifest["gates"][0]["archives"]:
             raise ProofPackError("self-test did not collect archive digest")
+        if not manifest["build_provenance"]["ebpf"]:
+            raise ProofPackError("self-test did not collect eBPF build provenance")
         if not (args.output_dir / "manifest.json").exists():
             raise ProofPackError("self-test did not write manifest")
 

--- a/scripts/ci/assay_runner_gated_paths.json
+++ b/scripts/ci/assay_runner_gated_paths.json
@@ -1,0 +1,34 @@
+{
+  "schema": "assay.runner.gated_paths.v0",
+  "all_gate_prefixes": [
+    "crates/assay-runner-schema/",
+    "crates/assay-runner-core/",
+    "crates/assay-runner-linux/",
+    "crates/assay-monitor/",
+    "crates/assay-ebpf/",
+    "crates/assay-xtask/"
+  ],
+  "all_gate_paths": [
+    ".github/workflows/runner-spike-delegated.yml",
+    ".github/workflows/runner-spike-sdk.yml",
+    ".github/actions/canonical-ebpf-build/action.yml",
+    "crates/assay-cli/src/cli/commands/runner_spike.rs",
+    "crates/assay-cli/src/cgroup.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+    "scripts/ci/assay_runner_delegated_proof_pack.py",
+    "scripts/ci/assay_runner_gated_paths.json"
+  ],
+  "content_provenance_paths": [
+    "crates/assay-runner-schema",
+    "crates/assay-runner-core",
+    "crates/assay-runner-linux",
+    "crates/assay-monitor",
+    "crates/assay-ebpf",
+    "crates/assay-xtask",
+    "scripts/ci",
+    ".github/workflows/runner-spike-delegated.yml",
+    ".github/workflows/runner-spike-sdk.yml",
+    ".github/actions/canonical-ebpf-build"
+  ]
+}

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -21,6 +21,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from enum import IntEnum
+from functools import lru_cache
 from pathlib import Path
 from typing import Iterable
 
@@ -30,6 +31,7 @@ DEPENDABOT_FLOW_DOC = "docs/reference/runner/dependabot-lane-flow.md"
 GATED_PATHS_DOC = "scripts/ci/assay_runner_gated_paths.json"
 DELEGATED_WORKFLOW_NAME = "Runner Spike Delegated"
 COMMENT_MARKER = "<!-- assay-runner-lane-check -->"
+STATUS_CONTEXT = "lane-check/proof"
 # 404 is retryable here because GitHub can briefly return it for freshly
 # created PR metadata endpoints such as /pulls/{number}/files.
 RETRYABLE_HTTP_CODES = {404, 502, 503, 504}
@@ -175,6 +177,7 @@ def starts(path: str, prefix: str) -> bool:
     return path == prefix.rstrip("/") or path.startswith(prefix.rstrip("/") + "/")
 
 
+@lru_cache(maxsize=1)
 def load_gated_path_config() -> GatedPathConfig:
     root = Path(__file__).resolve().parents[2]
     manifest_path = root / GATED_PATHS_DOC
@@ -608,7 +611,7 @@ def status_target_url() -> str:
 def post_commit_status(api: GitHubApi, sha: str, passed: bool, description: str) -> None:
     payload: dict[str, object] = {
         "state": "success" if passed else "failure",
-        "context": "lane-check",
+        "context": STATUS_CONTEXT,
         "description": description[:140],
     }
     target_url = status_target_url()
@@ -804,6 +807,7 @@ def self_test() -> None:
     assert "head_sha" in delegated_run_diagnostic({**valid_run, "head_sha": "def456"}, "1", "abc123")
     assert "conclusion" in delegated_run_diagnostic({**valid_run, "conclusion": "failure"}, "1", "abc123")
     assert "workflow name" in delegated_run_diagnostic({**valid_run, "name": "CI"}, "1", "abc123")
+    _test_event_resolution_and_status_payload()
 
     dependabot_pr = PullRequest(
         number=1,
@@ -829,6 +833,67 @@ def self_test() -> None:
     # touching the classifier itself, including any future PR that
     # might silently re-introduce a spike dependency.
     _assert_assay_cli_does_not_consume_spike()
+
+
+def _test_event_resolution_and_status_payload() -> None:
+    from tempfile import NamedTemporaryFile
+
+    class _FakeApi:
+        def __init__(self) -> None:
+            self.requests: list[tuple[str, str, object | None]] = []
+
+        def request(self, method: str, path: str, payload: object | None = None) -> object:
+            self.requests.append((method, path, payload))
+            if path == "/commits/deadbeef/pulls":
+                return [{"number": 79}]
+            return {}
+
+    def with_event(event_name: str, event: object) -> str | None:
+        old_name = os.environ.get("GITHUB_EVENT_NAME")
+        old_path = os.environ.get("GITHUB_EVENT_PATH")
+        with NamedTemporaryFile("w", encoding="utf-8") as handle:
+            json.dump(event, handle)
+            handle.flush()
+            os.environ["GITHUB_EVENT_NAME"] = event_name
+            os.environ["GITHUB_EVENT_PATH"] = handle.name
+            try:
+                return resolve_pr_number_from_event(_FakeApi())
+            finally:
+                if old_name is None:
+                    os.environ.pop("GITHUB_EVENT_NAME", None)
+                else:
+                    os.environ["GITHUB_EVENT_NAME"] = old_name
+                if old_path is None:
+                    os.environ.pop("GITHUB_EVENT_PATH", None)
+                else:
+                    os.environ["GITHUB_EVENT_PATH"] = old_path
+
+    assert with_event("pull_request", {"pull_request": {"number": 42}}) == "42"
+    assert with_event("workflow_dispatch", {"inputs": {"pr_number": "43"}}) == "43"
+    assert with_event("workflow_run", {"workflow_run": {"pull_requests": [{"number": 44}]}}) == "44"
+    assert with_event("workflow_run", {"workflow_run": {"head_sha": "deadbeef"}}) == "79"
+
+    fake = _FakeApi()
+    old_repo = os.environ.pop("GITHUB_REPOSITORY", None)
+    old_run_id = os.environ.pop("GITHUB_RUN_ID", None)
+    try:
+        post_commit_status(fake, "abc123", True, "ok")
+    finally:
+        if old_repo is not None:
+            os.environ["GITHUB_REPOSITORY"] = old_repo
+        if old_run_id is not None:
+            os.environ["GITHUB_RUN_ID"] = old_run_id
+    assert fake.requests == [
+        (
+            "POST",
+            "/statuses/abc123",
+            {
+                "state": "success",
+                "context": STATUS_CONTEXT,
+                "description": "ok",
+            },
+        )
+    ]
 
 
 def _test_connection_resilience() -> None:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -21,11 +21,13 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from enum import IntEnum
+from pathlib import Path
 from typing import Iterable
 
 
 CONTRACT_DOC = "docs/reference/runner/ci-lanes.md"
 DEPENDABOT_FLOW_DOC = "docs/reference/runner/dependabot-lane-flow.md"
+GATED_PATHS_DOC = "scripts/ci/assay_runner_gated_paths.json"
 DELEGATED_WORKFLOW_NAME = "Runner Spike Delegated"
 COMMENT_MARKER = "<!-- assay-runner-lane-check -->"
 # 404 is retryable here because GitHub can briefly return it for freshly
@@ -81,6 +83,12 @@ class PullRequest:
     author_login: str
     head_sha: str
     files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GatedPathConfig:
+    all_gate_prefixes: tuple[str, ...]
+    all_gate_paths: frozenset[str]
 
 
 class GitHubApi:
@@ -167,7 +175,19 @@ def starts(path: str, prefix: str) -> bool:
     return path == prefix.rstrip("/") or path.startswith(prefix.rstrip("/") + "/")
 
 
+def load_gated_path_config() -> GatedPathConfig:
+    root = Path(__file__).resolve().parents[2]
+    manifest_path = root / GATED_PATHS_DOC
+    with manifest_path.open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    return GatedPathConfig(
+        all_gate_prefixes=tuple(str(path) for path in manifest["all_gate_prefixes"]),
+        all_gate_paths=frozenset(str(path) for path in manifest["all_gate_paths"]),
+    )
+
+
 def classify_file(path: str) -> tuple[Gate, str | None]:
+    gated_paths = load_gated_path_config()
     docs_runner_prefixes = (
         "docs/reference/runner/",
         "docs/notes/ASSAY-RUNNER-",
@@ -182,25 +202,10 @@ def classify_file(path: str) -> tuple[Gate, str | None]:
     }:
         return Gate.NONE, None
 
-    all_prefixes = (
-        "crates/assay-runner-schema/",
-        "crates/assay-runner-core/",
-        "crates/assay-runner-linux/",
-        "crates/assay-monitor/",
-        "crates/assay-ebpf/",
-        "crates/assay-xtask/",
-    )
-    if any(starts(path, prefix) for prefix in all_prefixes):
+    if any(starts(path, prefix) for prefix in gated_paths.all_gate_prefixes):
         return Gate.ALL, f"{path}: shared runner/eBPF/monitor/xtask code requires gates=all"
 
-    if path in {
-        ".github/workflows/runner-spike-delegated.yml",
-        ".github/workflows/runner-spike-sdk.yml",
-        "crates/assay-cli/src/cli/commands/runner_spike.rs",
-        "crates/assay-cli/src/cgroup.rs",
-        "Cargo.toml",
-        "Cargo.lock",
-    }:
+    if path in gated_paths.all_gate_paths:
         return Gate.ALL, f"{path}: runner workflow, CLI, cgroup, or workspace dependency surface requires gates=all"
 
     if path.startswith("scripts/ci/runner-spike-kernel-only-"):
@@ -314,6 +319,51 @@ def load_pr(api: GitHubApi, number: int) -> PullRequest:
             )
             return fallback
         raise
+
+
+def resolve_pr_number_from_event(api: GitHubApi) -> str | None:
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path:
+        return None
+    try:
+        with open(event_path, encoding="utf-8") as handle:
+            event = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if event_name == "pull_request":
+        raw_pr = event.get("pull_request") or {}
+        number = raw_pr.get("number")
+        return str(number) if number else None
+
+    if event_name == "workflow_dispatch":
+        value = (event.get("inputs") or {}).get("pr_number", "")
+        return str(value) if value else None
+
+    if event_name != "workflow_run":
+        return None
+
+    workflow_run = event.get("workflow_run") or {}
+    pull_requests = workflow_run.get("pull_requests") or []
+    if pull_requests:
+        number = pull_requests[0].get("number")
+        return str(number) if number else None
+
+    # Manual workflow_dispatch runs can omit workflow_run.pull_requests.
+    # Fall back to GitHub's commit-associated PR endpoint for the run SHA.
+    head_sha = str(workflow_run.get("head_sha") or "")
+    if not head_sha:
+        return None
+    try:
+        pulls = api.request("GET", f"/commits/{head_sha}/pulls")
+    except TRANSIENT_REQUEST_ERRORS as exc:
+        print(f"warning: could not resolve PR for delegated run: {exc}", file=sys.stderr)
+        return None
+    if not isinstance(pulls, list) or not pulls:
+        return None
+    number = dict(pulls[0]).get("number")
+    return str(number) if number else None
 
 
 def load_pr_from_event_and_git(number: int) -> PullRequest | None:
@@ -546,7 +596,44 @@ def post_or_update_comment(
         api.request("POST", f"/issues/{pr_number}/comments", {"body": body})
 
 
-def run_check(api: GitHubApi, pr_number: int, *, comment: bool) -> int:
+def status_target_url() -> str:
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if repo and run_id:
+        return f"{server_url}/{repo}/actions/runs/{run_id}"
+    return ""
+
+
+def post_commit_status(api: GitHubApi, sha: str, passed: bool, description: str) -> None:
+    payload: dict[str, object] = {
+        "state": "success" if passed else "failure",
+        "context": "lane-check",
+        "description": description[:140],
+    }
+    target_url = status_target_url()
+    if target_url:
+        payload["target_url"] = target_url
+    api.request("POST", f"/statuses/{sha}", payload)
+
+
+def maybe_status(
+    api: GitHubApi,
+    sha: str,
+    passed: bool,
+    description: str,
+    *,
+    status: bool,
+) -> None:
+    if not status:
+        return
+    try:
+        post_commit_status(api, sha, passed, description)
+    except TRANSIENT_REQUEST_ERRORS as exc:
+        print(f"warning: could not post commit status: {exc}", file=sys.stderr)
+
+
+def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) -> int:
     pr = load_pr(api, pr_number)
     classification = classify_files(pr.files)
     comments = safe_load_issue_comments(api, pr.number)
@@ -562,6 +649,13 @@ def run_check(api: GitHubApi, pr_number: int, *, comment: bool) -> int:
     if classification.gate == Gate.NONE:
         body = comment_body(classification, pr, True, "No runner-impacting paths were detected.")
         maybe_comment(api, pr.number, comments, body, comment=comment and existing_lane_comment(comments))
+        maybe_status(
+            api,
+            pr.head_sha,
+            True,
+            "no delegated runner proof required",
+            status=status,
+        )
         return 0
 
     run_ids = run_ids_from_text(api.repo, text)
@@ -588,6 +682,12 @@ def run_check(api: GitHubApi, pr_number: int, *, comment: bool) -> int:
     detail = "\n\n".join(details)
     body = comment_body(classification, pr, passed, detail)
     maybe_comment(api, pr.number, comments, body, comment=comment)
+    status_description = (
+        f"delegated proof accepted: gates={classification.gate.label}"
+        if passed
+        else f"delegated proof required: gates={classification.gate.label}"
+    )
+    maybe_status(api, pr.head_sha, passed, status_description, status=status)
 
     if passed:
         return 0
@@ -616,6 +716,11 @@ def maybe_comment(
 
 
 def self_test() -> None:
+    gated_paths = load_gated_path_config()
+    assert "crates/assay-runner-core/" in gated_paths.all_gate_prefixes
+    assert ".github/actions/canonical-ebpf-build/action.yml" in gated_paths.all_gate_paths
+    assert GATED_PATHS_DOC in gated_paths.all_gate_paths
+
     cases = [
         (["docs/reference/runner/ci-lanes.md"], Gate.NONE),
         (["docs/reference/observability/claim-boundary-positioning.md"], Gate.NONE),
@@ -638,6 +743,8 @@ def self_test() -> None:
             Gate.OPENAI_AGENTS_KERNEL_POLICY,
         ),
         (["scripts/ci/assay_runner_delegated_proof_pack.py"], Gate.ALL),
+        (["scripts/ci/assay_runner_gated_paths.json"], Gate.ALL),
+        ([".github/actions/canonical-ebpf-build/action.yml"], Gate.ALL),
         # Read-only contract validators under scripts/ci/ do not exercise
         # the kernel, eBPF, or runner runtime path. They project over
         # normalized evidence files only. The cross-runtime-diff v0
@@ -898,9 +1005,11 @@ def _assert_assay_cli_does_not_consume_spike() -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--resolve-pr-from-event", action="store_true")
     parser.add_argument("--pr-number", type=int, default=int(os.environ.get("PR_NUMBER", "0") or "0"))
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
     parser.add_argument("--comment", action="store_true")
+    parser.add_argument("--status", action="store_true")
     args = parser.parse_args()
 
     if args.self_test:
@@ -915,11 +1024,16 @@ def main() -> int:
     if not args.repo:
         print("--repo or GITHUB_REPOSITORY is required", file=sys.stderr)
         return 2
+    api = GitHubApi(args.repo, token)
+    if args.resolve_pr_from_event:
+        pr_number = resolve_pr_number_from_event(api) or ""
+        print(f"pr_number={pr_number}")
+        return 0
     if args.pr_number <= 0:
         print("--pr-number or PR_NUMBER is required", file=sys.stderr)
         return 2
 
-    return run_check(GitHubApi(args.repo, token), args.pr_number, comment=args.comment)
+    return run_check(api, args.pr_number, comment=args.comment, status=args.status)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Hardens the first layer of the Assay-Runner delegated proof path without changing the proof acceptance contract yet.

Changes:
- serialize trusted `assay-bpf-runner` proof producers with a host-global concurrency group;
- add `.github/actions/canonical-ebpf-build` as the canonical eBPF build/provenance action;
- emit `target/assay-ebpf.provenance.json` with object digest, size, mtime, workflow metadata, and gated-path tree OIDs for future content-addressed validation;
- include optional eBPF build provenance in the delegated proof-pack artifact;
- add a `workflow_run` refresh path so `lane-check` can re-evaluate after `Runner Spike Delegated` completes from a default-branch context;
- document the staged hardening plan in `docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md`.

## Non-goals

This PR intentionally does not add:
- GitHub artifact attestations;
- tree-OID proof acceptance;
- merge queue support;
- Assay evidence-bundle dogfooding;
- a broad rewrite of every experimental self-hosted workflow.

Those are follow-up layers after this low-risk serialization/provenance step lands.

## Verification

- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `python3 scripts/ci/assay_runner_delegated_proof_pack.py --self-test`
- `actionlint .github/workflows/assay-runner-lane-check.yml .github/workflows/runner-spike-delegated.yml .github/workflows/host-capability-proof.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "action yaml ok"' .github/actions/canonical-ebpf-build/action.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a canonical eBPF build flow that produces a build provenance record alongside the compiled artifact.
  * Lane checks can now run from delegated workflow completions and update PR feedback more consistently.
  * Added commit-status updates for delegated proof results.

* **Bug Fixes**
  * Improved handling for PR number detection across different workflow trigger types.
  * Reduced accidental cancellation of in-progress self-hosted CI runs by serializing them under a shared concurrency group.

* **Documentation**
  * Updated CI reference docs and added a rollout plan for delegated proof hardening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->