### PR TITLE
chore(release): prepare v3.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.32.0] - 2026-07-04
+
+### Added
+- Add the `gateway-evidence-replay` workspace crate: a deterministic offline replay verifier for
+  retained gateway-path evidence, with `gateway-path.v0` contract fixtures and a four-bundle demo. It
+  verifies only the retained path facts and explicitly does not claim provider honesty, model-output
+  truth, policy compliance, or end-to-end action trust.
+- Add skill supply-chain evidence commands to the Assay CLI:
+  - `assay evidence capture-skill-supply-chain`
+  - `assay evidence verify-skill-supply-chain`
+  - `assay evidence project-skill-bom`
+  - `assay evidence adapt-skill-scan`
+  The flow captures skill supply-chain facts, verifies the retained carrier, projects CycloneDX SBOM
+  evidence, and adapts scanner output to SARIF without turning those facts into a trust score.
+- Add gateway replay Gate-D demo docs and implemented-standards references, including the standalone
+  `gateway-evidence-replay` ecosystem pointer.
+
+### Changed
+- Harden the delegated runner proof layer: canonical eBPF build provenance, attested delegated proof
+  packs, content-addressed proof acceptance, stricter hostile-input limits, and self-tests for the
+  proof consumer path.
+- Simplify and harden CI workflows: preserve queued bpf-host runs, follow artifact redirects safely,
+  reduce workflow hot-path cost, archive obsolete experiment workflows, and consolidate ADR-025
+  nightly evidence into one sequenced informational workflow while preserving the readiness artifact
+  contract during the transition.
+- Update public discovery metadata (`CITATION.cff`, `README.md`, `llms.txt`, and PyPI keywords).
+
+### Fixed
+- Strip C1 terminal controls in render-safety handling.
+- Harden skill capture symlink containment.
+- Fix the eBPF LSM emit path to write current `MonitorEvent` records, with attach-smoke coverage for
+  ABI skew.
+- Resolve eBPF artifact paths from Cargo JSON messages instead of filesystem guessing.
+- Close shell-injection risk in MCP registry publish tag resolution and tighten workflow token
+  permissions.
+
 ## [3.31.1] - 2026-06-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "aya",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1770,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "3.31.1"
+version = "3.32.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4524,7 +4524,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5099,7 +5099,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5926,7 +5926,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.31.1"
+version = "3.32.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
## Summary
- bump the workspace package version to 3.32.0
- update CHANGELOG.md for the gateway replay, skill supply-chain, runner-proof, workflow-hardening, and security-fix wave
- refresh Cargo.lock for the workspace version bump

## Verification
- cargo metadata --no-deps --format-version 1
- cargo check -p assay-cli -p gateway-evidence-replay --locked
- pre-commit run --files CHANGELOG.md Cargo.toml Cargo.lock
- cargo publish -p assay-cli --dry-run --locked
- pre-push hooks: cargo fmt, cargo audit, cargo clippy, linux compile gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new workspace and CLI capabilities for replaying evidence and managing supply-chain evidence workflows.
  * Expanded gateway replay documentation for the demo environment.

* **Bug Fixes**
  * Improved terminal output safety, symlink containment, and event-path handling.
  * Fixed artifact path resolution and reduced publish-related token and tag risks.

* **Chores**
  * Updated the release version to 3.32.0.
  * Included broader CI and metadata hardening improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->