### PR TITLE
fix(ci): the CI gate asks why a job was skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,33 +729,81 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           EBPF_SMOKE_REQUIRED: ${{ needs.scope.outputs.ebpf_smoke_required }}
           EBPF_SMOKE_UBUNTU_RESULT: ${{ needs.ebpf-smoke-ubuntu.result }}
+          MCP_REGISTRY_TOUCHED: ${{ needs.scope.outputs.mcp_registry_touched }}
         shell: bash
         run: |
           set -euo pipefail
 
-          for pair in \
-            "scope:${SCOPE_RESULT}" \
-            "deps-security:${DEPS_SECURITY_RESULT}" \
-            "clippy:${CLIPPY_RESULT}" \
-            "distribution-boundary:${DISTRIBUTION_BOUNDARY_RESULT}" \
-            "vendored-packs:${VENDORED_PACKS_RESULT}" \
-            "mcp-registry-foundation:${MCP_REGISTRY_FOUNDATION_RESULT}" \
-            "perf:${PERF_RESULT}" \
-            "test:${TEST_RESULT}" \
-            "ebpf-smoke-ubuntu:${EBPF_SMOKE_UBUNTU_RESULT}"
+          # `skipped` used to be accepted unconditionally, and the two scope outputs the gate
+          # imported were only echoed. A gate that never asks WHY a job was skipped cannot tell
+          # "the classifier said this PR does not need it" from "the job's own `if:` broke and it
+          # will never run again": both arrive as `skipped` and both read green. The sharpest
+          # instance is `ebpf-smoke-ubuntu`, whose condition is the `== 'true'` form, so a typo in
+          # the output name evaluates to `'' == 'true'` and disarms it silently and permanently.
+          #
+          # So each job is now paired with the condition under which it was expected to run, taken
+          # from that job's own `if:`. Expected-to-run means `success`; only a job whose condition
+          # was false may be `skipped`. `mcp_registry_touched` is imported for the first time here:
+          # the gate needed three scope outputs to answer this question and had two.
+          if [[ "${LIGHTWEIGHT_ONLY}" == "true" ]]; then
+            code_gated_expectation="optional"
+          else
+            code_gated_expectation="required"
+          fi
+          if [[ "${EBPF_SMOKE_REQUIRED}" == "true" ]]; then
+            ebpf_expectation="required"
+          else
+            ebpf_expectation="optional"
+          fi
+          if [[ "${MCP_REGISTRY_TOUCHED}" == "true" ]]; then
+            registry_expectation="required"
+          else
+            registry_expectation="optional"
+          fi
+
+          failures=0
+          for triple in \
+            "scope|${SCOPE_RESULT}|required" \
+            "deps-security|${DEPS_SECURITY_RESULT}|${code_gated_expectation}" \
+            "clippy|${CLIPPY_RESULT}|${code_gated_expectation}" \
+            "distribution-boundary|${DISTRIBUTION_BOUNDARY_RESULT}|required" \
+            "vendored-packs|${VENDORED_PACKS_RESULT}|required" \
+            "mcp-registry-foundation|${MCP_REGISTRY_FOUNDATION_RESULT}|${registry_expectation}" \
+            "perf|${PERF_RESULT}|${code_gated_expectation}" \
+            "test|${TEST_RESULT}|${code_gated_expectation}" \
+            "ebpf-smoke-ubuntu|${EBPF_SMOKE_UBUNTU_RESULT}|${ebpf_expectation}"
           do
-            name="${pair%%:*}"
-            result="${pair#*:}"
+            name="${triple%%|*}"
+            rest="${triple#*|}"
+            result="${rest%%|*}"
+            expectation="${rest##*|}"
+
             case "${result}" in
-              success|skipped)
+              success)
+                ;;
+              skipped)
+                if [[ "${expectation}" == "required" ]]; then
+                  echo "::error::${name} was skipped, but this run required it to execute." \
+                       "lightweight_only=${LIGHTWEIGHT_ONLY}" \
+                       "ebpf_smoke_required=${EBPF_SMOKE_REQUIRED}" \
+                       "mcp_registry_touched=${MCP_REGISTRY_TOUCHED}." \
+                       "A job that never runs reports the same result as one deliberately not run;" \
+                       "check that job's \`if:\` against the scope output it reads."
+                  failures=$((failures + 1))
+                fi
                 ;;
               *)
-                echo "Required CI dependency ${name} ended with ${result}"
-                exit 1
+                echo "::error::Required CI dependency ${name} ended with ${result}"
+                failures=$((failures + 1))
                 ;;
             esac
           done
 
           echo "lightweight_only=${LIGHTWEIGHT_ONLY}"
           echo "ebpf_smoke_required=${EBPF_SMOKE_REQUIRED}"
-          echo "All required CI jobs passed or were intentionally skipped."
+          echo "mcp_registry_touched=${MCP_REGISTRY_TOUCHED}"
+          if (( failures > 0 )); then
+            echo "${failures} required CI dependenc(ies) did not satisfy the gate."
+            exit 1
+          fi
+          echo "All required CI jobs ran and passed; skipped jobs were scoped out."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,20 +745,29 @@ jobs:
           # from that job's own `if:`. Expected-to-run means `success`; only a job whose condition
           # was false may be `skipped`. `mcp_registry_touched` is imported for the first time here:
           # the gate needed three scope outputs to answer this question and had two.
+          # Every one of these reads "only an explicit, expected value may relax the gate".
+          #
+          # The three outputs are not symmetric in the workflow: `lightweight_only` gates its jobs
+          # with `!= 'true'` (a typo fails toward running, which is safe) while
+          # `ebpf_smoke_required` and `mcp_registry_touched` use `== 'true'` (a typo fails toward
+          # skipping, silently and permanently). So for the latter two an empty value IS the typo
+          # signature, and treating empty as "not required" would let the gate fail open on exactly
+          # the case it was written to catch. Only the literal "false" relaxes them; empty,
+          # misspelled or missing means the run must show its work.
           if [[ "${LIGHTWEIGHT_ONLY}" == "true" ]]; then
             code_gated_expectation="optional"
           else
             code_gated_expectation="required"
           fi
-          if [[ "${EBPF_SMOKE_REQUIRED}" == "true" ]]; then
-            ebpf_expectation="required"
-          else
+          if [[ "${EBPF_SMOKE_REQUIRED}" == "false" ]]; then
             ebpf_expectation="optional"
-          fi
-          if [[ "${MCP_REGISTRY_TOUCHED}" == "true" ]]; then
-            registry_expectation="required"
           else
+            ebpf_expectation="required"
+          fi
+          if [[ "${MCP_REGISTRY_TOUCHED}" == "false" ]]; then
             registry_expectation="optional"
+          else
+            registry_expectation="required"
           fi
 
           failures=0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/(reconcile-docs-auto-pr|test-reconcile-docs-auto-pr)\.sh|\.github/workflows/(docs-auto-update|ci|assay-runner-lane-check|host-capability-check)\.yml|\.pre-commit-config\.yaml)$
 
+      - id: ci-gate-expectations-self-test
+        name: CI gate expectation contract
+        entry: bash scripts/ci/test-ci-gate-expectations.sh
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/test-ci-gate-expectations\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
+
       - id: mcp-registry-release-txn-self-test
         name: MCP Registry release transaction self-test
         entry: bash scripts/ci/test-mcp-registry-release-txn.sh

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -163,6 +163,45 @@ out="$(run_gate fail "empty lightweight_only with skipped code jobs" \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
 grep -qi "was skipped, but this run required it" <<<"$out" \
   || fail "an empty lightweight_only must be treated as not-lightweight, got: $out"
-echo "ok: an empty scope output is treated as the strict case, not the permissive one"
+echo "ok: an empty lightweight_only is treated as the strict case, not the permissive one"
+
+# The same discipline for the two outputs whose jobs use the `== 'true'` form. Those are the ones
+# a typo disarms silently, so empty must not read as "not required" — the first version of this
+# gate only got `lightweight_only` right and left both of these failing open, which is the defect
+# it was written to close, surviving in the fix.
+out="$(run_gate fail "empty ebpf_smoke_required with the job skipped" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED= EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
+grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
+  || fail "an empty ebpf_smoke_required must be strict, got: $out"
+
+out="$(run_gate fail "empty mcp_registry_touched with the job skipped" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=)"
+grep -q "mcp-registry-foundation was skipped" <<<"$out" \
+  || fail "an empty mcp_registry_touched must be strict, got: $out"
+
+# A wrong-case value is the same class as empty: GitHub compares these outputs as strings, so
+# `TRUE` is not `true` and the job silently never runs.
+out="$(run_gate fail "wrong-case ebpf_smoke_required" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED=TRUE EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
+grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
+  || fail "a wrong-case ebpf_smoke_required must be strict, got: $out"
+echo "ok: empty or wrong-case == 'true' outputs are strict, so a disarmed job cannot read green"
+
+# And the legitimate relaxations still work: an explicit false scopes the job out.
+run_gate pass "explicit false relaxes both" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
+echo "ok: an explicit false still scopes its job out"
 
 echo "PASS: CI gate expectation contract"

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The `CI` gate decides whether a run is green. It accepted `skipped` unconditionally, so a job
+# whose own `if:` had broken reported exactly what a deliberately scoped-out job reports, and the
+# gate had no way to tell them apart. It imported two scope outputs and echoed both.
+#
+# This runs the gate's decision logic against constructed states. Extracting the shell out of the
+# workflow to test it would give a second copy that can drift from the one CI executes; instead the
+# block is read out of `ci.yml` at the line it lives on and run as-is, so the thing under test is
+# the thing that ships.
+#
+# Each case pins an outcome, not merely "something failed" — a gate that goes red for the wrong
+# reason is the failure mode one layer up from the one being fixed.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Pull the gate's `run:` body out of the workflow: everything between the "Evaluate required job
+# results" step's `run: |` and the end of that block. Indentation-based, which is what YAML gives.
+extract_gate() {
+  python3 - "$WORKFLOW" <<'PY'
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+start = None
+for i, line in enumerate(lines):
+    if line.strip() == "- name: Evaluate required job results":
+        start = i
+        break
+if start is None:
+    sys.exit("could not find the gate step in ci.yml")
+
+run_at = None
+for i in range(start, len(lines)):
+    if lines[i].strip() == "run: |":
+        run_at = i
+        break
+if run_at is None:
+    sys.exit("the gate step has no `run: |` block")
+
+indent = len(lines[run_at]) - len(lines[run_at].lstrip())
+body = []
+for line in lines[run_at + 1 :]:
+    if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+        break
+    body.append(line[indent + 2 :] if len(line) > indent + 2 else "")
+print("\n".join(body))
+PY
+}
+
+GATE="$(extract_gate)"
+[[ -n "$GATE" ]] || fail "extracted an empty gate body — the workflow shape changed"
+grep -q "MCP_REGISTRY_TOUCHED" <<<"$GATE" \
+  || fail "the gate does not read mcp_registry_touched; three scope outputs decide whether a job should run"
+
+# Run the gate under one environment. Echoes the exit code and captured output.
+run_gate() {
+  local expected="$1" name="$2"
+  shift 2
+  local out rc=0
+  out="$(env "$@" bash -c "$GATE" 2>&1)" || rc=$?
+  if [[ "$expected" == "pass" && $rc -ne 0 ]]; then
+    echo "$out" >&2
+    fail "$name: expected the gate to pass, it exited $rc"
+  fi
+  if [[ "$expected" == "fail" && $rc -eq 0 ]]; then
+    echo "$out" >&2
+    fail "$name: expected the gate to fail, it passed"
+  fi
+  printf '%s' "$out"
+}
+
+ok="success"
+
+# A full run with every job green.
+run_gate pass "everything green" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
+echo "ok: a complete green run passes"
+
+# A docs-only run: the four code-gated jobs are legitimately scoped out.
+run_gate pass "lightweight scoped out" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
+  EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
+echo "ok: a documentation-only run passes with its jobs scoped out"
+
+# The defect: a code-bearing run where a job that should have executed did not. Before this change
+# every one of these was green.
+for job in DEPS_SECURITY CLIPPY PERF TEST; do
+  out="$(run_gate fail "silently skipped $job" \
+    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+    DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+    MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
+    EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false \
+    "${job}_RESULT=skipped")"
+  grep -qi "was skipped, but this run required it" <<<"$out" \
+    || fail "$job skipped: the gate failed, but not for the skip — got: $out"
+done
+echo "ok: a code-gated job that silently did not run fails the gate, and is named"
+
+# The eBPF case the audit called sharpest: the `== 'true'` form disarms on a typo.
+out="$(run_gate fail "ebpf required but skipped" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED=true EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
+grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
+  || fail "the ebpf case failed for the wrong reason: $out"
+echo "ok: ebpf-smoke-ubuntu skipped while required fails the gate"
+
+# The output the gate did not read at all until now.
+out="$(run_gate fail "registry touched but skipped" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=true)"
+grep -q "mcp-registry-foundation was skipped" <<<"$out" \
+  || fail "the registry case failed for the wrong reason: $out"
+echo "ok: mcp-registry-foundation skipped while touched fails the gate"
+
+# Unconditional jobs may never be skipped, whatever the scope says.
+for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS; do
+  out="$(run_gate fail "unconditional $job skipped" \
+    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+    DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+    MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
+    EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false \
+    "${job}_RESULT=skipped")"
+  grep -qi "was skipped, but this run required it" <<<"$out" \
+    || fail "$job: expected the unconditional-skip message, got: $out"
+done
+echo "ok: a job with no condition may not be skipped even on a docs-only run"
+
+# Failure still fails, and scope failing takes the basis for every other judgement with it.
+run_gate fail "a job failed" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=failure \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
+  EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
+run_gate fail "scope itself skipped" \
+  SCOPE_RESULT=skipped LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
+  EBPF_SMOKE_REQUIRED= EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED= >/dev/null
+echo "ok: an outright failure fails, and a skipped scope fails"
+
+# An empty scope output is the typo signature: `'' == 'true'` is false, so the job silently never
+# runs. Treating empty as "not required" would reproduce the defect through the fix.
+out="$(run_gate fail "empty lightweight_only with skipped code jobs" \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+  MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
+  EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
+grep -qi "was skipped, but this run required it" <<<"$out" \
+  || fail "an empty lightweight_only must be treated as not-lightweight, got: $out"
+echo "ok: an empty scope output is treated as the strict case, not the permissive one"
+
+echo "PASS: CI gate expectation contract"


### PR DESCRIPTION
Third and last of the remaining audit items. The gate that decides whether a run is green could not tell a scoped-out job from a broken one.

## The defect

`skipped` was accepted unconditionally, and the two scope outputs the gate imported were only echoed at the end. So a job whose own `if:` had broken reported **exactly** what a deliberately scoped-out job reports, and the gate had no way to distinguish them: both arrive as `skipped`, both read green.

The sharpest instance is `ebpf-smoke-ubuntu`. Its condition is the `== 'true'` form, so a typo in the output name evaluates to `'' == 'true'` — false — and the job is disarmed silently and permanently while the gate stays green. The `!= 'true'` form used by clippy/test/deps-security/perf fails *toward running*, so for those the break has to be in the classifier itself.

## The fix

Each job is now paired with the condition under which it was expected to run, **taken from that job's own `if:`** — I read all nine and derived the mapping rather than assuming it. Expected-to-run means `success`; only a job whose condition was false may be `skipped`.

## That derivation found something the audit had not

The gate needs **three** scope outputs to answer this question and imported **two**. `mcp_registry_touched` decides whether `mcp-registry-foundation` runs, and the gate had never read it — so that job could vanish entirely without leaving a trace. It is imported and enforced now.

An **empty** scope output is treated as the strict case. Empty is the typo signature (`'' == 'true'` is false), so reading it as "not required" would reproduce the defect through the fix.

## Tested, and against what ships

The test extracts the gate's `run:` block from `ci.yml` at the line it lives on and runs it. Copying the shell into a fixture would give a second version that can drift from the one CI executes — the same failure this repository has hit repeatedly tonight.

Eight cases, each pinning an outcome rather than "something went red":

| case | expected |
|---|---|
| complete green run | pass |
| docs-only run, code jobs scoped out | pass |
| each of deps-security / clippy / perf / test silently not running | fail, **naming the job** |
| `ebpf-smoke-ubuntu` skipped while required | fail, naming it |
| `mcp-registry-foundation` skipped while touched | fail, naming it |
| unconditional job skipped, even on a docs-only run | fail |
| outright failure, and a skipped `scope` | fail |
| empty `lightweight_only` with code jobs skipped | fail |

**Negative control**: restoring the old accept-skipped logic makes the suite fail at `silently skipped DEPS_SECURITY: expected the gate to fail, it passed`. Every one of those cases was green before this change.

Wired into pre-commit on the three files that can break it.

## Verification

Worktree `assay-cigate`, branched from `3f137304`: contract test passes, `actionlint` clean, `zizmor` no findings, `shellcheck` clean, `pre-commit` passes including the new hook.

## Scope note

This changes only the gate's judgement. No job's own condition is touched, so which jobs run on a given PR is unchanged — what changes is whether a run where one of them silently did not run can still report success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)