### PR TITLE
fix(deps): use supported Actions cooldown schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 7
     ignore:
       # Major version bumps need manual review (breaking changes)
       - dependency-name: "*"


### PR DESCRIPTION
## Summary

Remove the three semver-specific cooldown keys from the `github-actions` Dependabot entry. Dependabot rejects those keys for that ecosystem, which made every newly rebased dependency PR carry a configuration failure.

The supported `default-days: 7` cooldown remains in place. Cargo and pip keep their semver-specific cooldowns because Dependabot accepts them for those ecosystems.

## Verification

- Ruby YAML parse
- `pre-commit run --files .github/dependabot.yml`
- `git diff --check`

## Non-claims

This does not change dependency versions or relax the existing major-update ignore policy.
