### PR TITLE
chore(release): prepare v3.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.34.0] - 2026-07-19
+
+### Added
+- Add `ASSAY-W005`, an evidence lint rule that flags approval bases declaring an opaque or
+  unrecognized retained view (`encrypted`, or any value the reviewer cannot read), so content-review
+  claims over them cap at incomplete. A present-but-empty or non-string view fails closed rather than
+  being silently skipped, and integrity verification never lifts the verdict. Reserves the
+  `encrypted` retained-view vocabulary (key holder, salted plaintext commitment, preimage
+  content-type, payload location, opacity reason); no emitter exists yet, the reservation keeps
+  imported or future records on a known shape.
+- Bind the approval-artifact retention digest into `assay.enforcement_decision.v0`, carrying the
+  retained view and its artifact digest alongside the decision.
+- Bind kernel socket events to their originating cgroup in the runner, so network events attribute to
+  the process that made them.
+
+### Fixed
+- Make the GitHub Release publish step idempotent: if a release for the tag already exists (for
+  example a prior partial run left an empty release), attach the assets and refresh metadata instead
+  of failing, so built artifacts and the crates.io/PyPI publish are no longer stranded.
+- Adapt the registry to the `x509-cert` 0.3.0 accessor API.
+
 ## [3.33.0] - 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "aya",
  "chrono",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "3.33.0"
+version = "3.34.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.33.0"
+version = "3.34.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Prepares **Assay v3.34.0** (minor). Cutting it off current `main`, which now carries the idempotent-publish fix (#1817), so the tag build self-heals rather than repeating the v3.33.0 empty-release failure.

Version chosen as **3.34.0** (not 3.33.1) because `main` carries `feat` commits since 3.33.0 (#1806, #1798).

### Included since 3.33.0
- **Added:** ASSAY-W005 opaque/unknown retained-view lint + reserved encrypted-view vocabulary (#1816); approval-artifact retention-digest binding (#1806); kernel socket→cgroup event binding (#1798)
- **Fixed:** idempotent GitHub Release publish (#1817); x509-cert 0.3.0 accessor adaptation (#1815)

### Contents
- `Cargo.toml` workspace version 3.33.0 → 3.34.0
- `Cargo.lock` — 22 workspace-crate version bumps only (verified `cargo check --workspace --locked --offline`; no dependency re-resolution)
- `CHANGELOG.md` — [3.34.0] entry

After merge, tagging `v3.34.0` triggers the release workflow (build → idempotent GitHub Release → crates.io / PyPI via the `crates`/`pypi` environments). `v3.32.0` is currently pinned Latest as the mitigation; it will be repointed to v3.34.0 once assets publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)