### PR TITLE
build(deps): update landlock to 0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,9 +2878,9 @@ checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "landlock"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+checksum = "4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1"
 dependencies = [
  "enumflags2",
  "libc",

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -86,7 +86,7 @@ ratatui = { workspace = true, optional = true }
 crossterm = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock = "=0.4.5"
+landlock = "=0.4.7"
 
 
 


### PR DESCRIPTION
## Summary

- update the Linux-only `landlock` dependency from 0.4.5 to 0.4.7
- retain Assay's existing V1-V4 ABI requests and fail-closed behavior
- supersede Dependabot PR #1902 with an isolated, locally verified update

## Stack

- base: #1909 (`jsonschema` 0.49.2)
- this PR contains one additional dependency change and must merge after #1909

## Compatibility review

Landlock 0.4.6 adds ABI 8 `all_threads` support and 0.4.7 adds ABI 9 `ResolveUnix`. Those capabilities are additive. Assay's current enforcement and diagnostics code continues to request and classify only the already-supported V1-V4 capabilities.

## Verification

- `cargo test -p assay-cli --bin assay landlock --locked` (26 passed)
- `cargo test -p assay-cli --test contract_sandbox_policy_load_fail_closed --locked` (5 passed)
- `cargo check -p assay-cli --all-targets --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push workspace clippy with `-D warnings`
- pre-push Linux compile gate

## Non-claims

This PR does not claim ABI 8/9 enforcement, change the sandbox policy model, or broaden the evidence emitted by enforcement-health diagnostics.
