### PR TITLE
chore(release): prepare v3.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.33.0] - 2026-07-05
+
+### Added
+- Add the opt-in `assay.denied_call_observation.v0` carrier for caller-visible MCP proxy denials.
+  It records the tool name, target digest when classification can bind one, structured proxy-deny
+  fields, and a response-line digest, while keeping caller observations separate from
+  `assay.enforcement_decision.v0` verdict records.
+- Add `ASSAY-W004`, a bundle-index-backed evidence lint rule for enforcement-attribution overreads.
+  It flags denied-call observations that lack a bound deny decision, and observations contradicted by
+  a bound allow decision, without treating the lint finding as proof of enforcement correctness.
+
 ## [3.32.0] - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "aya",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1598,7 +1598,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1770,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "3.32.0"
+version = "3.33.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3099,7 +3099,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4466,7 +4466,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4524,7 +4524,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4929,7 +4929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5099,7 +5099,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5112,7 +5112,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5926,7 +5926,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.32.0"
+version = "3.33.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Prepares the v3.33.0 release line for the denied-call observation carrier and ASSAY-W004 lint rule.

Release truth:
- code is already merged on main via #1795 and #1796
- this PR bumps the workspace version to 3.33.0
- CHANGELOG adds only the two post-v3.32.0 shipped items
- Cargo.lock is regenerated from workspace metadata

Verification:
- git diff --check
- cargo metadata --no-deps --format-version 1 (workspace local packages all report 3.33.0)
- pre-commit hooks during commit: fmt, cargo deny, TOML, token hygiene, typos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for clearer, caller-visible proxy denial observations, including recorded tool, target, and structured details.
  * Added a new evidence check to flag inconsistencies in denied-call observations.
* **Chores**
  * Updated the workspace version to **v3.33.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->