### PR TITLE
docs(conformance): point Gate 2 at candidate.2

### DIFF
--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -102,12 +102,12 @@ steps:
     env:
       GH_TOKEN: ${{ github.token }}
     run: |
-      gh release download privileged-mcp-action-v0-candidate.1 \
+      gh release download privileged-mcp-action-v0-candidate.2 \
         --repo Rul1an/assay \
         --pattern privileged-mcp-action-v0-clean-room.tar.gz
 
   - name: Run conformance
-    uses: Rul1an/assay/.github/actions/privileged-mcp-action-conformance@privileged-mcp-action-v0-candidate.1
+    uses: Rul1an/assay/.github/actions/privileged-mcp-action-conformance@975ee0129a421925cad78b84ffc02144aa655679
     with:
       pack: privileged-mcp-action-v0-clean-room.tar.gz
       entrypoint: ./target/release/my-verifier
@@ -118,7 +118,8 @@ steps:
       report: privileged-mcp-action-conformance.json
 ```
 
-For a long-lived workflow, resolve the release tag to its full commit and pin the action to that SHA.
+The action above is pinned to the full source commit for `candidate.2`. Keep full-commit pinning when
+updating the release used by a long-lived workflow.
 
 ## Claim ceiling
 

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -26,20 +26,24 @@ digest describes.
 ### Clean-room path
 
 The release
-[`privileged-mcp-action-v0-candidate.1`](https://github.com/Rul1an/assay/releases/tag/privileged-mcp-action-v0-candidate.1)
+[`privileged-mcp-action-v0-candidate.2`](https://github.com/Rul1an/assay/releases/tag/privileged-mcp-action-v0-candidate.2)
 contains a deterministic, attested clean-room pack. It carries `spec.md`, `descriptor.json`, and
 thirteen opaque cases. It omits expected outcomes, semantic case names, the vector generator, and
 Assay's implementation.
 
 ```bash
-tag=privileged-mcp-action-v0-candidate.1
+tag=privileged-mcp-action-v0-candidate.2
 gh release download "$tag" --repo Rul1an/assay \
   --pattern privileged-mcp-action-v0-clean-room.tar.gz \
-  --pattern SHA256SUMS
+  --pattern SHA256SUMS \
+  --pattern attestation-bundle.json
 shasum -a 256 -c SHA256SUMS
 gh attestation verify privileged-mcp-action-v0-clean-room.tar.gz \
   --repo Rul1an/assay \
-  --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml
+  --bundle attestation-bundle.json \
+  --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml \
+  --source-digest 975ee0129a421925cad78b84ffc02144aa655679 \
+  --source-ref refs/tags/privileged-mcp-action-v0-candidate.2
 ```
 
 Follow [`CONFORMANCE-PROTOCOL.md`](CONFORMANCE-PROTOCOL.md): implement before scoring, preserve the
@@ -47,6 +51,10 @@ first run, disclose the materials read, and publish a machine-readable run recor
 [`IMPLEMENTATION-REPORT.template.md`](IMPLEMENTATION-REPORT.template.md). The reusable composite
 action at `.github/actions/privileged-mcp-action-conformance` standardizes invocation and scoring;
 it does not provide verifier logic.
+
+The implementation may be a minimal standalone command in any language. It does not need to
+integrate with Assay or an MCP runtime. A disclosed mismatch is useful evidence too: it identifies a
+profile or corpus boundary that needs reconciliation.
 
 What the claim needs is a reimplementation from the spec, so three **answer or implementation
 surfaces** in this repository are deliberately out of bounds until the implementation is frozen:


### PR DESCRIPTION
## Summary

- replace stale failed `candidate.1` download instructions with the attested `candidate.2` release
- make checksum and offline attestation verification copy-pasteable with exact source pins
- pin the reusable action to the full release-source commit
- clarify that a minimal standalone verifier or a disclosed mismatch is a useful Gate-2 contribution

## Verification

- `python3 -m unittest conformance/privileged-mcp-action-v0/tests/test_activation_kit.py` (14 tests)
- downloaded `candidate.2`, reproduced `SHA256SUMS`, and verified the bundled GitHub attestation with source commit and tag constraints
- `git diff --check`

## Non-claims

- does not alter the profile, corpus, scorer, release assets, or candidate digest
- does not claim an independent reproduction has occurred
- leaves the historical `candidate.1` schema identifier unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated conformance guidance to use the newer candidate.2 release.
  * Added source digest and reference verification instructions.
  * Clarified that conformance implementations may be standalone commands in any language.
  * Updated GitHub Actions examples to use full commit SHA pinning for reproducible workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->