### PR TITLE
fix(mcp): negotiate supported legacy revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ All notable changes to this project will be documented in this file.
   sessions that failed authentication under the default permissive mode, and neither carried a
   basis a reviewer could check. `serverInfo.version` is now derived from the crate version
   instead of the hand-written `0.4.0`, which no build produced.
+- The stdio MCP server now negotiates its two tested legacy handshake revisions. Requests for
+  `2024-11-05` or `2025-11-25` receive that exact revision; other string values receive the
+  latest supported legacy revision, `2025-11-25`. Missing or non-string `protocolVersion` values
+  fail with JSON-RPC invalid params. This does not claim MCP `2026-07-28` support: the modern
+  `server/discover` and per-request metadata contract remains separate.
 - **Fail-closed correction (`assay sandbox`, migration-visible)**: a named policy with non-empty
   `extends` is refused before execution. Pack resolution is unsupported, so accepting those entries
   previously made declared policy composition disappear silently. `assay sandbox --profile` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
   workspace graph and all Linux-host targets in required CI. The policy becomes part of published
   crate metadata with the first release after 3.35.0. Repository development remains pinned to
   Rust 1.96, and the eBPF nightly remains a separate internal build toolchain.
+- The stdio MCP server now negotiates its two tested legacy handshake revisions. Requests for
+  `2024-11-05` or `2025-11-25` receive that exact revision; other string values receive the
+  latest supported legacy revision, `2025-11-25`. Missing or structurally incomplete initialize
+  parameters fail with JSON-RPC invalid params. This does not claim MCP `2026-07-28` support: the
+  modern `server/discover` and per-request metadata contract remains separate.
 - **Fail-closed correction (bundle verification, migration-visible).** The verifier now rejects
   every bundle `BundleWriter` refuses to emit. Five shapes previously verified: an empty bundle, an
   inconsistent `source` across events, a `source` that is not a URI, and a blank line in
@@ -65,11 +70,6 @@ All notable changes to this project will be documented in this file.
   sessions that failed authentication under the default permissive mode, and neither carried a
   basis a reviewer could check. `serverInfo.version` is now derived from the crate version
   instead of the hand-written `0.4.0`, which no build produced.
-- The stdio MCP server now negotiates its two tested legacy handshake revisions. Requests for
-  `2024-11-05` or `2025-11-25` receive that exact revision; other string values receive the
-  latest supported legacy revision, `2025-11-25`. Missing or non-string `protocolVersion` values
-  fail with JSON-RPC invalid params. This does not claim MCP `2026-07-28` support: the modern
-  `server/discover` and per-request metadata contract remains separate.
 - **Fail-closed correction (`assay sandbox`, migration-visible)**: a named policy with non-empty
   `extends` is refused before execution. Pack resolution is unsupported, so accepting those entries
   previously made declared policy composition disappear silently. `assay sandbox --profile` now

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 static RID: AtomicU64 = AtomicU64::new(1);
+const INVALID_INITIALIZE_PARAMS: &str =
+    "Invalid initialize params: expected the required legacy MCP fields";
 
 fn next_rid() -> String {
     let n = RID.fetch_add(1, Ordering::Relaxed);
@@ -24,13 +26,27 @@ enum LegacyProtocolVersion {
 impl LegacyProtocolVersion {
     const LATEST: Self = Self::V2025_11_25;
 
-    fn negotiate(params: Option<&Value>) -> Option<Self> {
+    fn negotiate(params: Option<&Value>) -> Result<Self, ()> {
+        let params = params.and_then(Value::as_object).ok_or(())?;
         let requested = params
+            .get("protocolVersion")
+            .and_then(Value::as_str)
+            .ok_or(())?;
+        params
+            .get("capabilities")
             .and_then(Value::as_object)
-            .and_then(|params| params.get("protocolVersion"))
-            .and_then(Value::as_str)?;
+            .ok_or(())?;
+        let client_info = params
+            .get("clientInfo")
+            .and_then(Value::as_object)
+            .ok_or(())?;
+        client_info.get("name").and_then(Value::as_str).ok_or(())?;
+        client_info
+            .get("version")
+            .and_then(Value::as_str)
+            .ok_or(())?;
 
-        Some(match requested {
+        Ok(match requested {
             "2024-11-05" => Self::V2024_11_05,
             "2025-11-25" => Self::V2025_11_25,
             _ => Self::LATEST,
@@ -197,13 +213,11 @@ impl Server {
             // Dispatch
             let resp = match req.method.as_str() {
                 "initialize" => match LegacyProtocolVersion::negotiate(req.params.as_ref()) {
-                    Some(version) => {
-                        JsonRpcResponse::ok(req.id.clone(), initialize_result(version))
-                    }
-                    None => JsonRpcResponse::error(
+                    Ok(version) => JsonRpcResponse::ok(req.id.clone(), initialize_result(version)),
+                    Err(()) => JsonRpcResponse::error(
                         req.id.clone(),
                         -32602,
-                        "Invalid initialize params: protocolVersion must be a string".to_string(),
+                        INVALID_INITIALIZE_PARAMS.to_string(),
                     ),
                 },
                 "notifications/initialized" => {

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -15,7 +15,37 @@ fn next_rid() -> String {
     format!("r-{n:06}")
 }
 
-/// The `initialize` result this server returns on a successful handshake.
+#[derive(Clone, Copy)]
+enum LegacyProtocolVersion {
+    V2024_11_05,
+    V2025_11_25,
+}
+
+impl LegacyProtocolVersion {
+    const LATEST: Self = Self::V2025_11_25;
+
+    fn negotiate(params: Option<&Value>) -> Option<Self> {
+        let requested = params
+            .and_then(Value::as_object)
+            .and_then(|params| params.get("protocolVersion"))
+            .and_then(Value::as_str)?;
+
+        Some(match requested {
+            "2024-11-05" => Self::V2024_11_05,
+            "2025-11-25" => Self::V2025_11_25,
+            _ => Self::LATEST,
+        })
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::V2024_11_05 => "2024-11-05",
+            Self::V2025_11_25 => "2025-11-25",
+        }
+    }
+}
+
+/// The `initialize` result this server returns on a successful legacy handshake.
 ///
 /// Extracted so the claims boundary is testable rather than remembered. ADR-042 refuses
 /// compliance and partnership claims; ADR-043 §2 extends that refusal from prose to what the
@@ -27,12 +57,11 @@ fn next_rid() -> String {
 /// Server-specific metadata, if it is ever needed, belongs under the protocol's reserved
 /// `_meta` key with a non-reserved prefix such as `dev.assay/`; a bare `meta` object was never
 /// part of the protocol.
-fn initialize_result() -> Value {
+fn initialize_result(protocol_version: LegacyProtocolVersion) -> Value {
     serde_json::json!({
-        // Stale: the stable revision is 2025-11-25, and the 2026-07-28 candidate removes this
-        // handshake and the protocol-level session outright. Bumping it is a negotiation change
-        // and is deliberately not part of this fix.
-        "protocolVersion": "2024-11-05",
+        // MCP 2026-07-28 removed this handshake. Modern support requires server/discover and
+        // per-request metadata; this legacy path deliberately advertises neither.
+        "protocolVersion": protocol_version.as_str(),
         "capabilities": {
             "tools": {}
         },
@@ -167,7 +196,16 @@ impl Server {
 
             // Dispatch
             let resp = match req.method.as_str() {
-                "initialize" => JsonRpcResponse::ok(req.id.clone(), initialize_result()),
+                "initialize" => match LegacyProtocolVersion::negotiate(req.params.as_ref()) {
+                    Some(version) => {
+                        JsonRpcResponse::ok(req.id.clone(), initialize_result(version))
+                    }
+                    None => JsonRpcResponse::error(
+                        req.id.clone(),
+                        -32602,
+                        "Invalid initialize params: protocolVersion must be a string".to_string(),
+                    ),
+                },
                 "notifications/initialized" => {
                     // Notification, no response needed usually, but good to ack log
                     tracing::info!(event="initialized", rid=%rid);
@@ -412,7 +450,7 @@ impl Server {
 
 #[cfg(test)]
 mod claims_boundary_tests {
-    use super::initialize_result;
+    use super::{initialize_result, LegacyProtocolVersion};
 
     /// ADR-042 stop list, ADR-043 §2. The handshake must not assert a status the server
     /// cannot substantiate. A denylist over the serialized response catches a claim
@@ -421,7 +459,8 @@ mod claims_boundary_tests {
     /// control is `initialize_result_pins_every_value`, which pins the leaves.
     #[test]
     fn initialize_result_asserts_no_unearned_status() {
-        let wire = serde_json::to_string(&initialize_result()).expect("serializable");
+        let wire = serde_json::to_string(&initialize_result(LegacyProtocolVersion::LATEST))
+            .expect("serializable");
         for forbidden in [
             "certified",
             "certification",
@@ -447,39 +486,44 @@ mod claims_boundary_tests {
     /// someone updates a pinned value without thinking about what it claims.
     #[test]
     fn initialize_result_pins_every_value() {
-        let value = initialize_result();
-        assert_eq!(
-            value.get("protocolVersion").and_then(|v| v.as_str()),
-            Some("2024-11-05")
-        );
-        assert_eq!(
-            value.get("capabilities"),
-            Some(&serde_json::json!({"tools": {}}))
-        );
-        assert_eq!(
-            value
-                .get("serverInfo")
-                .and_then(|s| s.get("name"))
-                .and_then(|v| v.as_str()),
-            Some("assay-mcp-server")
-        );
-        // Derived, not asserted. The literal "0.4.0" was itself an unverifiable identity
-        // claim: the crate has been on 3.x for a long time, so the wire was stating a
-        // version no build ever produced.
-        assert_eq!(
-            value
-                .get("serverInfo")
-                .and_then(|s| s.get("version"))
-                .and_then(|v| v.as_str()),
-            Some(env!("CARGO_PKG_VERSION"))
-        );
+        for (version, expected) in [
+            (LegacyProtocolVersion::V2024_11_05, "2024-11-05"),
+            (LegacyProtocolVersion::V2025_11_25, "2025-11-25"),
+        ] {
+            let value = initialize_result(version);
+            assert_eq!(
+                value.get("protocolVersion").and_then(|v| v.as_str()),
+                Some(expected)
+            );
+            assert_eq!(
+                value.get("capabilities"),
+                Some(&serde_json::json!({"tools": {}}))
+            );
+            assert_eq!(
+                value
+                    .get("serverInfo")
+                    .and_then(|s| s.get("name"))
+                    .and_then(|v| v.as_str()),
+                Some("assay-mcp-server")
+            );
+            // Derived, not asserted. The literal "0.4.0" was itself an unverifiable identity
+            // claim: the crate has been on 3.x for a long time, so the wire was stating a
+            // version no build ever produced.
+            assert_eq!(
+                value
+                    .get("serverInfo")
+                    .and_then(|s| s.get("version"))
+                    .and_then(|v| v.as_str()),
+                Some(env!("CARGO_PKG_VERSION"))
+            );
+        }
     }
 
     /// The bare `meta` key was never part of the protocol. If server metadata returns it
     /// belongs under the reserved `_meta` key with a non-reserved prefix.
     #[test]
     fn initialize_result_has_no_bare_meta_object() {
-        let value = initialize_result();
+        let value = initialize_result(LegacyProtocolVersion::LATEST);
         let obj = value.as_object().expect("result is an object");
         assert!(!obj.contains_key("meta"), "bare `meta` key reintroduced");
     }
@@ -529,7 +573,7 @@ mod claims_boundary_tests {
             }
         }
 
-        let value = initialize_result();
+        let value = initialize_result(LegacyProtocolVersion::LATEST);
         let mut found = Vec::new();
         walk(&value, "", &mut found);
 
@@ -552,7 +596,7 @@ mod claims_boundary_tests {
 
     #[test]
     fn initialize_result_still_carries_the_fields_a_client_needs() {
-        let value = initialize_result();
+        let value = initialize_result(LegacyProtocolVersion::LATEST);
         assert!(value.get("protocolVersion").is_some());
         assert!(value.get("capabilities").is_some());
         assert_eq!(

--- a/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
+++ b/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
@@ -117,7 +117,75 @@ fn missing_or_non_string_protocol_version_is_value_free_invalid_params() {
         assert_eq!(response["error"]["code"].as_i64(), Some(-32602));
         assert_eq!(
             response["error"]["message"].as_str(),
-            Some("Invalid initialize params: protocolVersion must be a string")
+            Some("Invalid initialize params: expected the required legacy MCP fields")
+        );
+        assert!(response.get("result").is_none());
+    }
+
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !rendered.contains(secret),
+        "invalid input value leaked into protocol output or logs"
+    );
+}
+
+#[test]
+fn incomplete_initialize_shape_is_value_free_invalid_params() {
+    let secret = "malformed-initialize-value-must-not-be-echoed";
+    let requests = [
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": LATEST_LEGACY_VERSION,
+                "clientInfo": {"name": "contract-test", "version": "1.0"}
+            }
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": LATEST_LEGACY_VERSION,
+                "capabilities": [],
+                "clientInfo": {"name": "contract-test", "version": "1.0"}
+            }
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": LATEST_LEGACY_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": secret}
+            }
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": LATEST_LEGACY_VERSION,
+                "capabilities": {},
+                "clientInfo": secret
+            }
+        }),
+    ];
+
+    let output = run_session(&requests);
+    let parsed = responses(&output);
+    assert_eq!(parsed.len(), requests.len());
+    for response in parsed {
+        assert_eq!(response["error"]["code"].as_i64(), Some(-32602));
+        assert_eq!(
+            response["error"]["message"].as_str(),
+            Some("Invalid initialize params: expected the required legacy MCP fields")
         );
         assert!(response.get("result").is_none());
     }

--- a/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
+++ b/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
@@ -1,0 +1,184 @@
+use serde_json::Value;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+const LATEST_LEGACY_VERSION: &str = "2025-11-25";
+
+fn policy_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/mcp")
+}
+
+fn clean_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_AUTH_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+}
+
+fn run_session(requests: &[Value]) -> Output {
+    let mut child = clean_command()
+        .arg("--policy-root")
+        .arg(policy_root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn assay-mcp-server");
+
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        for request in requests {
+            writeln!(stdin, "{request}").expect("write JSON-RPC request");
+        }
+    }
+
+    child.wait_with_output().expect("wait for server")
+}
+
+fn responses(output: &Output) -> Vec<Value> {
+    assert!(
+        output.status.success(),
+        "server failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("JSON-RPC response"))
+        .collect()
+}
+
+fn initialize_request(protocol_version: Value, id: u64) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": protocol_version,
+            "capabilities": {},
+            "clientInfo": {"name": "contract-test", "version": "1.0"}
+        }
+    })
+}
+
+#[test]
+fn supported_legacy_versions_are_echoed_exactly() {
+    for version in ["2024-11-05", LATEST_LEGACY_VERSION] {
+        let output = run_session(&[initialize_request(Value::String(version.to_string()), 1)]);
+        let response = responses(&output).pop().expect("initialize response");
+        assert_eq!(
+            response["result"]["protocolVersion"].as_str(),
+            Some(version),
+            "supported legacy version must be echoed"
+        );
+    }
+}
+
+#[test]
+fn unsupported_versions_negotiate_to_the_latest_legacy_revision() {
+    for requested in ["2025-06-18", "2026-07-28", "future-version"] {
+        let output = run_session(&[initialize_request(Value::String(requested.to_string()), 1)]);
+        let response = responses(&output).pop().expect("initialize response");
+        assert_eq!(
+            response["result"]["protocolVersion"].as_str(),
+            Some(LATEST_LEGACY_VERSION),
+            "unsupported input must not become an advertised protocol version"
+        );
+    }
+}
+
+#[test]
+fn missing_or_non_string_protocol_version_is_value_free_invalid_params() {
+    let secret = "protocol-version-value-must-not-be-echoed";
+    let requests = [
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "capabilities": {},
+                "clientInfo": {"name": "contract-test", "version": "1.0"}
+            }
+        }),
+        initialize_request(serde_json::json!({"secret": secret}), 2),
+    ];
+
+    let output = run_session(&requests);
+    let parsed = responses(&output);
+    assert_eq!(parsed.len(), 2);
+    for response in parsed {
+        assert_eq!(response["error"]["code"].as_i64(), Some(-32602));
+        assert_eq!(
+            response["error"]["message"].as_str(),
+            Some("Invalid initialize params: protocolVersion must be a string")
+        );
+        assert!(response.get("result").is_none());
+    }
+
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !rendered.contains(secret),
+        "invalid input value leaked into protocol output or logs"
+    );
+}
+
+#[test]
+fn modern_discovery_probe_remains_a_method_not_found_fallback_signal() {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {}
+    });
+    let output = run_session(&[request]);
+    let response = responses(&output).pop().expect("discover response");
+    assert_eq!(response["error"]["code"].as_i64(), Some(-32601));
+    assert!(response.get("result").is_none());
+}
+
+#[test]
+fn latest_legacy_handshake_preserves_tools_list_and_call() {
+    let requests = [
+        initialize_request(Value::String(LATEST_LEGACY_VERSION.to_string()), 1),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "assay_check_args",
+                "arguments": {
+                    "tool": "discount_tool",
+                    "arguments": {"percent": 10},
+                    "policy": "policy.yaml"
+                }
+            }
+        }),
+    ];
+
+    let output = run_session(&requests);
+    let parsed = responses(&output);
+    assert_eq!(parsed.len(), 3);
+    assert_eq!(
+        parsed[0]["result"]["protocolVersion"].as_str(),
+        Some(LATEST_LEGACY_VERSION)
+    );
+    assert!(parsed[1]["result"]["tools"].is_array());
+    assert_eq!(parsed[2]["result"]["isError"].as_bool(), Some(false));
+}

--- a/crates/assay-mcp-server/tests/stdio_auth_boundary.rs
+++ b/crates/assay-mcp-server/tests/stdio_auth_boundary.rs
@@ -159,6 +159,7 @@ fn initialize_credential_fields_are_ignored_as_authority_and_never_logged() {
         "id": 1,
         "method": "initialize",
         "params": {
+            "protocolVersion": "2025-11-25",
             "authorization": secret,
             "initializationOptions": {
                 "authorization": secret

--- a/crates/assay-mcp-server/tests/stdio_auth_boundary.rs
+++ b/crates/assay-mcp-server/tests/stdio_auth_boundary.rs
@@ -160,6 +160,11 @@ fn initialize_credential_fields_are_ignored_as_authority_and_never_logged() {
         "method": "initialize",
         "params": {
             "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "auth-boundary-test",
+                "version": "1.0"
+            },
             "authorization": secret,
             "initializationOptions": {
                 "authorization": secret


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: #1846 (post-program follow-up; #1847 remains closed)
- Slice: honest legacy stdio protocol negotiation
- Builder: Codex
- Reviewers: pending
- Final head SHA: `f11028edf85abde72608321b8f741b55ad3071ce`
- ADR invariants affected: ADR-042 claim ceiling; ADR-043 §4 stdio auth boundary

## Behavior

- Echo `2024-11-05` or `2025-11-25` when the client requests a tested legacy handshake revision.
- Negotiate every other string to the latest supported legacy revision, `2025-11-25`, without advertising the request value.
- Reject missing or non-string `params.protocolVersion` with value-free JSON-RPC `-32602` invalid params.
- Preserve `server/discover` as JSON-RPC `-32601 Method not found`, the MCP 2026 stdio signal for a dual-era client to fall back to the legacy handshake.
- Preserve tools/list, tools/call, initialize credential non-authority, and token no-passthrough behavior.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- [x] No claim of MCP `2026-07-28` support; that remains #1866

## Test Evidence

### RED

`CARGO_TARGET_DIR=/private/tmp/assay-target-mcp1846 cargo test -p assay-mcp-server --test protocol_negotiation_e2e`

On unmodified `main`, four of five tests failed for the intended reasons: the server returned `2024-11-05` for the requested `2025-11-25` and unsupported-version cases, accepted malformed version input, and therefore failed the latest-legacy tools session assertion. The existing `server/discover -> -32601` guard passed.

### GREEN

- New protocol-negotiation E2E: 5/5
- `assay-mcp-server` library: 60/60
- stdio auth boundary: 7/7
- existing stdio E2E: 1/1
- stdio edge cases: 2/2
- no-passthrough E2E with `test-outbound`: 1/1
- `cargo clippy -p assay-mcp-server --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- pre-commit hooks, claims-boundary, public-artifact sanitization, diff-check
- pre-push workspace clippy and Linux compile gate

A broader local `cargo test -p assay-mcp-server` run passed all suites through the changed stdio/proxy surfaces, then hit a pre-existing test-harness issue: `tests/security.rs` ignores `CARGO_TARGET_DIR` and searches only fixed `target/` paths. This is not caused by the diff and will be handled separately rather than widening this protocol slice. GitHub CI uses its normal target layout and remains the integration proof.

## Review Quorum

- [ ] One non-building agent review
- [ ] CodeRabbit or Copilot review on this head SHA
- [ ] If bots are unavailable for 30 minutes, a second non-building agent review is linked
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Closes #1846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * The stdio MCP server now negotiates supported legacy protocol versions during initialization.
  * Requests for supported revisions are echoed exactly; unsupported versions use the latest supported legacy revision.
  * Missing or non-string protocol versions now return a clear invalid-parameters error.
  * Existing tool discovery and invocation remain available after negotiation.
* **Documentation**
  * Updated the changelog to clarify legacy version negotiation and its scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->