### PR TITLE
fix(monitor): refuse unsupported IPv6 CIDR policies

### DIFF
--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -66,6 +66,29 @@ fn enforcement_failure_exit(health_written: bool, retained_exit: i32) -> i32 {
     }
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn tier1_enforcement_requested(compiled: &assay_policy::tiers::CompiledPolicy) -> bool {
+    let tier1 = &compiled.tier1;
+    !tier1.file_deny_exact.is_empty()
+        || !tier1.file_deny_prefix.is_empty()
+        || !tier1.inode_deny_exact.is_empty()
+        || !tier1.network_allow_cidrs.is_empty()
+        || !tier1.network_deny_cidrs.is_empty()
+        || !tier1.network_deny_ports.is_empty()
+        || !tier1.network_allow_ports.is_empty()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn startup_failure_health(
+    network_enforcement_requested: bool,
+) -> enforcement_health::EnforcementHealth {
+    if network_enforcement_requested {
+        enforcement_health::EnforcementHealth::failed(enforcement_health::SCOPE_IPV4_TCP_CONNECT)
+    } else {
+        enforcement_health::EnforcementHealth::absent(enforcement_health::SCOPE_IPV4_TCP_CONNECT)
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn compile_runtime_enforcement_policy(
     cfg: &assay_core::mcp::runtime_features::RuntimeMonitorConfig,
@@ -150,6 +173,10 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                 || !compiled.tier1.network_deny_cidrs.is_empty()
         })
         .unwrap_or(false);
+    let tier1_enforcement_requested = compiled_policy
+        .as_ref()
+        .map(tier1_enforcement_requested)
+        .unwrap_or(false);
 
     if let Some(compiled) = compiled_policy.as_ref() {
         // The compiler accepts IPv6 CIDRs, but the shipped enforcement target attaches only
@@ -195,9 +222,26 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         if !args.quiet {
             emit_out!("⚠️  MONITOR_ALL enabled: Bypassing Cgroup filtering.");
         }
-        monitor.set_monitor_all(true)?;
+        if let Err(e) = monitor.set_monitor_all(true) {
+            emit_err!("Failed to enable MONITOR_ALL: {}", e);
+            return Ok(startup_failure_exit(
+                &args,
+                network_enforcement_requested,
+                40,
+            ));
+        }
 
-        let v = monitor.get_config_u32(assay_common::KEY_MONITOR_ALL)?;
+        let v = match monitor.get_config_u32(assay_common::KEY_MONITOR_ALL) {
+            Ok(value) => value,
+            Err(e) => {
+                emit_err!("Failed to verify MONITOR_ALL: {}", e);
+                return Ok(startup_failure_exit(
+                    &args,
+                    network_enforcement_requested,
+                    40,
+                ));
+            }
+        };
         emit_out!(
             "DEBUG: CONFIG[{}]={} confirmed",
             assay_common::KEY_MONITOR_ALL,
@@ -208,7 +252,11 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                 "❌ Failed to enable MONITOR_ALL (CONFIG[{}] != 1)",
                 assay_common::KEY_MONITOR_ALL
             );
-            return Ok(40);
+            return Ok(startup_failure_exit(
+                &args,
+                network_enforcement_requested,
+                40,
+            ));
         }
     }
 
@@ -228,7 +276,11 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         if !cgroups.is_empty() {
             if let Err(e) = monitor.set_monitored_cgroups(&cgroups) {
                 emit_err!("Error: Failed to populate Cgroup map: {}", e);
-                return Ok(40);
+                return Ok(startup_failure_exit(
+                    &args,
+                    network_enforcement_requested,
+                    40,
+                ));
             }
             if !args.quiet {
                 emit_err!("Monitored Cgroups: {:?}", cgroups);
@@ -382,13 +434,17 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         }
 
         if let Err(e) = monitor.set_tier1_rules(&compiled) {
-            if network_enforcement_requested {
+            if tier1_enforcement_requested {
                 emit_err!(
-                    "FATAL: failed to install Tier 1 rules for requested egress enforcement: {} \
+                    "FATAL: failed to install requested Tier 1 enforcement rules: {} \
                      (fail-closed, not reporting a partially loaded policy as active)",
                     e
                 );
-                return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
+                return Ok(startup_failure_exit(
+                    &args,
+                    network_enforcement_requested,
+                    exit_codes::EXIT_WOULD_BLOCK,
+                ));
             }
             emit_err!(
                 "Warning: Failed to load Tier 1 rules (LSM might be unavailable): {}",
@@ -440,7 +496,17 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         }
     }
 
-    let mut stream = monitor.listen().map_err(|e| anyhow::anyhow!(e))?;
+    let mut stream = match monitor.listen() {
+        Ok(stream) => stream,
+        Err(e) => {
+            emit_err!("Failed to start monitor event stream: {}", e);
+            return Ok(startup_failure_exit(
+                &args,
+                network_enforcement_requested,
+                40,
+            ));
+        }
+    };
 
     let mut timeout = match args.duration {
         Some(d) => tokio::time::sleep(d.into()).boxed(),
@@ -582,9 +648,7 @@ fn startup_failure_exit(
     network_enforcement_requested: bool,
     retained_exit: i32,
 ) -> i32 {
-    if network_enforcement_requested {
-        failed_enforcement_exit(args, retained_exit)
-    } else {
-        retained_exit
-    }
+    let health_written =
+        write_enforcement_health(args, startup_failure_health(network_enforcement_requested));
+    enforcement_failure_exit(health_written, retained_exit)
 }

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -57,10 +57,72 @@ pub(crate) async fn run(args: super::MonitorArgs) -> anyhow::Result<i32> {
     }
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn enforcement_refusal_exit(health_written: bool) -> i32 {
+    if health_written {
+        crate::exit_codes::EXIT_WOULD_BLOCK
+    } else {
+        crate::exit_codes::EXIT_INFRA_ERROR
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn compile_runtime_enforcement_policy(
+    cfg: &assay_core::mcp::runtime_features::RuntimeMonitorConfig,
+) -> assay_policy::tiers::CompiledPolicy {
+    let mut policy = assay_policy::tiers::Policy::default();
+
+    for rule in &cfg.rules {
+        let is_enforcement = matches!(
+            rule.action,
+            assay_core::mcp::runtime_features::MonitorAction::TriggerKill
+                | assay_core::mcp::runtime_features::MonitorAction::Deny
+        );
+
+        if !is_enforcement {
+            continue;
+        }
+
+        match rule.rule_type {
+            assay_core::mcp::runtime_features::MonitorRuleType::FileOpen => {
+                policy
+                    .files
+                    .deny
+                    .extend(rule.match_config.path_globs.iter().cloned());
+                if let Some(not) = &rule.match_config.not {
+                    policy.files.allow.extend(not.path_globs.iter().cloned());
+                }
+            }
+            assay_core::mcp::runtime_features::MonitorRuleType::NetConnect => {
+                for dest in &rule.match_config.dest_globs {
+                    let is_cidr = if let Some((ip_part, prefix_part)) = dest.split_once('/') {
+                        ip_part.parse::<std::net::IpAddr>().is_ok()
+                            && prefix_part.parse::<u8>().is_ok()
+                    } else {
+                        false
+                    };
+
+                    if is_cidr {
+                        policy.network.deny_cidrs.push(dest.clone());
+                    } else if let Ok(port) = dest.parse::<u16>() {
+                        policy.network.deny_ports.push(port);
+                    } else {
+                        policy.network.deny_destinations.push(dest.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    assay_policy::tiers::compile(&policy)
+}
+
 #[cfg(target_os = "linux")]
 async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
     use assay_common::{get_inode_generation, strict_open};
     use assay_monitor::Monitor;
+    use enforcement_health::{EnforcementHealth, SCOPE_IPV4_TCP_CONNECT};
 
     let mut runtime_config = None;
     let mut kill_config = None;
@@ -76,6 +138,26 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
             runtime_config = Some(rm);
         }
         kill_config = p.kill_switch;
+    }
+
+    let compiled_policy = runtime_config
+        .as_ref()
+        .map(compile_runtime_enforcement_policy);
+
+    if let Some(compiled) = compiled_policy.as_ref() {
+        // The compiler accepts IPv6 CIDRs, but the shipped enforcement target attaches only
+        // connect4 and loads only CIDR_RULES_V4. Refuse before loading or attaching eBPF; warning
+        // and continuing would turn an IPv6 policy into an undisclosed IPv4 subset.
+        if let Err(e) = assay_monitor::validate_network_enforcement_support(compiled) {
+            emit_err!(
+                "FATAL: egress enforcement policy cannot be installed: {} (fail-closed, not \
+                 running a partially enforced policy)",
+                e
+            );
+            let health_written =
+                write_enforcement_health(&args, EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT));
+            return Ok(enforcement_refusal_exit(health_written));
+        }
     }
 
     let ebpf_path = match args.ebpf.as_ref() {
@@ -158,73 +240,9 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
     let rules = rules::compile_active_rules(runtime_config.as_ref());
 
     // Enforcement truth for the enforcement_health.v0 artifact: did egress enforcement actually attach?
-    use enforcement_health::{EnforcementHealth, SCOPE_IPV4_TCP_CONNECT};
     let mut enforcement_active = false;
 
-    if let Some(cfg) = &runtime_config {
-        let mut t1_policy = assay_policy::tiers::Policy::default();
-
-        for r in &cfg.rules {
-            let is_enforcement = matches!(
-                r.action,
-                assay_core::mcp::runtime_features::MonitorAction::TriggerKill
-                    | assay_core::mcp::runtime_features::MonitorAction::Deny
-            );
-
-            if !is_enforcement {
-                continue;
-            }
-
-            match r.rule_type {
-                assay_core::mcp::runtime_features::MonitorRuleType::FileOpen => {
-                    for glob in &r.match_config.path_globs {
-                        t1_policy.files.deny.push(glob.clone());
-                    }
-                    if let Some(not) = &r.match_config.not {
-                        for glob in &not.path_globs {
-                            t1_policy.files.allow.push(glob.clone());
-                        }
-                    }
-                }
-                assay_core::mcp::runtime_features::MonitorRuleType::NetConnect => {
-                    for dest in &r.match_config.dest_globs {
-                        let is_cidr = if let Some((ip_part, prefix_part)) = dest.split_once('/') {
-                            ip_part.parse::<std::net::IpAddr>().is_ok()
-                                && prefix_part.parse::<u8>().is_ok()
-                        } else {
-                            false
-                        };
-
-                        if is_cidr {
-                            t1_policy.network.deny_cidrs.push(dest.clone());
-                        } else if let Ok(port) = dest.parse::<u16>() {
-                            t1_policy.network.deny_ports.push(port);
-                        } else {
-                            t1_policy.network.deny_destinations.push(dest.clone());
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let mut compiled = assay_policy::tiers::compile(&t1_policy);
-
-        // The compiler accepts IPv6 CIDRs, but the shipped enforcement target attaches only
-        // connect4 and loads only CIDR_RULES_V4. Refuse before resolving file rules or mutating any
-        // kernel map; warning and continuing would turn an IPv6 policy into an undisclosed IPv4
-        // subset.
-        if let Err(e) = assay_monitor::validate_network_enforcement_support(&compiled) {
-            emit_err!(
-                "FATAL: egress enforcement policy cannot be installed: {} (fail-closed, not \
-                 running a partially enforced policy)",
-                e
-            );
-            let _ =
-                write_enforcement_health(&args, EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT));
-            return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
-        }
-
+    if let Some(mut compiled) = compiled_policy {
         let mut inode_rules = Vec::with_capacity(compiled.tier1.file_deny_exact.len());
 
         for rule in &compiled.tier1.file_deny_exact {
@@ -374,12 +392,13 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     );
                     // Honesty: a requested-but-failed enforcement must record `failed`, never look
                     // like `absent` (not requested), so write the artifact BEFORE the fail-closed exit.
-                    // A write failure here is already covered by the non-zero exit below.
-                    let _ = write_enforcement_health(
+                    // Distinguish enforcement refusal from an infrastructure failure to retain the
+                    // requested carrier.
+                    let health_written = write_enforcement_health(
                         &args,
                         EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT),
                     );
-                    return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
+                    return Ok(enforcement_refusal_exit(health_written));
                 }
             };
             if let Err(e) = monitor.attach_network_cgroup(&cgroup_file) {
@@ -387,11 +406,11 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     "FATAL: egress enforcement requested but connect4 attach failed: {} (fail-closed, not running audit-only)",
                     e
                 );
-                let _ = write_enforcement_health(
+                let health_written = write_enforcement_health(
                     &args,
                     EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT),
                 );
-                return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
+                return Ok(enforcement_refusal_exit(health_written));
             }
             enforcement_active = true;
             if !args.quiet {

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -210,6 +210,21 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
 
         let mut compiled = assay_policy::tiers::compile(&t1_policy);
 
+        // The compiler accepts IPv6 CIDRs, but the shipped enforcement target attaches only
+        // connect4 and loads only CIDR_RULES_V4. Refuse before resolving file rules or mutating any
+        // kernel map; warning and continuing would turn an IPv6 policy into an undisclosed IPv4
+        // subset.
+        if let Err(e) = assay_monitor::validate_network_enforcement_support(&compiled) {
+            emit_err!(
+                "FATAL: egress enforcement policy cannot be installed: {} (fail-closed, not \
+                 running a partially enforced policy)",
+                e
+            );
+            let _ =
+                write_enforcement_health(&args, EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT));
+            return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
+        }
+
         let mut inode_rules = Vec::with_capacity(compiled.tier1.file_deny_exact.len());
 
         for rule in &compiled.tier1.file_deny_exact {

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -58,9 +58,9 @@ pub(crate) async fn run(args: super::MonitorArgs) -> anyhow::Result<i32> {
 }
 
 #[cfg(any(target_os = "linux", test))]
-fn enforcement_refusal_exit(health_written: bool) -> i32 {
+fn enforcement_failure_exit(health_written: bool, retained_exit: i32) -> i32 {
     if health_written {
-        crate::exit_codes::EXIT_WOULD_BLOCK
+        retained_exit
     } else {
         crate::exit_codes::EXIT_INFRA_ERROR
     }
@@ -143,6 +143,13 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
     let compiled_policy = runtime_config
         .as_ref()
         .map(compile_runtime_enforcement_policy);
+    let network_enforcement_requested = compiled_policy
+        .as_ref()
+        .map(|compiled| {
+            !compiled.tier1.network_deny_ports.is_empty()
+                || !compiled.tier1.network_deny_cidrs.is_empty()
+        })
+        .unwrap_or(false);
 
     if let Some(compiled) = compiled_policy.as_ref() {
         // The compiler accepts IPv6 CIDRs, but the shipped enforcement target attaches only
@@ -154,9 +161,7 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                  running a partially enforced policy)",
                 e
             );
-            let health_written =
-                write_enforcement_health(&args, EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT));
-            return Ok(enforcement_refusal_exit(health_written));
+            return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
         }
     }
 
@@ -167,14 +172,22 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
 
     if !ebpf_path.exists() {
         emit_err!("Error: eBPF object not found at {}. Build it with 'cargo xtask build-ebpf' or provide --ebpf <path>", ebpf_path.display());
-        return Ok(40);
+        return Ok(startup_failure_exit(
+            &args,
+            network_enforcement_requested,
+            40,
+        ));
     }
 
     let mut monitor = match Monitor::load_file(&ebpf_path) {
         Ok(m) => m,
         Err(e) => {
             emit_err!("Failed to load eBPF: {}", e);
-            return Ok(40);
+            return Ok(startup_failure_exit(
+                &args,
+                network_enforcement_requested,
+                40,
+            ));
         }
     };
 
@@ -227,7 +240,11 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
 
     if let Err(e) = monitor.attach() {
         emit_err!("Failed to attach probes: {}", e);
-        return Ok(40);
+        return Ok(startup_failure_exit(
+            &args,
+            network_enforcement_requested,
+            40,
+        ));
     }
 
     if !args.quiet {
@@ -365,6 +382,14 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         }
 
         if let Err(e) = monitor.set_tier1_rules(&compiled) {
+            if network_enforcement_requested {
+                emit_err!(
+                    "FATAL: failed to install Tier 1 rules for requested egress enforcement: {} \
+                     (fail-closed, not reporting a partially loaded policy as active)",
+                    e
+                );
+                return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
+            }
             emit_err!(
                 "Warning: Failed to load Tier 1 rules (LSM might be unavailable): {}",
                 e
@@ -394,11 +419,7 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     // like `absent` (not requested), so write the artifact BEFORE the fail-closed exit.
                     // Distinguish enforcement refusal from an infrastructure failure to retain the
                     // requested carrier.
-                    let health_written = write_enforcement_health(
-                        &args,
-                        EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT),
-                    );
-                    return Ok(enforcement_refusal_exit(health_written));
+                    return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
                 }
             };
             if let Err(e) = monitor.attach_network_cgroup(&cgroup_file) {
@@ -406,11 +427,7 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     "FATAL: egress enforcement requested but connect4 attach failed: {} (fail-closed, not running audit-only)",
                     e
                 );
-                let health_written = write_enforcement_health(
-                    &args,
-                    EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT),
-                );
-                return Ok(enforcement_refusal_exit(health_written));
+                return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
             }
             enforcement_active = true;
             if !args.quiet {
@@ -496,7 +513,8 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
 
     // enforcement_health.v0 artifact (explicit, never parsed from stdout). active when enforcement
     // attached; absent when it was not requested. The `failed` case is written on the fail-closed abort
-    // path above, before exit, so requested-but-failed never reads as not-requested.
+    // Network-enforcement validation, installation, and attach failures above write `failed`
+    // before their handled nonzero exits.
     if args.enforcement_health.is_some() {
         let health = if enforcement_active {
             EnforcementHealth::active(SCOPE_IPV4_TCP_CONNECT, blocked_count, allowed_count)
@@ -546,5 +564,27 @@ fn write_enforcement_health(
         }
     } else {
         true
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn failed_enforcement_exit(args: &super::MonitorArgs, retained_exit: i32) -> i32 {
+    let health_written = write_enforcement_health(
+        args,
+        enforcement_health::EnforcementHealth::failed(enforcement_health::SCOPE_IPV4_TCP_CONNECT),
+    );
+    enforcement_failure_exit(health_written, retained_exit)
+}
+
+#[cfg(target_os = "linux")]
+fn startup_failure_exit(
+    args: &super::MonitorArgs,
+    network_enforcement_requested: bool,
+    retained_exit: i32,
+) -> i32 {
+    if network_enforcement_requested {
+        failed_enforcement_exit(args, retained_exit)
+    } else {
+        retained_exit
     }
 }

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -79,6 +79,11 @@ fn tier1_enforcement_requested(compiled: &assay_policy::tiers::CompiledPolicy) -
 }
 
 #[cfg(any(target_os = "linux", test))]
+fn network_enforcement_requested(compiled: &assay_policy::tiers::CompiledPolicy) -> bool {
+    !compiled.tier1.network_deny_ports.is_empty() || !compiled.tier1.network_deny_cidrs.is_empty()
+}
+
+#[cfg(any(target_os = "linux", test))]
 fn startup_failure_health(
     network_enforcement_requested: bool,
 ) -> enforcement_health::EnforcementHealth {
@@ -168,14 +173,7 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         .map(compile_runtime_enforcement_policy);
     let network_enforcement_requested = compiled_policy
         .as_ref()
-        .map(|compiled| {
-            !compiled.tier1.network_deny_ports.is_empty()
-                || !compiled.tier1.network_deny_cidrs.is_empty()
-        })
-        .unwrap_or(false);
-    let tier1_enforcement_requested = compiled_policy
-        .as_ref()
-        .map(tier1_enforcement_requested)
+        .map(network_enforcement_requested)
         .unwrap_or(false);
 
     if let Some(compiled) = compiled_policy.as_ref() {
@@ -434,17 +432,15 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         }
 
         if let Err(e) = monitor.set_tier1_rules(&compiled) {
-            if tier1_enforcement_requested {
+            if let Some(exit_code) =
+                tier1_install_failure_exit(&args, &compiled, exit_codes::EXIT_WOULD_BLOCK)
+            {
                 emit_err!(
                     "FATAL: failed to install requested Tier 1 enforcement rules: {} \
                      (fail-closed, not reporting a partially loaded policy as active)",
                     e
                 );
-                return Ok(startup_failure_exit(
-                    &args,
-                    network_enforcement_requested,
-                    exit_codes::EXIT_WOULD_BLOCK,
-                ));
+                return Ok(exit_code);
             }
             emit_err!(
                 "Warning: Failed to load Tier 1 rules (LSM might be unavailable): {}",
@@ -604,7 +600,7 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
 /// Write the enforcement_health.v0 artifact to `--enforcement-health <path>` if set. No-op otherwise.
 /// Returns `false` only when the artifact was requested but could not be written; on the fail-closed
 /// abort paths the caller already exits non-zero, on the success path the caller must not exit 0.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 fn write_enforcement_health(
     args: &super::MonitorArgs,
     health: enforcement_health::EnforcementHealth,
@@ -642,7 +638,7 @@ fn failed_enforcement_exit(args: &super::MonitorArgs, retained_exit: i32) -> i32
     enforcement_failure_exit(health_written, retained_exit)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 fn startup_failure_exit(
     args: &super::MonitorArgs,
     network_enforcement_requested: bool,
@@ -651,4 +647,14 @@ fn startup_failure_exit(
     let health_written =
         write_enforcement_health(args, startup_failure_health(network_enforcement_requested));
     enforcement_failure_exit(health_written, retained_exit)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn tier1_install_failure_exit(
+    args: &super::MonitorArgs,
+    compiled: &assay_policy::tiers::CompiledPolicy,
+    retained_exit: i32,
+) -> Option<i32> {
+    tier1_enforcement_requested(compiled)
+        .then(|| startup_failure_exit(args, network_enforcement_requested(compiled), retained_exit))
 }

--- a/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
@@ -6,13 +6,26 @@
 //! See move-map/checklist artifacts in Commit C.
 
 #[test]
-fn enforcement_refusal_exit_distinguishes_artifact_write_failure() {
+fn enforcement_failure_exit_distinguishes_artifact_write_failure() {
     assert_eq!(
-        super::enforcement_refusal_exit(true),
+        super::enforcement_failure_exit(true, crate::exit_codes::EXIT_WOULD_BLOCK),
         crate::exit_codes::EXIT_WOULD_BLOCK
     );
     assert_eq!(
-        super::enforcement_refusal_exit(false),
+        super::enforcement_failure_exit(false, crate::exit_codes::EXIT_WOULD_BLOCK),
         crate::exit_codes::EXIT_INFRA_ERROR
+    );
+}
+
+#[test]
+fn enforcement_failure_exit_preserves_runtime_failure_and_prioritizes_carrier_failure() {
+    assert_eq!(super::enforcement_failure_exit(true, 40), 40);
+    assert_eq!(
+        super::enforcement_failure_exit(false, 40),
+        crate::exit_codes::EXIT_INFRA_ERROR
+    );
+    assert_eq!(
+        super::enforcement_failure_exit(true, crate::exit_codes::EXIT_WOULD_BLOCK),
+        crate::exit_codes::EXIT_WOULD_BLOCK
     );
 }

--- a/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
@@ -63,3 +63,72 @@ fn tier1_enforcement_detection_includes_file_only_policies() {
         });
     assert!(super::tier1_enforcement_requested(&compiled));
 }
+
+fn monitor_args_with_health(
+    path: std::path::PathBuf,
+) -> crate::cli::commands::monitor::MonitorArgs {
+    crate::cli::commands::monitor::MonitorArgs {
+        pid: Vec::new(),
+        ebpf: None,
+        print: false,
+        quiet: true,
+        duration: None,
+        policy: None,
+        monitor_all: false,
+        enforcement_health: Some(path),
+    }
+}
+
+fn file_only_tier1_policy() -> assay_policy::tiers::CompiledPolicy {
+    let mut compiled = assay_policy::tiers::CompiledPolicy {
+        tier1: assay_policy::tiers::Tier1Rules::default(),
+        tier2: assay_policy::tiers::Tier2Rules::default(),
+        stats: assay_policy::tiers::CompilationStats::default(),
+    };
+    compiled
+        .tier1
+        .file_deny_prefix
+        .push(assay_policy::tiers::PathRule {
+            rule_id: 1,
+            path: "/sensitive".to_string(),
+            hash: 0,
+        });
+    compiled
+}
+
+#[test]
+fn file_only_tier1_install_failure_refuses_and_retains_absent_network_health() {
+    let output_dir = tempfile::TempDir::new().expect("temp output dir");
+    let health_path = output_dir.path().join("enforcement-health.json");
+    let args = monitor_args_with_health(health_path.clone());
+
+    assert_eq!(
+        super::tier1_install_failure_exit(
+            &args,
+            &file_only_tier1_policy(),
+            crate::exit_codes::EXIT_WOULD_BLOCK,
+        ),
+        Some(crate::exit_codes::EXIT_WOULD_BLOCK)
+    );
+
+    let health: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(health_path).expect("read retained enforcement health"),
+    )
+    .expect("parse retained enforcement health");
+    assert_eq!(health["network_enforcement"], "absent");
+}
+
+#[test]
+fn file_only_tier1_install_failure_prioritizes_carrier_write_failure() {
+    let unwritable_target = tempfile::TempDir::new().expect("directory is not a file");
+    let args = monitor_args_with_health(unwritable_target.path().to_path_buf());
+
+    assert_eq!(
+        super::tier1_install_failure_exit(
+            &args,
+            &file_only_tier1_policy(),
+            crate::exit_codes::EXIT_WOULD_BLOCK,
+        ),
+        Some(crate::exit_codes::EXIT_INFRA_ERROR)
+    );
+}

--- a/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
@@ -29,3 +29,37 @@ fn enforcement_failure_exit_preserves_runtime_failure_and_prioritizes_carrier_fa
         crate::exit_codes::EXIT_WOULD_BLOCK
     );
 }
+
+#[test]
+fn startup_failure_health_distinguishes_requested_network_enforcement() {
+    use super::enforcement_health::NetworkEnforcement;
+
+    assert_eq!(
+        super::startup_failure_health(false).network_enforcement,
+        NetworkEnforcement::Absent
+    );
+    assert_eq!(
+        super::startup_failure_health(true).network_enforcement,
+        NetworkEnforcement::Failed
+    );
+}
+
+#[test]
+fn tier1_enforcement_detection_includes_file_only_policies() {
+    let mut compiled = assay_policy::tiers::CompiledPolicy {
+        tier1: assay_policy::tiers::Tier1Rules::default(),
+        tier2: assay_policy::tiers::Tier2Rules::default(),
+        stats: assay_policy::tiers::CompilationStats::default(),
+    };
+    assert!(!super::tier1_enforcement_requested(&compiled));
+
+    compiled
+        .tier1
+        .file_deny_prefix
+        .push(assay_policy::tiers::PathRule {
+            rule_id: 1,
+            path: "/sensitive".to_string(),
+            hash: 0,
+        });
+    assert!(super::tier1_enforcement_requested(&compiled));
+}

--- a/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/tests.rs
@@ -4,3 +4,15 @@
 //! Step1 monitor contract tests remain in:
 //! `crates/assay-cli/src/cli/commands/monitor.rs`.
 //! See move-map/checklist artifacts in Commit C.
+
+#[test]
+fn enforcement_refusal_exit_distinguishes_artifact_write_failure() {
+    assert_eq!(
+        super::enforcement_refusal_exit(true),
+        crate::exit_codes::EXIT_WOULD_BLOCK
+    );
+    assert_eq!(
+        super::enforcement_refusal_exit(false),
+        crate::exit_codes::EXIT_INFRA_ERROR
+    );
+}

--- a/crates/assay-cli/tests/contract_monitor_cli.rs
+++ b/crates/assay-cli/tests/contract_monitor_cli.rs
@@ -132,7 +132,7 @@ fn contract_monitor_ipv6_refusal_precedes_ebpf_load_and_writes_failed_health() {
 
     let stderr = normalize(&assert.get_output().stderr);
     assert!(
-        stderr.contains("IPv6 CIDR rules cannot be installed"),
+        stderr.contains("current enforcement target supports IPv4/TCP only"),
         "IPv6 refusal diagnostic changed unexpectedly: {stderr}"
     );
     assert!(

--- a/crates/assay-cli/tests/contract_monitor_cli.rs
+++ b/crates/assay-cli/tests/contract_monitor_cli.rs
@@ -4,7 +4,7 @@ use assert_cmd::Command;
 #[cfg(target_os = "linux")]
 use std::io::Write;
 #[cfg(target_os = "linux")]
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 fn normalize(s: &[u8]) -> String {
     String::from_utf8_lossy(s).replace("\r\n", "\n")
@@ -88,5 +88,88 @@ fn contract_monitor_parse_fail_policy_exit_2() {
             || stderr.contains("line")
             || stderr.contains("column"),
         "parse-fail diagnostic line changed unexpectedly: {stderr}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn ipv6_runtime_policy() -> NamedTempFile {
+    let mut policy = NamedTempFile::new().expect("temp policy");
+    policy
+        .write_all(
+            br#"runtime_monitor:
+  enabled: true
+  provider: "ebpf"
+  rules:
+    - id: "deny-ipv6"
+      type: "net_connect"
+      match:
+        dest_globs: ["2001:db8::/32"]
+      action: "deny"
+"#,
+        )
+        .expect("write IPv6 policy");
+    policy
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn contract_monitor_ipv6_refusal_precedes_ebpf_load_and_writes_failed_health() {
+    let policy = ipv6_runtime_policy();
+    let output_dir = TempDir::new().expect("temp output dir");
+    let health_path = output_dir.path().join("enforcement-health.json");
+
+    let mut cmd = Command::cargo_bin("assay").expect("assay binary");
+    let assert = cmd
+        .arg("monitor")
+        .arg("--policy")
+        .arg(policy.path())
+        .arg("--ebpf")
+        .arg("/definitely/missing/assay-ebpf.o")
+        .arg("--enforcement-health")
+        .arg(&health_path)
+        .assert()
+        .code(4);
+
+    let stderr = normalize(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("IPv6 CIDR rules cannot be installed"),
+        "IPv6 refusal diagnostic changed unexpectedly: {stderr}"
+    );
+    assert!(
+        health_path.is_file(),
+        "fail-closed refusal must retain the requested health artifact"
+    );
+    let health: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&health_path).expect("read retained enforcement health"),
+    )
+    .expect("parse retained enforcement health");
+    assert_eq!(
+        health["network_enforcement"], "failed",
+        "unsupported policy must retain failed, never absent"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn contract_monitor_ipv6_refusal_returns_infra_error_when_health_write_fails() {
+    let policy = ipv6_runtime_policy();
+    let unwritable_target = TempDir::new().expect("directory cannot be overwritten as a file");
+
+    let mut cmd = Command::cargo_bin("assay").expect("assay binary");
+    let assert = cmd
+        .arg("monitor")
+        .arg("--policy")
+        .arg(policy.path())
+        .arg("--ebpf")
+        .arg("/definitely/missing/assay-ebpf.o")
+        .arg("--enforcement-health")
+        .arg(unwritable_target.path())
+        .assert()
+        .code(3);
+
+    let stderr = normalize(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("failed to write enforcement_health artifact"),
+        "artifact-write failure diagnostic changed unexpectedly: {stderr}"
     );
 }

--- a/crates/assay-cli/tests/contract_monitor_cli.rs
+++ b/crates/assay-cli/tests/contract_monitor_cli.rs
@@ -186,6 +186,53 @@ fn contract_monitor_missing_ebpf_returns_infra_error_when_failed_health_cannot_b
 
 #[cfg(target_os = "linux")]
 #[test]
+fn contract_monitor_missing_ebpf_retains_absent_health_without_network_enforcement() {
+    let output_dir = TempDir::new().expect("temp output dir");
+    let health_path = output_dir.path().join("enforcement-health.json");
+
+    let mut cmd = Command::cargo_bin("assay").expect("assay binary");
+    cmd.arg("monitor")
+        .arg("--ebpf")
+        .arg("/definitely/missing/assay-ebpf.o")
+        .arg("--enforcement-health")
+        .arg(&health_path)
+        .assert()
+        .code(40);
+
+    let health: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&health_path).expect("read retained enforcement health"),
+    )
+    .expect("parse retained enforcement health");
+    assert_eq!(
+        health["network_enforcement"], "absent",
+        "a startup failure without requested network enforcement must not claim failure"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn contract_monitor_missing_ebpf_returns_infra_error_when_absent_health_cannot_be_written() {
+    let unwritable_target = TempDir::new().expect("directory cannot be overwritten as a file");
+
+    let mut cmd = Command::cargo_bin("assay").expect("assay binary");
+    let assert = cmd
+        .arg("monitor")
+        .arg("--ebpf")
+        .arg("/definitely/missing/assay-ebpf.o")
+        .arg("--enforcement-health")
+        .arg(unwritable_target.path())
+        .assert()
+        .code(3);
+
+    let stderr = normalize(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("failed to write enforcement_health artifact"),
+        "artifact-write failure diagnostic changed unexpectedly: {stderr}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn contract_monitor_ipv6_refusal_precedes_ebpf_load_and_writes_failed_health() {
     let policy = ipv6_runtime_policy();
     let output_dir = TempDir::new().expect("temp output dir");

--- a/crates/assay-cli/tests/contract_monitor_cli.rs
+++ b/crates/assay-cli/tests/contract_monitor_cli.rs
@@ -112,6 +112,79 @@ fn ipv6_runtime_policy() -> NamedTempFile {
 }
 
 #[cfg(target_os = "linux")]
+fn ipv4_runtime_policy() -> NamedTempFile {
+    let mut policy = NamedTempFile::new().expect("temp policy");
+    policy
+        .write_all(
+            br#"runtime_monitor:
+  enabled: true
+  provider: "ebpf"
+  rules:
+    - id: "deny-ipv4"
+      type: "net_connect"
+      match:
+        dest_globs: ["198.51.100.0/24"]
+      action: "deny"
+"#,
+        )
+        .expect("write IPv4 policy");
+    policy
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn contract_monitor_missing_ebpf_retains_failed_health_for_requested_enforcement() {
+    let policy = ipv4_runtime_policy();
+    let output_dir = TempDir::new().expect("temp output dir");
+    let health_path = output_dir.path().join("enforcement-health.json");
+
+    let mut cmd = Command::cargo_bin("assay").expect("assay binary");
+    cmd.arg("monitor")
+        .arg("--policy")
+        .arg(policy.path())
+        .arg("--ebpf")
+        .arg("/definitely/missing/assay-ebpf.o")
+        .arg("--enforcement-health")
+        .arg(&health_path)
+        .assert()
+        .code(40);
+
+    let health: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&health_path).expect("read retained enforcement health"),
+    )
+    .expect("parse retained enforcement health");
+    assert_eq!(
+        health["network_enforcement"], "failed",
+        "requested enforcement that cannot start must never read as absent"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn contract_monitor_missing_ebpf_returns_infra_error_when_failed_health_cannot_be_written() {
+    let policy = ipv4_runtime_policy();
+    let unwritable_target = TempDir::new().expect("directory cannot be overwritten as a file");
+
+    let mut cmd = Command::cargo_bin("assay").expect("assay binary");
+    let assert = cmd
+        .arg("monitor")
+        .arg("--policy")
+        .arg(policy.path())
+        .arg("--ebpf")
+        .arg("/definitely/missing/assay-ebpf.o")
+        .arg("--enforcement-health")
+        .arg(unwritable_target.path())
+        .assert()
+        .code(3);
+
+    let stderr = normalize(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("failed to write enforcement_health artifact"),
+        "artifact-write failure diagnostic changed unexpectedly: {stderr}"
+    );
+}
+
+#[cfg(target_os = "linux")]
 #[test]
 fn contract_monitor_ipv6_refusal_precedes_ebpf_load_and_writes_failed_health() {
     let policy = ipv6_runtime_policy();

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -67,6 +67,37 @@ pub struct Monitor {
     _stub: (),
 }
 
+/// Validate network rules against the enforcement target shipped by `assay-monitor`.
+///
+/// The policy compiler accepts both address families, while the userspace loader currently
+/// populates only `CIDR_RULES_V4` and attaches only `connect4_hook`. Refuse IPv6 here so a valid
+/// policy can never be partially projected into IPv4 maps and then reported as enforced.
+pub fn validate_network_enforcement_support(
+    compiled: &assay_policy::tiers::CompiledPolicy,
+) -> Result<(), MonitorError> {
+    let ipv6_allow = compiled
+        .tier1
+        .network_allow_cidrs
+        .iter()
+        .filter(|rule| rule.parsed.addr().is_ipv6())
+        .count();
+    let ipv6_deny = compiled
+        .tier1
+        .network_deny_cidrs
+        .iter()
+        .filter(|rule| rule.parsed.addr().is_ipv6())
+        .count();
+
+    if ipv6_allow != 0 || ipv6_deny != 0 {
+        return Err(MonitorError::EnforcementUnavailable(format!(
+            "the current enforcement target supports IPv4/TCP only; policy contains {ipv6_allow} \
+             IPv6 allow CIDR rule(s) and {ipv6_deny} IPv6 deny CIDR rule(s)"
+        )));
+    }
+
+    Ok(())
+}
+
 impl Monitor {
     /// Load eBPF object bytes from file (Linux). Non-Linux returns NotSupported.
     pub fn load_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, MonitorError> {
@@ -133,6 +164,8 @@ impl Monitor {
         &mut self,
         compiled: &assay_policy::tiers::CompiledPolicy,
     ) -> Result<(), MonitorError> {
+        validate_network_enforcement_support(compiled)?;
+
         #[cfg(target_os = "linux")]
         return self.inner.set_tier1_rules(compiled);
 
@@ -230,7 +263,23 @@ impl Monitor {
 
 #[cfg(test)]
 mod tests {
-    use super::MonitorStatsSnapshot;
+    use super::{validate_network_enforcement_support, MonitorStatsSnapshot};
+    use assay_policy::tiers::{compile, FilePolicy, NetworkPolicy, Policy, ProcessPolicy};
+
+    fn compiled_network_policy(
+        allow_cidrs: &[&str],
+        deny_cidrs: &[&str],
+    ) -> assay_policy::tiers::CompiledPolicy {
+        compile(&Policy {
+            files: FilePolicy::default(),
+            network: NetworkPolicy {
+                allow_cidrs: allow_cidrs.iter().map(|cidr| (*cidr).to_string()).collect(),
+                deny_cidrs: deny_cidrs.iter().map(|cidr| (*cidr).to_string()).collect(),
+                ..Default::default()
+            },
+            processes: ProcessPolicy::default(),
+        })
+    }
 
     #[test]
     fn monitor_stats_snapshot_reports_ringbuf_pressure() {
@@ -243,5 +292,58 @@ mod tests {
 
         assert!(stats.has_ringbuf_pressure());
         assert_eq!(stats.total_ringbuf_dropped(), 6);
+    }
+
+    #[test]
+    fn ipv4_only_network_rules_are_supported() {
+        let compiled = compiled_network_policy(&["10.0.0.0/8"], &["203.0.113.0/24"]);
+
+        validate_network_enforcement_support(&compiled)
+            .expect("the current target supports IPv4 CIDR rules");
+    }
+
+    #[test]
+    fn ipv6_allow_rules_fail_closed_with_a_stable_reason() {
+        let compiled = compiled_network_policy(&["2001:db8::/32"], &[]);
+
+        let err = validate_network_enforcement_support(&compiled)
+            .expect_err("an IPv6 allow rule must not be silently dropped");
+
+        assert_eq!(
+            err.to_string(),
+            "network enforcement unavailable: the current enforcement target supports IPv4/TCP \
+             only; policy contains 1 IPv6 allow CIDR rule(s) and 0 IPv6 deny CIDR rule(s)"
+        );
+    }
+
+    #[test]
+    fn ipv6_deny_rules_fail_closed_with_a_stable_reason() {
+        let compiled = compiled_network_policy(&[], &["2001:db8:1::/48"]);
+
+        let err = validate_network_enforcement_support(&compiled)
+            .expect_err("an IPv6 deny rule must not be silently dropped");
+
+        assert_eq!(
+            err.to_string(),
+            "network enforcement unavailable: the current enforcement target supports IPv4/TCP \
+             only; policy contains 0 IPv6 allow CIDR rule(s) and 1 IPv6 deny CIDR rule(s)"
+        );
+    }
+
+    #[test]
+    fn mixed_ipv4_and_ipv6_rules_do_not_partially_apply() {
+        let compiled = compiled_network_policy(
+            &["10.0.0.0/8", "2001:db8::/32"],
+            &["203.0.113.0/24", "2001:db8:1::/48"],
+        );
+
+        let err = validate_network_enforcement_support(&compiled)
+            .expect_err("a mixed policy must be refused before its IPv4 subset can be applied");
+
+        assert!(
+            err.to_string()
+                .contains("1 IPv6 allow CIDR rule(s) and 1 IPv6 deny CIDR rule(s)"),
+            "the refusal must account for both unsupported rule classes: {err}"
+        );
     }
 }

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -261,6 +261,10 @@ impl LinuxMonitor {
     }
 
     pub fn set_tier1_rules(&mut self, compiled: &CompiledPolicy) -> Result<(), MonitorError> {
+        // Validate before taking the BPF lock or touching any map. A mixed IPv4/IPv6 policy must
+        // not leave a successfully-loaded IPv4 subset behind when the IPv6 half is unsupported.
+        crate::validate_network_enforcement_support(compiled)?;
+
         let mut bpf = self.bpf.lock().unwrap();
 
         // 1. File Path Exact Matches

--- a/docs/guides/runtime-monitor.md
+++ b/docs/guides/runtime-monitor.md
@@ -37,9 +37,13 @@ Assay hooks the `file_open` LSM gate. It allows or denies access based on:
 - **Cgroup Scoping**: Automatically monitors only the processes within the target MCP sandbox.
 
 ### Network Egress Control
-Uses Cgroup `connect4` and `connect6` hooks to enforce:
+Uses the Cgroup `connect4` hook to enforce IPv4/TCP `connect()` rules:
 - **Port Blocklists**: Block SSH, Telnet, or internal databases.
-- **CIDR Allowlists**: Restrict outbound traffic to known safe endpoints (e.g., API gateways).
+- **IPv4 CIDR rules**: Restrict outbound traffic to known safe endpoints (e.g., API gateways).
+
+IPv6 CIDR policies are refused before any rule map is changed; they are not silently reduced to
+their IPv4 subset. IPv6, UDP/QUIC, DNS resolution, already-open sockets, raw sockets, and
+proxy/tunnel identity remain outside the enforcement claim tracked in issue #1576.
 
 ## 3. Developer Workflow
 

--- a/docs/guides/runtime-monitor.md
+++ b/docs/guides/runtime-monitor.md
@@ -39,7 +39,9 @@ Assay hooks the `file_open` LSM gate. It allows or denies access based on:
 ### Network Egress Control
 Uses the Cgroup `connect4` hook to enforce IPv4/TCP `connect()` rules:
 - **Port Blocklists**: Block SSH, Telnet, or internal databases.
-- **IPv4 CIDR rules**: Restrict outbound traffic to known safe endpoints (e.g., API gateways).
+- **IPv4 CIDR deny rules**: Block matching destination ranges.
+- **IPv4 CIDR allow exceptions**: Exempt more-specific ranges from a broader deny; an allow CIDR
+  alone does not restrict unmatched traffic.
 
 IPv6 CIDR policies are refused before any rule map is changed; they are not silently reduced to
 their IPv4 subset. IPv6, UDP/QUIC, DNS resolution, already-open sockets, raw sockets, and


### PR DESCRIPTION
## Description

The policy compiler accepts IPv6 CIDRs, but the shipped runtime enforcement path loads only `CIDR_RULES_V4` and attaches only `connect4_hook`. Before this change, IPv6 allow and deny rules were silently omitted while the remaining IPv4 subset could be loaded and described as enforced.

This is the deliberately minimal honesty slice for #1576, not IPv6 implementation:

- validate compiled allow and deny CIDRs against the current IPv4/TCP target;
- reject IPv6 before the BPF lock or any rule-map mutation;
- make the CLI report failed enforcement health and exit non-zero instead of continuing with a partial policy;
- correct the runtime guide from `connect4` + `connect6` to the shipped `connect4` claim.

The broader IPv6, UDP/QUIC, DNS, existing-socket, raw-socket and proxy/tunnel work remains tracked by #1576 and is not claimed here.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Verification
- [x] `cargo check` passes (pre-push Linux compile gate via the repository's Multipass path)
- [x] `cargo test` passes
- [ ] Ran a demo suite

Focused evidence:

- `cargo test -p assay-monitor`: 11/11
- `cargo test -p assay-policy --test network_egress_compile`: 3/3
- `cargo test -p assay-cli monitor_next`: 16/16
- `cargo clippy -p assay-monitor -p assay-cli --all-targets -- -D warnings`
- `uv run --with-requirements docs/requirements-ci.txt mkdocs build --strict`
- `python3 scripts/ci/check-public-artifact-sanitization.py`
- mutation control: disabling the IPv6 guard makes both allow and deny refusal tests fail

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Non-claims

- No IPv6 hook is attached or asserted.
- No UDP/QUIC enforcement is added.
- No claim is made that the full #1576 tracker is closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime monitor now rejects policies with unsupported IPv6 tier1 network allow/deny rules before any enforcement is applied.
  * Fail-closed behavior: on validation/installation/attach failures, the CLI exits with the expected “would block”/infra error codes and records `enforcement-health` as `failed` for the affected scope.
  * Prevents partially-applied enforcement and improves early error handling.

* **Documentation**
  * Updated Runtime Monitor “Network Egress Control” to clarify connect4-based IPv4/TCP enforcement semantics and refused IPv6 handling.

* **Tests**
  * Added unit and Linux CLI coverage for missing eBPF artifacts and IPv6 refusal, including exit codes and `enforcement-health` output checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->