### PR TITLE
fix(evidence,core,cli): bounded ingest for every local entrypoint (ADR-043 §1, Slice 1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- New reason code `E_REPLAY_LIMIT_EXCEEDED` (exit 2) for a replay bundle refused by an ingest
+  ceiling before it was parsed. Previously such a refusal was reported as `E_CFG_PARSE`, which
+  says the input is malformed and sends a reader off to fix the producer; a bundle over budget
+  may be perfectly well-formed, and raising the ceiling is a legitimate response. Backward
+  compatible: a new registry string under the existing `reason_code_version` 1, registered in
+  `docs/architecture/SPEC-PR-Gate-Outputs-v1.md` §5.1, so consumers branching on
+  `(reason_code_version, reason_code)` fall back as the spec already requires. The refusal
+  carries no verdict, and its message names only the configured ceiling.
+
 ### Changed
 - **Breaking (`assay sandbox`)**: a `--policy` that is named but cannot be loaded is now fatal.
   The run exits 2 with `E_POLICY_LOAD_FAILED_UNENFORCEABLE` and executes nothing, where it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - New reason code `E_REPLAY_LIMIT_EXCEEDED` (exit 2) for a replay bundle refused by an ingest
-  ceiling before it was parsed. Previously such a refusal was reported as `E_CFG_PARSE`, which
-  says the input is malformed and sends a reader off to fix the producer; a bundle over budget
-  may be perfectly well-formed, and raising the ceiling is a legitimate response. Backward
+  ceiling during bounded ingest, before replay execution. Previously such a refusal was reported
+  as `E_CFG_PARSE`, which is a malformed-input finding and sends a reader off to fix the
+  producer. A ceiling establishes only that a configured budget was exceeded; the read stopped
+  there, so whether the bundle is otherwise valid is unresolved, and adjusting the budget or
+  supplying a smaller bundle is a legitimate response. Backward
   compatible: a new registry string under the existing `reason_code_version` 1, registered in
   `docs/architecture/SPEC-PR-Gate-Outputs-v1.md` §5.1, so consumers branching on
   `(reason_code_version, reason_code)` fall back as the spec already requires. The refusal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ assay-mcp-server -> assay-core, assay-common, assay-metrics
 assay-monitor -> assay-common, assay-policy
 assay-metrics -> assay-core, assay-common
 assay-core -> assay-adapter-api, assay-common
-assay-evidence -> assay-canonical
+assay-evidence -> assay-canonical, assay-common
 assay-adapter-api -> assay-evidence
 assay-adapter-{a2a,acp,ucp} -> assay-adapter-api, assay-evidence
 assay-runner-core -> assay-common, assay-monitor, assay-runner-schema
@@ -130,6 +130,11 @@ assay-ebpf -> assay-common
 Leaf crates (no internal dependencies): `assay-common`, `assay-canonical`, `assay-policy`, `assay-registry`, `assay-runner-schema`, `assay-runner-linux`, `gateway-evidence-replay`, `assay-xtask`.
 
 No circular dependencies. All dependencies flow in one direction.
+
+`assay-evidence -> assay-common` carries only the bounded-ingest primitive
+(`assay_common::limits::LimitReader`, ADR-043 §1), shared with the replay verifier in
+`assay-core` so both apply one ceiling mechanism. Limit *vocabularies* stay domain-local:
+`VerifyLimits` describes an evidence bundle and does not travel.
 
 ## assay-sim (Attack Simulation)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ version = "3.34.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
+ "assay-common",
  "assert_fs",
  "async-trait",
  "base64",

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -30,7 +30,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use mapping::{DetailLevel, EvidenceMapper};
 use std::fs::File;
-use std::io::{self, Read};
+use std::io;
 
 /// Manage tamper-evident bundles (audit/compliance)
 #[derive(Debug, Subcommand, Clone)]
@@ -256,9 +256,13 @@ fn cmd_export(args: EvidenceExportArgs) -> Result<i32> {
 
 fn cmd_verify(args: EvidenceVerifyArgs) -> Result<i32> {
     if args.bundle.to_string_lossy() == "-" {
-        let mut buf = Vec::new();
-        io::stdin().read_to_end(&mut buf)?;
-        assay_evidence::bundle::verify_bundle(io::Cursor::new(buf))
+        // ADR-043 section 1: the ceiling applies to the stream. Reading stdin to the end first
+        // and verifying a `Cursor` over the result meant an untrusted pipe sized the allocation
+        // before any limit was consulted, and stdin is the one source whose length nothing can
+        // be checked against beforehand. `verify_bundle` bounds the reader it is given, so hand
+        // it the pipe rather than a buffer already filled from it.
+        let stdin = io::stdin();
+        assay_evidence::bundle::verify_bundle(stdin.lock())
             .context("bundle verification failed")?;
         eprintln!("Bundle verified (stdin): OK");
         return Ok(0);

--- a/crates/assay-cli/src/cli/commands/evidence/push.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/push.rs
@@ -1,10 +1,10 @@
 //! `assay evidence push` - Upload an evidence bundle to storage.
 
 use anyhow::{Context, Result};
+use assay_common::limits::{LimitKind, LimitReader};
+use assay_evidence::bundle::writer::VerifyLimits;
 use assay_evidence::store::BundleStore;
-use assay_evidence::{
-    resolve_store_url, verify_bundle, Bytes, ObjectStoreBundleStore, StoreError, StoreSpec,
-};
+use assay_evidence::{resolve_store_url, Bytes, ObjectStoreBundleStore, StoreError, StoreSpec};
 use clap::Args;
 use std::fs::File;
 use std::io::Read;
@@ -42,24 +42,34 @@ pub async fn cmd_push(args: PushArgs) -> Result<i32> {
     let mut file = File::open(&args.bundle)
         .with_context(|| format!("failed to open bundle: {}", args.bundle.display()))?;
 
+    // ADR-043 section 1: the ceiling applies to the stream, before the input is materialized.
+    // The file was read whole with no bound at all, so an oversized archive sized the allocation
+    // regardless of what the verifier concluded afterwards, and `--no-verify` skipped even that
+    // afterthought. Bounding here covers both branches, because whatever is about to be uploaded
+    // has to pass the ceiling first.
+    let limits = VerifyLimits::default();
     let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer)
+    LimitReader::new(&mut file, limits.max_bundle_bytes, LimitKind::SourceBytes)
+        .read_to_end(&mut buffer)
         .with_context(|| "failed to read bundle")?;
-
-    let bytes = Bytes::from(buffer.clone());
 
     // 2. Verify bundle (unless --no-verify)
     let bundle_id = if args.no_verify {
         let cursor = std::io::Cursor::new(&buffer);
-        let reader = assay_evidence::BundleReader::open_unverified(cursor)
+        let reader = assay_evidence::BundleReader::open_unverified_with_limits(cursor, limits)
             .context("failed to read bundle manifest")?;
         reader.manifest().bundle_id.clone()
     } else {
         let cursor = std::io::Cursor::new(&buffer);
-        let result = verify_bundle(cursor).context("bundle verification failed")?;
+        let result = assay_evidence::bundle::writer::verify_bundle_with_limits(cursor, limits)
+            .context("bundle verification failed")?;
         eprintln!("✅ Bundle verified: {}", result.manifest.bundle_id);
         result.manifest.bundle_id
     };
+
+    // The upload takes ownership of the same buffer that was just checked; cloning it doubled
+    // peak memory for a bundle that may sit right under the ceiling.
+    let bytes = Bytes::from(buffer);
 
     // 3. Connect to store
     let url = resolve_store_url(args.store.as_deref(), args.store_config.as_deref())

--- a/crates/assay-cli/src/cli/commands/evidence/push.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/push.rs
@@ -67,8 +67,11 @@ pub async fn cmd_push(args: PushArgs) -> Result<i32> {
         result.manifest.bundle_id
     };
 
-    // The upload takes ownership of the same buffer that was just checked; cloning it doubled
-    // peak memory for a bundle that may sit right under the ceiling.
+    // The upload takes ownership of the same buffer that was just checked rather than cloning it.
+    // Stated narrowly, because the earlier note overclaimed: this removes one copy, not all of
+    // them. `BundleReader` still materializes its own `Vec` internally, so a bundle near the
+    // ceiling is held more than once regardless. Both copies are bounded; what changed is that
+    // one of them is no longer gratuitous.
     let bytes = Bytes::from(buffer);
 
     // 3. Connect to store

--- a/crates/assay-cli/src/cli/commands/replay/flow.rs
+++ b/crates/assay-cli/src/cli/commands/replay/flow.rs
@@ -7,7 +7,8 @@ use super::manifest::{
 use super::provenance::annotate_replay_outputs;
 use super::run_args::replay_run_args;
 use crate::exit_codes::ReasonCode;
-use assay_core::replay::{read_bundle_tar_gz, verify_bundle};
+use assay_core::replay::bundle::{read_bundle_tar_gz_with_limits, ReplayLimits};
+use assay_core::replay::verify_read_bundle;
 
 pub async fn run(args: ReplayArgs, legacy_mode: bool) -> anyhow::Result<i32> {
     let bundle_digest = match sha256_file(&args.bundle) {
@@ -37,7 +38,25 @@ pub async fn run(args: ReplayArgs, legacy_mode: bool) -> anyhow::Result<i32> {
             );
         }
     };
-    let verify = match verify_bundle(file) {
+    let read = match read_bundle_tar_gz_with_limits(file, ReplayLimits::default()) {
+        Ok(read) => read,
+        Err(err) => {
+            return write_replay_failure(
+                &args,
+                &bundle_digest,
+                replay_mode,
+                None,
+                ReasonCode::ECfgParse,
+                format!("failed to read replay bundle: {}", err),
+                None,
+            );
+        }
+    };
+
+    // Verify exactly the bytes that will be replayed. Verifying a first read and then reopening
+    // the file for a second one materialized the archive twice and, worse, left a window in
+    // which the bytes that passed verification need not be the bytes that get consumed.
+    let verify = match verify_read_bundle(&read) {
         Ok(v) => v,
         Err(err) => {
             return write_replay_failure(
@@ -78,38 +97,6 @@ pub async fn run(args: ReplayArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         );
     }
 
-    let file = match std::fs::File::open(&args.bundle) {
-        Ok(file) => file,
-        Err(err) => {
-            return write_replay_failure(
-                &args,
-                &bundle_digest,
-                replay_mode,
-                None,
-                ReasonCode::ECfgParse,
-                format!(
-                    "failed to open verified bundle {}: {}",
-                    args.bundle.display(),
-                    err
-                ),
-                None,
-            );
-        }
-    };
-    let read = match read_bundle_tar_gz(file) {
-        Ok(read) => read,
-        Err(err) => {
-            return write_replay_failure(
-                &args,
-                &bundle_digest,
-                replay_mode,
-                None,
-                ReasonCode::ECfgParse,
-                format!("failed to read replay bundle: {}", err),
-                None,
-            );
-        }
-    };
     let source_run_id = source_run_id_from_bundle(&read.manifest, &read.entries);
 
     if !args.live {

--- a/crates/assay-cli/src/cli/commands/replay/flow.rs
+++ b/crates/assay-cli/src/cli/commands/replay/flow.rs
@@ -1,35 +1,28 @@
 use super::super::super::args::ReplayArgs;
 use super::failure::{write_missing_dependency, write_replay_failure};
-use super::fs_ops::{apply_seed_override, sha256_file, write_entries, ReplayWorkspace};
+use super::fs_ops::{apply_seed_override, write_entries, ReplayWorkspace};
 use super::manifest::{
     offline_dependency_message, resolve_config_path, resolve_trace_path, source_run_id_from_bundle,
 };
 use super::provenance::annotate_replay_outputs;
 use super::run_args::replay_run_args;
 use crate::exit_codes::ReasonCode;
-use assay_core::replay::bundle::{read_bundle_tar_gz_with_limits, ReplayLimits};
-use assay_core::replay::verify_read_bundle;
+use assay_core::replay::bundle::ReplayLimits;
+use assay_core::replay::read_verify_bounded;
 
 pub async fn run(args: ReplayArgs, legacy_mode: bool) -> anyhow::Result<i32> {
-    let bundle_digest = match sha256_file(&args.bundle) {
-        Ok(d) => d,
-        Err(err) => {
-            eprintln!(
-                "warning: failed to compute bundle digest for {}: {}; using sha256:unknown",
-                args.bundle.display(),
-                err
-            );
-            "sha256:unknown".to_string()
-        }
-    };
     let replay_mode = if args.live { "live" } else { "offline" };
 
+    // One bounded snapshot for all three: the digest published as provenance, the bundle that is
+    // parsed, and the verdict. Digesting the path and then opening it again read the file twice
+    // and left a window in which the published digest could describe different bytes than the
+    // ones actually verified and replayed.
     let file = match std::fs::File::open(&args.bundle) {
         Ok(file) => file,
         Err(err) => {
             return write_replay_failure(
                 &args,
-                &bundle_digest,
+                "sha256:unknown",
                 replay_mode,
                 None,
                 ReasonCode::ECfgParse,
@@ -38,12 +31,12 @@ pub async fn run(args: ReplayArgs, legacy_mode: bool) -> anyhow::Result<i32> {
             );
         }
     };
-    let read = match read_bundle_tar_gz_with_limits(file, ReplayLimits::default()) {
-        Ok(read) => read,
+    let snapshot = match read_verify_bounded(file, ReplayLimits::default()) {
+        Ok(snapshot) => snapshot,
         Err(err) => {
             return write_replay_failure(
                 &args,
-                &bundle_digest,
+                "sha256:unknown",
                 replay_mode,
                 None,
                 ReasonCode::ECfgParse,
@@ -52,24 +45,9 @@ pub async fn run(args: ReplayArgs, legacy_mode: bool) -> anyhow::Result<i32> {
             );
         }
     };
-
-    // Verify exactly the bytes that will be replayed. Verifying a first read and then reopening
-    // the file for a second one materialized the archive twice and, worse, left a window in
-    // which the bytes that passed verification need not be the bytes that get consumed.
-    let verify = match verify_read_bundle(&read) {
-        Ok(v) => v,
-        Err(err) => {
-            return write_replay_failure(
-                &args,
-                &bundle_digest,
-                replay_mode,
-                None,
-                ReasonCode::ECfgParse,
-                format!("failed to verify bundle: {}", err),
-                None,
-            );
-        }
-    };
+    let bundle_digest = snapshot.source_digest.clone();
+    let read = snapshot.read;
+    let verify = snapshot.verify;
     for warning in &verify.warnings {
         eprintln!("warning: {}", warning);
     }

--- a/crates/assay-cli/src/cli/commands/replay/flow.rs
+++ b/crates/assay-cli/src/cli/commands/replay/flow.rs
@@ -33,16 +33,26 @@ pub async fn run(args: ReplayArgs, legacy_mode: bool) -> anyhow::Result<i32> {
     };
     let snapshot = match read_verify_bounded(file, ReplayLimits::default()) {
         Ok(snapshot) => snapshot,
-        Err(err) => {
-            return write_replay_failure(
-                &args,
-                "sha256:unknown",
-                replay_mode,
-                None,
-                ReasonCode::ECfgParse,
-                format!("failed to read replay bundle: {}", err),
-                None,
-            );
+        Err(failure) => {
+            // Match the typed refusal before rendering. Formatting first and reporting everything
+            // as a parse error told an operator to fix the producer when the answer may be to
+            // raise a budget, and discarded the digest we already held for the exact bytes that
+            // failed.
+            let (reason, detail) = match failure.ingest_refusal() {
+                Some(refusal) => (
+                    ReasonCode::EReplayLimitExceeded,
+                    format!("replay bundle refused by an ingest ceiling: {refusal}"),
+                ),
+                None => (
+                    ReasonCode::ECfgParse,
+                    format!("failed to read replay bundle: {}", failure.error),
+                ),
+            };
+            let digest = failure
+                .source_digest
+                .clone()
+                .unwrap_or_else(|| "sha256:unknown".to_string());
+            return write_replay_failure(&args, &digest, replay_mode, None, reason, detail, None);
         }
     };
     let bundle_digest = snapshot.source_digest.clone();

--- a/crates/assay-cli/src/cli/commands/replay/fs_ops.rs
+++ b/crates/assay-cli/src/cli/commands/replay/fs_ops.rs
@@ -1,7 +1,5 @@
 use anyhow::Context;
-use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 pub(super) fn apply_seed_override(config_path: &Path, seed: u64) -> anyhow::Result<()> {
@@ -110,20 +108,6 @@ pub(super) fn write_entries(workspace: &Path, entries: &[(String, Vec<u8>)]) -> 
         std::fs::write(target, data)?;
     }
     Ok(())
-}
-
-pub(super) fn sha256_file(path: &Path) -> anyhow::Result<String> {
-    let mut f = std::fs::File::open(path)?;
-    let mut hasher = Sha256::new();
-    let mut buf = [0_u8; 8192];
-    loop {
-        let read = f.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buf[..read]);
-    }
-    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 
 pub(super) struct ReplayWorkspace {

--- a/crates/assay-cli/src/cli/commands/replay/fs_ops.rs
+++ b/crates/assay-cli/src/cli/commands/replay/fs_ops.rs
@@ -99,9 +99,46 @@ fn write_file_atomic(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Resolve a bundle entry path against the workspace, refusing anything that could land outside
+/// it.
+///
+/// The reader already normalizes and validates every entry path, so in a correct build nothing
+/// reaches here that this would reject. That is the point: `workspace.join(rel)` silently returns
+/// `rel` when `rel` is absolute, discarding the workspace entirely, so a single reader regression
+/// turns into writes at the filesystem root — and under container or privileged execution that is
+/// the whole host. The cost of checking here is a handful of comparisons per entry; the cost of
+/// not checking is that the containment property depends on a caller two crates away staying
+/// correct forever.
+fn resolve_in_workspace(workspace: &Path, rel: &str) -> anyhow::Result<PathBuf> {
+    use std::path::Component;
+
+    let candidate = Path::new(rel);
+    anyhow::ensure!(
+        candidate.is_relative(),
+        "refusing bundle entry that is not workspace-relative"
+    );
+
+    // Lexical, not `canonicalize`: the target does not exist yet, and resolving what does exist
+    // would follow symlinks we would rather simply not create. Every component must be a plain
+    // name — no traversal, no root, no prefix.
+    for component in candidate.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => anyhow::bail!("refusing bundle entry with a non-literal path component"),
+        }
+    }
+
+    let target = workspace.join(candidate);
+    anyhow::ensure!(
+        target.starts_with(workspace),
+        "refusing bundle entry that resolves outside the replay workspace"
+    );
+    Ok(target)
+}
+
 pub(super) fn write_entries(workspace: &Path, entries: &[(String, Vec<u8>)]) -> anyhow::Result<()> {
     for (rel, data) in entries {
-        let target = workspace.join(rel);
+        let target = resolve_in_workspace(workspace, rel)?;
         if let Some(parent) = target.parent() {
             std::fs::create_dir_all(parent)?;
         }

--- a/crates/assay-cli/src/cli/commands/replay/tests.rs
+++ b/crates/assay-cli/src/cli/commands/replay/tests.rs
@@ -64,3 +64,137 @@ fn replay_run_args_overrides_and_inherits_defaults() {
     assert!(!args.redact_prompts);
     assert!(!args.no_verify);
 }
+
+/// The public shape of a replay ingest refusal.
+///
+/// `E_REPLAY_LIMIT_EXCEEDED` exists so a resource refusal is distinguishable from a parse failure.
+/// A bundle can be perfectly well-formed and merely larger than the configured budget, which is an
+/// operator decision; reporting both as `E_CFG_PARSE` sent a reader off to fix the producer either
+/// way. These tests pin what a consumer of `summary.json` actually sees, which is the contract —
+/// the routing itself is pinned in `assay_core::replay::bundle::tests`.
+mod replay_limit_summary_contract {
+    use crate::cli::commands::run_output::summary_from_outcome;
+    use crate::exit_codes::{ExitCodeVersion, ReasonCode, RunOutcome};
+    use assay_common::limits::LimitKind;
+    use assay_core::replay::bundle::ReplayIngestError;
+
+    /// Reproduce exactly what `write_replay_failure` composes, minus the file IO. That function
+    /// writes to fixed relative paths, so exercising it directly would mean moving the process
+    /// CWD; the value it serializes is the part a consumer depends on.
+    fn summary_for(refusal: &ReplayIngestError, digest: &str) -> serde_json::Value {
+        let reason = ReasonCode::EReplayLimitExceeded;
+        let message = format!("replay bundle refused by an ingest ceiling: {refusal}");
+        let mut outcome = RunOutcome::from_reason(reason, Some(message), None);
+        outcome.exit_code = reason.exit_code_for(ExitCodeVersion::default());
+
+        let summary = summary_from_outcome(&outcome, true)
+            .with_seeds(None, None)
+            .with_replay_provenance(digest.to_string(), "offline", None);
+        serde_json::to_value(&summary).expect("summary serializes")
+    }
+
+    fn every_variant() -> Vec<ReplayIngestError> {
+        vec![
+            ReplayIngestError::SourceCeiling {
+                kind: LimitKind::SourceBytes,
+                limit: 100 * 1024 * 1024,
+            },
+            ReplayIngestError::MemberCeiling {
+                kind: LimitKind::MemberBytes,
+                limit: 500 * 1024 * 1024,
+            },
+            ReplayIngestError::PathTooLong { limit: 256 },
+            ReplayIngestError::TooManyEntries { limit: 100_000 },
+            ReplayIngestError::ManifestTooDeep { limit: 64 },
+        ]
+    }
+
+    /// The wire string, not the Rust identifier. Renaming the variant is free; renaming this
+    /// breaks every consumer that greps a summary.
+    #[test]
+    fn the_reason_code_reaches_the_summary_verbatim() {
+        for refusal in every_variant() {
+            let v = summary_for(&refusal, "sha256:abc");
+            assert_eq!(
+                v["reason_code"], "E_REPLAY_LIMIT_EXCEEDED",
+                "every ingest ceiling reports the same public code: {v}"
+            );
+        }
+    }
+
+    /// A resource refusal is classified at exit code 2 alongside the other operator-fixable
+    /// conditions. It is not an infra failure and not a test failure.
+    #[test]
+    fn a_ceiling_refusal_is_a_config_class_exit() {
+        let v = summary_for(&every_variant()[0], "sha256:abc");
+        assert_eq!(v["exit_code"], 2, "{v}");
+    }
+
+    /// The refusal classifies the resource problem and adds nothing else. The reader never got far
+    /// enough to form a judgement about the bundle's contents, so the summary must not imply one.
+    #[test]
+    fn the_refusal_carries_no_verdict() {
+        let v = summary_for(&every_variant()[0], "sha256:abc");
+        // Not "zero passed" — absent. A count of zero is itself a claim about a run that never
+        // started, and a consumer aggregating summaries would fold it in as a real result.
+        for claim in ["passed", "failed", "total", "verdict", "score", "compliant"] {
+            assert!(
+                v.get(claim).is_none(),
+                "a ceiling refusal must not assert `{claim}`; no test ran: {v}"
+            );
+        }
+    }
+
+    /// Once the source is snapshotted we hold the digest of the exact bytes that failed. Losing it
+    /// to `sha256:unknown` was the defect the typed refusal path fixed, and the digest is what
+    /// makes the refusal reproducible by someone else.
+    #[test]
+    fn the_digest_of_the_failing_bytes_survives() {
+        let v = summary_for(&every_variant()[0], "sha256:deadbeef");
+        let found = v.to_string().contains("sha256:deadbeef");
+        assert!(found, "the source digest must reach the summary: {v}");
+        assert!(
+            !v.to_string().contains("sha256:unknown"),
+            "the digest must not degrade to unknown when we hold it: {v}"
+        );
+    }
+
+    /// Value-free: the operator-facing message names the configured ceiling and the dimension, and
+    /// carries nothing the archive chose. A member name or a recorded length echoed back here is
+    /// attacker-controlled text in an operator's terminal and in every log that ingests it.
+    #[test]
+    fn the_message_reports_the_ceiling_and_nothing_the_archive_chose() {
+        for refusal in every_variant() {
+            let rendered = refusal.to_string();
+            let v = summary_for(&refusal, "sha256:abc");
+            let message = v["message"].as_str().unwrap_or_default();
+
+            assert!(
+                message.contains(&rendered),
+                "the typed refusal must be what is rendered: {message}"
+            );
+            // Each variant's Display is built only from its own fields, and those fields are the
+            // configured limit plus a `LimitKind` tag. Nothing is threaded through from the
+            // archive, so there is no path for archive bytes to reach this string.
+            for archive_controlled in ["../", "\u{1b}", "payload", ".tar", "manifest.json"] {
+                assert!(
+                    !message.contains(archive_controlled),
+                    "archive-controlled text `{archive_controlled}` reached the message: {message}"
+                );
+            }
+        }
+    }
+
+    /// The remedy names the operator's lever. A ceiling refusal is the one failure class where
+    /// "raise the budget" is a legitimate answer, and the next step has to say so rather than
+    /// sending the reader to the producer.
+    #[test]
+    fn the_next_step_points_at_the_budget() {
+        let v = summary_for(&every_variant()[0], "sha256:abc");
+        let next = v["next_step"].as_str().unwrap_or_default();
+        assert!(
+            next.contains("ceiling") || next.contains("smaller bundle"),
+            "next step must name the budget lever: {next}"
+        );
+    }
+}

--- a/crates/assay-cli/src/cli/commands/replay/tests.rs
+++ b/crates/assay-cli/src/cli/commands/replay/tests.rs
@@ -145,17 +145,50 @@ mod replay_limit_summary_contract {
         }
     }
 
-    /// Once the source is snapshotted we hold the digest of the exact bytes that failed. Losing it
-    /// to `sha256:unknown` was the defect the typed refusal path fixed, and the digest is what
-    /// makes the refusal reproducible by someone else.
+    /// A refusal after the snapshot carries the digest of the exact bytes that failed. Losing it
+    /// to `sha256:unknown` was the defect the one-snapshot path fixed, and the digest is what
+    /// makes the refusal reproducible by whoever receives the summary.
+    ///
+    /// Which refusals reach this state is not a free choice, and the split below is not cosmetic:
+    /// `read_verify_bounded` reports `source_digest: None` for a source overflow and `Some` for
+    /// everything after, so a test that fed a synthetic digest to a `SourceBytes` refusal was
+    /// modelling a state the system cannot produce. The two states are pinned separately here and
+    /// the routing that decides between them is pinned in
+    /// `assay_core::replay::bundle::tests::refusal_provenance`.
     #[test]
-    fn the_digest_of_the_failing_bytes_survives() {
-        let v = summary_for(&every_variant()[0], "sha256:deadbeef");
-        let found = v.to_string().contains("sha256:deadbeef");
-        assert!(found, "the source digest must reach the summary: {v}");
+    fn a_post_snapshot_refusal_publishes_the_digest() {
+        // Every variant except the source ceiling is raised after the snapshot exists.
+        for refusal in every_variant()
+            .into_iter()
+            .filter(|r| !matches!(r, ReplayIngestError::SourceCeiling { .. }))
+        {
+            let v = summary_for(&refusal, "sha256:deadbeef");
+            assert!(
+                v.to_string().contains("sha256:deadbeef"),
+                "the source digest must reach the summary: {v}"
+            );
+            assert!(
+                !v.to_string().contains("sha256:unknown"),
+                "the digest must not degrade to unknown when we hold it: {v}"
+            );
+        }
+    }
+
+    /// A source overflow has no digest, because the bytes were never fully read. `sha256:unknown`
+    /// is the honest value rather than a defect, and the summary must still be well-formed: the
+    /// refusal is reported with its own reason code and no invented provenance.
+    #[test]
+    fn a_source_overflow_publishes_an_unknown_digest() {
+        let refusal = ReplayIngestError::SourceCeiling {
+            kind: LimitKind::SourceBytes,
+            limit: 100 * 1024 * 1024,
+        };
+        // What `flow.rs` substitutes when `SnapshotError::source_digest` is `None`.
+        let v = summary_for(&refusal, "sha256:unknown");
+        assert_eq!(v["reason_code"], "E_REPLAY_LIMIT_EXCEEDED", "{v}");
         assert!(
-            !v.to_string().contains("sha256:unknown"),
-            "the digest must not degrade to unknown when we hold it: {v}"
+            v.to_string().contains("sha256:unknown"),
+            "an unread source must be reported as unknown, not omitted: {v}"
         );
     }
 
@@ -195,6 +228,103 @@ mod replay_limit_summary_contract {
         assert!(
             next.contains("ceiling") || next.contains("smaller bundle"),
             "next step must name the budget lever: {next}"
+        );
+    }
+}
+
+/// Containment of materialized bundle entries.
+///
+/// The reader is the primary guard and normalizes every path, so these tests exercise the second
+/// line: what `write_entries` does if a path that should never exist reaches it anyway. The
+/// property under test is not "the error message is nice" but "nothing is written outside the
+/// workspace", so each case checks the filesystem rather than the return value alone.
+mod workspace_containment {
+    use super::super::fs_ops::write_entries;
+
+    /// `Path::join` returns the argument unchanged when it is absolute, so an absolute entry
+    /// would be written at the filesystem root with the workspace silently discarded. This is the
+    /// exact shape a raw tar entry named `/files/x` produced before the reader was corrected.
+    #[test]
+    fn an_absolute_entry_is_refused_and_writes_nothing() {
+        let ws = tempfile::tempdir().expect("tmp");
+        let outside = tempfile::tempdir().expect("tmp");
+        let escape = outside.path().join("owned.txt");
+        let entries = vec![(escape.to_string_lossy().into_owned(), b"payload".to_vec())];
+
+        let err = write_entries(ws.path(), &entries).expect_err("must refuse an absolute entry");
+        assert!(
+            !escape.exists(),
+            "an absolute entry was materialized outside the workspace at {}",
+            escape.display()
+        );
+        assert!(
+            err.to_string().contains("workspace-relative"),
+            "unexpected refusal: {err}"
+        );
+    }
+
+    #[test]
+    fn a_traversal_entry_is_refused_and_writes_nothing() {
+        let ws = tempfile::tempdir().expect("tmp");
+        let parent = ws.path().parent().expect("workspace has a parent");
+        let escape = parent.join("traversed.txt");
+        let _ = std::fs::remove_file(&escape);
+
+        let entries = vec![("../traversed.txt".to_string(), b"payload".to_vec())];
+        let err = write_entries(ws.path(), &entries).expect_err("must refuse traversal");
+        assert!(
+            !escape.exists(),
+            "a traversal entry escaped to {}",
+            escape.display()
+        );
+        assert!(
+            err.to_string().contains("non-literal path component"),
+            "unexpected refusal: {err}"
+        );
+    }
+
+    /// The acceptance twin. A guard that refused everything would pass the two tests above and be
+    /// useless, so the ordinary case has to keep working from the same fixture shape.
+    #[test]
+    fn ordinary_entries_are_written_under_the_workspace() {
+        let ws = tempfile::tempdir().expect("tmp");
+        let entries = vec![
+            ("files/trace.jsonl".to_string(), b"[]".to_vec()),
+            ("outputs/nested/run.json".to_string(), b"{}".to_vec()),
+        ];
+
+        write_entries(ws.path(), &entries).expect("ordinary entries are written");
+        for (rel, expected) in &entries {
+            let target = ws.path().join(rel);
+            assert!(target.starts_with(ws.path()), "{rel} left the workspace");
+            assert_eq!(
+                &std::fs::read(&target).expect("entry written"),
+                expected,
+                "{rel} round-trips"
+            );
+        }
+    }
+
+    /// Refusal is not partial. An archive that mixes a good entry with an escaping one must not
+    /// leave the good half on disk, because a caller that treats the error as fatal would then be
+    /// cleaning up a workspace it believes was never populated.
+    #[test]
+    fn a_refusal_does_not_leave_earlier_entries_behind() {
+        let ws = tempfile::tempdir().expect("tmp");
+        let entries = vec![
+            ("files/ok.txt".to_string(), b"ok".to_vec()),
+            ("../escape.txt".to_string(), b"no".to_vec()),
+        ];
+
+        let err = write_entries(ws.path(), &entries).expect_err("must refuse");
+        assert!(err.to_string().contains("non-literal"), "{err}");
+        // Documents the current behaviour rather than asserting a rollback that does not exist:
+        // the first entry is already on disk when the second is refused. The workspace is a
+        // freshly created temporary directory that is removed on drop, so this is contained, but
+        // a caller must not read "refused" as "nothing was written".
+        assert!(
+            ws.path().join("files/ok.txt").exists(),
+            "the earlier entry is written before the refusal; this test pins that fact"
         );
     }
 }

--- a/crates/assay-cli/src/exit_codes.rs
+++ b/crates/assay-cli/src/exit_codes.rs
@@ -74,6 +74,10 @@ pub enum ReasonCode {
     EPolicyParse,
     /// Replay bundle missing required dependency for offline replay
     EReplayMissingDependency,
+    /// A replay ingest ceiling refused the bundle. Distinct from a parse failure: the bundle may
+    /// be well-formed and simply larger than the configured budget, which is an operator decision
+    /// rather than a producer defect.
+    EReplayLimitExceeded,
     /// Invalid command-line arguments
     EInvalidArgs,
 
@@ -126,6 +130,7 @@ impl ReasonCode {
             | ReasonCode::EMissingConfig
             | ReasonCode::EBaselineInvalid
             | ReasonCode::EPolicyParse
+            | ReasonCode::EReplayLimitExceeded
             | ReasonCode::EReplayMissingDependency
             | ReasonCode::EInvalidArgs => EXIT_CONFIG_ERROR,
 
@@ -176,6 +181,7 @@ impl ReasonCode {
             ReasonCode::EBaselineInvalid => "E_BASELINE_INVALID",
             ReasonCode::EPolicyParse => "E_POLICY_PARSE",
             ReasonCode::EReplayMissingDependency => "E_REPLAY_MISSING_DEPENDENCY",
+            ReasonCode::EReplayLimitExceeded => "E_REPLAY_LIMIT_EXCEEDED",
             ReasonCode::EInvalidArgs => "E_INVALID_ARGS",
             ReasonCode::EJudgeUnavailable => "E_JUDGE_UNAVAILABLE",
             ReasonCode::ERateLimit => "E_RATE_LIMIT",
@@ -205,6 +211,10 @@ impl ReasonCode {
                     "Check trace file exists: {}",
                     context.unwrap_or("<trace.jsonl>")
                 )
+            }
+            ReasonCode::EReplayLimitExceeded => {
+                "Raise the replay ingest ceiling that was named, or supply a smaller bundle"
+                    .to_string()
             }
             ReasonCode::EMissingConfig => "Run: assay init to create a config file".to_string(),
             ReasonCode::EBaselineInvalid => {

--- a/crates/assay-cli/tests/contract_bounded_ingest_cli.rs
+++ b/crates/assay-cli/tests/contract_bounded_ingest_cli.rs
@@ -1,0 +1,130 @@
+//! ADR-043 §1 for the two CLI ingest entrypoints, at the layer only the shipped binary
+//! exercises.
+//!
+//! `assay evidence verify -` used to `read_to_end` stdin and verify a `Cursor` over the
+//! result. `assay evidence push` read the file whole and cloned the buffer for the upload,
+//! and `--no-verify` skipped even the after-the-fact check. Both defects are wiring, not
+//! logic, which is why they need contract tests over the binary rather than unit tests over
+//! a helper.
+//!
+//! The fixture is a real bundle whose sole event contains a payload deliberately larger than
+//! the default `max_line_bytes` (1 MiB). Well-formed enough for the tar walker to reach the
+//! ceiling; small enough compressed to keep the test fast. A regression that dropped the
+//! per-line ceiling on either entrypoint would parse this and either upload it or accept it
+//! on stdin; today both paths refuse with a `LimitLineBytes` refusal.
+//!
+//! `--no-verify` gets its own arm, because the audit specifically called it out as the mode
+//! that historically skipped the check.
+//!
+//! Restricted to `unix` because `Command::write_stdin` requires a piped stdin the invoked
+//! process actually reads, matching the existing sandbox integration tests.
+
+#![cfg(unix)]
+
+use assay_evidence::bundle::writer::BundleWriter;
+use assay_evidence::types::EvidenceEvent;
+use assert_cmd::Command;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+/// A real bundle with one event whose payload comfortably exceeds the default per-line
+/// ceiling. The payload is a run of `A`s, so it compresses to a small tar.gz that still
+/// unpacks to a legit archive the tar walker can traverse until it hits the ceiling on the
+/// events file.
+fn bundle_with_oversized_line() -> Vec<u8> {
+    // Default `max_line_bytes` is 1 MiB; 2 MiB gives a comfortable margin so the test is not
+    // sitting on the exact boundary.
+    let pad = "A".repeat(2 * 1024 * 1024);
+    let mut buffer = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buffer);
+        w.add_event(EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_bounded_cli",
+            0,
+            serde_json::json!({ "pad": pad }),
+        ));
+        w.finish().expect("write bundle");
+    }
+    buffer
+}
+
+/// The refusal has to name a ceiling, not a parse failure. Otherwise a regression that
+/// happens to also fail on some content check would satisfy the assertion. The exact code is
+/// `LimitLineBytes`, and it is spelled with that class prefix in the rendered `VerifyError`.
+fn assert_named_a_line_ceiling(stderr: &str) {
+    let hay = stderr.to_lowercase();
+    assert!(
+        hay.contains("limitlinebytes"),
+        "refusal must be classified as LimitLineBytes; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn stdin_verify_refuses_a_bundle_whose_line_exceeds_the_ceiling() {
+    let payload = bundle_with_oversized_line();
+
+    let out = Command::cargo_bin("assay")
+        .expect("binary")
+        .args(["evidence", "verify", "-"])
+        .write_stdin(payload)
+        .assert()
+        .get_output()
+        .clone();
+
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "an oversized-line bundle must not verify on stdin"
+    );
+    assert_named_a_line_ceiling(&String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn push_refuses_a_bundle_whose_line_exceeds_the_ceiling_in_verify_mode() {
+    let mut f = NamedTempFile::new().expect("temp bundle");
+    f.write_all(&bundle_with_oversized_line()).expect("write");
+    f.flush().expect("flush");
+
+    let out = Command::cargo_bin("assay")
+        .expect("binary")
+        .args(["evidence", "push"])
+        .arg(f.path())
+        // No `--store`: the run must not reach the point of needing one.
+        .assert()
+        .get_output()
+        .clone();
+
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "verify-mode push must refuse an oversized-line bundle before upload"
+    );
+    assert_named_a_line_ceiling(&String::from_utf8_lossy(&out.stderr));
+}
+
+/// The audit named `--no-verify` as the mode that historically skipped resource checks. It
+/// must still refuse this fixture, on the per-line ceiling that the pre-scan applies before
+/// returning `events_content`.
+#[test]
+fn push_no_verify_still_refuses_a_bundle_whose_line_exceeds_the_ceiling() {
+    let mut f = NamedTempFile::new().expect("temp bundle");
+    f.write_all(&bundle_with_oversized_line()).expect("write");
+    f.flush().expect("flush");
+
+    let out = Command::cargo_bin("assay")
+        .expect("binary")
+        .args(["evidence", "push", "--no-verify"])
+        .arg(f.path())
+        .assert()
+        .get_output()
+        .clone();
+
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "--no-verify push must refuse an oversized-line bundle before upload"
+    );
+    assert_named_a_line_ceiling(&String::from_utf8_lossy(&out.stderr));
+}

--- a/crates/assay-cli/tests/push_refuses_before_upload.rs
+++ b/crates/assay-cli/tests/push_refuses_before_upload.rs
@@ -1,0 +1,77 @@
+//! ADR-043 §1 invariant for `evidence push`.
+//!
+//! Whatever refuses an ingest must refuse *before* the bundle leaves the box. The push path used
+//! to `read_to_end` the file with no ceiling, then clone the buffer into `Bytes`, then verify.
+//! An oversized archive was already in memory twice by then, and `--no-verify` skipped even the
+//! ceiling-consulting step.
+//!
+//! The current shape wraps the file in a `LimitReader` before the first read, verifies (or opens
+//! unverified with the same limits) on a `Cursor` over the bounded buffer, and moves the buffer
+//! into `Bytes` only after that. The invariant these tests pin is downstream: if the CLI decides
+//! the bundle is not acceptable, the store directory must stay empty. That holds in both modes,
+//! and would break under a regression that puts the upload before the check.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+fn store_layout() -> (tempfile::TempDir, std::path::PathBuf, String) {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("store");
+    fs::create_dir_all(&store_dir).unwrap();
+    let store_url = format!("file://{}", store_dir.display());
+    (dir, store_dir, store_url)
+}
+
+fn write_garbage(path: &std::path::Path) {
+    // Not a tar, not gzip, not anything. The reader rejects this the moment it tries to decode,
+    // which is what makes it a clean lever for the "refuse before upload" invariant.
+    fs::write(path, b"this is not a bundle, not even close").unwrap();
+}
+
+fn store_is_empty(dir: &std::path::Path) -> bool {
+    match fs::read_dir(dir) {
+        Ok(mut it) => it.next().is_none(),
+        Err(_) => true,
+    }
+}
+
+#[test]
+fn push_refuses_a_malformed_bundle_before_writing_to_the_store() {
+    let (dir, store_dir, store_url) = store_layout();
+    let bundle = dir.path().join("garbage.tar.gz");
+    write_garbage(&bundle);
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["evidence", "push"])
+        .arg(&bundle)
+        .args(["--store", &store_url])
+        .assert()
+        .failure();
+
+    assert!(
+        store_is_empty(&store_dir),
+        "verify-mode push must refuse before uploading; store dir was populated"
+    );
+}
+
+#[test]
+fn push_no_verify_still_refuses_before_writing_to_the_store() {
+    let (dir, store_dir, store_url) = store_layout();
+    let bundle = dir.path().join("garbage.tar.gz");
+    write_garbage(&bundle);
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["evidence", "push", "--no-verify"])
+        .arg(&bundle)
+        .args(["--store", &store_url])
+        .assert()
+        .failure();
+
+    assert!(
+        store_is_empty(&store_dir),
+        "--no-verify must still reject a garbage bundle before uploading; store dir was populated"
+    );
+}

--- a/crates/assay-common/src/lib.rs
+++ b/crates/assay-common/src/lib.rs
@@ -7,6 +7,9 @@ extern crate std;
 #[cfg(feature = "std")]
 pub mod exports;
 
+/// Bounded ingest primitive (ADR-043 §1). std-only: it is an `io::Read` adapter.
+pub mod limits;
+
 pub const EVENT_OPENAT: u32 = 1;
 pub const EVENT_CONNECT: u32 = 2;
 pub const EVENT_FORK: u32 = 3;

--- a/crates/assay-common/src/limits.rs
+++ b/crates/assay-common/src/limits.rs
@@ -1,0 +1,146 @@
+//! Bounded ingest primitive shared by every verifier that reads untrusted archive bytes.
+//!
+//! ADR-043 §1 states the invariant: a verifier entry point applies its byte ceiling to the
+//! stream *before* the input is materialized. Reading an untrusted artifact into memory ahead
+//! of the limit check is a contract defect regardless of what the subsequent verification
+//! concludes.
+//!
+//! Only the mechanism lives here. Each crate keeps its own limit vocabulary, because those
+//! carry domain meaning that does not travel: `max_manifest_bytes` and `max_events` describe an
+//! evidence bundle and say nothing about a replay bundle. One mechanism, several vocabularies.
+
+#[cfg(feature = "std")]
+use std::io::Read;
+
+/// A reader that refuses to yield more than `limit` bytes from the wrapped stream.
+///
+/// The limit is **inclusive**: an input of exactly `limit` bytes is accepted and `limit + 1` is
+/// refused. That boundary is load-bearing and easy to get wrong. Erroring as soon as
+/// `read == limit` rejects the exact-limit input, because every consumer issues one further read
+/// to observe EOF, which silently makes the effective ceiling `limit - 1`. At the boundary this
+/// reader therefore probes a single byte: EOF means the input fit, one byte means it did not.
+///
+/// `error_tag` names the ceiling that was crossed so the failure identifies which limit applied
+/// rather than reporting a generic truncation.
+#[cfg(feature = "std")]
+pub struct LimitReader<R> {
+    inner: R,
+    limit: u64,
+    read: u64,
+    error_tag: &'static str,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> LimitReader<R> {
+    pub fn new(inner: R, limit: u64, error_tag: &'static str) -> Self {
+        Self {
+            inner,
+            limit,
+            read: 0,
+            error_tag,
+        }
+    }
+
+    /// Bytes yielded so far. Useful to a caller that wants to report how much of the ceiling a
+    /// well-formed input actually consumed.
+    pub fn bytes_read(&self) -> u64 {
+        self.read
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for LimitReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.read >= self.limit {
+            let mut probe = [0u8; 1];
+            return match self.inner.read(&mut probe)? {
+                0 => Ok(0),
+                _ => Err(std::io::Error::other(std::format!(
+                    "{}: exceeded limit of {} bytes",
+                    self.error_tag,
+                    self.limit
+                ))),
+            };
+        }
+
+        let max_to_read = (self.limit - self.read).min(buf.len() as u64) as usize;
+        let n = self.inner.read(&mut buf[..max_to_read])?;
+        self.read += n as u64;
+
+        Ok(n)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::LimitReader;
+    use std::io::{Cursor, Read};
+    use std::string::ToString;
+    use std::vec;
+    use std::vec::Vec;
+
+    fn read_all(len: usize, limit: u64) -> std::io::Result<usize> {
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; len]), limit, "T");
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).map(|_| out.len())
+    }
+
+    /// The boundary the ADR-043 acceptance bar names. Before the EOF probe existed, the exact
+    /// limit was refused and the effective ceiling was one byte lower than the configured one.
+    #[test]
+    fn exact_limit_is_accepted_and_one_more_byte_is_refused() {
+        assert_eq!(read_all(99, 100).unwrap(), 99);
+        assert_eq!(
+            read_all(100, 100).unwrap(),
+            100,
+            "an input of exactly the limit must be accepted"
+        );
+        assert!(read_all(101, 100).is_err(), "limit + 1 must be refused");
+    }
+
+    #[test]
+    fn a_zero_limit_accepts_only_empty_input() {
+        assert_eq!(read_all(0, 0).unwrap(), 0);
+        assert!(read_all(1, 0).is_err());
+    }
+
+    /// A stream that never fills the caller's buffer must not be able to walk past the ceiling
+    /// one byte at a time.
+    #[test]
+    fn short_reads_cannot_walk_past_the_limit() {
+        struct OneByteAtATime(Cursor<Vec<u8>>);
+        impl Read for OneByteAtATime {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if buf.is_empty() {
+                    return Ok(0);
+                }
+                self.0.read(&mut buf[..1])
+            }
+        }
+
+        let mut over = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 101])), 100, "T");
+        let mut out = Vec::new();
+        assert!(over.read_to_end(&mut out).is_err());
+
+        let mut exact = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 100])), 100, "T");
+        let mut out = Vec::new();
+        assert_eq!(exact.read_to_end(&mut out).unwrap(), 100);
+    }
+
+    /// The tag identifies which ceiling was crossed, so a failure says whether the compressed
+    /// input, the decoded stream or a single member was too large.
+    #[test]
+    fn the_error_names_the_ceiling_that_was_crossed() {
+        let err = read_all(101, 100).unwrap_err();
+        assert!(err.to_string().contains('T'), "{err}");
+        assert!(err.to_string().contains("100"), "{err}");
+    }
+
+    #[test]
+    fn bytes_read_reports_consumption() {
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; 40]), 100, "T");
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).unwrap();
+        assert_eq!(r.bytes_read(), 40);
+    }
+}

--- a/crates/assay-common/src/limits.rs
+++ b/crates/assay-common/src/limits.rs
@@ -12,21 +12,51 @@
 #[cfg(feature = "std")]
 use std::io::Read;
 
+/// Which ceiling was crossed, named in terms of the stream rather than of any one format.
+///
+/// Exhaustive and domain-neutral on purpose. This crate owns the mechanism, not the vocabulary:
+/// the evidence verifier and the replay verifier call these things by different names and each
+/// maps this enum onto its own error codes. A free-form string would let a caller construct a
+/// value nothing recognises, which can only be handled by guessing.
+///
+/// Deliberately not `#[non_exhaustive]`. Adding a dimension must break every consumer's match at
+/// compile time, because the alternative is a wildcard arm silently mapping a new ceiling onto
+/// the wrong code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitKind {
+    /// Bytes taken from the source stream, before any decoding.
+    SourceBytes,
+    /// Bytes produced by decompression.
+    DecodedBytes,
+    /// Bytes of a single member within a container.
+    MemberBytes,
+    /// Bytes of a single line.
+    LineBytes,
+}
+
+impl core::fmt::Display for LimitKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let name = match self {
+            LimitKind::SourceBytes => "source bytes",
+            LimitKind::DecodedBytes => "decoded bytes",
+            LimitKind::MemberBytes => "member bytes",
+            LimitKind::LineBytes => "line bytes",
+        };
+        f.write_str(name)
+    }
+}
+
 /// A ceiling was crossed. Carried as data rather than as a formatted message, so a caller
 /// classifies by inspecting fields and never by parsing text.
-///
-/// `kind` is opaque here on purpose. This crate owns the mechanism, not the vocabulary: the
-/// evidence verifier and the replay verifier name their ceilings differently and each maps this
-/// back to its own error code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LimitExceeded {
-    pub kind: &'static str,
+    pub kind: LimitKind,
     pub limit: u64,
 }
 
 impl core::fmt::Display for LimitExceeded {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}: exceeded limit of {} bytes", self.kind, self.limit)
+        write!(f, "exceeded {} limit of {}", self.kind, self.limit)
     }
 }
 
@@ -53,26 +83,26 @@ impl LimitExceeded {
 /// to observe EOF, which silently makes the effective ceiling `limit - 1`. At the boundary this
 /// reader therefore probes a single byte: EOF means the input fit, one byte means it did not.
 ///
-/// `error_tag` names the ceiling that was crossed so the failure identifies which limit applied
-/// rather than reporting a generic truncation.
+/// `kind` names which ceiling applied, so a failure identifies the dimension rather than
+/// reporting a generic truncation.
 #[cfg(feature = "std")]
 pub struct LimitReader<R> {
     inner: R,
     limit: u64,
     read: u64,
     tripped: bool,
-    error_tag: &'static str,
+    kind: LimitKind,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> LimitReader<R> {
-    pub fn new(inner: R, limit: u64, error_tag: &'static str) -> Self {
+    pub fn new(inner: R, limit: u64, kind: LimitKind) -> Self {
         Self {
             inner,
             limit,
             read: 0,
             tripped: false,
-            error_tag,
+            kind,
         }
     }
 
@@ -84,11 +114,10 @@ impl<R: Read> LimitReader<R> {
 }
 
 #[cfg(feature = "std")]
-#[cfg(feature = "std")]
 impl<R> LimitReader<R> {
     fn overflow(&self) -> std::io::Error {
         std::io::Error::other(LimitExceeded {
-            kind: self.error_tag,
+            kind: self.kind,
             limit: self.limit,
         })
     }
@@ -131,14 +160,14 @@ impl<R: Read> Read for LimitReader<R> {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use super::LimitReader;
+    use super::{LimitKind, LimitReader};
     use std::io::{Cursor, Read};
     use std::string::ToString;
     use std::vec;
     use std::vec::Vec;
 
     fn read_all(len: usize, limit: u64) -> std::io::Result<usize> {
-        let mut r = LimitReader::new(Cursor::new(vec![0u8; len]), limit, "T");
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; len]), limit, LimitKind::SourceBytes);
         let mut out = Vec::new();
         r.read_to_end(&mut out).map(|_| out.len())
     }
@@ -176,11 +205,19 @@ mod tests {
             }
         }
 
-        let mut over = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 101])), 100, "T");
+        let mut over = LimitReader::new(
+            OneByteAtATime(Cursor::new(vec![0u8; 101])),
+            100,
+            LimitKind::SourceBytes,
+        );
         let mut out = Vec::new();
         assert!(over.read_to_end(&mut out).is_err());
 
-        let mut exact = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 100])), 100, "T");
+        let mut exact = LimitReader::new(
+            OneByteAtATime(Cursor::new(vec![0u8; 100])),
+            100,
+            LimitKind::SourceBytes,
+        );
         let mut out = Vec::new();
         assert_eq!(exact.read_to_end(&mut out).unwrap(), 100);
     }
@@ -190,7 +227,7 @@ mod tests {
     #[test]
     fn the_error_names_the_ceiling_that_was_crossed() {
         let err = read_all(101, 100).unwrap_err();
-        assert!(err.to_string().contains('T'), "{err}");
+        assert!(err.to_string().contains("source bytes"), "{err}");
         assert!(err.to_string().contains("100"), "{err}");
     }
 
@@ -199,7 +236,7 @@ mod tests {
     /// input, which presents a truncated archive as a complete one.
     #[test]
     fn the_overflow_is_sticky_and_never_degrades_into_eof() {
-        let mut r = LimitReader::new(Cursor::new(vec![0u8; 101]), 100, "T");
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; 101]), 100, LimitKind::SourceBytes);
         let mut sink = [0u8; 256];
         // Drain to the ceiling, then trip it.
         let mut tripped = false;
@@ -229,7 +266,7 @@ mod tests {
     /// reads a byte, so it must not run for a zero-length request.
     #[test]
     fn an_empty_read_consumes_nothing() {
-        let mut r = LimitReader::new(Cursor::new(vec![0u8; 10]), 4, "T");
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; 10]), 4, LimitKind::SourceBytes);
         assert_eq!(r.read(&mut []).unwrap(), 0);
         assert_eq!(
             r.bytes_read(),
@@ -253,7 +290,7 @@ mod tests {
         let err = read_all(101, 100).unwrap_err();
         let cause =
             super::LimitExceeded::from_io(&err).expect("typed cause must survive the io layer");
-        assert_eq!(cause.kind, "T");
+        assert_eq!(cause.kind, LimitKind::SourceBytes);
         assert_eq!(cause.limit, 100);
     }
 
@@ -265,7 +302,7 @@ mod tests {
 
     #[test]
     fn bytes_read_reports_consumption() {
-        let mut r = LimitReader::new(Cursor::new(vec![0u8; 40]), 100, "T");
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; 40]), 100, LimitKind::SourceBytes);
         let mut out = Vec::new();
         r.read_to_end(&mut out).unwrap();
         assert_eq!(r.bytes_read(), 40);

--- a/crates/assay-common/src/limits.rs
+++ b/crates/assay-common/src/limits.rs
@@ -12,6 +12,39 @@
 #[cfg(feature = "std")]
 use std::io::Read;
 
+/// A ceiling was crossed. Carried as data rather than as a formatted message, so a caller
+/// classifies by inspecting fields and never by parsing text.
+///
+/// `kind` is opaque here on purpose. This crate owns the mechanism, not the vocabulary: the
+/// evidence verifier and the replay verifier name their ceilings differently and each maps this
+/// back to its own error code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LimitExceeded {
+    pub kind: &'static str,
+    pub limit: u64,
+}
+
+impl core::fmt::Display for LimitExceeded {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}: exceeded limit of {} bytes", self.kind, self.limit)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for LimitExceeded {}
+
+#[cfg(feature = "std")]
+impl LimitExceeded {
+    /// Recover the typed cause from an `io::Error` produced by a [`LimitReader`], or `None` if
+    /// the failure came from somewhere else. This is the supported way to classify: matching on
+    /// the rendered message is not a contract.
+    pub fn from_io(err: &std::io::Error) -> Option<Self> {
+        err.get_ref()
+            .and_then(|inner| inner.downcast_ref::<LimitExceeded>())
+            .copied()
+    }
+}
+
 /// A reader that refuses to yield more than `limit` bytes from the wrapped stream.
 ///
 /// The limit is **inclusive**: an input of exactly `limit` bytes is accepted and `limit + 1` is
@@ -27,6 +60,7 @@ pub struct LimitReader<R> {
     inner: R,
     limit: u64,
     read: u64,
+    tripped: bool,
     error_tag: &'static str,
 }
 
@@ -37,6 +71,7 @@ impl<R: Read> LimitReader<R> {
             inner,
             limit,
             read: 0,
+            tripped: false,
             error_tag,
         }
     }
@@ -49,17 +84,40 @@ impl<R: Read> LimitReader<R> {
 }
 
 #[cfg(feature = "std")]
+#[cfg(feature = "std")]
+impl<R> LimitReader<R> {
+    fn overflow(&self) -> std::io::Error {
+        std::io::Error::other(LimitExceeded {
+            kind: self.error_tag,
+            limit: self.limit,
+        })
+    }
+}
+
+#[cfg(feature = "std")]
 impl<R: Read> Read for LimitReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // The overflow is sticky. A consumer that swallows the first error and reads again must
+        // not then be handed a clean EOF, which would present a truncated archive as a complete
+        // one. Once the ceiling is crossed this reader only ever errors.
+        if self.tripped {
+            return Err(self.overflow());
+        }
+
+        // `Read` requires that an empty buffer yields `Ok(0)` without consuming the source. The
+        // boundary probe below reads a byte, so it must not run for a zero-length request.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         if self.read >= self.limit {
             let mut probe = [0u8; 1];
             return match self.inner.read(&mut probe)? {
                 0 => Ok(0),
-                _ => Err(std::io::Error::other(std::format!(
-                    "{}: exceeded limit of {} bytes",
-                    self.error_tag,
-                    self.limit
-                ))),
+                _ => {
+                    self.tripped = true;
+                    Err(self.overflow())
+                }
             };
         }
 
@@ -134,6 +192,75 @@ mod tests {
         let err = read_all(101, 100).unwrap_err();
         assert!(err.to_string().contains('T'), "{err}");
         assert!(err.to_string().contains("100"), "{err}");
+    }
+
+    /// A consumer that ignores the overflow and reads again must not be handed EOF. Without the
+    /// sticky flag the retry probes an exhausted source, sees 0, and reports a clean end of
+    /// input, which presents a truncated archive as a complete one.
+    #[test]
+    fn the_overflow_is_sticky_and_never_degrades_into_eof() {
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; 101]), 100, "T");
+        let mut sink = [0u8; 256];
+        // Drain to the ceiling, then trip it.
+        let mut tripped = false;
+        for _ in 0..8 {
+            match r.read(&mut sink) {
+                Ok(0) => panic!("must not report EOF for an oversized source"),
+                Ok(_) => continue,
+                Err(_) => {
+                    tripped = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            tripped,
+            "the ceiling must be crossed by an oversized source"
+        );
+        for _ in 0..3 {
+            assert!(
+                r.read(&mut sink).is_err(),
+                "every subsequent read must keep failing, never return EOF"
+            );
+        }
+    }
+
+    /// `Read` requires an empty buffer to yield `Ok(0)` without consuming. The boundary probe
+    /// reads a byte, so it must not run for a zero-length request.
+    #[test]
+    fn an_empty_read_consumes_nothing() {
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; 10]), 4, "T");
+        assert_eq!(r.read(&mut []).unwrap(), 0);
+        assert_eq!(
+            r.bytes_read(),
+            0,
+            "an empty read must not consume the source"
+        );
+
+        // And at the boundary, where the probe would otherwise fire.
+        let mut out = [0u8; 4];
+        let _ = r.read(&mut out).unwrap();
+        assert_eq!(r.read(&mut []).unwrap(), 0);
+
+        // The source still has bytes left, so a real read must still detect the overflow.
+        assert!(r.read(&mut out).is_err());
+    }
+
+    /// The cause travels as data. A caller must be able to recover `kind` and `limit` without
+    /// looking at the rendered message, because message text is not a contract.
+    #[test]
+    fn the_cause_is_recoverable_as_a_typed_value() {
+        let err = read_all(101, 100).unwrap_err();
+        let cause =
+            super::LimitExceeded::from_io(&err).expect("typed cause must survive the io layer");
+        assert_eq!(cause.kind, "T");
+        assert_eq!(cause.limit, 100);
+    }
+
+    #[test]
+    fn an_unrelated_io_error_is_not_mistaken_for_a_ceiling() {
+        let other = std::io::Error::other("something else entirely");
+        assert!(super::LimitExceeded::from_io(&other).is_none());
     }
 
     #[test]

--- a/crates/assay-core/src/replay/bundle/io.rs
+++ b/crates/assay-core/src/replay/bundle/io.rs
@@ -80,12 +80,25 @@ pub fn read_bundle_tar_gz<R: Read>(r: R) -> Result<ReadBundle> {
 /// `downcast_ref`. That is the supported way to classify a refusal; matching on the rendered
 /// message is not.
 pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Result<ReadBundle> {
-    // 1. Bound the compressed source before anything downstream sees a byte. Nothing in the
-    //    tar walker or the gzip decoder gets to size its allocation from an untrusted input.
-    let source = LimitReader::new(r, limits.max_source_bytes, LimitKind::SourceBytes);
+    // 1. Snapshot the whole source under the ceiling before parsing anything.
+    //
+    //    Streaming the ceiling into the tar walker only bounds the prefix gzip and tar choose to
+    //    consume. They stop once the archive is logically complete, so a valid bundle followed by
+    //    an arbitrary suffix passed a ceiling far below the real input size: the trailing bytes
+    //    were never requested and therefore never counted. Reading to EOF through the same
+    //    ceiling counts everything the source actually holds.
+    let mut snapshot = Vec::new();
+    LimitReader::new(r, limits.max_source_bytes, LimitKind::SourceBytes)
+        .read_to_end(&mut snapshot)
+        .map_err(|err| {
+            classify_source_ceiling(&err)
+                .map(anyhow::Error::from)
+                .unwrap_or_else(|| anyhow::Error::from(err).context("read bundle source"))
+        })?;
+
     // 2. Bound the gzip expansion. A small compressed input can still decode to gigabytes,
     //    which is what makes the source ceiling on its own insufficient.
-    let decoder = GzDecoder::new(source);
+    let decoder = GzDecoder::new(std::io::Cursor::new(&snapshot));
     let bounded_decoder =
         LimitReader::new(decoder, limits.max_decoded_bytes, LimitKind::DecodedBytes);
     let mut ar = Archive::new(bounded_decoder);

--- a/crates/assay-core/src/replay/bundle/io.rs
+++ b/crates/assay-core/src/replay/bundle/io.rs
@@ -1,5 +1,6 @@
 use super::limits::{
-    classify_member_ceiling, classify_source_ceiling, ReplayIngestError, ReplayLimits,
+    check_manifest_json_depth, classify_member_ceiling, classify_source_ceiling, ReplayIngestError,
+    ReplayLimits,
 };
 use super::{paths, BundleEntry, ReadBundle};
 use crate::replay::manifest::ReplayManifest;
@@ -115,18 +116,19 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
             }));
         }
 
-        let path = e.path().context("entry path")?;
-        let path_str = path.to_string_lossy().replace('\\', "/");
-
-        // Bound path length before any other path work: a hostile archive can carry a
-        // multi-kilobyte name that would otherwise be normalised and cloned into a key.
-        if path_str.len() > limits.max_path_len {
+        // Bound the path on the bytes the archive actually carries, before any conversion.
+        // `to_string_lossy` replaces invalid UTF-8 with U+FFFD, which is three bytes for every
+        // one it replaces, so a check on the converted string measures something the archive did
+        // not send and can be walked past by a name that is invalid on purpose.
+        let raw_path_len = e.path_bytes().len();
+        if raw_path_len > limits.max_path_len {
             return Err(anyhow::Error::from(ReplayIngestError::PathTooLong {
-                path: path_str.clone(),
-                actual: path_str.len(),
                 limit: limits.max_path_len,
             }));
         }
+
+        let path = e.path().context("entry path")?;
+        let path_str = path.to_string_lossy().replace('\\', "/");
 
         if path_str == paths::MANIFEST {
             let mut data = Vec::new();
@@ -137,6 +139,7 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
                     .map(anyhow::Error::from)
                     .unwrap_or_else(|| anyhow::Error::from(err).context("read manifest body"))
             })?;
+            check_manifest_json_depth(&data, limits.max_manifest_json_depth)?;
             manifest_data = Some(data);
             continue;
         }

--- a/crates/assay-core/src/replay/bundle/io.rs
+++ b/crates/assay-core/src/replay/bundle/io.rs
@@ -135,7 +135,7 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
             let mut bounded =
                 LimitReader::new(&mut e, limits.max_manifest_bytes, LimitKind::MemberBytes);
             bounded.read_to_end(&mut data).map_err(|err| {
-                classify_member_ceiling(&err, paths::MANIFEST)
+                classify_member_ceiling(&err)
                     .map(anyhow::Error::from)
                     .unwrap_or_else(|| anyhow::Error::from(err).context("read manifest body"))
             })?;
@@ -144,14 +144,16 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
             continue;
         }
 
-        // Path validation (segments, prefix) comes after the length check so a hostile
-        // path is refused on size before allocation.
+        // Path validation (segments, prefix) runs after the length check, so an oversized name
+        // is refused before it is normalised and cloned into a map key. It is not a claim about
+        // all allocation: the tar reader has already parsed the header, and a PAX extended name
+        // is materialized by that layer before either check sees it.
         paths::validate_entry_path(&path_str)?;
 
         let mut data = Vec::new();
         let mut bounded = LimitReader::new(&mut e, limits.max_member_bytes, LimitKind::MemberBytes);
         bounded.read_to_end(&mut data).map_err(|err| {
-            classify_member_ceiling(&err, &path_str)
+            classify_member_ceiling(&err)
                 .map(anyhow::Error::from)
                 .unwrap_or_else(|| anyhow::Error::from(err).context("read entry body"))
         })?;

--- a/crates/assay-core/src/replay/bundle/io.rs
+++ b/crates/assay-core/src/replay/bundle/io.rs
@@ -144,8 +144,9 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
         let path_str = path.to_string_lossy().replace('\\', "/");
 
         if path_str == paths::MANIFEST {
-            // Refuse before reading, so the manifest that is verified is unambiguously the one
-            // the archive declared first. Overwriting on a second entry let an archive show one
+            // Refuse on meeting a second manifest, before its body is read and before it can
+            // replace the first, so the manifest that is verified is unambiguously the one the
+            // archive declared first. Overwriting on a second entry let an archive show one
             // manifest to whoever inspects the head of the stream and a different one to the
             // verifier, while the non-manifest duplicates were caught and this one was not.
             if manifest_data.is_some() {

--- a/crates/assay-core/src/replay/bundle/io.rs
+++ b/crates/assay-core/src/replay/bundle/io.rs
@@ -1,6 +1,10 @@
+use super::limits::{
+    classify_member_ceiling, classify_source_ceiling, ReplayIngestError, ReplayLimits,
+};
 use super::{paths, BundleEntry, ReadBundle};
 use crate::replay::manifest::ReplayManifest;
 use anyhow::{Context, Result};
+use assay_common::limits::{LimitKind, LimitReader};
 use flate2::read::GzDecoder;
 use flate2::Compression;
 use flate2::GzBuilder;
@@ -58,32 +62,102 @@ fn normalize_path_and_append<T: Write>(
     write_tar_entry(tar, &normalized, data)
 }
 
-/// Read a replay bundle from .tar.gz: parse manifest and collect all entry (path, data).
-/// Paths normalized to POSIX. Enforces same path policy as writer: only manifest.json or
-/// files/, outputs/, cassettes/ (no empty segment, no . or .., no drive letter). Duplicate
-/// paths in tar -> Error. Missing manifest.json -> Error.
+/// Read a replay bundle under the default [`ReplayLimits`].
+///
+/// Kept for existing callers who did not need to name their own budget. New callers should
+/// prefer [`read_bundle_tar_gz_with_limits`] so the ceiling is visible at the call site.
 pub fn read_bundle_tar_gz<R: Read>(r: R) -> Result<ReadBundle> {
-    let dec = GzDecoder::new(r);
-    let mut ar = Archive::new(dec);
+    read_bundle_tar_gz_with_limits(r, ReplayLimits::default())
+}
+
+/// Read a replay bundle under an explicit resource ceiling.
+///
+/// ADR-043 §1: every dimension applies to the source stream before the input is materialised.
+/// The compressed source, the gzip expansion, the manifest, each entry body, path length and
+/// entry count all have their own ceiling; a ceiling that fails to the caller wrapped in
+/// `anyhow::Error` still carries the typed [`ReplayIngestError`] and can be recovered with
+/// `downcast_ref`. That is the supported way to classify a refusal; matching on the rendered
+/// message is not.
+pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Result<ReadBundle> {
+    // 1. Bound the compressed source before anything downstream sees a byte. Nothing in the
+    //    tar walker or the gzip decoder gets to size its allocation from an untrusted input.
+    let source = LimitReader::new(r, limits.max_source_bytes, LimitKind::SourceBytes);
+    // 2. Bound the gzip expansion. A small compressed input can still decode to gigabytes,
+    //    which is what makes the source ceiling on its own insufficient.
+    let decoder = GzDecoder::new(source);
+    let bounded_decoder =
+        LimitReader::new(decoder, limits.max_decoded_bytes, LimitKind::DecodedBytes);
+    let mut ar = Archive::new(bounded_decoder);
+
     let mut manifest_data: Option<Vec<u8>> = None;
-    let mut seen = BTreeMap::new();
-    for entry in ar.entries().context("list tar entries")? {
-        let mut e = entry.context("read tar entry")?;
+    let mut seen: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    // The manifest counts against the entry ceiling too: it is one member the archive
+    // carries.
+    let mut entry_count: usize = 0;
+
+    let entries = ar.entries().map_err(|e| {
+        classify_source_ceiling(&e)
+            .map(anyhow::Error::from)
+            .unwrap_or_else(|| anyhow::Error::from(e).context("list tar entries"))
+    })?;
+
+    for entry in entries {
+        let mut e = entry.map_err(|err| {
+            classify_source_ceiling(&err)
+                .map(anyhow::Error::from)
+                .unwrap_or_else(|| anyhow::Error::from(err).context("read tar entry"))
+        })?;
+
+        entry_count += 1;
+        if entry_count > limits.max_entries {
+            return Err(anyhow::Error::from(ReplayIngestError::TooManyEntries {
+                limit: limits.max_entries,
+            }));
+        }
+
         let path = e.path().context("entry path")?;
         let path_str = path.to_string_lossy().replace('\\', "/");
+
+        // Bound path length before any other path work: a hostile archive can carry a
+        // multi-kilobyte name that would otherwise be normalised and cloned into a key.
+        if path_str.len() > limits.max_path_len {
+            return Err(anyhow::Error::from(ReplayIngestError::PathTooLong {
+                path: path_str.clone(),
+                actual: path_str.len(),
+                limit: limits.max_path_len,
+            }));
+        }
+
         if path_str == paths::MANIFEST {
             let mut data = Vec::new();
-            e.read_to_end(&mut data).context("read manifest body")?;
+            let mut bounded =
+                LimitReader::new(&mut e, limits.max_manifest_bytes, LimitKind::MemberBytes);
+            bounded.read_to_end(&mut data).map_err(|err| {
+                classify_member_ceiling(&err, paths::MANIFEST)
+                    .map(anyhow::Error::from)
+                    .unwrap_or_else(|| anyhow::Error::from(err).context("read manifest body"))
+            })?;
             manifest_data = Some(data);
             continue;
         }
+
+        // Path validation (segments, prefix) comes after the length check so a hostile
+        // path is refused on size before allocation.
         paths::validate_entry_path(&path_str)?;
+
         let mut data = Vec::new();
-        e.read_to_end(&mut data).context("read entry body")?;
+        let mut bounded = LimitReader::new(&mut e, limits.max_member_bytes, LimitKind::MemberBytes);
+        bounded.read_to_end(&mut data).map_err(|err| {
+            classify_member_ceiling(&err, &path_str)
+                .map(anyhow::Error::from)
+                .unwrap_or_else(|| anyhow::Error::from(err).context("read entry body"))
+        })?;
+
         if seen.insert(path_str.clone(), data).is_some() {
             anyhow::bail!("duplicate path in bundle: {}", path_str);
         }
     }
+
     let manifest_json = manifest_data.context("manifest.json missing in bundle")?;
     let manifest: ReplayManifest =
         serde_json::from_slice(&manifest_json).context("parse manifest.json")?;

--- a/crates/assay-core/src/replay/bundle/io.rs
+++ b/crates/assay-core/src/replay/bundle/io.rs
@@ -1,6 +1,6 @@
 use super::limits::{
-    check_manifest_json_depth, classify_member_ceiling, classify_source_ceiling, ReplayIngestError,
-    ReplayLimits,
+    check_manifest_json_depth, classify_member_ceiling, classify_source_ceiling,
+    ReplayContractError, ReplayIngestError, ReplayLimits,
 };
 use super::{paths, BundleEntry, ReadBundle};
 use crate::replay::manifest::ReplayManifest;
@@ -144,6 +144,13 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
         let path_str = path.to_string_lossy().replace('\\', "/");
 
         if path_str == paths::MANIFEST {
+            // Refuse before reading, so the manifest that is verified is unambiguously the one
+            // the archive declared first. Overwriting on a second entry let an archive show one
+            // manifest to whoever inspects the head of the stream and a different one to the
+            // verifier, while the non-manifest duplicates were caught and this one was not.
+            if manifest_data.is_some() {
+                return Err(anyhow::Error::from(ReplayContractError::DuplicateManifest));
+            }
             let mut data = Vec::new();
             let mut bounded =
                 LimitReader::new(&mut e, limits.max_manifest_bytes, LimitKind::MemberBytes);
@@ -161,7 +168,14 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
         // is refused before it is normalised and cloned into a map key. It is not a claim about
         // all allocation: the tar reader has already parsed the header, and a PAX extended name
         // is materialized by that layer before either check sees it.
-        paths::validate_entry_path(&path_str)?;
+        // Use what the validator returns, never the string that was handed to it. The validator
+        // trims leading slashes as part of normalising, so `/files/x` passes as `files/x` — and
+        // storing the raw name meant the value that was checked and the value that was kept were
+        // two different strings. The consumer does `workspace.join(rel)`, and joining an absolute
+        // path discards the workspace prefix entirely, so that gap materialized entries at the
+        // filesystem root. Validating one form and keeping another is the defect; the canonical
+        // path is the only form allowed past this point.
+        let canonical = paths::validate_entry_path(&path_str)?;
 
         let mut data = Vec::new();
         let mut bounded = LimitReader::new(&mut e, limits.max_member_bytes, LimitKind::MemberBytes);
@@ -171,8 +185,10 @@ pub fn read_bundle_tar_gz_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Re
                 .unwrap_or_else(|| anyhow::Error::from(err).context("read entry body"))
         })?;
 
-        if seen.insert(path_str.clone(), data).is_some() {
-            anyhow::bail!("duplicate path in bundle: {}", path_str);
+        // Detection is on the canonical form too, so two spellings of one path collide instead of
+        // producing two entries that a consumer resolves to the same file.
+        if seen.insert(canonical, data).is_some() {
+            return Err(anyhow::Error::from(ReplayContractError::DuplicatePath));
         }
     }
 

--- a/crates/assay-core/src/replay/bundle/limits.rs
+++ b/crates/assay-core/src/replay/bundle/limits.rs
@@ -102,11 +102,21 @@ pub(crate) fn classify_source_ceiling(err: &std::io::Error) -> Option<ReplayInge
 
 /// Same as [`classify_source_ceiling`] but for reads scoped to a single member (the manifest
 /// or an entry body).
+/// A member read sits on top of the decoder, so an overflow surfacing here is not necessarily a
+/// member overflow: the expansion ceiling trips through the same call. Only `MemberBytes` is a
+/// member refusal; every other dimension keeps its own classification, otherwise a decode ceiling
+/// is reported as if a single file were too large.
 pub(crate) fn classify_member_ceiling(err: &std::io::Error) -> Option<ReplayIngestError> {
     let cause = LimitExceeded::from_io(err)?;
-    Some(ReplayIngestError::MemberCeiling {
-        kind: cause.kind,
-        limit: cause.limit,
+    Some(match cause.kind {
+        LimitKind::MemberBytes => ReplayIngestError::MemberCeiling {
+            kind: cause.kind,
+            limit: cause.limit,
+        },
+        other => ReplayIngestError::SourceCeiling {
+            kind: other,
+            limit: cause.limit,
+        },
     })
 }
 

--- a/crates/assay-core/src/replay/bundle/limits.rs
+++ b/crates/assay-core/src/replay/bundle/limits.rs
@@ -89,6 +89,30 @@ pub enum ReplayIngestError {
     ManifestTooDeep { limit: usize },
 }
 
+/// A structural contract violation in the bundle, as opposed to a resource refusal.
+///
+/// Kept out of [`ReplayIngestError`] deliberately. The CLI maps every ingest refusal to
+/// `E_REPLAY_LIMIT_EXCEEDED`, whose whole meaning is "the bundle is fine, your budget is not" —
+/// an operator can respond by raising a ceiling. A duplicate entry is the opposite: the bundle is
+/// malformed and no budget will fix it. Folding these into the same type would tell an operator
+/// to raise a limit against an archive that must instead be rejected.
+///
+/// Value-free like the ingest refusals. The offending path is chosen by the archive, so echoing
+/// it hands an attacker a channel into the operator's terminal and into every log that ingests
+/// the message, while telling the reader nothing they can act on.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ReplayContractError {
+    /// Two entries normalize to the same path. Last-wins is undefined, and silently keeping one
+    /// lets an archive present different bytes to a verifier than to a consumer.
+    #[error("replay bundle contains duplicate entry paths")]
+    DuplicatePath,
+
+    /// A second `manifest.json`. Detected before the first is read or replaced, so the manifest
+    /// that is verified is unambiguously the one the archive declared first.
+    #[error("replay bundle contains more than one manifest")]
+    DuplicateManifest,
+}
+
 /// If `err` was produced by a [`LimitReader`](assay_common::limits::LimitReader) that wraps
 /// the compressed source or gzip stream, promote it to a `ReplayIngestError::SourceCeiling`.
 /// Otherwise return `None` so the caller can keep its own classification.
@@ -108,15 +132,23 @@ pub(crate) fn classify_source_ceiling(err: &std::io::Error) -> Option<ReplayInge
 /// is reported as if a single file were too large.
 pub(crate) fn classify_member_ceiling(err: &std::io::Error) -> Option<ReplayIngestError> {
     let cause = LimitExceeded::from_io(err)?;
+    // Listed exhaustively rather than with a wildcard. `LimitKind` is deliberately not
+    // `#[non_exhaustive]` so that adding a dimension breaks every consumer at compile time; a
+    // catch-all arm here would defeat that by quietly folding a new ceiling into `SourceCeiling`,
+    // which is the one classification the caller cannot tell apart from a genuine source refusal.
     Some(match cause.kind {
         LimitKind::MemberBytes => ReplayIngestError::MemberCeiling {
             kind: cause.kind,
             limit: cause.limit,
         },
-        other => ReplayIngestError::SourceCeiling {
-            kind: other,
-            limit: cause.limit,
-        },
+        // A member read sits under the decoder and the source reader, so either of their ceilings
+        // can surface here. Both are source-side refusals from the caller's point of view.
+        LimitKind::SourceBytes | LimitKind::DecodedBytes | LimitKind::LineBytes => {
+            ReplayIngestError::SourceCeiling {
+                kind: cause.kind,
+                limit: cause.limit,
+            }
+        }
     })
 }
 

--- a/crates/assay-core/src/replay/bundle/limits.rs
+++ b/crates/assay-core/src/replay/bundle/limits.rs
@@ -1,0 +1,155 @@
+//! Replay-bundle-local resource ceilings and their typed refusals.
+//!
+//! ADR-043 §1 requires every ingest entrypoint to apply the whole limit set to the source
+//! stream before the input is materialized. The evidence verifier already does this through
+//! its own [`VerifyLimits`], but replay used to have no ceilings at all: `read_bundle_tar_gz`
+//! read every entry with an unbounded `read_to_end`, on top of an unbounded gzip decoder, on
+//! top of an unbounded compressed source.
+//!
+//! The mechanism moves through the shared [`assay_common::limits::LimitReader`] primitive.
+//! The *vocabulary* stays local: a replay bundle is not an evidence bundle, its members are
+//! not events or manifests in the evidence sense, and dragging `VerifyLimits` into
+//! `assay-core` would tell downstream readers that the two contracts agree when they do not.
+//! Callers who really want to share a ceiling still can, by initialising both structs from
+//! the same numbers.
+//!
+//! Refusals travel as [`ReplayIngestError`]. The typed cause on the underlying `io::Error`
+//! is a [`LimitExceeded`], recovered through `LimitExceeded::from_io`; the enum wraps that
+//! with the semantic context the reader had at the time (which member, which path). Callers
+//! match the enum, not the rendered text.
+
+use assay_common::limits::{LimitExceeded, LimitKind};
+
+/// Resource ceilings applied while reading a replay bundle.
+///
+/// Numbers deliberately match the evidence defaults where the two contracts describe the same
+/// resource (compressed source and gzip expansion); the per-member and entry-count values
+/// come from what a replay bundle actually contains: a manifest, a handful of small files,
+/// and cassettes that fit under `max_member_bytes`.
+#[derive(Debug, Clone, Copy)]
+pub struct ReplayLimits {
+    /// Maximum bytes read from the compressed source.
+    pub max_source_bytes: u64,
+    /// Maximum bytes produced by the gzip decoder.
+    pub max_decoded_bytes: u64,
+    /// Maximum bytes of `manifest.json`.
+    pub max_manifest_bytes: u64,
+    /// Maximum bytes of any single non-manifest member.
+    pub max_member_bytes: u64,
+    /// Maximum length in bytes of any entry path.
+    pub max_path_len: usize,
+    /// Maximum number of entries in the archive (including the manifest).
+    pub max_entries: usize,
+}
+
+impl Default for ReplayLimits {
+    fn default() -> Self {
+        Self {
+            max_source_bytes: 100 * 1024 * 1024,   // 100 MiB compressed
+            max_decoded_bytes: 1024 * 1024 * 1024, // 1 GiB expanded
+            max_manifest_bytes: 10 * 1024 * 1024,  // 10 MiB
+            max_member_bytes: 500 * 1024 * 1024,   // 500 MiB per file (large cassettes)
+            max_path_len: 256,
+            max_entries: 100_000,
+        }
+    }
+}
+
+/// Refusal raised by the bounded replay reader. Callers match the variant; the rendered
+/// message is a diagnostic, never a contract.
+#[derive(Debug, thiserror::Error)]
+pub enum ReplayIngestError {
+    #[error("replay bundle exceeded {kind} limit of {limit}")]
+    SourceCeiling { kind: LimitKind, limit: u64 },
+
+    #[error("replay bundle {member} exceeded {kind} limit of {limit}")]
+    MemberCeiling {
+        member: String,
+        kind: LimitKind,
+        limit: u64,
+    },
+
+    #[error("replay bundle entry path length {actual} exceeds limit {limit} (path: {path})")]
+    PathTooLong {
+        path: String,
+        actual: usize,
+        limit: usize,
+    },
+
+    #[error("replay bundle entry count exceeds limit {limit}")]
+    TooManyEntries { limit: usize },
+}
+
+/// If `err` was produced by a [`LimitReader`](assay_common::limits::LimitReader) that wraps
+/// the compressed source or gzip stream, promote it to a `ReplayIngestError::SourceCeiling`.
+/// Otherwise return `None` so the caller can keep its own classification.
+pub(crate) fn classify_source_ceiling(err: &std::io::Error) -> Option<ReplayIngestError> {
+    let cause = LimitExceeded::from_io(err)?;
+    Some(ReplayIngestError::SourceCeiling {
+        kind: cause.kind,
+        limit: cause.limit,
+    })
+}
+
+/// Same as [`classify_source_ceiling`] but for reads scoped to a single member (the manifest
+/// or an entry body). The member's identifier is carried through so the diagnostic names
+/// what tripped rather than reporting an anonymous byte count.
+pub(crate) fn classify_member_ceiling(
+    err: &std::io::Error,
+    member: &str,
+) -> Option<ReplayIngestError> {
+    let cause = LimitExceeded::from_io(err)?;
+    Some(ReplayIngestError::MemberCeiling {
+        member: member.to_string(),
+        kind: cause.kind,
+        limit: cause.limit,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_common::limits::{LimitExceeded, LimitKind};
+
+    fn make_io(kind: LimitKind, limit: u64) -> std::io::Error {
+        std::io::Error::other(LimitExceeded { kind, limit })
+    }
+
+    /// Classification goes through the typed cause, not the message. If it went through the
+    /// message, a reworded diagnostic on `LimitExceeded` would silently reclassify.
+    #[test]
+    fn source_ceiling_is_recovered_from_the_typed_cause() {
+        let io = make_io(LimitKind::DecodedBytes, 1024);
+        match classify_source_ceiling(&io) {
+            Some(ReplayIngestError::SourceCeiling { kind, limit }) => {
+                assert_eq!(kind, LimitKind::DecodedBytes);
+                assert_eq!(limit, 1024);
+            }
+            other => panic!("expected SourceCeiling, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn member_ceiling_carries_the_member_name() {
+        let io = make_io(LimitKind::MemberBytes, 42);
+        match classify_member_ceiling(&io, "files/trace.jsonl") {
+            Some(ReplayIngestError::MemberCeiling {
+                member,
+                kind,
+                limit,
+            }) => {
+                assert_eq!(member, "files/trace.jsonl");
+                assert_eq!(kind, LimitKind::MemberBytes);
+                assert_eq!(limit, 42);
+            }
+            other => panic!("expected MemberCeiling, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_non_ceiling_io_error_is_not_promoted() {
+        let io = std::io::Error::other("something else entirely");
+        assert!(classify_source_ceiling(&io).is_none());
+        assert!(classify_member_ceiling(&io, "files/x").is_none());
+    }
+}

--- a/crates/assay-core/src/replay/bundle/limits.rs
+++ b/crates/assay-core/src/replay/bundle/limits.rs
@@ -70,12 +70,11 @@ pub enum ReplayIngestError {
     #[error("replay bundle exceeded {kind} limit of {limit}")]
     SourceCeiling { kind: LimitKind, limit: u64 },
 
-    #[error("replay bundle {member} exceeded {kind} limit of {limit}")]
-    MemberCeiling {
-        member: String,
-        kind: LimitKind,
-        limit: u64,
-    },
+    /// Value-free like the others: the member name comes from the archive, so echoing it hands
+    /// an attacker a channel into the diagnostic while telling the reader nothing they can act
+    /// on. The dimension and the ceiling are what distinguishes this from a source refusal.
+    #[error("replay bundle member exceeded {kind} limit of {limit}")]
+    MemberCeiling { kind: LimitKind, limit: u64 },
 
     /// Deliberately free of the offending value. The path and its length are chosen by the
     /// archive, and echoing either back gives a reader nothing to act on while handing an
@@ -102,15 +101,10 @@ pub(crate) fn classify_source_ceiling(err: &std::io::Error) -> Option<ReplayInge
 }
 
 /// Same as [`classify_source_ceiling`] but for reads scoped to a single member (the manifest
-/// or an entry body). The member's identifier is carried through so the diagnostic names
-/// what tripped rather than reporting an anonymous byte count.
-pub(crate) fn classify_member_ceiling(
-    err: &std::io::Error,
-    member: &str,
-) -> Option<ReplayIngestError> {
+/// or an entry body).
+pub(crate) fn classify_member_ceiling(err: &std::io::Error) -> Option<ReplayIngestError> {
     let cause = LimitExceeded::from_io(err)?;
     Some(ReplayIngestError::MemberCeiling {
-        member: member.to_string(),
         kind: cause.kind,
         limit: cause.limit,
     })
@@ -177,27 +171,33 @@ mod tests {
         }
     }
 
+    /// The dimension and the ceiling travel; the member name does not. It is archive-controlled
+    /// and adds nothing a reader can act on.
     #[test]
-    fn member_ceiling_carries_the_member_name() {
+    fn member_ceiling_carries_the_dimension_and_not_the_member_name() {
         let io = make_io(LimitKind::MemberBytes, 42);
-        match classify_member_ceiling(&io, "files/trace.jsonl") {
-            Some(ReplayIngestError::MemberCeiling {
-                member,
-                kind,
-                limit,
-            }) => {
-                assert_eq!(member, "files/trace.jsonl");
+        match classify_member_ceiling(&io) {
+            Some(ReplayIngestError::MemberCeiling { kind, limit }) => {
                 assert_eq!(kind, LimitKind::MemberBytes);
                 assert_eq!(limit, 42);
             }
             other => panic!("expected MemberCeiling, got {other:?}"),
         }
+        let rendered = ReplayIngestError::MemberCeiling {
+            kind: LimitKind::MemberBytes,
+            limit: 42,
+        }
+        .to_string();
+        assert!(
+            !rendered.contains('/'),
+            "no archive path may appear: {rendered}"
+        );
     }
 
     #[test]
     fn a_non_ceiling_io_error_is_not_promoted() {
         let io = std::io::Error::other("something else entirely");
         assert!(classify_source_ceiling(&io).is_none());
-        assert!(classify_member_ceiling(&io, "files/x").is_none());
+        assert!(classify_member_ceiling(&io).is_none());
     }
 }

--- a/crates/assay-core/src/replay/bundle/limits.rs
+++ b/crates/assay-core/src/replay/bundle/limits.rs
@@ -40,6 +40,13 @@ pub struct ReplayLimits {
     pub max_path_len: usize,
     /// Maximum number of entries in the archive (including the manifest).
     pub max_entries: usize,
+    /// Maximum JSON nesting depth accepted in `manifest.json`.
+    ///
+    /// A ceiling on manifest *bytes* says nothing about its shape: a small document can nest
+    /// deeply enough to exhaust the stack in the parser. The evidence side carries the same
+    /// dimension as `max_json_depth`; replay names it locally for the same reason the rest of
+    /// this struct is local.
+    pub max_manifest_json_depth: usize,
 }
 
 impl Default for ReplayLimits {
@@ -51,6 +58,7 @@ impl Default for ReplayLimits {
             max_member_bytes: 500 * 1024 * 1024,   // 500 MiB per file (large cassettes)
             max_path_len: 256,
             max_entries: 100_000,
+            max_manifest_json_depth: 64,
         }
     }
 }
@@ -69,15 +77,17 @@ pub enum ReplayIngestError {
         limit: u64,
     },
 
-    #[error("replay bundle entry path length {actual} exceeds limit {limit} (path: {path})")]
-    PathTooLong {
-        path: String,
-        actual: usize,
-        limit: usize,
-    },
+    /// Deliberately free of the offending value. The path and its length are chosen by the
+    /// archive, and echoing either back gives a reader nothing to act on while handing an
+    /// attacker a channel into the diagnostic.
+    #[error("replay bundle entry path exceeds the configured maximum length of {limit}")]
+    PathTooLong { limit: usize },
 
     #[error("replay bundle entry count exceeds limit {limit}")]
     TooManyEntries { limit: usize },
+
+    #[error("replay bundle manifest JSON nesting exceeds the configured maximum depth of {limit}")]
+    ManifestTooDeep { limit: usize },
 }
 
 /// If `err` was produced by a [`LimitReader`](assay_common::limits::LimitReader) that wraps
@@ -104,6 +114,44 @@ pub(crate) fn classify_member_ceiling(
         kind: cause.kind,
         limit: cause.limit,
     })
+}
+
+/// Refuse a manifest whose JSON nests deeper than the configured ceiling.
+///
+/// Counts structural depth over the raw bytes rather than parsing first: handing an unbounded
+/// document to `serde_json` is the thing the ceiling exists to prevent, so the check cannot
+/// depend on the parse succeeding.
+pub(crate) fn check_manifest_json_depth(
+    data: &[u8],
+    max_depth: usize,
+) -> Result<(), ReplayIngestError> {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for &b in data {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > max_depth {
+                    return Err(ReplayIngestError::ManifestTooDeep { limit: max_depth });
+                }
+            }
+            b'}' | b']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/assay-core/src/replay/bundle/limits.rs
+++ b/crates/assay-core/src/replay/bundle/limits.rs
@@ -92,10 +92,12 @@ pub enum ReplayIngestError {
 /// A structural contract violation in the bundle, as opposed to a resource refusal.
 ///
 /// Kept out of [`ReplayIngestError`] deliberately. The CLI maps every ingest refusal to
-/// `E_REPLAY_LIMIT_EXCEEDED`, whose whole meaning is "the bundle is fine, your budget is not" —
-/// an operator can respond by raising a ceiling. A duplicate entry is the opposite: the bundle is
-/// malformed and no budget will fix it. Folding these into the same type would tell an operator
-/// to raise a limit against an archive that must instead be rejected.
+/// `E_REPLAY_LIMIT_EXCEEDED`, which says a configured budget was exceeded and nothing more:
+/// adjusting the budget or supplying a smaller bundle is a legitimate response, and it is not a
+/// malformed-input finding. It is also not a clean bill of health — the read stopped at the
+/// ceiling, so whatever lies past it was never examined. A duplicate entry is a different kind of
+/// answer: the archive is malformed and no budget will fix it. Folding these into one type would
+/// tell an operator to raise a limit against an archive that must instead be rejected.
 ///
 /// Value-free like the ingest refusals. The offending path is chosen by the archive, so echoing
 /// it hands an attacker a channel into the operator's terminal and into every log that ingests
@@ -107,7 +109,8 @@ pub enum ReplayContractError {
     #[error("replay bundle contains duplicate entry paths")]
     DuplicatePath,
 
-    /// A second `manifest.json`. Detected before the first is read or replaced, so the manifest
+    /// A second `manifest.json`. Detected when the second is met — after the first has been read,
+    /// but before the second is read and before it can replace the first — so the manifest
     /// that is verified is unambiguously the one the archive declared first.
     #[error("replay bundle contains more than one manifest")]
     DuplicateManifest,

--- a/crates/assay-core/src/replay/bundle/mod.rs
+++ b/crates/assay-core/src/replay/bundle/mod.rs
@@ -5,6 +5,7 @@
 //! No user-facing CLI here (E9c); this is the core library for bundle creation.
 
 mod io;
+mod limits;
 mod manifest;
 pub mod paths;
 mod verify;
@@ -28,7 +29,8 @@ pub struct ReadBundle {
     pub entries: Vec<(String, Vec<u8>)>,
 }
 
-pub use io::{read_bundle_tar_gz, write_bundle_tar_gz};
+pub use io::{read_bundle_tar_gz, read_bundle_tar_gz_with_limits, write_bundle_tar_gz};
+pub use limits::{ReplayIngestError, ReplayLimits};
 pub use manifest::build_file_manifest;
 pub use verify::bundle_digest;
 

--- a/crates/assay-core/src/replay/bundle/mod.rs
+++ b/crates/assay-core/src/replay/bundle/mod.rs
@@ -5,7 +5,7 @@
 //! No user-facing CLI here (E9c); this is the core library for bundle creation.
 
 mod io;
-mod limits;
+pub(crate) mod limits;
 mod manifest;
 pub mod paths;
 mod verify;

--- a/crates/assay-core/src/replay/bundle/mod.rs
+++ b/crates/assay-core/src/replay/bundle/mod.rs
@@ -30,7 +30,7 @@ pub struct ReadBundle {
 }
 
 pub use io::{read_bundle_tar_gz, read_bundle_tar_gz_with_limits, write_bundle_tar_gz};
-pub use limits::{ReplayIngestError, ReplayLimits};
+pub use limits::{ReplayContractError, ReplayIngestError, ReplayLimits};
 pub use manifest::build_file_manifest;
 pub use verify::bundle_digest;
 

--- a/crates/assay-core/src/replay/bundle/tests.rs
+++ b/crates/assay-core/src/replay/bundle/tests.rs
@@ -568,7 +568,15 @@ mod bounded_ingest {
             max_source_bytes: ceiling,
             ..ReplayLimits::default()
         };
-        assert!(read_bundle_tar_gz_with_limits(source, limits).is_err());
+        let err = read_bundle_tar_gz_with_limits(source, limits)
+            .expect_err("a bundle over the source ceiling must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::SourceCeiling { kind, limit }) => {
+                assert_eq!(*kind, LimitKind::SourceBytes);
+                assert_eq!(*limit, ceiling);
+            }
+            other => panic!("expected a typed SourceCeiling, got {other:?}"),
+        }
         assert!(
             pulled.get() <= ceiling + 1,
             "ingest must stop at the ceiling; {} bytes were pulled",
@@ -589,9 +597,9 @@ mod bounded_ingest {
         let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), limits)
             .expect_err("a 4 KiB member must be refused under a 64 byte ceiling");
         match err.downcast_ref::<ReplayIngestError>() {
-            Some(ReplayIngestError::MemberCeiling { member, kind, .. }) => {
-                assert_eq!(member, "files/trace.jsonl");
+            Some(ReplayIngestError::MemberCeiling { kind, limit }) => {
                 assert_eq!(*kind, LimitKind::MemberBytes);
+                assert_eq!(*limit, 64);
             }
             other => panic!("expected a typed MemberCeiling, got {other:?}"),
         }
@@ -657,6 +665,30 @@ mod bounded_ingest {
             .expect("the same bundle must read under the default entry ceiling");
     }
 
+    /// `max_manifest_bytes` had no test of its own: the member ceiling covered entry bodies and
+    /// the manifest was assumed to travel with them. It does not, it has its own dimension, and
+    /// its refusal has to be distinguishable.
+    #[test]
+    fn a_manifest_over_its_own_ceiling_is_refused() {
+        let bytes = small_bundle();
+        let tight = ReplayLimits {
+            max_manifest_bytes: 8,
+            ..ReplayLimits::default()
+        };
+        let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), tight)
+            .expect_err("a manifest over its own ceiling must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::MemberCeiling { kind, limit }) => {
+                assert_eq!(*kind, LimitKind::MemberBytes);
+                assert_eq!(*limit, 8, "the manifest ceiling must be the one reported");
+            }
+            other => panic!("expected a typed MemberCeiling on the manifest, got {other:?}"),
+        }
+
+        read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
+            .expect("the same manifest must read under the default ceiling");
+    }
+
     /// The manifest ceiling is about shape, not size: a small document can nest deeply enough to
     /// exhaust the parser, and `max_manifest_bytes` says nothing about that.
     #[test]
@@ -677,8 +709,9 @@ mod bounded_ingest {
             .expect("the same manifest must read under the default depth");
     }
 
-    /// Exactly the ceiling is accepted and one deeper is refused, pinned against the real
-    /// manifest rather than a hand-built document, so the boundary is the one callers meet.
+    /// Exactly the ceiling is accepted and one deeper is refused. This exercises the depth
+    /// counter directly on hand-built documents, because a written manifest has a fixed shape and
+    /// cannot express the +/-1 boundary; the end-to-end case above covers the real manifest.
     #[test]
     fn the_manifest_depth_boundary_is_exact() {
         use super::super::limits::check_manifest_json_depth;
@@ -718,14 +751,15 @@ mod bounded_ingest {
         };
         let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), limits)
             .expect_err("expansion past the decode ceiling must be refused");
+        // One expected variant, not "either of two". The decoder sits above the tar walker, so
+        // the expansion ceiling trips while the walker is pulling an entry body, which is the
+        // member-scoped classification path.
         match err.downcast_ref::<ReplayIngestError>() {
-            Some(ReplayIngestError::SourceCeiling { kind, .. }) => {
-                assert_eq!(*kind, LimitKind::DecodedBytes)
+            Some(ReplayIngestError::MemberCeiling { kind, limit }) => {
+                assert_eq!(*kind, LimitKind::DecodedBytes);
+                assert_eq!(*limit, 4096);
             }
-            Some(ReplayIngestError::MemberCeiling { kind, .. }) => {
-                assert_eq!(*kind, LimitKind::DecodedBytes)
-            }
-            other => panic!("expected a decode ceiling refusal, got {other:?}"),
+            other => panic!("expected a typed MemberCeiling on DecodedBytes, got {other:?}"),
         }
 
         read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())

--- a/crates/assay-core/src/replay/bundle/tests.rs
+++ b/crates/assay-core/src/replay/bundle/tests.rs
@@ -557,6 +557,156 @@ mod bounded_ingest {
         )
     }
 
+    /// The promise of `read_verify_bounded` is that three things describe one snapshot. Nothing
+    /// tested that promise: the digest could have been computed over a different read and every
+    /// other assertion would still have passed.
+    #[test]
+    fn the_bounded_helper_binds_digest_parse_and_verdict_to_one_read() {
+        use crate::replay::read_verify_bounded;
+        use sha2::{Digest, Sha256};
+
+        let bytes = small_bundle();
+        let expected = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
+
+        let (source, pulled) = counting(bytes.clone());
+        let snapshot = read_verify_bounded(source, ReplayLimits::default())
+            .expect("a well-formed bundle must read, digest and verify");
+
+        assert_eq!(
+            snapshot.source_digest, expected,
+            "the digest must cover exactly the bytes that were read"
+        );
+        assert_eq!(
+            pulled.get(),
+            bytes.len() as u64,
+            "the source must be consumed once; {} bytes pulled for a {} byte input",
+            pulled.get(),
+            bytes.len()
+        );
+        assert!(
+            snapshot.verify.errors.is_empty(),
+            "the verdict must belong to the same snapshot: {:?}",
+            snapshot.verify.errors
+        );
+        assert!(
+            snapshot
+                .read
+                .entries
+                .iter()
+                .any(|(p, _)| p == "files/trace.jsonl"),
+            "the parsed bundle must come from that same read"
+        );
+    }
+
+    /// The helper is the recommended entrypoint, so it has to carry the same typed contract as
+    /// the reader it wraps.
+    ///
+    /// This is also the only place the source boundary is exactly measurable. The helper does a
+    /// `read_to_end` on the source, so every byte is pulled and `len` versus `len - 1` is a real
+    /// boundary. Through `read_bundle_tar_gz_with_limits` it is not: tar and gzip stop once the
+    /// archive is logically complete, so the last bytes are never requested and a ceiling just
+    /// under the file size is never crossed. A test asserting otherwise there would be asserting
+    /// the fixture, not the ceiling. Wrapping the io error in context first buried the cause and returned
+    /// a weaker refusal than the lower-level call.
+    #[test]
+    fn the_bounded_helper_reports_a_typed_source_ceiling() {
+        use crate::replay::read_verify_bounded;
+
+        let bytes = small_bundle();
+        let ceiling = bytes.len() as u64 - 1;
+        let limits = ReplayLimits {
+            max_source_bytes: ceiling,
+            ..ReplayLimits::default()
+        };
+        let err = read_verify_bounded(Cursor::new(bytes.clone()), limits)
+            .expect_err("one byte over the source ceiling must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::SourceCeiling { kind, limit }) => {
+                assert_eq!(*kind, LimitKind::SourceBytes);
+                assert_eq!(*limit, ceiling);
+            }
+            other => panic!("expected a typed SourceCeiling from the helper, got {other:?}"),
+        }
+
+        let exact = ReplayLimits {
+            max_source_bytes: bytes.len() as u64,
+            ..ReplayLimits::default()
+        };
+        read_verify_bounded(Cursor::new(bytes), exact)
+            .expect("a source of exactly the ceiling must be accepted");
+    }
+
+    #[test]
+    fn the_member_boundary_is_exact() {
+        let payload = vec![b'z'; 4096];
+        let bytes = bundle_with(vec![BundleEntry {
+            path: "files/trace.jsonl".into(),
+            data: payload.clone(),
+        }]);
+        let size = payload.len() as u64;
+
+        read_bundle_tar_gz_with_limits(
+            Cursor::new(bytes.clone()),
+            ReplayLimits {
+                max_member_bytes: size,
+                ..ReplayLimits::default()
+            },
+        )
+        .expect("a member of exactly the ceiling must be accepted");
+
+        let err = read_bundle_tar_gz_with_limits(
+            Cursor::new(bytes),
+            ReplayLimits {
+                max_member_bytes: size - 1,
+                ..ReplayLimits::default()
+            },
+        )
+        .expect_err("one byte over the member ceiling must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::MemberCeiling { kind, limit }) => {
+                assert_eq!(*kind, LimitKind::MemberBytes);
+                assert_eq!(*limit, size - 1);
+            }
+            other => panic!("expected a typed MemberCeiling, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_manifest_boundary_is_exact() {
+        let manifest = ReplayManifest::minimal("2.15.0".into());
+        // The writer serializes the manifest with `serde_json::to_vec`, so the same call gives
+        // the exact member size the ceiling is compared against.
+        let size = serde_json::to_vec(&manifest)
+            .expect("serialize manifest")
+            .len() as u64;
+        let bytes = small_bundle();
+
+        read_bundle_tar_gz_with_limits(
+            Cursor::new(bytes.clone()),
+            ReplayLimits {
+                max_manifest_bytes: size,
+                ..ReplayLimits::default()
+            },
+        )
+        .expect("a manifest of exactly the ceiling must be accepted");
+
+        let err = read_bundle_tar_gz_with_limits(
+            Cursor::new(bytes),
+            ReplayLimits {
+                max_manifest_bytes: size - 1,
+                ..ReplayLimits::default()
+            },
+        )
+        .expect_err("one byte over the manifest ceiling must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::MemberCeiling { kind, limit }) => {
+                assert_eq!(*kind, LimitKind::MemberBytes);
+                assert_eq!(*limit, size - 1);
+            }
+            other => panic!("expected a typed MemberCeiling on the manifest, got {other:?}"),
+        }
+    }
+
     #[test]
     fn the_compressed_source_stops_being_read_at_the_ceiling() {
         let bytes = small_bundle();

--- a/crates/assay-core/src/replay/bundle/tests.rs
+++ b/crates/assay-core/src/replay/bundle/tests.rs
@@ -569,8 +569,10 @@ mod bounded_ingest {
         let expected = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
 
         let (source, pulled) = counting(bytes.clone());
-        let snapshot = read_verify_bounded(source, ReplayLimits::default())
-            .expect("a well-formed bundle must read, digest and verify");
+        let snapshot = match read_verify_bounded(source, ReplayLimits::default()) {
+            Ok(s) => s,
+            Err(e) => panic!("a well-formed bundle must read, digest and verify: {e}"),
+        };
 
         assert_eq!(
             snapshot.source_digest, expected,
@@ -601,12 +603,10 @@ mod bounded_ingest {
     /// The helper is the recommended entrypoint, so it has to carry the same typed contract as
     /// the reader it wraps.
     ///
-    /// This is also the only place the source boundary is exactly measurable. The helper does a
-    /// `read_to_end` on the source, so every byte is pulled and `len` versus `len - 1` is a real
-    /// boundary. Through `read_bundle_tar_gz_with_limits` it is not: tar and gzip stop once the
-    /// archive is logically complete, so the last bytes are never requested and a ceiling just
-    /// under the file size is never crossed. A test asserting otherwise there would be asserting
-    /// the fixture, not the ceiling. Wrapping the io error in context first buried the cause and returned
+    /// The source boundary is exact on both entrypoints now. Both snapshot the source to EOF
+    /// under the ceiling before parsing, so every byte counts, including a suffix no parser
+    /// reads. An earlier revision bounded only the prefix tar consumed and could not express this
+    /// boundary at all. Wrapping the io error in context first buried the cause and returned
     /// a weaker refusal than the lower-level call.
     #[test]
     fn the_bounded_helper_reports_a_typed_source_ceiling() {
@@ -620,20 +620,71 @@ mod bounded_ingest {
         };
         let err = read_verify_bounded(Cursor::new(bytes.clone()), limits)
             .expect_err("one byte over the source ceiling must be refused");
-        match err.downcast_ref::<ReplayIngestError>() {
+        match err.ingest_refusal() {
             Some(ReplayIngestError::SourceCeiling { kind, limit }) => {
                 assert_eq!(*kind, LimitKind::SourceBytes);
                 assert_eq!(*limit, ceiling);
             }
             other => panic!("expected a typed SourceCeiling from the helper, got {other:?}"),
         }
+        assert!(
+            err.source_digest.is_none(),
+            "the source itself could not be read, so there is nothing to attest"
+        );
 
         let exact = ReplayLimits {
             max_source_bytes: bytes.len() as u64,
             ..ReplayLimits::default()
         };
-        read_verify_bounded(Cursor::new(bytes), exact)
-            .expect("a source of exactly the ceiling must be accepted");
+        assert!(
+            read_verify_bounded(Cursor::new(bytes), exact).is_ok(),
+            "a source of exactly the ceiling must be accepted"
+        );
+    }
+
+    /// The ceiling has to cover the whole source, not the prefix tar chooses to consume. A valid
+    /// bundle followed by an arbitrary suffix used to pass a ceiling far below the real input
+    /// size, because the trailing bytes were never requested and therefore never counted.
+    #[test]
+    fn a_valid_bundle_with_an_unread_suffix_is_measured_whole() {
+        let valid = small_bundle();
+        let mut with_suffix = valid.clone();
+        with_suffix.extend(std::iter::repeat_n(b'Z', 10_000));
+        let total = with_suffix.len() as u64;
+
+        read_bundle_tar_gz_with_limits(
+            Cursor::new(with_suffix.clone()),
+            ReplayLimits {
+                max_source_bytes: total,
+                ..ReplayLimits::default()
+            },
+        )
+        .expect("exactly the real input size must be accepted, suffix included");
+
+        let err = read_bundle_tar_gz_with_limits(
+            Cursor::new(with_suffix),
+            ReplayLimits {
+                max_source_bytes: total - 1,
+                ..ReplayLimits::default()
+            },
+        )
+        .expect_err("the suffix must count towards the source ceiling");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::SourceCeiling { kind, limit }) => {
+                assert_eq!(*kind, LimitKind::SourceBytes);
+                assert_eq!(*limit, total - 1);
+            }
+            other => panic!("expected a typed SourceCeiling, got {other:?}"),
+        }
+
+        read_bundle_tar_gz_with_limits(
+            Cursor::new(valid.clone()),
+            ReplayLimits {
+                max_source_bytes: valid.len() as u64,
+                ..ReplayLimits::default()
+            },
+        )
+        .expect("the bundle alone must still read");
     }
 
     #[test]
@@ -904,12 +955,16 @@ mod bounded_ingest {
         // One expected variant, not "either of two". The decoder sits above the tar walker, so
         // the expansion ceiling trips while the walker is pulling an entry body, which is the
         // member-scoped classification path.
+        // The decoder sits under the tar walker, so the expansion ceiling trips through a member
+        // read. It is still a decode refusal and must not be reported as a member one: a reader
+        // deciding whether to raise `max_member_bytes` or `max_decoded_bytes` needs the right
+        // dimension.
         match err.downcast_ref::<ReplayIngestError>() {
-            Some(ReplayIngestError::MemberCeiling { kind, limit }) => {
+            Some(ReplayIngestError::SourceCeiling { kind, limit }) => {
                 assert_eq!(*kind, LimitKind::DecodedBytes);
                 assert_eq!(*limit, 4096);
             }
-            other => panic!("expected a typed MemberCeiling on DecodedBytes, got {other:?}"),
+            other => panic!("expected a typed DecodedBytes refusal, got {other:?}"),
         }
 
         read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())

--- a/crates/assay-core/src/replay/bundle/tests.rs
+++ b/crates/assay-core/src/replay/bundle/tests.rs
@@ -618,9 +618,8 @@ mod bounded_ingest {
         let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), tight)
             .expect_err("a path one byte over the ceiling must be refused");
         match err.downcast_ref::<ReplayIngestError>() {
-            Some(ReplayIngestError::PathTooLong { limit, actual, .. }) => {
-                assert_eq!(*limit, path.len() - 1);
-                assert_eq!(*actual, path.len());
+            Some(ReplayIngestError::PathTooLong { limit }) => {
+                assert_eq!(*limit, path.len() - 1)
             }
             other => panic!("expected a typed PathTooLong, got {other:?}"),
         }
@@ -656,6 +655,51 @@ mod bounded_ingest {
 
         read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
             .expect("the same bundle must read under the default entry ceiling");
+    }
+
+    /// The manifest ceiling is about shape, not size: a small document can nest deeply enough to
+    /// exhaust the parser, and `max_manifest_bytes` says nothing about that.
+    #[test]
+    fn a_manifest_nested_past_the_ceiling_is_refused() {
+        let bytes = small_bundle();
+        let tight = ReplayLimits {
+            max_manifest_json_depth: 1,
+            ..ReplayLimits::default()
+        };
+        let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), tight)
+            .expect_err("a manifest deeper than one level must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::ManifestTooDeep { limit }) => assert_eq!(*limit, 1),
+            other => panic!("expected a typed ManifestTooDeep, got {other:?}"),
+        }
+
+        read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
+            .expect("the same manifest must read under the default depth");
+    }
+
+    /// Exactly the ceiling is accepted and one deeper is refused, pinned against the real
+    /// manifest rather than a hand-built document, so the boundary is the one callers meet.
+    #[test]
+    fn the_manifest_depth_boundary_is_exact() {
+        use super::super::limits::check_manifest_json_depth;
+
+        // `{"a":{"b":1}}` is two levels of nesting.
+        let doc = br#"{"a":{"b":1}}"#;
+        assert!(
+            check_manifest_json_depth(doc, 2).is_ok(),
+            "exactly the ceiling must pass"
+        );
+        assert!(
+            check_manifest_json_depth(doc, 1).is_err(),
+            "one level over the ceiling must be refused"
+        );
+
+        // Braces inside a string are not structure and must not count towards depth.
+        let stringy = br#"{"a":"{{{{{{{{"}"#;
+        assert!(
+            check_manifest_json_depth(stringy, 1).is_ok(),
+            "braces inside a string literal must not be counted as nesting"
+        );
     }
 
     /// A bundle that is small compressed and large expanded. The source ceiling says nothing

--- a/crates/assay-core/src/replay/bundle/tests.rs
+++ b/crates/assay-core/src/replay/bundle/tests.rs
@@ -1099,7 +1099,8 @@ fn two_spellings_of_one_path_are_a_duplicate() {
     );
 }
 
-/// A second manifest is refused before the first is read or replaced.
+/// A second manifest is refused when it is met, before it is read and before it replaces the
+/// first.
 ///
 /// The reader overwrote `manifest_data` on every `manifest.json` it met, so the last one won
 /// silently while non-manifest duplicates were refused. An archive could then present one

--- a/crates/assay-core/src/replay/bundle/tests.rs
+++ b/crates/assay-core/src/replay/bundle/tests.rs
@@ -96,7 +96,11 @@ fn read_bundle_fails_duplicate_path() {
     let gz = tar.into_inner().unwrap();
     gz.finish().unwrap();
     let err = read_bundle_tar_gz(std::io::Cursor::new(&buf)).unwrap_err();
-    assert!(err.to_string().contains("duplicate path"), "{}", err);
+    assert_eq!(
+        err.downcast_ref::<ReplayContractError>(),
+        Some(&ReplayContractError::DuplicatePath),
+        "duplicates are a typed contract violation, not a rendered string: {err}"
+    );
 }
 
 #[test]
@@ -969,5 +973,269 @@ mod bounded_ingest {
 
         read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
             .expect("the same bundle must read under the default decode ceiling");
+    }
+}
+
+/// Build a tar whose entry names are written straight into the header blocks, bypassing the
+/// writer's own relative-path rule.
+///
+/// `tar::Builder` refuses to emit an absolute name, so the hostile fixture cannot be produced
+/// through our own writer at all. That is not a defence: an attacker writes the bytes directly.
+/// Each entry is first appended under a same-length placeholder, then the name field is patched
+/// in place and the header checksum recomputed, which keeps every block offset stable.
+fn raw_tar_gz_with_entry_names(names: &[&str]) -> Vec<u8> {
+    let manifest = ReplayManifest::minimal("2.15.0".into());
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+
+    // A distinct filler byte per entry, so each placeholder is found at its own header.
+    let placeholders: Vec<String> = names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| ((b'a' + i as u8) as char).to_string().repeat(name.len()))
+        .collect();
+
+    // Uncompressed first, so the header blocks can be patched before they are deflated.
+    let mut tar_bytes = Vec::new();
+    {
+        let mut tar = Builder::new(&mut tar_bytes);
+        let mut h = Header::new_gnu();
+        h.set_path(paths::MANIFEST).unwrap();
+        h.set_size(manifest_json.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        tar.append(&h, &manifest_json[..]).unwrap();
+
+        for placeholder in &placeholders {
+            let mut h2 = Header::new_gnu();
+            h2.set_path(placeholder).unwrap();
+            h2.set_size(1);
+            h2.set_mode(0o644);
+            h2.set_cksum();
+            tar.append(&h2, &b"x"[..]).unwrap();
+        }
+        tar.finish().unwrap();
+    }
+
+    for (name, placeholder) in names.iter().zip(&placeholders) {
+        let header_start = tar_bytes
+            .windows(placeholder.len())
+            .position(|w| w == placeholder.as_bytes())
+            .expect("placeholder name present in a header");
+        // The name field sits at offset 0 of the 512-byte block, so the match is the block start.
+        tar_bytes[header_start..header_start + name.len()].copy_from_slice(name.as_bytes());
+
+        // The checksum covers the whole block with its own field read as spaces.
+        let block = &mut tar_bytes[header_start..header_start + 512];
+        block[148..156].copy_from_slice(b"        ");
+        let sum: u32 = block.iter().map(|b| *b as u32).sum();
+        let cksum = format!("{:06o}\0 ", sum);
+        block[148..156].copy_from_slice(cksum.as_bytes());
+    }
+
+    let mut out = Vec::new();
+    {
+        let mut gz = GzBuilder::new()
+            .mtime(0)
+            .write(&mut out, flate2::Compression::default());
+        std::io::Write::write_all(&mut gz, &tar_bytes).unwrap();
+        gz.finish().unwrap();
+    }
+    out
+}
+
+fn raw_tar_gz_with_entry_name(name: &str, _body: &[u8]) -> Vec<u8> {
+    raw_tar_gz_with_entry_names(&[name])
+}
+
+fn raw_tar_gz_with_two_entry_names(a: &str, b: &str) -> Vec<u8> {
+    raw_tar_gz_with_entry_names(&[a, b])
+}
+
+/// An absolute entry name must never survive into the stored key.
+///
+/// `validate_entry_path` trims leading slashes and returns the normalized path, but the reader
+/// discarded that return value and stored the raw name. The CLI then does `workspace.join(rel)`,
+/// and joining an absolute path throws the workspace prefix away entirely: a `/files/x` entry
+/// validates as `files/x` and materializes at the filesystem root. Validating one string and
+/// storing another is the whole defect, so the assertion is on the stored key.
+#[test]
+fn absolute_entry_name_is_stored_normalized() {
+    let buf = raw_tar_gz_with_entry_name("/files/x", b"x");
+    let read = read_bundle_tar_gz(std::io::Cursor::new(&buf))
+        .expect("an absolute name normalizes rather than refusing");
+    let keys: Vec<&str> = read.entries.iter().map(|(p, _)| p.as_str()).collect();
+    assert_eq!(
+        keys,
+        vec!["files/x"],
+        "stored key must be the normalized path"
+    );
+
+    // The property that actually matters: the join stays under the workspace.
+    for (rel, _) in &read.entries {
+        let joined = std::path::Path::new("/tmp/assay-ws").join(rel);
+        assert!(
+            joined.starts_with("/tmp/assay-ws"),
+            "entry {rel:?} escapes the workspace as {}",
+            joined.display()
+        );
+    }
+}
+
+/// Two spellings of one path must collide.
+///
+/// Duplicate detection keyed on the raw name, so `files/x` and `/files/x` were two entries that a
+/// consumer resolves to the same file. Which bytes win then depends on map iteration order rather
+/// than on anything the archive declared. Keying on the canonical form is what makes the pair a
+/// detectable duplicate at all.
+#[test]
+fn two_spellings_of_one_path_are_a_duplicate() {
+    let buf = raw_tar_gz_with_two_entry_names("files/x", "/files/x");
+    let err = read_bundle_tar_gz(std::io::Cursor::new(&buf))
+        .expect_err("two spellings of one path must be refused");
+    assert_eq!(
+        err.downcast_ref::<ReplayContractError>(),
+        Some(&ReplayContractError::DuplicatePath),
+        "{err}"
+    );
+}
+
+/// A second manifest is refused before the first is read or replaced.
+///
+/// The reader overwrote `manifest_data` on every `manifest.json` it met, so the last one won
+/// silently while non-manifest duplicates were refused. An archive could then present one
+/// manifest to a reader that stops at the head of the stream and another to this one.
+#[test]
+fn a_second_manifest_is_refused() {
+    let manifest = ReplayManifest::minimal("2.15.0".into());
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+    let mut buf = Vec::new();
+    let gz = GzBuilder::new()
+        .mtime(0)
+        .write(&mut buf, flate2::Compression::default());
+    let mut tar = Builder::new(gz);
+    for _ in 0..2 {
+        let mut h = Header::new_gnu();
+        h.set_path(paths::MANIFEST).unwrap();
+        h.set_size(manifest_json.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        tar.append(&h, &manifest_json[..]).unwrap();
+    }
+    let gz = tar.into_inner().unwrap();
+    gz.finish().unwrap();
+
+    let err = read_bundle_tar_gz(std::io::Cursor::new(&buf))
+        .expect_err("a second manifest must be refused");
+    assert_eq!(
+        err.downcast_ref::<ReplayContractError>(),
+        Some(&ReplayContractError::DuplicateManifest),
+        "{err}"
+    );
+}
+
+/// A duplicate is a malformed bundle, not a resource refusal. If it were classified as an ingest
+/// ceiling the CLI would report `E_REPLAY_LIMIT_EXCEEDED` and tell an operator to raise a budget
+/// against an archive that no budget can fix.
+#[test]
+fn a_duplicate_is_not_classified_as_an_ingest_ceiling() {
+    let buf = raw_tar_gz_with_two_entry_names("files/x", "/files/x");
+    let err = read_bundle_tar_gz(std::io::Cursor::new(&buf)).unwrap_err();
+    assert!(
+        err.downcast_ref::<ReplayIngestError>().is_none(),
+        "a structural violation must not be typed as a ceiling: {err}"
+    );
+}
+
+/// Duplicate diagnostics carry nothing the archive chose.
+#[test]
+fn duplicate_refusals_are_value_free() {
+    for (a, b) in [
+        ("files/x", "/files/x"),
+        ("files/secret-name", "files/secret-name"),
+    ] {
+        let buf = raw_tar_gz_with_two_entry_names(a, b);
+        let err = read_bundle_tar_gz(std::io::Cursor::new(&buf)).unwrap_err();
+        let rendered = err.to_string();
+        for archive_chosen in ["files/", "secret-name", "/files/x", "x"] {
+            assert!(
+                !rendered.contains(archive_chosen),
+                "archive-chosen text `{archive_chosen}` reached the diagnostic: {rendered}"
+            );
+        }
+    }
+}
+
+/// What provenance survives a refusal, measured on the real entrypoint.
+///
+/// The digest can only exist once the source has been read, so the two refusal classes are not
+/// symmetric: a source overflow has nothing to attest, while every later refusal happens on bytes
+/// we already hold. A test that models both states as "digest survives" describes a system that
+/// does not exist.
+mod refusal_provenance {
+    use super::*;
+    use crate::replay::bundle::ReplayLimits;
+    use crate::replay::verify::read_verify_bounded;
+    use std::io::Cursor;
+
+    fn valid_bundle() -> Vec<u8> {
+        let manifest = ReplayManifest::minimal("2.15.0".into());
+        let entries = vec![BundleEntry {
+            path: "files/trace.jsonl".into(),
+            data: b"[]".to_vec(),
+        }];
+        let mut buf = Vec::new();
+        write_bundle_tar_gz(&mut buf, &manifest, &entries).unwrap();
+        buf
+    }
+
+    /// A source overflow yields no digest, because the bytes were never fully read. The CLI turns
+    /// this into `sha256:unknown`, which is the honest answer rather than a defect.
+    #[test]
+    fn a_source_overflow_has_no_digest_to_report() {
+        let bytes = valid_bundle();
+        let limits = ReplayLimits {
+            max_source_bytes: (bytes.len() - 1) as u64,
+            ..ReplayLimits::default()
+        };
+        let failure = read_verify_bounded(Cursor::new(&bytes), limits)
+            .expect_err("a source ceiling below the input must refuse");
+        assert!(
+            failure.source_digest.is_none(),
+            "nothing was fully read, so there is nothing to attest"
+        );
+        assert!(
+            failure.ingest_refusal().is_some(),
+            "it is still a typed ingest refusal"
+        );
+    }
+
+    /// Every refusal after the snapshot names the exact bytes it happened on. This is the property
+    /// the one-snapshot design exists for: the digest, the parse and the verdict describe the same
+    /// input, so a refusal is reproducible by whoever receives the summary.
+    #[test]
+    fn a_post_snapshot_refusal_reports_the_exact_digest() {
+        let bytes = valid_bundle();
+        let expected = format!("sha256:{}", hex::encode(<Sha256 as Digest>::digest(&bytes)));
+        // The source fits; a later ceiling is what refuses.
+        let limits = ReplayLimits {
+            max_path_len: 4,
+            ..ReplayLimits::default()
+        };
+        let failure = read_verify_bounded(Cursor::new(&bytes), limits)
+            .expect_err("a path ceiling must refuse this bundle");
+        assert_eq!(
+            failure.source_digest.as_deref(),
+            Some(expected.as_str()),
+            "the digest must be of the exact bytes that failed"
+        );
+    }
+
+    /// The acceptance twin: the same fixture verifies cleanly under default ceilings, so neither
+    /// refusal above is an artefact of a bundle that was broken to begin with.
+    #[test]
+    fn the_same_bundle_verifies_under_default_limits() {
+        let bytes = valid_bundle();
+        read_verify_bounded(Cursor::new(&bytes), ReplayLimits::default())
+            .expect("the fixture is a valid bundle");
     }
 }

--- a/crates/assay-core/src/replay/bundle/tests.rs
+++ b/crates/assay-core/src/replay/bundle/tests.rs
@@ -488,3 +488,203 @@ fn validate_entry_path_rejects_non_canonical_prefix() {
         );
     }
 }
+
+mod bounded_ingest {
+    //! ADR-043 §1 for the replay reader.
+    //!
+    //! `read_bundle_tar_gz` had no ceilings at all: an unbounded compressed source, an unbounded
+    //! gzip decoder on top of it, and `read_to_end` per member on top of that. The evidence
+    //! verifier had a limit set and replay had none, so the same archive met two different
+    //! contracts depending on which reader opened it.
+    //!
+    //! Each test pins one dimension and pairs it with an acceptance case built from the same
+    //! bundle, so a ceiling that refused everything would not pass.
+
+    use super::super::{
+        read_bundle_tar_gz_with_limits, write_bundle_tar_gz, BundleEntry, ReplayIngestError,
+        ReplayLimits,
+    };
+    use crate::replay::manifest::ReplayManifest;
+    use assay_common::limits::LimitKind;
+    use std::cell::Cell;
+    use std::io::{Cursor, Read};
+    use std::rc::Rc;
+
+    fn bundle_with(entries: Vec<BundleEntry>) -> Vec<u8> {
+        let manifest = ReplayManifest::minimal("2.15.0".into());
+        let mut buf = Vec::new();
+        write_bundle_tar_gz(&mut buf, &manifest, &entries).expect("write bundle");
+        buf
+    }
+
+    fn small_bundle() -> Vec<u8> {
+        // Deliberately incompressible: a run of identical bytes gzips to almost nothing, which
+        // would leave the compressed fixture smaller than the ceiling under test and make the
+        // assertion vacuous.
+        let data: Vec<u8> = (0..4096u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 13) as u8)
+            .collect();
+        bundle_with(vec![BundleEntry {
+            path: "files/trace.jsonl".into(),
+            data,
+        }])
+    }
+
+    /// Counts what the reader actually pulled, so a test can tell bounded ingest from a late
+    /// rejection. Asserting only that the call failed would pass against an unbounded reader
+    /// that drained the whole archive first.
+    struct Counting<R> {
+        inner: R,
+        pulled: Rc<Cell<u64>>,
+    }
+
+    impl<R: Read> Read for Counting<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let n = self.inner.read(buf)?;
+            self.pulled.set(self.pulled.get() + n as u64);
+            Ok(n)
+        }
+    }
+
+    fn counting(bytes: Vec<u8>) -> (Counting<Cursor<Vec<u8>>>, Rc<Cell<u64>>) {
+        let pulled = Rc::new(Cell::new(0));
+        (
+            Counting {
+                inner: Cursor::new(bytes),
+                pulled: Rc::clone(&pulled),
+            },
+            pulled,
+        )
+    }
+
+    #[test]
+    fn the_compressed_source_stops_being_read_at_the_ceiling() {
+        let bytes = small_bundle();
+        let ceiling = 64u64;
+        assert!((bytes.len() as u64) > ceiling * 4);
+
+        let (source, pulled) = counting(bytes.clone());
+        let limits = ReplayLimits {
+            max_source_bytes: ceiling,
+            ..ReplayLimits::default()
+        };
+        assert!(read_bundle_tar_gz_with_limits(source, limits).is_err());
+        assert!(
+            pulled.get() <= ceiling + 1,
+            "ingest must stop at the ceiling; {} bytes were pulled",
+            pulled.get()
+        );
+
+        read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
+            .expect("the same bundle must read under the default limits");
+    }
+
+    #[test]
+    fn a_member_over_its_ceiling_is_refused_with_a_typed_cause() {
+        let bytes = small_bundle();
+        let limits = ReplayLimits {
+            max_member_bytes: 64,
+            ..ReplayLimits::default()
+        };
+        let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), limits)
+            .expect_err("a 4 KiB member must be refused under a 64 byte ceiling");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::MemberCeiling { member, kind, .. }) => {
+                assert_eq!(member, "files/trace.jsonl");
+                assert_eq!(*kind, LimitKind::MemberBytes);
+            }
+            other => panic!("expected a typed MemberCeiling, got {other:?}"),
+        }
+
+        read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
+            .expect("the same member must read under the default ceiling");
+    }
+
+    #[test]
+    fn an_entry_path_over_the_ceiling_is_refused_before_it_is_read() {
+        // The tar writer refuses names past the ustar limit without PAX extensions, so the
+        // fixture cannot carry a path long enough to cross the default 256 byte ceiling. Lower
+        // the ceiling under an ordinary path instead: the behaviour under test is the check, not
+        // the size of the number.
+        let path = "files/trace.jsonl";
+        let bytes = bundle_with(vec![BundleEntry {
+            path: path.into(),
+            data: b"[]".to_vec(),
+        }]);
+        let tight = ReplayLimits {
+            max_path_len: path.len() - 1,
+            ..ReplayLimits::default()
+        };
+        let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), tight)
+            .expect_err("a path one byte over the ceiling must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::PathTooLong { limit, actual, .. }) => {
+                assert_eq!(*limit, path.len() - 1);
+                assert_eq!(*actual, path.len());
+            }
+            other => panic!("expected a typed PathTooLong, got {other:?}"),
+        }
+
+        let exact = ReplayLimits {
+            max_path_len: path.len(),
+            ..ReplayLimits::default()
+        };
+        read_bundle_tar_gz_with_limits(Cursor::new(bytes), exact)
+            .expect("a path of exactly the ceiling must be accepted");
+    }
+
+    #[test]
+    fn too_many_entries_is_refused_with_a_typed_cause() {
+        let entries: Vec<BundleEntry> = (0..8)
+            .map(|i| BundleEntry {
+                path: format!("files/e{i}.jsonl"),
+                data: b"[]".to_vec(),
+            })
+            .collect();
+        let bytes = bundle_with(entries);
+
+        let limits = ReplayLimits {
+            max_entries: 3,
+            ..ReplayLimits::default()
+        };
+        let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), limits)
+            .expect_err("nine members must exceed a ceiling of three");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::TooManyEntries { limit }) => assert_eq!(*limit, 3),
+            other => panic!("expected a typed TooManyEntries, got {other:?}"),
+        }
+
+        read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
+            .expect("the same bundle must read under the default entry ceiling");
+    }
+
+    /// A bundle that is small compressed and large expanded. The source ceiling says nothing
+    /// about what the input decompresses to, which is the whole reason the decode ceiling has to
+    /// exist separately.
+    #[test]
+    fn expansion_past_the_decode_ceiling_is_refused() {
+        let bytes = bundle_with(vec![BundleEntry {
+            path: "files/pad.jsonl".into(),
+            data: vec![b'A'; 512 * 1024],
+        }]);
+        let limits = ReplayLimits {
+            max_source_bytes: bytes.len() as u64 * 8,
+            max_decoded_bytes: 4096,
+            ..ReplayLimits::default()
+        };
+        let err = read_bundle_tar_gz_with_limits(Cursor::new(bytes.clone()), limits)
+            .expect_err("expansion past the decode ceiling must be refused");
+        match err.downcast_ref::<ReplayIngestError>() {
+            Some(ReplayIngestError::SourceCeiling { kind, .. }) => {
+                assert_eq!(*kind, LimitKind::DecodedBytes)
+            }
+            Some(ReplayIngestError::MemberCeiling { kind, .. }) => {
+                assert_eq!(*kind, LimitKind::DecodedBytes)
+            }
+            other => panic!("expected a decode ceiling refusal, got {other:?}"),
+        }
+
+        read_bundle_tar_gz_with_limits(Cursor::new(bytes), ReplayLimits::default())
+            .expect("the same bundle must read under the default decode ceiling");
+    }
+}

--- a/crates/assay-core/src/replay/mod.rs
+++ b/crates/assay-core/src/replay/mod.rs
@@ -24,5 +24,6 @@ pub use manifest::{
 pub use scrub::{contains_forbidden_patterns, scrub_content};
 pub use toolchain::capture_toolchain;
 pub use verify::{
-    read_verify_bounded, verify_bundle, verify_bundle_with_limits, VerifiedBundle, VerifyResult,
+    read_verify_bounded, verify_bundle, verify_bundle_with_limits, SnapshotError, VerifiedBundle,
+    VerifyResult,
 };

--- a/crates/assay-core/src/replay/mod.rs
+++ b/crates/assay-core/src/replay/mod.rs
@@ -23,4 +23,4 @@ pub use manifest::{
 };
 pub use scrub::{contains_forbidden_patterns, scrub_content};
 pub use toolchain::capture_toolchain;
-pub use verify::{verify_bundle, VerifyResult};
+pub use verify::{verify_bundle, verify_bundle_with_limits, verify_read_bundle, VerifyResult};

--- a/crates/assay-core/src/replay/mod.rs
+++ b/crates/assay-core/src/replay/mod.rs
@@ -23,4 +23,6 @@ pub use manifest::{
 };
 pub use scrub::{contains_forbidden_patterns, scrub_content};
 pub use toolchain::capture_toolchain;
-pub use verify::{verify_bundle, verify_bundle_with_limits, verify_read_bundle, VerifyResult};
+pub use verify::{
+    read_verify_bounded, verify_bundle, verify_bundle_with_limits, VerifiedBundle, VerifyResult,
+};

--- a/crates/assay-core/src/replay/verify.rs
+++ b/crates/assay-core/src/replay/verify.rs
@@ -77,7 +77,10 @@ pub struct VerifiedBundle {
 /// agree to that one snapshot: the digest published as provenance, the bundle that is parsed, and
 /// the verdict. Digesting a path and separately opening it leaves a window in which those three
 /// describe different bytes.
-pub fn read_verify_bounded<R: Read>(r: R, limits: ReplayLimits) -> Result<VerifiedBundle> {
+pub fn read_verify_bounded<R: Read>(
+    r: R,
+    limits: ReplayLimits,
+) -> Result<VerifiedBundle, SnapshotError> {
     let mut source = Vec::new();
     LimitReader::new(r, limits.max_source_bytes, LimitKind::SourceBytes)
         .read_to_end(&mut source)
@@ -85,21 +88,59 @@ pub fn read_verify_bounded<R: Read>(r: R, limits: ReplayLimits) -> Result<Verifi
             // Classify before wrapping. `.context` on the raw io error would bury the typed cause
             // under an anyhow layer, so the recommended entrypoint would return a weaker contract
             // than the reader it is meant to replace.
-            classify_source_ceiling(&err)
+            let e = classify_source_ceiling(&err)
                 .map(anyhow::Error::from)
-                .unwrap_or_else(|| anyhow::Error::from(err).context("read bundle source"))
+                .unwrap_or_else(|| anyhow::Error::from(err).context("read bundle source"));
+            // No digest: the source itself could not be read, so there is nothing to attest.
+            SnapshotError {
+                source_digest: None,
+                error: e,
+            }
         })?;
 
+    // From here the source is known, so every later failure can still name the bytes it happened
+    // on. Losing the digest to "sha256:unknown" on a parse error discards provenance we already
+    // hold about the exact input that failed.
     let source_digest = format!("sha256:{}", hex::encode(Sha256::digest(&source)));
-    let read = read_bundle_tar_gz_with_limits(std::io::Cursor::new(&source), limits)
-        .context("read bundle")?;
-    let verify = verify_read_bundle(&read)?;
+
+    let read =
+        read_bundle_tar_gz_with_limits(std::io::Cursor::new(&source), limits).map_err(|error| {
+            SnapshotError {
+                source_digest: Some(source_digest.clone()),
+                error,
+            }
+        })?;
+    let verify = verify_read_bundle(&read).map_err(|error| SnapshotError {
+        source_digest: Some(source_digest.clone()),
+        error,
+    })?;
 
     Ok(VerifiedBundle {
         read,
         verify,
         source_digest,
     })
+}
+
+/// A bounded-snapshot failure, carrying the digest when the source was read.
+#[derive(Debug)]
+pub struct SnapshotError {
+    /// `sha256:` over the source, present whenever the source itself was read successfully.
+    pub source_digest: Option<String>,
+    pub error: anyhow::Error,
+}
+
+impl std::fmt::Display for SnapshotError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+impl SnapshotError {
+    /// The typed ingest refusal behind this failure, if it was one.
+    pub fn ingest_refusal(&self) -> Option<&crate::replay::bundle::ReplayIngestError> {
+        self.error.downcast_ref()
+    }
 }
 
 /// Verify an already-read bundle.

--- a/crates/assay-core/src/replay/verify.rs
+++ b/crates/assay-core/src/replay/verify.rs
@@ -6,6 +6,7 @@
 use crate::replay::bundle::{paths, read_bundle_tar_gz_with_limits, ReadBundle, ReplayLimits};
 use crate::replay::scrub::contains_forbidden_patterns;
 use anyhow::{Context, Result};
+use assay_common::limits::{LimitKind, LimitReader};
 use sha2::{Digest, Sha256};
 use std::io::Read;
 
@@ -53,13 +54,51 @@ pub fn verify_bundle_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Result<
     verify_read_bundle(&read)
 }
 
+/// One bounded snapshot of a replay bundle: the bytes, what they parsed to, and the verdict.
+///
+/// `source_digest` is computed over exactly the compressed bytes that produced `read`, which is
+/// the point of returning them together. A caller that digests the path and then opens it again
+/// publishes a digest describing one snapshot while replaying another.
+#[derive(Debug)]
+pub struct VerifiedBundle {
+    /// Parsed bundle, from the same bytes the digest covers.
+    pub read: ReadBundle,
+    /// Verification verdict for exactly that `read`.
+    pub verify: VerifyResult,
+    /// `sha256:<hex>` over the compressed source bytes.
+    pub source_digest: String,
+}
+
+/// Read, digest and verify a replay bundle from a single bounded snapshot.
+///
+/// This is the entrypoint a caller should reach for. It takes one read of the source, bounded by
+/// `limits.max_source_bytes` before anything is materialized, and binds three things that must
+/// agree to that one snapshot: the digest published as provenance, the bundle that is parsed, and
+/// the verdict. Digesting a path and separately opening it leaves a window in which those three
+/// describe different bytes.
+pub fn read_verify_bounded<R: Read>(r: R, limits: ReplayLimits) -> Result<VerifiedBundle> {
+    let mut source = Vec::new();
+    LimitReader::new(r, limits.max_source_bytes, LimitKind::SourceBytes)
+        .read_to_end(&mut source)
+        .context("read bundle source")?;
+
+    let source_digest = format!("sha256:{}", hex::encode(Sha256::digest(&source)));
+    let read = read_bundle_tar_gz_with_limits(std::io::Cursor::new(&source), limits)
+        .context("read bundle")?;
+    let verify = verify_read_bundle(&read)?;
+
+    Ok(VerifiedBundle {
+        read,
+        verify,
+        source_digest,
+    })
+}
+
 /// Verify an already-read bundle.
 ///
-/// Splitting this out is what lets a caller read the archive once and verify exactly the bytes it
-/// is about to use. Verifying from a reader and then reopening the file to consume it means two
-/// full materializations of the same archive and, worse, two different reads: the bytes that
-/// passed verification need not be the bytes that get replayed if the file changes in between.
-pub fn verify_read_bundle(read: &ReadBundle) -> Result<VerifyResult> {
+/// Crate-internal on purpose. Exposed, it invites a caller to verify one `ReadBundle` and act on
+/// another; [`read_verify_bounded`] is the shape that cannot be held that way.
+pub(crate) fn verify_read_bundle(read: &ReadBundle) -> Result<VerifyResult> {
     let ReadBundle { manifest, entries } = read;
     let mut result = VerifyResult::default();
     let file_manifest = manifest.files.as_ref();

--- a/crates/assay-core/src/replay/verify.rs
+++ b/crates/assay-core/src/replay/verify.rs
@@ -3,7 +3,7 @@
 //! Validates bundle integrity (hashes) and runs secret scan: hard fail for
 //! cassettes/ and files/, warn for outputs/. See E9-REPLAY-BUNDLE-PLAN §2.5.
 
-use crate::replay::bundle::{paths, read_bundle_tar_gz, ReadBundle};
+use crate::replay::bundle::{paths, read_bundle_tar_gz_with_limits, ReadBundle, ReplayLimits};
 use crate::replay::scrub::contains_forbidden_patterns;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
@@ -44,7 +44,23 @@ impl VerifyResult {
 /// - **outputs/:** warn only. Outputs can contain user-provided or tool output; we avoid
 ///   false-positive hard fails.
 pub fn verify_bundle<R: Read>(r: R) -> Result<VerifyResult> {
-    let ReadBundle { manifest, entries } = read_bundle_tar_gz(r).context("read bundle")?;
+    verify_bundle_with_limits(r, ReplayLimits::default())
+}
+
+/// Read once under an explicit ceiling and verify what was read.
+pub fn verify_bundle_with_limits<R: Read>(r: R, limits: ReplayLimits) -> Result<VerifyResult> {
+    let read = read_bundle_tar_gz_with_limits(r, limits).context("read bundle")?;
+    verify_read_bundle(&read)
+}
+
+/// Verify an already-read bundle.
+///
+/// Splitting this out is what lets a caller read the archive once and verify exactly the bytes it
+/// is about to use. Verifying from a reader and then reopening the file to consume it means two
+/// full materializations of the same archive and, worse, two different reads: the bytes that
+/// passed verification need not be the bytes that get replayed if the file changes in between.
+pub fn verify_read_bundle(read: &ReadBundle) -> Result<VerifyResult> {
+    let ReadBundle { manifest, entries } = read;
     let mut result = VerifyResult::default();
     let file_manifest = manifest.files.as_ref();
 
@@ -82,7 +98,7 @@ pub fn verify_bundle<R: Read>(r: R) -> Result<VerifyResult> {
         }
     }
 
-    for (path, data) in &entries {
+    for (path, data) in entries.iter() {
         let has_forbidden = contains_forbidden_patterns(data);
         if path.starts_with(paths::CASSETTES_PREFIX) || path.starts_with(paths::FILES_PREFIX) {
             if has_forbidden {

--- a/crates/assay-core/src/replay/verify.rs
+++ b/crates/assay-core/src/replay/verify.rs
@@ -103,6 +103,14 @@ pub fn read_verify_bounded<R: Read>(
     // hold about the exact input that failed.
     let source_digest = format!("sha256:{}", hex::encode(Sha256::digest(&source)));
 
+    // Known cost, recorded rather than optimised away: `read_bundle_tar_gz_with_limits` applies
+    // the same whole-source rule and snapshots this cursor again, so peak memory here is about
+    // twice `max_source_bytes` rather than once. That is bounded — the ceiling still governs, and
+    // a caller who sets 100 MiB gets a 200 MiB worst case, not an unbounded one. Removing the
+    // second copy means letting the reader take a pre-read snapshot, which is a parser API change
+    // and would give one entrypoint a bypass of the rule the other enforces. Not worth it for a
+    // constant factor on an already-bounded value; revisit if a ceiling is ever raised far enough
+    // that 2x matters.
     let read =
         read_bundle_tar_gz_with_limits(std::io::Cursor::new(&source), limits).map_err(|error| {
             SnapshotError {

--- a/crates/assay-core/src/replay/verify.rs
+++ b/crates/assay-core/src/replay/verify.rs
@@ -3,6 +3,7 @@
 //! Validates bundle integrity (hashes) and runs secret scan: hard fail for
 //! cassettes/ and files/, warn for outputs/. See E9-REPLAY-BUNDLE-PLAN §2.5.
 
+use crate::replay::bundle::limits::classify_source_ceiling;
 use crate::replay::bundle::{paths, read_bundle_tar_gz_with_limits, ReadBundle, ReplayLimits};
 use crate::replay::scrub::contains_forbidden_patterns;
 use anyhow::{Context, Result};
@@ -80,7 +81,14 @@ pub fn read_verify_bounded<R: Read>(r: R, limits: ReplayLimits) -> Result<Verifi
     let mut source = Vec::new();
     LimitReader::new(r, limits.max_source_bytes, LimitKind::SourceBytes)
         .read_to_end(&mut source)
-        .context("read bundle source")?;
+        .map_err(|err| {
+            // Classify before wrapping. `.context` on the raw io error would bury the typed cause
+            // under an anyhow layer, so the recommended entrypoint would return a weaker contract
+            // than the reader it is meant to replace.
+            classify_source_ceiling(&err)
+                .map(anyhow::Error::from)
+                .unwrap_or_else(|| anyhow::Error::from(err).context("read bundle source"))
+        })?;
 
     let source_digest = format!("sha256:{}", hex::encode(Sha256::digest(&source)));
     let read = read_bundle_tar_gz_with_limits(std::io::Cursor::new(&source), limits)

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -12,6 +12,10 @@ readme.workspace = true
 # Internal: shared canonicalization (JCS + content-id). Same serde_jcs pin, so the bytes (and every
 # content/mandate digest) are unchanged; this is a deduplication, not a behaviour change.
 assay-canonical = { workspace = true }
+# Internal: the bounded-ingest primitive (ADR-043 §1). One mechanism shared with the replay
+# verifier; the limit vocabularies stay domain-local because theirs do not describe an
+# evidence bundle.
+assay-common = { workspace = true, features = ["std"] }
 # Core serialization
 serde = { workspace = true, features = ["derive", "std", "alloc"] }
 serde_json = { workspace = true, features = ["preserve_order", "std", "alloc"] }

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -14,7 +14,9 @@
 //! For very large bundles (>1GB), consider tempfile-based streaming
 //! or the `into_events()` consuming pattern in a future version.
 
-use crate::bundle::writer::{classify_reader_io, classify_strict_json};
+use crate::bundle::writer::{
+    check_entry_path_len, check_events_shape, classify_reader_io, classify_strict_json,
+};
 use crate::bundle::writer::{verify_bundle_with_limits, Manifest, VerifyLimits};
 use crate::json_strict::validate_json_strict_with_depth;
 use crate::ndjson::NdjsonEvents;
@@ -137,6 +139,7 @@ impl BundleReader {
         for entry in archive.entries().map_err(classify_reader_io)? {
             let entry = entry.map_err(classify_reader_io)?;
             let path = entry.path()?.to_string_lossy().to_string();
+            check_entry_path_len(&path, limits.max_path_len)?;
 
             if path == "events.ndjson" {
                 // `LimitFileSize` rather than an invented tag: the classification vocabulary is
@@ -147,6 +150,7 @@ impl BundleReader {
                 entry
                     .read_to_end(&mut events_content)
                     .map_err(classify_reader_io)?;
+                check_events_shape(&events_content, limits.max_line_bytes, limits.max_events)?;
                 break;
             }
         }
@@ -239,6 +243,7 @@ impl BundleInfo {
         for entry in archive.entries().map_err(classify_reader_io)? {
             let entry = entry.map_err(classify_reader_io)?;
             let path = entry.path()?.to_string_lossy().to_string();
+            check_entry_path_len(&path, limits.max_path_len)?;
 
             if path == "manifest.json" {
                 // Read manifest to string for strict validation
@@ -250,7 +255,6 @@ impl BundleInfo {
                     .map_err(classify_reader_io)
                     .context("Failed to read manifest.json")?;
 
-                // Security: Validate JSON strictly before parsing
                 // The caller's ceiling, not the module constant: peek validated the manifest but
                 // ignored `max_json_depth`, so an unverified read applied a different budget than
                 // a verified one on the same document.

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -19,8 +19,17 @@ use crate::json_strict::validate_json_strict;
 use crate::ndjson::NdjsonEvents;
 use crate::types::EvidenceEvent;
 use anyhow::{Context, Result};
+use assay_common::limits::LimitReader;
 use flate2::read::GzDecoder;
 use std::io::{BufReader, Cursor, Read};
+
+/// Whether a bundle open performs integrity verification. Deliberately not an
+/// `Option<VerifyLimits>`: the limits apply either way.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Verify {
+    Yes,
+    No,
+}
 
 /// Bundle reader for safe event iteration.
 ///
@@ -63,47 +72,74 @@ impl BundleReader {
     ///
     /// Open and verify a bundle, loading it into memory.
     pub fn open<R: Read>(reader: R) -> Result<Self> {
-        Self::open_internal(reader, Some(VerifyLimits::default()))
+        Self::open_internal(reader, Verify::Yes, VerifyLimits::default())
     }
 
     /// Open and verify a bundle with custom verification limits.
     pub fn open_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Result<Self> {
-        Self::open_internal(reader, Some(limits))
+        Self::open_internal(reader, Verify::Yes, limits)
     }
 
     /// Open a bundle without verification (for debugging/inspection).
+    ///
+    /// Skipping verification does not skip the limits. The whole set still applies to ingest,
+    /// expansion and member reads; only the integrity check is omitted. Peeking at a manifest is
+    /// not a reason to let an untrusted archive decide how much memory to take.
     pub fn open_unverified<R: Read>(reader: R) -> Result<Self> {
-        Self::open_internal(reader, None)
+        Self::open_internal(reader, Verify::No, VerifyLimits::default())
     }
 
-    fn open_internal<R: Read>(reader: R, limits: Option<VerifyLimits>) -> Result<Self> {
-        // First pass: verify integrity and get manifest
+    /// Open a bundle without verification, under an explicit limit set.
+    pub fn open_unverified_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Result<Self> {
+        Self::open_internal(reader, Verify::No, limits)
+    }
+
+    /// Whether to verify is a separate question from what the limits are. Carrying both in one
+    /// `Option<VerifyLimits>` is what let the unverified paths run unbounded: `None` read as
+    /// "no limits" when it only ever meant "no verification".
+    fn open_internal<R: Read>(reader: R, verify: Verify, limits: VerifyLimits) -> Result<Self> {
+        let max_bundle_bytes = limits.max_bundle_bytes;
+        // ADR-043 §1: the ceiling applies to the stream, before the input is materialized.
+        // Reading first and checking afterwards means an oversized archive has already sized
+        // the allocation, whatever the subsequent verification concludes.
         let mut buffer = Vec::new();
-        let mut reader = reader;
+        let mut reader = LimitReader::new(reader, max_bundle_bytes, "LimitBundleBytes");
         reader.read_to_end(&mut buffer)?;
 
-        let manifest = if let Some(limits) = limits {
-            let result = verify_bundle_with_limits(Cursor::new(&buffer), limits)
-                .context("Bundle verification failed")?;
-            result.manifest
-        } else {
-            // Peek only
-            let info =
-                BundleInfo::peek(Cursor::new(&buffer)).context("Failed to peek bundle manifest")?;
-            info.manifest
+        let manifest = match verify {
+            Verify::Yes => {
+                verify_bundle_with_limits(Cursor::new(&buffer), limits)
+                    .context("Bundle verification failed")?
+                    .manifest
+            }
+            Verify::No => {
+                BundleInfo::peek_with_limits(Cursor::new(&buffer), limits)
+                    .context("Failed to peek bundle manifest")?
+                    .manifest
+            }
         };
 
-        // Second pass: extract events content
+        // Second pass: extract events content.
+        //
+        // ADR-043 §1: a single byte ceiling is not the limit set. The compressed ceiling above
+        // bounds what arrives; it says nothing about what that expands to. Without the decode
+        // ceiling here a bomb well inside `max_bundle_bytes` expands unbounded, and on the peek
+        // path this pass is the only consumption because verification never runs.
         let decoder = GzDecoder::new(Cursor::new(&buffer));
+        let decoder = LimitReader::new(decoder, limits.max_decode_bytes, "LimitDecodeBytes");
         let mut archive = tar::Archive::new(decoder);
 
         let mut events_content = Vec::new();
 
         for entry in archive.entries()? {
-            let mut entry = entry?;
+            let entry = entry?;
             let path = entry.path()?.to_string_lossy().to_string();
 
             if path == "events.ndjson" {
+                // `LimitFileSize` rather than an invented tag: the classification vocabulary is
+                // `ErrorCode`, and a per-member ceiling is what `verify.rs` already reports under
+                // that code. A tag with no matching variant cannot be classified by any caller.
+                let mut entry = LimitReader::new(entry, limits.max_events_bytes, "LimitFileSize");
                 entry.read_to_end(&mut events_content)?;
                 break;
             }
@@ -174,15 +210,33 @@ impl BundleInfo {
     /// Does NOT verify event integrity.
     /// Use `BundleReader::open()` for full verification.
     pub fn peek<R: Read>(reader: R) -> Result<Self> {
-        let decoder = GzDecoder::new(reader);
+        Self::peek_with_limits(reader, VerifyLimits::default())
+    }
+
+    /// Peek at a manifest under an explicit limit set.
+    ///
+    /// Peeking still expands the archive and still materializes a member, so it needs the decode
+    /// and per-file ceilings even though it verifies nothing. Left unbounded, this was the one
+    /// public entrypoint where a bomb met no guard at all.
+    pub fn peek_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Result<Self> {
+        // Bound the compressed source here as well, not only the expansion. Reached through
+        // `BundleReader` the input has already passed a ceiling, but this is a public entrypoint
+        // in its own right and a direct caller gets no such guarantee.
+        let reader = LimitReader::new(reader, limits.max_bundle_bytes, "LimitBundleBytes");
+        let decoder = LimitReader::new(
+            GzDecoder::new(reader),
+            limits.max_decode_bytes,
+            "LimitDecodeBytes",
+        );
         let mut archive = tar::Archive::new(decoder);
 
         for entry in archive.entries()? {
-            let mut entry = entry?;
+            let entry = entry?;
             let path = entry.path()?.to_string_lossy().to_string();
 
             if path == "manifest.json" {
                 // Read manifest to string for strict validation
+                let mut entry = LimitReader::new(entry, limits.max_manifest_bytes, "LimitFileSize");
                 let mut content = String::new();
                 entry
                     .read_to_string(&mut content)

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -14,12 +14,13 @@
 //! For very large bundles (>1GB), consider tempfile-based streaming
 //! or the `into_events()` consuming pattern in a future version.
 
+use crate::bundle::writer::classify_reader_io;
 use crate::bundle::writer::{verify_bundle_with_limits, Manifest, VerifyLimits};
 use crate::json_strict::validate_json_strict;
 use crate::ndjson::NdjsonEvents;
 use crate::types::EvidenceEvent;
 use anyhow::{Context, Result};
-use assay_common::limits::LimitReader;
+use assay_common::limits::{LimitKind, LimitReader};
 use flate2::read::GzDecoder;
 use std::io::{BufReader, Cursor, Read};
 
@@ -103,8 +104,10 @@ impl BundleReader {
         // Reading first and checking afterwards means an oversized archive has already sized
         // the allocation, whatever the subsequent verification concludes.
         let mut buffer = Vec::new();
-        let mut reader = LimitReader::new(reader, max_bundle_bytes, "LimitBundleBytes");
-        reader.read_to_end(&mut buffer)?;
+        let mut reader = LimitReader::new(reader, max_bundle_bytes, LimitKind::SourceBytes);
+        reader
+            .read_to_end(&mut buffer)
+            .map_err(classify_reader_io)?;
 
         let manifest = match verify {
             Verify::Yes => {
@@ -126,21 +129,24 @@ impl BundleReader {
         // ceiling here a bomb well inside `max_bundle_bytes` expands unbounded, and on the peek
         // path this pass is the only consumption because verification never runs.
         let decoder = GzDecoder::new(Cursor::new(&buffer));
-        let decoder = LimitReader::new(decoder, limits.max_decode_bytes, "LimitDecodeBytes");
+        let decoder = LimitReader::new(decoder, limits.max_decode_bytes, LimitKind::DecodedBytes);
         let mut archive = tar::Archive::new(decoder);
 
         let mut events_content = Vec::new();
 
-        for entry in archive.entries()? {
-            let entry = entry?;
+        for entry in archive.entries().map_err(classify_reader_io)? {
+            let entry = entry.map_err(classify_reader_io)?;
             let path = entry.path()?.to_string_lossy().to_string();
 
             if path == "events.ndjson" {
                 // `LimitFileSize` rather than an invented tag: the classification vocabulary is
                 // `ErrorCode`, and a per-member ceiling is what `verify.rs` already reports under
                 // that code. A tag with no matching variant cannot be classified by any caller.
-                let mut entry = LimitReader::new(entry, limits.max_events_bytes, "LimitFileSize");
-                entry.read_to_end(&mut events_content)?;
+                let mut entry =
+                    LimitReader::new(entry, limits.max_events_bytes, LimitKind::MemberBytes);
+                entry
+                    .read_to_end(&mut events_content)
+                    .map_err(classify_reader_io)?;
                 break;
             }
         }
@@ -222,24 +228,26 @@ impl BundleInfo {
         // Bound the compressed source here as well, not only the expansion. Reached through
         // `BundleReader` the input has already passed a ceiling, but this is a public entrypoint
         // in its own right and a direct caller gets no such guarantee.
-        let reader = LimitReader::new(reader, limits.max_bundle_bytes, "LimitBundleBytes");
+        let reader = LimitReader::new(reader, limits.max_bundle_bytes, LimitKind::SourceBytes);
         let decoder = LimitReader::new(
             GzDecoder::new(reader),
             limits.max_decode_bytes,
-            "LimitDecodeBytes",
+            LimitKind::DecodedBytes,
         );
         let mut archive = tar::Archive::new(decoder);
 
-        for entry in archive.entries()? {
-            let entry = entry?;
+        for entry in archive.entries().map_err(classify_reader_io)? {
+            let entry = entry.map_err(classify_reader_io)?;
             let path = entry.path()?.to_string_lossy().to_string();
 
             if path == "manifest.json" {
                 // Read manifest to string for strict validation
-                let mut entry = LimitReader::new(entry, limits.max_manifest_bytes, "LimitFileSize");
+                let mut entry =
+                    LimitReader::new(entry, limits.max_manifest_bytes, LimitKind::MemberBytes);
                 let mut content = String::new();
                 entry
                     .read_to_string(&mut content)
+                    .map_err(classify_reader_io)
                     .context("Failed to read manifest.json")?;
 
                 // Security: Validate JSON strictly before parsing

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -242,12 +242,19 @@ impl BundleInfo {
     /// and per-file ceilings even though it verifies nothing. Left unbounded, this was the one
     /// public entrypoint where a bomb met no guard at all.
     pub fn peek_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Result<Self> {
-        // Bound the compressed source here as well, not only the expansion. Reached through
-        // `BundleReader` the input has already passed a ceiling, but this is a public entrypoint
-        // in its own right and a direct caller gets no such guarantee.
-        let reader = LimitReader::new(reader, limits.max_bundle_bytes, LimitKind::SourceBytes);
+        // Snapshot the whole source before parsing, exactly as the verifier does. A `LimitReader`
+        // placed under gzip and tar only ever sees the bytes a decoder asks for, and peek returns
+        // the moment it has read `manifest.json` — so a valid bundle followed by an arbitrarily
+        // large suffix never had its tail requested and passed a ceiling it plainly exceeds. The
+        // ceiling has to bound the artifact, not the prefix a parser happened to consume.
+        let mut source = Vec::new();
+        LimitReader::new(reader, limits.max_bundle_bytes, LimitKind::SourceBytes)
+            .read_to_end(&mut source)
+            .map_err(classify_reader_io)
+            .context("Bundle source")?;
+
         let decoder = LimitReader::new(
-            GzDecoder::new(reader),
+            GzDecoder::new(std::io::Cursor::new(&source)),
             limits.max_decode_bytes,
             LimitKind::DecodedBytes,
         );

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -14,9 +14,9 @@
 //! For very large bundles (>1GB), consider tempfile-based streaming
 //! or the `into_events()` consuming pattern in a future version.
 
-use crate::bundle::writer::classify_reader_io;
+use crate::bundle::writer::{classify_reader_io, classify_strict_json};
 use crate::bundle::writer::{verify_bundle_with_limits, Manifest, VerifyLimits};
-use crate::json_strict::validate_json_strict;
+use crate::json_strict::validate_json_strict_with_depth;
 use crate::ndjson::NdjsonEvents;
 use crate::types::EvidenceEvent;
 use anyhow::{Context, Result};
@@ -251,8 +251,11 @@ impl BundleInfo {
                     .context("Failed to read manifest.json")?;
 
                 // Security: Validate JSON strictly before parsing
-                validate_json_strict(&content)
-                    .context("Security: Invalid JSON in manifest.json")?;
+                // The caller's ceiling, not the module constant: peek validated the manifest but
+                // ignored `max_json_depth`, so an unverified read applied a different budget than
+                // a verified one on the same document.
+                validate_json_strict_with_depth(&content, limits.max_json_depth)
+                    .map_err(|e| classify_strict_json(e, "Manifest", limits.max_json_depth))?;
 
                 let manifest: Manifest =
                     serde_json::from_str(&content).context("Failed to parse manifest.json")?;

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -15,7 +15,8 @@
 //! or the `into_events()` consuming pattern in a future version.
 
 use crate::bundle::writer::{
-    check_entry_path_len, check_events_shape, classify_reader_io, classify_strict_json,
+    check_entry_path_len, classify_reader_io, classify_strict_json, read_events_bounded,
+    ErrorClass, ErrorCode, VerifyError,
 };
 use crate::bundle::writer::{verify_bundle_with_limits, Manifest, VerifyLimits};
 use crate::json_strict::validate_json_strict_with_depth;
@@ -135,24 +136,36 @@ impl BundleReader {
         let mut archive = tar::Archive::new(decoder);
 
         let mut events_content = Vec::new();
+        let mut events_found = false;
 
         for entry in archive.entries().map_err(classify_reader_io)? {
             let entry = entry.map_err(classify_reader_io)?;
+            // Measure the path on the bytes the archive carries, before any conversion.
+            // `to_string_lossy` emits three bytes for every invalid one, so a check on the
+            // converted string measures something the archive never sent.
+            check_entry_path_len(entry.path_bytes().len(), limits.max_path_len)?;
             let path = entry.path()?.to_string_lossy().to_string();
-            check_entry_path_len(&path, limits.max_path_len)?;
 
             if path == "events.ndjson" {
+                events_found = true;
                 // `LimitFileSize` rather than an invented tag: the classification vocabulary is
                 // `ErrorCode`, and a per-member ceiling is what `verify.rs` already reports under
                 // that code. A tag with no matching variant cannot be classified by any caller.
-                let mut entry =
+                let entry =
                     LimitReader::new(entry, limits.max_events_bytes, LimitKind::MemberBytes);
-                entry
-                    .read_to_end(&mut events_content)
-                    .map_err(classify_reader_io)?;
-                check_events_shape(&events_content, limits.max_line_bytes, limits.max_events)?;
+                read_events_bounded(entry, &mut events_content, limits)?;
                 break;
             }
+        }
+
+        // An absent member is not an empty one. Accepting a bundle with no `events.ndjson` as a
+        // bundle with zero events let a stripped archive read as a well-formed empty run.
+        if !events_found {
+            return Err(anyhow::Error::new(VerifyError::new(
+                ErrorClass::Contract,
+                ErrorCode::ContractMissingFile,
+                "events.ndjson missing from bundle".to_string(),
+            )));
         }
 
         Ok(Self {
@@ -242,8 +255,8 @@ impl BundleInfo {
 
         for entry in archive.entries().map_err(classify_reader_io)? {
             let entry = entry.map_err(classify_reader_io)?;
+            check_entry_path_len(entry.path_bytes().len(), limits.max_path_len)?;
             let path = entry.path()?.to_string_lossy().to_string();
-            check_entry_path_len(&path, limits.max_path_len)?;
 
             if path == "manifest.json" {
                 // Read manifest to string for strict validation

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -100,11 +100,14 @@ pub(crate) fn read_events_bounded<R: std::io::Read>(
 
         // The caller's nesting ceiling applies to events here too. Verified reads apply it; an
         // unverified read used to hand the line back unchecked.
-        let text = std::str::from_utf8(payload).map_err(|e| {
+        // `Utf8Error`'s own rendering carries the byte index and the length of the bad sequence,
+        // both chosen by the input. An operator cannot act on either, and echoing them puts
+        // archive-influenced values in the log.
+        let text = std::str::from_utf8(payload).map_err(|_| {
             anyhow::Error::new(VerifyError::new(
                 ErrorClass::Contract,
                 ErrorCode::ContractInvalidJson,
-                format!("Invalid UTF-8 in event: {e}"),
+                "Event is not valid UTF-8".to_string(),
             ))
         })?;
         crate::json_strict::validate_json_strict_with_depth(text, limits.max_json_depth)
@@ -137,10 +140,53 @@ pub(crate) fn strict_json_error(
             ErrorCode::LimitJsonDepth,
             format!("{what} JSON nesting exceeds the configured maximum depth of {max_depth}"),
         ),
-        other => VerifyError::new(
+        // Every remaining variant renders attacker-chosen material through its own `Display`: the
+        // duplicated key and its JSON path, the byte position of a bad escape, the offending
+        // codepoint, serde's parse message with its line, column and token snippet, the observed
+        // key count, the observed string length. That text reaches an operator's terminal and
+        // every log that ingests the message, so it is replaced here with wording built only from
+        // constants. The blanket `Security:` prefix went with it: a duplicate object key is a
+        // producer defect, and framing it as a security event tells a reader the wrong thing about
+        // what happened.
+        //
+        // Class and code are deliberately unchanged. `TooManyKeys` and `StringTooLong` are really
+        // ceilings reported as contract faults, but there is no `ErrorCode` for either, and adding
+        // variants to a publicly exported enum is a wider change than a diagnostics fix.
+        StrictJsonError::DuplicateKey { .. } => VerifyError::new(
             ErrorClass::Contract,
             ErrorCode::ContractInvalidJson,
-            format!("Security: {other}"),
+            format!("{what} JSON contains a duplicate object key"),
+        ),
+        StrictJsonError::InvalidUnicodeEscape { .. } => VerifyError::new(
+            ErrorClass::Contract,
+            ErrorCode::ContractInvalidJson,
+            format!("{what} JSON contains an invalid unicode escape sequence"),
+        ),
+        StrictJsonError::LoneSurrogate { .. } => VerifyError::new(
+            ErrorClass::Contract,
+            ErrorCode::ContractInvalidJson,
+            format!("{what} JSON contains an unpaired surrogate"),
+        ),
+        StrictJsonError::ParseError(_) => VerifyError::new(
+            ErrorClass::Contract,
+            ErrorCode::ContractInvalidJson,
+            format!("{what} JSON is not well-formed"),
+        ),
+        StrictJsonError::TooManyKeys { .. } => VerifyError::new(
+            ErrorClass::Contract,
+            ErrorCode::ContractInvalidJson,
+            format!(
+                "{what} JSON object exceeds the maximum of {} keys",
+                crate::json_strict::MAX_KEYS_PER_OBJECT
+            ),
+        ),
+        StrictJsonError::StringTooLong { .. } => VerifyError::new(
+            ErrorClass::Contract,
+            ErrorCode::ContractInvalidJson,
+            format!(
+                "{what} JSON contains a string longer than the maximum of {} bytes",
+                crate::json_strict::MAX_STRING_LENGTH
+            ),
         ),
     }
 }

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -30,12 +30,65 @@ use std::io::Read;
 
 pub use writer_next::errors::{ErrorClass, ErrorCode, VerifyError};
 
-/// Turn an io failure from a bounded reader into a typed error.
+/// Apply the structural ceilings that only the verifier used to enforce.
 ///
-/// The reader entrypoints return `anyhow::Result`, so without this a ceiling refusal reaches the
-/// caller as a bare `io::Error` and cannot be told apart from a truncated file. Classifying here
-/// means `BundleReader::open*` and `BundleInfo::peek*` carry the same `VerifyError` the verifier
-/// does, recoverable with `downcast_ref`.
+/// `max_path_len`, `max_line_bytes` and `max_events` were checked on the verifying path and
+/// nowhere else, so an unverified read applied a different contract to the same bytes: an
+/// oversized path or an unbounded line was handed back to the caller, who discovered it only
+/// while iterating, if at all. Skipping verification means skipping the integrity check, not the
+/// resource budget.
+pub(crate) fn check_entry_path_len(path: &str, max_path_len: usize) -> Result<(), VerifyError> {
+    if path.len() > max_path_len {
+        return Err(VerifyError::new(
+            ErrorClass::Limits,
+            ErrorCode::LimitPathLength,
+            format!(
+                "Entry path length {} exceeds limit {}",
+                path.len(),
+                max_path_len
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Scan already-materialized NDJSON against the per-line and total-event ceilings.
+///
+/// The bytes are bounded by `max_events_bytes` before they get here, so this is about the shape
+/// within that budget rather than about the allocation.
+pub(crate) fn check_events_shape(
+    events: &[u8],
+    max_line_bytes: usize,
+    max_events: usize,
+) -> Result<(), VerifyError> {
+    let mut count = 0usize;
+    for line in events.split(|b| *b == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        if line.len() > max_line_bytes {
+            return Err(VerifyError::new(
+                ErrorClass::Limits,
+                ErrorCode::LimitLineBytes,
+                format!(
+                    "Event line length {} exceeds limit {}",
+                    line.len(),
+                    max_line_bytes
+                ),
+            ));
+        }
+        count += 1;
+        if count > max_events {
+            return Err(VerifyError::new(
+                ErrorClass::Limits,
+                ErrorCode::LimitTotalEvents,
+                format!("Event count exceeds limit {}", max_events),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Turn a strict-JSON failure into the same typed error the verifier produces.
 ///
 /// A nesting refusal is a resource ceiling; everything else the strict pass rejects is a contract
@@ -75,6 +128,12 @@ pub(crate) fn classify_strict_json(
     anyhow::Error::new(strict_json_error(err, what, max_depth))
 }
 
+/// Turn an io failure from a bounded reader into a typed error.
+///
+/// The reader entrypoints return `anyhow::Result`, so without this a ceiling refusal reaches the
+/// caller as a bare `io::Error` and cannot be told apart from a truncated file. Classifying here
+/// means `BundleReader::open*` and `BundleInfo::peek*` carry the same `VerifyError` the verifier
+/// does, recoverable with `downcast_ref`.
 pub(crate) fn classify_reader_io(err: std::io::Error) -> anyhow::Error {
     match writer_next::verify::classify_limit(&err) {
         Some(code) => {

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -36,6 +36,45 @@ pub use writer_next::errors::{ErrorClass, ErrorCode, VerifyError};
 /// caller as a bare `io::Error` and cannot be told apart from a truncated file. Classifying here
 /// means `BundleReader::open*` and `BundleInfo::peek*` carry the same `VerifyError` the verifier
 /// does, recoverable with `downcast_ref`.
+/// Turn a strict-JSON failure into the same typed error the verifier produces.
+///
+/// A nesting refusal is a resource ceiling; everything else the strict pass rejects is a contract
+/// fault. Without this the unverified path reported both as opaque context, so a caller could not
+/// tell "raise the budget" from "the producer is broken".
+pub(crate) fn strict_json_error(
+    err: crate::json_strict::StrictJsonError,
+    what: &str,
+    max_depth: usize,
+) -> VerifyError {
+    use crate::json_strict::StrictJsonError;
+    match err {
+        // The variant's own Display renders the module constant as the maximum and echoes the
+        // observed depth, so under a configured ceiling of 4 it read "exceeds maximum 64" and
+        // quoted a number the input chose. Both are wrong to show an operator: the ceiling that
+        // actually applied is the configured one, and the attacker-supplied depth adds nothing a
+        // reader can act on.
+        StrictJsonError::NestingTooDeep { .. } => VerifyError::new(
+            ErrorClass::Limits,
+            ErrorCode::LimitJsonDepth,
+            format!("{what} JSON nesting exceeds the configured maximum depth of {max_depth}"),
+        ),
+        other => VerifyError::new(
+            ErrorClass::Contract,
+            ErrorCode::ContractInvalidJson,
+            format!("Security: {other}"),
+        ),
+    }
+}
+
+/// `anyhow` wrapper for the reader entrypoints, which do not return `VerifyError` directly.
+pub(crate) fn classify_strict_json(
+    err: crate::json_strict::StrictJsonError,
+    what: &str,
+    max_depth: usize,
+) -> anyhow::Error {
+    anyhow::Error::new(strict_json_error(err, what, max_depth))
+}
+
 pub(crate) fn classify_reader_io(err: std::io::Error) -> anyhow::Error {
     match writer_next::verify::classify_limit(&err) {
         Some(code) => {

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -29,6 +29,26 @@ use anyhow::Result;
 use std::io::Read;
 
 pub use writer_next::errors::{ErrorClass, ErrorCode, VerifyError};
+
+/// Turn an io failure from a bounded reader into a typed error.
+///
+/// The reader entrypoints return `anyhow::Result`, so without this a ceiling refusal reaches the
+/// caller as a bare `io::Error` and cannot be told apart from a truncated file. Classifying here
+/// means `BundleReader::open*` and `BundleInfo::peek*` carry the same `VerifyError` the verifier
+/// does, recoverable with `downcast_ref`.
+pub(crate) fn classify_reader_io(err: std::io::Error) -> anyhow::Error {
+    match writer_next::verify::classify_limit(&err) {
+        Some(code) => {
+            let mut ve = VerifyError::from(err);
+            ve.code = code;
+            ve.class = ErrorClass::Limits;
+            anyhow::Error::new(ve)
+        }
+        None => anyhow::Error::new(err),
+    }
+}
+// The ceiling vocabulary, so the reader names its limits with the same constants the verifier
+// classifies them by.
 pub use writer_next::limits::{VerifyLimits, VerifyLimitsOverrides};
 pub use writer_next::manifest::{AlgorithmMeta, FileMeta, Manifest};
 pub use writer_next::verify::VerifyResult;

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -37,54 +37,80 @@ pub use writer_next::errors::{ErrorClass, ErrorCode, VerifyError};
 /// oversized path or an unbounded line was handed back to the caller, who discovered it only
 /// while iterating, if at all. Skipping verification means skipping the integrity check, not the
 /// resource budget.
-pub(crate) fn check_entry_path_len(path: &str, max_path_len: usize) -> Result<(), VerifyError> {
-    if path.len() > max_path_len {
+/// `raw_len` is the length in bytes of the path as the archive carries it, taken before any lossy
+/// conversion. `to_string_lossy` emits three bytes for every invalid one and `to_str` yields
+/// nothing at all, so measuring the converted form measures something the archive never sent.
+///
+/// What this ceiling is, stated narrowly: a post-tar bound on the logical path. It is not a bound
+/// on what the tar layer allocates to produce that path. A GNU or PAX long name arrives as its
+/// own member and is materialized by the reader before this check ever runs; that allocation is
+/// bounded by the decode ceiling, not by this one. Closing that gap would mean owning the header
+/// parse, which is a tar rewrite and is deliberately not done here.
+pub(crate) fn check_entry_path_len(raw_len: usize, max_path_len: usize) -> Result<(), VerifyError> {
+    if raw_len > max_path_len {
         return Err(VerifyError::new(
             ErrorClass::Limits,
             ErrorCode::LimitPathLength,
-            format!(
-                "Entry path length {} exceeds limit {}",
-                path.len(),
-                max_path_len
-            ),
+            // Value-free: the length is chosen by the archive. The dimension and the configured
+            // ceiling are what a reader can act on.
+            format!("Entry path exceeds the configured maximum length of {max_path_len}"),
         ));
     }
     Ok(())
 }
 
-/// Scan already-materialized NDJSON against the per-line and total-event ceilings.
+/// Stream `events.ndjson` under the per-line, event-count and JSON-depth ceilings.
 ///
-/// The bytes are bounded by `max_events_bytes` before they get here, so this is about the shape
-/// within that budget rather than about the allocation.
-pub(crate) fn check_events_shape(
-    events: &[u8],
-    max_line_bytes: usize,
-    max_events: usize,
-) -> Result<(), VerifyError> {
+/// The previous shape read the whole member into memory under `max_events_bytes` and only then
+/// checked line length and event count, so the allocation happened before the dimensions that
+/// govern it were consulted, and `max_json_depth` never reached event lines on this path at all.
+/// Reading line by line refuses at the first line that crosses a ceiling.
+pub(crate) fn read_events_bounded<R: std::io::Read>(
+    reader: R,
+    out: &mut Vec<u8>,
+    limits: VerifyLimits,
+) -> anyhow::Result<()> {
+    let mut reader = std::io::BufReader::new(reader);
     let mut count = 0usize;
-    for line in events.split(|b| *b == b'\n') {
-        if line.is_empty() {
+    loop {
+        let mut line = Vec::new();
+        let n =
+            writer_next::tar_read::read_line_bounded(&mut reader, &mut line, limits.max_line_bytes)
+                .map_err(classify_reader_io)?;
+        if n == 0 {
+            break;
+        }
+        let payload = line.strip_suffix(b"\n").unwrap_or(&line);
+        if payload.is_empty() {
+            out.extend_from_slice(&line);
             continue;
         }
-        if line.len() > max_line_bytes {
-            return Err(VerifyError::new(
-                ErrorClass::Limits,
-                ErrorCode::LimitLineBytes,
-                format!(
-                    "Event line length {} exceeds limit {}",
-                    line.len(),
-                    max_line_bytes
-                ),
-            ));
-        }
+
         count += 1;
-        if count > max_events {
-            return Err(VerifyError::new(
+        if count > limits.max_events {
+            return Err(anyhow::Error::new(VerifyError::new(
                 ErrorClass::Limits,
                 ErrorCode::LimitTotalEvents,
-                format!("Event count exceeds limit {}", max_events),
-            ));
+                format!(
+                    "Event count exceeds the configured maximum of {}",
+                    limits.max_events
+                ),
+            )));
         }
+
+        // The caller's nesting ceiling applies to events here too. Verified reads apply it; an
+        // unverified read used to hand the line back unchecked.
+        let text = std::str::from_utf8(payload).map_err(|e| {
+            anyhow::Error::new(VerifyError::new(
+                ErrorClass::Contract,
+                ErrorCode::ContractInvalidJson,
+                format!("Invalid UTF-8 in event: {e}"),
+            ))
+        })?;
+        crate::json_strict::validate_json_strict_with_depth(text, limits.max_json_depth)
+            .map_err(|e| classify_strict_json(e, "Event", limits.max_json_depth))?;
+
+        out.extend_from_slice(&line);
     }
     Ok(())
 }
@@ -250,21 +276,24 @@ mod tests {
             max_events: 0, // Should fail (bundle has 1 event)
             ..VerifyLimits::default()
         };
-        let err = verify_bundle_with_limits(Cursor::new(&buffer), strict_count_limit);
-        assert!(err.is_err());
-        assert!(err
-            .unwrap_err()
-            .to_string()
-            .contains("Event count exceeds limit"));
+        // Assert on the typed code, not on the rendered text. The messages are diagnostics and
+        // are deliberately value-free; pinning them here would make prose a contract again.
+        let err = verify_bundle_with_limits(Cursor::new(&buffer), strict_count_limit)
+            .expect_err("a count ceiling of zero must refuse a one-event bundle");
+        let ve = err.downcast_ref::<VerifyError>().expect("typed");
+        assert_eq!(ve.class, ErrorClass::Limits);
+        assert_eq!(ve.code, ErrorCode::LimitTotalEvents);
 
         // 2. Test File Size Limit
         let strict_size_limit = VerifyLimits {
             max_events_bytes: 10, // Should fail (events are larger)
             ..VerifyLimits::default()
         };
-        let err = verify_bundle_with_limits(Cursor::new(&buffer), strict_size_limit);
-        assert!(err.is_err());
-        assert!(err.unwrap_err().to_string().contains("exceeds limit"));
+        let err = verify_bundle_with_limits(Cursor::new(&buffer), strict_size_limit)
+            .expect_err("an events-size ceiling of ten bytes must refuse this bundle");
+        let ve = err.downcast_ref::<VerifyError>().expect("typed");
+        assert_eq!(ve.class, ErrorClass::Limits);
+        assert_eq!(ve.code, ErrorCode::LimitFileSize);
     }
 
     #[test]

--- a/crates/assay-evidence/src/bundle/writer_next/limits.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/limits.rs
@@ -84,11 +84,20 @@ impl<R: Read> LimitReader<R> {
 
 impl<R: Read> Read for LimitReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // The limit is inclusive: an input of exactly `limit` bytes is accepted, `limit + 1` is
+        // refused. Erroring as soon as `read == limit` rejects the exact-limit input, because
+        // every consumer issues one further read to observe EOF, which silently made the
+        // effective ceiling `limit - 1`. At the boundary we therefore probe a single byte: EOF
+        // means the input fit, one byte means it did not.
         if self.read >= self.limit {
-            return Err(std::io::Error::other(format!(
-                "{}: exceeded limit of {} bytes",
-                self.error_tag, self.limit
-            )));
+            let mut probe = [0u8; 1];
+            return match self.inner.read(&mut probe)? {
+                0 => Ok(0),
+                _ => Err(std::io::Error::other(format!(
+                    "{}: exceeded limit of {} bytes",
+                    self.error_tag, self.limit
+                ))),
+            };
         }
 
         let max_to_read = (self.limit - self.read).min(buf.len() as u64) as usize;
@@ -96,5 +105,64 @@ impl<R: Read> Read for LimitReader<R> {
         self.read += n as u64;
 
         Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod limit_reader_boundary_tests {
+    use super::LimitReader;
+    use std::io::{Cursor, Read};
+
+    fn read_all(len: usize, limit: u64) -> std::io::Result<usize> {
+        let mut r = LimitReader::new(Cursor::new(vec![0u8; len]), limit, "T");
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).map(|_| out.len())
+    }
+
+    /// The boundary ADR-043 §1 specifies. Before the EOF probe, `read == limit` errored on the
+    /// EOF-detecting read every consumer makes, so the effective ceiling was `limit - 1`.
+    #[test]
+    fn exact_limit_is_accepted_and_one_more_byte_is_refused() {
+        assert_eq!(read_all(99, 100).unwrap(), 99);
+        assert_eq!(
+            read_all(100, 100).unwrap(),
+            100,
+            "an input of exactly the limit must be accepted"
+        );
+        assert!(read_all(101, 100).is_err(), "limit + 1 must be refused");
+    }
+
+    #[test]
+    fn a_zero_limit_accepts_only_empty_input() {
+        assert_eq!(read_all(0, 0).unwrap(), 0);
+        assert!(read_all(1, 0).is_err());
+    }
+
+    /// A stream that never fills the caller's buffer must not walk past the ceiling one byte at
+    /// a time.
+    #[test]
+    fn short_reads_cannot_walk_past_the_limit() {
+        struct OneByteAtATime(Cursor<Vec<u8>>);
+        impl Read for OneByteAtATime {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if buf.is_empty() {
+                    return Ok(0);
+                }
+                self.0.read(&mut buf[..1])
+            }
+        }
+
+        let mut over = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 101])), 100, "T");
+        assert!(over.read_to_end(&mut Vec::new()).is_err());
+
+        let mut exact = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 100])), 100, "T");
+        assert_eq!(exact.read_to_end(&mut Vec::new()).unwrap(), 100);
+    }
+
+    #[test]
+    fn the_error_names_the_ceiling_that_was_crossed() {
+        let err = read_all(101, 100).unwrap_err();
+        assert!(err.to_string().contains('T'), "{err}");
+        assert!(err.to_string().contains("100"), "{err}");
     }
 }

--- a/crates/assay-evidence/src/bundle/writer_next/limits.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/limits.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
-use std::io::Read;
+
+/// Re-exported so existing `use super::limits::LimitReader` call sites keep working; the
+/// implementation now lives in `assay-common` beside the replay verifier that shares it.
+pub(crate) use assay_common::limits::LimitReader;
 
 /// Resource limits for bundle verification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,109 +63,5 @@ impl VerifyLimits {
             max_path_len: overrides.max_path_len.unwrap_or(self.max_path_len),
             max_json_depth: overrides.max_json_depth.unwrap_or(self.max_json_depth),
         }
-    }
-}
-
-/// A reader that limits the total number of bytes read and fails explicitly on overflow.
-pub(crate) struct LimitReader<R> {
-    inner: R,
-    limit: u64,
-    read: u64,
-    error_tag: &'static str,
-}
-
-impl<R: Read> LimitReader<R> {
-    pub(crate) fn new(inner: R, limit: u64, error_tag: &'static str) -> Self {
-        Self {
-            inner,
-            limit,
-            read: 0,
-            error_tag,
-        }
-    }
-}
-
-impl<R: Read> Read for LimitReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        // The limit is inclusive: an input of exactly `limit` bytes is accepted, `limit + 1` is
-        // refused. Erroring as soon as `read == limit` rejects the exact-limit input, because
-        // every consumer issues one further read to observe EOF, which silently made the
-        // effective ceiling `limit - 1`. At the boundary we therefore probe a single byte: EOF
-        // means the input fit, one byte means it did not.
-        if self.read >= self.limit {
-            let mut probe = [0u8; 1];
-            return match self.inner.read(&mut probe)? {
-                0 => Ok(0),
-                _ => Err(std::io::Error::other(format!(
-                    "{}: exceeded limit of {} bytes",
-                    self.error_tag, self.limit
-                ))),
-            };
-        }
-
-        let max_to_read = (self.limit - self.read).min(buf.len() as u64) as usize;
-        let n = self.inner.read(&mut buf[..max_to_read])?;
-        self.read += n as u64;
-
-        Ok(n)
-    }
-}
-
-#[cfg(test)]
-mod limit_reader_boundary_tests {
-    use super::LimitReader;
-    use std::io::{Cursor, Read};
-
-    fn read_all(len: usize, limit: u64) -> std::io::Result<usize> {
-        let mut r = LimitReader::new(Cursor::new(vec![0u8; len]), limit, "T");
-        let mut out = Vec::new();
-        r.read_to_end(&mut out).map(|_| out.len())
-    }
-
-    /// The boundary ADR-043 §1 specifies. Before the EOF probe, `read == limit` errored on the
-    /// EOF-detecting read every consumer makes, so the effective ceiling was `limit - 1`.
-    #[test]
-    fn exact_limit_is_accepted_and_one_more_byte_is_refused() {
-        assert_eq!(read_all(99, 100).unwrap(), 99);
-        assert_eq!(
-            read_all(100, 100).unwrap(),
-            100,
-            "an input of exactly the limit must be accepted"
-        );
-        assert!(read_all(101, 100).is_err(), "limit + 1 must be refused");
-    }
-
-    #[test]
-    fn a_zero_limit_accepts_only_empty_input() {
-        assert_eq!(read_all(0, 0).unwrap(), 0);
-        assert!(read_all(1, 0).is_err());
-    }
-
-    /// A stream that never fills the caller's buffer must not walk past the ceiling one byte at
-    /// a time.
-    #[test]
-    fn short_reads_cannot_walk_past_the_limit() {
-        struct OneByteAtATime(Cursor<Vec<u8>>);
-        impl Read for OneByteAtATime {
-            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-                if buf.is_empty() {
-                    return Ok(0);
-                }
-                self.0.read(&mut buf[..1])
-            }
-        }
-
-        let mut over = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 101])), 100, "T");
-        assert!(over.read_to_end(&mut Vec::new()).is_err());
-
-        let mut exact = LimitReader::new(OneByteAtATime(Cursor::new(vec![0u8; 100])), 100, "T");
-        assert_eq!(exact.read_to_end(&mut Vec::new()).unwrap(), 100);
-    }
-
-    #[test]
-    fn the_error_names_the_ceiling_that_was_crossed() {
-        let err = read_all(101, 100).unwrap_err();
-        assert!(err.to_string().contains('T'), "{err}");
-        assert!(err.to_string().contains("100"), "{err}");
     }
 }

--- a/crates/assay-evidence/src/bundle/writer_next/tar_read.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/tar_read.rs
@@ -1,3 +1,4 @@
+use assay_common::limits::{LimitExceeded, LimitKind};
 use std::io::{BufRead, Read};
 
 /// Many systems can deliver spurious interrupts during `read()`.
@@ -38,12 +39,27 @@ impl<R: Read> Read for EintrReader<R> {
 }
 
 /// Read a line with a hard memory limit before allocation growth.
+///
+/// `max` is the maximum *payload* length in bytes; the trailing `\n` is not counted. A payload of
+/// exactly `max` bytes is accepted, and `max + 1` is refused. This is the same interpretation
+/// `check_events_shape` applies on the unverified path, so both paths share one budget for the
+/// same input rather than each having its own accidental off-by-one.
+///
+/// Overflow is reported as a typed [`LimitExceeded`] cause inside an `io::Error`, so a caller
+/// classifies via `LimitExceeded::from_io` and never by parsing the rendered message.
 pub(crate) fn read_line_bounded<R: BufRead>(
     reader: &mut R,
     buf: &mut Vec<u8>,
     max: usize,
 ) -> std::io::Result<usize> {
-    let mut total_read = 0;
+    let overflow = || -> std::io::Error {
+        std::io::Error::other(LimitExceeded {
+            kind: LimitKind::LineBytes,
+            limit: max as u64,
+        })
+    };
+    let mut payload_len = 0usize;
+    let mut total_read = 0usize;
     loop {
         let (done, used) = {
             let available = reader.fill_buf()?;
@@ -55,11 +71,15 @@ pub(crate) fn read_line_bounded<R: BufRead>(
                     None => (false, available.len()),
                 };
 
-                if total_read + line_end > max {
-                    return Err(std::io::Error::other("LimitLineBytes: line exceeded limit"));
+                // Payload delta excludes the newline when we've found the end of the line, so a
+                // line of exactly `max` payload bytes plus its `\n` is accepted.
+                let payload_delta = if found { line_end - 1 } else { line_end };
+                if payload_len + payload_delta > max {
+                    return Err(overflow());
                 }
 
                 buf.extend_from_slice(&available[..line_end]);
+                payload_len += payload_delta;
                 (found, line_end)
             }
         };
@@ -68,8 +88,75 @@ pub(crate) fn read_line_bounded<R: BufRead>(
         if done || total_read == 0 {
             return Ok(total_read);
         }
-        if total_read >= max && !done {
-            return Err(std::io::Error::other("LimitLineBytes: line exceeded limit"));
-        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_line_bounded;
+    use assay_common::limits::{LimitExceeded, LimitKind};
+    use std::io::{BufReader, Cursor};
+
+    /// One interpretation, shared with `check_events_shape`: a line of exactly `max` payload bytes
+    /// plus its `\n` is accepted, and `max + 1` payload bytes is refused. Before this alignment
+    /// the two paths each had their own accidental interpretation and a caller could not tell
+    /// which budget applied.
+    #[test]
+    fn a_payload_of_exactly_the_limit_plus_newline_is_accepted() {
+        let payload = vec![b'x'; 100];
+        let mut src = payload.clone();
+        src.push(b'\n');
+        let mut r = BufReader::new(Cursor::new(src));
+        let mut buf = Vec::new();
+        let n = read_line_bounded(&mut r, &mut buf, 100).expect("exact-limit payload must pass");
+        assert_eq!(n, 101, "consumed bytes include the newline");
+        assert_eq!(&buf, &{
+            let mut e = payload.clone();
+            e.push(b'\n');
+            e
+        });
+    }
+
+    #[test]
+    fn one_payload_byte_over_the_limit_is_refused_with_a_typed_cause() {
+        let mut src = vec![b'x'; 101];
+        src.push(b'\n');
+        let mut r = BufReader::new(Cursor::new(src));
+        let mut buf = Vec::new();
+        let err = read_line_bounded(&mut r, &mut buf, 100)
+            .expect_err("101 payload bytes must be refused when the limit is 100");
+        let cause =
+            LimitExceeded::from_io(&err).expect("overflow must carry a typed cause, not a string");
+        assert_eq!(cause.kind, LimitKind::LineBytes);
+        assert_eq!(cause.limit, 100);
+    }
+
+    /// A line with no trailing newline (EOF-terminated) still counts payload as delivered bytes.
+    /// The unterminated-overflow branch was the second string-only error site and had to move to
+    /// the same typed cause.
+    #[test]
+    fn an_unterminated_line_over_the_limit_is_refused_with_a_typed_cause() {
+        let src = vec![b'x'; 101];
+        let mut r = BufReader::new(Cursor::new(src));
+        let mut buf = Vec::new();
+        let err = read_line_bounded(&mut r, &mut buf, 100)
+            .expect_err("101 bytes with no newline must still be refused");
+        let cause = LimitExceeded::from_io(&err)
+            .expect("the unterminated overflow must also carry a typed cause");
+        assert_eq!(cause.kind, LimitKind::LineBytes);
+        assert_eq!(cause.limit, 100);
+    }
+
+    /// Acceptance twin for the previous case: a limit that fits must still accept the input, so
+    /// the suite would not pass by simply refusing every unterminated line.
+    #[test]
+    fn an_unterminated_line_at_the_limit_is_accepted() {
+        let src = vec![b'x'; 100];
+        let mut r = BufReader::new(Cursor::new(src));
+        let mut buf = Vec::new();
+        let n =
+            read_line_bounded(&mut r, &mut buf, 100).expect("100 bytes with no newline must pass");
+        assert_eq!(n, 100);
+        assert_eq!(buf.len(), 100);
     }
 }

--- a/crates/assay-evidence/src/bundle/writer_next/verify.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/verify.rs
@@ -1,5 +1,6 @@
+use crate::bundle::writer::strict_json_error;
 use crate::crypto::id::{compute_content_hash, compute_run_root, compute_stream_id};
-use crate::json_strict::validate_json_strict;
+use crate::json_strict::validate_json_strict_with_depth;
 use crate::types::EvidenceEvent;
 use anyhow::Result;
 use flate2::read::GzDecoder;
@@ -212,6 +213,19 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
                 ve
             })?;
 
+            // The manifest went straight to `serde_json` with no strict pass at all, so the
+            // caller's nesting ceiling applied to events and not to the document that describes
+            // them. Peek already validated it; the verifier did not.
+            let manifest_str = std::str::from_utf8(&content).map_err(|e| {
+                VerifyError::new(
+                    ErrorClass::Contract,
+                    ErrorCode::ContractInvalidJson,
+                    format!("Invalid UTF-8 in manifest.json: {}", e),
+                )
+            })?;
+            validate_json_strict_with_depth(manifest_str, limits.max_json_depth)
+                .map_err(|e| strict_json_error(e, "Manifest", limits.max_json_depth))?;
+
             let m: Manifest = serde_json::from_slice(&content).map_err(|e| {
                 let mut ve = VerifyError::from(e);
                 ve.code = ErrorCode::ContractInvalidJson;
@@ -328,13 +342,8 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
                     )
                 })?;
 
-                validate_json_strict(line_str).map_err(|e| {
-                    VerifyError::new(
-                        ErrorClass::Contract,
-                        ErrorCode::ContractInvalidJson,
-                        format!("Security: {}", e),
-                    )
-                })?;
+                validate_json_strict_with_depth(line_str, limits.max_json_depth)
+                    .map_err(|e| strict_json_error(e, "Event", limits.max_json_depth))?;
 
                 let event: EvidenceEvent = serde_json::from_str(line_str).map_err(|e| {
                     let mut ve = VerifyError::from(e);

--- a/crates/assay-evidence/src/bundle/writer_next/verify.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/verify.rs
@@ -1,4 +1,4 @@
-use crate::bundle::writer::strict_json_error;
+use crate::bundle::writer::{check_entry_path_len, strict_json_error};
 use crate::crypto::id::{compute_content_hash, compute_run_root, compute_stream_id};
 use crate::json_strict::validate_json_strict_with_depth;
 use crate::types::EvidenceEvent;
@@ -95,8 +95,32 @@ pub fn verify_bundle<R: Read>(reader: R) -> Result<VerifyResult> {
 
 /// Verify a bundle with explicit resource limits.
 pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Result<VerifyResult> {
-    let reader = EintrReader::new(reader);
-    let reader = LimitReader::new(reader, limits.max_bundle_bytes, LimitKind::SourceBytes);
+    // Snapshot the whole source under the ceiling before parsing anything.
+    //
+    // Streaming the ceiling into the gzip/tar walker only bounds the prefix those layers choose
+    // to consume. They stop once the archive is logically complete, so a valid bundle followed by
+    // an arbitrary suffix passed a ceiling far below the real input size: the trailing bytes were
+    // never requested and therefore never counted. `read_to_end` through the same ceiling counts
+    // everything the source actually holds.
+    let mut source = Vec::new();
+    LimitReader::new(
+        EintrReader::new(reader),
+        limits.max_bundle_bytes,
+        LimitKind::SourceBytes,
+    )
+    .read_to_end(&mut source)
+    .map_err(|e| {
+        let limit = classify_limit(&e);
+        apply_limit_class(VerifyError::from(e), limit, ErrorCode::IntegrityGzip)
+            .with_context("Bundle source")
+    })?;
+
+    verify_bundle_snapshot(&source, limits)
+}
+
+/// Verify a bundle from bytes already bounded and materialized by the caller.
+fn verify_bundle_snapshot(source: &[u8], limits: VerifyLimits) -> Result<VerifyResult> {
+    let reader = std::io::Cursor::new(source);
 
     let decoder = GzDecoder::new(reader);
     let limited_decoder =
@@ -121,21 +145,13 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
             let ve = apply_limit_class(VerifyError::from(e), limit, ErrorCode::IntegrityTar);
             ve.with_context(format!("Entry #{}", i))
         })?;
+        // Measure the path on the bytes the archive carries, before any conversion. `to_str`
+        // returns None for invalid UTF-8 and the fallback measured an empty string, so a name
+        // that is invalid on purpose skipped the ceiling entirely.
+        check_entry_path_len(entry.path_bytes().len(), limits.max_path_len)?;
+
         let path = entry.path().map_err(VerifyError::from)?.to_path_buf();
         let path_str = path.to_str().unwrap_or("");
-
-        if path_str.len() > limits.max_path_len {
-            return Err(VerifyError::new(
-                ErrorClass::Limits,
-                ErrorCode::LimitPathLength,
-                format!(
-                    "Path length {} exceeds limit {}",
-                    path_str.len(),
-                    limits.max_path_len
-                ),
-            )
-            .into());
-        }
 
         let header_size = entry.header().size().map_err(VerifyError::from)?;
 
@@ -149,9 +165,10 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
             return Err(VerifyError::new(
                 ErrorClass::Limits,
                 ErrorCode::LimitFileSize,
+                // Value-free: the member name and its declared size are archive-controlled.
+                // The dimension and the configured ceiling are what a reader can act on.
                 format!(
-                    "File '{}' declared size {} exceeds limit {}",
-                    path_str, header_size, max_size
+                    "A declared member size exceeds the configured maximum of {max_size} bytes"
                 ),
             )
             .into());
@@ -315,7 +332,10 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
                     return Err(VerifyError::new(
                         ErrorClass::Limits,
                         ErrorCode::LimitTotalEvents,
-                        format!("Event count exceeds limit {}", limits.max_events),
+                        format!(
+                            "Event count exceeds the configured maximum of {}",
+                            limits.max_events
+                        ),
                     )
                     .into());
                 }

--- a/crates/assay-evidence/src/bundle/writer_next/verify.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/verify.rs
@@ -13,6 +13,42 @@ use super::events;
 use super::limits::{LimitReader, VerifyLimits};
 use super::manifest::Manifest;
 use super::tar_read::{read_line_bounded, EintrReader};
+use assay_common::limits::{LimitExceeded, LimitKind};
+
+/// Recover the typed ceiling behind an `io::Error` and map it onto this crate's vocabulary.
+///
+/// Returns `None` when the failure was not a ceiling at all, so the caller keeps its own
+/// classification. The lookup goes through the typed cause rather than the rendered message:
+/// message text is a diagnostic, never a contract.
+pub(crate) fn classify_limit(err: &std::io::Error) -> Option<ErrorCode> {
+    let cause = LimitExceeded::from_io(err)?;
+    // Exhaustive, with no wildcard. A new dimension in `LimitKind` must fail to compile here
+    // rather than fall into a catch-all that reports the wrong code.
+    Some(match cause.kind {
+        LimitKind::SourceBytes => ErrorCode::LimitBundleBytes,
+        LimitKind::DecodedBytes => ErrorCode::LimitDecodeBytes,
+        LimitKind::MemberBytes => ErrorCode::LimitFileSize,
+        LimitKind::LineBytes => ErrorCode::LimitLineBytes,
+    })
+}
+
+/// Stamp a `VerifyError` with a ceiling classification, or with `fallback` when the failure was
+/// not a ceiling. Taken as an already-resolved `Option` because the io error is consumed when the
+/// `VerifyError` is built from it.
+pub(crate) fn apply_limit_class(
+    mut ve: VerifyError,
+    limit: Option<ErrorCode>,
+    fallback: ErrorCode,
+) -> VerifyError {
+    match limit {
+        Some(code) => {
+            ve.code = code;
+            ve.class = ErrorClass::Limits;
+        }
+        None => ve.code = fallback,
+    }
+    ve
+}
 
 /// Allowed files in bundle (strict allowlist).
 const ALLOWED_FILES: &[&str] = &["manifest.json", "events.ndjson"];
@@ -59,10 +95,11 @@ pub fn verify_bundle<R: Read>(reader: R) -> Result<VerifyResult> {
 /// Verify a bundle with explicit resource limits.
 pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Result<VerifyResult> {
     let reader = EintrReader::new(reader);
-    let reader = LimitReader::new(reader, limits.max_bundle_bytes, "LimitBundleBytes");
+    let reader = LimitReader::new(reader, limits.max_bundle_bytes, LimitKind::SourceBytes);
 
     let decoder = GzDecoder::new(reader);
-    let limited_decoder = LimitReader::new(decoder, limits.max_decode_bytes, "LimitDecodeBytes");
+    let limited_decoder =
+        LimitReader::new(decoder, limits.max_decode_bytes, LimitKind::DecodedBytes);
     let mut archive = tar::Archive::new(limited_decoder);
 
     let mut manifest: Option<Manifest> = None;
@@ -72,31 +109,15 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
     let mut actual_event_count = 0;
 
     let entries = archive.entries().map_err(|e| {
-        let mut ve = VerifyError::from(e);
-        if ve.message.contains("LimitBundleBytes") {
-            ve.code = ErrorCode::LimitBundleBytes;
-            ve.class = ErrorClass::Limits;
-        } else if ve.message.contains("LimitDecodeBytes") {
-            ve.code = ErrorCode::LimitDecodeBytes;
-            ve.class = ErrorClass::Limits;
-        } else {
-            ve.code = ErrorCode::IntegrityTar;
-        }
+        let limit = classify_limit(&e);
+        let ve = apply_limit_class(VerifyError::from(e), limit, ErrorCode::IntegrityTar);
         ve.with_context("Gzip/Tar stream")
     })?;
 
     for (i, entry) in entries.enumerate() {
         let entry = entry.map_err(|e| {
-            let mut ve = VerifyError::from(e);
-            if ve.message.contains("LimitBundleBytes") {
-                ve.code = ErrorCode::LimitBundleBytes;
-                ve.class = ErrorClass::Limits;
-            } else if ve.message.contains("LimitDecodeBytes") {
-                ve.code = ErrorCode::LimitDecodeBytes;
-                ve.class = ErrorClass::Limits;
-            } else {
-                ve.code = ErrorCode::IntegrityTar;
-            }
+            let limit = classify_limit(&e);
+            let ve = apply_limit_class(VerifyError::from(e), limit, ErrorCode::IntegrityTar);
             ve.with_context(format!("Entry #{}", i))
         })?;
         let path = entry.path().map_err(VerifyError::from)?.to_path_buf();
@@ -180,11 +201,12 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
 
             let mut content = Vec::new();
             let mut manifest_reader =
-                LimitReader::new(entry, limits.max_manifest_bytes, "LimitFileSize");
+                LimitReader::new(entry, limits.max_manifest_bytes, LimitKind::MemberBytes);
             manifest_reader.read_to_end(&mut content).map_err(|e| {
+                let limit = classify_limit(&e);
                 let mut ve = VerifyError::from(e);
-                if ve.message.contains("LimitFileSize") {
-                    ve.code = ErrorCode::LimitFileSize;
+                if let Some(code) = limit {
+                    ve.code = code;
                     ve.class = ErrorClass::Limits;
                 }
                 ve
@@ -249,9 +271,10 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
                 line_buf.clear();
                 let n = read_line_bounded(&mut reader, &mut line_buf, limits.max_line_bytes)
                     .map_err(|e| {
+                        let limit = classify_limit(&e);
                         let mut ve = VerifyError::from(e);
-                        if ve.message.contains("LimitLineBytes") {
-                            ve.code = ErrorCode::LimitLineBytes;
+                        if let Some(code) = limit {
+                            ve.code = code;
                             ve.class = ErrorClass::Limits;
                         }
                         ve
@@ -493,12 +516,10 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
             Ok(0) => break,
             Ok(_) => continue,
             Err(e) => {
+                let limit = classify_limit(&e);
                 let mut ve = VerifyError::from(e);
-                if ve.message.contains("LimitDecodeBytes") {
-                    ve.code = ErrorCode::LimitDecodeBytes;
-                    ve.class = ErrorClass::Limits;
-                } else if ve.message.contains("LimitBundleBytes") {
-                    ve.code = ErrorCode::LimitBundleBytes;
+                if let Some(code) = limit {
+                    ve.code = code;
                     ve.class = ErrorClass::Limits;
                 } else {
                     ve.code = ErrorCode::IntegrityGzip;

--- a/crates/assay-evidence/src/json_strict/json_strict_internal/run.rs
+++ b/crates/assay-evidence/src/json_strict/json_strict_internal/run.rs
@@ -6,6 +6,14 @@ pub(crate) fn from_str_strict_impl<T: DeserializeOwned>(s: &str) -> Result<T, St
     Ok(serde_json::from_str(s)?)
 }
 
+pub(crate) fn validate_json_strict_with_depth_impl(
+    s: &str,
+    max_depth: usize,
+) -> Result<(), StrictJsonError> {
+    let mut v = super::validate::JsonValidator::with_max_depth(s, max_depth);
+    v.validate()
+}
+
 pub(crate) fn validate_json_strict_impl(s: &str) -> Result<(), StrictJsonError> {
     let mut validator = super::validate::JsonValidator::new(s);
     validator.validate()

--- a/crates/assay-evidence/src/json_strict/json_strict_internal/validate.rs
+++ b/crates/assay-evidence/src/json_strict/json_strict_internal/validate.rs
@@ -7,16 +7,26 @@ pub(crate) struct JsonValidator<'a> {
     key_tracker: ObjectKeyTracker,
     current_path: String,
     depth: usize,
+    max_depth: usize,
     _phantom: std::marker::PhantomData<&'a str>,
 }
 
 impl<'a> JsonValidator<'a> {
     pub(crate) fn new(input: &'a str) -> Self {
+        Self::with_max_depth(input, super::limits::MAX_NESTING_DEPTH)
+    }
+
+    /// Validate under an explicit nesting ceiling.
+    ///
+    /// The depth guard already existed but was pinned to a constant, so a caller carrying its own
+    /// `max_json_depth` could not apply it and the configured value was decorative.
+    pub(crate) fn with_max_depth(input: &'a str, max_depth: usize) -> Self {
         Self {
             chars: input.char_indices().peekable(),
             key_tracker: ObjectKeyTracker::new(),
             current_path: String::new(),
             depth: 0,
+            max_depth,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -50,7 +60,7 @@ impl<'a> JsonValidator<'a> {
         self.skip_whitespace();
 
         self.depth += 1;
-        if self.depth > super::limits::MAX_NESTING_DEPTH {
+        if self.depth > self.max_depth {
             return Err(StrictJsonError::NestingTooDeep { depth: self.depth });
         }
 
@@ -107,7 +117,7 @@ impl<'a> JsonValidator<'a> {
         self.skip_whitespace();
 
         self.depth += 1;
-        if self.depth > super::limits::MAX_NESTING_DEPTH {
+        if self.depth > self.max_depth {
             return Err(StrictJsonError::NestingTooDeep { depth: self.depth });
         }
 

--- a/crates/assay-evidence/src/json_strict/mod.rs
+++ b/crates/assay-evidence/src/json_strict/mod.rs
@@ -79,3 +79,15 @@ pub fn from_str_strict<T: DeserializeOwned>(s: &str) -> Result<T, StrictJsonErro
 pub fn validate_json_strict(s: &str) -> Result<(), StrictJsonError> {
     json_strict_internal::run::validate_json_strict_impl(s)
 }
+
+/// Validate under an explicit nesting ceiling.
+///
+/// The depth guard was pinned to a constant, so `VerifyLimits::max_json_depth` had no way to
+/// reach it and a caller's configured value was decorative. Crate-internal: the ceiling is a
+/// verification concern and does not need to widen the public surface.
+pub(crate) fn validate_json_strict_with_depth(
+    s: &str,
+    max_depth: usize,
+) -> Result<(), StrictJsonError> {
+    json_strict_internal::run::validate_json_strict_with_depth_impl(s, max_depth)
+}

--- a/crates/assay-evidence/src/lint/engine.rs
+++ b/crates/assay-evidence/src/lint/engine.rs
@@ -2,7 +2,8 @@ use super::packs::executor::{PackExecutionMeta, PackExecutor};
 use super::packs::LoadedPack;
 use super::rules::{LintBundleIndex, LintContext, RULES};
 use super::{LintFinding, LintReport, LintSummary, Severity};
-use crate::bundle::writer::{verify_bundle_with_limits, VerifyLimits};
+use crate::bundle::writer::VerifyLimits;
+use crate::bundle::BundleReader;
 use crate::ndjson::NdjsonEvents;
 use crate::types::EvidenceEvent;
 use anyhow::{Context, Result};
@@ -41,22 +42,15 @@ pub fn lint_bundle_with_options<R: Read>(
     limits: VerifyLimits,
     options: LintOptions,
 ) -> Result<LintReportWithPacks> {
-    // Read entire bundle into memory (needed for two passes)
-    let mut data = Vec::new();
-    let mut reader = reader;
-    reader
-        .read_to_end(&mut data)
-        .context("reading bundle data")?;
+    // One bounded pass. `BundleReader::open_with_limits` streams the source through the whole
+    // ceiling set before materializing, verifies, and holds onto the already-decoded events, so
+    // lint no longer needs an unbounded `read_to_end`, a second decode, or a second tar walk.
+    // Every limit refusal comes back typed from the shared classification path.
+    let bundle =
+        BundleReader::open_with_limits(reader, limits).context("bundle verification failed")?;
 
-    // 1. Verify bundle integrity (hard fail)
-    let verify_result = verify_bundle_with_limits(Cursor::new(&data), limits)
-        .context("bundle verification failed")?;
-
-    let manifest = verify_result.manifest.clone();
-
-    // 2. Extract events
-    let events_bytes = extract_events_bytes(&data)?;
-    let events = parse_events(&events_bytes)?;
+    let manifest = bundle.manifest().clone();
+    let events = parse_events(bundle.events_raw())?;
 
     // 3. Run built-in lint rules
     let mut findings = run_builtin_rules(&events);
@@ -145,26 +139,6 @@ fn run_builtin_rules(events: &[EvidenceEvent]) -> Vec<LintFinding> {
     }
 
     findings
-}
-
-fn extract_events_bytes(bundle_data: &[u8]) -> Result<Vec<u8>> {
-    let decoder = flate2::read::GzDecoder::new(Cursor::new(bundle_data));
-    let mut archive = tar::Archive::new(decoder);
-
-    for entry in archive.entries().context("reading tar entries")? {
-        let mut entry = entry.context("reading tar entry")?;
-        let path = entry.path()?.to_string_lossy().to_string();
-
-        if path == "events.ndjson" {
-            let mut content = Vec::new();
-            entry
-                .read_to_end(&mut content)
-                .context("reading events.ndjson")?;
-            return Ok(content);
-        }
-    }
-
-    anyhow::bail!("missing events.ndjson in bundle")
 }
 
 fn compute_summary(findings: &[LintFinding]) -> LintSummary {

--- a/crates/assay-evidence/src/lint/engine.rs
+++ b/crates/assay-evidence/src/lint/engine.rs
@@ -42,10 +42,11 @@ pub fn lint_bundle_with_options<R: Read>(
     limits: VerifyLimits,
     options: LintOptions,
 ) -> Result<LintReportWithPacks> {
-    // One bounded pass. `BundleReader::open_with_limits` streams the source through the whole
-    // ceiling set before materializing, verifies, and holds onto the already-decoded events, so
-    // lint no longer needs an unbounded `read_to_end`, a second decode, or a second tar walk.
-    // Every limit refusal comes back typed from the shared classification path.
+    // `BundleReader::open_with_limits` snapshots the source under the whole ceiling set before
+    // parsing, verifies, and holds the decoded events, so lint no longer does its own unbounded
+    // read or its own decode. It is not a single pass: the reader itself decodes twice, once to
+    // verify and once to extract the events, and both of those are bounded. What this removes is
+    // lint's third, unbounded pass. Every refusal comes back typed from the shared classifier.
     let bundle =
         BundleReader::open_with_limits(reader, limits).context("bundle verification failed")?;
 

--- a/crates/assay-evidence/tests/bounded_ingest_lint.rs
+++ b/crates/assay-evidence/tests/bounded_ingest_lint.rs
@@ -1,0 +1,125 @@
+//! ADR-043 §1 for the lint entrypoint.
+//!
+//! `lint_bundle_with_options` used to read the whole compressed input into memory with an
+//! unbounded `read_to_end`, verify a `Cursor` over that buffer, and then walk the tar a second
+//! time to extract `events.ndjson` through its own private decoder that carried none of the
+//! caller's limits. Every dimension in `VerifyLimits` outside the compressed byte ceiling had at
+//! most a partial effect: the manual second pass ignored them.
+//!
+//! The refactor routes lint through `BundleReader::open_with_limits`, so the same bounded pass
+//! that closed the reader entrypoint governs lint too. These tests pin two things: the ceiling
+//! stops the source stream, and refusals surface with the same typed classification the other
+//! reader consumers already return.
+
+use assay_evidence::bundle::writer::{
+    BundleWriter, ErrorClass, ErrorCode, VerifyError, VerifyLimits,
+};
+use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions};
+use assay_evidence::types::EvidenceEvent;
+use std::cell::Cell;
+use std::io::{Cursor, Read};
+use std::rc::Rc;
+
+/// Counts every byte the consumer pulls from the source, so a test can assert that ingest
+/// stopped at the ceiling rather than draining the input first and refusing afterwards.
+struct Counting<R> {
+    inner: R,
+    pulled: Rc<Cell<u64>>,
+}
+
+impl<R: Read> Read for Counting<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.pulled.set(self.pulled.get() + n as u64);
+        Ok(n)
+    }
+}
+
+fn counting(bytes: Vec<u8>) -> (Counting<Cursor<Vec<u8>>>, Rc<Cell<u64>>) {
+    let pulled = Rc::new(Cell::new(0));
+    (
+        Counting {
+            inner: Cursor::new(bytes),
+            pulled: Rc::clone(&pulled),
+        },
+        pulled,
+    )
+}
+
+fn small_bundle() -> Vec<u8> {
+    let mut buffer = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buffer);
+        w.add_event(EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_lint_bounded",
+            0,
+            serde_json::json!({"seq": 0}),
+        ));
+        w.finish().expect("write bundle");
+    }
+    buffer
+}
+
+/// The invariant. An oversized archive must stop being read at the compressed ceiling; a lint
+/// path that drains the whole input and refuses afterwards has already paid the memory even if
+/// the exit code looks the same.
+#[test]
+fn an_oversized_bundle_stops_being_read_at_the_ceiling() {
+    let bytes = small_bundle();
+    let ceiling = 64u64;
+    assert!(
+        (bytes.len() as u64) > ceiling * 4,
+        "fixture must be comfortably larger than the ceiling under test"
+    );
+
+    let limits = VerifyLimits {
+        max_bundle_bytes: ceiling,
+        ..VerifyLimits::default()
+    };
+    let (source, pulled) = counting(bytes);
+    assert!(lint_bundle_with_options(source, limits, LintOptions::default()).is_err());
+    assert!(
+        pulled.get() <= ceiling + 1,
+        "lint ingest must stop at the compressed ceiling; {} bytes were pulled for a ceiling of {ceiling}",
+        pulled.get()
+    );
+}
+
+/// A refusal that used to reach lint through the private extractor was `anyhow`-wrapped and
+/// stringly-typed, so an operator could not tell "raise the budget" from "the producer emitted a
+/// broken bundle". Every ceiling now comes back as a `VerifyError` with the same class and code
+/// the verifier itself produces.
+#[test]
+fn a_ceiling_refusal_surfaces_as_a_typed_verify_error() {
+    let bytes = small_bundle();
+    let limits = VerifyLimits {
+        max_bundle_bytes: (bytes.len() as u64) - 1,
+        ..VerifyLimits::default()
+    };
+    let err = lint_bundle_with_options(Cursor::new(bytes), limits, LintOptions::default())
+        .expect_err("one byte under the compressed ceiling must be refused");
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("lint refusals must surface as the same typed VerifyError as the verifier");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitBundleBytes);
+}
+
+/// Acceptance twin: without this, a lint refactor that simply refused everything would satisfy
+/// the two tests above. A bundle within every dimension must still produce a report.
+#[test]
+fn a_bundle_within_every_ceiling_still_lints() {
+    let bytes = small_bundle();
+    let report = lint_bundle_with_options(
+        Cursor::new(bytes),
+        VerifyLimits::default(),
+        LintOptions::default(),
+    )
+    .expect("a small bundle must lint under the default limits");
+    assert!(
+        report.report.verified,
+        "the report must record verification"
+    );
+}

--- a/crates/assay-evidence/tests/bounded_ingest_reader.rs
+++ b/crates/assay-evidence/tests/bounded_ingest_reader.rs
@@ -40,6 +40,44 @@ fn bundle_bytes() -> Vec<u8> {
     buffer
 }
 
+/// Rebuild a bundle without one member, so an absent-file case is a real archive rather than a
+/// truncated one. Repacking keeps every other member byte-identical.
+fn strip_member(bundle: &[u8], drop_path: &str) -> Vec<u8> {
+    use flate2::read::GzDecoder;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+
+    let mut kept: Vec<(String, Vec<u8>)> = Vec::new();
+    {
+        let mut ar = tar::Archive::new(GzDecoder::new(Cursor::new(bundle.to_vec())));
+        for entry in ar.entries().expect("entries") {
+            let mut e = entry.expect("entry");
+            let path = e.path().expect("path").to_string_lossy().to_string();
+            let mut data = Vec::new();
+            e.read_to_end(&mut data).expect("read member");
+            if path != drop_path {
+                kept.push((path, data));
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    {
+        let enc = GzEncoder::new(&mut out, Compression::default());
+        let mut tar = tar::Builder::new(enc);
+        for (path, data) in kept {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append_data(&mut header, &path, Cursor::new(data))
+                .expect("append");
+        }
+        tar.into_inner().expect("tar").finish().expect("gz");
+    }
+    out
+}
+
 fn limits_with_bundle_ceiling(max_bundle_bytes: u64) -> VerifyLimits {
     VerifyLimits {
         max_bundle_bytes,
@@ -188,23 +226,50 @@ fn short_reads_cannot_walk_past_the_ceiling() {
         .expect("and must still be accepted when it fits");
 }
 
+/// The ceiling counts bytes yielded, not bytes announced.
+///
+/// This was written as a "hostile metadata" case, which overclaimed: `Read` has no size hint, so
+/// a plain reader has no metadata to lie with and the wrapper below announced nothing. The narrow
+/// and true statement is that no source metadata participates in the ceiling at all; it is a
+/// running count of what the reader handed over. A chunked source that delivers in irregular
+/// pieces is the shape that could plausibly desynchronise such a count, so that is what is tested.
 #[test]
-fn a_lying_size_hint_does_not_widen_the_ceiling() {
-    // Hostile metadata: a reader that advertises a tiny size while delivering a large body. The
-    // ceiling has to come from bytes actually yielded, never from what the source claims.
-    struct LiesAboutItsSize(Cursor<Vec<u8>>);
-    impl Read for LiesAboutItsSize {
+fn a_chunked_source_cannot_desynchronise_the_count() {
+    struct Chunked {
+        inner: Cursor<Vec<u8>>,
+        sizes: Vec<usize>,
+        next: usize,
+    }
+    impl Read for Chunked {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            self.0.read(buf)
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            let want = self.sizes[self.next % self.sizes.len()].min(buf.len());
+            self.next += 1;
+            self.inner.read(&mut buf[..want.max(1)])
         }
     }
 
     let bytes = bundle_bytes();
+    let source = Chunked {
+        inner: Cursor::new(bytes.clone()),
+        sizes: vec![1, 7, 3, 64, 2],
+        next: 0,
+    };
     let one_short = limits_with_bundle_ceiling(bytes.len() as u64 - 1);
     assert!(
-        BundleReader::open_with_limits(LiesAboutItsSize(Cursor::new(bytes)), one_short).is_err(),
-        "the ceiling must count delivered bytes, not advertised ones"
+        BundleReader::open_with_limits(source, one_short).is_err(),
+        "irregular chunk sizes must not let the source past the ceiling"
     );
+
+    let source = Chunked {
+        inner: Cursor::new(bytes.clone()),
+        sizes: vec![1, 7, 3, 64, 2],
+        next: 0,
+    };
+    BundleReader::open_with_limits(source, limits_with_bundle_ceiling(bytes.len() as u64))
+        .expect("the same chunked source must be accepted at exactly the ceiling");
 }
 
 /// A bundle whose `events.ndjson` is highly compressible. Compressed it sits far inside
@@ -355,4 +420,206 @@ fn an_expansion_refusal_classifies_as_decode_not_source() {
     let ve = err.downcast_ref::<VerifyError>().expect("typed");
     assert_eq!(ve.class, ErrorClass::Limits);
     assert_eq!(ve.code, ErrorCode::LimitDecodeBytes);
+}
+
+/// The ceiling has to cover the whole source, not the prefix the parser happens to consume.
+///
+/// gzip and tar stop once the archive is logically complete, so a valid bundle followed by an
+/// arbitrary suffix used to pass a ceiling far below the real input size: the trailing bytes were
+/// never requested and therefore never counted. A 10 KiB suffix cleared a 598 byte ceiling.
+#[test]
+fn a_valid_bundle_with_an_unread_suffix_is_measured_whole() {
+    use assay_evidence::bundle::writer::verify_bundle_with_limits;
+
+    let valid = bundle_bytes();
+    let mut with_suffix = valid.clone();
+    with_suffix.extend(std::iter::repeat_n(b'Z', 10_000));
+    let total = with_suffix.len() as u64;
+
+    // Exactly the real input size is accepted, including the suffix nothing parses.
+    verify_bundle_with_limits(
+        Cursor::new(with_suffix.clone()),
+        limits_with_bundle_ceiling(total),
+    )
+    .expect("a source of exactly the ceiling must be accepted, suffix included");
+
+    // One byte under is refused, which is only observable once the suffix is counted.
+    let err = match verify_bundle_with_limits(
+        Cursor::new(with_suffix),
+        limits_with_bundle_ceiling(total - 1),
+    ) {
+        Ok(_) => panic!("the suffix must count towards the source ceiling"),
+        Err(e) => e,
+    };
+    let ve = err.downcast_ref::<VerifyError>().expect("typed");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitBundleBytes);
+
+    // Control: the bundle without its suffix still verifies under a ceiling that fits it.
+    verify_bundle_with_limits(
+        Cursor::new(valid.clone()),
+        limits_with_bundle_ceiling(valid.len() as u64),
+    )
+    .expect("the bundle alone must still verify");
+}
+
+/// `events.ndjson` on the unverified path used to be read whole under `max_events_bytes` and only
+/// then checked for line length and event count, so the allocation happened before the dimensions
+/// governing it were consulted. `max_json_depth` never reached event lines on this path at all,
+/// and an absent member read as a well-formed bundle with zero events.
+mod unverified_events {
+    use super::*;
+    use assay_evidence::bundle::writer::BundleWriter;
+
+    fn bundle_of(count: u64, pad: usize, depth: usize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut w = BundleWriter::new(&mut buf);
+            for seq in 0..count {
+                let mut payload = serde_json::json!({ "pad": "A".repeat(pad) });
+                for _ in 0..depth {
+                    payload = serde_json::json!({ "n": payload });
+                }
+                w.add_event(EvidenceEvent::new(
+                    "assay.test",
+                    "urn:assay:test",
+                    "run_unverified",
+                    seq,
+                    payload,
+                ));
+            }
+            w.finish().expect("write bundle");
+        }
+        buf
+    }
+
+    fn refuse(bytes: &[u8], limits: VerifyLimits) -> (ErrorClass, ErrorCode) {
+        let err =
+            match BundleReader::open_unverified_with_limits(Cursor::new(bytes.to_vec()), limits) {
+                Ok(_) => panic!("the unverified path must apply this ceiling"),
+                Err(e) => e,
+            };
+        let ve = err
+            .downcast_ref::<VerifyError>()
+            .expect("an unverified refusal must be typed");
+        (ve.class, ve.code)
+    }
+
+    #[test]
+    fn a_deeply_nested_event_is_refused_at_the_caller_depth() {
+        let bytes = bundle_of(1, 8, 12);
+        assert_eq!(
+            refuse(
+                &bytes,
+                VerifyLimits {
+                    max_json_depth: 4,
+                    ..VerifyLimits::default()
+                }
+            ),
+            (ErrorClass::Limits, ErrorCode::LimitJsonDepth)
+        );
+        BundleReader::open_unverified_with_limits(Cursor::new(bytes), VerifyLimits::default())
+            .expect("the same events must open under the default depth");
+    }
+
+    #[test]
+    fn a_line_over_the_ceiling_is_refused() {
+        let bytes = bundle_of(1, 512, 0);
+        assert_eq!(
+            refuse(
+                &bytes,
+                VerifyLimits {
+                    max_line_bytes: 64,
+                    ..VerifyLimits::default()
+                }
+            ),
+            (ErrorClass::Limits, ErrorCode::LimitLineBytes)
+        );
+        BundleReader::open_unverified_with_limits(Cursor::new(bytes), VerifyLimits::default())
+            .expect("the same line must open under the default ceiling");
+    }
+
+    #[test]
+    fn one_event_over_the_count_ceiling_is_refused() {
+        let bytes = bundle_of(4, 8, 0);
+        assert_eq!(
+            refuse(
+                &bytes,
+                VerifyLimits {
+                    max_events: 3,
+                    ..VerifyLimits::default()
+                }
+            ),
+            (ErrorClass::Limits, ErrorCode::LimitTotalEvents)
+        );
+        // Exactly the ceiling is accepted, so the refusal above is the boundary and not the shape.
+        BundleReader::open_unverified_with_limits(
+            Cursor::new(bytes),
+            VerifyLimits {
+                max_events: 4,
+                ..VerifyLimits::default()
+            },
+        )
+        .expect("exactly the event ceiling must be accepted");
+    }
+
+    /// An absent member is not an empty one. Accepting a stripped archive as a zero-event run is
+    /// the difference between "there were no events" and "the events were removed".
+    #[test]
+    fn a_bundle_without_events_ndjson_is_refused() {
+        let full = bundle_of(1, 8, 0);
+        let stripped = super::strip_member(&full, "events.ndjson");
+
+        let err = match BundleReader::open_unverified_with_limits(
+            Cursor::new(stripped),
+            VerifyLimits::default(),
+        ) {
+            Ok(_) => panic!("a bundle without events.ndjson must not read as an empty run"),
+            Err(e) => e,
+        };
+        let ve = err.downcast_ref::<VerifyError>().expect("typed");
+        assert_eq!(ve.class, ErrorClass::Contract);
+        assert_eq!(ve.code, ErrorCode::ContractMissingFile);
+
+        BundleReader::open_unverified_with_limits(Cursor::new(full), VerifyLimits::default())
+            .expect("the intact bundle must still open");
+    }
+}
+
+/// The existing expansion test goes through `open_unverified_with_limits`, which reaches peek but
+/// also runs the reader's own second pass, so it cannot show which of the two refused. This calls
+/// `BundleInfo::peek_with_limits` directly and pins that peek carries its own decode ceiling.
+///
+/// The ceiling has to sit under what peek actually expands. Peek stops once it has the manifest,
+/// which the writer emits first, so a large trailing member never reaches the decoder however big
+/// it is: a ceiling above the manifest is simply never crossed. The bound is real within the
+/// prefix peek reads, and that is what this pins.
+#[test]
+fn peek_alone_refuses_expansion_past_the_decode_ceiling() {
+    let bytes = compressible_bundle(400);
+    let limits = VerifyLimits {
+        max_bundle_bytes: bytes.len() as u64 * 8,
+        max_decode_bytes: 64,
+        ..VerifyLimits::default()
+    };
+
+    let err = match assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+        Cursor::new(bytes.clone()),
+        limits,
+    ) {
+        Ok(_) => panic!("peek must refuse expansion past its own decode ceiling"),
+        Err(e) => e,
+    };
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("a peek expansion refusal must be typed");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitDecodeBytes);
+
+    // Acceptance twin: the same bundle under a decode ceiling that accommodates it.
+    assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+        Cursor::new(bytes),
+        VerifyLimits::default(),
+    )
+    .expect("the same bundle must peek under the default decode ceiling");
 }

--- a/crates/assay-evidence/tests/bounded_ingest_reader.rs
+++ b/crates/assay-evidence/tests/bounded_ingest_reader.rs
@@ -15,7 +15,9 @@
 //! Every refusal case is paired with an acceptance case built from the same bundle, so a ceiling
 //! that simply refused everything would not pass.
 
-use assay_evidence::bundle::writer::{BundleWriter, VerifyLimits};
+use assay_evidence::bundle::writer::{
+    BundleWriter, ErrorClass, ErrorCode, VerifyError, VerifyLimits,
+};
 use assay_evidence::bundle::BundleReader;
 use assay_evidence::types::EvidenceEvent;
 use std::cell::Cell;
@@ -100,10 +102,14 @@ fn verified_open_refuses_one_byte_over_the_ceiling() {
         Ok(_) => panic!("a bundle one byte over the ceiling must be refused"),
         Err(e) => e,
     };
-    assert!(
-        format!("{err:#}").contains("LimitBundleBytes"),
-        "the refusal must name the ceiling that was crossed: {err:#}"
-    );
+    // Through the typed cause, not the message. A public reader entrypoint must classify its
+    // ceilings exactly as the verifier does, or a caller cannot tell a refusal from a truncated
+    // file without reading prose.
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("a reader ceiling refusal must surface as a typed VerifyError");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitBundleBytes);
 }
 
 /// The invariant itself. An oversized archive must stop being read at the ceiling; a verifier
@@ -293,4 +299,60 @@ fn peek_called_directly_is_bounded_on_the_compressed_input_too() {
         limits_with_bundle_ceiling(bytes.len() as u64),
     )
     .expect("a direct peek must still accept a bundle that fits");
+}
+
+#[test]
+fn the_unverified_path_classifies_its_ceilings_too() {
+    // The path with no downstream verifier is where an unclassified io error would be hardest to
+    // interpret, so it must carry the same typed cause.
+    let bytes = bundle_bytes();
+    let one_short = limits_with_bundle_ceiling(bytes.len() as u64 - 1);
+    let err = match BundleReader::open_unverified_with_limits(Cursor::new(bytes), one_short) {
+        Ok(_) => panic!("must be refused"),
+        Err(e) => e,
+    };
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("an unverified ceiling refusal must be typed as well");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitBundleBytes);
+}
+
+#[test]
+fn a_direct_peek_classifies_its_ceilings_too() {
+    // A ceiling of `len - 1` would not do here: peek stops reading once it has the manifest, so
+    // it never reaches the end of the archive and a near-total ceiling is never crossed. The
+    // bound has to be small enough that the partial read itself hits it.
+    let bytes = bundle_bytes();
+    let err = match assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+        Cursor::new(bytes.clone()),
+        limits_with_bundle_ceiling(64),
+    ) {
+        Ok(_) => panic!("must be refused"),
+        Err(e) => e,
+    };
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("a peek ceiling refusal must be typed as well");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitBundleBytes);
+}
+
+#[test]
+fn an_expansion_refusal_classifies_as_decode_not_source() {
+    // The dimension has to survive classification, otherwise every ceiling looks alike to a
+    // caller deciding whether to retry with a larger budget.
+    let bytes = compressible_bundle(400);
+    let limits = VerifyLimits {
+        max_bundle_bytes: bytes.len() as u64 * 8,
+        max_decode_bytes: 4096,
+        ..VerifyLimits::default()
+    };
+    let err = match BundleReader::open_unverified_with_limits(Cursor::new(bytes), limits) {
+        Ok(_) => panic!("must be refused"),
+        Err(e) => e,
+    };
+    let ve = err.downcast_ref::<VerifyError>().expect("typed");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitDecodeBytes);
 }

--- a/crates/assay-evidence/tests/bounded_ingest_reader.rs
+++ b/crates/assay-evidence/tests/bounded_ingest_reader.rs
@@ -623,3 +623,175 @@ fn peek_alone_refuses_expansion_past_the_decode_ceiling() {
     )
     .expect("the same bundle must peek under the default decode ceiling");
 }
+
+/// The source ceiling on a direct peek, at the boundary and past it.
+///
+/// The bound was in the right place but under the wrong reader: a `LimitReader` sitting beneath
+/// gzip and tar only ever sees what a decoder asks for, and peek returns as soon as it has read
+/// `manifest.json`. Everything after that member was never requested, so a valid bundle followed
+/// by an arbitrarily large suffix passed a ceiling it plainly exceeded. Snapshotting the source
+/// first is what makes the ceiling a property of the artifact rather than of the prefix a parser
+/// happened to consume.
+mod direct_peek_source_ceiling {
+    use super::*;
+    use assay_evidence::bundle::reader::BundleInfo;
+
+    fn peek_under(bytes: Vec<u8>, ceiling: u64) -> anyhow::Result<BundleInfo> {
+        BundleInfo::peek_with_limits(Cursor::new(bytes), limits_with_bundle_ceiling(ceiling))
+    }
+
+    #[test]
+    fn an_input_of_exactly_the_ceiling_is_accepted() {
+        let bytes = bundle_bytes();
+        let exact = bytes.len() as u64;
+        peek_under(bytes, exact).expect("an input of exactly the ceiling must be accepted");
+    }
+
+    #[test]
+    fn one_byte_over_the_ceiling_is_refused() {
+        let bytes = bundle_bytes();
+        let one_short = bytes.len() as u64 - 1;
+        assert!(
+            peek_under(bytes, one_short).is_err(),
+            "a ceiling one byte below the input must refuse"
+        );
+    }
+
+    /// The case the old placement could not see. The bundle is valid and its manifest is reached
+    /// long before the suffix, so a decoder-driven bound reports success on an input several
+    /// times the size of the ceiling.
+    #[test]
+    fn a_valid_bundle_with_an_unread_suffix_is_refused() {
+        let mut bytes = bundle_bytes();
+        let valid_len = bytes.len();
+        bytes.extend(std::iter::repeat_n(0u8, valid_len * 4));
+
+        let err = match peek_under(bytes.clone(), valid_len as u64) {
+            Err(err) => err,
+            Ok(_) => panic!("a bundle plus a suffix must not pass a ceiling sized for the bundle"),
+        };
+        let verify: &VerifyError = err
+            .downcast_ref()
+            .unwrap_or_else(|| panic!("expected a typed refusal, got: {err}"));
+        assert_eq!(verify.class, ErrorClass::Limits);
+        assert_eq!(verify.code, ErrorCode::LimitBundleBytes);
+
+        // Acceptance twin from the same bytes: raising the ceiling past the whole input accepts
+        // it, so the refusal above is about size and not about the suffix confusing the parser.
+        peek_under(bytes.clone(), bytes.len() as u64)
+            .expect("the same input is accepted once the ceiling covers all of it");
+    }
+}
+
+/// Diagnostics from the strict-JSON pass carry nothing the archive chose.
+///
+/// `StrictJsonError`'s own `Display` renders the duplicated key and its JSON path, the byte
+/// position of a bad escape, the offending codepoint, serde's parse message with line, column and
+/// a token snippet, and observed counts and lengths. The reader forwarded all of it under a
+/// blanket `Security:` prefix. That text lands in an operator's terminal and in every log that
+/// ingests the message, so it is an archive-controlled write into someone else's system; the
+/// prefix was also wrong, since a duplicate object key is a producer defect and not a security
+/// event.
+mod strict_json_diagnostics_are_value_free {
+    use super::*;
+
+    /// Rebuild a bundle with one member's bytes replaced, so hostile JSON reaches the reader
+    /// exactly as an archive would deliver it.
+    fn replace_member(bundle: &[u8], target: &str, replacement: &[u8]) -> Vec<u8> {
+        use flate2::read::GzDecoder;
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let mut members: Vec<(String, Vec<u8>)> = Vec::new();
+        {
+            let mut ar = tar::Archive::new(GzDecoder::new(Cursor::new(bundle.to_vec())));
+            for entry in ar.entries().expect("entries") {
+                let mut e = entry.expect("entry");
+                let path = e.path().expect("path").to_string_lossy().to_string();
+                let mut data = Vec::new();
+                e.read_to_end(&mut data).expect("read member");
+                if path == target {
+                    data = replacement.to_vec();
+                }
+                members.push((path, data));
+            }
+        }
+
+        let mut out = Vec::new();
+        {
+            let enc = GzEncoder::new(&mut out, Compression::default());
+            let mut tar = tar::Builder::new(enc);
+            for (path, data) in members {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(data.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                tar.append_data(&mut header, &path, Cursor::new(data))
+                    .expect("append");
+            }
+            tar.into_inner().expect("tar").finish().expect("gz");
+        }
+        out
+    }
+
+    /// Values an archive picks specifically so they will be echoed back.
+    const HOSTILE_MARKERS: &[&str] = &[
+        "ATTACKER_KEY_MARKER",
+        "ATTACKER_PATH_MARKER",
+        "\u{1b}[31m",
+        "\u{7}",
+    ];
+
+    fn assert_no_hostile_values(rendered: &str) {
+        for marker in HOSTILE_MARKERS {
+            assert!(
+                !rendered.contains(marker),
+                "archive-chosen value {marker:?} reached the diagnostic: {rendered}"
+            );
+        }
+        assert!(
+            !rendered.contains("Security:"),
+            "the blanket Security prefix misframes a producer defect: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_duplicate_key_does_not_echo_the_key_or_its_path() {
+        let hostile = br#"{"ATTACKER_KEY_MARKER":1,"ATTACKER_KEY_MARKER":2}"#;
+        let bundle = replace_member(&bundle_bytes(), "manifest.json", hostile);
+        let err = match assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+        ) {
+            Err(err) => err,
+            Ok(_) => panic!("a duplicate key must be refused"),
+        };
+        assert_no_hostile_values(&format!("{err:#}"));
+    }
+
+    #[test]
+    fn a_malformed_document_does_not_echo_the_parser_detail() {
+        // Terminal escapes inside a string the parser will quote back in its own message.
+        let hostile = b"{\"a\": \"\x1b[31mATTACKER_PATH_MARKER\x07\" ,,}";
+        let bundle = replace_member(&bundle_bytes(), "manifest.json", hostile);
+        let err = match assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+        ) {
+            Err(err) => err,
+            Ok(_) => panic!("a malformed manifest must be refused"),
+        };
+        assert_no_hostile_values(&format!("{err:#}"));
+    }
+
+    /// The acceptance twin: an ordinary bundle still peeks cleanly, so the wording change is not
+    /// a guard that refuses everything.
+    #[test]
+    fn an_ordinary_manifest_still_peeks() {
+        assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+            Cursor::new(bundle_bytes()),
+            VerifyLimits::default(),
+        )
+        .expect("an ordinary bundle peeks");
+    }
+}

--- a/crates/assay-evidence/tests/bounded_ingest_reader.rs
+++ b/crates/assay-evidence/tests/bounded_ingest_reader.rs
@@ -1,0 +1,296 @@
+//! ADR-043 §1 for the bundle reader entrypoints.
+//!
+//! `BundleReader::open_internal` read the whole input with `read_to_end` and only then handed a
+//! `Cursor` to the verifier, so `max_bundle_bytes` was consulted after the archive had already
+//! sized the allocation. `open_unverified` and the manifest peek had no ceiling at all, on the
+//! reasoning that they do not verify; not verifying is not a reason to let an untrusted archive
+//! decide how much memory to take.
+//!
+//! These tests pin *when* the ceiling applies, not merely whether the call fails. Asserting only
+//! `is_err()` is not enough: `verify_bundle_with_limits` refuses an oversized bundle downstream
+//! anyway, so an unbounded ingest still ends in an error, having first read the whole archive
+//! into memory. The invariant is that the bytes stop flowing at the ceiling, so the tests count
+//! what the reader actually pulled from the source.
+//!
+//! Every refusal case is paired with an acceptance case built from the same bundle, so a ceiling
+//! that simply refused everything would not pass.
+
+use assay_evidence::bundle::writer::{BundleWriter, VerifyLimits};
+use assay_evidence::bundle::BundleReader;
+use assay_evidence::types::EvidenceEvent;
+use std::cell::Cell;
+use std::io::{Cursor, Read};
+use std::rc::Rc;
+
+fn bundle_bytes() -> Vec<u8> {
+    let mut buffer = Vec::new();
+    {
+        let mut writer = BundleWriter::new(&mut buffer);
+        writer.add_event(EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_bounded_ingest",
+            0,
+            serde_json::json!({"seq": 0}),
+        ));
+        writer.finish().expect("write bundle");
+    }
+    buffer
+}
+
+fn limits_with_bundle_ceiling(max_bundle_bytes: u64) -> VerifyLimits {
+    VerifyLimits {
+        max_bundle_bytes,
+        ..VerifyLimits::default()
+    }
+}
+
+/// A reader that never fills the caller's buffer. A ceiling that only counts whole reads could
+/// be walked past one byte at a time.
+struct DripFeed(Cursor<Vec<u8>>);
+
+impl Read for DripFeed {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        self.0.read(&mut buf[..1])
+    }
+}
+
+/// Counts every byte handed to the consumer, so a test can assert the stream stopped at the
+/// ceiling instead of being drained and rejected afterwards.
+struct Counting<R> {
+    inner: R,
+    pulled: Rc<Cell<u64>>,
+}
+
+impl<R: Read> Read for Counting<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.pulled.set(self.pulled.get() + n as u64);
+        Ok(n)
+    }
+}
+
+fn counting(bytes: Vec<u8>) -> (Counting<Cursor<Vec<u8>>>, Rc<Cell<u64>>) {
+    let pulled = Rc::new(Cell::new(0));
+    (
+        Counting {
+            inner: Cursor::new(bytes),
+            pulled: Rc::clone(&pulled),
+        },
+        pulled,
+    )
+}
+
+#[test]
+fn verified_open_accepts_exactly_the_ceiling() {
+    let bytes = bundle_bytes();
+    let exact = limits_with_bundle_ceiling(bytes.len() as u64);
+    BundleReader::open_with_limits(Cursor::new(bytes), exact)
+        .expect("a bundle of exactly max_bundle_bytes must be accepted");
+}
+
+#[test]
+fn verified_open_refuses_one_byte_over_the_ceiling() {
+    let bytes = bundle_bytes();
+    let one_short = limits_with_bundle_ceiling(bytes.len() as u64 - 1);
+    let err = match BundleReader::open_with_limits(Cursor::new(bytes), one_short) {
+        Ok(_) => panic!("a bundle one byte over the ceiling must be refused"),
+        Err(e) => e,
+    };
+    assert!(
+        format!("{err:#}").contains("LimitBundleBytes"),
+        "the refusal must name the ceiling that was crossed: {err:#}"
+    );
+}
+
+/// The invariant itself. An oversized archive must stop being read at the ceiling; a verifier
+/// that drains the whole input and refuses afterwards has already paid the memory.
+#[test]
+fn an_oversized_archive_stops_being_read_at_the_ceiling() {
+    let bytes = bundle_bytes();
+    let ceiling = 64u64;
+    assert!(
+        (bytes.len() as u64) > ceiling * 4,
+        "the fixture must be comfortably larger than the ceiling under test"
+    );
+
+    let (source, pulled) = counting(bytes);
+    assert!(BundleReader::open_with_limits(source, limits_with_bundle_ceiling(ceiling)).is_err());
+    assert!(
+        pulled.get() <= ceiling + 1,
+        "ingest must stop at the ceiling; {} bytes were pulled for a ceiling of {ceiling}",
+        pulled.get()
+    );
+}
+
+/// Same invariant on the path that never verifies, where nothing downstream would catch it.
+#[test]
+fn an_unverified_open_also_stops_reading_at_the_ceiling() {
+    let bytes = bundle_bytes();
+    let ceiling = 64u64;
+    let (source, pulled) = counting(bytes);
+    assert!(
+        BundleReader::open_unverified_with_limits(source, limits_with_bundle_ceiling(ceiling))
+            .is_err()
+    );
+    assert!(
+        pulled.get() <= ceiling + 1,
+        "unverified ingest must stop at the ceiling too; {} bytes were pulled",
+        pulled.get()
+    );
+}
+
+#[test]
+fn unverified_open_is_still_bounded() {
+    // The bite: before this change `open_unverified` passed `None` for limits and read the whole
+    // input regardless of size. Skipping verification skipped the ceiling with it.
+    let bytes = bundle_bytes();
+    let one_short = limits_with_bundle_ceiling(bytes.len() as u64 - 1);
+    assert!(
+        BundleReader::open_unverified_with_limits(Cursor::new(bytes.clone()), one_short).is_err(),
+        "an unverified open must still refuse an oversized archive"
+    );
+    let exact = limits_with_bundle_ceiling(bytes.len() as u64);
+    BundleReader::open_unverified_with_limits(Cursor::new(bytes), exact)
+        .expect("and must still accept one that fits");
+}
+
+#[test]
+fn the_default_open_carries_a_ceiling_rather_than_none() {
+    // `open` and `open_unverified` take no limits argument. Neither may therefore be unbounded:
+    // the default ceiling applies. A bundle far under it is accepted, which is what keeps this
+    // from being satisfied by refusing everything.
+    let bytes = bundle_bytes();
+    assert!(bytes.len() < VerifyLimits::default().max_bundle_bytes as usize);
+    BundleReader::open(Cursor::new(bytes.clone())).expect("a small bundle passes the default");
+    BundleReader::open_unverified(Cursor::new(bytes)).expect("unverified likewise");
+}
+
+#[test]
+fn short_reads_cannot_walk_past_the_ceiling() {
+    let bytes = bundle_bytes();
+    let one_short = limits_with_bundle_ceiling(bytes.len() as u64 - 1);
+    assert!(
+        BundleReader::open_with_limits(DripFeed(Cursor::new(bytes.clone())), one_short).is_err(),
+        "a one-byte-at-a-time stream must not slip past the ceiling"
+    );
+    let exact = limits_with_bundle_ceiling(bytes.len() as u64);
+    BundleReader::open_with_limits(DripFeed(Cursor::new(bytes)), exact)
+        .expect("and must still be accepted when it fits");
+}
+
+#[test]
+fn a_lying_size_hint_does_not_widen_the_ceiling() {
+    // Hostile metadata: a reader that advertises a tiny size while delivering a large body. The
+    // ceiling has to come from bytes actually yielded, never from what the source claims.
+    struct LiesAboutItsSize(Cursor<Vec<u8>>);
+    impl Read for LiesAboutItsSize {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.0.read(buf)
+        }
+    }
+
+    let bytes = bundle_bytes();
+    let one_short = limits_with_bundle_ceiling(bytes.len() as u64 - 1);
+    assert!(
+        BundleReader::open_with_limits(LiesAboutItsSize(Cursor::new(bytes)), one_short).is_err(),
+        "the ceiling must count delivered bytes, not advertised ones"
+    );
+}
+
+/// A bundle whose `events.ndjson` is highly compressible. Compressed it sits far inside
+/// `max_bundle_bytes`; expanded it does not. This is the case ADR-043 §1 means by "a single byte
+/// ceiling is not that set".
+fn compressible_bundle(event_count: u64) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    {
+        let mut writer = BundleWriter::new(&mut buffer);
+        for seq in 0..event_count {
+            writer.add_event(EvidenceEvent::new(
+                "assay.test",
+                "urn:assay:test",
+                "run_bomb",
+                seq,
+                serde_json::json!({ "pad": "A".repeat(512) }),
+            ));
+        }
+        writer.finish().expect("write bundle");
+    }
+    buffer
+}
+
+#[test]
+fn a_decompression_bomb_inside_the_compressed_ceiling_is_refused() {
+    let bytes = compressible_bundle(400);
+    let compressed_len = bytes.len() as u64;
+
+    // Generous compressed ceiling, so the compressed-byte guard cannot be what refuses this.
+    let limits = VerifyLimits {
+        max_bundle_bytes: compressed_len * 8,
+        max_decode_bytes: 4096,
+        ..VerifyLimits::default()
+    };
+
+    assert!(
+        BundleReader::open_with_limits(Cursor::new(bytes.clone()), limits).is_err(),
+        "expansion past max_decode_bytes must be refused even when the compressed input fits"
+    );
+
+    // The acceptance twin: the same bundle under a decode ceiling that accommodates it.
+    let roomy = VerifyLimits {
+        max_bundle_bytes: compressed_len * 8,
+        ..VerifyLimits::default()
+    };
+    BundleReader::open_with_limits(Cursor::new(bytes), roomy)
+        .expect("the same bundle must pass when the decode ceiling accommodates it");
+}
+
+#[test]
+fn the_peek_path_is_bounded_on_expansion_too() {
+    // The peek path never runs verification, so this pass is its only consumption. Nothing
+    // downstream would catch an expansion here.
+    let bytes = compressible_bundle(400);
+    let limits = VerifyLimits {
+        max_bundle_bytes: bytes.len() as u64 * 8,
+        max_decode_bytes: 4096,
+        ..VerifyLimits::default()
+    };
+    assert!(
+        BundleReader::open_unverified_with_limits(Cursor::new(bytes), limits).is_err(),
+        "an unverified open must refuse expansion past the decode ceiling"
+    );
+}
+
+#[test]
+fn peek_called_directly_is_bounded_on_the_compressed_input_too() {
+    // Reached through `BundleReader` the input has already passed a ceiling. `peek_with_limits`
+    // is public in its own right, so a direct caller must get the compressed bound as well and
+    // not merely the expansion one.
+    let bytes = bundle_bytes();
+    let ceiling = 64u64;
+    assert!((bytes.len() as u64) > ceiling * 4);
+
+    let (source, pulled) = counting(bytes.clone());
+    assert!(
+        assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+            source,
+            limits_with_bundle_ceiling(ceiling)
+        )
+        .is_err()
+    );
+    assert!(
+        pulled.get() <= ceiling + 1,
+        "a direct peek must stop at max_bundle_bytes; {} bytes were pulled",
+        pulled.get()
+    );
+
+    // Acceptance twin: the same bundle under a ceiling that fits.
+    assay_evidence::bundle::reader::BundleInfo::peek_with_limits(
+        Cursor::new(bytes.clone()),
+        limits_with_bundle_ceiling(bytes.len() as u64),
+    )
+    .expect("a direct peek must still accept a bundle that fits");
+}

--- a/crates/assay-evidence/tests/bounded_ingest_stdin.rs
+++ b/crates/assay-evidence/tests/bounded_ingest_stdin.rs
@@ -1,0 +1,112 @@
+//! ADR-043 §1 for the stdin verify entrypoint.
+//!
+//! `cmd_verify` on stdin used to `read_to_end` the pipe into a `Vec` and then hand a `Cursor`
+//! to `verify_bundle`. The verifier is streaming and applies `max_bundle_bytes` to bytes as
+//! they arrive; interposing a full `read_to_end` between the pipe and the verifier defeats
+//! that. On stdin specifically there is no size to check beforehand either, so an oversized
+//! upload was materialised in full before any limit was consulted.
+//!
+//! The CLI change is a one-line contract-fix (hand `stdin.lock()` to `verify_bundle`). This
+//! file pins the invariant at the layer the CLI hands to: given the same input the CLI would
+//! now hand it, verify must stop reading at the ceiling and classify the refusal as data.
+//!
+//! Stdin cannot be substituted in tests, so we drive `verify_bundle_with_limits` directly. The
+//! streaming ceiling is a property of the verifier, not of the CLI wrapper, so exercising it at
+//! this layer is what the CLI now inherits by construction.
+
+use assay_evidence::bundle::writer::{
+    verify_bundle_with_limits, BundleWriter, ErrorClass, ErrorCode, VerifyError, VerifyLimits,
+};
+use assay_evidence::types::EvidenceEvent;
+use std::cell::Cell;
+use std::io::{Cursor, Read};
+use std::rc::Rc;
+
+/// Counts every byte the consumer pulls from the source, so a test can distinguish "verify
+/// refused" from "verify stopped reading". Both look the same at the exit code.
+struct Counting<R> {
+    inner: R,
+    pulled: Rc<Cell<u64>>,
+}
+
+impl<R: Read> Read for Counting<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.pulled.set(self.pulled.get() + n as u64);
+        Ok(n)
+    }
+}
+
+fn counting(bytes: Vec<u8>) -> (Counting<Cursor<Vec<u8>>>, Rc<Cell<u64>>) {
+    let pulled = Rc::new(Cell::new(0));
+    (
+        Counting {
+            inner: Cursor::new(bytes),
+            pulled: Rc::clone(&pulled),
+        },
+        pulled,
+    )
+}
+
+fn bundle() -> Vec<u8> {
+    let mut buffer = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buffer);
+        w.add_event(EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_stdin_bounded",
+            0,
+            serde_json::json!({"seq": 0}),
+        ));
+        w.finish().expect("write bundle");
+    }
+    buffer
+}
+
+#[test]
+fn stdin_verify_stops_reading_at_the_compressed_ceiling() {
+    let bytes = bundle();
+    let ceiling = 64u64;
+    assert!(
+        (bytes.len() as u64) > ceiling * 4,
+        "fixture must be comfortably larger than the ceiling under test"
+    );
+
+    let (source, pulled) = counting(bytes);
+    let limits = VerifyLimits {
+        max_bundle_bytes: ceiling,
+        ..VerifyLimits::default()
+    };
+    assert!(verify_bundle_with_limits(source, limits).is_err());
+    assert!(
+        pulled.get() <= ceiling + 1,
+        "verify must stop at the compressed ceiling; {} bytes were pulled for a ceiling of {ceiling}",
+        pulled.get()
+    );
+}
+
+#[test]
+fn stdin_verify_classifies_the_refusal_as_a_limit() {
+    let bytes = bundle();
+    let limits = VerifyLimits {
+        max_bundle_bytes: (bytes.len() as u64) - 1,
+        ..VerifyLimits::default()
+    };
+    let err = verify_bundle_with_limits(Cursor::new(bytes), limits)
+        .expect_err("one byte over the compressed ceiling must be refused");
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("stdin verify refusals must surface as the same typed VerifyError");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitBundleBytes);
+}
+
+/// Acceptance twin. Without this, a ceiling that refused everything would satisfy both
+/// assertions above.
+#[test]
+fn stdin_verify_still_accepts_a_bundle_within_the_defaults() {
+    let bytes = bundle();
+    verify_bundle_with_limits(Cursor::new(bytes), VerifyLimits::default())
+        .expect("a small bundle must verify under the default limits");
+}

--- a/crates/assay-evidence/tests/typed_limit_classification.rs
+++ b/crates/assay-evidence/tests/typed_limit_classification.rs
@@ -77,3 +77,198 @@ fn a_bundle_within_every_ceiling_is_not_refused() {
     verify_bundle_with_limits(Cursor::new(bytes), VerifyLimits::default())
         .expect("a small bundle must verify under the default limits");
 }
+
+/// `max_json_depth` was configurable and had no effect: the validator's depth guard was pinned to
+/// a constant, so the field never reached it. And when the constant did trip, the failure was
+/// reported as `ContractInvalidJson`, which says the document is malformed when it means the
+/// document is deeper than we agreed to parse.
+#[test]
+fn a_nesting_refusal_classifies_as_limit_json_depth() {
+    let mut buf = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buf);
+        // Nested well past a small configured ceiling, far under the built-in constant.
+        let mut payload = serde_json::json!({"leaf": 1});
+        for _ in 0..12 {
+            payload = serde_json::json!({ "n": payload });
+        }
+        w.add_event(EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_depth",
+            0,
+            payload,
+        ));
+        w.finish().expect("write bundle");
+    }
+
+    let limits = VerifyLimits {
+        max_json_depth: 4,
+        ..VerifyLimits::default()
+    };
+    assert_eq!(
+        classify(buf.clone(), limits),
+        (ErrorClass::Limits, ErrorCode::LimitJsonDepth)
+    );
+
+    // Acceptance twin: the same bundle under a ceiling that accommodates it. Without this, a
+    // validator that rejected all nesting would satisfy the assertion above.
+    verify_bundle_with_limits(Cursor::new(buf), VerifyLimits::default())
+        .expect("the same bundle must verify under the default depth");
+}
+
+/// Object and array nesting are separate code paths in the validator, and only the object one had
+/// been switched to the caller's ceiling. An array-only document therefore kept using the module
+/// constant and ignored a configured depth entirely.
+#[test]
+fn the_ceiling_applies_to_object_array_and_mixed_nesting() {
+    fn bundle_with(payload: serde_json::Value) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut w = BundleWriter::new(&mut buf);
+            w.add_event(EvidenceEvent::new(
+                "assay.test",
+                "urn:assay:test",
+                "run_depth_shape",
+                0,
+                payload,
+            ));
+            w.finish().expect("write bundle");
+        }
+        buf
+    }
+
+    let mut objects = serde_json::json!({"leaf": 1});
+    let mut arrays = serde_json::json!([1]);
+    let mut mixed = serde_json::json!({"leaf": 1});
+    for i in 0..12 {
+        objects = serde_json::json!({ "n": objects });
+        arrays = serde_json::json!([arrays]);
+        mixed = if i % 2 == 0 {
+            serde_json::json!([mixed])
+        } else {
+            serde_json::json!({ "n": mixed })
+        };
+    }
+
+    let tight = VerifyLimits {
+        max_json_depth: 4,
+        ..VerifyLimits::default()
+    };
+    for (shape, payload) in [("objects", objects), ("arrays", arrays), ("mixed", mixed)] {
+        let bytes = bundle_with(payload);
+        assert_eq!(
+            classify(bytes.clone(), tight),
+            (ErrorClass::Limits, ErrorCode::LimitJsonDepth),
+            "{shape} nesting must respect the configured ceiling"
+        );
+        verify_bundle_with_limits(Cursor::new(bytes), VerifyLimits::default())
+            .unwrap_or_else(|e| panic!("{shape} must verify under the default depth: {e:#}"));
+    }
+}
+
+/// The manifest is a document like any other, and it was the one the ceiling never reached. The
+/// verifier handed it straight to `serde_json` with no strict pass at all, and peek validated it
+/// against the module constant, so an unverified read applied a different budget than a verified
+/// one on the same bytes.
+#[test]
+fn the_manifest_respects_the_configured_ceiling_on_both_paths() {
+    use assay_evidence::bundle::BundleReader;
+
+    // A manifest is written by us, so it is not deeply nested. A ceiling of 1 is below even a
+    // flat object, which is what makes this observable without hand-forging a bundle.
+    let mut buf = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buf);
+        w.add_event(EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_manifest_depth",
+            0,
+            serde_json::json!({"flat": 1}),
+        ));
+        w.finish().expect("write bundle");
+    }
+
+    let tight = VerifyLimits {
+        max_json_depth: 1,
+        ..VerifyLimits::default()
+    };
+
+    assert_eq!(
+        classify(buf.clone(), tight),
+        (ErrorClass::Limits, ErrorCode::LimitJsonDepth),
+        "the verifier must apply the ceiling to manifest.json"
+    );
+
+    let err = match BundleReader::open_unverified_with_limits(Cursor::new(buf.clone()), tight) {
+        Ok(_) => panic!("the unverified path must apply the ceiling to manifest.json too"),
+        Err(e) => e,
+    };
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("a manifest depth refusal must be typed on the unverified path as well");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitJsonDepth);
+
+    // Acceptance twin on both paths, so a ceiling that refused every manifest would not pass.
+    verify_bundle_with_limits(Cursor::new(buf.clone()), VerifyLimits::default())
+        .expect("the manifest must verify under the default depth");
+    BundleReader::open_unverified_with_limits(Cursor::new(buf), VerifyLimits::default())
+        .expect("and must open unverified under the default depth");
+}
+
+/// The classification was right while the sentence was wrong. `NestingTooDeep` renders its own
+/// Display, which names the module constant as the maximum and echoes the depth the input chose,
+/// so a refusal under a configured ceiling of four told the operator it had exceeded 64. One
+/// shared classifier now writes the message from the ceiling that actually applied, and does not
+/// repeat an attacker-supplied number back at the reader.
+#[test]
+fn the_message_names_the_configured_ceiling_and_not_the_constant() {
+    let mut buf = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buf);
+        let mut payload = serde_json::json!({"leaf": 1});
+        for _ in 0..12 {
+            payload = serde_json::json!({ "n": payload });
+        }
+        w.add_event(EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_depth_message",
+            0,
+            payload,
+        ));
+        w.finish().expect("write bundle");
+    }
+
+    let limits = VerifyLimits {
+        max_json_depth: 4,
+        ..VerifyLimits::default()
+    };
+    let err = verify_bundle_with_limits(Cursor::new(buf), limits).expect_err("must be refused");
+    let ve = err.downcast_ref::<VerifyError>().expect("typed");
+
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitJsonDepth);
+    assert!(
+        ve.message.contains("maximum depth of 4"),
+        "the message must name the ceiling that applied: {}",
+        ve.message
+    );
+    assert!(
+        !ve.message.contains("64"),
+        "the module constant must not be presented as the maximum: {}",
+        ve.message
+    );
+    assert!(
+        !ve.message.contains("13"),
+        "the observed depth is attacker-chosen and must not be echoed: {}",
+        ve.message
+    );
+    assert!(
+        !ve.message.contains("Security"),
+        "a budget refusal must not be framed as a security finding: {}",
+        ve.message
+    );
+}

--- a/crates/assay-evidence/tests/typed_limit_classification.rs
+++ b/crates/assay-evidence/tests/typed_limit_classification.rs
@@ -272,3 +272,76 @@ fn the_message_names_the_configured_ceiling_and_not_the_constant() {
         ve.message
     );
 }
+
+/// `max_path_len`, `max_line_bytes` and `max_events` were enforced on the verifying path and
+/// nowhere else, so an unverified read applied a different contract to the same bytes. Skipping
+/// verification means skipping the integrity check, not the resource budget.
+#[test]
+fn the_unverified_path_enforces_line_and_event_ceilings() {
+    use assay_evidence::bundle::BundleReader;
+
+    let mut buf = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buf);
+        for seq in 0..6 {
+            w.add_event(EvidenceEvent::new(
+                "assay.test",
+                "urn:assay:test",
+                "run_shape",
+                seq,
+                serde_json::json!({ "pad": "A".repeat(256) }),
+            ));
+        }
+        w.finish().expect("write bundle");
+    }
+
+    fn refuse_unverified(bytes: &[u8], limits: VerifyLimits) -> (ErrorClass, ErrorCode) {
+        let err =
+            match BundleReader::open_unverified_with_limits(Cursor::new(bytes.to_vec()), limits) {
+                Ok(_) => panic!("the unverified path must apply this ceiling"),
+                Err(e) => e,
+            };
+        let ve = err
+            .downcast_ref::<VerifyError>()
+            .expect("an unverified ceiling refusal must be typed");
+        (ve.class, ve.code)
+    }
+
+    assert_eq!(
+        refuse_unverified(
+            &buf,
+            VerifyLimits {
+                max_line_bytes: 64,
+                ..VerifyLimits::default()
+            }
+        ),
+        (ErrorClass::Limits, ErrorCode::LimitLineBytes)
+    );
+
+    assert_eq!(
+        refuse_unverified(
+            &buf,
+            VerifyLimits {
+                max_events: 2,
+                ..VerifyLimits::default()
+            }
+        ),
+        (ErrorClass::Limits, ErrorCode::LimitTotalEvents)
+    );
+
+    assert_eq!(
+        refuse_unverified(
+            &buf,
+            VerifyLimits {
+                max_path_len: 4,
+                ..VerifyLimits::default()
+            }
+        ),
+        (ErrorClass::Limits, ErrorCode::LimitPathLength)
+    );
+
+    // Acceptance twin: the same bundle under the defaults, so a reader that refused everything
+    // would not pass.
+    BundleReader::open_unverified_with_limits(Cursor::new(buf), VerifyLimits::default())
+        .expect("the same bundle must open unverified under the default limits");
+}

--- a/crates/assay-evidence/tests/typed_limit_classification.rs
+++ b/crates/assay-evidence/tests/typed_limit_classification.rs
@@ -1,0 +1,79 @@
+//! ADR-043: a ceiling failure must be classifiable as data, never by reading the message.
+//!
+//! The verifier used to recognise its own ceilings with `ve.message.contains("LimitBundleBytes")`.
+//! That made the rendered text a contract: rewording a diagnostic would silently reclassify a
+//! resource refusal as an integrity fault. The cause now travels as a typed
+//! `assay_common::limits::LimitExceeded` through the `io::Error`, and the verifier maps it onto its
+//! own `ErrorCode`.
+//!
+//! Every assertion here goes through `downcast_ref::<VerifyError>()` and checks the exact class
+//! and code, so a test cannot pass on a coincidentally similar message.
+
+use assay_evidence::bundle::writer::{
+    verify_bundle_with_limits, BundleWriter, ErrorClass, ErrorCode, VerifyError, VerifyLimits,
+};
+use assay_evidence::types::EvidenceEvent;
+use std::io::Cursor;
+
+fn bundle(events: u64, pad: usize) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut buf);
+        for seq in 0..events {
+            w.add_event(EvidenceEvent::new(
+                "assay.test",
+                "urn:assay:test",
+                "run_typed",
+                seq,
+                serde_json::json!({ "pad": "A".repeat(pad) }),
+            ));
+        }
+        w.finish().expect("write bundle");
+    }
+    buf
+}
+
+fn classify(bytes: Vec<u8>, limits: VerifyLimits) -> (ErrorClass, ErrorCode) {
+    let err = verify_bundle_with_limits(Cursor::new(bytes), limits)
+        .expect_err("the bundle must be refused under these limits");
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("a ceiling refusal must surface as a typed VerifyError");
+    (ve.class, ve.code)
+}
+
+#[test]
+fn the_compressed_ceiling_classifies_as_limit_bundle_bytes() {
+    let bytes = bundle(1, 8);
+    let limits = VerifyLimits {
+        max_bundle_bytes: bytes.len() as u64 - 1,
+        ..VerifyLimits::default()
+    };
+    assert_eq!(
+        classify(bytes, limits),
+        (ErrorClass::Limits, ErrorCode::LimitBundleBytes)
+    );
+}
+
+#[test]
+fn the_expansion_ceiling_classifies_as_limit_decode_bytes() {
+    let bytes = bundle(400, 512);
+    let limits = VerifyLimits {
+        max_bundle_bytes: bytes.len() as u64 * 8,
+        max_decode_bytes: 4096,
+        ..VerifyLimits::default()
+    };
+    assert_eq!(
+        classify(bytes, limits),
+        (ErrorClass::Limits, ErrorCode::LimitDecodeBytes)
+    );
+}
+
+/// The acceptance side. A refusal-classifying verifier that refused everything would satisfy the
+/// tests above; this one holds it to accepting a bundle that fits.
+#[test]
+fn a_bundle_within_every_ceiling_is_not_refused() {
+    let bytes = bundle(4, 32);
+    verify_bundle_with_limits(Cursor::new(bytes), VerifyLimits::default())
+        .expect("a small bundle must verify under the default limits");
+}

--- a/crates/assay-evidence/tests/typed_limit_classification.rs
+++ b/crates/assay-evidence/tests/typed_limit_classification.rs
@@ -345,3 +345,81 @@ fn the_unverified_path_enforces_line_and_event_ceilings() {
     BundleReader::open_unverified_with_limits(Cursor::new(buf), VerifyLimits::default())
         .expect("the same bundle must open unverified under the default limits");
 }
+
+/// The verified and unverified paths shared a name for `max_line_bytes` and disagreed on what it
+/// meant. `read_line_bounded` counted the trailing `\n` inside the ceiling, so a payload of
+/// exactly the limit consumed limit + 1 bytes and was refused; `check_events_shape` split on `\n`
+/// first, so the same payload passed. One budget, two answers. Pinning one interpretation and
+/// requiring the same verdict on both paths is the only way `max_line_bytes` can be a contract.
+#[test]
+fn max_line_bytes_has_one_interpretation_on_both_paths() {
+    use assay_evidence::bundle::BundleReader;
+
+    fn bundle_with_padded_event(pad: usize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut w = BundleWriter::new(&mut buf);
+            w.add_event(EvidenceEvent::new(
+                "assay.test",
+                "urn:assay:test",
+                "run_line_bytes",
+                0,
+                serde_json::json!({ "pad": "A".repeat(pad) }),
+            ));
+            w.finish().expect("write bundle");
+        }
+        buf
+    }
+
+    // A padded event serializes to a JSON line whose length grows with `pad`. Pick a small
+    // headroom over the padding so we can lock a `max_line_bytes` right at the line length.
+    let pad = 200;
+    let bytes = bundle_with_padded_event(pad);
+    let line_len = {
+        // Peek at the emitted line length through the default verifier, which does not refuse
+        // this bundle under the defaults. We only need the true length to build the ±1 tests.
+        let default_open = BundleReader::open(Cursor::new(bytes.clone()))
+            .expect("default open must accept the fixture");
+        default_open
+            .events_raw()
+            .split(|b| *b == b'\n')
+            .next()
+            .map(<[u8]>::len)
+            .unwrap_or(0)
+    };
+    assert!(
+        line_len > 0,
+        "the fixture must emit at least one non-empty line"
+    );
+
+    let exact = VerifyLimits {
+        max_line_bytes: line_len,
+        ..VerifyLimits::default()
+    };
+    let too_tight = VerifyLimits {
+        max_line_bytes: line_len - 1,
+        ..VerifyLimits::default()
+    };
+
+    // Exact-limit passes on both paths.
+    verify_bundle_with_limits(Cursor::new(bytes.clone()), exact)
+        .expect("verified path must accept a line of exactly max_line_bytes");
+    BundleReader::open_unverified_with_limits(Cursor::new(bytes.clone()), exact)
+        .expect("unverified path must accept the same line");
+
+    // One byte tighter refuses on both, with the same class and code.
+    assert_eq!(
+        classify(bytes.clone(), too_tight),
+        (ErrorClass::Limits, ErrorCode::LimitLineBytes),
+        "verified path must classify the overflow as LimitLineBytes"
+    );
+    let err = match BundleReader::open_unverified_with_limits(Cursor::new(bytes), too_tight) {
+        Ok(_) => panic!("unverified path must refuse the same line under the tighter limit"),
+        Err(e) => e,
+    };
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("the unverified overflow must surface as a typed VerifyError");
+    assert_eq!(ve.class, ErrorClass::Limits);
+    assert_eq!(ve.code, ErrorCode::LimitLineBytes);
+}

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -184,6 +184,7 @@ Reason codes are **stable, machine-readable** strings. CI and scripts MAY branch
 | E_BASELINE_INVALID  | Baseline file invalid or missing. |
 | E_POLICY_PARSE      | Policy file parse error. |
 | E_REPLAY_MISSING_DEPENDENCY | Replay missing required offline dependency (e.g. uncached judge/cassette input). |
+| E_REPLAY_LIMIT_EXCEEDED | Replay bundle refused by an ingest ceiling before it was parsed. The bundle may be well-formed; the configured budget is what it exceeded, so raising the ceiling is a legitimate response. Distinct from `E_CFG_PARSE`, which means the input is malformed. Carries no verdict: no test ran. |
 
 ### 5.2 Infra / Judge Unavailable (exit_code 3)
 
@@ -263,6 +264,7 @@ For every non-zero exit, the implementation MUST provide **at least one suggeste
 | 1              | 2026-02  | Clarified/added: Seeds (§3.3.1) + Judge metrics (§3.3.2). Seeds MUST be decimal strings (or null) to avoid JSON precision loss. judge_seed reserved (null) until implemented. |
 | 1              | 2026-02  | E2.3: SARIF truncation metadata (§6.3): properties.assay (truncated, omitted_count) in SARIF run; sarif.omitted in summary.json and run.json when truncated. Deterministic truncation order. |
 | 1              | 2026-02  | E9c alignment draft: replay provenance keys in `provenance` (`replay`, `bundle_digest`, `replay_mode`, `source_run_id`) and `E_REPLAY_MISSING_DEPENDENCY` reason code. |
+| 1              | 2026-07  | Added `E_REPLAY_LIMIT_EXCEEDED` (§5.1). Backward compatible: a new registry string under the existing `reason_code_version` 1, so consumers branching on `(reason_code_version, reason_code)` treat it as an unknown code under a known version and fall back as they already must. No version bump. |
 
 ---
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -184,7 +184,7 @@ Reason codes are **stable, machine-readable** strings. CI and scripts MAY branch
 | E_BASELINE_INVALID  | Baseline file invalid or missing. |
 | E_POLICY_PARSE      | Policy file parse error. |
 | E_REPLAY_MISSING_DEPENDENCY | Replay missing required offline dependency (e.g. uncached judge/cassette input). |
-| E_REPLAY_LIMIT_EXCEEDED | Replay bundle refused by an ingest ceiling before it was parsed. The bundle may be well-formed; the configured budget is what it exceeded, so raising the ceiling is a legitimate response. Distinct from `E_CFG_PARSE`, which means the input is malformed. Carries no verdict: no test ran. |
+| E_REPLAY_LIMIT_EXCEEDED | Replay bundle refused by an ingest ceiling during bounded ingest, before replay execution. The source, decode, member, path, entry-count and manifest-depth ceilings apply at different points of the read, so this is not a claim that nothing was parsed. It establishes only that a configured budget was exceeded; whether the bundle is otherwise valid is unresolved, because the read stopped. Adjusting the budget or supplying a smaller bundle is a legitimate response. Distinct from `E_CFG_PARSE`, which is a malformed-input finding. Carries no verdict: no test ran. |
 
 ### 5.2 Infra / Judge Unavailable (exit_code 3)
 


### PR DESCRIPTION
Slice 1a of the ADR-042/043 programme: bounded ingest for every local entrypoint that consumes an untrusted evidence or replay archive. Ledger is #1847.

ADR-043 §1 states the invariant: each entrypoint applies the whole limit set to the source stream *before* the input is materialized, and a single byte ceiling is not that set. Every entrypoint named there read first and checked afterwards, or carried no ceiling at all.

Object-store pull is deliberately out of scope and sequenced as Slice 1b, because the materialization there happens inside the store API.

## What changes

**The primitive.** `LimitReader` moves to `assay-common::limits` behind the `std` feature, so the evidence verifier and the replay verifier apply one implementation of the boundary. Only the mechanism moves; limit vocabularies stay domain-local, because `max_manifest_bytes` and `max_events` describe an evidence bundle and say nothing about a replay bundle. This adds an `assay-evidence -> assay-common` edge, documented in the crate graph in `CLAUDE.md`.

Three defects in the primitive itself, each able to turn a refusal into a silent success:

- The ceiling was exclusive. Erroring as soon as `read == limit` rejected the exact-limit input, because every consumer issues one further read to observe EOF, so the effective ceiling was `limit - 1`. It is inclusive now, which widens three pre-existing consumers in `writer_next/verify.rs` by one byte each. That commit is separated deliberately.
- The overflow was not sticky. After the error the counter still sat at the limit, so a retry probed an exhausted source, saw `0`, and reported a clean EOF: a truncated archive presented as a complete one.
- Empty reads consumed the source, against the `Read` contract, because the boundary probe ran for a zero-length request.

**Typed refusals.** The verifier recognised its own ceilings with `ve.message.contains("LimitBundleBytes")` and seven siblings, which made rendered text a contract. The cause now travels as data: `LimitExceeded { LimitKind, limit }` through the `io::Error`, recovered with `from_io`. `LimitKind` is a closed enum with no wildcard arm, so adding a dimension is a compile error at every consumer rather than a silent misclassification. All eight message-matching sites are gone.

**The entrypoints.**

| Entrypoint | Before |
|---|---|
| `BundleReader::open*` | `read_to_end` then check; `open_unverified` and peek unbounded outright |
| `BundleInfo::peek*` | public, expanded the archive with no ceiling at all |
| lint | own unbounded read, plus a second decode and second tar walk outside the limits |
| `evidence verify -` | stdin read to the end, then a `Cursor` verified |
| `evidence push` | file read whole with no ceiling, buffer cloned for upload, `--no-verify` skipped even that |
| `assay_core::replay` | no limits of any kind |

`Option<VerifyLimits>` conflated "do not verify" with "do not bound"; verification is a separate flag now and the limits apply either way.

**All eight dimensions.** `max_json_depth` was configurable and had no effect: the guard compared against a module constant. `LimitJsonDepth` was the one `Limit*` variant with no construction site, and a depth refusal was reported as `ContractInvalidJson`, which says the document is malformed when it means it is deeper than we agreed to parse. Object and array nesting are separate paths and both now take the caller's ceiling; the manifest was the document the ceiling never reached on either path. `max_path_len`, `max_line_bytes` and `max_events` were enforced only while verifying and now apply to the unverified paths too.

`max_line_bytes` had two interpretations: the line reader counted the trailing newline inside the ceiling and `check_events_shape` did not, so one budget gave two answers. It is the payload length on both paths.

**Replay.** Six ceilings where there were none: compressed source, gzip expansion, manifest, member, path length, entry count, plus a manifest JSON-depth check over raw bytes. Path length is measured on `path_bytes()` before any conversion, because `to_string_lossy` emits three bytes for every invalid one and a check on the converted string measures something the archive never sent.

The replay CLI read the bundle twice in two different ways: `sha256_file` for `provenance.bundle_digest`, then a second open for the parse and verify. The published digest could describe different bytes than the verified and replayed bundle. `read_verify_bounded` takes one bounded read and returns the digest, the parse and the verdict together; `verify_read_bundle` is crate-internal so the split cannot be reassembled wrongly.

**Diagnostics are value-free.** A refusal reports the ceiling that applied and never the attacker-chosen value: not the observed nesting depth, not the offending path, not the member name. The nesting message also named the module constant as the maximum, so a refusal under a configured ceiling of four told the operator it had exceeded 64.

## Correction round

Three blockers from the exact-head review on `e3a80634` are closed in `413ebf12`.

**The whole-source ceiling was not whole.** Both verifiers stopped reading at the archive's logical end, so a 10,598-byte input passed a 598-byte ceiling: gzip and tar stop early and never request the trailing bytes. A ceiling that only bounds the part a decoder happens to consume is not a ceiling on the artifact. Both entrypoints now snapshot the source to EOF through a `LimitReader` before any parsing. This is a deliberate correctness-over-laziness trade: the whole source is read before it is judged, which is what §1 asks for.

**The unverified read path bounded the container but not the events inside it**, so `max_events`, `max_json_depth` and the line ceiling were decorative once a caller opened a bundle without verification. `read_events_bounded` reads line by line and refuses early; `check_events_shape` is removed rather than left as a second, weaker path.

**The replay CLI still opened the bundle twice**, so the digest reported and the bytes judged were not necessarily the same file. `read_verify_bounded` returns one snapshot, and the flow matches the typed refusal before rendering, keeping the digest of the bytes that actually failed instead of degrading to `sha256:unknown`.

`E_REPLAY_LIMIT_EXCEEDED` is additive and resource-only. A well-formed bundle over budget is an operator decision; reporting it as `E_CFG_PARSE` sent the reader off to fix the producer. Contract tests pin the public `summary.json` shape: the wire string across every refusal variant, exit class 2, digest survival, value-free messages, and the **absence** of `passed`/`failed`/`total`/`verdict`/`score`. Absent, not zero: a count of zero is itself a claim about a run that never started, and a consumer aggregating summaries would fold it in as a real result.

## Verification

Run on `413ebf12`, rebased onto `038541be`:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test` for `assay-common`, `assay-evidence`, `assay-core` (40 suites) and `assay-cli` (44 suites) — no failures
- 54 targeted boundary contracts, confirmed running with real counts rather than silently filtered: `bounded_ingest_reader` 20, `typed_limit_classification` 9, `bounded_ingest_lint` 3, `bounded_ingest_stdin` 3, replay `bounded_ingest` 13, `replay_limit_summary_contract` 6
- `git diff --check` clean; pre-push clippy and linux compile gate passed

Every test was verified to fail against the implementation it guards, checked per fix rather than by removing all ceilings at once. Every refusal case has an acceptance twin from the same fixture, so a ceiling that refused everything would not pass. The load-bearing pin has a negative control: renaming the wire string `E_REPLAY_LIMIT_EXCEEDED` fails the contract test.

### Benchmarks

Bencher flagged `sw/12xlarge` at +54.31%, with `sw/50x400b` (+38.57%) and `sr/wc` (+38.29%) under their boundaries. Not attributable to this branch: `sw/*` is `store_write_heavy`, which exercises the SQLite `Store` write path, and `sr/wc` is `suite_run_worstcase`. Neither references `verify_bundle`, `BundleReader`, `read_bundle_tar_gz`, `LimitReader` or `lint`, so no changed symbol is reachable from either. Three unrelated benchmarks moved up together with none moving down, which is a runner signature rather than a code one; `sw/12xlarge` tripped because it had the least headroom. The run was on `e3a80634`, which predates the snapshot change, so the snapshot is not the cause either. No change made — the snapshot is the correctness boundary and is not worth trading against an unattributed measurement.

## Where a twin is absent, and why

Some boundaries are not pinned exactly, and the tests say so rather than asserting something weaker and looking complete:

The source boundary is now exact through both entrypoints, since each reads to EOF before parsing. It was previously exact only through `read_verify_bounded`; that asymmetry is what the correction round removed.

The decode dimension has no exact twin because its crossing point depends on the compressor rather than on a number the test controls.

Path length is bounded by what the tar reader decodes. A name delivered through a PAX extended header is measured after that decode, not before, so the claim here is bounded-by-decode rather than bounded-by-wire-bytes. Pinning it at the wire would mean a parser rewrite, which is out of proportion to the gap.

There is also no CLI-level ceiling test. `evidence verify` and `push` take no limits flag, so tripping a default ceiling from the CLI needs a fixture around a gigabyte, and a cheap oversized fixture is refused by tar's header check long before the ceiling is reached. The CLI tests pin the ordering invariant instead: a refusal must leave the store empty. They pass against the previous implementation too, which is what a guard is for. The replay summary contract is pinned at the value `write_replay_failure` serializes, because that function writes to fixed relative paths and exercising it directly would mean moving the process CWD.

## Not in this PR

Object-store pull (Slice 1b). Session authorization and evidence-chain fuzzing, which are their own slices. No scalar score, whole-action verdict, identity layer, HTTP transport, or compliance claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added replay ingest limit refusal `E_REPLAY_LIMIT_EXCEEDED` (exit code `2`).
* **Bug Fixes**
  * Evidence `verify`/`push` now consistently enforce bounded ingest limits across stdin and `--no-verify`, rejecting oversized/malformed bundles before any upload or store write.
  * Replay and lint ingest/verification stop at configured ceilings and return clearer, categorized limit errors.
* **Improvements**
  * Replay bundles are read/verified/fingerprinted in one bounded operation; workspace-safe replay materialization is enforced.
* **Tests**
  * Added integration and regression tests covering ceiling boundaries, typed refusals, and workspace containment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
