### PR TITLE
test(scripts): resolve the assay binary the way the other scripts already do

### DIFF
--- a/scripts/verify_cli_contract.sh
+++ b/scripts/verify_cli_contract.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 # Build debug binary first to ensure freshness
 cargo build --bin assay
 
-ASSAY="./target/debug/assay"
+# Same resolution order as perf_assess.sh and soak_test.sh: explicit override, then
+# CARGO_TARGET_DIR, then the default layout.
+ASSAY="${ASSAY:-${CARGO_TARGET_DIR:-target}/debug/assay}"
 
 run_expect() {
   local name="$1"; shift

--- a/tests/integration/phase6-check.sh
+++ b/tests/integration/phase6-check.sh
@@ -3,7 +3,10 @@ set -e
 # Phase 6 Refined Integration Check
 # SOTA Patterns, Safe Path, Fail-Closed Marker
 
-BINARY="./target/debug/assay"
+# Resolve like the perf and soak scripts already do: an explicit ASSAY wins, then
+# CARGO_TARGET_DIR, then the default layout. Hardcoding ./target/debug means the script cannot
+# find a binary when run from a git worktree, since cargo puts it in the shared target dir.
+BINARY="${ASSAY:-${CARGO_TARGET_DIR:-target}/debug/assay}"
 if [ ! -f "$BINARY" ]; then
     echo "Binary not found, building..."
     cargo build -p assay-cli


### PR DESCRIPTION
`tests/integration/phase6-check.sh` and `scripts/verify_cli_contract.sh` hardcoded `./target/debug/assay`. Cargo puts the binary in `CARGO_TARGET_DIR` when that is set, which is the normal situation in a git worktree, so neither script could find it there.

This surfaced during the ADR-043 review: verifying #1842 from a worktree required moving that worktree's `target` aside and symlinking it to the main checkout. That works, but it couples two working copies to one target directory and leaves strays behind, and the next person working in a worktree hits the same wall.

`perf_e2e.sh`, `perf_assess.sh` and `soak_test.sh` already solve this with an overridable `ASSAY`. Both scripts now use the same resolution order, so there is one convention rather than two:

```sh
ASSAY="${ASSAY:-${CARGO_TARGET_DIR:-target}/debug/assay}"
```

An explicit `ASSAY` wins, then `CARGO_TARGET_DIR`, then the default layout. Nothing changes when neither variable is set.

## Verification

Run from the main checkout, unchanged behaviour:

- `bash tests/integration/phase6-check.sh` passes
- `bash scripts/verify_cli_contract.sh` passes

Run from a throwaway `git worktree`, which failed before this change with `./target/debug/assay: No such file or directory`:

- with `CARGO_TARGET_DIR` pointing at the main target: passes
- with an explicit `ASSAY=...`: passes

shellcheck passes through the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)