### PR TITLE
fix(registry): adapt to x509-cert 0.3.0 accessor API

### DIFF
--- a/crates/assay-registry/src/sigstore_identity.rs
+++ b/crates/assay-registry/src/sigstore_identity.rs
@@ -82,14 +82,14 @@ pub fn verify_identity_offline(
         Ok(c) => c,
         Err(_) => return IdentityOutcome::new(CheckStatus::Failed, "malformed leaf certificate"),
     };
-    let tbs = &cert.tbs_certificate;
+    let tbs = cert.tbs_certificate();
 
     // Fulcio profile: issued certs MUST have an empty subject; the identity lives in the SAN.
-    if !tbs.subject.0.is_empty() {
+    if !tbs.subject().is_empty() {
         return IdentityOutcome::new(CheckStatus::Failed, "certificate has a non-empty subject");
     }
 
-    let extensions = match &tbs.extensions {
+    let extensions = match tbs.extensions() {
         Some(exts) => exts.as_slice(),
         None => {
             return IdentityOutcome::new(CheckStatus::IdentityMismatch, "no certificate extensions")

--- a/crates/assay-registry/src/sigstore_signature.rs
+++ b/crates/assay-registry/src/sigstore_signature.rs
@@ -58,7 +58,7 @@ pub fn verify_leaf_ecdsa_signature_over_bytes(
         Ok(c) => c,
         Err(_) => return SignatureOutcome::new(CheckStatus::Failed, "malformed leaf certificate"),
     };
-    let spki_der = match cert.tbs_certificate.subject_public_key_info.to_der() {
+    let spki_der = match cert.tbs_certificate().subject_public_key_info().to_der() {
         Ok(d) => d,
         Err(_) => {
             return SignatureOutcome::new(CheckStatus::Failed, "malformed leaf public key info")


### PR DESCRIPTION
## Description

The dependabot bump of `x509-cert` 0.2.5 → 0.3.0 (#1814) broke the workspace build on `main`. In 0.3.0 several `TbsCertificate` fields became private and are now exposed as accessor methods. This updates the sigstore signature/identity verification in `assay-registry` accordingly:

| Old (0.2.5) | New (0.3.0) |
|---|---|
| `cert.tbs_certificate` | `cert.tbs_certificate()` |
| `…subject_public_key_info` | `…subject_public_key_info()` |
| `tbs.subject.0.is_empty()` | `tbs.subject().is_empty()` |
| `&tbs.extensions` | `tbs.extensions()` |

Only `assay-registry` depends on `x509-cert`, so this is the full scope of the change (2 files, 4 lines).

The post-merge failure affected `CI` (clippy + test + perf), `Kernel Matrix CI`, `Smoke Install (E2E)`, `Perf (main baseline)`, `Runner Spike SDK` and `assay-action-contract-tests` — all cascading from `assay-registry` failing to compile.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Verification
- [x] `cargo check` passes (`cargo build -p assay-registry`)
- [x] `cargo test` passes (`cargo test -p assay-registry` — all unit/integration/doc tests, incl. the sigstore signature & identity tests that exercise the changed code)
- [x] `cargo clippy -p assay-registry --all-targets -- -D warnings` is clean

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. <!-- existing sigstore tests cover the changed paths; no new behavior introduced -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xEq8vT4HJK9enDfcMpq4i

---
_Generated by [Claude Code](https://claude.ai/code/session_011xEq8vT4HJK9enDfcMpq4i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal certificate parsing and public-key access during signature and identity verification.
  * Preserved existing validation rules and error handling for invalid certificates and signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->