### PR TITLE
feat(mcp): add denied-call observation carrier (assay.denied_call_observation.v0)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -70,6 +70,11 @@ enum Mode {
         /// fails closed (it is not forwarded).
         #[arg(long)]
         enforcement_decision_out: Option<PathBuf>,
+        /// Optional NDJSON path for `assay.denied_call_observation.v0`: one record per answered
+        /// proxy denial, retaining a digest/projection of the caller-visible denial surface. This is
+        /// an observation carrier, not a policy verdict.
+        #[arg(long)]
+        denied_call_observation_out: Option<PathBuf>,
         /// Optional NDJSON path for the per-call `assay.manifest_establish.v0` carrier (Increment 2c):
         /// one record per `tools/call` describing the establish JOURNEY (path + run_outcome), sibling to
         /// and separate from `assay.enforcement_decision.v0` (the verdict carrier). It carries no raw
@@ -153,6 +158,7 @@ async fn main() -> Result<()> {
             enforce_policy,
             declared_mcp_manifest,
             enforcement_decision_out,
+            denied_call_observation_out,
             manifest_establish_out,
             tool_conformance_out,
             manifest_establish_budget_ms,
@@ -191,6 +197,7 @@ async fn main() -> Result<()> {
                     policy: Some(policy),
                     baseline: Some(baseline),
                     decision_out: enforcement_decision_out,
+                    denied_call_observation_out,
                     establish_out: manifest_establish_out,
                     tool_conformance_out,
                     establish_budget: std::time::Duration::from_millis(budget_ms),

--- a/crates/assay-mcp-server/src/proxy/call.rs
+++ b/crates/assay-mcp-server/src/proxy/call.rs
@@ -9,12 +9,16 @@ use super::establish_runner::{run_establish, EstablishRunOutcome};
 use super::io::{
     append_decision_record, forward_line, proxy_error_line, PROXY_DENIED, PROXY_FAILED,
 };
-use super::{annotation_conformance, enforce, establish, observer::Observer, relay_routing};
+use super::{
+    annotation_conformance, denied_observation, enforce, establish, observer::Observer,
+    relay_routing,
+};
 
 pub(super) struct EnforcementRuntime<'a> {
     pub(super) policy: &'a enforce::EnforcePolicy,
     pub(super) baseline: &'a enforce::DeclaredManifest,
     pub(super) decision_out: &'a Option<PathBuf>,
+    pub(super) denied_call_observation_out: &'a Option<PathBuf>,
     pub(super) establish_out: &'a Option<PathBuf>,
     pub(super) tool_conformance_out: &'a Option<PathBuf>,
     pub(super) establish_budget: Duration,
@@ -179,12 +183,24 @@ pub(super) async fn handle_tools_call<W: AsyncWriteExt + Unpin>(
         // A deny stands regardless of a record-write failure; a missing deny-record is logged above.
         match v.get("id") {
             Some(id) if !id.is_null() => {
-                let _ = runtime.tx.send(proxy_error_line(
+                let response_line = proxy_error_line(
                     id.clone(),
                     PROXY_DENIED,
                     decision.reason,
                     &format!("tools/call denied by enforcing proxy: {}", decision.reason),
-                ));
+                );
+                if let Some(path) = runtime.denied_call_observation_out {
+                    let record = denied_observation::denied_call_observation_record(
+                        tool_name,
+                        decision.target_digest.as_deref(),
+                        PROXY_DENIED,
+                        decision.reason,
+                        &response_line,
+                    );
+                    let _ =
+                        append_record_or_log("denied_call_observation_write_failed", path, &record);
+                }
+                let _ = runtime.tx.send(response_line);
             }
             _ => { /* denied notification: nothing to answer, drop it */ }
         }

--- a/crates/assay-mcp-server/src/proxy/denied_observation.rs
+++ b/crates/assay-mcp-server/src/proxy/denied_observation.rs
@@ -1,0 +1,72 @@
+//! Caller-visible denial observation carrier.
+//!
+//! This is deliberately separate from `assay.enforcement_decision.v0`: it records that the proxy
+//! answered the caller with a proxy-originated denial surface. It does not decide policy and does not
+//! assert anything about the upstream side effect.
+
+use assay_mcp_server::tool_decision::sanitize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+pub const DENIED_CALL_OBSERVATION_SCHEMA: &str = "assay.denied_call_observation.v0";
+
+pub fn denied_call_observation_record(
+    tool_name: &str,
+    target_digest: Option<&str>,
+    error_code: i32,
+    reason: &str,
+    caller_visible_response_line: &str,
+) -> Value {
+    json!({
+        "schema": DENIED_CALL_OBSERVATION_SCHEMA,
+        "call": {
+            "tool_name": sanitize(tool_name),
+            "target_digest": target_digest,
+        },
+        "caller_visible_error": {
+            "code": error_code,
+            "origin": "assay-proxy",
+            "reason": reason,
+        },
+        "caller_visible_response_digest": sha256_bytes(caller_visible_response_line.as_bytes()),
+        "non_claims": [
+            "caller-visible proxy denial observation only; policy decision lives in assay.enforcement_decision.v0",
+            "does not assert or verify the upstream side effect",
+            "does not assert maliciousness, safety, approval, or whole-action trust",
+            "must not be read as a replacement for the bound enforcement decision record"
+        ]
+    })
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_is_observation_not_verdict() {
+        let response = r#"{"jsonrpc":"2.0","id":9,"error":{"code":-32042,"message":"tools/call denied by enforcing proxy: credential_scope","data":{"origin":"assay-proxy","reason":"credential_scope"}}}"#;
+        let rec = denied_call_observation_record(
+            "github.add_deploy_key",
+            Some("sha256:abc"),
+            -32042,
+            "credential_scope",
+            response,
+        );
+
+        assert_eq!(rec["schema"], DENIED_CALL_OBSERVATION_SCHEMA);
+        assert_eq!(rec["call"]["tool_name"], "github.add_deploy_key");
+        assert_eq!(rec["call"]["target_digest"], "sha256:abc");
+        assert_eq!(rec["caller_visible_error"]["origin"], "assay-proxy");
+        assert!(rec["caller_visible_response_digest"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:"));
+        assert!(rec.get("decision").is_none());
+        assert!(rec.get("target").is_none());
+        assert!(rec.get("arguments").is_none());
+    }
+}

--- a/crates/assay-mcp-server/src/proxy/enforce/policy.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce/policy.rs
@@ -13,6 +13,10 @@ pub struct EnforceInputs {
     pub policy: Option<EnforcePolicy>,
     pub baseline: Option<DeclaredManifest>,
     pub decision_out: Option<PathBuf>,
+    /// Optional NDJSON path for `assay.denied_call_observation.v0`: the caller-visible proxy-deny
+    /// surface, bound to the call's tool and target digest when classification provides one. This is
+    /// an observation carrier, not the policy verdict.
+    pub denied_call_observation_out: Option<PathBuf>,
     pub establish_out: Option<PathBuf>,
     /// Optional NDJSON path for the per-call `assay.tool_annotation_conformance.v0` carrier
     /// (Increment 5b): the server's declared annotation hints vs Assay's observed call

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -17,6 +17,7 @@
 //! "how completely was it observed" lives in the separate observation-health artifact, never folded in.
 
 pub mod annotation_conformance;
+pub mod denied_observation;
 pub mod enforce;
 pub mod establish;
 pub mod relay_routing;
@@ -75,6 +76,7 @@ pub async fn run(
         policy,
         baseline,
         decision_out,
+        denied_call_observation_out,
         establish_out,
         tool_conformance_out,
         establish_budget,
@@ -251,6 +253,7 @@ pub async fn run(
                     policy,
                     baseline,
                     decision_out: &decision_out,
+                    denied_call_observation_out: &denied_call_observation_out,
                     establish_out: &establish_out,
                     tool_conformance_out: &tool_conformance_out,
                     establish_budget,

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -8,6 +8,8 @@
 
 #[path = "proxy_enforce_pdp_e2e/conformance.rs"]
 mod conformance;
+#[path = "proxy_enforce_pdp_e2e/denied_observation.rs"]
+mod denied_observation;
 #[path = "proxy_enforce_pdp_e2e/drift_allow.rs"]
 mod drift_allow;
 #[path = "proxy_enforce_pdp_e2e/establish.rs"]

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/denied_observation.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/denied_observation.rs
@@ -1,0 +1,149 @@
+use serde_json::Value;
+use std::io::BufReader;
+use std::process::{Command, Stdio};
+
+use crate::support::*;
+
+fn spawn_enforce_with_denied_observations(
+    log: &std::path::Path,
+    policy: &std::path::Path,
+    denied_observations: &std::path::Path,
+) -> std::process::Child {
+    Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "proxy-enforce",
+            "--upstream-command",
+            python(),
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            mock_path().to_str().unwrap(),
+            "--enforce-policy",
+            policy.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            approved_baseline_path().to_str().unwrap(),
+            "--denied-call-observation-out",
+            denied_observations.to_str().unwrap(),
+        ])
+        .env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_MODE", "normal")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy")
+}
+
+fn read_denied_observation_records(path: &std::path::Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("denied observation record JSON"))
+        .collect()
+}
+
+#[test]
+fn denied_call_observation_records_caller_visible_proxy_denial_without_becoming_verdict() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let denied_observations = dir.path().join("denied_observations.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_with_denied_observations(&log, &policy, &denied_observations);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 19,
+            "method": "tools/call",
+            "params": {
+                "name": "github.add_deploy_key",
+                "arguments": {"owner": "acme", "repo": "prod-app"}
+            }
+        }),
+    );
+    let response = read_response(&mut out);
+    assert_eq!(response["error"]["code"], PROXY_DENIED);
+    assert_eq!(response["error"]["data"]["origin"], "assay-proxy");
+    assert_eq!(
+        response["error"]["data"]["reason"],
+        "manifest_current_observation_incomplete"
+    );
+    shutdown(child, stdin);
+
+    let records = read_denied_observation_records(&denied_observations);
+    assert_eq!(
+        records.len(),
+        1,
+        "one denied observation per answered denial"
+    );
+    let rec = &records[0];
+    assert_eq!(rec["schema"], "assay.denied_call_observation.v0");
+    assert_eq!(rec["call"]["tool_name"], "github.add_deploy_key");
+    assert!(
+        rec["call"]["target_digest"]
+            .as_str()
+            .is_some_and(|digest| digest.starts_with("sha256:")),
+        "record must bind to the classified call target: {rec}"
+    );
+    assert_eq!(rec["caller_visible_error"]["code"], PROXY_DENIED);
+    assert_eq!(rec["caller_visible_error"]["origin"], "assay-proxy");
+    assert_eq!(
+        rec["caller_visible_error"]["reason"],
+        "manifest_current_observation_incomplete"
+    );
+    assert!(
+        rec["caller_visible_response_digest"]
+            .as_str()
+            .is_some_and(|digest| digest.starts_with("sha256:")),
+        "record must retain a digest of the exact caller-visible response: {rec}"
+    );
+    assert!(
+        rec.get("decision").is_none(),
+        "observation carrier must not become a verdict carrier"
+    );
+    assert!(rec["non_claims"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|claim| claim.as_str().unwrap().contains("policy decision")));
+}
+
+#[test]
+fn denied_call_observation_flag_off_writes_no_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let denied_observations = dir.path().join("denied_observations.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "tools/call",
+            "params": {
+                "name": "github.add_deploy_key",
+                "arguments": {"owner": "acme", "repo": "prod-app"}
+            }
+        }),
+    );
+    let response = read_response(&mut out);
+    assert_eq!(response["error"]["code"], PROXY_DENIED);
+    shutdown(child, stdin);
+
+    assert!(
+        !denied_observations.exists(),
+        "denied observation file is opt-in"
+    );
+}

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -283,6 +283,26 @@ regardless (a missing deny-record is a completeness gap, logged, not a safety ga
   one. They never overlap: one is "could the mechanism enforce", the other is "what did the proxy
   decide for this call".
 
+## 11a. Denied-call observation record (separate carrier)
+
+The `assay.denied_call_observation.v0` artifact is an optional sibling carrier for the caller-visible
+proxy denial surface. It exists for post-hoc review of attribution claims such as "the caller saw an
+Assay proxy denial", without turning the observation into a policy verdict. The record carries the
+called tool name, the classified target digest when classification produced one, the proxy error code,
+`origin: assay-proxy`, the machine reason, and a `sha256:` digest of the exact JSON-RPC response line
+sent to the caller.
+
+**Implementation:** opt-in via `--denied-call-observation-out <path>` in `proxy-enforce`; the proxy
+appends one compact NDJSON record for each answered `proxy_denied` `tools/call`. The carrier is not
+written for allowed calls, and with the flag absent no file is created. A write failure is logged but
+does not change the denial response: the call is already fail-closed, and a missing observation record
+is a completeness gap, not a reason to synthesize a different verdict.
+
+**Non-claims:** this carrier does not decide policy, does not assert the upstream side effect, does
+not certify safety or maliciousness, and does not replace `assay.enforcement_decision.v0`. A consumer
+that wants to bind a caller-visible proxy denial to a policy decision must join this observation record
+to a digest-bound `assay.enforcement_decision.v0` deny record for the same tool and target digest.
+
 **Correlation (forward-looking, not shipped):** v0 carries no request-id, so a record is correlated to
 its call and to an upstream observation by order + content. An optional, caller-supplied, opaque
 per-call correlation id — echoed by the proxy, never minted by it (so the record stays deterministic),


### PR DESCRIPTION
## What

Adds an **opt-in** sibling carrier next to `assay.enforcement_decision.v0`: with
`--denied-call-observation-out <path>`, the enforcing proxy appends one compact NDJSON
`assay.denied_call_observation.v0` record for each answered `proxy_denied` `tools/call`.

The record retains the caller-visible denial surface, digest-bound to the call:

- `call.tool_name` + `call.target_digest` (same digest the decision record binds on)
- `caller_visible_error` — code `-32042` (`PROXY_DENIED`), `origin: assay-proxy`, the
  precedence-pinned machine reason
- `caller_visible_response_digest` — sha256 of the exact JSON-RPC response line sent to the caller
- explicit `non_claims` (observation only; no policy verdict, no upstream side-effect claim, no
  whole-action claim; not a replacement for the bound decision record)

## Why

A refusal the caller observed and the proxy's policy decision are different artifacts. Today the
decision record is retained but the caller-visible denial surface is not, so a reviewer cannot
check post-hoc whether an "the proxy denied this" reading is backed by a bound decision record.
This carrier closes that gap on the observation side while keeping the three carriers
(decision / observation / mechanism) strictly separate.

Companion consumer: ASSAY-W004 lint rule (separate PR on `codex/enforcement-attribution-w004`)
reads exactly this schema.

## Verification

- `cargo test -p assay-mcp-server denied_observation --locked`
- `cargo test -p assay-mcp-server --test proxy_enforce_pdp_e2e --locked` (incl. "writes one
  observation on denied call" and "flag off writes no file")
- `cargo clippy -p assay-mcp-server --tests --locked -- -D warnings`
- Reference doc updated (`docs/reference/mcp-upstream-proxy-enforcement.md` §11a)

Behavior is unchanged with the flag absent; a write failure is logged and never alters the denial
response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional denied-call observation output for proxy enforcement mode.
  * Proxy-denied `tools/call` requests can now emit a new NDJSON record with the tool name, target digest when available, error details, and a digest of the caller-visible response.

* **Bug Fixes**
  * Denied-call handling now writes the observation record before returning the denial response, ensuring the event is captured consistently.

* **Documentation**
  * Updated the enforcement guide with the new opt-in observation artifact and its expected contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->