### PR TITLE
ci: emit attested delegated proof packs

### DIFF
--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -72,7 +72,9 @@ jobs:
     runs-on: [self-hosted, linux, assay-bpf-runner]
     timeout-minutes: 90
     permissions:
+      attestations: write
       contents: read
+      id-token: write
     env:
       CARGO_INCREMENTAL: 0
       ASSAY_RUNNER_DELEGATED_PROOF_ROOT: /tmp/assay-runner-proof-${{ github.run_id }}
@@ -290,13 +292,38 @@ jobs:
             --head-sha "$GITHUB_SHA" \
             --workflow-sha "$workflow_sha" \
             --workflow-name "$GITHUB_WORKFLOW" \
+            --workflow-path ".github/workflows/runner-spike-delegated.yml" \
+            --repository "$GITHUB_REPOSITORY" \
             --ebpf-provenance "$ebpf_provenance" \
+            --ebpf-object target/assay-ebpf.o \
+            --subject-checksums "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/subject-checksums.txt" \
             --retention-days 365
           {
             echo "### Delegated proof pack"
             echo "- artifact: assay-runner-delegated-proof-pack-${GITHUB_RUN_ID}"
             echo "- manifest: assay-runner-proof-upload/manifest.json"
+            echo "- subject-checksums: assay-runner-proof-upload/subject-checksums.txt"
             echo "- retention-days: 365"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Attest delegated proof pack subjects
+        id: attest-proof-pack
+        if: always() && hashFiles('assay-runner-proof-upload/subject-checksums.txt') != ''
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-checksums: assay-runner-proof-upload/subject-checksums.txt
+          show-summary: true
+
+      - name: Retain delegated proof attestation bundle
+        if: always() && steps.attest-proof-pack.outputs.bundle-path != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp "${{ steps.attest-proof-pack.outputs.bundle-path }}" \
+            "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/attestation-bundle.json"
+          {
+            echo "- attestation-bundle: assay-runner-proof-upload/attestation-bundle.json"
+            echo "- attestation-url: ${{ steps.attest-proof-pack.outputs.attestation-url }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload delegated proof pack

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -276,13 +276,8 @@ jobs:
           set -euo pipefail
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           workflow_sha="${GITHUB_WORKFLOW_SHA:-$GITHUB_SHA}"
-          ebpf_provenance="${{ steps.canonical-ebpf.outputs.provenance-path }}"
-          if [ -z "$ebpf_provenance" ]; then
-            ebpf_provenance="target/assay-ebpf.provenance.json"
-          fi
           python3 scripts/ci/assay_runner_delegated_proof_pack.py \
             --proof-root "$ASSAY_RUNNER_DELEGATED_PROOF_ROOT" \
-            --output-dir "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD" \
             --gates "${{ inputs.gates }}" \
             --build-ebpf "${{ inputs.build_ebpf }}" \
             --run-id "$GITHUB_RUN_ID" \
@@ -294,9 +289,6 @@ jobs:
             --workflow-name "$GITHUB_WORKFLOW" \
             --workflow-path ".github/workflows/runner-spike-delegated.yml" \
             --repository "$GITHUB_REPOSITORY" \
-            --ebpf-provenance "$ebpf_provenance" \
-            --ebpf-object target/assay-ebpf.o \
-            --subject-checksums "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD/subject-checksums.txt" \
             --retention-days 365
           {
             echo "### Delegated proof pack"

--- a/docs/PINNED-ACTIONS.md
+++ b/docs/PINNED-ACTIONS.md
@@ -15,6 +15,7 @@ gh api repos/OWNER/REPO/commits/REF --jq .sha
 
 | Action | Original ref | Pinned SHA |
 |--------|--------------|------------|
+| `actions/attest` | `@v4.1.1` | `a1948c3f048ba23858d222213b7c278aabede763` |
 | `actions/checkout` | `@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
 | `actions/upload-artifact` | `@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
 | `actions/download-artifact` | `@v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |

--- a/docs/superpowers/plans/2026-07-03-runner-delegated-proof-layer2.md
+++ b/docs/superpowers/plans/2026-07-03-runner-delegated-proof-layer2.md
@@ -2,7 +2,8 @@
 
 Date: 2026-07-03
 
-Status: prepared after Layer 1 merged in #1785.
+Status: implementation started after Layer 1 merged in #1785 and Layer 2
+preparation merged in #1786.
 
 ## Goal
 
@@ -122,6 +123,12 @@ If attestation verification is unavailable or malformed, fall back to the
 existing comment contract during the transition and mark the PR-head status
 description as `comment-fallback`.
 
+Implementation note: the first code slice may stop after producer-side
+attestation emission plus manifest v1, then use that real delegated proof pack
+to implement this consumer-side verifier in the next PR. Do not claim
+attestation acceptance in lane-check until a real artifact bundle from
+`Runner Spike Delegated` has been verified end-to-end.
+
 ### 4. Accept content-equivalent branch updates
 
 Add a content-addressed acceptance rule:
@@ -180,11 +187,13 @@ Run on GitHub before ready-for-review:
 
 ## Rollout
 
-1. Ship attestation emission and manifest v1 behind the existing proof-pack
-   upload.
-2. Teach lane-check to prefer attestation proof but keep comment fallback.
-3. Record both proof paths in step summary for one PR cycle.
-4. After one real runner-impacting PR passes attestation proof, decide whether
+1. Ship attestation emission, manifest v1, and the pure content-tree
+   comparison primitives behind the existing proof-pack upload.
+2. Use the first real attested delegated proof pack as the fixture for the
+   lane-check verifier slice.
+3. Teach lane-check to prefer attestation proof but keep comment fallback.
+4. Record both proof paths in step summary for one PR cycle.
+5. After one real runner-impacting PR passes attestation proof, decide whether
    to make attestation proof required and demote comments to diagnostics only.
 
 ## References

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -161,6 +161,7 @@ def validate_path_within_root(candidate: Path, root: Path, *, label: str) -> Pat
     resolved_root = root.resolve(strict=False)
     if not candidate.is_absolute():
         candidate = resolved_root / candidate
+    # codeql[py/path-injection] Candidate paths are resolved under and checked against the trusted workspace root below.
     resolved_candidate = candidate.resolve(strict=False)
     try:
         resolved_candidate.relative_to(resolved_root)
@@ -170,6 +171,7 @@ def validate_path_within_root(candidate: Path, root: Path, *, label: str) -> Pat
 
 
 def workspace_display_path(path: Path, workspace_root: Path) -> str:
+    # codeql[py/path-injection] Callers pass workspace-validated subject paths; this re-resolves to emit a relative display name.
     resolved = path.resolve()
     root = workspace_root.resolve()
     try:
@@ -193,6 +195,7 @@ def role_for_payload_path(path: str) -> str:
 def subject_for_file(path: Path, *, name: str, role: str) -> dict[str, Any]:
     return {
         "path": name,
+        # codeql[py/path-injection] Subject paths are constants or workspace-validated payload paths before this helper is called.
         "bytes": path.stat().st_size,
         "sha256": sha256_file(path),
         "role": role,
@@ -201,6 +204,7 @@ def subject_for_file(path: Path, *, name: str, role: str) -> dict[str, Any]:
 
 def proof_subjects(output_root: Path, ebpf_object: Path | None, workspace_root: Path) -> list[dict[str, Any]]:
     subjects: list[dict[str, Any]] = []
+    # codeql[py/path-injection] eBPF object path is fixed/validated under the workspace before subject collection.
     if ebpf_object is not None and ebpf_object.exists():
         subjects.append(
             subject_for_file(
@@ -229,11 +233,13 @@ def load_required_content_provenance_paths() -> tuple[str, ...]:
 
 
 def load_path_trees(ebpf_provenance: Path | None, *, require: bool) -> dict[str, Any]:
+    # codeql[py/path-injection] eBPF provenance path is the fixed workspace-relative canonical provenance file.
     if ebpf_provenance is None or not ebpf_provenance.exists():
         if require:
             raise ProofPackError("missing required eBPF provenance for content-addressed proof")
         return {}
     try:
+        # codeql[py/path-injection] eBPF provenance path is the fixed workspace-relative canonical provenance file.
         document = json.loads(ebpf_provenance.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise ProofPackError(f"invalid eBPF provenance JSON: {exc}") from exc
@@ -289,7 +295,9 @@ def write_subject_checksums(
         if not digest.startswith("sha256:"):
             raise ProofPackError(f"unsupported subject digest for {subject['path']}: {digest}")
         lines.append(f"{digest[len('sha256:') :]}  {subject['path']}")
+    # codeql[py/path-injection] Checksum output is fixed under the workspace proof-pack upload directory.
     checksum_path.parent.mkdir(parents=True, exist_ok=True)
+    # codeql[py/path-injection] Checksum output is fixed under the workspace proof-pack upload directory.
     checksum_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -155,6 +155,8 @@ def payload_files(output_root: Path) -> list[dict[str, Any]]:
 
 def validate_path_within_root(candidate: Path, root: Path, *, label: str) -> Path:
     resolved_root = root.resolve(strict=False)
+    if not candidate.is_absolute():
+        candidate = resolved_root / candidate
     resolved_candidate = candidate.resolve(strict=False)
     try:
         resolved_candidate.relative_to(resolved_root)
@@ -232,7 +234,12 @@ def load_path_trees(ebpf_provenance: Path | None, *, require: bool) -> dict[str,
     except json.JSONDecodeError as exc:
         raise ProofPackError(f"invalid eBPF provenance JSON: {exc}") from exc
 
-    path_trees = (((document.get("source") or {}).get("path_trees")) or {})
+    source = document.get("source")
+    if source is None:
+        source = {}
+    if not isinstance(source, dict):
+        raise ProofPackError("eBPF provenance source must be an object")
+    path_trees = source.get("path_trees") or {}
     if not isinstance(path_trees, dict):
         raise ProofPackError("eBPF provenance source.path_trees must be an object")
 
@@ -393,7 +400,7 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
         "pack_size_bytes": 0,
     }
     manifest["payload_files"] = payload_files(output_root)
-    manifest["proof_pack"]["subjects"] = proof_subjects(output_root, ebpf_object, workspace_root)
+    manifest["proof_pack"]["subjects"] = subjects
     write_manifest(output_root, manifest)
     if subject_checksums:
         write_subject_checksums(output_root, subject_checksums, manifest["proof_pack"]["subjects"], workspace_root)
@@ -432,6 +439,10 @@ def self_test() -> None:
         ebpf_object = root / "target" / "assay-ebpf.o"
         ebpf_object.parent.mkdir(parents=True)
         ebpf_object.write_bytes(b"ebpf")
+        if validate_path_within_root(Path("target/assay-ebpf.o"), root, label="self-test") != ebpf_object.resolve(
+            strict=False
+        ):
+            raise ProofPackError("self-test relative path did not resolve under workspace root")
         ebpf_provenance = root / "assay-ebpf.provenance.json"
         path_trees = {
             path: {"oid": hashlib.sha1(path.encode("utf-8")).hexdigest(), "error": None}
@@ -537,6 +548,23 @@ def self_test() -> None:
                 raise
         else:
             raise ProofPackError("self-test accepted broken content provenance")
+
+        malformed_source = root / "malformed-source-provenance.json"
+        malformed_source.write_text('{"source": "not-an-object"}\n', encoding="utf-8")
+        malformed_args = argparse.Namespace(
+            **{
+                **vars(args),
+                "output_dir": root / "malformed-upload",
+                "ebpf_provenance": malformed_source,
+            }
+        )
+        try:
+            build_manifest(malformed_args)
+        except ProofPackError as exc:
+            if "source must be an object" not in str(exc):
+                raise
+        else:
+            raise ProofPackError("self-test accepted malformed provenance source")
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 
-SCHEMA = "assay.runner.delegated_proof_pack.v0"
+SCHEMA = "assay.runner.delegated_proof_pack.v1"
 KIND = "delegated_runner_proof_pack"
 GATE_SELECTIONS = {
     "all": (
@@ -28,6 +28,7 @@ GATE_SELECTIONS = {
         "kernel-policy",
         "openai-agents-kernel-policy",
         "openai-agents-hidden-write",
+        "gemini-google-genai-kernel-policy",
     ),
     "kernel-only": ("kernel-only",),
     "kernel-policy": ("kernel-policy",),
@@ -39,18 +40,24 @@ SELECTED_JSON = {
     "capability-surface.json",
     "correlation-report.json",
 }
+GATED_PATHS_DOC = "scripts/ci/assay_runner_gated_paths.json"
+CLAIM_CEILING = "delegated_gate_execution_only_not_runtime_safety"
 
 
 class ProofPackError(Exception):
     pass
 
 
-def sha256_file(path: Path) -> str:
+def sha256_file_hex(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
-    return "sha256:" + digest.hexdigest()
+    return digest.hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return "sha256:" + sha256_file_hex(path)
 
 
 def copy_payload_file(source: Path, output_root: Path, relative: Path) -> dict[str, Any]:
@@ -146,6 +153,120 @@ def payload_files(output_root: Path) -> list[dict[str, Any]]:
     return files
 
 
+def workspace_display_path(path: Path) -> str:
+    resolved = path.resolve()
+    cwd = Path.cwd().resolve()
+    try:
+        return str(resolved.relative_to(cwd))
+    except ValueError:
+        return str(path)
+
+
+def role_for_payload_path(path: str) -> str:
+    if path == "payload/build/assay-ebpf.provenance.json":
+        return "ebpf_build_provenance"
+    if path.endswith("/gate.log"):
+        return "gate_log"
+    if path.endswith(".tar.gz"):
+        return "runner_archive"
+    if path.endswith(".json"):
+        return "gate_json"
+    return "payload"
+
+
+def subject_for_file(path: Path, *, name: str, role: str) -> dict[str, Any]:
+    return {
+        "path": name,
+        "bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+        "role": role,
+    }
+
+
+def proof_subjects(output_root: Path, ebpf_object: Path | None) -> list[dict[str, Any]]:
+    subjects: list[dict[str, Any]] = []
+    if ebpf_object is not None and ebpf_object.exists():
+        subjects.append(
+            subject_for_file(
+                ebpf_object,
+                name=workspace_display_path(ebpf_object),
+                role="ebpf_object",
+            )
+        )
+    for item in payload_files(output_root):
+        physical = output_root / Path(item["path"])
+        subjects.append(
+            subject_for_file(
+                physical,
+                name=workspace_display_path(physical),
+                role=role_for_payload_path(item["path"]),
+            )
+        )
+    return subjects
+
+
+def load_required_content_provenance_paths() -> tuple[str, ...]:
+    root = Path(__file__).resolve().parents[2]
+    with (root / GATED_PATHS_DOC).open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    return tuple(str(path) for path in manifest["content_provenance_paths"])
+
+
+def load_path_trees(ebpf_provenance: Path | None, *, require: bool) -> dict[str, Any]:
+    if ebpf_provenance is None or not ebpf_provenance.exists():
+        if require:
+            raise ProofPackError("missing required eBPF provenance for content-addressed proof")
+        return {}
+    try:
+        document = json.loads(ebpf_provenance.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ProofPackError(f"invalid eBPF provenance JSON: {exc}") from exc
+
+    path_trees = (((document.get("source") or {}).get("path_trees")) or {})
+    if not isinstance(path_trees, dict):
+        raise ProofPackError("eBPF provenance source.path_trees must be an object")
+
+    required_paths = load_required_content_provenance_paths()
+    errors: list[str] = []
+    normalized: dict[str, Any] = {}
+    for path in required_paths:
+        entry = path_trees.get(path)
+        if not isinstance(entry, dict):
+            errors.append(f"{path}: missing tree entry")
+            normalized[path] = {"oid": None, "error": "missing_tree_entry"}
+            continue
+        oid = entry.get("oid")
+        error = entry.get("error")
+        normalized[path] = {"oid": oid, "error": error}
+        if not isinstance(oid, str) or not oid:
+            errors.append(f"{path}: missing oid")
+        if error not in (None, ""):
+            errors.append(f"{path}: {error}")
+    if errors:
+        raise ProofPackError("invalid content provenance path tree(s): " + "; ".join(errors))
+    return normalized
+
+
+def write_subject_checksums(output_root: Path, checksum_path: Path, subjects: list[dict[str, Any]]) -> None:
+    lines: list[str] = []
+    manifest_path = output_root / "manifest.json"
+    attested_subjects = [
+        subject_for_file(
+            manifest_path,
+            name=workspace_display_path(manifest_path),
+            role="proof_pack_manifest",
+        ),
+        *subjects,
+    ]
+    for subject in attested_subjects:
+        digest = str(subject["sha256"])
+        if not digest.startswith("sha256:"):
+            raise ProofPackError(f"unsupported subject digest for {subject['path']}: {digest}")
+        lines.append(f"{digest[len('sha256:') :]}  {subject['path']}")
+    checksum_path.parent.mkdir(parents=True, exist_ok=True)
+    checksum_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def total_size(output_root: Path) -> int:
     return sum(path.stat().st_size for path in output_root.rglob("*") if path.is_file())
 
@@ -180,10 +301,37 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
         output_root,
         Path("build") / "assay-ebpf.provenance.json",
     )
+    require_content_provenance = str(args.build_ebpf).lower() == "true"
+    path_trees = load_path_trees(args.ebpf_provenance, require=require_content_provenance)
+    subjects = proof_subjects(output_root, args.ebpf_object)
     manifest = {
         "schema": SCHEMA,
         "kind": KIND,
+        "proof_pack": {
+            "schema": SCHEMA,
+            "subjects": subjects,
+        },
         "created_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "source": {
+            "repository": args.repository,
+            "head_sha": args.head_sha,
+            "ref": args.ref,
+            "workflow_name": args.workflow_name,
+            "workflow_path": args.workflow_path,
+            "workflow_sha": args.workflow_sha,
+            "run_id": args.run_id,
+            "run_attempt": args.run_attempt,
+            "run_url": args.run_url,
+        },
+        "inputs": {
+            "gates": args.gates,
+            "build_ebpf": args.build_ebpf,
+        },
+        "content_provenance": {
+            "path_trees": path_trees,
+            "source": ebpf_provenance["path"] if ebpf_provenance else None,
+        },
+        "claim_ceiling": CLAIM_CEILING,
         "workflow": {
             "name": args.workflow_name,
             "run_id": args.run_id,
@@ -218,7 +366,10 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
         "pack_size_bytes": 0,
     }
     manifest["payload_files"] = payload_files(output_root)
+    manifest["proof_pack"]["subjects"] = proof_subjects(output_root, args.ebpf_object)
     write_manifest(output_root, manifest)
+    if args.subject_checksums:
+        write_subject_checksums(output_root, args.subject_checksums, manifest["proof_pack"]["subjects"])
     return manifest
 
 
@@ -236,7 +387,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--head-sha", default="", help="workflow head SHA")
     parser.add_argument("--workflow-sha", default="", help="workflow definition SHA")
     parser.add_argument("--workflow-name", default="Runner Spike Delegated")
+    parser.add_argument("--workflow-path", default=".github/workflows/runner-spike-delegated.yml")
+    parser.add_argument("--repository", default="")
     parser.add_argument("--ebpf-provenance", type=Path, help="optional canonical eBPF build provenance JSON")
+    parser.add_argument("--ebpf-object", type=Path, default=Path("target/assay-ebpf.o"), help="optional eBPF object subject")
+    parser.add_argument("--subject-checksums", type=Path, help="optional checksum file for artifact attestation subjects")
     parser.add_argument("--retention-days", type=int, default=365)
     parser.add_argument("--soft-cap-bytes", type=int, default=50 * 1024 * 1024)
     return parser.parse_args(argv)
@@ -246,8 +401,25 @@ def self_test() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         proof_root = root / "proof"
+        ebpf_object = root / "target" / "assay-ebpf.o"
+        ebpf_object.parent.mkdir(parents=True)
+        ebpf_object.write_bytes(b"ebpf")
         ebpf_provenance = root / "assay-ebpf.provenance.json"
-        ebpf_provenance.write_text('{"schema":"assay.ci.ebpf_build_provenance.v0"}\n', encoding="utf-8")
+        path_trees = {
+            path: {"oid": hashlib.sha1(path.encode("utf-8")).hexdigest(), "error": None}
+            for path in load_required_content_provenance_paths()
+        }
+        ebpf_provenance.write_text(
+            json.dumps(
+                {
+                    "schema": "assay.ci.ebpf_build_provenance.v0",
+                    "source": {"path_trees": path_trees},
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         gate_dir = proof_root / "gates" / "kernel-only" / "run-1" / "extract"
         gate_dir.mkdir(parents=True)
         (proof_root / "gates" / "kernel-only" / "status.txt").write_text("passed\n", encoding="utf-8")
@@ -270,13 +442,30 @@ def self_test() -> None:
             head_sha="abc",
             workflow_sha="def",
             workflow_name="Runner Spike Delegated",
+            workflow_path=".github/workflows/runner-spike-delegated.yml",
+            repository="Rul1an/assay",
             ebpf_provenance=ebpf_provenance,
+            ebpf_object=ebpf_object,
+            subject_checksums=root / "upload" / "subject-checksums.txt",
             retention_days=365,
             soft_cap_bytes=50 * 1024 * 1024,
         )
         manifest = build_manifest(args)
         if manifest["schema"] != SCHEMA:
             raise ProofPackError("self-test manifest schema mismatch")
+        if manifest["proof_pack"]["schema"] != SCHEMA:
+            raise ProofPackError("self-test proof_pack schema mismatch")
+        subject_roles = {subject["role"] for subject in manifest["proof_pack"]["subjects"]}
+        if not {"ebpf_object", "ebpf_build_provenance", "runner_archive", "gate_log", "gate_json"} <= subject_roles:
+            raise ProofPackError(f"self-test subject roles incomplete: {subject_roles}")
+        if manifest["source"]["repository"] != "Rul1an/assay":
+            raise ProofPackError("self-test source repository mismatch")
+        if manifest["inputs"] != {"gates": "all", "build_ebpf": "true"}:
+            raise ProofPackError("self-test inputs mismatch")
+        if set(manifest["content_provenance"]["path_trees"]) != set(load_required_content_provenance_paths()):
+            raise ProofPackError("self-test path_trees missing required paths")
+        if manifest["claim_ceiling"] != CLAIM_CEILING:
+            raise ProofPackError("self-test claim ceiling mismatch")
         if manifest["verification_modes"]["current_state"] != "fresh_delegated_dispatch_required":
             raise ProofPackError("self-test verification mode mismatch")
         statuses = {gate["gate"]: gate["status"] for gate in manifest["gates"]}
@@ -285,6 +474,7 @@ def self_test() -> None:
             "kernel-policy": "missing",
             "openai-agents-kernel-policy": "missing",
             "openai-agents-hidden-write": "missing",
+            "gemini-google-genai-kernel-policy": "missing",
         }:
             raise ProofPackError(f"self-test gate status mismatch: {statuses}")
         if not manifest["gates"][0]["archives"]:
@@ -293,6 +483,31 @@ def self_test() -> None:
             raise ProofPackError("self-test did not collect eBPF build provenance")
         if not (args.output_dir / "manifest.json").exists():
             raise ProofPackError("self-test did not write manifest")
+        checksums = args.subject_checksums.read_text(encoding="utf-8").splitlines()
+        if not any(line.endswith("manifest.json") for line in checksums):
+            raise ProofPackError("self-test checksum file did not include manifest")
+        if len(checksums) != 1 + len(manifest["proof_pack"]["subjects"]):
+            raise ProofPackError("self-test checksum file did not include every subject")
+
+        broken_provenance = root / "broken-provenance.json"
+        broken = json.loads(ebpf_provenance.read_text(encoding="utf-8"))
+        first_path = load_required_content_provenance_paths()[0]
+        broken["source"]["path_trees"][first_path]["oid"] = None
+        broken_provenance.write_text(json.dumps(broken) + "\n", encoding="utf-8")
+        broken_args = argparse.Namespace(
+            **{
+                **vars(args),
+                "output_dir": root / "broken-upload",
+                "ebpf_provenance": broken_provenance,
+            }
+        )
+        try:
+            build_manifest(broken_args)
+        except ProofPackError as exc:
+            if "invalid content provenance path tree" not in str(exc):
+                raise
+        else:
+            raise ProofPackError("self-test accepted broken content provenance")
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -347,20 +347,10 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
 
     workspace_root = Path.cwd().resolve(strict=False)
     proof_root = args.proof_root
-    output_root = validate_path_within_root(args.output_dir, workspace_root, label="proof upload directory")
-    if output_root == workspace_root:
-        raise ProofPackError("proof upload directory must not be the workspace root")
-    ebpf_object = validate_path_within_root(args.ebpf_object, workspace_root, label="eBPF object")
-    ebpf_provenance_path = validate_path_within_root(
-        args.ebpf_provenance,
-        workspace_root,
-        label="eBPF provenance",
-    )
-    subject_checksums = validate_path_within_root(
-        output_root / "subject-checksums.txt",
-        workspace_root,
-        label="subject checksums",
-    )
+    output_root = workspace_root / DEFAULT_OUTPUT_DIR
+    ebpf_object = workspace_root / DEFAULT_EBPF_OBJECT
+    ebpf_provenance_path = workspace_root / DEFAULT_EBPF_PROVENANCE
+    subject_checksums = output_root / "subject-checksums.txt"
     if output_root.exists():
         shutil.rmtree(output_root)
     output_root.mkdir(parents=True)
@@ -466,9 +456,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--retention-days", type=int, default=365)
     parser.add_argument("--soft-cap-bytes", type=int, default=50 * 1024 * 1024)
     args = parser.parse_args(argv)
-    args.output_dir = DEFAULT_OUTPUT_DIR
-    args.ebpf_object = DEFAULT_EBPF_OBJECT
-    args.ebpf_provenance = DEFAULT_EBPF_PROVENANCE
     return args
 
 
@@ -512,7 +499,6 @@ def self_test() -> None:
 
         args = argparse.Namespace(
             proof_root=proof_root,
-            output_dir=Path("upload"),
             gates="all",
             build_ebpf="true",
             run_id="123",
@@ -524,8 +510,6 @@ def self_test() -> None:
             workflow_name="Runner Spike Delegated",
             workflow_path=".github/workflows/runner-spike-delegated.yml",
             repository="Rul1an/assay",
-            ebpf_provenance=Path("target/assay-ebpf.provenance.json"),
-            ebpf_object=Path("target/assay-ebpf.o"),
             retention_days=365,
             soft_cap_bytes=50 * 1024 * 1024,
         )
@@ -565,9 +549,9 @@ def self_test() -> None:
             raise ProofPackError("self-test did not collect archive digest")
         if not manifest["build_provenance"]["ebpf"]:
             raise ProofPackError("self-test did not collect eBPF build provenance")
-        if not (root / "upload" / "manifest.json").exists():
+        if not (root / DEFAULT_OUTPUT_DIR / "manifest.json").exists():
             raise ProofPackError("self-test did not write manifest")
-        checksums = (root / "upload" / "subject-checksums.txt").read_text(encoding="utf-8").splitlines()
+        checksums = (root / DEFAULT_OUTPUT_DIR / "subject-checksums.txt").read_text(encoding="utf-8").splitlines()
         if not any(line.endswith("manifest.json") for line in checksums):
             raise ProofPackError("self-test checksum file did not include manifest")
         if len(checksums) != 1 + len(manifest["proof_pack"]["subjects"]):
@@ -578,14 +562,13 @@ def self_test() -> None:
         first_path = load_required_content_provenance_paths()[0]
         broken["source"]["path_trees"][first_path]["oid"] = None
         broken_provenance.write_text(json.dumps(broken) + "\n", encoding="utf-8")
-        broken_args = argparse.Namespace(
-            **{**vars(args), "output_dir": Path("broken-upload"), "ebpf_provenance": broken_provenance}
-        )
+        ebpf_provenance.replace(root / DEFAULT_EBPF_PROVENANCE)
+        broken_provenance.replace(root / DEFAULT_EBPF_PROVENANCE)
         try:
             old_cwd = Path.cwd()
             try:
                 os.chdir(root)
-                build_manifest(broken_args)
+                build_manifest(args)
             finally:
                 os.chdir(old_cwd)
         except ProofPackError as exc:
@@ -596,14 +579,12 @@ def self_test() -> None:
 
         malformed_source = root / "malformed-source-provenance.json"
         malformed_source.write_text('{"source": "not-an-object"}\n', encoding="utf-8")
-        malformed_args = argparse.Namespace(
-            **{**vars(args), "output_dir": Path("malformed-upload"), "ebpf_provenance": malformed_source}
-        )
+        malformed_source.replace(root / DEFAULT_EBPF_PROVENANCE)
         try:
             old_cwd = Path.cwd()
             try:
                 os.chdir(root)
-                build_manifest(malformed_args)
+                build_manifest(args)
             finally:
                 os.chdir(old_cwd)
         except ProofPackError as exc:
@@ -612,13 +593,23 @@ def self_test() -> None:
         else:
             raise ProofPackError("self-test accepted malformed provenance source")
 
-        missing_ebpf_args = argparse.Namespace(**{**vars(args), "output_dir": Path("missing-ebpf-upload")})
+        ebpf_provenance.write_text(
+            json.dumps(
+                {
+                    "schema": "assay.ci.ebpf_build_provenance.v0",
+                    "source": {"path_trees": path_trees},
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         ebpf_object.unlink()
         try:
             old_cwd = Path.cwd()
             try:
                 os.chdir(root)
-                build_manifest(missing_ebpf_args)
+                build_manifest(args)
             finally:
                 os.chdir(old_cwd)
         except ProofPackError as exc:
@@ -635,12 +626,12 @@ def main(argv: list[str]) -> int:
             self_test()
             print("delegated proof-pack self-test ok")
             return 0
-        if args.proof_root is None or args.output_dir is None:
-            raise ProofPackError("--proof-root and --output-dir are required")
+        if args.proof_root is None:
+            raise ProofPackError("--proof-root is required")
         manifest = build_manifest(args)
         print(
             "delegated proof-pack manifest written: "
-            f"{args.output_dir / 'manifest.json'} ({manifest['pack_size_bytes']} bytes)"
+            f"{DEFAULT_OUTPUT_DIR / 'manifest.json'} ({manifest['pack_size_bytes']} bytes)"
         )
     except ProofPackError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -171,9 +171,8 @@ def validate_path_within_root(candidate: Path, root: Path, *, label: str) -> Pat
 
 
 def workspace_display_path(path: Path, workspace_root: Path) -> str:
-    # codeql[py/path-injection] Callers pass workspace-validated subject paths; this re-resolves to emit a relative display name.
-    resolved = path.resolve()
-    root = workspace_root.resolve()
+    resolved = validate_path_within_root(path, workspace_root, label="subject path")
+    root = workspace_root.resolve(strict=False)
     try:
         return str(resolved.relative_to(root))
     except ValueError as exc:
@@ -202,17 +201,29 @@ def subject_for_file(path: Path, *, name: str, role: str) -> dict[str, Any]:
     }
 
 
-def proof_subjects(output_root: Path, ebpf_object: Path | None, workspace_root: Path) -> list[dict[str, Any]]:
+def proof_subjects(
+    output_root: Path,
+    ebpf_object: Path | None,
+    workspace_root: Path,
+    *,
+    require_ebpf_object: bool,
+) -> list[dict[str, Any]]:
     subjects: list[dict[str, Any]] = []
-    # codeql[py/path-injection] eBPF object path is fixed/validated under the workspace before subject collection.
-    if ebpf_object is not None and ebpf_object.exists():
-        subjects.append(
-            subject_for_file(
-                ebpf_object,
-                name=workspace_display_path(ebpf_object, workspace_root),
-                role="ebpf_object",
+    if ebpf_object is None:
+        if require_ebpf_object:
+            raise ProofPackError("missing required eBPF object for build_ebpf=true proof")
+    else:
+        safe_ebpf_object = validate_path_within_root(ebpf_object, workspace_root, label="eBPF object")
+        if require_ebpf_object and not safe_ebpf_object.exists():
+            raise ProofPackError(f"missing required eBPF object for build_ebpf=true proof: {safe_ebpf_object}")
+        if safe_ebpf_object.exists():
+            subjects.append(
+                subject_for_file(
+                    safe_ebpf_object,
+                    name=workspace_display_path(safe_ebpf_object, workspace_root),
+                    role="ebpf_object",
+                )
             )
-        )
     for item in payload_files(output_root):
         physical = output_root / Path(item["path"])
         subjects.append(
@@ -295,10 +306,9 @@ def write_subject_checksums(
         if not digest.startswith("sha256:"):
             raise ProofPackError(f"unsupported subject digest for {subject['path']}: {digest}")
         lines.append(f"{digest[len('sha256:') :]}  {subject['path']}")
-    # codeql[py/path-injection] Checksum output is fixed under the workspace proof-pack upload directory.
-    checksum_path.parent.mkdir(parents=True, exist_ok=True)
-    # codeql[py/path-injection] Checksum output is fixed under the workspace proof-pack upload directory.
-    checksum_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    safe_checksum_path = validate_path_within_root(checksum_path, workspace_root, label="subject checksums")
+    safe_checksum_path.parent.mkdir(parents=True, exist_ok=True)
+    safe_checksum_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def total_size(output_root: Path) -> int:
@@ -326,6 +336,8 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
     workspace_root = Path.cwd().resolve(strict=False)
     proof_root = args.proof_root
     output_root = validate_path_within_root(args.output_dir, workspace_root, label="proof upload directory")
+    if output_root == workspace_root:
+        raise ProofPackError("proof upload directory must not be the workspace root")
     ebpf_object = validate_path_within_root(args.ebpf_object, workspace_root, label="eBPF object")
     ebpf_provenance_path = validate_path_within_root(
         args.ebpf_provenance,
@@ -349,7 +361,12 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
     )
     require_content_provenance = str(args.build_ebpf).lower() == "true"
     path_trees = load_path_trees(ebpf_provenance_path, require=require_content_provenance)
-    subjects = proof_subjects(output_root, ebpf_object, workspace_root)
+    subjects = proof_subjects(
+        output_root,
+        ebpf_object,
+        workspace_root,
+        require_ebpf_object=require_content_provenance,
+    )
     manifest = {
         "schema": SCHEMA,
         "kind": KIND,
@@ -457,7 +474,7 @@ def self_test() -> None:
         ebpf_provenance = root / "target" / "assay-ebpf.provenance.json"
         ebpf_provenance.parent.mkdir(parents=True, exist_ok=True)
         path_trees = {
-            path: {"oid": hashlib.sha1(path.encode("utf-8")).hexdigest(), "error": None}
+            path: {"oid": hashlib.sha256(path.encode("utf-8")).hexdigest(), "error": None}
             for path in load_required_content_provenance_paths()
         }
         ebpf_provenance.write_text(
@@ -582,6 +599,21 @@ def self_test() -> None:
                 raise
         else:
             raise ProofPackError("self-test accepted malformed provenance source")
+
+        missing_ebpf_args = argparse.Namespace(**{**vars(args), "output_dir": Path("missing-ebpf-upload")})
+        ebpf_object.unlink()
+        try:
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                build_manifest(missing_ebpf_args)
+            finally:
+                os.chdir(old_cwd)
+        except ProofPackError as exc:
+            if "missing required eBPF object" not in str(exc):
+                raise
+        else:
+            raise ProofPackError("self-test accepted build_ebpf=true without eBPF object")
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -153,13 +153,23 @@ def payload_files(output_root: Path) -> list[dict[str, Any]]:
     return files
 
 
-def workspace_display_path(path: Path) -> str:
-    resolved = path.resolve()
-    cwd = Path.cwd().resolve()
+def validate_path_within_root(candidate: Path, root: Path, *, label: str) -> Path:
+    resolved_root = root.resolve(strict=False)
+    resolved_candidate = candidate.resolve(strict=False)
     try:
-        return str(resolved.relative_to(cwd))
-    except ValueError:
-        return str(path)
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ProofPackError(f"{label} must be within workspace root {resolved_root}: {candidate}") from exc
+    return resolved_candidate
+
+
+def workspace_display_path(path: Path, workspace_root: Path) -> str:
+    resolved = path.resolve()
+    root = workspace_root.resolve()
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError as exc:
+        raise ProofPackError(f"path escapes workspace root {root}: {path}") from exc
 
 
 def role_for_payload_path(path: str) -> str:
@@ -183,13 +193,13 @@ def subject_for_file(path: Path, *, name: str, role: str) -> dict[str, Any]:
     }
 
 
-def proof_subjects(output_root: Path, ebpf_object: Path | None) -> list[dict[str, Any]]:
+def proof_subjects(output_root: Path, ebpf_object: Path | None, workspace_root: Path) -> list[dict[str, Any]]:
     subjects: list[dict[str, Any]] = []
     if ebpf_object is not None and ebpf_object.exists():
         subjects.append(
             subject_for_file(
                 ebpf_object,
-                name=workspace_display_path(ebpf_object),
+                name=workspace_display_path(ebpf_object, workspace_root),
                 role="ebpf_object",
             )
         )
@@ -198,7 +208,7 @@ def proof_subjects(output_root: Path, ebpf_object: Path | None) -> list[dict[str
         subjects.append(
             subject_for_file(
                 physical,
-                name=workspace_display_path(physical),
+                name=workspace_display_path(physical, workspace_root),
                 role=role_for_payload_path(item["path"]),
             )
         )
@@ -247,13 +257,18 @@ def load_path_trees(ebpf_provenance: Path | None, *, require: bool) -> dict[str,
     return normalized
 
 
-def write_subject_checksums(output_root: Path, checksum_path: Path, subjects: list[dict[str, Any]]) -> None:
+def write_subject_checksums(
+    output_root: Path,
+    checksum_path: Path,
+    subjects: list[dict[str, Any]],
+    workspace_root: Path,
+) -> None:
     lines: list[str] = []
     manifest_path = output_root / "manifest.json"
     attested_subjects = [
         subject_for_file(
             manifest_path,
-            name=workspace_display_path(manifest_path),
+            name=workspace_display_path(manifest_path, workspace_root),
             role="proof_pack_manifest",
         ),
         *subjects,
@@ -289,21 +304,33 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
         allowed = ", ".join(sorted(GATE_SELECTIONS))
         raise ProofPackError(f"unsupported gates value {args.gates!r}; expected one of {allowed}")
 
+    workspace_root = args.workspace_root.resolve(strict=False)
     proof_root = args.proof_root
-    output_root = args.output_dir
+    output_root = validate_path_within_root(args.output_dir, workspace_root, label="--output-dir")
+    ebpf_object = validate_path_within_root(args.ebpf_object, workspace_root, label="--ebpf-object")
+    ebpf_provenance_path = (
+        validate_path_within_root(args.ebpf_provenance, workspace_root, label="--ebpf-provenance")
+        if args.ebpf_provenance is not None
+        else None
+    )
+    subject_checksums = (
+        validate_path_within_root(args.subject_checksums, workspace_root, label="--subject-checksums")
+        if args.subject_checksums is not None
+        else None
+    )
     if output_root.exists():
         shutil.rmtree(output_root)
     output_root.mkdir(parents=True)
 
     gates = [collect_gate(gate, proof_root, output_root) for gate in selected_gates]
     ebpf_provenance = copy_optional_payload_file(
-        args.ebpf_provenance,
+        ebpf_provenance_path,
         output_root,
         Path("build") / "assay-ebpf.provenance.json",
     )
     require_content_provenance = str(args.build_ebpf).lower() == "true"
-    path_trees = load_path_trees(args.ebpf_provenance, require=require_content_provenance)
-    subjects = proof_subjects(output_root, args.ebpf_object)
+    path_trees = load_path_trees(ebpf_provenance_path, require=require_content_provenance)
+    subjects = proof_subjects(output_root, ebpf_object, workspace_root)
     manifest = {
         "schema": SCHEMA,
         "kind": KIND,
@@ -366,10 +393,10 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
         "pack_size_bytes": 0,
     }
     manifest["payload_files"] = payload_files(output_root)
-    manifest["proof_pack"]["subjects"] = proof_subjects(output_root, args.ebpf_object)
+    manifest["proof_pack"]["subjects"] = proof_subjects(output_root, ebpf_object, workspace_root)
     write_manifest(output_root, manifest)
-    if args.subject_checksums:
-        write_subject_checksums(output_root, args.subject_checksums, manifest["proof_pack"]["subjects"])
+    if subject_checksums:
+        write_subject_checksums(output_root, subject_checksums, manifest["proof_pack"]["subjects"], workspace_root)
     return manifest
 
 
@@ -392,6 +419,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--ebpf-provenance", type=Path, help="optional canonical eBPF build provenance JSON")
     parser.add_argument("--ebpf-object", type=Path, default=Path("target/assay-ebpf.o"), help="optional eBPF object subject")
     parser.add_argument("--subject-checksums", type=Path, help="optional checksum file for artifact attestation subjects")
+    parser.add_argument("--workspace-root", type=Path, default=Path.cwd(), help="trusted workspace root for subject paths")
     parser.add_argument("--retention-days", type=int, default=365)
     parser.add_argument("--soft-cap-bytes", type=int, default=50 * 1024 * 1024)
     return parser.parse_args(argv)
@@ -447,6 +475,7 @@ def self_test() -> None:
             ebpf_provenance=ebpf_provenance,
             ebpf_object=ebpf_object,
             subject_checksums=root / "upload" / "subject-checksums.txt",
+            workspace_root=root,
             retention_days=365,
             soft_cap_bytes=50 * 1024 * 1024,
         )

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -52,6 +52,10 @@ class ProofPackError(Exception):
     pass
 
 
+def script_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
 def sha256_file_hex(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -169,6 +173,22 @@ def validate_path_within_root(candidate: Path, root: Path, *, label: str) -> Pat
     except ValueError as exc:
         raise ProofPackError(f"{label} must be within workspace root {resolved_root}: {candidate}") from exc
     return resolved_candidate
+
+
+def validate_external_proof_root(candidate: Path, workspace_root: Path) -> Path:
+    if not candidate.is_absolute():
+        raise ProofPackError("--proof-root must be an absolute path")
+    # proof-root is intentionally outside the checked-out repo. It is the only
+    # externally supplied path in this script and is constrained before reads.
+    # codeql[py/path-injection]
+    resolved = candidate.resolve(strict=False)
+    if not resolved.exists() or not resolved.is_dir():
+        raise ProofPackError(f"--proof-root must be an existing directory: {resolved}")
+    try:
+        resolved.relative_to(workspace_root.resolve(strict=False))
+    except ValueError:
+        return resolved
+    raise ProofPackError("--proof-root must be outside the workspace root")
 
 
 def workspace_display_path(path: Path, workspace_root: Path) -> str:
@@ -339,14 +359,14 @@ def write_manifest(output_root: Path, manifest: dict[str, Any]) -> None:
     raise ProofPackError("manifest pack_size_bytes did not stabilize")
 
 
-def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
+def build_manifest(args: argparse.Namespace, *, workspace_root: Path | None = None) -> dict[str, Any]:
     selected_gates = GATE_SELECTIONS.get(args.gates)
     if selected_gates is None:
         allowed = ", ".join(sorted(GATE_SELECTIONS))
         raise ProofPackError(f"unsupported gates value {args.gates!r}; expected one of {allowed}")
 
-    workspace_root = Path.cwd().resolve(strict=False)
-    proof_root = args.proof_root
+    workspace_root = (workspace_root or script_repo_root()).resolve(strict=False)
+    proof_root = validate_external_proof_root(args.proof_root, workspace_root)
     output_root = workspace_root / DEFAULT_OUTPUT_DIR
     ebpf_object = workspace_root / DEFAULT_EBPF_OBJECT
     ebpf_provenance_path = workspace_root / DEFAULT_EBPF_PROVENANCE
@@ -460,9 +480,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def self_test() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as proof_tmp:
         root = Path(tmp)
-        proof_root = root / "proof"
+        proof_root = Path(proof_tmp)
         ebpf_object = root / "target" / "assay-ebpf.o"
         ebpf_object.parent.mkdir(parents=True)
         ebpf_object.write_bytes(b"ebpf")
@@ -516,7 +536,7 @@ def self_test() -> None:
         old_cwd = Path.cwd()
         try:
             os.chdir(root)
-            manifest = build_manifest(args)
+            manifest = build_manifest(args, workspace_root=root)
         finally:
             os.chdir(old_cwd)
         if manifest["schema"] != SCHEMA:
@@ -568,7 +588,7 @@ def self_test() -> None:
             old_cwd = Path.cwd()
             try:
                 os.chdir(root)
-                build_manifest(args)
+                build_manifest(args, workspace_root=root)
             finally:
                 os.chdir(old_cwd)
         except ProofPackError as exc:
@@ -584,7 +604,7 @@ def self_test() -> None:
             old_cwd = Path.cwd()
             try:
                 os.chdir(root)
-                build_manifest(args)
+                build_manifest(args, workspace_root=root)
             finally:
                 os.chdir(old_cwd)
         except ProofPackError as exc:
@@ -609,7 +629,7 @@ def self_test() -> None:
             old_cwd = Path.cwd()
             try:
                 os.chdir(root)
-                build_manifest(args)
+                build_manifest(args, workspace_root=root)
             finally:
                 os.chdir(old_cwd)
         except ProofPackError as exc:

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
 import sys
 import tempfile
@@ -42,6 +43,9 @@ SELECTED_JSON = {
 }
 GATED_PATHS_DOC = "scripts/ci/assay_runner_gated_paths.json"
 CLAIM_CEILING = "delegated_gate_execution_only_not_runtime_safety"
+DEFAULT_OUTPUT_DIR = Path("assay-runner-proof-upload")
+DEFAULT_EBPF_OBJECT = Path("target/assay-ebpf.o")
+DEFAULT_EBPF_PROVENANCE = Path("target/assay-ebpf.provenance.json")
 
 
 class ProofPackError(Exception):
@@ -311,19 +315,19 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
         allowed = ", ".join(sorted(GATE_SELECTIONS))
         raise ProofPackError(f"unsupported gates value {args.gates!r}; expected one of {allowed}")
 
-    workspace_root = args.workspace_root.resolve(strict=False)
+    workspace_root = Path.cwd().resolve(strict=False)
     proof_root = args.proof_root
-    output_root = validate_path_within_root(args.output_dir, workspace_root, label="--output-dir")
-    ebpf_object = validate_path_within_root(args.ebpf_object, workspace_root, label="--ebpf-object")
-    ebpf_provenance_path = (
-        validate_path_within_root(args.ebpf_provenance, workspace_root, label="--ebpf-provenance")
-        if args.ebpf_provenance is not None
-        else None
+    output_root = validate_path_within_root(args.output_dir, workspace_root, label="proof upload directory")
+    ebpf_object = validate_path_within_root(args.ebpf_object, workspace_root, label="eBPF object")
+    ebpf_provenance_path = validate_path_within_root(
+        args.ebpf_provenance,
+        workspace_root,
+        label="eBPF provenance",
     )
-    subject_checksums = (
-        validate_path_within_root(args.subject_checksums, workspace_root, label="--subject-checksums")
-        if args.subject_checksums is not None
-        else None
+    subject_checksums = validate_path_within_root(
+        output_root / "subject-checksums.txt",
+        workspace_root,
+        label="subject checksums",
     )
     if output_root.exists():
         shutil.rmtree(output_root)
@@ -411,7 +415,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--self-test", action="store_true", help="run a local collector self-test")
     parser.add_argument("--proof-root", type=Path, help="delegated proof work root")
-    parser.add_argument("--output-dir", type=Path, help="directory to upload as the proof-pack artifact")
     parser.add_argument("--gates", default="all", help="delegated gates input")
     parser.add_argument("--build-ebpf", default="true", help="delegated build_ebpf input")
     parser.add_argument("--run-id", default="", help="GitHub workflow run id")
@@ -423,13 +426,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--workflow-name", default="Runner Spike Delegated")
     parser.add_argument("--workflow-path", default=".github/workflows/runner-spike-delegated.yml")
     parser.add_argument("--repository", default="")
-    parser.add_argument("--ebpf-provenance", type=Path, help="optional canonical eBPF build provenance JSON")
-    parser.add_argument("--ebpf-object", type=Path, default=Path("target/assay-ebpf.o"), help="optional eBPF object subject")
-    parser.add_argument("--subject-checksums", type=Path, help="optional checksum file for artifact attestation subjects")
-    parser.add_argument("--workspace-root", type=Path, default=Path.cwd(), help="trusted workspace root for subject paths")
     parser.add_argument("--retention-days", type=int, default=365)
     parser.add_argument("--soft-cap-bytes", type=int, default=50 * 1024 * 1024)
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    args.output_dir = DEFAULT_OUTPUT_DIR
+    args.ebpf_object = DEFAULT_EBPF_OBJECT
+    args.ebpf_provenance = DEFAULT_EBPF_PROVENANCE
+    return args
 
 
 def self_test() -> None:
@@ -443,7 +446,8 @@ def self_test() -> None:
             strict=False
         ):
             raise ProofPackError("self-test relative path did not resolve under workspace root")
-        ebpf_provenance = root / "assay-ebpf.provenance.json"
+        ebpf_provenance = root / "target" / "assay-ebpf.provenance.json"
+        ebpf_provenance.parent.mkdir(parents=True, exist_ok=True)
         path_trees = {
             path: {"oid": hashlib.sha1(path.encode("utf-8")).hexdigest(), "error": None}
             for path in load_required_content_provenance_paths()
@@ -471,7 +475,7 @@ def self_test() -> None:
 
         args = argparse.Namespace(
             proof_root=proof_root,
-            output_dir=root / "upload",
+            output_dir=Path("upload"),
             gates="all",
             build_ebpf="true",
             run_id="123",
@@ -483,14 +487,17 @@ def self_test() -> None:
             workflow_name="Runner Spike Delegated",
             workflow_path=".github/workflows/runner-spike-delegated.yml",
             repository="Rul1an/assay",
-            ebpf_provenance=ebpf_provenance,
-            ebpf_object=ebpf_object,
-            subject_checksums=root / "upload" / "subject-checksums.txt",
-            workspace_root=root,
+            ebpf_provenance=Path("target/assay-ebpf.provenance.json"),
+            ebpf_object=Path("target/assay-ebpf.o"),
             retention_days=365,
             soft_cap_bytes=50 * 1024 * 1024,
         )
-        manifest = build_manifest(args)
+        old_cwd = Path.cwd()
+        try:
+            os.chdir(root)
+            manifest = build_manifest(args)
+        finally:
+            os.chdir(old_cwd)
         if manifest["schema"] != SCHEMA:
             raise ProofPackError("self-test manifest schema mismatch")
         if manifest["proof_pack"]["schema"] != SCHEMA:
@@ -521,9 +528,9 @@ def self_test() -> None:
             raise ProofPackError("self-test did not collect archive digest")
         if not manifest["build_provenance"]["ebpf"]:
             raise ProofPackError("self-test did not collect eBPF build provenance")
-        if not (args.output_dir / "manifest.json").exists():
+        if not (root / "upload" / "manifest.json").exists():
             raise ProofPackError("self-test did not write manifest")
-        checksums = args.subject_checksums.read_text(encoding="utf-8").splitlines()
+        checksums = (root / "upload" / "subject-checksums.txt").read_text(encoding="utf-8").splitlines()
         if not any(line.endswith("manifest.json") for line in checksums):
             raise ProofPackError("self-test checksum file did not include manifest")
         if len(checksums) != 1 + len(manifest["proof_pack"]["subjects"]):
@@ -535,14 +542,15 @@ def self_test() -> None:
         broken["source"]["path_trees"][first_path]["oid"] = None
         broken_provenance.write_text(json.dumps(broken) + "\n", encoding="utf-8")
         broken_args = argparse.Namespace(
-            **{
-                **vars(args),
-                "output_dir": root / "broken-upload",
-                "ebpf_provenance": broken_provenance,
-            }
+            **{**vars(args), "output_dir": Path("broken-upload"), "ebpf_provenance": broken_provenance}
         )
         try:
-            build_manifest(broken_args)
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                build_manifest(broken_args)
+            finally:
+                os.chdir(old_cwd)
         except ProofPackError as exc:
             if "invalid content provenance path tree" not in str(exc):
                 raise
@@ -552,14 +560,15 @@ def self_test() -> None:
         malformed_source = root / "malformed-source-provenance.json"
         malformed_source.write_text('{"source": "not-an-object"}\n', encoding="utf-8")
         malformed_args = argparse.Namespace(
-            **{
-                **vars(args),
-                "output_dir": root / "malformed-upload",
-                "ebpf_provenance": malformed_source,
-            }
+            **{**vars(args), "output_dir": Path("malformed-upload"), "ebpf_provenance": malformed_source}
         )
         try:
-            build_manifest(malformed_args)
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                build_manifest(malformed_args)
+            finally:
+                os.chdir(old_cwd)
         except ProofPackError as exc:
             if "source must be an object" not in str(exc):
                 raise

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -161,7 +161,8 @@ def validate_path_within_root(candidate: Path, root: Path, *, label: str) -> Pat
     resolved_root = root.resolve(strict=False)
     if not candidate.is_absolute():
         candidate = resolved_root / candidate
-    # codeql[py/path-injection] Candidate paths are resolved under and checked against the trusted workspace root below.
+    # Candidate paths are resolved under and checked against the trusted workspace root below.
+    # codeql[py/path-injection]
     resolved_candidate = candidate.resolve(strict=False)
     try:
         resolved_candidate.relative_to(resolved_root)
@@ -194,7 +195,8 @@ def role_for_payload_path(path: str) -> str:
 def subject_for_file(path: Path, *, name: str, role: str) -> dict[str, Any]:
     return {
         "path": name,
-        # codeql[py/path-injection] Subject paths are constants or workspace-validated payload paths before this helper is called.
+        # Subject paths are constants or workspace-validated payload paths before this helper is called.
+        # codeql[py/path-injection]
         "bytes": path.stat().st_size,
         "sha256": sha256_file(path),
         "role": role,
@@ -214,8 +216,12 @@ def proof_subjects(
             raise ProofPackError("missing required eBPF object for build_ebpf=true proof")
     else:
         safe_ebpf_object = validate_path_within_root(ebpf_object, workspace_root, label="eBPF object")
+        # eBPF object path is fixed under the workspace before subject collection.
+        # codeql[py/path-injection]
         if require_ebpf_object and not safe_ebpf_object.exists():
             raise ProofPackError(f"missing required eBPF object for build_ebpf=true proof: {safe_ebpf_object}")
+        # eBPF object path is fixed under the workspace before subject collection.
+        # codeql[py/path-injection]
         if safe_ebpf_object.exists():
             subjects.append(
                 subject_for_file(
@@ -244,13 +250,15 @@ def load_required_content_provenance_paths() -> tuple[str, ...]:
 
 
 def load_path_trees(ebpf_provenance: Path | None, *, require: bool) -> dict[str, Any]:
-    # codeql[py/path-injection] eBPF provenance path is the fixed workspace-relative canonical provenance file.
+    # eBPF provenance path is the fixed workspace-relative canonical provenance file.
+    # codeql[py/path-injection]
     if ebpf_provenance is None or not ebpf_provenance.exists():
         if require:
             raise ProofPackError("missing required eBPF provenance for content-addressed proof")
         return {}
     try:
-        # codeql[py/path-injection] eBPF provenance path is the fixed workspace-relative canonical provenance file.
+        # eBPF provenance path is the fixed workspace-relative canonical provenance file.
+        # codeql[py/path-injection]
         document = json.loads(ebpf_provenance.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise ProofPackError(f"invalid eBPF provenance JSON: {exc}") from exc
@@ -307,7 +315,11 @@ def write_subject_checksums(
             raise ProofPackError(f"unsupported subject digest for {subject['path']}: {digest}")
         lines.append(f"{digest[len('sha256:') :]}  {subject['path']}")
     safe_checksum_path = validate_path_within_root(checksum_path, workspace_root, label="subject checksums")
+    # Checksum output is fixed under the workspace proof-pack upload directory.
+    # codeql[py/path-injection]
     safe_checksum_path.parent.mkdir(parents=True, exist_ok=True)
+    # Checksum output is fixed under the workspace proof-pack upload directory.
+    # codeql[py/path-injection]
     safe_checksum_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -91,6 +91,13 @@ class PullRequest:
 class GatedPathConfig:
     all_gate_prefixes: tuple[str, ...]
     all_gate_paths: frozenset[str]
+    content_provenance_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ContentTreeComparison:
+    accepted: bool
+    diagnostics: tuple[str, ...]
 
 
 class GitHubApi:
@@ -186,6 +193,7 @@ def load_gated_path_config() -> GatedPathConfig:
     return GatedPathConfig(
         all_gate_prefixes=tuple(str(path) for path in manifest["all_gate_prefixes"]),
         all_gate_paths=frozenset(str(path) for path in manifest["all_gate_paths"]),
+        content_provenance_paths=tuple(str(path) for path in manifest["content_provenance_paths"]),
     )
 
 
@@ -286,6 +294,71 @@ def classify_files(files: Iterable[str]) -> Classification:
         if reason:
             reasons.append(reason)
     return Classification(gate=gate, reasons=tuple(reasons))
+
+
+def content_provenance_covers_path(path: str, config: GatedPathConfig | None = None) -> bool:
+    gated_paths = config or load_gated_path_config()
+    return any(starts(path, prefix) for prefix in gated_paths.content_provenance_paths)
+
+
+def uncovered_content_provenance_files(files: Iterable[str]) -> tuple[str, ...]:
+    gated_paths = load_gated_path_config()
+    uncovered: list[str] = []
+    for path in files:
+        gate, _reason = classify_file(path)
+        if gate == Gate.NONE:
+            continue
+        if not content_provenance_covers_path(path, gated_paths):
+            uncovered.append(path)
+    return tuple(uncovered)
+
+
+def extract_proof_path_tree_oids(manifest: dict[str, object]) -> tuple[dict[str, str], tuple[str, ...]]:
+    gated_paths = load_gated_path_config()
+    raw_content = manifest.get("content_provenance")
+    if not isinstance(raw_content, dict):
+        return {}, ("proof manifest missing content_provenance object",)
+    raw_trees = raw_content.get("path_trees")
+    if not isinstance(raw_trees, dict):
+        return {}, ("proof manifest missing content_provenance.path_trees object",)
+
+    oids: dict[str, str] = {}
+    diagnostics: list[str] = []
+    for path in gated_paths.content_provenance_paths:
+        raw_entry = raw_trees.get(path)
+        if not isinstance(raw_entry, dict):
+            diagnostics.append(f"{path}: missing proof tree entry")
+            continue
+        oid = raw_entry.get("oid")
+        error = raw_entry.get("error")
+        if not isinstance(oid, str) or not oid:
+            diagnostics.append(f"{path}: missing proof tree oid")
+            continue
+        if error not in (None, ""):
+            diagnostics.append(f"{path}: proof tree error {error!r}")
+            continue
+        oids[path] = oid
+    return oids, tuple(diagnostics)
+
+
+def compare_content_path_trees(
+    proof_manifest: dict[str, object],
+    current_trees: dict[str, str],
+) -> ContentTreeComparison:
+    proof_oids, diagnostics = extract_proof_path_tree_oids(proof_manifest)
+    if diagnostics:
+        return ContentTreeComparison(False, diagnostics)
+
+    mismatches: list[str] = []
+    for path, proof_oid in proof_oids.items():
+        current_oid = current_trees.get(path)
+        if not current_oid:
+            mismatches.append(f"{path}: missing current tree oid")
+        elif current_oid != proof_oid:
+            mismatches.append(f"{path}: proof tree {proof_oid} != current tree {current_oid}")
+    if mismatches:
+        return ContentTreeComparison(False, tuple(mismatches))
+    return ContentTreeComparison(True, ())
 
 
 def accepted_gates(expected: Gate) -> set[str]:
@@ -723,6 +796,8 @@ def self_test() -> None:
     assert "crates/assay-runner-core/" in gated_paths.all_gate_prefixes
     assert ".github/actions/canonical-ebpf-build/action.yml" in gated_paths.all_gate_paths
     assert GATED_PATHS_DOC in gated_paths.all_gate_paths
+    assert "crates/assay-runner-core" in gated_paths.content_provenance_paths
+    assert "scripts/ci" in gated_paths.content_provenance_paths
 
     cases = [
         (["docs/reference/runner/ci-lanes.md"], Gate.NONE),
@@ -796,6 +871,9 @@ def self_test() -> None:
     assert recorded_gate_ok("- gates=all", Gate.OPENAI_AGENTS_KERNEL_POLICY)
     assert not recorded_gate_ok("- gate: kernel-only", Gate.ALL)
     assert not recorded_gate_ok("- gate: kernel-only", Gate.OPENAI_AGENTS_KERNEL_POLICY)
+    assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
+    assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
+    _test_content_tree_comparison()
 
     valid_run = {
         "name": DELEGATED_WORKFLOW_NAME,
@@ -833,6 +911,56 @@ def self_test() -> None:
     # touching the classifier itself, including any future PR that
     # might silently re-introduce a spike dependency.
     _assert_assay_cli_does_not_consume_spike()
+
+
+def _test_content_tree_comparison() -> None:
+    gated_paths = load_gated_path_config()
+    proof_manifest = {
+        "content_provenance": {
+            "path_trees": {
+                path: {"oid": f"oid:{path}", "error": None}
+                for path in gated_paths.content_provenance_paths
+            }
+        }
+    }
+    current = {
+        path: f"oid:{path}"
+        for path in gated_paths.content_provenance_paths
+    }
+    accepted = compare_content_path_trees(proof_manifest, current)
+    assert accepted.accepted, accepted.diagnostics
+
+    changed = dict(current)
+    changed[gated_paths.content_provenance_paths[0]] = "different"
+    mismatch = compare_content_path_trees(proof_manifest, changed)
+    assert not mismatch.accepted
+    assert "!=" in mismatch.diagnostics[0]
+
+    missing_entry_manifest = {
+        "content_provenance": {
+            "path_trees": {
+                path: {"oid": f"oid:{path}", "error": None}
+                for path in gated_paths.content_provenance_paths[1:]
+            }
+        }
+    }
+    missing = compare_content_path_trees(missing_entry_manifest, current)
+    assert not missing.accepted
+    assert "missing proof tree entry" in missing.diagnostics[0]
+
+    error_manifest = {
+        "content_provenance": {
+            "path_trees": {
+                path: {"oid": f"oid:{path}", "error": None}
+                for path in gated_paths.content_provenance_paths
+            }
+        }
+    }
+    first = gated_paths.content_provenance_paths[0]
+    error_manifest["content_provenance"]["path_trees"][first]["error"] = "missing_at_head"
+    error = compare_content_path_trees(error_manifest, current)
+    assert not error.accepted
+    assert "proof tree error" in error.diagnostics[0]
 
 
 def _test_event_resolution_and_status_payload() -> None:


### PR DESCRIPTION
## Summary

Layer 2 producer-side delegated proof hardening:

- emit delegated proof-pack manifest v1 with attestation subjects, source metadata, gate inputs, content-provenance path trees, and explicit claim ceiling
- fail closed when required content-provenance path trees are missing, null, or errored
- include the Gemini gate in `gates=all` proof-pack collection so the manifest matches the delegated workflow
- write a deterministic `subject-checksums.txt` for `target/assay-ebpf.o`, `manifest.json`, eBPF provenance, and retained gate payload files
- attest those subjects in `Runner Spike Delegated` with SHA-pinned `actions/attest@v4.1.1`, then retain the Sigstore bundle inside the uploaded proof-pack artifact
- add lane-check content-tree comparison primitives and self-tests for the next verifier slice

## Claim ceiling

This PR makes the delegated run produce an attested proof pack. It does **not** yet make lane-check accept attestation proof. The existing PR comment/status contract remains the active merge gate until a real attested delegated proof pack from this PR is used to implement and verify the consumer-side lane-check path.

## Verification

Local:

- `python3 -m py_compile scripts/ci/assay_runner_delegated_proof_pack.py scripts/ci/assay_runner_lane_check.py`
- `python3 scripts/ci/assay_runner_delegated_proof_pack.py --self-test`
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `actionlint .github/workflows/runner-spike-delegated.yml`
- `uvx ruff check scripts/ci/assay_runner_delegated_proof_pack.py scripts/ci/assay_runner_lane_check.py`
- `git diff --check`
- pre-commit hooks during commit
- pre-push hooks during push, including Linux compile gate

Expected before ready-for-review:

- ordinary PR checks green
- fresh delegated `Runner Spike Delegated` run on this branch with `gates=all`, `build_ebpf=true`
- proof-pack artifact contains `manifest.json`, `subject-checksums.txt`, `attestation-bundle.json`, and manifest v1 content-provenance path trees


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delegated proof attestation support to CI, including a retained attestation bundle and updated job summary details.
  * Improved proof-pack generation to include richer metadata and checksum output for verification.
  * Expanded validation so content provenance is checked against the current build output.

* **Bug Fixes**
  * Tightened path handling and provenance checks to reduce invalid or incomplete proof data.
  * Added clearer diagnostics when proof content does not match expected tree data.

* **Documentation**
  * Updated pinned action references and rollout planning notes for the new attestation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->