### PR TITLE
ADR profile side (M-2): the bundle_id check enters the documented verification order

### DIFF
--- a/docs/profiles/privileged-mcp-action/v0.md
+++ b/docs/profiles/privileged-mcp-action/v0.md
@@ -130,7 +130,12 @@ then `events.ndjson`.
   length.
 - Verification checks structure, the two-file allowlist, path safety, file hashes and sizes, per-event
   content-hash recomputation, the id contract, contiguous sequence from 0, run-id consistency, event
-  count, and the run-root recomputation, **in that order and before any profile semantics**.
+  count, the run-root recomputation, and finally the manifest's `bundle_id` against that recomputed
+  root, **in that order and before any profile semantics**. The `bundle_id` comparison is last on
+  purpose: placed earlier it would report a tampered `run_root` as a `bundle_id` disagreement, and an
+  implementation that reports the wrong one of the two is harder to debug than one that rejects late.
+  Both are required, so a bundle satisfying only one of them MUST be rejected -- including the case
+  where the two manifest fields agree with each other but not with the recomputed chain.
 
 ## 5. Verification stages
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ADR Boundary Slice

- Canonical ledger: #1866
- Slice: attestation-subject ADR, profile side (M-2 from the slice-2 review)
- Builder: Cursor
- Reviewers: <!-- pending -->
- Final head SHA: `cf5775c3` — on `main` at `f327376f`
- ADR invariants affected: prepares the profile half of the attestation-subject ADR

## Behavior

Documentation only. `docs/profiles/privileged-mcp-action/v0.md:126` makes `bundle_id` normative — `run_root` and `bundle_id` MUST both equal the chain — while the enumerated verification order five lines below ended at the run-root recomputation. Since #1883 enforces the equality as check 14, the profile that exists to be implementable *without reading Assay code* described a verifier that accepts what Assay rejects.

The order now ends with the `bundle_id` comparison and states two things the previous wording left open:

- why it is last (placed earlier it reports a tampered `run_root` as a `bundle_id` disagreement, which is harder to debug)
- that two manifest fields agreeing with each other but not with the recomputed chain must still be rejected

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

## Test Evidence

Outcome-neutral for the frozen corpus, measured rather than assumed:

```
13 vectoren, 0 met bundle_id != run_root
-> de nieuwe spec-eis verandert geen enkele verwachte uitkomst
```

No expected outcome moves, so no independent implementation's score changes. `check-claims-boundary.py` passes with `finding_count=0`. No code touched.

## The vector is deliberately absent, and that needs a decision

The review asked for a conformance vector exercising a `bundle_id` mismatch, since none of the thirteen does. I did not add one, because doing so collides with a public commitment and the collision is the more interesting finding.

The corpus digest `sha256:a943120f…` is published in #1840, pinned to release `privileged-mcp-action-v0-candidate.2`, source commit `975ee012`, and a signed attestation, and described there as a **frozen 13-case corpus**. `CONFORMANCE-PROTOCOL.md:135` repeats "the pinned 13-case corpus". A fourteenth case changes the digest, and neither document defines a revision path.

The tension is real in both directions, and worth stating plainly because it sharpens M-2 rather than deferring it:

`build_clean_room_pack.py:78` ships `v0.md` into the released pack as `spec.md`, read from the pinned source commit. So candidate.2 keeps the old spec text and this change does not alter released bytes. But that means an implementor working blind-from-spec against candidate.2 builds a verifier that accepts `bundle_id` mismatches, scores 100% because no vector exercises it, and diverges from Assay on a normative MUST. The corpus cannot see the difference — which is precisely why the vector matters, and precisely why adding it quietly to a frozen corpus would be the wrong way to get it.

Two ways forward, both decisions rather than implementation details:

1. **Cut `candidate.3`** with fourteen cases and a new digest, retiring candidate.2 as superseded. Honest, and it makes the divergence detectable. Cost: any in-flight independent reproduction is scored against a corpus that changed under it.
2. **Hold the vector** until the current challenge closes, and record the gap so the next revision carries it. Cost: the divergence stays undetectable for as long as the challenge runs.

I lean towards 2 with an explicit recorded gap, because #1840's value comes from the pin holding still, and the behaviour itself is already covered by a deterministic property test (`a_bundle_id_that_disagrees_with_the_chain_root_is_rejected`, merged in #1883). What the corpus adds is *third-party detectability*, not coverage — and that is worth one release cycle of delay rather than a moved pin.

Either way it belongs in the joint ADR text, since it is the same role-splitting decision seen from the conformance side.

## Review Quorum

- [ ] One non-building agent review
- [ ] CodeRabbit or Copilot review on this head SHA
- [ ] If bots were unavailable for 30 minutes, a second non-building agent review is linked
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f98a1-4a62-777c-a7a1-5ad834163f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Stage 1 bundle verification sequence.
  * Specified that `bundle_id` comparison occurs after `run_root` recomputation.
  * Documented that bundles passing only one of these checks must be rejected.
  * Added clarification on error reporting when verification fields disagree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->