### PR TITLE
build(deps): update time to 0.3.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5308,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -5330,9 +5330,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary

- update `time` from 0.3.53 to 0.3.54
- update the matching `time-macros` lockfile entry from 0.2.31 to 0.2.32
- supersede Dependabot PR #1908 with a clean one-commit branch from current `main`

## Risk

Patch-only, lockfile-only update. Both `time` 0.3.53 and 0.3.54 declare Rust 1.88, so this does not raise the dependency graph's existing MSRV. Issue #1906 separately tracks reconciliation of Assay's public Rust 1.70 claim.

## Verification

- `cargo test -p assay-mcp-server --locked`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
- pre-commit hooks, including `cargo deny`
- pre-push workspace clippy with `-D warnings`
- pre-push Linux compile gate
