### PR TITLE
feat(mcp): bind approval artifact retention digest

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -241,6 +241,117 @@ mod tests {
     }
 
     #[test]
+    fn test_with_policy_context_projects_approval_artifact_retention_digest() {
+        let artifact = ApprovalArtifact {
+            approval_id: "apr_001".to_string(),
+            approver: "alice@example.com".to_string(),
+            issued_at: "2026-03-11T11:00:00Z".to_string(),
+            expires_at: "2026-03-11T12:00:00Z".to_string(),
+            scope: "tool:deploy".to_string(),
+            bound_tool: "deploy_service".to_string(),
+            bound_resource: "service/prod".to_string(),
+        };
+        let expected_digest = format!(
+            "sha256:{}",
+            crate::fingerprint::sha256_hex(&crate::mcp::jcs::to_string(&artifact).unwrap())
+        );
+
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_approval_digest".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW)
+        .with_policy_context(PolicyDecisionEventContext {
+            approval_state: Some("approved".to_string()),
+            approval_artifact: Some(artifact),
+            approval_freshness: Some(ApprovalFreshness::Fresh),
+            ..PolicyDecisionEventContext::default()
+        });
+
+        let json = serde_json::to_value(&event).unwrap();
+        let data = &json["data"];
+        assert_eq!(
+            data["approval_artifact_digest"],
+            serde_json::json!(expected_digest)
+        );
+        assert_eq!(data["approval_artifact_digest_alg"], "sha256");
+        assert_eq!(
+            data["approval_artifact_digest_profile"],
+            "assay.approval_artifact.structured_meta_jcs.v0"
+        );
+        assert_eq!(data["approval_retained_view"], "structured_meta_jcs");
+        assert_eq!(
+            data["approval_retention_non_claims"],
+            serde_json::json!([
+                "not_rendered_ui_view",
+                "not_user_seen_bytes",
+                "not_raw_byte_retention",
+                "not_model_behavior_truth",
+                "not_user_intent_truth"
+            ])
+        );
+    }
+
+    #[test]
+    fn test_with_policy_context_omits_approval_retention_without_artifact() {
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_no_approval_digest".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW)
+        .with_policy_context(PolicyDecisionEventContext {
+            approval_state: Some("required".to_string()),
+            approval_artifact: None,
+            ..PolicyDecisionEventContext::default()
+        });
+
+        let json = serde_json::to_value(&event).unwrap();
+        let data = json["data"].as_object().unwrap();
+        assert!(!data.contains_key("approval_artifact_digest"));
+        assert!(!data.contains_key("approval_artifact_digest_alg"));
+        assert!(!data.contains_key("approval_artifact_digest_profile"));
+        assert!(!data.contains_key("approval_retained_view"));
+        assert!(!data.contains_key("approval_retention_non_claims"));
+    }
+
+    #[test]
+    fn test_approval_artifact_retention_digest_changes_with_bound_resource() {
+        let base = ApprovalArtifact {
+            approval_id: "apr_001".to_string(),
+            approver: "alice@example.com".to_string(),
+            issued_at: "2026-03-11T11:00:00Z".to_string(),
+            expires_at: "2026-03-11T12:00:00Z".to_string(),
+            scope: "tool:deploy".to_string(),
+            bound_tool: "deploy_service".to_string(),
+            bound_resource: "service/prod".to_string(),
+        };
+        let mut changed = base.clone();
+        changed.bound_resource = "service/staging".to_string();
+
+        let digest_for = |artifact: ApprovalArtifact| {
+            DecisionEvent::new(
+                "assay://test".to_string(),
+                "tc_digest_change".to_string(),
+                "deploy_service".to_string(),
+            )
+            .allow(reason_codes::P_POLICY_ALLOW)
+            .with_policy_context(PolicyDecisionEventContext {
+                approval_state: Some("approved".to_string()),
+                approval_artifact: Some(artifact),
+                approval_freshness: Some(ApprovalFreshness::Fresh),
+                ..PolicyDecisionEventContext::default()
+            })
+            .data
+            .approval_artifact_digest
+            .expect("approval artifact should project a digest")
+        };
+
+        assert_ne!(digest_for(base), digest_for(changed));
+    }
+
+    #[test]
     fn test_with_policy_context_sets_complete_context_contract_fields() {
         let context = PolicyDecisionEventContext {
             lane: Some("lane-prod".to_string()),

--- a/crates/assay-core/src/mcp/decision_next/builder.rs
+++ b/crates/assay-core/src/mcp/decision_next/builder.rs
@@ -41,6 +41,11 @@ impl DecisionEvent {
                 scope: None,
                 approval_bound_tool: None,
                 approval_bound_resource: None,
+                approval_artifact_digest: None,
+                approval_artifact_digest_alg: None,
+                approval_artifact_digest_profile: None,
+                approval_retained_view: None,
+                approval_retention_non_claims: None,
                 approval_freshness: None,
                 approval_failure_reason: None,
                 scope_type: None,
@@ -245,6 +250,8 @@ impl DecisionEvent {
         self.data.obligations = obligations;
         self.data.obligation_outcomes = obligation_outcomes;
         self.data.approval_state = approval_state;
+        self.data
+            .apply_approval_artifact_retention(approval_artifact.as_ref());
         if let Some(artifact) = approval_artifact {
             self.data.approval_id = Some(artifact.approval_id);
             self.data.approver = Some(artifact.approver);

--- a/crates/assay-core/src/mcp/decision_next/event_types.rs
+++ b/crates/assay-core/src/mcp/decision_next/event_types.rs
@@ -539,7 +539,8 @@ impl DecisionData {
         if let Some(artifact) = artifact {
             if let Ok(canonical) = crate::mcp::jcs::to_string(artifact) {
                 self.approval_artifact_digest = Some(format!(
-                    "sha256:{}",
+                    "{}:{}",
+                    APPROVAL_ARTIFACT_DIGEST_ALG_SHA256,
                     crate::fingerprint::sha256_hex(&canonical)
                 ));
                 self.approval_artifact_digest_alg =

--- a/crates/assay-core/src/mcp/decision_next/event_types.rs
+++ b/crates/assay-core/src/mcp/decision_next/event_types.rs
@@ -19,6 +19,21 @@ pub const POLICY_SNAPSHOT_DIGEST_ALG_SHA256: &str = "sha256";
 pub const POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY: &str = "jcs:mcp_policy";
 /// Bounded schema tag for the supported MCP policy snapshot projection.
 pub const POLICY_SNAPSHOT_SCHEMA_V1: &str = "assay.mcp.policy.snapshot.v1";
+/// Digest algorithm for retained approval-artifact basis.
+pub const APPROVAL_ARTIFACT_DIGEST_ALG_SHA256: &str = "sha256";
+/// Canonicalization/profile for retained structured approval artifacts.
+pub const APPROVAL_ARTIFACT_PROFILE_STRUCTURED_META_JCS_V0: &str =
+    "assay.approval_artifact.structured_meta_jcs.v0";
+/// Retained view class for approval artifacts parsed from `_meta.approval`.
+pub const APPROVAL_RETAINED_VIEW_STRUCTURED_META_JCS: &str = "structured_meta_jcs";
+/// Non-claims carried with structured approval artifact retention.
+pub const APPROVAL_RETENTION_NON_CLAIMS: &[&str] = &[
+    "not_rendered_ui_view",
+    "not_user_seen_bytes",
+    "not_raw_byte_retention",
+    "not_model_behavior_truth",
+    "not_user_intent_truth",
+];
 
 /// Reason codes for tool decisions (SPEC-Mandate-v1.0.4 §7.10).
 pub mod reason_codes {
@@ -245,6 +260,21 @@ pub struct DecisionData {
     /// Approval artifact bound resource
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approval_bound_resource: Option<String>,
+    /// Digest of the retained structured approval artifact basis
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_artifact_digest: Option<String>,
+    /// Digest algorithm for `approval_artifact_digest`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_artifact_digest_alg: Option<String>,
+    /// Profile/canonicalization used for `approval_artifact_digest`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_artifact_digest_profile: Option<String>,
+    /// Retained view class for the approval basis
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_retained_view: Option<String>,
+    /// Explicit non-claims for structured approval retention
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_retention_non_claims: Option<Vec<String>>,
     /// Freshness status derived from approval validity window
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approval_freshness: Option<ApprovalFreshness>,
@@ -497,5 +527,41 @@ impl DecisionData {
             self.tool_definition_schema = None;
             self.tool_definition_source = None;
         }
+    }
+
+    /// Project the retained structured approval basis into explicit digest
+    /// fields. This is not a UI-view claim: it binds only the parsed
+    /// `_meta.approval` artifact under the named profile.
+    pub(crate) fn apply_approval_artifact_retention(
+        &mut self,
+        artifact: Option<&ApprovalArtifact>,
+    ) {
+        if let Some(artifact) = artifact {
+            if let Ok(canonical) = crate::mcp::jcs::to_string(artifact) {
+                self.approval_artifact_digest = Some(format!(
+                    "sha256:{}",
+                    crate::fingerprint::sha256_hex(&canonical)
+                ));
+                self.approval_artifact_digest_alg =
+                    Some(APPROVAL_ARTIFACT_DIGEST_ALG_SHA256.to_string());
+                self.approval_artifact_digest_profile =
+                    Some(APPROVAL_ARTIFACT_PROFILE_STRUCTURED_META_JCS_V0.to_string());
+                self.approval_retained_view =
+                    Some(APPROVAL_RETAINED_VIEW_STRUCTURED_META_JCS.to_string());
+                self.approval_retention_non_claims = Some(
+                    APPROVAL_RETENTION_NON_CLAIMS
+                        .iter()
+                        .map(|claim| (*claim).to_string())
+                        .collect(),
+                );
+                return;
+            }
+        }
+
+        self.approval_artifact_digest = None;
+        self.approval_artifact_digest_alg = None;
+        self.approval_artifact_digest_profile = None;
+        self.approval_retained_view = None;
+        self.approval_retention_non_claims = None;
     }
 }

--- a/crates/assay-core/src/mcp/proxy/decisions.rs
+++ b/crates/assay-core/src/mcp/proxy/decisions.rs
@@ -109,6 +109,9 @@ pub(super) fn emit_decision(
     event.data.obligation_outcomes =
         crate::mcp::obligations::execute_log_only(&metadata.obligations, tool);
     event.data.approval_state = metadata.approval_state.clone();
+    event
+        .data
+        .apply_approval_artifact_retention(metadata.approval_artifact.as_ref());
     if let Some(artifact) = &metadata.approval_artifact {
         event.data.approval_id = Some(artifact.approval_id.clone());
         event.data.approver = Some(artifact.approver.clone());
@@ -155,6 +158,7 @@ pub(super) fn emit_decision(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::policy::{ApprovalArtifact, ApprovalFreshness};
     use crate::mcp::tool_definition::{
         TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1,
         TOOL_DEFINITION_DIGEST_ALG_SHA256, TOOL_DEFINITION_SCHEMA_V1,
@@ -327,6 +331,72 @@ mod tests {
         assert_eq!(data.lane.as_deref(), Some("local-dev"));
         assert_eq!(data.principal.as_deref(), Some("user:alice"));
         assert_eq!(data.auth_context_summary.as_deref(), Some("local session"));
+    }
+
+    #[test]
+    fn proxy_contract_emit_decision_projects_approval_retention_digest() {
+        let artifact = ApprovalArtifact {
+            approval_id: "apr_001".to_string(),
+            approver: "alice@example.com".to_string(),
+            issued_at: "2026-03-11T11:00:00Z".to_string(),
+            expires_at: "2026-03-11T12:00:00Z".to_string(),
+            scope: "tool:deploy".to_string(),
+            bound_tool: "deploy_service".to_string(),
+            bound_resource: "service/prod".to_string(),
+        };
+        let expected_digest = format!(
+            "sha256:{}",
+            crate::fingerprint::sha256_hex(&crate::mcp::jcs::to_string(&artifact).unwrap())
+        );
+        let emitter = Arc::new(CapturingEmitter::new());
+        let emitter_trait: Arc<dyn DecisionEmitter> = emitter.clone();
+        let metadata = PolicyMatchMetadata {
+            approval_state: Some("approved".to_string()),
+            approval_artifact: Some(artifact),
+            approval_freshness: Some(ApprovalFreshness::Fresh),
+            ..PolicyMatchMetadata::default()
+        };
+
+        emit_decision(
+            &emitter_trait,
+            "assay://test",
+            "tc_approval_retention",
+            "deploy_service",
+            Decision::Allow,
+            reason_codes::P_POLICY_ALLOW,
+            None,
+            None,
+            &metadata,
+            None,
+        );
+
+        let events = emitter.events.lock().unwrap();
+        let data = &events[0].data;
+        assert_eq!(
+            data.approval_artifact_digest.as_deref(),
+            Some(expected_digest.as_str())
+        );
+        assert_eq!(data.approval_artifact_digest_alg.as_deref(), Some("sha256"));
+        assert_eq!(
+            data.approval_artifact_digest_profile.as_deref(),
+            Some("assay.approval_artifact.structured_meta_jcs.v0")
+        );
+        assert_eq!(
+            data.approval_retained_view.as_deref(),
+            Some("structured_meta_jcs")
+        );
+        assert_eq!(
+            data.approval_retention_non_claims.as_deref(),
+            Some(
+                &[
+                    "not_rendered_ui_view".to_string(),
+                    "not_user_seen_bytes".to_string(),
+                    "not_raw_byte_retention".to_string(),
+                    "not_model_behavior_truth".to_string(),
+                    "not_user_intent_truth".to_string(),
+                ][..]
+            )
+        );
     }
 
     #[test]

--- a/docs/reference/config/policies.md
+++ b/docs/reference/config/policies.md
@@ -212,6 +212,13 @@ Use these when you want:
 - runtime enforcement that file or resource arguments stay in-bounds
 - redaction of secrets before downstream logging or evidence export
 
+When an `approval_required` obligation is evaluated from a supplied
+`_meta.approval` artifact, the decision event also carries a digest/profile for
+that structured approval artifact. This binds the projected approval summary
+fields to the retained `_meta.approval` basis under
+`assay.approval_artifact.structured_meta_jcs.v0`. It is not a rendered UI view
+claim, not raw byte retention, and not proof of what a user saw or intended.
+
 ## Tool Pins
 
 `tool_pins` protect against tool-definition drift by pinning the expected server, tool name, and hashes:


### PR DESCRIPTION
## Summary

Adds a minimal producer-side retention slice for approval-required decisions.

When an existing `_meta.approval` artifact is present and projected into `enforcement_decision.v0`, the decision event now also carries optional digest/profile metadata for that structured approval artifact:

- `approval_artifact_digest`
- `approval_artifact_digest_alg`
- `approval_artifact_digest_profile`
- `approval_retained_view`
- `approval_retention_non_claims`

The first profile is `assay.approval_artifact.structured_meta_jcs.v0`, using the existing JCS path over the parsed approval artifact.

## Claim ceiling

This is structured approval-artifact retention only. It does not claim to capture the rendered UI view, raw user-seen bytes, raw hostile metadata, sanitizer coverage, model behavior truth, or user intent. It binds the projected approval summary fields to the retained `_meta.approval` basis under a named profile.

## Why

The approval-view retention probe showed that a reviewer needs an explicit retained basis before reading approval-binding claims. The repo reality check found an existing narrow producer path (`_meta.approval` -> `ApprovalArtifact` -> `enforcement_decision.v0`), so this PR keeps the slice there instead of adding a standalone approval-view carrier.

## Verification

- `cargo test -p assay-core approval_artifact_retention`
- `cargo test -p assay-core approval_required`
- `cargo clippy -p assay-core --all-targets -- -D warnings`
- `cargo test -p assay-core --lib`
- `cargo test -p assay-core`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Decision events now project approval-artifact retention metadata, including an approval digest, digest algorithm/profile, a retained view label, and retained non-claim details when an approval artifact is provided.
* **Tests**
  * Added unit and proxy-level coverage to verify JSON inclusion/exclusion of retention fields and to ensure the digest changes when the approval artifact basis changes.
* **Documentation**
  * Updated policy documentation to clarify that approval evaluation produces digest/profile data tied to the structured approval artifact basis, not view-claim content or raw retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->