### PR TITLE
docs(adr): accept ADR-044, and drop the clause its own dependency made dead

### DIFF
--- a/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
+++ b/docs/architecture/ADR-044-attestation-subject-is-the-artifact.md
@@ -1,7 +1,8 @@
 # ADR-044: The attestation subject is the artifact, not the semantic chain
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-27
+- Accepted: 2026-07-28
 - Supersedes: none
 - Amends: ADR-039 (evidence bundle attestation)
 
@@ -155,11 +156,18 @@ predicateType = https://assay.dev/attestation/evidence-bundle/v1
 }
 ```
 
-All fields are required except `run.time_window`, which is **`null` for a zero-event bundle**. The
-verifier accepts a bundle with no events, so that bundle has no earliest and no latest event `time`
-and cannot satisfy a mandatory window; a schema that demanded one would be unsatisfiable for a
-bundle the format permits. `null` is the honest encoding of "the artifact does not carry this", and
-it is not the same as the field being absent, which is a malformed predicate.
+**All fields are required, `run.time_window` included.**
+
+The draft made that field nullable for a zero-event bundle, because the verifier accepted one and a
+mandatory window would have been unsatisfiable for a shape the format permitted. That is no longer
+true: `450b80e3` (PR #1889) made the verifier reject every bundle `BundleWriter` refuses to emit,
+and an empty event list is the first thing the writer refuses. A zero-event bundle cannot verify, so
+it cannot reach an attestation, so a predicate field accommodating it would regulate a case that
+cannot occur.
+
+The nullable clause is removed rather than kept as harmless slack. Dead contract text is what this
+ADR objects to elsewhere — a rule nobody can trigger reads as a rule someone once needed, and the
+next reader has no way to tell which.
 
 `run_root` lives in `semantic_equivalence` and nowhere else. Every field derivable from the archive
 — the semantic root, `run_id`, `event_count`, producer name, version and `git` — MUST be recomputed
@@ -250,6 +258,10 @@ author alone:
 - PR #1886 (`content_hash_field_inventory.rs`) — **merged**. The "what the chain does not carry"
   section cites an enforced mechanism rather than an intended one, which was the condition for
   moving this ADR out of draft.
+- PR #1889 (`450b80e3`, writer/verifier symmetry) — **merged**, and it changed this decision rather
+  than merely unblocking it: `run.time_window` is required because a zero-event bundle no longer
+  verifies. Recorded here because a decision that quietly follows a change in another slice is one
+  nobody can re-derive later.
 
 ## Implementation evidence
 


### PR DESCRIPTION
Two changes, and the second is the reason the first can happen honestly.

## The dead clause

The predicate made `run.time_window` **nullable for a zero-event bundle**, with a stated reason: the verifier accepted such a bundle, so a mandatory window would have been unsatisfiable for a shape the format permitted.

`450b80e3` (PR #1889) removed that shape. The verifier now rejects every bundle `BundleWriter` refuses to emit, and an empty event list is the writer's first refusal. A zero-event bundle cannot verify → cannot reach an attestation → the field is simply **required**.

Removed rather than kept as harmless slack. A rule nobody can trigger reads as a rule someone once needed, and the next reader has no way to tell which. Dead contract text is what this ADR objects to elsewhere; leaving it would be that defect inside the document that names it.

`#1889` is recorded in **Dependencies** as having *changed* the decision rather than merely unblocking it — a decision that quietly follows a change in another slice is one nobody can re-derive later.

## Status → Accepted

Both dependencies are merged (#1886 the enforced field inventory, #1889 the symmetry property). The attestation and profile halves were co-authored across two agents, the three open questions were settled by the co-author rather than by the author alone, and two review rounds reshaped the analysis materially — including the correction that the forgery survives because *nothing is matched*, not because it matches.

## What acceptance does not authorise

Implementation. The subject-digest runtime data flow, the split verification API (`verify_envelope` keeping a typed *signature-verified, artifact-unmatched* result; `verify_attestation_for_bundle` doing the byte match) and predicate v1 are their own slices with their own review rounds. Existing attestations must be re-issued, and there is no migration that preserves them — that is the finding, not a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Accepted the attestation subject architecture decision, dated July 28, 2026.
  * Clarified that all attestation fields, including `run.time_window`, are required.
  * Documented that zero-event bundles are rejected during verification and updated the related dependency notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->