### PR TITLE
docs(profile): restore the canonical normative URI and pin the docs domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ Repositories that compose with Assay's evidence layer:
 - [gateway-evidence-replay](https://github.com/Rul1an/gateway-evidence-replay) — deterministic offline replay verifier for gateway-path evidence bundles.
 - [RGE-Bench](https://github.com/rge-bench/rge-bench) — a neutral, externally reproduced conformance kit for evidence reviewability, maintained separately under its own machine-checked neutrality guard.
 
+## Open profile: privileged-mcp-action/v0
+
+[`privileged-mcp-action/v0`](docs/profiles/privileged-mcp-action/v0.md)
+is a composition and verification contract over evidence records that already exist: what a
+privileged MCP tool call decided, what was observed of its effect, and what stays unproven. It adds
+no new envelope and no aggregate verdict.
+
+It ships with a [13-vector conformance corpus](conformance/privileged-mcp-action-v0)
+(5 accept, 8 reject) whose digest is a **candidate**: it is not called reproduced until a non-author
+implementation derives the expected outcomes from the specification text alone.
+
+**That reproduction is open, and the invitation is real:
+[#1840](https://github.com/Rul1an/assay/issues/1840).** Any language, any stack. The invitation
+names the exact commit the current digest describes, and the
+[corpus README](conformance/privileged-mcp-action-v0/README.md) says which inputs are in bounds,
+which two implementation surfaces are not, and gives a sparse checkout that materialises only the
+inputs.
+
 ## Contributing
 
 ```bash

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -6,14 +6,60 @@ Vectors for the [Privileged MCP Action Evidence Profile v0](../../docs/profiles/
 - `MANIFEST.json` declares each vector's expected `bundle_integrity`, profile `verdict`, and (for
   accepts) the full expected claim matrix. That triple is the **normative comparison surface**; the
   `first_failure_informative` codes are this generator's own vocabulary and informative only. An
-  independent implementation SHOULD report a free-form reason per reject in its own words, so a
-  wrong-reason reject cannot silently score as agreement.
+  independent implementation SHOULD report a free-form reason per reject in its own words. Reasons
+  are reviewer-visible but not scored; a different reason does not change agreement on the
+  normative surface.
 - `descriptor.json` is the machine-readable profile descriptor (record set, closed vocabularies,
   binding key, stages, report shape).
 - `gen_vectors.py` regenerates everything deterministically (standard library only; two runs are
   byte-identical). The corpus digest in the manifest changes on any vector edit.
 - The corpus digest is a **candidate** until an independent, non-author implementation reproduces
   the expected outcomes from the specification text alone.
+
+## Attempting the independent reproduction
+
+The corpus digest stays a **candidate** until a non-author implementation reproduces the expected
+outcomes from the specification text alone. The open invitation is
+[#1840](https://github.com/Rul1an/assay/issues/1840), which names the exact commit the current
+digest describes.
+
+What the claim needs is a reimplementation from the spec, so two **implementation surfaces** in this
+repository are deliberately out of bounds for such an attempt:
+
+| Out of bounds | Why |
+|---|---|
+| `gen_vectors.py` (in this directory) | It is the generator. Reading it turns a reimplementation into a port, and the resulting agreement would only show that the code was copied correctly. |
+| `crates/assay-cli` — `assay evidence import privileged-mcp-action` and `assay evidence verify-privileged-mcp-action` | Same reason: our implementation of the same spec. |
+
+In bounds, and enough on their own: this README, [`../../docs/profiles/privileged-mcp-action/v0.md`](../../docs/profiles/privileged-mcp-action/v0.md),
+`descriptor.json`, `MANIFEST.json`, and the vector bundles. The spec restates the bundle essentials
+on purpose so it can be implemented without reading ours.
+
+To materialise only those inputs — no generator, no `crates/` — use a sparse checkout at the commit
+the invitation pins:
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/Rul1an/assay.git assay-corpus
+cd assay-corpus
+git checkout <commit named in #1840>
+git sparse-checkout set --no-cone \
+  '/docs/profiles/privileged-mcp-action/v0.md' \
+  '/conformance/privileged-mcp-action-v0/**' \
+  '!/conformance/privileged-mcp-action-v0/gen_vectors.py'
+```
+
+This does not materialize either out-of-bounds surface in the working tree. A sparse clone still
+carries the repository index and can fetch other blobs later, so it is a convenience for keeping the
+boundary rather than a guarantee of it. Nothing here is enforced and nothing needs to be — it is a
+boundary an attempt keeps for its own result to mean anything, and saying which paths those are
+costs nothing.
+
+The normative comparison surface is `expected.bundle_integrity`, `expected.verdict` and
+`expected.claims` per vector, plus the corpus digest. `first_failure_informative` is this
+generator's own vocabulary and is **not** part of that surface: report rejects in your own words.
+A reject for a different reason than ours still agrees on the normative surface — the reason is
+reviewer-visible rather than scored, and exists so a human comparing the two runs can see where the
+readings diverge.
 
 Verify a vector's bundle integrity with the shipped tooling:
 

--- a/conformance/privileged-mcp-action-v0/descriptor.json
+++ b/conformance/privileged-mcp-action-v0/descriptor.json
@@ -3,7 +3,7 @@
   "profile": "privileged-mcp-action/v0",
   "status": "experimental-open-profile",
   "spec": "docs/profiles/privileged-mcp-action/v0.md",
-  "normative_uri": "https://docs.assay.dev/profiles/privileged-mcp-action/v0/",
+  "normative_uri": "https://docs.getassay.dev/profiles/privileged-mcp-action/v0/",
   "records": {
     "required": [
       {

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.getassay.dev

--- a/docs/profiles/privileged-mcp-action/v0.md
+++ b/docs/profiles/privileged-mcp-action/v0.md
@@ -2,8 +2,14 @@
 
 - Profile id: `privileged-mcp-action/v0`
 - Status: **experimental open profile** (not a standard; see "Versioning and maturity")
-- Normative URI: `https://docs.assay.dev/profiles/privileged-mcp-action/v0/`
-- Conformance corpus: [`conformance/privileged-mcp-action-v0/`](https://github.com/Rul1an/assay/tree/main/conformance/privileged-mcp-action-v0) (13 vectors, digest in its `MANIFEST.json`)
+- Normative URI: `https://docs.getassay.dev/profiles/privileged-mcp-action/v0/`
+- Conformance corpus: [`../../../conformance/privileged-mcp-action-v0/`](../../../conformance/privileged-mcp-action-v0)
+  (13 vectors, corpus digest in its `MANIFEST.json`)
+- Independent reproduction wanted: [#1840](https://github.com/Rul1an/assay/issues/1840), which names
+  the exact commit the current corpus digest describes.
+
+In-repository links here are relative, so a reader who obtained this file at some commit follows
+them to the corpus at that same commit. The digest describes one set of bytes.
 
 The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as described in RFC 2119.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,11 @@
 # Assay Documentation Site
-# docs.assay.dev
+# docs.getassay.dev
 # Built with MkDocs + Material theme
 
 site_name: Assay
-site_url: https://docs.assay.dev
+# Canonical publication surface; docs/CNAME must carry the same host so a
+# `mkdocs gh-deploy --force` cannot drop the custom domain from gh-pages.
+site_url: https://docs.getassay.dev
 site_description: "CI-native evidence compiler and Trust Basis artifacts for agent systems"
 site_author: Assay Team
 exclude_docs: /README.md


### PR DESCRIPTION
The `privileged-mcp-action/v0` corpus digest is a **candidate** until a non-author implementation derives the expected outcomes from the specification text alone. The invitation is #1840. This makes that attempt possible to start, and stops the merge from breaking the docs domain on the way.

## Merging this would have dropped the custom domain

`.github/workflows/docs.yml` runs `mkdocs gh-deploy --force` on any push to `main` touching `docs/**` — and this branch touches `docs/`. Without a `CNAME` in the docs **source**, a forced redeploy rewrites `gh-pages` and takes the custom domain with it.

`docs/CNAME` now carries `docs.getassay.dev`, and `site_url` matches it, so sitemap, canonical links and social metadata stop naming a host that never existed.

## The normative URI is restored, on both surfaces

The canonical documentation host is `docs.getassay.dev`, and it serves [the profile page](https://docs.getassay.dev/profiles/privileged-mcp-action/v0/) today.

An earlier revision of this branch concluded the normative URI was dead and removed it. That conclusion came from testing the wrong hostname — `docs.assay.dev`, which indeed does not resolve. The profile keeps a normative URI, and it now names the surface that publishes it, with the same value in the spec header and in `descriptor.json`, the machine-readable input #1840 names.

## Reproducing without reading the implementation

`gen_vectors.py` sits in the corpus directory and is the one file a from-spec attempt must not read: reading it turns a reimplementation into a port. `crates/assay-cli` is the second such surface.

```bash
git clone --filter=blob:none --sparse https://github.com/Rul1an/assay.git assay-corpus
cd assay-corpus
git checkout <commit named in #1840>
git sparse-checkout set --no-cone \
  '/docs/profiles/privileged-mcp-action/v0.md' \
  '/conformance/privileged-mcp-action-v0/**' \
  '!/conformance/privileged-mcp-action-v0/gen_vectors.py'
```

Run against the repository this yields 16 files — spec, corpus README, descriptor, manifest, 13 vectors. It **does not materialize either out-of-bounds surface in the working tree**; a sparse clone still carries the repository index and can fetch other blobs later, so it keeps the boundary rather than guaranteeing it.

## Smaller corrections

- The reason claim was too strong. Reasons are explicitly not part of the normative surface, so a reject for a different reason still agrees on `bundle_integrity` and `verdict`. It is **reviewer-visible rather than scored**. Corrected here and in #1840.
- In-repository links are relative, so a reader who obtained the spec at some commit follows them to the corpus at that same commit.
- The incident narrative about the old hostname is out of the profile header — it belongs to this change, not to the profile semantics.
- The repository README had no path to the profile, the corpus or the invitation, and now has one.

## What does not change

No vector, `MANIFEST.json`, or descriptor-record byte changes. The corpus digest method is `sha256 over concat(vector sha256)`, so this text sits outside it and **`a943120f` is stable** — checked before the first edit, because a documentation change that moved the digest would invalidate the target under reproduction.

## Verification, with the real toolchain

| Check | Result |
|---|---|
| `mkdocs build --strict` | succeeds |
| built `site/CNAME` | `docs.getassay.dev` |
| sitemap host | `https://docs.getassay.dev/` |
| built profile page | carries the corrected normative URI |
| `https://docs.getassay.dev/profiles/privileged-mcp-action/v0/` | `HTTP 200` |
| sparse checkout, executed | 16 files, neither out-of-bounds surface present |
| `scripts/ci/check-public-artifact-sanitization.py` | passed |
| `cargo test -p assay-cli --test conformance_privileged_mcp_action` | green |
| `git status` under `vectors/` and `MANIFEST.json` | zero changes |

## Deliberately not in this PR

Five source files still name the old host: two lint/SARIF rule URIs, a legacy policy path, and two docs pages. Those are **route hygiene**, not deployment persistence, and several of the routes need pages that do not exist yet (`/lint/`, `/packs/schema/`, and `/config/policies/` which is really `/reference/config/policies/`). They belong in a separate docs-contract change together with a `mkdocs build --strict` CI gate that asserts `site/CNAME` and the canonical pages exist.

## Post-merge

Re-pin #1840 to the squash-merge commit at **full 40-character SHA**, noting that this was a locator and documentation update and that corpus digest `a943120f…` did not change. Then enable **Enforce HTTPS** in GitHub Pages once the toggle is available — the certificate is active but HTTP currently returns `200` rather than redirecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
