### PR TITLE
build(deps): update jsonwebtoken to 11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "base64",
  "ed25519-dalek 2.2.0",

--- a/crates/assay-mcp-server/Cargo.toml
+++ b/crates/assay-mcp-server/Cargo.toml
@@ -32,7 +32,7 @@ moka = { version = "0.12", features = ["sync"] }
 
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }
-jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
+jsonwebtoken = { version = "11.0", default-features = false, features = ["rust_crypto", "use_pem"] }
 base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 url = { version = "2.5", features = ["serde"] }
@@ -43,7 +43,7 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 tempfile.workspace = true
 wiremock = "0.6"
-jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
+jsonwebtoken = { version = "11.0", default-features = false, features = ["rust_crypto", "use_pem"] }
 base64 = "0.22"
 # uuid = { version = "1.0", features = ["v4"] } # Removed in favor of SystemTime
 rsa = "0.9"

--- a/crates/assay-mcp-server/src/auth/tests.rs
+++ b/crates/assay-mcp-server/src/auth/tests.rs
@@ -28,9 +28,8 @@ fn valid_claims() -> serde_json::Value {
 async fn test_alg_whitelist_enforcement() {
     let mut header = Header::new(Algorithm::HS256);
     header.alg = Algorithm::HS256; // We use HS256 to sign, but Validator expects RS/ES.
-                                   // Actually, `jsonwebtoken` crate doesn't easily let us forge "none" signed tokens that verify() checks
-                                   // without `insecure_disable_signature_validation`.
-                                   // But our Validator explicitly checks `header.alg` whitelist BEFORE verification.
+                                   // The Validator checks `header.alg` against its allowlist
+                                   // before key resolution and cryptographic verification.
 
     // Let's test the whitelist logic.
     let claims = valid_claims();

--- a/crates/assay-mcp-server/src/auth/validation.rs
+++ b/crates/assay-mcp-server/src/auth/validation.rs
@@ -124,7 +124,7 @@ impl TokenValidator {
             None
         };
 
-        // If no key found and strict -> fail
+        // Missing verification keys fail closed in every mode.
         let decoding_key = match key {
             Some(k) => k,
             None => {

--- a/crates/assay-mcp-server/src/auth/validation.rs
+++ b/crates/assay-mcp-server/src/auth/validation.rs
@@ -133,14 +133,8 @@ impl TokenValidator {
                         "Unable to resolve signing key (kid missing or lookup failed)"
                     ));
                 }
-                // In permissive, or if no JWKS configured (testing), what do we do?
-                // We can use `insecure_disable_signature_validation` FOR TESTING/PERMISSIVE only.
-                // But `jsonwebtoken` validation requires a Key.
-
-                // Fallback for Permissive logging: Try decode without verification to show contents/errors
-                // This is technically unsafe but allowed in Permissive "audit mode" if explicitly desired.
-                // For now, let's treat "Missing Key" as a hard error even in permissive unless we are explicitly "no-auth".
-                // But wait, if JWKS is not configured, `jwks` is None.
+                // No insecure decode fallback is permitted. Even in the legacy
+                // permissive mode, a missing verification key remains a hard error.
                 if config.jwks_uri.is_none() {
                     // No auth configured.
                     return Err(anyhow::anyhow!("Auth not configured (missing JWKS URI)"));


### PR DESCRIPTION
## Summary

- update the MCP server's normal and test `jsonwebtoken` dependencies from 10.4 to 11.0
- preserve the existing feature set (`rust_crypto`, `use_pem`)
- keep JWT handling confined to the deprecated compatibility surface
- supersede Dependabot PR #1900 with an isolated, locally verified major update

## Compatibility review

`jsonwebtoken` 11 makes several APIs and enums more explicitly constrained, including non-exhaustive enum changes and removal/renaming of legacy helpers. Assay uses only `decode`, `decode_header`, `Algorithm`, `Validation`, and PEM decoding keys; those call paths compile unchanged. The public Assay auth types remain deprecated compatibility-only and are still disconnected from `Server::run` authorization.

## Verification

- `cargo test -p assay-mcp-server --locked`
  - 60 library tests
  - 89 binary tests
  - all integration and E2E targets, including RS256, legacy rejection, no-passthrough, stdio auth refusal, initialize non-authority, and proxy enforcement
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push workspace clippy with `-D warnings`
- pre-push Linux compile gate

## Non-claims

This PR does not add stdio authentication, OAuth, HTTP transport, identity federation, or MCP protocol-version support. It does not make initialize credentials authoritative.
