### PR TITLE
ADR-044 (proposed): the attestation subject is the artifact, not the semantic chain

### DIFF
--- a/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
+++ b/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
@@ -1,0 +1,150 @@
+# ADR-044: The attestation subject is the artifact, not the semantic chain
+
+- Status: Proposed
+- Date: 2026-07-27
+- Supersedes: none
+- Amends: ADR-039 (evidence bundle attestation)
+
+## Context
+
+`run_root` serves two purposes that cannot both be served by one value, and the collision is
+currently resolved in favour of the wrong one.
+
+Its first purpose is semantic equivalence. It chains the per-event `content_hash`, and that hash
+covers `{specversion, type, datacontenttype, subject?, data}` and nothing else. Excluding `time`,
+stream identity and producer metadata is deliberate and correct: it is what allows the same events,
+repackaged later by a different producer, to keep the same hash. That property is normative in
+`docs/profiles/privileged-mcp-action/v0.md`, it is what `conformance/privileged-mcp-action-v0`
+depends on, and it is precisely what issue #1840 asks third parties to reproduce.
+
+Its second purpose is to be the in-toto subject digest. `statement_from_manifest` puts
+`manifest.run_root` in `subject[0].digest.sha256`, so the DSSE signature is bound to that value.
+
+The in-toto v1 Statement specification is explicit about what a subject digest is:
+
+> Subjects are assumed to be _immutable_, i.e. the artifacts identified by the subject SHOULD NOT
+> change.
+
+> Subject artifacts are matched purely by digest, regardless of content type.
+
+`run_root` is not immutable with respect to the artifact, by construction. Two bundles that differ
+in `run_id`, producer, timestamps, the PII flag and `source` share it.
+
+### Reproduction
+
+Taking `fuzz/corpus/bundle_reader/valid-three-events` and rewriting the stream identity
+consistently — every event's `assayrunid` and `id`, the manifest's `run_id`, the producer, the PII
+flag and the timestamps — then re-pinning only the `events.ndjson` digest:
+
+```
+run_id:   run_verifier_property_0001 -> forged_run_identity_000100
+producer: assay-evidence-property-test -> forged-producer
+assaypii: false -> true
+time:     2023-11-14 -> 2099-01-01
+run_root: sha256:6af106bd... UNCHANGED
+=> VERIFIED OK
+```
+
+The same holds for `source` alone, on the shipped fixture `tests/fixtures/evidence/test-bundle.tar.gz`:
+rewriting it across all five events and re-pinning only the file digest verifies clean with
+`run_root` bit-identical (`sha256:7a47bb25...` before and after).
+
+So a valid DSSE signature over a genuine bundle matches a forged bundle **by digest**, which is the
+only thing an in-toto verifier is told to match on. The consequence is not that the signature is
+weak; it is that the signature answers a different question than the one a consumer asks. It
+attests "these events, in this order, carry this semantic content". A consumer reading
+`subject.digest` reasonably believes it attests "this artifact".
+
+Nothing in this analysis says the exclusion list is wrong. Widening `content_hash` would break
+deterministic re-export, break the clean-room conformance pack, and re-merge the two roles rather
+than separating them. The defect is the reuse, not the digest.
+
+### What the chain does not carry
+
+The complete inventory is enforced by `crates/assay-evidence/tests/content_hash_field_inventory.rs`
+rather than restated here, because every hand-written copy of it has gone stale. The load-bearing
+consequence for this decision: `source` — the CloudEvents field naming the system that produced
+the stream — is outside the chain, alongside `run_id`, `seq`, producer identity and version,
+`git_sha`, `policy_id`, `time`, trace context, and the `contains_pii` / `contains_secrets` flags.
+
+An attestation over `run_root` therefore does not establish **who produced the events, when, under
+which policy, or whether they were classified as containing personal data**.
+
+## Decision
+
+**1. The subject digest is the digest of the bundle bytes.**
+
+`subject[0].digest.sha256` becomes the SHA-256 of the `.tar.gz` a consumer holds. That value is
+already a pinned determinism input — `docs/spec/EVIDENCE-CONTRACT-v1.md:125` lists "SHA-256 of the
+entire compressed tar.gz" among the three exact inputs — so this introduces no new computation, only
+a new use of one the format already fixes. It is *not* `bundle_id`, which equals `run_root` and is
+therefore a semantic value; `subject[0].name` keeps the bundle identifier for human reference.
+
+**2. Provenance moves into the predicate.**
+
+`run_id`, `run_root`, producer identity and version, `git_sha`, `event_count` and the run's time
+window are predicate fields. The predicate sits inside the DSSE envelope, so these are signed; they
+are simply not the matching key. This is the same split SLSA and cosign use: subject identifies the
+bytes, predicate says what is claimed about them.
+
+**3. `run_root` MUST NOT appear as a second entry in the same `DigestSet`.**
+
+This is normative and not stylistic. The in-toto `DigestSet` rule is:
+
+> Two DigestSets SHOULD be considered matching if ANY acceptable field matches.
+
+A `DigestSet` carrying both `sha256` (artifact) and a custom `run_root` field would match a forged
+bundle on the second key, restoring the exact defect this ADR removes, through a field added to
+document it. `run_root` belongs in the predicate, where matching semantics do not apply.
+
+**4. The two roles are named wherever either is used.**
+
+`run_root` is the *semantic equivalence digest*: equal iff two bundles carry the same events, in the
+same order, with the same content. The bundle digest is the *artifact digest*: equal iff the bytes
+are identical. A document or comment that says an attestation "binds the bundle content" without
+saying which of the two is meant is not making a checkable statement.
+
+## Consequences
+
+Existing attestations do not verify against the new subject rule and must be re-issued. There is no
+migration path that preserves them, because their subject digest does not identify their artifact —
+that is the finding.
+
+Consumers matching on `subject.digest` gain artifact identity and lose the ability to recognise a
+re-export as "the same evidence". That recognition is still available, from `run_root` in the
+predicate, and it becomes an explicit act rather than an accident of which digest was in the
+matching position.
+
+The clean-room conformance pack is unaffected. `pack_format.py` contains no reference to `run_root`
+at all: `rewrite_bundle_stream_identity` rewrites `assayrunid`, the event `id`s and the manifest
+`run_id`, re-pins the `events.ndjson` digest, and leaves the chain root untouched by never
+addressing it. That is the property #1840 relies on. Under this decision the same rewriting
+produces a bundle with an unchanged semantic digest and a *different* artifact digest — which is
+exactly the distinction the pack exists to demonstrate, now expressible instead of collapsed.
+
+Verifier behaviour does not change. `bundle_id == run_root` remains the enforced manifest
+invariant (check 14, ADR-043 lineage); this ADR governs what the attestation binds, not what the
+verifier accepts.
+
+## Open
+
+- Whether the predicate keeps a `semantic_equivalence` block naming `run_root` explicitly, or
+  whether `run_root` sits at the predicate top level. Preference: a named block, so a consumer
+  cannot mistake it for a second artifact digest.
+- The `corpus_digest_method` string in the conformance manifest is ambiguous between the prefixed
+  and bare-hex readings of "vector sha256" (the implementation uses the prefixed form). Same class
+  of defect — a digest procedure that two honest implementers read differently — and it should be
+  disambiguated in the same pass.
+
+## Implementation evidence
+
+Measured on `7ba8f066`, worktree `assay-adr044`:
+
+- consistent stream-identity rewrite verifies clean with `run_root` unchanged (probe against
+  `verify_bundle_with_limits`, default limits);
+- `source`-only rewrite on `tests/fixtures/evidence/test-bundle.tar.gz` verifies clean, `run_root`
+  bit-identical, independently reproduced;
+- `statement_from_manifest` (`crates/assay-evidence/src/attestation.rs`) places `manifest.run_root`
+  in the subject digest;
+- in-toto v1 Statement text quoted above read from the specification repository, not from a
+  secondary description.

--- a/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
+++ b/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
@@ -83,9 +83,9 @@ than separating them. The defect is the reuse, not the digest.
 ### What the chain does not carry
 
 The complete inventory is not restated here, because every hand-written copy of it has gone stale.
-It is enforced by `crates/assay-evidence/tests/content_hash_field_inventory.rs`, which **does not
-yet exist on `main`** — it lands with PR #1886, and this ADR takes a hard dependency on that merge.
-Until then the citation names an intended mechanism, not an available one. The load-bearing
+It is enforced by `crates/assay-evidence/tests/content_hash_field_inventory.rs`, on `main` since
+PR #1886: an exhaustive destructure of `EvidenceEvent` fails the build when a field is added, and
+each emitted field is classified by observing whether mutating it moves the hash. The load-bearing
 consequence for this decision: `source` — the CloudEvents field naming the system that produced
 the stream — is outside the chain, alongside `run_id`, `seq`, producer identity and version,
 `git_sha`, `policy_id`, `time`, trace context, and the `contains_pii` / `contains_secrets` flags.
@@ -247,8 +247,9 @@ author alone:
 
 ## Dependencies
 
-- PR #1886 (`content_hash_field_inventory.rs`) must merge before this ADR is Accepted; the "what the
-  chain does not carry" section cites a mechanism that does not exist on `main` until then.
+- PR #1886 (`content_hash_field_inventory.rs`) — **merged**. The "what the chain does not carry"
+  section cites an enforced mechanism rather than an intended one, which was the condition for
+  moving this ADR out of draft.
 
 ## Implementation evidence
 

--- a/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
+++ b/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
@@ -69,9 +69,12 @@ The forgery therefore survives not because it matches, but because **nothing is 
 the producer side alone does not establish artifact identity: a correct subject digest that no
 consumer compares is still an unchecked field. The decision below has to cover both ends.
 
-The signature is not weak. It attests "these events, in this order, carry this semantic content" —
-a true and useful statement. A consumer reading `subject.digest` reasonably believes it attests
-"this artifact", and no part of the current path makes that belief checkable.
+The signature is not weak, and describing what it does establish takes the same care as the subject
+correction. It authenticates the Statement and the semantic root *asserted* in it. Only once that
+root has been recomputed from a verified bundle may a consumer conclude that the signer attested
+those ordered content-hash inputs — until then, "these events, in this order" is a claim the
+envelope carries, not one it proves. A consumer reading `subject.digest` reasonably believes the
+attestation names an artifact, and no part of the current path makes that belief checkable either.
 
 Nothing in this analysis says the exclusion list is wrong. Widening `content_hash` would break
 deterministic re-export, break the clean-room conformance pack, and re-merge the two roles rather
@@ -109,9 +112,20 @@ archive is finalised and threaded into statement construction. It is *not* `bund
 
 A correct subject digest that nobody compares is still an unchecked field, and that is the state the
 reproduction above actually documents. `verify_envelope` currently returns the Statement without
-touching `subject`. It MUST, given the archive bytes, recompute their SHA-256 and reject a mismatch
-before returning; a caller that has no bytes to offer MUST get a distinct result meaning
-*signature-verified, artifact-unmatched*, never a plain success.
+touching `subject`.
+
+The obligation is a second, explicit step rather than an overload of the first:
+
+- `verify_envelope(envelope, key)` keeps its present job — payload type, signature, Statement type —
+  and its result is typed as *signature-verified, artifact-unmatched*. That is a state, not an error
+  and not a success.
+- `verify_attestation_for_bundle(envelope, key, bundle_bytes)` recomputes the SHA-256 of those bytes,
+  matches it against the single subject, validates the predicate version, and cross-checks the
+  derivable fields. Only this call can return a fully verified attestation.
+
+Splitting them keeps the weaker outcome nameable in the type system. Folding the byte match into
+`verify_envelope` would make "I verified the attestation" mean two different things depending on
+which argument the caller happened to have, which is the ambiguity this ADR exists to remove.
 
 Producer-side changes alone do not establish artifact identity. Both ends move or neither does.
 
@@ -119,20 +133,42 @@ Producer-side changes alone do not establish artifact identity. Both ends move o
 
 The current builder accepts arbitrary JSON under `evidence-bundle/v0`, so a legacy statement and a
 conforming one are indistinguishable. This decision introduces a new predicate type — a fresh
-version, not a relaxation of the old one — whose required fields are specified rather than
-conventional:
+version, not a relaxation of the old one:
+
+```
+predicateType = https://assay.dev/attestation/evidence-bundle/v1
+```
 
 ```json
-"semantic_equivalence": {
-  "algorithm": "assay-run-root-v1",
-  "value": "sha256:..."
+{
+  "schema_version": 1,
+  "semantic_equivalence": {
+    "algorithm": "assay-run-root-v1",
+    "value": "sha256:<64 lowercase hex>"
+  },
+  "run": {
+    "run_id": "<string>",
+    "event_count": "<non-negative integer>",
+    "producer": { "name": "<string>", "version": "<string>", "git": "<string>" },
+    "time_window": { "start": "<RFC 3339 UTC>", "end": "<RFC 3339 UTC>" }
+  }
 }
 ```
 
-`run_root` lives there and nowhere else. Required provenance fields: `run_id`, producer name and
-version, `git_sha`, `event_count`, and the run's time window. Values derivable from the matched
-bundle MUST be cross-checked against it by the consumer; a predicate that disagrees with the artifact
-it is attached to is a rejection, not a note.
+All fields are required except `run.time_window`, which is **`null` for a zero-event bundle**. The
+verifier accepts a bundle with no events, so that bundle has no earliest and no latest event `time`
+and cannot satisfy a mandatory window; a schema that demanded one would be unsatisfiable for a
+bundle the format permits. `null` is the honest encoding of "the artifact does not carry this", and
+it is not the same as the field being absent, which is a malformed predicate.
+
+`run_root` lives in `semantic_equivalence` and nowhere else. Every field derivable from the archive
+— the semantic root, `run_id`, `event_count`, producer name, version and `git` — MUST be recomputed
+or read from the *verified* bundle and compared exactly; a predicate that disagrees with the artifact
+it is attached to is a rejection, not a note. Where the source events disagree among themselves
+about producer identity, the bundle is rejected before the predicate is consulted.
+
+Unknown fields within a known major version are ignored. An **unknown major version fails closed**:
+a consumer that cannot evaluate the predicate MUST NOT report the attestation as verified.
 
 The named block exists so a consumer cannot read the semantic digest as a second artifact digest.
 That is the same confusion at one remove, and naming is what prevents it.
@@ -183,9 +219,13 @@ addressing it. That is the property #1840 relies on. Under this decision the sam
 produces a bundle with an unchanged semantic digest and a *different* artifact digest — which is
 exactly the distinction the pack exists to demonstrate, now expressible instead of collapsed.
 
-Verifier behaviour does not change. `bundle_id == run_root` remains the enforced manifest
-invariant (check 14, ADR-043 lineage); this ADR governs what the attestation binds, not what the
-verifier accepts.
+Bundle verification remains unchanged: `bundle_id == run_root` is still check 14, on the ADR-043
+lineage, and the set of bundles the verifier accepts is untouched.
+
+Attestation verification changes materially, and the first draft's "verifier behaviour does not
+change" was wrong about which verifier it meant. Attestation verification gains artifact-byte
+matching, a typed signature-only state, predicate-version validation, and bundle-to-predicate
+consistency checks.
 
 ## Resolved during drafting
 
@@ -196,9 +236,11 @@ author alone:
   out of in-toto's artifact-matching namespace instead of relying on readers to know the difference.
 - **Corpus digest wording**: `corpus_digest_method` is to state that the hash is taken over each
   stored `vectors[i].sha256` **string including the literal `sha256:` prefix**, each followed by LF,
-  in manifest order. The implementation already does this; the sentence did not say so, and the
-  bare-hex reading is the more natural one — a procedure two honest implementers read differently is
-  the same defect class as this ADR's, one layer down.
+  in manifest order, and that the **result is stored as the literal `sha256:` followed by 64
+  lowercase hexadecimal characters**. The implementation already does both; the sentence pinned
+  neither, and an unambiguous input with an implicit output is only half a procedure. The bare-hex
+  reading of the input is the more natural one — a procedure two honest implementers read
+  differently is the same defect class as this ADR's, one layer down.
 - **Clean-room pack**: confirmed unaffected. It carries no DSSE attestations at all, and rewritten
   bundles keep `run_root` while their artifact bytes change — which is the distinction this decision
   makes expressible.

--- a/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
+++ b/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
@@ -49,11 +49,29 @@ The same holds for `source` alone, on the shipped fixture `tests/fixtures/eviden
 rewriting it across all five events and re-pinning only the file digest verifies clean with
 `run_root` bit-identical (`sha256:7a47bb25...` before and after).
 
-So a valid DSSE signature over a genuine bundle matches a forged bundle **by digest**, which is the
-only thing an in-toto verifier is told to match on. The consequence is not that the signature is
-weak; it is that the signature answers a different question than the one a consumer asks. It
-attests "these events, in this order, carry this semantic content". A consumer reading
-`subject.digest` reasonably believes it attests "this artifact".
+The conclusion this reproduction supports is narrower than "the forged bundle matches", and the
+narrower statement is the more serious one.
+
+A conforming in-toto consumer hashes the `.tar.gz` it holds and compares that to
+`subject[0].digest.sha256`. The stored value is `run_root`, which is not the SHA-256 of any archive.
+So under conforming matching **neither the genuine bundle nor the forged one matches** — the subject
+digest is not merely wrong about which artifact it names, it names no artifact at all.
+
+Assay's own consumer does not perform that comparison. `verify_envelope` checks the DSSE payload
+type, verifies the Ed25519 signature over the PAE, asserts the Statement `_type`, and returns the
+Statement. It never touches `subject`. So today:
+
+- a conforming consumer rejects every bundle, genuine or forged, for failing to match;
+- Assay's consumer accepts both, because it matches nothing;
+- the forged bundle "matches" only under a non-standard comparison of `run_root` against `run_root`.
+
+The forgery therefore survives not because it matches, but because **nothing is matched**. Fixing
+the producer side alone does not establish artifact identity: a correct subject digest that no
+consumer compares is still an unchecked field. The decision below has to cover both ends.
+
+The signature is not weak. It attests "these events, in this order, carry this semantic content" —
+a true and useful statement. A consumer reading `subject.digest` reasonably believes it attests
+"this artifact", and no part of the current path makes that belief checkable.
 
 Nothing in this analysis says the exclusion list is wrong. Widening `content_hash` would break
 deterministic re-export, break the clean-room conformance pack, and re-merge the two roles rather
@@ -61,8 +79,10 @@ than separating them. The defect is the reuse, not the digest.
 
 ### What the chain does not carry
 
-The complete inventory is enforced by `crates/assay-evidence/tests/content_hash_field_inventory.rs`
-rather than restated here, because every hand-written copy of it has gone stale. The load-bearing
+The complete inventory is not restated here, because every hand-written copy of it has gone stale.
+It is enforced by `crates/assay-evidence/tests/content_hash_field_inventory.rs`, which **does not
+yet exist on `main`** — it lands with PR #1886, and this ADR takes a hard dependency on that merge.
+Until then the citation names an intended mechanism, not an available one. The load-bearing
 consequence for this decision: `source` — the CloudEvents field naming the system that produced
 the stream — is outside the chain, alongside `run_id`, `seq`, producer identity and version,
 `git_sha`, `policy_id`, `time`, trace context, and the `contains_pii` / `contains_secrets` flags.
@@ -72,37 +92,78 @@ which policy, or whether they were classified as containing personal data**.
 
 ## Decision
 
-**1. The subject digest is the digest of the bundle bytes.**
+**1. The subject digest is the digest of the completed archive bytes.**
 
-`subject[0].digest.sha256` becomes the SHA-256 of the `.tar.gz` a consumer holds. That value is
-already a pinned determinism input — `docs/spec/EVIDENCE-CONTRACT-v1.md:125` lists "SHA-256 of the
-entire compressed tar.gz" among the three exact inputs — so this introduces no new computation, only
-a new use of one the format already fixes. It is *not* `bundle_id`, which equals `run_root` and is
-therefore a semantic value; `subject[0].name` keeps the bundle identifier for human reference.
+`subject[0].digest.sha256` becomes the SHA-256 of the finished `.tar.gz` — the exact byte sequence a
+consumer receives, gzip trailer included. `subject[0].name` keeps the bundle identifier for human
+reference.
 
-**2. Provenance moves into the predicate.**
+This defines no new digest, and the distinction matters: the format already fixes this value as a
+determinism input (`docs/spec/EVIDENCE-CONTRACT-v1.md:125`, "SHA-256 of the entire compressed
+tar.gz"). It does require **new runtime data flow**. `statement_from_manifest` receives only a
+`Manifest` today and cannot see the container, so the archive digest has to be computed where the
+archive is finalised and threaded into statement construction. It is *not* `bundle_id`, which equals
+`run_root` and is therefore a semantic value.
 
-`run_id`, `run_root`, producer identity and version, `git_sha`, `event_count` and the run's time
-window are predicate fields. The predicate sits inside the DSSE envelope, so these are signed; they
-are simply not the matching key. This is the same split SLSA and cosign use: subject identifies the
-bytes, predicate says what is claimed about them.
+**2. Consumers MUST match the subject against the bytes they hold.**
 
-**3. `run_root` MUST NOT appear as a second entry in the same `DigestSet`.**
+A correct subject digest that nobody compares is still an unchecked field, and that is the state the
+reproduction above actually documents. `verify_envelope` currently returns the Statement without
+touching `subject`. It MUST, given the archive bytes, recompute their SHA-256 and reject a mismatch
+before returning; a caller that has no bytes to offer MUST get a distinct result meaning
+*signature-verified, artifact-unmatched*, never a plain success.
 
-This is normative and not stylistic. The in-toto `DigestSet` rule is:
+Producer-side changes alone do not establish artifact identity. Both ends move or neither does.
+
+**3. The predicate is versioned, with a schema, and carries provenance in named blocks.**
+
+The current builder accepts arbitrary JSON under `evidence-bundle/v0`, so a legacy statement and a
+conforming one are indistinguishable. This decision introduces a new predicate type — a fresh
+version, not a relaxation of the old one — whose required fields are specified rather than
+conventional:
+
+```json
+"semantic_equivalence": {
+  "algorithm": "assay-run-root-v1",
+  "value": "sha256:..."
+}
+```
+
+`run_root` lives there and nowhere else. Required provenance fields: `run_id`, producer name and
+version, `git_sha`, `event_count`, and the run's time window. Values derivable from the matched
+bundle MUST be cross-checked against it by the consumer; a predicate that disagrees with the artifact
+it is attached to is a rejection, not a note.
+
+The named block exists so a consumer cannot read the semantic digest as a second artifact digest.
+That is the same confusion at one remove, and naming is what prevents it.
+
+**4. Exactly one subject, and it identifies an artifact.**
+
+Stronger than barring `run_root` from a `DigestSet`, and for the reason the upstream spec gives:
+every `DigestSet` entry is required to identify an immutable artifact, so a semantic-equivalence
+identifier is out of place anywhere in the subject array, not just alongside `sha256`.
+
+The narrow rule remains true and is why the broad one is needed — the `DigestSet` rule is:
 
 > Two DigestSets SHOULD be considered matching if ANY acceptable field matches.
 
-A `DigestSet` carrying both `sha256` (artifact) and a custom `run_root` field would match a forged
-bundle on the second key, restoring the exact defect this ADR removes, through a field added to
-document it. `run_root` belongs in the predicate, where matching semantics do not apply.
+A second key would match a forged bundle through the very field added to document the problem. But
+barring one field invites the next one; requiring a single artifact subject closes the class.
 
-**4. The two roles are named wherever either is used.**
+**5. The two roles are named wherever either is used.**
 
-`run_root` is the *semantic equivalence digest*: equal iff two bundles carry the same events, in the
-same order, with the same content. The bundle digest is the *artifact digest*: equal iff the bytes
-are identical. A document or comment that says an attestation "binds the bundle content" without
-saying which of the two is meant is not making a checkable statement.
+`run_root` is the *semantic equivalence digest*. Equal values are intended to mean two bundles carry
+the same ordered sequence of content-hash inputs — not that the events are equal objects: the
+excluded fields may differ, which is the whole point of the exclusion. The archive digest is the
+*artifact digest*: equal values are intended to mean identical bytes.
+
+Both are identity relations under their chosen algorithm rather than mathematical biconditionals,
+and SHA-256 collision resistance is the assumption underneath each. Stating them as `iff` would
+overclaim in two directions at once — the first because equal roots permit different events, the
+second because digest equality is computational, not logical.
+
+A document or comment saying an attestation "binds the bundle content" without saying which of the
+two is meant is not making a checkable statement.
 
 ## Consequences
 
@@ -126,15 +187,26 @@ Verifier behaviour does not change. `bundle_id == run_root` remains the enforced
 invariant (check 14, ADR-043 lineage); this ADR governs what the attestation binds, not what the
 verifier accepts.
 
-## Open
+## Resolved during drafting
 
-- Whether the predicate keeps a `semantic_equivalence` block naming `run_root` explicitly, or
-  whether `run_root` sits at the predicate top level. Preference: a named block, so a consumer
-  cannot mistake it for a second artifact digest.
-- The `corpus_digest_method` string in the conformance manifest is ambiguous between the prefixed
-  and bare-hex readings of "vector sha256" (the implementation uses the prefixed form). Same class
-  of defect — a digest procedure that two honest implementers read differently — and it should be
-  disambiguated in the same pass.
+Three questions were left open in the first draft and settled by the co-author rather than by the
+author alone:
+
+- **Predicate layout**: the named `semantic_equivalence` block, because it keeps semantic identity
+  out of in-toto's artifact-matching namespace instead of relying on readers to know the difference.
+- **Corpus digest wording**: `corpus_digest_method` is to state that the hash is taken over each
+  stored `vectors[i].sha256` **string including the literal `sha256:` prefix**, each followed by LF,
+  in manifest order. The implementation already does this; the sentence did not say so, and the
+  bare-hex reading is the more natural one — a procedure two honest implementers read differently is
+  the same defect class as this ADR's, one layer down.
+- **Clean-room pack**: confirmed unaffected. It carries no DSSE attestations at all, and rewritten
+  bundles keep `run_root` while their artifact bytes change — which is the distinction this decision
+  makes expressible.
+
+## Dependencies
+
+- PR #1886 (`content_hash_field_inventory.rs`) must merge before this ADR is Accepted; the "what the
+  chain does not carry" section cites a mechanism that does not exist on `main` until then.
 
 ## Implementation evidence
 
@@ -146,5 +218,8 @@ Measured on `7ba8f066`, worktree `assay-adr044`:
   bit-identical, independently reproduced;
 - `statement_from_manifest` (`crates/assay-evidence/src/attestation.rs`) places `manifest.run_root`
   in the subject digest;
+- `verify_envelope` (same file) checks payload type, signature and Statement `_type`, then returns
+  the Statement — it reads `subject` nowhere, which is what makes the missing consumer-side match a
+  finding about the present rather than a hypothetical;
 - in-toto v1 Statement text quoted above read from the specification repository, not from a
   secondary description.


### PR DESCRIPTION
Draft until #1886 merges — the ADR takes a hard dependency on it. The decision text is now co-authored: the profile side settled three open questions and two rounds of review reshaped the analysis materially.

## The finding, corrected by review into something sharper

`run_root` serves two purposes and one value cannot serve both. As a **semantic equivalence digest** it is correct and must not change — that is what lets the same events be repackaged later by a different producer and keep the same hash, which the profile requires and #1840 asks the world to reproduce. As the **in-toto subject digest** it is wrong: the spec requires an immutable artifact identifier and matches subjects purely by digest.

My first draft concluded that a signature over a genuine bundle *matches* a forged one. Review corrected that, and the correction is worse news:

- a conforming consumer hashes the archive it holds and compares against `subject.digest`; since that field holds `run_root`, **neither the genuine nor the forged bundle matches**;
- `verify_envelope` reads `subject` nowhere — payload type, signature, Statement type, return;
- the forgery "matches" only under a non-standard `run_root`-to-`run_root` comparison.

**The forgery survives because nothing is matched.** A correct subject digest that no consumer compares would still be an unchecked field, which is why the decision had to cover both ends.

Reproduced, not argued: a consistent stream-identity rewrite (`run_id`, every event `id`, producer, timestamps, PII flag) verifies clean with `run_root` bit-identical; a `source`-only rewrite on the shipped `test-bundle.tar.gz` does the same.

## Five decisions

1. **Subject is the completed archive digest** — the finished `.tar.gz`, gzip trailer included. No new digest definition; the format already pins this value. It does need new runtime data flow, since `statement_from_manifest` sees only a `Manifest` and never the container.
2. **Consumers MUST match it**, as a second explicit call. `verify_envelope` keeps its job and its result is typed *signature-verified, artifact-unmatched*; `verify_attestation_for_bundle(…, bundle_bytes)` does subject matching, predicate validation and cross-checks. Two calls rather than an overload, so the weaker outcome is a state instead of a special error.
3. **Predicate v1, fully specified** — `predicateType`, object shape, field types, required-ness. `time_window` is **`null` for a zero-event bundle**, because the verifier accepts those and a mandatory window would be unsatisfiable for a shape the format permits. Unknown fields ignored within a major version; unknown major version **fails closed**.
4. **Exactly one subject, identifying an artifact** — broader than barring `run_root` from a `DigestSet`, because the spec already requires every entry to identify an immutable artifact, and barring one field invites the next.
5. **Both roles named wherever either is used**, stated as identity relations under their algorithms rather than as `iff`.

## What this deliberately does not do

Widen `content_hash`. That breaks deterministic re-export, breaks the clean-room pack, and re-merges the roles instead of separating them. The defect is the reuse, not the digest.

## Claims of mine that did not survive checking

Recorded because the ADR argues for exactly this discipline:

- the tar digest is a pinned determinism input, **not** `bundle_id` — which equals `run_root` and is therefore semantic. Opposite of my own point.
- `pack_format.py` preserves `run_root` by containing **zero** references to it, not by handling it.
- I cited `content_hash_field_inventory.rs` as though it existed; it lands with #1886 and is now a declared dependency.
- "Verifier behaviour does not change" named the wrong verifier: bundle verification is unchanged, attestation verification changes materially.
- "It attests these events, in this order" overclaimed: the signature authenticates the Statement and its *asserted* root; only a root recomputed from a verified bundle licenses the stronger reading.
- I described the decision as "four parts becoming six". There are five. On an ADR about values that must agree wherever they appear, the count in the PR text has to match the document.

## Resolved by the co-author

Predicate layout (the named block), corpus-digest wording (input **and** output encoding — an unambiguous input with an implicit output is half a procedure), and confirmation that the clean-room pack is unaffected: it carries no DSSE attestations, and rewritten bundles keep `run_root` while their artifact bytes change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)