### PR TITLE
fix(release): record a skipped registry publication explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -730,9 +730,10 @@ jobs:
     needs: [release-contract, release, publish-mcp-registry]
     # always(): a failed publication must still be recorded on the release.
     # Gate on the release job, not the publish result: a prerelease's skipped
-    # publication gets an explicit marker (absence must never read clean),
-    # while a failed release has no release record to annotate and its run is
-    # already red.
+    # publication gets an explicit marker (absence must never read clean).
+    # A failed release records nothing — its run is already red, at most a
+    # stranded partial release exists, and the recovery re-run re-stamps the
+    # marker after the release step completes.
     if: ${{ always() && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -727,10 +727,13 @@ jobs:
 
   record-mcp-registry-result:
     name: Record MCP Registry result
-    needs: [release-contract, publish-mcp-registry]
-    # always(): a failed publication must still be recorded on the release;
-    # skipped (prerelease) publishes record nothing.
-    if: ${{ always() && needs.publish-mcp-registry.result != 'skipped' }}
+    needs: [release-contract, release, publish-mcp-registry]
+    # always(): a failed publication must still be recorded on the release.
+    # Gate on the release job, not the publish result: a prerelease's skipped
+    # publication gets an explicit marker (absence must never read clean),
+    # while a failed release has no release record to annotate and its run is
+    # already red.
+    if: ${{ always() && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/ci/record-mcp-registry-result.sh
+++ b/scripts/ci/record-mcp-registry-result.sh
@@ -28,7 +28,15 @@ case "$RESULT" in
     label="$RESULT"
     ;;
   skipped)
-    label="skipped (prerelease; stable releases only)"
+    # Observe the reason instead of asserting it: this script cannot see WHY
+    # the publish job skipped, but the version itself carries the one
+    # condition the publish gate skips on today. Any other skip cause gets a
+    # bare "skipped" rather than a claimed explanation.
+    if [[ "$VERSION" == *-rc* || "$VERSION" == *-beta* ]]; then
+      label="skipped (prerelease; stable releases only)"
+    else
+      label="skipped"
+    fi
     ;;
   *)
     echo "RESULT must be a terminal job result (success|failure|cancelled|skipped), got: ${RESULT:-<empty>}" >&2

--- a/scripts/ci/record-mcp-registry-result.sh
+++ b/scripts/ci/record-mcp-registry-result.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 #
 # Inputs (env):
 #   VERSION  release tag, e.g. v3.35.0
-#   RESULT   terminal job result: success | failure | cancelled
+#   RESULT   terminal job result: success | failure | cancelled | skipped
+#            (skipped = the prerelease exclusion; recorded explicitly so a
+#            marker-less release stays distinguishable from one that predates
+#            the release transaction — absence must never read clean)
 #   RUN_URL  URL of the workflow run that carried the publication
 #
 # Idempotent: exactly one marker line survives, so retries and re-runs replace
@@ -21,9 +24,14 @@ MARKER="<!-- mcp-registry-status -->"
 [[ -n "$RUN_URL" ]] || { echo "RUN_URL is required" >&2; exit 1; }
 
 case "$RESULT" in
-  success|failure|cancelled) ;;
+  success|failure|cancelled)
+    label="$RESULT"
+    ;;
+  skipped)
+    label="skipped (prerelease; stable releases only)"
+    ;;
   *)
-    echo "RESULT must be a terminal job result (success|failure|cancelled), got: ${RESULT:-<empty>}" >&2
+    echo "RESULT must be a terminal job result (success|failure|cancelled|skipped), got: ${RESULT:-<empty>}" >&2
     exit 1
     ;;
 esac
@@ -36,6 +44,6 @@ gh release view "$VERSION" --json body --jq .body > "$notes"
 grep -vF "$MARKER" "$notes" > "${notes}.next" || true
 mv "${notes}.next" "$notes"
 
-printf '\n%s MCP Registry publication: %s (%s)\n' "$MARKER" "$RESULT" "$RUN_URL" >> "$notes"
+printf '\n%s MCP Registry publication: %s (%s)\n' "$MARKER" "$label" "$RUN_URL" >> "$notes"
 
 gh release edit "$VERSION" --notes-file "$notes"

--- a/scripts/ci/test-mcp-registry-release-txn.sh
+++ b/scripts/ci/test-mcp-registry-release-txn.sh
@@ -148,6 +148,9 @@ echo "ok: check-mcp-registry-version cases"
 
 record_case() {
   local name="$1" result="$2" initial_body="$3" expect_success="$4"
+  local version="${5:-v3.35.0}"
+  local forbid_text="${6:-}"
+  local require_text="${7:-}"
   local temp_dir
   temp_dir="$(mktemp -d)"
   mkdir -p "${temp_dir}/bin"
@@ -182,7 +185,7 @@ EOF
   local rc=0
   PATH="${temp_dir}/bin:${PATH}" \
     FAKE_RELEASE_BODY="${temp_dir}/release-body.md" \
-    VERSION="v3.35.0" \
+    VERSION="$version" \
     RESULT="$result" \
     RUN_URL="https://github.com/Rul1an/assay/actions/runs/123" \
     bash "$RECORD" >/dev/null 2>"${temp_dir}/stderr" || rc=$?
@@ -194,6 +197,14 @@ EOF
       || fail "record: $name must link the registry run"
     grep -q "$result" "${temp_dir}/release-body.md" \
       || fail "record: $name must record the terminal result"
+    if [[ -n "$forbid_text" ]]; then
+      grep -q "$forbid_text" "${temp_dir}/release-body.md" \
+        && fail "record: $name must not claim '$forbid_text'"
+    fi
+    if [[ -n "$require_text" ]]; then
+      grep -q "$require_text" "${temp_dir}/release-body.md" \
+        || fail "record: $name must state '$require_text'"
+    fi
   else
     [[ "$rc" -ne 0 ]] || fail "record: $name unexpectedly succeeded"
   fi
@@ -208,8 +219,15 @@ record_case "rerun replaces the previous marker" success \
 record_case "unknown result is refused" bogus "release notes body" false
 # A prerelease's skipped publication must leave an explicit marker: absence
 # on a release record must stay distinguishable from a pre-feature release
-# (AGENTS.md: absence never reads clean).
-record_case "skipped writes an explicit marker" skipped "release notes body" true
+# (AGENTS.md: absence never reads clean). The reason annotation is observed
+# from the version, never asserted: a skip the mechanism cannot explain gets
+# a bare "skipped", not a claimed cause.
+record_case "skipped on a prerelease names the prerelease reason" skipped \
+  "release notes body" true "v3.36.0-rc.1" "" "prerelease"
+record_case "skipped on a beta names the prerelease reason" skipped \
+  "release notes body" true "v3.36.0-beta.2" "" "prerelease"
+record_case "skipped on a stable version claims no reason" skipped \
+  "release notes body" true "v3.35.0" "prerelease"
 
 echo "ok: record-mcp-registry-result cases"
 
@@ -302,11 +320,15 @@ if "needs.release.result == 'success'" not in record:
     )
 # The if-condition reads needs.release.result, so `release` must stay in the
 # needs list: dropping it makes the expression evaluate empty and the record
-# job silently never runs again.
-if "needs: [release-contract, release, publish-mcp-registry]" not in record:
-    sys.exit("wiring: record job needs must list release-contract, release, publish-mcp-registry")
-if "publish-mcp-registry" not in record:
-    sys.exit("wiring: record job must depend on the publish job")
+# job silently never runs again. Parse the list instead of matching an exact
+# string, so a YAML-identical reorder cannot trip the pin.
+needs_match = re.search(r"needs:\s*\[([^\]]*)\]", record)
+if not needs_match:
+    sys.exit("wiring: record job must declare an inline needs list")
+needs_items = [item.strip() for item in needs_match.group(1).split(",")]
+for needed in ("release", "publish-mcp-registry", "release-contract"):
+    if needed not in needs_items:
+        sys.exit(f"wiring: record job needs must include {needed}")
 if "contents: write" not in record:
     sys.exit("wiring: record job needs contents: write to edit the release")
 PY

--- a/scripts/ci/test-mcp-registry-release-txn.sh
+++ b/scripts/ci/test-mcp-registry-release-txn.sh
@@ -206,7 +206,10 @@ record_case "rerun replaces the previous marker" success \
   "release notes body
 <!-- mcp-registry-status --> MCP Registry publication: failure (https://github.com/Rul1an/assay/actions/runs/99)" true
 record_case "unknown result is refused" bogus "release notes body" false
-record_case "skipped result is refused" skipped "release notes body" false
+# A prerelease's skipped publication must leave an explicit marker: absence
+# on a release record must stay distinguishable from a pre-feature release
+# (AGENTS.md: absence never reads clean).
+record_case "skipped writes an explicit marker" skipped "release notes body" true
 
 echo "ok: record-mcp-registry-result cases"
 
@@ -292,8 +295,11 @@ if "contents: write" in publish:
 
 if "always()" not in record:
     sys.exit("wiring: record job must run on publish failure too")
-if "skipped" not in record:
-    sys.exit("wiring: record job must not fire for skipped prerelease publishes")
+if "needs.release.result == 'success'" not in record:
+    sys.exit(
+        "wiring: record job must run exactly when a release record exists — "
+        "including prerelease skips, excluding failed releases"
+    )
 if "publish-mcp-registry" not in record:
     sys.exit("wiring: record job must depend on the publish job")
 if "contents: write" not in record:

--- a/scripts/ci/test-mcp-registry-release-txn.sh
+++ b/scripts/ci/test-mcp-registry-release-txn.sh
@@ -300,6 +300,11 @@ if "needs.release.result == 'success'" not in record:
         "wiring: record job must run exactly when a release record exists — "
         "including prerelease skips, excluding failed releases"
     )
+# The if-condition reads needs.release.result, so `release` must stay in the
+# needs list: dropping it makes the expression evaluate empty and the record
+# job silently never runs again.
+if "needs: [release-contract, release, publish-mcp-registry]" not in record:
+    sys.exit("wiring: record job needs must list release-contract, release, publish-mcp-registry")
 if "publish-mcp-registry" not in record:
     sys.exit("wiring: record job must depend on the publish job")
 if "contents: write" not in record:


### PR DESCRIPTION
## Summary

Follow-up to #1873, from Cursor's spot-check of the merged release transaction.

The record job gated on `needs.publish-mcp-registry.result != 'skipped'`, so a skipped publication — prerelease exclusion, or any future skip path — left **no marker at all** on the release record. Absence was indistinguishable from a release that predates the transaction, which is exactly the ambiguity the transaction exists to remove (and AGENTS.md's rule: absence never reads clean).

- the record job now gates on `needs.release.result == 'success'`: it runs exactly when a release record exists to annotate
- a prerelease's skipped publication writes an explicit marker: `MCP Registry publication: skipped (prerelease; stable releases only) (run link)`
- a failed release still records nothing — there is no release record to annotate and its run is already red
- `record-mcp-registry-result.sh` accepts `skipped` as a terminal value with its own label; unknown values stay refused

## Verification

- `bash scripts/ci/test-mcp-registry-release-txn.sh` — red before (skipped-marker case + new wiring pin), green after
- `pre-commit run --files …` incl. the transaction self-test hook — passed

## Claim boundary

The live proof of the skipped-marker path requires the next prerelease tag; the success-marker path requires the next stable release. Neither is claimed proven by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)