### PR TITLE
feat(conformance): add clean-room profile activation kit

### DIFF
--- a/.github/actions/privileged-mcp-action-conformance/action.yml
+++ b/.github/actions/privileged-mcp-action-conformance/action.yml
@@ -1,0 +1,70 @@
+name: Privileged MCP Action v0 conformance
+
+description: Run a supplied verifier against the pinned opaque corpus and emit a run record.
+
+inputs:
+  entrypoint:
+    description: Command that accepts one bundle path and emits one profile report JSON object.
+    required: true
+  pack:
+    description: Path to the privileged-mcp-action-v0 clean-room pack.
+    required: true
+  implementation-name:
+    description: Human-readable implementation name.
+    required: true
+  reproduction-mode:
+    description: Disclosed authorship mode from the conformance protocol.
+    required: true
+  implementation-version:
+    description: Implementation version.
+    required: false
+    default: ""
+  implementation-source:
+    description: Public implementation source URL.
+    required: true
+  implementation-commit:
+    description: Full implementation source commit.
+    required: true
+  report:
+    description: Output path for the machine-readable run record.
+    required: false
+    default: privileged-mcp-action-conformance.json
+
+outputs:
+  report:
+    description: Path to the machine-readable run record.
+    value: ${{ inputs.report }}
+
+runs:
+  using: composite
+  steps:
+    - name: Score opaque conformance cases
+      shell: bash
+      env:
+        ASSAY_CONFORMANCE_ENTRYPOINT: ${{ inputs.entrypoint }}
+        ASSAY_CONFORMANCE_PACK: ${{ inputs.pack }}
+        ASSAY_CONFORMANCE_IMPLEMENTATION_NAME: ${{ inputs.implementation-name }}
+        ASSAY_CONFORMANCE_REPRODUCTION_MODE: ${{ inputs.reproduction-mode }}
+        ASSAY_CONFORMANCE_IMPLEMENTATION_VERSION: ${{ inputs.implementation-version }}
+        ASSAY_CONFORMANCE_IMPLEMENTATION_SOURCE: ${{ inputs.implementation-source }}
+        ASSAY_CONFORMANCE_IMPLEMENTATION_COMMIT: ${{ inputs.implementation-commit }}
+        ASSAY_CONFORMANCE_REPORT: ${{ inputs.report }}
+      run: |
+        set -euo pipefail
+        repo_root="$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)"
+        args=(
+          --pack "$ASSAY_CONFORMANCE_PACK"
+          --manifest "$repo_root/conformance/privileged-mcp-action-v0/MANIFEST.json"
+          --entrypoint "$ASSAY_CONFORMANCE_ENTRYPOINT"
+          --implementation-name "$ASSAY_CONFORMANCE_IMPLEMENTATION_NAME"
+          --implementation-source "$ASSAY_CONFORMANCE_IMPLEMENTATION_SOURCE"
+          --implementation-commit "$ASSAY_CONFORMANCE_IMPLEMENTATION_COMMIT"
+          --reproduction-mode "$ASSAY_CONFORMANCE_REPRODUCTION_MODE"
+          --output "$ASSAY_CONFORMANCE_REPORT"
+        )
+        if [[ -n "$ASSAY_CONFORMANCE_IMPLEMENTATION_VERSION" ]]; then
+          args+=(--implementation-version "$ASSAY_CONFORMANCE_IMPLEMENTATION_VERSION")
+        fi
+        python3 \
+          "$repo_root/conformance/privileged-mcp-action-v0/scripts/score_candidate.py" \
+          "${args[@]}"

--- a/.github/workflows/privileged-mcp-action-conformance.yml
+++ b/.github/workflows/privileged-mcp-action-conformance.yml
@@ -1,0 +1,106 @@
+name: Privileged MCP Action conformance kit
+
+on:
+  pull_request:
+    paths:
+      - "conformance/privileged-mcp-action-v0/**"
+      - ".github/actions/privileged-mcp-action-conformance/**"
+      - ".github/workflows/privileged-mcp-action-conformance.yml"
+      - ".github/workflows/privileged-mcp-action-pack-release.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "conformance/privileged-mcp-action-v0/**"
+      - ".github/actions/privileged-mcp-action-conformance/**"
+      - ".github/workflows/privileged-mcp-action-conformance.yml"
+      - ".github/workflows/privileged-mcp-action-pack-release.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: privileged-mcp-action-conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  activation-kit:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13.8"
+
+      - name: Run activation-kit contract tests
+        run: |
+          set -euo pipefail
+          python3 -m unittest \
+            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+
+      - name: Validate public JSON documents
+        run: |
+          set -euo pipefail
+          python3 -m json.tool \
+            conformance/privileged-mcp-action-v0/report.schema.json >/dev/null
+          python3 -m json.tool \
+            conformance/privileged-mcp-action-v0/descriptor.json >/dev/null
+
+      - name: Prove deterministic pack build
+        run: |
+          set -euo pipefail
+          source_commit="$(git rev-parse HEAD)"
+          builder=conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
+          python3 "$builder" \
+            --repo-root . \
+            --source-commit "$source_commit" \
+            --output /tmp/pack-a.tar.gz
+          python3 "$builder" \
+            --repo-root . \
+            --source-commit "$source_commit" \
+            --output /tmp/pack-b.tar.gz
+          cmp /tmp/pack-a.tar.gz /tmp/pack-b.tar.gz
+
+      - name: Build the reference verifier for a transformation check
+        run: |
+          cargo test -p assay-cli --test conformance_privileged_mcp_action
+
+      - name: Prove opaque rendering preserves all normative outcomes
+        uses: ./.github/actions/privileged-mcp-action-conformance
+        with:
+          pack: /tmp/pack-a.tar.gz
+          entrypoint: ${{ github.workspace }}/target/debug/assay evidence verify-privileged-mcp-action --format json
+          implementation-name: Assay reference verifier (transformation check only)
+          implementation-source: ${{ github.server_url }}/${{ github.repository }}
+          implementation-commit: ${{ github.sha }}
+          reproduction-mode: other_disclosed
+          report: /tmp/reference-transformation-check.json
+
+      - name: Check transformation summary
+        run: |
+          python3 \
+            conformance/privileged-mcp-action-v0/scripts/validate_run_record.py \
+            /tmp/reference-transformation-check.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("/tmp/reference-transformation-check.json").read_text())
+          expected = {
+              "execution_error": 0,
+              "match": 13,
+              "mismatch": 0,
+              "harness_error": 0,
+              "review_warnings": 0,
+              "total": 13,
+          }
+          if report["summary"] != expected:
+              raise SystemExit(f"unexpected transformation summary: {report['summary']}")
+          PY

--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -1,0 +1,134 @@
+name: Publish Privileged MCP Action clean-room pack
+
+on:
+  push:
+    tags:
+      - "privileged-mcp-action-v0-candidate.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: privileged-mcp-action-pack-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-pack:
+    runs-on: ubuntu-24.04
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13.8"
+
+      - name: Verify tag and build deterministic pack
+        run: |
+          set -euo pipefail
+          case "$GITHUB_REF_NAME" in
+            privileged-mcp-action-v0-candidate.*) ;;
+            *) echo "unexpected release tag: $GITHUB_REF_NAME" >&2; exit 2 ;;
+          esac
+          if [[ "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" != "tag" ]]; then
+            echo "release requires an annotated tag object: $GITHUB_REF_NAME" >&2
+            exit 2
+          fi
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor HEAD origin/main
+          mkdir -p release
+          source_commit="$(git rev-parse HEAD)"
+          builder=conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
+          python3 "$builder" \
+            --repo-root . \
+            --source-commit "$source_commit" \
+            --output release/privileged-mcp-action-v0-clean-room.tar.gz
+          python3 "$builder" \
+            --repo-root . \
+            --source-commit "$source_commit" \
+            --output /tmp/pack-second.tar.gz
+          cmp release/privileged-mcp-action-v0-clean-room.tar.gz /tmp/pack-second.tar.gz
+          (
+            cd release
+            sha256sum privileged-mcp-action-v0-clean-room.tar.gz > SHA256SUMS
+          )
+
+      - name: Run pack contract tests
+        run: |
+          set -euo pipefail
+          python3 -m unittest \
+            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+
+      - name: Build the reference verifier for a transformation check
+        run: |
+          cargo test -p assay-cli --test conformance_privileged_mcp_action
+
+      - name: Prove released rendering preserves all normative outcomes
+        uses: ./.github/actions/privileged-mcp-action-conformance
+        with:
+          pack: release/privileged-mcp-action-v0-clean-room.tar.gz
+          entrypoint: ${{ github.workspace }}/target/debug/assay evidence verify-privileged-mcp-action --format json
+          implementation-name: Assay reference verifier (transformation check only)
+          implementation-source: ${{ github.server_url }}/${{ github.repository }}
+          implementation-commit: ${{ github.sha }}
+          reproduction-mode: other_disclosed
+          report: /tmp/reference-transformation-check.json
+
+      - name: Check released transformation summary
+        run: |
+          python3 \
+            conformance/privileged-mcp-action-v0/scripts/validate_run_record.py \
+            /tmp/reference-transformation-check.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("/tmp/reference-transformation-check.json").read_text())
+          expected = {
+              "execution_error": 0,
+              "harness_error": 0,
+              "match": 13,
+              "mismatch": 0,
+              "review_warnings": 0,
+              "total": 13,
+          }
+          if report["summary"] != expected:
+              raise SystemExit(f"unexpected transformation summary: {report['summary']}")
+          PY
+
+      - name: Attest release pack
+        id: attest
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-checksums: release/SHA256SUMS
+          show-summary: true
+
+      - name: Retain attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          test -n "$ATTESTATION_BUNDLE"
+          cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
+
+      - name: Publish immutable release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            release/privileged-mcp-action-v0-clean-room.tar.gz \
+            release/SHA256SUMS \
+            release/attestation-bundle.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "Privileged MCP Action v0 clean-room conformance pack" \
+            --notes "Inputs-only pack for implementing privileged-mcp-action/v0 from the tagged profile. The asset omits expected outcomes and Assay implementation code. See the tagged conformance protocol for the claim ceiling."

--- a/README.md
+++ b/README.md
@@ -173,10 +173,12 @@ implementation derives the expected outcomes from the specification text alone.
 
 **That reproduction is open, and the invitation is real:
 [#1840](https://github.com/Rul1an/assay/issues/1840).** Any language, any stack. The invitation
-names the exact commit the current digest describes, and the
-[corpus README](conformance/privileged-mcp-action-v0/README.md) says which inputs are in bounds,
-which two implementation surfaces are not, and gives a sparse checkout that materialises only the
-inputs.
+names the exact commit the current digest describes. The
+[clean-room protocol](conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md) provides an
+opaque, attested inputs pack, a one-command scoring action, and an implementation-report template
+without supplying verifier logic or expected outcomes. The
+[corpus README](conformance/privileged-mcp-action-v0/README.md) states the authorship boundary and
+the claim ceiling.
 
 ## Contributing
 

--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -1,0 +1,127 @@
+# Privileged MCP Action v0 conformance protocol
+
+This protocol lets an independently authored verifier receive opaque cases before their canonical
+expectations are disclosed. It standardizes invocation and reporting only. It does not supply
+verifier logic, interpret the profile, or establish that an implementation is independent.
+
+## Authorship order
+
+1. Obtain the clean-room pack.
+2. Read `spec.md` and `descriptor.json`.
+3. Implement a command that consumes one bundle path and emits the profile report.
+4. Freeze the implementation commit and record all materials consulted.
+5. Run the scorer. It snapshots the canonical oracle into scorer-private memory for tamper resistance,
+   executes every opaque case without passing that oracle to the candidate, and only then compares.
+6. Publish the implementation source, run record, and completed implementation report.
+
+Reading Assay's verifier, `gen_vectors.py`, the canonical `MANIFEST.json`, or a prior scored report
+before step 4 changes the methodological classification. Disclose that access rather than describing
+the run as blind.
+
+## Candidate command
+
+The scorer appends one opaque bundle path to the command supplied as `--entrypoint`:
+
+```text
+<entrypoint tokens> <bundle-path>
+```
+
+The command:
+
+- MUST emit exactly one UTF-8 JSON object on stdout;
+- MUST use the report shape in Section 3 of the profile;
+- MUST NOT require a network connection;
+- SHOULD emit at least one free-form finding for an invalid verdict;
+- MAY write diagnostics to stderr;
+- MAY return a non-zero process status for rejected cases, because exit status is recorded but not
+  part of the normative comparison surface.
+
+The scorer compares only `bundle_integrity`, `verdict` when integrity passes, and the full `claims`
+object when the verdict is valid. Free-form findings are reviewer-visible and not scored.
+
+The process timeout and output ceilings are operational guardrails, not a code-execution sandbox.
+On POSIX the scorer kills the initial process group it creates, but candidate code can deliberately
+move a child into another group. Run code you do not trust in a separate job, VM, or container and do
+not place credentials in that environment.
+
+## Reproduction modes
+
+The implementation report self-declares one mode:
+
+| Mode | Meaning |
+|---|---|
+| `blind_from_spec` | The implementation was frozen before any expected outcome, semantic vector name, generator, Assay verifier, or prior scored report was read. |
+| `from_spec_then_conformance` | The implementation is independently authored, but conformance materials informed a later revision. |
+| `commissioned_clean_room` | The implementation was commissioned, with payment independent of agreement or divergence, and authorship inputs were limited to the disclosed clean-room set. |
+| `other_disclosed` | The preceding labels do not fit; the implementation report explains the actual sequence. |
+
+These are provenance descriptions, not scores. The scorer records the selected label but cannot
+verify it.
+
+## Scoring
+
+Run from an Assay source checkout at the pinned activation-kit revision:
+
+```bash
+python3 conformance/privileged-mcp-action-v0/scripts/score_candidate.py \
+  --pack privileged-mcp-action-v0-clean-room.tar.gz \
+  --manifest conformance/privileged-mcp-action-v0/MANIFEST.json \
+  --entrypoint "./my-verifier --format json" \
+  --implementation-name "my verifier" \
+  --implementation-source "https://github.com/example/my-verifier" \
+  --implementation-commit "<full commit>" \
+  --reproduction-mode blind_from_spec \
+  --output implementation-report.json
+```
+
+Exit status is `0` for complete normative agreement, `1` for a completed run with at least one
+normative mismatch, and `2` for an execution or harness error. A mismatch is a useful result and
+should be published rather than repaired by reading another implementation.
+
+The scorer records the pack SHA-256 and its declared source commit, but does not verify release
+provenance. Verify the release attestation before relying on that declaration and record the
+verification result in the implementation report.
+
+## GitHub Actions
+
+Build the candidate verifier before invoking the composite action. The action appends
+each opaque bundle path to `entrypoint` and writes the machine-readable report; it never imports
+Assay's verifier.
+
+```yaml
+permissions:
+  contents: read
+
+steps:
+  - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+  - name: Build candidate
+    run: ./build-my-verifier.sh
+
+  - name: Download clean-room pack
+    env:
+      GH_TOKEN: ${{ github.token }}
+    run: |
+      gh release download privileged-mcp-action-v0-candidate.1 \
+        --repo Rul1an/assay \
+        --pattern privileged-mcp-action-v0-clean-room.tar.gz
+
+  - name: Run conformance
+    uses: Rul1an/assay/.github/actions/privileged-mcp-action-conformance@privileged-mcp-action-v0-candidate.1
+    with:
+      pack: privileged-mcp-action-v0-clean-room.tar.gz
+      entrypoint: ./target/release/my-verifier
+      implementation-name: my-verifier
+      implementation-source: ${{ github.server_url }}/${{ github.repository }}
+      implementation-commit: ${{ github.sha }}
+      reproduction-mode: blind_from_spec
+      report: privileged-mcp-action-conformance.json
+```
+
+For a long-lived workflow, resolve the release tag to its full commit and pin the action to that SHA.
+
+## Claim ceiling
+
+A matching run demonstrates agreement on the pinned 13-case corpus. It does not establish
+implementation independence, security, compliance, complete profile determinacy, or any provider
+outcome. Those claims require separate evidence.

--- a/conformance/privileged-mcp-action-v0/IMPLEMENTATION-REPORT.template.md
+++ b/conformance/privileged-mcp-action-v0/IMPLEMENTATION-REPORT.template.md
@@ -1,0 +1,55 @@
+# Privileged MCP Action v0 implementation report
+
+## Implementation
+
+- Name:
+- Source repository:
+- Full implementation commit:
+- Language and runtime:
+- Author or organization:
+- Contact:
+
+## Reproduction method
+
+- Mode: `blind_from_spec | from_spec_then_conformance | commissioned_clean_room | other_disclosed`
+- Implementation frozen at:
+- First scorer run at:
+- Materials read before the implementation was frozen:
+- Materials first read after the implementation was frozen:
+- Prior relationship to the profile authors:
+- Funding or compensation, including whether payment depended on the result:
+
+## Pinned inputs
+
+- Clean-room pack release:
+- Pack SHA-256:
+- Pack attestation verification:
+- Pack-declared source commit:
+- Scorer pack-provenance status:
+- Source corpus digest:
+- Rendered-set digest:
+- Scorer commit:
+
+## Result
+
+- Machine-readable run record:
+- Normative matches:
+- Normative mismatches:
+- Execution errors:
+- Harness errors:
+- Reviewer warnings:
+
+For every mismatch, describe the reading derived from the specification before comparing it with the
+canonical expectation. Do not replace the original implementation commit or first run record.
+
+## Verification
+
+- Command used:
+- CI run:
+- Operating system:
+- Re-run result:
+
+## Non-claims
+
+This report records one implementation's result against the pinned corpus. It does not by itself
+establish independence, security, compliance, complete profile determinacy, or provider outcomes.

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -23,36 +23,61 @@ outcomes from the specification text alone. The open invitation is
 [#1840](https://github.com/Rul1an/assay/issues/1840), which names the exact commit the current
 digest describes.
 
-What the claim needs is a reimplementation from the spec, so two **implementation surfaces** in this
-repository are deliberately out of bounds for such an attempt:
+### Clean-room path
+
+The release
+[`privileged-mcp-action-v0-candidate.1`](https://github.com/Rul1an/assay/releases/tag/privileged-mcp-action-v0-candidate.1)
+contains a deterministic, attested clean-room pack. It carries `spec.md`, `descriptor.json`, and
+thirteen opaque cases. It omits expected outcomes, semantic case names, the vector generator, and
+Assay's implementation.
+
+```bash
+tag=privileged-mcp-action-v0-candidate.1
+gh release download "$tag" --repo Rul1an/assay \
+  --pattern privileged-mcp-action-v0-clean-room.tar.gz \
+  --pattern SHA256SUMS
+shasum -a 256 -c SHA256SUMS
+gh attestation verify privileged-mcp-action-v0-clean-room.tar.gz \
+  --repo Rul1an/assay \
+  --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml
+```
+
+Follow [`CONFORMANCE-PROTOCOL.md`](CONFORMANCE-PROTOCOL.md): implement before scoring, preserve the
+first run, disclose the materials read, and publish a machine-readable run record plus the completed
+[`IMPLEMENTATION-REPORT.template.md`](IMPLEMENTATION-REPORT.template.md). The reusable composite
+action at `.github/actions/privileged-mcp-action-conformance` standardizes invocation and scoring;
+it does not provide verifier logic.
+
+What the claim needs is a reimplementation from the spec, so three **answer or implementation
+surfaces** in this repository are deliberately out of bounds until the implementation is frozen:
 
 | Out of bounds | Why |
 |---|---|
 | `gen_vectors.py` (in this directory) | It is the generator. Reading it turns a reimplementation into a port, and the resulting agreement would only show that the code was copied correctly. |
 | `crates/assay-cli` — `assay evidence import privileged-mcp-action` and `assay evidence verify-privileged-mcp-action` | Same reason: our implementation of the same spec. |
+| `MANIFEST.json` and prior scored reports | They carry the expected outcomes. Reading them before implementation turns conformance into an answer-guided repair pass. |
 
-In bounds, and enough on their own: this README, [`../../docs/profiles/privileged-mcp-action/v0.md`](../../docs/profiles/privileged-mcp-action/v0.md),
-`descriptor.json`, `MANIFEST.json`, and the vector bundles. The spec restates the bundle essentials
-on purpose so it can be implemented without reading ours.
+In bounds for authorship, and enough on their own: the clean-room pack's `spec.md`,
+`descriptor.json`, and opaque bundle cases. The spec restates the bundle essentials on purpose so it
+can be implemented without reading ours.
 
-To materialise only those inputs — no generator, no `crates/` — use a sparse checkout at the commit
-the invitation pins:
+Without the release pack, materialize only the specification:
 
 ```bash
 git clone --filter=blob:none --sparse https://github.com/Rul1an/assay.git assay-corpus
 cd assay-corpus
 git checkout <commit named in #1840>
 git sparse-checkout set --no-cone \
-  '/docs/profiles/privileged-mcp-action/v0.md' \
-  '/conformance/privileged-mcp-action-v0/**' \
-  '!/conformance/privileged-mcp-action-v0/gen_vectors.py'
+  '/docs/profiles/privileged-mcp-action/v0.md'
 ```
 
-This does not materialize either out-of-bounds surface in the working tree. A sparse clone still
-carries the repository index and can fetch other blobs later, so it is a convenience for keeping the
-boundary rather than a guarantee of it. Nothing here is enforced and nothing needs to be — it is a
-boundary an attempt keeps for its own result to mean anything, and saying which paths those are
-costs nothing.
+Use `descriptor.json` from the release pack. The canonical descriptor beside the corpus carries a
+`corpus` member and is therefore answer-bearing before implementation freeze; it is deliberately not
+part of this fallback checkout.
+
+After freezing the implementation, fetch the canonical expectations and scorer for reconciliation.
+A sparse clone can fetch other blobs later, so this is a convenience for keeping the boundary rather
+than a guarantee of it. The run report discloses what was actually read.
 
 The normative comparison surface is `expected.bundle_integrity`, `expected.verdict` and
 `expected.claims` per vector, plus the corpus digest. `first_failure_informative` is this

--- a/conformance/privileged-mcp-action-v0/report.schema.json
+++ b/conformance/privileged-mcp-action-v0/report.schema.json
@@ -1,0 +1,436 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/privileged-mcp-action-v0-candidate.1/conformance/privileged-mcp-action-v0/report.schema.json",
+  "title": "Privileged MCP Action v0 conformance run",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "profile",
+    "source_corpus_digest",
+    "rendered_set_digest",
+    "pack_sha256",
+    "pack_declared_source_commit",
+    "pack_provenance_verification",
+    "implementation",
+    "summary",
+    "harness_errors",
+    "cases",
+    "non_claims"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.privileged_mcp_action.conformance_run.v0"
+    },
+    "profile": {
+      "const": "privileged-mcp-action/v0"
+    },
+    "source_corpus_digest": {
+      "$ref": "#/$defs/sha256"
+    },
+    "rendered_set_digest": {
+      "$ref": "#/$defs/sha256"
+    },
+    "pack_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "pack_declared_source_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "pack_provenance_verification": {
+      "const": "not_performed_by_scorer"
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "source",
+        "commit",
+        "reproduction_mode"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^https?://[^\\s]+$"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "reproduction_mode": {
+          "enum": [
+            "blind_from_spec",
+            "from_spec_then_conformance",
+            "commissioned_clean_room",
+            "other_disclosed"
+          ]
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "match",
+        "mismatch",
+        "execution_error",
+        "harness_error",
+        "review_warnings"
+      ],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "match": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mismatch": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "execution_error": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "harness_error": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "review_warnings": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "harness_errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 13,
+      "maxItems": 13,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/matchCase"
+          },
+          {
+            "$ref": "#/$defs/mismatchCase"
+          },
+          {
+            "$ref": "#/$defs/executionErrorCase"
+          },
+          {
+            "$ref": "#/$defs/harnessErrorCase"
+          }
+        ]
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "prefixItems": [
+        {
+          "const": "a matching run demonstrates agreement on the pinned corpus only"
+        },
+        {
+          "const": "a matching run does not establish implementation independence"
+        },
+        {
+          "const": "the scorer records but does not verify the pack's declared source commit"
+        },
+        {
+          "const": "the scorer does not assess security, compliance, or provider outcomes"
+        },
+        {
+          "const": "candidate process limits are operational bounds, not a sandbox"
+        }
+      ],
+      "items": false
+    }
+  },
+  "$defs": {
+    "matchCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "input_sha256",
+        "status",
+        "observed",
+        "exit_code",
+        "stderr_present"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^case-[0-9]{3}$"
+        },
+        "input_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "status": {
+          "const": "match"
+        },
+        "observed": {
+          "$ref": "#/$defs/normativeSurface"
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "stderr_present": {
+          "type": "boolean"
+        },
+        "review_warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "mismatchCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "input_sha256",
+        "status",
+        "observed",
+        "exit_code",
+        "stderr_present"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^case-[0-9]{3}$"
+        },
+        "input_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "status": {
+          "const": "mismatch"
+        },
+        "observed": {
+          "$ref": "#/$defs/normativeSurface"
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "stderr_present": {
+          "type": "boolean"
+        },
+        "review_warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "executionErrorCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "input_sha256",
+        "status",
+        "error"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^case-[0-9]{3}$"
+        },
+        "input_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "status": {
+          "const": "execution_error"
+        },
+        "error": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "harnessErrorCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "input_sha256",
+        "status",
+        "error"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^case-[0-9]{3}$"
+        },
+        "input_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "status": {
+          "const": "harness_error"
+        },
+        "error": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "normativeSurface": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/integrityFailSurface"
+        },
+        {
+          "$ref": "#/$defs/invalidSurface"
+        },
+        {
+          "$ref": "#/$defs/validSurface"
+        }
+      ]
+    },
+    "integrityFailSurface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bundle_integrity"
+      ],
+      "properties": {
+        "bundle_integrity": {
+          "const": "fail"
+        }
+      }
+    },
+    "invalidSurface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bundle_integrity",
+        "verdict"
+      ],
+      "properties": {
+        "bundle_integrity": {
+          "const": "pass"
+        },
+        "verdict": {
+          "const": "invalid"
+        }
+      }
+    },
+    "validSurface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bundle_integrity",
+        "verdict",
+        "claims"
+      ],
+      "properties": {
+        "bundle_integrity": {
+          "const": "pass"
+        },
+        "verdict": {
+          "const": "valid"
+        },
+        "claims": {
+          "$ref": "#/$defs/claimMatrix"
+        }
+      }
+    },
+    "claimMatrix": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_decision_recorded",
+        "caller_visible_denial",
+        "upstream_delivery",
+        "external_side_effect"
+      ],
+      "properties": {
+        "policy_decision_recorded": {
+          "$ref": "#/$defs/claimResult"
+        },
+        "caller_visible_denial": {
+          "$ref": "#/$defs/claimResult"
+        },
+        "upstream_delivery": {
+          "$ref": "#/$defs/claimResult"
+        },
+        "external_side_effect": {
+          "$ref": "#/$defs/claimResult"
+        }
+      }
+    },
+    "claimResult": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status"
+          ],
+          "properties": {
+            "status": {
+              "const": "incomplete"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "source_class"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "confirmed",
+                "refuted"
+              ]
+            },
+            "source_class": {
+              "enum": [
+                "producer_reported",
+                "issuer_attested",
+                "receiver_receipt",
+                "boundary_observed",
+                "third_party_observed",
+                "unknown"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/conformance/privileged-mcp-action-v0/scripts/bounded_process.py
+++ b/conformance/privileged-mcp-action-v0/scripts/bounded_process.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Run a child process with hard timeout and output ceilings."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+
+@dataclass(frozen=True)
+class BoundedResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+class ProcessLimitError(RuntimeError):
+    pass
+
+
+class ProcessCaptureError(ProcessLimitError):
+    pass
+
+
+def _terminate_and_reap(process: subprocess.Popen[bytes]) -> None:
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except PermissionError:
+            # macOS reports EPERM when only the unsignalable zombie leader
+            # remains in the group. WNOWAIT still keeps its PID unrecycled.
+            if sys.platform != "darwin" or not _leader_exited_without_reaping(process):
+                raise
+        except ProcessLookupError:
+            pass
+    elif process.poll() is None:
+        process.kill()
+    process.wait()
+
+
+def _leader_exited_without_reaping(process: subprocess.Popen[bytes]) -> bool:
+    if os.name != "posix":
+        return process.poll() is not None
+    # Keep the leader as a zombie until its process group is swept. That keeps
+    # its PID from being recycled before killpg targets the original group.
+    return (
+        os.waitid(
+            os.P_PID,
+            process.pid,
+            os.WEXITED | os.WNOHANG | os.WNOWAIT,
+        )
+        is not None
+    )
+
+
+def _capture_stream(stream: BinaryIO, limit: int, exceeded: threading.Event) -> bytes:
+    collected = bytearray()
+    while True:
+        chunk = stream.read(min(64 * 1024, limit + 1 - len(collected)))
+        if not chunk:
+            break
+        collected.extend(chunk)
+        if len(collected) > limit:
+            exceeded.set()
+            break
+    return bytes(collected)
+
+
+def _close_pipes(process: subprocess.Popen[bytes]) -> None:
+    if process.stdout is not None:
+        process.stdout.close()
+    if process.stderr is not None:
+        process.stderr.close()
+
+
+def run_bounded(
+    command: Sequence[str],
+    *,
+    timeout_seconds: int,
+    stdout_limit: int,
+    stderr_limit: int,
+    cwd: Path | None = None,
+) -> BoundedResult:
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+    if stdout_limit < 0 or stderr_limit < 0:
+        raise ValueError("output limits must be non-negative")
+
+    # This helper intentionally runs the caller-supplied argv without a shell. It
+    # bounds I/O and the initial POSIX process group, but it is not a sandbox:
+    # a child that creates another group leaves that operational boundary.
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=os.name == "posix",
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    exceeded = threading.Event()
+    capture_failed = threading.Event()
+    outputs: dict[str, bytes] = {}
+    capture_failures: dict[str, Exception] = {}
+
+    def capture(name: str, stream: BinaryIO, limit: int) -> None:
+        try:
+            outputs[name] = _capture_stream(stream, limit, exceeded)
+        except OSError as error:
+            capture_failures[name] = error
+            capture_failed.set()
+
+    threads = [
+        threading.Thread(
+            target=capture,
+            args=("stdout", process.stdout, stdout_limit),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=capture,
+            args=("stderr", process.stderr, stderr_limit),
+            daemon=True,
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        if exceeded.is_set() or capture_failed.is_set():
+            _terminate_and_reap(process)
+            break
+        if time.monotonic() >= deadline:
+            _terminate_and_reap(process)
+            for thread in threads:
+                thread.join(timeout=1)
+            _close_pipes(process)
+            raise ProcessLimitError(f"process timed out after {timeout_seconds}s")
+        if _leader_exited_without_reaping(process):
+            _terminate_and_reap(process)
+            break
+        time.sleep(0.01)
+
+    # A candidate may let its leader exit while descendants retain the capture
+    # pipes or continue in the background. The process group was swept before
+    # the leader was reaped, so process.pid cannot have been recycled.
+    for thread in threads:
+        thread.join(timeout=1)
+    if capture_failures:
+        _close_pipes(process)
+        failed_streams = ", ".join(sorted(capture_failures))
+        raise ProcessCaptureError(f"process output capture failed: {failed_streams}")
+    if exceeded.is_set():
+        _close_pipes(process)
+        raise ProcessLimitError("process output exceeded its byte ceiling")
+    if any(thread.is_alive() for thread in threads):
+        _close_pipes(process)
+        raise ProcessLimitError("process output capture did not terminate")
+    result = BoundedResult(
+        returncode=process.returncode,
+        stdout=outputs["stdout"],
+        stderr=outputs["stderr"],
+    )
+    _close_pipes(process)
+    return result

--- a/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
+++ b/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Build a deterministic, inputs-only clean-room conformance pack."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+
+from bounded_process import ProcessLimitError, run_bounded
+from pack_format import (
+    clean_room_descriptor,
+    clean_room_spec,
+    deterministic_tar_gz,
+    opaque_case_id,
+    opaque_run_id,
+    ordered_vectors,
+    rewrite_bundle_stream_identity,
+)
+
+
+PACK_ROOT = "privileged-mcp-action-v0"
+PACK_SCHEMA = "assay.privileged_mcp_action.clean_room_pack.v0"
+PROFILE = "privileged-mcp-action/v0"
+CORPUS_PATH = "conformance/privileged-mcp-action-v0"
+SPEC_PATH = "docs/profiles/privileged-mcp-action/v0.md"
+DESCRIPTOR_PATH = f"{CORPUS_PATH}/descriptor.json"
+MANIFEST_PATH = f"{CORPUS_PATH}/MANIFEST.json"
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+MAX_GIT_BLOB_BYTES = 32 * 1024 * 1024
+MAX_GIT_ERROR_BYTES = 64 * 1024
+
+README = """\
+# Privileged MCP Action v0 clean-room pack
+
+This pack contains the specification, machine-readable descriptor, and thirteen
+opaque evidence-bundle cases. It deliberately omits expected outcomes, semantic
+case names, the vector generator, and Assay's implementation.
+
+Implement the profile from `spec.md` and `descriptor.json` before running a
+scorer. Your implementation should accept one bundle path and emit exactly one
+JSON report in the report shape defined by the profile. The scorer and canonical
+expectations are post-implementation reconciliation surfaces, not authorship
+inputs.
+
+`cases.json` binds each opaque case to its bytes and records the declared source
+commit, source-corpus digest, and rendered-set digest. It does not contain expected
+results. Verify the release attestation separately before relying on pack provenance.
+"""
+
+
+def sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def git_bytes(repo_root: Path, commit: str, path: str) -> bytes:
+    result = run_bounded(
+        ["git", "show", f"{commit}:{path}"],
+        cwd=repo_root,
+        timeout_seconds=30,
+        stdout_limit=MAX_GIT_BLOB_BYTES,
+        stderr_limit=MAX_GIT_ERROR_BYTES,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"cannot read {path} at {commit}: "
+            f"{result.stderr.decode('utf-8', errors='replace').strip()}"
+        )
+    return result.stdout
+
+
+def build_pack(repo_root: Path, source_commit: str) -> bytes:
+    if not FULL_SHA.fullmatch(source_commit):
+        raise ValueError("--source-commit must be a full lowercase 40-hex Git commit")
+
+    spec = clean_room_spec(git_bytes(repo_root, source_commit, SPEC_PATH))
+    descriptor = clean_room_descriptor(
+        git_bytes(repo_root, source_commit, DESCRIPTOR_PATH)
+    )
+    manifest_bytes = git_bytes(repo_root, source_commit, MANIFEST_PATH)
+    manifest = json.loads(manifest_bytes)
+
+    cases = []
+    seen_source_digests: set[str] = set()
+    packed_bundle_by_digest: dict[str, bytes] = {}
+    for index, vector in enumerate(ordered_vectors(manifest["vectors"]), start=1):
+        bundle = git_bytes(
+            repo_root,
+            source_commit,
+            f"{CORPUS_PATH}/{vector['file']}",
+        )
+        digest = sha256(bundle)
+        if digest != vector["sha256"]:
+            raise ValueError(f"source vector digest mismatch for {vector['file']}")
+        if digest in seen_source_digests:
+            raise ValueError(f"duplicate source vector bytes: {digest}")
+        seen_source_digests.add(digest)
+        case_id = opaque_case_id(index)
+        bundle = rewrite_bundle_stream_identity(
+            bundle,
+            opaque_run_id(index),
+        )
+        digest = sha256(bundle)
+        if digest in packed_bundle_by_digest:
+            raise ValueError(f"duplicate rendered case bytes: {digest}")
+        packed_bundle_by_digest[digest] = bundle
+        cases.append(
+            {
+                "id": case_id,
+                "file": f"cases/{case_id}.bundle.tar.gz",
+                "sha256": digest,
+            }
+        )
+
+    case_index = {
+        "schema": PACK_SCHEMA,
+        "profile": PROFILE,
+        "declared_source_commit": source_commit,
+        "source_corpus_digest": manifest["corpus_digest"],
+        "rendered_set_digest": sha256(
+            "".join(case["sha256"] + "\n" for case in cases).encode()
+        ),
+        "case_count": len(cases),
+        "cases": cases,
+    }
+    files = {
+        "README.md": README.encode(),
+        "cases.json": (
+            json.dumps(case_index, indent=2, sort_keys=True) + "\n"
+        ).encode(),
+        "descriptor.json": descriptor,
+        "spec.md": spec,
+    }
+    files.update(
+        {
+            case["file"]: packed_bundle_by_digest[case["sha256"]]
+            for case in cases
+        }
+    )
+    return deterministic_tar_gz(
+        {f"{PACK_ROOT}/{name}": data for name, data in files.items()}
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        pack = build_pack(args.repo_root.resolve(), args.source_commit)
+    except (
+        OSError,
+        EOFError,
+        ProcessLimitError,
+        RecursionError,
+        ValueError,
+        KeyError,
+        json.JSONDecodeError,
+    ) as error:
+        print(f"clean-room pack build failed: {error}", file=__import__("sys").stderr)
+        return 2
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(pack)
+    print(f"wrote {args.output} ({sha256(pack)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/privileged-mcp-action-v0/scripts/pack_format.py
+++ b/conformance/privileged-mcp-action-v0/scripts/pack_format.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Deterministic clean-room rendering helpers shared by the pack builder and scorer."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+import tarfile
+from typing import Any, BinaryIO, Iterable
+
+MAX_SOURCE_BUNDLE_BYTES = 16 * 1024 * 1024
+MAX_MANIFEST_BYTES = 1024 * 1024
+MAX_EVENTS_BYTES = 8 * 1024 * 1024
+EXPECTED_BUNDLE_MEMBERS = ("manifest.json", "events.ndjson")
+MAX_SOURCE_ARCHIVE_BYTES = 12 * 1024 * 1024
+MAX_MEMBER_NAME_BYTES = 512
+
+
+class BoundedReader:
+    """Limit bytes returned by a binary stream, including one overflow probe."""
+
+    def __init__(self, source: BinaryIO, limit: int) -> None:
+        self.source = source
+        self.limit = limit
+        self.consumed = 0
+
+    def read(self, size: int = -1) -> bytes:
+        remaining_with_probe = self.limit + 1 - self.consumed
+        if remaining_with_probe <= 0:
+            raise ValueError(f"decoded stream exceeds {self.limit} bytes")
+        requested = remaining_with_probe if size < 0 else min(size, remaining_with_probe)
+        data = self.source.read(requested)
+        self.consumed += len(data)
+        if self.consumed > self.limit:
+            raise ValueError(f"decoded stream exceeds {self.limit} bytes")
+        return data
+
+
+def ordered_vectors(vectors: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(vectors, key=lambda vector: vector["sha256"])
+
+
+def opaque_case_id(index: int) -> str:
+    return f"case-{index:03d}"
+
+
+def opaque_run_id(index: int) -> str:
+    return f"pmav0-{opaque_case_id(index)}"
+
+
+def sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def add_tar_file(archive: tarfile.TarFile, name: str, data: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    info.mode = 0o644
+    info.mtime = 0
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    archive.addfile(info, io.BytesIO(data))
+
+
+def deterministic_tar_gz(
+    files: dict[str, bytes],
+    *,
+    preserve_order: bool = False,
+) -> bytes:
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w", format=tarfile.PAX_FORMAT) as archive:
+        names = files if preserve_order else sorted(files)
+        for name in names:
+            add_tar_file(archive, name, files[name])
+    output = io.BytesIO()
+    with gzip.GzipFile(fileobj=output, mode="wb", filename="", mtime=0) as stream:
+        stream.write(tar_buffer.getvalue())
+    return output.getvalue()
+
+
+def bundle_files(bundle: bytes) -> tuple[dict[str, Any], bytes]:
+    if len(bundle) > MAX_SOURCE_BUNDLE_BYTES:
+        raise ValueError(f"source bundle exceeds {MAX_SOURCE_BUNDLE_BYTES} bytes")
+    values: dict[str, bytes] = {}
+    with gzip.GzipFile(fileobj=io.BytesIO(bundle)) as decoded:
+        bounded = BoundedReader(decoded, MAX_SOURCE_ARCHIVE_BYTES)
+        with tarfile.open(fileobj=bounded, mode="r|") as archive:
+            for index, member in enumerate(archive):
+                if index >= len(EXPECTED_BUNDLE_MEMBERS):
+                    raise ValueError("source bundle contains surplus members")
+                if len(member.name.encode("utf-8")) > MAX_MEMBER_NAME_BYTES:
+                    raise ValueError("source bundle member name is too long")
+                expected_name = EXPECTED_BUNDLE_MEMBERS[index]
+                if member.name != expected_name or not member.isfile():
+                    raise ValueError(
+                        "source bundle must contain manifest.json then events.ndjson"
+                    )
+                limit = (
+                    MAX_MANIFEST_BYTES
+                    if member.name == "manifest.json"
+                    else MAX_EVENTS_BYTES
+                )
+                if member.size > limit:
+                    raise ValueError(f"{member.name} exceeds {limit} bytes")
+                source = archive.extractfile(member)
+                if source is None:
+                    raise ValueError(f"cannot read source bundle member {member.name}")
+                data = source.read(limit + 1)
+                if len(data) > limit:
+                    raise ValueError(f"{member.name} expands past {limit} bytes")
+                values[member.name] = data
+    if tuple(values) != EXPECTED_BUNDLE_MEMBERS:
+        raise ValueError("source bundle is missing required members")
+    return json.loads(values["manifest.json"]), values["events.ndjson"]
+
+
+def rewrite_bundle_stream_identity(bundle: bytes, opaque_run_id: str) -> bytes:
+    """Replace answer-bearing stream ids without changing non-identity event fields."""
+    manifest, source_events = bundle_files(bundle)
+    declared = manifest["files"]["events.ndjson"]
+    source_integrity_clean = (
+        declared["sha256"] == sha256(source_events)
+        and declared["bytes"] == len(source_events)
+    )
+
+    source_without_identity = []
+    rewritten = []
+    seen_ids: set[str] = set()
+    for line in source_events.splitlines():
+        event = json.loads(line)
+        source_event = dict(event)
+        source_event.pop("id", None)
+        source_event.pop("assayrunid", None)
+        source_without_identity.append(source_event)
+        sequence = event["assayseq"]
+        if isinstance(sequence, bool) or not isinstance(sequence, int):
+            raise ValueError("stream-identity rewrite requires integer assayseq values")
+        rewritten_id = f"{opaque_run_id}:{sequence}"
+        if rewritten_id in seen_ids:
+            raise ValueError(
+                f"stream-identity rewrite would collide on assayseq {sequence!r}"
+            )
+        seen_ids.add(rewritten_id)
+        event["assayrunid"] = opaque_run_id
+        event["id"] = rewritten_id
+        rewritten.append(
+            json.dumps(event, separators=(",", ":"), sort_keys=True).encode() + b"\n"
+        )
+    events = b"".join(rewritten)
+    rewritten_without_identity = []
+    for line in events.splitlines():
+        event = json.loads(line)
+        event.pop("id", None)
+        event.pop("assayrunid", None)
+        rewritten_without_identity.append(event)
+    if rewritten_without_identity != source_without_identity:
+        raise ValueError("stream-identity rewrite changed a non-identity event field")
+
+    manifest["run_id"] = opaque_run_id
+    if source_integrity_clean:
+        manifest["files"]["events.ndjson"]["sha256"] = sha256(events)
+        manifest["files"]["events.ndjson"]["bytes"] = len(events)
+    manifest_bytes = (
+        json.dumps(manifest, separators=(",", ":"), sort_keys=True).encode() + b"\n"
+    )
+    return deterministic_tar_gz(
+        {
+            "manifest.json": manifest_bytes,
+            "events.ndjson": events,
+        },
+        preserve_order=True,
+    )
+
+
+def clean_room_spec(spec: bytes) -> bytes:
+    text = spec.decode("utf-8")
+    start_heading = "## 8. Conformance corpus"
+    end_heading = "## 9. Versioning and maturity"
+    start = text.find(start_heading)
+    end = text.find(end_heading)
+    if start < 0 or end < 0 or end <= start:
+        raise ValueError(
+            "canonical spec must contain ordered sections "
+            f"{start_heading!r} and {end_heading!r}"
+        )
+    replacement = """\
+## 8. Clean-room rendering note
+
+The canonical document's informative conformance-corpus section is omitted from this pack because it
+names answer-bearing corpus surfaces. Sections 1 through 7 and 9 onward are unchanged.
+
+"""
+    return (text[:start] + replacement + text[end:]).encode()
+
+
+def clean_room_descriptor(descriptor: bytes) -> bytes:
+    value = json.loads(descriptor)
+    value.pop("corpus", None)
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()

--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""Run a candidate implementation against opaque cases, then score normative results."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import re
+import shlex
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+from bounded_process import ProcessCaptureError, ProcessLimitError, run_bounded
+from pack_format import (
+    BoundedReader,
+    opaque_case_id,
+    opaque_run_id,
+    ordered_vectors,
+    rewrite_bundle_stream_identity,
+)
+from validate_run_record import (
+    RUN_NON_CLAIMS,
+    validate_normative_surface,
+    validate_run_record,
+)
+
+PACK_ROOT = "privileged-mcp-action-v0"
+PACK_SCHEMA = "assay.privileged_mcp_action.clean_room_pack.v0"
+RUN_SCHEMA = "assay.privileged_mcp_action.conformance_run.v0"
+PROFILE = "privileged-mcp-action/v0"
+REPORT_SCHEMA = "assay.privileged_mcp_action.verify.report.v0"
+REPRODUCTION_MODES = (
+    "blind_from_spec",
+    "from_spec_then_conformance",
+    "commissioned_clean_room",
+    "other_disclosed",
+)
+MAX_PACK_BYTES = 100 * 1024 * 1024
+MAX_MEMBER_BYTES = 16 * 1024 * 1024
+EXPECTED_PACK_MEMBERS = 17
+MAX_PACK_ARCHIVE_BYTES = 32 * 1024 * 1024
+MAX_MEMBER_NAME_BYTES = 512
+MAX_OUTPUT_BYTES = 1024 * 1024
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class CandidateError(ValueError):
+    pass
+
+
+class HarnessError(RuntimeError):
+    pass
+
+
+def sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def read_member(
+    archive: tarfile.TarFile,
+    member: tarfile.TarInfo,
+) -> bytes:
+    if not member.isfile():
+        raise ValueError(f"pack member is not a regular file: {member.name}")
+    if member.size > MAX_MEMBER_BYTES:
+        raise ValueError(f"pack member exceeds {MAX_MEMBER_BYTES} bytes: {member.name}")
+    source = archive.extractfile(member)
+    if source is None:
+        raise ValueError(f"cannot read pack member: {member.name}")
+    data = source.read(MAX_MEMBER_BYTES + 1)
+    if len(data) > MAX_MEMBER_BYTES:
+        raise ValueError(f"pack member expands past {MAX_MEMBER_BYTES} bytes: {member.name}")
+    return data
+
+
+def load_pack(pack: Path, destination: Path) -> dict[str, Any]:
+    if pack.stat().st_size > MAX_PACK_BYTES:
+        raise ValueError(f"pack exceeds {MAX_PACK_BYTES} bytes")
+    files: dict[str, bytes] = {}
+    expanded_bytes = 0
+    with pack.open("rb") as raw:
+        with gzip.GzipFile(fileobj=raw) as decoded:
+            bounded = BoundedReader(decoded, MAX_PACK_ARCHIVE_BYTES)
+            with tarfile.open(fileobj=bounded, mode="r|") as archive:
+                for index_number, member in enumerate(archive):
+                    if index_number >= EXPECTED_PACK_MEMBERS:
+                        raise ValueError("pack contains surplus members")
+                    if len(member.name.encode("utf-8")) > MAX_MEMBER_NAME_BYTES:
+                        raise ValueError("pack member name is too long")
+                    if member.name in files:
+                        raise ValueError("pack contains duplicate member names")
+                    expanded_bytes += member.size
+                    if expanded_bytes > MAX_PACK_ARCHIVE_BYTES:
+                        raise ValueError(
+                            f"pack expands past {MAX_PACK_ARCHIVE_BYTES} bytes"
+                        )
+                    files[member.name] = read_member(archive, member)
+
+    if len(files) != EXPECTED_PACK_MEMBERS:
+        raise ValueError("pack member count is invalid")
+    index_name = f"{PACK_ROOT}/cases.json"
+    if index_name not in files:
+        raise ValueError("pack is missing cases.json")
+    index = json.loads(files[index_name])
+    if index.get("schema") != PACK_SCHEMA or index.get("profile") != PROFILE:
+        raise ValueError("pack schema or profile mismatch")
+    if not FULL_SHA.fullmatch(index.get("declared_source_commit", "")):
+        raise ValueError("pack declared_source_commit is not a full commit")
+    if not SHA256.fullmatch(index.get("source_corpus_digest", "")):
+        raise ValueError("pack source_corpus_digest is malformed")
+    if not SHA256.fullmatch(index.get("rendered_set_digest", "")):
+        raise ValueError("pack rendered_set_digest is malformed")
+    cases = index.get("cases")
+    if (
+        not isinstance(cases, list)
+        or len(cases) != 13
+        or index.get("case_count") != len(cases)
+    ):
+        raise ValueError("pack case count is invalid")
+
+    expected_names = {
+        f"{PACK_ROOT}/README.md",
+        f"{PACK_ROOT}/cases.json",
+        f"{PACK_ROOT}/descriptor.json",
+        f"{PACK_ROOT}/spec.md",
+    }
+    seen_ids: set[str] = set()
+    seen_hashes: set[str] = set()
+    for index_number, case in enumerate(cases, start=1):
+        case_id = case.get("id")
+        relative = case.get("file")
+        expected_hash = case.get("sha256")
+        expected_id = opaque_case_id(index_number)
+        if case_id != expected_id or case_id in seen_ids:
+            raise ValueError("pack case ids must be ordered unique case numbers")
+        if not isinstance(relative, str):
+            raise ValueError(f"{case_id}: case path must be a string")
+        path = PurePosixPath(relative)
+        if (
+            path.is_absolute()
+            or ".." in path.parts
+            or path.as_posix() != f"cases/{case_id}.bundle.tar.gz"
+        ):
+            raise ValueError(f"{case_id}: unsafe case path")
+        if not SHA256.fullmatch(expected_hash or ""):
+            raise ValueError(f"{case_id}: malformed case digest")
+        member_name = f"{PACK_ROOT}/{path.as_posix()}"
+        expected_names.add(member_name)
+        data = files.get(member_name)
+        if data is None:
+            raise ValueError(f"{case_id}: pack member is missing")
+        digest = sha256(data)
+        if digest != expected_hash:
+            raise ValueError(f"{case_id}: case digest mismatch")
+        if digest in seen_hashes:
+            raise ValueError(f"{case_id}: duplicate case bytes")
+        seen_ids.add(case_id)
+        seen_hashes.add(digest)
+        output = destination / f"{case_id}.bundle.tar.gz"
+        output.write_bytes(data)
+        case["_local_path"] = str(output)
+
+    if set(files) != expected_names:
+        raise ValueError("pack contains missing or surplus members")
+    rendered_set_digest = sha256(
+        "".join(case["sha256"] + "\n" for case in cases).encode()
+    )
+    if rendered_set_digest != index["rendered_set_digest"]:
+        raise ValueError("pack rendered_set_digest does not bind its cases")
+    return index
+
+
+def parse_candidate_report(stdout: bytes) -> dict[str, Any]:
+    try:
+        value = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, RecursionError) as error:
+        raise CandidateError(f"stdout is not exactly one JSON document: {error}") from error
+    if not isinstance(value, dict):
+        raise CandidateError("candidate report must be a JSON object")
+    integrity = value.get("bundle_integrity")
+    if integrity not in {"pass", "fail"}:
+        raise CandidateError("bundle_integrity must be pass or fail")
+    if integrity == "fail":
+        if "verdict" in value or "claims" in value:
+            raise CandidateError("integrity-fail report must omit verdict and claims")
+        return value
+    verdict = value.get("verdict")
+    if verdict not in {"valid", "invalid"}:
+        raise CandidateError("pass report verdict must be valid or invalid")
+    if verdict == "valid" and not isinstance(value.get("claims"), dict):
+        raise CandidateError("valid report must carry a claims object")
+    if verdict == "invalid" and "claims" in value:
+        raise CandidateError("invalid report must omit claims")
+    try:
+        validate_normative_surface(normative_surface(value))
+    except (KeyError, TypeError, ValueError) as error:
+        raise CandidateError(f"candidate normative result is invalid: {error}") from error
+    return value
+
+
+def run_candidate(
+    command: list[str],
+    bundle: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    try:
+        completed = run_bounded(
+            [*command, str(bundle)],
+            timeout_seconds=timeout_seconds,
+            stdout_limit=MAX_OUTPUT_BYTES,
+            stderr_limit=MAX_OUTPUT_BYTES,
+        )
+    except ProcessCaptureError as error:
+        raise HarnessError(f"candidate output capture failed: {error}") from error
+    except ProcessLimitError as error:
+        raise CandidateError(f"candidate execution limit exceeded: {error}") from error
+    except OSError as error:
+        raise CandidateError(
+            f"candidate process could not start ({type(error).__name__})"
+        ) from error
+    report = parse_candidate_report(completed.stdout)
+    return {
+        "exit_code": completed.returncode,
+        "report": report,
+        "stderr_present": bool(completed.stderr),
+    }
+
+
+def load_expectations(manifest_path: Path) -> tuple[dict[str, Any], str, str]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    expected_by_hash: dict[str, Any] = {}
+    vectors = ordered_vectors(manifest["vectors"])
+    for index, vector in enumerate(vectors, start=1):
+        source = (manifest_path.parent / vector["file"]).read_bytes()
+        if sha256(source) != vector["sha256"]:
+            raise ValueError(f"canonical source digest mismatch for {vector['file']}")
+        transformed = rewrite_bundle_stream_identity(
+            source,
+            opaque_run_id(index),
+        )
+        digest = sha256(transformed)
+        if digest in expected_by_hash:
+            raise ValueError(f"duplicate rendered vector digest: {digest}")
+        expected = vector["expected"]
+        projected = normative_surface(expected)
+        if projected != expected:
+            raise ValueError(
+                f"canonical expected surface contains surplus fields for {vector['file']}"
+            )
+        expected_by_hash[digest] = projected
+    rendered_set_digest = sha256(
+        "".join(digest + "\n" for digest in expected_by_hash).encode()
+    )
+    return expected_by_hash, manifest["corpus_digest"], rendered_set_digest
+
+
+def normative_surface(report: dict[str, Any]) -> dict[str, Any]:
+    result = {"bundle_integrity": report["bundle_integrity"]}
+    if report["bundle_integrity"] == "pass":
+        result["verdict"] = report["verdict"]
+        if report["verdict"] == "valid":
+            result["claims"] = report["claims"]
+    return result
+
+
+def has_reviewer_reason(report: dict[str, Any]) -> bool:
+    findings = report.get("findings")
+    if not isinstance(findings, list):
+        return False
+    return any(
+        (isinstance(finding, str) and bool(finding.strip()))
+        or (
+            isinstance(finding, dict)
+            and any(
+                isinstance(value, str) and bool(value.strip())
+                for value in finding.values()
+            )
+        )
+        for finding in findings
+    )
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pack", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--entrypoint", required=True)
+    parser.add_argument("--implementation-name", required=True)
+    parser.add_argument(
+        "--reproduction-mode",
+        choices=REPRODUCTION_MODES,
+        required=True,
+    )
+    parser.add_argument("--implementation-version")
+    parser.add_argument("--implementation-source", required=True)
+    parser.add_argument("--implementation-commit", required=True)
+    parser.add_argument("--timeout-seconds", type=positive_int, default=30)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    command = shlex.split(args.entrypoint)
+    if not command:
+        print("--entrypoint must not be empty", file=sys.stderr)
+        return 2
+    implementation_source = urlparse(args.implementation_source)
+    if (
+        implementation_source.scheme not in {"http", "https"}
+        or not implementation_source.netloc
+    ):
+        print("--implementation-source must be an absolute HTTP(S) URL", file=sys.stderr)
+        return 2
+    if not FULL_SHA.fullmatch(args.implementation_commit):
+        print("--implementation-commit must be a full lowercase 40-hex commit", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            pack = load_pack(args.pack, Path(tmp))
+            pack_digest = sha256_file(args.pack)
+        except (
+            OSError,
+            EOFError,
+            ValueError,
+            KeyError,
+            RecursionError,
+            json.JSONDecodeError,
+            tarfile.TarError,
+        ) as error:
+            print(f"invalid clean-room pack: {error}", file=sys.stderr)
+            return 2
+
+        try:
+            (
+                expected_by_hash,
+                source_corpus_digest,
+                rendered_set_digest,
+            ) = load_expectations(args.manifest)
+        except (
+            OSError,
+            EOFError,
+            ValueError,
+            KeyError,
+            RecursionError,
+            json.JSONDecodeError,
+        ) as error:
+            print(f"cannot load canonical expectations: {error}", file=sys.stderr)
+            return 2
+
+        # Snapshot the oracle before candidate code runs so it cannot rewrite the
+        # comparison inputs. The snapshot is scorer-private and is never passed to
+        # the candidate; comparisons still happen only after every opaque execution.
+        observations = []
+        for case in pack["cases"]:
+            try:
+                execution = run_candidate(
+                    command,
+                    Path(case["_local_path"]),
+                    args.timeout_seconds,
+                )
+                observations.append({"case": case, "execution": execution})
+            except HarnessError as error:
+                observations.append({"case": case, "harness_error": str(error)})
+            except (OSError, CandidateError) as error:
+                observations.append({"case": case, "error": str(error)})
+
+        harness_errors = []
+        if source_corpus_digest != pack["source_corpus_digest"]:
+            harness_errors.append("pack and canonical source corpus digests differ")
+        if rendered_set_digest != pack["rendered_set_digest"]:
+            harness_errors.append("pack and canonical rendered-set digests differ")
+        pack_hashes = {case["sha256"] for case in pack["cases"]}
+        expectation_hashes = set(expected_by_hash)
+        missing_expectations = pack_hashes - expectation_hashes
+        missing_cases = expectation_hashes - pack_hashes
+        if missing_expectations:
+            harness_errors.append(
+                f"{len(missing_expectations)} opaque case(s) lack canonical expectations"
+            )
+        if missing_cases:
+            harness_errors.append(
+                f"{len(missing_cases)} canonical expectation(s) lack opaque cases"
+            )
+
+        cases = []
+        counts = {
+            "total": len(observations),
+            "match": 0,
+            "mismatch": 0,
+            "execution_error": 0,
+            "harness_error": 0,
+            "review_warnings": 0,
+        }
+        for observation in observations:
+            case = observation["case"]
+            result: dict[str, Any] = {
+                "case_id": case["id"],
+                "input_sha256": case["sha256"],
+            }
+            if "harness_error" in observation:
+                result.update(
+                    status="harness_error",
+                    error=observation["harness_error"],
+                )
+                counts["harness_error"] += 1
+                cases.append(result)
+                continue
+            if "error" in observation:
+                result.update(status="execution_error", error=observation["error"])
+                counts["execution_error"] += 1
+                cases.append(result)
+                continue
+            execution = observation["execution"]
+            observed = normative_surface(execution["report"])
+            expected = expected_by_hash.get(case["sha256"])
+            if expected is None:
+                result.update(
+                    status="harness_error",
+                    error="opaque case is absent from canonical expectations",
+                )
+                counts["harness_error"] += 1
+                cases.append(result)
+                continue
+            matched = observed == expected
+            result.update(
+                status="match" if matched else "mismatch",
+                observed=observed,
+                exit_code=execution["exit_code"],
+                stderr_present=execution["stderr_present"],
+            )
+            counts[result["status"]] += 1
+            warnings = []
+            if (
+                observed.get("bundle_integrity") == "pass"
+                and observed.get("verdict") == "invalid"
+                and not has_reviewer_reason(execution["report"])
+            ):
+                warnings.append("reject_reason_missing")
+            if execution["report"].get("schema") != REPORT_SCHEMA:
+                warnings.append("report_schema_missing_or_unexpected")
+            if execution["report"].get("profile") != PROFILE:
+                warnings.append("report_profile_missing_or_unexpected")
+            if warnings:
+                result["review_warnings"] = warnings
+                counts["review_warnings"] += len(warnings)
+            cases.append(result)
+
+    report = {
+        "schema": RUN_SCHEMA,
+        "profile": PROFILE,
+        "source_corpus_digest": pack["source_corpus_digest"],
+        "rendered_set_digest": pack["rendered_set_digest"],
+        "pack_sha256": pack_digest,
+        "pack_declared_source_commit": pack["declared_source_commit"],
+        "pack_provenance_verification": "not_performed_by_scorer",
+        "implementation": {
+            "name": args.implementation_name,
+            "version": args.implementation_version,
+            "source": args.implementation_source,
+            "commit": args.implementation_commit,
+            "reproduction_mode": args.reproduction_mode,
+        },
+        "summary": counts,
+        "harness_errors": harness_errors,
+        "cases": cases,
+        "non_claims": list(RUN_NON_CLAIMS),
+    }
+    try:
+        validate_run_record(report)
+    except (KeyError, TypeError, ValueError) as error:
+        print(f"scorer produced an invalid run record: {error}", file=sys.stderr)
+        return 2
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(counts, sort_keys=True))
+    if counts["execution_error"] or counts["harness_error"] or harness_errors:
+        return 2
+    if counts["mismatch"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
+++ b/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Validate conformance-run shape and cross-field consistency."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+
+RUN_SCHEMA = "assay.privileged_mcp_action.conformance_run.v0"
+PROFILE = "privileged-mcp-action/v0"
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+STATUSES = {"match", "mismatch", "execution_error", "harness_error"}
+CLAIM_NAMES = {
+    "policy_decision_recorded",
+    "caller_visible_denial",
+    "upstream_delivery",
+    "external_side_effect",
+}
+CLAIM_STATUSES = {"confirmed", "incomplete", "refuted"}
+SOURCE_CLASSES = {
+    "producer_reported",
+    "issuer_attested",
+    "receiver_receipt",
+    "boundary_observed",
+    "third_party_observed",
+    "unknown",
+}
+MAX_RUN_RECORD_BYTES = 4 * 1024 * 1024
+MAX_JSON_DEPTH = 64
+RUN_NON_CLAIMS = (
+    "a matching run demonstrates agreement on the pinned corpus only",
+    "a matching run does not establish implementation independence",
+    "the scorer records but does not verify the pack's declared source commit",
+    "the scorer does not assess security, compliance, or provider outcomes",
+    "candidate process limits are operational bounds, not a sandbox",
+)
+REPRODUCTION_MODES = {
+    "blind_from_spec",
+    "from_spec_then_conformance",
+    "commissioned_clean_room",
+    "other_disclosed",
+}
+TOP_LEVEL_KEYS = {
+    "schema",
+    "profile",
+    "source_corpus_digest",
+    "rendered_set_digest",
+    "pack_sha256",
+    "pack_declared_source_commit",
+    "pack_provenance_verification",
+    "implementation",
+    "summary",
+    "harness_errors",
+    "cases",
+    "non_claims",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def load_run_record(path: Path) -> Any:
+    with path.open("rb") as source:
+        data = source.read(MAX_RUN_RECORD_BYTES + 1)
+    require(
+        len(data) <= MAX_RUN_RECORD_BYTES,
+        f"run record exceeds {MAX_RUN_RECORD_BYTES} bytes",
+    )
+    text = data.decode("utf-8")
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            require(depth <= MAX_JSON_DEPTH, f"run record nesting exceeds {MAX_JSON_DEPTH}")
+        elif character in "]}":
+            depth -= 1
+    return json.loads(text)
+
+
+def validate_normative_surface(value: dict[str, Any]) -> None:
+    require(isinstance(value, dict), "observed result must be an object")
+    integrity = value.get("bundle_integrity")
+    require(integrity in {"pass", "fail"}, "observed bundle_integrity is invalid")
+    if integrity == "fail":
+        require(
+            set(value) == {"bundle_integrity"},
+            "integrity-fail observed result has surplus fields",
+        )
+        return
+
+    verdict = value.get("verdict")
+    require(verdict in {"valid", "invalid"}, "pass observed verdict is invalid")
+    if verdict == "invalid":
+        require(
+            set(value) == {"bundle_integrity", "verdict"},
+            "invalid observed result has surplus fields",
+        )
+        return
+
+    require(
+        set(value) == {"bundle_integrity", "verdict", "claims"},
+        "valid observed result has missing or surplus fields",
+    )
+    claims = value["claims"]
+    require(
+        isinstance(claims, dict) and set(claims) == CLAIM_NAMES,
+        "valid observed claims are incomplete or contain surplus claims",
+    )
+    for name, claim in claims.items():
+        require(isinstance(claim, dict), f"{name} claim must be an object")
+        status = claim.get("status")
+        require(status in CLAIM_STATUSES, f"{name} claim status is invalid")
+        if status == "incomplete":
+            require(
+                set(claim) == {"status"},
+                f"{name} incomplete claim must omit source_class",
+            )
+        else:
+            require(
+                set(claim) == {"status", "source_class"},
+                f"{name} decided claim must carry only status and source_class",
+            )
+            require(
+                claim["source_class"] in SOURCE_CLASSES,
+                f"{name} claim source_class is invalid",
+            )
+
+
+def validate_run_record(report: dict[str, Any]) -> None:
+    require(set(report) == TOP_LEVEL_KEYS, "run record has missing or surplus fields")
+    require(report["schema"] == RUN_SCHEMA, "run record schema mismatch")
+    require(report["profile"] == PROFILE, "run record profile mismatch")
+    for field in ("source_corpus_digest", "rendered_set_digest", "pack_sha256"):
+        require(bool(SHA256.fullmatch(report[field])), f"{field} is malformed")
+    require(
+        bool(FULL_SHA.fullmatch(report["pack_declared_source_commit"])),
+        "pack_declared_source_commit is malformed",
+    )
+    require(
+        report["pack_provenance_verification"] == "not_performed_by_scorer",
+        "pack provenance verification value is unsupported",
+    )
+
+    implementation = report["implementation"]
+    require(isinstance(implementation, dict), "implementation must be an object")
+    require(
+        set(implementation)
+        == {"name", "version", "source", "commit", "reproduction_mode"},
+        "implementation has missing or surplus fields",
+    )
+    require(
+        isinstance(implementation["name"], str) and bool(implementation["name"]),
+        "implementation name is missing",
+    )
+    require(
+        implementation["version"] is None
+        or isinstance(implementation["version"], str),
+        "implementation version is invalid",
+    )
+    source = urlparse(implementation.get("source", ""))
+    require(
+        source.scheme in {"http", "https"} and bool(source.netloc),
+        "implementation source must be an absolute HTTP(S) URL",
+    )
+    require(
+        bool(FULL_SHA.fullmatch(implementation.get("commit", ""))),
+        "implementation commit is malformed",
+    )
+    require(
+        implementation["reproduction_mode"] in REPRODUCTION_MODES,
+        "implementation reproduction_mode is invalid",
+    )
+
+    cases = report["cases"]
+    require(isinstance(cases, list) and len(cases) == 13, "run must contain 13 cases")
+    require(all(isinstance(case, dict) for case in cases), "each case must be an object")
+    expected_ids = [f"case-{index:03d}" for index in range(1, 14)]
+    require(
+        [case.get("case_id") for case in cases] == expected_ids,
+        "case ids must be complete and ordered",
+    )
+    status_counts: Counter[str] = Counter()
+    for case in cases:
+        status = case.get("status")
+        require(status in STATUSES, "case status is invalid")
+        require(bool(SHA256.fullmatch(case.get("input_sha256", ""))), "case digest is malformed")
+        status_counts[status] += 1
+        if status in {"match", "mismatch"}:
+            require(
+                set(case)
+                <= {
+                    "case_id",
+                    "input_sha256",
+                    "status",
+                    "observed",
+                    "exit_code",
+                    "stderr_present",
+                    "review_warnings",
+                },
+                f"{status} case has surplus fields",
+            )
+            require("observed" in case, f"{status} case is missing observed result")
+            validate_normative_surface(case["observed"])
+            require(type(case.get("exit_code")) is int, f"{status} case is missing exit_code")
+            require(
+                isinstance(case.get("stderr_present"), bool),
+                f"{status} case is missing stderr_present",
+            )
+            require("error" not in case, f"{status} case must not carry error")
+            warnings = case.get("review_warnings", [])
+            require(
+                isinstance(warnings, list)
+                and all(isinstance(warning, str) for warning in warnings),
+                f"{status} review_warnings is invalid",
+            )
+        else:
+            require(
+                set(case) == {"case_id", "input_sha256", "status", "error"},
+                f"{status} case has missing or surplus fields",
+            )
+            require(
+                isinstance(case.get("error"), str) and bool(case["error"]),
+                f"{status} case is missing error",
+            )
+            require("observed" not in case, f"{status} case must not carry observed result")
+
+    summary = report["summary"]
+    require(isinstance(summary, dict), "summary must be an object")
+    expected_summary_keys = {
+        "total",
+        "match",
+        "mismatch",
+        "execution_error",
+        "harness_error",
+        "review_warnings",
+    }
+    require(set(summary) == expected_summary_keys, "summary has missing or surplus fields")
+    require(
+        all(type(summary[field]) is int and summary[field] >= 0 for field in expected_summary_keys),
+        "summary counts must be non-negative integers",
+    )
+    require(summary["total"] == len(cases), "summary total does not match cases")
+    for status in STATUSES:
+        require(
+            summary[status] == status_counts[status],
+            f"summary {status} count does not match cases",
+        )
+    require(
+        sum(status_counts.values()) == summary["total"],
+        "case status counts do not match total",
+    )
+    harness_errors = report["harness_errors"]
+    require(
+        isinstance(harness_errors, list)
+        and all(isinstance(error, str) and bool(error) for error in harness_errors),
+        "harness_errors must contain non-empty strings",
+    )
+    warning_count = sum(len(case.get("review_warnings", [])) for case in cases)
+    require(
+        summary["review_warnings"] == warning_count,
+        "summary review_warnings count does not match cases",
+    )
+    require(
+        report["non_claims"] == list(RUN_NON_CLAIMS),
+        "non_claims must match the fixed run-record claim ceiling",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = load_run_record(args.report)
+        if not isinstance(report, dict):
+            raise ValueError("run record must be an object")
+        validate_run_record(report)
+    except (
+        OSError,
+        ValueError,
+        KeyError,
+        TypeError,
+        RecursionError,
+        json.JSONDecodeError,
+    ) as error:
+        print(f"invalid conformance run record: {error}", file=__import__("sys").stderr)
+        return 2
+    print(f"validated {args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -1,0 +1,900 @@
+#!/usr/bin/env python3
+"""Contract tests for the clean-room conformance activation kit."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+CORPUS_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = CORPUS_DIR.parents[1]
+BUILD_SCRIPT = CORPUS_DIR / "scripts" / "build_clean_room_pack.py"
+SCORE_SCRIPT = CORPUS_DIR / "scripts" / "score_candidate.py"
+VALIDATE_SCRIPT = CORPUS_DIR / "scripts" / "validate_run_record.py"
+SOURCE_COMMIT = "f709800ee4d3d1f16d99aa3a186e9ce7ca72ac1c"
+IMPLEMENTATION_COMMIT = "1" * 40
+
+
+def sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed ({result.returncode}): {args}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def read_archive(path: Path) -> dict[str, bytes]:
+    with tarfile.open(path, "r:gz") as archive:
+        return {
+            member.name: archive.extractfile(member).read()
+            for member in archive.getmembers()
+            if member.isfile()
+        }
+
+
+def read_bundle(bundle: bytes) -> tuple[dict, list[dict], bytes]:
+    with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz") as archive:
+        members = {member.name: member for member in archive.getmembers()}
+        manifest = json.load(archive.extractfile(members["manifest.json"]))
+        events_bytes = archive.extractfile(members["events.ndjson"]).read()
+    return manifest, [json.loads(line) for line in events_bytes.splitlines()], events_bytes
+
+
+class CleanRoomPackTests(unittest.TestCase):
+    def build(self, output: Path) -> None:
+        run(
+            str(BUILD_SCRIPT),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--source-commit",
+            SOURCE_COMMIT,
+            "--output",
+            str(output),
+        )
+
+    def test_pack_is_deterministic_opaque_and_inputs_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "first.tar.gz"
+            second = Path(tmp) / "second.tar.gz"
+            self.build(first)
+            self.build(second)
+
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+            files = read_archive(first)
+            names = sorted(files)
+            self.assertIn("privileged-mcp-action-v0/spec.md", names)
+            self.assertIn("privileged-mcp-action-v0/descriptor.json", names)
+            self.assertIn("privileged-mcp-action-v0/cases.json", names)
+            self.assertIn("privileged-mcp-action-v0/README.md", names)
+
+            case_names = [
+                name
+                for name in names
+                if name.startswith("privileged-mcp-action-v0/cases/")
+            ]
+            self.assertEqual(len(case_names), 13)
+            self.assertTrue(
+                all(
+                    Path(name).name.startswith("case-")
+                    and Path(name).name.endswith(".bundle.tar.gz")
+                    for name in case_names
+                )
+            )
+
+            joined_names = "\n".join(names)
+            for forbidden in (
+                "MANIFEST.json",
+                "gen_vectors.py",
+                "crates/",
+                "ok-",
+                "bad-",
+            ):
+                self.assertNotIn(forbidden, joined_names)
+
+            cases = json.loads(files["privileged-mcp-action-v0/cases.json"])
+            self.assertEqual(
+                cases["source_corpus_digest"],
+                "sha256:a943120f6b142d7e4e45c357dc06cddaeb596c90e935ac0c8e26856425757571",
+            )
+            self.assertRegex(cases["rendered_set_digest"], r"^sha256:[0-9a-f]{64}$")
+            self.assertEqual(cases["declared_source_commit"], SOURCE_COMMIT)
+            self.assertEqual(cases["case_count"], 13)
+            self.assertNotIn("expected", json.dumps(cases))
+            self.assertNotIn("description", json.dumps(cases))
+
+            manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+            source_hashes = {vector["sha256"] for vector in manifest["vectors"]}
+            packed_hashes = {
+                sha256(files[f"privileged-mcp-action-v0/{case['file']}"])
+                for case in cases["cases"]
+            }
+            self.assertTrue(packed_hashes.isdisjoint(source_hashes))
+
+            for case in cases["cases"]:
+                bundle = files[f"privileged-mcp-action-v0/{case['file']}"]
+                with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz") as archive:
+                    self.assertEqual(
+                        [member.name for member in archive.getmembers()],
+                        ["manifest.json", "events.ndjson"],
+                    )
+                    inner = b"".join(
+                        archive.extractfile(member).read()
+                        for member in archive.getmembers()
+                        if member.isfile()
+                    )
+                self.assertNotIn(b"pmav0-ok-", inner)
+                self.assertNotIn(b"pmav0-bad-", inner)
+
+            public_inputs = b"\n".join(
+                data for name, data in files.items() if "/cases/" not in name
+            )
+            for forbidden in (
+                b"gen_vectors.py",
+                b"first_failure_informative",
+                b"ok-005",
+                b"bad-105",
+                b"bad-108",
+            ):
+                self.assertNotIn(forbidden, public_inputs)
+
+    def test_archive_metadata_is_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "pack.tar.gz"
+            self.build(output)
+            with gzip.GzipFile(fileobj=io.BytesIO(output.read_bytes())) as stream:
+                tar_bytes = stream.read()
+            with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:") as archive:
+                for member in archive.getmembers():
+                    self.assertEqual(member.mtime, 0)
+                    self.assertEqual(member.uid, 0)
+                    self.assertEqual(member.gid, 0)
+                    self.assertEqual(member.uname, "")
+                    self.assertEqual(member.gname, "")
+            files = read_archive(output)
+            for name, bundle in files.items():
+                if "/cases/" not in name:
+                    continue
+                with tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz") as archive:
+                    for member in archive.getmembers():
+                        self.assertEqual(member.mtime, 0)
+                        self.assertEqual(member.uid, 0)
+                        self.assertEqual(member.gid, 0)
+                        self.assertEqual(member.uname, "")
+                        self.assertEqual(member.gname, "")
+
+    def test_rendering_changes_only_stream_identity_and_preserves_integrity_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "pack.tar.gz"
+            self.build(output)
+            files = read_archive(output)
+            cases = json.loads(files["privileged-mcp-action-v0/cases.json"])["cases"]
+            manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+            vectors = sorted(manifest["vectors"], key=lambda vector: vector["sha256"])
+
+            for case, vector in zip(cases, vectors, strict=True):
+                source = (CORPUS_DIR / vector["file"]).read_bytes()
+                rendered = files[f"privileged-mcp-action-v0/{case['file']}"]
+                source_manifest, source_events, source_event_bytes = read_bundle(source)
+                rendered_manifest, rendered_events, rendered_event_bytes = read_bundle(rendered)
+
+                source_clean = (
+                    source_manifest["files"]["events.ndjson"]["sha256"]
+                    == sha256(source_event_bytes)
+                    and source_manifest["files"]["events.ndjson"]["bytes"]
+                    == len(source_event_bytes)
+                )
+                rendered_clean = (
+                    rendered_manifest["files"]["events.ndjson"]["sha256"]
+                    == sha256(rendered_event_bytes)
+                    and rendered_manifest["files"]["events.ndjson"]["bytes"]
+                    == len(rendered_event_bytes)
+                )
+                self.assertEqual(rendered_clean, source_clean, case["id"])
+
+                self.assertEqual(len(rendered_events), len(source_events))
+                for original, opaque in zip(source_events, rendered_events, strict=True):
+                    original = dict(original)
+                    opaque = dict(opaque)
+                    original.pop("id")
+                    original.pop("assayrunid")
+                    opaque.pop("id")
+                    opaque.pop("assayrunid")
+                    self.assertEqual(opaque, original, case["id"])
+
+                source_manifest = dict(source_manifest)
+                rendered_manifest = dict(rendered_manifest)
+                source_manifest.pop("run_id")
+                rendered_manifest.pop("run_id")
+                source_manifest["files"] = dict(source_manifest["files"])
+                rendered_manifest["files"] = dict(rendered_manifest["files"])
+                source_manifest["files"].pop("events.ndjson")
+                rendered_manifest["files"].pop("events.ndjson")
+                self.assertEqual(rendered_manifest, source_manifest, case["id"])
+
+    def test_source_bundle_rejects_surplus_or_oversize_members(self) -> None:
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            from pack_format import bundle_files, deterministic_tar_gz
+        finally:
+            sys.path.pop(0)
+
+        manifest = b'{"files":{"events.ndjson":{"bytes":0,"sha256":"sha256:x"}}}\n'
+        with self.subTest(reason="surplus"):
+            bundle = deterministic_tar_gz(
+                {
+                    "manifest.json": manifest,
+                    "events.ndjson": b"",
+                    "surplus": b"x",
+                },
+                preserve_order=True,
+            )
+            with self.assertRaisesRegex(ValueError, "surplus"):
+                bundle_files(bundle)
+
+        with self.subTest(reason="oversize"):
+            bundle = deterministic_tar_gz(
+                {
+                    "manifest.json": manifest,
+                    "events.ndjson": b"x" * (8 * 1024 * 1024 + 1),
+                },
+                preserve_order=True,
+            )
+            with self.assertRaisesRegex(ValueError, "exceeds"):
+                bundle_files(bundle)
+
+    def test_stream_identity_rewrite_rejects_duplicate_sequences(self) -> None:
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            from pack_format import deterministic_tar_gz, rewrite_bundle_stream_identity
+        finally:
+            sys.path.pop(0)
+
+        cases = (
+            (
+                (
+                    b'{"assayrunid":"source","assayseq":1,"id":"source:first"}\n'
+                    b'{"assayrunid":"source","assayseq":1,"id":"source:second"}\n'
+                ),
+                "collide on assayseq 1",
+            ),
+            (
+                b'{"assayrunid":"source","assayseq":"1","id":"source:string"}\n',
+                "requires integer assayseq values",
+            ),
+            (
+                b'{"assayrunid":"source","assayseq":[1],"id":"source:list"}\n',
+                "requires integer assayseq values",
+            ),
+        )
+        for events, error in cases:
+            with self.subTest(error=error):
+                manifest = {
+                    "run_id": "source",
+                    "files": {
+                        "events.ndjson": {
+                            "bytes": len(events),
+                            "sha256": sha256(events),
+                        }
+                    },
+                }
+                bundle = deterministic_tar_gz(
+                    {
+                        "manifest.json": (
+                            json.dumps(
+                                manifest,
+                                separators=(",", ":"),
+                                sort_keys=True,
+                            ).encode()
+                            + b"\n"
+                        ),
+                        "events.ndjson": events,
+                    },
+                    preserve_order=True,
+                )
+                with self.assertRaisesRegex(ValueError, error):
+                    rewrite_bundle_stream_identity(bundle, "pmav0-case-001")
+
+
+class CandidateScorerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.tmp.name)
+        cls.pack = cls.root / "pack.tar.gz"
+        run(
+            str(BUILD_SCRIPT),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--source-commit",
+            SOURCE_COMMIT,
+            "--output",
+            str(cls.pack),
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.tmp.cleanup()
+
+    def candidate(
+        self,
+        mode: str,
+        *,
+        oracle_to_rewrite: Path | None = None,
+        pack_to_mutate: Path | None = None,
+    ) -> Path:
+        manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+        pack_files = read_archive(self.pack)
+        cases = json.loads(pack_files["privileged-mcp-action-v0/cases.json"])["cases"]
+        vectors = sorted(manifest["vectors"], key=lambda vector: vector["sha256"])
+        expected_by_sha = {
+            case["sha256"]: vector["expected"]
+            for case, vector in zip(cases, vectors, strict=True)
+        }
+        script = self.root / f"candidate-{mode}.py"
+        script.write_text(
+            textwrap.dedent(
+                f"""\
+                import hashlib
+                import json
+                from pathlib import Path
+                import subprocess
+                import sys
+
+                expected = {expected_by_sha!r}
+                data = Path(sys.argv[1]).read_bytes()
+                digest = "sha256:" + hashlib.sha256(data).hexdigest()
+                result = dict(expected[digest])
+                mode = {mode!r}
+                oracle_to_rewrite = {str(oracle_to_rewrite) if oracle_to_rewrite else None!r}
+                pack_to_mutate = {str(pack_to_mutate) if pack_to_mutate else None!r}
+                if mode == "rewrite-oracle":
+                    manifest_path = Path(oracle_to_rewrite)
+                    manifest = json.loads(manifest_path.read_text())
+                    for vector in manifest["vectors"]:
+                        vector["expected"] = {{"bundle_integrity": "fail"}}
+                    manifest_path.write_text(json.dumps(manifest))
+                    result = {{"bundle_integrity": "fail"}}
+                if mode == "mutate-pack":
+                    pack_path = Path(pack_to_mutate)
+                    pack_path.write_bytes(pack_path.read_bytes() + b"x")
+                if mode == "mismatch" and result.get("verdict") == "valid":
+                    result["verdict"] = "invalid"
+                    result.pop("claims", None)
+                if mode == "malformed":
+                    print("not json")
+                    raise SystemExit(2)
+                if mode == "oversize-integer":
+                    sys.stdout.write('{{"attacker_number":' + "9" * 5000 + '}}')
+                    raise SystemExit(0)
+                if mode == "flood":
+                    subprocess.Popen([
+                        sys.executable,
+                        "-c",
+                        "import pathlib,time; time.sleep(0.5); "
+                        "pathlib.Path({str(self.root / 'escaped-child')!r}).write_text('escaped')",
+                    ])
+                    sys.stdout.write("x" * (2 * 1024 * 1024))
+                    raise SystemExit(2)
+                report = {{
+                    "schema": "assay.privileged_mcp_action.verify.report.v0",
+                    "profile": "privileged-mcp-action/v0",
+                    "non_claims": [
+                        "allow does not prove upstream delivery",
+                        "deny does not establish maliciousness",
+                        "caller-visible denial does not prove external side-effect absence",
+                        "bundle integrity does not upgrade source class",
+                    ],
+                    **result,
+                }}
+                if result.get("bundle_integrity") == "pass" and result.get("verdict") == "invalid":
+                    if mode != "reasonless":
+                        report["findings"] = [{{"detail": "candidate explanation"}}]
+                else:
+                    report["findings"] = []
+                if mode == "utf16":
+                    sys.stdout.buffer.write(json.dumps(report).encode("utf-16"))
+                    raise SystemExit(0)
+                print(json.dumps(report))
+                if mode == "trailing":
+                    print("second document")
+                """
+            )
+        )
+        return script
+
+    def score(
+        self,
+        candidate: Path,
+        output: Path,
+        *,
+        pack: Path | None = None,
+        manifest: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return run(
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(pack or self.pack),
+            "--manifest",
+            str(manifest or CORPUS_DIR / "MANIFEST.json"),
+            "--entrypoint",
+            shlex.join([sys.executable, str(candidate)]),
+            "--implementation-name",
+            "test implementation",
+            "--implementation-source",
+            "https://example.test/verifier",
+            "--implementation-commit",
+            IMPLEMENTATION_COMMIT,
+            "--reproduction-mode",
+            "blind_from_spec",
+            "--output",
+            str(output),
+            check=False,
+        )
+
+    def test_matching_candidate_scores_all_cases(self) -> None:
+        output = self.root / "report.json"
+        result = self.score(self.candidate("match"), output)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(output.read_text())
+        self.assertEqual(report["summary"], {
+            "total": 13,
+            "match": 13,
+            "mismatch": 0,
+            "execution_error": 0,
+            "harness_error": 0,
+            "review_warnings": 0,
+        })
+        self.assertEqual(
+            report["source_corpus_digest"],
+            "sha256:a943120f6b142d7e4e45c357dc06cddaeb596c90e935ac0c8e26856425757571",
+        )
+        self.assertRegex(report["rendered_set_digest"], r"^sha256:[0-9a-f]{64}$")
+        self.assertEqual(
+            {case["case_id"] for case in report["cases"]},
+            {f"case-{index:03d}" for index in range(1, 14)},
+        )
+        self.assertEqual(
+            report["implementation"]["reproduction_mode"],
+            "blind_from_spec",
+        )
+        self.assertEqual(
+            report["pack_provenance_verification"],
+            "not_performed_by_scorer",
+        )
+        self.assertEqual(run(str(VALIDATE_SCRIPT), str(output)).returncode, 0)
+        self.assertNotIn("ok-", output.read_text())
+        self.assertNotIn("bad-", output.read_text())
+
+        report["summary"]["match"] -= 1
+        tampered = self.root / "tampered-report.json"
+        tampered.write_text(json.dumps(report))
+        self.assertEqual(
+            run(str(VALIDATE_SCRIPT), str(tampered), check=False).returncode,
+            2,
+        )
+
+    def test_normative_mismatch_fails(self) -> None:
+        output = self.root / "mismatch.json"
+        result = self.score(self.candidate("mismatch"), output)
+        self.assertEqual(result.returncode, 1)
+        report = json.loads(output.read_text())
+        self.assertGreater(report["summary"]["mismatch"], 0)
+
+    def test_malformed_trailing_or_flooded_output_is_execution_error(self) -> None:
+        for mode in ("malformed", "oversize-integer", "trailing", "utf16", "flood"):
+            with self.subTest(mode=mode):
+                output = self.root / f"{mode}.json"
+                result = self.score(self.candidate(mode), output)
+                self.assertEqual(result.returncode, 2)
+                report = json.loads(output.read_text())
+                self.assertGreater(report["summary"]["execution_error"], 0)
+                if mode == "flood" and os.name == "posix":
+                    time.sleep(2)
+                    self.assertFalse((self.root / "escaped-child").exists())
+
+    def test_manifest_pack_desynchronization_is_harness_error(self) -> None:
+        manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+        manifest["vectors"] = manifest["vectors"][:-1]
+        manifest_root = self.root / "canonical"
+        manifest_root.mkdir()
+        (manifest_root / "vectors").symlink_to(CORPUS_DIR / "vectors")
+        manifest_path = manifest_root / "MANIFEST.json"
+        manifest_path.write_text(json.dumps(manifest))
+        output = self.root / "desync.json"
+
+        result = run(
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(self.pack),
+            "--manifest",
+            str(manifest_path),
+            "--entrypoint",
+            shlex.join([sys.executable, str(self.candidate("match"))]),
+            "--implementation-name",
+            "test implementation",
+            "--implementation-source",
+            "https://example.test/verifier",
+            "--implementation-commit",
+            IMPLEMENTATION_COMMIT,
+            "--reproduction-mode",
+            "blind_from_spec",
+            "--output",
+            str(output),
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        report = json.loads(output.read_text())
+        self.assertGreater(report["summary"]["harness_error"], 0)
+        self.assertEqual(report["summary"]["execution_error"], 0)
+        self.assertTrue(report["harness_errors"])
+        self.assertEqual(
+            report["summary"]["harness_error"],
+            sum(case["status"] == "harness_error" for case in report["cases"]),
+        )
+
+    def test_global_harness_diagnostic_is_not_a_case_status(self) -> None:
+        manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+        manifest["corpus_digest"] = "sha256:" + "0" * 64
+        manifest_root = self.root / "canonical-global-diagnostic"
+        manifest_root.mkdir()
+        (manifest_root / "vectors").symlink_to(CORPUS_DIR / "vectors")
+        manifest_path = manifest_root / "MANIFEST.json"
+        manifest_path.write_text(json.dumps(manifest))
+        output = self.root / "global-diagnostic.json"
+
+        result = run(
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(self.pack),
+            "--manifest",
+            str(manifest_path),
+            "--entrypoint",
+            shlex.join([sys.executable, str(self.candidate("match"))]),
+            "--implementation-name",
+            "test implementation",
+            "--implementation-source",
+            "https://example.test/verifier",
+            "--implementation-commit",
+            IMPLEMENTATION_COMMIT,
+            "--reproduction-mode",
+            "blind_from_spec",
+            "--output",
+            str(output),
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        report = json.loads(output.read_text())
+        self.assertEqual(report["summary"]["match"], 13)
+        self.assertEqual(report["summary"]["harness_error"], 0)
+        self.assertEqual(len(report["harness_errors"]), 1)
+        self.assertEqual(run(str(VALIDATE_SCRIPT), str(output)).returncode, 0)
+
+    def test_run_record_rejects_non_object_cases_and_impossible_observed_shapes(self) -> None:
+        output = self.root / "validator-source.json"
+        result = self.score(self.candidate("match"), output)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        clean = json.loads(output.read_text())
+        mutations = {
+            "non-object-case": lambda report: report["cases"].__setitem__(0, "not-an-object"),
+            "empty-observed": lambda report: report["cases"][0].__setitem__("observed", {}),
+            "relative-source": lambda report: report["implementation"].__setitem__(
+                "source", "./verifier"
+            ),
+            "wrong-harness-count": lambda report: report["summary"].__setitem__(
+                "harness_error", 1
+            ),
+            "boolean-exit-code": lambda report: report["cases"][0].__setitem__(
+                "exit_code", True
+            ),
+            "boolean-summary-count": lambda report: report["summary"].__setitem__(
+                "mismatch", False
+            ),
+            "replaced-non-claims": lambda report: report.__setitem__(
+                "non_claims",
+                ["certifies security", "certifies compliance", "certifies provider outcomes"],
+            ),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                report = json.loads(json.dumps(clean))
+                mutate(report)
+                path = self.root / f"{name}.json"
+                path.write_text(json.dumps(report))
+                invalid = run(str(VALIDATE_SCRIPT), str(path), check=False)
+                self.assertEqual(invalid.returncode, 2, invalid.stderr)
+
+    def test_standalone_run_record_validator_bounds_bytes_and_nesting(self) -> None:
+        oversized = self.root / "oversized-run-record.json"
+        oversized.write_bytes(b'{"padding":"' + b"x" * (4 * 1024 * 1024) + b'"}')
+        too_deep = self.root / "deep-run-record.json"
+        too_deep.write_text("[" * 65 + "0" + "]" * 65)
+
+        for path, diagnostic in (
+            (oversized, "exceeds 4194304 bytes"),
+            (too_deep, "nesting exceeds 64"),
+        ):
+            with self.subTest(path=path.name):
+                result = run(str(VALIDATE_SCRIPT), str(path), check=False)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(diagnostic, result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_candidate_cannot_rewrite_oracle_or_report_a_mutated_pack_hash(self) -> None:
+        manifest_root = self.root / "oracle-snapshot"
+        manifest_root.mkdir()
+        (manifest_root / "vectors").symlink_to(CORPUS_DIR / "vectors")
+        manifest_path = manifest_root / "MANIFEST.json"
+        manifest_path.write_bytes((CORPUS_DIR / "MANIFEST.json").read_bytes())
+        oracle_output = self.root / "oracle-rewrite.json"
+
+        oracle_result = self.score(
+            self.candidate("rewrite-oracle", oracle_to_rewrite=manifest_path),
+            oracle_output,
+            manifest=manifest_path,
+        )
+
+        self.assertEqual(oracle_result.returncode, 1)
+        oracle_report = json.loads(oracle_output.read_text())
+        self.assertGreater(oracle_report["summary"]["mismatch"], 0)
+        self.assertEqual(oracle_report["summary"]["harness_error"], 0)
+
+        mutable_pack = self.root / "mutable-pack.tar.gz"
+        mutable_pack.write_bytes(self.pack.read_bytes())
+        original_pack_hash = sha256(mutable_pack.read_bytes())
+        pack_output = self.root / "pack-mutation.json"
+        pack_result = self.score(
+            self.candidate("mutate-pack", pack_to_mutate=mutable_pack),
+            pack_output,
+            pack=mutable_pack,
+        )
+
+        self.assertEqual(pack_result.returncode, 0, pack_result.stderr)
+        self.assertNotEqual(sha256(mutable_pack.read_bytes()), original_pack_hash)
+        self.assertEqual(
+            json.loads(pack_output.read_text())["pack_sha256"],
+            original_pack_hash,
+        )
+
+    def test_timeout_kills_candidate_process_group(self) -> None:
+        marker = self.root / "escaped-timeout-child"
+        candidate = self.root / "candidate-timeout.py"
+        candidate.write_text(
+            textwrap.dedent(
+                f"""\
+                import subprocess
+                import sys
+                import time
+
+                subprocess.Popen([
+                    sys.executable,
+                    "-c",
+                    "import pathlib,time; time.sleep(1.2); "
+                    "pathlib.Path({str(marker)!r}).write_text('escaped')",
+                ])
+                time.sleep(5)
+                """
+            )
+        )
+        bundle = self.root / "ignored.bundle"
+        bundle.write_bytes(b"ignored")
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            from score_candidate import CandidateError, run_candidate
+        finally:
+            sys.path.pop(0)
+
+        with self.assertRaisesRegex(CandidateError, "timed out"):
+            run_candidate([sys.executable, str(candidate)], bundle, 1)
+        if os.name == "posix":
+            time.sleep(1.5)
+            self.assertFalse(marker.exists())
+
+    @unittest.skipUnless(os.name == "posix", "process-group containment requires POSIX")
+    def test_leader_exit_still_kills_descendants_holding_capture_pipes(self) -> None:
+        marker = self.root / "escaped-after-leader-exit"
+        candidate = self.root / "candidate-leader-exits.py"
+        candidate.write_text(
+            textwrap.dedent(
+                f"""\
+                import subprocess
+                import sys
+
+                subprocess.Popen([
+                    sys.executable,
+                    "-c",
+                    "import pathlib,time; time.sleep(1.2); "
+                    "pathlib.Path({str(marker)!r}).write_text('escaped'); time.sleep(5)",
+                ])
+                """
+            )
+        )
+        bundle = self.root / "ignored-after-leader-exit.bundle"
+        bundle.write_bytes(b"ignored")
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            from score_candidate import CandidateError, run_candidate
+        finally:
+            sys.path.pop(0)
+
+        with self.assertRaises(CandidateError):
+            run_candidate([sys.executable, str(candidate)], bundle, 5)
+        time.sleep(1.5)
+        self.assertFalse(marker.exists())
+
+    def test_non_positive_timeout_is_rejected_before_execution(self) -> None:
+        output = self.root / "invalid-timeout.json"
+        result = run(
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(self.pack),
+            "--manifest",
+            str(CORPUS_DIR / "MANIFEST.json"),
+            "--entrypoint",
+            shlex.join([sys.executable, str(self.candidate("match"))]),
+            "--implementation-name",
+            "test implementation",
+            "--implementation-source",
+            "https://example.test/verifier",
+            "--implementation-commit",
+            IMPLEMENTATION_COMMIT,
+            "--reproduction-mode",
+            "blind_from_spec",
+            "--timeout-seconds",
+            "0",
+            "--output",
+            str(output),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("must be a positive integer", result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_capture_failure_is_a_harness_error_not_empty_output(self) -> None:
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            from bounded_process import ProcessCaptureError, run_bounded
+        finally:
+            sys.path.pop(0)
+
+        with (
+            mock.patch(
+                "bounded_process._capture_stream",
+                side_effect=OSError("synthetic capture failure"),
+            ),
+            self.assertRaisesRegex(
+                ProcessCaptureError,
+                r"process output capture failed: stderr, stdout",
+            ),
+        ):
+            run_bounded(
+                [sys.executable, "-c", "pass"],
+                timeout_seconds=5,
+                stdout_limit=1024,
+                stderr_limit=1024,
+            )
+
+    def test_capture_failure_is_recorded_as_harness_error(self) -> None:
+        output = self.root / "capture-harness-error.json"
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            import score_candidate
+        finally:
+            sys.path.pop(0)
+
+        argv = [
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(self.pack),
+            "--manifest",
+            str(CORPUS_DIR / "MANIFEST.json"),
+            "--entrypoint",
+            "unused-candidate",
+            "--implementation-name",
+            "test implementation",
+            "--implementation-source",
+            "https://example.test/verifier",
+            "--implementation-commit",
+            IMPLEMENTATION_COMMIT,
+            "--reproduction-mode",
+            "blind_from_spec",
+            "--output",
+            str(output),
+        ]
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch.object(
+                score_candidate,
+                "run_candidate",
+                side_effect=score_candidate.HarnessError("synthetic capture failure"),
+            ),
+        ):
+            self.assertEqual(score_candidate.main(), 2)
+
+        report = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(report["summary"]["harness_error"], 13)
+        self.assertEqual(report["summary"]["execution_error"], 0)
+        self.assertTrue(
+            all(case["status"] == "harness_error" for case in report["cases"])
+        )
+
+    def test_reject_reason_is_visible_but_not_scored(self) -> None:
+        output = self.root / "reasonless.json"
+        result = self.score(self.candidate("reasonless"), output)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(output.read_text())
+        self.assertEqual(report["summary"]["match"], 13)
+        self.assertGreater(report["summary"]["review_warnings"], 0)
+        self.assertTrue(
+            any(
+                "reject_reason_missing" in case.get("review_warnings", [])
+                for case in report["cases"]
+            )
+        )
+
+    def test_duplicate_or_surplus_pack_members_fail_closed(self) -> None:
+        files = read_archive(self.pack)
+        for mode in ("duplicate", "surplus"):
+            with self.subTest(mode=mode):
+                tampered = self.root / f"{mode}.tar.gz"
+                with tarfile.open(tampered, "w:gz") as archive:
+                    for name, data in files.items():
+                        info = tarfile.TarInfo(name)
+                        info.size = len(data)
+                        archive.addfile(info, io.BytesIO(data))
+                    if mode == "duplicate":
+                        name = "privileged-mcp-action-v0/cases.json"
+                        data = files[name]
+                    else:
+                        name = "privileged-mcp-action-v0/answers.txt"
+                        data = b"unexpected"
+                    info = tarfile.TarInfo(name)
+                    info.size = len(data)
+                    archive.addfile(info, io.BytesIO(data))
+
+                output = self.root / f"{mode}-report.json"
+                result = self.score(self.candidate("match"), output, pack=tampered)
+                self.assertEqual(result.returncode, 2)
+                self.assertFalse(output.exists())
+
+    def test_truncated_gzip_pack_is_invalid_input_not_a_mismatch(self) -> None:
+        truncated = self.root / "truncated.tar.gz"
+        data = self.pack.read_bytes()
+        truncated.write_bytes(data[: len(data) // 2])
+        output = self.root / "truncated-report.json"
+
+        result = self.score(self.candidate("match"), output, pack=truncated)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertNotIn("Traceback", result.stderr)
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- build an inputs-only, deterministic clean-room pack for `privileged-mcp-action/v0`
- invoke supplied candidate verifiers through one report protocol and score only the existing manifest normative surface
- publish a reusable composite action plus an annotated-tag workflow that checks, attests, and releases the pack

The opaque rendering rewrites only stream identity fields that are outside event content hashes. It preserves every other parsed event field, ordering, and each source case's integrity pass/fail state. The canonical 13 vector files and source corpus digest remain byte-unchanged.

## Authorship Boundary

The released pack contains the normative specification, a descriptor with corpus metadata removed, and 13 cases with opaque names and stream ids. It excludes expected outcomes, semantic vector names, `gen_vectors.py`, and Assay's verifier. The scorer snapshots the canonical oracle into scorer-private memory for tamper resistance, passes only opaque case paths to the candidate, and performs comparisons after all executions.

The run record binds the pre-execution pack bytes, source-corpus digest, and rendered-set digest. It labels the embedded source commit as declared and records that scorer-side provenance verification was not performed. Release-attestation verification remains an explicit, separate implementation-report input.

## Verification

- `python3 -m unittest conformance/privileged-mcp-action-v0/tests/test_activation_kit.py` (21 tests)
- `cargo test -p assay-cli --test conformance_privileged_mcp_action` (2 tests)
- transformed-pack system check: 13/13 normative matches, 0 warnings/errors
- deterministic `3694580a` pack: two builds byte-identical (`11cf583f52ecea9fb8db5f407672ce9b8cfef475ba2dd649c738884e4e69494e`)
- candidate oracle/pack mutation cannot forge the recorded comparison inputs
- generated report accepted by both the semantic validator and Draft 2020-12 schema; impossible normative surfaces, altered claim ceilings, boolean counters/exit codes, and malformed provenance rejected
- non-UTF-8 candidate JSON, JSON resource errors, truncated gzip input, oversized run records, and deep run records return invalid-input status 2 without traceback
- bounded candidate-output tests kill descendants that remain in the initial POSIX process group on overflow, timeout, and leader-first exit; other process groups are explicitly outside this operational guardrail
- case-status counts and global harness diagnostics are validated independently
- actionlint, YAML validation, typos, `git diff --check`, and targeted Ruff RUF021
- pre-push workspace clippy and Linux compile gate

## Non-Claims

This kit does not provide verifier logic, certify independence, add a score or detector, establish a code-execution sandbox, or establish security, compliance, complete profile determinacy, or provider outcomes. A matching run demonstrates agreement on the pinned corpus only.

## Post-Merge

After this exact head is reviewed and merged, create annotated tag `privileged-mcp-action-v0-candidate.1`. The tag workflow must publish the pack, `SHA256SUMS`, and its attestation bundle successfully before #1840 is updated with the release link.

Refs #1840.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clean-room conformance protocol for independently verifying Privileged MCP Action implementations.
  * Added deterministic, attested release packs with checksum and provenance verification.
  * Added a one-command scoring action that generates machine-readable conformance reports.
  * Added strict report validation, implementation-report guidance, and documented claim limitations.

* **CI/CD**
  * Added automated conformance, reproducibility, security-boundary, and report-validation checks.
  * Added automated publication of verified release packs with checksums and attestations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->