### PR TITLE
feat(runner): bind kernel socket events to cgroups

### DIFF
--- a/crates/assay-cli/src/cli/commands/monitor_next/output.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/output.rs
@@ -39,6 +39,33 @@ pub(crate) fn decode_file_blocked_payload(data: &[u8]) -> Option<(u64, u64, u64,
     Some((dev, ino, cgroup_id, rule_id))
 }
 
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn decode_blocked_net_payload(data: &[u8]) -> Option<(u64, String, u16, u32)> {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    if data.len() < 40 {
+        return None;
+    }
+
+    let cgroup_id = u64::from_ne_bytes(data[0..8].try_into().ok()?);
+    let family = u16::from_ne_bytes(data[8..10].try_into().ok()?);
+    let port = u16::from_ne_bytes(data[10..12].try_into().ok()?);
+    let rule_id = u32::from_ne_bytes(data[32..36].try_into().ok()?);
+    let dst = match family {
+        2 => {
+            let addr = Ipv4Addr::new(data[12], data[13], data[14], data[15]);
+            addr.to_string()
+        }
+        10 => {
+            let addr = Ipv6Addr::from(<[u8; 16]>::try_from(&data[16..32]).ok()?);
+            addr.to_string()
+        }
+        _ => return None,
+    };
+
+    Some((cgroup_id, dst, port, rule_id))
+}
+
 #[cfg(target_os = "linux")]
 pub(crate) fn log_violation(pid: u32, rule_id: &str, quiet: bool) {
     if !quiet {
@@ -107,11 +134,17 @@ pub(crate) fn format_monitor_event(event_type: u32, pid: u32, data: &[u8]) -> Op
             ),
         },
         11 => format!("[PID {}] 🟢 ALLOWED FILE: {}", pid, decode_utf8_cstr(data)),
-        20 => format!(
-            "[PID {}] 🛡️ BLOCKED NET : {}",
-            pid,
-            dump_prefix_hex(data, 20)
-        ),
+        20 => match decode_blocked_net_payload(data) {
+            Some((cgroup_id, dst, port, rule_id)) => format!(
+                "[PID {}] 🛡️ BLOCKED NET: dst={} port={} cgroup={} rule_id={}",
+                pid, dst, port, cgroup_id, rule_id
+            ),
+            None => format!(
+                "[PID {}] 🛡️ BLOCKED NET : {}",
+                pid,
+                dump_prefix_hex(data, 20)
+            ),
+        },
         112 => {
             let dev = read_u64(data, 0);
             let ino = read_u64(data, 8);
@@ -171,7 +204,7 @@ pub(crate) fn log_monitor_event(event: &assay_common::MonitorEvent, args: &Monit
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_file_blocked_payload, format_monitor_event};
+    use super::{decode_blocked_net_payload, decode_file_blocked_payload, format_monitor_event};
     use assay_common::{EVENT_CONNECT, EVENT_FILE_BLOCKED, EVENT_OPENAT};
 
     #[test]
@@ -184,6 +217,20 @@ mod tests {
 
         let decoded = decode_file_blocked_payload(&data).expect("payload should decode");
         assert_eq!(decoded, (42, 7, 99, 1234));
+    }
+
+    #[test]
+    fn decode_blocked_net_payload_reads_binary_layout() {
+        let mut data = [0u8; 40];
+        data[0..8].copy_from_slice(&42u64.to_ne_bytes());
+        data[8..10].copy_from_slice(&2u16.to_ne_bytes());
+        data[10..12].copy_from_slice(&443u16.to_ne_bytes());
+        data[12..16].copy_from_slice(&[203, 0, 113, 7]);
+        data[32..36].copy_from_slice(&9u32.to_ne_bytes());
+
+        let decoded = decode_blocked_net_payload(&data).expect("payload should decode");
+
+        assert_eq!(decoded, (42, "203.0.113.7".to_string(), 443, 9));
     }
 
     // The line shapes below are the producer contract that Plimsoll's capture scraper parses (see
@@ -218,6 +265,24 @@ mod tests {
         assert!(line.starts_with("[PID 4242] "), "{line}");
         assert!(
             line.ends_with(" BLOCKED FILE: dev=1 ino=2 cgroup=3 rule_id=4"),
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn blocked_net_event_formats_decoded_payload() {
+        let mut data = [0u8; 40];
+        data[0..8].copy_from_slice(&42u64.to_ne_bytes());
+        data[8..10].copy_from_slice(&2u16.to_ne_bytes());
+        data[10..12].copy_from_slice(&443u16.to_ne_bytes());
+        data[12..16].copy_from_slice(&u32::from_ne_bytes([203, 0, 113, 7]).to_ne_bytes());
+        data[32..36].copy_from_slice(&9u32.to_ne_bytes());
+
+        let line = format_monitor_event(20, 4242, &data).unwrap();
+
+        assert!(line.starts_with("[PID 4242] "), "{line}");
+        assert!(
+            line.ends_with(" BLOCKED NET: dst=203.0.113.7 port=443 cgroup=42 rule_id=9"),
             "{line}"
         );
     }

--- a/crates/assay-cli/src/cli/commands/monitor_next/output.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/output.rs
@@ -39,31 +39,21 @@ pub(crate) fn decode_file_blocked_payload(data: &[u8]) -> Option<(u64, u64, u64,
     Some((dev, ino, cgroup_id, rule_id))
 }
 
+/// Decode a type-20 (`EVENT_CONNECT_BLOCKED`) payload into the fields the live
+/// view renders: `(cgroup_id, destination, port, rule_id)`.
+///
+/// Thin adapter over [`assay_monitor::events::decode_blocked_socket_payload`], the
+/// single decode surface shared with the runner evidence exporter, so the byte
+/// layout lives in exactly one place next to the projection that writes it.
 #[cfg(any(target_os = "linux", test))]
 pub(crate) fn decode_blocked_net_payload(data: &[u8]) -> Option<(u64, String, u16, u32)> {
-    use std::net::{Ipv4Addr, Ipv6Addr};
-
-    if data.len() < 40 {
-        return None;
-    }
-
-    let cgroup_id = u64::from_ne_bytes(data[0..8].try_into().ok()?);
-    let family = u16::from_ne_bytes(data[8..10].try_into().ok()?);
-    let port = u16::from_ne_bytes(data[10..12].try_into().ok()?);
-    let rule_id = u32::from_ne_bytes(data[32..36].try_into().ok()?);
-    let dst = match family {
-        2 => {
-            let addr = Ipv4Addr::new(data[12], data[13], data[14], data[15]);
-            addr.to_string()
-        }
-        10 => {
-            let addr = Ipv6Addr::from(<[u8; 16]>::try_from(&data[16..32]).ok()?);
-            addr.to_string()
-        }
-        _ => return None,
-    };
-
-    Some((cgroup_id, dst, port, rule_id))
+    let decoded = assay_monitor::events::decode_blocked_socket_payload(data)?;
+    Some((
+        decoded.cgroup_id,
+        decoded.destination,
+        decoded.port,
+        decoded.rule_id,
+    ))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs
@@ -22,7 +22,7 @@ pub(super) async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> any
     use super::exit_status::{
         cgroup_correlation_label, exit_signal, exit_status_code, exit_status_label,
     };
-    use super::logs::apply_policy_then_sdk_logs_if_requested;
+    use super::logs::apply_policy_then_sdk_logs_with_session_cgroup_if_requested;
     use super::phases::{record_phase, write_phase_timing_log};
     use super::spec::{build_spec, bundle_output_path};
 
@@ -244,7 +244,12 @@ pub(super) async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> any
     let after_stats = monitor.snapshot_stats()?;
     let capture = builder.finish(&before_stats, &after_stats);
     capture.apply_to_archive(&mut archive, cgroup_correlation)?;
-    apply_policy_then_sdk_logs_if_requested(&spec, &args, &mut archive)?;
+    apply_policy_then_sdk_logs_with_session_cgroup_if_requested(
+        &spec,
+        &args,
+        &mut archive,
+        session_cgroup.id(),
+    )?;
     spec.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
     record_phase(&mut phases, "event_flush_ms", event_flush_start);
 

--- a/crates/assay-cli/src/cli/commands/runner_spike/logs.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike/logs.rs
@@ -7,10 +7,29 @@ pub(super) fn apply_policy_then_sdk_logs_if_requested(
     args: &RunnerSpikeRunArgs,
     archive: &mut assay_runner_core::RunnerSpikeArchive,
 ) -> anyhow::Result<()> {
+    apply_policy_then_sdk_logs_inner(spec, args, archive, None)
+}
+
+#[cfg(any(target_os = "linux", test))]
+pub(super) fn apply_policy_then_sdk_logs_with_session_cgroup_if_requested(
+    spec: &RunSpec,
+    args: &RunnerSpikeRunArgs,
+    archive: &mut assay_runner_core::RunnerSpikeArchive,
+    session_cgroup_id: u64,
+) -> anyhow::Result<()> {
+    apply_policy_then_sdk_logs_inner(spec, args, archive, Some(session_cgroup_id))
+}
+
+fn apply_policy_then_sdk_logs_inner(
+    spec: &RunSpec,
+    args: &RunnerSpikeRunArgs,
+    archive: &mut assay_runner_core::RunnerSpikeArchive,
+    session_cgroup_id: Option<u64>,
+) -> anyhow::Result<()> {
     // Policy must be applied before SDK: SDK cross-checks read policy
     // correlation bindings and the mismatch determinism gate relies on stable
     // ambiguity ordering.
-    apply_policy_decision_log_if_requested(spec, args, archive)?;
+    apply_policy_decision_log_if_requested(spec, args, archive, session_cgroup_id)?;
     apply_sdk_event_log_if_requested(spec, args, archive)?;
     Ok(())
 }
@@ -19,6 +38,7 @@ fn apply_policy_decision_log_if_requested(
     spec: &RunSpec,
     args: &RunnerSpikeRunArgs,
     archive: &mut assay_runner_core::RunnerSpikeArchive,
+    session_cgroup_id: Option<u64>,
 ) -> anyhow::Result<()> {
     let Some(path) = args.policy_decision_log.as_ref() else {
         return Ok(());
@@ -32,7 +52,11 @@ fn apply_policy_decision_log_if_requested(
     })?;
     let capture =
         assay_runner_core::PolicyLayerCapture::from_decision_ndjson(spec.run_id.clone(), &bytes)?;
-    capture.apply_to_archive(archive)?;
+    if let Some(session_cgroup_id) = session_cgroup_id {
+        capture.apply_to_archive_with_session_cgroup(archive, session_cgroup_id)?;
+    } else {
+        capture.apply_to_archive(archive)?;
+    }
     Ok(())
 }
 
@@ -54,4 +78,53 @@ fn apply_sdk_event_log_if_requested(
     let capture = assay_runner_core::SdkLayerCapture::from_sdk_ndjson(spec.run_id.clone(), &bytes)?;
     capture.apply_to_archive(archive)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::commands::runner_spike::args::{RedactArg, RedactionKeyArg};
+    use assay_runner_schema::{CgroupCorrelationStatus, KernelLayerStatus};
+
+    fn args_with_policy_decision_log(path: std::path::PathBuf) -> RunnerSpikeRunArgs {
+        RunnerSpikeRunArgs {
+            agent_shim: "none".to_string(),
+            run_id: Some("run_001".to_string()),
+            output: None,
+            kernel_capture: false,
+            ebpf: None,
+            kernel_drain_ms: 100,
+            policy_decision_log: Some(path),
+            sdk_event_log: None,
+            phase_timing_log: None,
+            redact: RedactArg::ShapeAndFlag,
+            redaction_key: RedactionKeyArg::Ephemeral,
+            unsafe_disable_redaction: false,
+            command: vec!["true".to_string()],
+        }
+    }
+
+    #[test]
+    fn session_cgroup_id_flows_into_policy_correlation_binding() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy_log = dir.path().join("policy.ndjson");
+        std::fs::write(
+            &policy_log,
+            br#"{"type":"assay.tool.decision","source":"assay://runner-spike/run_001","data":{"tool":"read_file","decision":"allow","tool_call_id":"tc_runner_policy_001"}}
+"#,
+        )
+        .unwrap();
+        let args = args_with_policy_decision_log(policy_log);
+        let spec = RunSpec::new(args.command.clone()).with_run_id("run_001");
+        let mut archive = assay_runner_core::RunnerSpikeArchive::empty("run_001", "linux");
+        archive.observation_health.kernel_layer = KernelLayerStatus::Complete;
+        archive.observation_health.cgroup_correlation = CgroupCorrelationStatus::Clean;
+        archive.kernel_layer_ndjson = b"{\"schema\":\"assay.runner.kernel_event.v0\"}\n".to_vec();
+
+        apply_policy_then_sdk_logs_with_session_cgroup_if_requested(&spec, &args, &mut archive, 42)
+            .unwrap();
+
+        assert_eq!(archive.correlation_report.bindings.len(), 1);
+        assert_eq!(archive.correlation_report.bindings[0].cgroup_id, Some(42));
+    }
 }

--- a/crates/assay-common/src/lib.rs
+++ b/crates/assay-common/src/lib.rs
@@ -73,6 +73,21 @@ pub struct MonitorEvent {
     pub data: [u8; DATA_LEN],
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SocketEvent {
+    pub event_type: u32,
+    pub pid: u32,
+    pub timestamp_ns: u64,
+    pub cgroup_id: u64,
+    pub family: u16,
+    pub port: u16,
+    pub addr_v4: u32,
+    pub addr_v6: [u8; 16],
+    pub rule_id: u32,
+    pub action: u32,
+}
+
 /// Key used to identify an inode in BPF maps.
 ///
 /// # ABI and kernel assumptions
@@ -180,6 +195,11 @@ const _: [(); 552] = [(); core::mem::size_of::<MonitorEvent>()];
 
 // Alignment is 8 because the ABI carries u64/i64 syscall metadata.
 const _: [(); 8] = [(); core::mem::align_of::<MonitorEvent>()];
+
+// SocketEvent is the eBPF/userspace ABI emitted by cgroup_sock_addr hooks.
+// Size: 4 + 4 + 8 + 8 + 2 + 2 + 4 + 16 + 4 + 4 = 56 bytes.
+const _: [(); 56] = [(); core::mem::size_of::<SocketEvent>()];
+const _: [(); 8] = [(); core::mem::align_of::<SocketEvent>()];
 
 #[cfg(all(target_os = "linux", feature = "std"))]
 pub fn get_inode_generation(fd: std::os::fd::RawFd) -> std::io::Result<u32> {

--- a/crates/assay-ebpf/src/socket_lsm.rs
+++ b/crates/assay-ebpf/src/socket_lsm.rs
@@ -1,6 +1,7 @@
 use assay_common::{
-    SOCKET_STATS_LEN, SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT,
-    SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
+    SocketEvent, SOCKET_STATS_LEN, SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR,
+    SOCKET_STAT_BLOCKED_PORT, SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED,
+    SOCKET_STAT_RINGBUF_DROPPED,
 };
 use aya_ebpf::{
     bindings::bpf_sock_addr,
@@ -36,20 +37,6 @@ static SOCKET_EVENTS: RingBuf = RingBuf::with_byte_size(128 * 1024, 0);
 
 #[map]
 static SOCKET_STATS: Array<u64> = Array::with_max_entries(SOCKET_STATS_LEN, 0);
-
-#[repr(C)]
-struct SocketEvent {
-    event_type: u32,
-    pid: u32,
-    timestamp_ns: u64,
-    cgroup_id: u64,
-    family: u16,
-    port: u16,
-    addr_v4: u32,
-    addr_v6: [u8; 16],
-    rule_id: u32,
-    action: u32,
-}
 
 #[cgroup_sock_addr(connect4)]
 pub fn connect4_hook(ctx: SockAddrContext) -> i32 {

--- a/crates/assay-monitor/src/events.rs
+++ b/crates/assay-monitor/src/events.rs
@@ -59,6 +59,80 @@ pub fn parse_socket_event(bytes: &[u8]) -> Result<MonitorEvent, MonitorError> {
     Ok(out)
 }
 
+/// AF_INET / AF_INET6 as reported by the Linux socket layer. The eBPF probes only
+/// ever emit these two families for an `EVENT_CONNECT_BLOCKED` record.
+const AF_INET: u16 = 2;
+const AF_INET6: u16 = 10;
+
+/// Number of leading `MonitorEvent::data` bytes [`parse_socket_event`] populates
+/// for an `EVENT_CONNECT_BLOCKED` record. Decoders bounds-check against this.
+pub const BLOCKED_SOCKET_PAYLOAD_LEN: usize = 40;
+
+/// Decoded fields of an `EVENT_CONNECT_BLOCKED` payload written by
+/// [`parse_socket_event`].
+///
+/// This is the single decode surface for the projected socket payload: both the
+/// CLI live view and the runner evidence exporter read blocked-connect fields
+/// through [`decode_blocked_socket_payload`] rather than re-implementing the byte
+/// offsets, so the layout stays pinned in one place next to its writer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockedSocket {
+    pub cgroup_id: u64,
+    pub family: u16,
+    pub port: u16,
+    /// Bare destination address without a port, e.g. `203.0.113.7` or `2001:db8::1`.
+    /// Formatted exactly once, here, at decode time.
+    pub destination: String,
+    pub rule_id: u32,
+}
+
+impl BlockedSocket {
+    /// Render `destination:port`, bracketing IPv6 hosts like a [`std::net::SocketAddr`].
+    pub fn endpoint(&self) -> String {
+        if self.family == AF_INET6 {
+            format!("[{}]:{}", self.destination, self.port)
+        } else {
+            format!("{}:{}", self.destination, self.port)
+        }
+    }
+}
+
+/// Decode the `EVENT_CONNECT_BLOCKED` payload that [`parse_socket_event`] writes
+/// into `MonitorEvent::data`.
+///
+/// Returns `None` on a short buffer or an unsupported address family, matching the
+/// fail-closed contract of the other decoders. The `port` field is native-endian
+/// because the projection copies the `SocketEvent` fields verbatim (no byte-order
+/// conversion), unlike a raw kernel `sockaddr`.
+pub fn decode_blocked_socket_payload(data: &[u8]) -> Option<BlockedSocket> {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    if data.len() < BLOCKED_SOCKET_PAYLOAD_LEN {
+        return None;
+    }
+
+    // Offsets mirror the payload table documented on `parse_socket_event`:
+    // | cgroup_id u64 @0 | family u16 @8 | port u16 @10 | addr_v4 @12 |
+    // | addr_v6 [u8;16] @16 | rule_id u32 @32 |.
+    let cgroup_id = u64::from_ne_bytes(data[0..8].try_into().ok()?);
+    let family = u16::from_ne_bytes(data[8..10].try_into().ok()?);
+    let port = u16::from_ne_bytes(data[10..12].try_into().ok()?);
+    let rule_id = u32::from_ne_bytes(data[32..36].try_into().ok()?);
+    let destination = match family {
+        AF_INET => Ipv4Addr::new(data[12], data[13], data[14], data[15]).to_string(),
+        AF_INET6 => Ipv6Addr::from(<[u8; 16]>::try_from(&data[16..32]).ok()?).to_string(),
+        _ => return None,
+    };
+
+    Some(BlockedSocket {
+        cgroup_id,
+        family,
+        port,
+        destination,
+        rule_id,
+    })
+}
+
 /// Interpret `event.data` as a C-style nul-terminated string slice.
 ///
 /// Useful for EVENT_OPENAT payloads where eBPF writes a path into `data`.
@@ -142,5 +216,59 @@ mod tests {
         assert_eq!(&event.data[12..16], &[203, 0, 113, 7]);
         assert_eq!(&event.data[32..36], &17_u32.to_ne_bytes());
         assert_eq!(&event.data[36..40], &2_u32.to_ne_bytes());
+    }
+
+    /// The projection and the decoder must agree on the payload layout: whatever
+    /// `parse_socket_event` writes, `decode_blocked_socket_payload` reads back.
+    /// This round-trip is what makes the offset table impossible to drift.
+    #[test]
+    fn decode_blocked_socket_payload_round_trips_parse_socket_event() {
+        let mut bytes = vec![0_u8; core::mem::size_of::<assay_common::SocketEvent>()];
+        bytes[0..4].copy_from_slice(&assay_common::EVENT_CONNECT_BLOCKED.to_ne_bytes());
+        bytes[16..24].copy_from_slice(&99_u64.to_ne_bytes()); // cgroup_id
+        bytes[24..26].copy_from_slice(&AF_INET.to_ne_bytes()); // family
+        bytes[26..28].copy_from_slice(&443_u16.to_ne_bytes()); // port
+        bytes[28..32].copy_from_slice(&[203, 0, 113, 7]); // addr_v4
+        bytes[48..52].copy_from_slice(&17_u32.to_ne_bytes()); // rule_id
+
+        let event = parse_socket_event(&bytes).unwrap();
+        let decoded = decode_blocked_socket_payload(&event.data).expect("payload should decode");
+
+        assert_eq!(
+            decoded,
+            BlockedSocket {
+                cgroup_id: 99,
+                family: AF_INET,
+                port: 443,
+                destination: "203.0.113.7".to_string(),
+                rule_id: 17,
+            }
+        );
+        assert_eq!(decoded.endpoint(), "203.0.113.7:443");
+    }
+
+    #[test]
+    fn decode_blocked_socket_payload_reads_ipv6_and_brackets_endpoint() {
+        let mut data = [0_u8; BLOCKED_SOCKET_PAYLOAD_LEN];
+        data[0..8].copy_from_slice(&7_u64.to_ne_bytes());
+        data[8..10].copy_from_slice(&AF_INET6.to_ne_bytes());
+        data[10..12].copy_from_slice(&8080_u16.to_ne_bytes());
+        data[16..32].copy_from_slice(&std::net::Ipv6Addr::LOCALHOST.octets());
+        data[32..36].copy_from_slice(&5_u32.to_ne_bytes());
+
+        let decoded = decode_blocked_socket_payload(&data).expect("payload should decode");
+
+        assert_eq!(decoded.family, AF_INET6);
+        assert_eq!(decoded.destination, "::1");
+        assert_eq!(decoded.endpoint(), "[::1]:8080");
+    }
+
+    #[test]
+    fn decode_blocked_socket_payload_rejects_short_buffer_and_unknown_family() {
+        assert!(decode_blocked_socket_payload(&[0_u8; BLOCKED_SOCKET_PAYLOAD_LEN - 1]).is_none());
+
+        let mut data = [0_u8; BLOCKED_SOCKET_PAYLOAD_LEN];
+        data[8..10].copy_from_slice(&1_u16.to_ne_bytes()); // AF_UNIX, unsupported here
+        assert!(decode_blocked_socket_payload(&data).is_none());
     }
 }

--- a/crates/assay-monitor/src/events.rs
+++ b/crates/assay-monitor/src/events.rs
@@ -28,6 +28,37 @@ pub fn parse_event(bytes: &[u8]) -> Result<MonitorEvent, MonitorError> {
     }
 }
 
+/// Project a fixed-size cgroup socket event into the stable monitor event stream.
+///
+/// The cgroup_sock_addr eBPF programs emit `SocketEvent` records on a separate
+/// ring buffer. Userspace normalizes them into `EVENT_CONNECT_BLOCKED`
+/// `MonitorEvent`s so downstream evidence exporters consume one event shape.
+pub fn parse_socket_event(bytes: &[u8]) -> Result<MonitorEvent, MonitorError> {
+    let need = core::mem::size_of::<assay_common::SocketEvent>();
+    if bytes.len() < need {
+        return Err(MonitorError::InvalidEvent {
+            got: bytes.len(),
+            need,
+        });
+    }
+
+    let mut out = MonitorEvent::zeroed();
+    out.event_type = u32::from_ne_bytes(bytes[0..4].try_into().expect("slice length checked"));
+    out.pid = u32::from_ne_bytes(bytes[4..8].try_into().expect("slice length checked"));
+
+    // Payload ABI consumed by CLI display and runner retained evidence:
+    // | cgroup_id u64 | family u16 | port u16 | addr_v4 u32 |
+    // | addr_v6 [u8;16] | rule_id u32 | action u32 |.
+    out.data[0..8].copy_from_slice(&bytes[16..24]);
+    out.data[8..10].copy_from_slice(&bytes[24..26]);
+    out.data[10..12].copy_from_slice(&bytes[26..28]);
+    out.data[12..16].copy_from_slice(&bytes[28..32]);
+    out.data[16..32].copy_from_slice(&bytes[32..48]);
+    out.data[32..36].copy_from_slice(&bytes[48..52]);
+    out.data[36..40].copy_from_slice(&bytes[52..56]);
+    Ok(out)
+}
+
 /// Interpret `event.data` as a C-style nul-terminated string slice.
 ///
 /// Useful for EVENT_OPENAT payloads where eBPF writes a path into `data`.
@@ -86,5 +117,30 @@ mod tests {
     fn parse_event_accepts_exact_size_record() {
         let ev = parse_event(&vec![0u8; core::mem::size_of::<MonitorEvent>()]);
         assert!(ev.is_ok(), "a record of the exact pinned size must parse");
+    }
+
+    #[test]
+    fn parse_socket_event_projects_blocked_connect_payload() {
+        let mut bytes = vec![0_u8; core::mem::size_of::<assay_common::SocketEvent>()];
+        bytes[0..4].copy_from_slice(&assay_common::EVENT_CONNECT_BLOCKED.to_ne_bytes());
+        bytes[4..8].copy_from_slice(&4242_u32.to_ne_bytes());
+        bytes[8..16].copy_from_slice(&123_u64.to_ne_bytes());
+        bytes[16..24].copy_from_slice(&99_u64.to_ne_bytes());
+        bytes[24..26].copy_from_slice(&2_u16.to_ne_bytes());
+        bytes[26..28].copy_from_slice(&443_u16.to_ne_bytes());
+        bytes[28..32].copy_from_slice(&[203, 0, 113, 7]);
+        bytes[48..52].copy_from_slice(&17_u32.to_ne_bytes());
+        bytes[52..56].copy_from_slice(&2_u32.to_ne_bytes());
+
+        let event = parse_socket_event(&bytes).unwrap();
+
+        assert_eq!(event.event_type, assay_common::EVENT_CONNECT_BLOCKED);
+        assert_eq!(event.pid, 4242);
+        assert_eq!(&event.data[0..8], &99_u64.to_ne_bytes());
+        assert_eq!(&event.data[8..10], &2_u16.to_ne_bytes());
+        assert_eq!(&event.data[10..12], &443_u16.to_ne_bytes());
+        assert_eq!(&event.data[12..16], &[203, 0, 113, 7]);
+        assert_eq!(&event.data[32..36], &17_u32.to_ne_bytes());
+        assert_eq!(&event.data[36..40], &2_u32.to_ne_bytes());
     }
 }

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -448,7 +448,7 @@ impl LinuxMonitor {
     pub fn listen(&mut self) -> Result<EventStream, MonitorError> {
         let (tx, rx) = mpsc::channel(1024);
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
-        let (mut events_ring_buf, mut lsm_ring_buf) = {
+        let (mut events_ring_buf, mut lsm_ring_buf, mut socket_ring_buf) = {
             let mut bpf = self.bpf.lock().unwrap();
             let events_map = bpf
                 .take_map("EVENTS")
@@ -456,9 +456,11 @@ impl LinuxMonitor {
             let lsm_events_map = bpf
                 .take_map("LSM_EVENTS")
                 .ok_or(MonitorError::MapNotFound { name: "LSM_EVENTS" })?;
+            let socket_events_map = bpf.take_map("SOCKET_EVENTS");
             (
                 RingBuf::try_from(events_map)?,
                 RingBuf::try_from(lsm_events_map)?,
+                socket_events_map.map(RingBuf::try_from).transpose()?,
             )
         };
 
@@ -498,6 +500,26 @@ impl LinuxMonitor {
                     }
                     if tx.blocking_send(ev).is_err() {
                         break 'outer;
+                    }
+                }
+
+                // Poll cgroup socket events and project them into type-20
+                // MonitorEvent payloads so downstream evidence exporters retain
+                // cgroup/rule binding fields instead of opaque hex.
+                if let Some(socket_ring_buf) = socket_ring_buf.as_mut() {
+                    while let Some(item) = socket_ring_buf.next() {
+                        if item.is_empty() {
+                            continue;
+                        }
+                        let ev = events::parse_socket_event(&item);
+                        if matches!(&ev, Err(MonitorError::InvalidEvent { .. }))
+                            && mismatch.fetch_add(1, Ordering::Relaxed) == 0
+                        {
+                            eprintln!("{STALE_OBJECT_WARNING}");
+                        }
+                        if tx.blocking_send(ev).is_err() {
+                            break 'outer;
+                        }
                     }
                 }
                 if !ready {

--- a/crates/assay-runner-core/src/kernel.rs
+++ b/crates/assay-runner-core/src/kernel.rs
@@ -40,6 +40,14 @@ pub struct KernelLayerEvent {
     pub kind: String,
     pub value: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub cgroup_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_destination: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flags: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<u64>,
@@ -158,6 +166,10 @@ impl KernelLayerBuilder {
             event_type: event.event_type,
             kind: decoded.kind,
             value: decoded.value,
+            cgroup_id: decoded.cgroup_id,
+            network_destination: decoded.network_destination,
+            network_port: decoded.network_port,
+            rule_id: decoded.rule_id,
             flags: decoded.flags,
             mode: decoded.mode,
             resolve: decoded.resolve,

--- a/crates/assay-runner-core/src/kernel/decode.rs
+++ b/crates/assay-runner-core/src/kernel/decode.rs
@@ -79,10 +79,12 @@ fn decoded_open_event(event: &MonitorEvent) -> DecodedKernelEvent {
 }
 
 fn decoded_connect_blocked_event(event: &MonitorEvent) -> DecodedKernelEvent {
-    if let Some(blocked) = decode_blocked_socket_payload(&event.data) {
+    // Decode through the shared surface in assay-monitor so this exporter and the
+    // CLI live view never drift on the projected socket-payload byte layout.
+    if let Some(blocked) = assay_monitor::events::decode_blocked_socket_payload(&event.data) {
         return DecodedKernelEvent {
             kind: "connect_blocked".to_string(),
-            value: Some(blocked.endpoint),
+            value: Some(blocked.endpoint()),
             cgroup_id: Some(blocked.cgroup_id),
             network_destination: Some(blocked.destination),
             network_port: Some(blocked.port),
@@ -97,48 +99,6 @@ fn decoded_connect_blocked_event(event: &MonitorEvent) -> DecodedKernelEvent {
         };
     }
     decoded_plain_event("connect_blocked", decode_sockaddr_endpoint(&event.data))
-}
-
-struct BlockedSocketPayload {
-    cgroup_id: u64,
-    destination: String,
-    endpoint: String,
-    port: u16,
-    rule_id: u32,
-}
-
-fn decode_blocked_socket_payload(bytes: &[u8]) -> Option<BlockedSocketPayload> {
-    if bytes.len() < 40 {
-        return None;
-    }
-    let cgroup_id = u64::from_ne_bytes(bytes[0..8].try_into().ok()?);
-    let family = u16::from_ne_bytes(bytes[8..10].try_into().ok()?);
-    let port = u16::from_ne_bytes(bytes[10..12].try_into().ok()?);
-    let rule_id = u32::from_ne_bytes(bytes[32..36].try_into().ok()?);
-    match family {
-        2 => {
-            let destination = Ipv4Addr::new(bytes[12], bytes[13], bytes[14], bytes[15]).to_string();
-            Some(BlockedSocketPayload {
-                endpoint: format!("{destination}:{port}"),
-                destination,
-                port,
-                cgroup_id,
-                rule_id,
-            })
-        }
-        10 => {
-            let destination =
-                Ipv6Addr::from(<[u8; 16]>::try_from(&bytes[16..32]).ok()?).to_string();
-            Some(BlockedSocketPayload {
-                endpoint: format!("[{destination}]:{port}"),
-                destination,
-                port,
-                cgroup_id,
-                rule_id,
-            })
-        }
-        _ => None,
-    }
 }
 
 fn open_access_mode(flags: u64) -> &'static str {

--- a/crates/assay-runner-core/src/kernel/decode.rs
+++ b/crates/assay-runner-core/src/kernel/decode.rs
@@ -8,6 +8,10 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 pub(super) struct DecodedKernelEvent {
     pub(super) kind: String,
     pub(super) value: Option<String>,
+    pub(super) cgroup_id: Option<u64>,
+    pub(super) network_destination: Option<String>,
+    pub(super) network_port: Option<u16>,
+    pub(super) rule_id: Option<u32>,
     pub(super) flags: Option<u64>,
     pub(super) mode: Option<u64>,
     pub(super) resolve: Option<u64>,
@@ -25,9 +29,7 @@ pub(super) fn decode_monitor_event(event: &MonitorEvent) -> DecodedKernelEvent {
         EVENT_SENDMSG => decoded_plain_event("sendmsg", decode_sockaddr_endpoint(&event.data)),
         EVENT_EXEC => decoded_plain_event("exec", decode_c_string(&event.data)),
         EVENT_FILE_BLOCKED => decoded_plain_event("file_blocked", decode_c_string(&event.data)),
-        EVENT_CONNECT_BLOCKED => {
-            decoded_plain_event("connect_blocked", decode_sockaddr_endpoint(&event.data))
-        }
+        EVENT_CONNECT_BLOCKED => decoded_connect_blocked_event(event),
         other => decoded_plain_event(&format!("event_{other}"), None),
     }
 }
@@ -36,6 +38,10 @@ fn decoded_plain_event(kind: &str, value: Option<String>) -> DecodedKernelEvent 
     DecodedKernelEvent {
         kind: kind.to_string(),
         value,
+        cgroup_id: None,
+        network_destination: None,
+        network_port: None,
+        rule_id: None,
         flags: None,
         mode: None,
         resolve: None,
@@ -51,6 +57,10 @@ fn decoded_open_event(event: &MonitorEvent) -> DecodedKernelEvent {
     DecodedKernelEvent {
         kind: "openat".to_string(),
         value: decode_c_string(&event.data),
+        cgroup_id: None,
+        network_destination: None,
+        network_port: None,
+        rule_id: None,
         flags: Some(flags),
         mode: Some(event.mode),
         resolve: (event.resolve != 0).then_some(event.resolve),
@@ -65,6 +75,69 @@ fn decoded_open_event(event: &MonitorEvent) -> DecodedKernelEvent {
             }
             .to_string(),
         ),
+    }
+}
+
+fn decoded_connect_blocked_event(event: &MonitorEvent) -> DecodedKernelEvent {
+    if let Some(blocked) = decode_blocked_socket_payload(&event.data) {
+        return DecodedKernelEvent {
+            kind: "connect_blocked".to_string(),
+            value: Some(blocked.endpoint),
+            cgroup_id: Some(blocked.cgroup_id),
+            network_destination: Some(blocked.destination),
+            network_port: Some(blocked.port),
+            rule_id: Some(blocked.rule_id),
+            flags: None,
+            mode: None,
+            resolve: None,
+            return_value: None,
+            access_mode: None,
+            operation_flags: Vec::new(),
+            status: None,
+        };
+    }
+    decoded_plain_event("connect_blocked", decode_sockaddr_endpoint(&event.data))
+}
+
+struct BlockedSocketPayload {
+    cgroup_id: u64,
+    destination: String,
+    endpoint: String,
+    port: u16,
+    rule_id: u32,
+}
+
+fn decode_blocked_socket_payload(bytes: &[u8]) -> Option<BlockedSocketPayload> {
+    if bytes.len() < 40 {
+        return None;
+    }
+    let cgroup_id = u64::from_ne_bytes(bytes[0..8].try_into().ok()?);
+    let family = u16::from_ne_bytes(bytes[8..10].try_into().ok()?);
+    let port = u16::from_ne_bytes(bytes[10..12].try_into().ok()?);
+    let rule_id = u32::from_ne_bytes(bytes[32..36].try_into().ok()?);
+    match family {
+        2 => {
+            let destination = Ipv4Addr::new(bytes[12], bytes[13], bytes[14], bytes[15]).to_string();
+            Some(BlockedSocketPayload {
+                endpoint: format!("{destination}:{port}"),
+                destination,
+                port,
+                cgroup_id,
+                rule_id,
+            })
+        }
+        10 => {
+            let destination =
+                Ipv6Addr::from(<[u8; 16]>::try_from(&bytes[16..32]).ok()?).to_string();
+            Some(BlockedSocketPayload {
+                endpoint: format!("[{destination}]:{port}"),
+                destination,
+                port,
+                cgroup_id,
+                rule_id,
+            })
+        }
+        _ => None,
     }
 }
 

--- a/crates/assay-runner-core/src/kernel/tests/events.rs
+++ b/crates/assay-runner-core/src/kernel/tests/events.rs
@@ -197,20 +197,30 @@ fn ipv4_connect_event_records_network_capability() {
 
 #[test]
 fn connect_blocked_event_records_network_capability() {
-    let mut sockaddr = [0_u8; 16];
-    sockaddr[0..2].copy_from_slice(&2_u16.to_ne_bytes());
-    sockaddr[2..4].copy_from_slice(&443_u16.to_be_bytes());
-    sockaddr[4..8].copy_from_slice(&[10, 0, 0, 5]);
+    let mut socket_payload = [0_u8; 512];
+    socket_payload[0..8].copy_from_slice(&99_u64.to_ne_bytes());
+    socket_payload[8..10].copy_from_slice(&2_u16.to_ne_bytes());
+    socket_payload[10..12].copy_from_slice(&443_u16.to_ne_bytes());
+    socket_payload[12..16].copy_from_slice(&[10, 0, 0, 5]);
+    socket_payload[32..36].copy_from_slice(&17_u32.to_ne_bytes());
+    socket_payload[36..40].copy_from_slice(&2_u32.to_ne_bytes());
     let mut builder = KernelLayerBuilder::new("run_001").unwrap();
 
     builder
-        .push_monitor_event(&event(EVENT_CONNECT_BLOCKED, &sockaddr))
+        .push_monitor_event(&event(EVENT_CONNECT_BLOCKED, &socket_payload))
         .unwrap();
     let capture = builder.finish(
         &MonitorStatsSnapshot::default(),
         &MonitorStatsSnapshot::default(),
     );
+    let record: KernelLayerEvent = serde_json::from_slice(&capture.kernel_layer_ndjson).unwrap();
 
+    assert_eq!(record.kind, "connect_blocked");
+    assert_eq!(record.value.as_deref(), Some("10.0.0.5:443"));
+    assert_eq!(record.cgroup_id, Some(99));
+    assert_eq!(record.network_destination.as_deref(), Some("10.0.0.5"));
+    assert_eq!(record.network_port, Some(443));
+    assert_eq!(record.rule_id, Some(17));
     assert!(capture
         .capability_surface
         .network_endpoints

--- a/crates/assay-runner-core/src/policy.rs
+++ b/crates/assay-runner-core/src/policy.rs
@@ -142,6 +142,22 @@ impl PolicyLayerCapture {
         self,
         archive: &mut RunnerSpikeArchive,
     ) -> Result<(), PolicyLayerError> {
+        self.apply_to_archive_inner(archive, None)
+    }
+
+    pub fn apply_to_archive_with_session_cgroup(
+        self,
+        archive: &mut RunnerSpikeArchive,
+        session_cgroup_id: u64,
+    ) -> Result<(), PolicyLayerError> {
+        self.apply_to_archive_inner(archive, Some(session_cgroup_id))
+    }
+
+    fn apply_to_archive_inner(
+        self,
+        archive: &mut RunnerSpikeArchive,
+        session_cgroup_id: Option<u64>,
+    ) -> Result<(), PolicyLayerError> {
         let PolicyLayerCapture {
             run_id,
             policy_layer_ndjson,
@@ -179,10 +195,18 @@ impl PolicyLayerCapture {
                 .mark_partial("policy_events_without_kernel_events");
         }
 
+        let unique_session_cgroup_id = session_cgroup_id.filter(|_| events.len() == 1);
+        if session_cgroup_id.is_some() && unique_session_cgroup_id.is_none() {
+            archive
+                .correlation_report
+                .mark_partial("session_cgroup_ambiguous_for_multiple_policy_events");
+        }
+
         for event in events {
             archive.correlation_report.add_binding(CorrelationBinding {
                 tool_call_id: event.tool_call_id,
                 policy_decision: Some(event.decision),
+                cgroup_id: unique_session_cgroup_id,
                 kernel_event_count,
                 window: BindingWindow {
                     start: "run_started".to_string(),
@@ -241,6 +265,9 @@ mod tests {
 
     const DECISION: &[u8] = br#"{"specversion":"1.0","id":"evt_decision_001","type":"assay.tool.decision","source":"assay://runner-spike/run_001","time":"2026-05-20T00:00:00Z","data":{"tool":"read_file","decision":"allow","reason_code":"P_TOOL_ALLOWED","tool_call_id":"tc_runner_policy_001"}}
 "#;
+    const TWO_DECISIONS: &[u8] = br#"{"type":"assay.tool.decision","source":"assay://runner-spike/run_001","data":{"tool":"read_file","decision":"allow","tool_call_id":"tc_runner_policy_001"}}
+{"type":"assay.tool.decision","source":"assay://runner-spike/run_001","data":{"tool":"write_file","decision":"deny","tool_call_id":"tc_runner_policy_002"}}
+"#;
 
     #[test]
     fn decision_log_records_policy_layer_and_surface() {
@@ -276,6 +303,55 @@ mod tests {
             "tc_runner_policy_001"
         );
         assert_eq!(archive.correlation_report.bindings[0].kernel_event_count, 1);
+    }
+
+    #[test]
+    fn unique_session_cgroup_records_tool_call_binding_key() {
+        let capture = PolicyLayerCapture::from_decision_ndjson("run_001", DECISION).unwrap();
+        let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+        archive.observation_health.kernel_layer = KernelLayerStatus::Complete;
+        archive.observation_health.cgroup_correlation = CgroupCorrelationStatus::Clean;
+        archive.kernel_layer_ndjson = b"{\"schema\":\"assay.runner.kernel_event.v0\"}\n".to_vec();
+
+        capture
+            .apply_to_archive_with_session_cgroup(&mut archive, 42)
+            .unwrap();
+
+        assert_eq!(archive.correlation_report.bindings.len(), 1);
+        assert_eq!(
+            archive.correlation_report.bindings[0].tool_call_id,
+            "tc_runner_policy_001"
+        );
+        assert_eq!(archive.correlation_report.bindings[0].cgroup_id, Some(42));
+        assert!(archive.correlation_report.ambiguities.is_empty());
+    }
+
+    #[test]
+    fn shared_session_cgroup_does_not_claim_per_call_binding_for_multiple_policy_events() {
+        let capture = PolicyLayerCapture::from_decision_ndjson("run_001", TWO_DECISIONS).unwrap();
+        let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+        archive.observation_health.kernel_layer = KernelLayerStatus::Complete;
+        archive.observation_health.cgroup_correlation = CgroupCorrelationStatus::Clean;
+        archive.kernel_layer_ndjson = b"{\"schema\":\"assay.runner.kernel_event.v0\"}\n".to_vec();
+
+        capture
+            .apply_to_archive_with_session_cgroup(&mut archive, 42)
+            .unwrap();
+
+        assert_eq!(
+            archive.correlation_report.status,
+            assay_runner_schema::CorrelationStatus::Partial
+        );
+        assert!(archive
+            .correlation_report
+            .bindings
+            .iter()
+            .all(|binding| binding.cgroup_id.is_none()));
+        assert!(archive
+            .correlation_report
+            .ambiguities
+            .iter()
+            .any(|ambiguity| ambiguity == "session_cgroup_ambiguous_for_multiple_policy_events"));
     }
 
     #[test]

--- a/crates/assay-runner-core/src/sdk.rs
+++ b/crates/assay-runner-core/src/sdk.rs
@@ -344,6 +344,7 @@ mod tests {
             .add_binding(assay_runner_schema::CorrelationBinding {
                 tool_call_id: "tc_runner_policy_001".to_string(),
                 policy_decision: Some("allow".to_string()),
+                cgroup_id: None,
                 kernel_event_count: 1,
                 window: assay_runner_schema::BindingWindow {
                     start: "run_started".to_string(),
@@ -370,6 +371,7 @@ mod tests {
             .add_binding(assay_runner_schema::CorrelationBinding {
                 tool_call_id: "tc_different_policy_call".to_string(),
                 policy_decision: Some("allow".to_string()),
+                cgroup_id: None,
                 kernel_event_count: 1,
                 window: assay_runner_schema::BindingWindow {
                     start: "run_started".to_string(),

--- a/crates/assay-runner-schema/src/correlation.rs
+++ b/crates/assay-runner-schema/src/correlation.rs
@@ -21,6 +21,8 @@ pub struct BindingWindow {
 pub struct CorrelationBinding {
     pub tool_call_id: String,
     pub policy_decision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cgroup_id: Option<u64>,
     pub kernel_event_count: u64,
     pub window: BindingWindow,
 }

--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -125,6 +125,20 @@ These fields are optional so older v0 archives remain readable. Consumers that
 need read/write/create/remove distinctions must require the optional open
 metadata and treat older archives as inconclusive for that dimension.
 
+`connect_blocked` events may additionally carry decoded socket metadata:
+
+| Field | Type | Required | Semantics |
+|---|---|---:|---|
+| `cgroup_id` | integer | no | Linux cgroup id observed on the structured blocked-socket event |
+| `network_destination` | string | no | Decoded destination address for the blocked socket event |
+| `network_port` | integer | no | Decoded destination port for the blocked socket event |
+| `rule_id` | integer | no | Policy rule id carried by the blocked-socket event |
+
+These fields are optional and only describe the retained blocked-socket event
+that emitted them. Absence means the archive does not carry this binding key or
+decoded socket detail for the event; consumers must not infer that no blocked
+socket event occurred elsewhere.
+
 Open metadata example:
 
 ```json
@@ -156,6 +170,24 @@ Undecoded event example:
   "event_type": 999,
   "kind": "event_999",
   "value": null
+}
+```
+
+Blocked socket example:
+
+```json
+{
+  "schema": "assay.runner.kernel_event.v0",
+  "run_id": "run_001",
+  "seq": 4,
+  "pid": 1234,
+  "event_type": 20,
+  "kind": "connect_blocked",
+  "value": "198.51.100.7:25",
+  "cgroup_id": 123456789,
+  "network_destination": "198.51.100.7",
+  "network_port": 25,
+  "rule_id": 7
 }
 ```
 
@@ -330,6 +362,7 @@ Binding fields:
 |---|---|---:|---|
 | `tool_call_id` | string | yes | Tool-call id used to bind SDK and policy layers |
 | `policy_decision` | string or null | yes | Matched coarse policy outcome, when present (`allow` or `deny` in v0 accepted fixtures) |
+| `cgroup_id` | integer | no | Session cgroup id used as an adapter-derived binding key when the run has exactly one policy decision; absent when the key is unavailable or ambiguous |
 | `kernel_event_count` | integer | yes | Count of normalized kernel events in the binding window |
 | `window.start` | string | yes | Inclusive window start marker |
 | `window.end` | string | yes | Inclusive window end marker |
@@ -347,6 +380,13 @@ stable tool-call id, the runner must report a partial or failed correlation
 state until a separate call-id-less fixture and contract explicitly define the
 fallback semantics.
 
+When kernel capture is run inside a single session cgroup and the archive
+contains exactly one policy decision, v0 may retain that session `cgroup_id` on
+the binding as an adapter-derived join key. If the same session cgroup covers
+multiple policy decisions, the join is ambiguous: the binding must omit
+`cgroup_id` and the report must mark `status=partial` with
+`session_cgroup_ambiguous_for_multiple_policy_events`.
+
 Example:
 
 ```json
@@ -358,6 +398,7 @@ Example:
     {
       "tool_call_id": "tc_runner_policy_001",
       "policy_decision": "allow",
+      "cgroup_id": 123456789,
       "kernel_event_count": 2,
       "window": {
         "start": "run_started",

--- a/docs/reference/runner/schema/kernel-event-v0.schema.json
+++ b/docs/reference/runner/schema/kernel-event-v0.schema.json
@@ -107,6 +107,25 @@
         "error"
       ],
       "description": "Derived from return_value for open-style events."
+    },
+    "cgroup_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Linux cgroup id decoded from structured connect_blocked socket events when available."
+    },
+    "network_destination": {
+      "type": "string",
+      "description": "Decoded network destination address for structured connect_blocked socket events."
+    },
+    "network_port": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Decoded network destination port for structured connect_blocked socket events."
+    },
+    "rule_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Policy rule id decoded from structured connect_blocked socket events when available."
     }
   },
   "allOf": [
@@ -271,7 +290,11 @@
       "pid": 1234,
       "event_type": 20,
       "kind": "connect_blocked",
-      "value": "198.51.100.7:25"
+      "value": "198.51.100.7:25",
+      "cgroup_id": 123456789,
+      "network_destination": "198.51.100.7",
+      "network_port": 25,
+      "rule_id": 7
     },
     {
       "schema": "assay.runner.kernel_event.v0",

--- a/scripts/ci/runner-spike-gemini-google-genai-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-gemini-google-genai-three-run-determinism.sh
@@ -90,9 +90,20 @@ def read_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def normalize_correlation_for_determinism(report):
+    """Keep run-local binding keys in artifacts, but ignore them for repeatability."""
+    normalized = json.loads(json.dumps(report))
+    for binding in normalized.get("bindings", []):
+        if "cgroup_id" in binding:
+            binding["cgroup_id"] = "<run-local-cgroup-id>"
+    return normalized
+
+
 baseline_health = read_json(tmp_root / "run-1" / "extract" / "observation-health.json")
 baseline_surface = read_json(tmp_root / "run-1" / "extract" / "capability-surface.json")
-baseline_correlation = read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+baseline_correlation = normalize_correlation_for_determinism(
+    read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+)
 baseline_sdk = (tmp_root / "run-1" / "extract" / "layers" / "sdk.ndjson").read_text(
     encoding="utf-8"
 )
@@ -103,7 +114,9 @@ baseline_policy = (tmp_root / "run-1" / "extract" / "layers" / "policy.ndjson").
 for run in (2, 3):
     health = read_json(tmp_root / f"run-{run}" / "extract" / "observation-health.json")
     surface = read_json(tmp_root / f"run-{run}" / "extract" / "capability-surface.json")
-    correlation = read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    correlation = normalize_correlation_for_determinism(
+        read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    )
     sdk = (tmp_root / f"run-{run}" / "extract" / "layers" / "sdk.ndjson").read_text(
         encoding="utf-8"
     )

--- a/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh
@@ -82,9 +82,20 @@ def read_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def normalize_correlation_for_determinism(report):
+    """Keep run-local binding keys in artifacts, but ignore them for repeatability."""
+    normalized = json.loads(json.dumps(report))
+    for binding in normalized.get("bindings", []):
+        if "cgroup_id" in binding:
+            binding["cgroup_id"] = "<run-local-cgroup-id>"
+    return normalized
+
+
 baseline_health = read_json(tmp_root / "run-1" / "extract" / "observation-health.json")
 baseline_surface = read_json(tmp_root / "run-1" / "extract" / "capability-surface.json")
-baseline_correlation = read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+baseline_correlation = normalize_correlation_for_determinism(
+    read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+)
 baseline_policy = (tmp_root / "run-1" / "extract" / "layers" / "policy.ndjson").read_text(
     encoding="utf-8"
 )
@@ -92,7 +103,9 @@ baseline_policy = (tmp_root / "run-1" / "extract" / "layers" / "policy.ndjson").
 for run in (2, 3):
     health = read_json(tmp_root / f"run-{run}" / "extract" / "observation-health.json")
     surface = read_json(tmp_root / f"run-{run}" / "extract" / "capability-surface.json")
-    correlation = read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    correlation = normalize_correlation_for_determinism(
+        read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    )
     policy = (tmp_root / f"run-{run}" / "extract" / "layers" / "policy.ndjson").read_text(
         encoding="utf-8"
     )

--- a/scripts/ci/runner-spike-openai-agents-kernel-policy-acceptance.sh
+++ b/scripts/ci/runner-spike-openai-agents-kernel-policy-acceptance.sh
@@ -243,7 +243,7 @@ sdk_events = [
     json.loads(line)
     for line in (extract_dir / "layers/sdk.ndjson").read_text(encoding="utf-8").splitlines()
 ]
-expect(len(policy_events) == 1, f"expected one policy event, got {len(policy_events)}")
+expect(policy_events, "expected at least one policy event")
 expect(len(sdk_events) == 3, f"expected three sdk events, got {len(sdk_events)}")
 
 policy_event = policy_events[0]
@@ -254,8 +254,11 @@ expect(policy_event["tool"] == "read_file", "policy event tool mismatch")
 expect(policy_event["decision"] == "allow", "policy event decision mismatch")
 
 source_events = [json.loads(line) for line in decision_log.read_text(encoding="utf-8").splitlines() if line.strip()]
-expect(len(source_events) == 1, f"expected one source decision event, got {len(source_events)}")
-expect(source_events[0]["type"] == "assay.tool.decision", "source decision event type mismatch")
+expect(
+    len(source_events) == len(policy_events),
+    f"source decision event count mismatch: source={len(source_events)} policy={len(policy_events)}",
+)
+expect(all(event["type"] == "assay.tool.decision" for event in source_events), "source decision event type mismatch")
 expect(
     source_events[0]["data"]["tool_call_id"] == policy_tool_call_id,
     "source decision tool_call_id mismatch",
@@ -310,9 +313,22 @@ else:
     expect(not hidden_write_events, "matched_safe_read recorded unexpected hidden write kernel event")
 
 bindings = correlation.get("bindings", [])
-expect(correlation["status"] == "clean", f"correlation status must be clean, got {correlation['status']!r}")
-expect(correlation.get("ambiguities", []) == [], f"correlation ambiguities must be empty: {correlation.get('ambiguities', [])!r}")
-expect(len(bindings) == 1, f"expected one correlation binding, got {len(bindings)}")
+ambiguities = correlation.get("ambiguities", [])
+session_cgroup_ambiguity = "session_cgroup_ambiguous_for_multiple_policy_events"
+if len(policy_events) == 1:
+    expect(correlation["status"] == "clean", f"correlation status must be clean, got {correlation['status']!r}")
+    expect(ambiguities == [], f"correlation ambiguities must be empty: {ambiguities!r}")
+    expect(len(bindings) == 1, f"expected one correlation binding, got {len(bindings)}")
+else:
+    expect(correlation["status"] == "partial", f"multi-decision correlation status must be partial, got {correlation['status']!r}")
+    expect(
+        ambiguities == [session_cgroup_ambiguity],
+        f"multi-decision correlation ambiguity mismatch: {ambiguities!r}",
+    )
+    expect(
+        len(bindings) == len(policy_events),
+        f"expected one correlation binding per policy event, got {len(bindings)} for {len(policy_events)} policy events",
+    )
 binding = bindings[0]
 expect(binding["tool_call_id"] == policy_tool_call_id, "binding tool_call_id mismatch")
 expect(binding["policy_decision"] == "allow", "binding policy_decision mismatch")

--- a/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh
@@ -84,9 +84,20 @@ def read_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def normalize_correlation_for_determinism(report):
+    """Keep run-local binding keys in artifacts, but ignore them for repeatability."""
+    normalized = json.loads(json.dumps(report))
+    for binding in normalized.get("bindings", []):
+        if "cgroup_id" in binding:
+            binding["cgroup_id"] = "<run-local-cgroup-id>"
+    return normalized
+
+
 baseline_health = read_json(tmp_root / "run-1" / "extract" / "observation-health.json")
 baseline_surface = read_json(tmp_root / "run-1" / "extract" / "capability-surface.json")
-baseline_correlation = read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+baseline_correlation = normalize_correlation_for_determinism(
+    read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+)
 baseline_sdk = (tmp_root / "run-1" / "extract" / "layers" / "sdk.ndjson").read_text(
     encoding="utf-8"
 )
@@ -97,7 +108,9 @@ baseline_policy = (tmp_root / "run-1" / "extract" / "layers" / "policy.ndjson").
 for run in (2, 3):
     health = read_json(tmp_root / f"run-{run}" / "extract" / "observation-health.json")
     surface = read_json(tmp_root / f"run-{run}" / "extract" / "capability-surface.json")
-    correlation = read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    correlation = normalize_correlation_for_determinism(
+        read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    )
     sdk = (tmp_root / f"run-{run}" / "extract" / "layers" / "sdk.ndjson").read_text(
         encoding="utf-8"
     )


### PR DESCRIPTION
## Summary
- share the cgroup socket-event ABI between eBPF and userspace
- project SOCKET_EVENTS records into structured type-20 monitor events instead of opaque hex
- retain cgroup_id, network destination, port, and rule_id on runner kernel-event exports
- thread unique session cgroup ids into policy correlation bindings, while marking shared-session joins as partial rather than overclaiming per-call attribution

## Claim ceiling
This adds a kernel-boundary binding key where the carrier can support it. A unique session cgroup can bind a single policy event; a shared session cgroup across multiple policy events stays partial and does not claim per-call attribution.

## Verification
- cargo test -p assay-monitor
- cargo test -p assay-runner-core kernel::tests::events -- --nocapture
- cargo test -p assay-cli blocked_net -- --nocapture
- cargo test -p assay-cli session_cgroup_id_flows_into_policy_correlation_binding -- --nocapture
- cargo test -p assay-runner-schema
- cargo check -p assay-ebpf
- cargo clippy -p assay-common -p assay-ebpf -p assay-monitor -p assay-runner-schema -p assay-runner-core -p assay-cli --all-targets -- -D warnings
- git diff --check origin/main...HEAD
- pre-push hook: cargo clippy (workspace, deny warnings) + linux compile gate

## Notes
Draft until the delegated runner lane proof lands on this exact head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added socket telemetry ingestion to monitoring and runner output.
  * Enhanced blocked/`connect_blocked` event reporting with decoded destination, port, cgroup ID, and rule ID.
  * Correlation reports can now include an optional cgroup ID when it can be unambiguously determined.
* **Bug Fixes**
  * Improved formatting fallback for blocked network events when payload decoding fails.
* **Documentation**
  * Updated runner artifact and schema references for the new optional fields.
* **Chores**
  * Updated determinism checks to ignore run-local cgroup ID differences in correlation reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->