### PR TITLE
docs(agents): repair two regressions from #1865 and harden the quorum against non-reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,15 +53,16 @@ including its explicit non-claims, or amend the decision through a new ADR.
 - Never turn absence of evidence, failed validation, skipped review, or unavailable infrastructure
   into a clean result.
 - Keep public strings free of private strategy, product-roadmap language, and unearned claims.
-- Stage by explicit pathspec. Never stage by the absence of one: bare `git add -A`, bare `git add .`,
-  `git add -u`, and `git commit -a`/`-am` all commit whatever the tree happens to be carrying at that
-  moment, which is a property of the moment and not of the change under review. A pathspec scopes the
-  command back to the change, so `git add -A demo/output` is fine and `git add -A` is not.
-- Pin a tool version in one place, and have both the install and the invocation read that one value —
-  as `.github/workflows/fuzz-smoke.yml` does with `env: FUZZ_TOOLCHAIN`. Two literals that must agree
-  will eventually disagree. Echo the value in the run so a version claim can be checked against the
-  log, while remembering what that check does not cover: the same workflow records a `cargo +nightly`
-  bypass that leaves the log still naming the pinned toolchain.
+- Stage with a pathspec that names the change. The test is whether the command could pick up a file
+  you did not touch: if it could, it commits a property of the moment rather than the change under
+  review. `git add -A <paths the change touches>` passes; `git add -A`, `git add -A .`, `git add .`,
+  `git add -u` and `git commit -am` all fail it. The list is illustrative and the test is the rule —
+  the set of ways to stage a whole tree is open, so enumerating it would only look complete.
+- Pin a tool version in one place, and have both the install and the invocation read that one value.
+  The defect is two literals that must agree and are free to drift — an install pinning a version that
+  a config file or a second workflow states again. Echo the value in the run so a version claim can be
+  checked against the log, while remembering what that check does not cover: an invocation can select
+  a different toolchain through an alias while the log still names the pinned one.
 
 ## Review Quorum
 
@@ -71,7 +72,14 @@ The builder's self-review does not count. On the final head SHA, require:
 2. if both bots are skipped, rate-limited, or unavailable for 30 minutes after the last push, two
    non-building agent reviews.
 
-`skipped` is not `pass`. A new push invalidates reviews on the prior head.
+`skipped` is not `pass`. A new push invalidates reviews on the prior head, and the head a review was
+measured on is the head it counts for — a merge commit that brings `main` into the branch is a new
+head like any other.
+
+A review record that says it did not review is not a review. A bot that returns `COMMENTED` with
+"unable to review — quota limit", or a check that reports `pass` alongside "review rate limited",
+leaves no findings and no reviewer; it is unavailable infrastructure wearing the shape of a verdict,
+and it satisfies neither route. Read what a record says, not that it exists.
 
 Auto-merge may be enabled only when:
 
@@ -96,20 +104,21 @@ Before pushing:
 - run clippy with `-D warnings` for the affected targets;
 - inspect `git diff --check` and the public-surface strings.
 
+GitHub Actions is the final integration proof. Never weaken, bypass, or relabel a required check to
+make a branch mergeable.
+
 ### Measurement provenance
 
 A measurement carries its provenance, or it is a claim with extra steps. When a number, a count, or a
-pass/fail reaches a PR body, a review, or a programme-ledger entry, it states the exact SHA it was
-measured on — not a branch name, which moves and which is how a stale checkout passes for a current
-one — plus the worktree when more than one is active, and the binary or toolchain when the number
-depends on one.
+pass/fail reaches a PR body, a review, or a programme-ledger entry, it states the exact SHA the
+reported tree was committed as — not a branch name, which moves and which is how a stale checkout
+passes for a current one — plus the worktree when more than one is active, and the binary or toolchain
+when the number depends on one. Measuring before the push is the normal case; commit first and report
+that SHA, rather than reporting a tree no one else can address.
 
 The failure mode this catches is not arithmetic but attribution: the number is right and the tree,
 ref, artifact, or build it describes is not. Name the artifact too when a generated form exists, since
 a correct reading of a generated layer is still the wrong layer.
-
-GitHub Actions is the final integration proof. Never weaken, bypass, or relabel a required check to
-make a branch mergeable.
 
 ## Tool Boundaries
 


### PR DESCRIPTION
Four changes to `AGENTS.md`, and they are not the same kind of thing. **Two are
regressions that #1865 shipped** — look there first.

| # | Kind | What |
|---|---|---|
| 1 | **regression** | `### Measurement provenance` captured the required-check rule |
| 2 | **regression** | the staging rule enumerated an open shell surface |
| 3 | new rule | a review record that says it did not review is not a review |
| 4 | clarification | pre-push measurements: commit first, report that SHA |

## 1. Regression — a docs change weakened the rule against weakening things

At `f0344b29`, "GitHub Actions is the final integration proof. Never weaken, bypass,
or relabel a required check to make a branch mergeable" sat directly under
`## Verification`. #1865 inserted `### Measurement provenance` above it, so at
`62c1d361` that paragraph falls inside a subsection about attributing numbers
(`AGENTS.md:99` heading, `:111-112` paragraph, next `##` at `:114`).

This is live on `main` now. A bot summary on #1865 had already misfiled the rule as a
contribution-practices note, which is the failure in miniature: a reader takes its
scope from the heading above it. The paragraph moves back above the subsection.

## 2. Regression — the staging rule listed forms instead of stating a test

The merged text names four forms and then gives a principle. `git add -A .` and
`git add -A :/` both carry a pathspec, both satisfy the principle as written, and
both stage the whole tree — the original incident class, reachable through a
spelling the list does not name. `git add --all` and `git stage -A` are unnamed too.

The rule is now the test, with the list explicitly illustrative:

> Stage with a pathspec that names the change. The test is whether the command could
> pick up a file you did not touch.

Same lesson as an open union in a schema: do not encode a closed set where the
surface is open. The `demo/output` example becomes a placeholder — a concrete
repository path inside a general contract is the dangling-pointer class that #1865
spent its second half removing.

## 3. New rule — a record that denies itself is not a verdict

On #1865, Copilot returned `COMMENTED` on the exact head with 119 bytes: "unable to
review — quota limit". CodeRabbit reported check status `pass` next to "review rate
limited". Both are review-shaped artifacts with no findings and no reviewer.
`skipped is not pass` covered an absent review, not a present one that denies itself.

The same clause records that a merge commit bringing `main` into the branch is a new
head like any other. #1865 merged on `5e9fdc96` while its quorum was measured on
`c78f3b96` — the PR that introduced "a new push invalidates reviews on the prior
head" violated it in its own merge. Content was identical, so nothing unreviewed
shipped; the trail is what was wrong.

## 4. Clarification

The provenance rule sits under a list headed "Before pushing", where the measured
tree often has no SHA. It now says to commit first and report that SHA rather than
report a tree no one else can address.

## Also

The pin rule stops citing `fuzz-smoke.yml` as its exemplar and describes the defect
instead. Naming a file a programme participant wrote reads as self-congratulation,
and the clearest instance in this repository is an unfixed duplicate: `pip install
pre-commit==4.4.0` at `.github/workflows/kernel-matrix.yml:63`, with the same version
stated again at `.pre-commit-config.yaml:2`. That fix is a workflow change, not a
docs one, and is tracked separately.

## Verification

Measured on `d4513a09`, branched from `62c1d361`, worktree `scratchpad/agents2`.
`pre-commit` over `AGENTS.md`: merge conflicts, end-of-file, trailing whitespace,
typos and `cargo fmt --check` pass; the rest skip with no matching files. `git diff
--check` clean. Longest line 114, unchanged. Heading order verified at the commit:
`## Verification` → CI-integrity paragraph → `### Measurement provenance` →
`## Tool Boundaries`. One file, staged by explicit path.