### PR TITLE
feat(evidence): ASSAY-W004 enforcement-attribution binding lint

### DIFF
--- a/crates/assay-evidence/src/lint/engine.rs
+++ b/crates/assay-evidence/src/lint/engine.rs
@@ -1,6 +1,6 @@
 use super::packs::executor::{PackExecutionMeta, PackExecutor};
 use super::packs::LoadedPack;
-use super::rules::{LintContext, RULES};
+use super::rules::{LintBundleIndex, LintContext, RULES};
 use super::{LintFinding, LintReport, LintSummary, Severity};
 use crate::bundle::writer::{verify_bundle_with_limits, VerifyLimits};
 use crate::ndjson::NdjsonEvents;
@@ -128,11 +128,13 @@ fn parse_events(events_bytes: &[u8]) -> Result<Vec<EvidenceEvent>> {
 /// Run built-in lint rules on events.
 fn run_builtin_rules(events: &[EvidenceEvent]) -> Vec<LintFinding> {
     let mut findings = Vec::new();
+    let bundle_index = LintBundleIndex::from_events(events);
 
     for (line_idx, event) in events.iter().enumerate() {
         let ctx = LintContext {
             line_number: line_idx + 1,
             seq: event.seq as usize,
+            bundle_index: &bundle_index,
         };
 
         for rule in RULES {

--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -1,5 +1,9 @@
 use super::{EventLocation, LintFinding, Severity};
 use crate::types::EvidenceEvent;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+type RuleCheck = for<'a> fn(&EvidenceEvent, &LintContext<'a>) -> Option<LintFinding>;
 
 /// Rule definition for the lint registry.
 pub struct RuleDefinition {
@@ -11,13 +15,62 @@ pub struct RuleDefinition {
     /// CVSS-like security severity (0.0–10.0) for GitHub Code Scanning integration.
     /// Only set for security-relevant rules.
     pub security_severity: Option<&'static str>,
-    pub check: fn(&EvidenceEvent, &LintContext) -> Option<LintFinding>,
+    pub check: RuleCheck,
 }
 
 /// Context passed to rule checks.
-pub struct LintContext {
+pub struct LintContext<'a> {
     pub line_number: usize, // 1-indexed
     pub seq: usize,
+    pub bundle_index: &'a LintBundleIndex,
+}
+
+/// Bundle-wide structural index used by built-in lint rules.
+///
+/// Rules stay single-event callbacks, but they can consult this precomputed
+/// view when a claim can only be checked against sibling records in the same
+/// verified bundle. The index is intentionally structural: it reads pinned
+/// schema fields and never searches prose/log text.
+#[derive(Debug, Default)]
+pub struct LintBundleIndex {
+    enforcement_decisions: BTreeMap<EnforcementDecisionKey, Vec<EnforcementDecisionSummary>>,
+}
+
+impl LintBundleIndex {
+    pub fn from_events(events: &[EvidenceEvent]) -> Self {
+        let mut index = Self::default();
+        for event in events {
+            if let Some((key, decision)) = extract_enforcement_decision(event) {
+                index
+                    .enforcement_decisions
+                    .entry(key)
+                    .or_default()
+                    .push(decision);
+            }
+        }
+        index
+    }
+
+    fn enforcement_decisions_for(
+        &self,
+        key: &EnforcementDecisionKey,
+    ) -> &[EnforcementDecisionSummary] {
+        self.enforcement_decisions
+            .get(key)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct EnforcementDecisionKey {
+    tool_name: String,
+    target_digest: String,
+}
+
+#[derive(Debug)]
+struct EnforcementDecisionSummary {
+    decision: String,
 }
 
 /// Static rule registry.
@@ -58,6 +111,16 @@ pub static RULES: &[RuleDefinition] = &[
         security_severity: Some("6.5"),
         check: check_secrets_flag_consistency,
     },
+    RuleDefinition {
+        id: "ASSAY-W004",
+        default_severity: Severity::Warn,
+        description:
+            "Observed enforcement marker is not supported by a bound enforcement decision record",
+        help_uri: Some("https://docs.assay.dev/lint/ASSAY-W004"),
+        tags: &["security", "enforcement", "attribution"],
+        security_severity: Some("4.0"),
+        check: check_enforcement_attribution_binding,
+    },
 ];
 
 /// Patterns that suggest secrets in subjects.
@@ -77,7 +140,7 @@ const SECRET_PATTERNS: &[&str] = &[
     "github_pat_",
 ];
 
-fn check_secret_in_subject(event: &EvidenceEvent, ctx: &LintContext) -> Option<LintFinding> {
+fn check_secret_in_subject(event: &EvidenceEvent, ctx: &LintContext<'_>) -> Option<LintFinding> {
     let subject = event.subject.as_deref()?;
     let lower = subject.to_lowercase();
 
@@ -105,7 +168,7 @@ fn check_secret_in_subject(event: &EvidenceEvent, ctx: &LintContext) -> Option<L
     None
 }
 
-fn check_pii_flag_consistency(event: &EvidenceEvent, ctx: &LintContext) -> Option<LintFinding> {
+fn check_pii_flag_consistency(event: &EvidenceEvent, ctx: &LintContext<'_>) -> Option<LintFinding> {
     if event.contains_pii && event.subject.as_deref().filter(|s| !s.is_empty()).is_some() {
         return Some(
             LintFinding::new(
@@ -125,7 +188,7 @@ fn check_pii_flag_consistency(event: &EvidenceEvent, ctx: &LintContext) -> Optio
     None
 }
 
-fn check_source_format(event: &EvidenceEvent, ctx: &LintContext) -> Option<LintFinding> {
+fn check_source_format(event: &EvidenceEvent, ctx: &LintContext<'_>) -> Option<LintFinding> {
     // Convention: source should be urn: or https:// scheme
     if !event.source.starts_with("urn:") && !event.source.starts_with("https://") {
         return Some(
@@ -149,7 +212,10 @@ fn check_source_format(event: &EvidenceEvent, ctx: &LintContext) -> Option<LintF
     None
 }
 
-fn check_secrets_flag_consistency(event: &EvidenceEvent, ctx: &LintContext) -> Option<LintFinding> {
+fn check_secrets_flag_consistency(
+    event: &EvidenceEvent,
+    ctx: &LintContext<'_>,
+) -> Option<LintFinding> {
     // If subject contains a secret pattern but contains_secrets is false, warn
     if let Some(subject) = &event.subject {
         let lower = subject.to_lowercase();
@@ -175,4 +241,86 @@ fn check_secrets_flag_consistency(event: &EvidenceEvent, ctx: &LintContext) -> O
         }
     }
     None
+}
+
+fn check_enforcement_attribution_binding(
+    event: &EvidenceEvent,
+    ctx: &LintContext<'_>,
+) -> Option<LintFinding> {
+    let key = extract_proxy_refusal_marker(event)?;
+    let decisions = ctx.bundle_index.enforcement_decisions_for(&key);
+
+    if decisions.iter().any(|record| record.decision == "deny") {
+        return None;
+    }
+
+    let message = if decisions.iter().any(|record| record.decision == "allow") {
+        format!(
+            "Observed response carries an enforcement marker for '{}' but is contradicted by a digest-bound allow record",
+            key.tool_name
+        )
+    } else {
+        format!(
+            "Observed response carries an enforcement marker for '{}' but no digest-bound assay.enforcement_decision.v0 deny record was retained",
+            key.tool_name
+        )
+    };
+
+    Some(
+        LintFinding::new(
+            "ASSAY-W004",
+            Severity::Warn,
+            message,
+            Some(EventLocation {
+                seq: ctx.seq,
+                line: ctx.line_number,
+                event_type: Some(event.type_.clone()),
+            }),
+            vec![
+                "security".into(),
+                "enforcement".into(),
+                "attribution".into(),
+            ],
+        )
+        .with_help_uri("https://docs.assay.dev/lint/ASSAY-W004"),
+    )
+}
+
+fn extract_enforcement_decision(
+    event: &EvidenceEvent,
+) -> Option<(EnforcementDecisionKey, EnforcementDecisionSummary)> {
+    let payload = &event.payload;
+    if payload.get("schema").and_then(Value::as_str) != Some("assay.enforcement_decision.v0") {
+        return None;
+    }
+
+    let key = EnforcementDecisionKey {
+        tool_name: non_empty(payload.pointer("/tool/name")?.as_str()?)?.to_string(),
+        target_digest: non_empty(payload.pointer("/action/target_digest")?.as_str()?)?.to_string(),
+    };
+    let decision = non_empty(payload.get("decision")?.as_str()?)?.to_string();
+
+    Some((key, EnforcementDecisionSummary { decision }))
+}
+
+fn extract_proxy_refusal_marker(event: &EvidenceEvent) -> Option<EnforcementDecisionKey> {
+    let payload = &event.payload;
+    let observed_response = payload.get("observed_response")?.as_str()?;
+    let response: Value = serde_json::from_str(observed_response).ok()?;
+    if response.pointer("/error/data/assay_proxy")?.as_str()? != "deny" {
+        return None;
+    }
+
+    Some(EnforcementDecisionKey {
+        tool_name: non_empty(payload.pointer("/call/tool_name")?.as_str()?)?.to_string(),
+        target_digest: non_empty(payload.pointer("/call/target_digest")?.as_str()?)?.to_string(),
+    })
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
 }

--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -256,12 +256,12 @@ fn check_enforcement_attribution_binding(
 
     let message = if decisions.iter().any(|record| record.decision == "allow") {
         format!(
-            "Observed response carries an enforcement marker for '{}' but is contradicted by a digest-bound allow record",
+            "Denied-call observation for '{}' is contradicted by a digest-bound allow record",
             key.tool_name
         )
     } else {
         format!(
-            "Observed response carries an enforcement marker for '{}' but no digest-bound assay.enforcement_decision.v0 deny record was retained",
+            "Denied-call observation for '{}' is not backed by a digest-bound assay.enforcement_decision.v0 deny record",
             key.tool_name
         )
     };
@@ -303,19 +303,24 @@ fn extract_enforcement_decision(
     Some((key, EnforcementDecisionSummary { decision }))
 }
 
-// The marker is the SHIPPED proxy deny wire shape (assay-mcp-server/src/proxy/io.rs):
-// `PROXY_DENIED = -32042` with `error.data.origin == "assay-proxy"`. Both are required so an
-// upstream error that merely reuses the code, or a data blob that merely names the origin,
-// does not read as an enforcement marker.
+// The marker is the SHIPPED denied-call observation carrier
+// (assay-mcp-server/src/proxy/denied_observation.rs): schema
+// `assay.denied_call_observation.v0` whose caller-visible error is the proxy deny wire shape,
+// `PROXY_DENIED = -32042` with `origin == "assay-proxy"` (assay-mcp-server/src/proxy/io.rs).
+// All three are required so an event that merely reuses the code, or merely names the origin,
+// does not read as an enforcement marker. An observation without a target digest is unbindable
+// and out of this rule's scope (binding cannot be checked for it).
+const DENIED_CALL_OBSERVATION_SCHEMA: &str = "assay.denied_call_observation.v0";
 const PROXY_DENIED_CODE: i64 = -32042;
 const PROXY_ORIGIN: &str = "assay-proxy";
 
 fn extract_proxy_refusal_marker(event: &EvidenceEvent) -> Option<EnforcementDecisionKey> {
     let payload = &event.payload;
-    let observed_response = payload.get("observed_response")?.as_str()?;
-    let response: Value = serde_json::from_str(observed_response).ok()?;
-    if response.pointer("/error/code")?.as_i64()? != PROXY_DENIED_CODE
-        || response.pointer("/error/data/origin")?.as_str()? != PROXY_ORIGIN
+    if payload.get("schema").and_then(Value::as_str) != Some(DENIED_CALL_OBSERVATION_SCHEMA) {
+        return None;
+    }
+    if payload.pointer("/caller_visible_error/code")?.as_i64()? != PROXY_DENIED_CODE
+        || payload.pointer("/caller_visible_error/origin")?.as_str()? != PROXY_ORIGIN
     {
         return None;
     }

--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -303,11 +303,20 @@ fn extract_enforcement_decision(
     Some((key, EnforcementDecisionSummary { decision }))
 }
 
+// The marker is the SHIPPED proxy deny wire shape (assay-mcp-server/src/proxy/io.rs):
+// `PROXY_DENIED = -32042` with `error.data.origin == "assay-proxy"`. Both are required so an
+// upstream error that merely reuses the code, or a data blob that merely names the origin,
+// does not read as an enforcement marker.
+const PROXY_DENIED_CODE: i64 = -32042;
+const PROXY_ORIGIN: &str = "assay-proxy";
+
 fn extract_proxy_refusal_marker(event: &EvidenceEvent) -> Option<EnforcementDecisionKey> {
     let payload = &event.payload;
     let observed_response = payload.get("observed_response")?.as_str()?;
     let response: Value = serde_json::from_str(observed_response).ok()?;
-    if response.pointer("/error/data/assay_proxy")?.as_str()? != "deny" {
+    if response.pointer("/error/code")?.as_i64()? != PROXY_DENIED_CODE
+        || response.pointer("/error/data/origin")?.as_str()? != PROXY_ORIGIN
+    {
         return None;
     }
 

--- a/crates/assay-evidence/tests/lint_test.rs
+++ b/crates/assay-evidence/tests/lint_test.rs
@@ -52,30 +52,41 @@ fn create_bundle_from_events(events: Vec<EvidenceEvent>) -> Vec<u8> {
     buffer
 }
 
+/// Mirrors the shipped `assay.denied_call_observation.v0` producer
+/// (assay-mcp-server/src/proxy/denied_observation.rs).
 fn observed_proxy_refusal_event(seq: u64, tool_name: &str, target_digest: &str) -> EvidenceEvent {
+    denied_call_observation_event(seq, tool_name, serde_json::json!(target_digest))
+}
+
+fn denied_call_observation_event(
+    seq: u64,
+    tool_name: &str,
+    target_digest: serde_json::Value,
+) -> EvidenceEvent {
     let mut event = EvidenceEvent::new(
         "assay.mcp_call.observed",
         "urn:assay:test",
         "run_lint",
         seq,
         serde_json::json!({
+            "schema": "assay.denied_call_observation.v0",
             "call": {
                 "tool_name": tool_name,
                 "target_digest": target_digest
             },
-            "observed_response": serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 7,
-                "error": {
-                    "code": -32042,
-                    "message": "tool call denied by policy",
-                    "data": {
-                        "origin": "assay-proxy",
-                        "reason": "credential_scope_insufficient"
-                    }
-                }
-            })
-            .to_string()
+            "caller_visible_error": {
+                "code": -32042,
+                "origin": "assay-proxy",
+                "reason": "credential_scope_insufficient"
+            },
+            "caller_visible_response_digest":
+                "sha256:6d5a1f3b8c9e2d4a7b0c1e5f8a3d6b9c2e5f8a1d4b7c0e3f6a9d2c5b8e1f4a7d",
+            "non_claims": [
+                "caller-visible proxy denial observation only; policy decision lives in assay.enforcement_decision.v0",
+                "does not assert or verify the upstream side effect",
+                "does not assert maliciousness, safety, approval, or whole-action trust",
+                "must not be read as a replacement for the bound enforcement decision record"
+            ]
         }),
     );
     event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
@@ -161,7 +172,7 @@ fn test_w004_flags_proxy_marker_without_bound_decision_record() {
     assert_eq!(findings.len(), 1, "expected one ASSAY-W004 finding");
     assert!(findings[0]
         .message
-        .contains("no digest-bound assay.enforcement_decision.v0 deny record"));
+        .contains("not backed by a digest-bound assay.enforcement_decision.v0 deny record"));
 }
 
 #[test]
@@ -232,6 +243,26 @@ fn test_w004_does_not_match_prose_only_guardrail_log() {
             .iter()
             .all(|finding| finding.rule_id != "ASSAY-W004"),
         "ASSAY-W004 must not fall back to producer-log prose matching"
+    );
+}
+
+#[test]
+fn test_w004_skips_unbindable_observation_without_target_digest() {
+    // The shipped carrier emits `target_digest: null` when classification produced no digest.
+    // Binding cannot be checked for such an observation, so it is out of W004's scope.
+    let bundle = create_bundle_from_events(vec![denied_call_observation_event(
+        0,
+        "fs_write",
+        serde_json::Value::Null,
+    )]);
+    let report = lint_bundle(Cursor::new(&bundle), VerifyLimits::default()).unwrap();
+
+    assert!(
+        report
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "ASSAY-W004"),
+        "an unbindable observation must not produce an ASSAY-W004 finding"
     );
 }
 

--- a/crates/assay-evidence/tests/lint_test.rs
+++ b/crates/assay-evidence/tests/lint_test.rs
@@ -42,6 +42,98 @@ fn create_bundle_with_secret_subject() -> Vec<u8> {
     buffer
 }
 
+fn create_bundle_from_events(events: Vec<EvidenceEvent>) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer.finish().unwrap();
+    buffer
+}
+
+fn observed_proxy_refusal_event(seq: u64, tool_name: &str, target_digest: &str) -> EvidenceEvent {
+    let mut event = EvidenceEvent::new(
+        "assay.mcp_call.observed",
+        "urn:assay:test",
+        "run_lint",
+        seq,
+        serde_json::json!({
+            "call": {
+                "tool_name": tool_name,
+                "target_digest": target_digest
+            },
+            "observed_response": serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "error": {
+                    "code": -32600,
+                    "message": "tool call denied by policy",
+                    "data": {
+                        "assay_proxy": "deny",
+                        "reason": "credential_scope"
+                    }
+                }
+            })
+            .to_string()
+        }),
+    );
+    event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
+    event
+}
+
+fn enforcement_decision_event(
+    seq: u64,
+    tool_name: &str,
+    target_digest: &str,
+    decision: &str,
+) -> EvidenceEvent {
+    let mut event = EvidenceEvent::new(
+        "assay.enforcement_decision",
+        "urn:assay:test",
+        "run_lint",
+        seq,
+        serde_json::json!({
+            "schema": "assay.enforcement_decision.v0",
+            "tool": {
+                "name": tool_name,
+                "action_class": "fs_write"
+            },
+            "action": {
+                "verb": "write",
+                "resource_type": "file",
+                "target": {
+                    "path": "/workspace/out/report.md"
+                },
+                "target_digest": target_digest
+            },
+            "decision": decision,
+            "reason": decision,
+            "fail_closed": decision == "deny"
+        }),
+    );
+    event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
+    event
+}
+
+fn prose_only_guardrail_log_event(seq: u64) -> EvidenceEvent {
+    let mut event = EvidenceEvent::new(
+        "assay.mcp_call.observed",
+        "urn:assay:test",
+        "run_lint",
+        seq,
+        serde_json::json!({
+            "call": {
+                "tool_name": "fs_write",
+                "target_digest": "sha256:call-target"
+            },
+            "producer_log": ["guardrail blocked this call"]
+        }),
+    );
+    event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
+    event
+}
+
 #[test]
 fn test_golden_bundle_zero_findings() {
     let bundle = create_golden_bundle();
@@ -50,6 +142,97 @@ fn test_golden_bundle_zero_findings() {
     assert!(report.verified);
     assert_eq!(report.findings.len(), 0);
     assert_eq!(report.summary.total, 0);
+}
+
+#[test]
+fn test_w004_flags_proxy_marker_without_bound_decision_record() {
+    let bundle = create_bundle_from_events(vec![observed_proxy_refusal_event(
+        0,
+        "fs_write",
+        "sha256:call-target",
+    )]);
+    let report = lint_bundle(Cursor::new(&bundle), VerifyLimits::default()).unwrap();
+
+    let findings: Vec<_> = report
+        .findings
+        .iter()
+        .filter(|finding| finding.rule_id == "ASSAY-W004")
+        .collect();
+    assert_eq!(findings.len(), 1, "expected one ASSAY-W004 finding");
+    assert!(findings[0]
+        .message
+        .contains("no digest-bound assay.enforcement_decision.v0 deny record"));
+}
+
+#[test]
+fn test_w004_flags_proxy_marker_contradicted_by_bound_allow_record() {
+    let bundle = create_bundle_from_events(vec![
+        observed_proxy_refusal_event(0, "fs_write", "sha256:call-target"),
+        enforcement_decision_event(1, "fs_write", "sha256:call-target", "allow"),
+    ]);
+    let report = lint_bundle(Cursor::new(&bundle), VerifyLimits::default()).unwrap();
+
+    let findings: Vec<_> = report
+        .findings
+        .iter()
+        .filter(|finding| finding.rule_id == "ASSAY-W004")
+        .collect();
+    assert_eq!(findings.len(), 1, "expected one ASSAY-W004 finding");
+    assert!(findings[0].message.contains("contradicted by"));
+}
+
+#[test]
+fn test_w004_accepts_proxy_marker_with_bound_deny_record() {
+    let bundle = create_bundle_from_events(vec![
+        observed_proxy_refusal_event(0, "fs_write", "sha256:call-target"),
+        enforcement_decision_event(1, "fs_write", "sha256:call-target", "deny"),
+    ]);
+    let report = lint_bundle(Cursor::new(&bundle), VerifyLimits::default()).unwrap();
+
+    assert!(
+        report
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "ASSAY-W004"),
+        "bound deny record should satisfy ASSAY-W004"
+    );
+}
+
+#[test]
+fn test_w004_sarif_rule_includes_security_severity() {
+    let bundle = create_bundle_from_events(vec![observed_proxy_refusal_event(
+        0,
+        "fs_write",
+        "sha256:call-target",
+    )]);
+    let report = lint_bundle(Cursor::new(&bundle), VerifyLimits::default()).unwrap();
+    let sarif = to_sarif(&report);
+
+    let rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .unwrap();
+    let w004_rule = rules
+        .iter()
+        .find(|rule| rule["id"] == "ASSAY-W004")
+        .unwrap();
+    assert_eq!(
+        w004_rule["properties"]["security-severity"].as_str(),
+        Some("4.0")
+    );
+}
+
+#[test]
+fn test_w004_does_not_match_prose_only_guardrail_log() {
+    let bundle = create_bundle_from_events(vec![prose_only_guardrail_log_event(0)]);
+    let report = lint_bundle(Cursor::new(&bundle), VerifyLimits::default()).unwrap();
+
+    assert!(
+        report
+            .findings
+            .iter()
+            .all(|finding| finding.rule_id != "ASSAY-W004"),
+        "ASSAY-W004 must not fall back to producer-log prose matching"
+    );
 }
 
 #[test]

--- a/crates/assay-evidence/tests/lint_test.rs
+++ b/crates/assay-evidence/tests/lint_test.rs
@@ -67,11 +67,11 @@ fn observed_proxy_refusal_event(seq: u64, tool_name: &str, target_digest: &str) 
                 "jsonrpc": "2.0",
                 "id": 7,
                 "error": {
-                    "code": -32600,
+                    "code": -32042,
                     "message": "tool call denied by policy",
                     "data": {
-                        "assay_proxy": "deny",
-                        "reason": "credential_scope"
+                        "origin": "assay-proxy",
+                        "reason": "credential_scope_insufficient"
                     }
                 }
             })


### PR DESCRIPTION
## What

Two pieces, two commits plus a carrier alignment:

1. **`LintBundleIndex`** — a bundle-wide structural index carried in `LintContext`. Built-in
   rules stay single-event callbacks but can consult a precomputed view of sibling records in the
   same verified bundle. Structural only: it reads pinned schema fields and never searches
   prose/log text. First index: `assay.enforcement_decision.v0` records keyed by
   `(tool.name, action.target_digest)`.

2. **`ASSAY-W004`** (warn, `security-severity: 4.0`) — a retained
   `assay.denied_call_observation.v0` record (caller-visible proxy denial: code `-32042`,
   `origin: assay-proxy`) must be backed by a digest-bound
   `assay.enforcement_decision.v0` **deny** record in the same bundle. Two findings:
   - not backed by any bound deny record;
   - contradicted by a bound **allow** record for the same tool + target digest.

## Boundaries

- No prose fallback: a "guardrail blocked" log line without the structural carrier triggers
  nothing (pinned by test).
- An unbindable observation (`target_digest: null`, as the carrier emits when classification
  produced no digest) is out of scope (pinned by test).
- The rule flags unsupported or contradicted attribution **claims**; it never confirms
  attribution, never scores a bundle, and adds no aggregate verdict.

## Relation

Consumer companion to #1795 (`assay.denied_call_observation.v0` producer). Test fixtures mirror
that producer's record verbatim; the crates stay independent, so merge order is flexible —
reviewing #1795 first reads best.

## Verification

- `cargo test -p assay-evidence --test lint_test --locked` (12/12, incl. SARIF metadata test)
- `cargo test -p assay-evidence --locked` (all suites)
- `cargo clippy -p assay-evidence --tests --locked -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)