### PR TITLE
fix(ci): fail closed when the required lane-check/proof status cannot land

### DIFF
--- a/.github/workflows/assay-runner-lane-check.yml
+++ b/.github/workflows/assay-runner-lane-check.yml
@@ -31,11 +31,17 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - name: Checkout base helper
+      - name: Checkout trusted helper
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+          # pull_request: the PR base, so a PR can never run its own edited
+          #   gatekeeper. workflow_dispatch: main, because the privileged
+          #   refresh holds statuses: write and must never execute helper code
+          #   from the dispatched ref (which a PR author controls); the head
+          #   SHA is data, not code. workflow_run: github.sha is the default
+          #   branch head, already trusted.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'workflow_dispatch' && 'main' || github.sha) }}
 
       - name: Verify lane-check helper exists
         shell: bash

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -18,6 +18,10 @@ on:
       - "crates/assay-monitor/**"
       - "scripts/**"
       - ".github/workflows/kernel-matrix.yml"
+      # The lane self-test pins guards inside this workflow file; run the
+      # head-side pre-commit leg when it changes, because the lane workflow
+      # itself checks out the PR base and would validate the base copy.
+      - ".github/workflows/assay-runner-lane-check.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1487,14 +1487,24 @@ def maybe_status(
         # `lane-check/proof` is the required branch-protection context
         # (issue #1869). A permission refusal is the one tolerated miss: a
         # read-only token (Dependabot/fork contexts) can never post it, the
-        # head stays unproven, and only a privileged dispatch refreshes it.
-        # Everything else must fail the run rather than leave a green job
-        # whose required status silently never landed.
-        if exc.code in (401, 403):
+        # head stays unproven, and only a privileged dispatch from a trusted
+        # ref refreshes it. Everything else must fail the run rather than
+        # leave a green job whose required status silently never landed.
+        # GitHub also answers rate limiting with 403; that is transient for a
+        # write-capable token, so it propagates instead of masquerading as a
+        # permission refusal with the wrong remedy.
+        headers = getattr(exc, "headers", None)
+        rate_limited = headers is not None and (
+            headers.get("Retry-After") is not None
+            or headers.get("X-RateLimit-Remaining") == "0"
+        )
+        if exc.code in (401, 403) and not rate_limited:
             print(
                 "warning: token cannot write commit statuses "
                 f"({exc.code}); the required '{STATUS_CONTEXT}' context stays "
-                "missing until a privileged workflow_dispatch refreshes it",
+                "missing until a privileged workflow_dispatch (run from a "
+                "trusted ref, never from a ref carrying untrusted changes) "
+                "refreshes it",
                 file=sys.stderr,
             )
             return
@@ -2158,6 +2168,35 @@ def _test_required_status_fail_closed() -> None:
     maybe_status(forbidden, "abc123", True, "ok", status=True)
     assert forbidden.calls == [("POST", "/statuses/abc123")]
 
+    # (2b) GitHub also answers rate limiting with 403. That is transient, not
+    #      a permission refusal: a write-capable run must not read green while
+    #      its required status silently never landed, so these propagate.
+    import email.message
+
+    secondary = email.message.Message()
+    secondary["Retry-After"] = "60"
+    rate_limited = _RaisingApi(
+        urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", secondary, None)  # type: ignore[arg-type]
+    )
+    try:
+        maybe_status(rate_limited, "abc123", True, "ok", status=True)
+    except urllib.error.HTTPError:
+        pass
+    else:
+        raise AssertionError("maybe_status must fail closed on secondary rate limits")
+
+    primary = email.message.Message()
+    primary["X-RateLimit-Remaining"] = "0"
+    exhausted = _RaisingApi(
+        urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", primary, None)  # type: ignore[arg-type]
+    )
+    try:
+        maybe_status(exhausted, "abc123", True, "ok", status=True)
+    except urllib.error.HTTPError:
+        pass
+    else:
+        raise AssertionError("maybe_status must fail closed on an exhausted rate limit")
+
     # (3) A 5xx HTTPError is not a permission refusal and must propagate.
     server_error = _RaisingApi(
         urllib.error.HTTPError("https://api.github.com", 502, "Bad Gateway", None, None)  # type: ignore[arg-type]
@@ -2178,10 +2217,12 @@ def _test_required_status_fail_closed() -> None:
 def _test_lane_workflow_contract_pins() -> None:
     """Pin the exact-head and never-read-clean guards of the lane workflow.
 
-    The helper is checked out from the PR base, so this file and the workflow
-    travel together; if a future edit drops one of these guards, the self-test
-    (pre-commit and the base-ref run) goes red before the guard disappears
-    from the enforcement path.
+    Script and workflow are always read from the same checkout, so the pins
+    are self-consistent — but the lane workflow's own run checks out the PR
+    BASE, which still contains the guards when a PR removes them. The
+    head-side tripwire is pre-commit (locally via the lane-check hook, and in
+    CI via the kernel-matrix lint leg, whose trigger paths include the lane
+    workflow file for exactly this reason).
     """
 
     workflow = (
@@ -2207,6 +2248,12 @@ def _test_lane_workflow_contract_pins() -> None:
     # The workflow must actually request the required-context posting.
     assert "args+=(--status)" in text
     assert "statuses: write" in text
+
+    # A privileged dispatch runs with statuses: write, so it must execute the
+    # trusted helper from main — never code from the dispatched ref, which a
+    # PR author controls. (The dispatched ref's own workflow file still runs;
+    # dispatching on a ref carrying untrusted changes stays forbidden.)
+    assert "github.event_name == 'workflow_dispatch' && 'main'" in text
 
 
 def _test_connection_resilience() -> None:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1483,8 +1483,22 @@ def maybe_status(
         return
     try:
         post_commit_status(api, sha, passed, description)
-    except TRANSIENT_REQUEST_ERRORS as exc:
-        print(f"warning: could not post commit status: {exc}", file=sys.stderr)
+    except urllib.error.HTTPError as exc:
+        # `lane-check/proof` is the required branch-protection context
+        # (issue #1869). A permission refusal is the one tolerated miss: a
+        # read-only token (Dependabot/fork contexts) can never post it, the
+        # head stays unproven, and only a privileged dispatch refreshes it.
+        # Everything else must fail the run rather than leave a green job
+        # whose required status silently never landed.
+        if exc.code in (401, 403):
+            print(
+                "warning: token cannot write commit statuses "
+                f"({exc.code}); the required '{STATUS_CONTEXT}' context stays "
+                "missing until a privileged workflow_dispatch refreshes it",
+                file=sys.stderr,
+            )
+            return
+        raise
 
 
 def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) -> int:
@@ -1703,6 +1717,8 @@ def self_test() -> None:
 
     _test_connection_resilience()
     _test_artifact_redirect_drops_authorization()
+    _test_required_status_fail_closed()
+    _test_lane_workflow_contract_pins()
 
     # Phase 2D Slice 6B mechanical absence check: assert that assay-cli no
     # longer consumes the assay-runner-spike wrapper. The check is
@@ -2099,6 +2115,98 @@ def _test_event_resolution_and_status_payload() -> None:
             },
         )
     ]
+
+
+def _test_required_status_fail_closed() -> None:
+    """The `lane-check/proof` commit status is the branch-protection contract
+    (issue #1869): it must land on the exact PR head or the run must fail
+    visibly. Only a permission refusal (read-only token, e.g. Dependabot or
+    fork contexts) may degrade to a warning, because those contexts can never
+    post the status themselves and rely on a privileged dispatch instead.
+    """
+
+    # The migration anchor: branch protection requires this exact context.
+    assert STATUS_CONTEXT == "lane-check/proof"
+
+    class _RaisingApi:
+        def __init__(self, exc: Exception) -> None:
+            self.exc = exc
+            self.calls: list[tuple[str, str]] = []
+
+        def request(self, method: str, path: str, payload: object | None = None) -> object:
+            self.calls.append((method, path))
+            raise self.exc
+
+    # (1) A transient failure that survives the request-level retries must
+    #     propagate: a green run whose required status never landed is the
+    #     silent-liveness failure this guards against.
+    flaky = _RaisingApi(urllib.error.URLError("connection reset"))
+    try:
+        maybe_status(flaky, "abc123", True, "ok", status=True)
+    except urllib.error.URLError:
+        pass
+    else:
+        raise AssertionError("maybe_status must fail closed on non-permission errors")
+    assert flaky.calls == [("POST", "/statuses/abc123")]
+
+    # (2) A permission refusal is the documented read-only-token path: warn,
+    #     do not fail the run. The status stays missing, branch protection
+    #     stays blocked, and the privileged dispatch refreshes it.
+    forbidden = _RaisingApi(
+        urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", None, None)  # type: ignore[arg-type]
+    )
+    maybe_status(forbidden, "abc123", True, "ok", status=True)
+    assert forbidden.calls == [("POST", "/statuses/abc123")]
+
+    # (3) A 5xx HTTPError is not a permission refusal and must propagate.
+    server_error = _RaisingApi(
+        urllib.error.HTTPError("https://api.github.com", 502, "Bad Gateway", None, None)  # type: ignore[arg-type]
+    )
+    try:
+        maybe_status(server_error, "abc123", False, "broken", status=True)
+    except urllib.error.HTTPError:
+        pass
+    else:
+        raise AssertionError("maybe_status must fail closed on server errors")
+
+    # (4) Without --status nothing is posted at all.
+    silent = _RaisingApi(urllib.error.URLError("unused"))
+    maybe_status(silent, "abc123", True, "ok", status=False)
+    assert silent.calls == []
+
+
+def _test_lane_workflow_contract_pins() -> None:
+    """Pin the exact-head and never-read-clean guards of the lane workflow.
+
+    The helper is checked out from the PR base, so this file and the workflow
+    travel together; if a future edit drops one of these guards, the self-test
+    (pre-commit and the base-ref run) goes red before the guard disappears
+    from the enforcement path.
+    """
+
+    workflow = (
+        Path(__file__).resolve().parent.parent.parent
+        / ".github"
+        / "workflows"
+        / "assay-runner-lane-check.yml"
+    )
+    text = workflow.read_text(encoding="utf-8")
+
+    # Skipped or unassociated workflow_run events must never read clean:
+    # only completed dispatch-triggered delegated runs enter the job at all,
+    # and a delegated run with no resolvable PR ends in an explicit no-op.
+    assert "github.event.workflow_run.event == 'workflow_dispatch'" in text
+    assert "No associated pull request found" in text
+
+    # Exact-head behavior for privileged refreshes: the dispatched run must
+    # bind itself to the expected head and re-check that the PR still points
+    # at it before any status is posted.
+    assert 'if [[ "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]]' in text
+    assert 'if [[ "$pr_head" != "$EXPECTED_HEAD_SHA" ]]' in text
+
+    # The workflow must actually request the required-context posting.
+    assert "args+=(--status)" in text
+    assert "statuses: write" in text
 
 
 def _test_connection_resilience() -> None:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1485,20 +1485,24 @@ def maybe_status(
         post_commit_status(api, sha, passed, description)
     except urllib.error.HTTPError as exc:
         # `lane-check/proof` is the required branch-protection context
-        # (issue #1869). A permission refusal is the one tolerated miss: a
-        # read-only token (Dependabot/fork contexts) can never post it, the
-        # head stays unproven, and only a privileged dispatch from a trusted
-        # ref refreshes it. Everything else must fail the run rather than
-        # leave a green job whose required status silently never landed.
-        # GitHub also answers rate limiting with 403; that is transient for a
-        # write-capable token, so it propagates instead of masquerading as a
-        # permission refusal with the wrong remedy.
+        # (issue #1869). A permission refusal is tolerated in exactly one
+        # context: a pull_request event, whose token can be read-only by
+        # design (Dependabot/fork PRs) and can never post the status; the
+        # head stays unproven and only a privileged dispatch from a trusted
+        # ref refreshes it. The privileged refresh contexts themselves
+        # (workflow_dispatch, workflow_run) exist to post this status and
+        # always hold statuses: write — a 403 there is misconfiguration, and
+        # tolerating it would recreate the green-run-with-missing-status
+        # failure inside its own exemption. GitHub also answers rate limiting
+        # with 403; that is transient, so it propagates too instead of
+        # masquerading as a permission refusal with the wrong remedy.
         headers = getattr(exc, "headers", None)
         rate_limited = headers is not None and (
             headers.get("Retry-After") is not None
             or headers.get("X-RateLimit-Remaining") == "0"
         )
-        if exc.code in (401, 403) and not rate_limited:
+        event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+        if exc.code in (401, 403) and not rate_limited and event_name == "pull_request":
             print(
                 "warning: token cannot write commit statuses "
                 f"({exc.code}); the required '{STATUS_CONTEXT}' context stays "
@@ -2159,43 +2163,87 @@ def _test_required_status_fail_closed() -> None:
         raise AssertionError("maybe_status must fail closed on non-permission errors")
     assert flaky.calls == [("POST", "/statuses/abc123")]
 
-    # (2) A permission refusal is the documented read-only-token path: warn,
-    #     do not fail the run. The status stays missing, branch protection
-    #     stays blocked, and the privileged dispatch refreshes it.
-    forbidden = _RaisingApi(
-        urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", None, None)  # type: ignore[arg-type]
-    )
-    maybe_status(forbidden, "abc123", True, "ok", status=True)
-    assert forbidden.calls == [("POST", "/statuses/abc123")]
+    # (2) A permission refusal on a pull_request event is the documented
+    #     read-only-token path (Dependabot/forks): warn, do not fail the run.
+    #     The status stays missing, branch protection stays blocked, and the
+    #     privileged dispatch refreshes it.
+    old_event = os.environ.get("GITHUB_EVENT_NAME")
 
-    # (2b) GitHub also answers rate limiting with 403. That is transient, not
-    #      a permission refusal: a write-capable run must not read green while
-    #      its required status silently never landed, so these propagate.
-    import email.message
+    def with_event_name(value: str | None):
+        if value is None:
+            os.environ.pop("GITHUB_EVENT_NAME", None)
+        else:
+            os.environ["GITHUB_EVENT_NAME"] = value
 
-    secondary = email.message.Message()
-    secondary["Retry-After"] = "60"
-    rate_limited = _RaisingApi(
-        urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", secondary, None)  # type: ignore[arg-type]
-    )
     try:
-        maybe_status(rate_limited, "abc123", True, "ok", status=True)
-    except urllib.error.HTTPError:
-        pass
-    else:
-        raise AssertionError("maybe_status must fail closed on secondary rate limits")
+        with_event_name("pull_request")
+        forbidden = _RaisingApi(
+            urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", None, None)  # type: ignore[arg-type]
+        )
+        maybe_status(forbidden, "abc123", True, "ok", status=True)
+        assert forbidden.calls == [("POST", "/statuses/abc123")]
 
-    primary = email.message.Message()
-    primary["X-RateLimit-Remaining"] = "0"
-    exhausted = _RaisingApi(
-        urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", primary, None)  # type: ignore[arg-type]
-    )
-    try:
-        maybe_status(exhausted, "abc123", True, "ok", status=True)
-    except urllib.error.HTTPError:
-        pass
-    else:
-        raise AssertionError("maybe_status must fail closed on an exhausted rate limit")
+        # (2a) The privileged refresh contexts exist to post this status and
+        #      always hold statuses: write: a 403 there is misconfiguration,
+        #      not an expected read-only token, and a green run whose only
+        #      job silently failed is exactly the class this fix removes.
+        for privileged_event in ("workflow_dispatch", "workflow_run"):
+            with_event_name(privileged_event)
+            misconfigured = _RaisingApi(
+                urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", None, None)  # type: ignore[arg-type]
+            )
+            try:
+                maybe_status(misconfigured, "abc123", True, "ok", status=True)
+            except urllib.error.HTTPError:
+                pass
+            else:
+                raise AssertionError(
+                    f"maybe_status must fail closed on 403 under {privileged_event}"
+                )
+
+        # (2b) GitHub also answers rate limiting with 403. That is transient,
+        #      not a permission refusal, so it must propagate even in the one
+        #      context whose permission refusals are tolerated.
+        import email.message
+
+        with_event_name("pull_request")
+        secondary = email.message.Message()
+        secondary["Retry-After"] = "60"
+        rate_limited = _RaisingApi(
+            urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", secondary, None)  # type: ignore[arg-type]
+        )
+        try:
+            maybe_status(rate_limited, "abc123", True, "ok", status=True)
+        except urllib.error.HTTPError:
+            pass
+        else:
+            raise AssertionError("maybe_status must fail closed on secondary rate limits")
+
+        primary = email.message.Message()
+        primary["X-RateLimit-Remaining"] = "0"
+        exhausted = _RaisingApi(
+            urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", primary, None)  # type: ignore[arg-type]
+        )
+        try:
+            maybe_status(exhausted, "abc123", True, "ok", status=True)
+        except urllib.error.HTTPError:
+            pass
+        else:
+            raise AssertionError("maybe_status must fail closed on an exhausted rate limit")
+
+        # (2c) An unknown or absent event context fails closed too.
+        with_event_name(None)
+        unknown = _RaisingApi(
+            urllib.error.HTTPError("https://api.github.com", 403, "Forbidden", None, None)  # type: ignore[arg-type]
+        )
+        try:
+            maybe_status(unknown, "abc123", True, "ok", status=True)
+        except urllib.error.HTTPError:
+            pass
+        else:
+            raise AssertionError("maybe_status must fail closed on 403 in unknown contexts")
+    finally:
+        with_event_name(old_event)
 
     # (3) A 5xx HTTPError is not a permission refusal and must propagate.
     server_error = _RaisingApi(
@@ -2218,11 +2266,14 @@ def _test_lane_workflow_contract_pins() -> None:
     """Pin the exact-head and never-read-clean guards of the lane workflow.
 
     Script and workflow are always read from the same checkout, so the pins
-    are self-consistent — but the lane workflow's own run checks out the PR
-    BASE, which still contains the guards when a PR removes them. The
-    head-side tripwire is pre-commit (locally via the lane-check hook, and in
-    CI via the kernel-matrix lint leg, whose trigger paths include the lane
-    workflow file for exactly this reason).
+    are self-consistent — but which tree that is depends on the event: the
+    lane workflow's pull_request run checks out the PR BASE (which still
+    contains the guards when a PR removes them), a workflow_dispatch run
+    checks out main, and a workflow_run refresh the default-branch head. The
+    head-side tripwire for a PR editing these files is therefore pre-commit
+    (locally via the lane-check hook, and in CI via the kernel-matrix lint
+    leg, whose trigger paths include the lane workflow file for exactly this
+    reason).
     """
 
     workflow = (
@@ -2245,9 +2296,14 @@ def _test_lane_workflow_contract_pins() -> None:
     assert 'if [[ "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]]' in text
     assert 'if [[ "$pr_head" != "$EXPECTED_HEAD_SHA" ]]' in text
 
-    # The workflow must actually request the required-context posting.
+    # The workflow must actually request the required-context posting, and
+    # the statuses: write grant must sit on the posting job itself, under a
+    # workflow-level default deny.
     assert "args+=(--status)" in text
-    assert "statuses: write" in text
+    assert "\npermissions: {}\n" in text
+    jobs_section = text.split("\njobs:\n", 1)[1]
+    lane_job = jobs_section.split("lane-check:\n", 1)[1]
+    assert "statuses: write" in lane_job
 
     # A privileged dispatch runs with statuses: write, so it must execute the
     # trusted helper from main — never code from the dispatched ref, which a


### PR DESCRIPTION
## Summary

Code slice of #1869 (the branch-protection swap follows separately, after an empirical gated test PR, per the issue's migration order).

- `lane-check/proof` is the context branch protection will require; the helper already posts it on the exact PR head, which is what lets a same-head delegated proof satisfy the gate without a manual rerun
- `maybe_status` previously swallowed every posting failure with a warning — a green run whose required status never landed. It now propagates all failures except a 401/403 permission refusal
- 401/403 stays a (clearly marked) warning because that is the documented read-only-token path: Dependabot and fork contexts can never post the status themselves, branch protection stays safely blocked, and only a privileged `workflow_dispatch` refresh can land it
- self-tests now pin: the required context name, the fail-closed matrix (transient error → raise, 403 → warn, 5xx → raise, no `--status` → no call), and the lane workflow's exact-head + never-read-clean guards (`workflow_run.event == 'workflow_dispatch'` gate, unassociated-run no-op, `EXPECTED_HEAD_SHA` double check, `--status` wiring)

Refs #1869.

## Verification

- `python3 scripts/ci/assay_runner_lane_check.py --self-test` — red before the fix on the fail-closed case, green after
- `pre-commit run --files scripts/ci/assay_runner_lane_check.py` — passed (includes the lane-check self-test hook)

## Migration plan (after merge, tracked on #1869)

1. Add `lane-check/proof` to the required contexts alongside `lane-check` (both required during transition).
2. Open a gated test PR: verify it starts blocked, dispatch a delegated proof for the final head, and confirm the required context updates on that SHA with no manual rerun and stale proof still rejected.
3. Only then drop `lane-check` from the required set, keeping the Actions check-run informational.

## Claim boundary

This PR changes error semantics and pins contracts; it does not change which contexts branch protection requires, and it does not claim the migration works end-to-end until the gated test PR proves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lane-check reliability by allowing only expected permission refusals during pull requests while failing safely on other status-reporting errors.
  * Added clearer handling for rate-limit responses.

* **CI Improvements**
  * Changes to the lane-check workflow now trigger the kernel matrix checks.
  * Trusted helper code is resolved from the appropriate workflow reference to improve validation safety.

* **Tests**
  * Added coverage for status-reporting failures, rate limits, permission refusals, and workflow configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->