### PR TITLE
slice 2: repair the untrue integrity sentences and guard the required-context set

### DIFF
--- a/.github/rulesets/main-required-ci-contexts.json
+++ b/.github/rulesets/main-required-ci-contexts.json
@@ -22,15 +22,11 @@
             "integration_id": 15368
           },
           {
-            "context": "lane-check",
+            "context": "lane-check/proof",
             "integration_id": 15368
           },
           {
             "context": "host-capability-check",
-            "integration_id": 15368
-          },
-          {
-            "context": "public-artifact-sanitization",
             "integration_id": 15368
           }
         ]

--- a/.github/workflows/claims-boundary.yml
+++ b/.github/workflows/claims-boundary.yml
@@ -10,6 +10,8 @@ on:
       - "assay-action/action.yml"
       - "assay-action/action.yaml"
       - "scripts/ci/check-claims-boundary.py"
+      - "scripts/ci/check-required-contexts.py"
+      - ".github/rulesets/**"
       - ".github/workflows/claims-boundary.yml"
   workflow_dispatch:
 
@@ -32,3 +34,9 @@ jobs:
 
       - name: Scan public prose
         run: python3 scripts/ci/check-claims-boundary.py
+
+      - name: Self-test required-contexts guard
+        run: python3 scripts/ci/check-required-contexts.py --self-test
+
+      - name: Check the required-context set agrees across every location
+        run: python3 scripts/ci/check-required-contexts.py

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -53,10 +53,11 @@ Repository state observed on 2026-06-11:
     skips;
   - kernel/eBPF gating that avoids self-hosted runner work unless relevant;
   - delegated runner lane proof for selected runner-sensitive PRs.
-- Live branch protection on `main`, observed through GitHub on 2026-06-11,
-  requires `CI`, `lane-check`, and `host-capability-check` with strict
-  up-to-date status checks enabled. `docs/BRANCH-PROTECTION-SETUP.md` should
-  stay reconciled with that live state.
+- Live branch protection on `main` with strict up-to-date status checks enabled.
+  The required contexts are named once, in section 6 "Required Context Names";
+  this entry deliberately does not repeat them. It used to, and the copy went
+  stale when the set changed -- naming a value twice in one document is the
+  drift, not the cure.
 - Existing public docs and evidence artifacts include guides, references,
   receipt schemas, MCP proxy docs, runner fixtures, experiment reports, JUnit,
   SARIF, Trust Basis output, and compressed evidence examples.

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -441,8 +441,12 @@ Before making any branch-protection changes:
 Currently required live branch-protection contexts:
 
 - `CI`
-- `lane-check`
 - `host-capability-check`
+- `lane-check/proof` (commit status posted by `scripts/ci/assay_runner_lane_check.py`)
+
+The bare `lane-check` Actions job still runs and reports, but stopped being required in
+the #1869 migration (PR #1878): the proof status is posted on the exact PR head and
+refreshes on a same-head delegated proof, which the check-run cannot.
 
 Context groups that should stay visible and reviewed when relevant:
 
@@ -462,20 +466,29 @@ Observed from the CI baseline implementation PR `#1638`:
 Proposed required context names for the next branch-protection review:
 
 - `CI`
-- `lane-check`
 - `host-capability-check`
-- `public-artifact-sanitization`
+- `lane-check/proof`
+- `public-artifact-sanitization` (proposal only; deliberately absent from the
+  checked-in ruleset, see below)
 
 Checked-in ruleset activation lives at
 `.github/rulesets/main-required-ci-contexts.json`.
 
 Import note: the checked-in ruleset is config-as-code only until imported in
-GitHub settings. It intentionally mirrors the current live branch protection for
-`CI`, `lane-check`, and `host-capability-check`, so importing it does not weaken
-the existing required-check set. Add `bypass_actors` only if the repository
-owner intentionally wants to preserve an admin bypass path; otherwise
+GitHub settings, which makes it an importable description of the required set that
+nothing reconciles against reality. It therefore carries exactly the three contexts
+above that are live, and no proposals: a proposal that ships inside an importable
+artifact gets promoted by whoever imports it, without the review it is waiting for.
+Importing the ruleset as checked in neither weakens nor widens the existing
+required-check set. Add `bypass_actors` only if the repository owner intentionally
+wants to preserve an admin bypass path; otherwise
 `strict_required_status_checks_policy: true` means merges must be rebased-current
 and green.
+
+The three locations that name this set drift apart when one of them is edited alone:
+that is how `lane-check` outlived its retirement here and in the troubleshooting
+section of `docs/BRANCH-PROTECTION-SETUP.md` after PR #1878 removed it everywhere
+else. `scripts/ci/check-required-contexts.py` now fails when they disagree.
 
 Do not make these required in this slice:
 

--- a/crates/assay-evidence/src/attestation.rs
+++ b/crates/assay-evidence/src/attestation.rs
@@ -9,8 +9,11 @@
 //! log on its own.
 //!
 //! It also does not identify the artifact. The subject digest is `manifest.run_root`,
-//! a chain over per-event content hashes that deliberately exclude stream identity,
-//! `time`, producer metadata and the PII flag so a re-export stays stable. A bundle
+//! a chain over per-event content hashes, and those cover exactly
+//! `{specversion, type, datacontenttype, subject?, data}` so a re-export stays stable.
+//! Everything else is outside by construction, including stream identity, `time`,
+//! trace context, producer and policy metadata, and the privacy flags; the enumerated
+//! list lives in `crypto/id.rs`. A bundle
 //! whose run id, event ids, producer, timestamps and PII flags are rewritten
 //! consistently therefore has the same `run_root` and satisfies the same attestation.
 //! in-toto expects the reverse -- subjects are immutable and matched purely by digest

--- a/crates/assay-evidence/src/attestation.rs
+++ b/crates/assay-evidence/src/attestation.rs
@@ -4,9 +4,18 @@
 //! envelope, reusing the mandate DSSE primitives (PAE + Ed25519). The anchor
 //! (a transparency log or timestamp) stays pluggable and external.
 //!
-//! Honest boundary: an attestation binds who-said-it and the bundle content. It
-//! does NOT upgrade observed support, and provides no trust root or transparency
+//! Honest boundary: an attestation binds who-said-it and the *semantic event chain*.
+//! It does NOT upgrade observed support, and provides no trust root or transparency
 //! log on its own.
+//!
+//! It also does not identify the artifact. The subject digest is `manifest.run_root`,
+//! a chain over per-event content hashes that deliberately exclude stream identity,
+//! `time`, producer metadata and the PII flag so a re-export stays stable. A bundle
+//! whose run id, event ids, producer, timestamps and PII flags are rewritten
+//! consistently therefore has the same `run_root` and satisfies the same attestation.
+//! in-toto expects the reverse -- subjects are immutable and matched purely by digest
+//! -- so treating a satisfied envelope as proof of *which* bundle you hold reads a
+//! guarantee into the subject that it does not carry. See ADR-039 "Non-claims".
 
 use crate::bundle::Manifest;
 use crate::crypto::jcs;
@@ -42,7 +51,11 @@ pub struct InTotoStatement {
     pub predicate: serde_json::Value,
 }
 
-/// Build an in-toto v1 Statement whose subject is the bundle's integrity root.
+/// Build an in-toto v1 Statement whose subject digest is the bundle's chain root.
+///
+/// The chain root is an equivalence digest over event *semantics*, not a digest of the
+/// bundle bytes, so this subject does not distinguish two bundles that carry the same
+/// events under a different stream identity. See the module docs for what that costs.
 pub fn statement_from_manifest(
     manifest: &Manifest,
     predicate: serde_json::Value,

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -511,9 +511,13 @@ mod tests {
                 },
             );
 
-            // Calculate run_root
+            // Calculate run_root. The profile requires bundle_id to carry the same value, so the
+            // placeholder above has to be replaced here rather than left as "test": this fixture
+            // is hand-built, and a hand-built manifest that skips the contract only tests the
+            // checks that happen to run.
             let content_hash = event.content_hash.as_ref().unwrap();
             manifest.run_root = compute_run_root(std::slice::from_ref(content_hash));
+            manifest.bundle_id = manifest.run_root.clone();
 
             let manifest_json = serde_json::to_vec(&manifest).unwrap();
             let mut manifest_hasher = Sha256::new();

--- a/crates/assay-evidence/src/bundle/writer_next/errors.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/errors.rs
@@ -39,6 +39,7 @@ pub enum ErrorCode {
     ContractDuplicateFile,
     ContractUnexpectedFile,
     ContractRunIdMismatch,
+    ContractBundleIdMismatch,
     ContractSequenceGap,
     ContractSequenceStart,
     ContractTimestampRegression,

--- a/crates/assay-evidence/src/bundle/writer_next/verify.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/verify.rs
@@ -82,6 +82,7 @@ pub struct VerifyResult {
 /// 11. **Run ID Consistency**: All events have same run_id as manifest
 /// 12. **Event Count**: Matches manifest.event_count
 /// 13. **Run Root**: Recomputed value matches manifest.run_root
+/// 14. **Bundle ID**: manifest.bundle_id equals manifest.run_root
 ///
 /// # Errors
 ///
@@ -440,10 +441,17 @@ fn verify_bundle_snapshot(source: &[u8], limits: VerifyLimits) -> Result<VerifyR
                 }
 
                 // Check 9, the ID contract. Documented at the top of this function since the
-                // format was written, but never executed: the id is outside the per-event content
-                // hash, so a forged stream identity survived every other check once the container
-                // was resealed. Ordered after the run_id and seq checks so a mismatch here is
-                // always the id itself and not one of its two inputs.
+                // format was written, but never executed until ADR-043: the id is outside the
+                // per-event content hash, so an id that disagrees with its own run_id and seq
+                // survived every other check once the container was resealed. Ordered after the
+                // run_id and seq checks so a mismatch here is always the id itself and not one of
+                // its two inputs.
+                //
+                // What this does not close: the contract is internal, so a *consistent* rewrite
+                // satisfies it. Rewrite the manifest run_id and every event's run_id and id
+                // together and the bundle still verifies, because the chain root is computed over
+                // content hashes that exclude identity by design. Binding a bundle to its identity
+                // needs a second digest, not a stricter version of this check.
                 // The id contract is `run_id:seq`, so it only means something if the split is
                 // unambiguous. The writer refuses a run_id containing a colon for exactly this
                 // reason; without the same rule here the verifier accepts bundles its own writer
@@ -517,6 +525,20 @@ fn verify_bundle_snapshot(source: &[u8], limits: VerifyLimits) -> Result<VerifyR
                     ErrorClass::Integrity,
                     ErrorCode::IntegrityRunRootMismatch,
                     "Run root mismatch",
+                )
+                .into());
+            }
+
+            // Check 14, the bundle id contract. The profile makes it normative -- "the manifest's
+            // `run_root` and `bundle_id` MUST both equal it" -- but nothing derives one from the
+            // other at read time, so the two could disagree and still verify. Ordered after the
+            // chain check on purpose: a mutated run_root stays a root mismatch, and this fires
+            // only when the chain is sound and its second copy in the manifest is not.
+            if m.bundle_id != m.run_root {
+                return Err(VerifyError::new(
+                    ErrorClass::Contract,
+                    ErrorCode::ContractBundleIdMismatch,
+                    "bundle_id must equal run_root",
                 )
                 .into());
             }

--- a/crates/assay-evidence/src/bundle/writer_next/verify.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/verify.rs
@@ -534,7 +534,12 @@ fn verify_bundle_snapshot(source: &[u8], limits: VerifyLimits) -> Result<VerifyR
             // other at read time, so the two could disagree and still verify. Ordered after the
             // chain check on purpose: a mutated run_root stays a root mismatch, and this fires
             // only when the chain is sound and its second copy in the manifest is not.
-            if m.bundle_id != m.run_root {
+            //
+            // Compared against the *computed* root rather than `m.run_root`. The two are equal
+            // by the check above, so this is the same comparison today; it stops being the same
+            // comparison the moment someone reorders these checks, and a contract that is only
+            // sound because of what runs before it is one edit away from being decorative.
+            if m.bundle_id != computed_run_root {
                 return Err(VerifyError::new(
                     ErrorClass::Contract,
                     ErrorCode::ContractBundleIdMismatch,

--- a/crates/assay-evidence/tests/verifier_fail_closed_properties.rs
+++ b/crates/assay-evidence/tests/verifier_fail_closed_properties.rs
@@ -273,6 +273,36 @@ fn a_mutated_run_root_is_a_run_root_mismatch() {
     );
 }
 
+/// The profile makes `bundle_id` normative: "the manifest's `run_root` and `bundle_id` MUST both
+/// equal it" (`docs/profiles/privileged-mcp-action/v0.md:126`). Nothing derives one from the other
+/// at read time, so without this check the two can disagree and the bundle still verifies — a
+/// normative MUST with no mechanism behind it. Ordered after the chain check so a mutated
+/// `run_root` still fails as a root mismatch; this fires only when the chain is sound and the
+/// second copy of it is not.
+#[test]
+fn a_bundle_id_that_disagrees_with_the_chain_root_is_rejected() {
+    let bundle = valid_bundle(2);
+    let (manifest, events) = unpack(&bundle);
+
+    let mut m: serde_json::Value = serde_json::from_slice(&manifest).expect("manifest json");
+    assert_eq!(
+        m["bundle_id"], m["run_root"],
+        "the writer must emit them equal, or this test proves nothing about the verifier"
+    );
+    m["bundle_id"] = serde_json::json!(format!("sha256:{}", "0".repeat(64)));
+    let tampered = serde_json::to_vec(&m).expect("reserialize");
+
+    // No reseal: only the manifest changed, and its recorded events digest still matches.
+    let (class, code) = expect_rejected(
+        &repack(&[("manifest.json", &tampered), ("events.ndjson", &events)]),
+        "a manifest whose bundle_id does not equal its chain root",
+    );
+    assert_eq!(
+        (class, code),
+        (ErrorClass::Contract, ErrorCode::ContractBundleIdMismatch)
+    );
+}
+
 /// `verify.rs` documents check 9 as "ID Contract: event.id == run_id:seq". The id is outside the
 /// per-event content hash, so nothing else catches a forged one once the manifest is resealed.
 /// A documented check that does not run is the exact failure ADR-043 is about, and it sits on the

--- a/crates/assay-evidence/tests/verify_strict_test.rs
+++ b/crates/assay-evidence/tests/verify_strict_test.rs
@@ -270,9 +270,11 @@ fn test_verifier_rejects_missing_content_hash_raw_tar() {
     // Build manifest that references the correct hash (but the event in the archive has None)
     let manifest = serde_json::json!({
         "schema_version": 1,
-        // Equal to run_root, as the profile requires: this fixture is about the missing
-        // content_hash, so every other part of the manifest has to be conformant or the
-        // rejection could be explained by something the test is not claiming to exercise.
+        // Equal to run_root, so the bundle_id contract is not what rejects this fixture.
+        // The manifest is not otherwise conformant -- `run_root` below is a single event's
+        // content hash rather than a chain over one, which `compute_run_root` would not
+        // produce -- but verification stops at the missing content_hash long before the
+        // chain check, so that stays out of the way of what this test is about.
         "bundle_id": correct_hash,
         "producer": {"name": "test", "version": "1.0"},
         "run_id": "run_deterministic_test",
@@ -514,9 +516,10 @@ fn test_reject_extra_file() {
         let manifest = serde_json::json!({
             "schema_version": 1,
             // Equal to run_root: the extra member is appended after events.ndjson, so the
-            // events block completes before the allowlist sees it. A placeholder here would
-            // reject the bundle on the bundle_id contract and this test would pass while
-            // proving nothing about the extra file it is named for.
+            // events block completes before the allowlist sees it. With the placeholder that
+            // used to sit here the bundle is rejected on the bundle_id contract, and since
+            // the assertion below matches on "Unexpected file" the test goes red -- failing
+            // for a reason that has nothing to do with the extra file it is named for.
             "bundle_id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "producer": {"name": "test", "version": "1.0"},
             "run_id": "run_test",

--- a/crates/assay-evidence/tests/verify_strict_test.rs
+++ b/crates/assay-evidence/tests/verify_strict_test.rs
@@ -270,7 +270,10 @@ fn test_verifier_rejects_missing_content_hash_raw_tar() {
     // Build manifest that references the correct hash (but the event in the archive has None)
     let manifest = serde_json::json!({
         "schema_version": 1,
-        "bundle_id": "test-missing-hash",
+        // Equal to run_root, as the profile requires: this fixture is about the missing
+        // content_hash, so every other part of the manifest has to be conformant or the
+        // rejection could be explained by something the test is not claiming to exercise.
+        "bundle_id": correct_hash,
         "producer": {"name": "test", "version": "1.0"},
         "run_id": "run_deterministic_test",
         "event_count": 1,
@@ -510,7 +513,11 @@ fn test_reject_extra_file() {
         // 1. Manifest
         let manifest = serde_json::json!({
             "schema_version": 1,
-            "bundle_id": "test",
+            // Equal to run_root: the extra member is appended after events.ndjson, so the
+            // events block completes before the allowlist sees it. A placeholder here would
+            // reject the bundle on the bundle_id contract and this test would pass while
+            // proving nothing about the extra file it is named for.
+            "bundle_id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "producer": {"name": "test", "version": "1.0"},
             "run_id": "run_test",
             "event_count": 0,

--- a/docs/BRANCH-PROTECTION-SETUP.md
+++ b/docs/BRANCH-PROTECTION-SETUP.md
@@ -179,10 +179,10 @@ If a PR shows a required check **CIExpected** that never completes, branch prote
 **Fix:** In **Settings → Branches → Branch protection rule for `main`**, under
 "Require status checks", remove **CIExpected** and add **CI** (from
 `.github/workflows/ci.yml`) plus the current required live contexts
-`lane-check` and `host-capability-check`. Save.
+`host-capability-check` and `lane-check/proof`. Save.
 
 **Via API:** Inspect with `gh api repos/OWNER/REPO/branches/main/protection`.
-Ensure `required_status_checks.contexts` contains `CI`, `lane-check`, and
-`host-capability-check`, and does not contain `CIExpected`. Re-apply using the
-JSON in Option B above with
-`"contexts": ["CI", "lane-check", "host-capability-check"]`.
+Ensure `required_status_checks.contexts` contains `CI`, `host-capability-check`,
+and `lane-check/proof`, and does not contain `CIExpected` or the retired bare
+`lane-check`. Re-apply using the JSON in Option B above with
+`"contexts": ["CI", "host-capability-check", "lane-check/proof"]`.

--- a/docs/architecture/ADR-039-evidence-bundle-attestation.md
+++ b/docs/architecture/ADR-039-evidence-bundle-attestation.md
@@ -43,9 +43,21 @@ shape; it is intentionally not built, to avoid freezing a predicate no one consu
 
 ## Non-claims
 
-- Attestation binds who-said-it and the content; it does not upgrade observed support
-  (proven in the attested-observed work) and provides no trust root or transparency
+- Attestation binds who-said-it and the semantic event chain; it does not upgrade observed
+  support (proven in the attested-observed work) and provides no trust root or transparency
   log.
+- **The subject does not identify the artifact.** `statement_from_manifest` uses
+  `manifest.run_root` as the subject digest, and `run_root` chains the per-event content
+  hashes. Those cover `{specversion, type, datacontenttype, subject?, data}` and deliberately
+  exclude stream identity, `time`, producer metadata and the PII flag, so that a re-export at a
+  different time keeps the same chain. The cost of that property is that a bundle whose
+  `run_id`, event ids, producer, timestamps and PII flags are all rewritten *consistently* has a
+  bit-identical `run_root` and satisfies the same attestation. in-toto assumes the opposite:
+  "Subjects are assumed to be immutable" and subjects are "matched purely by digest". So a
+  consumer who reads a satisfied attestation as proof of *which* bundle they hold is relying on
+  a property this subject does not have. The repair is to separate the two roles, not to widen
+  the digest -- widening it would break the deterministic re-export five documents specify.
+  Tracked as its own ADR on the programme ledger (#1866).
 
 ## References
 

--- a/docs/architecture/ADR-039-evidence-bundle-attestation.md
+++ b/docs/architecture/ADR-039-evidence-bundle-attestation.md
@@ -48,15 +48,19 @@ shape; it is intentionally not built, to avoid freezing a predicate no one consu
   log.
 - **The subject does not identify the artifact.** `statement_from_manifest` uses
   `manifest.run_root` as the subject digest, and `run_root` chains the per-event content
-  hashes. Those cover `{specversion, type, datacontenttype, subject?, data}` and deliberately
-  exclude stream identity, `time`, producer metadata and the PII flag, so that a re-export at a
-  different time keeps the same chain. The cost of that property is that a bundle whose
+  hashes. Those cover exactly `{specversion, type, datacontenttype, subject?, data}` and nothing
+  else, so a re-export at a different time keeps the same chain. Everything outside that set is
+  excluded by construction -- stream identity, `time`, trace context, producer and policy
+  metadata, and the privacy flags; `crypto/id.rs` carries the enumerated list, and it is the one
+  place worth reading, because a second copy of it is a second thing to keep true. The cost of
+  that property is that a bundle whose
   `run_id`, event ids, producer, timestamps and PII flags are all rewritten *consistently* has a
   bit-identical `run_root` and satisfies the same attestation. in-toto assumes the opposite:
   "Subjects are assumed to be immutable" and subjects are "matched purely by digest". So a
   consumer who reads a satisfied attestation as proof of *which* bundle they hold is relying on
   a property this subject does not have. The repair is to separate the two roles, not to widen
-  the digest -- widening it would break the deterministic re-export five documents specify.
+  the digest -- widening it would break the deterministic re-export the profile makes normative
+  (`docs/profiles/privileged-mcp-action/v0.md:124`) and `crypto/id.rs` implements.
   Tracked as its own ADR on the programme ledger (#1866).
 
 ## References

--- a/scripts/ci/check-required-contexts.py
+++ b/scripts/ci/check-required-contexts.py
@@ -64,7 +64,14 @@ def ruleset_contexts(text: str) -> list[str]:
 
 
 def ci_contract_contexts(text: str) -> list[str]:
-    """The bullet list under the anchor, read until the list ends."""
+    """The bullet list immediately under the anchor.
+
+    "Immediately" is the load-bearing word. Scanning forward until some bullet list turns up
+    means that deleting the list under the anchor silently promotes the next list in the
+    document to being the required set, and the guard reports agreement about the wrong
+    paragraph. So: blank lines may separate the anchor from its list, and the first
+    non-blank line that is not a bullet ends the search -- whether or not anything was found.
+    """
     lines = text.splitlines()
     try:
         start = next(i for i, line in enumerate(lines) if line.strip() == CI_CONTRACT_ANCHOR)
@@ -79,10 +86,14 @@ def ci_contract_contexts(text: str) -> list[str]:
         if match:
             # Names carry a trailing parenthetical gloss in this list; keep the name only.
             found.append(match.group(1).strip())
-        elif found:
+        elif not line.strip() and not found:
+            continue
+        else:
             break
     if not found:
-        raise DriftError(f"{CI_CONTRACT}: the list under the anchor is empty")
+        raise DriftError(
+            f"{CI_CONTRACT}: no bullet list directly under anchor {CI_CONTRACT_ANCHOR!r}"
+        )
     return found
 
 
@@ -123,6 +134,24 @@ def read_repo(path: Path) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
 
 
+def _drop_list_under_anchor(text: str) -> str:
+    """Remove only the bullets directly under the anchor, keeping the anchor and later lists.
+
+    Later lists have to survive, or the mutation cannot tell the two parsers apart: strip every
+    bullet in the file and even a parser that scans onward finds nothing and reports correctly.
+    The case worth testing is the one where there is still something further down to grab.
+    """
+    lines = text.splitlines(keepends=True)
+    start = next(i for i, line in enumerate(lines) if line.strip() == CI_CONTRACT_ANCHOR)
+    cursor = start + 1
+    while cursor < len(lines) and not lines[cursor].strip():
+        cursor += 1
+    end = cursor
+    while end < len(lines) and BULLET_RE.match(lines[end]):
+        end += 1
+    return "".join(lines[: start + 1] + lines[end:])
+
+
 def self_test() -> int:
     """A guard nobody has seen fail is a guard nobody knows works."""
     baseline = {p: read_repo(p) for p in (RULESET, CI_CONTRACT, RUNBOOK)}
@@ -130,28 +159,60 @@ def self_test() -> int:
         print("self-test: the repository is already drifting; fix that first", file=sys.stderr)
         return 1
 
-    cases = [
+    # Each case names the outcome it requires, because "something went red" is the weakest
+    # assertion available and it is how a guard ends up right by accident. A deleted list
+    # must be reported as a missing list; if it surfaces as a mismatch instead, the parser
+    # walked on and adopted a different paragraph, which is the bug and not the detection.
+    mismatch_cases = [
         (CI_CONTRACT, lambda t: t.replace("- `host-capability-check`", "- `retired-context`", 1)),
         # Inside the array specifically: a name in the runbook's prose is out of scope by
         # design, so a mutation there proves nothing about the guard either way.
         (RUNBOOK, lambda t: t.replace('"CI", "host-capability-check"', '"CI"', 1)),
         (RULESET, lambda t: t.replace('"host-capability-check"', '"retired-context"', 1)),
+    ]
+    unreadable_cases = [
         (CI_CONTRACT, lambda t: t.replace(CI_CONTRACT_ANCHOR, "Contexts, probably:", 1)),
         (RUNBOOK, lambda t: t.replace('"contexts"', '"former_contexts"')),
+        (CI_CONTRACT, _drop_list_under_anchor),
     ]
-    for path, mutate in cases:
+
+    def apply(path: Path, mutate) -> dict | None:
         mutated = dict(baseline)
         mutated[path] = mutate(baseline[path])
         if mutated[path] == baseline[path]:
             print(f"self-test: mutation for {path} did not apply", file=sys.stderr)
+            return None
+        return mutated
+
+    for path, mutate in mismatch_cases:
+        mutated = apply(path, mutate)
+        if mutated is None:
             return 1
         try:
             problems = check(mutated.__getitem__)
-        except DriftError:
-            continue
+        except DriftError as exc:
+            print(f"self-test: drift in {path} was unreadable, expected a mismatch: {exc}",
+                  file=sys.stderr)
+            return 1
         if not problems:
             print(f"self-test: drift in {path} went undetected", file=sys.stderr)
             return 1
+
+    for path, mutate in unreadable_cases:
+        mutated = apply(path, mutate)
+        if mutated is None:
+            return 1
+        try:
+            check(mutated.__getitem__)
+        except DriftError:
+            continue
+        print(
+            f"self-test: an unreadable {path} did not raise; the guard located a set it "
+            "should not have been able to find",
+            file=sys.stderr,
+        )
+        return 1
+
     print("check-required-contexts self-test=passed")
     return 0
 

--- a/scripts/ci/check-required-contexts.py
+++ b/scripts/ci/check-required-contexts.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Pin the required branch-protection contexts to one value across every place that names them.
+
+Three files describe the same set: the importable ruleset, the CI contract, and the
+branch-protection runbook. Nothing reconciled them, so an edit to one left the others
+describing a set that no longer exists. PR #1878 retired the bare `lane-check` context in
+three documents and missed these, and the stale name survived in an artifact whose whole
+purpose is to be imported into live protection.
+
+The guard is the mechanism that a written "remember to update the others" is not. It reads
+each location through an explicit anchor and fails when the anchor is missing, so
+restructuring a document surfaces as an error rather than as a check that quietly stops
+looking.
+
+Scope, so the green result is not read as more than it is: this compares the *structured*
+statements of the set -- the ruleset entries, the anchored bullet list, and the
+`"contexts": [...]` arrays an operator would copy. Surrounding prose is deliberately not
+matched, because the runbook legitimately names `lane-check` as the informational job it
+still is, and a guard that cannot tell that from a stale requirement would be turned off.
+
+Usage:
+    check-required-contexts.py             # verify the three locations agree
+    check-required-contexts.py --self-test # prove each parser detects a drift
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RULESET = Path(".github/rulesets/main-required-ci-contexts.json")
+CI_CONTRACT = Path("CI-CONTRACT.md")
+RUNBOOK = Path("docs/BRANCH-PROTECTION-SETUP.md")
+
+CI_CONTRACT_ANCHOR = "Currently required live branch-protection contexts:"
+BULLET_RE = re.compile(r"^-\s+`([^`]+)`")
+CONTEXTS_ARRAY_RE = re.compile(r'"contexts"\s*:\s*(\[[^\]]*\])')
+
+
+class DriftError(Exception):
+    """A location disagrees with the ruleset, or its anchor is gone."""
+
+
+def ruleset_contexts(text: str) -> list[str]:
+    """The importable artifact is the source of truth: it is the one that can be applied."""
+    doc = json.loads(text)
+    found: list[str] = []
+    for rule in doc.get("rules", []):
+        if rule.get("type") != "required_status_checks":
+            continue
+        for check in rule.get("parameters", {}).get("required_status_checks", []):
+            found.append(check["context"])
+    if not found:
+        raise DriftError(
+            f"{RULESET}: no required_status_checks rule found; the guard cannot "
+            "determine the required set"
+        )
+    return found
+
+
+def ci_contract_contexts(text: str) -> list[str]:
+    """The bullet list under the anchor, read until the list ends."""
+    lines = text.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == CI_CONTRACT_ANCHOR)
+    except StopIteration:
+        raise DriftError(
+            f"{CI_CONTRACT}: anchor {CI_CONTRACT_ANCHOR!r} is gone; the guard cannot "
+            "locate the required set"
+        ) from None
+    found: list[str] = []
+    for line in lines[start + 1 :]:
+        match = BULLET_RE.match(line)
+        if match:
+            # Names carry a trailing parenthetical gloss in this list; keep the name only.
+            found.append(match.group(1).strip())
+        elif found:
+            break
+    if not found:
+        raise DriftError(f"{CI_CONTRACT}: the list under the anchor is empty")
+    return found
+
+
+def runbook_contexts(text: str) -> list[list[str]]:
+    """Every `"contexts": [...]` array in the runbook, each of which must match."""
+    arrays = [json.loads(m.group(1)) for m in CONTEXTS_ARRAY_RE.finditer(text)]
+    if not arrays:
+        raise DriftError(
+            f'{RUNBOOK}: no `"contexts": [...]` array found; the guard cannot locate '
+            "the required set"
+        )
+    return arrays
+
+
+def compare(expected: list[str], actual: list[str], where: str) -> list[str]:
+    """Set comparison, because these three lists are legitimately ordered differently."""
+    if set(expected) == set(actual):
+        return []
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    detail = []
+    if missing:
+        detail.append(f"missing {missing}")
+    if extra:
+        detail.append(f"unexpected {extra}")
+    return [f"{where}: {', '.join(detail)} (ruleset requires {sorted(expected)})"]
+
+
+def check(read) -> list[str]:
+    expected = ruleset_contexts(read(RULESET))
+    problems = compare(expected, ci_contract_contexts(read(CI_CONTRACT)), str(CI_CONTRACT))
+    for index, array in enumerate(runbook_contexts(read(RUNBOOK))):
+        problems += compare(expected, array, f"{RUNBOOK} contexts array #{index + 1}")
+    return problems
+
+
+def read_repo(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def self_test() -> int:
+    """A guard nobody has seen fail is a guard nobody knows works."""
+    baseline = {p: read_repo(p) for p in (RULESET, CI_CONTRACT, RUNBOOK)}
+    if check(baseline.__getitem__):
+        print("self-test: the repository is already drifting; fix that first", file=sys.stderr)
+        return 1
+
+    cases = [
+        (CI_CONTRACT, lambda t: t.replace("- `host-capability-check`", "- `retired-context`", 1)),
+        # Inside the array specifically: a name in the runbook's prose is out of scope by
+        # design, so a mutation there proves nothing about the guard either way.
+        (RUNBOOK, lambda t: t.replace('"CI", "host-capability-check"', '"CI"', 1)),
+        (RULESET, lambda t: t.replace('"host-capability-check"', '"retired-context"', 1)),
+        (CI_CONTRACT, lambda t: t.replace(CI_CONTRACT_ANCHOR, "Contexts, probably:", 1)),
+        (RUNBOOK, lambda t: t.replace('"contexts"', '"former_contexts"')),
+    ]
+    for path, mutate in cases:
+        mutated = dict(baseline)
+        mutated[path] = mutate(baseline[path])
+        if mutated[path] == baseline[path]:
+            print(f"self-test: mutation for {path} did not apply", file=sys.stderr)
+            return 1
+        try:
+            problems = check(mutated.__getitem__)
+        except DriftError:
+            continue
+        if not problems:
+            print(f"self-test: drift in {path} went undetected", file=sys.stderr)
+            return 1
+    print("check-required-contexts self-test=passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="prove the parsers detect drift")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        problems = check(read_repo)
+    except DriftError as exc:
+        print(f"required-contexts=failed\n{exc}", file=sys.stderr)
+        return 1
+
+    if problems:
+        print("required-contexts=failed", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        print(
+            "\nThe required-context set is named in three places and they must agree. "
+            "The ruleset is the source of truth because it is the one that can be imported.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("required-contexts=passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ADR Boundary Slice

- Canonical ledger: #1866
- Slice: 2 (the untrue sentences, `bundle_id` MUST, ruleset trap)
- Builder: Cursor
- Reviewers: adversarial pass on `a3491338` — merge-with-followup, no Critical/High
- Final head SHA: `4246a355` — every measurement below is stated against this SHA, on `main` at `a867173b` (slice 1 merged)
- ADR invariants affected: ADR-039 non-claims; ADR-043 §"stop list binds emitted artifacts"

## Behavior

Three changes, one of them observable.

**Observable.** The verifier gains check 14: `manifest.bundle_id` must equal the chain root. The profile already made this normative — `docs/profiles/privileged-mcp-action/v0.md:126` says "the manifest's `run_root` and `bundle_id` MUST both equal it" — and nothing enforced it. A bundle carrying an all-zeros `bundle_id` beside an intact `run_root` verified clean. New code `ContractBundleIdMismatch`, class `Contract`.

Ordered **after** the chain check: a mutated `run_root` stays `IntegrityRunRootMismatch`, and the new code fires only when the chain is sound and its second copy in the manifest disagrees. The comparison is against `computed_run_root`, not `m.run_root` — identical today because check 13 has already equated them, but it stays sound if the two are ever reordered rather than being sound only because of what runs before it.

**Prose, no behaviour.** ADR-039 and the `attestation.rs` module doc said an attestation binds "who-said-it and the content". True of the semantic event chain, untrue of the artifact — and load-bearing, because `statement_from_manifest` puts `manifest.run_root` in the in-toto subject digest while `run_root` chains content hashes covering exactly `{specversion, type, datacontenttype, subject?, data}`.

**Config.** The checked-in ruleset required the retired bare `lane-check` and the proposal-only `public-artifact-sanitization`, and did not require `lane-check/proof`. Importing it would have dropped the live proof gate and promoted a proposal in one action, while `CI-CONTRACT.md` described it as mirroring live protection.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

Explicitly **not** claimed: check 14 does not bind a bundle to its identity. A consistent rewrite of `run_id` and every event id still verifies, because the chain root excludes identity. Confirmed by the reviewer against this branch. That is the separate ADR on #1866, and widening `content_hash` is the wrong repair — it breaks the deterministic re-export the profile makes normative.

## Test Evidence

### RED

```
$ cargo test -p assay-evidence --test verifier_fail_closed_properties a_bundle_id_that_disagrees
test a_bundle_id_that_disagrees_with_the_chain_root_is_rejected ... FAILED

panicked at verifier_fail_closed_properties.rs:155:
a manifest whose bundle_id does not equal its chain root must not verify: ()
```

`must not verify: ()` is the `Ok(())` arm: the tampered bundle verified.

Negative control for the config guard, with the stale value pinned back into the ruleset:

```
$ python3 scripts/ci/check-required-contexts.py
required-contexts=failed
  CI-CONTRACT.md: missing ['lane-check'], unexpected ['lane-check/proof']
  docs/BRANCH-PROTECTION-SETUP.md contexts array #1: missing ['lane-check'] ...
  docs/BRANCH-PROTECTION-SETUP.md contexts array #2: missing ['lane-check'] ...
```

### GREEN

| Command | Result |
|---|---|
| `cargo test -p assay-evidence` | 35 lanes ok, 0 failed |
| `cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it -- --skip test_no_passthrough_e2e` | 194 lanes ok, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| `check-required-contexts.py --self-test` / plain | passed / passed |
| `check-claims-boundary.py` | passed, finding_count=0 |
| all 13 conformance vectors through `assay evidence verify` | outcomes unchanged |

**Two fixtures broke, and that is the finding.** `test_crlf_bom_tolerance` and `test_reject_extra_file` hand-built manifests with `bundle_id: "test"` beside real chain roots. They had never satisfied the profile; they passed because nothing checked. `test_reject_extra_file` is the sharper one: its extra member is appended after `events.ndjson`, so the events block completes first, and with the placeholder the bundle is rejected on the bundle_id contract while the assertion matches `"Unexpected file"` — verified by restoring it: RED at `verify_strict_test.rs:568`.

Every other bundle in the tree already held the invariant: the thirteen conformance vectors and the fuzz corpus, checked individually.

## Review round (findings on `a3491338`)

All in-PR items are fixed on `4246a355`. M-2 is deferred to the ADR slice as proposed.

**M-1 — the sixth instance, inside my own repair.** `CI-CONTRACT.md:56-59` still named the pre-#1878 live set and told the reader to reconcile the runbook to it, 385 lines above the block this PR corrected. The guard cannot see it: prose outside the anchored list, exactly the scope limit its docstring documents. Rather than widen the guard, the second enumeration is gone — the entry now points at section 6, the only place that names the set. A value stated once cannot drift from itself.

**L-1 — an untrue sentence about untrue sentences.** My comment said the placeholder fixture "would pass while proving nothing". It goes red. Corrected, and verified by restoring the placeholder rather than reasoning about it.

**L-2** — the neighbouring comment claimed the whole manifest was conformant while its `run_root` is a single event's content hash. Now says what is true and why it does not matter there.

**L-3** — check 14 compares against `computed_run_root`.

**L-4** — both boundary notes restated the exclusion list partially, missing trace context and `policy_id`. They now state the inclusion set, exhaustive by construction, and point at `crypto/id.rs` rather than keeping a second copy true.

**L-5 — in the guard itself.** It scanned forward past the anchor until it found any bullet list, so deleting the list under the anchor silently promoted the next paragraph — the silent pass I claimed the anchor design excluded. Fixed, and the self-test now distinguishes a missing list from a mismatch instead of accepting "something went red". The first version of that self-test case proved nothing: it stripped every bullet in the file, so both the old and new parser reported correctly. With later lists left in place the old parser fails with "located a set it should not have been able to find".

**L-6** — "five documents" was a number I had not counted. Replaced with the two sources that can be pointed at.

## Provenance notes

Two things verified rather than taken on report, because both had been mis-cited earlier in this programme:

- `conformance/.../scripts/pack_format.py:121-176` exists and contains zero `run_root` references. Running `rewrite_bundle_stream_identity` over every vector gives **13/13 sharing their source root**. `gen_vectors.py` does recompute the root, but it is the generator, not the rewriter.
- The bad-101/ok-001 root collision inside the vector set is a *declared* one: `bad-101` differs in `data`, so its stored root is a copied stale value, and the bundle is rejected on the file digest. Not an instance of this defect.

Live branch protection could not be read from this environment (403 on the protection API), so the required set is taken from the freshest in-repo observation: PR #1878, "observed live on 2026-07-27".

## Mechanism, not another note

`scripts/ci/check-required-contexts.py` treats the ruleset as source of truth — it is the one that can be applied — and fails when the CI contract's anchored list or either runbook `"contexts"` array disagrees. A missing anchor, or a missing list under a present anchor, fails rather than passing silently.

This surfaced that **PR #1878's own repair was incomplete**: it fixed three documents and missed both `CI-CONTRACT.md` and the troubleshooting section of `docs/BRANCH-PROTECTION-SETUP.md`. Fifth instance of the incomplete-peer-list pattern slice 1 traced through the advisory ignores; M-1 above is the sixth, in this PR.

It runs in the claims-boundary workflow, so it is visible on any PR touching these paths but **not merge-blocking**. Making it required is coupled to the open finding that the `CI` gate ignores its own variables, which is a separate slice.

## Review Quorum

- [x] One non-building agent review (adversarial pass on `a3491338`, merge-with-followup)
- [ ] CodeRabbit or Copilot review on this head SHA
- [ ] If bots were unavailable for 30 minutes, a second non-building agent review is linked
- [x] Every actionable finding is fixed or has a technical disposition (M-2 deferred to the ADR slice)
- [ ] Any delegated proof targets this exact head SHA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bundle verification now rejects manifests whose bundle ID does not match the computed run root.
  * Updated verification fixtures to correctly exercise specific failure scenarios.

* **CI**
  * Required branch protection checks now use `lane-check/proof`.
  * Added automated detection to identify inconsistencies in required-check configurations.

* **Documentation**
  * Clarified attestation subject semantics, verification boundaries, and branch-protection troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->