### PR TITLE
ci(msrv): enforce Rust 1.89 public floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,8 +68,8 @@ updates:
       # sysinfo 0.38+ has breaking API changes (method signatures changed)
       - dependency-name: "sysinfo"
         update-types: ["version-update:semver-major"]
-      # serial_test 4 requires Rust 1.93.1, above Assay's documented Rust 1.70+ floor.
-      # Revisit only with an explicit MSRV policy change.
+      # 2026-07-28: serial_test 4 requires Rust 1.93.1, above Assay's public Rust 1.89 MSRV.
+      # Revisit at the next explicit MSRV review; do not raise the floor for one dev dependency.
       - dependency-name: "serial_test"
         update-types: ["version-update:semver-major"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
 
 permissions: {}
 
+env:
+  ASSAY_PUBLIC_MSRV: "1.89.0"
+
 jobs:
   scope:
     name: Detect CI scope
@@ -219,6 +222,43 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  public-msrv:
+    name: Public crates MSRV
+    needs: [scope]
+    if: needs.scope.outputs.lightweight_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - name: Install Linux deps (for build scripts)
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev || {
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y \
+              -o Acquire::Retries=10 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 \
+              -o Acquire::CompressionTypes::Order::=gz \
+              -o Acquire::ForceIPv4=true \
+              -o Acquire::Languages=none
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
+          }
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: ${{ env.ASSAY_PUBLIC_MSRV }}
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: public-msrv-${{ env.ASSAY_PUBLIC_MSRV }}
+      - name: Test MSRV package selection
+        run: python3 scripts/ci/test_check_msrv_metadata.py
+      - name: Verify public crate MSRV
+        run: scripts/ci/check-msrv-policy.sh
 
   distribution-boundary:
     name: Distribution boundary check
@@ -734,7 +774,7 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     if: always()
-    needs: [scope, deps-security, clippy, distribution-boundary, vendored-packs, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
+    needs: [scope, deps-security, clippy, public-msrv, distribution-boundary, vendored-packs, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
     steps:
       - name: Evaluate required job results
         env:
@@ -742,6 +782,7 @@ jobs:
           LIGHTWEIGHT_ONLY: ${{ needs.scope.outputs.lightweight_only }}
           DEPS_SECURITY_RESULT: ${{ needs.deps-security.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
+          PUBLIC_MSRV_RESULT: ${{ needs.public-msrv.result }}
           DISTRIBUTION_BOUNDARY_RESULT: ${{ needs.distribution-boundary.result }}
           VENDORED_PACKS_RESULT: ${{ needs.vendored-packs.result }}
           MCP_REGISTRY_FOUNDATION_RESULT: ${{ needs.mcp-registry-foundation.result }}
@@ -795,6 +836,7 @@ jobs:
             "scope|${SCOPE_RESULT}|required" \
             "deps-security|${DEPS_SECURITY_RESULT}|${code_gated_expectation}" \
             "clippy|${CLIPPY_RESULT}|${code_gated_expectation}" \
+            "public-msrv|${PUBLIC_MSRV_RESULT}|${code_gated_expectation}" \
             "distribution-boundary|${DISTRIBUTION_BOUNDARY_RESULT}|required" \
             "vendored-packs|${VENDORED_PACKS_RESULT}|required" \
             "mcp-registry-foundation|${MCP_REGISTRY_FOUNDATION_RESULT}|${registry_expectation}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Declare Rust 1.89 as the MSRV for all public crates and enforce that floor against the locked
+  workspace graph and all Linux-host targets in required CI. The policy becomes part of published
+  crate metadata with the first release after 3.35.0. Repository development remains pinned to
+  Rust 1.96, and the eBPF nightly remains a separate internal build toolchain.
 - **Fail-closed correction (bundle verification, migration-visible).** The verifier now rejects
   every bundle `BundleWriter` refuses to emit. Five shapes previously verified: an empty bundle, an
   inconsistent `source` across events, a `source` that is not a URI, and a blank line in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ missing_errors_doc = "allow"
 [workspace.package]
 version = "3.35.0"
 edition = "2021"
+rust-version = "1.89"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
 authors = ["Assay"]

--- a/crates/assay-canonical/Cargo.toml
+++ b/crates/assay-canonical/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-canonical"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Deterministic canonicalization: RFC 8785 (JCS) bytes, sha256 content-addressed IDs, and schema-aware set-path normalization for semantic digests."
 license.workspace = true
 repository.workspace = true

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-cli"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/assay-common/Cargo.toml
+++ b/crates/assay-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-common"
 version.workspace = true
 edition = "2021"
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-evidence"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/assay-mcp-server/Cargo.toml
+++ b/crates/assay-mcp-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-mcp-server"
 version.workspace = true
 edition = "2021"
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/assay-metrics/Cargo.toml
+++ b/crates/assay-metrics/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-metrics"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/assay-monitor/Cargo.toml
+++ b/crates/assay-monitor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-monitor"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Userspace monitor for Assay eBPF programs"
 license.workspace = true
 repository.workspace = true

--- a/crates/assay-policy/Cargo.toml
+++ b/crates/assay-policy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-policy"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Policy types and compilation logic for Assay"
 license.workspace = true
 repository.workspace = true

--- a/crates/assay-registry/Cargo.toml
+++ b/crates/assay-registry/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-registry"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/assay-runner-core/Cargo.toml
+++ b/crates/assay-runner-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-runner-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/assay-runner-linux/Cargo.toml
+++ b/crates/assay-runner-linux/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-runner-linux"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/assay-runner-schema/Cargo.toml
+++ b/crates/assay-runner-schema/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-runner-schema"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/assay-sim/Cargo.toml
+++ b/crates/assay-sim/Cargo.toml
@@ -2,6 +2,7 @@
 name = "assay-sim"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/docs/DEVELOPER_HANDOFF.md
+++ b/docs/DEVELOPER_HANDOFF.md
@@ -59,7 +59,8 @@ cargo run -p assay-cli -- evidence verify tests/fixtures/evidence/test-bundle.ta
 
 ### Prerequisites
 
-- Rust 1.75+ (2021 edition)
+- Rust 1.96.0 via `rust-toolchain.toml`; published crates retain a
+  [Rust 1.89 MSRV](reference/rust-support.md)
 - Linux for eBPF features (macOS/Windows for core features)
 - Python 3.10+ (for SDK development)
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -16,7 +16,9 @@ This guide covers:
 
 ## Prerequisites
 
-- **Rust 1.70+** or **Python 3.9+**
+- **Rust 1.96** for repository development, **Rust 1.89+** for public-crate
+  source installs, or **Python 3.9+** for Python SDK use (**Python 3.10+** for
+  SDK development)
 - An MCP session log (or use our example)
 - 5 minutes ☕
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,7 +21,10 @@ Install Assay on your system.
     ```
 
     **Note:** The crate is named `assay-cli`, but the binary is `assay`.
-    Requires Rust 1.70+. Builds from source (~2 minutes).
+    The Rust 1.89 MSRV policy takes effect with the first release after 3.35.0;
+    earlier releases did not declare an MSRV. `--locked` uses the lockfile shipped
+    with the release selected by Cargo. Builds from source (~2 minutes). See
+    [Rust support](../reference/rust-support.md).
 
 === "Homebrew (macOS)"
 

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -54,6 +54,8 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - `assay-xtask`
   - `gateway-evidence-replay`
 - [ ] **Public Crate Policy Check**: Run `bash scripts/ci/check-public-crate-policy.sh`.
+- [ ] **Public MSRV Check**: Run
+  `ASSAY_PUBLIC_MSRV=1.89.0 scripts/ci/check-msrv-policy.sh`.
 - [ ] **Token Scopes**: If using a token fallback, ensure it has `publish-update` scope.
 
 ### 3. Execution
@@ -74,7 +76,16 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - Step: `Create GitHub Release` (uploads only the preflighted files from `release/`).
 
 ### 4. Verification
-- [ ] **Install Check**: `cargo install assay-cli --version X.Y.Z`
+- [ ] **Published MSRV Install Check**: use a fresh install root so Cargo cannot reuse an existing
+  installation, then execute the resulting binary:
+  ```bash
+  install_root="$(mktemp -d)"
+  trap 'rm -rf "$install_root"' EXIT
+  rustup run 1.89.0 cargo install assay-cli \
+    --locked --version X.Y.Z --root "$install_root"
+  "$install_root/bin/assay" --version
+  ```
+  This exercises the lockfile shipped with the published CLI rather than the workspace lock.
 - [ ] **LSM Smoke Test**: Manually dispatch the `lsm-smoke-test` workflow or run `scripts/verify_lsm_docker.sh --release-tag vX.Y.Z`.
 - [ ] **SBOM Asset Check**: Confirm the GitHub release includes `assay-${VERSION}-sbom-cyclonedx.tar.gz` and `assay-${VERSION}-sbom-cyclonedx.tar.gz.sha256`.
 - [ ] **MCPB Asset Check**: Confirm the GitHub release includes `assay-mcp-server-${VERSION}-linux.mcpb` and `assay-mcp-server-${VERSION}-linux.mcpb.sha256`.

--- a/docs/reference/rust-support.md
+++ b/docs/reference/rust-support.md
@@ -1,0 +1,46 @@
+# Rust Support
+
+Assay separates the minimum supported Rust version (MSRV) of its published crates from the
+toolchain used to develop the full workspace.
+
+## Published Crates
+
+The public crate set defined by `scripts/ci/check-public-crate-policy.sh` supports Rust **1.89.0**
+in the checked-in source tree. Each public package exposes `rust-version = "1.89"` through Cargo
+metadata. This becomes a published-crate guarantee with the first release after 3.35.0; published
+releases through 3.35.0 did not declare an MSRV.
+
+CI checks every public workspace package, its default feature set, and all targets available on
+the Linux CI host with Rust 1.89.0 against the workspace `Cargo.lock`. That build is the
+compatibility check for the checked-in workspace graph, including local path dependencies.
+
+For a source install that uses the lockfile shipped with the release selected by Cargo, use:
+
+```bash
+cargo install assay-cli --locked
+```
+
+The workspace CI lane does not claim that a packaged crate's lockfile is byte-identical to the
+workspace lockfile. This policy also does not promise that an unconstrained future dependency
+resolution will retain the same floor, or that target-specific dependencies unavailable on the
+Linux CI host have been compiled there.
+
+## Workspace Toolchain
+
+Repository development uses Rust **1.96.0**, pinned in `rust-toolchain.toml`. That newer toolchain
+drives formatting, clippy, tests, release work, and the full workspace. It does not silently raise
+the published-crate MSRV.
+
+The eBPF build uses its own dated nightly toolchain. That compiler is an internal build
+requirement, not part of the public crate MSRV claim.
+
+## Raising The Floor
+
+An MSRV increase is an explicit compatibility decision. A change must update, in one pull request:
+
+1. workspace and public-package `rust-version` metadata;
+2. the pinned MSRV CI toolchain;
+3. installation and developer documentation;
+4. dependency holds whose rationale names the old floor.
+
+Dependency convenience alone is not sufficient reason to raise the floor.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
   - Getting Started:
     - getting-started/index.md
     - Installation: getting-started/installation.md
+    - Rust Support: reference/rust-support.md
     - Quick Start: getting-started/quickstart.md
     - Your First Test: getting-started/first-test.md
     - CI Integration: getting-started/ci-integration.md

--- a/scripts/ci/check-msrv-policy.sh
+++ b/scripts/ci/check-msrv-policy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ASSAY_PUBLIC_MSRV:?ASSAY_PUBLIC_MSRV must be set}"
+expected_toolchain="$ASSAY_PUBLIC_MSRV"
+expected_metadata="${expected_toolchain%.0}"
+public_package_file="$(mktemp)"
+trap 'rm -f "$public_package_file"' EXIT
+
+command -v cargo >/dev/null 2>&1 || { echo "cargo missing" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing" >&2; exit 1; }
+command -v rustup >/dev/null 2>&1 || { echo "rustup missing" >&2; exit 1; }
+
+echo "public-msrv-toolchain=${expected_toolchain}"
+scripts/ci/check-public-crate-policy.sh
+cargo metadata --locked --format-version 1 |
+  python3 scripts/ci/check_msrv_metadata.py "$expected_metadata" > "$public_package_file"
+
+if [[ "${ASSAY_MSRV_METADATA_ONLY:-0}" == "1" ]]; then
+  exit 0
+fi
+
+rustc_version="$(rustup run "$expected_toolchain" rustc --version)"
+if [[ "$rustc_version" != "rustc ${expected_toolchain} "* ]]; then
+  echo "expected rustc ${expected_toolchain}, got: ${rustc_version}" >&2
+  exit 1
+fi
+
+package_args=()
+while IFS= read -r crate; do
+  package_args+=("-p" "$crate")
+done < "$public_package_file"
+
+rustup run "$expected_toolchain" cargo check \
+  --locked \
+  --all-targets \
+  "${package_args[@]}"
+
+echo "public-msrv-check=passed"

--- a/scripts/ci/check_msrv_metadata.py
+++ b/scripts/ci/check_msrv_metadata.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from typing import Any
+
+
+def version_tuple(value: str) -> tuple[int, int, int]:
+    parts = [int(part) for part in value.split(".")]
+    return tuple((parts + [0, 0, 0])[:3])
+
+
+def select_public_workspace_packages(
+    metadata: dict[str, Any],
+) -> list[dict[str, Any]]:
+    workspace_members = set(metadata["workspace_members"])
+    return sorted(
+        (
+            package
+            for package in metadata["packages"]
+            if package["id"] in workspace_members
+            and package.get("source") is None
+            and package.get("publish", ["default"]) != []
+        ),
+        key=lambda package: package["name"],
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: check_msrv_metadata.py EXPECTED_VERSION")
+
+    metadata = json.load(sys.stdin)
+    expected_text = sys.argv[1]
+    expected = version_tuple(expected_text)
+    public = select_public_workspace_packages(metadata)
+    if not public:
+        raise SystemExit("MSRV policy found no public workspace crates")
+
+    bad_public = [
+        f'{package["name"]}={package.get("rust_version") or "<missing>"}'
+        for package in public
+        if version_tuple(package.get("rust_version") or "0") != expected
+    ]
+    if bad_public:
+        raise SystemExit(
+            "public crate rust-version metadata must equal "
+            f'{expected_text}: {", ".join(bad_public)}'
+        )
+
+    for package in public:
+        print(package["name"])
+    print(f"public-msrv-metadata={expected_text}", file=sys.stderr)
+    print(f"public-crates={len(public)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -58,6 +58,25 @@ GATE="$(extract_gate)"
 [[ -n "$GATE" ]] || fail "extracted an empty gate body — the workflow shape changed"
 grep -q "MCP_REGISTRY_TOUCHED" <<<"$GATE" \
   || fail "the gate does not read mcp_registry_touched; three scope outputs decide whether a job should run"
+grep -q "PUBLIC_MSRV_RESULT" <<<"$GATE" \
+  || fail "the gate does not inspect the public-msrv result"
+if sed -n '/^run_gate()/,/^}/p' "$0" | grep -q 'PUBLIC_MSRV_RESULT=success'; then
+  fail "run_gate must not inject a successful MSRV result into every scenario"
+fi
+python3 - "$WORKFLOW" <<'PY' || fail "the required CI rollup does not need public-msrv"
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+for index, line in enumerate(lines):
+    if line == "  ci:":
+        for candidate in lines[index + 1 : index + 10]:
+            if candidate.strip().startswith("needs:"):
+                if "public-msrv" not in candidate:
+                    sys.exit(1)
+                sys.exit(0)
+        break
+sys.exit(1)
+PY
 
 # Run the gate under one environment. Echoes the exit code and captured output.
 run_gate() {
@@ -81,6 +100,7 @@ ok="success"
 # A full run with every job green.
 run_gate pass "everything green" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
@@ -91,14 +111,16 @@ run_gate pass "lightweight scoped out" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
+  PUBLIC_MSRV_RESULT=skipped \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
 echo "ok: a documentation-only run passes with its jobs scoped out"
 
 # The defect: a code-bearing run where a job that should have executed did not. Before this change
 # every one of these was green.
-for job in DEPS_SECURITY CLIPPY PERF TEST; do
+for job in DEPS_SECURITY CLIPPY PUBLIC_MSRV PERF TEST; do
   out="$(run_gate fail "silently skipped $job" \
     SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+    PUBLIC_MSRV_RESULT=$ok \
     DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
     MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
     EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false \
@@ -111,6 +133,7 @@ echo "ok: a code-gated job that silently did not run fails the gate, and is name
 # The eBPF case the audit called sharpest: the `== 'true'` form disarms on a typo.
 out="$(run_gate fail "ebpf required but skipped" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=true EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
@@ -121,6 +144,7 @@ echo "ok: ebpf-smoke-ubuntu skipped while required fails the gate"
 # The output the gate did not read at all until now.
 out="$(run_gate fail "registry touched but skipped" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=true)"
@@ -132,6 +156,7 @@ echo "ok: mcp-registry-foundation skipped while touched fails the gate"
 for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS; do
   out="$(run_gate fail "unconditional $job skipped" \
     SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+    PUBLIC_MSRV_RESULT=skipped \
     DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
     MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
     EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false \
@@ -144,20 +169,35 @@ echo "ok: a job with no condition may not be skipped even on a docs-only run"
 # Failure still fails, and scope failing takes the basis for every other judgement with it.
 run_gate fail "a job failed" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=failure \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
 run_gate fail "scope itself skipped" \
   SCOPE_RESULT=skipped LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  PUBLIC_MSRV_RESULT=skipped \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
   EBPF_SMOKE_REQUIRED= EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED= >/dev/null
 echo "ok: an outright failure fails, and a skipped scope fails"
 
+for result in failure ""; do
+  out="$(run_gate fail "public-msrv result ${result:-empty}" \
+    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+    PUBLIC_MSRV_RESULT="$result" \
+    DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
+    MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
+    EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
+  grep -q "public-msrv" <<<"$out" \
+    || fail "public-msrv ${result:-empty}: the gate failed without naming the job"
+done
+echo "ok: a failed or missing public-msrv result fails closed and names the job"
+
 # An empty scope output is the typo signature: `'' == 'true'` is false, so the job silently never
 # runs. Treating empty as "not required" would reproduce the defect through the fix.
 out="$(run_gate fail "empty lightweight_only with skipped code jobs" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  PUBLIC_MSRV_RESULT=skipped \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
@@ -171,6 +211,7 @@ echo "ok: an empty lightweight_only is treated as the strict case, not the permi
 # it was written to close, surviving in the fix.
 out="$(run_gate fail "empty ebpf_smoke_required with the job skipped" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED= EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
@@ -179,6 +220,7 @@ grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
 
 out="$(run_gate fail "empty mcp_registry_touched with the job skipped" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=)"
@@ -189,6 +231,7 @@ grep -q "mcp-registry-foundation was skipped" <<<"$out" \
 # `TRUE` is not `true` and the job silently never runs.
 out="$(run_gate fail "wrong-case ebpf_smoke_required" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=TRUE EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false)"
@@ -199,6 +242,7 @@ echo "ok: empty or wrong-case == 'true' outputs are strict, so a disarmed job ca
 # And the legitimate relaxations still work: an explicit false scopes the job out.
 run_gate pass "explicit false relaxes both" \
   SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null

--- a/scripts/ci/test_check_msrv_metadata.py
+++ b/scripts/ci/test_check_msrv_metadata.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from check_msrv_metadata import select_public_workspace_packages
+
+
+class PublicWorkspacePackageSelectionTests(unittest.TestCase):
+    repo_root = Path(__file__).resolve().parents[2]
+
+    @staticmethod
+    def metadata_fixture() -> dict[str, object]:
+        return {
+            "workspace_members": [
+                "workspace-public 1.0.0 (path+file:///repo/public)",
+                "workspace-private 1.0.0 (path+file:///repo/private)",
+            ],
+            "packages": [
+                {
+                    "id": "workspace-public 1.0.0 (path+file:///repo/public)",
+                    "name": "workspace-public",
+                    "source": None,
+                    "publish": None,
+                    "rust_version": "1.89",
+                },
+                {
+                    "id": "workspace-private 1.0.0 (path+file:///repo/private)",
+                    "name": "workspace-private",
+                    "source": None,
+                    "publish": [],
+                    "rust_version": None,
+                },
+                {
+                    "id": "external-path 1.0.0 (path+file:///tmp/external)",
+                    "name": "external-path",
+                    "source": None,
+                    "publish": None,
+                    "rust_version": "1.99",
+                },
+            ],
+        }
+
+    def test_excludes_publishable_path_dependency_outside_workspace(self) -> None:
+        selected = select_public_workspace_packages(self.metadata_fixture())
+
+        self.assertEqual(
+            [package["name"] for package in selected],
+            ["workspace-public"],
+        )
+
+    def test_cli_reads_metadata_from_stdin_and_writes_package_names_to_stdout(
+        self,
+    ) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).with_name("check_msrv_metadata.py")),
+                "1.89",
+            ],
+            input=json.dumps(self.metadata_fixture()),
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "workspace-public\n")
+        self.assertIn("public-msrv-metadata=1.89", result.stderr)
+        self.assertIn("public-crates=1", result.stderr)
+
+    def test_policy_check_requires_explicit_msrv_toolchain(self) -> None:
+        env = os.environ.copy()
+        env.pop("ASSAY_PUBLIC_MSRV", None)
+        env["ASSAY_MSRV_METADATA_ONLY"] = "1"
+
+        result = subprocess.run(
+            ["scripts/ci/check-msrv-policy.sh"],
+            cwd=self.repo_root,
+            env=env,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ASSAY_PUBLIC_MSRV must be set", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1906.

## What changed

- declares Rust 1.89 as the MSRV for all 14 published workspace crates;
- runs those crates, default features, and all Linux-host targets against the committed lockfile on Rust 1.89;
- makes the MSRV lane load-bearing in the required `CI` rollup, including fail-closed empty/skipped-result contract tests;
- binds package selection to Cargo `workspace_members`, with a regression fixture proving a publishable external path dependency is excluded;
- documents the public floor separately from the Rust 1.96 developer toolchain and dated eBPF nightly;
- retains the `serial_test` 4 hold because it requires Rust 1.93.1.

The 1.89 floor is derived from the checked-in dependency graph; `crc-fast 1.10.0` is the highest declared floor currently used by the public graph. Raising the project floor solely for one dev dependency is intentionally avoided.

## Verification

- `scripts/ci/check-msrv-policy.sh` on Rust 1.89: 14 public crates, pass
- `scripts/ci/test-ci-gate-expectations.sh`: pass
- `python3 scripts/ci/test_check_msrv_metadata.py`: pass
- repository pre-commit/actionlint/shellcheck/cargo-deny hooks: pass
- `mkdocs build --strict`: pass
- claims-boundary and public-artifact sanitization: pass
- independent pre-push review findings on package selection and gate masking: fixed and against tested

## Boundaries

This guarantees the committed, locked default-feature graph and targets available on the Linux CI host. It does not promise that an unconstrained future dependency resolution or unbuilt target-specific dependency retains Rust 1.89.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust requirements to Rust 1.89+ for installation and getting started.
  * Added documentation explaining public crate compatibility and development toolchains.
  * Added the Rust Support section to the documentation navigation.

* **Chores**
  * Declared Rust 1.89 as the minimum supported version for published crates.
  * Added automated CI validation to verify public crate compatibility and enforce MSRV policy.
  * Updated release checks to include public MSRV validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->