### PR TITLE
test(mcp): respect Cargo binary target path

### DIFF
--- a/crates/assay-mcp-server/tests/security.rs
+++ b/crates/assay-mcp-server/tests/security.rs
@@ -5,33 +5,6 @@ use tokio::process::Command;
 
 #[tokio::test]
 async fn test_path_traversal_prevention() -> Result<()> {
-    // 1. Setup Server
-    let status = Command::new("cargo")
-        .args(["build", "-p", "assay-mcp-server"])
-        .status()
-        .await?;
-    assert!(status.success());
-    // Resolve binary path
-    let bin_name = if cfg!(windows) {
-        "assay-mcp-server.exe"
-    } else {
-        "assay-mcp-server"
-    };
-    let mut bin_path = std::env::current_dir()?.join("target/debug").join(bin_name);
-    if !bin_path.exists() {
-        // Try workspace root from crate dir
-        bin_path = std::env::current_dir()?
-            .join("../../target/debug")
-            .join(bin_name);
-    }
-    if !bin_path.exists() {
-        panic!(
-            "Could not find {} binary at {:?} or in ../../target",
-            bin_name,
-            std::env::current_dir()?.join("target/debug").join(bin_name)
-        );
-    }
-
     // Create a temp policy root
     let temp_root = std::env::temp_dir().join(format!(
         "assay_sec_{}",
@@ -50,7 +23,7 @@ async fn test_path_traversal_prevention() -> Result<()> {
     tokio::fs::write(&secret_file, "secret: true").await?;
     let secret_rel_path = "../secret_config.yaml";
 
-    let mut cmd = Command::new(bin_path)
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .arg("--policy-root")
         .arg(&temp_root)
         .stdin(Stdio::piped())


### PR DESCRIPTION
## Summary

- use Cargo's `CARGO_BIN_EXE_assay-mcp-server` integration-test binary path;
- remove the nested `cargo build` and fixed `target/` path guesses;
- keep the existing path-traversal behavior test unchanged.

## Why

The test failed in isolated worktrees whenever `CARGO_TARGET_DIR` pointed outside the checkout, even after Cargo had successfully built the binary. This made the repository's required isolated-target verification fail for a test-harness reason rather than a product defect.

## Verification

### RED on `main` (`906baded`)

```bash
CARGO_TARGET_DIR=/private/tmp/assay-target-mcp1846 \
  cargo test -p assay-mcp-server --test security
```

Failed after a successful build because `tests/security.rs` searched only fixed local target paths.

### GREEN on `06a1bcebd58bb68cd098db38735dc7ebff24b788`

```bash
CARGO_TARGET_DIR=/private/tmp/assay-target-mcp1920 \
  cargo test -p assay-mcp-server --test security
```

- focused path-traversal integration test: 1/1
- clippy for the security integration target with `-D warnings`
- fmt, diff-check, pre-commit hooks
- pre-push workspace clippy and Linux compile gate

No production code or user-facing behavior changes.

Closes #1920


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved security test execution by using the automatically resolved server binary.
  * Retained validation for path traversal and symlink-based escape prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->