### PR TITLE
fix(ci): keep docs update PR current

### DIFF
--- a/.github/workflows/assay-runner-lane-check.yml
+++ b/.github/workflows/assay-runner-lane-check.yml
@@ -12,6 +12,10 @@ on:
         description: "Pull request number to classify"
         required: true
         type: number
+      expected_head_sha:
+        description: "Expected PR head SHA"
+        required: false
+        type: string
 
 permissions: {}
 
@@ -68,12 +72,24 @@ jobs:
         if: steps.pr.outputs.pr_number != ''
         shell: bash
         env:
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           DELEGATED_WORKFLOW_RUN_ID: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || '' }}
         run: |
           set -euo pipefail
+          if [[ -n "$EXPECTED_HEAD_SHA" ]]; then
+            if [[ "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]]; then
+              echo "dispatched lane-check head ${GITHUB_SHA} does not match expected ${EXPECTED_HEAD_SHA}" >&2
+              exit 2
+            fi
+            pr_head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+            if [[ "$pr_head" != "$EXPECTED_HEAD_SHA" ]]; then
+              echo "PR #${PR_NUMBER} moved from ${EXPECTED_HEAD_SHA} to ${pr_head}" >&2
+              exit 2
+            fi
+          fi
           args=(--comment)
           if python3 scripts/ci/assay_runner_lane_check.py --help | grep -q -- "--status"; then
             args+=(--status)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [ main, "debug/**", "docs/auto-update" ]
   pull_request:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number for an exact-head docs-only run"
+        required: false
+        type: string
+      expected_head_sha:
+        description: "Expected head SHA for an exact-head docs-only run"
+        required: false
+        type: string
 
 permissions: {}
 
@@ -14,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       lightweight_only: ${{ steps.detect.outputs.lightweight_only }}
       changed_file_count: ${{ steps.detect.outputs.changed_file_count }}
@@ -28,11 +38,43 @@ jobs:
 
       - id: detect
         shell: bash
+        env:
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           changed_file="$RUNNER_TEMP/changed_files.txt"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" &&
+                -n "$DISPATCH_PR_NUMBER" ]]; then
+            if [[ -z "$EXPECTED_HEAD_SHA" ||
+                  "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]]; then
+              echo "dispatched CI head ${GITHUB_SHA} does not match expected ${EXPECTED_HEAD_SHA:-<empty>}" >&2
+              exit 2
+            fi
+            pr_head="$(
+              gh api "repos/${GITHUB_REPOSITORY}/pulls/${DISPATCH_PR_NUMBER}" \
+                --jq '.head.sha'
+            )"
+            if [[ "$pr_head" != "$EXPECTED_HEAD_SHA" ]]; then
+              echo "PR #${DISPATCH_PR_NUMBER} moved from ${EXPECTED_HEAD_SHA} to ${pr_head}" >&2
+              exit 2
+            fi
+            gh api \
+              --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${DISPATCH_PR_NUMBER}/files?per_page=100" \
+              --jq '.[].filename' > "$changed_file"
+            if [[ ! -s "$changed_file" ]] ||
+              grep -Ev '^(docs/|.*\.md$|mkdocs\.yml$)' "$changed_file" >/dev/null; then
+              echo "workflow_dispatch PR must contain a non-empty docs-only file set" >&2
+              exit 2
+            fi
+            lightweight_only=true
+            mcp_registry_touched=false
+            ebpf_smoke_required=false
+            self_hosted_ebpf_required=false
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             : > "$changed_file"
             lightweight_only=false
             mcp_registry_touched=false

--- a/.github/workflows/docs-auto-update.yml
+++ b/.github/workflows/docs-auto-update.yml
@@ -3,10 +3,6 @@ name: Auto-Update Docs
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/workflows/docs-auto-update.yml"
   workflow_dispatch:
     inputs:
       force_update:
@@ -14,6 +10,10 @@ on:
         required: false
         default: false
         type: boolean
+
+concurrency:
+  group: docs-auto-update
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -25,7 +25,7 @@ jobs:
     # Only run on main repo, not forks
     if: github.repository == 'Rul1an/assay'
     permissions:
-      checks: write # publish the required CI check on generated docs PRs
+      actions: write # dispatch the canonical required-check workflows
       contents: write # create-pull-request commits docs changes to docs/auto-update
       pull-requests: write # create and auto-merge the generated docs PR
     steps:
@@ -99,38 +99,47 @@ jobs:
           delete-branch: true
           labels: documentation,automated
 
-      - name: Publish required CI check for docs PR
-        if: steps.changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pull-request-number != ''
+      - name: Reconcile existing docs PR with main
+        id: reconcile_pr
+        env:
+          EXPECTED_BASE_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: bash scripts/ci/reconcile-docs-auto-pr.sh
+
+      - name: Dispatch required workflows for reconciled docs head
+        if: >-
+          steps.reconcile_pr.outputs.pr_number != '' &&
+          (steps.changes.outputs.has_changes == 'true' ||
+          steps.reconcile_pr.outputs.branch_updated == 'true' ||
+          (github.event_name == 'workflow_dispatch' && inputs.force_update))
         env:
           GH_TOKEN: ${{ github.token }}
-          CREATED_PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+          BRANCH: docs/auto-update
+          EXPECTED_HEAD_SHA: ${{ steps.reconcile_pr.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.reconcile_pr.outputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
-          pr_number="${CREATED_PR_NUMBER}"
-          head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid')"
-          payload_file="$(mktemp)"
-          jq -n \
-            --arg head_sha "$head_sha" \
-            --arg summary "Generated docs-only update; required CI satisfied by docs-auto-update workflow." \
-            '{
-              name: "CI",
-              head_sha: $head_sha,
-              status: "completed",
-              conclusion: "success",
-              output: {
-                title: "CI",
-                summary: $summary
-              }
-            }' > "$payload_file"
-          gh api "repos/${REPO}/check-runs" \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            --input "$payload_file"
-          rm -f "$payload_file"
+          set -euo pipefail
+          gh workflow run ci.yml \
+            --repo "$REPO" \
+            --ref "$BRANCH" \
+            -f "pr_number=${PR_NUMBER}" \
+            -f "expected_head_sha=${EXPECTED_HEAD_SHA}"
+          gh workflow run assay-runner-lane-check.yml \
+            --repo "$REPO" \
+            --ref "$BRANCH" \
+            -f "pr_number=${PR_NUMBER}" \
+            -f "expected_head_sha=${EXPECTED_HEAD_SHA}"
+          gh workflow run host-capability-check.yml \
+            --repo "$REPO" \
+            --ref "$BRANCH" \
+            -f "pr_number=${PR_NUMBER}" \
+            -f "expected_head_sha=${EXPECTED_HEAD_SHA}"
 
       - name: Enable auto-merge for docs PR
-        if: steps.changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pull-request-number != ''
+        if: steps.reconcile_pr.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          CREATED_PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+          CREATED_PR_NUMBER: ${{ steps.reconcile_pr.outputs.pr_number }}
         run: gh pr merge "$CREATED_PR_NUMBER" --auto --squash

--- a/.github/workflows/host-capability-check.yml
+++ b/.github/workflows/host-capability-check.yml
@@ -10,6 +10,16 @@ name: Host Capability Check
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to classify"
+        required: true
+        type: number
+      expected_head_sha:
+        description: "Expected PR head SHA"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -34,5 +44,20 @@ jobs:
       - name: Validate host-capability proof
         shell: bash
         env:
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/ci/assay_host_capability_check.py --pr "${{ github.event.pull_request.number }}"
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$EXPECTED_HEAD_SHA" ]]; then
+            if [[ "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]]; then
+              echo "dispatched host-capability head ${GITHUB_SHA} does not match expected ${EXPECTED_HEAD_SHA}" >&2
+              exit 2
+            fi
+            pr_head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+            if [[ "$pr_head" != "$EXPECTED_HEAD_SHA" ]]; then
+              echo "PR #${PR_NUMBER} moved from ${EXPECTED_HEAD_SHA} to ${pr_head}" >&2
+              exit 2
+            fi
+          fi
+          python3 scripts/ci/assay_host_capability_check.py --pr "$PR_NUMBER"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/assay_runner_lane_check\.py|scripts/ci/assay_runner_gated_paths\.json|\.github/workflows/assay-runner-lane-check\.yml|\.pre-commit-config\.yaml)$
 
+      - id: docs-auto-update-reconcile-self-test
+        name: Docs auto-update reconciliation self-test
+        entry: bash scripts/ci/test-reconcile-docs-auto-pr.sh
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/(reconcile-docs-auto-pr|test-reconcile-docs-auto-pr)\.sh|\.github/workflows/(docs-auto-update|ci|assay-runner-lane-check|host-capability-check)\.yml|\.pre-commit-config\.yaml)$
+
   # shellcheck (bash) — use system binary to avoid SSL/download issues
   - repo: local
     hooks:

--- a/scripts/ci/reconcile-docs-auto-pr.sh
+++ b/scripts/ci/reconcile-docs-auto-pr.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${EXPECTED_BASE_SHA:?EXPECTED_BASE_SHA is required}"
+
+BRANCH="${BRANCH:-docs/auto-update}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-12}"
+RETRY_SECONDS="${RETRY_SECONDS:-5}"
+
+write_output() {
+  printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+}
+
+live_base_sha() {
+  gh api "repos/${REPO}/commits/${BASE_BRANCH}" --jq '.sha'
+}
+
+observed_base="$(live_base_sha)"
+if [[ "$observed_base" != "$EXPECTED_BASE_SHA" ]]; then
+  echo "main advanced from ${EXPECTED_BASE_SHA} to ${observed_base}; refusing stale docs generation" >&2
+  exit 2
+fi
+
+pr_json="$(
+  gh pr list \
+    --repo "$REPO" \
+    --state open \
+    --head "$BRANCH" \
+    --base "$BASE_BRANCH" \
+    --json number
+)"
+
+pr_count="$(jq 'length' <<<"$pr_json")"
+if [[ "$pr_count" -eq 0 ]]; then
+  write_output pr_number ""
+  write_output head_sha ""
+  write_output branch_updated false
+  echo "No open ${BRANCH} pull request."
+  exit 0
+fi
+
+if [[ "$pr_count" -ne 1 ]]; then
+  echo "expected exactly one open docs PR for ${BRANCH}; found ${pr_count}" >&2
+  exit 2
+fi
+
+pr_number="$(jq -r '.[0].number' <<<"$pr_json")"
+repo_owner="${REPO%%/*}"
+initial_head=""
+head_sha=""
+merge_state="UNKNOWN"
+update_requested=false
+last_requested_head=""
+stable=false
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  current="$(
+    gh pr view "$pr_number" \
+      --repo "$REPO" \
+      --json \
+author,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,mergeStateStatus
+  )"
+
+  author_login="$(jq -r '.author.login' <<<"$current")"
+  base_ref="$(jq -r '.baseRefName' <<<"$current")"
+  base_sha="$(jq -r '.baseRefOid' <<<"$current")"
+  head_ref="$(jq -r '.headRefName' <<<"$current")"
+  head_sha="$(jq -r '.headRefOid' <<<"$current")"
+  head_owner="$(jq -r '.headRepositoryOwner.login' <<<"$current")"
+  cross_repo="$(jq -r '.isCrossRepository' <<<"$current")"
+  merge_state="$(jq -r '.mergeStateStatus' <<<"$current")"
+
+  if [[ "$author_login" != "app/github-actions" ||
+        "$base_ref" != "$BASE_BRANCH" ||
+        "$head_ref" != "$BRANCH" ||
+        "$head_owner" != "$repo_owner" ||
+        "$cross_repo" != "false" ]]; then
+    echo "docs PR #${pr_number} has unexpected author, repository, or branch identity" >&2
+    exit 2
+  fi
+  if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
+    echo "docs PR #${pr_number} is missing its head SHA" >&2
+    exit 2
+  fi
+  [[ -n "$initial_head" ]] || initial_head="$head_sha"
+
+  case "$merge_state" in
+    CLEAN | BLOCKED | UNSTABLE | HAS_HOOKS)
+      if [[ "$base_sha" != "$EXPECTED_BASE_SHA" ]]; then
+        echo "docs PR #${pr_number} is stable on base ${base_sha}, expected ${EXPECTED_BASE_SHA}" >&2
+        exit 2
+      fi
+      stable=true
+      break
+      ;;
+    BEHIND)
+      if [[ "$head_sha" != "$last_requested_head" ]]; then
+        gh api \
+          --method PUT \
+          "repos/${REPO}/pulls/${pr_number}/update-branch" \
+          -f "expected_head_sha=${head_sha}" >/dev/null
+        update_requested=true
+        last_requested_head="$head_sha"
+      fi
+      ;;
+    UNKNOWN)
+      ;;
+    DIRTY)
+      echo "docs PR #${pr_number} has merge state DIRTY; refusing automatic update" >&2
+      exit 2
+      ;;
+    *)
+      echo "docs PR #${pr_number} has unsupported merge state ${merge_state}" >&2
+      exit 2
+      ;;
+  esac
+
+  sleep "$RETRY_SECONDS"
+done
+
+if [[ "$stable" != "true" ]]; then
+  echo "docs PR #${pr_number} did not reach a stable merge state" >&2
+  exit 2
+fi
+if [[ "$update_requested" == "true" && "$head_sha" == "$initial_head" ]]; then
+  echo "docs PR #${pr_number} did not advance from ${initial_head}" >&2
+  exit 2
+fi
+
+files_json="$(
+  gh api \
+    --paginate \
+    --slurp \
+    "repos/${REPO}/pulls/${pr_number}/files?per_page=100"
+)"
+if ! jq -e '
+  type == "array" and
+  length > 0 and
+  all(.[]; type == "array") and
+  ([.[][]] | length > 0)
+' >/dev/null <<<"$files_json"; then
+  echo "docs PR #${pr_number} returned an invalid or empty files response" >&2
+  exit 2
+fi
+
+non_docs="$(jq -c '[.[][] | .filename | select(startswith("docs/") | not)]' <<<"$files_json")"
+if [[ "$non_docs" != "[]" ]]; then
+  echo "docs PR #${pr_number} contains non-doc paths: ${non_docs}" >&2
+  exit 2
+fi
+
+final_state="$(
+  gh pr view "$pr_number" \
+    --repo "$REPO" \
+    --json baseRefOid,headRefOid
+)"
+final_head="$(jq -r '.headRefOid' <<<"$final_state")"
+final_base="$(jq -r '.baseRefOid' <<<"$final_state")"
+if [[ "$final_head" != "$head_sha" ]]; then
+  echo "docs PR #${pr_number} moved from ${head_sha} to ${final_head} during validation" >&2
+  exit 2
+fi
+if [[ "$final_base" != "$EXPECTED_BASE_SHA" ]]; then
+  echo "docs PR #${pr_number} ended on base ${final_base}, expected ${EXPECTED_BASE_SHA}" >&2
+  exit 2
+fi
+observed_base="$(live_base_sha)"
+if [[ "$observed_base" != "$EXPECTED_BASE_SHA" ]]; then
+  echo "main advanced from ${EXPECTED_BASE_SHA} to ${observed_base} during validation" >&2
+  exit 2
+fi
+
+write_output pr_number "$pr_number"
+write_output head_sha "$head_sha"
+write_output branch_updated "$update_requested"
+
+echo "Docs PR #${pr_number}: head=${head_sha} state=${merge_state} updated=${update_requested}"

--- a/scripts/ci/test-reconcile-docs-auto-pr.sh
+++ b/scripts/ci/test-reconcile-docs-auto-pr.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/ci/reconcile-docs-auto-pr.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_line() {
+  grep -Fxq "$2" "$1" || fail "missing '$2' in $1"
+}
+
+valid_view() {
+  local number="$1"
+  local head="$2"
+  local state="$3"
+  local base="${4:-base-main}"
+  jq -cn \
+    --argjson number "$number" \
+    --arg head "$head" \
+    --arg state "$state" \
+    --arg base "$base" \
+    '{
+      number: $number,
+      author: {login: "app/github-actions"},
+      baseRefName: "main",
+      baseRefOid: $base,
+      headRefName: "docs/auto-update",
+      headRefOid: $head,
+      headRepositoryOwner: {login: "Rul1an"},
+      isCrossRepository: false,
+      mergeStateStatus: $state
+    }'
+}
+
+run_case() {
+  local name="$1"
+  local list_json="$2"
+  local view_jsonl="${3:-}"
+  local files_json="${4:-}"
+  local expect_success="${5:-true}"
+  local live_base="${6:-base-main}"
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  [[ -n "$files_json" ]] || files_json='[[{"filename":"docs/generated.md"}]]'
+
+  mkdir -p "${temp_dir}/bin"
+  cat > "${temp_dir}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+case "$1 $2" in
+  "pr list")
+    printf '%s\n' "$FAKE_LIST_JSON"
+    ;;
+  "pr view")
+    count="$(cat "$FAKE_VIEW_COUNT")"
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$FAKE_VIEW_COUNT"
+    response="$(sed -n "${count}p" "$FAKE_VIEW_FILE")"
+    [[ -n "$response" ]] || response="$(tail -n 1 "$FAKE_VIEW_FILE")"
+    if [[ " $* " == *" --jq .headRefOid "* ]]; then
+      jq -r '.headRefOid' <<<"$response"
+    else
+      printf '%s\n' "$response"
+    fi
+    ;;
+  "api --paginate")
+    printf '%s\n' "$FAKE_FILES_JSON"
+    ;;
+  "api --method")
+    printf '%s\n' '{"message":"Updating pull request branch."}'
+    ;;
+  *)
+    if [[ "$1" == "api" && "$2" == repos/*/commits/* ]]; then
+      count="$(cat "$FAKE_BASE_COUNT")"
+      count=$((count + 1))
+      printf '%s\n' "$count" > "$FAKE_BASE_COUNT"
+      response="$(sed -n "${count}p" "$FAKE_BASE_FILE")"
+      [[ -n "$response" ]] || response="$(tail -n 1 "$FAKE_BASE_FILE")"
+      printf '%s\n' "$response"
+    else
+      echo "unexpected gh invocation: $*" >&2
+      exit 91
+    fi
+    ;;
+esac
+EOF
+  chmod +x "${temp_dir}/bin/gh"
+
+  export FAKE_GH_LOG="${temp_dir}/gh.log"
+  export FAKE_LIST_JSON="$list_json"
+  export FAKE_VIEW_FILE="${temp_dir}/view.jsonl"
+  export FAKE_VIEW_COUNT="${temp_dir}/view.count"
+  export FAKE_FILES_JSON="$files_json"
+  export FAKE_BASE_FILE="${temp_dir}/base-sha.txt"
+  export FAKE_BASE_COUNT="${temp_dir}/base-sha.count"
+  export GITHUB_OUTPUT="${temp_dir}/outputs"
+  printf '%s\n' "$view_jsonl" > "$FAKE_VIEW_FILE"
+  printf '0\n' > "$FAKE_VIEW_COUNT"
+  printf '%s\n' "$live_base" > "$FAKE_BASE_FILE"
+  printf '0\n' > "$FAKE_BASE_COUNT"
+
+  if PATH="${temp_dir}/bin:${PATH}" \
+    EXPECTED_BASE_SHA="base-main" \
+    REPO="Rul1an/assay" \
+    MAX_ATTEMPTS=3 \
+    RETRY_SECONDS=0 \
+    bash "$SCRIPT" >"${temp_dir}/stdout" 2>"${temp_dir}/stderr"; then
+    [[ "$expect_success" == "true" ]] || fail "$name unexpectedly succeeded"
+  else
+    [[ "$expect_success" == "false" ]] || {
+      cat "${temp_dir}/stderr" >&2
+      fail "$name unexpectedly failed"
+    }
+  fi
+
+  CASE_DIR="$temp_dir"
+}
+
+cleanup_case() {
+  rm -rf "$CASE_DIR"
+}
+
+run_case "no PR" '[]'
+assert_line "$GITHUB_OUTPUT" "pr_number="
+assert_line "$GITHUB_OUTPUT" "head_sha="
+assert_line "$GITHUB_OUTPUT" "branch_updated=false"
+! grep -q '^api --method' "$FAKE_GH_LOG" || fail "no-PR case updated a branch"
+cleanup_case
+
+run_case "current PR" '[{"number":42}]' "$(valid_view 42 head-current CLEAN)"
+assert_line "$GITHUB_OUTPUT" "pr_number=42"
+assert_line "$GITHUB_OUTPUT" "head_sha=head-current"
+assert_line "$GITHUB_OUTPUT" "branch_updated=false"
+! grep -q '^api --method' "$FAKE_GH_LOG" || fail "current PR updated a branch"
+cleanup_case
+
+run_case "behind PR" \
+  '[{"number":43}]' \
+  "$(valid_view 43 head-old BEHIND base-old)
+$(valid_view 43 head-new BLOCKED)"
+assert_line "$GITHUB_OUTPUT" "head_sha=head-new"
+assert_line "$GITHUB_OUTPUT" "branch_updated=true"
+grep -Fq "expected_head_sha=head-old" "$FAKE_GH_LOG" ||
+  fail "update was not bound to the observed head"
+cleanup_case
+
+run_case "raced update" \
+  '[{"number":44}]' \
+  "$(valid_view 44 head-old BEHIND base-old)
+$(valid_view 44 head-raced BEHIND base-raced)
+$(valid_view 44 head-current BLOCKED)"
+assert_line "$GITHUB_OUTPUT" "head_sha=head-current"
+[[ "$(grep -c '^api --method' "$FAKE_GH_LOG")" -eq 2 ]] ||
+  fail "raced BEHIND head was not reconciled again"
+grep -Fq "expected_head_sha=head-raced" "$FAKE_GH_LOG" ||
+  fail "second update was not bound to the raced head"
+cleanup_case
+
+run_case "same update remains in flight" \
+  '[{"number":54}]' \
+  "$(valid_view 54 head-old BEHIND base-old)
+$(valid_view 54 head-old BEHIND base-old)
+$(valid_view 54 head-new BLOCKED)"
+assert_line "$GITHUB_OUTPUT" "head_sha=head-new"
+[[ "$(grep -c '^api --method' "$FAKE_GH_LOG")" -eq 1 ]] ||
+  fail "same in-flight head received duplicate update requests"
+cleanup_case
+
+run_case "unknown then behind" \
+  '[{"number":45}]' \
+  "$(valid_view 45 head-old UNKNOWN base-old)
+$(valid_view 45 head-old BEHIND base-old)
+$(valid_view 45 head-new CLEAN)"
+assert_line "$GITHUB_OUTPUT" "head_sha=head-new"
+assert_line "$GITHUB_OUTPUT" "branch_updated=true"
+cleanup_case
+
+run_case "unknown stays unknown" \
+  '[{"number":46}]' \
+  "$(valid_view 46 head-old UNKNOWN)" \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false
+grep -Fq "did not reach a stable merge state" "$CASE_DIR/stderr" ||
+  fail "persistent UNKNOWN diagnostic missing"
+cleanup_case
+
+run_case "dirty PR" \
+  '[{"number":47}]' \
+  "$(valid_view 47 head-dirty DIRTY)" \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false
+grep -Fq "merge state DIRTY" "$CASE_DIR/stderr" ||
+  fail "DIRTY diagnostic missing"
+cleanup_case
+
+run_case "update did not advance" \
+  '[{"number":52}]' \
+  "$(valid_view 52 head-stuck BEHIND)
+$(valid_view 52 head-stuck CLEAN)" \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false
+grep -Fq "did not advance from head-stuck" "$CASE_DIR/stderr" ||
+  fail "stuck update diagnostic missing"
+cleanup_case
+
+run_case "duplicate PRs" \
+  '[{"number":48},{"number":49}]' \
+  '' \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false
+grep -Fq "expected exactly one open docs PR" "$CASE_DIR/stderr" ||
+  fail "duplicate PR diagnostic missing"
+cleanup_case
+
+run_case "non-doc change" \
+  '[{"number":50}]' \
+  "$(valid_view 50 head-source CLEAN)" \
+  '[[{"filename":"docs/generated.md"},{"filename":"src/main.rs"}]]' \
+  false
+grep -Fq "contains non-doc paths" "$CASE_DIR/stderr" ||
+  fail "non-doc diagnostic missing"
+cleanup_case
+
+cross_repo="$(
+  valid_view 51 head-fork CLEAN |
+    jq -c '.isCrossRepository = true | .headRepositoryOwner.login = "attacker"'
+)"
+run_case "cross-repository PR" \
+  '[{"number":51}]' \
+  "$cross_repo" \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false
+grep -Fq "unexpected author, repository, or branch identity" "$CASE_DIR/stderr" ||
+  fail "cross-repository diagnostic missing"
+cleanup_case
+
+run_case "main advanced during generation" \
+  '[{"number":55}]' \
+  "$(valid_view 55 head-current CLEAN)" \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false \
+  base-new
+grep -Fq "main advanced from base-main to base-new" "$CASE_DIR/stderr" ||
+  fail "stale generation diagnostic missing"
+cleanup_case
+
+run_case "main advances during validation" \
+  '[{"number":56}]' \
+  "$(valid_view 56 head-current CLEAN)" \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false \
+  "base-main
+base-new"
+grep -Fq "main advanced from base-main to base-new during validation" "$CASE_DIR/stderr" ||
+  fail "final base-race diagnostic missing"
+cleanup_case
+
+run_case "head moves during file validation" \
+  '[{"number":53}]' \
+  "$(valid_view 53 head-validated CLEAN)
+$(valid_view 53 head-moved CLEAN)" \
+  '[[{"filename":"docs/generated.md"}]]' \
+  false
+grep -Fq "moved from head-validated to head-moved during validation" "$CASE_DIR/stderr" ||
+  fail "post-file-validation head race diagnostic missing"
+cleanup_case
+
+check_workflow_contract() {
+  # shellcheck disable=SC2016 # Ruby source and GitHub expressions are literal.
+  ruby -ryaml -e '
+    def load_yaml(path)
+      YAML.safe_load_file(path, aliases: false)
+    end
+
+    docs, ci, lane, host = ARGV.map { |path| load_yaml(path) }
+    docs_on = docs["on"] || docs[true]
+    ci_on = ci["on"] || ci[true]
+    lane_on = lane["on"] || lane[true]
+    host_on = host["on"] || host[true]
+
+    abort("docs workflow must run on every main push") unless
+      docs_on.dig("push", "branches") == ["main"] && !docs_on.dig("push").key?("paths-ignore")
+    abort("docs workflow must cancel stale generation") unless
+      docs.dig("concurrency", "group") == "docs-auto-update" &&
+      docs.dig("concurrency", "cancel-in-progress") == true
+    abort("docs workflow needs actions: write") unless
+      docs.dig("jobs", "generate-docs", "permissions", "actions") == "write"
+    abort("docs workflow must not synthesize checks") if
+      docs.dig("jobs", "generate-docs", "permissions").key?("checks")
+
+    docs_steps = docs.dig("jobs", "generate-docs", "steps")
+    reconcile = docs_steps.find { |step| step["name"] == "Reconcile existing docs PR with main" }
+    abort("reconciliation is not bound to the generation base") unless
+      reconcile && reconcile.dig("env", "EXPECTED_BASE_SHA").to_s.include?("github.sha")
+    dispatch = docs_steps.find { |step| step["name"] == "Dispatch required workflows for reconciled docs head" }
+    abort("missing required-workflow dispatch step") unless dispatch
+    dispatch_if = dispatch["if"].to_s
+    %w[has_changes branch_updated force_update].each do |term|
+      abort("dispatch condition missing #{term}") unless dispatch_if.include?(term)
+    end
+    dispatch_run = dispatch["run"].to_s
+    %w[ci.yml assay-runner-lane-check.yml host-capability-check.yml].each do |workflow|
+      abort("missing dispatch for #{workflow}") unless
+        dispatch_run.include?("gh workflow run #{workflow}")
+    end
+    abort("dispatches are not branch-bound") unless
+      dispatch_run.scan(%r{--ref "\$BRANCH"}).length == 3
+    abort("dispatches are not expected-head-bound") unless
+      dispatch_run.scan(/expected_head_sha=/).length == 3 &&
+      dispatch.dig("env", "EXPECTED_HEAD_SHA").to_s.include?("reconcile_pr.outputs.head_sha")
+    abort("docs workflow still creates required check-runs") if
+      dispatch_run.include?("check-runs")
+
+    ci_inputs = ci_on.dig("workflow_dispatch", "inputs")
+    abort("CI dispatch inputs missing") unless
+      ci_inputs.key?("pr_number") && ci_inputs.key?("expected_head_sha")
+    abort("CI scope lacks pull-request read permission") unless
+      ci.dig("jobs", "scope", "permissions", "pull-requests") == "read"
+    ci_run = ci.dig("jobs", "scope", "steps").find { |step| step["id"] == "detect" }["run"].to_s
+    %w[GITHUB_SHA EXPECTED_HEAD_SHA pulls/ files?per_page=100].each do |term|
+      abort("CI dispatch guard missing #{term}") unless ci_run.include?(term)
+    end
+
+    lane_inputs = lane_on.dig("workflow_dispatch", "inputs")
+    abort("lane expected-head input missing") unless lane_inputs.key?("expected_head_sha")
+    lane_run = lane.dig("jobs", "lane-check", "steps")
+      .find { |step| step["name"] == "Check PR delegated lane proof" }["run"].to_s
+    %w[GITHUB_SHA EXPECTED_HEAD_SHA pulls/].each do |term|
+      abort("lane dispatch guard missing #{term}") unless lane_run.include?(term)
+    end
+
+    host_inputs = host_on.dig("workflow_dispatch", "inputs")
+    abort("host dispatch inputs missing") unless
+      host_inputs.key?("pr_number") && host_inputs.key?("expected_head_sha")
+    host_run = host.dig("jobs", "check", "steps")
+      .find { |step| step["name"] == "Validate host-capability proof" }["run"].to_s
+    %w[GITHUB_SHA EXPECTED_HEAD_SHA pulls/].each do |term|
+      abort("host dispatch guard missing #{term}") unless host_run.include?(term)
+    end
+  ' "$@"
+}
+
+DOCS_WORKFLOW="${ROOT}/.github/workflows/docs-auto-update.yml"
+CI_WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+LANE_WORKFLOW="${ROOT}/.github/workflows/assay-runner-lane-check.yml"
+HOST_WORKFLOW="${ROOT}/.github/workflows/host-capability-check.yml"
+
+check_workflow_contract \
+  "$DOCS_WORKFLOW" \
+  "$CI_WORKFLOW" \
+  "$LANE_WORKFLOW" \
+  "$HOST_WORKFLOW"
+
+mutation_dir="$(mktemp -d)"
+trap 'rm -rf "$mutation_dir"' EXIT
+cp "$DOCS_WORKFLOW" "$mutation_dir/docs.yml"
+cp "$CI_WORKFLOW" "$mutation_dir/ci.yml"
+cp "$LANE_WORKFLOW" "$mutation_dir/lane.yml"
+cp "$HOST_WORKFLOW" "$mutation_dir/host.yml"
+
+ruby -pi -e 'sub("cancel-in-progress: true", "cancel-in-progress: false")' \
+  "$mutation_dir/docs.yml"
+if check_workflow_contract \
+  "$mutation_dir/docs.yml" \
+  "$mutation_dir/ci.yml" \
+  "$mutation_dir/lane.yml" \
+  "$mutation_dir/host.yml" >/dev/null 2>&1; then
+  fail "workflow contract accepted stale-run concurrency"
+fi
+
+cp "$DOCS_WORKFLOW" "$mutation_dir/docs.yml"
+ruby -pi -e \
+  'sub("gh workflow run host-capability-check.yml", "echo skipped-host-workflow")' \
+  "$mutation_dir/docs.yml"
+if check_workflow_contract \
+  "$mutation_dir/docs.yml" \
+  "$mutation_dir/ci.yml" \
+  "$mutation_dir/lane.yml" \
+  "$mutation_dir/host.yml" >/dev/null 2>&1; then
+  fail "workflow contract accepted a missing canonical dispatch"
+fi
+
+cp "$DOCS_WORKFLOW" "$mutation_dir/docs.yml"
+ruby -pi -e 'gsub("expected_head_sha=", "unbound_head_sha=")' \
+  "$mutation_dir/docs.yml"
+if check_workflow_contract \
+  "$mutation_dir/docs.yml" \
+  "$mutation_dir/ci.yml" \
+  "$mutation_dir/lane.yml" \
+  "$mutation_dir/host.yml" >/dev/null 2>&1; then
+  fail "workflow contract accepted an unbound dispatch"
+fi
+
+echo "docs auto-update reconciliation tests passed"


### PR DESCRIPTION
## Summary

- reconcile the singleton `docs/auto-update` PR on every `main` push, including non-doc changes that can leave generated docs behind
- cancel stale generation, bind reconciliation to the triggering `main` SHA, and compare-and-swap branch updates without repeating an in-flight request
- validate the bot-owned same-repository PR and require a non-empty docs-only file set before triggering CI
- dispatch the canonical `CI`, `lane-check`, and `host-capability-check` workflows on the docs branch, with each workflow enforcing both the expected SHA and the live PR head
- leave branch protection and auto-merge as the final authority; no duplicate or synthetic required contexts are created

Closes #1857.

## Verification

- `bash scripts/ci/test-reconcile-docs-auto-pr.sh`
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `python3 scripts/ci/assay_host_capability_check.py --self-test`
- focused `pre-commit run --files ...` over all seven changed files
- `actionlint` over all four changed workflows (with the repository’s documented `concurrency.queue` compatibility ignore)
- `zizmor` over the newly privileged docs, CI, and host workflows: no findings
- `shellcheck scripts/ci/reconcile-docs-auto-pr.sh scripts/ci/test-reconcile-docs-auto-pr.sh`
- pre-push workspace clippy and Linux compile gate

The helper tests cover current, behind, raced, same-head in-flight, unknown, dirty, stale-base, moved-head, duplicate, cross-repository, non-doc, and non-advancing cases. A structural YAML contract check plus negative mutations pins stale-run cancellation, all three canonical dispatches, and exact-head binding.

## Claim boundary

This closes the stale-branch deadlock only for the repository-owned docs update PR. It does not relax branch protection, create synthetic required checks, generalize to arbitrary pull requests, or claim success before the canonical workflows finish. Final acceptance requires a live generated docs PR to reconcile, receive the three required contexts from their existing workflow producers on its final head, and merge unattended.