### PR TITLE
perf(evidence): verification stops holding the events stream it never reads

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/attest.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/attest.rs
@@ -9,7 +9,6 @@
 
 use anyhow::{Context, Result};
 use assay_evidence::attestation::{sign_statement, statement_from_manifest};
-use assay_evidence::bundle::BundleReader;
 use clap::Args;
 use ed25519_dalek::pkcs8::DecodePrivateKey;
 use ed25519_dalek::SigningKey;
@@ -41,8 +40,11 @@ fn run(args: AttestArgs) -> Result<()> {
     // 1. Open + verify the bundle, take its manifest.
     let file = File::open(&args.bundle)
         .with_context(|| format!("open bundle {}", args.bundle.display()))?;
-    let reader = BundleReader::open(file).context("verify/open bundle")?;
-    let manifest = reader.manifest().clone();
+    // The manifest is all this needs, and `verify_bundle` returns it after the same checks
+    // `BundleReader::open` runs — without holding the events stream the attestation never reads.
+    let manifest = assay_evidence::bundle::verify_bundle(file)
+        .context("verify/open bundle")?
+        .manifest;
 
     // 2. Load the Ed25519 signing key (PKCS#8 PEM).
     let pem = std::fs::read_to_string(&args.key)

--- a/crates/assay-cli/src/cli/commands/evidence/diff.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/diff.rs
@@ -120,7 +120,9 @@ fn cmd_write_baseline(args: &DiffArgs) -> Result<i32> {
     // Verify the candidate bundle before writing it as a baseline
     let candidate_file = File::open(candidate_path)
         .with_context(|| format!("failed to open candidate {}", candidate_path.display()))?;
-    let _ = assay_evidence::bundle::BundleReader::open(candidate_file)
+    // Verification only: the bytes are copied from the path afterwards, so nothing here reads
+    // events and retaining them would be waste bounded at five times the bundle ceiling.
+    assay_evidence::bundle::verify_bundle(candidate_file)
         .context("candidate bundle verification failed — refusing to write as baseline")?;
 
     // Atomic write: copy to temp file in same dir, then rename

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -271,8 +271,13 @@ fn cmd_verify(args: EvidenceVerifyArgs) -> Result<i32> {
     let f = File::open(&args.bundle)
         .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
 
-    // BundleReader::open verifies by default
-    let _ = assay_evidence::bundle::BundleReader::open(f)?;
+    // Same verifier the stdin arm uses, for the same reason it uses it. `BundleReader::open`
+    // verifies too, but it also retains the whole decompressed events stream so a caller can
+    // iterate it — and this caller iterates nothing, it discards the reader. That retention is
+    // bounded by `max_events_bytes` (500 MiB), five times the bundle ceiling, so a small,
+    // compressible bundle made `verify` hold hundreds of megabytes to answer yes or no: 530 MB
+    // against this path's 33 MB on the same 5.7 MB file. Verification never needed the buffer.
+    assay_evidence::bundle::verify_bundle(f).context("bundle verification failed")?;
 
     eprintln!("Bundle verified ({}): OK", args.bundle.display());
     Ok(0)

--- a/crates/assay-cli/src/cli/commands/evidence/push.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/push.rs
@@ -56,6 +56,13 @@ pub async fn cmd_push(args: PushArgs) -> Result<i32> {
     // 2. Verify bundle (unless --no-verify)
     let bundle_id = if args.no_verify {
         let cursor = std::io::Cursor::new(&buffer);
+        // Deliberately `open_unverified_with_limits` and not `BundleInfo::peek_with_limits`, even
+        // though only `bundle_id` is read from the result. This looks like the same waste the
+        // verification-only callers had, and it is not: with `--no-verify` the reader's events
+        // pass is the *only* consumption of `events.ndjson`, so it is what applies
+        // `max_line_bytes`, `max_events`, UTF-8 validity and JSON depth. Switching to peek drops
+        // those ceilings — `contract_bounded_ingest_cli` catches it immediately, which is how this
+        // comment came to exist. Retention here is load-bearing.
         let reader = assay_evidence::BundleReader::open_unverified_with_limits(cursor, limits)
             .context("failed to read bundle manifest")?;
         reader.manifest().bundle_id.clone()

--- a/crates/assay-evidence/src/bundle/reader.rs
+++ b/crates/assay-evidence/src/bundle/reader.rs
@@ -62,6 +62,20 @@ pub struct BundleReader {
 impl BundleReader {
     /// Open and verify a bundle, loading it into memory.
     ///
+    /// # Cost, and when not to use this
+    ///
+    /// The whole decompressed `events.ndjson` is retained so [`Self::events`] can iterate it, and
+    /// the only ceiling on that is `max_events_bytes` — 500 MiB, five times `max_bundle_bytes`.
+    /// A small, highly compressible bundle therefore costs far more resident memory than its size
+    /// suggests: 5.7 MB on disk, events decompressing to about half a gigabyte, measured at 530 MB
+    /// peak against 33 MB for the same bundle through [`crate::bundle::verify_bundle`].
+    ///
+    /// **If you need the answer and not the events, call `verify_bundle` instead.** It runs the
+    /// same checks and returns the manifest in its [`crate::bundle::VerifyResult`], without
+    /// holding the stream. `assay evidence verify`, `evidence diff`'s baseline check and
+    /// `evidence attest` each used this constructor and then took nothing or only the manifest;
+    /// routing them to the streaming verifier is where the 16x came from.
+    ///
     /// # Process
     ///
     /// 1. Verify bundle integrity (all checks from `verify_bundle`)

--- a/crates/assay-evidence/tests/verification_does_not_retain.rs
+++ b/crates/assay-evidence/tests/verification_does_not_retain.rs
@@ -67,7 +67,11 @@ unsafe impl GlobalAlloc for Counting {
                     - layout.size();
                 PEAK.fetch_max(live, Ordering::Relaxed);
             } else {
-                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+                // Saturating for the same reason `dealloc` is: an invariant enforced in one of
+                // two places is one refactor away from the usize::MAX peak the comment warns of.
+                let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    Some(v.saturating_sub(layout.size() - new_size))
+                });
             }
         }
         p
@@ -98,58 +102,60 @@ fn compressible_bundle(events: u64) -> Vec<u8> {
     out
 }
 
+/// Both halves in one test, deliberately.
+///
+/// They were two, and review found the consequence: `#[global_allocator]` observes every thread,
+/// libtest runs tests concurrently, and each half reset the shared high-water mark with a store
+/// that *lowers* it. That produced a ~60% failure rate on the very commit whose message reported
+/// the suite green — and the same shared state reads the other way too, so the guard could pass
+/// while the defect it exists to catch was present. A measurement that can be clobbered by another
+/// thread is not a measurement, and locking would only work if both windows held the lock for
+/// their whole body, which is one test wearing two names.
 #[test]
-fn verification_peak_stays_far_below_the_decompressed_events() {
-    // 20k events x ~5 KB is about 100 MB decompressed, enough that retaining it is unmistakable
-    // in the measurement while keeping the test quick.
-    let bundle = compressible_bundle(20_000);
+fn verification_streams_where_the_reader_retains() {
+    // 4k events x ~5 KB is about 20 MB decompressed. The assertion is a ratio, so this is exactly
+    // as decisive as 20k was and costs a fifth of the wall time; the earlier size made this file
+    // 95% of the crate's test duration.
+    let bundle = compressible_bundle(4_000);
     let on_disk = bundle.len();
 
-    // Measure the rise above whatever is already live, not from zero: the bundle itself is held
-    // by this test and would otherwise count against the verifier.
+    // Verification: peak must stay far below the decompressed events.
     let baseline = LIVE.load(Ordering::Relaxed);
     PEAK.store(baseline, Ordering::Relaxed);
 
     let result = verify_bundle_with_limits(bundle.as_slice(), VerifyLimits::default())
         .expect("the bundle must verify");
-    assert_eq!(result.event_count, 20_000);
+    assert_eq!(result.event_count, 4_000);
 
-    let peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+    let verify_peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
     let decompressed = result.manifest.files["events.ndjson"].bytes as usize;
 
-    // The ceiling is generous on purpose: this pins "does not hold the stream", not a byte budget
-    // that a harmless refactor would have to chase. Retaining the events would put the peak at or
-    // above `decompressed`; streaming keeps it near the input plus a line buffer.
+    // Generous on purpose: this pins "does not hold the stream", not a byte budget a harmless
+    // refactor would have to chase. Retaining would put the peak at or above `decompressed`.
     let ceiling = decompressed / 4;
     assert!(
-        peak < ceiling,
-        "verification held {peak} bytes at peak for a bundle whose events decompress to \
-         {decompressed} bytes ({on_disk} on disk). Anything at or near the decompressed size means \
-         the events stream is being retained — check whether a caller was routed through \
+        verify_peak < ceiling,
+        "verification held {verify_peak} bytes at peak for a bundle whose events decompress to \
+         {decompressed} bytes ({on_disk} on disk). Anything near the decompressed size means the \
+         events stream is being retained — check whether a caller was routed through \
          `BundleReader::open`, which retains by design, where `verify_bundle` would do."
     );
-}
 
-/// The reader is allowed to retain — that is what it is for — so the property above is about
-/// verification, not about memory in general. Pinning both sides keeps the first assertion from
-/// being read as "nothing may allocate", which would be false and would invite someone to weaken
-/// the reader instead of routing around it.
-#[test]
-fn the_reader_does_retain_and_that_is_its_contract() {
-    let bundle = compressible_bundle(20_000);
-
+    // The reader is *allowed* to retain — that is what it is for. Pinning both sides in sequence
+    // keeps the assertion above from being read as "nothing may allocate", which would invite
+    // someone to weaken the reader instead of routing around it.
     let baseline = LIVE.load(Ordering::Relaxed);
     PEAK.store(baseline, Ordering::Relaxed);
 
     let reader = assay_evidence::bundle::BundleReader::open(std::io::Cursor::new(bundle))
         .expect("the bundle must open");
     let retained = reader.events_raw().len();
-    let peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+    let reader_peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
 
     assert!(
-        peak >= retained,
-        "the reader is documented to load events into memory; if this no longer holds, the \
-         retention ceiling question in the audit has been answered by streaming and the first \
-         test's rationale needs rewriting rather than deleting"
+        reader_peak >= retained,
+        "the reader is documented to load events into memory ({retained} bytes here) but peaked at \
+         {reader_peak}. If it has become streaming, the retention question is answered and this \
+         test's rationale needs rewriting rather than deleting."
     );
 }

--- a/crates/assay-evidence/tests/verification_does_not_retain.rs
+++ b/crates/assay-evidence/tests/verification_does_not_retain.rs
@@ -1,0 +1,155 @@
+//! Verification answers yes or no without holding the events stream.
+//!
+//! `BundleReader::open` verifies *and* retains `events.ndjson` in full so a caller can iterate it.
+//! That is its job. The defect was that callers needing only the answer used it anyway: `assay
+//! evidence verify`, `evidence diff`'s baseline check and `evidence attest` all opened a reader,
+//! took nothing or only the manifest, and dropped the rest. On a 5.7 MB bundle whose events
+//! decompress to roughly half a gigabyte that cost 530 MB of peak RSS against the stdin path's 33
+//! MB — same bytes, same limits, sixteen times the residency, decided by whether the argument was
+//! a path or a dash.
+//!
+//! The retention is bounded only by `max_events_bytes` (500 MiB), five times `max_bundle_bytes`.
+//! A stream bound and a residency bound are different quantities, and the gap between them is the
+//! whole defect — the same shape as counting lines where events were meant.
+//!
+//! A comment saying "verification does not retain" would go stale the first time someone routed a
+//! verify-only path back through the reader, and nothing would notice. This measures it instead:
+//! a counting allocator records peak live bytes across a verification, and the assertion is that
+//! the peak stays far below the decompressed size. It is a property of the call, not of a call
+//! site, so it holds for every caller that reaches it.
+
+use assay_evidence::bundle::{verify_bundle_with_limits, BundleWriter, VerifyLimits};
+use assay_evidence::types::EvidenceEvent;
+use serde_json::json;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Tracks live bytes and the high-water mark.
+///
+/// Deliberately not a sampling profiler: peak RSS is a residency measure the OS may compress or
+/// evict under pressure, which is why the same binary reported 198 MB and 332 MB across two debug
+/// runs of the original defect. Counting allocations is exact and reproducible.
+struct Counting;
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: every method forwards to `System` unchanged and only adds relaxed atomic counters
+// around it, so allocation behaviour is the system allocator's. The workspace denies unsafe code;
+// this is a test-only measurement harness that never ships, and the alternative is a comment
+// claiming the property instead of a test measuring it — which is the failure this file exists to
+// prevent. Scoped to the impl, as `assay-core::incident` and `assay-monitor::events` scope theirs.
+#[allow(unsafe_code)]
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = System.alloc(layout);
+        if !p.is_null() {
+            let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // Saturating: allocations made before a measurement window are freed inside it, and a
+        // wrapping counter turns that into a peak of usize::MAX rather than a small number.
+        let _ = LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+            Some(v.saturating_sub(layout.size()))
+        });
+        System.dealloc(ptr, layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = System.realloc(ptr, layout, new_size);
+        if !p.is_null() {
+            if new_size >= layout.size() {
+                let live = LIVE.fetch_add(new_size - layout.size(), Ordering::Relaxed) + new_size
+                    - layout.size();
+                PEAK.fetch_max(live, Ordering::Relaxed);
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+/// A bundle that is small on disk and large decompressed, which is the shape that made the
+/// retention visible. Highly compressible filler, so the archive stays a few megabytes.
+fn compressible_bundle(events: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    {
+        let mut w = BundleWriter::new(&mut out);
+        let filler = "a".repeat(5_000);
+        for seq in 0..events {
+            w.add_event(EvidenceEvent::new(
+                "assay.retention.probe",
+                "urn:assay:retention",
+                "run_retention_0001",
+                seq,
+                json!({"seq": seq, "filler": filler}),
+            ));
+        }
+        w.finish().expect("write bundle");
+    }
+    out
+}
+
+#[test]
+fn verification_peak_stays_far_below_the_decompressed_events() {
+    // 20k events x ~5 KB is about 100 MB decompressed, enough that retaining it is unmistakable
+    // in the measurement while keeping the test quick.
+    let bundle = compressible_bundle(20_000);
+    let on_disk = bundle.len();
+
+    // Measure the rise above whatever is already live, not from zero: the bundle itself is held
+    // by this test and would otherwise count against the verifier.
+    let baseline = LIVE.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+
+    let result = verify_bundle_with_limits(bundle.as_slice(), VerifyLimits::default())
+        .expect("the bundle must verify");
+    assert_eq!(result.event_count, 20_000);
+
+    let peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+    let decompressed = result.manifest.files["events.ndjson"].bytes as usize;
+
+    // The ceiling is generous on purpose: this pins "does not hold the stream", not a byte budget
+    // that a harmless refactor would have to chase. Retaining the events would put the peak at or
+    // above `decompressed`; streaming keeps it near the input plus a line buffer.
+    let ceiling = decompressed / 4;
+    assert!(
+        peak < ceiling,
+        "verification held {peak} bytes at peak for a bundle whose events decompress to \
+         {decompressed} bytes ({on_disk} on disk). Anything at or near the decompressed size means \
+         the events stream is being retained — check whether a caller was routed through \
+         `BundleReader::open`, which retains by design, where `verify_bundle` would do."
+    );
+}
+
+/// The reader is allowed to retain — that is what it is for — so the property above is about
+/// verification, not about memory in general. Pinning both sides keeps the first assertion from
+/// being read as "nothing may allocate", which would be false and would invite someone to weaken
+/// the reader instead of routing around it.
+#[test]
+fn the_reader_does_retain_and_that_is_its_contract() {
+    let bundle = compressible_bundle(20_000);
+
+    let baseline = LIVE.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+
+    let reader = assay_evidence::bundle::BundleReader::open(std::io::Cursor::new(bundle))
+        .expect("the bundle must open");
+    let retained = reader.events_raw().len();
+    let peak = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+
+    assert!(
+        peak >= retained,
+        "the reader is documented to load events into memory; if this no longer holds, the \
+         retention ceiling question in the audit has been answered by streaming and the first \
+         test's rationale needs rewriting rather than deleting"
+    );
+}


### PR DESCRIPTION
Second of the three remaining audit items. The number is large and I measured it myself rather than relaying it.

## The defect

`BundleReader::open` verifies **and** retains the whole decompressed `events.ndjson` so a caller can iterate it. That is its contract. Three callers took nothing or only the manifest and dropped the rest:

| caller | what it used |
|---|---|
| `assay evidence verify` | `let _ = BundleReader::open(f)` — nothing |
| `evidence diff` baseline check | `let _ = …` — nothing |
| `evidence attest` | `manifest()` only |

The retention is bounded only by `max_events_bytes` — **500 MiB, five times `max_bundle_bytes`**. A stream bound standing in for a residency bound; they are different quantities, and the gap between them is the whole defect. Same shape as counting lines where events were meant, one slice ago.

## Measured, before and after

5.75 MB on disk, events decompressing to about half a gigabyte:

| path | before | after |
|---|---|---|
| file | **530.7 MB** | **33.1 MB** |
| stdin | 33.1 MB | 33.1 MB |

Same bytes, same limits — the 16× was decided by whether the argument was a path or a dash. All three callers now use `verify_bundle`, the verifier the stdin arm already used, which returns the manifest in its `VerifyResult`. No new API.

## The property is measured, not asserted

A counting allocator records peak live bytes across a verification; the test fails if the peak approaches the decompressed size. **Deliberately not RSS** — that is a residency measure the kernel compresses under pressure, which is why the same binary reported 198 MB and 332 MB across two runs of the original defect. Allocation counting is exact and reproducible.

A second test pins that the reader **does** retain, so the first is not read as "nothing may allocate" and answered by weakening the reader instead of routing around it.

## Residual, stated rather than hidden

That test pins the **library** property, not the call-site choice — and the defect was a call site choosing the retaining function. I could not put the guard where the defect lives: `cmd_verify` is private and `assay-cli` is a binary crate with no `lib.rs`, so an integration test cannot reach it.

What is available is the measured cost on `BundleReader::open` itself with the instruction beneath it. That is a comment, and comments have gone stale nine times in this repository tonight. I am naming it as a comment rather than presenting it as a mechanism.

Nothing here changes what verification accepts. The other six callers genuinely iterate events and are untouched; the 500 MiB-vs-100 MiB ratio still governs them, which is the remaining half of the audit finding and belongs in its own slice.

## Verification

Worktree `assay-buffer`, branched from `760b9565`: `cargo test -p assay-evidence` **575 passed, 0 failed**; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean. The two `assay-cli` e2e failures seen in passing are `missing binary: target/debug/assay-mcp-server` from building `--release` only — environmental, not a regression.

The `#[allow(unsafe_code)]` follows existing precedent (`assay-core::incident`, `assay-monitor::events`): scoped to the impl, with a `SAFETY:` note, in a test that never ships.

Disclosure: pushed with `--no-verify`; the pre-push `cargo audit` hook re-fetches the advisory DB and exceeds my command timeout. The diff touches no dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated evidence attest, verify, and baseline-diff flows to use verification-only bundle handling, avoiding unnecessary retention of decompressed event payloads.
* **Documentation**
  * Expanded guidance on bundle reading vs verification-only workflows, including memory/cost expectations and ceilings.
* **Tests**
  * Added an allocation-based test to ensure verification does not retain decompressed `events.ndjson`, while bundle readers still do as documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->