### PR TITLE
test(ci): #1869 migration gate proof — DO NOT MERGE

### DIFF
--- a/tests/fixtures/runner-spike/kernel-only-agent.sh
+++ b/tests/fixtures/runner-spike/kernel-only-agent.sh
@@ -17,3 +17,5 @@ cat "$input_file" >/dev/null
 printf '%s\n' "assay runner kernel-only fixture output" > "$output_file"
 
 /usr/bin/env ASSAY_RUNNER_KERNEL_ONLY_FIXTURE=1 >/dev/null
+
+# issue-1869 migration gate test: no-op marker (2026-07-27), safe to delete


### PR DESCRIPTION
Empirical step 2 of the #1869 migration, per the agreed protocol. This PR touches a kernel-only gated fixture and exists only to prove, on exact SHAs:

1. it starts blocked on the app-pinned `lane-check/proof` required context — asserted by reading the posted contexts on the head SHA against the required set, never the merge button or job conclusions;
2. a delegated proof for the final head refreshes the required context on that SHA without a manual rerun;
3. a stale proof does not validate a newer head;
4. the `strict: true` interaction cost: after the proof lands, a main advance forces a branch update → new SHA → measures whether a fresh dispatch is required.

Interpretation key, agreed up front: the status is posted with `github.token`, so it should attribute to the Actions app and match the `app_id: 15368` pin. If the required context stays unsatisfied while the status is present and green, the failure is in the pin's app-id or another poster — not in token attribution.

Will be closed without merging; the fixture change is a comment-only no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)