### PR TITLE
docs(conformance): verify Gate 2 pack before scoring

### DIFF
--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -104,7 +104,16 @@ steps:
     run: |
       gh release download privileged-mcp-action-v0-candidate.2 \
         --repo Rul1an/assay \
-        --pattern privileged-mcp-action-v0-clean-room.tar.gz
+        --pattern privileged-mcp-action-v0-clean-room.tar.gz \
+        --pattern SHA256SUMS \
+        --pattern attestation-bundle.json
+      sha256sum -c SHA256SUMS
+      gh attestation verify privileged-mcp-action-v0-clean-room.tar.gz \
+        --repo Rul1an/assay \
+        --bundle attestation-bundle.json \
+        --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml \
+        --source-digest 975ee0129a421925cad78b84ffc02144aa655679 \
+        --source-ref refs/tags/privileged-mcp-action-v0-candidate.2
 
   - name: Run conformance
     uses: Rul1an/assay/.github/actions/privileged-mcp-action-conformance@975ee0129a421925cad78b84ffc02144aa655679


### PR DESCRIPTION
## Summary

- make the GitHub Actions example verify `SHA256SUMS` and the release attestation before invoking the scorer
- constrain attestation verification to the exact source commit and candidate.2 tag

Follow-up to the valid CodeRabbit finding on #1861. The separate air-gapped trusted-root suggestion is not adopted: this protocol does not promise air-gapped verification, and pinning a trust root into the candidate would create a stale-root lifecycle.

## Verification

- `python3 -m unittest conformance/privileged-mcp-action-v0/tests/test_activation_kit.py`
- independently executed the documented checksum and attestation commands against the released assets
- `git diff --check`

## Non-claims

- no profile, corpus, scorer, action, or release-asset changes
- no independent reproduction claim