### PR TITLE
chore(release): prepare v3.35.0

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Ruby for release contract parser
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.3.12"
+          bundler-cache: false
+
       - name: Verify software and conformance release channels stay separate
         run: bash scripts/ci/test-release-channel-separation.sh
 

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -6,8 +6,9 @@ name: MCP Registry Publish
 # release.yml already RENDERS server.json and attaches it as a release asset, but never publishes
 # it, so the registry entry lags the current release (the last manual publish was 3.9.2). This adds
 # the missing publish step. It is a small standalone workflow on purpose: it does not touch the
-# release build pipeline, it auto-publishes on every release, and it can refresh an existing release
-# on demand via workflow_dispatch.
+# release build pipeline, it auto-publishes stable releases, and it can refresh an existing stable
+# release on demand via workflow_dispatch. GitHub prereleases remain outside the official registry
+# so a newer RC or beta cannot displace the latest stable server version.
 #
 # GitHub OIDC proves the io.github.<owner> namespace belongs to this repository owner, so no stored
 # registry secret is needed.
@@ -26,6 +27,10 @@ permissions:
   contents: read
   id-token: write # OIDC: proves the io.github.<owner> namespace == repository owner
 
+env:
+  MCP_PUBLISHER_VERSION: "v1.7.9"
+  MCP_PUBLISHER_LINUX_AMD64_SHA256: "ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"
+
 concurrency:
   group: mcp-registry-publish
   cancel-in-progress: false
@@ -33,8 +38,13 @@ concurrency:
 jobs:
   publish:
     name: Publish to MCP registry
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
       - name: Resolve release tag
         id: tag
         # Tag/input values reach the shell only via env, never via ${{ }} inside run:
@@ -43,21 +53,11 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "release" ]; then
-            tag="$RELEASE_TAG"
-          else
-            tag="$INPUT_VERSION"
-          fi
-          # [[ =~ ]] anchors on the whole string (grep -E matches per line, which
-          # would let a newline-bearing dispatch input smuggle a second
-          # GITHUB_OUTPUT line past the check).
-          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
-            echo "::error::expected a vX.Y.Z release tag, got '$tag'"
-            exit 1
-          fi
+          tag="$(bash scripts/ci/resolve-mcp-registry-tag.sh)"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Download server.json from the release
@@ -75,10 +75,12 @@ jobs:
       - name: Install mcp-publisher
         run: |
           set -euo pipefail
-          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" \
-            | tar xz mcp-publisher
+          archive=mcp-publisher_linux_amd64.tar.gz
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${archive}" \
+            -o "$archive"
+          printf '%s  %s\n' "$MCP_PUBLISHER_LINUX_AMD64_SHA256" "$archive" | sha256sum -c -
+          tar xzf "$archive" mcp-publisher
           chmod +x mcp-publisher
 
       - name: Validate server.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,37 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  release-contract:
+    name: Validate release version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Bind requested release to workspace version
+        id: version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
+          RELEASE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          version="$(bash scripts/ci/resolve-release-version.sh)"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
   # ============================================================
   # Build matrix for all platforms
   # ============================================================
   build:
     name: Build ${{ matrix.target }}
+    needs: release-contract
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -155,29 +181,11 @@ jobs:
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} --package assay-cli
 
-      - name: Get version
-        id: version
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
-        run: |
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            V="${RELEASE_VERSION_INPUT}"
-          else
-            V="${GITHUB_REF#refs/tags/}"
-          fi
-          if [[ "$V" == *$'\n'* || "$V" == *$'\r'* ]]; then
-            echo "::error::Release version must be a single-line value."
-            exit 1
-          fi
-          printf 'version=%s\n' "$V" >> "$GITHUB_OUTPUT"
-
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
         run: |
           ARCHIVE_NAME="assay-${VERSION}-${{ matrix.target }}"
           mkdir -p "dist/${ARCHIVE_NAME}"
@@ -191,7 +199,7 @@ jobs:
         if: matrix.archive == 'zip'
         shell: pwsh
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
         run: |
           $VERSION = $env:VERSION
           $ARCHIVE_NAME = "assay-${VERSION}-${{ matrix.target }}"
@@ -211,6 +219,7 @@ jobs:
 
   build-mcp-server-linux:
     name: Build assay-mcp-server ${{ matrix.target }}
+    needs: release-contract
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -288,28 +297,10 @@ jobs:
       - name: Build assay-mcp-server binary
         run: cargo build --release --target ${{ matrix.target }} --package assay-mcp-server
 
-      - name: Get version
-        id: version
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
-        run: |
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            V="${RELEASE_VERSION_INPUT}"
-          else
-            V="${GITHUB_REF#refs/tags/}"
-          fi
-          if [[ "$V" == *$'\n'* || "$V" == *$'\r'* ]]; then
-            echo "::error::Release version must be a single-line value."
-            exit 1
-          fi
-          printf 'version=%s\n' "$V" >> "$GITHUB_OUTPUT"
-
       - name: Package assay-mcp-server
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
         run: |
           ARCHIVE_NAME="assay-mcp-server-${VERSION}-${{ matrix.target }}"
           mkdir -p "dist/${ARCHIVE_NAME}"
@@ -331,7 +322,7 @@ jobs:
   # ============================================================
   release:
     name: Create Release
-    needs: [build, build-mcp-server-linux]
+    needs: [release-contract, build, build-mcp-server-linux]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -349,24 +340,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Get version
-        id: version
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
-        run: |
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            V="${RELEASE_VERSION_INPUT}"
-          else
-            V="${GITHUB_REF#refs/tags/}"
-          fi
-          if [[ "$V" == *$'\n'* || "$V" == *$'\r'* ]]; then
-            echo "::error::Release version must be a single-line value."
-            exit 1
-          fi
-          printf 'version=%s\n' "$V" >> "$GITHUB_OUTPUT"
-
       - name: Install CycloneDX generator
         shell: bash
         run: cargo install cargo-cyclonedx --version 0.5.9 --locked
@@ -374,7 +347,7 @@ jobs:
       - name: Generate CycloneDX SBOM bundle
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -408,7 +381,7 @@ jobs:
       - name: Build assay-mcp-server MCPB
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
         run: |
           set -euo pipefail
           bash scripts/ci/build_mcpb_bundle.sh \
@@ -420,7 +393,7 @@ jobs:
       - name: Render generated registry metadata
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -510,7 +483,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSETS_DIR: release
-          OUT_SUMMARY: release/assay-${{ steps.version.outputs.version }}-release-provenance.json
+          OUT_SUMMARY: release/assay-${{ needs.release-contract.outputs.version }}-release-provenance.json
           OUT_RAW_DIR: artifacts/release-provenance/raw
           REPO: ${{ github.repository }}
           SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/release.yml
@@ -526,10 +499,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSETS_DIR: release
-          PROVENANCE_SUMMARY: release/assay-${{ steps.version.outputs.version }}-release-provenance.json
-          PROVENANCE_SUMMARY_SHA256: release/assay-${{ steps.version.outputs.version }}-release-provenance.json.sha256
-          OUT_ARCHIVE: release/assay-${{ steps.version.outputs.version }}-release-proof-kit.tar.gz
-          VERSION: ${{ steps.version.outputs.version }}
+          PROVENANCE_SUMMARY: release/assay-${{ needs.release-contract.outputs.version }}-release-provenance.json
+          PROVENANCE_SUMMARY_SHA256: release/assay-${{ needs.release-contract.outputs.version }}-release-provenance.json.sha256
+          OUT_ARCHIVE: release/assay-${{ needs.release-contract.outputs.version }}-release-proof-kit.tar.gz
+          VERSION: ${{ needs.release-contract.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -538,7 +511,7 @@ jobs:
 
       - name: Check release asset preflight
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
           ASSETS_DIR: release
           REPO: ${{ github.repository }}
         shell: bash
@@ -559,7 +532,7 @@ jobs:
         id: notes
         env:
           REPO: ${{ github.repository }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -607,7 +580,7 @@ jobs:
           text = text.replace("__VERSION__", os.environ["VERSION"])
           text = text.replace(
               "__CHANGELOG_URL__",
-              f"https://github.com/{os.environ['REPO']}/blob/main/CHANGELOG.md",
+              f"https://github.com/{os.environ['REPO']}/blob/{os.environ['VERSION']}/CHANGELOG.md",
           )
           notes.write_text(text)
           PY
@@ -615,7 +588,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -738,6 +711,7 @@ jobs:
   # ============================================================
   wheels:
     name: Build Wheels
+    needs: release-contract
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.35.0] - 2026-07-27
+
 ### Added
+- Publish the open `privileged-mcp-action/v0` evidence profile, its 13-vector conformance corpus,
+  and typed importer and verifier support for one classified privileged MCP `tools/call`. The
+  profile keeps policy decisions, caller-visible outcomes and optional observations distinct. It
+  does not establish provider-side effects, generic identity, policy correctness, whole-action
+  trust or a scalar score.
+- Aim the evidence-bundle fuzz target at the evidence-chain verifier and add deterministic
+  properties for chain order, truncation, digest mutation and fail-closed error classification.
+  Required CI runs the property suite; a path-triggered and nightly lane runs bounded fuzz smoke
+  with a pinned seed corpus.
 - New reason code `E_REPLAY_LIMIT_EXCEEDED` (exit 2) for a replay bundle refused by an ingest
   ceiling during bounded ingest, before replay execution. Previously such a refusal was reported
   as `E_CFG_PARSE`, which is a malformed-input finding and sends a reader off to fix the
@@ -17,7 +28,17 @@ All notable changes to this project will be documented in this file.
   carries no verdict, and its message names only the configured ceiling.
 
 ### Changed
-- **Breaking (`assay sandbox`)**: a `--policy` that is named but cannot be loaded is now fatal.
+- Apply the complete configured ingest limit set before materialization across verified and
+  unverified evidence reads, manifest peeks, lint, stdin verification, push including
+  `--no-verify`, object-store pull and replay bundles. Exact limits are accepted; limit plus one,
+  decompression expansion, excessive lines, events, paths and JSON depth fail closed with typed
+  limit classifications.
+- Make the stdio MCP authorization boundary explicit. Any configured `ASSAY_AUTH_*` variable now
+  fails startup before protocol I/O, and token-like values in `initialize` grant no authority and
+  are neither logged nor used as identity. This does not add HTTP/OAuth support and does not change
+  ProxyEnforce's explicit local policy caller input.
+- **Fail-closed correction (`assay sandbox`, migration-visible)**: a `--policy` that is named but
+  cannot be loaded is now fatal.
   The run exits 2 with `E_POLICY_LOAD_FAILED_UNENFORCEABLE` and executes nothing, where it
   previously printed a warning and continued under the built-in `mcp-server-minimal` pack.
   `--fail-closed` does not create this obligation and does not change the outcome; naming a
@@ -29,15 +50,26 @@ All notable changes to this project will be documented in this file.
   sessions that failed authentication under the default permissive mode, and neither carried a
   basis a reviewer could check. `serverInfo.version` is now derived from the crate version
   instead of the hand-written `0.4.0`, which no build produced.
-- **Breaking (`assay sandbox`)**: a named policy with non-empty `extends` is refused before
-  execution. Pack resolution is unsupported, so accepting those entries previously made
-  declared policy composition disappear silently. `assay sandbox --profile` now emits an empty
-  `extends` list instead of references to unresolved packs.
+- **Fail-closed correction (`assay sandbox`, migration-visible)**: a named policy with non-empty
+  `extends` is refused before execution. Pack resolution is unsupported, so accepting those entries
+  previously made declared policy composition disappear silently. `assay sandbox --profile` now
+  emits an empty `extends` list instead of references to unresolved packs.
+
+The two sandbox corrections close cases where requested enforcement could not be honored; they do
+not remove a supported enforcement contract. They ship on the `3.x` line as correctness and
+integrity fixes rather than a new major version. Operators that relied on permissive substitution
+must remove the explicit `--policy`, supply a loadable policy without unresolved `extends`, or
+expect exit 2 with no command execution.
 
 ### Fixed
 - Publish clean-room conformance packs as prereleases that are explicitly ineligible for GitHub's
   software `Latest` pointer. Installers, the embedded Action and runner maintenance also reject a
   non-`vX.Y.Z` latest tag before constructing a CLI asset URL.
+- Keep Assay RC and beta releases out of the official MCP Registry. GitHub prereleases remain
+  available for testing, but neither their automatic release event nor a manual registry dispatch
+  may publish a prerelease version that would sort above the latest stable server. Registry
+  publication also executes a version- and digest-pinned `mcp-publisher` rather than an unverified
+  binary from the upstream `latest` release.
 - Reject line breaks in explicit embedded Action versions before writing step outputs, preventing
   multi-line input from adding attacker-chosen Action outputs while preserving published tags such
   as `v2.1`. Two-component historical tags now retain their download identity while verifying the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "aya",
  "chrono",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.34.0"
+version = "3.35.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -75,14 +75,14 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.19.1" }
-assay-common = { path = "crates/assay-common", version = "3.19.1", default-features = false }
+assay-core = { path = "crates/assay-core", version = "3.35.0" }
+assay-common = { path = "crates/assay-common", version = "3.35.0", default-features = false }
 assay-monitor = { path = "crates/assay-monitor", version = "3.19.1" }
 assay-metrics = { path = "crates/assay-metrics", version = "3.19.1" }
 assay-policy = { path = "crates/assay-policy", version = "3.19.1" }
 assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.19.1" }
 assay-canonical = { path = "crates/assay-canonical", version = "3.19.1" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.19.1" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.35.0" }
 assay-sim = { path = "crates/assay-sim", version = "3.19.1" }
 assay-registry = { path = "crates/assay-registry", version = "3.19.1" }
 assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.19.1" }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,13 +1,13 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-07-22, current release `v3.34.0`):** the released line
-> carries the approval-artifact retention digest and retained-view declaration,
-> fail-closed `ASSAY-W005` handling for opaque or unknown retained views, and
-> Runner socket-event attribution by cgroup. It also carries the earlier
-> `v3.32.0`/`v3.33.0` bounded-evidence work: skill supply-chain evidence,
-> gateway replay, caller-visible denied-call observations, and `ASSAY-W004`.
-> Commits on `main` after the tag are dependency maintenance plus a
-> golden-vector newline fix, not a new evidence-contract wave.
+> **Status sync (2026-07-27, `v3.35.0` release line):** this line
+> adds the open `privileged-mcp-action/v0` profile, corpus, importer and verifier,
+> and accepts ADR-043 after bounded ingest, the explicit stdio-auth boundary,
+> and evidence-verifier fuzz/property coverage landed. The same line makes named
+> sandbox policy loading fail before execution when requested composition cannot
+> be enforced. Assay-Runner remains on the shared workspace version but adds no
+> new runtime or eBPF semantics beyond the cgroup attribution shipped in
+> `v3.34.0`.
 > The current execution posture remains trigger-led: keep Assay-Runner
 > repository extraction and further CLI grouping gated, preserve claim
 > ceilings on every producer and lint rule, and do not turn retained-view or

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -12,6 +12,10 @@ This document outlines the canonical checklist for releasing new versions of Ass
 - [ ] **Update Lockfile**: Run `cargo check --workspace` to update `Cargo.lock`.
 - [ ] **Changelog**: Update `CHANGELOG.md` with new features and fixes.
 - [ ] **Lints**: Run `cargo clippy --workspace --all-targets` to ensure no new warnings.
+- [ ] **Release parser toolchain**: Use Ruby `3.3.12` with Psych `5.1.2`.
+  GitHub Actions installs the pinned Ruby before running the release-channel
+  contract; the local version-line preflight fails closed on another parser
+  toolchain so YAML key semantics cannot drift between operator and CI.
 - [ ] **Version-line preflight**: Bind the workspace to the intended stable tag before it exists:
   ```bash
   EXPECTED_RELEASE=vX.Y.Z CHECK_VM=0 \
@@ -28,6 +32,7 @@ This document outlines the canonical checklist for releasing new versions of Ass
 - [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the release tag on every current crates.io crate:
   - `assay-common`
   - `assay-registry`
+  - `assay-canonical`
   - `assay-evidence`
   - `assay-core`
   - `assay-metrics`
@@ -47,13 +52,14 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - `assay-it` (distributed through PyPI wheels, not crates.io)
   - `assay-ebpf`
   - `assay-xtask`
+  - `gateway-evidence-replay`
 - [ ] **Public Crate Policy Check**: Run `bash scripts/ci/check-public-crate-policy.sh`.
 - [ ] **Token Scopes**: If using a token fallback, ensure it has `publish-update` scope.
 
 ### 3. Execution
 - [ ] **Tag**: Create and push the git tag.
   ```bash
-  git tag vX.Y.Z
+  git tag -a vX.Y.Z -m "Assay vX.Y.Z"
   git push origin vX.Y.Z
   ```
 - [ ] **Watch CI**: Monitor the `release.yml` workflow.

--- a/scripts/ci/check-assay-version-line.sh
+++ b/scripts/ci/check-assay-version-line.sh
@@ -6,6 +6,8 @@ VM_NAME="${VM_NAME:-assay-bpf-runner}"
 HARNESS_DIR="${HARNESS_DIR:-../Assay-Harness}"
 CHECK_VM="${CHECK_VM:-1}"
 EXPECTED_RELEASE="${EXPECTED_RELEASE:-}"
+REQUIRED_RUBY_VERSION="3.3.12"
+REQUIRED_PSYCH_VERSION="5.1.2"
 
 failures=0
 
@@ -17,6 +19,16 @@ fail() {
   failures=$((failures + 1))
   note "FAIL: $*"
 }
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "release version-line parser requires Ruby ${REQUIRED_RUBY_VERSION} with Psych ${REQUIRED_PSYCH_VERSION}" >&2
+  exit 1
+fi
+parser_versions="$(ruby -ryaml -e 'print [RUBY_VERSION, Psych::VERSION].join(" ")')"
+if [[ "$parser_versions" != "${REQUIRED_RUBY_VERSION} ${REQUIRED_PSYCH_VERSION}" ]]; then
+  echo "release version-line parser requires Ruby ${REQUIRED_RUBY_VERSION} with Psych ${REQUIRED_PSYCH_VERSION}; found ${parser_versions}" >&2
+  exit 1
+fi
 
 latest_tag() {
   local tag

--- a/scripts/ci/resolve-mcp-registry-tag.sh
+++ b/scripts/ci/resolve-mcp-registry-tag.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT_NAME="${EVENT_NAME:-}"
+RELEASE_TAG="${RELEASE_TAG:-}"
+RELEASE_PRERELEASE="${RELEASE_PRERELEASE:-}"
+INPUT_VERSION="${INPUT_VERSION:-}"
+
+case "$EVENT_NAME" in
+  release)
+    if [[ "$RELEASE_PRERELEASE" != "false" ]]; then
+      echo "MCP Registry publication is limited to stable GitHub releases" >&2
+      exit 1
+    fi
+    tag="$RELEASE_TAG"
+    ;;
+  workflow_dispatch)
+    tag="$INPUT_VERSION"
+    ;;
+  *)
+    echo "unsupported MCP Registry publish event: ${EVENT_NAME:-<empty>}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$tag" == *$'\n'* || "$tag" == *$'\r'* ]]; then
+  echo "MCP Registry release tag must be a single-line value" >&2
+  exit 1
+fi
+if [[ ! "$tag" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "MCP Registry publication requires a stable vX.Y.Z release tag: ${tag:-<empty>}" >&2
+  exit 1
+fi
+
+printf '%s\n' "$tag"

--- a/scripts/ci/resolve-release-version.sh
+++ b/scripts/ci/resolve-release-version.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVENT_NAME="${EVENT_NAME:-}"
+RELEASE_VERSION_INPUT="${RELEASE_VERSION_INPUT:-}"
+RELEASE_REF="${RELEASE_REF:-${GITHUB_REF:-}}"
+
+case "$EVENT_NAME" in
+  workflow_dispatch)
+    requested="$RELEASE_VERSION_INPUT"
+    ;;
+  push)
+    if [[ "$RELEASE_REF" != refs/tags/* ]]; then
+      echo "release push must target a tag ref: ${RELEASE_REF:-<empty>}" >&2
+      exit 1
+    fi
+    requested="${RELEASE_REF#refs/tags/}"
+    ;;
+  *)
+    echo "unsupported release event: ${EVENT_NAME:-<empty>}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$requested" == *$'\n'* || "$requested" == *$'\r'* ]]; then
+  echo "release version must be a single-line value" >&2
+  exit 1
+fi
+if [[ ! "$requested" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-(rc|beta)[.][0-9]+)?$ ]]; then
+  echo "release version must be vX.Y.Z, vX.Y.Z-rc.N, or vX.Y.Z-beta.N: ${requested:-<empty>}" >&2
+  exit 1
+fi
+
+workspace_version="$(
+  awk '
+    $0 == "[workspace.package]" { in_workspace_package = 1; next }
+    /^\[/ && $0 != "[workspace.package]" { in_workspace_package = 0 }
+    in_workspace_package && $1 == "version" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' "$REPO_ROOT/Cargo.toml"
+)"
+if [[ ! "$workspace_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-(rc|beta)[.][0-9]+)?$ ]]; then
+  echo "could not read a supported workspace version from Cargo.toml" >&2
+  exit 1
+fi
+
+expected="v${workspace_version}"
+if [[ "$requested" != "$expected" ]]; then
+  echo "release version ${requested} does not match workspace version ${expected}" >&2
+  exit 1
+fi
+
+printf '%s\n' "$requested"

--- a/scripts/ci/test-release-channel-separation.sh
+++ b/scripts/ci/test-release-channel-separation.sh
@@ -4,6 +4,24 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 EXPECTED_ERROR="latest Assay release is not a stable software tag"
 FAKE_TAG="privileged-mcp-action-v0-candidate.2"
+WORKSPACE_VERSION="$(
+  awk '
+    $0 == "[workspace.package]" { in_workspace_package = 1; next }
+    /^\[/ && $0 != "[workspace.package]" { in_workspace_package = 0 }
+    in_workspace_package && $1 == "version" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' "$REPO_ROOT/Cargo.toml"
+)"
+if [[ ! "$WORKSPACE_VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "could not read a stable workspace version from Cargo.toml" >&2
+  exit 1
+fi
+VALID_TAG="v${WORKSPACE_VERSION}"
+LATEST_TAG="v1.0.0"
+export FAKE_ASSAY_VERSION="$WORKSPACE_VERSION"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -19,6 +37,24 @@ require_literal() {
 PACK_WORKFLOW=".github/workflows/privileged-mcp-action-pack-release.yml"
 require_literal "$PACK_WORKFLOW" "--prerelease"
 require_literal "$PACK_WORKFLOW" "--latest=false"
+require_literal ".github/workflows/release.yml" \
+  'version="$(bash scripts/ci/resolve-release-version.sh)"'
+require_literal ".github/workflows/release.yml" \
+  'VERSION: ${{ needs.release-contract.outputs.version }}'
+MCP_REGISTRY_WORKFLOW=".github/workflows/mcp-registry-publish.yml"
+require_literal "$MCP_REGISTRY_WORKFLOW" \
+  "if: \${{ github.event_name != 'release' || github.event.release.prerelease == false }}"
+require_literal "$MCP_REGISTRY_WORKFLOW" \
+  'tag="$(bash scripts/ci/resolve-mcp-registry-tag.sh)"'
+require_literal "$MCP_REGISTRY_WORKFLOW" 'MCP_PUBLISHER_VERSION: "v1.7.9"'
+require_literal "$MCP_REGISTRY_WORKFLOW" \
+  'MCP_PUBLISHER_LINUX_AMD64_SHA256: "ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"'
+require_literal "$MCP_REGISTRY_WORKFLOW" \
+  'printf '\''%s  %s\n'\'' "$MCP_PUBLISHER_LINUX_AMD64_SHA256" "$archive" | sha256sum -c -'
+if grep -Fq -- "/releases/latest/" "$REPO_ROOT/$MCP_REGISTRY_WORKFLOW"; then
+  echo "$MCP_REGISTRY_WORKFLOW must not execute an unpinned latest publisher" >&2
+  exit 1
+fi
 
 for consumer in \
   scripts/install.sh \
@@ -87,7 +123,6 @@ rejects_fake_latest env GITHUB_OUTPUT="$TMP_DIR/action-invalid.out" \
 rejects_fake_latest bash -c \
   'source "$1"; latest_assay_tag' _ "$REPO_ROOT/infra/bpf-runner/health_check.sh"
 
-VALID_TAG="v3.35.0"
 FAKE_TAG="$VALID_TAG" GITHUB_OUTPUT="$TMP_DIR/action-valid.out" \
   PATH="$TMP_DIR/bin:$PATH" \
   bash "$REPO_ROOT/assay-action/resolve-version.sh" latest
@@ -99,6 +134,130 @@ require_literal_from_path() {
     exit 1
   fi
 }
+
+run_logged() {
+  local log_file="$1"
+  shift
+  if ! "$@" >"$log_file" 2>&1; then
+    cat "$log_file" >&2
+    return 1
+  fi
+}
+
+resolved_dispatch="$(
+  EVENT_NAME=workflow_dispatch RELEASE_VERSION_INPUT="$VALID_TAG" \
+    bash "$REPO_ROOT/scripts/ci/resolve-release-version.sh"
+)"
+if [[ "$resolved_dispatch" != "$VALID_TAG" ]]; then
+  echo "release resolver changed a workspace-matching dispatch version" >&2
+  exit 1
+fi
+
+resolved_push="$(
+  EVENT_NAME=push RELEASE_REF="refs/tags/$VALID_TAG" \
+    bash "$REPO_ROOT/scripts/ci/resolve-release-version.sh"
+)"
+if [[ "$resolved_push" != "$VALID_TAG" ]]; then
+  echo "release resolver changed a workspace-matching pushed tag" >&2
+  exit 1
+fi
+
+if EVENT_NAME=workflow_dispatch RELEASE_VERSION_INPUT="$LATEST_TAG" \
+  bash "$REPO_ROOT/scripts/ci/resolve-release-version.sh" \
+  >"$TMP_DIR/release-version-mismatch.log" 2>&1
+then
+  echo "release resolver accepted a tag that differs from the workspace version" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/release-version-mismatch.log" \
+  "release version $LATEST_TAG does not match workspace version $VALID_TAG"
+
+if EVENT_NAME=workflow_dispatch RELEASE_VERSION_INPUT="${VALID_TAG}"$'\nextra' \
+  bash "$REPO_ROOT/scripts/ci/resolve-release-version.sh" \
+  >"$TMP_DIR/release-version-injected.log" 2>&1
+then
+  echo "release resolver accepted a version containing a line break" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/release-version-injected.log" \
+  "release version must be a single-line value"
+
+if EVENT_NAME=workflow_dispatch RELEASE_VERSION_INPUT="${VALID_TAG}-rc.1" \
+  bash "$REPO_ROOT/scripts/ci/resolve-release-version.sh" \
+  >"$TMP_DIR/release-version-prerelease.log" 2>&1
+then
+  echo "release resolver accepted a prerelease tag for a stable workspace" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/release-version-prerelease.log" \
+  "release version ${VALID_TAG}-rc.1 does not match workspace version $VALID_TAG"
+
+mkdir -p "$TMP_DIR/prerelease-repo/scripts/ci"
+cp "$REPO_ROOT/scripts/ci/resolve-release-version.sh" \
+  "$TMP_DIR/prerelease-repo/scripts/ci/resolve-release-version.sh"
+cat >"$TMP_DIR/prerelease-repo/Cargo.toml" <<'EOF'
+[workspace]
+
+[workspace.package]
+version = "3.36.0-rc.1"
+EOF
+resolved_prerelease="$(
+  EVENT_NAME=workflow_dispatch RELEASE_VERSION_INPUT="v3.36.0-rc.1" \
+    bash "$TMP_DIR/prerelease-repo/scripts/ci/resolve-release-version.sh"
+)"
+if [[ "$resolved_prerelease" != "v3.36.0-rc.1" ]]; then
+  echo "release resolver changed a workspace-matching prerelease version" >&2
+  exit 1
+fi
+
+registry_release_tag="$(
+  EVENT_NAME=release RELEASE_TAG="$VALID_TAG" RELEASE_PRERELEASE=false \
+    bash "$REPO_ROOT/scripts/ci/resolve-mcp-registry-tag.sh"
+)"
+if [[ "$registry_release_tag" != "$VALID_TAG" ]]; then
+  echo "MCP Registry resolver changed a stable release tag" >&2
+  exit 1
+fi
+
+registry_dispatch_tag="$(
+  EVENT_NAME=workflow_dispatch INPUT_VERSION="$VALID_TAG" \
+    bash "$REPO_ROOT/scripts/ci/resolve-mcp-registry-tag.sh"
+)"
+if [[ "$registry_dispatch_tag" != "$VALID_TAG" ]]; then
+  echo "MCP Registry resolver changed a stable dispatch tag" >&2
+  exit 1
+fi
+
+if EVENT_NAME=release RELEASE_TAG="v3.36.0-rc.1" RELEASE_PRERELEASE=true \
+  bash "$REPO_ROOT/scripts/ci/resolve-mcp-registry-tag.sh" \
+  >"$TMP_DIR/registry-prerelease-event.log" 2>&1
+then
+  echo "MCP Registry resolver accepted a GitHub prerelease" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/registry-prerelease-event.log" \
+  "MCP Registry publication is limited to stable GitHub releases"
+
+if EVENT_NAME=workflow_dispatch INPUT_VERSION="v3.36.0-beta.1" \
+  bash "$REPO_ROOT/scripts/ci/resolve-mcp-registry-tag.sh" \
+  >"$TMP_DIR/registry-prerelease-dispatch.log" 2>&1
+then
+  echo "MCP Registry resolver accepted a prerelease dispatch tag" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/registry-prerelease-dispatch.log" \
+  "MCP Registry publication requires a stable vX.Y.Z release tag"
+
+if EVENT_NAME=workflow_dispatch INPUT_VERSION="${VALID_TAG}"$'\nextra' \
+  bash "$REPO_ROOT/scripts/ci/resolve-mcp-registry-tag.sh" \
+  >"$TMP_DIR/registry-injected-dispatch.log" 2>&1
+then
+  echo "MCP Registry resolver accepted a tag containing a line break" >&2
+  exit 1
+fi
+require_literal_from_path "$TMP_DIR/registry-injected-dispatch.log" \
+  "MCP Registry release tag must be a single-line value"
+
 require_literal_from_path "$TMP_DIR/action-valid.out" "resolved_version=$VALID_TAG"
 require_literal_from_path "$TMP_DIR/action-valid.out" "resolved_version_plain=${VALID_TAG#v}"
 require_literal_from_path "$TMP_DIR/action-valid.out" "skip_install=true"
@@ -107,7 +266,7 @@ for state_file in output path env state summary; do
   : >"$TMP_DIR/action-child-$state_file.out"
 done
 : >"$TMP_DIR/action-child-invocations.out"
-FAKE_MUTATE_ACTION_STATE=1 FAKE_ASSAY_VERSION="3.35.0" \
+FAKE_MUTATE_ACTION_STATE=1 FAKE_ASSAY_VERSION="$WORKSPACE_VERSION" \
   FAKE_INVOCATION_COUNTER="$TMP_DIR/action-child-invocations.out" \
   GITHUB_OUTPUT="$TMP_DIR/action-child-output.out" \
   GITHUB_PATH="$TMP_DIR/action-child-path.out" \
@@ -282,31 +441,31 @@ on:
       assay_version:
         default: "v3.27.0"
 EOF
-FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+run_logged "$TMP_DIR/version-line-release-prep.log" \
+  env FAKE_TAG="$LATEST_TAG" EXPECTED_RELEASE="$VALID_TAG" CHECK_VM=0 \
   HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
-  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
-  >"$TMP_DIR/version-line-release-prep.log"
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh"
 require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
-  "latest_release=v3.33.0"
+  "latest_release=$LATEST_TAG"
 require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
-  "release_target=v3.34.0"
+  "release_target=$VALID_TAG"
 require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
   "harness_compatibility_assay_version=v3.27.0"
 require_literal_from_path "$TMP_DIR/version-line-release-prep.log" \
   "version_line_status=ok"
 
-FAKE_TAG="v3.33.0" FAKE_VM_VERSION="3.33.0" \
-  EXPECTED_RELEASE="v3.34.0" CHECK_VM=1 \
+run_logged "$TMP_DIR/version-line-vm-latest.log" \
+  env FAKE_TAG="$LATEST_TAG" FAKE_VM_VERSION="${LATEST_TAG#v}" \
+  EXPECTED_RELEASE="$VALID_TAG" CHECK_VM=1 \
   HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
-  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
-  >"$TMP_DIR/version-line-vm-latest.log"
+  bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh"
 require_literal_from_path "$TMP_DIR/version-line-vm-latest.log" \
-  "vm_assay_version=3.33.0"
+  "vm_assay_version=${LATEST_TAG#v}"
 require_literal_from_path "$TMP_DIR/version-line-vm-latest.log" \
   "version_line_status=ok"
 
-if FAKE_TAG="v3.33.0" FAKE_VM_VERSION="3.34.0" \
-  EXPECTED_RELEASE="v3.34.0" CHECK_VM=1 \
+if FAKE_TAG="$LATEST_TAG" FAKE_VM_VERSION="$WORKSPACE_VERSION" \
+  EXPECTED_RELEASE="$VALID_TAG" CHECK_VM=1 \
   HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
   bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
   >"$TMP_DIR/version-line-vm-target.log" 2>&1
@@ -315,7 +474,7 @@ then
   exit 1
 fi
 require_literal_from_path "$TMP_DIR/version-line-vm-target.log" \
-  "VM assay version v3.34.0 does not match latest release v3.33.0"
+  "VM assay version $VALID_TAG does not match latest release $LATEST_TAG"
 
 mkdir -p "$TMP_DIR/harness-lookalike/.github/workflows"
 cat >"$TMP_DIR/harness-lookalike/.github/workflows/harness-ci.yml" <<'EOF'
@@ -331,7 +490,7 @@ jobs:
               assay_version:
                 default: "v9.9.9"
 EOF
-if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+if FAKE_TAG="$LATEST_TAG" EXPECTED_RELEASE="$VALID_TAG" CHECK_VM=0 \
   HARNESS_DIR="$TMP_DIR/harness-lookalike" PATH="$TMP_DIR/bin:$PATH" \
   bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
   >"$TMP_DIR/version-line-lookalike.log" 2>&1
@@ -349,7 +508,7 @@ on:
         default: "v3.27.0"
         default: "v9.9.9"
 EOF
-if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+if FAKE_TAG="$LATEST_TAG" EXPECTED_RELEASE="$VALID_TAG" CHECK_VM=0 \
   HARNESS_DIR="$TMP_DIR/harness-duplicate" PATH="$TMP_DIR/bin:$PATH" \
   bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
   >"$TMP_DIR/version-line-duplicate.log" 2>&1
@@ -371,7 +530,7 @@ true:
       assay_version:
         default: "v9.9.9"
 EOF
-if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+if FAKE_TAG="$LATEST_TAG" EXPECTED_RELEASE="$VALID_TAG" CHECK_VM=0 \
   HARNESS_DIR="$TMP_DIR/harness-semantic-duplicate" PATH="$TMP_DIR/bin:$PATH" \
   bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
   >"$TMP_DIR/version-line-semantic-duplicate.log" 2>&1
@@ -393,7 +552,7 @@ true:
       assay_version:
         default: "v9.9.9"
 EOF
-if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="v3.34.0" CHECK_VM=0 \
+if FAKE_TAG="$LATEST_TAG" EXPECTED_RELEASE="$VALID_TAG" CHECK_VM=0 \
   HARNESS_DIR="$TMP_DIR/harness-tagged-duplicate" PATH="$TMP_DIR/bin:$PATH" \
   bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
   >"$TMP_DIR/version-line-tagged-duplicate.log" 2>&1
@@ -403,7 +562,7 @@ then
 fi
 
 INVALID_TARGET="$FAKE_TAG"
-if FAKE_TAG="v3.33.0" EXPECTED_RELEASE="$INVALID_TARGET" CHECK_VM=0 \
+if FAKE_TAG="$LATEST_TAG" EXPECTED_RELEASE="$INVALID_TARGET" CHECK_VM=0 \
   HARNESS_DIR="$TMP_DIR/harness" PATH="$TMP_DIR/bin:$PATH" \
   bash "$REPO_ROOT/scripts/ci/check-assay-version-line.sh" \
   >"$TMP_DIR/version-line-invalid-target.log" 2>&1


### PR DESCRIPTION
## Summary

Prepare the Assay `v3.35.0` release line after the release-channel and version-line contracts landed.

- bump the workspace and all workspace crates to `3.35.0`
- record the evidence-chain, profile/conformance, release-channel and sandbox-policy changes in the changelog
- update the roadmap release truth without adding new Runner runtime or eBPF semantics
- align release documentation and the tag-triggered release workflow with the 14-crate public publish contract
- bind the requested release tag to `workspace.package.version` in one fail-closed preflight before builds, wheels or publication
- pin Ruby 3.3.12 with Psych 5.1.2 for deterministic release-contract YAML parsing
- derive release-contract fixtures from the workspace version so the check remains valid at the release boundary
- keep RC and beta GitHub releases supported while excluding them from the official MCP Registry
- pin and SHA-256-verify mcp-publisher v1.7.9 before it executes with registry OIDC authority

## Behavior changes

- `assay sandbox --policy <path>` now exits 2 without execution when the named policy cannot load
- named policies with non-empty `extends` are refused because pack resolution is not implemented

These are fail-closed correctness and integrity fixes for requested enforcement that could not be honored, not removal of a supported enforcement contract. The documented default policy still applies only when no explicit `--policy` is named.

## Verification

- `bash scripts/ci/test-release-channel-separation.sh` under Ruby 3.3.12 / Psych 5.1.2
- `EXPECTED_RELEASE=v3.35.0 CHECK_VM=0 bash scripts/ci/check-assay-version-line.sh`
- `bash scripts/ci/check-public-crate-policy.sh`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/roelschuurkes/assay-v3.35.0-release-target cargo check --locked --workspace --all-targets`
- `pre-commit run --all-files`
- `git diff --check`
- `cargo package --locked -p <crate> --list` passed for each of the 14 public crates; actual publication remains the ordered, visibility-waiting `publish_idempotent.sh` path

Pre-tag semantics are intentional: the workspace targets `v3.35.0`; GitHub Latest and the self-hosted runner remain on public `v3.34.0` until the new release is published. The Harness default remains the separately proved `v3.27.0` compatibility baseline.

## Non-claims

This release does not add a scalar trust score, whole-action verdict, generic identity/federation layer, provider-outcome verification, broad MCP scanner, compliance claim, or new Assay-Runner runtime/eBPF semantics beyond the cgroup attribution already shipped in `v3.34.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `privileged-mcp-action/v0` evidence profile, with typed import and verification support.
  - Added targeted evidence-bundle fuzzing and deterministic property coverage.

- **Changes**
  - Enforced configured ingest limits before evidence materialization.
  - Strengthened stdio MCP authorization boundaries and startup validation.
  - Policy loading now fails before execution when requested composition cannot be enforced.

- **Bug Fixes**
  - Corrected sandbox policy composition and enforcement for unresolved extensions.
  - Improved release and MCP Registry publishing reliability.

- **Documentation**
  - Updated the changelog, roadmap, and release procedures for version 3.35.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->