### PR TITLE
fix(mcp): bound stdio auth surface

### DIFF
--- a/crates/assay-mcp-server/src/auth/config.rs
+++ b/crates/assay-mcp-server/src/auth/config.rs
@@ -6,6 +6,11 @@ use url::Url;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
+/// Compatibility-only legacy mode.
+///
+/// The stdio server does not use this type for authentication or identity. It remains public for
+/// one compatibility window while transport authentication is deferred to a future HTTP ADR.
+#[deprecated(note = "stdio authentication is unsupported; this legacy type is compatibility-only")]
 pub enum AuthMode {
     /// Log warnings for invalid tokens but allow the request (unless malformed).
     #[default]
@@ -15,6 +20,11 @@ pub enum AuthMode {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Compatibility-only legacy authentication configuration.
+///
+/// `Server::run` does not consume this configuration. The server and proxy binaries reject the
+/// `ASSAY_AUTH_*` namespace before protocol I/O; standard OAuth belongs to a future HTTP transport.
+#[deprecated(note = "stdio authentication is unsupported; this legacy type is compatibility-only")]
 pub struct AuthConfig {
     pub mode: AuthMode,
     pub jwks_uri: Option<Url>,
@@ -38,6 +48,13 @@ impl Default for AuthConfig {
 }
 
 impl AuthConfig {
+    /// Parse the legacy compatibility surface.
+    ///
+    /// This does not enable authentication in the stdio server and is retained only so downstream
+    /// callers can migrate without an immediate public API removal.
+    #[deprecated(
+        note = "stdio authentication is unsupported; this legacy parser is compatibility-only"
+    )]
     pub fn from_env() -> Self {
         let mut cfg = Self::default();
 
@@ -59,7 +76,7 @@ impl AuthConfig {
                         // This will cause JwksProvider init to fail or skip, preventing startup or auth.
                         cfg.jwks_uri = None;
                     } else {
-                        eprintln!("WARN: JWKS URI '{}' is not HTTPS. This is UNSAFE.", v);
+                        eprintln!("WARN: configured JWKS URI is not HTTPS. This is UNSAFE.");
                         cfg.jwks_uri = Some(u);
                     }
                 } else {

--- a/crates/assay-mcp-server/src/auth/jwks.rs
+++ b/crates/assay-mcp-server/src/auth/jwks.rs
@@ -24,6 +24,7 @@ struct JwksResponse {
 }
 
 #[derive(Clone)]
+#[deprecated(note = "stdio authentication is unsupported; this legacy type is compatibility-only")]
 pub struct JwksProvider {
     cache: Cache<String, Arc<DecodingKey>>, // map kid -> key
     client: Client,

--- a/crates/assay-mcp-server/src/auth/mod.rs
+++ b/crates/assay-mcp-server/src/auth/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 pub mod config;
 pub mod jwks;
 pub mod sensitive_headers;

--- a/crates/assay-mcp-server/src/auth/sensitive_headers.rs
+++ b/crates/assay-mcp-server/src/auth/sensitive_headers.rs
@@ -1,4 +1,4 @@
-//! No pass-through of inbound auth to downstream (E6a.3).
+//! No pass-through of inbound credential-shaped fields to downstream (E6a.3).
 //!
 //! **Security invariant:** Inbound authentication material MUST NOT be forwarded to any
 //! downstream HTTP call (LLM/judge/proxy). Outbound requests MUST be built from an allowlist

--- a/crates/assay-mcp-server/src/auth/validation.rs
+++ b/crates/assay-mcp-server/src/auth/validation.rs
@@ -6,6 +6,7 @@ use jsonwebtoken::{decode, decode_header, Algorithm, Validation};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[deprecated(note = "stdio authentication is unsupported; this legacy type is compatibility-only")]
 pub struct Claims {
     pub sub: String,
     pub iss: Option<String>,
@@ -16,6 +17,7 @@ pub struct Claims {
     pub resource: Option<serde_json::Value>, // RFC 8707: string or array
 }
 
+#[deprecated(note = "stdio authentication is unsupported; this legacy type is compatibility-only")]
 pub struct TokenValidator {
     jwks: Option<JwksProvider>,
     static_key: Option<std::sync::Arc<jsonwebtoken::DecodingKey>>,

--- a/crates/assay-mcp-server/src/config.rs
+++ b/crates/assay-mcp-server/src/config.rs
@@ -1,5 +1,30 @@
+#![allow(deprecated)]
+
 use crate::auth::config::AuthConfig;
 use std::env;
+
+fn configured_server_auth_variables() -> Vec<String> {
+    let mut names: Vec<String> = env::vars_os()
+        .map(|(name, _)| name.to_string_lossy().into_owned())
+        .filter(|name| name.to_ascii_uppercase().starts_with("ASSAY_AUTH_"))
+        .collect();
+    names.sort();
+    names
+}
+
+/// Reject legacy auth configuration for stdio server and proxy modes.
+///
+/// Only environment-variable names are reported. Values are never read into diagnostics.
+pub fn reject_unsupported_stdio_auth_env() -> anyhow::Result<()> {
+    let auth_variables = configured_server_auth_variables();
+    if !auth_variables.is_empty() {
+        anyhow::bail!(
+            "ASSAY_AUTH_* configuration is unsupported for stdio server modes; unset: {}",
+            auth_variables.join(", ")
+        );
+    }
+    Ok(())
+}
 
 #[derive(Clone, Debug)]
 pub struct ServerConfig {
@@ -9,6 +34,13 @@ pub struct ServerConfig {
     pub max_field_bytes: usize,
     pub cache_entries: u64,
     pub log_level: String,
+    /// Compatibility-only configuration surface.
+    ///
+    /// The stdio server does not consume this field for authentication or identity. Server and
+    /// proxy binaries reject `ASSAY_AUTH_*` configuration before protocol I/O.
+    #[deprecated(
+        note = "stdio authentication is unsupported; this legacy field is compatibility-only"
+    )]
     pub auth: AuthConfig,
 }
 
@@ -57,7 +89,6 @@ impl ServerConfig {
         if let Ok(v) = env::var("ASSAY_LOG") {
             cfg.log_level = v;
         }
-        cfg.auth = AuthConfig::from_env();
         cfg
     }
 }

--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -124,8 +124,14 @@ fn init_logging(log_level: &str) {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    // Do not use eprintln here, use tracing after init
-    // But config loads from env first.
+
+    // The stdio server and proxies do not implement transport authentication. Reject the entire
+    // reserved namespace before logging, policy loading, child spawning, or protocol I/O. The
+    // offline SARIF projection is not a server and remains independent of this boundary.
+    if !matches!(&args.mode, Some(Mode::EnforcementSarif { .. })) {
+        config::reject_unsupported_stdio_auth_env()?;
+    }
+
     let cfg = config::ServerConfig::from_env();
 
     init_logging(&cfg.log_level);
@@ -244,7 +250,11 @@ async fn main() -> Result<()> {
             tracing::info!(
                 event = "server_start",
                 policy_root = ?args.policy_root,
-                config = ?cfg
+                timeout_ms = cfg.timeout_ms,
+                max_msg_bytes = cfg.max_msg_bytes,
+                max_tool_calls = cfg.max_tool_calls,
+                max_field_bytes = cfg.max_field_bytes,
+                cache_entries = cfg.cache_entries,
             );
             Server::run(args.policy_root, cfg).await
         }

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -1,4 +1,3 @@
-use crate::auth::{AuthMode, JwksProvider, TokenValidator};
 use crate::config::ServerConfig;
 use crate::tools::{self};
 use anyhow::Result;
@@ -103,6 +102,8 @@ use crate::cache::PolicyCaches;
 
 impl Server {
     pub async fn run(policy_root: std::path::PathBuf, cfg: ServerConfig) -> Result<()> {
+        crate::config::reject_unsupported_stdio_auth_env()?;
+
         let caches = PolicyCaches::new(cfg.cache_entries);
 
         // Canonicalize root once
@@ -117,34 +118,6 @@ impl Server {
         };
         let stdin = io::stdin();
         let mut stdout = io::stdout();
-
-        // Initialize Auth Validator (E6 Hardening)
-        if cfg.auth.mode == AuthMode::Permissive {
-            eprintln!("WARN: RUNNING IN PERMISSIVE AUTH MODE - NOT FOR PRODUCTION. Set ASSAY_AUTH_MODE=strict to enforce security.");
-        }
-        let validator = {
-            let jwks = if let Some(uri) = &cfg.auth.jwks_uri {
-                match JwksProvider::new(uri.clone()) {
-                    Ok(p) => Some(p),
-                    Err(e) => {
-                        let msg = format!(
-                            "Failed to initialize JWKS provider (SSRF/Config Check): {}",
-                            e
-                        );
-                        tracing::error!("{}", msg);
-                        eprintln!("ERROR: {}", msg);
-                        // In Strict mode, an invalid JWKS URI (e.g. unsafe IP) is a hard blocker
-                        if cfg.auth.mode == AuthMode::Strict {
-                            return Err(anyhow::anyhow!(msg));
-                        }
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-            TokenValidator::new(jwks)
-        };
 
         for line in stdin.lock().lines() {
             let line = line?;
@@ -194,70 +167,7 @@ impl Server {
 
             // Dispatch
             let resp = match req.method.as_str() {
-                "initialize" => {
-                    // Auth Hardening (E6)
-                    let check_result = if let Some(params) = &req.params {
-                        // Strategy: Check `authorization` (standard-ish) or `initializationOptions.authorization`
-                        let token_cand = params
-                            .get("authorization")
-                            .or_else(|| {
-                                params
-                                    .get("initializationOptions")
-                                    .and_then(|o| o.get("authorization"))
-                            })
-                            .and_then(|v| v.as_str());
-
-                        if let Some(raw_token) = token_cand {
-                            let token = raw_token.strip_prefix("Bearer ").unwrap_or(raw_token);
-                            match validator.validate(token, &cfg.auth).await {
-                                Ok(claims) => {
-                                    tracing::info!(
-                                        event = "auth_success",
-                                        rid = %rid,
-                                        iss = ?claims.iss,
-                                        ok = true
-                                    );
-                                    Ok(())
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        event = "auth_failure",
-                                        rid = %rid,
-                                        error = %e,
-                                        mode = ?cfg.auth.mode
-                                    );
-                                    if cfg.auth.mode == AuthMode::Strict {
-                                        Err(e)
-                                    } else {
-                                        Ok(()) // Permissive: Allow but warn
-                                    }
-                                }
-                            }
-                        } else {
-                            // Missing token
-                            if cfg.auth.mode == AuthMode::Strict && cfg.auth.jwks_uri.is_some() {
-                                let e =
-                                    anyhow::anyhow!("Missing authorization token (Strict mode)");
-                                tracing::warn!(event = "auth_missing", rid = %rid);
-                                Err(e)
-                            } else {
-                                Ok(())
-                            }
-                        }
-                    } else {
-                        Ok(())
-                    };
-
-                    if let Err(e) = check_result {
-                        JsonRpcResponse::error(
-                            req.id.clone(),
-                            -32000,
-                            format!("Authentication Failed: {}", e),
-                        )
-                    } else {
-                        JsonRpcResponse::ok(req.id.clone(), initialize_result())
-                    }
-                }
+                "initialize" => JsonRpcResponse::ok(req.id.clone(), initialize_result()),
                 "notifications/initialized" => {
                     // Notification, no response needed usually, but good to ack log
                     tracing::info!(event="initialized", rid=%rid);

--- a/crates/assay-mcp-server/src/token_passthrough.rs
+++ b/crates/assay-mcp-server/src/token_passthrough.rs
@@ -1,9 +1,9 @@
 //! `assay.token_passthrough_conformance.v0` (MCP01a-3) — credential-boundary conformance.
 //!
 //! The confused-deputy invariant: only a component that **consumes** inbound auth can leak that
-//! consumed credential as a passthrough. This carrier reports, value-free, that the consuming path
-//! (the `server.rs` validator + the outbound tool surface) does not re-emit a consumed inbound
-//! authentication value on its outbound headers, bodies, or spawned env.
+//! consumed credential as a passthrough. The standalone stdio server consumes no authentication
+//! field. This carrier reports that boundary explicitly and retains the value-sentinel checks as
+//! negative evidence against accidental re-emission on Assay-originated outbound surfaces.
 //!
 //! The transparent stdio relay (`proxy::run`) is explicitly OUT of scope: it consumes no inbound
 //! auth, originates no outbound HTTP with it, and injects no child env, so its verbatim JSON-RPC
@@ -20,10 +20,8 @@ pub struct ProbedSource {
     pub source: String,
     /// Always true: a known inbound-credential location the boundary watches.
     pub probed: bool,
-    /// True only where the tested consuming path actually validates this field as authn. On the
-    /// stdio consuming path the `server.rs` validator consumes the initialize-param auth fields; the
-    /// `http.*` headers are the outbound-forbidden denylist (`SENSITIVE_HEADER_NAMES`) and are
-    /// consumed as inbound authn only under an HTTP transport, which this topology does not exercise.
+    /// True only where the tested topology actually validates this field as authentication. The
+    /// standalone stdio server has no transport-authentication mechanism, so every source is false.
     pub consumed: bool,
 }
 
@@ -54,11 +52,11 @@ pub struct TokenPassthroughConformance {
     pub non_claims: Vec<String>,
 }
 
-/// Does the EXACT consumed inbound value appear on a captured outbound surface? Value-exact on
+/// Does the EXACT inbound sentinel value appear on a captured outbound surface? Value-exact on
 /// purpose: an arbitrary credential-shaped payload with a different value is not a leak (the negative
 /// control), so this never becomes a payload sanitizer.
-pub fn value_leaks(consumed_value: &str, outbound_surface: &str) -> bool {
-    !consumed_value.is_empty() && outbound_surface.contains(consumed_value)
+pub fn value_leaks(inbound_value: &str, outbound_surface: &str) -> bool {
+    !inbound_value.is_empty() && outbound_surface.contains(inbound_value)
 }
 
 fn source(s: &str, consumed: bool) -> ProbedSource {
@@ -69,23 +67,26 @@ fn source(s: &str, consumed: bool) -> ProbedSource {
     }
 }
 
-/// The conformance report for the consuming-path topology. `transport_header` and `json_body` are
-/// checked by the value-sentinel e2e; `environment` is `not_applicable` because the consuming path
-/// (the `server.rs` validator) spawns no child — only the out-of-scope transparent relay spawns, and
-/// it injects no inbound auth into the child env.
+/// The conformance report for the standalone stdio topology. `transport_header` and `json_body` are
+/// checked by the value-sentinel e2e; `environment` is `not_applicable` because the standalone server
+/// spawns no child. The out-of-scope transparent relay spawns a child but does not interpret relayed
+/// initialize fields as Assay authentication or identity.
+///
+/// The historical function name remains for source compatibility; the returned topology names the
+/// corrected non-consuming boundary.
 pub fn consuming_path_conformance() -> TokenPassthroughConformance {
     TokenPassthroughConformance {
         schema: SCHEMA.to_string(),
-        topology: "consuming_path".to_string(),
+        topology: "standalone_stdio_non_consuming".to_string(),
         probed_inbound_auth_sources: vec![
-            // http.* are probed (the outbound-forbidden denylist), consumed as inbound authn only
-            // under an HTTP transport, which the stdio consuming path does not exercise.
             source("http.authorization", false),
             source("http.cookie", false),
             source("http.x_api_key", false),
-            // The stdio consuming path's `server.rs` validator consumes these as authn.
-            source("initialize.params.authorization", true),
-            source("initialize.params.initializationOptions.authorization", true),
+            source("initialize.params.authorization", false),
+            source(
+                "initialize.params.initializationOptions.authorization",
+                false,
+            ),
         ],
         outbound_channels: vec![
             OutboundChannel {
@@ -118,9 +119,9 @@ pub fn consuming_path_conformance() -> TokenPassthroughConformance {
                     .to_string(),
         },
         non_claims: vec![
-            "tracks only consumed inbound authentication values".to_string(),
-            "probed http.* header sources are the outbound-forbidden denylist; they are consumed as \
-             inbound authn only under an HTTP transport, not on this stdio consuming path"
+            "standalone stdio does not authenticate initialize fields".to_string(),
+            "probed http.* header sources are an outbound-forbidden denylist, not evidence of an \
+             HTTP transport or inbound authentication mechanism"
                 .to_string(),
             "does not scrub arbitrary credential-shaped user payload".to_string(),
             "transparent relay forwarding is not treated as a confused-deputy leak when the relay \
@@ -152,16 +153,16 @@ mod tests {
 
     #[test]
     fn value_leak_is_exact_not_shape_based() {
-        let consumed = "Bearer INBOUND_TOKEN_NEVER_FORWARD";
-        // The exact consumed value on an outbound surface is a leak.
+        let inbound_sentinel = "Bearer INBOUND_TOKEN_NEVER_FORWARD";
+        // The exact inbound sentinel on an outbound surface is a leak.
         assert!(value_leaks(
-            consumed,
+            inbound_sentinel,
             "x-fwd: Bearer INBOUND_TOKEN_NEVER_FORWARD"
         ));
         // Negative control: a different credential-shaped value is NOT a leak (not a sanitizer).
         assert!(!value_leaks(
-            consumed,
-            r#"{"authorization":"not-the-consumed-sentinel"}"#
+            inbound_sentinel,
+            r#"{"authorization":"not-the-inbound-sentinel"}"#
         ));
         assert!(!value_leaks("", "anything"));
     }
@@ -170,7 +171,7 @@ mod tests {
     fn consuming_path_report_is_clean_and_value_free() {
         let report = consuming_path_conformance();
         assert!(is_clean(&report));
-        // env is not_applicable (consuming path spawns nothing), not a fake pass.
+        // env is not_applicable (standalone stdio spawns nothing), not a fake pass.
         let env = report
             .outbound_channels
             .iter()
@@ -181,22 +182,13 @@ mod tests {
         // value-free: no token values anywhere in the serialized carrier.
         let blob = serde_json::to_string(&report).unwrap();
         assert!(!blob.contains("NEVER_FORWARD") && !blob.contains("Bearer "));
-        // Every source is probed; only the initialize-param fields the server.rs validator actually
-        // consumes are marked consumed (the http.* denylist is not, on this stdio consuming path).
+        assert_eq!(report.topology, "standalone_stdio_non_consuming");
+        // Every source is probed, and none is promoted into authentication or identity.
         assert!(report.probed_inbound_auth_sources.iter().all(|s| s.probed));
-        let consumed: Vec<&str> = report
+        assert!(report
             .probed_inbound_auth_sources
             .iter()
-            .filter(|s| s.consumed)
-            .map(|s| s.source.as_str())
-            .collect();
-        assert_eq!(
-            consumed,
-            vec![
-                "initialize.params.authorization",
-                "initialize.params.initializationOptions.authorization",
-            ]
-        );
+            .all(|source| !source.consumed));
     }
 
     #[test]

--- a/crates/assay-mcp-server/tests/auth_integration.rs
+++ b/crates/assay-mcp-server/tests/auth_integration.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use assay_mcp_server::auth::{AuthConfig, AuthMode, TokenValidator};
 // We need to run server or simulate logic
 use wiremock::matchers::{method, path};
@@ -5,8 +7,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
 #[expect(clippy::field_reassign_with_default)]
-async fn test_auth_rejection_e2e_simulation() {
-    // We simulate the auth logic flow here to prove E6 behavior
+async fn test_legacy_validator_rejects_invalid_token() {
+    // Compatibility-only validation primitive. The stdio server does not call this path.
     // 1. Setup JWKS mock
     let mock_server = MockServer::start().await;
 
@@ -18,7 +20,7 @@ async fn test_auth_rejection_e2e_simulation() {
         .mount(&mock_server)
         .await;
 
-    // 2. Config Strict
+    // 2. Configure the standalone compatibility object.
     let mut config = AuthConfig::default();
     config.mode = AuthMode::Strict;
     config.jwks_uri = Some(mock_server.uri().parse().unwrap());

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -1,8 +1,9 @@
 //! E6a.3 no-pass-through E2E test.
 //!
-//! Invariant: inbound auth (e.g. from initialize params) must never appear on any outbound
-//! HTTP request. We send inbound auth, trigger the test-only outbound call, then assert
-//! the mock received no sensitive headers. Run with: cargo test -p assay-mcp-server --features test-outbound no_passthrough
+//! Invariant: credential-shaped initialize fields are not authentication on standalone stdio and
+//! must never appear on any Assay-originated outbound HTTP request. We send a sentinel field,
+//! trigger the test-only outbound call, then assert the mock received no sensitive headers or
+//! sentinel values. Run with: cargo test -p assay-mcp-server --features test-outbound no_passthrough
 
 use assay_mcp_server::auth::SENSITIVE_HEADER_NAMES;
 use std::io::{BufRead, BufReader, Write};
@@ -92,7 +93,8 @@ async fn test_no_passthrough_e2e() {
     let stdout = child.stdout.take().expect("stdout");
     let mut reader = BufReader::new(stdout);
 
-    // 1. Initialize with inbound auth + multiple sensitive params (server must not forward any to downstream)
+    // 1. Initialize with credential-shaped fields. The server must neither interpret them as
+    // authentication nor forward them downstream.
     let req_init = serde_json::json!({
         "jsonrpc": "2.0",
         "method": "initialize",
@@ -153,13 +155,13 @@ async fn test_no_passthrough_e2e() {
         "expected exactly one outbound request (tool must not have skipped; check ASSAY_TEST_OUTBOUND_URL)"
     );
     assert_no_sensitive_headers(&received);
-    // MCP01a-3 value-sentinel: the EXACT consumed inbound auth value must not re-emit on ANY outbound
-    // surface (header values, URL, or body), not just be absent by header name. Every inbound auth
+    // MCP01a-3 value-sentinel: the EXACT inbound value must not re-emit on ANY outbound surface
+    // (header values, URL, or body), not just be absent by header name. Every inbound field
     // value above carries the marker `NEVER_FORWARD`, so its presence anywhere outbound is a leak.
     assert_no_inbound_value_leaked(&received);
 }
 
-/// Value-sentinel proof (MCP01a-3): the consumed inbound credential VALUE never appears on an outbound
+/// Value-sentinel proof (MCP01a-3): the inbound credential-shaped VALUE never appears on an outbound
 /// surface. Checks header values, the URL, and the body, not header names. Value-free failure (the
 /// surface, not the value).
 fn assert_no_inbound_value_leaked(requests: &[wiremock::Request]) {
@@ -172,8 +174,8 @@ fn assert_no_inbound_value_leaked(requests: &[wiremock::Request]) {
         surfaces.push(String::from_utf8_lossy(&req.body).to_string());
         if surfaces.iter().any(|s| s.contains(INBOUND_VALUE_SENTINEL)) {
             panic!(
-                "MCP01a-3 value passthrough violated: request #{} re-emitted a consumed inbound \
-                 authentication value on an outbound surface (header value, URL, or body). \
+                "MCP01a-3 value passthrough violated: request #{} re-emitted an inbound \
+                 credential-shaped value on an outbound surface (header value, URL, or body). \
                  Sentinel marker {INBOUND_VALUE_SENTINEL:?} found; value not logged.",
                 i + 1
             );

--- a/crates/assay-mcp-server/tests/server_run_auth_boundary.rs
+++ b/crates/assay-mcp-server/tests/server_run_auth_boundary.rs
@@ -1,0 +1,47 @@
+use assay_mcp_server::config::ServerConfig;
+use assay_mcp_server::server::Server;
+use std::path::PathBuf;
+
+const AUTH_VARIABLE: &str = "AsSaY_Auth_DIRECT_LIBRARY_TEST";
+const SECRET_VALUE: &str = "library-secret-must-not-appear";
+
+struct AuthEnvGuard;
+
+impl AuthEnvGuard {
+    fn set() -> Self {
+        std::env::set_var(AUTH_VARIABLE, SECRET_VALUE);
+        Self
+    }
+}
+
+impl Drop for AuthEnvGuard {
+    fn drop(&mut self) {
+        std::env::remove_var(AUTH_VARIABLE);
+    }
+}
+
+#[tokio::test]
+async fn public_server_run_rejects_auth_configuration_before_other_work() {
+    let _guard = AuthEnvGuard::set();
+
+    let error = Server::run(
+        PathBuf::from("policy-root-must-not-be-read"),
+        ServerConfig::default(),
+    )
+    .await
+    .expect_err("public library entrypoint must reject stdio auth configuration");
+    let diagnostic = format!("{error:#}");
+
+    assert!(
+        diagnostic.contains("unsupported") && diagnostic.contains(AUTH_VARIABLE),
+        "diagnostic must name the unsupported boundary and variable: {diagnostic}"
+    );
+    assert!(
+        !diagnostic.contains(SECRET_VALUE),
+        "diagnostic leaked the configured auth value: {diagnostic}"
+    );
+    assert!(
+        !diagnostic.contains("invalid --policy-root"),
+        "auth refusal must happen before policy-root access: {diagnostic}"
+    );
+}

--- a/crates/assay-mcp-server/tests/stdio_auth_boundary.rs
+++ b/crates/assay-mcp-server/tests/stdio_auth_boundary.rs
@@ -1,0 +1,201 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+const SECRET_VALUE: &str = "must-not-appear-in-diagnostics";
+
+fn clean_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_AUTH_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+}
+
+fn run_with_auth_env(args: &[&str], name: &str, stdin: &[u8]) -> Output {
+    let mut command = clean_command();
+    command
+        .args(args)
+        .env(name, SECRET_VALUE)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = command.spawn().expect("spawn assay-mcp-server");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(stdin)
+        .expect("write child stdin");
+    child.wait_with_output().expect("wait for server")
+}
+
+fn assert_value_free_auth_refusal(output: &Output, variable: &str) {
+    assert!(!output.status.success(), "legacy auth config must fail");
+    assert!(
+        output.stdout.is_empty(),
+        "refusal must happen before protocol output: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unsupported") && stderr.contains(variable),
+        "diagnostic must name the unsupported boundary and variable: {stderr}"
+    );
+    assert!(
+        !stderr.contains(SECRET_VALUE),
+        "diagnostic leaked the configured auth value: {stderr}"
+    );
+}
+
+fn policy_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/mcp")
+}
+
+#[test]
+fn standalone_rejects_known_auth_configuration_before_protocol_io() {
+    let output = run_with_auth_env(
+        &["--policy-root", "does-not-need-to-exist"],
+        "ASSAY_AUTH_MODE",
+        br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+    );
+    assert_value_free_auth_refusal(&output, "ASSAY_AUTH_MODE");
+}
+
+#[test]
+fn proxy_rejects_unknown_auth_configuration_before_spawning_upstream() {
+    let output = run_with_auth_env(
+        &[
+            "proxy",
+            "--upstream-command",
+            "this-command-must-never-be-spawned",
+        ],
+        "ASSAY_AUTH_FUTURE_OPTION",
+        b"",
+    );
+    assert_value_free_auth_refusal(&output, "ASSAY_AUTH_FUTURE_OPTION");
+}
+
+#[test]
+fn enforcing_proxy_rejects_auth_configuration_before_loading_policy() {
+    let output = run_with_auth_env(
+        &[
+            "proxy-enforce",
+            "--upstream-command",
+            "this-command-must-never-be-spawned",
+            "--enforce-policy",
+            "does-not-need-to-exist.yaml",
+            "--declared-mcp-manifest",
+            "does-not-need-to-exist.json",
+        ],
+        "ASSAY_AUTH_JWKS_URI",
+        b"",
+    );
+    assert_value_free_auth_refusal(&output, "ASSAY_AUTH_JWKS_URI");
+}
+
+#[test]
+fn offline_sarif_projection_ignores_server_auth_environment() {
+    let output = run_with_auth_env(
+        &["enforcement-sarif", "--input", "-", "--output", "-"],
+        "ASSAY_AUTH_MODE",
+        b"",
+    );
+    assert!(
+        output.status.success(),
+        "offline projection must remain independent of server auth configuration: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let sarif: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid SARIF JSON output");
+    assert_eq!(sarif["version"], "2.1.0");
+    assert!(!String::from_utf8_lossy(&output.stderr).contains(SECRET_VALUE));
+}
+
+#[test]
+fn refusal_names_all_configured_variables_in_stable_order_without_values() {
+    let mut command = clean_command();
+    command
+        .args(["--policy-root", "does-not-need-to-exist"])
+        .env("ASSAY_AUTH_Z_FUTURE", "second-secret")
+        .env("ASSAY_AUTH_A_FUTURE", "first-secret")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let output = command.output().expect("run assay-mcp-server");
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let first = stderr.find("ASSAY_AUTH_A_FUTURE").expect("first name");
+    let second = stderr.find("ASSAY_AUTH_Z_FUTURE").expect("second name");
+    assert!(first < second, "variable names must be sorted: {stderr}");
+    assert!(!stderr.contains("first-secret") && !stderr.contains("second-secret"));
+}
+
+#[test]
+fn lowercase_auth_namespace_is_rejected_for_cross_platform_consistency() {
+    let output = run_with_auth_env(
+        &["--policy-root", "does-not-need-to-exist"],
+        "assay_auth_mode",
+        b"",
+    );
+    assert_value_free_auth_refusal(&output, "assay_auth_mode");
+}
+
+#[test]
+fn initialize_credential_fields_are_ignored_as_authority_and_never_logged() {
+    let secret = "Bearer initialize-secret-must-not-be-logged";
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "authorization": secret,
+            "initializationOptions": {
+                "authorization": secret
+            }
+        }
+    });
+
+    let mut command = clean_command();
+    command
+        .arg("--policy-root")
+        .arg(policy_root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().expect("spawn assay-mcp-server");
+    writeln!(
+        child.stdin.take().expect("child stdin"),
+        "{}",
+        serde_json::to_string(&request).expect("serialize request")
+    )
+    .expect("write request");
+    let output = child.wait_with_output().expect("wait for server");
+
+    assert!(output.status.success(), "{:?}", output.status);
+    let response: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("initialize response");
+    assert!(response.get("result").is_some(), "{response}");
+    assert!(response.get("error").is_none(), "{response}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains(secret),
+        "initialize value leaked: {stderr}"
+    );
+    assert!(
+        !stderr.contains("auth_success")
+            && !stderr.contains("auth_failure")
+            && !stderr.contains("auth_missing"),
+        "initialize was interpreted as authentication: {stderr}"
+    );
+}


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: #1847
- Slice: ADR-043 slice 2, honest stdio authentication boundary
- Builder: Codex
- Reviewers: independent security reviewer plus CodeRabbit/Copilot
- Final head SHA: `6ae5b8d3be5a73425b3cad7aa4d5e9eaabf292f7`
- ADR invariants affected: ADR-043 section 4; ADR-042 privileged MCP-call scope

## Behavior

The standalone stdio server and both proxy modes now reject every configured
`ASSAY_AUTH_*` variable before logging, policy loading, child spawning, or
protocol I/O. The diagnostic names sorted variable names only and never their
values. The same guard runs at the binary boundary and in public `Server::run`.

The server no longer interprets non-standard `initialize` credential fields as
authentication or identity. Existing public auth types remain as a
compatibility-only surface; their environment parser is deprecated and
value-free. The offline `enforcement-sarif` projection remains independent of
server auth configuration.

Transparent proxy relay behavior is unchanged: client `initialize` bytes may
still be relayed verbatim to the intended upstream, but Assay does not consume
them as auth. ProxyEnforce's static policy caller is unchanged.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- No claim of MCP `2026-07-28` support; protocol migration remains #1846.

## Test Evidence

### RED

Before production changes:

```text
cargo test -p assay-mcp-server --test stdio_auth_boundary -- --nocapture
3 failed, 1 passed
```

Standalone continued to policy loading/logging, observe proxy could start, and
enforcing proxy reached policy loading. The offline SARIF control passed.

### GREEN

```text
cargo test -p assay-mcp-server --all-features --tests --quiet
cargo clippy -p assay-mcp-server --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
git diff --check
```

All pass on the rebased final head. The new boundary suite is 7/7 and includes
known/unknown variables, case-insensitive namespace handling, deterministic
value-free diagnostics, all three server modes, the offline control, and an
initialize non-authority/no-log test.

## Review Quorum

- [ ] One non-building agent review on this head SHA
- [ ] CodeRabbit or Copilot review on this head SHA
- [ ] If bots were unavailable for 30 minutes, a second non-building agent review is linked
- [ ] Every actionable finding is fixed or has a technical disposition
- [x] Any delegated proof targets this exact head SHA (not required by lane classifier)

Pre-publication security review found and closed a public-library bypass,
case-insensitive environment bypass, and a value-bearing legacy diagnostic.
That review was performed before the final rebase and therefore does not count
toward the final-head quorum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standalone stdio mode now rejects unsupported authentication environment settings before startup or protocol output.
  * Credential-shaped initialization fields are ignored as authentication and are not forwarded or logged.
  * Authentication error messages no longer expose configured secret values.
  * SARIF projection continues to operate independently of server authentication settings.

* **Deprecations**
  * Legacy stdio authentication configuration and validation interfaces are now marked compatibility-only.

* **Tests**
  * Added coverage for authentication boundary enforcement, secret protection, variable ordering, and credential passthrough prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->