### PR TITLE
docs(adr): bound ADR-043 §4 to the transport that actually exists

### DIFF
--- a/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
+++ b/docs/architecture/ADR-043-evidence-chain-integrity-invariants.md
@@ -75,22 +75,29 @@ so they can be enforced mechanically rather than remembered.
    target for fuzzing and property testing. Coverage of an adjacent bundle format does not satisfy
    this, and a target that exists but never runs in CI does not either.
 
-4. **Authorization is stated, not grown — and never optional at runtime.** ADR-042 refuses generic
-   agent identity and delegation, so this repository does not build an identity provider. Within
-   that limit four rules hold, and documenting the current behaviour is not one of the options:
-   - With no authentication configured, the server makes no authenticated or certified claim.
-   - With authentication configured, missing or unusable key material fails at startup rather than
-     passing at runtime. A control that refuses an unsafe configuration never thereby disables the
-     enforcement it was protecting.
-   - A failed validation never yields an authorized request, in any mode.
-   - Every privileged method checks the authorization state of the request it is serving, not of a
-     handshake that preceded it. This is also the direction MCP is taking: the
-     [`2026-07-28` release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/),
-     locked on 2026-05-21 and due to publish on 2026-07-28, removes the `initialize`/`initialized`
-     handshake (SEP-2575) and the protocol-level session (SEP-2567). Read as of this ADR's date that
-     is a candidate rather than a published spec, which affects the timing of the argument and not
-     its direction: per-request state is the durable target either way, and a handshake-anchored
-     gate would be built on a mechanism the protocol is dropping.
+4. **Authorization is bounded by the transport, and this transport has none.** ADR-042 refuses
+   generic agent identity and delegation. On a stdio server that refusal has a concrete
+   consequence rather than an abstract one: there is no transport to authenticate, so the honest
+   move is to say so and refuse configuration that pretends otherwise. Approximating an auth layer
+   here is the failure, not the absence of one. Four rules follow, and documenting the current
+   behaviour is not one of the options:
+   - The stdio server performs no transport authentication and makes no authenticated or certified
+     claim on any surface.
+   - The token check on `initialize` is removed rather than repaired. It was a proprietary route
+     that never covered any other method, and no request is authorized by it.
+   - Any `ASSAY_AUTH_*` configuration is a startup failure raised before protocol I/O begins, never
+     a permissive pass. A control that refuses an unsafe configuration must not thereby disable the
+     enforcement it was protecting, which is exactly how the JWKS composition failed open.
+   - Inbound token-shaped values are never logged, never treated as identity, and never forwarded
+     to an upstream.
+
+   Two things stay deliberately outside this decision. Standard OAuth belongs to a future
+   transport ADR, not to a stdio server; the
+   [MCP `2026-07-28` release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+   removes the handshake (SEP-2575) and the protocol session (SEP-2567), so that work is a protocol
+   migration with its own decision rather than a patch here. And the enforcing proxy's declared
+   caller and policy identity is local enforcement input, not a transport auth claim; it is
+   unaffected.
 
 5. **A named policy that cannot be loaded is fatal.** When the operator names a `--policy`, failure
    to load it ends the run, unconditionally. `--fail-closed` does not create that obligation; it
@@ -108,9 +115,10 @@ so they can be enforced mechanically rather than remembered.
 - §2 widens the claims boundary beyond prose. This is the mechanism ADR-042 relies on for "cannot
   erode by accretion", and it currently has a blind spot the size of the product. A closed set of
   wire claims costs a fixture to maintain and buys a guard that cannot be evaded by string building.
-- §4 accepts a smaller auth surface rather than a larger one, and pays for it with four rules that
-  hold at runtime rather than a documented exception. Per-request state, not session state, is the
-  target; work anchored to the handshake is work with a known expiry.
+- §4 removes an auth surface rather than growing one. The cost is that an operator who sets
+  `ASSAY_AUTH_*` today gets a startup failure instead of a silent partial check; that is the point,
+  because the partial check was the fail-open. The public `auth` types can stay one release as a
+  deprecated compatibility surface provided they are fully decoupled from the server loop.
 - §5 changes default behaviour: a named policy that fails to load stops the run instead of falling
   back. That trades a convenience for an honest contract, and it is the reason this is an ADR rather
   than a bug fix.
@@ -120,12 +128,13 @@ so they can be enforced mechanically rather than remembered.
   The kernel-observation posture is unchanged: eBPF validation running post-merge rather than on
   pull requests remains consistent with its supporting status.
 
-Four implementation slices follow from the decisions, in this order:
+Five implementation slices follow from the decisions:
 
-1. Bounded ingest across the five entrypoints in §1, with per-axis tests.
+1. Bounded ingest across the entrypoints named in §1, with a test per limit axis.
 2. Remove the unfounded wire claims and stand up the closed claim set from §2.
 3. Policy-load semantics from §5, including the default-behaviour change.
-4. Runtime authorization from §4, and an evidence-chain fuzz target for §3.
+4. The §4 boundary: remove the `initialize` token route, refuse `ASSAY_AUTH_*` at startup.
+5. Point the bundle fuzz target at the evidence-chain verifier and add the properties in §3.
 
 ## Appendix: reproduction
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Preflight correction for the ADR-042/043 implementation programme, against the ADR-043 that merged in #1841.

§4 as merged requires that "every privileged method checks the authorization state of the request it is serving". On a stdio server that presumes an authorization layer which does not exist, and would send the slice-2 implementor to build one. `assay-mcp-server` has no HTTP dependency and no socket binding — verified: no `axum`/`hyper`/`actix`/`TcpListener`/`bind(` anywhere in the crate — it reads JSON-RPC from stdin.

The honest boundary is to perform no transport authentication and to refuse configuration that pretends otherwise. §4 now reads:

- The stdio server performs no transport authentication and makes no authenticated or certified claim on any surface.
- The token check on `initialize` is removed rather than repaired. It was a proprietary route that never covered any other method, and no request is authorized by it.
- Any `ASSAY_AUTH_*` configuration is a startup failure raised before protocol I/O begins, never a permissive pass. A control that refuses an unsafe configuration must not thereby disable the enforcement it was protecting — which is exactly how the JWKS composition failed open.
- Inbound token-shaped values are never logged, never treated as identity, and never forwarded upstream.

Two things are placed explicitly outside the decision, so slice 2 cannot drift into them:

- **Standard OAuth belongs to a future transport ADR.** The [MCP `2026-07-28` release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) removes the handshake (SEP-2575) and the protocol session (SEP-2567), so that is a protocol migration with its own decision — tracked separately as #1846 — not a patch here.
- **The enforcing proxy is unaffected.** Its declared caller and policy identity is local enforcement input, not a transport auth claim.

Consequences and the slice list are updated to match: the auth slice now reads "remove the `initialize` token route, refuse `ASSAY_AUTH_*` at startup", and the fuzz work is split out as its own slice, giving five rather than four.

## Why this is a correction and not a new decision

Nothing here widens ADR-042 or ADR-043. It narrows §4 onto the transport that exists and removes an instruction that would have produced the opposite of the intended result: an approximated auth layer on a transport that cannot carry one. The `auth` types can remain one release as a deprecated compatibility surface provided they are decoupled from the server loop; that is stated in Consequences.

## Type of Change
- [x] Documentation update

## Verification
- [x] `python3 scripts/ci/check-claims-boundary.py` passes (self-test and scan, 0 findings) — required for `docs/**` changes
- [x] `typos` passes
- [x] stdio-only claim verified in source before it was written into the ADR
- [x] #1846 confirmed open as the separate protocol-migration track
- [ ] `cargo check` / `cargo test` — not applicable, no code changed

## Checklist
- [x] Follows the ADR conventions in `docs/architecture/adrs.md` and the header style of ADR-042
- [x] ADR-043 stays `Proposed`; it is not eligible for `Accepted` until the ingest, auth-boundary and fuzz slices are merged
- [ ] Tests — none; this is a decision record

## Notes for the reviewer

- This is the preflight item that gates slice 2. Landing it before that slice starts is the point.
- Builder is Cursor; per the programme's quorum rule this needs one non-building agent review plus CodeRabbit or Copilot, and the review must sit on the final head SHA.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture decision record to clarify that the stdio server provides no transport authentication or authenticated identity claims.
  * Documented removal of the initialization token route.
  * Specified that `ASSAY_AUTH_*` configuration causes startup failure rather than a partial runtime check.
  * Clarified that inbound token-like values are not logged, treated as identity, or forwarded upstream.
  * Updated implementation guidance and verification alignment accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->