### PR TITLE
fix(fuzz): give the fuzz lockfile an updater, an auditor and a consumer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,7 +99,8 @@ updates:
   # lock is kept rather than deleted — cargo-fuzz's own generated `.gitignore` covers
   # `target/corpus/artifacts/coverage` and not `Cargo.lock`, and this is a `publish = false` binary
   # crate, for which committing the lock is the Cargo convention — so it needs an updater to match
-  # the `--locked` the fuzz lane now passes.
+  # the staleness assertion the fuzz lane now runs. That assertion is a separate
+  # `cargo metadata --locked` step, not a flag on the fuzz run: `cargo fuzz run` has no `--locked`.
   - package-ecosystem: "cargo"
     directory: "/fuzz"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,3 +90,29 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 7
+
+  # Cargo - the fuzz crate carries its own lockfile.
+  #
+  # `Cargo.toml` sets `exclude = ["fuzz"]`, so the root cargo entry above never sees this tree and
+  # `fuzz/Cargo.lock` had no updater at all: it sat at workspace 3.34.0 against a 3.35.0 tree,
+  # missing a dependency edge, holding six advisories the root lock had already moved past. The
+  # lock is kept rather than deleted — cargo-fuzz's own generated `.gitignore` covers
+  # `target/corpus/artifacts/coverage` and not `Cargo.lock`, and this is a `publish = false` binary
+  # crate, for which committing the lock is the Cargo convention — so it needs an updater to match
+  # the `--locked` the fuzz lane now passes.
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "rust"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,20 @@ jobs:
           # RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upgrade; assay-mcp-server JWT (see deny.toml)
           cargo audit --ignore RUSTSEC-2023-0071
 
+      - name: cargo audit (RustSec) — fuzz lockfile
+        run: |
+          # `Cargo.toml` sets `exclude = ["fuzz"]`, so the audit above cannot see this lockfile and
+          # it was covered by nothing: not this job, not the OSV scanner (which rejects Rust locks
+          # by design), not dependabot (scoped to `/`). It accumulated six advisories the root tree
+          # had already moved past. Audited separately because the exclusion is deliberate and the
+          # blind spot it creates is not.
+          #
+          # No ignores: the fuzz tree does not reach `jsonwebtoken`, so the one advisory the root
+          # carries has nothing to match here. If that changes, add it in `deny.toml`,
+          # `.cargo/audit.toml`, the step above and the pre-push hook together — that list is kept
+          # in lockstep by hand and has drifted before.
+          cargo audit --file fuzz/Cargo.lock
+
   clippy:
     name: Clippy (deny warnings)
     needs: [scope]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,8 @@ jobs:
           cargo audit --ignore RUSTSEC-2023-0071
 
       - name: cargo audit (RustSec) — fuzz lockfile
+        # `always()`: coverage should not drop out exactly when the tree is already unhealthy.
+        if: always()
         run: |
           # `Cargo.toml` sets `exclude = ["fuzz"]`, so the audit above cannot see this lockfile and
           # it was covered by nothing: not this job, not the OSV scanner (which rejects Rust locks
@@ -175,11 +177,13 @@ jobs:
           # had already moved past. Audited separately because the exclusion is deliberate and the
           # blind spot it creates is not.
           #
-          # No ignores: the fuzz tree does not reach `jsonwebtoken`, so the one advisory the root
-          # carries has nothing to match here. If that changes, add it in `deny.toml`,
-          # `.cargo/audit.toml`, the step above and the pre-push hook together — that list is kept
-          # in lockstep by hand and has drifted before.
-          cargo audit --file fuzz/Cargo.lock
+          # Run from a directory with no `.cargo/audit.toml`. cargo-audit reads that config from the
+          # cwd, so invoking this from the repo root would silently inherit the root's ignore list —
+          # measured: RUSTSEC-2023-0071 is suppressed from the root and reported from elsewhere. That
+          # would defeat the reason this step exists. An advisory that matches only the fuzz tree is
+          # then a deliberate decision, not a silent pass; there is nowhere for it to be quietly
+          # excused, which is the point.
+          ( cd "${RUNNER_TEMP}" && cargo audit --file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock" )
 
   clippy:
     name: Clippy (deny warnings)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,10 @@ jobs:
           cargo audit --ignore RUSTSEC-2023-0071
 
       - name: cargo audit (RustSec) — fuzz lockfile
-        # `always()`: coverage should not drop out exactly when the tree is already unhealthy.
-        if: always()
+        # Runs when the root audit above fails, so coverage does not drop out exactly when the tree
+        # is already unhealthy. `!cancelled()` rather than `always()`: a cancelled run should stop,
+        # and `always()` would keep this step going after someone hit cancel or a timeout fired.
+        if: ${{ !cancelled() }}
         run: |
           # `Cargo.toml` sets `exclude = ["fuzz"]`, so the audit above cannot see this lockfile and
           # it was covered by nothing: not this job, not the OSV scanner (which rejects Rust locks

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -12,6 +12,13 @@ on:
     paths:
       - "fuzz/**"
       - "crates/assay-evidence/**"
+      # `assay-core` is a direct fuzz dependency, and the root manifest carries the workspace
+      # version every path dep inherits. Without these two, a release bump touches neither
+      # `fuzz/**` nor `crates/assay-evidence/**`, so the lock silently goes stale exactly the way
+      # it did before -- and the staleness assertion then fails on whatever unrelated PR next
+      # touches this lane, misattributing the break to whoever happened to be passing.
+      - "crates/assay-core/**"
+      - "Cargo.toml"
       - ".github/workflows/fuzz-smoke.yml"
   schedule:
     # Nightly, longer budget. Off the PR path so a slow campaign never gates a merge.
@@ -119,7 +126,7 @@ jobs:
           # `assay-evidence -> assay-common` edge, and no CI run could have said so. A lockfile CI
           # does not honour cannot reproduce a fuzz finding, which is the only reason to keep one.
           ( cd fuzz && cargo "+${FUZZ_TOOLCHAIN}" metadata --locked --format-version 1 >/dev/null ) \
-            || { echo "::error::fuzz/Cargo.lock is stale; run 'cargo update' in fuzz/ and commit it"; exit 1; }
+            || { echo "::error::fuzz/Cargo.lock is stale; run 'cargo update --workspace' in fuzz/ and commit it"; exit 1; }
           cargo "+${FUZZ_TOOLCHAIN}" fuzz run bundle_reader \
             "${RUNNER_TEMP}/fuzz-out" fuzz/corpus/bundle_reader \
             -- \

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -111,12 +111,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/fuzz-out"
           # Report what actually runs, so the log carries the toolchain rather than an assumption.
           rustc "+${FUZZ_TOOLCHAIN}" --version --verbose
-          # `--locked`: without it cargo resolves freshly in the runner and rewrites the lock, so
-          # the checked-in `fuzz/Cargo.lock` bound nothing and its staleness was invisible — it
-          # sat at workspace 3.34.0 against a 3.35.0 tree, missing the `assay-evidence ->
-          # assay-common` edge, and nobody could have noticed from a CI run. A lockfile that CI
+          # Assert the checked-in lock is current before fuzzing. `cargo fuzz run` has no
+          # `--locked` — its BuildOptions carry only profile and feature flags — so the guarantee
+          # has to be stated separately rather than passed through. Without it cargo resolves
+          # freshly in the runner and rewrites the lock, so `fuzz/Cargo.lock` bound nothing and its
+          # staleness was invisible: it sat at workspace 3.34.0 against a 3.35.0 tree, missing the
+          # `assay-evidence -> assay-common` edge, and no CI run could have said so. A lockfile CI
           # does not honour cannot reproduce a fuzz finding, which is the only reason to keep one.
-          cargo "+${FUZZ_TOOLCHAIN}" fuzz run --locked bundle_reader \
+          ( cd fuzz && cargo "+${FUZZ_TOOLCHAIN}" metadata --locked --format-version 1 >/dev/null ) \
+            || { echo "::error::fuzz/Cargo.lock is stale; run 'cargo update' in fuzz/ and commit it"; exit 1; }
+          cargo "+${FUZZ_TOOLCHAIN}" fuzz run bundle_reader \
             "${RUNNER_TEMP}/fuzz-out" fuzz/corpus/bundle_reader \
             -- \
             -runs="${RUNS}" \

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -134,8 +134,15 @@ jobs:
           # staleness was invisible: it sat at workspace 3.34.0 against a 3.35.0 tree, missing the
           # `assay-evidence -> assay-common` edge, and no CI run could have said so. A lockfile CI
           # does not honour cannot reproduce a fuzz finding, which is the only reason to keep one.
+          #
+          # The wrapper adds an exit code and nothing else. `--locked` also fails on an unparsable
+          # manifest, an unavailable dependency, a registry or network fault, or a broken toolchain,
+          # so a message naming one cause is a diagnosis this step never made — and the remedy it
+          # used to print, `cargo update --workspace`, is actively wrong during a registry outage.
+          # Only stdout is redirected, since that is the metadata JSON; Cargo's stderr stays the
+          # diagnosis. Pinned by `scripts/ci/test-fuzz-lane-contract.sh`.
           ( cd fuzz && cargo "+${FUZZ_TOOLCHAIN}" metadata --locked --format-version 1 >/dev/null ) \
-            || { echo "::error::fuzz/Cargo.lock is stale; run 'cargo update --workspace' in fuzz/ and commit it"; exit 1; }
+            || { echo "::error::locked fuzz metadata validation failed; inspect the Cargo error above"; exit 1; }
           cargo "+${FUZZ_TOOLCHAIN}" fuzz run bundle_reader \
             "${RUNNER_TEMP}/fuzz-out" fuzz/corpus/bundle_reader \
             -- \

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -111,7 +111,12 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/fuzz-out"
           # Report what actually runs, so the log carries the toolchain rather than an assumption.
           rustc "+${FUZZ_TOOLCHAIN}" --version --verbose
-          cargo "+${FUZZ_TOOLCHAIN}" fuzz run bundle_reader \
+          # `--locked`: without it cargo resolves freshly in the runner and rewrites the lock, so
+          # the checked-in `fuzz/Cargo.lock` bound nothing and its staleness was invisible — it
+          # sat at workspace 3.34.0 against a 3.35.0 tree, missing the `assay-evidence ->
+          # assay-common` edge, and nobody could have noticed from a CI run. A lockfile that CI
+          # does not honour cannot reproduce a fuzz finding, which is the only reason to keep one.
+          cargo "+${FUZZ_TOOLCHAIN}" fuzz run --locked bundle_reader \
             "${RUNNER_TEMP}/fuzz-out" fuzz/corpus/bundle_reader \
             -- \
             -runs="${RUNS}" \

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -18,6 +18,13 @@ on:
       # it did before -- and the staleness assertion then fails on whatever unrelated PR next
       # touches this lane, misattributing the break to whoever happened to be passing.
       - "crates/assay-core/**"
+      # The rest of the local graph `cargo metadata --locked` resolves in `fuzz/`. Naming only the
+      # two obvious crates left three uncovered, so a change in any of them could alter code,
+      # manifest or lock without this lane running. `scripts/ci/test-fuzz-lane-contract.sh` derives
+      # this set from `fuzz/Cargo.lock` and fails when it drifts, rather than trusting this list.
+      - "crates/assay-adapter-api/**"
+      - "crates/assay-canonical/**"
+      - "crates/assay-common/**"
       - "Cargo.toml"
       - ".github/workflows/fuzz-smoke.yml"
   schedule:

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -30,7 +30,16 @@ permissions: {}
 env:
   # One source of truth for the toolchain: the install step and the run step must not be able to
   # disagree, which is exactly how a dated pin gets bypassed.
-  FUZZ_TOOLCHAIN: nightly-2026-07-24
+  # Bumped from nightly-2026-07-24, which ICEs building tokio 1.53.1 under cargo-fuzz's sanitizer
+  # flags: `rustc_codegen_ssa/src/mir/operand.rs:291: not immediate: OperandRef(Uninit ...)`.
+  # Reproduced locally on aarch64-apple-darwin with the same rustc commit, so it is the toolchain
+  # and not the runner. `cargo check` cannot see it — no sanitizer instrumentation — which is why
+  # the pin is only moved after a real `cargo fuzz run` on the candidate.
+  #
+  # Verified on this exact combination before pinning: `cargo check --locked --all-targets` in
+  # `fuzz/`, and `cargo fuzz run bundle_reader` with the CI parameters (20000 runs, 14s, 776 new
+  # units, peak RSS 412 MB, no crash).
+  FUZZ_TOOLCHAIN: nightly-2026-07-28
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,10 @@ repos:
         entry: bash scripts/ci/test-fuzz-lane-contract.sh
         language: system
         pass_filenames: false
-        files: ^(scripts/ci/test-fuzz-lane-contract\.sh|\.github/workflows/fuzz-smoke\.yml|\.pre-commit-config\.yaml)$
+        # `fuzz/Cargo.{toml,lock}` included: the contract derives the lane's required path filter
+        # from the lock, so a change there can invalidate the assertion without touching either
+        # file that used to trigger this hook.
+        files: ^(scripts/ci/test-fuzz-lane-contract\.sh|\.github/workflows/fuzz-smoke\.yml|fuzz/Cargo\.(toml|lock)|\.pre-commit-config\.yaml)$
 
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/(reconcile-docs-auto-pr|test-reconcile-docs-auto-pr)\.sh|\.github/workflows/(docs-auto-update|ci|assay-runner-lane-check|host-capability-check)\.yml|\.pre-commit-config\.yaml)$
 
+      - id: fuzz-lane-contract-self-test
+        name: Fuzz lane contract
+        entry: bash scripts/ci/test-fuzz-lane-contract.sh
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/test-fuzz-lane-contract\.sh|\.github/workflows/fuzz-smoke\.yml|\.pre-commit-config\.yaml)$
+
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract
         entry: bash scripts/ci/test-ci-gate-expectations.sh

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -60,31 +60,31 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "assay-evidence",
  "hex",
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "assay-canonical"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "hex",
  "serde",
  "serde_jcs",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "assay-common"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "chrono",
  "libc",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -115,7 +115,7 @@ dependencies = [
  "md5",
  "nix 0.27.1",
  "pkcs8",
- "rand 0.8.5",
+ "rand 0.8.7",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
@@ -131,7 +131,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -140,10 +140,11 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
+ "assay-common",
  "async-trait",
  "base64",
  "bytes",
@@ -154,14 +155,14 @@ dependencies = [
  "globset",
  "hex",
  "object_store",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_jcs",
  "serde_json",
  "serde_yaml",
  "sha2",
  "tar",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -180,13 +181,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -197,15 +198,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -213,14 +214,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -252,9 +254,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -273,19 +275,19 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -295,27 +297,21 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -325,9 +321,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -342,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -354,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -429,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -439,18 +435,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -506,14 +502,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -570,13 +566,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -619,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -673,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
@@ -685,13 +681,12 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -729,12 +724,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -750,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -766,9 +755,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -781,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -791,15 +780,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -808,38 +797,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -891,23 +880,23 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -918,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -946,28 +935,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1002,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1012,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1022,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1041,9 +1015,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
@@ -1056,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1070,7 +1044,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1078,15 +1051,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1142,12 +1114,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1155,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1168,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1182,15 +1155,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1202,15 +1175,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1220,12 +1193,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -1240,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1250,14 +1217,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1265,16 +1230,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1293,51 +1248,79 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonschema"
-version = "0.48.5"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
+checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1355,7 +1338,7 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rustls",
  "serde",
  "serde_json",
@@ -1366,18 +1349,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.5"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
+checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.48.5"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1394,12 +1377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,9 +1384,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1417,14 +1394,11 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1446,9 +1420,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1461,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1483,15 +1457,15 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "micromap"
@@ -1511,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1568,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1602,11 +1576,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1658,12 +1631,12 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.10.2",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -1715,7 +1688,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1742,12 +1715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,21 +1726,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1788,20 +1749,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1818,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1830,7 +1781,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1838,21 +1789,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1860,23 +1812,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1895,23 +1847,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1921,7 +1863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -1936,16 +1878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,24 +1888,24 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
+name = "rand_pcg"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1999,15 +1931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,34 +1938,34 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "referencing"
-version = "0.48.5"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
+checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2057,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2069,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2080,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2124,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2194,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2222,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2237,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2249,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2259,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2286,9 +2209,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2298,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2334,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2347,14 +2270,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2388,15 +2311,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2404,33 +2327,33 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2456,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2506,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2531,9 +2454,25 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2543,15 +2482,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2603,7 +2542,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2614,9 +2553,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2640,7 +2590,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2660,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2676,7 +2626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2684,49 +2634,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2734,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2749,9 +2679,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2766,13 +2696,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2787,13 +2717,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2815,20 +2746,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2862,7 +2793,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2897,12 +2828,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2940,7 +2865,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3001,27 +2926,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3032,23 +2948,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3056,46 +2968,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -3112,22 +3002,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3145,18 +3023,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3199,7 +3077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3208,7 +3086,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3232,7 +3110,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3243,7 +3121,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3272,29 +3150,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3308,57 +3168,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3367,34 +3189,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3403,28 +3201,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3433,34 +3213,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3469,122 +3225,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -3598,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3609,68 +3265,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3679,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3690,17 +3346,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -58,10 +58,28 @@ toolchain configuration). Report the failure and let Cargo's stderr say why:\n  
   # 3. Cargo's stderr must stay visible. Only stdout is noise here — the metadata JSON.
   #    Any `2>` form, not an enumeration of them: `2>/dev/null` and `2>&1` were listed, so
   #    `2>cargo-error.log` passed both this test and actionlint while putting the only real
-  #    diagnosis in a file nobody reads. Checked across the whole anchored block, since the
-  #    redirect can sit on the invocation or on its `||` arm.
-  if grep -qE '2>' <<<"$guard_block"; then
-    fail "the guard redirects stderr, which discards the only real diagnosis it has:\n$guard_block"
+  #    diagnosis in a file nobody reads.
+  #
+  #    Scoped to the entire `Fuzz smoke` run block, not to the guard's own two lines. fd2 is step
+  #    state, not line state: `exec 2>cargo-error.log` anywhere above the guard redirects it just
+  #    as effectively, and a two-line window cannot see that. The property being promised is that
+  #    the step's stderr reaches the log, so the check has to cover the step.
+  local run_block
+  run_block="$(awk '
+    /^      - name: Fuzz smoke[[:space:]]*$/ { in_step=1; next }
+    in_step && /^      - / { in_step=0 }
+    in_step && /^        run: \|[[:space:]]*$/ { in_run=1; next }
+    in_run {
+      if ($0 !~ /^          / && $0 !~ /^[[:space:]]*$/) { in_run=0 } else { print }
+    }
+  ' "$wf")"
+  [[ -n "$run_block" ]] || fail "could not read the \`Fuzz smoke\` run block from ${wf##*/}"
+  grep -qF 'metadata --locked' <<<"$run_block" \
+    || fail "the extracted \`Fuzz smoke\` run block does not contain the guard, so scanning it \
+proves nothing"
+  if grep -qE '2>' <<<"$run_block"; then
+    fail "the fuzz step redirects stderr, which discards the only real diagnosis it has:\n\
+$(grep -nE '2>' <<<"$run_block")"
   fi
 
   # 4. The failure must still be a failure — asserted on the guard's own `||` arm, not on the file.
@@ -172,6 +190,21 @@ if ( check_workflow "$comment_mutant" ) >/dev/null 2>&1; then
 file rather than the active \`pull_request.paths\` sequence"
 fi
 echo "ok: commenting out a path entry turns the contract red"
+
+# Negative control: move the redirect off the guard line. `exec 2>` sets fd2 for the rest of the
+# step, so Cargo's diagnosis is gone just the same -- but a check windowed on the guard's own two
+# lines never sees it, and actionlint has no opinion. Same promised property, one scope wider.
+exec_mutant="$(mktemp)"
+trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant" "$comment_mutant" "$exec_mutant"' EXIT
+sed 's|^          # Assert the checked-in lock is current before fuzzing.|          exec 2>cargo-error.log\
+&|' "$WORKFLOW" > "$exec_mutant"
+grep -q '^          exec 2>cargo-error.log$' "$exec_mutant" \
+  || fail "the exec-redirect mutation did not apply, so it proves nothing"
+if ( check_workflow "$exec_mutant" ) >/dev/null 2>&1; then
+  fail "an \`exec 2>\` earlier in the step left the contract green — the stderr check is \
+windowed on the guard rather than on the step"
+fi
+echo "ok: an \`exec 2>\` earlier in the step turns the contract red"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
 echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -24,6 +24,14 @@ fail() {
 
 [[ -f "$WORKFLOW" ]] || fail "missing ${WORKFLOW#"$ROOT"/}"
 
+# One root for every temporary the test builds -- mutant workflows and behavioural sandboxes alike.
+# Each mutant run aborts partway through check_workflow by design, so a cleanup line placed after
+# the assertions is never reached. A single trap owns this: `trap ... EXIT` *replaces* the previous
+# handler rather than adding to it, so a chain of re-traps quietly drops whatever the earlier ones
+# covered -- which is how the sandboxes were leaking one per failed mutant.
+SANDBOX_ROOT="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX_ROOT"' EXIT
+
 # Every assertion takes the workflow path, so the same logic can be run against a deliberately
 # broken copy below. A control that lives only in someone's shell history is not a control.
 check_workflow() {
@@ -77,16 +85,54 @@ toolchain configuration). Report the failure and let Cargo's stderr say why:\n  
   grep -qF 'metadata --locked' <<<"$run_block" \
     || fail "the extracted \`Fuzz smoke\` run block does not contain the guard, so scanning it \
 proves nothing"
-  #    Matched as an operator class, not as one spelling. `2>` alone missed `exec 2<>file`, which
-  #    opens fd2 read/write on the file and hides Cargo's stderr exactly as well -- confirmed by
-  #    writing a sentinel to stderr under it and finding it in the file, not on the terminal.
-  #    `&>`/`&>>` and `|&` carry stderr away too, so the class covers those rather than waiting for
-  #    each to be found separately.
-  local hide_fd2='2[<>]|&>|\|&'
-  if grep -qE "$hide_fd2" <<<"$run_block"; then
-    fail "the fuzz step redirects stderr, which discards the only real diagnosis it has:\n\
-$(grep -nE "$hide_fd2" <<<"$run_block")"
-  fi
+  #    Proved by running the step rather than by pattern-matching it. Matching text was wrong in
+  #    both directions at once: a step-level `shell: bash {0} 2>cargo-error.log` redirects the whole
+  #    script from outside the block a regex can see, and a comment saying `2>cargo-error.log`
+  #    turned the check red while changing nothing. Each new operator spelling only moved the line.
+  #
+  #    So: pin the shell, then execute the extracted script against a `cargo` that fails the way
+  #    `--locked` fails, and require the diagnosis to arrive on the step's own stderr.
+  local shell_line
+  shell_line="$(awk '
+    /^      - name: Fuzz smoke[[:space:]]*$/ { in_step=1; next }
+    in_step && /^      - / { in_step=0 }
+    in_step && /^        shell:/ { print; exit }
+  ' "$wf")"
+  [[ "$shell_line" == "        shell: bash" ]] \
+    || fail "the fuzz step needs a plain \`shell: bash\`; a custom shell line redirects the whole \
+script's stderr from outside the script, where nothing in the run block can see it. Got:\n  \
+${shell_line:-<none>}"
+
+  local sandbox rc=0
+  local sentinel="CARGO-STDERR-SENTINEL-4d1f9a"
+  sandbox="$(mktemp -d "${SANDBOX_ROOT}/wf.XXXXXX")"
+  mkdir -p "$sandbox/bin" "$sandbox/fuzz" "$sandbox/tmp"
+  awk '{ sub(/^          /, ""); print }' <<<"$run_block" > "$sandbox/step.sh"
+
+  # `cargo` fails only for the guard, the way a `--locked` violation does: a message on stderr and
+  # a nonzero exit. Everything else succeeds, so a green run means the guard did its job.
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'if [[ "$*" == *"metadata --locked"* ]]; then'
+    echo "  echo \"error: the lock file needs to be updated -- ${sentinel}\" >&2"
+    echo '  exit 1'
+    echo 'fi'
+    echo 'exit 0'
+  } > "$sandbox/bin/cargo"
+  printf '#!/usr/bin/env bash\necho "rustc 0.0.0-mock"\n' > "$sandbox/bin/rustc"
+  chmod +x "$sandbox/bin/cargo" "$sandbox/bin/rustc"
+
+  ( cd "$sandbox" && PATH="$sandbox/bin:$PATH" RUNNER_TEMP="$sandbox/tmp" \
+      FUZZ_TOOLCHAIN="nightly-mock" RUNS=1 MAX_TOTAL_TIME=1 \
+      bash step.sh ) >"$sandbox/out" 2>"$sandbox/err" || rc=$?
+
+  [[ "$rc" -ne 0 ]] \
+    || fail "the fuzz step exited 0 even though \`cargo metadata --locked\` failed"
+  grep -q '::error::locked fuzz metadata validation failed' "$sandbox/out" \
+    || fail "the guard's wrapper message never printed:\n$(cat "$sandbox/out")"
+  grep -q "$sentinel" "$sandbox/err" \
+    || fail "Cargo's stderr did not reach the step's stderr, so the only real diagnosis is \
+invisible to a reviewer. Step stderr was:\n$(cat "$sandbox/err")"
 
   # 4. The failure must still be a failure — asserted on the guard's own `||` arm, not on the file.
   #    Searching the whole workflow passed on the seed-corpus check's unrelated `exit 1`, so
@@ -143,8 +189,7 @@ check_workflow "$WORKFLOW"
 
 # Negative control: strip the guard's exit and nothing else. The seed-corpus check keeps its own
 # `exit 1`, which is exactly the state that used to pass.
-mutant="$(mktemp)"
-trap 'rm -f "$mutant"' EXIT
+mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
 sed 's|\(inspect the Cargo error above"\); exit 1; }|\1; }|' "$WORKFLOW" > "$mutant"
 if ! grep -q 'exit 1' "$mutant"; then
   fail "the mutation removed every exit, so it does not isolate the guard"
@@ -158,8 +203,7 @@ echo "ok: removing only the guard's exit turns the contract red"
 # Negative control: send stderr to a file. It is not `/dev/null` and not `2>&1`, so the enumerated
 # form of this check passed it -- and actionlint passes it too, since the shell is valid. The
 # diagnosis simply lands somewhere no reviewer looks.
-redirect_mutant="$(mktemp)"
-trap 'rm -f "$mutant" "$redirect_mutant"' EXIT
+redirect_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
 sed 's|--format-version 1 >/dev/null )|--format-version 1 >/dev/null 2>cargo-error.log )|' \
   "$WORKFLOW" > "$redirect_mutant"
 grep -q '2>cargo-error.log' "$redirect_mutant" \
@@ -173,8 +217,7 @@ echo "ok: redirecting Cargo's stderr to a file turns the contract red"
 # Negative control: drop one crate from the path filter. This is the state the branch shipped in --
 # three of the five local crates were simply absent -- so the assertion that catches it has to be
 # shown catching it.
-paths_mutant="$(mktemp)"
-trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant"' EXIT
+paths_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
 grep -v '"crates/assay-common/\*\*"' "$WORKFLOW" > "$paths_mutant"
 if ( check_workflow "$paths_mutant" ) >/dev/null 2>&1; then
   fail "dropping a local crate from the path filter left the contract green — the coverage \
@@ -185,8 +228,7 @@ echo "ok: dropping a local crate from the path filter turns the contract red"
 # Negative control: comment the entry out instead of deleting it. The line is still in the file and
 # still says the crate's name, so a whole-file grep called it covered — while `pull_request.paths`
 # no longer carries it and actionlint sees nothing wrong.
-comment_mutant="$(mktemp)"
-trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant" "$comment_mutant"' EXIT
+comment_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
 sed 's|^      - "crates/assay-common/\*\*"|      # - "crates/assay-common/**"|' \
   "$WORKFLOW" > "$comment_mutant"
 grep -q '^      # - "crates/assay-common/\*\*"' "$comment_mutant" \
@@ -200,8 +242,7 @@ echo "ok: commenting out a path entry turns the contract red"
 # Negative control: move the redirect off the guard line. `exec 2>` sets fd2 for the rest of the
 # step, so Cargo's diagnosis is gone just the same -- but a check windowed on the guard's own two
 # lines never sees it, and actionlint has no opinion. Same promised property, one scope wider.
-exec_mutant="$(mktemp)"
-trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant" "$comment_mutant" "$exec_mutant"' EXIT
+exec_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
 sed 's|^          # Assert the checked-in lock is current before fuzzing.|          exec 2>cargo-error.log\
 &|' "$WORKFLOW" > "$exec_mutant"
 grep -q '^          exec 2>cargo-error.log$' "$exec_mutant" \
@@ -214,9 +255,7 @@ echo "ok: an \`exec 2>\` earlier in the step turns the contract red"
 
 # Negative control: `2<>` opens fd2 read/write on a file. It is a different operator, not a
 # different target, so a check spelled `2>` never saw it -- and the step's stderr is just as gone.
-readwrite_mutant="$(mktemp)"
-trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant" "$comment_mutant" "$exec_mutant" \
-  "$readwrite_mutant"' EXIT
+readwrite_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
 sed 's|^          # Assert the checked-in lock is current before fuzzing.|          exec 2<>cargo-error.log\
 &|' "$WORKFLOW" > "$readwrite_mutant"
 grep -q '^          exec 2<>cargo-error.log$' "$readwrite_mutant" \
@@ -226,6 +265,36 @@ if ( check_workflow "$readwrite_mutant" ) >/dev/null 2>&1; then
 than the redirection operators that hide fd2"
 fi
 echo "ok: an \`exec 2<>\` turns the contract red"
+
+# Negative control: redirect from the step's `shell:` line. It is outside the run block entirely,
+# so no amount of scanning the script can see it -- only pinning the shell can.
+shell_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
+awk '
+  /^      - name: Fuzz smoke[[:space:]]*$/ { in_step=1 }
+  in_step && /^        shell: bash$/ { print "        shell: bash {0} 2>cargo-error.log"; in_step=0; next }
+  { print }
+' "$WORKFLOW" > "$shell_mutant"
+grep -q 'shell: bash {0} 2>cargo-error.log' "$shell_mutant" \
+  || fail "the custom-shell mutation did not apply, so it proves nothing"
+if ( check_workflow "$shell_mutant" ) >/dev/null 2>&1; then
+  fail "a step-level \`shell:\` redirect left the contract green — the stderr proof does not \
+cover how the script is invoked"
+fi
+echo "ok: a step-level \`shell:\` redirect turns the contract red"
+
+# Positive control: a comment that merely names a redirect changes nothing and must stay green.
+# The previous static check matched the text and went red on it, which is a false alarm on a line
+# warning against the very thing the test exists to catch.
+comment_ok="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
+sed 's|^          # Assert the checked-in lock is current before fuzzing.|          # Never add 2>cargo-error.log here\
+&|' "$WORKFLOW" > "$comment_ok"
+grep -q '# Never add 2>cargo-error.log here' "$comment_ok" \
+  || fail "the comment control did not apply, so it proves nothing"
+if ! ( check_workflow "$comment_ok" ) >/dev/null 2>&1; then
+  fail "a comment naming a redirect turned the contract red — the check reacts to text rather \
+than to behaviour"
+fi
+echo "ok: a comment naming a redirect leaves the contract green"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
 echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Contract assertions for the fuzz lane's lock-staleness guard.
+#
+# The guard wraps `cargo metadata --locked`, and a wrapper that names one cause for every failure
+# is a diagnosis the command did not make. `--locked` fails on a stale lock, but equally on an
+# unparsable manifest, an unavailable dependency, a registry or network fault, or a broken
+# toolchain — and the first version of this wrapper reported all of them as "fuzz/Cargo.lock is
+# stale" and told the reader to run `cargo update --workspace`. On a registry outage that advice
+# is wrong and, followed, would rewrite a lock that was never the problem.
+#
+# So the wrapper must add exit-code discipline and nothing else: Cargo's own stderr stays visible
+# and stays the diagnosis. These assertions pin that, because prose in a comment is what went
+# stale last time.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/fuzz-smoke.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$WORKFLOW" ]] || fail "missing ${WORKFLOW#"$ROOT"/}"
+
+# The guard is the `||` arm attached to the `cargo metadata --locked` invocation, so anchor on
+# that rather than on any line mentioning a lock — the seed-corpus check also emits `::error::`.
+guard_line="$(grep -n -A1 'metadata --locked' "$WORKFLOW" | grep '::error::' | head -1 || true)"
+[[ -n "$guard_line" ]] || fail "no error message attached to the \`cargo metadata --locked\` guard"
+guard_msg="${guard_line#*::error::}"
+
+# 1. The message must not name a cause the command did not establish.
+for claim in stale "cargo update" "out of date" outdated regenerate; do
+  if grep -qi -- "$claim" <<<"$guard_msg"; then
+    fail "the lock-guard message claims '$claim', but \`cargo metadata --locked\` fails for \
+several unrelated reasons (bad manifest, unavailable dependency, registry or network fault, \
+toolchain configuration). Report the failure and let Cargo's stderr say why:\n  $guard_msg"
+  fi
+done
+
+# 2. It must point the reader at the real diagnosis rather than replacing it.
+grep -qiE 'cargo error|error above|output above' <<<"$guard_msg" \
+  || fail "the lock-guard message should send the reader to Cargo's own error, got:\n  $guard_msg"
+
+# 3. Cargo's stderr must stay visible. Only stdout is noise here — the metadata JSON.
+guard_cmd="$(grep -n 'metadata --locked' "$WORKFLOW" | head -1 | cut -d: -f2-)"
+[[ -n "$guard_cmd" ]] || fail "no \`cargo metadata --locked\` invocation found"
+if grep -qE '2>[&]?[/ ]?(dev/null|1)' <<<"$guard_cmd"; then
+  fail "the guard redirects stderr, which discards the only real diagnosis it has:\n  $guard_cmd"
+fi
+
+# 4. The failure must still be a failure. A guard that reports and continues is not a guard.
+grep -q 'exit 1' "$WORKFLOW" || fail "the lock guard does not exit nonzero"
+
+# 5. The toolchain pin stays dated. A channel alias would hide both a break and its fix, which is
+#    exactly what happened when nightly-2026-07-24 began ICEing on tokio under sanitizer coverage.
+pin="$(grep -E '^\s*FUZZ_TOOLCHAIN:' "$WORKFLOW" | head -1 | sed 's/.*: *//')"
+[[ "$pin" =~ ^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+  || fail "FUZZ_TOOLCHAIN must be a dated nightly, got: ${pin:-<empty>}"
+
+echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
+echo "ok: FUZZ_TOOLCHAIN is dated (${pin})"
+echo "PASS: fuzz lane contract"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -108,8 +108,12 @@ ${shell_line:-<none>}"
   # stderr capture while leaving the script itself untouched. The harness below executes the script,
   # so it can never see a preamble the runner would have sourced first. Matched as an active mapping
   # key, one name, no env parsing: a line that is commented out sources nothing and stays green.
+  #    YAML lets a key be plain, single-quoted or double-quoted, and all three are the same key.
+  #    An unquoted-only match called `"BASH_ENV": file` absent while actionlint called it valid, so
+  #    the three forms are spelled out here rather than claimed. Still one name and no parser.
   local bash_env_line
-  bash_env_line="$(grep -nE '^[[:space:]]*BASH_ENV[[:space:]]*:' "$wf" | head -1 || true)"
+  local bash_env_key=$'^[[:space:]]*("BASH_ENV"|\'BASH_ENV\'|BASH_ENV)[[:space:]]*:'
+  bash_env_line="$(grep -nE "$bash_env_key" "$wf" | head -1 || true)"
   [[ -z "$bash_env_line" ]] \
     || fail "this lane must not set \`BASH_ENV\`: bash sources it before the step's own script, so
 a preamble can redirect the step's stderr without appearing in the script at all. Found:\n  \
@@ -333,6 +337,21 @@ if ( check_workflow "$bash_env_mutant" ) >/dev/null 2>&1; then
 which is where the harness starts looking"
 fi
 echo "ok: a step-level \`BASH_ENV\` turns the contract red"
+
+# Negative control: quote the key. `"BASH_ENV": file` is the same mapping key to YAML and to the
+# runner, and actionlint accepts it -- only a match written for the bare word missed it.
+quoted_env_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
+awk '
+  /^          RUNS: / && !done { print "          \"BASH_ENV\": .github/fuzz-preamble.sh"; done=1 }
+  { print }
+' "$WORKFLOW" > "$quoted_env_mutant"
+grep -q '^          "BASH_ENV": ' "$quoted_env_mutant" \
+  || fail "the quoted-key mutation did not apply, so it proves nothing"
+if ( check_workflow "$quoted_env_mutant" ) >/dev/null 2>&1; then
+  fail "a quoted \`\"BASH_ENV\"\` key left the contract green — the check matches one spelling \
+of the key rather than the key"
+fi
+echo "ok: a quoted \`BASH_ENV\` key turns the contract red"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
 echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -77,9 +77,15 @@ toolchain configuration). Report the failure and let Cargo's stderr say why:\n  
   grep -qF 'metadata --locked' <<<"$run_block" \
     || fail "the extracted \`Fuzz smoke\` run block does not contain the guard, so scanning it \
 proves nothing"
-  if grep -qE '2>' <<<"$run_block"; then
+  #    Matched as an operator class, not as one spelling. `2>` alone missed `exec 2<>file`, which
+  #    opens fd2 read/write on the file and hides Cargo's stderr exactly as well -- confirmed by
+  #    writing a sentinel to stderr under it and finding it in the file, not on the terminal.
+  #    `&>`/`&>>` and `|&` carry stderr away too, so the class covers those rather than waiting for
+  #    each to be found separately.
+  local hide_fd2='2[<>]|&>|\|&'
+  if grep -qE "$hide_fd2" <<<"$run_block"; then
     fail "the fuzz step redirects stderr, which discards the only real diagnosis it has:\n\
-$(grep -nE '2>' <<<"$run_block")"
+$(grep -nE "$hide_fd2" <<<"$run_block")"
   fi
 
   # 4. The failure must still be a failure — asserted on the guard's own `||` arm, not on the file.
@@ -205,6 +211,21 @@ if ( check_workflow "$exec_mutant" ) >/dev/null 2>&1; then
 windowed on the guard rather than on the step"
 fi
 echo "ok: an \`exec 2>\` earlier in the step turns the contract red"
+
+# Negative control: `2<>` opens fd2 read/write on a file. It is a different operator, not a
+# different target, so a check spelled `2>` never saw it -- and the step's stderr is just as gone.
+readwrite_mutant="$(mktemp)"
+trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant" "$comment_mutant" "$exec_mutant" \
+  "$readwrite_mutant"' EXIT
+sed 's|^          # Assert the checked-in lock is current before fuzzing.|          exec 2<>cargo-error.log\
+&|' "$WORKFLOW" > "$readwrite_mutant"
+grep -q '^          exec 2<>cargo-error.log$' "$readwrite_mutant" \
+  || fail "the read/write redirect mutation did not apply, so it proves nothing"
+if ( check_workflow "$readwrite_mutant" ) >/dev/null 2>&1; then
+  fail "an \`exec 2<>\` left the contract green — the stderr check matches one spelling rather \
+than the redirection operators that hide fd2"
+fi
+echo "ok: an \`exec 2<>\` turns the contract red"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
 echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -29,10 +29,16 @@ fail() {
 check_workflow() {
   local wf="$1"
 
-  # The guard is the `||` arm attached to the `cargo metadata --locked` invocation, so anchor on
-  # that rather than on any line mentioning a lock — the seed-corpus check also emits `::error::`.
-  local guard_line guard_msg guard_cmd pin
-  guard_line="$(grep -n -A1 'metadata --locked' "$wf" | grep '::error::' | head -1 || true)"
+  # The guard is the `||` arm attached to the `cargo metadata --locked` invocation. Anchor on the
+  # invocation *line number*, not on any line mentioning a lock: the seed-corpus check also emits
+  # `::error::`, and the workflow's own comments name the command in prose — a plain grep picked a
+  # comment block and every assertion below then reported on the wrong two lines.
+  local guard_ln guard_block guard_line guard_msg pin
+  guard_ln="$(grep -nE '^[^#]*cargo[^#]*metadata --locked' "$wf" | head -1 | cut -d: -f1)"
+  [[ -n "$guard_ln" ]] || fail "no \`cargo metadata --locked\` invocation found"
+  guard_block="$(sed -n "${guard_ln},$((guard_ln + 1))p" "$wf")"
+
+  guard_line="$(grep '::error::' <<<"$guard_block" | head -1 || true)"
   [[ -n "$guard_line" ]] || fail "no error message attached to the \`cargo metadata --locked\` guard"
   guard_msg="${guard_line#*::error::}"
 
@@ -50,10 +56,12 @@ toolchain configuration). Report the failure and let Cargo's stderr say why:\n  
     || fail "the lock-guard message should send the reader to Cargo's own error, got:\n  $guard_msg"
 
   # 3. Cargo's stderr must stay visible. Only stdout is noise here — the metadata JSON.
-  guard_cmd="$(grep -n 'metadata --locked' "$wf" | head -1 | cut -d: -f2-)"
-  [[ -n "$guard_cmd" ]] || fail "no \`cargo metadata --locked\` invocation found"
-  if grep -qE '2>[&]?[/ ]?(dev/null|1)' <<<"$guard_cmd"; then
-    fail "the guard redirects stderr, which discards the only real diagnosis it has:\n  $guard_cmd"
+  #    Any `2>` form, not an enumeration of them: `2>/dev/null` and `2>&1` were listed, so
+  #    `2>cargo-error.log` passed both this test and actionlint while putting the only real
+  #    diagnosis in a file nobody reads. Checked across the whole anchored block, since the
+  #    redirect can sit on the invocation or on its `||` arm.
+  if grep -qE '2>' <<<"$guard_block"; then
+    fail "the guard redirects stderr, which discards the only real diagnosis it has:\n$guard_block"
   fi
 
   # 4. The failure must still be a failure — asserted on the guard's own `||` arm, not on the file.
@@ -69,6 +77,27 @@ toolchain configuration). Report the failure and let Cargo's stderr say why:\n  
   [[ "$pin" =~ ^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
     || fail "FUZZ_TOOLCHAIN must be a dated nightly, got: ${pin:-<empty>}"
   PIN="$pin"
+
+  # 6. Every local crate the fuzz graph resolves must trigger this lane.
+  #
+  #    Derived from `fuzz/Cargo.lock` rather than listed: a package with no `source` is a path
+  #    dependency, so the set comes from the same file the lane pins. Listing them by hand is what
+  #    left `assay-adapter-api`, `assay-canonical` and `assay-common` uncovered while
+  #    `assay-core` and `assay-evidence` were named -- a change in any of the three could alter
+  #    code, manifest or lock without this lane ever running, which is the staleness this whole
+  #    branch exists to stop. Offline and cheap: no cargo invocation.
+  local locals missing=""
+  locals="$(awk '/^\[\[package\]\]/{name="";src=0} /^name = /{gsub(/[",]/,"",$3); name=$3} \
+                 /^source = /{src=1} /^$/{if(name!="" && !src) print name} \
+                 END{if(name!="" && !src) print name}' \
+            "${ROOT}/fuzz/Cargo.lock" | grep -v '^assay-fuzz$' | sort -u)"
+  [[ -n "$locals" ]] || fail "could not derive local path dependencies from fuzz/Cargo.lock"
+  while read -r crate; do
+    [[ -n "$crate" ]] || continue
+    grep -qF "\"crates/${crate}/**\"" "$wf" || missing="${missing} ${crate}"
+  done <<<"$locals"
+  [[ -z "$missing" ]] || fail "the fuzz lane resolves these local crates but does not trigger on \
+them, so a change there can go untested:${missing}"
 }
 
 check_workflow "$WORKFLOW"
@@ -86,6 +115,33 @@ if ( check_workflow "$mutant" ) >/dev/null 2>&1; then
 bound to the guard"
 fi
 echo "ok: removing only the guard's exit turns the contract red"
+
+# Negative control: send stderr to a file. It is not `/dev/null` and not `2>&1`, so the enumerated
+# form of this check passed it -- and actionlint passes it too, since the shell is valid. The
+# diagnosis simply lands somewhere no reviewer looks.
+redirect_mutant="$(mktemp)"
+trap 'rm -f "$mutant" "$redirect_mutant"' EXIT
+sed 's|--format-version 1 >/dev/null )|--format-version 1 >/dev/null 2>cargo-error.log )|' \
+  "$WORKFLOW" > "$redirect_mutant"
+grep -q '2>cargo-error.log' "$redirect_mutant" \
+  || fail "the redirect mutation did not apply, so it proves nothing"
+if ( check_workflow "$redirect_mutant" ) >/dev/null 2>&1; then
+  fail "sending Cargo's stderr to a file left the contract green — the check enumerates redirect \
+forms instead of rejecting them"
+fi
+echo "ok: redirecting Cargo's stderr to a file turns the contract red"
+
+# Negative control: drop one crate from the path filter. This is the state the branch shipped in --
+# three of the five local crates were simply absent -- so the assertion that catches it has to be
+# shown catching it.
+paths_mutant="$(mktemp)"
+trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant"' EXIT
+grep -v '"crates/assay-common/\*\*"' "$WORKFLOW" > "$paths_mutant"
+if ( check_workflow "$paths_mutant" ) >/dev/null 2>&1; then
+  fail "dropping a local crate from the path filter left the contract green — the coverage \
+assertion is not bound to the lockfile"
+fi
+echo "ok: dropping a local crate from the path filter turns the contract red"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
 echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -86,7 +86,22 @@ toolchain configuration). Report the failure and let Cargo's stderr say why:\n  
   #    `assay-core` and `assay-evidence` were named -- a change in any of the three could alter
   #    code, manifest or lock without this lane ever running, which is the staleness this whole
   #    branch exists to stop. Offline and cheap: no cargo invocation.
-  local locals missing=""
+  #    Read from the `on.pull_request.paths` sequence itself, not from the file. A crate name
+  #    appears in this workflow's own prose too, so a whole-file grep answered "covered" for
+  #    `# - "crates/assay-common/**"` -- a commented-out entry that triggers nothing, and that
+  #    actionlint passes as valid YAML. The extractor takes only `- ` items inside that one block.
+  local paths_active locals missing=""
+  paths_active="$(awk '
+    /^  pull_request:[[:space:]]*$/ { in_pr=1; next }
+    /^  [^[:space:]]/              { in_pr=0; in_paths=0 }
+    in_pr && /^    paths:[[:space:]]*$/ { in_paths=1; next }
+    in_pr && /^    [^[:space:]]/  { in_paths=0 }
+    in_paths && /^      -[[:space:]]/ { print }
+  ' "$wf")"
+  [[ -n "$paths_active" ]] \
+    || fail "could not read the \`on.pull_request.paths\` sequence from ${wf##*/}"
+
+  local locals
   locals="$(awk '/^\[\[package\]\]/{name="";src=0} /^name = /{gsub(/[",]/,"",$3); name=$3} \
                  /^source = /{src=1} /^$/{if(name!="" && !src) print name} \
                  END{if(name!="" && !src) print name}' \
@@ -94,7 +109,7 @@ toolchain configuration). Report the failure and let Cargo's stderr say why:\n  
   [[ -n "$locals" ]] || fail "could not derive local path dependencies from fuzz/Cargo.lock"
   while read -r crate; do
     [[ -n "$crate" ]] || continue
-    grep -qF "\"crates/${crate}/**\"" "$wf" || missing="${missing} ${crate}"
+    grep -qF "\"crates/${crate}/**\"" <<<"$paths_active" || missing="${missing} ${crate}"
   done <<<"$locals"
   [[ -z "$missing" ]] || fail "the fuzz lane resolves these local crates but does not trigger on \
 them, so a change there can go untested:${missing}"
@@ -142,6 +157,21 @@ if ( check_workflow "$paths_mutant" ) >/dev/null 2>&1; then
 assertion is not bound to the lockfile"
 fi
 echo "ok: dropping a local crate from the path filter turns the contract red"
+
+# Negative control: comment the entry out instead of deleting it. The line is still in the file and
+# still says the crate's name, so a whole-file grep called it covered — while `pull_request.paths`
+# no longer carries it and actionlint sees nothing wrong.
+comment_mutant="$(mktemp)"
+trap 'rm -f "$mutant" "$redirect_mutant" "$paths_mutant" "$comment_mutant"' EXIT
+sed 's|^      - "crates/assay-common/\*\*"|      # - "crates/assay-common/**"|' \
+  "$WORKFLOW" > "$comment_mutant"
+grep -q '^      # - "crates/assay-common/\*\*"' "$comment_mutant" \
+  || fail "the comment mutation did not apply, so it proves nothing"
+if ( check_workflow "$comment_mutant" ) >/dev/null 2>&1; then
+  fail "commenting out a path entry left the contract green — the coverage assertion reads the \
+file rather than the active \`pull_request.paths\` sequence"
+fi
+echo "ok: commenting out a path entry turns the contract red"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
 echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -24,41 +24,69 @@ fail() {
 
 [[ -f "$WORKFLOW" ]] || fail "missing ${WORKFLOW#"$ROOT"/}"
 
-# The guard is the `||` arm attached to the `cargo metadata --locked` invocation, so anchor on
-# that rather than on any line mentioning a lock — the seed-corpus check also emits `::error::`.
-guard_line="$(grep -n -A1 'metadata --locked' "$WORKFLOW" | grep '::error::' | head -1 || true)"
-[[ -n "$guard_line" ]] || fail "no error message attached to the \`cargo metadata --locked\` guard"
-guard_msg="${guard_line#*::error::}"
+# Every assertion takes the workflow path, so the same logic can be run against a deliberately
+# broken copy below. A control that lives only in someone's shell history is not a control.
+check_workflow() {
+  local wf="$1"
 
-# 1. The message must not name a cause the command did not establish.
-for claim in stale "cargo update" "out of date" outdated regenerate; do
-  if grep -qi -- "$claim" <<<"$guard_msg"; then
-    fail "the lock-guard message claims '$claim', but \`cargo metadata --locked\` fails for \
+  # The guard is the `||` arm attached to the `cargo metadata --locked` invocation, so anchor on
+  # that rather than on any line mentioning a lock — the seed-corpus check also emits `::error::`.
+  local guard_line guard_msg guard_cmd pin
+  guard_line="$(grep -n -A1 'metadata --locked' "$wf" | grep '::error::' | head -1 || true)"
+  [[ -n "$guard_line" ]] || fail "no error message attached to the \`cargo metadata --locked\` guard"
+  guard_msg="${guard_line#*::error::}"
+
+  # 1. The message must not name a cause the command did not establish.
+  for claim in stale "cargo update" "out of date" outdated regenerate; do
+    if grep -qi -- "$claim" <<<"$guard_msg"; then
+      fail "the lock-guard message claims '$claim', but \`cargo metadata --locked\` fails for \
 several unrelated reasons (bad manifest, unavailable dependency, registry or network fault, \
 toolchain configuration). Report the failure and let Cargo's stderr say why:\n  $guard_msg"
+    fi
+  done
+
+  # 2. It must point the reader at the real diagnosis rather than replacing it.
+  grep -qiE 'cargo error|error above|output above' <<<"$guard_msg" \
+    || fail "the lock-guard message should send the reader to Cargo's own error, got:\n  $guard_msg"
+
+  # 3. Cargo's stderr must stay visible. Only stdout is noise here — the metadata JSON.
+  guard_cmd="$(grep -n 'metadata --locked' "$wf" | head -1 | cut -d: -f2-)"
+  [[ -n "$guard_cmd" ]] || fail "no \`cargo metadata --locked\` invocation found"
+  if grep -qE '2>[&]?[/ ]?(dev/null|1)' <<<"$guard_cmd"; then
+    fail "the guard redirects stderr, which discards the only real diagnosis it has:\n  $guard_cmd"
   fi
-done
 
-# 2. It must point the reader at the real diagnosis rather than replacing it.
-grep -qiE 'cargo error|error above|output above' <<<"$guard_msg" \
-  || fail "the lock-guard message should send the reader to Cargo's own error, got:\n  $guard_msg"
+  # 4. The failure must still be a failure — asserted on the guard's own `||` arm, not on the file.
+  #    Searching the whole workflow passed on the seed-corpus check's unrelated `exit 1`, so
+  #    removing only this guard's exit left the contract green. An assertion scoped wider than its
+  #    subject reports on something else.
+  grep -q 'exit 1' <<<"$guard_line" \
+    || fail "the lock guard reports but does not exit nonzero:\n  $guard_line"
 
-# 3. Cargo's stderr must stay visible. Only stdout is noise here — the metadata JSON.
-guard_cmd="$(grep -n 'metadata --locked' "$WORKFLOW" | head -1 | cut -d: -f2-)"
-[[ -n "$guard_cmd" ]] || fail "no \`cargo metadata --locked\` invocation found"
-if grep -qE '2>[&]?[/ ]?(dev/null|1)' <<<"$guard_cmd"; then
-  fail "the guard redirects stderr, which discards the only real diagnosis it has:\n  $guard_cmd"
+  # 5. The toolchain pin stays dated. A channel alias would hide both a break and its fix, which is
+  #    exactly what happened when nightly-2026-07-24 began ICEing on tokio under sanitizer coverage.
+  pin="$(grep -E '^\s*FUZZ_TOOLCHAIN:' "$wf" | head -1 | sed 's/.*: *//')"
+  [[ "$pin" =~ ^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+    || fail "FUZZ_TOOLCHAIN must be a dated nightly, got: ${pin:-<empty>}"
+  PIN="$pin"
+}
+
+check_workflow "$WORKFLOW"
+
+# Negative control: strip the guard's exit and nothing else. The seed-corpus check keeps its own
+# `exit 1`, which is exactly the state that used to pass.
+mutant="$(mktemp)"
+trap 'rm -f "$mutant"' EXIT
+sed 's|\(inspect the Cargo error above"\); exit 1; }|\1; }|' "$WORKFLOW" > "$mutant"
+if ! grep -q 'exit 1' "$mutant"; then
+  fail "the mutation removed every exit, so it does not isolate the guard"
 fi
-
-# 4. The failure must still be a failure. A guard that reports and continues is not a guard.
-grep -q 'exit 1' "$WORKFLOW" || fail "the lock guard does not exit nonzero"
-
-# 5. The toolchain pin stays dated. A channel alias would hide both a break and its fix, which is
-#    exactly what happened when nightly-2026-07-24 began ICEing on tokio under sanitizer coverage.
-pin="$(grep -E '^\s*FUZZ_TOOLCHAIN:' "$WORKFLOW" | head -1 | sed 's/.*: *//')"
-[[ "$pin" =~ ^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
-  || fail "FUZZ_TOOLCHAIN must be a dated nightly, got: ${pin:-<empty>}"
+if ( check_workflow "$mutant" ) >/dev/null 2>&1; then
+  fail "removing only the guard's exit left the contract green — the fail-closed assertion is not \
+bound to the guard"
+fi
+echo "ok: removing only the guard's exit turns the contract red"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
-echo "ok: FUZZ_TOOLCHAIN is dated (${pin})"
+echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"
 echo "PASS: fuzz lane contract"

--- a/scripts/ci/test-fuzz-lane-contract.sh
+++ b/scripts/ci/test-fuzz-lane-contract.sh
@@ -103,6 +103,18 @@ proves nothing"
 script's stderr from outside the script, where nothing in the run block can see it. Got:\n  \
 ${shell_line:-<none>}"
 
+  # `BASH_ENV` names a file bash sources before the script, and `--noprofile --norc` does not
+  # suppress it -- confirmed by running a preamble that does `exec 2>file`, which empties the outer
+  # stderr capture while leaving the script itself untouched. The harness below executes the script,
+  # so it can never see a preamble the runner would have sourced first. Matched as an active mapping
+  # key, one name, no env parsing: a line that is commented out sources nothing and stays green.
+  local bash_env_line
+  bash_env_line="$(grep -nE '^[[:space:]]*BASH_ENV[[:space:]]*:' "$wf" | head -1 || true)"
+  [[ -z "$bash_env_line" ]] \
+    || fail "this lane must not set \`BASH_ENV\`: bash sources it before the step's own script, so
+a preamble can redirect the step's stderr without appearing in the script at all. Found:\n  \
+$bash_env_line"
+
   local sandbox rc=0
   local sentinel="CARGO-STDERR-SENTINEL-4d1f9a"
   sandbox="$(mktemp -d "${SANDBOX_ROOT}/wf.XXXXXX")"
@@ -122,7 +134,18 @@ ${shell_line:-<none>}"
   printf '#!/usr/bin/env bash\necho "rustc 0.0.0-mock"\n' > "$sandbox/bin/rustc"
   chmod +x "$sandbox/bin/cargo" "$sandbox/bin/rustc"
 
-  ( cd "$sandbox" && PATH="$sandbox/bin:$PATH" RUNNER_TEMP="$sandbox/tmp" \
+  # The mocks only mean something if they are the ones that run.
+  local tool resolved
+  for tool in cargo rustc; do
+    resolved="$(PATH="$sandbox/bin:$PATH" command -v "$tool" || true)"
+    [[ "$resolved" == "$sandbox/bin/$tool" ]] \
+      || fail "the sandbox PATH does not win for \`$tool\`: it resolved to ${resolved:-<none>}, so \
+the run below would exercise the real toolchain instead of the mock"
+  done
+
+  # `env -u BASH_ENV`: whatever the caller's environment carries must not decide whether this proof
+  # holds. The workflow is checked for it above; here the harness itself is put beyond its reach.
+  ( cd "$sandbox" && env -u BASH_ENV PATH="$sandbox/bin:$PATH" RUNNER_TEMP="$sandbox/tmp" \
       FUZZ_TOOLCHAIN="nightly-mock" RUNS=1 MAX_TOTAL_TIME=1 \
       bash step.sh ) >"$sandbox/out" 2>"$sandbox/err" || rc=$?
 
@@ -286,7 +309,7 @@ echo "ok: a step-level \`shell:\` redirect turns the contract red"
 # The previous static check matched the text and went red on it, which is a false alarm on a line
 # warning against the very thing the test exists to catch.
 comment_ok="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
-sed 's|^          # Assert the checked-in lock is current before fuzzing.|          # Never add 2>cargo-error.log here\
+sed 's|^          # Assert the checked-in lock is current before fuzzing.|          # Never add 2>cargo-error.log here, and never set BASH_ENV: anything\
 &|' "$WORKFLOW" > "$comment_ok"
 grep -q '# Never add 2>cargo-error.log here' "$comment_ok" \
   || fail "the comment control did not apply, so it proves nothing"
@@ -294,7 +317,22 @@ if ! ( check_workflow "$comment_ok" ) >/dev/null 2>&1; then
   fail "a comment naming a redirect turned the contract red — the check reacts to text rather \
 than to behaviour"
 fi
-echo "ok: a comment naming a redirect leaves the contract green"
+echo "ok: a comment naming a redirect or BASH_ENV leaves the contract green"
+
+# Negative control: set `BASH_ENV` on the step. The script is untouched, so extracting and running
+# it proves nothing -- the runner would have sourced a preamble before the first line ever ran.
+bash_env_mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX")"
+awk '
+  /^          RUNS: / && !done { print "          BASH_ENV: .github/fuzz-preamble.sh"; done=1 }
+  { print }
+' "$WORKFLOW" > "$bash_env_mutant"
+grep -q '^          BASH_ENV: ' "$bash_env_mutant" \
+  || fail "the BASH_ENV mutation did not apply, so it proves nothing"
+if ( check_workflow "$bash_env_mutant" ) >/dev/null 2>&1; then
+  fail "a step-level \`BASH_ENV\` left the contract green — bash sources it before the script, \
+which is where the harness starts looking"
+fi
+echo "ok: a step-level \`BASH_ENV\` turns the contract red"
 
 echo "ok: the lock guard reports without diagnosing, keeps Cargo's stderr, and fails closed"
 echo "ok: FUZZ_TOOLCHAIN is dated (${PIN})"


### PR DESCRIPTION
Closes #1882. Rebased on `e99026a5`; head `d276424c`.

## Discovery changed the framing twice

**First.** The issue reads as "six advisories in `fuzz/Cargo.lock`". Measuring showed that is the symptom — every affected crate (`crossbeam-epoch`, `quinn-proto`, `rustls-webpki`, `anyhow`) was already patched in the **root** lock and older here. Not a different risk surface, a stale snapshot of the same one, because nothing updated it, nothing audited it, and nothing honoured it:

- `Cargo.toml:31` sets `exclude = ["fuzz"]`, so the root audit cannot see it
- the OSV scanner rejects Rust locks by design
- dependabot's cargo entry is scoped to `/`
- the fuzz lane ran without any lock enforcement

**Second, and it cost a CI round.** Making the lock load-bearing exposed a real toolchain break, which is exactly what a lock nobody honoured had been hiding.

## Keep or delete: the convention decides

**cargo-fuzz's own generated `.gitignore`** (from `src/templates.rs`) is `target`, `corpus`, `artifacts`, `coverage` — `Cargo.lock` is not in it. And `fuzz/Cargo.toml` is a `publish = false` crate with `[[bin]]` targets, for which committing the lock is the Cargo convention. The reason to keep one is reproducing a finding, and a lock CI ignores cannot do that. So: make it real.

## What the PR does

1. **Regenerate** the lock on the current base: 375 → 336 crates, workspace 3.34.0 → 3.35.0, the missing `assay-evidence → assay-common` edge restored, `cargo audit` clean.
2. **Assert the lock is current** with `cargo metadata --locked` before the run. **Not `cargo fuzz run --locked`** — cargo-fuzz has no such flag; its `BuildOptions` carry only profile and feature options, and CI rejected the first attempt with `unexpected argument '--locked'`. An explicit assertion is the better shape anyway: it fails with `fuzz/Cargo.lock is stale` rather than burying it in cargo output.
3. **Dependabot entry for `/fuzz`** and a **separate `cargo audit` step**, run from `RUNNER_TEMP` so it does not silently inherit the root's `.cargo/audit.toml` ignore list — measured both ways: RUSTSEC-2023-0071 is suppressed from the repo root and reported from elsewhere.
4. **Path filters extended** to `crates/assay-core/**` and root `Cargo.toml`. Without them a release bump touches neither `fuzz/**` nor `crates/assay-evidence/**`, so the exact staleness this PR fixes would recur and then fail on someone else's PR.
5. **Toolchain pin bumped** — see below.

## The toolchain break, reproduced not inferred

`nightly-2026-07-24` ICEs compiling `tokio 1.53.1` under cargo-fuzz's sanitizer flags:

```
rustc_codegen_ssa/src/mir/operand.rs:291: not immediate:
OperandRef(Uninit @ UnsafeCell<MaybeUninit<Notified<Arc<Handle>>>>)
```

Reproduced locally on aarch64-apple-darwin with the same rustc commit `89c61a75` and the same flag set, so it is the toolchain, not the runner.

**My earlier verification could not have caught it.** I had reported the lock good on the strength of `cargo check`, which does no sanitizer instrumentation — the wrong layer for this claim, and CI found it rather than I.

`nightly-2026-07-28`, the next dated release, builds it. Pinned only after running **both** gates on that exact combination:

| gate | result |
|---|---|
| `cargo check --locked --all-targets` in `fuzz/` | Finished, 38.4s |
| **real** `cargo fuzz run bundle_reader`, CI parameters | 20 000 runs / 14s, 776 new units, peak RSS 412 MB, no crash |

Output corpus went to a scratch directory, so the checked-in seeds are untouched. Still **dated, not floating**: the whole point is that a compiler change can break this lane, and a channel alias would hide both the break and the fix.

## Follow-ups, deliberately not in this PR

- **`bundle_reader` does not use `assay-core`** — it imports only `assay_evidence` — but `assay-core` is a plain dependency of the fuzz package, so every target compiles `reqwest`, `tokio`, `rustls` and `quinn`. The ICE was in a crate this target never touches. Making `assay-core` optional behind a feature that only `policy_yaml` enables would remove the trigger rather than step around it, and shrink the lane.
- The regenerated lock now runs **ahead** of the root on 104 crate versions. An argument for the new audit step, but worth stating: the fuzz tree is now genuinely a second surface.
- `cargo deny` is not extended to it (licenses/bans/sources unchecked), and `.pre-commit-config.yaml`'s `files: ^Cargo\.lock$` never matches `fuzz/Cargo.lock`.

## History note

Rebased rather than merged, on instruction. Per the rule in #1880, rewritten history does not carry a review even when content is identical — so the records on `4233c500` and `3e31aa7e` do not transfer, and this head needs its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Automation**
  * Improved automated dependency monitoring for the fuzzing setup with weekly, fuzz-scoped updates.
  * Added a fuzz-specific Rust security audit to catch advisories tied to the fuzz lockfile.
  * Expanded the fuzz smoke workflow to rerun on more relevant manifest changes and fail early when fuzz lock/metadata checks don’t pass.
  * Updated the pinned fuzz toolchain to the latest nightly.
* **Tests / Quality Gates**
  * Added a pre-commit contract check to validate the fuzz workflow’s expected fail-fast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->