### PR TITLE
docs(adr): ADR-043 evidence-chain integrity invariants (amends ADR-042)

### DIFF
--- a/docs/architecture/ADR-042-evidence-first-positioning.md
+++ b/docs/architecture/ADR-042-evidence-first-positioning.md
@@ -3,6 +3,8 @@
 - Status: Accepted
 - Date: 2026-07-24
 - Supersedes: none
+- Amended by: [ADR-043](ADR-043-evidence-chain-integrity-invariants.md) (proposed) — states the
+  integrity invariants this decision implies, without changing the scope or the stop list
 
 ## Context
 

--- a/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
+++ b/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
@@ -52,17 +52,21 @@ so they can be enforced mechanically rather than remembered.
    limited to functions named "verify": it holds for any entrypoint that parses or semantically
    consumes an untrusted artifact, which today means the bundle reader, the lint engine, the push
    path in both its verifying and `--no-verify` branches, the CLI stdin path, and the replay reader.
-   Each applies its ceilings to the source stream before the input is materialized. One byte ceiling
-   is not the rule, because it does not cover a decompression bomb: the axes are compressed bytes,
-   decoded bytes, entry and event counts, and individual member sizes. `VerifyLimits` already
-   carries all four, so the defect is where they are applied and not that they are missing. The
-   pattern is already in the tree: `assay_evidence::trust_basis::generation` takes
-   `max_bundle_bytes + 1` before reading.
+   Each applies the whole limit set to the source stream before the input is materialized, and a
+   single byte ceiling is not that set. `VerifyLimits` already carries eight dimensions — compressed
+   and decoded bytes, per-file sizes, event and line counts, path length and JSON nesting — so a
+   decompression bomb is already named by `max_decode_bytes` and nothing needs adding to the
+   vocabulary. The defect is the order in which the existing set is applied, plus the replay reader,
+   which carries no limits at all. The pattern is already in the tree:
+   `assay_evidence::generate_trust_basis` takes `max_bundle_bytes + 1` off the reader before
+   reading.
 
-2. **The stop list binds emitted artifacts, not only prose.** ADR-042 §3 refuses compliance and
-   safe-agent claims. That refusal covers what the software puts on the wire and into evidence, on
-   the same terms as what the documentation says. A field asserting certification, partnership, or
-   an equivalent status is removed unless it carries a basis a reviewer can check. The mechanism is
+2. **The stop list binds emitted artifacts, not only prose.** ADR-042 §3 already refuses compliance
+   and safe-agent claims; a field asserting certification or partner status is such a claim, so this
+   is that entry applied to a second surface rather than a new entry. The refusal covers what the
+   software puts on the wire and into evidence, on the same terms as what the documentation says. A
+   field asserting certification, partnership, or an equivalent status is removed unless it
+   carries a basis a reviewer can check. The mechanism is
    a closed set of public wire status claims, asserted structurally against generated responses and
    schema fixtures — not a pattern scan over source literals, which is simultaneously noisy and
    blind to output composed indirectly.
@@ -80,11 +84,13 @@ so they can be enforced mechanically rather than remembered.
      enforcement it was protecting.
    - A failed validation never yields an authorized request, in any mode.
    - Every privileged method checks the authorization state of the request it is serving, not of a
-     handshake that preceded it. This is also the direction the MCP
-     [`2026-07-28` revision](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
-     takes by removing the `initialize`/`initialized` handshake (SEP-2575) and the protocol-level
-     session (SEP-2567), so per-request state is the durable target and a handshake-anchored gate
-     would be built on a mechanism the protocol is dropping.
+     handshake that preceded it. This is also the direction MCP is taking: the
+     [`2026-07-28` release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/),
+     locked on 2026-05-21 and due to publish on 2026-07-28, removes the `initialize`/`initialized`
+     handshake (SEP-2575) and the protocol-level session (SEP-2567). Read as of this ADR's date that
+     is a candidate rather than a published spec, which affects the timing of the argument and not
+     its direction: per-request state is the durable target either way, and a handshake-anchored
+     gate would be built on a mechanism the protocol is dropping.
 
 5. **A named policy that cannot be loaded is fatal.** When the operator names a `--policy`, failure
    to load it ends the run, unconditionally. `--fail-closed` does not create that obligation; it
@@ -108,9 +114,11 @@ so they can be enforced mechanically rather than remembered.
 - §5 changes default behaviour: a named policy that fails to load stops the run instead of falling
   back. That trades a convenience for an honest contract, and it is the reason this is an ADR rather
   than a bug fix.
-- This ADR adds nothing to the ADR-042 stop list and removes nothing from it, so it amends rather
-  than supersedes. The kernel-observation posture is unchanged: eBPF validation running post-merge
-  rather than on pull requests remains consistent with its supporting status.
+- This ADR adds no entry to the ADR-042 stop list and removes none, so it amends rather than
+  supersedes. Every example it names maps onto an entry that is already there — the wire claims onto
+  the compliance and safe-agent refusal, the claim ceilings onto the whole-action-verdict refusal.
+  The kernel-observation posture is unchanged: eBPF validation running post-merge rather than on
+  pull requests remains consistent with its supporting status.
 
 Four implementation slices follow from the decisions, in this order:
 
@@ -129,7 +137,7 @@ Resource behaviour, reproducible as written:
 |---|---|---|
 | Ingest exceeds the ceiling | counting reader through `BundleReader::open` vs `verify_bundle_with_limits`, 150 MiB input | 157,286,400 bytes read vs 32,768; ceiling is 104,857,600 |
 | Memory tracks input | `assay evidence verify` on 50 / 200 / 600 MB files | 72 / 222 / 622 MB peak resident |
-| Policy substitution | `assay sandbox --fail-closed --policy <broken>` | warning, built-in policy applied, child ran, exit 0 |
+| Policy substitution | `assay sandbox --fail-closed --policy <any file that does not parse as a policy> -- /bin/echo hi` | warning naming the load error, built-in pack applied, child ran, exit 0 |
 
 Authorization behaviour, stated as outcomes. These four were measured the same way, but the
 step-by-step recipes are withheld from this record until the §4 slice lands, then restored here. The
@@ -146,10 +154,11 @@ The policy-substitution row stays reproducible because it is an operator self-mi
 rather than a path a third party can trigger: it needs write access to the policy file the operator
 themselves named, and its effect is a weaker sandbox for that same operator.
 
-Each finding was run against a control so it is not an artifact of the setup. Repacking the
-untouched fixture bundle verifies clean, while changing one field of equal byte length fails with
-`IntegrityManifestHash`; the integrity chain does what the profile says. For the JWKS composition
-the two runs differ only in the URI scheme, which isolates the cause to the refusal path itself.
+Each finding was run against a control so it is not an artifact of the setup. Repacking
+`tests/fixtures/evidence/test-bundle.tar.gz` untouched verifies clean, while changing one field of
+that bundle to a value of equal byte length fails with `IntegrityManifestHash`; the integrity chain
+does what the profile says. For the JWKS composition the two runs differ only in the URI scheme,
+which isolates the cause to the refusal path itself.
 Finding 1 was independently challenged on the grounds that the verifier streams correctly, and
 re-confirmed: it does stream, but only over an already-materialized buffer. The privileged-action
 conformance corpus reproduces all thirteen vectors, and every policy-decision gate has a passing

--- a/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
+++ b/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
@@ -17,15 +17,26 @@ findings, with reproduction steps in the appendix:
 
 - The reference verifier applies its own resource ceiling after it has already materialized the
   input. `assay evidence verify` on a 600 MB file peaks at 622 MB resident while
-  `VerifyLimits::max_bundle_bytes` is 100 MB. An independent verifier written from the profile text
-  would apply the ceiling first and behave differently from the reference on the same input.
-- The MCP server emits `"certified": true` in every successful `initialize` response, including a
-  session opened with a forged `alg:none` token. The claims-boundary guard that keeps the stop list
+  `VerifyLimits::max_bundle_bytes` is 100 MB. The ceiling is passed correctly and the `LimitReader`
+  is a genuine streaming guard; the defect is that `BundleReader::open_internal` reads the input to
+  the end first, so that guard streams from a `Cursor` over a `Vec` that is already complete. At
+  process level it therefore bounds nothing. An independent verifier written from the profile text
+  would apply the ceiling to the source stream and behave differently from the reference.
+- The MCP server emits `"certified": true` and `"partner": "agent_framework"` in every successful
+  `initialize` response. Neither carries a basis a reviewer can check, and `meta` is not a protocol
+  field at all — the reserved key is `_meta`. The claims-boundary guard that keeps the stop list
   honest scans prose paths only, so it cannot see anything the binaries assert on the wire.
 - The bundle fuzz target covers `assay_core::replay::verify_bundle`, a different bundle format from
   the evidence chain, and the replay module carries no resource ceiling at all.
 - Token validation runs only in the `initialize` branch. A `tools/call` sent without a handshake
   reaches tool dispatch even with authentication configured in strict mode.
+- The default `AuthMode` is `Permissive`, where a correct rejection is downgraded to a pass. The
+  algorithm allowlist does reject `alg:none` as designed; the surrounding policy then opens the
+  session anyway. The weakness is in the mode, not in the validation.
+- Two individually defensible auth decisions compose into a fail-open. In strict mode a non-HTTPS
+  JWKS URI is refused and the field is set to `None`; the missing-token check then requires
+  `jwks_uri.is_some()` and admits the request. Strict mode with a rejected JWKS URI has no
+  authentication left, and a caller who sends no token fares better than one who sends a bad token.
 - The sandbox substitutes a built-in policy when the file named by `--policy` fails to load, also
   under `--fail-closed`, and records no identity for the policy that actually applied.
 
@@ -56,9 +67,14 @@ so they can be enforced mechanically rather than remembered.
 4. **Session authorization is stated, not grown.** ADR-042 refuses generic agent identity and
    delegation, so this repository does not build an identity provider. It does owe an honest
    boundary: a handshake-only check is not request authorization, and must not be presented as one.
-   Either the privileged method surface refuses an unauthenticated session, or the auth boundary is
-   documented as out of the trust boundary and the default mode of a released binary does not accept
-   a token it failed to validate.
+   Of the two ways to settle that, documenting the boundary is preferred over building a session
+   gate, because the MCP
+   [`2026-07-28` revision](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+   removes the `initialize`/`initialized` handshake (SEP-2575) and the protocol-level session
+   (SEP-2567); a gate anchored to the handshake would be built on a mechanism the protocol is
+   dropping. Either way, the default mode of a released binary
+   does not accept a token it failed to validate, and a control that refuses unsafe configuration
+   never thereby disables the enforcement it was protecting.
 
 5. **A supporting capability records what it enforced, or states nothing about enforcement.** When
    an enforcement path substitutes a different policy than the operator named, that substitution is
@@ -90,11 +106,15 @@ Measured on `main` at `9fabad8b`, debug binaries, Linux x86_64.
 | Memory tracks input | `assay evidence verify` on 50 / 200 / 600 MB files | 72 / 222 / 622 MB peak resident |
 | Forged token accepted | `initialize` with an `alg:none` token, default mode | session opened, `"certified": true` returned |
 | No token accepted | `initialize` with no token, `ASSAY_AUTH_MODE=strict`, no JWKS | session opened |
+| JWKS scheme flips enforcement | `initialize` with no token, strict mode, `http://` JWKS URI | session opened; the same call with an `https://` URI is refused as `Missing authorization token (Strict mode)` |
 | Call without handshake | `tools/call` with no prior `initialize`, strict mode with JWKS | reached tool dispatch |
 | Policy substitution | `assay sandbox --fail-closed --policy <broken>` | warning, built-in policy applied, child ran, exit 0 |
 
-Two controls were run so the findings are not artifacts of the setup. Repacking the untouched
-fixture bundle verifies clean, while changing one field of equal byte length fails with
-`IntegrityManifestHash`; the integrity chain does what the profile says. The privileged-action
+Each finding was run against a control so it is not an artifact of the setup. Repacking the
+untouched fixture bundle verifies clean, while changing one field of equal byte length fails with
+`IntegrityManifestHash`; the integrity chain does what the profile says. For the JWKS composition
+the two runs differ only in the URI scheme, which isolates the cause to the refusal path itself.
+Finding 1 was independently challenged on the grounds that the verifier streams correctly, and
+re-confirmed: it does stream, but only over an already-materialized buffer. The privileged-action
 conformance corpus reproduces all thirteen vectors, and every policy-decision gate has a passing
 test, including `unknown_required_scope_fails_closed`.

--- a/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
+++ b/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
@@ -13,15 +13,18 @@ checkable by someone who does not trust us, and the stop list must not erode by 
 
 A verification pass over the current `main` found that both obligations have gaps at the exact
 places ADR-042 makes load-bearing, while the decision layer it describes holds up well. The measured
-findings, with reproduction steps in the appendix:
+findings follow; the appendix carries the evidence, and reproduction steps for everything except the
+authorization paths that are still open:
 
 - The reference verifier applies its own resource ceiling after it has already materialized the
   input. `assay evidence verify` on a 600 MB file peaks at 622 MB resident while
   `VerifyLimits::max_bundle_bytes` is 100 MB. The ceiling is passed correctly and the `LimitReader`
   is a genuine streaming guard; the defect is that `BundleReader::open_internal` reads the input to
   the end first, so that guard streams from a `Cursor` over a `Vec` that is already complete. At
-  process level it therefore bounds nothing. An independent verifier written from the profile text
-  would apply the ceiling to the source stream and behave differently from the reference.
+  process level it therefore bounds nothing. The profile requires decompression and size limits
+  before any profile parsing without pinning a value, so this is a resource-contract defect in the
+  reference implementation against its own stated security consideration — not a divergence in the
+  verdict an independent verifier would reach.
 - The MCP server emits `"certified": true` and `"partner": "agent_framework"` in every successful
   `initialize` response. Neither carries a basis a reviewer can check, and `meta` is not a protocol
   field at all — the reserved key is `_meta`. The claims-boundary guard that keeps the stop list
@@ -45,70 +48,103 @@ so they can be enforced mechanically rather than remembered.
 
 ## Decision
 
-1. **Bounded ingest is a verifier contract, not an optimization.** Every verifier entry point
-   applies its byte ceiling to the stream before the input is materialized. Reading an untrusted
-   artifact into memory ahead of the limit check is a contract defect regardless of what the
-   subsequent verification concludes. This binds the evidence bundle reader, the lint engine, the
-   evidence push path, the CLI stdin path, and the replay reader, which has no ceiling today. The
+1. **Bounded ingest binds every entrypoint that consumes untrusted evidence.** The obligation is not
+   limited to functions named "verify": it holds for any entrypoint that parses or semantically
+   consumes an untrusted artifact, which today means the bundle reader, the lint engine, the push
+   path in both its verifying and `--no-verify` branches, the CLI stdin path, and the replay reader.
+   Each applies its ceilings to the source stream before the input is materialized. One byte ceiling
+   is not the rule, because it does not cover a decompression bomb: the axes are compressed bytes,
+   decoded bytes, entry and event counts, and individual member sizes. `VerifyLimits` already
+   carries all four, so the defect is where they are applied and not that they are missing. The
    pattern is already in the tree: `assay_evidence::trust_basis::generation` takes
    `max_bundle_bytes + 1` before reading.
 
 2. **The stop list binds emitted artifacts, not only prose.** ADR-042 §3 refuses compliance and
    safe-agent claims. That refusal covers what the software puts on the wire and into evidence, on
    the same terms as what the documentation says. A field asserting certification, partnership, or
-   an equivalent status is removed unless it carries a basis a reviewer can check. The
-   claims-boundary guard's scope extends to emitted literals, so the guard covers the product and
-   not only the description of it.
+   an equivalent status is removed unless it carries a basis a reviewer can check. The mechanism is
+   a closed set of public wire status claims, asserted structurally against generated responses and
+   schema fixtures — not a pattern scan over source literals, which is simultaneously noisy and
+   blind to output composed indirectly.
 
 3. **Verification effort follows the golden path.** The evidence-chain verifier is the primary
    target for fuzzing and property testing. Coverage of an adjacent bundle format does not satisfy
    this, and a target that exists but never runs in CI does not either.
 
-4. **Session authorization is stated, not grown.** ADR-042 refuses generic agent identity and
-   delegation, so this repository does not build an identity provider. It does owe an honest
-   boundary: a handshake-only check is not request authorization, and must not be presented as one.
-   Of the two ways to settle that, documenting the boundary is preferred over building a session
-   gate, because the MCP
-   [`2026-07-28` revision](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
-   removes the `initialize`/`initialized` handshake (SEP-2575) and the protocol-level session
-   (SEP-2567); a gate anchored to the handshake would be built on a mechanism the protocol is
-   dropping. Either way, the default mode of a released binary
-   does not accept a token it failed to validate, and a control that refuses unsafe configuration
-   never thereby disables the enforcement it was protecting.
+4. **Authorization is stated, not grown — and never optional at runtime.** ADR-042 refuses generic
+   agent identity and delegation, so this repository does not build an identity provider. Within
+   that limit four rules hold, and documenting the current behaviour is not one of the options:
+   - With no authentication configured, the server makes no authenticated or certified claim.
+   - With authentication configured, missing or unusable key material fails at startup rather than
+     passing at runtime. A control that refuses an unsafe configuration never thereby disables the
+     enforcement it was protecting.
+   - A failed validation never yields an authorized request, in any mode.
+   - Every privileged method checks the authorization state of the request it is serving, not of a
+     handshake that preceded it. This is also the direction the MCP
+     [`2026-07-28` revision](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+     takes by removing the `initialize`/`initialized` handshake (SEP-2575) and the protocol-level
+     session (SEP-2567), so per-request state is the durable target and a handshake-anchored gate
+     would be built on a mechanism the protocol is dropping.
 
-5. **A supporting capability records what it enforced, or states nothing about enforcement.** When
-   an enforcement path substitutes a different policy than the operator named, that substitution is
-   either fatal or recorded with the identity of the policy that actually applied. The golden path
-   already binds `declared_policy_digest`; a capability that cannot do the same makes no
-   enforcement statement in evidence.
+5. **A named policy that cannot be loaded is fatal.** When the operator names a `--policy`, failure
+   to load it ends the run, unconditionally. `--fail-closed` does not create that obligation; it
+   only makes ignoring it more obviously wrong. Substituting a built-in pack for a named policy does
+   not honour the CLI contract, and recording the substitution afterwards does not repair it.
+   Substitution is legitimate only where no policy was named and a documented default applies, and
+   there the identity of the policy that actually applied is recorded. The golden path already binds
+   `declared_policy_digest`; a capability that cannot do the same makes no enforcement statement in
+   evidence.
 
 ## Consequences
 
 - The invariants in §1 and §3 are testable, so they can move from review attention into CI: a
-  resource-ceiling test per verifier entry point, and a fuzz target aimed at the evidence chain.
-- §2 widens the claims-boundary guard beyond prose. This is the mechanism ADR-042 relies on for
-  "cannot erode by accretion", and it currently has a blind spot the size of the product.
-- §4 accepts a smaller auth surface rather than a larger one. Making the boundary explicit is
-  cheaper than building session identity, and it is what the stop list already asks for.
-- §5 keeps the supporting capabilities inside the same epistemology as the golden path without
-  promoting them to co-equal product directions.
+  per-axis ceiling test for each entrypoint, and a fuzz target aimed at the evidence chain.
+- §2 widens the claims boundary beyond prose. This is the mechanism ADR-042 relies on for "cannot
+  erode by accretion", and it currently has a blind spot the size of the product. A closed set of
+  wire claims costs a fixture to maintain and buys a guard that cannot be evaded by string building.
+- §4 accepts a smaller auth surface rather than a larger one, and pays for it with four rules that
+  hold at runtime rather than a documented exception. Per-request state, not session state, is the
+  target; work anchored to the handshake is work with a known expiry.
+- §5 changes default behaviour: a named policy that fails to load stops the run instead of falling
+  back. That trades a convenience for an honest contract, and it is the reason this is an ADR rather
+  than a bug fix.
 - This ADR adds nothing to the ADR-042 stop list and removes nothing from it, so it amends rather
   than supersedes. The kernel-observation posture is unchanged: eBPF validation running post-merge
   rather than on pull requests remains consistent with its supporting status.
+
+Four implementation slices follow from the decisions, in this order:
+
+1. Bounded ingest across the five entrypoints in §1, with per-axis tests.
+2. Remove the unfounded wire claims and stand up the closed claim set from §2.
+3. Policy-load semantics from §5, including the default-behaviour change.
+4. Runtime authorization from §4, and an evidence-chain fuzz target for §3.
 
 ## Appendix: reproduction
 
 Measured on `main` at `9fabad8b`, debug binaries, Linux x86_64.
 
+Resource behaviour, reproducible as written:
+
 | Observation | Command | Result |
 |---|---|---|
 | Ingest exceeds the ceiling | counting reader through `BundleReader::open` vs `verify_bundle_with_limits`, 150 MiB input | 157,286,400 bytes read vs 32,768; ceiling is 104,857,600 |
 | Memory tracks input | `assay evidence verify` on 50 / 200 / 600 MB files | 72 / 222 / 622 MB peak resident |
-| Forged token accepted | `initialize` with an `alg:none` token, default mode | session opened, `"certified": true` returned |
-| No token accepted | `initialize` with no token, `ASSAY_AUTH_MODE=strict`, no JWKS | session opened |
-| JWKS scheme flips enforcement | `initialize` with no token, strict mode, `http://` JWKS URI | session opened; the same call with an `https://` URI is refused as `Missing authorization token (Strict mode)` |
-| Call without handshake | `tools/call` with no prior `initialize`, strict mode with JWKS | reached tool dispatch |
 | Policy substitution | `assay sandbox --fail-closed --policy <broken>` | warning, built-in policy applied, child ran, exit 0 |
+
+Authorization behaviour, stated as outcomes. These four were measured the same way, but the
+step-by-step recipes are withheld from this record until the §4 slice lands, then restored here. The
+findings are what the decision needs; the recipes are not:
+
+| Observation | Result |
+|---|---|
+| Permissive mode admits a token the validator rejected | session opened, and the response asserted `certified` |
+| Strict mode without usable key material admits a request carrying no token | session opened |
+| A refused JWKS URI removes the enforcement it was meant to protect | the identical call with an accepted URI is correctly refused; only the scheme differs |
+| A privileged method is dispatched without any prior authorization | reached tool dispatch |
+
+The policy-substitution row stays reproducible because it is an operator self-misconfiguration
+rather than a path a third party can trigger: it needs write access to the policy file the operator
+themselves named, and its effect is a weaker sandbox for that same operator.
 
 Each finding was run against a control so it is not an artifact of the setup. Repacking the
 untouched fixture bundle verifies clean, while changing one field of equal byte length fails with

--- a/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
+++ b/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
@@ -1,0 +1,100 @@
+# ADR-043: Evidence-chain integrity invariants
+
+- Status: Proposed
+- Date: 2026-07-25
+- Supersedes: none
+- Amends: ADR-042 (evidence-first positioning and scope freeze)
+
+## Context
+
+ADR-042 made the evidence artifact the product and the enforcing proxy its reference producer. Two
+of its consequences carry obligations that were never written down as testable rules: claims must be
+checkable by someone who does not trust us, and the stop list must not erode by accretion.
+
+A verification pass over the current `main` found that both obligations have gaps at the exact
+places ADR-042 makes load-bearing, while the decision layer it describes holds up well. The measured
+findings, with reproduction steps in the appendix:
+
+- The reference verifier applies its own resource ceiling after it has already materialized the
+  input. `assay evidence verify` on a 600 MB file peaks at 622 MB resident while
+  `VerifyLimits::max_bundle_bytes` is 100 MB. An independent verifier written from the profile text
+  would apply the ceiling first and behave differently from the reference on the same input.
+- The MCP server emits `"certified": true` in every successful `initialize` response, including a
+  session opened with a forged `alg:none` token. The claims-boundary guard that keeps the stop list
+  honest scans prose paths only, so it cannot see anything the binaries assert on the wire.
+- The bundle fuzz target covers `assay_core::replay::verify_bundle`, a different bundle format from
+  the evidence chain, and the replay module carries no resource ceiling at all.
+- Token validation runs only in the `initialize` branch. A `tools/call` sent without a handshake
+  reaches tool dispatch even with authentication configured in strict mode.
+- The sandbox substitutes a built-in policy when the file named by `--policy` fails to load, also
+  under `--fail-closed`, and records no identity for the policy that actually applied.
+
+None of these need a new product direction. They need the rules that ADR-042 implies to be stated
+so they can be enforced mechanically rather than remembered.
+
+## Decision
+
+1. **Bounded ingest is a verifier contract, not an optimization.** Every verifier entry point
+   applies its byte ceiling to the stream before the input is materialized. Reading an untrusted
+   artifact into memory ahead of the limit check is a contract defect regardless of what the
+   subsequent verification concludes. This binds the evidence bundle reader, the lint engine, the
+   evidence push path, the CLI stdin path, and the replay reader, which has no ceiling today. The
+   pattern is already in the tree: `assay_evidence::trust_basis::generation` takes
+   `max_bundle_bytes + 1` before reading.
+
+2. **The stop list binds emitted artifacts, not only prose.** ADR-042 §3 refuses compliance and
+   safe-agent claims. That refusal covers what the software puts on the wire and into evidence, on
+   the same terms as what the documentation says. A field asserting certification, partnership, or
+   an equivalent status is removed unless it carries a basis a reviewer can check. The
+   claims-boundary guard's scope extends to emitted literals, so the guard covers the product and
+   not only the description of it.
+
+3. **Verification effort follows the golden path.** The evidence-chain verifier is the primary
+   target for fuzzing and property testing. Coverage of an adjacent bundle format does not satisfy
+   this, and a target that exists but never runs in CI does not either.
+
+4. **Session authorization is stated, not grown.** ADR-042 refuses generic agent identity and
+   delegation, so this repository does not build an identity provider. It does owe an honest
+   boundary: a handshake-only check is not request authorization, and must not be presented as one.
+   Either the privileged method surface refuses an unauthenticated session, or the auth boundary is
+   documented as out of the trust boundary and the default mode of a released binary does not accept
+   a token it failed to validate.
+
+5. **A supporting capability records what it enforced, or states nothing about enforcement.** When
+   an enforcement path substitutes a different policy than the operator named, that substitution is
+   either fatal or recorded with the identity of the policy that actually applied. The golden path
+   already binds `declared_policy_digest`; a capability that cannot do the same makes no
+   enforcement statement in evidence.
+
+## Consequences
+
+- The invariants in §1 and §3 are testable, so they can move from review attention into CI: a
+  resource-ceiling test per verifier entry point, and a fuzz target aimed at the evidence chain.
+- §2 widens the claims-boundary guard beyond prose. This is the mechanism ADR-042 relies on for
+  "cannot erode by accretion", and it currently has a blind spot the size of the product.
+- §4 accepts a smaller auth surface rather than a larger one. Making the boundary explicit is
+  cheaper than building session identity, and it is what the stop list already asks for.
+- §5 keeps the supporting capabilities inside the same epistemology as the golden path without
+  promoting them to co-equal product directions.
+- This ADR adds nothing to the ADR-042 stop list and removes nothing from it, so it amends rather
+  than supersedes. The kernel-observation posture is unchanged: eBPF validation running post-merge
+  rather than on pull requests remains consistent with its supporting status.
+
+## Appendix: reproduction
+
+Measured on `main` at `9fabad8b`, debug binaries, Linux x86_64.
+
+| Observation | Command | Result |
+|---|---|---|
+| Ingest exceeds the ceiling | counting reader through `BundleReader::open` vs `verify_bundle_with_limits`, 150 MiB input | 157,286,400 bytes read vs 32,768; ceiling is 104,857,600 |
+| Memory tracks input | `assay evidence verify` on 50 / 200 / 600 MB files | 72 / 222 / 622 MB peak resident |
+| Forged token accepted | `initialize` with an `alg:none` token, default mode | session opened, `"certified": true` returned |
+| No token accepted | `initialize` with no token, `ASSAY_AUTH_MODE=strict`, no JWKS | session opened |
+| Call without handshake | `tools/call` with no prior `initialize`, strict mode with JWKS | reached tool dispatch |
+| Policy substitution | `assay sandbox --fail-closed --policy <broken>` | warning, built-in policy applied, child ran, exit 0 |
+
+Two controls were run so the findings are not artifacts of the setup. Repacking the untouched
+fixture bundle verifies clean, while changing one field of equal byte length fails with
+`IntegrityManifestHash`; the integrity chain does what the profile says. The privileged-action
+conformance corpus reproduces all thirteen vectors, and every policy-decision gate has a passing
+test, including `unknown_required_scope_fails_closed`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

ADR-042 froze the scope and made the evidence artifact the product, but two of its consequences were never written down as testable rules: claims must be checkable by someone who does not trust us, and the stop list must not erode by accretion. A verification pass over `main` found gaps at exactly those load-bearing places, while the decision layer ADR-042 describes holds up well.

ADR-043 records the invariants that ADR-042 implies, as a **proposed** decision for the maintainer to accept or reject:

1. **Bounded ingest binds every entrypoint that consumes untrusted evidence** — not only functions named "verify". The whole existing `VerifyLimits` set applies to the source stream before materialization; nothing needs adding to that vocabulary.
2. **The stop list binds emitted artifacts, not only prose** — enforced by a closed set of public wire status claims asserted against generated responses, not a pattern scan over source literals.
3. **Verification effort follows the golden path** — the evidence-chain verifier is the primary fuzz target.
4. **Authorization is stated, not grown, and never optional at runtime** — four rules that hold at runtime, keyed to per-request authorization state rather than a handshake MCP is removing.
5. **A named policy that cannot be loaded is fatal** — unconditionally; recording a substituted policy does not repair a broken CLI contract.

Structured as an amendment rather than a supersession: it adds no entry to the ADR-042 stop list and removes none. Every example maps onto an entry already there — wire claims onto the compliance and safe-agent refusal, claim ceilings onto the whole-action-verdict refusal.

## Findings behind the invariants

Measured on `main` at `9fabad8b`. Each has a control arm. Resource findings are reproducible in the appendix as written; the authorization findings are stated as outcomes with the recipes withheld until the §4 slice lands.

| Observation | Result |
|---|---|
| `assay evidence verify` on 50 / 200 / 600 MB inputs | 72 / 222 / 622 MB peak resident, while `max_bundle_bytes` is 100 MB |
| `BundleReader::open` vs `verify_bundle_with_limits`, 150 MiB input | 157,286,400 bytes read vs 32,768 |
| Permissive mode admits a token the validator rejected | session opened, response asserted `certified` |
| Strict mode without usable key material admits a request with no token | session opened |
| A refused JWKS URI removes the enforcement it was meant to protect | identical call with an accepted URI is correctly refused; only the scheme differs |
| A privileged method dispatched without prior authorization | reached tool dispatch |
| `assay sandbox --fail-closed --policy <unparseable>` | warning, built-in pack applied, child ran, exit 0 |

## Review history

Four review rounds; every substantive point is folded in or declined with a reason.

**Round 2 — one missing finding, two wording defects.**
- **New: an auth fail-open by composition.** In strict mode a non-HTTPS JWKS URI is refused by setting the field to `None`; the missing-token check then requires `jwks_uri.is_some()` and admits the request. Sending no token fares better than sending a bad one. Control differs only in URI scheme.
- **Finding 1 challenged and re-confirmed.** `LimitReader` is a real streaming guard, but `open_internal` reads to the end before the verifier runs, so it streams over an already-complete `Vec`. The wording now names that mechanism.
- **`alg:none` reattributed.** The allowlist rejects it as designed; `Permissive` downgrades the rejection. The weakness is the mode.

**Round 3 — two escape hatches, two overclaims.**
- **§4 had a hatch**: "refuse unauthenticated sessions, *or* document the boundary" permitted documenting the bypass and stopping. Replaced with four runtime rules, keyed to per-request state.
- **§5 had a hatch**: "fatal *or* record the substituted identity" permitted the wrong branch for a named `--policy`. Now unconditionally fatal. **This changes default behaviour.**
- **§1 was too coarse** and **§2's mechanism was weak**: rewritten around "parses or semantically consumes", and around a closed claim set with structural tests.
- **Appendix overclaimed conformance**: the profile requires limits before parsing but pins no value, so this is a resource-contract defect against the profile's own security consideration, not a verdict divergence.

**Round 4 — bot review plus a struct check.**
- **Copilot: unusable API path.** `assay_evidence::trust_basis::generation` is a private module and the function is `pub(super)`. Now cites `assay_evidence::generate_trust_basis`, the crate-root re-export.
- **CodeRabbit: make the stop-list mapping explicit** rather than leaving it inferred. Done in §2 and in the amendment bullet.
- **CodeRabbit: the MCP reference overstated its status.** The `2026-07-28` revision is a release candidate, locked 2026-05-21, publishing three days after this ADR's date. Now labelled as a candidate, noting this affects the argument's timing and not its direction.
- **§1 corrected again**: `VerifyLimits` carries eight dimensions and `max_decode_bytes` already names a decompression bomb. The earlier four-axis phrasing would have sent an implementor hunting for limits that already exist. The defect is application order, plus the replay reader which has none.
- **Declined — CodeRabbit asked for executable recipes for the authorization findings.** Another reviewer asked for the opposite on disclosure grounds, and that argument wins while those paths are unfixed. The withholding is stated in the appendix and time-boxed to the §4 slice; the resource rows keep their commands and the control fixture is now named.

## Type of Change
- [x] Documentation update

## Verification
- [x] `python3 scripts/ci/check-claims-boundary.py` passes (self-test and scan, 0 findings) — required for `docs/**` changes
- [x] `typos` passes
- [x] MCP revision claims verified against the published release-candidate announcement, not taken second-hand
- [x] Profile text checked directly for the conformance claim (`docs/profiles/privileged-mcp-action/v0.md`, §10)
- [x] `VerifyLimits` field count and `trust_basis` visibility checked in source before citing them
- [ ] `cargo check` / `cargo test` — not applicable, no code changed

## Checklist
- [x] Follows the ADR conventions in `docs/architecture/adrs.md` and the header style of ADR-042
- [x] Documentation updated: ADR-042 carries an `Amended by` pointer
- [ ] Tests — none added; the decisions name the tests their implementation slices should add

## Notes for the reviewer

- **Status is `Proposed` and the PR stays draft** until the first slices land.
- **§5 is a behaviour change, not a bug fix.** A named policy that fails to load will stop the run, regardless of `--fail-closed`. That is the main thing to accept or reject, and an in-flight fix elsewhere currently implements the narrower `--fail-closed`-only form.
- **No code changed here.** Four implementation slices are named in Consequences, in order.
- **`docs/architecture/adrs.md` was deliberately not updated.** Its index stops at ADR-033 and omits ADR-034 through ADR-042.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a proposed architectural decision defining evidence-chain integrity invariants, including tighter resource limits, clearer session authorization boundaries, expanded claims-boundary protections for emitted artifacts, and guidance on accurately asserting enforcement.
  * Documented recommended verification/testing expectations, such as per-entry resource-ceiling checks and targeted fuzz/property testing for evidence-chain verification.
  * Updated the related architectural decision to reflect it is amended by the new integrity invariants proposal, without changing its scope or constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->