### PR TITLE
fix(release): run MCP Registry publication inside the release transaction

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -11,6 +11,12 @@ name: MCP Registry Publish
 # remain outside the official registry so a newer RC or beta cannot displace the latest stable
 # server version.
 #
+# Recovery order after a failed release-run publication: prefer re-running the failed jobs of
+# the release run (`gh run rerun <run-id> --failed`) — the pre-check turns an already-published
+# version into a clean no-op AND the release-record marker is refreshed to the terminal result.
+# A direct workflow_dispatch here also publishes idempotently, but it cannot update the release
+# record, so a stale "failure" marker would remain on the release notes.
+#
 # GitHub OIDC proves the io.github.<owner> namespace belongs to this repository owner, so no stored
 # registry secret is needed.
 
@@ -43,8 +49,13 @@ env:
 jobs:
   publish:
     name: Publish to MCP registry
+    # CAUTION: under workflow_call the caller's event is push/workflow_dispatch,
+    # so this condition can never skip the called job. Keep it that way: if a
+    # future edit lets this job skip in call context, the caller job reports
+    # success with no publication (all-skipped reusable workflows read green).
     if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Job-level on purpose: workflow-level concurrency is not applied when this
     # workflow runs as a workflow_call job, and the registry publish must stay
     # serialized across release runs and recovery dispatches.
@@ -121,10 +132,22 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           LOCAL_SERVER_JSON: server.json
-        # Terminal result = the registry read back the exact content we
-        # published, not just a zero exit from the publisher.
+        # Terminal result = the registry read back this release's version and
+        # package set, not just a zero exit from the publisher. Bounded retry
+        # absorbs read-after-write lag without weakening the check: only a
+        # clean "published" verdict passes.
         run: |
           set -euo pipefail
+          for delay in 5 15 30; do
+            status=""
+            status="$(bash scripts/ci/check-mcp-registry-version.sh)" || true
+            if [[ "$status" == "published" ]]; then
+              echo "Registry publication for ${TAG} confirmed."
+              exit 0
+            fi
+            echo "registry does not serve ${TAG} yet (status: ${status:-error}); retrying in ${delay}s" >&2
+            sleep "$delay"
+          done
           status="$(bash scripts/ci/check-mcp-registry-version.sh)"
           if [[ "$status" != "published" ]]; then
             echo "registry does not serve ${TAG} after publication (status: ${status})" >&2

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -3,12 +3,13 @@ name: MCP Registry Publish
 # Publish the rendered release/server.json to the official MCP registry
 # (registry.modelcontextprotocol.io) via GitHub OIDC.
 #
-# release.yml already RENDERS server.json and attaches it as a release asset, but never publishes
-# it, so the registry entry lags the current release (the last manual publish was 3.9.2). This adds
-# the missing publish step. It is a small standalone workflow on purpose: it does not touch the
-# release build pipeline, it auto-publishes stable releases, and it can refresh an existing stable
-# release on demand via workflow_dispatch. GitHub prereleases remain outside the official registry
-# so a newer RC or beta cannot displace the latest stable server version.
+# The primary path is a workflow_call from release.yml: releases created with GITHUB_TOKEN do not
+# emit a release.published event that starts new workflow runs, so a stable release publishes by
+# running this workflow as a dependent job inside the release run itself (issue #1870). The
+# release trigger stays for releases published outside that automation, and workflow_dispatch
+# stays as the idempotent recovery path for an already-built stable release. GitHub prereleases
+# remain outside the official registry so a newer RC or beta cannot displace the latest stable
+# server version.
 #
 # GitHub OIDC proves the io.github.<owner> namespace belongs to this repository owner, so no stored
 # registry secret is needed.
@@ -16,6 +17,12 @@ name: MCP Registry Publish
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: "Contract-validated release tag to publish, e.g. v3.36.0"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -23,6 +30,8 @@ on:
         required: true
         type: string
 
+# Standalone runs (release / workflow_dispatch) use this; for workflow_call the
+# caller job in release.yml grants the same two scopes.
 permissions:
   contents: read
   id-token: write # OIDC: proves the io.github.<owner> namespace == repository owner
@@ -31,15 +40,17 @@ env:
   MCP_PUBLISHER_VERSION: "v1.7.9"
   MCP_PUBLISHER_LINUX_AMD64_SHA256: "ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"
 
-concurrency:
-  group: mcp-registry-publish
-  cancel-in-progress: false
-
 jobs:
   publish:
     name: Publish to MCP registry
     if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
+    # Job-level on purpose: workflow-level concurrency is not applied when this
+    # workflow runs as a workflow_call job, and the registry publish must stay
+    # serialized across release runs and recovery dispatches.
+    concurrency:
+      group: mcp-registry-publish
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -72,7 +83,19 @@ jobs:
             --dir .
           test -s server.json
 
+      - name: Check whether this version is already published
+        id: existing
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          LOCAL_SERVER_JSON: server.json
+        run: |
+          set -euo pipefail
+          status="$(bash scripts/ci/check-mcp-registry-version.sh)"
+          echo "Registry status for ${TAG}: ${status}"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
       - name: Install mcp-publisher
+        if: ${{ steps.existing.outputs.status == 'absent' }}
         run: |
           set -euo pipefail
           archive=mcp-publisher_linux_amd64.tar.gz
@@ -84,10 +107,27 @@ jobs:
           chmod +x mcp-publisher
 
       - name: Validate server.json
+        if: ${{ steps.existing.outputs.status == 'absent' }}
         run: ./mcp-publisher validate server.json
 
       - name: Login (GitHub OIDC) and publish
+        if: ${{ steps.existing.outputs.status == 'absent' }}
         run: |
           set -euo pipefail
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish server.json
+
+      - name: Confirm the registry serves this version
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          LOCAL_SERVER_JSON: server.json
+        # Terminal result = the registry read back the exact content we
+        # published, not just a zero exit from the publisher.
+        run: |
+          set -euo pipefail
+          status="$(bash scripts/ci/check-mcp-registry-version.sh)"
+          if [[ "$status" != "published" ]]; then
+            echo "registry does not serve ${TAG} after publication (status: ${status})" >&2
+            exit 1
+          fi
+          echo "Registry publication for ${TAG} confirmed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -707,6 +707,50 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   # ============================================================
+  # Publish to the official MCP Registry (part of the release
+  # transaction; releases created with GITHUB_TOKEN emit no
+  # release.published event, so the publisher runs as a
+  # dependent job instead of relying on that trigger)
+  # ============================================================
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: [release-contract, release]
+    if: >-
+      (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc') && !contains(github.ref, '-beta')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.version, 'v') && !contains(github.event.inputs.version, '-rc') && !contains(github.event.inputs.version, '-beta'))
+    permissions:
+      contents: read
+      id-token: write # OIDC login to the MCP Registry
+    uses: ./.github/workflows/mcp-registry-publish.yml
+    with:
+      version: ${{ needs.release-contract.outputs.version }}
+
+  record-mcp-registry-result:
+    name: Record MCP Registry result
+    needs: [release-contract, publish-mcp-registry]
+    # always(): a failed publication must still be recorded on the release;
+    # skipped (prerelease) publishes record nothing.
+    if: ${{ always() && needs.publish-mcp-registry.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Link the registry run and terminal result on the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.release-contract.outputs.version }}
+          RESULT: ${{ needs.publish-mcp-registry.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          bash scripts/ci/record-mcp-registry-result.sh
+
+  # ============================================================
   # Build and Publish Python Wheels (PyPI)
   # ============================================================
   wheels:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/(reconcile-docs-auto-pr|test-reconcile-docs-auto-pr)\.sh|\.github/workflows/(docs-auto-update|ci|assay-runner-lane-check|host-capability-check)\.yml|\.pre-commit-config\.yaml)$
 
+      - id: mcp-registry-release-txn-self-test
+        name: MCP Registry release transaction self-test
+        entry: bash scripts/ci/test-mcp-registry-release-txn.sh
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/(resolve-mcp-registry-tag|check-mcp-registry-version|record-mcp-registry-result|test-mcp-registry-release-txn)\.sh|\.github/workflows/(mcp-registry-publish|release)\.yml|\.pre-commit-config\.yaml)$
+
   # shellcheck (bash) — use system binary to avoid SSL/download issues
   - repo: local
     hooks:

--- a/scripts/ci/check-mcp-registry-version.sh
+++ b/scripts/ci/check-mcp-registry-version.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ask the MCP Registry whether the version we are about to publish already
+# exists, and whether it matches the content we would publish.
+#
+# Inputs (env):
+#   TAG                stable release tag, e.g. v3.35.0
+#   LOCAL_SERVER_JSON  path to the server.json downloaded from the release
+#   REGISTRY_BASE_URL  optional, defaults to the official registry
+#
+# Stdout: "published" when the exact version exists with identical content,
+#         "absent" when the registry does not know the version yet.
+# Exit non-zero on any ambiguity: version/tag disagreement, content mismatch,
+# or an unexpected registry response. Callers use "published" to skip the
+# publish step (idempotent retry) and run this check again after publishing as
+# the terminal confirmation, so this script must never guess.
+
+TAG="${TAG:-}"
+LOCAL_SERVER_JSON="${LOCAL_SERVER_JSON:-}"
+REGISTRY_BASE_URL="${REGISTRY_BASE_URL:-https://registry.modelcontextprotocol.io}"
+
+[[ -n "$TAG" ]] || { echo "TAG is required" >&2; exit 1; }
+[[ -s "$LOCAL_SERVER_JSON" ]] || { echo "LOCAL_SERVER_JSON must be a non-empty file" >&2; exit 1; }
+
+name="$(jq -er '.name' "$LOCAL_SERVER_JSON")"
+version="$(jq -er '.version' "$LOCAL_SERVER_JSON")"
+local_sha="$(jq -er '.packages[0].fileSha256' "$LOCAL_SERVER_JSON")"
+
+if [[ "v${version}" != "$TAG" ]]; then
+  echo "release tag ${TAG} does not match server.json version ${version}" >&2
+  exit 1
+fi
+
+encoded_name="${name//\//%2F}"
+url="${REGISTRY_BASE_URL}/v0/servers/${encoded_name}/versions/${version}"
+
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+http_code="$(curl -sS -o "$body" -w '%{http_code}' "$url")"
+
+case "$http_code" in
+  404)
+    echo "absent"
+    ;;
+  200)
+    remote_name="$(jq -er '.server.name' "$body")"
+    remote_version="$(jq -er '.server.version' "$body")"
+    remote_sha="$(jq -er '.server.packages[0].fileSha256' "$body")"
+    if [[ "$remote_name" != "$name" || "$remote_version" != "$version" ]]; then
+      echo "registry returned ${remote_name}@${remote_version}, expected ${name}@${version}" >&2
+      exit 1
+    fi
+    if [[ "$remote_sha" != "$local_sha" ]]; then
+      echo "registry version ${version} exists with fileSha256 ${remote_sha}," \
+        "but this release would publish ${local_sha}; refusing to treat it as published" >&2
+      exit 1
+    fi
+    echo "published"
+    ;;
+  *)
+    echo "unexpected registry response ${http_code} from ${url}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/ci/check-mcp-registry-version.sh
+++ b/scripts/ci/check-mcp-registry-version.sh
@@ -26,6 +26,7 @@ REGISTRY_BASE_URL="${REGISTRY_BASE_URL:-https://registry.modelcontextprotocol.io
 name="$(jq -er '.name' "$LOCAL_SERVER_JSON")"
 version="$(jq -er '.version' "$LOCAL_SERVER_JSON")"
 local_sha="$(jq -er '.packages[0].fileSha256' "$LOCAL_SERVER_JSON")"
+local_packages="$(jq -Sc '.packages' "$LOCAL_SERVER_JSON")"
 
 if [[ "v${version}" != "$TAG" ]]; then
   echo "release tag ${TAG} does not match server.json version ${version}" >&2
@@ -38,7 +39,7 @@ url="${REGISTRY_BASE_URL}/v0/servers/${encoded_name}/versions/${version}"
 body="$(mktemp)"
 trap 'rm -f "$body"' EXIT
 
-http_code="$(curl -sS -o "$body" -w '%{http_code}' "$url")"
+http_code="$(curl -sS --max-time 30 -o "$body" -w '%{http_code}' "$url")"
 
 case "$http_code" in
   404)
@@ -48,6 +49,7 @@ case "$http_code" in
     remote_name="$(jq -er '.server.name' "$body")"
     remote_version="$(jq -er '.server.version' "$body")"
     remote_sha="$(jq -er '.server.packages[0].fileSha256' "$body")"
+    remote_packages="$(jq -Sc '.server.packages' "$body")"
     if [[ "$remote_name" != "$name" || "$remote_version" != "$version" ]]; then
       echo "registry returned ${remote_name}@${remote_version}, expected ${name}@${version}" >&2
       exit 1
@@ -55,6 +57,15 @@ case "$http_code" in
     if [[ "$remote_sha" != "$local_sha" ]]; then
       echo "registry version ${version} exists with fileSha256 ${remote_sha}," \
         "but this release would publish ${local_sha}; refusing to treat it as published" >&2
+      exit 1
+    fi
+    # The whole package set must match, not just the first artifact digest:
+    # a same-version entry with a different identifier, transport, or an
+    # extra package is not "already published", it is a divergence.
+    if [[ "$remote_packages" != "$local_packages" ]]; then
+      echo "registry version ${version} exists with a different package set" >&2
+      echo "  registry: ${remote_packages}" >&2
+      echo "  release:  ${local_packages}" >&2
       exit 1
     fi
     echo "published"

--- a/scripts/ci/record-mcp-registry-result.sh
+++ b/scripts/ci/record-mcp-registry-result.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Record the MCP Registry publication's terminal result on the GitHub release
+# record, so the release itself links the registry run and its outcome.
+#
+# Inputs (env):
+#   VERSION  release tag, e.g. v3.35.0
+#   RESULT   terminal job result: success | failure | cancelled
+#   RUN_URL  URL of the workflow run that carried the publication
+#
+# Idempotent: exactly one marker line survives, so retries and re-runs replace
+# the previous status instead of stacking history in the release notes.
+
+VERSION="${VERSION:-}"
+RESULT="${RESULT:-}"
+RUN_URL="${RUN_URL:-}"
+MARKER="<!-- mcp-registry-status -->"
+
+[[ -n "$VERSION" ]] || { echo "VERSION is required" >&2; exit 1; }
+[[ -n "$RUN_URL" ]] || { echo "RUN_URL is required" >&2; exit 1; }
+
+case "$RESULT" in
+  success|failure|cancelled) ;;
+  *)
+    echo "RESULT must be a terminal job result (success|failure|cancelled), got: ${RESULT:-<empty>}" >&2
+    exit 1
+    ;;
+esac
+
+notes="$(mktemp)"
+trap 'rm -f "$notes"' EXIT
+
+gh release view "$VERSION" --json body --jq .body > "$notes"
+
+grep -vF "$MARKER" "$notes" > "${notes}.next" || true
+mv "${notes}.next" "$notes"
+
+printf '\n%s MCP Registry publication: %s (%s)\n' "$MARKER" "$RESULT" "$RUN_URL" >> "$notes"
+
+gh release edit "$VERSION" --notes-file "$notes"

--- a/scripts/ci/record-mcp-registry-result.sh
+++ b/scripts/ci/record-mcp-registry-result.sh
@@ -29,7 +29,7 @@ case "$RESULT" in
 esac
 
 notes="$(mktemp)"
-trap 'rm -f "$notes"' EXIT
+trap 'rm -f "$notes" "${notes}.next"' EXIT
 
 gh release view "$VERSION" --json body --jq .body > "$notes"
 

--- a/scripts/ci/resolve-mcp-registry-tag.sh
+++ b/scripts/ci/resolve-mcp-registry-tag.sh
@@ -14,7 +14,12 @@ case "$EVENT_NAME" in
     fi
     tag="$RELEASE_TAG"
     ;;
-  workflow_dispatch)
+  workflow_dispatch|push)
+    # workflow_dispatch: direct recovery dispatch of this workflow.
+    # push: this workflow ran as a workflow_call job inside release.yml on a tag
+    # push; the caller passes the contract-validated version as the call input.
+    # Both paths require an explicit version and fall through to the stable-tag
+    # gate below, so a bare push with no input stays fail-closed.
     tag="$INPUT_VERSION"
     ;;
   *)

--- a/scripts/ci/test-mcp-registry-release-txn.sh
+++ b/scripts/ci/test-mcp-registry-release-txn.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Contract test for the MCP Registry release transaction (issue #1870):
+#   - resolve-mcp-registry-tag.sh: release / prerelease / workflow_dispatch /
+#     workflow_call-from-tag-push tag resolution, fail-closed on everything else
+#   - check-mcp-registry-version.sh: absent vs published vs content mismatch
+#   - record-mcp-registry-result.sh: idempotent terminal-result line on the release
+#   - workflow wiring: release.yml runs the publisher as a dependent job and
+#     mcp-registry-publish.yml stays dispatchable for idempotent recovery
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RESOLVE="${ROOT}/scripts/ci/resolve-mcp-registry-tag.sh"
+CHECK="${ROOT}/scripts/ci/check-mcp-registry-version.sh"
+RECORD="${ROOT}/scripts/ci/record-mcp-registry-result.sh"
+PUBLISH_WF="${ROOT}/.github/workflows/mcp-registry-publish.yml"
+RELEASE_WF="${ROOT}/.github/workflows/release.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------
+# resolve-mcp-registry-tag.sh
+# ---------------------------------------------------------------
+
+resolve_case() {
+  local name="$1" expect_success="$2" expect_tag="$3"
+  shift 3
+  local out
+  if out="$(env -i PATH="$PATH" "$@" bash "$RESOLVE" 2>/dev/null)"; then
+    [[ "$expect_success" == "true" ]] || fail "resolve: $name unexpectedly succeeded"
+    [[ "$out" == "$expect_tag" ]] || fail "resolve: $name returned '$out', expected '$expect_tag'"
+  else
+    [[ "$expect_success" == "false" ]] || fail "resolve: $name unexpectedly failed"
+  fi
+}
+
+resolve_case "stable release event" true "v3.35.0" \
+  EVENT_NAME=release RELEASE_TAG=v3.35.0 RELEASE_PRERELEASE=false
+resolve_case "prerelease release event is refused" false "" \
+  EVENT_NAME=release RELEASE_TAG=v3.36.0-rc1 RELEASE_PRERELEASE=true
+resolve_case "release event with unstated prerelease flag is refused" false "" \
+  EVENT_NAME=release RELEASE_TAG=v3.35.0
+resolve_case "manual dispatch" true "v3.35.0" \
+  EVENT_NAME=workflow_dispatch INPUT_VERSION=v3.35.0
+resolve_case "workflow_call from a tag push" true "v3.35.0" \
+  EVENT_NAME=push INPUT_VERSION=v3.35.0
+resolve_case "workflow_call from a dispatched release run" true "v3.35.0" \
+  EVENT_NAME=workflow_dispatch INPUT_VERSION=v3.35.0
+resolve_case "tag push without an explicit version input is refused" false "" \
+  EVENT_NAME=push
+resolve_case "rc tag is refused on every path" false "" \
+  EVENT_NAME=push INPUT_VERSION=v3.36.0-rc1
+resolve_case "beta tag is refused" false "" \
+  EVENT_NAME=workflow_dispatch INPUT_VERSION=v3.36.0-beta.1
+resolve_case "multi-line tag is refused" false "" \
+  EVENT_NAME=workflow_dispatch INPUT_VERSION="$(printf 'v3.35.0\nevil')"
+resolve_case "unsupported event is refused" false "" \
+  EVENT_NAME=schedule
+resolve_case "empty event is refused" false ""
+
+echo "ok: resolve-mcp-registry-tag cases"
+
+# ---------------------------------------------------------------
+# check-mcp-registry-version.sh
+# ---------------------------------------------------------------
+
+make_server_json() {
+  local path="$1" version="$2" sha="$3" name="${4:-io.github.Rul1an/assay-mcp-server}"
+  jq -cn --arg name "$name" --arg version "$version" --arg sha "$sha" \
+    '{name: $name, version: $version, packages: [{fileSha256: $sha}]}' > "$path"
+}
+
+check_case() {
+  local name="$1" http_code="$2" body_json="$3" local_json="$4" \
+    expect_success="$5" expect_status="${6:-}"
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  mkdir -p "${temp_dir}/bin"
+  cat > "${temp_dir}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "-o" ]]; then
+    out="$arg"
+  fi
+  prev="$arg"
+done
+[[ -n "$out" ]] || { echo "fake curl expects -o" >&2; exit 90; }
+cat "$FAKE_CURL_BODY" > "$out"
+printf '%s' "$FAKE_CURL_CODE"
+EOF
+  chmod +x "${temp_dir}/bin/curl"
+  printf '%s\n' "$body_json" > "${temp_dir}/body.json"
+
+  local out rc=0
+  out="$(PATH="${temp_dir}/bin:${PATH}" \
+    FAKE_CURL_BODY="${temp_dir}/body.json" \
+    FAKE_CURL_CODE="$http_code" \
+    TAG="v3.35.0" \
+    LOCAL_SERVER_JSON="$local_json" \
+    bash "$CHECK" 2>"${temp_dir}/stderr")" || rc=$?
+  if [[ "$expect_success" == "true" ]]; then
+    [[ "$rc" -eq 0 ]] || { cat "${temp_dir}/stderr" >&2; fail "check: $name unexpectedly failed"; }
+    [[ "$out" == "$expect_status" ]] || fail "check: $name returned '$out', expected '$expect_status'"
+  else
+    [[ "$rc" -ne 0 ]] || fail "check: $name unexpectedly succeeded"
+  fi
+  rm -rf "$temp_dir"
+}
+
+WORK="$(mktemp -d)"
+make_server_json "${WORK}/server.json" "3.35.0" "aaaa1111"
+make_server_json "${WORK}/other-sha.json" "3.35.0" "bbbb2222"
+make_server_json "${WORK}/wrong-version.json" "3.34.0" "aaaa1111"
+
+published_body="$(jq -cn '{server: {name: "io.github.Rul1an/assay-mcp-server", version: "3.35.0", packages: [{fileSha256: "aaaa1111"}]}}')"
+
+check_case "absent version reports absent" 404 '{"error":"not found"}' \
+  "${WORK}/server.json" true "absent"
+check_case "published identical version reports published" 200 "$published_body" \
+  "${WORK}/server.json" true "published"
+check_case "published version with different content fails closed" 200 "$published_body" \
+  "${WORK}/other-sha.json" false
+check_case "registry payload version mismatch fails closed" 200 "$published_body" \
+  "${WORK}/wrong-version.json" false
+check_case "unexpected registry status fails closed" 500 '{"error":"boom"}' \
+  "${WORK}/server.json" false
+check_case "tag and local server.json version must agree" 404 '{}' \
+  "${WORK}/wrong-version.json" false
+
+echo "ok: check-mcp-registry-version cases"
+
+# ---------------------------------------------------------------
+# record-mcp-registry-result.sh
+# ---------------------------------------------------------------
+
+record_case() {
+  local name="$1" result="$2" initial_body="$3" expect_success="$4"
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  mkdir -p "${temp_dir}/bin"
+  cat > "${temp_dir}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "release view")
+    cat "$FAKE_RELEASE_BODY"
+    ;;
+  "release edit")
+    notes_file=""
+    prev=""
+    for arg in "$@"; do
+      if [[ "$prev" == "--notes-file" ]]; then
+        notes_file="$arg"
+      fi
+      prev="$arg"
+    done
+    [[ -n "$notes_file" ]] || { echo "fake gh expects --notes-file" >&2; exit 90; }
+    cat "$notes_file" > "$FAKE_RELEASE_BODY"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 91
+    ;;
+esac
+EOF
+  chmod +x "${temp_dir}/bin/gh"
+  printf '%s\n' "$initial_body" > "${temp_dir}/release-body.md"
+
+  local rc=0
+  PATH="${temp_dir}/bin:${PATH}" \
+    FAKE_RELEASE_BODY="${temp_dir}/release-body.md" \
+    VERSION="v3.35.0" \
+    RESULT="$result" \
+    RUN_URL="https://github.com/Rul1an/assay/actions/runs/123" \
+    bash "$RECORD" >/dev/null 2>"${temp_dir}/stderr" || rc=$?
+  if [[ "$expect_success" == "true" ]]; then
+    [[ "$rc" -eq 0 ]] || { cat "${temp_dir}/stderr" >&2; fail "record: $name unexpectedly failed"; }
+    grep -c "mcp-registry-status" "${temp_dir}/release-body.md" | grep -qx "1" \
+      || fail "record: $name must leave exactly one status marker"
+    grep -q "actions/runs/123" "${temp_dir}/release-body.md" \
+      || fail "record: $name must link the registry run"
+    grep -q "$result" "${temp_dir}/release-body.md" \
+      || fail "record: $name must record the terminal result"
+  else
+    [[ "$rc" -ne 0 ]] || fail "record: $name unexpectedly succeeded"
+  fi
+  rm -rf "$temp_dir"
+}
+
+record_case "first success append" success "release notes body" true
+record_case "failure is recorded too" failure "release notes body" true
+record_case "rerun replaces the previous marker" success \
+  "release notes body
+<!-- mcp-registry-status --> MCP Registry publication: failure (https://github.com/Rul1an/assay/actions/runs/99)" true
+record_case "unknown result is refused" bogus "release notes body" false
+record_case "skipped result is refused" skipped "release notes body" false
+
+echo "ok: record-mcp-registry-result cases"
+
+# ---------------------------------------------------------------
+# Workflow wiring
+# ---------------------------------------------------------------
+
+wf_pin() {
+  local file="$1" pattern="$2" why="$3"
+  grep -Eq "$pattern" "$file" || fail "wiring: $why (pattern '$pattern' missing in ${file#"$ROOT"/})"
+}
+
+# The publish workflow must be callable from release.yml and keep manual recovery.
+wf_pin "$PUBLISH_WF" '^[[:space:]]*workflow_call:' \
+  "mcp-registry-publish.yml must expose workflow_call"
+wf_pin "$PUBLISH_WF" '^[[:space:]]*workflow_dispatch:' \
+  "mcp-registry-publish.yml must keep workflow_dispatch recovery"
+wf_pin "$PUBLISH_WF" '^[[:space:]]*release:' \
+  "mcp-registry-publish.yml must keep the release trigger for manually published releases"
+# Workflow-level concurrency is ignored for called workflows; the guard must sit on the job.
+awk '/^jobs:/{injobs=1} injobs && /concurrency:/{found=1} END{exit !found}' "$PUBLISH_WF" \
+  || fail "wiring: publish concurrency group must be declared at job level"
+wf_pin "$PUBLISH_WF" 'check-mcp-registry-version\.sh' \
+  "publish must consult the registry before and after publishing"
+grep -c 'check-mcp-registry-version\.sh' "$PUBLISH_WF" | grep -qx "2" \
+  || fail "wiring: publish must run the registry check twice (idempotency + terminal confirmation)"
+wf_pin "$PUBLISH_WF" 'MCP_PUBLISHER_LINUX_AMD64_SHA256' \
+  "publisher checksum enforcement must remain"
+wf_pin "$PUBLISH_WF" 'login github-oidc' \
+  "OIDC identity must remain the publication credential"
+wf_pin "$PUBLISH_WF" 'mcp-publisher validate server\.json' \
+  "release asset validation must remain"
+
+# release.yml must run the publisher as part of the release transaction.
+wf_pin "$RELEASE_WF" '^[[:space:]]*publish-mcp-registry:' \
+  "release.yml must have a publish-mcp-registry job"
+wf_pin "$RELEASE_WF" 'uses: \./\.github/workflows/mcp-registry-publish\.yml' \
+  "publish-mcp-registry must call the pinned local publisher workflow"
+wf_pin "$RELEASE_WF" 'version: \$\{\{ needs\.release-contract\.outputs\.version \}\}' \
+  "publisher must receive the contract-validated release version"
+wf_pin "$RELEASE_WF" '^[[:space:]]*record-mcp-registry-result:' \
+  "release.yml must record the registry terminal result on the release"
+wf_pin "$RELEASE_WF" 'record-mcp-registry-result\.sh' \
+  "record job must use the tested recording script"
+
+python3 - "$RELEASE_WF" <<'PY'
+import re
+import sys
+
+text = open(sys.argv[1]).read()
+
+def job_block(name):
+    match = re.search(rf"^  {name}:\n(.*?)(?=^  [a-zA-Z][\w-]*:|\Z)", text, re.S | re.M)
+    if not match:
+        sys.exit(f"wiring: job {name} not found in release.yml")
+    return match.group(1)
+
+publish = job_block("publish-mcp-registry")
+record = job_block("record-mcp-registry-result")
+
+for needed in ("release-contract", "release"):
+    if needed not in publish.split("uses:")[0]:
+        sys.exit(f"wiring: publish-mcp-registry must depend on {needed}")
+for guard in ("-rc", "-beta"):
+    if guard not in publish:
+        sys.exit(f"wiring: publish-mcp-registry must exclude {guard} prereleases")
+if "id-token: write" not in publish:
+    sys.exit("wiring: publish-mcp-registry must grant id-token: write for OIDC")
+if "contents: write" in publish:
+    sys.exit("wiring: publish-mcp-registry must not hold contents: write")
+
+if "always()" not in record:
+    sys.exit("wiring: record job must run on publish failure too")
+if "skipped" not in record:
+    sys.exit("wiring: record job must not fire for skipped prerelease publishes")
+if "publish-mcp-registry" not in record:
+    sys.exit("wiring: record job must depend on the publish job")
+if "contents: write" not in record:
+    sys.exit("wiring: record job needs contents: write to edit the release")
+PY
+
+echo "ok: workflow wiring"
+echo "PASS: mcp-registry release transaction contract"

--- a/scripts/ci/test-mcp-registry-release-txn.sh
+++ b/scripts/ci/test-mcp-registry-release-txn.sh
@@ -120,18 +120,25 @@ make_server_json "${WORK}/wrong-version.json" "3.34.0" "aaaa1111"
 
 published_body="$(jq -cn '{server: {name: "io.github.Rul1an/assay-mcp-server", version: "3.35.0", packages: [{fileSha256: "aaaa1111"}]}}')"
 
+divergent_packages_body="$(jq -cn '{server: {name: "io.github.Rul1an/assay-mcp-server", version: "3.35.0", packages: [{fileSha256: "aaaa1111", identifier: "https://elsewhere.example/other.mcpb"}]}}')"
+
 check_case "absent version reports absent" 404 '{"error":"not found"}' \
   "${WORK}/server.json" true "absent"
 check_case "published identical version reports published" 200 "$published_body" \
   "${WORK}/server.json" true "published"
 check_case "published version with different content fails closed" 200 "$published_body" \
   "${WORK}/other-sha.json" false
+check_case "same digest but divergent package set fails closed" 200 "$divergent_packages_body" \
+  "${WORK}/server.json" false
 check_case "registry payload version mismatch fails closed" 200 "$published_body" \
   "${WORK}/wrong-version.json" false
 check_case "unexpected registry status fails closed" 500 '{"error":"boom"}' \
   "${WORK}/server.json" false
 check_case "tag and local server.json version must agree" 404 '{}' \
   "${WORK}/wrong-version.json" false
+
+grep -q -- '--max-time' "$CHECK" \
+  || fail "check: registry curl must carry a bounded --max-time"
 
 echo "ok: check-mcp-registry-version cases"
 
@@ -224,10 +231,22 @@ awk '/^jobs:/{injobs=1} injobs && /concurrency:/{found=1} END{exit !found}' "$PU
   || fail "wiring: publish concurrency group must be declared at job level"
 wf_pin "$PUBLISH_WF" 'check-mcp-registry-version\.sh' \
   "publish must consult the registry before and after publishing"
-grep -c 'check-mcp-registry-version\.sh' "$PUBLISH_WF" | grep -qx "2" \
-  || fail "wiring: publish must run the registry check twice (idempotency + terminal confirmation)"
+wf_pin "$PUBLISH_WF" '^[[:space:]]*- name: Check whether this version is already published$' \
+  "publish must pre-check the registry for idempotent retries"
+wf_pin "$PUBLISH_WF" '^[[:space:]]*- name: Confirm the registry serves this version$' \
+  "publish must confirm the terminal result by reading the registry back"
 wf_pin "$PUBLISH_WF" 'MCP_PUBLISHER_LINUX_AMD64_SHA256' \
   "publisher checksum enforcement must remain"
+wf_pin "$PUBLISH_WF" '^[[:space:]]*timeout-minutes:' \
+  "publish job must carry a bounded timeout"
+wf_pin "$PUBLISH_WF" 'retrying in' \
+  "terminal confirmation must retry read-after-write lag before failing"
+# The publish job's if may only reference the release event: under
+# workflow_call the caller's event is push/workflow_dispatch, and any
+# condition that can skip the called job there turns an unpublished release
+# into a green caller job (all-skipped reusable workflows read success).
+grep -Eq "if: \\$\\{\\{ github\\.event_name != 'release' \\|\\| github\\.event\\.release\\.prerelease == false \\}\\}" "$PUBLISH_WF" \
+  || fail "wiring: publish job if-condition must stay release-event-only (all-skipped call reads green)"
 wf_pin "$PUBLISH_WF" 'login github-oidc' \
   "OIDC identity must remain the publication credential"
 wf_pin "$PUBLISH_WF" 'mcp-publisher validate server\.json' \


### PR DESCRIPTION
## Summary

- run the MCP Registry publisher as a `workflow_call` job inside `release.yml`, because releases created with `GITHUB_TOKEN` emit no `release.published` event that starts new workflow runs (this is what stranded v3.35.0 until manual dispatch 30229328824)
- gate the dependent job to stable tags on both the tag-push and dispatch paths; prereleases skip publication entirely
- keep OIDC identity, pinned publisher checksum, and `mcp-publisher validate` unchanged
- consult the registry before publishing: an already-published identical version is a clean no-op (idempotent retry), a same-version content mismatch fails closed instead of being treated as published
- confirm after publishing that the registry actually serves the exact content (`GET /v0/servers/{name}/versions/{version}`, verified live against the published 3.35.0 entry) — the terminal result is a registry read-back, not a publisher exit code
- record that terminal result and the run link on the GitHub release record via an idempotent marker line; failures are recorded too
- keep `workflow_dispatch` as the manual recovery path and the `release` trigger for releases published outside the automation
- move the publish concurrency group to job level, since workflow-level concurrency is not applied to called workflows

Closes #1870.

## Verification

- `bash scripts/ci/test-mcp-registry-release-txn.sh` — resolve (release/prerelease/dispatch/call/injection), registry check (absent/published/sha-mismatch/HTTP error), release-record idempotency, and structural workflow wiring incl. negative pins (no `contents: write` on the publish job, `always()` + skipped-guard on the record job); red before implementation, green after
- `pre-commit run --files …` incl. the new self-test hook — all passed
- `actionlint`, `zizmor` (no findings), `shellcheck` — clean

## Claim boundary

This makes publication part of the release run and verifiable from the release record. It does not retro-publish older versions, does not change what `server.json` contains, and the live end-to-end proof requires the next stable release to publish unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stable releases are now published to the official MCP Registry automatically.
  * Release notes now record the registry publication result and workflow link.
  * Repeated publication attempts safely skip versions already published with matching content.

* **Bug Fixes**
  * Added validation to prevent publishing mismatched versions or package contents.
  * Publication results are verified after publishing, with failures reported clearly.

* **Tests**
  * Added automated checks covering release routing, registry validation, workflow behavior, and result recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->