### PR TITLE
chore(deps): drop the two quick-xml ignores, their removal condition is met

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,3 +1,5 @@
-# Align with ci.yml and deny.toml: allow RUSTSEC-2023-0071 (rsa, no fix)
+# Align with the three peer locations that carry this list: deny.toml,
+# .github/workflows/ci.yml and the pre-push cargo-audit hook in .pre-commit-config.yaml.
+# Allow RUSTSEC-2023-0071 (rsa Marvin Attack, via jsonwebtoken; no fixed release).
 [advisories]
 ignore = ["RUSTSEC-2023-0071"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,7 @@ jobs:
         run: |
           rm -rf ~/.cargo/advisory-db
           # RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upgrade; assay-mcp-server JWT (see deny.toml)
-          # RUSTSEC-2026-0194/0195 (quick-xml): transitive via object_store 0.14.0; no compatible upgrade yet (see deny.toml)
-          cargo audit \
-            --ignore RUSTSEC-2023-0071 \
-            --ignore RUSTSEC-2026-0194 \
-            --ignore RUSTSEC-2026-0195
+          cargo audit --ignore RUSTSEC-2023-0071
 
   clippy:
     name: Clippy (deny warnings)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,11 +127,13 @@ repos:
 
       - id: cargo-audit
         name: cargo audit (RustSec)
-        # Keep the ignore list in lockstep with .github/workflows/ci.yml and deny.toml: these
-        # advisories are triaged as not reachable (rsa Marvin Attack; pyo3 0.24 nth/nth_back and
-        # PyCFunction::new_closure), retired by the pyo3 0.29 migration (#1651). quick-xml
-        # RUSTSEC-2026-0194/0195 is temporarily blocked by object_store 0.14.0 (see deny.toml).
-        entry: bash -lc 'cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176 --ignore RUSTSEC-2026-0177 --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195'
+        # Keep the ignore list in lockstep with .github/workflows/ci.yml and deny.toml.
+        # Only RUSTSEC-2023-0071 (rsa Marvin Attack, reached via jsonwebtoken) still matches a
+        # crate in the tree and has no fixed release. The pyo3 pair (RUSTSEC-2026-0176/0177) was
+        # retired by the pyo3 0.29 migration (#1651) and the quick-xml pair
+        # (RUSTSEC-2026-0194/0195) by object_store 0.14.1; both were left here after they stopped
+        # matching anything, which is what let the list drift out of lockstep.
+        entry: bash -lc 'cargo audit --ignore RUSTSEC-2023-0071'
         language: system
         pass_filenames: false
         files: ^Cargo\.lock$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,9 @@ repos:
 
       - id: cargo-audit
         name: cargo audit (RustSec)
-        # Keep the ignore list in lockstep with .github/workflows/ci.yml and deny.toml.
+        # Keep the ignore list in lockstep with the three peer locations that carry it:
+        # deny.toml, .github/workflows/ci.yml and .cargo/audit.toml. Naming all of them matters —
+        # an incomplete peer list is how this hook drifted in the first place.
         # Only RUSTSEC-2023-0071 (rsa Marvin Attack, reached via jsonwebtoken) still matches a
         # crate in the tree and has no fixed release. The pyo3 pair (RUSTSEC-2026-0176/0177) was
         # retired by the pyo3 0.29 migration (#1651) and the quick-xml pair

--- a/deny.toml
+++ b/deny.toml
@@ -27,12 +27,6 @@ ignore = [
     # rsa: transitive via jsonwebtoken (assay-mcp-server). No safe upgrade; timing sidechannel.
     # JWT verification is server-side; accept risk for MCP auth until jsonwebtoken/rsa offer a fix.
     "RUSTSEC-2023-0071",
-
-    # quick-xml: transitive via object_store 0.14.0. No compatible upgrade yet:
-    # object_store pins quick-xml ^0.40.1, while the fixed quick-xml is >=0.41.0.
-    # Remove both ignores when object_store releases a version that allows quick-xml >=0.41.0.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
 ]
 
 # =============================================================================


### PR DESCRIPTION
First slice of the post-audit sequencing. Placed first deliberately: it is the only item whose correctness condition is **written down in the repo itself and demonstrably satisfied** — a reviewer has to believe nothing, only run `cargo deny check advisories`.

`deny.toml:31-34` stated the condition verbatim:

> object_store pins quick-xml ^0.40.1, while the fixed quick-xml is >=0.41.0. **Remove both ignores when object_store releases a version that allows quick-xml >=0.41.0.**

`object_store` 0.14.1 allows it, `main` already resolves it, and `quick-xml` resolves to a **single** 0.41.0 entry — the fixed version. So RUSTSEC-2026-0194/0195 no longer match any crate in the tree, the block violated its own heading rule ("Only list advisories that currently match a crate in the tree"), and its comment ("transitive via object_store 0.14.0") was factually wrong at this SHA.

## Three places, not two

The list had to be kept in lockstep by hand across `deny.toml`, the `cargo audit` step in `ci.yml`, and the **pre-push hook in `.pre-commit-config.yaml`** — the third one was easy to miss and had drifted furthest: it carried five ignores of which **four** were dead. Besides the quick-xml pair, the pyo3 pair (RUSTSEC-2026-0176/0177) had already been retired by the pyo3 0.29 migration (#1651) and was simply left behind.

All three paths now pass exactly `RUSTSEC-2023-0071` (rsa Marvin Attack, reached via `jsonwebtoken → rsa 0.9.10`), which still matches and has no fixed release.

The drift has one cause worth naming: entries were added on a trigger and never removed on one.

## Verification

Worktree `assay-advisory`, branched from `412687b5`, local cargo-deny/cargo-audit:

- `cargo deny check advisories` → `advisories ok`
- `cargo audit --ignore RUSTSEC-2023-0071` → exit 0; none of RUSTSEC-2026-0176/0177/0194/0195 appears in the output
- pre-commit (incl. its own cargo-deny hook) → passed on both commits

## Claim boundary

This removes four dead ignores and restores lockstep. It does **not** add a mechanism that forces re-litigation by calendar — `deny.toml` cannot express expiry natively, and a test that fails on a named date is a separate change.

Origin: independent audit, corroborated against the recorded unblock trigger, which is what surfaced the third location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)