### PR TITLE
fix(release): separate target from compatibility pins

### DIFF
--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -12,6 +12,17 @@ This document outlines the canonical checklist for releasing new versions of Ass
 - [ ] **Update Lockfile**: Run `cargo check --workspace` to update `Cargo.lock`.
 - [ ] **Changelog**: Update `CHANGELOG.md` with new features and fixes.
 - [ ] **Lints**: Run `cargo clippy --workspace --all-targets` to ensure no new warnings.
+- [ ] **Version-line preflight**: Bind the workspace to the intended stable tag before it exists:
+  ```bash
+  EXPECTED_RELEASE=vX.Y.Z CHECK_VM=0 \
+    bash scripts/ci/check-assay-version-line.sh
+  ```
+  This is the workspace-only pre-tag check. On the host that owns the runner
+  VM, repeat it with `CHECK_VM=1` to prove the VM still matches GitHub Latest
+  while the workspace matches the intended release target.
+  The Harness default is an independently proven compatibility pin and may
+  intentionally lag the latest Assay release. The VM remains bound to the
+  current GitHub Latest release until the new tag is published.
 
 ### 2. Permissions Check (Crucial)
 - [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the release tag on every current crates.io crate:

--- a/scripts/ci/check-assay-version-line.sh
+++ b/scripts/ci/check-assay-version-line.sh
@@ -5,6 +5,7 @@ REPO="${REPO:-Rul1an/assay}"
 VM_NAME="${VM_NAME:-assay-bpf-runner}"
 HARNESS_DIR="${HARNESS_DIR:-../Assay-Harness}"
 CHECK_VM="${CHECK_VM:-1}"
+EXPECTED_RELEASE="${EXPECTED_RELEASE:-}"
 
 failures=0
 
@@ -31,6 +32,10 @@ latest_tag() {
   printf '%s\n' "$tag"
 }
 
+is_stable_tag() {
+  [[ "$1" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]
+}
+
 workspace_version() {
   awk '
     $0 == "[workspace.package]" { in_workspace_package = 1; next }
@@ -49,13 +54,44 @@ harness_version() {
     return 0
   fi
 
-  awk '
-    $1 == "default:" {
-      value = $2
-      gsub(/"/, "", value)
-      print value
-      exit
-    }
+  # shellcheck disable=SC2016 # Ruby reads the YAML structure, not shell variables.
+  ruby -ryaml -e '
+    def reject_duplicate_keys(node, scanner, path = [])
+      case node
+      when Psych::Nodes::Stream, Psych::Nodes::Document
+        node.children.each { |child| reject_duplicate_keys(child, scanner, path) }
+      when Psych::Nodes::Mapping
+        seen = {}
+        node.children.each_slice(2) do |key_node, value_node|
+          abort("complex YAML mapping keys are unsupported") unless
+            key_node.is_a?(Psych::Nodes::Scalar)
+          abort("explicitly tagged YAML mapping keys are unsupported") if
+            key_node.tag
+          raw_key = key_node.value
+          semantic_key = key_node.plain ? scanner.tokenize(raw_key) : raw_key
+          fingerprint = [semantic_key.class.name, semantic_key]
+          abort("duplicate YAML key at #{(path + [raw_key]).join(".")}") if
+            seen[fingerprint]
+          seen[fingerprint] = true
+          reject_duplicate_keys(value_node, scanner, path + [raw_key])
+        end
+      when Psych::Nodes::Sequence
+        node.children.each_with_index do |child, index|
+          reject_duplicate_keys(child, scanner, path + [index.to_s])
+        end
+      end
+    end
+
+    loader = Psych::ClassLoader::Restricted.new([], [])
+    scanner = Psych::ScalarScanner.new(loader)
+    reject_duplicate_keys(Psych.parse_file(ARGV.fetch(0)), scanner)
+    document = YAML.safe_load_file(ARGV.fetch(0), aliases: false)
+    triggers = document["on"] || document[true]
+    value = triggers
+      &.dig("workflow_dispatch", "inputs", "assay_version", "default")
+    abort("missing workflow_dispatch.inputs.assay_version.default") unless
+      value.is_a?(String) && !value.empty?
+    puts value
   ' "$workflow"
 }
 
@@ -78,6 +114,18 @@ else
   note "latest_release=${latest}"
 fi
 
+release_target="$latest"
+if [[ -n "$EXPECTED_RELEASE" ]]; then
+  if ! is_stable_tag "$EXPECTED_RELEASE"; then
+    fail "expected release is not a stable software tag: ${EXPECTED_RELEASE}"
+  else
+    release_target="$EXPECTED_RELEASE"
+  fi
+fi
+if [[ -n "$release_target" ]]; then
+  note "release_target=${release_target}"
+fi
+
 workspace="$(workspace_version)"
 if [[ -z "$workspace" ]]; then
   fail "could not read workspace.package.version from Cargo.toml"
@@ -89,7 +137,7 @@ harness="$(harness_version)"
 if [[ -z "$harness" ]]; then
   fail "could not read Harness CI assay_version default from ${HARNESS_DIR}"
 else
-  note "harness_assay_version=${harness}"
+  note "harness_compatibility_assay_version=${harness}"
 fi
 
 vm_version=""
@@ -104,12 +152,12 @@ else
   note "vm_assay_version=skipped"
 fi
 
-if [[ -n "$latest" && -n "$workspace" && "v${workspace}" != "$latest" ]]; then
-  fail "workspace version v${workspace} does not match latest release ${latest}"
+if [[ -n "$release_target" && -n "$workspace" && "v${workspace}" != "$release_target" ]]; then
+  fail "workspace version v${workspace} does not match release target ${release_target}"
 fi
 
-if [[ -n "$latest" && -n "$harness" && "$harness" != "$latest" ]]; then
-  fail "Harness compatibility default ${harness} does not match latest release ${latest}"
+if [[ -n "$harness" ]] && ! is_stable_tag "$harness"; then
+  fail "Harness compatibility default is not a stable software tag: ${harness}"
 fi
 
 if [[ "$CHECK_VM" == "1" && -n "$latest" && -n "$vm_version" && "v${vm_version}" != "$latest" ]]; then

--- a/scripts/ci/test-release-channel-separation.sh
+++ b/scripts/ci/test-release-channel-separation.sh
@@ -54,7 +54,15 @@ fi
 [[ -z "${FAKE_INVOCATION_COUNTER:-}" ]] || printf '1\n' >>"$FAKE_INVOCATION_COUNTER"
 printf 'assay %s\n' "${FAKE_ASSAY_VERSION:-3.35.0}"
 EOF
-chmod +x "$TMP_DIR/bin/curl" "$TMP_DIR/bin/jq" "$TMP_DIR/bin/assay"
+cat >"$TMP_DIR/bin/multipass" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_VM_VERSION:?}"
+EOF
+chmod +x \
+  "$TMP_DIR/bin/curl" \
+  "$TMP_DIR/bin/jq" \
+  "$TMP_DIR/bin/assay" \
+  "$TMP_DIR/bin/multipass"
 
 rejects_fake_latest() {
   local output
@@ -263,5 +271,147 @@ if [[ "$health_tag" != "$VALID_TAG" ]]; then
   echo "health_check.sh rejected stable latest tag $VALID_TAG" >&2
   exit 1
 fi
+
+mkdir -p "$TMP_DIR/harness/.github/workflows"
+cat >"$TMP_DIR/harness/.github/workflows/harness-ci.yml" <<'EOF'
+on:
+  workflow_dispatch:
+    inputs:
+      unrelated_version:
+        default: "v9.9.9"
+      assay_version:
+        default: "v3.27.0"
+EOF
+FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+  HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-release-prep.log"
+require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
+  "latest_release=v3.33.0"
+require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
+  "release_target=v3.34.0"
+require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
+  "harness_compatibility_assay_version=v3.27.0"
+require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
+  "version_line_status=ok"
+
+FAKE_TAG="v3.33.0" FAKE_VM_VERSION="3.33.0" \
+  EXPECTED_RELEASE="v3.34.0" CHECK_VM=1 \
+  HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-vm-latest.log"
+require_literal_from_path "$TMP_DIR/version-line-vm-latest.log" \
+  "vm_assay_version=3.33.0"
+require_literal_from_path "$TMP_DIR/version-line-vm-latest.log" \
+  "version_line_status=ok"
+
+if FAKE_TAG="v3.33.0" FAKE_VM_VERSION="3.34.0" \
+  EXPECTED_RELEASE="v3.34.0" CHECK_VM=1 \
+  HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-vm-target.log" 2>&1
+then
+  echo "version-line check accepted a VM on the release target instead of Latest" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/version-line-vm-target.log" \
+  "VM assay version v3.34.0 does not match latest release v3.33.0"
+
+mkdir -p "$TMP_DIR/harness-lookalike/.github/workflows"
+cat >"$TMP_DIR/harness-lookalike/.github/workflows/harness-ci.yml" <<'EOF'
+on:
+  push:
+jobs:
+  decoy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          workflow_dispatch:
+            inputs:
+              assay_version:
+                default: "v9.9.9"
+EOF
+if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+  HARNESS_DIR="$TMP_DIR/harness-lookalike" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-lookalike.log" 2>&1
+then
+  echo "version-line check accepted workflow YAML from a block scalar" >&2
+  exit 1
+fi
+
+mkdir -p "$TMP_DIR/harness-duplicate/.github/workflows"
+cat >"$TMP_DIR/harness-duplicate/.github/workflows/harness-ci.yml" <<'EOF'
+on:
+  workflow_dispatch:
+    inputs:
+      assay_version:
+        default: "v3.27.0"
+        default: "v9.9.9"
+EOF
+if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+  HARNESS_DIR="$TMP_DIR/harness-duplicate" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-duplicate.log" 2>&1
+then
+  echo "version-line check accepted a duplicate Harness version key" >&2
+  exit 1
+fi
+
+mkdir -p "$TMP_DIR/harness-semantic-duplicate/.github/workflows"
+cat >"$TMP_DIR/harness-semantic-duplicate/.github/workflows/harness-ci.yml" <<'EOF'
+on:
+  workflow_dispatch:
+    inputs:
+      assay_version:
+        default: "not-a-tag"
+true:
+  workflow_dispatch:
+    inputs:
+      assay_version:
+        default: "v9.9.9"
+EOF
+if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+  HARNESS_DIR="$TMP_DIR/harness-semantic-duplicate" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-semantic-duplicate.log" 2>&1
+then
+  echo "version-line check accepted semantically duplicate YAML keys" >&2
+  exit 1
+fi
+
+mkdir -p "$TMP_DIR/harness-tagged-duplicate/.github/workflows"
+cat >"$TMP_DIR/harness-tagged-duplicate/.github/workflows/harness-ci.yml" <<'EOF'
+!!bool "true":
+  workflow_dispatch:
+    inputs:
+      assay_version:
+        default: "not-a-tag"
+true:
+  workflow_dispatch:
+    inputs:
+      assay_version:
+        default: "v9.9.9"
+EOF
+if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+  HARNESS_DIR="$TMP_DIR/harness-tagged-duplicate" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-tagged-duplicate.log" 2>&1
+then
+  echo "version-line check accepted an explicitly tagged YAML key" >&2
+  exit 1
+fi
+
+INVALID_TARGET="$FAKE_TAG"
+if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="$INVALID_TARGET" CHECK_VM=0 \
+  HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
+  >"$TMP_DIR/version-line-invalid-target.log" 2>&1
+then
+  echo "version-line check accepted a non-software release target" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/version-line-invalid-target.log" \
+  "expected release is not a stable software tag: $INVALID_TARGET"
 
 echo "release channel separation contract passed"


### PR DESCRIPTION
## Summary

- distinguish the operational Latest release from an explicitly selected release target
- retain Assay-Harness v3.27.0 as an independently proven compatibility pin instead of mechanically rewriting it
- document the pre-tag version-line command and add negative contract coverage

## Verification

- `bash scripts/ci/test-release-channel-separation.sh`
- `EXPECTED_RELEASE=v3.34.0 CHECK_VM=0 bash scripts/ci/check-assay-version-line.sh`
- `shellcheck scripts/ci/check-assay-version-line.sh scripts/ci/test-release-channel-separation.sh`
- `pre-commit run --all-files`
- `git diff --check`

## Non-claims

This does not assert that Harness v3.27.0 is the latest Assay release. It records that the pin is a separate compatibility baseline, while `EXPECTED_RELEASE` names the release being prepared.