### PR TITLE
ci: preserve queued bpf-host runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,7 @@ jobs:
     concurrency:
       group: assay-bpf-runner-host
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: read
     # Self-hosted runner has Rust in /opt/rust; jobs run with --noprofile so PATH can be minimal.

--- a/.github/workflows/host-capability-proof.yml
+++ b/.github/workflows/host-capability-proof.yml
@@ -28,6 +28,7 @@ concurrency:
   # moved to an ephemeral runner model.
   group: assay-bpf-runner-host
   cancel-in-progress: false
+  queue: max
 
 jobs:
   proof:

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -292,6 +292,7 @@ jobs:
     concurrency:
       group: assay-bpf-runner-host
       cancel-in-progress: false
+      queue: max
     steps:
       - name: Nuke _actions cache (force fresh download for next job)
         shell: bash
@@ -341,6 +342,7 @@ jobs:
     concurrency:
       group: assay-bpf-runner-host
       cancel-in-progress: false
+      queue: max
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -20,6 +20,7 @@ permissions:
 concurrency:
   group: assay-bpf-runner-host
   cancel-in-progress: false
+  queue: max
 
 jobs:
   smoke:

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -28,6 +28,7 @@ concurrency:
   # downloaded-action cache state cannot race between back-to-back dispatches.
   group: assay-bpf-runner-host
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare-delegated-runner:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,14 @@ repos:
     rev: v1.7.10
     hooks:
       - id: actionlint
-        args: ["-config-file", ".github/actionlint.yaml"]
+        # GitHub Actions added concurrency.queue in May 2026; actionlint has not
+        # caught up yet (rhysd/actionlint#657). Keep all other actionlint checks
+        # active and remove this targeted ignore once upstream supports the key.
+        args:
+          - "-config-file"
+          - ".github/actionlint.yaml"
+          - "-ignore"
+          - 'unexpected key "queue" for "concurrency" section'
         files: ^\.github/workflows/.*\.ya?ml$
 
   # shellcheck (bash) — use system binary to avoid SSL/download issues

--- a/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
+++ b/docs/superpowers/plans/2026-07-03-runner-delegated-proof-hardening.md
@@ -25,7 +25,7 @@ Ship as the first PR.
 Known Layer 1 semantics:
 
 - The commit-status context emitted by lane-check is `lane-check/proof`, deliberately separate from the Actions job named `lane-check`. If the refresh path should satisfy branch protection without manually rerunning the pull-request check, `lane-check/proof` must be configured as the required status.
-- GitHub Actions added `queue: max` for concurrency groups in May 2026, which would remove the default single-pending-slot eviction behavior. Do not add it while the repository's required `actionlint` hook rejects that key; either update/configure the linter first or ship the queue change in its own compatibility PR. Layer 3 still moves the host to an ephemeral-runner model so serialization is not also a workspace-contamination boundary.
+- GitHub Actions added `queue: max` for concurrency groups in May 2026, which removes the default single-pending-slot eviction behavior. The bpf-host workflows now opt into that queue so delegated proofs, smoke runs, and kernel-matrix jobs are serialized instead of evicting each other. Upstream `actionlint` does not recognize the key yet (rhysd/actionlint#657), so the pre-commit hook carries a targeted parser-lag ignore until that support lands. Layer 3 still moves the host to an ephemeral-runner model so serialization is not also a workspace-contamination boundary.
 
 Non-goals for Layer 1:
 


### PR DESCRIPTION
## Summary

Restore the GitHub Actions `queue: max` setting on every workflow/job that shares the singleton `assay-bpf-runner-host` concurrency group.

This keeps delegated proofs, monitor attach smoke, host-capability proof, the self-hosted CI eBPF smoke, and kernel-matrix jobs serialized without GitHub's default one-pending-slot eviction. The default behavior can silently cancel a queued proof when a third host job arrives; `queue: max` allows up to 100 pending runs in the group.

## Scope

- Add `queue: max` to all `assay-bpf-runner-host` concurrency blocks.
- Keep `cancel-in-progress: false`; GitHub explicitly disallows `queue: max` with `cancel-in-progress: true`.
- Keep actionlint active, with a targeted temporary ignore for the known upstream parser lag (`rhysd/actionlint#657`) until actionlint recognizes `concurrency.queue`.
- Update the runner delegated proof hardening plan to record the compatibility state.

## Claim ceiling

This preserves queued host work and prevents pending-slot eviction. It does not make the persistent self-hosted runner safe against workspace contamination by itself; Layer 3 still moves the bpf host to an ephemeral runner model.

## Verification

- `pre-commit run actionlint --all-files`
- `actionlint -config-file .github/actionlint.yaml -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/monitor-attach-smoke.yml .github/workflows/host-capability-proof.yml .github/workflows/runner-spike-delegated.yml .github/workflows/ci.yml .github/workflows/kernel-matrix.yml`
- `git diff --check`
- pre-push hooks: merge-conflict, YAML, token hygiene, typos, actionlint, cargo fmt, cargo clippy, linux compile gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow queue handling so repeated runs are queued more predictably instead of being skipped or interrupted.
  * Applied this behavior across several CI and runner-related workflows to make scheduled and back-to-back checks more reliable.

* **Documentation**
  * Updated the hardening plan to reflect the new queueing behavior and the temporary linting workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->