### PR TITLE
fix(sandbox,mcp): state unwritten artifacts on refusal, assert the handshake on the wire

### DIFF
--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -19,6 +19,31 @@ use env::build_env_filter;
 use profile::maybe_profile_begin;
 use tmp::create_scoped_tmp;
 
+/// State which requested artifacts were not produced, and why.
+///
+/// `write_enforcement_health_v1` already states the rule for the success path: a requested
+/// artifact that cannot be written is an error, "so the caller does not exit successfully in a
+/// state where the evidence is absent on disk". The refusal paths did not honour the other half
+/// of it. They exit before `maybe_profile_finish`, which is the only place artifacts are
+/// written, so `--profile`, `--bundle`, `--enforcement-health` and `--otel-jsonl` all resolved
+/// to nothing with no statement at all.
+///
+/// A refusal happens before the child runs, so there is genuinely nothing to profile and no
+/// enforcement to describe. Writing an empty artifact would be worse than writing none: it
+/// would look like a measured run. What the caller is owed is the sentence, not the file.
+fn report_unwritten_artifacts(args: &SandboxArgs, reason: &str) {
+    for (flag, path) in [
+        ("--profile", args.profile.as_ref()),
+        ("--bundle", args.bundle.as_ref()),
+        ("--enforcement-health", args.enforcement_health.as_ref()),
+        ("--otel-jsonl", args.otel_jsonl.as_ref()),
+    ] {
+        if let Some(path) = path {
+            eprintln!("NOTE: {flag} {} not written: {reason}", path.display());
+        }
+    }
+}
+
 pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
     let mut deferred_profile_events: Vec<ProfileEvent> = Vec::new();
     eprintln!("Assay Sandbox v0.1");
@@ -42,6 +67,7 @@ pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
     if args.enforce && !matches!(backend, BackendType::Landlock) {
         if args.fail_closed {
             eprintln!("ERROR: Active enforcement requested (--enforce) but no containment backend available.");
+            report_unwritten_artifacts(&args, "no containment backend, nothing was executed");
             return Ok(exit_codes::POLICY_UNENFORCEABLE);
         }
         deferred_profile_events.push(ProfileEvent::AuditFallback {
@@ -149,6 +175,10 @@ pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
                 eprintln!("E_POLICY_LOAD_FAILED_UNENFORCEABLE");
                 eprintln!("       the named policy did not load and no substitute was applied");
                 metrics::increment("policy_load_failed");
+                report_unwritten_artifacts(
+                    &args,
+                    "the named policy did not load, nothing was executed",
+                );
                 return Ok(exit_codes::POLICY_UNENFORCEABLE);
             }
         }
@@ -222,6 +252,10 @@ pub async fn run(args: SandboxArgs) -> anyhow::Result<i32> {
                 compat.conflicts.len()
             );
             metrics::increment("policy_conflict_fail_closed");
+            report_unwritten_artifacts(
+                &args,
+                "policy conflict under --fail-closed, nothing was executed",
+            );
             return Ok(exit_codes::POLICY_UNENFORCEABLE);
         }
 

--- a/crates/assay-cli/tests/contract_sandbox_policy_load_fail_closed.rs
+++ b/crates/assay-cli/tests/contract_sandbox_policy_load_fail_closed.rs
@@ -158,3 +158,43 @@ fn the_documented_default_still_applies_when_no_policy_is_named() {
         run.stderr
     );
 }
+
+#[test]
+fn a_refusal_states_which_requested_artifacts_were_not_written() {
+    // `write_enforcement_health_v1` calls a requested artifact that cannot be written an
+    // error, "so the caller does not exit successfully in a state where the evidence is
+    // absent on disk". A refusal exits before `maybe_profile_finish`, the only place
+    // artifacts are written, so the file is absent either way. The caller is owed the
+    // sentence rather than an empty path to discover later.
+    let policy = broken_policy();
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let profile = tmp.path().join("prof.yaml");
+    let bundle = tmp.path().join("bundle.tar.gz");
+
+    let out = Command::cargo_bin("assay")
+        .expect("binary")
+        .env("XDG_DATA_HOME", tmp.path())
+        .args(["sandbox", "--policy"])
+        .arg(policy.path())
+        .arg("--profile")
+        .arg(&profile)
+        .arg("--bundle")
+        .arg(&bundle)
+        .args(["--", "echo", MARKER])
+        .assert()
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(out.status.code(), Some(2), "stderr:\n{stderr}");
+    assert!(
+        !profile.exists() && !bundle.exists(),
+        "a refused run must not leave artifacts that look like a measured run"
+    );
+    for flag in ["--profile", "--bundle"] {
+        assert!(
+            stderr.contains(flag) && stderr.contains("not written"),
+            "refusal must state that {flag} was not written.\nstderr:\n{stderr}"
+        );
+    }
+}

--- a/crates/assay-mcp-server/tests/stdio_e2e.rs
+++ b/crates/assay-mcp-server/tests/stdio_e2e.rs
@@ -60,6 +60,41 @@ fn test_stdio_flow() {
     let resp: Value = serde_json::from_str(&line).expect("Failed to parse init response");
     assert!(resp.get("result").is_some(), "Init failed: {:?}", resp);
 
+    // The unit tests in `server.rs` pin `initialize_result()`, but the original defect was an
+    // inline literal at the call site, so a helper the dispatcher no longer returns would leave
+    // those tests green. This is the same boundary checked where it actually matters: on the
+    // wire, out of a real handshake against a real process.
+    let result = &resp["result"];
+    let wire = serde_json::to_string(result).expect("serializable");
+    for forbidden in [
+        "certified",
+        "certification",
+        "partner",
+        "compliant",
+        "compliance",
+        "approved",
+        "endorsed",
+        "accredited",
+    ] {
+        assert!(
+            !wire.to_ascii_lowercase().contains(forbidden),
+            "initialize asserted `{forbidden}` on the wire without a checkable basis: {wire}"
+        );
+    }
+    assert!(
+        result.get("meta").is_none(),
+        "bare `meta` key returned on the wire: {wire}"
+    );
+    assert_eq!(
+        result["serverInfo"]["name"].as_str(),
+        Some("assay-mcp-server")
+    );
+    assert_eq!(
+        result["serverInfo"]["version"].as_str(),
+        Some(env!("CARGO_PKG_VERSION")),
+        "wire version must be the crate version, not a hand-written literal"
+    );
+
     // 2. List Tools
     let req_list = serde_json::json!({
         "jsonrpc": "2.0",


### PR DESCRIPTION
Follow-up to the review of #1842. Two findings there were real but not caused by that PR, so they were deliberately kept out of it rather than smuggled into a fix. This is where they land.

**Stacked on #1842.** The base is `codex/adr043-cheap-fixes`, because both touch `sandbox.rs`. Merge #1842 first; this rebases onto `main` cleanly once it does.

## Requested artifacts vanished silently on every refusal

`maybe_profile_finish` is the only place sandbox artifacts are written, and it is reached from `run_child`. All three early returns in `run()` skip it, so `--profile`, `--bundle`, `--enforcement-health` and `--otel-jsonl` resolved to nothing with no statement at all: exit 2, and an empty path for the caller to discover later.

The codebase already states the rule for the other direction. `write_enforcement_health_v1` calls a requested artifact that cannot be written an error, "so the caller does not exit successfully in a state where the evidence is absent on disk". The refusal paths did not honour the same principle.

They now name every requested artifact they did not produce, and why:

```
ERROR: Failed to load policy broken.yaml: fs.allow[0]: invalid type: map, expected a string
E_POLICY_LOAD_FAILED_UNENFORCEABLE
NOTE: --profile prof.yaml not written: the named policy did not load, nothing was executed
NOTE: --bundle out.tar.gz not written: the named policy did not load, nothing was executed
```

No artifact is fabricated. A refusal happens before the child runs, so there is genuinely nothing to profile and no enforcement to describe; writing an empty file would be worse than writing none, because it would look like a measured run. What the caller is owed here is the sentence, not the file.

## The MCP claims boundary was pinned on the helper, not the wire

`initialize_result()` has unit tests, but the defect those tests exist for was an inline literal at the call site. A helper the dispatcher no longer returned would have left all of them green.

`tests/stdio_e2e.rs` already performs a real handshake against a real process and asserted only that `result` was present. It now checks the same boundary where it actually matters: no status claim anywhere in the serialized response, no bare `meta` key, and `serverInfo.version` equal to the crate version rather than a hand-written literal.

## Tests

Four contract tests over the shipped binary, plus the strengthened wire assertion. The new artifact test was verified to fail with the reporting removed and pass with it, and it asserts both halves: the artifacts are absent, and their absence is stated.

## Not in this PR

`extends:` is deserialized and never resolved. A policy naming packs runs with none of them and still reports `(loaded)`, and the sharpest case is self-inflicted: `assay sandbox --profile` writes `extends: [pack:deny-all, pack:mcp-server-minimal]`, and feeding that file back through `--policy` discards both. That is the same silent-substitution class this branch is cleaning up, one layer higher.

It is not a refactor, though. `Policy::merge` has exactly one caller and it is a unit test, nothing resolves a `pack:` string anywhere, and `deny-all` does not exist as code at all while `profile/suggest.rs` already emits references to it. Closing it means designing a resolver and adding a missing pack, which deserves its own decision rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
