### PR TITLE
feat(evidence): ASSAY-W005 opaque/unknown retained-view lint + reserved encrypted-view vocabulary

### DIFF
--- a/crates/assay-core/src/mcp/decision_next/event_types.rs
+++ b/crates/assay-core/src/mcp/decision_next/event_types.rs
@@ -35,6 +35,35 @@ pub const APPROVAL_RETENTION_NON_CLAIMS: &[&str] = &[
     "not_user_intent_truth",
 ];
 
+/// RESERVED retained-view class for an encrypted/opaque approval basis. No Assay path retains
+/// ciphertext today, so nothing emits this value; it is reserved so a record that does retain an
+/// encrypted body (imported or future) declares it instead of minting an ad-hoc value. A reader
+/// must treat this view as not readable: content-review claims over the basis cap at
+/// `incomplete` regardless of bundle/chain verification.
+#[allow(dead_code)] // reserved vocabulary: no emitter exists by design
+pub const APPROVAL_RETAINED_VIEW_ENCRYPTED: &str = "encrypted";
+/// Reserved field beside an `encrypted` retained view: the party holding the decryption key.
+/// Opacity is reviewer-relative — without this a reviewer cannot even tell whether the record
+/// is opaque *to them*.
+#[allow(dead_code)] // reserved vocabulary: no emitter exists by design
+pub const APPROVAL_ENCRYPTED_FIELD_KEY_HOLDER: &str = "approval_encryption_key_holder";
+/// Reserved field: SALTED commitment to the plaintext (salt disclosed together with the
+/// plaintext, never retained). Salted rather than a bare digest so low-entropy content is not
+/// dictionary-recoverable from the commitment; a retained commitment makes a later disclosure
+/// checkable without holding the key.
+#[allow(dead_code)] // reserved vocabulary: no emitter exists by design
+pub const APPROVAL_ENCRYPTED_FIELD_PLAINTEXT_COMMITMENT: &str = "approval_plaintext_commitment";
+/// Reserved field: media type of the plaintext the commitment covers.
+#[allow(dead_code)] // reserved vocabulary: no emitter exists by design
+pub const APPROVAL_ENCRYPTED_FIELD_PREIMAGE_CONTENT_TYPE: &str = "approval_preimage_content_type";
+/// Reserved field: hint where the plaintext or ciphertext may be found.
+#[allow(dead_code)] // reserved vocabulary: no emitter exists by design
+pub const APPROVAL_ENCRYPTED_FIELD_PAYLOAD_LOCATION: &str = "approval_payload_location";
+/// Reserved field: optional machine-readable reason the content is opaque
+/// (e.g. PII, trade secret, regulatory confidentiality).
+#[allow(dead_code)] // reserved vocabulary: no emitter exists by design
+pub const APPROVAL_ENCRYPTED_FIELD_OPACITY_REASON: &str = "approval_opacity_reason";
+
 /// Reason codes for tool decisions (SPEC-Mandate-v1.0.4 §7.10).
 pub mod reason_codes {
     // Policy decisions (P_*)

--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -315,17 +315,24 @@ fn check_retained_view_readability(
     if payload.get("schema").and_then(Value::as_str) != Some("assay.enforcement_decision.v0") {
         return None;
     }
-    let view = non_empty(payload.get("approval_retained_view")?.as_str()?)?;
+    // A retained-view claim is only in scope when the field is present. Absent means the record
+    // makes no such claim, so W005 does not apply.
+    let raw_view = payload.get("approval_retained_view")?;
+
+    // Present but empty or non-string collapses to `None` and fails closed below as an
+    // opaque/unknown view — never silently skipped (integrity is a floor, never a lift).
+    let view = raw_view.as_str().and_then(non_empty);
 
     // The one shipped readable view: a digest-recomputable structured basis. Silent.
-    if view == RETAINED_VIEW_STRUCTURED_META_JCS {
+    if view == Some(RETAINED_VIEW_STRUCTURED_META_JCS) {
         return None;
     }
 
     // Fail-closed reading: an opaque view caps content-review at incomplete even when the
     // bundle verifies (integrity is a floor, never a lift), and the two opaque states differ
-    // in recovery path; an unrecognized view is treated as not readable, never as readable.
-    let message = if view == RETAINED_VIEW_ENCRYPTED {
+    // in recovery path; an unrecognized, empty, or non-string view is treated as not readable,
+    // never as readable.
+    let message = if view == Some(RETAINED_VIEW_ENCRYPTED) {
         if payload
             .get(ENCRYPTED_PLAINTEXT_COMMITMENT_FIELD)
             .and_then(Value::as_str)
@@ -343,11 +350,16 @@ fn check_retained_view_readability(
                 .to_string()
         }
     } else {
-        format!(
-            "Approval basis declares unknown retained view '{}' — fail-closed: content-review \
-             claims cap at incomplete",
-            view
-        )
+        match view {
+            Some(view) => format!(
+                "Approval basis declares unknown retained view '{}' — fail-closed: content-review \
+                 claims cap at incomplete",
+                view
+            ),
+            None => "Approval basis declares an empty or non-string retained view — fail-closed: \
+                     content-review claims cap at incomplete"
+                .to_string(),
+        }
     };
 
     Some(

--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -121,6 +121,17 @@ pub static RULES: &[RuleDefinition] = &[
         security_severity: Some("4.0"),
         check: check_enforcement_attribution_binding,
     },
+    RuleDefinition {
+        id: "ASSAY-W005",
+        default_severity: Severity::Warn,
+        description:
+            "Approval basis declares an opaque or unknown retained view — content-review claims \
+             over it cap at incomplete",
+        help_uri: Some("https://docs.assay.dev/lint/ASSAY-W005"),
+        tags: &["retention", "review", "sufficiency"],
+        security_severity: None,
+        check: check_retained_view_readability,
+    },
 ];
 
 /// Patterns that suggest secrets in subjects.
@@ -283,6 +294,75 @@ fn check_enforcement_attribution_binding(
             ],
         )
         .with_help_uri("https://docs.assay.dev/lint/ASSAY-W004"),
+    )
+}
+
+// W005 keys on the SHIPPED approval-retention block of `assay.enforcement_decision.v0`
+// (assay-core src/mcp/decision_next/event_types.rs): `approval_retained_view` with today's only
+// emitted value `structured_meta_jcs`, plus the RESERVED `encrypted` value and its
+// `approval_plaintext_commitment` sibling (no emitter yet — reserved for imported or future
+// records that retain an encrypted body). Values are mirrored here because assay-evidence does
+// not depend on assay-core; keep them in sync with the producer constants.
+const RETAINED_VIEW_STRUCTURED_META_JCS: &str = "structured_meta_jcs";
+const RETAINED_VIEW_ENCRYPTED: &str = "encrypted";
+const ENCRYPTED_PLAINTEXT_COMMITMENT_FIELD: &str = "approval_plaintext_commitment";
+
+fn check_retained_view_readability(
+    event: &EvidenceEvent,
+    ctx: &LintContext<'_>,
+) -> Option<LintFinding> {
+    let payload = &event.payload;
+    if payload.get("schema").and_then(Value::as_str) != Some("assay.enforcement_decision.v0") {
+        return None;
+    }
+    let view = non_empty(payload.get("approval_retained_view")?.as_str()?)?;
+
+    // The one shipped readable view: a digest-recomputable structured basis. Silent.
+    if view == RETAINED_VIEW_STRUCTURED_META_JCS {
+        return None;
+    }
+
+    // Fail-closed reading: an opaque view caps content-review at incomplete even when the
+    // bundle verifies (integrity is a floor, never a lift), and the two opaque states differ
+    // in recovery path; an unrecognized view is treated as not readable, never as readable.
+    let message = if view == RETAINED_VIEW_ENCRYPTED {
+        if payload
+            .get(ENCRYPTED_PLAINTEXT_COMMITMENT_FIELD)
+            .and_then(Value::as_str)
+            .and_then(non_empty)
+            .is_some()
+        {
+            "Approval basis declares an encrypted retained view (opaque_bindable: a plaintext \
+             commitment travels) — content-review claims cap at incomplete; a later disclosure \
+             is checkable against the commitment"
+                .to_string()
+        } else {
+            "Approval basis declares an encrypted retained view (opaque_unbindable: no plaintext \
+             commitment) — content-review claims cap at incomplete; recoverable only by key \
+             disclosure"
+                .to_string()
+        }
+    } else {
+        format!(
+            "Approval basis declares unknown retained view '{}' — fail-closed: content-review \
+             claims cap at incomplete",
+            view
+        )
+    };
+
+    Some(
+        LintFinding::new(
+            "ASSAY-W005",
+            Severity::Warn,
+            message,
+            Some(EventLocation {
+                seq: ctx.seq,
+                line: ctx.line_number,
+                event_type: Some(event.type_.clone()),
+            }),
+            vec!["retention".into(), "review".into(), "sufficiency".into()],
+        )
+        .with_help_uri("https://docs.assay.dev/lint/ASSAY-W005"),
     )
 }
 

--- a/crates/assay-evidence/tests/lint_test.rs
+++ b/crates/assay-evidence/tests/lint_test.rs
@@ -285,17 +285,24 @@ fn approval_decision_event(
         },
         "decision": "allow"
     });
+    // The producer only emits `approval_plaintext_commitment` alongside an `encrypted` retained
+    // view. Requesting it for any other view (or none) is a test-authoring mistake, not a shape
+    // the emitter can produce, so reject it here rather than let the helper fabricate it.
+    assert!(
+        !with_plaintext_commitment || retained_view == Some("encrypted"),
+        "approval_plaintext_commitment only travels with an `encrypted` retained view",
+    );
     if let Some(view) = retained_view {
         payload["approval_retained_view"] = serde_json::json!(view);
         payload["approval_artifact_digest"] = serde_json::json!(
             "sha256:2b7c1e5f8a3d6b9c2e5f8a1d4b7c0e3f6a9d2c5b8e1f4a7d6d5a1f3b8c9e2d4a"
         );
         payload["approval_artifact_digest_alg"] = serde_json::json!("sha256");
-    }
-    if with_plaintext_commitment {
-        payload["approval_plaintext_commitment"] = serde_json::json!(
-            "sha256:8a3d6b9c2e5f8a1d4b7c0e3f6a9d2c5b8e1f4a7d6d5a1f3b8c9e2d4a2b7c1e5f"
-        );
+        if with_plaintext_commitment {
+            payload["approval_plaintext_commitment"] = serde_json::json!(
+                "sha256:8a3d6b9c2e5f8a1d4b7c0e3f6a9d2c5b8e1f4a7d6d5a1f3b8c9e2d4a2b7c1e5f"
+            );
+        }
     }
     let mut event = EvidenceEvent::new(
         "assay.enforcement_decision",
@@ -349,6 +356,28 @@ fn test_w005_flags_unknown_retained_view_fail_closed() {
     assert_eq!(findings.len(), 1, "expected one ASSAY-W005 finding");
     assert!(findings[0].contains("unknown retained view 'rendered_screenshot'"));
     assert!(findings[0].contains("fail-closed"));
+}
+
+#[test]
+fn test_w005_flags_empty_retained_view_fail_closed() {
+    // A present-but-empty declaration is unusable, not absent: it must fail closed as opaque,
+    // never be silently skipped.
+    let bundle = create_bundle_from_events(vec![approval_decision_event(0, Some(""), false)]);
+    let findings = w005_findings(&bundle);
+    assert_eq!(findings.len(), 1, "expected one ASSAY-W005 finding");
+    assert!(findings[0].contains("empty or non-string retained view"));
+    assert!(findings[0].contains("fail-closed"));
+}
+
+#[test]
+fn test_w005_flags_non_string_retained_view_fail_closed() {
+    // A present-but-non-string declaration is likewise unusable and fails closed.
+    let mut event = approval_decision_event(0, Some("encrypted"), false);
+    event.payload["approval_retained_view"] = serde_json::json!(42);
+    let bundle = create_bundle_from_events(vec![event]);
+    let findings = w005_findings(&bundle);
+    assert_eq!(findings.len(), 1, "expected one ASSAY-W005 finding");
+    assert!(findings[0].contains("empty or non-string retained view"));
 }
 
 #[test]

--- a/crates/assay-evidence/tests/lint_test.rs
+++ b/crates/assay-evidence/tests/lint_test.rs
@@ -266,6 +266,116 @@ fn test_w004_skips_unbindable_observation_without_target_digest() {
     );
 }
 
+/// Mirrors the shipped approval-retention block on `assay.enforcement_decision.v0`
+/// (assay-core src/mcp/decision_next/event_types.rs). `retained_view` None omits the block
+/// entirely, matching a decision without an approval basis.
+fn approval_decision_event(
+    seq: u64,
+    retained_view: Option<&str>,
+    with_plaintext_commitment: bool,
+) -> EvidenceEvent {
+    let mut payload = serde_json::json!({
+        "schema": "assay.enforcement_decision.v0",
+        "tool": { "name": "fs_write", "action_class": "fs_write" },
+        "action": {
+            "verb": "write",
+            "resource_type": "file",
+            "target": { "path": "/workspace/out/report.md" },
+            "target_digest": "sha256:call-target"
+        },
+        "decision": "allow"
+    });
+    if let Some(view) = retained_view {
+        payload["approval_retained_view"] = serde_json::json!(view);
+        payload["approval_artifact_digest"] = serde_json::json!(
+            "sha256:2b7c1e5f8a3d6b9c2e5f8a1d4b7c0e3f6a9d2c5b8e1f4a7d6d5a1f3b8c9e2d4a"
+        );
+        payload["approval_artifact_digest_alg"] = serde_json::json!("sha256");
+    }
+    if with_plaintext_commitment {
+        payload["approval_plaintext_commitment"] = serde_json::json!(
+            "sha256:8a3d6b9c2e5f8a1d4b7c0e3f6a9d2c5b8e1f4a7d6d5a1f3b8c9e2d4a2b7c1e5f"
+        );
+    }
+    let mut event = EvidenceEvent::new(
+        "assay.enforcement_decision",
+        "urn:assay:test",
+        "run_lint",
+        seq,
+        payload,
+    );
+    event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
+    event
+}
+
+fn w005_findings(bundle: &[u8]) -> Vec<String> {
+    let report = lint_bundle(Cursor::new(bundle), VerifyLimits::default()).unwrap();
+    report
+        .findings
+        .iter()
+        .filter(|finding| finding.rule_id == "ASSAY-W005")
+        .map(|finding| finding.message.clone())
+        .collect()
+}
+
+#[test]
+fn test_w005_flags_encrypted_retained_view_as_opaque_unbindable() {
+    let bundle =
+        create_bundle_from_events(vec![approval_decision_event(0, Some("encrypted"), false)]);
+    let findings = w005_findings(&bundle);
+    assert_eq!(findings.len(), 1, "expected one ASSAY-W005 finding");
+    assert!(findings[0].contains("opaque_unbindable"));
+    assert!(findings[0].contains("cap at incomplete"));
+}
+
+#[test]
+fn test_w005_flags_encrypted_view_with_commitment_as_opaque_bindable() {
+    let bundle =
+        create_bundle_from_events(vec![approval_decision_event(0, Some("encrypted"), true)]);
+    let findings = w005_findings(&bundle);
+    assert_eq!(findings.len(), 1, "expected one ASSAY-W005 finding");
+    assert!(findings[0].contains("opaque_bindable"));
+    assert!(findings[0].contains("checkable against the commitment"));
+}
+
+#[test]
+fn test_w005_flags_unknown_retained_view_fail_closed() {
+    let bundle = create_bundle_from_events(vec![approval_decision_event(
+        0,
+        Some("rendered_screenshot"),
+        false,
+    )]);
+    let findings = w005_findings(&bundle);
+    assert_eq!(findings.len(), 1, "expected one ASSAY-W005 finding");
+    assert!(findings[0].contains("unknown retained view 'rendered_screenshot'"));
+    assert!(findings[0].contains("fail-closed"));
+}
+
+#[test]
+fn test_w005_silent_on_shipped_structured_meta_jcs_view() {
+    let bundle = create_bundle_from_events(vec![approval_decision_event(
+        0,
+        Some("structured_meta_jcs"),
+        false,
+    )]);
+    assert!(
+        w005_findings(&bundle).is_empty(),
+        "the shipped readable view must not produce an ASSAY-W005 finding"
+    );
+}
+
+#[test]
+fn test_w005_silent_without_approval_retention_block() {
+    let bundle = create_bundle_from_events(vec![
+        approval_decision_event(0, None, false),
+        enforcement_decision_event(1, "fs_write", "sha256:call-target", "deny"),
+    ]);
+    assert!(
+        w005_findings(&bundle).is_empty(),
+        "a decision without a declared retained view is out of W005's scope"
+    );
+}
+
 #[test]
 fn test_secret_in_subject_detected() {
     let bundle = create_bundle_with_secret_subject();


### PR DESCRIPTION
## What

Adds a fail-closed **lint rule** (evidence-side) that flags approval bases whose retained view is opaque or unrecognized, plus the reserved producer **vocabulary** for declaring an encrypted retained view. Scope is detection and reserved constants only — no runtime/consumer behavior changes in this PR.

### ASSAY-W005 (new lint rule, warn)

Fires when an `assay.enforcement_decision.v0` approval basis declares a retained view the reviewer cannot read:

- `encrypted` with a plaintext commitment retained → **opaque_bindable**: content-review claims cap at `incomplete`, but a later disclosure is checkable against the commitment.
- `encrypted` without a commitment → **opaque_unbindable**: cap at `incomplete`, recoverable only by key disclosure.
- any unrecognized view value → fail-closed: cap at `incomplete` (an unknown view is never treated as readable).

The shipped `structured_meta_jcs` view stays silent, and a decision without an approval-retention block is out of scope. The rule keys strictly on the shipped producer shape (same pattern as ASSAY-W004), and bundle verification does not lift the verdict: integrity checks establish that a record is unaltered, not that it is reviewable.

### Reserved encrypted-view vocabulary (assay-core)

Beside the existing approval-retention constants: the `encrypted` retained-view value plus field names for key holder, **salted** plaintext commitment (salted so low-entropy content is not dictionary-recoverable from the commitment; salt disclosed with the plaintext, never retained), preimage content type, payload location, and an optional opacity reason. No emitter exists by design — no Assay path retains ciphertext today; the reservation ensures imported or future records declare a known shape instead of an ad-hoc value. Field shapes follow existing public patterns (COSE Hash Envelope's preimage content-type + payload location headers, SD-CWT-style salted commitments, C2PA-style redaction reasons) rather than minting new ones.

## Verification

- 7 W005 tests (bindable / unbindable / unknown-view / empty & non-string fail-closed / shipped-view-silent / no-block-silent); full `cargo test -p assay-evidence` green
- `cargo test -p assay-core --lib`: 425 passed (incl. the 9 approval-retention tests)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt` + pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added lint rule **ASSAY-W005** to warn when approval retained-view content is not sufficiently readable/verifyable.
  - Recognizes encrypted retained views and checks for the presence of the associated plaintext commitment metadata.

- **Bug Fixes**
  - Warnings now fail-closed for unknown, empty, or non-string retained-view values, with messages tailored to the detected condition.
  - Structured retained-view approvals and decisions without approval-retention details remain unaffected.

- **Tests**
  - Added lint test coverage for encrypted, structured, missing, unknown, empty, and malformed retained-view scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
