### PR TITLE
fix(ci): materialize annotated release tag

### DIFF
--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -38,8 +38,16 @@ jobs:
             privileged-mcp-action-v0-candidate.*) ;;
             *) echo "unexpected release tag: $GITHUB_REF_NAME" >&2; exit 2 ;;
           esac
+          git fetch --force origin \
+            "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME"
           if [[ "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" != "tag" ]]; then
             echo "release requires an annotated tag object: $GITHUB_REF_NAME" >&2
+            exit 2
+          fi
+          tag_commit="$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "release tag $GITHUB_REF_NAME peels to $tag_commit; checked-out HEAD is $head_commit" >&2
             exit 2
           fi
           git fetch --no-tags origin main


### PR DESCRIPTION
## Summary

- explicitly fetch the triggering tag object before checking that it is annotated
- verify the fetched tag peels to the commit checked out for the release job

The first `privileged-mcp-action-v0-candidate.1` run failed before building because `actions/checkout` left only the peeled commit locally, so `git cat-file -t refs/tags/...` could not see the remote annotated tag. The tag itself remains unchanged and points to merged commit `ff5c6a83`. A fresh `--no-tags` clone reproduced the missing-ref state; the explicit fetch materialized a `tag` object that peeled to the expected commit.

## Verification

- actionlint pre-commit hook
- `git diff --check`
- real no-tags clone + explicit tag fetch + object-type and peeled-commit assertions

After merge, publish a new immutable `privileged-mcp-action-v0-candidate.2` tag. Do not move or reuse candidate.1.

Refs #1840.