### PR TITLE
fix(store,cli): bounded object-store pull (ADR-043 §1, Slice 1b)

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/pull.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/pull.rs
@@ -1,8 +1,12 @@
 //! `assay evidence pull` - Download an evidence bundle from storage.
 
 use anyhow::{Context, Result};
+use assay_evidence::sanitize::sanitize_terminal;
 use assay_evidence::store::BundleStore;
-use assay_evidence::{resolve_store_url, ObjectStoreBundleStore, StoreError, StoreSpec};
+use assay_evidence::store::{BoundedGetError, StreamCeiling};
+use assay_evidence::{
+    resolve_store_url, ObjectStoreBundleStore, StoreError, StoreSpec, VerifyLimits,
+};
 use clap::Args;
 use std::fs::File;
 use std::io::Write;
@@ -45,15 +49,65 @@ pub async fn cmd_pull(args: PullArgs) -> Result<i32> {
         .await
         .with_context(|| "failed to connect to store")?;
 
+    // ADR-043 section 1: the ceiling applies to the source before the input is materialized.
+    // `evidence push` bounds its side with `VerifyLimits::default().max_bundle_bytes`; pull takes
+    // the same number from the same place, so the two ends of the same transfer agree and there is
+    // no second, unrelated default to keep in step. Downloading more than the verifier would ever
+    // accept cannot help.
+    let ceiling = StreamCeiling::new(VerifyLimits::default().max_bundle_bytes);
+
     if let Some(bundle_id) = &args.bundle_id {
         // Single bundle download
-        pull_single(&store, bundle_id, &args.out, args.verify).await
+        pull_single(&store, bundle_id, &args.out, args.verify, ceiling).await
     } else if let Some(run_id) = &args.run_id {
         // Download all bundles for a run
-        pull_run(&store, run_id, &args.out, args.verify).await
+        pull_run(&store, run_id, &args.out, args.verify, ceiling).await
     } else {
         anyhow::bail!("Either --bundle-id or --run-id is required");
     }
+}
+
+/// Render a caller- or store-supplied string for a terminal.
+///
+/// A bundle id and a run id arrive from the command line or from a listing the store produced,
+/// and both are echoed straight into a terminal. Escape sequences in either can rewrite the line,
+/// hide what was printed, or drive a terminal's own OSC handlers, so nothing untrusted is written
+/// raw. Display only: the store lookup always uses the original string, because sanitizing an
+/// identifier before a lookup would silently ask for a different object.
+fn shown(value: &str) -> String {
+    sanitize_terminal(value)
+}
+
+/// Build the output filename for a bundle, as a single path component that cannot escape.
+///
+/// The previous form was `bundle_id.replace(':', "_")` with `.tar.gz` appended, which strips only
+/// the character that happens to appear in a well-formed id. A `--bundle-id` of `../../etc/x`
+/// survived intact and `out.join` then resolved it outside the directory the operator chose; on
+/// Windows a backslash did the same. The id is caller input, and the fix is not to enumerate the
+/// dangerous characters but to permit the harmless ones.
+///
+/// Strict ASCII allowlist, everything else mapped to `_`, so the result is always exactly one
+/// component with no separator and no traversal segment. The stored id is untouched — this
+/// changes only what the file on disk is called.
+fn bundle_filename(bundle_id: &str) -> String {
+    let mut stem: String = bundle_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    // An id of only rejected characters still yields underscores, so this catches the empty input
+    // alone. `.tar.gz` by itself would be a hidden file with no name.
+    if stem.is_empty() {
+        stem.push_str("bundle");
+    }
+
+    format!("{stem}.tar.gz")
 }
 
 async fn pull_single(
@@ -61,13 +115,33 @@ async fn pull_single(
     bundle_id: &str,
     out: &Path,
     verify: bool,
+    ceiling: StreamCeiling,
 ) -> Result<i32> {
-    eprintln!("Downloading: {}", bundle_id);
+    eprintln!("Downloading: {}", shown(bundle_id));
 
-    let bytes = match store.get_bundle(bundle_id).await {
+    // The bounded method rather than the trait's `get_bundle`, which ends in
+    // `GetResult::bytes().await` and hands back an object that is already fully in memory. The
+    // trait method stays as compatibility surface for other callers; this is the entrypoint the
+    // CLI uses, and it is the one ADR-043 section 1 names.
+    let bytes = match store.get_bundle_bounded(bundle_id, ceiling).await {
         Ok(b) => b,
-        Err(StoreError::NotFound { .. }) => {
-            eprintln!("❌ Bundle not found: {}", bundle_id);
+        // Every resource refusal in one arm, keyed on the predicate rather than on the variant
+        // list. Enumerating variants here would send any dimension added later to the catch-all
+        // below, turning a budget refusal into an unrelated exit code — and `BoundedGetError` is
+        // `#[non_exhaustive]` precisely so dimensions can be added.
+        Err(e) if e.is_resource_refusal() => {
+            // Refuse before any output path is computed or created, so a refusal leaves nothing
+            // behind for a later run to mistake for a complete download.
+            //
+            // This says a configured budget was exceeded and nothing else. It is not a claim that
+            // the remote bundle is invalid: the download stopped at the chunk that crossed a
+            // ceiling, so the bundle was never read far enough to be assessed.
+            eprintln!("❌ Download refused: {}", e);
+            eprintln!("   The bundle was not downloaded and was not assessed.");
+            return Ok(2);
+        }
+        Err(BoundedGetError::Store(StoreError::NotFound { .. })) => {
+            eprintln!("❌ Bundle not found: {}", shown(bundle_id));
             return Ok(2); // Exit code 2 for not found
         }
         Err(e) => return Err(e).context("failed to download bundle"),
@@ -75,8 +149,7 @@ async fn pull_single(
 
     // Determine output path
     let out_path = if out.is_dir() {
-        let filename = format!("{}.tar.gz", bundle_id.replace(':', "_"));
-        out.join(filename)
+        out.join(bundle_filename(bundle_id))
     } else {
         out.to_path_buf()
     };
@@ -105,6 +178,7 @@ async fn pull_run(
     run_id: &str,
     out_dir: &PathBuf,
     verify: bool,
+    ceiling: StreamCeiling,
 ) -> Result<i32> {
     // Ensure output is a directory
     if out_dir.exists() && !out_dir.is_dir() {
@@ -118,26 +192,34 @@ async fn pull_run(
     let bundle_ids = store
         .list_bundles_for_run(run_id)
         .await
-        .with_context(|| format!("failed to list bundles for run: {}", run_id))?;
+        .with_context(|| format!("failed to list bundles for run: {}", shown(run_id)))?;
 
     if bundle_ids.is_empty() {
-        eprintln!("⚠️  No bundles found for run: {}", run_id);
+        eprintln!("⚠️  No bundles found for run: {}", shown(run_id));
         return Ok(0);
     }
 
-    eprintln!("Found {} bundle(s) for run: {}", bundle_ids.len(), run_id);
+    eprintln!(
+        "Found {} bundle(s) for run: {}",
+        bundle_ids.len(),
+        shown(run_id)
+    );
 
     let mut errors = 0;
     for bundle_id in &bundle_ids {
-        match pull_single(store, bundle_id, out_dir, verify).await {
+        match pull_single(store, bundle_id, out_dir, verify, ceiling).await {
             Ok(0) => {}
             Ok(code) => {
                 errors += 1;
-                eprintln!("Warning: bundle {} returned exit code {}", bundle_id, code);
+                eprintln!(
+                    "Warning: bundle {} returned exit code {}",
+                    shown(bundle_id),
+                    code
+                );
             }
             Err(e) => {
                 errors += 1;
-                eprintln!("Error downloading {}: {}", bundle_id, e);
+                eprintln!("Error downloading {}: {}", shown(bundle_id), e);
             }
         }
     }
@@ -152,5 +234,294 @@ async fn pull_run(
     } else {
         eprintln!("✅ Downloaded {} bundle(s)", bundle_ids.len());
         Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod bounded_pull {
+    use super::*;
+    use assay_evidence::store::BundleStore;
+    use assay_evidence::Bytes;
+
+    /// An in-memory store holding one bundle of `size` bytes.
+    async fn seeded_store(bundle_id: &str, size: usize) -> ObjectStoreBundleStore {
+        let store = ObjectStoreBundleStore::memory();
+        store
+            .put_bundle(bundle_id, Bytes::from(vec![b'x'; size]))
+            .await
+            .expect("seed");
+        store
+    }
+
+    fn entries(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .expect("read dir")
+            .map(|e| e.expect("entry").file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// The property a user can check without reading any code: a refused download leaves no file.
+    ///
+    /// Asserting only the exit code would not be enough. The old path materialized the object
+    /// before the CLI saw it, so "the command failed" and "nothing was written" were separate
+    /// facts, and a future change that streams straight to disk would keep the exit code while
+    /// leaving a truncated archive behind. A leftover prefix is worse than no file at all: it has
+    /// a plausible name and a later run cannot tell it from a complete download.
+    #[tokio::test]
+    async fn an_oversized_single_pull_writes_no_file() {
+        let id = "sha256:toobig";
+        let store = seeded_store(id, 10_000).await;
+        let out = tempfile::tempdir().expect("tmp");
+
+        let code = pull_single(&store, id, out.path(), false, StreamCeiling::new(100))
+            .await
+            .expect("a ceiling refusal is an exit code, not an error");
+
+        assert_eq!(code, 2, "a refused download exits 2");
+        assert!(
+            entries(out.path()).is_empty(),
+            "a refused download must leave the output directory empty, found {:?}",
+            entries(out.path())
+        );
+    }
+
+    /// The same property through the run path, which delegates to `pull_single`. Bounding one
+    /// function covers both entrypoints, and this is what proves it rather than assuming it.
+    #[tokio::test]
+    async fn an_oversized_run_pull_writes_no_file() {
+        let id = "sha256:toobig";
+        let run = "run-42";
+        let store = seeded_store(id, 10_000).await;
+        store.link_run_bundle(run, id).await.expect("link");
+        let out = tempfile::tempdir().expect("tmp");
+        let out_dir = out.path().to_path_buf();
+
+        let code = pull_run(&store, run, &out_dir, false, StreamCeiling::new(100))
+            .await
+            .expect("run pull returns a code");
+
+        assert_eq!(code, 1, "a run with a refused bundle reports errors");
+        assert!(
+            entries(out.path()).is_empty(),
+            "no bundle in the run may be materialized, found {:?}",
+            entries(out.path())
+        );
+    }
+
+    /// The acceptance twin. Same fixture shape, ceiling that fits: the file appears with the exact
+    /// bytes. A guard that refused everything would pass both tests above and fail this one.
+    #[tokio::test]
+    async fn a_bundle_within_the_ceiling_is_written_intact() {
+        let id = "sha256:fits";
+        let store = seeded_store(id, 4096).await;
+        let out = tempfile::tempdir().expect("tmp");
+
+        let code = pull_single(
+            &store,
+            id,
+            out.path(),
+            false,
+            StreamCeiling::new(100 * 1024),
+        )
+        .await
+        .expect("ordinary download");
+
+        assert_eq!(code, 0);
+        let written = entries(out.path());
+        assert_eq!(written.len(), 1, "exactly one file, found {written:?}");
+        let body = std::fs::read(out.path().join(&written[0])).expect("read back");
+        assert_eq!(body, vec![b'x'; 4096], "bytes must round-trip");
+    }
+
+    /// Exactly the ceiling is accepted end to end, and one byte more is refused, with the file
+    /// system as the witness in both directions.
+    #[tokio::test]
+    async fn the_ceiling_boundary_holds_through_the_cli_path() {
+        let out = tempfile::tempdir().expect("tmp");
+        let exact = seeded_store("sha256:exact", 100).await;
+        assert_eq!(
+            pull_single(
+                &exact,
+                "sha256:exact",
+                out.path(),
+                false,
+                StreamCeiling::new(100)
+            )
+            .await
+            .expect("exact"),
+            0
+        );
+        assert_eq!(entries(out.path()).len(), 1);
+
+        let out2 = tempfile::tempdir().expect("tmp");
+        let over = seeded_store("sha256:over", 101).await;
+        assert_eq!(
+            pull_single(
+                &over,
+                "sha256:over",
+                out2.path(),
+                false,
+                StreamCeiling::new(100)
+            )
+            .await
+            .expect("over"),
+            2
+        );
+        assert!(entries(out2.path()).is_empty());
+    }
+
+    /// A missing bundle still exits 2 and writes nothing, unchanged by this slice.
+    #[tokio::test]
+    async fn a_missing_bundle_still_exits_two_and_writes_nothing() {
+        let store = ObjectStoreBundleStore::memory();
+        let out = tempfile::tempdir().expect("tmp");
+
+        let code = pull_single(
+            &store,
+            "sha256:nonexistent",
+            out.path(),
+            false,
+            StreamCeiling::new(100 * 1024),
+        )
+        .await
+        .expect("not found is an exit code");
+
+        assert_eq!(code, 2);
+        assert!(entries(out.path()).is_empty());
+    }
+}
+
+/// Untrusted identifiers reaching a terminal and a filesystem path.
+///
+/// A bundle id comes from the command line and a run id can come from a store listing; both are
+/// echoed and one of them names a file. Neither was treated as untrusted.
+#[cfg(test)]
+mod untrusted_identifiers {
+    use super::*;
+    use assay_evidence::store::BundleStore;
+    use assay_evidence::Bytes;
+
+    /// The acceptance twin, and the shape every existing caller already sees. A well-formed id
+    /// must keep the name it has always had, or this stops being a hardening change and becomes a
+    /// rename that breaks whatever is looking for the file.
+    #[test]
+    fn a_well_formed_id_keeps_its_familiar_name() {
+        assert_eq!(bundle_filename("sha256:abc"), "sha256_abc.tar.gz");
+        assert_eq!(
+            bundle_filename("sha256:0a1b2c3d4e5f"),
+            "sha256_0a1b2c3d4e5f.tar.gz"
+        );
+    }
+
+    /// The filename is always exactly one component. Asserting on the string alone would miss the
+    /// point, so this asks the path type: after joining, is the parent still the directory the
+    /// operator chose?
+    #[test]
+    fn no_id_can_name_a_file_outside_the_chosen_directory() {
+        let out = Path::new("/tmp/assay-out");
+        for hostile in [
+            "../../etc/passwd",
+            "../escape",
+            "..",
+            "/absolute/path",
+            r"..\..\windows\system32\cfg",
+            r"C:\Windows\System32\drivers",
+            "nested/dir/file",
+            "a/../../b",
+            "\u{0}nul",
+        ] {
+            let name = bundle_filename(hostile);
+            let joined = out.join(&name);
+
+            assert_eq!(
+                joined.parent(),
+                Some(out),
+                "id {hostile:?} produced {name:?}, which does not sit directly in the out dir"
+            );
+            assert_eq!(
+                Path::new(&name).components().count(),
+                1,
+                "id {hostile:?} produced {name:?}, which is more than one component"
+            );
+            assert!(
+                !name.contains('/') && !name.contains('\\'),
+                "id {hostile:?} produced {name:?}, which still carries a separator"
+            );
+            assert!(name.ends_with(".tar.gz"), "{name:?}");
+        }
+    }
+
+    /// Terminal control sequences never reach the filename either. `..` survives as text because
+    /// `.` is a legitimate character in a name; what makes it harmless is that no separator does.
+    #[test]
+    fn the_filename_allowlist_admits_only_plain_ascii() {
+        let name = bundle_filename("sha\u{1b}[31m256:\u{7}abc\u{9c}");
+        assert_eq!(name, "sha__31m256__abc_.tar.gz");
+        assert!(
+            name.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')),
+            "{name:?}"
+        );
+    }
+
+    /// An id of nothing but rejected characters is still a name, and an empty one does not become
+    /// a hidden file called `.tar.gz`.
+    #[test]
+    fn a_degenerate_id_still_yields_a_usable_name() {
+        assert_eq!(bundle_filename(""), "bundle.tar.gz");
+        assert_eq!(bundle_filename("///"), "___.tar.gz");
+    }
+
+    /// Escape sequences are stripped before anything is printed. The identifier itself is not
+    /// changed by this — only what is written to the terminal.
+    #[test]
+    fn identifiers_are_stripped_before_they_reach_a_terminal() {
+        let hostile = "sha256:abc\u{1b}[2K\u{1b}]0;pwned\u{7}";
+        let rendered = shown(hostile);
+        for control in ['\u{1b}', '\u{7}'] {
+            assert!(
+                !rendered.contains(control),
+                "control character {control:?} survived into {rendered:?}"
+            );
+        }
+        assert!(
+            rendered.contains("sha256:abc"),
+            "the readable part must survive: {rendered:?}"
+        );
+    }
+
+    /// Sanitizing is for display only. The lookup uses the original string, because an id altered
+    /// on the way to the store is a request for a different object — which would turn a hardening
+    /// change into a silent wrong answer.
+    #[tokio::test]
+    async fn the_store_lookup_uses_the_unsanitized_id() {
+        // A legitimate id that `bundle_filename` would rewrite, so a lookup keyed on the display
+        // form would miss it.
+        let id = "sha256:abc";
+        let store = ObjectStoreBundleStore::memory();
+        store
+            .put_bundle(id, Bytes::from(vec![b'x'; 32]))
+            .await
+            .expect("seed");
+        let out = tempfile::tempdir().expect("tmp");
+
+        let code = pull_single(
+            &store,
+            id,
+            out.path(),
+            false,
+            StreamCeiling::new(100 * 1024),
+        )
+        .await
+        .expect("download");
+        assert_eq!(code, 0, "the raw id must still resolve in the store");
+
+        let written: Vec<String> = std::fs::read_dir(out.path())
+            .expect("read dir")
+            .map(|e| e.expect("entry").file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(written, vec!["sha256_abc.tar.gz".to_string()]);
     }
 }

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -58,7 +58,7 @@ getrandom = { version = "0.4", features = ["sys_rng"] }
 jsonschema.workspace = true
 tempfile = "3"
 assert_fs = "1.1"
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 criterion = "0.8"
 
 [[bench]]

--- a/crates/assay-evidence/src/store/bounded.rs
+++ b/crates/assay-evidence/src/store/bounded.rs
@@ -1,0 +1,525 @@
+//! Bounded accumulation of a remote object stream.
+//!
+//! ADR-043 §1 requires an ingest entrypoint to apply its ceiling to the source *before* the input
+//! is materialized. `BundleStore::get_bundle` ends in `GetResult::bytes().await`, which reads the
+//! whole object into memory and hands the caller a finished `Bytes`. A ceiling applied after that
+//! call describes something that has already happened.
+//!
+//! Only the accumulation lives here. The vocabulary stays local: a store ceiling bounds a remote
+//! download and says nothing about how an evidence bundle is verified afterwards.
+//!
+//! Scope of the bound: the accumulator never appends the chunk that would cross the ceiling and
+//! stops polling at that point. Because the stream yields whole `Bytes` values, one chunk above
+//! the ceiling may already have been delivered by the backend before its length can be tested, so
+//! peak resident input is the ceiling plus at most one such chunk.
+
+use std::time::Duration;
+
+use bytes::{Bytes, BytesMut};
+use futures::stream::{BoxStream, StreamExt};
+
+use super::StoreError;
+
+/// A chunk delivering fewer than this many bytes on average is not a transfer, it is a stall with
+/// extra steps. Used only to derive a chunk allowance from the byte ceiling, never as a per-chunk
+/// minimum: a legitimate final chunk is usually short.
+const MIN_AVERAGE_CHUNK_BYTES: u64 = 512;
+
+/// Floor on the chunk allowance, so a small byte ceiling still tolerates a chatty backend.
+const MIN_CHUNK_ALLOWANCE: usize = 1024;
+
+/// How long a single poll may go without the stream producing anything.
+///
+/// Deliberately longer than `object_store`'s own 30s request timeout, so this does not pre-empt the
+/// transport's error with a less informative one. It exists because that timeout is not guaranteed
+/// to be in play: `read_timeout` defaults to `None` in `object_store` 0.14.1, the options can be
+/// disabled outright, and the `file://` and in-memory backends never consult them at all.
+const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The ceilings applied to a download.
+///
+/// `max_source_bytes` is the only number a caller supplies, and it comes from the same place
+/// `evidence push` gets its own. The transport bounds are derived from it rather than exposed as a
+/// second knob, because they do not describe a policy an operator has an opinion about — they
+/// describe the shape of a transfer that is still making progress.
+///
+/// A byte ceiling alone bounds how much is retained, not how long the loop runs. A backend that
+/// yields empty chunks forever adds nothing to the total and is never refused by a byte count, so
+/// the byte ceiling has to be paired with something that bounds the iteration itself.
+/// Fields are crate-visible rather than public: `new` is the whole public surface, since the
+/// transport bounds are derived and a caller has no number to supply for them. Private fields
+/// already prevent outside construction and exhaustive matching; `#[non_exhaustive]` is kept on
+/// top so the guarantee survives someone later widening one of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StreamCeiling {
+    /// Bytes retained from the source.
+    pub(crate) max_source_bytes: u64,
+    /// Chunks accepted from the stream, counting empty ones.
+    pub(crate) max_chunks: usize,
+    /// How long one poll may wait before the download is treated as stalled.
+    pub(crate) idle_timeout: Duration,
+}
+
+impl StreamCeiling {
+    /// Derive a full ceiling from the byte budget.
+    pub fn new(max_source_bytes: u64) -> Self {
+        let derived = max_source_bytes / MIN_AVERAGE_CHUNK_BYTES;
+        let max_chunks = usize::try_from(derived)
+            .unwrap_or(usize::MAX)
+            .max(MIN_CHUNK_ALLOWANCE);
+        Self {
+            max_source_bytes,
+            max_chunks,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+        }
+    }
+
+    /// Override the transport bounds so a stall and a chunk flood are expressible without
+    /// transferring a real budget's worth of data. Test-only: there is no caller-facing reason to
+    /// set these, and exposing them would invite an operator to tune a number that describes
+    /// whether a transfer is progressing rather than a policy they hold an opinion about.
+    #[cfg(test)]
+    pub(crate) fn with_transport_bounds(
+        mut self,
+        max_chunks: usize,
+        idle_timeout: Duration,
+    ) -> Self {
+        self.max_chunks = max_chunks;
+        self.idle_timeout = idle_timeout;
+        self
+    }
+}
+
+/// Failure from a bounded download.
+///
+/// A new, narrow type rather than a `StoreError` variant. `StoreError` is public, exported from
+/// the crate root, and is not `#[non_exhaustive]`, so adding a variant breaks every downstream
+/// exhaustive match — and `cargo semver-checks` runs against this crate in CI. Widening an
+/// existing type to carry a new outcome would also hand the ceiling refusal to every caller of
+/// the trait, which is not what this slice bounds.
+///
+/// `#[non_exhaustive]` from the start, so this type does not recreate the trap it was introduced
+/// to avoid. `StoreError` is closed and therefore cannot grow a variant without a major bump;
+/// declaring that here while the enum is new costs a catch-all arm at the one external match site
+/// and keeps a future dimension additive.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BoundedGetError {
+    /// Anything the underlying store reports, including `NotFound`, passed through unchanged so a
+    /// caller keeps the classification it already handles.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+
+    /// The download exceeded its configured byte ceiling.
+    ///
+    /// The rendered message is a constant. The number of bytes that arrived, the object key and
+    /// the bundle id are all influenced or chosen by whoever produced the object, and echoing any
+    /// of them writes remote-controlled text into an operator's terminal and into every log that
+    /// ingests it. The configured ceiling travels as data on the variant for a caller that wants
+    /// to report it; it is deliberately absent from the message.
+    #[error("download refused: the source exceeded its configured byte ceiling")]
+    SourceCeiling { limit: u64 },
+
+    /// The source delivered more chunks than the transfer is allowed.
+    ///
+    /// This is the bound that terminates a stream of empty chunks. Such a stream adds nothing to
+    /// the byte total, so no byte ceiling will ever refuse it, and because each poll resolves
+    /// immediately the task never yields — which means a timeout wrapped around the loop is never
+    /// polled either. Counting is the only one of the three bounds that ends it.
+    #[error("download refused: the source delivered more chunks than the configured maximum")]
+    ChunkCount { limit: usize },
+
+    /// A single poll went longer than the idle timeout without producing anything.
+    ///
+    /// A different failure from the one above: here the stream is genuinely pending, so the task
+    /// does yield and the timer does fire. Neither bound subsumes the other.
+    #[error("download refused: the source stalled beyond the configured idle timeout")]
+    IdleTimeout { limit: Duration },
+}
+
+impl BoundedGetError {
+    /// True when the download was refused by a configured budget rather than failing in the store.
+    ///
+    /// One predicate covering every resource dimension, so a caller handles them in a single arm.
+    /// Enumerating the variants at the call site would send any dimension added later to whatever
+    /// catch-all follows, which for the CLI means an unrelated exit code for what is still a
+    /// budget refusal.
+    pub fn is_resource_refusal(&self) -> bool {
+        matches!(
+            self,
+            Self::SourceCeiling { .. } | Self::ChunkCount { .. } | Self::IdleTimeout { .. }
+        )
+    }
+}
+
+/// Would appending `chunk_len` to `total` cross `ceiling`?
+///
+/// Split out so the arithmetic is testable on its own. `checked_add` is not decoration: a running
+/// total near `u64::MAX` would wrap on a plain add and a wrapped total compares below any ceiling,
+/// turning an overflow into an accepted download. That total is not reachable over a real network,
+/// which is exactly why it would never be caught by an end-to-end test.
+///
+/// The boundary is inclusive: a source of exactly `ceiling` bytes is accepted, `ceiling + 1` is
+/// refused.
+fn would_exceed(total: u64, chunk_len: usize, ceiling: u64) -> bool {
+    match total.checked_add(chunk_len as u64) {
+        Some(next) => next > ceiling,
+        None => true,
+    }
+}
+
+/// Accumulate a chunked object stream, refusing as soon as the ceiling would be crossed.
+///
+/// On refusal the crossing chunk is never appended and the stream is not polled again.
+///
+/// This is not the same as the bytes stopping exactly at the ceiling, and the distinction is worth
+/// stating rather than glossing. The stream yields whole `Bytes` values, so by the time
+/// `chunk.len()` can be tested the backend has already delivered that chunk. Peak resident input
+/// can therefore be one already-delivered chunk above the ceiling. What the ceiling bounds is what
+/// this accumulator retains and how far it keeps reading, not the granularity at which the
+/// transport hands over data.
+pub(crate) async fn accumulate_bounded(
+    mut stream: BoxStream<'static, object_store::Result<Bytes>>,
+    ceiling: StreamCeiling,
+) -> Result<Bytes, BoundedGetError> {
+    let limit = ceiling.max_source_bytes;
+    let mut total: u64 = 0;
+    let mut chunks: usize = 0;
+    // Never sized from `meta.size`. That value is supplied by the remote and using it as a
+    // capacity hint lets a claimed size allocate memory before a single byte has been received,
+    // which is the allocation the ceiling exists to prevent.
+    let mut out = BytesMut::new();
+
+    loop {
+        // Bound the wait for each chunk, not the transfer as a whole: a long download that keeps
+        // making progress is fine, a stalled one is not.
+        let next = match tokio::time::timeout(ceiling.idle_timeout, stream.next()).await {
+            Ok(next) => next,
+            Err(_) => {
+                drop(stream);
+                return Err(BoundedGetError::IdleTimeout {
+                    limit: ceiling.idle_timeout,
+                });
+            }
+        };
+
+        let Some(chunk) = next else { break };
+
+        // Constant text. `object_store::Error`'s own rendering carries the store name and the
+        // object path, and a path is a key an operator does not choose — a bucket or prefix can
+        // be named by whoever writes to the store, and the message travels into a terminal and
+        // into every log that ingests it. The three refusals above are value-free; a transport
+        // failure on the same path leaking backend text would make that consistency decorative.
+        //
+        // The cost is real and worth naming: the backend's own explanation is dropped, so a
+        // genuine network fault reads the same as any other. That is the same trade the ceiling
+        // diagnostics already make, and the store failure is still distinguishable from a budget
+        // refusal by variant rather than by text.
+        let chunk = chunk.map_err(|_| {
+            BoundedGetError::Store(StoreError::Io {
+                message: "failed to read object stream".to_string(),
+            })
+        })?;
+
+        // Counted before any length is looked at, so an empty chunk still consumes allowance.
+        // Empty chunks are exactly the case a byte ceiling cannot see.
+        //
+        // `checked_add` for the same reason the byte total uses it: a wrapped counter compares
+        // below the allowance and would hand the loop back to the stream that overflowed it. The
+        // count is the bound that terminates an endless stream, so it is the last one that may
+        // silently wrap.
+        chunks = match chunks.checked_add(1) {
+            Some(n) => n,
+            None => {
+                drop(stream);
+                return Err(BoundedGetError::ChunkCount {
+                    limit: ceiling.max_chunks,
+                });
+            }
+        };
+        if chunks > ceiling.max_chunks {
+            drop(stream);
+            return Err(BoundedGetError::ChunkCount {
+                limit: ceiling.max_chunks,
+            });
+        }
+
+        if would_exceed(total, chunk.len(), limit) {
+            // Drop the stream without appending any part of this chunk, and do not poll again.
+            // This chunk has already been delivered by the backend; what is controlled here is
+            // that it is not retained and that no further chunk is requested. Truncating to the
+            // ceiling instead would hand the caller a prefix of an archive as though it were the
+            // archive.
+            drop(stream);
+            return Err(BoundedGetError::SourceCeiling { limit });
+        }
+
+        total += chunk.len() as u64;
+        out.extend_from_slice(&chunk);
+    }
+
+    Ok(out.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    fn chunks(sizes: &[usize]) -> BoxStream<'static, object_store::Result<Bytes>> {
+        let items: Vec<object_store::Result<Bytes>> = sizes
+            .iter()
+            .map(|n| Ok(Bytes::from(vec![b'x'; *n])))
+            .collect();
+        stream::iter(items).boxed()
+    }
+
+    async fn accumulate(sizes: &[usize], ceiling: u64) -> Result<Bytes, BoundedGetError> {
+        accumulate_bounded(chunks(sizes), StreamCeiling::new(ceiling)).await
+    }
+
+    /// The boundary the acceptance bar names, on the accumulator itself.
+    #[tokio::test]
+    async fn exactly_the_ceiling_is_accepted_and_one_more_byte_is_refused() {
+        assert_eq!(accumulate(&[99], 100).await.unwrap().len(), 99);
+        assert_eq!(
+            accumulate(&[100], 100).await.unwrap().len(),
+            100,
+            "a source of exactly the ceiling must be accepted"
+        );
+        assert!(
+            accumulate(&[101], 100).await.is_err(),
+            "ceiling + 1 must be refused"
+        );
+    }
+
+    /// A stream that delivers a byte at a time must not be able to walk past the ceiling.
+    #[tokio::test]
+    async fn short_chunks_cannot_walk_past_the_ceiling() {
+        let ones = vec![1usize; 101];
+        assert!(accumulate(&ones, 100).await.is_err());
+
+        let exact = vec![1usize; 100];
+        assert_eq!(accumulate(&exact, 100).await.unwrap().len(), 100);
+    }
+
+    /// The realistic remote shape: several sizeable chunks that only cross the ceiling together.
+    #[tokio::test]
+    async fn chunked_delivery_is_measured_in_total_not_per_chunk() {
+        assert_eq!(accumulate(&[40, 40, 20], 100).await.unwrap().len(), 100);
+        assert!(accumulate(&[40, 40, 21], 100).await.is_err());
+    }
+
+    /// One chunk larger than the whole ceiling is refused on its own, before it is appended.
+    #[tokio::test]
+    async fn a_single_oversized_chunk_is_refused_whole() {
+        let err = accumulate(&[10_000], 100).await.unwrap_err();
+        assert!(err.is_resource_refusal(), "{err}");
+    }
+
+    /// Polling stops at the crossing chunk, rather than the whole object being drained and judged
+    /// afterwards. The crossing chunk itself has already been delivered; what is asserted is that
+    /// nothing after it is requested.
+    ///
+    /// This is the property worth a test here. "No partial bytes survive" is not: the only way out
+    /// of a refusal is `Err`, so the accumulated buffer is unreachable no matter what was appended
+    /// to it, and a test asserting it would pass against an implementation that truncates to the
+    /// ceiling and returns the prefix. Counting what the stream was asked for cannot be satisfied
+    /// that way — an implementation that drains first pulls every chunk.
+    #[tokio::test]
+    async fn a_refusal_stops_pulling_from_the_stream() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let pulled = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&pulled);
+        // Ten chunks of 50; the ceiling is crossed on the third.
+        let inner = stream::iter((0..10).map(|_| Bytes::from(vec![b'x'; 50])));
+        let counted = inner
+            .map(move |b| {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(b)
+            })
+            .boxed();
+
+        let err = accumulate_bounded(counted, StreamCeiling::new(100))
+            .await
+            .expect_err("must refuse");
+        assert!(err.is_resource_refusal(), "{err}");
+        assert_eq!(
+            pulled.load(Ordering::SeqCst),
+            3,
+            "the stream must stop at the chunk that crosses the ceiling, not be drained"
+        );
+    }
+
+    /// The overflow arm of `checked_add`, which no end-to-end test can reach. A wrapped total
+    /// compares below any ceiling, so a plain add would turn this into an accepted download.
+    #[test]
+    fn an_arithmetic_overflow_refuses_rather_than_wrapping() {
+        assert!(
+            would_exceed(u64::MAX - 1, 8, u64::MAX),
+            "an addition that overflows must refuse, not wrap to a small total"
+        );
+        assert!(!would_exceed(0, 100, 100), "the exact boundary is accepted");
+        assert!(!would_exceed(90, 10, 100));
+        assert!(would_exceed(90, 11, 100));
+    }
+
+    /// The refusal names no remote-chosen value.
+    #[tokio::test]
+    async fn the_refusal_is_value_free() {
+        let err = accumulate(&[10_000], 100).await.unwrap_err();
+        let rendered = err.to_string();
+        for remote_chosen in ["10000", "10_000", "9900", "bundles/", "sha256:"] {
+            assert!(
+                !rendered.contains(remote_chosen),
+                "remote-chosen value {remote_chosen:?} reached the message: {rendered}"
+            );
+        }
+        // The configured ceiling travels as data, not as text.
+        match err {
+            BoundedGetError::SourceCeiling { limit } => assert_eq!(limit, 100),
+            other => panic!("expected a ceiling refusal, got {other:?}"),
+        }
+    }
+
+    /// The acceptance twin: an empty object is not refused by a zero-sized edge case.
+    #[tokio::test]
+    async fn an_empty_stream_is_accepted() {
+        assert_eq!(accumulate(&[], 100).await.unwrap().len(), 0);
+        assert_eq!(accumulate(&[0], 100).await.unwrap().len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod transport_bounds {
+    use super::*;
+    use futures::stream;
+    use std::time::Duration;
+
+    fn ceiling(max_chunks: usize) -> StreamCeiling {
+        StreamCeiling::new(1_000_000).with_transport_bounds(max_chunks, Duration::from_secs(60))
+    }
+
+    /// The case a byte ceiling structurally cannot see.
+    ///
+    /// Empty chunks add nothing to the total, so `would_exceed` never fires however many arrive.
+    /// Worse, each poll resolves immediately, so the task never yields and a timeout wrapped
+    /// around the whole loop is never polled either — this spins at full CPU rather than hanging
+    /// politely. Counting accepted chunks is the only one of the three bounds that ends it, which
+    /// is why the count includes empty chunks.
+    #[tokio::test]
+    async fn an_endless_stream_of_empty_chunks_is_refused_by_the_chunk_count() {
+        let endless = stream::repeat_with(|| Ok(Bytes::new())).boxed();
+        let err = accumulate_bounded(endless, ceiling(64))
+            .await
+            .expect_err("an endless empty stream must be refused, not accumulated forever");
+        match err {
+            BoundedGetError::ChunkCount { limit } => assert_eq!(limit, 64),
+            other => panic!("expected a chunk-count refusal, got {other:?}"),
+        }
+    }
+
+    /// Tiny non-empty chunks stay far under the byte ceiling and still exhaust the allowance.
+    #[tokio::test]
+    async fn many_tiny_chunks_are_refused_before_the_byte_ceiling() {
+        let tiny = stream::repeat_with(|| Ok(Bytes::from_static(b"x"))).boxed();
+        let err = accumulate_bounded(tiny, ceiling(32))
+            .await
+            .expect_err("a chatty stream must be refused on count");
+        assert!(matches!(err, BoundedGetError::ChunkCount { .. }), "{err:?}");
+    }
+
+    /// Exactly the allowance is accepted; one chunk more is refused. Same inclusive rule as bytes.
+    #[tokio::test]
+    async fn the_chunk_allowance_boundary_is_inclusive() {
+        let ten = |n: usize| stream::iter((0..n).map(|_| Ok(Bytes::from_static(b"x")))).boxed();
+        assert_eq!(
+            accumulate_bounded(ten(10), ceiling(10))
+                .await
+                .unwrap()
+                .len(),
+            10,
+            "exactly the allowance must be accepted"
+        );
+        assert!(
+            accumulate_bounded(ten(11), ceiling(10)).await.is_err(),
+            "allowance + 1 must be refused"
+        );
+    }
+
+    /// A stream that is genuinely pending is the case the timeout does catch. The task yields, so
+    /// the timer runs; `start_paused` advances the clock the moment the runtime goes idle, so this
+    /// costs no wall-clock time.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_stream_is_refused_by_the_idle_timeout() {
+        let stalled = stream::once(async {
+            futures::future::pending::<()>().await;
+            Ok(Bytes::new())
+        })
+        .boxed();
+
+        let ceiling =
+            StreamCeiling::new(1_000_000).with_transport_bounds(1024, Duration::from_secs(5));
+        let err = accumulate_bounded(stalled, ceiling)
+            .await
+            .expect_err("a stalled stream must be refused");
+        match err {
+            BoundedGetError::IdleTimeout { limit } => assert_eq!(limit, Duration::from_secs(5)),
+            other => panic!("expected an idle-timeout refusal, got {other:?}"),
+        }
+    }
+
+    /// A slow but progressing transfer is not a stall. Each poll lands inside the idle window even
+    /// though the whole transfer takes longer than it, which is the distinction the per-poll bound
+    /// exists to make.
+    #[tokio::test(start_paused = true)]
+    async fn a_slow_but_progressing_transfer_is_not_a_stall() {
+        let slow = stream::iter(0..10)
+            .then(|_| async {
+                tokio::time::sleep(Duration::from_secs(3)).await;
+                Ok(Bytes::from_static(b"xxxx"))
+            })
+            .boxed();
+
+        let ceiling =
+            StreamCeiling::new(1_000_000).with_transport_bounds(1024, Duration::from_secs(5));
+        let got = accumulate_bounded(slow, ceiling)
+            .await
+            .expect("30s of steady progress in 3s steps is not a stall");
+        assert_eq!(got.len(), 40);
+    }
+
+    /// The transport refusals are value-free too, and they are resource refusals like the byte
+    /// ceiling, so a caller handles all three in one arm.
+    #[tokio::test]
+    async fn transport_refusals_are_value_free_resource_refusals() {
+        let endless = stream::repeat_with(|| Ok(Bytes::new())).boxed();
+        let err = accumulate_bounded(endless, ceiling(8)).await.unwrap_err();
+        assert!(err.is_resource_refusal(), "{err}");
+        let rendered = err.to_string();
+        for remote_chosen in ["bundles/", "sha256:", "9", "8"] {
+            assert!(
+                !rendered.contains(remote_chosen),
+                "value {remote_chosen:?} reached the message: {rendered}"
+            );
+        }
+    }
+
+    /// The derivation, so the numbers are not folklore: the allowance follows the byte budget and
+    /// never drops below the floor.
+    #[test]
+    fn the_allowance_is_derived_from_the_byte_budget() {
+        let big = StreamCeiling::new(100 * 1024 * 1024);
+        assert_eq!(big.max_chunks, (100 * 1024 * 1024) / 512);
+        assert_eq!(big.idle_timeout, Duration::from_secs(60));
+
+        let small = StreamCeiling::new(100);
+        assert_eq!(
+            small.max_chunks, MIN_CHUNK_ALLOWANCE,
+            "a small budget still tolerates a chatty backend"
+        );
+    }
+}

--- a/crates/assay-evidence/src/store/mod.rs
+++ b/crates/assay-evidence/src/store/mod.rs
@@ -18,6 +18,7 @@
 //! runs/{run_id}/bundles/{bundle_id}.ref # Run-to-bundle index (for list --run-id)
 //! ```
 
+mod bounded;
 pub mod config;
 pub mod error;
 pub mod naming;
@@ -27,6 +28,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use serde::Serialize;
 
+pub use bounded::{BoundedGetError, StreamCeiling};
 pub use error::{StoreError, StoreResult};
 pub use naming::KeyBuilder;
 pub use object_store_backend::ObjectStoreBundleStore;

--- a/crates/assay-evidence/src/store/object_store_backend.rs
+++ b/crates/assay-evidence/src/store/object_store_backend.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 use futures::TryStreamExt;
 use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload};
 
+use super::bounded::{accumulate_bounded, BoundedGetError, StreamCeiling};
 use super::{BundleMeta, BundleStore, KeyBuilder, StoreError, StoreResult, StoreSpec, StoreStatus};
 
 /// Bundle store backed by `object_store`.
@@ -133,6 +134,82 @@ impl ObjectStoreBundleStore {
             inner: Arc::new(object_store::memory::InMemory::new()),
             keys: KeyBuilder::new(prefix),
         }
+    }
+
+    /// Build a store over an arbitrary backend. Private: the tests need a backend that misreports
+    /// object metadata, which no public constructor can produce and no caller should want.
+    #[cfg(test)]
+    fn from_parts(inner: Arc<dyn ObjectStore>, prefix: &str) -> Self {
+        Self {
+            inner,
+            keys: KeyBuilder::new(prefix),
+        }
+    }
+
+    /// Download a bundle under an explicit source-byte ceiling.
+    ///
+    /// [`BundleStore::get_bundle`] ends in `GetResult::bytes().await`, which materializes the whole
+    /// object before returning; a ceiling applied to its result describes an allocation that has
+    /// already happened. This streams instead: the accumulator never appends the chunk that would
+    /// cross the ceiling and stops polling there, which is what ADR-043 §1 asks of an ingest
+    /// entrypoint. Peak resident input is the ceiling plus at most one already-delivered backend
+    /// chunk, because a chunk's length cannot be tested before the stream has yielded it.
+    ///
+    /// The object's declared size is used only to refuse early, never to accept and never as a
+    /// capacity hint. Metadata is not ignored, and saying so would be inaccurate — it is simply
+    /// not the oracle: a store that under-reports gains nothing, because the streamed bytes are
+    /// counted and refused on their own. The cost of the early refusal is availability rather than
+    /// safety: a backend that over-reports a size will have a downloadable object refused. That
+    /// trade is deliberate, since the alternative is transferring up to a full ceiling's worth of
+    /// bytes from a source that has already told us it is too large.
+    ///
+    /// A refusal here says a configured budget was exceeded and nothing else. It is not a finding
+    /// about the remote bundle's validity, which this call never gets far enough to assess.
+    pub async fn get_bundle_bounded(
+        &self,
+        bundle_id: &str,
+        ceiling: StreamCeiling,
+    ) -> Result<Bytes, BoundedGetError> {
+        let key = self.keys.bundle_key(bundle_id);
+
+        // The initial fetch is bounded too, by the same idle timeout the stream polls use.
+        //
+        // Both transport bounds live inside the accumulator, which is only reached once this
+        // future resolves. A backend that accepts the request and then never answers it therefore
+        // slipped past every one of them: no chunk is ever counted, no poll is ever timed, and the
+        // call simply never returns. Bounding the stream but not the request that produces it
+        // leaves the one gap that costs nothing to close.
+        let fetched = match tokio::time::timeout(ceiling.idle_timeout, self.inner.get(&key)).await {
+            Ok(fetched) => fetched,
+            Err(_) => {
+                return Err(BoundedGetError::IdleTimeout {
+                    limit: ceiling.idle_timeout,
+                })
+            }
+        };
+
+        // A request that did complete keeps its own classification: this is still where a missing
+        // bundle becomes `NotFound` rather than a timeout.
+        //
+        // The fallback text is constant for the same reason the stream read's is. `NotFound` stays
+        // separate and still names the bundle id, which is the caller's own argument rather than
+        // anything the store chose.
+        let result = fetched.map_err(|e| match e {
+            object_store::Error::NotFound { .. } => StoreError::NotFound {
+                bundle_id: bundle_id.to_string(),
+            },
+            _ => StoreError::Io {
+                message: "failed to get bundle".to_string(),
+            },
+        })?;
+
+        if result.meta.size > ceiling.max_source_bytes {
+            return Err(BoundedGetError::SourceCeiling {
+                limit: ceiling.max_source_bytes,
+            });
+        }
+
+        accumulate_bounded(result.into_stream(), ceiling).await
     }
 
     /// Check store connectivity, access, and inventory.
@@ -493,5 +570,548 @@ mod tests {
 
         store.put_bundle(bundle_id, content).await.unwrap();
         assert!(store.bundle_exists(bundle_id).await.unwrap());
+    }
+}
+
+#[cfg(test)]
+mod bounded_download {
+    use super::*;
+    use crate::store::StreamCeiling;
+    use object_store::path::Path as ObjPath;
+    use object_store::{GetOptions, GetResult, ListResult, ObjectMeta, PutResult};
+    use std::ops::Range;
+
+    /// A backend that delegates everything but lies about how large an object is.
+    ///
+    /// No public constructor can build one, which is the point: the question is what happens when
+    /// a remote reports a size that does not match the bytes it then sends, and that is a property
+    /// of an untrusted store rather than of ours.
+    #[derive(Debug)]
+    struct MisreportingStore {
+        inner: object_store::memory::InMemory,
+        reported_size: u64,
+    }
+
+    impl std::fmt::Display for MisreportingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MisreportingStore")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for MisreportingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjPath,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjPath,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &ObjPath,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            let mut result = self.inner.get_opts(location, options).await?;
+            // The payload is untouched; only the declared size is a lie.
+            result.meta.size = self.reported_size;
+            Ok(result)
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<ObjPath>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjPath>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjPath,
+            to: &ObjPath,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &ObjPath,
+            ranges: &[Range<u64>],
+        ) -> object_store::Result<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+    }
+
+    async fn store_with(bundle_id: &str, body: Vec<u8>) -> ObjectStoreBundleStore {
+        let store = ObjectStoreBundleStore::memory();
+        store
+            .put_bundle(bundle_id, Bytes::from(body))
+            .await
+            .expect("seed");
+        store
+    }
+
+    /// Seed through the lying wrapper, so the stored bytes are real and only `meta.size` differs.
+    async fn misreporting_store_with(
+        bundle_id: &str,
+        body: Vec<u8>,
+        reported_size: u64,
+    ) -> ObjectStoreBundleStore {
+        let lying = Arc::new(MisreportingStore {
+            inner: object_store::memory::InMemory::new(),
+            reported_size,
+        });
+        let store = ObjectStoreBundleStore::from_parts(lying, "");
+        store
+            .put_bundle(bundle_id, Bytes::from(body))
+            .await
+            .expect("seed");
+        store
+    }
+
+    #[tokio::test]
+    async fn exact_and_over_the_ceiling() {
+        let id = "sha256:exact";
+        let store = store_with(id, vec![b'x'; 100]).await;
+
+        assert_eq!(
+            store
+                .get_bundle_bounded(id, StreamCeiling::new(100))
+                .await
+                .expect("exactly the ceiling must be accepted")
+                .len(),
+            100
+        );
+        let err = store
+            .get_bundle_bounded(id, StreamCeiling::new(99))
+            .await
+            .expect_err("one byte over the ceiling must refuse");
+        assert!(
+            matches!(err, BoundedGetError::SourceCeiling { .. }),
+            "expected a byte-ceiling refusal, got {err:?}"
+        );
+    }
+
+    /// `NotFound` still travels as itself, so the CLI's existing handling is unchanged.
+    #[tokio::test]
+    async fn a_missing_bundle_is_still_not_found() {
+        let store = ObjectStoreBundleStore::memory();
+        let err = store
+            .get_bundle_bounded("sha256:nonexistent", StreamCeiling::new(1024))
+            .await
+            .expect_err("missing bundle");
+        assert!(!err.is_resource_refusal(), "{err}");
+        match err {
+            BoundedGetError::Store(StoreError::NotFound { .. }) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    /// Under-reported size buys the remote nothing.
+    ///
+    /// The object declares one byte and delivers ten thousand. If the declared size were the
+    /// oracle the download would sail past the ceiling on the strength of a number the remote
+    /// chose. The streamed bytes are counted independently and refuse on their own.
+    #[tokio::test]
+    async fn an_under_reported_size_does_not_bypass_the_streamed_check() {
+        let id = "sha256:liar";
+        let store = misreporting_store_with(id, vec![b'x'; 10_000], 1).await;
+        let err = store
+            .get_bundle_bounded(id, StreamCeiling::new(100))
+            .await
+            .expect_err("a lying small size must not raise the ceiling");
+        assert!(
+            matches!(err, BoundedGetError::SourceCeiling { .. }),
+            "expected a byte-ceiling refusal, got {err:?}"
+        );
+    }
+
+    /// Over-reported size refuses early, and that costs availability rather than safety.
+    ///
+    /// The object declares far more than the ceiling and then delivers ten bytes, so this refusal
+    /// is a false one: the download would have fit. That is the accepted trade for not transferring
+    /// a ceiling's worth of bytes from a source that has already said it is too large. Recorded as
+    /// a test rather than left implicit, because it is a real behaviour a backend with sloppy
+    /// metadata will hit.
+    #[tokio::test]
+    async fn an_over_reported_size_refuses_early_even_though_the_body_would_fit() {
+        let id = "sha256:overstated";
+        let store = misreporting_store_with(id, vec![b'x'; 10], u64::MAX).await;
+        let err = store
+            .get_bundle_bounded(id, StreamCeiling::new(100))
+            .await
+            .expect_err("a declared size over the ceiling refuses before streaming");
+        assert!(
+            matches!(err, BoundedGetError::SourceCeiling { .. }),
+            "expected a byte-ceiling refusal, got {err:?}"
+        );
+
+        // And the same object is accepted once the ceiling covers the declared size, which shows
+        // the refusal came from the declaration rather than from the bytes.
+        let got = store
+            .get_bundle_bounded(id, StreamCeiling::new(u64::MAX))
+            .await
+            .expect("the body itself is ten bytes");
+        assert_eq!(got.len(), 10);
+    }
+
+    /// A backend that accepts the request and then never answers it.
+    ///
+    /// Everything else delegates, so the only difference from a working store is that `get_opts`
+    /// never resolves — which is what a silently dropped connection looks like from here.
+    #[derive(Debug)]
+    struct StallingStore {
+        inner: object_store::memory::InMemory,
+    }
+
+    impl std::fmt::Display for StallingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "StallingStore")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for StallingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjPath,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjPath,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            _location: &ObjPath,
+            _options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            futures::future::pending().await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<ObjPath>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjPath>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjPath,
+            to: &ObjPath,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &ObjPath,
+            ranges: &[Range<u64>],
+        ) -> object_store::Result<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+    }
+
+    /// The gap the stream bounds could not see.
+    ///
+    /// `max_chunks` and the per-poll timeout both live inside the accumulator, and the accumulator
+    /// is only reached once the initial fetch resolves. A backend that never answers therefore
+    /// slipped past both: no chunk was ever counted and no poll was ever timed, because neither
+    /// ever happened. `start_paused` advances the clock as soon as the runtime goes idle, so this
+    /// costs no wall-clock time — and if the bound were absent this test would not fail, it would
+    /// never return, which is the shape of the defect.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_initial_fetch_is_refused_by_the_idle_timeout() {
+        let stalling = Arc::new(StallingStore {
+            inner: object_store::memory::InMemory::new(),
+        });
+        let store = ObjectStoreBundleStore::from_parts(stalling, "");
+        let ceiling = StreamCeiling::new(100 * 1024)
+            .with_transport_bounds(1024, std::time::Duration::from_secs(5));
+
+        let err = store
+            .get_bundle_bounded("sha256:never-answered", ceiling)
+            .await
+            .expect_err("a fetch that never resolves must be refused");
+
+        match err {
+            BoundedGetError::IdleTimeout { limit } => {
+                assert_eq!(limit, std::time::Duration::from_secs(5))
+            }
+            other => panic!("expected an idle-timeout refusal, got {other:?}"),
+        }
+    }
+
+    /// The acceptance twin for the bound above: a store that answers promptly is not refused by
+    /// it, so the timeout does not simply reject every fetch.
+    #[tokio::test(start_paused = true)]
+    async fn a_prompt_fetch_is_not_refused_by_the_initial_timeout() {
+        let id = "sha256:prompt";
+        let store = store_with(id, vec![b'x'; 64]).await;
+        let ceiling = StreamCeiling::new(100 * 1024)
+            .with_transport_bounds(1024, std::time::Duration::from_secs(5));
+        assert_eq!(
+            store
+                .get_bundle_bounded(id, ceiling)
+                .await
+                .expect("a prompt store is not a stalled one")
+                .len(),
+            64
+        );
+    }
+
+    /// A string only the backend could have supplied. If it shows up in anything an operator
+    /// reads, the remote wrote into their terminal and their logs.
+    const SENTINEL: &str = "SENTINEL-bucket-9f3a/private-prefix/secret-object.tar.gz";
+
+    /// A backend that fails, carrying the sentinel in its own error.
+    ///
+    /// `fail_on_stream` chooses which of the two paths fails: the initial request, or a chunk read
+    /// once the request has succeeded. Both formatted `object_store::Error` into the surfaced
+    /// message, and `object_store::Error`'s rendering carries the store name and object path.
+    #[derive(Debug)]
+    struct FailingStore {
+        inner: object_store::memory::InMemory,
+        fail_on_stream: bool,
+    }
+
+    impl std::fmt::Display for FailingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FailingStore")
+        }
+    }
+
+    fn sentinel_error() -> object_store::Error {
+        object_store::Error::Generic {
+            store: "SENTINEL-bucket-9f3a",
+            source: format!("upstream said: {SENTINEL}").into(),
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for FailingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjPath,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjPath,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &ObjPath,
+            options: GetOptions,
+        ) -> object_store::Result<GetResult> {
+            if !self.fail_on_stream {
+                return Err(sentinel_error());
+            }
+            // The request succeeds; the body then fails partway through.
+            let mut result = self.inner.get_opts(location, options).await?;
+            result.payload =
+                object_store::GetResultPayload::Stream(Box::pin(futures::stream::iter(vec![
+                    Ok(Bytes::from_static(b"partial")),
+                    Err(sentinel_error()),
+                ])));
+            Ok(result)
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<ObjPath>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjPath>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjPath>,
+        ) -> object_store::Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjPath,
+            to: &ObjPath,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &ObjPath,
+            ranges: &[Range<u64>],
+        ) -> object_store::Result<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+    }
+
+    async fn failing_store(bundle_id: &str, fail_on_stream: bool) -> ObjectStoreBundleStore {
+        let backend = Arc::new(FailingStore {
+            inner: object_store::memory::InMemory::new(),
+            fail_on_stream,
+        });
+        let store = ObjectStoreBundleStore::from_parts(backend, "");
+        if fail_on_stream {
+            store
+                .put_bundle(bundle_id, Bytes::from(vec![b'x'; 64]))
+                .await
+                .expect("seed");
+        }
+        store
+    }
+
+    /// Both renderings, not only `Display`.
+    ///
+    /// `StoreError::Io` holds its text in a field, so a leak shows up in `Debug` too — and `Debug`
+    /// is what lands in a log line written with `{:?}` or in an `anyhow` chain. Checking only
+    /// `to_string()` would pass while the value still travelled.
+    fn assert_sentinel_absent(err: &BoundedGetError, path: &str) {
+        for rendered in [format!("{err}"), format!("{err:?}"), format!("{err:#?}")] {
+            for fragment in [
+                SENTINEL,
+                "SENTINEL-bucket-9f3a",
+                "private-prefix",
+                "secret-object",
+            ] {
+                assert!(
+                    !rendered.contains(fragment),
+                    "backend-chosen text {fragment:?} reached the {path} error: {rendered}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_failing_initial_fetch_does_not_echo_backend_text() {
+        let store = failing_store("sha256:whatever", false).await;
+        let err = store
+            .get_bundle_bounded("sha256:whatever", StreamCeiling::new(100 * 1024))
+            .await
+            .expect_err("the backend fails the request");
+        assert_sentinel_absent(&err, "initial fetch");
+    }
+
+    #[tokio::test]
+    async fn a_failing_stream_read_does_not_echo_backend_text() {
+        let id = "sha256:streamfail";
+        let store = failing_store(id, true).await;
+        let err = store
+            .get_bundle_bounded(id, StreamCeiling::new(100 * 1024))
+            .await
+            .expect_err("the backend fails partway through the body");
+        assert_sentinel_absent(&err, "stream read");
+    }
+
+    /// The acceptance twin. A constant message must not flatten the classification: a store
+    /// failure is still a store failure and a missing bundle is still `NotFound`, distinguished by
+    /// variant rather than by text, and neither is mistaken for a budget refusal.
+    #[tokio::test]
+    async fn ordinary_store_classification_survives_the_constant_message() {
+        let store = failing_store("sha256:whatever", false).await;
+        let err = store
+            .get_bundle_bounded("sha256:whatever", StreamCeiling::new(100 * 1024))
+            .await
+            .unwrap_err();
+        match &err {
+            BoundedGetError::Store(StoreError::Io { .. }) => {}
+            other => panic!("a backend failure must stay a store IO error, got {other:?}"),
+        }
+        assert!(!err.is_resource_refusal(), "not a budget refusal: {err}");
+
+        let missing = ObjectStoreBundleStore::memory();
+        let err = missing
+            .get_bundle_bounded("sha256:absent", StreamCeiling::new(100 * 1024))
+            .await
+            .unwrap_err();
+        match &err {
+            BoundedGetError::Store(StoreError::NotFound { bundle_id }) => {
+                assert_eq!(
+                    bundle_id, "sha256:absent",
+                    "NotFound still names the caller's own argument"
+                );
+            }
+            other => panic!("a missing bundle must stay NotFound, got {other:?}"),
+        }
+    }
+
+    /// The acceptance twin: an ordinary bundle round-trips byte-for-byte under a real ceiling.
+    #[tokio::test]
+    async fn an_ordinary_bundle_round_trips() {
+        let id = "sha256:ordinary";
+        let body = vec![b'a'; 4096];
+        let store = store_with(id, body.clone()).await;
+        let got = store
+            .get_bundle_bounded(id, StreamCeiling::new(100 * 1024 * 1024))
+            .await
+            .expect("ordinary download");
+        assert_eq!(got.as_ref(), body.as_slice());
     }
 }


### PR DESCRIPTION
Slice 1b of the ADR-042/043 programme: the remote pull entrypoint. Ledger is #1847. Slice 1a (#1852) covered every local entrypoint and deliberately left this one out, because the materialization happens inside the store API rather than in a reader we control.

`BundleStore::get_bundle` ends in `GetResult::bytes().await`. By the time `evidence pull` sees anything the whole object is in memory, so a ceiling applied to its result describes an allocation that has already happened.

## What changes

**The accumulator: three bounds, because one is not enough.**

*Bytes.* Inclusive — exactly the ceiling accepted, one more byte refused. `checked_add` on the running total, because a wrapped total compares below any ceiling and would turn an overflow into an accepted download. That total is unreachable over a real network, which is exactly why the arithmetic is a separate pure function with its own test.

*Chunks, counting empty ones.* A byte ceiling structurally cannot see a stream of empty chunks: they add nothing to the total, so no byte count ever refuses them. Worse, each poll resolves immediately, so the task never yields and a timeout wrapped around the loop is never polled either — it spins at full CPU rather than hanging politely. Counting accepted chunks is the only one of the three bounds that ends it, which is why empty chunks consume allowance, and the counter uses `checked_add` for the same reason the byte total does.

*Idle time.* The different failure: something genuinely pending, where the task does yield and the timer does fire. Applied per stream poll rather than per transfer, so a slow but progressing download is not a stall — **and applied to the initial fetch as well.** Both other bounds live inside the accumulator, and the accumulator is only reached once `inner.get(&key)` resolves, so a backend that accepts the request and never answers it counted no chunks and timed no polls: neither ever happened. A request that *does* complete keeps its own classification, so a missing bundle is still `NotFound` rather than a timeout. Neither transport bound subsumes the other.

This is not belt-and-braces over a transport that already protects itself. In `object_store` 0.14.1 the request timeout is 30s and `connect_timeout` 5s, but **`read_timeout` defaults to `None`**, the options can be disabled, and the `file://` and in-memory backends never consult `ClientOptions` at all.

**Ceiling shape.** One caller-supplied number. The transport bounds are derived from it (`max_chunks = max(1024, bytes/512)`, `idle_timeout = 60s`) rather than exposed as knobs, because they describe whether a transfer is still making progress rather than a policy an operator holds an opinion about. The idle timeout is deliberately longer than the transport's own 30s so it does not pre-empt a more informative error. `StreamCeiling`'s fields are crate-private, its only public constructor is `new`, and the transport override is test-only.

**The retrieval method.** `ObjectStoreBundleStore::get_bundle_bounded` is inherent, not a trait change. `pull.rs` takes the concrete type, so bounding the named entrypoint needs no redesign of `BundleStore` — it stays as compatibility surface for other callers, and this slice does not claim to bound every third-party implementor.

**The error type.** `BoundedGetError` is new and narrow rather than a `StoreError` variant. `StoreError` is public, exported from the crate root, and not `#[non_exhaustive]`, and `cargo semver-checks` runs against this crate in CI, so adding a variant is a major break. The new type is `#[non_exhaustive]` from the start so it does not recreate the same trap one release later, and the module is private: `BoundedGetError` and `StreamCeiling` are reachable only through `store::`. `NotFound` passes through unchanged.

**Value-free on the whole bounded path.** The three refusals were value-free, but the transport failures beside them were not: both the stream read and the initial fetch formatted `object_store::Error`, whose rendering carries the store name and the object path. A key is not something an operator chooses — a bucket or prefix can be named by whoever writes to the store — and the message travels into a terminal and into every log that ingests it. Both are constant text now. `NotFound` stays separate and still names the bundle id, which is the caller's own argument.

The cost is real and worth naming: the backend's own explanation is dropped, so a genuine network fault reads like any other. The classification survives, by variant rather than by text, and there is a test for that. The legacy trait `get_bundle` is left alone; this slice bounds the named pull entrypoint.

**Metadata.** The declared object size refuses early but never accepts, and is never used as a capacity hint — sizing a buffer from a remote-supplied number is the allocation the ceiling exists to prevent. Metadata is not ignored and the docs do not say it is; it is simply not the oracle. A store that under-reports gains nothing, because streamed bytes are counted independently.

**The CLI.** Single and run pull both go through the bounded method, the latter by delegation. The ceiling is `VerifyLimits::default().max_bundle_bytes`, the same source `evidence push` already uses, so the two ends of one transfer agree and there is no second unrelated default to keep in step. Resource refusals exit 2 through one arm keyed on `is_resource_refusal()` rather than on a variant list, so a dimension added later to a `#[non_exhaustive]` enum cannot fall through to an unrelated exit code. A refusal returns before any output path is computed. No new reason code; the refusal stays local to `pull_single`.

**Untrusted identifiers on the pull path.** A bundle id arrives from the command line and a run id can come from a store listing. Both were echoed to a terminal raw, so escape sequences in either could rewrite the line, hide what was printed, or reach a terminal's own OSC handlers. They are sanitized for display now, and only for display — the store lookup keeps the original string, because an identifier altered on its way to a lookup asks for a different object.

The worse one was the filename. `out.join(format!("{}.tar.gz", id.replace(':', "_")))` strips only the character a well-formed id happens to contain. A `--bundle-id` of `../../etc/x` survived intact and `out.join` then resolved it **outside the directory the operator chose**; a backslash did the same on Windows. The fix is not to enumerate dangerous characters but to permit harmless ones: a strict ASCII allowlist of `[A-Za-z0-9._-]`, everything else mapped to `_`, so the result is always exactly one path component with no separator and no traversal segment. `sha256:abc` still lands as `sha256_abc.tar.gz`; the stored id is untouched.

## Claim ceiling

The bound is on what the accumulator retains and how far it keeps reading — not on the granularity at which the transport hands over data.

The stream yields whole `Bytes` values, so a chunk has already been delivered by the backend by the time its length can be tested. **Peak resident input is the ceiling plus at most one such chunk.** This is not a claim that bytes stop arriving exactly at the ceiling, nor that nothing beyond it is ever received. The crossing chunk is never appended and the stream is not polled again; that is the whole of it.

A refusal says a configured budget was exceeded and nothing more. It is not a finding about the remote bundle's validity, which the download never gets far enough to assess.

## Accepted trade, recorded rather than left to be discovered

A backend that over-reports an object's size will have a downloadable object refused. That is a false refusal and it costs availability, not safety. The alternative is transferring up to a full ceiling's worth of bytes from a source that has already said it is too large. There is a test for it (`an_over_reported_size_refuses_early_even_though_the_body_would_fit`) so the behaviour is visible rather than surprising.

## Verification

Local, on `edb3bcca`:

- `cargo fmt --all --check` — clean
- `cargo clippy -p assay-evidence -p assay-cli --all-targets -- -D warnings` — clean (locally also `--workspace`)
- `git diff --check` — clean
- 36 tests: 15 accumulator, 10 store, 11 CLI
- Full suites: `assay-common` 2, `assay-evidence` 35, `assay-core` 40, `assay-cli` 44 — zero failures

Every property is proven by reverting the code it guards:

| Reverted | Result |
|---|---|
| exclusive boundary (`>=`) | 4 of 8 fail |
| `checked_add` overflow accepted | 1 fails |
| stream drained before judging | 1 fails |
| remote values echoed in the message | 1 fails |
| `meta.size` trusted as the oracle | 1 fails |
| early metadata reject removed | 1 fails |
| `pull_single` back on the unbounded trait method | 3 of 5 fail |
| output file written before the refusal | 3 of 5 fail |
| empty chunks excluded from the count | **hangs** — killed by a 2s watchdog |
| chunk allowance exclusive not inclusive | 1 fails |
| stream idle timeout removed | **hangs** — killed by a 2s watchdog |
| initial fetch left unbounded | **hangs** — killed by a 2s watchdog |
| stream read echoes the backend error | 1 fails |
| initial fetch echoes the backend error | 1 fails |
| old `replace(':')` filename restored | 3 of 6 fail |
| terminal sanitization removed | 1 fails |

Three of those mutants hang rather than fail, which is the finding rather than a testing inconvenience: without the chunk count an endless empty stream spins forever and a timeout around the loop cannot rescue it, because the task never yields; and without a bound on the initial fetch the call simply never returns. The watchdog guards only the run, never the compile.

The two compile-time properties are checked the same way: dropping the external catch-all arm yields `E0004`, and reaching for `store::bounded` yields `E0603`.

One test was rewritten during the round because a negative control did not bite. `a_refusal_yields_no_partial_bytes` stayed green against an implementation that truncates to the ceiling and returns the prefix — the accumulated buffer is unreachable on an `Err` no matter what was appended, so the test could not fail. It is now `a_refusal_stops_pulling_from_the_stream`, which counts chunks pulled and cannot be satisfied by draining first.

## An honest coverage boundary

The CLI cannot produce a `ChunkCount` or `IdleTimeout` refusal in a test, because the transport override is test-only and not visible from `assay-cli`. Coverage of that arm is compositional rather than end-to-end: a CLI test proves *predicate → exit 2*, and an `assay-evidence` test proves *transport refusal → predicate true*. Widening the public surface just to make a single end-to-end case expressible was not worth it.

## Not in this PR

No HTTP, OAuth or protocol work. No new verdict or score. No new reason code. No change to `StoreError` or the `BundleStore` trait. No claim that a ceiling refusal says anything about whether the remote bundle is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added download size limits for evidence bundles.
  - Downloads now stop safely when exceeding the allowed size, chunk count, or transfer idle time.
  - Exact-size downloads remain supported.
- **Bug Fixes**
  - Oversized or unavailable bundles are rejected before creating output files.
  - Single-bundle and run-based downloads now apply consistent transfer protections.
  - Improved handling of inaccurate remote size information and stalled transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


