### PR TITLE
docs: evidence-first positioning freeze (niche, one golden path, ADR-042)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <h1 align="center">Assay</h1>
   <p align="center">
-    <strong>Policy-as-code for MCP agents: enforce what a tool call can do, prove what it did, stay honest about what you can't.</strong><br />
-    <span>A deterministic, fail-closed gate for MCP tool calls — with real kernel-level (eBPF/LSM) enforcement on Linux and offline-verifiable evidence. CI-native, no backend, bounded by design.</span>
+    <strong>The open, recomputable evidence profile for privileged MCP tool actions.</strong><br />
+    <span>Assay records what a privileged tool call decided, what was observed, and what stays unproven, so a reviewer can replay the claim offline instead of trusting the agent's account of itself. Enforcement is deterministic and fail-closed, and the enforcing proxy is the reference producer rather than the contract itself. Kernel-level (eBPF/LSM) observation on Linux is an optional stronger vantage. CI-native, no backend, bounded by design.</span>
   </p>
   <p align="center">
     <a href="https://crates.io/crates/assay-cli"><img src="https://img.shields.io/crates/v/assay-cli.svg" alt="Crates.io"></a>
@@ -22,6 +22,8 @@
 ---
 
 Agents got real tool access through MCP — and tool poisoning, rug pulls, and confused-deputy OAuth came with it. Most tools scan a server or filter a prompt. Assay sits at the tool-call boundary and does three things, in order.
+
+**One golden path:** [examples/privileged-action-gate/](examples/privileged-action-gate/) runs the enforcing proxy against a privileged action, offline, and writes the replayable evidence record a reviewer can check without trusting the agent. Start there.
 
 ### Enforce, prove, stay honest
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -349,6 +349,10 @@ For `T1a` and `T1b`, the roadmap stays explicit about what the MVP does **not** 
 
 ### A. Protocol Adapters (Adapter-First Strategy)
 
+> Positioning note: the shipped adapters are maintained as supporting capabilities around the
+> privileged MCP action evidence line, per [ADR-042](architecture/ADR-042-evidence-first-positioning.md).
+> Any further protocol breadth is a separate maintainer decision, not a committed direction.
+
 Lightweight adapters that map protocol-specific events to Assay's `EvidenceEvent` + policy hooks:
 
 | Adapter | Protocol | Focus |
@@ -374,6 +378,9 @@ Status on `main`:
 **AAIF governance note:** MCP and A2A are now under the Agentic AI Foundation (Linux Foundation, Dec 2025). This reduces protocol fragmentation risk and makes adapter investments more durable.
 
 ### B. Connectors
+
+> The unchecked items below are monitoring candidates, not committed work.
+
 - [ ] **SIEM**: Splunk / Microsoft Sentinel export adapters
 - [x] **CI/CD**: GitHub Actions v2 ([Rul1an/assay-action@v2](https://github.com/marketplace/actions/assay-ai-agent-security)) / GitLab CI integration
 - [ ] **GitHub App**: Native policy drift detection in PRs
@@ -422,6 +429,10 @@ If yes, implement per [ADR-009](./architecture/ADR-009-WORM-Storage.md) and [ADR
 ## Q4 2026: Platform Features
 
 **Objective:** Advanced capabilities for larger deployments.
+
+> Status: everything in this section is exploratory and gated on demand signals; none of it is a
+> committed direction. The committed line stays privileged MCP action evidence
+> ([ADR-042](architecture/ADR-042-evidence-first-positioning.md)).
 
 ### A. Governance Dashboard (If Managed Store Exists)
 - [ ] **Policy Drift**: Trend lines, anomaly detection

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -432,12 +432,13 @@ If yes, implement per [ADR-009](./architecture/ADR-009-WORM-Storage.md) and [ADR
 
 > Status: everything in this section is exploratory and gated on demand signals; none of it is a
 > committed direction. The committed line stays privileged MCP action evidence
-> ([ADR-042](architecture/ADR-042-evidence-first-positioning.md)).
+> ([ADR-042](architecture/ADR-042-evidence-first-positioning.md)). Items on ADR-042's stop list
+> (aggregate scores among them) stay refused regardless of demand unless that ADR is superseded.
 
 ### A. Governance Dashboard (If Managed Store Exists)
 - [ ] **Policy Drift**: Trend lines, anomaly detection
-- [ ] **Degradation Reports**: Evidence health score
-- [ ] **Env Strictness Score**: Compliance posture metrics
+- [ ] **Degradation Reports**: per-axis evidence health readouts (never an aggregate score; see ADR-042)
+- [ ] **Env Strictness Posture**: per-control compliance readouts (never an aggregate score; see ADR-042)
 
 ### B. Assurance & Audit Readiness (If Managed Store Exists)
 - [ ] **Policy Exceptions**: Waivers with expiry, owner, rationale; audit trail for compliance exceptions

--- a/docs/architecture/ADR-042-evidence-first-positioning.md
+++ b/docs/architecture/ADR-042-evidence-first-positioning.md
@@ -1,0 +1,52 @@
+# ADR-042: Evidence-first positioning and scope freeze
+
+- Status: Accepted
+- Date: 2026-07-24
+- Supersedes: none
+
+## Context
+
+Assay's distinguishing property is not breadth. It is bounded, recomputable evidence with explicit
+claim ceilings: a record states what it can carry, and integrity never upgrades meaning. Adjacent
+tools cover broad agent governance well, and several of them are explicit that their audit logs
+record attempts and decisions rather than externally verified outcomes. The useful boundary for
+Assay is the evidence question that begins there.
+
+Without a written scope, that boundary erodes in the usual way: a score is added "for convenience",
+a verdict starts summarising things it cannot observe, and the claims stop being trustworthy
+precisely because they became broader.
+
+## Decision
+
+1. Assay is positioned evidence-first. The open profile for privileged MCP tool actions is the
+   contract. The enforcing proxy is the reference producer of that evidence, not the contract
+   itself, so independent producers and independent verifiers remain possible.
+
+2. In scope: MCP `tools/call`; explicitly classified privileged actions; the pre-call policy
+   decision; the caller-visible allow or deny outcome; optional post-action or boundary observation;
+   source class, coverage, digests and non-claims; offline replay and CI or SARIF projection.
+
+3. Out of scope, and refused by design (the stop list):
+   - No aggregate trust score, safety rating or cleanliness scalar of any kind.
+   - No whole-action verdict that collapses decision, observation and outcome into a single claim.
+   - No detector catalogue or heuristic content scanning: model reasoning, prompt safety and
+     content moderation are out.
+   - No generic agent identity, delegation or policy federation. Compose with the established
+     systems for those rather than reimplement them.
+   - No provider-side outcome verification. An allow is the decision to forward, never proof that
+     the action happened.
+   - No compliance or "safe agent" claims.
+   - No broad MCP scanning surface.
+
+4. The profile is published as an open profile. The word "standard" is not used for it until an
+   independent, non-author implementation reproduces the verifier from the specification text and a
+   neutral venue has actually taken it up.
+
+## Consequences
+
+- Claims stay bounded and therefore checkable by someone who does not trust us.
+- Work that does not strengthen the one evidence chain goes to HOLD rather than into the product.
+- Kernel observation, protocol adapters and packs are supporting capabilities, not co-equal product
+  directions.
+- The stop list is normative. Introducing any item on it requires an ADR that supersedes this one,
+  so the refusal cannot erode by accretion.

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -1,7 +1,7 @@
 # MCP upstream proxy — enforcing `tools/call` mode (P61e review-spec)
 
 Status: **shipped** (assay v3.24.0, `proxy-enforce`); this review-spec is kept as the P61e design of
-record. A new arc and the heaviest risk class in the proxy line. It extends
+record. This is the heaviest risk class in the proxy line. It extends
 the shipped, opt-in [manifest-observation proxy](mcp-upstream-proxy-mode.md) (P61a–d, assay v3.23.0)
 from observe-only to **enforcing**: it forwards a privileged `tools/call` only after a fail-closed
 policy decision. Tracked as [#1624]. The binding decisions are agreed (§16, "Resolved decisions"); this

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -1,6 +1,7 @@
 # MCP upstream proxy — enforcing `tools/call` mode (P61e review-spec)
 
-Status: **review-spec, no code.** A new arc and the heaviest risk class in the proxy line. It extends
+Status: **shipped** (assay v3.24.0, `proxy-enforce`); this review-spec is kept as the P61e design of
+record. A new arc and the heaviest risk class in the proxy line. It extends
 the shipped, opt-in [manifest-observation proxy](mcp-upstream-proxy-mode.md) (P61a–d, assay v3.23.0)
 from observe-only to **enforcing**: it forwards a privileged `tools/call` only after a fail-closed
 policy decision. Tracked as [#1624]. The binding decisions are agreed (§16, "Resolved decisions"); this
@@ -349,7 +350,7 @@ P61e-c  split gate-by-gate, each fail-closed and independently tested, NO forwar
         forward path: a call that clears every gate is forwarded; pdp_gate_unavailable is removed.
         (SHIPPED.)
 P61e-d  the assay.enforcement_decision.v0 record + the side-effect-evidence interaction (asserted),
-        kept separate from the observation artifact; Plimsoll consumes it separately (later). (SHIPPED:
+        kept separate from the observation artifact; a downstream consumer reads it separately. (SHIPPED:
         opt-in --enforcement-decision-out NDJSON, one record per decision, allow+deny, fail-closed on
         an unrecordable allow.)
 ```

--- a/docs/reference/mcp-upstream-proxy-mode.md
+++ b/docs/reference/mcp-upstream-proxy-mode.md
@@ -219,8 +219,9 @@ P61b  stdio upstream connection manager + initialize/initialized + tools/list fo
 P61c  tools/list pagination tracker + emit assay.mcp_manifest_observed.v0 + proxy observation-health   [SHIPPED v3.23.0]
 P61d  explicit proxy_unsupported behavior for tools/call (and non-allowlisted methods) in
       manifest-observation mode, with tests proving privileged calls are never forwarded               [SHIPPED v3.23.0]
-P61e  LATER, separate arc: enforcing tools/call proxy with a fail-closed policy decision point and the
-      full confused-deputy mitigations — only if/when specified (review-spec first)                    [NOT STARTED]
+P61e  separate arc: enforcing tools/call proxy with a fail-closed policy decision point and the
+      full confused-deputy mitigations, specified in mcp-upstream-proxy-enforcement.md and shipped
+      as the opt-in proxy-enforce mode                                                                 [SHIPPED v3.24.0]
 ```
 
 P61b carries the **negative forwarding invariant test from day one**: a `tools/call` sent in

--- a/docs/reference/mcp-upstream-proxy-mode.md
+++ b/docs/reference/mcp-upstream-proxy-mode.md
@@ -3,10 +3,10 @@
 Status: **shipped in assay v3.23.0** — manifest-observation v0 (P61a design, P61b forwarding skeleton,
 P61c live `tools/list` observation + `assay.mcp_manifest_observed.v0` emission, P61d denied-method
 hardening). The enforcing `tools/call` proxy (P61e) is a separate arc, specified in
-[mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) (review-spec, no code) — a heavier
-security boundary (caller authorization, upstream credential use, a policy decision before forwarding,
-confused-deputy prevention, `proxy_denied` semantics, side-effect-evidence interaction) that needs its
-own review-spec before any code. This doc remains the design of record for the shipped manifest-
+[mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) and shipped as the opt-in
+`proxy-enforce` mode in assay v3.24.0: a heavier security boundary (caller authorization, upstream
+credential use, a policy decision before forwarding, confused-deputy prevention, `proxy_denied`
+semantics, side-effect-evidence interaction) that got its own review-spec before any code. This doc remains the design of record for the shipped manifest-
 observation mode. Related: [mcp-manifest-drift.md](mcp-manifest-drift.md) (the artifact this mode
 feeds) and the [privileged-action evidence](privileged-action-evidence.md) set.
 

--- a/docs/reference/privileged-action-evidence.md
+++ b/docs/reference/privileged-action-evidence.md
@@ -11,7 +11,7 @@ observe path. This is additive; neither path migrates to or deprecates the other
 The enforcing path (the opt-in `assay-mcp-server proxy-enforce` mode, shipped in assay v3.24.0)
 decides each privileged `tools/call` before forwarding and records the decision as evidence:
 
-```
+```text
 tools/call under review
   -> pre-call manifest-establish journey      (assay.manifest_establish.v0, establish path only,
                                                never the verdict)

--- a/docs/reference/privileged-action-evidence.md
+++ b/docs/reference/privileged-action-evidence.md
@@ -5,7 +5,21 @@ through MCP tool calls. Kernel and network enforcement see that an agent connect
 not see that, through a tool call, it added a deploy key to a repository or a member to a workspace.
 That is the gap this set of records covers.
 
-The pieces compose into one chain:
+The pieces compose into one chain, fed by two sibling paths that coexist: an enforcing path and an
+observe path. This is additive; neither path migrates to or deprecates the other.
+
+The enforcing path (the opt-in `assay-mcp-server proxy-enforce` mode, shipped in assay v3.24.0)
+decides each privileged `tools/call` before forwarding and records the decision as evidence:
+
+```
+tools/call under review
+  -> pre-call manifest-establish journey      (assay.manifest_establish.v0, establish path only,
+                                               never the verdict)
+  -> fail-closed allow or deny, with reason   (assay.enforcement_decision.v0)
+  -> caller-visible deny observation          (assay.denied_call_observation.v0, opt-in sibling)
+```
+
+The observe-path carriers record and review what was seen around a call:
 
 ```
 observed tool call
@@ -20,6 +34,9 @@ observed tool call
 
 | Record | What it carries | Reference |
 |--------|-----------------|-----------|
+| `assay.enforcement_decision.v0` | the enforcing proxy's per-call allow or deny: decision, precedence-pinned reason, `fail_closed`, drift state, credential alias (never the token) | [mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) |
+| `assay.manifest_establish.v0` | the bounded pre-call re-list journey (establish path and run outcome), kept separate from the verdict | [mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) |
+| `assay.denied_call_observation.v0` | opt-in caller-visible proxy-deny observation, kept separate from `assay.enforcement_decision.v0` verdict records | [mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) |
 | `assay.tool_decision_surface.v0` | per-call: server, classified action + projected target, decision, response, redaction | [tool-decision-surface.md](tool-decision-surface.md) |
 | `assay.declared_tool_surface.v0` | declared/allowed privileged actions, for observed-vs-declared review | [declared-tool-surface.md](declared-tool-surface.md) |
 | `assay.tool_decision_truth.v0` | experimental declared-vs-observed policy-decision carrier, digest, verdict, and pack-row primitive | [tool-decision-truth.md](tool-decision-truth.md) |
@@ -72,17 +89,23 @@ observed tool definitions and a consumer that reviews a supplied artifact agains
 manifest-digest baseline, resolving a mismatch to `pending_tool_manifest_review`; and (assay v3.23.0)
 the **MCP upstream manifest-observation proxy mode**, which observes a live upstream `tools/list` and
 emits that artifact with honest completeness, while never executing tools through the proxy (see
-[mcp-upstream-proxy-mode.md](mcp-upstream-proxy-mode.md)).
+[mcp-upstream-proxy-mode.md](mcp-upstream-proxy-mode.md)); and (assay v3.24.0, P61e) the **enforcing
+`tools/call` proxy** (`assay-mcp-server proxy-enforce`), an explicit opt-in mode that decides each
+privileged `tools/call` before forwarding through fail-closed caller-allowance, credential-scope, and
+manifest-drift gates and emits the per-call `assay.enforcement_decision.v0` record, joined by the
+`assay.manifest_establish.v0` establish journey (v3.25.0) and the opt-in
+`assay.denied_call_observation.v0` deny observation (v3.33.0); spec:
+[mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md), runnable end to end in
+[examples/privileged-action-gate](../../examples/privileged-action-gate/).
 
 **Experiment-only (characterized, not a shipped feature):** the credential-overbreadth distribution
 (the scope lattice is a static model, not a provider-verified taxonomy); MCP tool lifecycle; the
 tool-decision truth-layer primitives and conformance vectors; and an OTel log-based event
 projection.
 
-**Parked (needs a separate design before any code):** granular per-tool manifest drift; and the
-enforcing `tools/call` proxy (a heavier security boundary — caller authorization, upstream credential
-use, a policy decision before forwarding, confused-deputy prevention — specified as a review-spec in
-[mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md), no code yet).
+**Parked (needs a separate design before any code):** granular per-tool manifest drift. (The
+enforcing `tools/call` proxy previously listed here shipped as `proxy-enforce` in assay v3.24.0; see
+the shipped list above.)
 
 The load-bearing boundary for the manifest line: **live upstream observation was not a small wiring
 step.** `assay-mcp-server` terminates the protocol and serves its own tools, so observing an upstream


### PR DESCRIPTION
## What

Docs-only positioning freeze. Five slices, one commit each:

1. **README** opens with the category: Assay as the open, recomputable evidence profile for privileged MCP tool actions, with one golden path linked prominently (`examples/privileged-action-gate/`). Enforcement and kernel observation become supporting copy.
2. **`docs/reference/privileged-action-evidence.md`** now carries the shipped enforcing path (`assay.manifest_establish.v0` -> `assay.enforcement_decision.v0` -> opt-in `assay.denied_call_observation.v0`) beside the observe chain, explicitly additive: neither path migrates to or deprecates the other.
3. **ROADMAP**: adapters, connectors, and platform items marked as supporting or monitoring, consistent with the protocol table's existing hedge. The table itself is untouched.
4. **ADR-042** freezes the evidence-first positioning and the stop list (no aggregate trust score, no whole-action verdict, no detector catalogue, no generic identity or policy federation, no provider-side outcome claims). The stop list is normative; superseding it requires a new ADR.
5. **Stale-status sweep**: the two proxy reference docs still said the enforcing `tools/call` proxy was "review-spec, no code", while `proxy-enforce` shipped in v3.24.0 (P61e-c) and the golden-path example runs it. Corrected to shipped, with the review-specs kept as design of record.

## Why

The public docs contradicted shipped reality: a working `proxy-enforce` golden path next to a reference index calling the same proxy "parked, no code yet". This PR makes the docs tell one consistent story and pins the scope in an ADR so it cannot erode by accretion.

## Invariants

- Docs-only: zero changes to code, schemas, fixtures, or vectors; v3.34.0 semantics untouched.
- The profile is called an open profile, not a standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated introductory guidance to highlight open, replayable evidence for privileged MCP actions and a streamlined offline example.
  - Clarified the project roadmap, committed scope, and explicitly exploratory areas.
  - Documented the shipped opt-in enforcement proxy mode and its evidence records.
  - Expanded privileged-action evidence guidance to explain enforcing and observation paths, record types, outcomes, and status.
  - Added an architecture decision record defining scope boundaries and claim limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->