### PR TITLE
fix(mcp,sandbox): remove unsupported handshake status claims; fail when a named policy cannot load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Breaking (`assay sandbox`)**: a `--policy` that is named but cannot be loaded is now fatal.
+  The run exits 2 with `E_POLICY_LOAD_FAILED_UNENFORCEABLE` and executes nothing, where it
+  previously printed a warning and continued under the built-in `mcp-server-minimal` pack.
+  `--fail-closed` does not create this obligation and does not change the outcome; naming a
+  policy does. Substitution remains in place where no `--policy` was given and the documented
+  default applies. An invocation that relied on the old fallback now fails instead of running
+  under containment the operator did not choose.
+- `assay mcp-server` no longer emits `meta.certified` or `meta.partner` in the `initialize`
+  result. Both were unconditional literals returned on every successful handshake, including
+  sessions that failed authentication under the default permissive mode, and neither carried a
+  basis a reviewer could check. `serverInfo.version` is now derived from the crate version
+  instead of the hand-written `0.4.0`, which no build produced.
+
+### Fixed
+- Sandbox policy documentation described a filesystem rule shape the loader has never
+  accepted (`- path:` mappings with `read`/`write` keys, against a schema of plain strings).
+  Copying an example verbatim used to produce a warning and now produces a hard failure, so
+  the reference, the CLI page and the security guide now describe the narrower contract the
+  sandbox runtime actually applies. The documented exit codes 3 and 4 for policy problems are
+  also corrected: no code path emitted them, and both cases are configuration errors, which
+  is 2.
+
 ## [3.34.0] - 2026-07-19
 
 ### Added

--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -3,7 +3,7 @@ use crate::cli::args::SandboxArgs;
 use crate::exit_codes;
 use crate::metrics;
 
-use crate::profile::{events::ProfileEvent, ProfileCollector};
+use crate::profile::events::ProfileEvent;
 
 mod bundle;
 mod child;
@@ -20,7 +20,6 @@ use profile::maybe_profile_begin;
 use tmp::create_scoped_tmp;
 
 pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
-    let mut profiler: Option<ProfileCollector> = None;
     let mut deferred_profile_events: Vec<ProfileEvent> = Vec::new();
     eprintln!("Assay Sandbox v0.1");
     eprintln!("──────────────────");
@@ -134,11 +133,23 @@ pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
                 p
             }
             Err(e) => {
-                if let Some(p) = &profiler {
-                    p.note(format!("failed to load policy: {}", e));
-                }
-                eprintln!("WARN: Failed to load policy: {}. Using default.", e);
-                crate::policy::mcp_server_minimal()
+                // ADR-043 §5: a named policy that cannot be loaded is fatal, unconditionally.
+                // `--fail-closed` does not create that obligation, it only makes ignoring it
+                // more obviously wrong. Naming --policy is an instruction; running the child
+                // under a built-in pack instead does not carry it out, and recording the
+                // substitution afterwards does not repair that. Substitution stays legitimate
+                // only on the path below, where no policy was named and a documented default
+                // applies.
+                //
+                // Nothing is recorded into the profiler here, and nothing can be: the run ends
+                // before `maybe_profile_begin()` has created a session, so there is no profile
+                // to record into and no artifact to record it in. The refusal is carried by the
+                // reason code and the metric, which is what a caller can actually observe.
+                eprintln!("ERROR: Failed to load policy {}: {}", path.display(), e);
+                eprintln!("E_POLICY_LOAD_FAILED_UNENFORCEABLE");
+                eprintln!("       the named policy did not load and no substitute was applied");
+                metrics::increment("policy_load_failed");
+                return Ok(exit_codes::POLICY_UNENFORCEABLE);
             }
         }
     } else {
@@ -174,7 +185,11 @@ pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
     let tmp_dir = create_scoped_tmp()?;
 
     // PR7: Initialize profiler if requested (passing tmp_dir for generalization)
-    profiler = maybe_profile_begin(&args, &cwd, Some(tmp_dir.path()));
+    // Bound here rather than pre-declared as None at the top of `run()`. The old shape left a
+    // long stretch in which `profiler` was in scope but always None, so a `p.note`/`p.record`
+    // written there compiled, read as if it captured the event, and never ran. Binding it at
+    // the point it is created makes that mistake a compile error instead of dead code.
+    let profiler = maybe_profile_begin(&args, &cwd, Some(tmp_dir.path()));
     if let Some(p) = &profiler {
         for event in deferred_profile_events.drain(..) {
             p.record(event);

--- a/crates/assay-cli/tests/contract_sandbox_policy_load_fail_closed.rs
+++ b/crates/assay-cli/tests/contract_sandbox_policy_load_fail_closed.rs
@@ -1,0 +1,160 @@
+//! ADR-043 §5: a named policy that cannot be loaded is fatal, unconditionally.
+//!
+//! `assay sandbox --policy <path>` used to fall back to the built-in `mcp-server-minimal`
+//! policy whenever the named file failed to load, including under `--fail-closed`: the child
+//! ran to completion under containment the operator never chose, and exit 0 reported success.
+//! Naming `--policy` is an instruction. Running something else does not carry it out, and
+//! `--fail-closed` is not what creates that obligation, it only makes ignoring it more
+//! obviously wrong.
+//!
+//! These are contract tests over the shipped binary rather than unit tests over a helper,
+//! because the defect was in the wiring and not in any single function.
+//!
+//! The child is `echo <marker>` rather than `true`, so the claim under test is checked
+//! directly: an exit code proves the CLI refused, but only an absent marker proves nothing was
+//! executed. The control arm inverts it and requires the marker, so a rule that simply refused
+//! everything could not pass the suite either.
+//!
+//! The marker travels on stdout rather than as a file. A filesystem marker looked equivalent
+//! and was not: on Linux the sandbox runs Landlock in containment, and `mcp-server-minimal`
+//! correctly denies writing into the outer `/tmp`, so the child ran and still left no file.
+//! Asserting on a channel the policy under test governs would have made the control arm a
+//! test of the default policy's deny rules instead of a test of the load-failure path.
+
+// `echo` is POSIX, and the neighbouring sandbox integration test gates itself the same way.
+// CI does not catch this on its own: the non-Linux matrix legs run
+// `cargo test --workspace --exclude assay-cli`, so a Windows break here would stay invisible
+// until that exclusion changes.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::io::Write;
+use std::path::Path;
+
+const MARKER: &str = "ASSAY_CHILD_RAN_MARKER";
+
+fn broken_policy() -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().expect("temp policy");
+    // Well-formed enough to be opened, not well-formed enough to parse as a policy.
+    writeln!(f, "this: is: not: a: valid: policy: document").expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+/// Outcome of one sandbox invocation over a child that announces itself on stdout, so "did it
+/// execute?" is an observable fact rather than an inference from the exit code.
+struct Run {
+    code: Option<i32>,
+    stderr: String,
+    child_ran: bool,
+    _data_home: tempfile::TempDir,
+}
+
+fn run_sandbox(extra: &[&str], policy: Option<&Path>) -> Run {
+    // The refusal path increments a counter, and the metrics store resolves its location from
+    // XDG_DATA_HOME with a fallback to ~/.local/share/assay. Without this the suite writes into
+    // the developer's and the runner's real metrics file, so a test run silently mutates state
+    // it does not own.
+    let data_home = tempfile::tempdir().expect("temp data home");
+
+    let mut cmd = Command::cargo_bin("assay").expect("binary");
+    cmd.env("XDG_DATA_HOME", data_home.path());
+    cmd.arg("sandbox");
+    cmd.args(extra);
+    if let Some(p) = policy {
+        cmd.arg("--policy").arg(p);
+    }
+    cmd.args(["--", "echo", MARKER]);
+
+    let out = cmd.assert().get_output().clone();
+    Run {
+        code: out.status.code(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        child_ran: String::from_utf8_lossy(&out.stdout).contains(MARKER),
+        _data_home: data_home,
+    }
+}
+
+#[test]
+fn a_named_policy_that_does_not_load_is_fatal_without_any_flag() {
+    let policy = broken_policy();
+    let run = run_sandbox(&[], Some(policy.path()));
+
+    assert_eq!(
+        run.code,
+        Some(2),
+        "naming --policy is an instruction; a load failure must end the run.\nstderr:\n{}",
+        run.stderr
+    );
+    assert!(
+        !run.child_ran,
+        "the child must never be executed when the named policy did not load.\nstderr:\n{}",
+        run.stderr
+    );
+    assert!(
+        run.stderr.contains("E_POLICY_LOAD_FAILED_UNENFORCEABLE"),
+        "refusal must carry its reason code.\nstderr:\n{}",
+        run.stderr
+    );
+    assert!(
+        !run.stderr.contains("mcp-server-minimal"),
+        "no substitute policy may be applied for a named policy.\nstderr:\n{}",
+        run.stderr
+    );
+}
+
+#[test]
+fn fail_closed_does_not_change_the_outcome_it_only_agrees_with_it() {
+    let policy = broken_policy();
+    let bare = run_sandbox(&[], Some(policy.path()));
+    let flagged = run_sandbox(&["--fail-closed"], Some(policy.path()));
+
+    assert_eq!(
+        flagged.code,
+        Some(2),
+        "--fail-closed must not be weaker than the default.\nstderr:\n{}",
+        flagged.stderr
+    );
+    assert!(
+        !flagged.child_ran,
+        "the child must never be executed under --fail-closed either.\nstderr:\n{}",
+        flagged.stderr
+    );
+    assert_eq!(
+        bare.code, flagged.code,
+        "the obligation comes from naming --policy, not from --fail-closed"
+    );
+}
+
+#[test]
+fn the_documented_default_still_applies_when_no_policy_is_named() {
+    // Substitution stays legitimate exactly where the operator named nothing. This is the
+    // control arm: a rule that refused here, or that never executed anything, would satisfy
+    // the two tests above while having broken the documented default.
+    let run = run_sandbox(&[], None);
+
+    // Pinned to exactly 0, not merely "not 2": a control arm that accepts any other failure
+    // would read green while the default path was broken in some unrelated way.
+    assert_eq!(
+        run.code,
+        Some(0),
+        "no --policy was named, so the documented default must still apply and the run must \
+         succeed.\nstderr:\n{}",
+        run.stderr
+    );
+    assert!(
+        run.child_ran,
+        "the default path must actually execute the child.\nstderr:\n{}",
+        run.stderr
+    );
+    assert!(
+        !run.stderr.contains("E_POLICY_LOAD_FAILED_UNENFORCEABLE"),
+        "the default path is not a load failure.\nstderr:\n{}",
+        run.stderr
+    );
+    assert!(
+        run.stderr.contains("mcp-server-minimal"),
+        "the default path must still name the policy it applied.\nstderr:\n{}",
+        run.stderr
+    );
+}

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -16,6 +16,37 @@ fn next_rid() -> String {
     format!("r-{n:06}")
 }
 
+/// The `initialize` result this server returns on a successful handshake.
+///
+/// Extracted so the claims boundary is testable rather than remembered. ADR-042 refuses
+/// compliance and partnership claims; ADR-043 §2 extends that refusal from prose to what the
+/// binary puts on the wire. This response previously carried a `meta` object asserting
+/// `certified: true` and a `partner`, unconditionally, on every successful handshake including
+/// sessions that had just failed authentication under the default permissive mode. Neither
+/// literal carried a basis a reviewer could check, so neither is emitted.
+///
+/// Server-specific metadata, if it is ever needed, belongs under the protocol's reserved
+/// `_meta` key with a non-reserved prefix such as `dev.assay/`; a bare `meta` object was never
+/// part of the protocol.
+fn initialize_result() -> Value {
+    serde_json::json!({
+        // Stale: the stable revision is 2025-11-25, and the 2026-07-28 candidate removes this
+        // handshake and the protocol-level session outright. Bumping it is a negotiation change
+        // and is deliberately not part of this fix.
+        "protocolVersion": "2024-11-05",
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": "assay-mcp-server",
+            // Derived from the crate, not written by hand. The previous literal "0.4.0" was
+            // an identity claim no build could substantiate, which is the same defect as the
+            // status claims this function was cleaned up to remove.
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    })
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct JsonRpcRequest {
     jsonrpc: String,
@@ -224,21 +255,7 @@ impl Server {
                             format!("Authentication Failed: {}", e),
                         )
                     } else {
-                        let caps = serde_json::json!({
-                            "protocolVersion": "2024-11-05", // Matches recent spec
-                            "capabilities": {
-                                "tools": {}
-                            },
-                            "serverInfo": {
-                                "name": "assay-mcp-server",
-                                "version": "0.4.0"
-                            },
-                            "meta": {
-                                "certified": true,
-                                "partner": "agent_framework"
-                            }
-                        });
-                        JsonRpcResponse::ok(req.id.clone(), caps)
+                        JsonRpcResponse::ok(req.id.clone(), initialize_result())
                     }
                 }
                 "notifications/initialized" => {
@@ -480,5 +497,160 @@ impl Server {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod claims_boundary_tests {
+    use super::initialize_result;
+
+    /// ADR-042 stop list, ADR-043 §2. The handshake must not assert a status the server
+    /// cannot substantiate. A denylist over the serialized response catches a claim
+    /// reintroduced anywhere in the object under any nesting, but it only knows the words
+    /// it was given, so it is the backstop here and not the primary control. The primary
+    /// control is `initialize_result_pins_every_value`, which pins the leaves.
+    #[test]
+    fn initialize_result_asserts_no_unearned_status() {
+        let wire = serde_json::to_string(&initialize_result()).expect("serializable");
+        for forbidden in [
+            "certified",
+            "certification",
+            "partner",
+            "compliant",
+            "compliance",
+            "approved",
+            "endorsed",
+            "accredited",
+        ] {
+            assert!(
+                !wire.to_ascii_lowercase().contains(forbidden),
+                "initialize result asserts `{forbidden}` without a checkable basis: {wire}"
+            );
+        }
+    }
+
+    /// Pinning paths is not enough, because a claim can live in a *value* on a permitted
+    /// path: `serverInfo.version: "0.4.0 (SOC 2 Type II attested)"` satisfies both the
+    /// allowlist and the denylist, since "attested" is not one of the eight words. The
+    /// response has four leaves, so pin all four. Anything asserted on the wire then has to
+    /// pass through this test, and the denylist is left as a backstop for the case where
+    /// someone updates a pinned value without thinking about what it claims.
+    #[test]
+    fn initialize_result_pins_every_value() {
+        let value = initialize_result();
+        assert_eq!(
+            value.get("protocolVersion").and_then(|v| v.as_str()),
+            Some("2024-11-05")
+        );
+        assert_eq!(
+            value.get("capabilities"),
+            Some(&serde_json::json!({"tools": {}}))
+        );
+        assert_eq!(
+            value
+                .get("serverInfo")
+                .and_then(|s| s.get("name"))
+                .and_then(|v| v.as_str()),
+            Some("assay-mcp-server")
+        );
+        // Derived, not asserted. The literal "0.4.0" was itself an unverifiable identity
+        // claim: the crate has been on 3.x for a long time, so the wire was stating a
+        // version no build ever produced.
+        assert_eq!(
+            value
+                .get("serverInfo")
+                .and_then(|s| s.get("version"))
+                .and_then(|v| v.as_str()),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    /// The bare `meta` key was never part of the protocol. If server metadata returns it
+    /// belongs under the reserved `_meta` key with a non-reserved prefix.
+    #[test]
+    fn initialize_result_has_no_bare_meta_object() {
+        let value = initialize_result();
+        let obj = value.as_object().expect("result is an object");
+        assert!(!obj.contains_key("meta"), "bare `meta` key reintroduced");
+    }
+
+    /// A denylist alone only catches the words we thought of. The response surface is small
+    /// and closed, so pin it: anything new on the wire has to be added here deliberately,
+    /// which is the point at which someone has to justify its basis.
+    ///
+    /// The walk is recursive on purpose. Pinning only the top level would leave
+    /// `serverInfo.vendorStatus` free to appear, which is the same defect one level down.
+    #[test]
+    fn initialize_result_surface_is_a_closed_set() {
+        const PERMITTED: &[&str] = &[
+            "protocolVersion",
+            "capabilities",
+            "capabilities.tools",
+            "serverInfo",
+            "serverInfo.name",
+            "serverInfo.version",
+        ];
+
+        // Descends through arrays as well as objects. An array element is addressed as
+        // `path[]` rather than `path[0]`, so the allowlist pins shape and not length: a
+        // future `capabilities.tools: [{"newField": true}]` surfaces as
+        // `capabilities.tools[].newField` and fails, instead of hiding inside a node the
+        // walk never entered.
+        fn walk(value: &serde_json::Value, prefix: &str, found: &mut Vec<String>) {
+            match value {
+                serde_json::Value::Object(obj) => {
+                    for (key, child) in obj {
+                        let path = if prefix.is_empty() {
+                            key.clone()
+                        } else {
+                            format!("{prefix}.{key}")
+                        };
+                        found.push(path.clone());
+                        walk(child, &path, found);
+                    }
+                }
+                serde_json::Value::Array(items) => {
+                    let path = format!("{prefix}[]");
+                    for child in items {
+                        walk(child, &path, found);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let value = initialize_result();
+        let mut found = Vec::new();
+        walk(&value, "", &mut found);
+
+        for path in &found {
+            assert!(
+                PERMITTED.contains(&path.as_str()),
+                "`{path}` was added to the initialize result without being declared here; \
+                 add it to PERMITTED only once its basis is checkable (ADR-042, ADR-043 §2)"
+            );
+        }
+        // Guard the guard: if the response shrinks, the allowlist must shrink with it, or it
+        // stops describing what actually goes on the wire.
+        for permitted in PERMITTED {
+            assert!(
+                found.iter().any(|p| p == permitted),
+                "`{permitted}` is declared permitted but no longer emitted; prune it"
+            );
+        }
+    }
+
+    #[test]
+    fn initialize_result_still_carries_the_fields_a_client_needs() {
+        let value = initialize_result();
+        assert!(value.get("protocolVersion").is_some());
+        assert!(value.get("capabilities").is_some());
+        assert_eq!(
+            value
+                .get("serverInfo")
+                .and_then(|s| s.get("name"))
+                .and_then(|n| n.as_str()),
+            Some("assay-mcp-server")
+        );
     }
 }

--- a/docs/guides/sandbox-security.md
+++ b/docs/guides/sandbox-security.md
@@ -13,7 +13,10 @@ MCP servers and AI agents execute code that may:
 - **Make unauthorized network connections**
 - **Interfere with other processes** via shared /tmp
 
-Assay's sandbox mitigates these risks using Linux Landlock LSM, environment scrubbing, and process isolation.
+Assay's sandbox mitigates filesystem and environment risks using Linux Landlock
+LSM, environment scrubbing, and process isolation. Network enforcement is a
+separate opt-in: `--enforce --enforce-net` accepts explicit TCP destination
+ports on compatible Linux hosts.
 
 ---
 
@@ -23,8 +26,8 @@ Assay's sandbox mitigates these risks using Linux Landlock LSM, environment scru
 # Run an MCP server in a secure sandbox
 assay sandbox -- npx @modelcontextprotocol/server-filesystem
 
-# With maximum security
-assay sandbox --env-strict --fail-closed -- ./untrusted-server
+# Require filesystem enforcement
+assay sandbox --enforce --env-strict --fail-closed -- ./untrusted-server
 ```
 
 ---
@@ -193,35 +196,29 @@ Landlock is a Linux Security Module that restricts filesystem access:
 Process: ./mcp-server
 
 Allowed paths:
-  /home/user/project/**  (read)
-  /tmp/assay-1000-123/** (read+write)
+  /home/user/project      (read+execute baseline)
+  /tmp/assay-1000-123    (full access baseline)
 
 Blocked paths:
-  /home/user/.ssh/**     ← DENIED
-  /var/lib/private-demo/credentials.txt  ← DENIED
-  /                      ← DENIED
+  paths not admitted by the Landlock allowlist
 ```
 
 ### Policy Example
 
 ```yaml
 # my-policy.yaml
-version: "1.0"
-name: "restricted-mcp"
+api_version: "assay/v1"
 
 fs:
-  allow:
-    - path: "${CWD}/**"
-      read: true
-      write: false
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
+  allow: []
   deny:
-    - path: "${HOME}/.ssh/**"
-    - path: "${HOME}/.aws/**"
-    - path: "${HOME}/.gnupg/**"
+    - "${HOME}/.ssh"
+    - "${HOME}/.aws"
+    - "${HOME}/.gnupg"
 ```
+
+If this file does not parse, `assay sandbox` exits 2 and runs nothing rather than falling
+back to a built-in pack.
 
 ```bash
 assay sandbox --policy my-policy.yaml -- ./mcp-server
@@ -235,9 +232,9 @@ Landlock is **allow-only**. It cannot enforce "deny X inside allowed Y":
 # ❌ This CANNOT be enforced:
 fs:
   allow:
-    - path: "${HOME}/**"      # Allow all of home
+    - "${HOME}"      # Allow all of home
   deny:
-    - path: "${HOME}/.ssh/**" # Deny .ssh (INSIDE allowed path)
+    - "${HOME}/.ssh" # Deny .ssh (INSIDE allowed path)
 ```
 
 **Assay detects this conflict** and:
@@ -246,19 +243,26 @@ fs:
 
 ### Best Practice: Minimal Allow Paths
 
-```yaml
-# ✅ Good: Specific paths
-fs:
-  allow:
-    - path: "${CWD}/src/**"
-    - path: "${CWD}/data/**"
-    - path: "${TMPDIR}/**"
+✅ Good: specific paths.
 
-# ❌ Bad: Overly broad
+```yaml
 fs:
   allow:
-    - path: "${HOME}/**"  # Too permissive!
+    - "${CWD}/src"
+    - "${CWD}/data"
 ```
+
+❌ Bad: overly broad.
+
+```yaml
+fs:
+  allow:
+    - "${HOME}"  # Too permissive!
+```
+
+An explicit `fs.allow` grants the current full-access Landlock permission set
+beneath that path. The sandbox policy format does not yet express separate
+read, write, and execute permissions, and it does not implement `/**` globs.
 
 ---
 
@@ -357,7 +361,7 @@ test:
 | Threat | Why |
 |--------|-----|
 | Kernel exploits | Requires root/CAP_SYS_ADMIN |
-| Network exfiltration | Requires `net: block` policy |
+| Network exfiltration | Requires `--enforce --enforce-net` and an explicit TCP-port allowlist |
 | Side-channel attacks | Out of scope for LSM |
 | Attacks within allowed paths | By design (allow means allow) |
 | Container escape | Use proper containers for that |
@@ -377,6 +381,7 @@ assay sandbox --env-strict -- ./mcp-server
 For **production** with untrusted code:
 ```bash
 assay sandbox \
+  --enforce \
   --env-strict \
   --fail-closed \
   --policy policies/locked.yaml \
@@ -413,8 +418,7 @@ The path isn't in your policy's allow list. Add it:
 ```yaml
 fs:
   allow:
-    - path: "/needed/path/**"
-      read: true
+    - "/needed/path"
 ```
 
 ### Checking Sandbox Capabilities

--- a/docs/reference/cli/sandbox.md
+++ b/docs/reference/cli/sandbox.md
@@ -17,7 +17,7 @@ assay sandbox [OPTIONS] -- <COMMAND> [ARGS...]
 The `assay sandbox` command executes an MCP server or any command inside a security sandbox. It provides:
 
 - **Filesystem isolation** via Linux Landlock LSM
-- **Network control** (audit or block)
+- **Optional TCP destination-port allowlisting** via `--enforce --enforce-net`
 - **Environment scrubbing** (credential leak prevention)
 - **Scoped `/tmp`** (per-run isolation)
 
@@ -33,6 +33,9 @@ This is the recommended way to run untrusted MCP servers in CI/CD or development
 |--------|-------------|
 | `--policy`, `-p` | Path to sandbox policy YAML (default: built-in minimal) |
 | `--fail-closed` | Exit if policy cannot be fully enforced (no degradation) |
+| `--enforce` | Require active Landlock filesystem enforcement |
+| `--enforce-net` | Enforce an explicit TCP destination-port allowlist; requires `--enforce` |
+| `--dry-run` | Audit without active blocking; conflicts with `--enforce` |
 
 ### Environment Control
 
@@ -133,36 +136,34 @@ assay sandbox --env-passthrough -- ./mcp-server
 
 Sandbox policies control filesystem access using Landlock LSM.
 
-### Built-in Policies
+### Implicit baseline
 
-| Policy | Description |
-|--------|-------------|
-| `minimal` | Read-only CWD, write to scoped /tmp only |
-| `development` | Read CWD, write to CWD + /tmp |
-| `mcp-server` | Tailored for typical MCP server needs |
+On a supported Linux host, the sandbox gives the working directory
+read-and-execute access and its scoped temporary directory full access before
+adding explicit policy allows. A custom `fs.allow` grants the current
+full-access Landlock permission set beneath the named path.
 
 ### Custom Policy
 
 ```yaml
 # my-policy.yaml
-version: "1.0"
-name: "my-sandbox"
+api_version: "assay/v1"
 
 fs:
   allow:
-    - path: "${CWD}/**"
-      read: true
-      write: false
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
+    - "${CWD}/data"
   deny:
-    - path: "${HOME}/.ssh/**"
-    - path: "${HOME}/.aws/**"
+    - "${HOME}/.ssh"
+    - "${HOME}/.aws"
 
 net:
-  mode: audit  # audit | block | allow
+  allow: []
+  deny: []
 ```
+
+If the file named by `--policy` does not parse, `assay sandbox` exits 2 with
+`E_POLICY_LOAD_FAILED_UNENFORCEABLE` and runs nothing. It does not fall back to a built-in
+pack, because that would run the workload under containment you did not choose.
 
 ```bash
 assay sandbox --policy my-policy.yaml -- ./mcp-server
@@ -174,8 +175,11 @@ assay sandbox --policy my-policy.yaml -- ./mcp-server
 |----------|-----------|
 | `${CWD}` | Current working directory |
 | `${HOME}` | User home directory |
-| `${TMPDIR}` | Scoped temp directory |
 | `${USER}` | Current username |
+
+The sandbox policy format does not implement `/**` globs or per-operation
+read/write/execute fields. `${TMPDIR}` is not expanded; Assay's scoped
+temporary directory is already part of the baseline.
 
 ---
 
@@ -188,9 +192,9 @@ Landlock is an **allow-only** LSM. It cannot enforce "deny X inside allowed Y".
 ```yaml
 fs:
   allow:
-    - path: "${HOME}/**"      # Allow all of home
+    - "${HOME}"      # Allow all of home
   deny:
-    - path: "${HOME}/.ssh/**" # Try to deny .ssh
+    - "${HOME}/.ssh" # Try to deny .ssh
 ```
 
 **Problem**: Landlock cannot block `.ssh` because it's inside the allowed `${HOME}`.
@@ -322,9 +326,11 @@ Backend: Landlock (Audit)
 |------|---------|
 | 0 | Command succeeded |
 | 1 | Command failed (pass-through exit code) |
-| 2 | Policy cannot be enforced (`--fail-closed`) |
-| 3 | Policy file not found |
-| 4 | Invalid policy syntax |
+| 2 | Policy cannot be enforced: a named `--policy` that is missing or does not parse, or a conflict under `--fail-closed` |
+
+Codes 3 and 4 were previously documented for a missing policy file and invalid policy
+syntax. No code path emitted them: `exit_codes.rs` reserves 3 for infrastructure failures
+and 4 for would-block, and both policy cases are configuration errors, which is 2.
 
 ---
 

--- a/docs/reference/sandbox-policies.md
+++ b/docs/reference/sandbox-policies.md
@@ -1,495 +1,210 @@
 # Sandbox Policies Reference
 
-Complete reference for Assay sandbox filesystem and network policies.
+This page documents the policy shape consumed by `assay sandbox --policy`.
+It does not describe the separate MCP policy format consumed by
+`assay policy validate`.
 
----
-
-## Overview
-
-Sandbox policies define what the sandboxed process can access:
-- **Filesystem**: Which paths can be read, written, or executed
-- **Network**: Which connections are allowed (future: egress filtering)
-
-Policies are enforced by **Linux Landlock LSM** at the kernel level.
-
----
-
-## Policy Schema
+## Current schema
 
 ```yaml
-version: "1.0"
-name: "policy-name"
+api_version: "assay/v1"
 
 fs:
   allow:
-    - path: "/some/path/**"
-      read: true
-      write: false
-      execute: false
+    - "/opt/example-data"
   deny:
-    - path: "/sensitive/path/**"
+    - "${HOME}/.ssh"
 
 net:
-  mode: audit  # audit | block | allow
+  allow: []
+  deny: []
 ```
 
----
+All entries under `fs` and `net` are strings. A named policy that is
+missing or cannot be parsed is fatal: `assay sandbox` exits 2 with
+`E_POLICY_LOAD_FAILED_UNENFORCEABLE` and does not start the child.
 
-## Filesystem Rules
+`api_version` defaults to `assay/v1`. The current loader deserializes this
+field but does not yet reject other values.
 
-### Allow Rules
+The schema also deserializes an `extends` list, but the sandbox runtime does
+not resolve or merge those entries. Keep `extends` empty until pack resolution
+is implemented.
 
-Specify paths the process can access:
+Unknown YAML keys are currently ignored by the loader. Do not use that as an
+extension mechanism: an ignored key has no enforcement effect.
+
+## Filesystem contract
+
+On Linux with Landlock available, the runtime installs these baseline rules:
+
+- the working directory is readable and executable;
+- the scoped Assay temporary directory has full filesystem access;
+- required system files are readable;
+- required runtime directories are readable and executable.
+
+Each entry in `fs.allow` names an existing file or directory and grants the
+Landlock access set used for explicit policy allows. For a directory, Landlock
+applies the rule beneath that directory. The current policy shape cannot
+express separate read, write, or execute permissions for a custom allow.
+
+Use exact paths:
 
 ```yaml
 fs:
   allow:
-    - path: "${CWD}/**"
-      read: true
-      write: true
-      execute: false
-
-    - path: "/usr/lib/**"
-      read: true
-      execute: true
-
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
+    - "${CWD}/data"
+    - "/opt/example-cache"
 ```
 
-### Permissions
+Do not append shell-style glob syntax such as `/**`. The runtime passes the
+expanded string to the filesystem and does not implement policy globs. A
+nonexistent path does not become an active Landlock rule.
 
-| Permission | Description |
-|------------|-------------|
-| `read` | Read file contents, list directories |
-| `write` | Create, modify, delete files and directories |
-| `execute` | Execute files, traverse directories |
-
-Default if not specified: `false`
-
-### Deny Rules
-
-Specify paths to explicitly deny:
+`fs.deny` is used for compatibility checking. Landlock is allowlist-based:
+paths not admitted by the baseline or an explicit allow are unavailable.
+A deny nested inside an allowed directory cannot be represented. Assay
+therefore degrades to audit mode, or exits 2 with `--fail-closed`, rather
+than claiming that the nested deny was enforced.
 
 ```yaml
+# Not enforceable: the allow grants the whole directory while the deny is nested in it.
 fs:
+  allow:
+    - "${HOME}"
   deny:
-    - path: "${HOME}/.ssh/**"
-    - path: "${HOME}/.aws/**"
-    - path: "${HOME}/.gnupg/**"
-    - path: "/var/lib/private-demo/credentials.txt"
-    - path: "/opt/private-demo/secrets.db"
+    - "${HOME}/.ssh"
 ```
 
-⚠️ **Important**: Deny rules have limitations. See [Landlock Limitations](#landlock-limitations).
+## Path expansion
 
----
+The filesystem enforcement path expands:
 
-## Path Variables
+| Token | Meaning |
+|---|---|
+| `~` at the start of a path | current home directory |
+| `${HOME}` | current home directory |
+| `${CWD}` | process current directory |
+| `${USER}` | current username |
 
-Policies support variable expansion:
+`${TMPDIR}` is not expanded. The scoped Assay temporary directory is already
+part of the baseline Landlock rules and should not be added through a literal
+`${TMPDIR}` policy entry.
 
-| Variable | Expansion | Example |
-|----------|-----------|---------|
-| `${CWD}` | Current working directory | `/home/user/project` |
-| `${HOME}` | User home directory | `/home/user` |
-| `${TMPDIR}` | Scoped temp directory | `/tmp/assay-1000-12345` |
-| `${USER}` | Current username | `user` |
+`--workdir` and `${CWD}` are not yet one contract: filesystem expansion reads
+the process current directory. Avoid combining a different `--workdir` with a
+`${CWD}` policy entry until that gap is closed.
 
-### Usage
+## Network contract
 
-```yaml
-fs:
-  allow:
-    - path: "${CWD}/**"         # /home/user/project/**
-    - path: "${HOME}/.config/**" # /home/user/.config/**
-    - path: "${TMPDIR}/**"       # /tmp/assay-1000-12345/**
-```
+Network policy has no enforcement effect unless both `--enforce` and
+`--enforce-net` are supplied and the host supports Landlock network rules.
 
-### Glob Patterns
-
-| Pattern | Meaning |
-|---------|---------|
-| `/**` | All files and subdirectories recursively |
-| `/*` | Direct children only |
-| (none) | Exact path match |
+The enforced form is an allowlist of explicit TCP destination ports:
 
 ```yaml
-fs:
-  allow:
-    - path: "${CWD}/**"      # Everything under CWD recursively
-    - path: "${CWD}/*"       # Only direct children of CWD
-    - path: "${CWD}/file.txt" # Exact file only
-```
-
----
-
-## Built-in Policies
-
-### minimal (Default)
-
-Read-only access to current directory, write only to scoped /tmp:
-
-```yaml
-version: "1.0"
-name: "minimal"
-
-fs:
-  allow:
-    - path: "${CWD}/**"
-      read: true
-      write: false
-      execute: false
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
-      execute: false
-
 net:
-  mode: audit
+  allow:
+    - "443"
+    - "tcp:8443"
+  deny: []
 ```
 
-### development
+The following forms are rejected by `--enforce-net`:
 
-Read/write access to current directory:
+- hostnames, IP addresses, CIDRs, and wildcards;
+- UDP, QUIC, or other non-TCP protocols;
+- port ranges and port 0;
+- every `net.deny` entry.
 
-```yaml
-version: "1.0"
-name: "development"
+Landlock can constrain TCP destination ports, not endpoint identity. Without
+`--enforce-net`, `net.allow` and `net.deny` are retained policy data but are not
+kernel network enforcement.
 
-fs:
-  allow:
-    - path: "${CWD}/**"
-      read: true
-      write: true
-      execute: false
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
-      execute: true
-    - path: "/usr/lib/**"
-      read: true
-      execute: true
-    - path: "/lib/**"
-      read: true
-      execute: true
+## Examples
 
-net:
-  mode: audit
-```
+### Baseline filesystem containment
 
-### mcp-server
-
-Tailored for typical MCP server needs:
+No explicit filesystem allow is required to read and execute from the working
+directory or to use Assay's scoped temporary directory:
 
 ```yaml
-version: "1.0"
-name: "mcp-server"
+api_version: "assay/v1"
 
 fs:
-  allow:
-    - path: "${CWD}/**"
-      read: true
-      write: false
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
-    - path: "/usr/**"
-      read: true
-      execute: true
-    - path: "/lib/**"
-      read: true
-      execute: true
-    - path: "/etc/ssl/**"
-      read: true
-    - path: "/etc/ca-certificates/**"
-      read: true
+  allow: []
   deny:
-    - path: "${HOME}/.ssh/**"
-    - path: "${HOME}/.aws/**"
-    - path: "${HOME}/.gnupg/**"
+    - "${HOME}/.ssh"
 
 net:
-  mode: audit
+  allow: []
+  deny: []
 ```
 
----
+### Writable data directory
 
-## Network Modes
-
-| Mode | Description |
-|------|-------------|
-| `audit` | Log connections but don't block (default) |
-| `block` | Block all network access |
-| `allow` | Allow all network access (no enforcement) |
+An explicit allow grants the current full-access policy permission set beneath
+that directory:
 
 ```yaml
-net:
-  mode: block  # Fully offline sandbox
-```
+api_version: "assay/v1"
 
-> **Note**: Fine-grained network rules (egress filtering by IP/port) require Landlock ABI v4+ (Linux 6.7+). Assay will show kernel requirements in `assay doctor`.
-
----
-
-## Landlock Limitations
-
-### Allow-Only Architecture
-
-Landlock is **allow-only**. You cannot deny a path inside an allowed parent:
-
-```yaml
-# ❌ CANNOT BE ENFORCED:
 fs:
   allow:
-    - path: "${HOME}/**"      # Allow all of home
-  deny:
-    - path: "${HOME}/.ssh/**" # Try to deny .ssh
+    - "${CWD}/output"
+  deny: []
+
+net:
+  allow: []
+  deny: []
 ```
 
-**Why**: Landlock evaluates from most-specific to least-specific. Once `${HOME}/**` allows access, the kernel permits it. There's no "deny override".
+### Enforced HTTPS destination port
 
-### How Assay Handles Conflicts
+Use this with `--enforce --enforce-net` on a compatible Linux host:
 
-When Assay detects a deny-inside-allow conflict:
+```yaml
+api_version: "assay/v1"
 
-1. **Warns** about the unenforced deny rule
-2. **Degrades to Audit mode** (logs but doesn't enforce)
-3. **Shows clear banner** indicating degraded security
+fs:
+  allow: []
+  deny: []
 
-```
-WARN: Landlock cannot enforce deny inside allowed path:
-      /home/user/.ssh (allowed by /home/user)
-INFO: Degrading to Audit mode (containment disabled)
-
-Backend: Landlock (Audit)
-  FS:  audit (degraded)
+net:
+  allow:
+    - "443"
+  deny: []
 ```
 
-### Fail-Closed Mode
+## Checking a sandbox policy
 
-Use `--fail-closed` to exit instead of degrading:
+There is not yet a dedicated validation command for this sandbox schema.
+`assay policy validate` validates the separate MCP policy format.
+
+To exercise sandbox loading with a harmless command:
 
 ```bash
-assay sandbox --fail-closed --policy my-policy.yaml -- ./server
-# ERROR: Policy cannot be fully enforced
-# exit 2
+assay sandbox --policy my-policy.yaml -- true
 ```
 
-### Best Practice: Minimal Allows
+This confirms that the file parses and passes the runtime's compatibility
+checks. On a supported Linux host it also applies the resulting containment
+before starting `true`.
 
-Avoid conflicts by using specific allow paths:
+Exit code 2 covers configuration that cannot be enforced, including:
 
-```yaml
-# ✅ Good: No conflicts possible
-fs:
-  allow:
-    - path: "${CWD}/src/**"
-    - path: "${CWD}/data/**"
-    - path: "${TMPDIR}/**"
-  deny:
-    - path: "${HOME}/.ssh/**"  # Not inside any allow → works!
-```
+- a missing or malformed named policy;
+- a Landlock compatibility conflict under `--fail-closed`;
+- a network policy that is not expressible under `--enforce-net`.
 
----
+## Current limitations
 
-## Policy Examples
-
-### Read-Only Project Access
-
-```yaml
-version: "1.0"
-name: "read-only"
-
-fs:
-  allow:
-    - path: "${CWD}/**"
-      read: true
-      write: false
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
-
-net:
-  mode: audit
-```
-
-### Offline Data Processing
-
-```yaml
-version: "1.0"
-name: "offline-processor"
-
-fs:
-  allow:
-    - path: "${CWD}/input/**"
-      read: true
-    - path: "${CWD}/output/**"
-      read: true
-      write: true
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
-
-net:
-  mode: block  # No network access
-```
-
-### CI Pipeline
-
-```yaml
-version: "1.0"
-name: "ci-locked"
-
-fs:
-  allow:
-    - path: "${CWD}/**"
-      read: true
-      write: true
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
-    - path: "/usr/**"
-      read: true
-      execute: true
-    - path: "/lib/**"
-      read: true
-      execute: true
-    - path: "/bin/**"
-      read: true
-      execute: true
-
-net:
-  mode: audit
-```
-
-### Security Research (Paranoid)
-
-```yaml
-version: "1.0"
-name: "paranoid"
-
-fs:
-  allow:
-    - path: "${TMPDIR}/**"
-      read: true
-      write: true
-  # Nothing else allowed!
-
-net:
-  mode: block
-```
-
----
-
-## Policy Validation
-
-### Check Syntax
-
-```bash
-assay policy validate my-policy.yaml
-```
-
-### Preview Enforcement
-
-```bash
-assay sandbox --verbose --policy my-policy.yaml -- true
-```
-
-Shows:
-- Expanded paths
-- Detected conflicts
-- Effective rules
-
----
-
-## Policy Compilation
-
-When `assay sandbox` runs, it:
-
-1. **Parses** the YAML policy
-2. **Expands** variables (`${CWD}` → `/home/user/project`)
-3. **Canonicalizes** paths (resolves symlinks, `..`, etc.)
-4. **Detects conflicts** (deny inside allow)
-5. **Builds Landlock ruleset** (allow rules only)
-6. **Applies** in pre_exec (after fork, before exec)
-
-### Compilation Errors
-
-| Error | Cause |
-|-------|-------|
-| `Path not found` | Variable expansion failed or path doesn't exist |
-| `Conflict detected` | Deny rule inside allow path |
-| `Invalid permission` | Unknown permission type |
-
----
-
-## Environment Integration
-
-Policies work with environment scrubbing:
-
-```bash
-# Policy + strict env
-assay sandbox \
-  --policy my-policy.yaml \
-  --env-strict \
-  -- ./server
-```
-
-The scoped `/tmp` created by the sandbox is automatically:
-- Added to the policy's allow list
-- Set as `TMPDIR`, `TMP`, `TEMP`
-
----
-
-## Diagnostics
-
-### Check Capabilities
-
-```bash
-assay doctor
-```
-
-Shows:
-- Landlock ABI version
-- Available filesystem scopes
-- Network enforcement availability
-
-### Debug Policy Application
-
-```bash
-assay sandbox --verbose --policy my-policy.yaml -- ./cmd
-```
-
-Shows:
-- Which rules were applied
-- Any conflicts or degradations
-- Effective security posture
-
----
-
-## Future: BPF-LSM
-
-For full deny-wins semantics, Assay will support **BPF-LSM** backend:
-
-```yaml
-backend: bpf-lsm  # Future
-
-fs:
-  allow:
-    - path: "${HOME}/**"
-  deny:
-    - path: "${HOME}/.ssh/**"  # Will be enforced!
-```
-
-BPF-LSM can express arbitrary allow/deny logic. Watch `assay doctor` for availability.
-
----
-
-## See Also
-
-- [assay sandbox CLI Reference](cli/sandbox.md)
-- [Sandbox Security Guide](../guides/sandbox-security.md)
-- [Environment Filtering Reference](sandbox-env.md)
-- [Landlock Documentation](https://docs.kernel.org/userspace-api/landlock.html)
+- `extends` is parsed but not resolved.
+- Unknown keys are ignored.
+- Custom filesystem allows do not carry per-operation permissions.
+- Policy globs such as `/**` are not implemented.
+- `${TMPDIR}` is not expanded.
+- `${CWD}` does not follow a different `--workdir`.
+- Network enforcement accepts explicit TCP ports only.
+- A host without the required Landlock support cannot provide the Linux
+  enforcement described here.

--- a/tests/integration/phase6-check.sh
+++ b/tests/integration/phase6-check.sh
@@ -58,12 +58,9 @@ version: "1.0"
 name: "conflict"
 fs:
   allow:
-     - path: "${HOME}/**"
-       read: true
+     - "${HOME}"
   deny:
-     - path: "${HOME}/.ssh/**"
-net:
-  mode: audit
+     - "${HOME}/.ssh"
 EOF
 
   set +e


### PR DESCRIPTION
Two bounded fixes from the ADR-043 verification pass, kept as separate commits.

## What changes

### Remove unsupported handshake claims

The MCP `initialize` result no longer emits unconditional `certified: true` and `partner: "agent_framework"` fields. The remaining response is a closed, value-pinned surface containing only the protocol version, capabilities, and package-derived server identity required by clients.

The boundary tests recurse through objects and arrays, reject a bare `meta` object, pin every leaf value, and retain the fields clients need.

### Fail when a named sandbox policy cannot load

`assay sandbox --policy <path>` no longer substitutes the built-in pack when the named file is missing or malformed. It exits 2 with `E_POLICY_LOAD_FAILED_UNENFORCEABLE` and does not start the child. `--fail-closed` yields the same result; the no-`--policy` default remains unchanged at exit 0.

The profiler is now bound only where a profile session is created, removing an earlier span where logging calls compiled but could never run. The refusal is observable through its reason code and metric; no profile artifact exists at that point.

## Runtime-contract documentation

The sandbox reference, CLI page, security guide, phase6 fixture, and changelog now describe what the runtime enforces, not merely what the YAML loader accepts:

- `extends` is parsed but not resolved;
- policy globs such as `/**` are not implemented;
- custom `fs.allow` entries grant the current full-access Landlock set and cannot express separate read/write/execute permissions;
- `${TMPDIR}` is not expanded;
- `assay policy validate` validates a different MCP policy format;
- network enforcement requires `--enforce --enforce-net` and accepts explicit TCP destination ports only.

Unknown YAML keys remain ignored, so the docs explicitly reject using them as an extension mechanism.

## Behaviour change

| Invocation | Before | After |
|---|---|---|
| `assay sandbox --policy <unreadable> -- cmd` | exit 0, built-in pack substituted | **exit 2**, nothing runs |
| same with `--fail-closed` | exit 0, built-in pack substituted | **exit 2**, identical result |
| `assay sandbox -- cmd` | exit 0, documented default applies | **exit 0, unchanged** |

The contract tests use child stdout markers: refusal arms require the marker to be absent, while the default control arm requires it to be present. `XDG_DATA_HOME` is isolated so the tests do not modify developer or runner metrics.

## Verification

- `cargo test -p assay-cli --test contract_sandbox_policy_load_fail_closed` (3/3)
- `cargo test -p assay-mcp-server claims_boundary_tests` (5/5)
- `cargo clippy -p assay-cli -p assay-mcp-server --all-targets -- -D warnings`
- all 16 current YAML fences in the three sandbox docs exercised through the built binary
- `bash tests/integration/phase6-check.sh`
- `mkdocs build --strict`

## Not in this PR

No `protocolVersion` change. Protocol negotiation is handled separately after this PR and ADR-043 merge. The remaining ADR-043 items, including bounded ingest, session authorization, and evidence-chain fuzzing, require their own design decisions.

## Merge order

Merge this PR first. Merge ADR-043 (#1841) only after this head is green and merged.
