### PR TITLE
docs(agents): repair #1865 regressions and harden the quorum against non-reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,15 +53,16 @@ including its explicit non-claims, or amend the decision through a new ADR.
 - Never turn absence of evidence, failed validation, skipped review, or unavailable infrastructure
   into a clean result.
 - Keep public strings free of private strategy, product-roadmap language, and unearned claims.
-- Stage by explicit pathspec. Never stage by the absence of one: bare `git add -A`, bare `git add .`,
-  `git add -u`, and `git commit -a`/`-am` all commit whatever the tree happens to be carrying at that
-  moment, which is a property of the moment and not of the change under review. A pathspec scopes the
-  command back to the change, so `git add -A demo/output` is fine and `git add -A` is not.
-- Pin a tool version in one place, and have both the install and the invocation read that one value —
-  as `.github/workflows/fuzz-smoke.yml` does with `env: FUZZ_TOOLCHAIN`. Two literals that must agree
-  will eventually disagree. Echo the value in the run so a version claim can be checked against the
-  log, while remembering what that check does not cover: the same workflow records a `cargo +nightly`
-  bypass that leaves the log still naming the pinned toolchain.
+- Stage with a pathspec that names the change. The test is whether the command could pick up a file
+  you did not touch: if it could, it commits a property of the moment rather than the change under
+  review. `git add -A <paths the change touches>` passes; `git add -A`, `git add -A .`, `git add .`,
+  `git add -u` and `git commit -am` all fail it. The list is illustrative and the test is the rule —
+  the set of ways to stage a whole tree is open, so enumerating it would only look complete.
+- Pin a tool version in one place, and have both the install and the invocation read that one value.
+  The defect is two literals that must agree and are free to drift — an install pinning a version that
+  a config file or a second workflow states again. Echo the value in the run so a version claim can be
+  checked against the log, while remembering what that check does not cover: an invocation can select
+  a different toolchain through an alias while the log still names the pinned one.
 
 ## Review Quorum
 
@@ -71,7 +72,14 @@ The builder's self-review does not count. On the final head SHA, require:
 2. if both bots are skipped, rate-limited, or unavailable for 30 minutes after the last push, two
    non-building agent reviews.
 
-`skipped` is not `pass`. A new push invalidates reviews on the prior head.
+`skipped` is not `pass`. A new push invalidates reviews on the prior head, and the head a review was
+measured on is the head it counts for — a merge commit that brings `main` into the branch is a new
+head like any other.
+
+A review record that says it did not review is not a review. A bot that returns `COMMENTED` with
+"unable to review — quota limit", or a check that reports `pass` alongside "review rate limited",
+leaves no findings and no reviewer; it is unavailable infrastructure wearing the shape of a verdict,
+and it satisfies neither route. Read what a record says, not that it exists.
 
 Auto-merge may be enabled only when:
 
@@ -96,20 +104,21 @@ Before pushing:
 - run clippy with `-D warnings` for the affected targets;
 - inspect `git diff --check` and the public-surface strings.
 
+GitHub Actions is the final integration proof. Never weaken, bypass, or relabel a required check to
+make a branch mergeable.
+
 ### Measurement provenance
 
 A measurement carries its provenance, or it is a claim with extra steps. When a number, a count, or a
-pass/fail reaches a PR body, a review, or a programme-ledger entry, it states the exact SHA it was
-measured on — not a branch name, which moves and which is how a stale checkout passes for a current
-one — plus the worktree when more than one is active, and the binary or toolchain when the number
-depends on one.
+pass/fail reaches a PR body, a review, or a programme-ledger entry, it states the exact SHA the
+reported tree was committed as — not a branch name, which moves and which is how a stale checkout
+passes for a current one — plus the worktree when more than one is active, and the binary or toolchain
+when the number depends on one. Measuring before the push is the normal case; commit first and report
+that SHA, rather than reporting a tree no one else can address.
 
 The failure mode this catches is not arithmetic but attribution: the number is right and the tree,
 ref, artifact, or build it describes is not. Name the artifact too when a generated form exists, since
 a correct reading of a generated layer is still the wrong layer.
-
-GitHub Actions is the final integration proof. Never weaken, bypass, or relabel a required check to
-make a branch mergeable.
 
 ## Tool Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,26 +69,28 @@ including its explicit non-claims, or amend the decision through a new ADR.
 The builder's self-review does not count. On the final head SHA, require:
 
 1. one non-building agent review plus CodeRabbit or Copilot; or
-2. if both bots are skipped, rate-limited, or unavailable for 30 minutes after the last push, two
-   non-building agent reviews.
+2. two non-building agent reviews, when both bots are skipped or silent for 30 minutes after the
+   last push — or immediately, when a bot's own record on the current head declares a limit.
 
 `skipped` is not `pass`. A new push invalidates reviews on the prior head, and the head a review was
 measured on is the head it counts for — a merge commit that brings `main` into the branch is a new
 head like any other. A review is revalidated for a new head only by a recorded equivalence check:
-the diff from the reviewed head to the new head over the files the PR changes is empty, and the new
-head adds only commits already on `main`. Put that check in the review record; without it, the
-review does not carry.
+the new head introduces no change, to any file, that is not already on `main` — its tree is what
+merging `main` into the reviewed head produces without conflicts. The check covers the whole tree,
+never a file list, so content outside the reviewed files cannot ride the carry. Put the check in
+the review record; without it, the review does not carry. Rewritten history (rebase, squash) does
+not carry a review even when the tree is identical: revalidation is for upstream advances only.
 
 A review record that says it did not review is not a review. A bot that returns `COMMENTED` with
 "unable to review — quota limit", or a check that reports `pass` alongside "review rate limited",
 leaves no findings and no reviewer; it is unavailable infrastructure wearing the shape of a verdict,
 and it satisfies neither route. Read what a record says, not that it exists. A limit-shaped record
-is, however, itself the observation that the reviewer is unavailable: an independent adversarial
-agent review satisfies that slot immediately — the 30-minute clock in route 2 covers silence, not a
-declared limit — provided the review record documents the substitution: which reviewer was limited,
-which agent reviewed instead, and on which head. Reviews count as artifacts bound to an exact head,
-not as entries in GitHub's review list; a reviewer whose tooling cannot submit a review record
-counts through a comment bound to the SHA it reviewed.
+is, however, itself the observation that the reviewer is unavailable, and route 2 opens immediately
+— provided the record declaring the limit is on the head the substitution covers (quotas reset; an
+earlier head's limit record does not carry forward), and the review record documents which reviewer
+was limited, which agent reviewed instead, and on which head. Reviews count as artifacts bound to
+an exact head, not as entries in GitHub's review list; a reviewer whose tooling cannot submit a
+review record counts through a comment bound to the SHA it reviewed.
 
 Auto-merge may be enabled only when:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,12 +74,21 @@ The builder's self-review does not count. On the final head SHA, require:
 
 `skipped` is not `pass`. A new push invalidates reviews on the prior head, and the head a review was
 measured on is the head it counts for — a merge commit that brings `main` into the branch is a new
-head like any other.
+head like any other. A review is revalidated for a new head only by a recorded equivalence check:
+the diff from the reviewed head to the new head over the files the PR changes is empty, and the new
+head adds only commits already on `main`. Put that check in the review record; without it, the
+review does not carry.
 
 A review record that says it did not review is not a review. A bot that returns `COMMENTED` with
 "unable to review — quota limit", or a check that reports `pass` alongside "review rate limited",
 leaves no findings and no reviewer; it is unavailable infrastructure wearing the shape of a verdict,
-and it satisfies neither route. Read what a record says, not that it exists.
+and it satisfies neither route. Read what a record says, not that it exists. A limit-shaped record
+is, however, itself the observation that the reviewer is unavailable: an independent adversarial
+agent review satisfies that slot immediately — the 30-minute clock in route 2 covers silence, not a
+declared limit — provided the review record documents the substitution: which reviewer was limited,
+which agent reviewed instead, and on which head. Reviews count as artifacts bound to an exact head,
+not as entries in GitHub's review list; a reviewer whose tooling cannot submit a review record
+counts through a comment bound to the SHA it reviewed.
 
 Auto-merge may be enabled only when:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,8 @@ measured on is the head it counts for — a merge commit that brings `main` into
 head like any other. A review is revalidated for a new head only by a recorded equivalence check
 with two conditions: the new head introduces no change, to any file, that is not already on `main`
 — its tree is what merging `main` into the reviewed head produces without conflicts — and the
-advance touched no file the review covered. The first covers the whole tree, never a file list, so
+advance from the reviewed head to the new head touched no file the review covered, meaning the
+PR's changed files as of the reviewed head. The first covers the whole tree, never a file list, so
 content outside the reviewed files cannot ride the carry; the second exists because an upstream
 change to a reviewed file changes what lands even though it smuggles nothing, and "the branch added
 nothing" is a neighbouring property of "what was reviewed is what merges", not the same one. Put
@@ -90,12 +91,12 @@ A review record that says it did not review is not a review. A bot that returns 
 "unable to review — quota limit", or a check that reports `pass` alongside "review rate limited",
 leaves no findings and no reviewer; it is unavailable infrastructure wearing the shape of a verdict,
 and it satisfies neither route. Read what a record says, not that it exists. A limit-shaped record
-is, however, itself the observation that the reviewer is unavailable, and route 2 opens immediately
-— provided the record declaring the limit is on the head the substitution covers (quotas reset; an
-earlier head's limit record does not carry forward), and the review record documents which reviewer
-was limited, which agent reviewed instead, and on which head. Reviews count as artifacts bound to
-an exact head, not as entries in GitHub's review list; a reviewer whose tooling cannot submit a
-review record counts through a comment bound to the SHA it reviewed.
+is, however, itself the observation that the reviewer is unavailable, and that bot's slot in route
+2 opens immediately — provided the record declaring the limit is on the head the substitution
+covers (quotas reset; an earlier head's limit record does not carry forward), and the review record
+documents which reviewer was limited, which agent reviewed instead, and on which head. Reviews
+count as artifacts bound to an exact head, not as entries in GitHub's review list; a reviewer whose
+tooling cannot submit a review record counts through a comment bound to the SHA it reviewed.
 
 Auto-merge may be enabled only when:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,17 +69,22 @@ including its explicit non-claims, or amend the decision through a new ADR.
 The builder's self-review does not count. On the final head SHA, require:
 
 1. one non-building agent review plus CodeRabbit or Copilot; or
-2. two non-building agent reviews, when both bots are skipped or silent for 30 minutes after the
-   last push — or immediately, when a bot's own record on the current head declares a limit.
+2. two non-building agent reviews, when each bot is skipped, silent for 30 minutes after the last
+   push, or declares a limit in its own record on the current head — a declared limit opens that
+   bot's slot immediately, while a merely silent bot still gets its 30 minutes.
 
 `skipped` is not `pass`. A new push invalidates reviews on the prior head, and the head a review was
 measured on is the head it counts for — a merge commit that brings `main` into the branch is a new
-head like any other. A review is revalidated for a new head only by a recorded equivalence check:
-the new head introduces no change, to any file, that is not already on `main` — its tree is what
-merging `main` into the reviewed head produces without conflicts. The check covers the whole tree,
-never a file list, so content outside the reviewed files cannot ride the carry. Put the check in
-the review record; without it, the review does not carry. Rewritten history (rebase, squash) does
-not carry a review even when the tree is identical: revalidation is for upstream advances only.
+head like any other. A review is revalidated for a new head only by a recorded equivalence check
+with two conditions: the new head introduces no change, to any file, that is not already on `main`
+— its tree is what merging `main` into the reviewed head produces without conflicts — and the
+advance touched no file the review covered. The first covers the whole tree, never a file list, so
+content outside the reviewed files cannot ride the carry; the second exists because an upstream
+change to a reviewed file changes what lands even though it smuggles nothing, and "the branch added
+nothing" is a neighbouring property of "what was reviewed is what merges", not the same one. Put
+both checks in the review record; without them, the review does not carry. Rewritten history
+(rebase, squash) does not carry a review even when the tree is identical: revalidation is for
+upstream advances only.
 
 A review record that says it did not review is not a review. A bot that returns `COMMENTED` with
 "unable to review — quota limit", or a check that reports `pass` alongside "review rate limited",


### PR DESCRIPTION
Implements #1872 in two commits:

**Commit 1** (`43e8099d`, cherry-picked clean from the prepared `d4513a09`, original authorship and verification preserved):
- regression: the CI-integrity rule ("never weaken, bypass, or relabel a required check") moves back above `### Measurement provenance`, out of the attribution subsection that had captured it
- regression: the staging rule becomes the test ("could the command pick up a file you did not touch?") with the enumeration explicitly illustrative; the concrete-path example becomes a placeholder
- new rule: a review record that says it did not review is not a review (Copilot "unable to review — quota limit", CodeRabbit `pass` + "review rate limited"), and a merge-of-main is a new head like any other
- clarification: measure-then-push means commit first and report that SHA
- the pin rule describes the defect instead of citing an exemplar file

**Commit 2** (`2ba1f094`, the three refinements from last night's sessions, resolving the tension between the issue text and the recurring-tension comment):
- **equivalence revalidation**: a new head still invalidates, but a review is revalidated by a recorded mechanical check — empty diff over the PR's files, only main-commits added. Without the record, it does not carry. (Observed three times in one night: #1871, #1873, #1874; under `strict: true` every main advance forces this cycle.)
- **immediate substitution on a declared limit** (explicit mandate from Rul1an): a limit-shaped record is itself the observation of unavailability — an independent adversarial agent review satisfies that slot at once, the 30-minute clock covers silence only, and the record must document which reviewer was limited, which agent stood in, and on which head
- **per-artifact counting**: reviews are artifacts bound to an exact head, not entries in GitHub's review list; comment-borne reviews (observed: Cursor) count through a comment bound to the reviewed SHA

Docs-only; the `pre-commit==4.4.0` duplicate in `kernel-matrix.yml:63` stays a separate workflow fix per the issue.

## Verification

On `2ba1f094` in worktree `assay-1872` (branched from `daefdadf`): pre-commit over `AGENTS.md` passes; `git diff --check` clean; longest line ≤ 114; heading order `## Verification` → CI-integrity paragraph → `### Measurement provenance` confirmed mechanically. One file, staged by explicit path.

Closes #1872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and review guidance with clearer staging and tool version requirements.
  * Expanded review quorum rules, including review validity, carry-forward checks, skipped results, and reviewer artifact tracking.
  * Clarified verification and measurement reporting requirements, including exact commit references and toolchain context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->