### PR TITLE
feat(evidence): privileged-mcp-action/v0 importer, verifier, and CI-enforced conformance

### DIFF
--- a/conformance/privileged-mcp-action-v0/MANIFEST.json
+++ b/conformance/privileged-mcp-action-v0/MANIFEST.json
@@ -144,8 +144,7 @@
       "sha256": "sha256:dbdc3e1bfb10dc7c0bc10c8b5203f375c5b56662addaa74a473624e99379c0d7",
       "description": "One byte flipped in the stored events file after the manifest was written: integrity fails before any profile semantics run.",
       "expected": {
-        "bundle_integrity": "fail",
-        "verdict": "invalid"
+        "bundle_integrity": "fail"
       },
       "first_failure_informative": "bundle_integrity"
     },

--- a/conformance/privileged-mcp-action-v0/gen_vectors.py
+++ b/conformance/privileged-mcp-action-v0/gen_vectors.py
@@ -277,7 +277,7 @@ VECTORS = [
             observation_record(),
         ],
         "tamper": True,
-        "expected": {"bundle_integrity": "fail", "verdict": "invalid"},
+        "expected": {"bundle_integrity": "fail"},
         "first_failure": "bundle_integrity",
         "description": "One byte flipped in the stored events file after the manifest was written: integrity fails before any profile semantics run.",
     },
@@ -388,8 +388,8 @@ def main() -> int:
         ),
         "corpus_digest": corpus_digest,
         "counts": {
-            "accept": sum(1 for v in manifest_vectors if v["expected"]["verdict"] == "valid"),
-            "reject": sum(1 for v in manifest_vectors if v["expected"]["verdict"] == "invalid"),
+            "accept": sum(1 for v in manifest_vectors if v["expected"].get("verdict") == "valid"),
+            "reject": sum(1 for v in manifest_vectors if v["expected"].get("verdict") != "valid"),
         },
         "vectors": manifest_vectors,
     }

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -11,6 +11,7 @@ pub mod mcp_execution_records;
 pub mod mcp_supersession;
 pub mod mcp_tunnel_observed;
 pub mod openfeature_details;
+pub mod privileged_mcp_action;
 pub mod project_skill_bom;
 pub mod promptfoo_jsonl;
 pub mod pull;
@@ -149,6 +150,9 @@ pub enum EvidenceImportCmd {
     /// Import Promptfoo CLI JSONL assertion component results
     #[command(name = "promptfoo-jsonl")]
     PromptfooJsonl(promptfoo_jsonl::PromptfooJsonlArgs),
+    /// Import privileged-mcp-action producer NDJSON records (decisions, observations, establish)
+    #[command(name = "privileged-mcp-action")]
+    PrivilegedMcpAction(privileged_mcp_action::PrivilegedMcpActionArgs),
     /// Import an experimental tool-decision-truth carrier as a bound recipe row
     #[command(name = "tool-decision-truth")]
     ToolDecisionTruth(tool_decision_truth::ToolDecisionTruthArgs),
@@ -204,6 +208,9 @@ fn cmd_import(args: EvidenceImportArgs) -> Result<i32> {
         }
         EvidenceImportCmd::LiveKitToolAction(a) => livekit_tool_action::cmd_livekit_tool_action(a),
         EvidenceImportCmd::PromptfooJsonl(a) => promptfoo_jsonl::cmd_promptfoo_jsonl(a),
+        EvidenceImportCmd::PrivilegedMcpAction(a) => {
+            privileged_mcp_action::cmd_privileged_mcp_action(a)
+        }
         EvidenceImportCmd::ToolDecisionTruth(a) => tool_decision_truth::cmd_tool_decision_truth(a),
         EvidenceImportCmd::SkillSupplyChain(a) => skill_supply_chain::cmd_skill_supply_chain(a),
     }

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -22,6 +22,7 @@ pub mod skill_supply_chain;
 pub mod skill_supply_chain_capture;
 pub mod store_status;
 pub mod tool_decision_truth;
+pub mod verify_privileged_mcp_action;
 pub mod verify_skill_supply_chain;
 pub mod verify_tool_decision_truth;
 
@@ -50,6 +51,9 @@ pub enum EvidenceCmd {
     /// Verify experimental tool-decision-truth recipe rows against their carriers in a bundle
     #[command(name = "verify-tool-decision-truth")]
     VerifyToolDecisionTruth(verify_tool_decision_truth::VerifyToolDecisionTruthArgs),
+    /// Verify a bundle against the privileged-mcp-action/v0 open profile (claim matrix output)
+    #[command(name = "verify-privileged-mcp-action")]
+    VerifyPrivilegedMcpAction(verify_privileged_mcp_action::VerifyPrivilegedMcpActionArgs),
     /// Verify experimental skill supply-chain carriers against the pinned contract in a bundle
     #[command(name = "verify-skill-supply-chain")]
     VerifySkillSupplyChain(verify_skill_supply_chain::VerifySkillSupplyChainArgs),
@@ -172,6 +176,9 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         }
         EvidenceCmd::VerifyToolDecisionTruth(a) => {
             verify_tool_decision_truth::cmd_verify_tool_decision_truth(a)
+        }
+        EvidenceCmd::VerifyPrivilegedMcpAction(a) => {
+            verify_privileged_mcp_action::cmd_verify_privileged_mcp_action(a)
         }
         EvidenceCmd::VerifySkillSupplyChain(a) => {
             verify_skill_supply_chain::cmd_verify_skill_supply_chain(a)

--- a/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
@@ -1,0 +1,244 @@
+//! EXPERIMENTAL: import privileged-mcp-action producer NDJSON records into one evidence bundle.
+//!
+//! Inputs are the shipped enforcing-proxy carriers of the `privileged-mcp-action/v0` open profile:
+//! `assay.enforcement_decision.v0` records (required file), plus optional
+//! `assay.denied_call_observation.v0` and `assay.manifest_establish.v0` files. Every record is
+//! wrapped byte-faithful as an evidence event whose type is the record's own `schema` member. The
+//! importer deliberately enforces NO profile semantics (cardinality, vocabularies, binding): those
+//! belong to the separate `evidence verify-privileged-mcp-action` verifier, and the conformance
+//! corpus requires that semantically invalid bundles (for example two decisions) stay producible.
+
+use crate::exit_codes;
+use anyhow::{bail, Context, Result};
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+use chrono::{DateTime, Utc};
+use clap::Args;
+use serde_json::Value;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+const EVENT_SOURCE: &str = "urn:assay:external:privileged-mcp-action";
+const DEFAULT_RUN_ID: &str = "import-privileged-mcp-action";
+
+#[derive(Debug, Args, Clone)]
+pub struct PrivilegedMcpActionArgs {
+    /// NDJSON file of assay.enforcement_decision.v0 records
+    #[arg(long, value_name = "PATH")]
+    pub decisions: PathBuf,
+
+    /// Optional NDJSON file of assay.denied_call_observation.v0 records
+    #[arg(long, value_name = "PATH")]
+    pub denied_observations: Option<PathBuf>,
+
+    /// Optional NDJSON file of assay.manifest_establish.v0 records
+    #[arg(long, value_name = "PATH")]
+    pub manifest_establish: Option<PathBuf>,
+
+    /// Output Assay evidence bundle path (.tar.gz)
+    #[arg(long, alias = "out", value_name = "PATH")]
+    pub bundle_out: PathBuf,
+
+    /// Assay import run id used for provenance and event ids
+    #[arg(long, default_value = DEFAULT_RUN_ID)]
+    pub run_id: String,
+
+    /// Import timestamp for deterministic fixtures (RFC3339 UTC recommended)
+    #[arg(long)]
+    pub import_time: Option<String>,
+}
+
+pub fn cmd_privileged_mcp_action(args: PrivilegedMcpActionArgs) -> Result<i32> {
+    if args.run_id.contains(':') {
+        bail!("run_id cannot contain ':' because event ids use run_id:seq");
+    }
+    let import_time = parse_import_time(args.import_time.as_deref())?;
+    let producer = ProducerMeta {
+        name: "assay-cli".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git: option_env!("ASSAY_GIT_SHA").map(str::to_string),
+    };
+
+    // Sequence order is fixed: all decisions in file order, then observations, then establish
+    // records. The order is provenance only; the verifier selects by payload schema, never by seq.
+    let mut records = read_ndjson_records(&args.decisions)?;
+    if let Some(path) = &args.denied_observations {
+        records.extend(read_ndjson_records(path)?);
+    }
+    if let Some(path) = &args.manifest_establish {
+        records.extend(read_ndjson_records(path)?);
+    }
+    if records.is_empty() {
+        bail!(
+            "no records found in {} (or the optional inputs); nothing to import",
+            args.decisions.display()
+        );
+    }
+
+    let out_file = File::create(&args.bundle_out)
+        .with_context(|| format!("failed to create bundle {}", args.bundle_out.display()))?;
+    let mut writer = BundleWriter::new(out_file).with_producer(producer.clone());
+    for (seq, (schema, payload)) in records.into_iter().enumerate() {
+        let event = EvidenceEvent::new(&schema, EVENT_SOURCE, &args.run_id, seq as u64, payload)
+            .with_time(import_time)
+            .with_producer(&producer);
+        writer.add_event(event);
+    }
+    writer
+        .finish()
+        .with_context(|| format!("failed to write bundle {}", args.bundle_out.display()))?;
+
+    eprintln!(
+        "Imported privileged-mcp-action records to {}",
+        args.bundle_out.display()
+    );
+    Ok(exit_codes::OK)
+}
+
+/// Read one NDJSON file into `(schema, payload)` pairs, byte-faithful.
+///
+/// Each non-blank line must parse as a JSON object carrying a string `schema` member: that string
+/// becomes the event type. Nothing else about the record is inspected here.
+fn read_ndjson_records(path: &Path) -> Result<Vec<(String, Value)>> {
+    let file =
+        File::open(path).with_context(|| format!("failed to open records {}", path.display()))?;
+    let mut records = Vec::new();
+    for (lineno, line) in BufReader::new(file).lines().enumerate() {
+        let line = line.with_context(|| format!("failed to read {}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let payload: Value = serde_json::from_str(&line)
+            .with_context(|| format!("{} line {}: invalid JSON", path.display(), lineno + 1))?;
+        let schema = payload
+            .get("schema")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        match schema {
+            Some(schema) => records.push((schema, payload)),
+            None => bail!(
+                "{} line {}: record has no string schema member; cannot type the event",
+                path.display(),
+                lineno + 1
+            ),
+        }
+    }
+    Ok(records)
+}
+
+fn parse_import_time(value: Option<&str>) -> Result<DateTime<Utc>> {
+    match value {
+        Some(value) => Ok(DateTime::parse_from_rfc3339(value)
+            .with_context(|| format!("invalid --import-time {value:?}; expected RFC3339"))?
+            .with_timezone(&Utc)),
+        None => Ok(Utc::now()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_evidence::bundle::BundleReader;
+    use serde_json::json;
+
+    fn decision(decision: &str) -> Value {
+        json!({
+            "schema": "assay.enforcement_decision.v0",
+            "decision": decision,
+            "tool": {"name": "github.add_deploy_key"}
+        })
+    }
+
+    fn observation() -> Value {
+        json!({
+            "schema": "assay.denied_call_observation.v0",
+            "call": {"tool_name": "github.add_deploy_key"}
+        })
+    }
+
+    fn write_ndjson(dir: &Path, name: &str, records: &[Value]) -> PathBuf {
+        let path = dir.join(name);
+        let mut body = String::new();
+        for r in records {
+            body.push_str(&serde_json::to_string(r).unwrap());
+            body.push('\n');
+        }
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    fn args(dir: &Path, decisions: PathBuf) -> PrivilegedMcpActionArgs {
+        PrivilegedMcpActionArgs {
+            decisions,
+            denied_observations: None,
+            manifest_establish: None,
+            bundle_out: dir.join("out.bundle.tar.gz"),
+            run_id: DEFAULT_RUN_ID.to_string(),
+            import_time: Some("2026-07-24T00:00:00Z".to_string()),
+        }
+    }
+
+    #[test]
+    fn import_wraps_records_byte_faithful_in_declared_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(dir.path(), "dec.ndjson", &[decision("deny")]);
+        let observations = write_ndjson(dir.path(), "obs.ndjson", &[observation()]);
+        let mut a = args(dir.path(), decisions);
+        a.denied_observations = Some(observations);
+        let code = cmd_privileged_mcp_action(a.clone()).unwrap();
+        assert_eq!(code, exit_codes::OK);
+
+        let reader = BundleReader::open(File::open(&a.bundle_out).unwrap()).unwrap();
+        assert_eq!(reader.manifest().event_count, 2);
+        let events = reader.events_vec().unwrap();
+        // Event type equals the record's own schema member; payload is the record byte-faithful.
+        assert_eq!(events[0].type_, "assay.enforcement_decision.v0");
+        assert_eq!(events[0].payload, decision("deny"));
+        assert_eq!(events[1].type_, "assay.denied_call_observation.v0");
+        assert_eq!(events[1].payload, observation());
+        assert_eq!(events[0].source, EVENT_SOURCE);
+    }
+
+    #[test]
+    fn import_does_not_enforce_profile_cardinality() {
+        // Two decisions in one file must stay producible (the verifier, not the importer, rejects
+        // them; the conformance corpus's two-decision vector depends on this split).
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(
+            dir.path(),
+            "dec.ndjson",
+            &[decision("deny"), decision("allow")],
+        );
+        let a = args(dir.path(), decisions);
+        cmd_privileged_mcp_action(a.clone()).unwrap();
+        let reader = BundleReader::open(File::open(&a.bundle_out).unwrap()).unwrap();
+        assert_eq!(reader.manifest().event_count, 2);
+    }
+
+    #[test]
+    fn import_rejects_record_without_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(dir.path(), "dec.ndjson", &[json!({"decision": "deny"})]);
+        let err = cmd_privileged_mcp_action(args(dir.path(), decisions)).unwrap_err();
+        assert!(err.to_string().contains("no string schema"));
+    }
+
+    #[test]
+    fn import_rejects_run_id_with_colon() {
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(dir.path(), "dec.ndjson", &[decision("deny")]);
+        let mut a = args(dir.path(), decisions);
+        a.run_id = "bad:run".to_string();
+        let err = cmd_privileged_mcp_action(a).unwrap_err();
+        assert!(err.to_string().contains("run_id cannot contain ':'"));
+    }
+
+    #[test]
+    fn import_rejects_empty_inputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(dir.path(), "dec.ndjson", &[]);
+        let err = cmd_privileged_mcp_action(args(dir.path(), decisions)).unwrap_err();
+        assert!(err.to_string().contains("nothing to import"));
+    }
+}

--- a/crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs
@@ -1,0 +1,887 @@
+//! EXPERIMENTAL: verify an evidence bundle against the privileged-mcp-action/v0 open profile.
+//!
+//! Spec: `docs/profiles/privileged-mcp-action/v0.md`. Four byte-pure stages:
+//! 1. bundle integrity (the shipped bundle verification, via `BundleReader::open` which runs
+//!    `verify_bundle_with_limits`; any failure means `bundle_integrity: "fail"` and nothing below
+//!    stage 1 is consumed);
+//! 2. statement well-formedness (cardinality, closed vocabularies, producer non-claims verbatim);
+//! 3. binding validity (marker triple + exact `(tool name, target digest)` byte equality);
+//! 4. claim recompute (the fixed matrix; establish records are diagnostic journey only).
+//!
+//! The output is a claim matrix, never a score. Refuted claims still exit 0: the report is the
+//! product and consumers gate on cells; only integrity failure or an invalid verdict exits 2.
+
+use crate::exit_codes;
+use anyhow::{Context, Result};
+use assay_evidence::bundle::BundleReader;
+use assay_evidence::types::EvidenceEvent;
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+const REPORT_SCHEMA: &str = "assay.privileged_mcp_action.verify.report.v0";
+const PROFILE_ID: &str = "privileged-mcp-action/v0";
+
+const DECISION_SCHEMA: &str = "assay.enforcement_decision.v0";
+const OBSERVATION_SCHEMA: &str = "assay.denied_call_observation.v0";
+const ESTABLISH_SCHEMA: &str = "assay.manifest_establish.v0";
+/// Profile namespaces: any payload schema with one of these prefixes that is not the exact `.v0`
+/// string is an unrecognized profile schema and fails closed.
+const PROFILE_NAMESPACES: &[&str] = &[
+    "assay.enforcement_decision.",
+    "assay.denied_call_observation.",
+    "assay.manifest_establish.",
+];
+
+const DECISION_VOCAB: &[&str] = &["allow", "deny"];
+const REASON_VOCAB: &[&str] = &[
+    "unclassified_tool_call",
+    "classification_incomplete",
+    "no_declared_allowance",
+    "credential_scope_unknown",
+    "credential_scope_insufficient",
+    "manifest_baseline_missing",
+    "manifest_observation_ambiguous",
+    "manifest_current_observation_incomplete",
+    "manifest_drifted_since_approval",
+    "allow",
+];
+const DRIFT_STATE_VOCAB: &[&str] = &[
+    "satisfied",
+    "baseline_missing",
+    "current_observation_incomplete",
+    "observation_ambiguous",
+    "drifted",
+    "not_evaluated",
+];
+const ESTABLISH_PATH_VOCAB: &[&str] = &[
+    "no_establish_needed",
+    "established_then_allowed",
+    "established_then_denied",
+    "immediate_deny",
+];
+
+/// Marker triple values (stage 3).
+const MARKER_ERROR_CODE: i64 = -32042;
+const MARKER_ORIGIN: &str = "assay-proxy";
+
+/// The producer's five decision non-claims, byte-exact (source of truth:
+/// `assay-mcp-server/src/proxy/enforce/records.rs`; the fourth carries U+2014).
+const DECISION_PRODUCER_NON_CLAIMS: &[&str] = &[
+    "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+    "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+    "credential referenced by alias only, never the token or declared scopes",
+    "deny is fail-closed caution and allow is a policy decision \u{2014} neither is a maliciousness verdict",
+    "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)",
+];
+
+/// The producer's four observation non-claims, byte-exact (source of truth:
+/// `assay-mcp-server/src/proxy/denied_observation.rs`).
+const OBSERVATION_PRODUCER_NON_CLAIMS: &[&str] = &[
+    "caller-visible proxy denial observation only; policy decision lives in assay.enforcement_decision.v0",
+    "does not assert or verify the upstream side effect",
+    "does not assert maliciousness, safety, approval, or whole-action trust",
+    "must not be read as a replacement for the bound enforcement decision record",
+];
+
+/// The four fixed report non-claims, verbatim from the spec, present in every report.
+const REPORT_NON_CLAIMS: [&str; 4] = [
+    "allow does not prove upstream delivery",
+    "deny does not establish maliciousness",
+    "caller-visible denial does not prove external side-effect absence",
+    "bundle integrity does not upgrade source class",
+];
+
+#[derive(Debug, Args, Clone)]
+pub struct VerifyPrivilegedMcpActionArgs {
+    /// Evidence bundle (.tar.gz) carrying privileged-mcp-action profile records
+    #[arg(value_name = "BUNDLE")]
+    pub bundle: PathBuf,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = VerifyFormat::Table)]
+    pub format: VerifyFormat,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum VerifyFormat {
+    Json,
+    Table,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Report {
+    pub schema: &'static str,
+    pub profile: &'static str,
+    pub bundle_integrity: &'static str,
+    /// Present only when `bundle_integrity` is `pass`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verdict: Option<&'static str>,
+    /// Present only when `verdict` is `valid`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claims: Option<Claims>,
+    pub findings: Vec<Finding>,
+    pub non_claims: [&'static str; 4],
+}
+
+#[derive(Debug, Serialize)]
+pub struct Claims {
+    pub policy_decision_recorded: ClaimCell,
+    pub caller_visible_denial: ClaimCell,
+    pub upstream_delivery: ClaimCell,
+    pub external_side_effect: ClaimCell,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClaimCell {
+    pub status: &'static str,
+    /// Only confirmed and refuted cells carry a source class; incomplete cells carry none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_class: Option<&'static str>,
+}
+
+impl ClaimCell {
+    fn confirmed() -> Self {
+        Self {
+            status: "confirmed",
+            source_class: Some("producer_reported"),
+        }
+    }
+    fn refuted() -> Self {
+        Self {
+            status: "refuted",
+            source_class: Some("producer_reported"),
+        }
+    }
+    fn incomplete() -> Self {
+        Self {
+            status: "incomplete",
+            source_class: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Finding {
+    pub id: String,
+    pub detail: String,
+}
+
+pub fn cmd_verify_privileged_mcp_action(args: VerifyPrivilegedMcpActionArgs) -> Result<i32> {
+    let report = verify_bundle_report(&args.bundle)?;
+    match args.format {
+        VerifyFormat::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        VerifyFormat::Table => print_table(&report),
+    }
+    let ok = report.bundle_integrity == "pass" && report.verdict == Some("valid");
+    Ok(if ok { exit_codes::OK } else { 2 })
+}
+
+/// Stage 1 + stages 2-4 over one bundle path. A file that cannot be opened at all is a usage error;
+/// a bundle that opens but fails verification is an integrity-fail report, never an error.
+pub fn verify_bundle_report(bundle: &Path) -> Result<Report> {
+    let file = File::open(bundle)
+        .with_context(|| format!("failed to open bundle {}", bundle.display()))?;
+    // Stage 1: BundleReader::open runs the full shipped bundle verification
+    // (verify_bundle_with_limits with default limits) before exposing any event.
+    let reader = match BundleReader::open(file) {
+        Ok(reader) => reader,
+        Err(err) => return Ok(integrity_fail_report(&err)),
+    };
+    let events = match reader.events_vec() {
+        Ok(events) => events,
+        Err(err) => return Ok(integrity_fail_report(&err)),
+    };
+    Ok(profile_report(&events))
+}
+
+fn integrity_fail_report(err: &anyhow::Error) -> Report {
+    Report {
+        schema: REPORT_SCHEMA,
+        profile: PROFILE_ID,
+        bundle_integrity: "fail",
+        verdict: None,
+        claims: None,
+        findings: vec![Finding {
+            id: "bundle_integrity".to_string(),
+            detail: format!("{err:#}"),
+        }],
+        non_claims: REPORT_NON_CLAIMS,
+    }
+}
+
+/// Stages 2-4 over the events of a bundle that already passed stage 1.
+pub fn profile_report(events: &[EvidenceEvent]) -> Report {
+    let mut violations: Vec<Finding> = Vec::new();
+
+    // Select profile events by the exact schema member of their payload.
+    let mut decisions: Vec<&Value> = Vec::new();
+    let mut observations: Vec<&Value> = Vec::new();
+    let mut establishes: Vec<&Value> = Vec::new();
+    for ev in events {
+        let schema = ev.payload.get("schema").and_then(Value::as_str);
+        match schema {
+            Some(s) if in_namespace(s) => {
+                if ev.type_ != s {
+                    violations.push(finding(
+                        "event_type_schema_mismatch",
+                        format!(
+                            "event {} has type {:?} but its payload declares schema {s:?}; the two must be equal",
+                            ev.id, ev.type_
+                        ),
+                    ));
+                }
+                match s {
+                    DECISION_SCHEMA => decisions.push(&ev.payload),
+                    OBSERVATION_SCHEMA => observations.push(&ev.payload),
+                    ESTABLISH_SCHEMA => establishes.push(&ev.payload),
+                    other => violations.push(finding(
+                        "unknown_profile_schema",
+                        format!(
+                            "payload schema {other:?} is inside the profile namespace but is not a recognized v0 record; unknown fails closed"
+                        ),
+                    )),
+                }
+            }
+            // In-namespace event TYPE without an in-namespace payload schema: the profile selects
+            // by the payload's schema member, so an envelope claiming a profile type that its
+            // payload does not declare is not an ignorable outside-the-profile event. Fail closed.
+            _ if in_namespace(&ev.type_) => violations.push(finding(
+                "unknown_profile_schema",
+                format!(
+                    "event {} has profile-namespace type {:?} but its payload does not declare that profile schema",
+                    ev.id, ev.type_
+                ),
+            )),
+            _ => {} // Outside the profile namespace: ignored (integrity still covered by stage 1).
+        }
+    }
+
+    // Stage 2: cardinality.
+    if decisions.len() != 1 {
+        violations.push(finding(
+            "decision_cardinality",
+            format!(
+                "exactly one assay.enforcement_decision.v0 payload is required, found {}; v0 is single-call by design",
+                decisions.len()
+            ),
+        ));
+    }
+    if observations.len() > 1 {
+        violations.push(finding(
+            "observation_cardinality",
+            format!(
+                "at most one assay.denied_call_observation.v0 payload is allowed, found {}",
+                observations.len()
+            ),
+        ));
+    }
+    if establishes.len() > 1 {
+        violations.push(finding(
+            "establish_cardinality",
+            format!(
+                "at most one assay.manifest_establish.v0 payload is allowed, found {}",
+                establishes.len()
+            ),
+        ));
+    }
+
+    // Stage 2: record constraints (only meaningful on the single instance of each record kind).
+    let decision = (decisions.len() == 1).then(|| decisions[0]);
+    let observation = (observations.len() == 1).then(|| observations[0]);
+    let establish = (establishes.len() == 1).then(|| establishes[0]);
+
+    if let Some(dec) = decision {
+        check_decision(dec, &mut violations);
+    }
+    if let Some(obs) = observation {
+        check_observation(obs, &mut violations);
+    }
+    if let Some(est) = establish {
+        check_establish(est, &mut violations);
+    }
+
+    // Stage 3: binding validity. An observation participates as a caller-visible denial marker only
+    // if the triple holds (schema exact + error code + origin); a marker must bind to the decision.
+    let marker = observation.filter(|obs| {
+        obs.get("caller_visible_error")
+            .map(|e| {
+                e.get("code").and_then(Value::as_i64) == Some(MARKER_ERROR_CODE)
+                    && e.get("origin").and_then(Value::as_str) == Some(MARKER_ORIGIN)
+            })
+            .unwrap_or(false)
+    });
+    let mut bound_marker = false;
+    if let Some(obs) = marker {
+        let obs_tool = obs
+            .get("call")
+            .and_then(|c| c.get("tool_name"))
+            .and_then(Value::as_str);
+        let obs_digest = obs
+            .get("call")
+            .and_then(|c| c.get("target_digest"))
+            .and_then(Value::as_str)
+            .filter(|d| !d.is_empty());
+        match (decision, obs_digest) {
+            (None, _) => violations.push(finding(
+                "marker_not_backed",
+                "a caller-visible denial marker is present with no decision record to back it"
+                    .to_string(),
+            )),
+            (Some(_), None) => violations.push(finding(
+                "marker_digest_unbindable",
+                "the marker's call.target_digest is null or empty, so it cannot bind to any decision"
+                    .to_string(),
+            )),
+            (Some(dec), Some(obs_digest)) => {
+                let dec_tool = dec
+                    .get("tool")
+                    .and_then(|t| t.get("name"))
+                    .and_then(Value::as_str);
+                let dec_digest = dec
+                    .get("action")
+                    .and_then(|a| a.get("target_digest"))
+                    .and_then(Value::as_str);
+                // Exact byte equality on both binding members; digests are never re-encoded.
+                if obs_tool.is_some() && obs_tool == dec_tool && Some(obs_digest) == dec_digest {
+                    bound_marker = true;
+                } else {
+                    violations.push(finding(
+                        "observation_binding",
+                        "the marker's (call.tool_name, call.target_digest) does not equal the decision's (tool.name, action.target_digest)"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    if !violations.is_empty() {
+        return Report {
+            schema: REPORT_SCHEMA,
+            profile: PROFILE_ID,
+            bundle_integrity: "pass",
+            verdict: Some("invalid"),
+            claims: None,
+            findings: violations,
+            non_claims: REPORT_NON_CLAIMS,
+        };
+    }
+
+    // Stage 4: claim recompute. From here the records are validated; the matrix is a deterministic
+    // function of (decision, bound marker), and the establish record changes no cell.
+    let mut notes: Vec<Finding> = Vec::new();
+    let dec = decision.expect("valid verdict implies exactly one decision");
+    let decided = dec
+        .get("decision")
+        .and_then(Value::as_str)
+        .expect("valid verdict implies vocabulary-checked decision");
+
+    let caller_visible_denial = match (decided, bound_marker) {
+        ("deny", true) => ClaimCell::confirmed(),
+        ("deny", false) | ("allow", false) => ClaimCell::incomplete(),
+        ("allow", true) => {
+            notes.push(finding(
+                "caller_visible_outcome_contradiction",
+                "the producer recorded an allow decision and a caller-visible denial for the same (tool, target); the caller-visible outcome is refuted"
+                    .to_string(),
+            ));
+            ClaimCell::refuted()
+        }
+        _ => unreachable!("decision vocabulary is closed"),
+    };
+
+    if let Some(est) = establish {
+        let path = est
+            .get("establish_path")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let contradiction = match decided {
+            "allow" => matches!(path, "immediate_deny" | "established_then_denied"),
+            "deny" => path == "established_then_allowed",
+            _ => false,
+        };
+        if contradiction {
+            notes.push(finding(
+                "establish_journey_contradiction",
+                format!(
+                    "establish_path {path:?} contradicts the recorded {decided:?} decision; the journey is diagnostic only and the matrix is unchanged"
+                ),
+            ));
+        }
+    }
+
+    Report {
+        schema: REPORT_SCHEMA,
+        profile: PROFILE_ID,
+        bundle_integrity: "pass",
+        verdict: Some("valid"),
+        claims: Some(Claims {
+            policy_decision_recorded: ClaimCell::confirmed(),
+            caller_visible_denial,
+            upstream_delivery: ClaimCell::incomplete(),
+            external_side_effect: ClaimCell::incomplete(),
+        }),
+        findings: notes,
+        non_claims: REPORT_NON_CLAIMS,
+    }
+}
+
+fn check_decision(dec: &Value, violations: &mut Vec<Finding>) {
+    check_vocab(dec, "decision", DECISION_VOCAB, violations);
+    check_vocab(dec, "reason", REASON_VOCAB, violations);
+    check_vocab(dec, "drift_state", DRIFT_STATE_VOCAB, violations);
+
+    let tool_name = dec
+        .get("tool")
+        .and_then(|t| t.get("name"))
+        .and_then(Value::as_str);
+    if tool_name.map(str::is_empty).unwrap_or(true) {
+        violations.push(finding(
+            "decision_tool_name",
+            "decision tool.name must be a non-empty string".to_string(),
+        ));
+    }
+
+    let digest = dec
+        .get("action")
+        .and_then(|a| a.get("target_digest"))
+        .and_then(Value::as_str);
+    if !digest.map(is_sha256_digest).unwrap_or(false) {
+        violations.push(finding(
+            "target_digest_missing",
+            "decision action.target_digest must be sha256:<64 lowercase hex>; a null digest cannot be bound and falls outside the profile"
+                .to_string(),
+        ));
+    }
+
+    // fail_closed is derived by the producer (true iff deny); divergence is malformation, not an
+    // alternative policy statement. Only checkable once the decision value itself is in vocabulary.
+    match (
+        dec.get("decision").and_then(Value::as_str),
+        dec.get("fail_closed").and_then(Value::as_bool),
+    ) {
+        (Some(d), Some(fc)) if DECISION_VOCAB.contains(&d) => {
+            if fc != (d == "deny") {
+                violations.push(finding(
+                    "fail_closed_derivation",
+                    format!("fail_closed is {fc} but the decision is {d:?}; fail_closed must equal (decision == \"deny\")"),
+                ));
+            }
+        }
+        (Some(d), None) if DECISION_VOCAB.contains(&d) => violations.push(finding(
+            "fail_closed_derivation",
+            "decision fail_closed must be a boolean".to_string(),
+        )),
+        _ => {} // The decision-vocabulary violation is already recorded.
+    }
+
+    check_non_claims(
+        dec,
+        DECISION_PRODUCER_NON_CLAIMS,
+        "decision_non_claims",
+        violations,
+    );
+}
+
+fn check_observation(obs: &Value, violations: &mut Vec<Finding>) {
+    let tool_name = obs
+        .get("call")
+        .and_then(|c| c.get("tool_name"))
+        .and_then(Value::as_str);
+    if tool_name.map(str::is_empty).unwrap_or(true) {
+        violations.push(finding(
+            "observation_tool_name",
+            "observation call.tool_name must be a non-empty string".to_string(),
+        ));
+    }
+
+    let error = obs.get("caller_visible_error");
+    for member in ["code", "origin", "reason"] {
+        let present = error
+            .and_then(|e| e.get(member))
+            .map(|v| !v.is_null())
+            .unwrap_or(false);
+        if !present {
+            violations.push(finding(
+                "observation_error_member",
+                format!("observation caller_visible_error.{member} must be present"),
+            ));
+        }
+    }
+
+    let digest = obs
+        .get("caller_visible_response_digest")
+        .and_then(Value::as_str);
+    if !digest.map(is_sha256_digest).unwrap_or(false) {
+        violations.push(finding(
+            "observation_response_digest",
+            "observation caller_visible_response_digest must be sha256:<64 lowercase hex>"
+                .to_string(),
+        ));
+    }
+
+    check_non_claims(
+        obs,
+        OBSERVATION_PRODUCER_NON_CLAIMS,
+        "observation_non_claims",
+        violations,
+    );
+}
+
+fn check_establish(est: &Value, violations: &mut Vec<Finding>) {
+    check_vocab(est, "establish_path", ESTABLISH_PATH_VOCAB, violations);
+
+    // establish_attempted must equal (run_outcome != "not_performed"); both members are required
+    // for the equality to be checkable, so a missing member fails closed.
+    match (
+        est.get("establish_attempted").and_then(Value::as_bool),
+        est.get("run_outcome").and_then(Value::as_str),
+    ) {
+        (Some(attempted), Some(outcome)) => {
+            if attempted != (outcome != "not_performed") {
+                violations.push(finding(
+                    "establish_attempted_derivation",
+                    format!(
+                        "establish_attempted is {attempted} but run_outcome is {outcome:?}; establish_attempted must equal (run_outcome != \"not_performed\")"
+                    ),
+                ));
+            }
+        }
+        _ => violations.push(finding(
+            "establish_attempted_derivation",
+            "establish record must carry boolean establish_attempted and string run_outcome"
+                .to_string(),
+        )),
+    }
+}
+
+fn check_vocab(record: &Value, member: &str, vocab: &[&str], violations: &mut Vec<Finding>) {
+    match record.get(member).and_then(Value::as_str) {
+        Some(value) if vocab.contains(&value) => {}
+        Some(value) => violations.push(finding(
+            &format!("{member}_vocabulary"),
+            format!(
+                "{member} {value:?} is outside the closed set {}",
+                vocab.join("|")
+            ),
+        )),
+        None => violations.push(finding(
+            &format!("{member}_vocabulary"),
+            format!(
+                "{member} must be a string from the closed set {}",
+                vocab.join("|")
+            ),
+        )),
+    }
+}
+
+/// Subset test: the record's `non_claims` array must contain every producer string verbatim
+/// (byte-exact); extra entries are allowed.
+fn check_non_claims(record: &Value, required: &[&str], id: &str, violations: &mut Vec<Finding>) {
+    let Some(array) = record.get("non_claims").and_then(Value::as_array) else {
+        violations.push(finding(
+            id,
+            "non_claims must be an array carrying the producer strings verbatim".to_string(),
+        ));
+        return;
+    };
+    for required_entry in required {
+        let present = array.iter().any(|v| v.as_str() == Some(*required_entry));
+        if !present {
+            violations.push(finding(
+                id,
+                format!("non_claims is missing the producer string {required_entry:?}"),
+            ));
+        }
+    }
+}
+
+fn in_namespace(schema: &str) -> bool {
+    PROFILE_NAMESPACES.iter().any(|p| schema.starts_with(p))
+}
+
+fn is_sha256_digest(value: &str) -> bool {
+    match value.strip_prefix("sha256:") {
+        Some(hex) => hex.len() == 64 && hex.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')),
+        None => false,
+    }
+}
+
+fn finding(id: &str, detail: String) -> Finding {
+    Finding {
+        id: id.to_string(),
+        detail,
+    }
+}
+
+fn print_table(report: &Report) {
+    println!("Privileged MCP Action Verification ({})", report.profile);
+    println!("=====================================================");
+    println!("Bundle integrity: {}", report.bundle_integrity);
+    if let Some(verdict) = report.verdict {
+        println!("Verdict:          {verdict}");
+    }
+    if let Some(claims) = &report.claims {
+        println!();
+        println!("Claim matrix:");
+        for (name, cell) in [
+            ("policy_decision_recorded", &claims.policy_decision_recorded),
+            ("caller_visible_denial", &claims.caller_visible_denial),
+            ("upstream_delivery", &claims.upstream_delivery),
+            ("external_side_effect", &claims.external_side_effect),
+        ] {
+            match cell.source_class {
+                Some(sc) => println!("  {name:<26} {:<10} ({sc})", cell.status),
+                None => println!("  {name:<26} {}", cell.status),
+            }
+        }
+    }
+    println!();
+    if report.findings.is_empty() {
+        println!("Findings: none");
+    } else {
+        println!("Findings:");
+        for f in &report.findings {
+            println!("  {:<36} {}", f.id, f.detail);
+        }
+    }
+    println!();
+    println!("Non-claims:");
+    for nc in &report.non_claims {
+        println!("  - {nc}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const TOOL: &str = "github.add_deploy_key";
+    const DIGEST: &str = "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc";
+
+    fn decision_payload(decision: &str) -> Value {
+        json!({
+            "schema": DECISION_SCHEMA,
+            "caller": {"id": "ci-agent"},
+            "tool": {"name": TOOL, "action_class": "github_deploy_key"},
+            "action": {
+                "verb": "create",
+                "resource_type": "github_deploy_key",
+                "target": {"provider": "github", "owner": "acme", "repo": "prod-app"},
+                "target_digest": DIGEST,
+            },
+            "decision": decision,
+            "reason": if decision == "allow" { "allow" } else { "no_declared_allowance" },
+            "fail_closed": decision == "deny",
+            "drift_state": if decision == "allow" { "satisfied" } else { "not_evaluated" },
+            "credential_alias": "gh-deploy",
+            "non_claims": DECISION_PRODUCER_NON_CLAIMS,
+        })
+    }
+
+    fn observation_payload() -> Value {
+        json!({
+            "schema": OBSERVATION_SCHEMA,
+            "call": {"tool_name": TOOL, "target_digest": DIGEST},
+            "caller_visible_error": {
+                "code": -32042,
+                "origin": "assay-proxy",
+                "reason": "no_declared_allowance",
+            },
+            "caller_visible_response_digest":
+                "sha256:ef5796d82cdedf4727caa82604687648c081271ac60e355a57089550a431f48b",
+            "non_claims": OBSERVATION_PRODUCER_NON_CLAIMS,
+        })
+    }
+
+    fn establish_payload(path: &str) -> Value {
+        json!({
+            "schema": ESTABLISH_SCHEMA,
+            "establish_path": path,
+            "establish_attempted": true,
+            "action_class": "github_deploy_key",
+            "run_outcome": "complete",
+        })
+    }
+
+    fn ev(payload: Value, seq: u64) -> EvidenceEvent {
+        let type_ = payload
+            .get("schema")
+            .and_then(Value::as_str)
+            .unwrap()
+            .to_string();
+        EvidenceEvent::new(type_, "urn:assay:test", "run", seq, payload)
+    }
+
+    fn status(report: &Report, claim: &str) -> String {
+        let claims = serde_json::to_value(report.claims.as_ref().unwrap()).unwrap();
+        claims[claim]["status"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn deny_with_bound_marker_confirms_both_confirmable_claims() {
+        let report = profile_report(&[
+            ev(decision_payload("deny"), 0),
+            ev(observation_payload(), 1),
+        ]);
+        assert_eq!(report.verdict, Some("valid"));
+        assert_eq!(status(&report, "policy_decision_recorded"), "confirmed");
+        assert_eq!(status(&report, "caller_visible_denial"), "confirmed");
+        assert_eq!(status(&report, "upstream_delivery"), "incomplete");
+        assert_eq!(status(&report, "external_side_effect"), "incomplete");
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn allow_with_bound_marker_refutes_caller_visible_outcome() {
+        let report = profile_report(&[
+            ev(decision_payload("allow"), 0),
+            ev(observation_payload(), 1),
+        ]);
+        assert_eq!(report.verdict, Some("valid"));
+        assert_eq!(status(&report, "caller_visible_denial"), "refuted");
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "caller_visible_outcome_contradiction"));
+    }
+
+    #[test]
+    fn incomplete_cells_carry_no_source_class() {
+        let report = profile_report(&[ev(decision_payload("deny"), 0)]);
+        let claims = serde_json::to_value(report.claims.as_ref().unwrap()).unwrap();
+        assert!(claims["caller_visible_denial"]
+            .get("source_class")
+            .is_none());
+        assert_eq!(
+            claims["policy_decision_recorded"]["source_class"],
+            json!("producer_reported")
+        );
+    }
+
+    #[test]
+    fn two_decisions_are_invalid_never_paired() {
+        let report = profile_report(&[
+            ev(decision_payload("deny"), 0),
+            ev(decision_payload("allow"), 1),
+        ]);
+        assert_eq!(report.verdict, Some("invalid"));
+        assert!(report.claims.is_none());
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "decision_cardinality"));
+    }
+
+    #[test]
+    fn unknown_in_namespace_schema_fails_closed() {
+        let report = profile_report(&[
+            ev(decision_payload("deny"), 0),
+            ev(
+                json!({"schema": "assay.enforcement_decision.v1", "decision": "deny"}),
+                1,
+            ),
+        ]);
+        assert_eq!(report.verdict, Some("invalid"));
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "unknown_profile_schema"));
+    }
+
+    #[test]
+    fn fail_closed_divergence_is_invalid() {
+        let mut dec = decision_payload("deny");
+        dec["fail_closed"] = json!(false);
+        let report = profile_report(&[ev(dec, 0)]);
+        assert_eq!(report.verdict, Some("invalid"));
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "fail_closed_derivation"));
+    }
+
+    #[test]
+    fn missing_producer_non_claim_is_invalid() {
+        let mut dec = decision_payload("deny");
+        dec["non_claims"] = json!(DECISION_PRODUCER_NON_CLAIMS[..4].to_vec());
+        let report = profile_report(&[ev(dec, 0)]);
+        assert_eq!(report.verdict, Some("invalid"));
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "decision_non_claims"));
+    }
+
+    #[test]
+    fn marker_binding_mismatch_is_invalid() {
+        let mut obs = observation_payload();
+        obs["call"]["target_digest"] =
+            json!("sha256:0000000000000000000000000000000000000000000000000000000000000000");
+        let report = profile_report(&[ev(decision_payload("deny"), 0), ev(obs, 1)]);
+        assert_eq!(report.verdict, Some("invalid"));
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "observation_binding"));
+    }
+
+    #[test]
+    fn marker_with_null_digest_is_unbindable() {
+        let mut obs = observation_payload();
+        obs["call"]["target_digest"] = Value::Null;
+        let report = profile_report(&[ev(decision_payload("deny"), 0), ev(obs, 1)]);
+        assert_eq!(report.verdict, Some("invalid"));
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "marker_digest_unbindable"));
+    }
+
+    #[test]
+    fn establish_contradiction_is_a_finding_not_a_cell_change() {
+        let report = profile_report(&[
+            ev(decision_payload("allow"), 0),
+            ev(establish_payload("immediate_deny"), 1),
+        ]);
+        assert_eq!(report.verdict, Some("valid"));
+        assert_eq!(status(&report, "caller_visible_denial"), "incomplete");
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "establish_journey_contradiction"));
+    }
+
+    #[test]
+    fn establish_attempted_divergence_is_invalid() {
+        let mut est = establish_payload("no_establish_needed");
+        est["run_outcome"] = json!("not_performed");
+        let report = profile_report(&[ev(decision_payload("allow"), 0), ev(est, 1)]);
+        assert_eq!(report.verdict, Some("invalid"));
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.id == "establish_attempted_derivation"));
+    }
+
+    #[test]
+    fn report_always_carries_the_four_fixed_non_claims() {
+        let report = profile_report(&[ev(decision_payload("deny"), 0)]);
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(value["non_claims"], json!(REPORT_NON_CLAIMS.to_vec()));
+        assert_eq!(value["schema"], json!(REPORT_SCHEMA));
+        assert_eq!(value["profile"], json!(PROFILE_ID));
+    }
+
+    #[test]
+    fn invalid_report_omits_claims_member_entirely() {
+        let report = profile_report(&[]);
+        assert_eq!(report.verdict, Some("invalid"));
+        let value = serde_json::to_value(&report).unwrap();
+        assert!(value.get("claims").is_none());
+    }
+}

--- a/crates/assay-cli/tests/conformance_privileged_mcp_action.rs
+++ b/crates/assay-cli/tests/conformance_privileged_mcp_action.rs
@@ -1,0 +1,140 @@
+//! Conformance harness for the privileged-mcp-action/v0 open profile.
+//!
+//! Runs `assay evidence verify-privileged-mcp-action` against every vector bundle in
+//! `conformance/privileged-mcp-action-v0/` and asserts the normative comparison surface of the
+//! corpus MANIFEST: `expected.bundle_integrity`, `expected.verdict`, and (for accepts) the full
+//! `expected.claims` object. `first_failure_informative` codes are the generator's own vocabulary
+//! and are deliberately NOT compared: an independent implementation is scored on outcomes.
+//!
+//! Report-shape invariants asserted on every vector: the report schema and profile ids, the four
+//! fixed non-claims verbatim, verdict absent on integrity failure, claims absent unless the
+//! verdict is valid, and the exit-code convention (0 iff pass + valid, else 2; a refuted claim
+//! cell still exits 0 because consumers gate on cells, not on the process exit).
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+const REPORT_SCHEMA: &str = "assay.privileged_mcp_action.verify.report.v0";
+const PROFILE_ID: &str = "privileged-mcp-action/v0";
+const REPORT_NON_CLAIMS: [&str; 4] = [
+    "allow does not prove upstream delivery",
+    "deny does not establish maliciousness",
+    "caller-visible denial does not prove external side-effect absence",
+    "bundle integrity does not upgrade source class",
+];
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../conformance/privileged-mcp-action-v0")
+}
+
+fn verify(bundle: &Path) -> (Value, i32) {
+    let output = Command::cargo_bin("assay")
+        .expect("assay binary")
+        .args(["evidence", "verify-privileged-mcp-action"])
+        .arg(bundle)
+        .args(["--format", "json"])
+        .output()
+        .expect("run verifier");
+    let report: Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("report for {} is not JSON: {e}", bundle.display()));
+    (report, output.status.code().expect("exit code"))
+}
+
+#[test]
+fn conformance_corpus_reproduces_all_expected_outcomes() {
+    let corpus = corpus_dir();
+    let manifest: Value = serde_json::from_str(
+        &std::fs::read_to_string(corpus.join("MANIFEST.json")).expect("read MANIFEST.json"),
+    )
+    .expect("parse MANIFEST.json");
+
+    let vectors = manifest["vectors"].as_array().expect("vectors array");
+    assert_eq!(vectors.len(), 13, "the v0 corpus carries 13 vectors");
+
+    for vector in vectors {
+        let id = vector["id"].as_str().expect("vector id");
+        let file = corpus.join(vector["file"].as_str().expect("vector file"));
+        let expected = &vector["expected"];
+        let (report, exit_code) = verify(&file);
+
+        // Report-shape invariants, every vector.
+        assert_eq!(report["schema"], REPORT_SCHEMA, "{id}: report schema");
+        assert_eq!(report["profile"], PROFILE_ID, "{id}: report profile");
+        assert_eq!(
+            report["non_claims"],
+            serde_json::json!(REPORT_NON_CLAIMS.to_vec()),
+            "{id}: the four fixed non-claims must be present verbatim"
+        );
+
+        let expected_integrity = expected["bundle_integrity"].as_str().unwrap();
+        assert_eq!(
+            report["bundle_integrity"].as_str(),
+            Some(expected_integrity),
+            "{id}: bundle_integrity"
+        );
+
+        if expected_integrity == "fail" {
+            // On integrity failure nothing below stage 1 is consumed: the spec requires verdict
+            // and claims to be ABSENT (the corpus MANIFEST's `verdict: invalid` for the tamper
+            // vector means "not accepted", which an absent verdict satisfies).
+            assert!(
+                report.get("verdict").is_none(),
+                "{id}: verdict absent on fail"
+            );
+            assert!(
+                report.get("claims").is_none(),
+                "{id}: claims absent on fail"
+            );
+            assert_eq!(exit_code, 2, "{id}: integrity failure exits 2");
+            continue;
+        }
+
+        let expected_verdict = expected["verdict"].as_str().unwrap();
+        assert_eq!(
+            report["verdict"].as_str(),
+            Some(expected_verdict),
+            "{id}: verdict"
+        );
+
+        if expected_verdict == "valid" {
+            // Accept vectors compare the FULL expected claim matrix, byte-for-byte as JSON values
+            // (statuses, source classes on confirmed/refuted cells, no source class on incomplete).
+            assert_eq!(&report["claims"], &expected["claims"], "{id}: claim matrix");
+            assert_eq!(
+                exit_code, 0,
+                "{id}: valid verdict exits 0 (refuted cells included)"
+            );
+        } else {
+            assert!(
+                report.get("claims").is_none(),
+                "{id}: claims absent on invalid verdict"
+            );
+            assert!(
+                report["findings"].as_array().is_some_and(|f| !f.is_empty()),
+                "{id}: an invalid verdict reports at least one free-form finding"
+            );
+            assert_eq!(exit_code, 2, "{id}: invalid verdict exits 2");
+        }
+    }
+}
+
+#[test]
+fn contradiction_vector_reports_the_contradiction_finding() {
+    // ok-005 is the refuted-cell vector: exit 0, but the caller_visible_outcome_contradiction
+    // finding must be present so a consumer that only reads findings still sees the conflict.
+    let bundle = corpus_dir().join("vectors/ok-005-allow-contradicted-by-denial.bundle.tar.gz");
+    let (report, exit_code) = verify(&bundle);
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        report["claims"]["caller_visible_denial"]["status"],
+        "refuted"
+    );
+    let findings = report["findings"].as_array().expect("findings");
+    assert!(
+        findings
+            .iter()
+            .any(|f| f["id"] == "caller_visible_outcome_contradiction"),
+        "refuted caller-visible outcome must carry the contradiction finding, got {findings:?}"
+    );
+}

--- a/docs/profiles/privileged-mcp-action/v0.md
+++ b/docs/profiles/privileged-mcp-action/v0.md
@@ -30,7 +30,9 @@ forward-looking design is in
 ## 2. Input records
 
 All inputs arrive inside one evidence bundle (Section 4). Events are selected by the exact `schema`
-member of their payload; the event's `type` MUST equal that schema string.
+member of their payload; the event's `type` MUST equal that schema string. A mismatch in either
+direction within the profile's namespaces (an in-namespace payload under a different type, or an
+in-namespace type over a payload that declares no in-namespace schema) is invalid, fail closed.
 
 **Required, exactly one:**
 
@@ -82,9 +84,11 @@ Closed vocabularies, fail-closed on anything else:
 
 - `bundle_integrity`: `pass` | `fail` (stage 1; the same member name and values the conformance
   manifest uses). On `fail`, `verdict` and `claims` MUST be absent and nothing below stage 1 may be
-  consumed.
+  consumed. The report MAY carry a single `bundle_integrity` finding with the bundle verifier's
+  error string, and the fixed `non_claims` are emitted in every report, failures included.
 - `verdict`: `valid` | `invalid` (stages 2-4). Present only when `bundle_integrity` is `pass`; on
-  `invalid`, `claims` MUST be absent.
+  `invalid`, `claims` MUST be absent and the verifier SHOULD report one free-form finding per
+  detected violation (all violations, not only the first).
 - claim `status`: `confirmed` | `incomplete` | `refuted`.
 - `source_class`: pinned to the gateway vocabulary
   (`producer_reported | issuer_attested | receiver_receipt | boundary_observed | third_party_observed | unknown`).
@@ -139,6 +143,8 @@ failure, never a semantic one.
 
 - Exactly one `assay.enforcement_decision.v0` payload (zero or more than one is invalid).
 - At most one `assay.denied_call_observation.v0`; at most one `assay.manifest_establish.v0`.
+- Record-level constraints below are evaluated only when the record kind is at its allowed
+  cardinality; a cardinality violation invalidates the bundle on its own.
 - Any payload whose `schema` starts with `assay.enforcement_decision.`,
   `assay.denied_call_observation.`, or `assay.manifest_establish.` but is not the exact `.v0` string
   is an unrecognized profile schema: **invalid**, fail closed.
@@ -151,7 +157,9 @@ failure, never a semantic one.
   - `drift_state` in `satisfied | baseline_missing | current_observation_incomplete |
     observation_ambiguous | drifted | not_evaluated`;
   - `tool.name` a non-empty string;
-  - `action.target_digest` a `sha256:`-prefixed 64-hex string. A null or absent target digest is
+  - `action.target_digest` exactly `sha256:` followed by 64 lowercase hexadecimal characters
+    (anything else, including an empty string, uppercase hex, or a wrong length, is invalid). A
+    null or absent target digest is
     invalid under this profile: v0 covers explicitly classified privileged actions, and an
     unclassified decision (which the producer emits with a null digest) cannot be bound and falls
     outside the profile;
@@ -160,12 +168,16 @@ failure, never a semantic one.
   - `non_claims` MUST be an array containing at least the five producer strings verbatim (the
     producer's fixed array; see the conformance corpus for the exact bytes).
 - Observation record constraints (when present): `call.tool_name` non-empty,
-  `caller_visible_error.code`, `caller_visible_error.origin`, `caller_visible_error.reason` present,
+  `caller_visible_error.code`, `caller_visible_error.origin`, `caller_visible_error.reason` present
+  and non-null (stage 2 checks presence; stage 3 compares typed values, so a string "-32042" is a
+  present member that never becomes a marker),
   `caller_visible_response_digest` a `sha256:`-prefixed 64-hex string, `non_claims` containing the
   four producer strings.
 - Establish record constraints (when present): `establish_path` in `no_establish_needed |
   established_then_allowed | established_then_denied | immediate_deny`;
-  `establish_attempted` MUST equal (`run_outcome` != `"not_performed"`).
+  `establish_attempted` MUST equal (`run_outcome` != `"not_performed"`). `run_outcome` MUST be a
+  string (its value set is open in v0) and `establish_attempted` MUST be a boolean; a missing or
+  wrongly typed member is invalid, since the equality must be checkable.
 
 **Stage 3: binding validity.** An observation participates as a caller-visible denial marker only if
 all three hold: `schema` is `assay.denied_call_observation.v0`, `caller_visible_error.code` is
@@ -175,6 +187,8 @@ whose binding pair does not match the decision, or a marker present with no deci
 **invalid** (a caller-visible enforcement marker that nothing backs is the exact condition lint rule
 ASSAY-W004 exists to catch; under this profile it is a validity failure, not a warning). A marker with
 a null or empty `call.target_digest` is unbindable and invalid for the same reason.
+An observation that is well-formed but fails the marker triple is **valid and inert**: it is not a
+marker, participates in no binding, and changes no claim cell.
 
 **Stage 4: claim recompute.** The claim matrix is a deterministic function of the validated records:
 
@@ -195,9 +209,10 @@ a null or empty `call.target_digest` is unbindable and invalid for the same reas
   profile's load-bearing honesty: an allow is the decision to forward, and no record in this profile
   has the vantage to carry delivery or side-effect truth. A future profile version may add stronger
   members for these cells; under v0 they cannot be confirmed by any input.
-- The establish record changes no cell. If its journey contradicts the verdict (for example
-  `establish_path: "immediate_deny"` beside `decision: "allow"`), the verifier MUST emit a finding
-  and MUST NOT alter the matrix.
+- The establish record changes no cell. The contradiction set is normative: `decision: "allow"`
+  beside `establish_path` `"immediate_deny"` or `"established_then_denied"`, and `decision:
+  "deny"` beside `"established_then_allowed"`; `"no_establish_needed"` never contradicts. On a
+  contradiction the verifier MUST emit a finding and MUST NOT alter the matrix.
 - The verifier does **not** recompute whether the policy decision was correct. It confirms which
   decision the producer recorded and whether sibling records support that decision within their
   ceilings.
@@ -233,7 +248,8 @@ The corpus at `conformance/privileged-mcp-action-v0/` carries 13 vectors (5 acce
 generated by a single deterministic generator (`gen_vectors.py`, standard library only, byte-identical
 on re-run). `MANIFEST.json` declares for every vector the expected `bundle_integrity`, the expected
 profile `verdict`, and for accepts the full expected claim matrix. **That triple is the normative
-comparison surface.** The `first_failure_informative` codes are the generator's own vocabulary and are
+comparison surface.** Integrity-fail vectors declare no `expected.verdict`: a conforming report
+omits the member on `bundle_integrity: "fail"`, and the comparison asserts its absence. The `first_failure_informative` codes are the generator's own vocabulary and are
 informative only, so an independent implementation is compared on outcomes, not on its reasons: it
 SHOULD report a free-form reason per reject in its own words, which makes wrong-reason agreement
 visible instead of silently scoring as parity.

--- a/examples/privileged-action-gate/README.md
+++ b/examples/privileged-action-gate/README.md
@@ -41,6 +41,24 @@ worth knowing about; it is evidence, not a denial.
 - observed behaviour is the proxy's classification of the call, not verification of the upstream
   side effect.
 
+## Open profile: claim matrix from the same records
+
+`run.sh` ends by turning two of the scenarios into evidence bundles under the
+`privileged-mcp-action/v0` open profile (spec: `docs/profiles/privileged-mcp-action/v0.md`). The
+enforcement records are imported byte-faithful and the profile verifier recomputes a claim matrix
+from the carried bytes alone:
+
+```bash
+assay evidence import privileged-mcp-action \
+  --decisions decisions.ndjson --denied-observations observations.ndjson \
+  --bundle-out action.bundle.tar.gz
+assay evidence verify-privileged-mcp-action action.bundle.tar.gz --format table
+```
+
+The denied path confirms both the recorded decision and the caller-visible denial; the allowed path
+confirms only the decision. `upstream_delivery` and `external_side_effect` stay incomplete in every
+row: no record here has the vantage to carry them, and the report says so in its non-claims.
+
 ## Wire it into a PR gate
 
 Project the decisions to SARIF and upload them to the GitHub Security tab. A denied privileged

--- a/examples/privileged-action-gate/run.sh
+++ b/examples/privileged-action-gate/run.sh
@@ -83,3 +83,64 @@ echo "Each call wrote an assay.enforcement_decision.v0 record (replayable)."
 echo "Non-claims: a deny is fail-closed caution, not a verdict on intent; an allow is the decision to"
 echo "forward, never proof the action happened; the mock performs no real GitHub call; the conformance"
 echo "signal is recorded beside the verdict and never changes or gates it."
+
+# ---- open profile: privileged-mcp-action/v0 (import + verify) ---------------------------------
+# Two of the scenarios above become evidence bundles under the open profile: the enforcement
+# records are imported byte-faithful, then the profile verifier recomputes the claim matrix from
+# the carried bytes alone. The matrix is the product; nothing here changes the verdicts above.
+
+# Locate the assay CLI (evidence import/verify), mirroring the proxy lookup. An installed assay
+# may predate the profile commands, so the chosen binary is validated before use.
+supports_profile() { "$1" evidence verify-privileged-mcp-action --help >/dev/null 2>&1; }
+if [ -x "../../target/debug/assay" ] && supports_profile "../../target/debug/assay"; then
+  ASSAY_CLI="$(cd ../.. && pwd)/target/debug/assay"
+elif command -v assay >/dev/null 2>&1 && supports_profile assay; then
+  ASSAY_CLI="assay"
+else
+  echo "building assay CLI (first run)..." >&2
+  (cd ../.. && cargo build -q -p assay-cli)
+  ASSAY_CLI="$(cd ../.. && pwd)/target/debug/assay"
+fi
+
+# capture <policy> <baseline> <mode> <dec_out> <obs_out>: one scenario, records kept, no output.
+capture() {
+  local policy="$1" baseline="$2" mode="$3" dec="$4" obs="$5"
+  : >"$dec"
+  printf '%s\n%s\n' "$INIT" "$CALL" \
+    | MOCK_MODE="$mode" "$ASSAY" proxy-enforce \
+        --upstream-command "$PY" --upstream-arg -u --upstream-arg "mock_github_mcp.py" \
+        --enforce-policy "$policy" \
+        --declared-mcp-manifest "$baseline" \
+        --enforcement-decision-out "$dec" \
+        --denied-call-observation-out "$obs" \
+        >/dev/null 2>&1 || true
+}
+
+# matrix <label> <bundle>: verify one bundle and print a compact claim-matrix line.
+matrix() {
+  local label="$1" bundle="$2"
+  "$ASSAY_CLI" evidence verify-privileged-mcp-action "$bundle" --format json \
+    | "$PY" -c '
+import json, sys
+label = sys.argv[1]
+report = json.load(sys.stdin)
+cells = " ".join("{}={}".format(name, cell["status"]) for name, cell in report["claims"].items())
+print("  {}: verdict={}  {}".format(label, report["verdict"], cells))
+' "$label"
+}
+
+echo
+echo "Open profile privileged-mcp-action/v0: import the records, recompute the claim matrix."
+capture policies/no-allowance.yaml baseline-approved.json approved "$WORK/pmadeny.ndjson" "$WORK/pmadeny-obs.ndjson"
+capture policies/allow.yaml        baseline-approved.json approved "$WORK/pmaallow.ndjson" "$WORK/pmaallow-obs.ndjson"
+
+"$ASSAY_CLI" evidence import privileged-mcp-action \
+  --decisions "$WORK/pmadeny.ndjson" --denied-observations "$WORK/pmadeny-obs.ndjson" \
+  --bundle-out "$WORK/pmadeny.bundle.tar.gz" 2>/dev/null
+"$ASSAY_CLI" evidence import privileged-mcp-action \
+  --decisions "$WORK/pmaallow.ndjson" \
+  --bundle-out "$WORK/pmaallow.bundle.tar.gz" 2>/dev/null
+
+matrix "denied path bundle " "$WORK/pmadeny.bundle.tar.gz"
+matrix "allowed path bundle" "$WORK/pmaallow.bundle.tar.gz"
+echo "The matrix is recomputed from carried bytes; delivery and side effect stay incomplete by design."

--- a/examples/privileged-action-gate/run.sh
+++ b/examples/privileged-action-gate/run.sh
@@ -106,6 +106,7 @@ fi
 capture() {
   local policy="$1" baseline="$2" mode="$3" dec="$4" obs="$5"
   : >"$dec"
+  : >"$obs"
   printf '%s\n%s\n' "$INIT" "$CALL" \
     | MOCK_MODE="$mode" "$ASSAY" proxy-enforce \
         --upstream-command "$PY" --upstream-arg -u --upstream-arg "mock_github_mcp.py" \


### PR DESCRIPTION
## What

Fase 2, second slice: the typed importer and verifier for the privileged-mcp-action/v0 open profile, the conformance harness that enforces corpus parity in CI, a golden-path extension, and ten normative spec clarifications the implementation surfaced.

1. **Importer** `assay evidence import privileged-mcp-action`: wraps producer NDJSON (`--decisions`, optional `--denied-observations` and `--manifest-establish`) byte-faithful as evidence events in the existing typed-importer pattern (`--bundle-out`/`--out`, `--run-id`, `--import-time` for deterministic fixtures). The importer enforces no profile semantics; the verifier does.
2. **Verifier** `assay evidence verify-privileged-mcp-action <bundle> --format {json|table}`: implements the profile's four byte-pure stages. Stage 1 reuses the shipped bundle verification; stages 2 to 4 apply the closed vocabularies fail-closed, the (tool name, target digest) binding with the marker triple, and the claim matrix. Report schema `assay.privileged_mcp_action.verify.report.v0` with `bundle_integrity`, `verdict`, per-claim cells carrying `producer_reported`, findings, and the four fixed non-claims. Exit 0 only on pass and valid.
3. **Conformance harness**: an integration test drives the real binary over all 13 corpus vectors and asserts the manifest's normative surface (`bundle_integrity`, `verdict`, and the full claim matrix for accepts). Corpus parity is now CI-enforced rather than asserted.
4. **Golden path**: `examples/privileged-action-gate/run.sh` now imports two scenario outputs into bundles and verifies them, printing the claim matrices; `verify.sh` is unchanged and still passes.
5. **Spec clarifications**: building the verifier from the spec text surfaced ten places where the text underdetermined behavior (the sharpest: the corpus expected a `verdict` member on the tamper vector that the spec forbids). All ten are codified normatively, matching what the implementation and corpus already do. The corpus manifest fix changes zero bundle bytes; the corpus digest is unchanged.

## Validation

- Conformance harness: 13/13 against `conformance/privileged-mcp-action-v0/MANIFEST.json` (first full run of the freshly built verifier already matched; no vector was adjusted to fit).
- `cargo clippy -p assay-cli --all-targets -- -D warnings` clean; `cargo fmt --check` clean; `cargo test -p assay-cli` green including 17 new unit tests; `examples/privileged-action-gate/verify.sh` OK.

## Invariants

- No new record envelope; the profile stays an open profile per ADR-042, and its corpus digest stays a candidate until an independent, non-author implementation reproduces the outcomes from the specification text alone.
- No aggregate score, no whole-action verdict; `upstream_delivery` and `external_side_effect` remain incomplete in every v0 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to import privileged action records into evidence bundles and verify those bundles.
  * Verification now reports integrity, validity, findings, and claim statuses in table or JSON formats.
  * Added example workflows demonstrating denied and allowed action scenarios.

* **Documentation**
  * Clarified profile validation rules, fail-closed behavior, reporting semantics, and claim handling.

* **Tests**
  * Added comprehensive conformance coverage for valid, invalid, tampered, and contradictory evidence bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->