### PR TITLE
build(deps): update direct base64 use to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
  "assay-sim",
  "assert_cmd",
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "clap",
  "criterion",
@@ -308,7 +308,7 @@ dependencies = [
  "assay-adapter-api",
  "assay-common",
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "criterion",
  "dirs",
@@ -368,7 +368,7 @@ dependencies = [
  "assay-common",
  "assert_fs",
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "criterion",
@@ -415,7 +415,7 @@ dependencies = [
  "assay-common",
  "assay-core",
  "assay-metrics",
- "base64",
+ "base64 0.23.0",
  "clap",
  "hex",
  "jsonwebtoken",
@@ -485,7 +485,7 @@ version = "3.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "dirs",
  "ecdsa",
@@ -819,6 +819,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -2436,7 +2442,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2841,7 +2847,7 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac 0.12.1",
@@ -3338,7 +3344,7 @@ checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc-fast",
@@ -3513,7 +3519,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -4353,7 +4359,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -4391,7 +4397,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -5222,7 +5228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
@@ -6266,7 +6272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -73,7 +73,7 @@ ed25519-dalek = { version = "3.0", features = ["pkcs8", "pem", "rand_core"] }
 getrandom = { version = "0.4", features = ["sys_rng"] }
 rand = "0.8"
 pkcs8 = { version = "0.11", features = ["pem"] }
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 sysinfo = "0.30"
 humantime = "2"
 tokio-stream = "0.1"

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -42,7 +42,7 @@ ed25519-dalek = { version = "3.0", features = ["pkcs8", "pem", "rand_core"] }
 rand = "0.8"
 pkcs8 = { version = "0.11", features = ["pem"] }
 spki = "0.8"
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 reqwest = { version = "0.12.26", default-features = false, features = ["json", "rustls-tls"] }
 hex.workspace = true
 md5 = "0.8.0"

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -26,7 +26,7 @@ serde_jcs = "=0.2.0"
 # Crypto & IDs
 sha2 = "0.11"
 hex = "0.4"
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 uuid = { version = "1.23", features = ["v7", "serde"] }
 chrono = { version = "0.4", features = ["serde", "clock", "std"], default-features = false }
 ed25519-dalek = { version = "3.0", features = ["alloc", "rand_core", "pkcs8"] }

--- a/crates/assay-mcp-server/Cargo.toml
+++ b/crates/assay-mcp-server/Cargo.toml
@@ -33,7 +33,7 @@ moka = { version = "0.12", features = ["sync"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }
 jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 url = { version = "2.5", features = ["serde"] }
 
@@ -44,7 +44,7 @@ tokio = { workspace = true, features = ["full"] }
 tempfile.workspace = true
 wiremock = "0.6"
 jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 # uuid = { version = "1.0", features = ["v4"] } # Removed in favor of SystemTime
 rsa = "0.9"
 rand = "0.8"

--- a/crates/assay-registry/Cargo.toml
+++ b/crates/assay-registry/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # Crypto (for signature verification)
 sha2 = "0.11"
 hex = "0.4"
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 ed25519-dalek = { version = "3.0", features = ["alloc", "pkcs8", "rand_core"] }
 pkcs8 = { version = "0.11", features = ["pem"] }
 
@@ -66,7 +66,7 @@ dirs = "6"
 rand = "0.8"
 
 [dev-dependencies]
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 getrandom = { version = "0.4", features = ["sys_rng"] }
 # Already a normal dependency; declared here too so integration tests can mutate Rekor v2 vectors cleanly.
 serde_json = { workspace = true, features = ["std"] }


### PR DESCRIPTION
## Summary

- update Assay's seven direct `base64` dependency entries from 0.22 to 0.23
- disable 0.23's new default `simd-unsafe` feature and enable only `std`
- retain 0.22 solely where transitive dependencies still require it
- supersede Dependabot PR #1897 with a security-curated, locally verified update

## Stack

- base: #1910 (`landlock` 0.4.7), which is based on #1909
- this PR contains one additional dependency change and must merge after #1910

## Compatibility and feature review

Base64 0.23 raises its MSRV to 1.71 and adds `simd-unsafe` to its default features. Assay uses the general-purpose `STANDARD` and `URL_SAFE_NO_PAD` engines, which remain scalar and require only `std`/`alloc`. Enabling unused unsafe SIMD code would add compiled surface without changing those call paths, so every direct dependency now uses:

```toml
base64 = { version = "0.23", default-features = false, features = ["std"] }
```

`cargo tree -e features -i base64@0.23.0` confirms `std`/`alloc` are enabled and `simd-unsafe` is absent.

## Verification

- `cargo test -p assay-core --lib --locked` (449 passed)
- `cargo test -p assay-evidence --lib --locked` (292 passed)
- `cargo test -p assay-registry --lib --locked` (276 passed)
- `cargo test -p assay-mcp-server --lib --locked` (60 passed)
- `cargo check -p assay-cli --all-targets --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push workspace clippy with `-D warnings`
- pre-push Linux compile gate

## Non-claims

This PR does not adopt Base64's SIMD engines, change encodings, migrate transitive consumers, or alter evidence/signature formats.
