### PR TITLE
fix(evidence): write golden-vector fixture with a trailing newline

### DIFF
--- a/crates/assay-evidence/tests/generate_golden_vectors.rs
+++ b/crates/assay-evidence/tests/generate_golden_vectors.rs
@@ -284,9 +284,12 @@ fn generate_golden_vectors_json() {
     // Write to fixture file
     let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/mandate_golden_vectors.json");
+    // Trailing newline keeps the regenerated file byte-identical to the
+    // committed one; without it every test run leaves the fixture dirty and
+    // the end-of-file-fixer pre-commit hook rewrites it mid-commit.
     std::fs::write(
         &fixture_path,
-        serde_json::to_string_pretty(&fixture).unwrap(),
+        format!("{}\n", serde_json::to_string_pretty(&fixture).unwrap()),
     )
     .expect("Failed to write fixture file");
     println!("\n✅ Written to: {}", fixture_path.display());


### PR DESCRIPTION
## What

`generate_golden_vectors_json` writes its fixture with `serde_json::to_string_pretty`, which emits no trailing newline. The committed fixture has one. Result: every `cargo test -p assay-evidence` (and every `cargo test --workspace`) rewrote `mandate_golden_vectors.json` without the newline and left it as a spurious modification in `git status`.

The `end-of-file-fixer` pre-commit hook then re-added the newline mid-commit, which fails the *first* commit attempt for anyone staging files in this area. The file had been sitting as an uncommitted modification across sessions for exactly this reason.

This appends the newline at the write site so the regenerated file is byte-identical to the committed one.

## Note on the original diagnosis

The symptom initially looked like "`origin/main` is missing the trailing newline." It isn't — `origin/main` and `HEAD` both end in `0a`. Only the *working tree* copy lost it, because it is regenerated on every test run. Committing the newline to the fixture would have been a no-op followed by immediate recurrence; the fix has to be in the generator.

## Byte-significance check

Safe for a golden-vector file. Nothing reads or hashes this fixture — `generate_golden_vectors.rs` is its only consumer and it only writes. The self-verification loop recomputes each `mandate_id` from the in-memory `hashable_canonical_jcs` string, never from file bytes. The trailing newline is outside the JSON grammar and outside anything digest-bound. (`generate_golden_fixtures.rs` references a different path, `tests/fixtures/mandate/golden_vectors.json`.)

## Verification

- Reproduced on a clean worktree: running the generator flipped the fixture's last byte `0a` -> `7d` and the tree clean -> modified.
- After the fix: generator rerun leaves the last byte at `0a` and the tree clean.
- `cargo test -p assay-evidence` fully green (263 unit + ~110 across integration binaries, 0 failures), no fixture modification afterward.
- Pre-commit hooks pass on the first attempt, including `end-of-file-fixer`.

## Follow-up worth considering (not in this PR)

This generator is really a code generator wearing a `#[test]` hat, and it writes into the source tree on every default suite invocation. If it causes trouble again, `#[ignore]` + an explicit `-- --ignored` run would decouple "regenerate the vectors" from "run the tests". Left alone here since that is a broader call about how the vectors are maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated generated test fixtures to include a consistent trailing newline.
  * Regenerated output now remains byte-identical to the committed fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->