### PR TITLE
ci(conformance): bind and publish privileged MCP candidate.3

### DIFF
--- a/.github/workflows/privileged-mcp-action-pack-release.yml
+++ b/.github/workflows/privileged-mcp-action-pack-release.yml
@@ -1,15 +1,13 @@
 name: Publish Privileged MCP Action clean-room pack
 
 on:
-  push:
-    tags:
-      - "privileged-mcp-action-v0-candidate.*"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: privileged-mcp-action-pack-${{ github.ref }}
+  group: privileged-mcp-action-pack
   cancel-in-progress: false
 
 jobs:
@@ -20,38 +18,41 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Check out tagged source
+      - name: Check out current main
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
           persist-credentials: false
+          # Re-runs retain the original workflow SHA. Pinning the checkout to it keeps a
+          # partially published candidate recoverable after main advances.
+          ref: ${{ github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13.8"
 
-      - name: Verify tag and build deterministic pack
+      - name: Validate candidate release contract
+        id: candidate
         run: |
           set -euo pipefail
-          case "$GITHUB_REF_NAME" in
-            privileged-mcp-action-v0-candidate.*) ;;
-            *) echo "unexpected release tag: $GITHUB_REF_NAME" >&2; exit 2 ;;
-          esac
-          git fetch --force origin \
-            "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME"
-          if [[ "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" != "tag" ]]; then
-            echo "release requires an annotated tag object: $GITHUB_REF_NAME" >&2
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "release controller must be dispatched from main, got $GITHUB_REF" >&2
             exit 2
           fi
-          tag_commit="$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{}")"
-          head_commit="$(git rev-parse HEAD)"
-          if [[ "$tag_commit" != "$head_commit" ]]; then
-            echo "release tag $GITHUB_REF_NAME peels to $tag_commit; checked-out HEAD is $head_commit" >&2
+          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
+            echo "checked-out main does not match the workflow source commit" >&2
             exit 2
           fi
-          git fetch --no-tags origin main
-          git merge-base --is-ancestor HEAD origin/main
+          python3 \
+            conformance/privileged-mcp-action-v0/scripts/validate_candidate_release.py \
+            --candidate conformance/privileged-mcp-action-v0/candidate-release.json \
+            --manifest conformance/privileged-mcp-action-v0/MANIFEST.json \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Build deterministic pack
+        run: |
+          set -euo pipefail
           mkdir -p release
           source_commit="$(git rev-parse HEAD)"
           builder=conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
@@ -133,12 +134,41 @@ jobs:
           test -n "$ATTESTATION_BUNDLE"
           cp "$ATTESTATION_BUNDLE" release/attestation-bundle.json
 
-      - name: Publish immutable release assets
+      - name: Publish release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ github.sha }}
+          TAG: ${{ steps.candidate.outputs.tag }}
         run: |
           set -euo pipefail
-          gh release create "$GITHUB_REF_NAME" \
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release already exists: $TAG" >&2
+            exit 2
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+            if [[ "$(git cat-file -t "refs/tags/$TAG")" != "tag" ]]; then
+              echo "existing release tag is not annotated: $TAG" >&2
+              exit 2
+            fi
+            if [[ "$(git rev-parse "refs/tags/$TAG^{}")" != "$SOURCE_COMMIT" ]]; then
+              echo "existing release tag does not name $SOURCE_COMMIT: $TAG" >&2
+              exit 2
+            fi
+          else
+            tag_object="$(
+              gh api --method POST "repos/$GITHUB_REPOSITORY/git/tags" \
+                -f tag="$TAG" \
+                -f message="Privileged MCP Action v0 clean-room conformance candidate ${TAG##*.}" \
+                -f object="$SOURCE_COMMIT" \
+                -f type=commit \
+                --jq .sha
+            )"
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$TAG" \
+              -f sha="$tag_object"
+          fi
+          gh release create "$TAG" \
             release/privileged-mcp-action-v0-clean-room.tar.gz \
             release/SHA256SUMS \
             release/attestation-bundle.json \
@@ -147,4 +177,4 @@ jobs:
             --prerelease \
             --latest=false \
             --title "Privileged MCP Action v0 clean-room conformance pack" \
-            --notes "Inputs-only pack for implementing privileged-mcp-action/v0 from the tagged profile. The asset omits expected outcomes and Assay implementation code. See the tagged conformance protocol for the claim ceiling."
+            --notes "Inputs-only pack for implementing privileged-mcp-action/v0 from the pinned profile commit. The asset omits expected outcomes and Assay implementation code. See the conformance protocol at the release tag for the claim ceiling."

--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -102,7 +102,9 @@ steps:
     env:
       GH_TOKEN: ${{ github.token }}
     run: |
-      gh release download privileged-mcp-action-v0-candidate.2 \
+      tag=privileged-mcp-action-v0-candidate.3
+      source_digest="$(gh api "repos/Rul1an/assay/commits/$tag" --jq .sha)"
+      gh release download "$tag" \
         --repo Rul1an/assay \
         --pattern privileged-mcp-action-v0-clean-room.tar.gz \
         --pattern SHA256SUMS \
@@ -112,11 +114,11 @@ steps:
         --repo Rul1an/assay \
         --bundle attestation-bundle.json \
         --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml \
-        --source-digest 975ee0129a421925cad78b84ffc02144aa655679 \
-        --source-ref refs/tags/privileged-mcp-action-v0-candidate.2
+        --source-digest "$source_digest" \
+        --source-ref refs/heads/main
 
   - name: Run conformance
-    uses: Rul1an/assay/.github/actions/privileged-mcp-action-conformance@975ee0129a421925cad78b84ffc02144aa655679
+    uses: Rul1an/assay/.github/actions/privileged-mcp-action-conformance@16ea2b84e472412e3e5c4d9dcabff61b7fac72f8
     with:
       pack: privileged-mcp-action-v0-clean-room.tar.gz
       entrypoint: ./target/release/my-verifier
@@ -127,8 +129,12 @@ steps:
       report: privileged-mcp-action-conformance.json
 ```
 
-The action above is pinned to the full source commit for `candidate.2`. Keep full-commit pinning when
-updating the release used by a long-lived workflow.
+The release controller runs only from `main`, validates `candidate-release.json` against the
+checked-out corpus, and creates the annotated tag after the pack, transformation check, and
+attestation succeed. Pack verification resolves that tag to the attested source commit. The
+composite action is pinned separately to the full commit carrying the action implementation; the
+`candidate.3` release-preparation change does not alter the invoked scoring path. Keep full-commit
+pinning when updating the action used by a long-lived workflow.
 
 ## Claim ceiling
 

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -20,19 +20,23 @@ Vectors for the [Privileged MCP Action Evidence Profile v0](../../docs/profiles/
 
 The corpus digest stays a **candidate** until a non-author implementation reproduces the expected
 outcomes from the specification text alone. The open invitation is
-[#1840](https://github.com/Rul1an/assay/issues/1840), which names the exact commit the current
-digest describes.
+[#1840](https://github.com/Rul1an/assay/issues/1840), which names the exact released snapshot
+available to an external implementer. When the corpus advances,
+[`candidate-release.json`](candidate-release.json) binds the next release before that issue is
+repinned to verified release bytes.
 
 ### Clean-room path
 
-The release
-[`privileged-mcp-action-v0-candidate.2`](https://github.com/Rul1an/assay/releases/tag/privileged-mcp-action-v0-candidate.2)
-contains a deterministic, attested clean-room pack. It carries `spec.md`, `descriptor.json`, and
-fourteen opaque cases. It omits expected outcomes, semantic case names, the vector generator, and
-Assay's implementation.
+The active release target is `privileged-mcp-action-v0-candidate.3`. Once its GitHub
+[Releases](https://github.com/Rul1an/assay/releases) entry is published, it contains a
+deterministic, attested clean-room pack with `spec.md`, `descriptor.json`, and fourteen opaque
+cases. It omits expected outcomes, semantic case names, the vector generator, and Assay's
+implementation. `candidate.2` remains unchanged historical input for the superseded 13-case
+digest; do not use it for a new attempt against the current corpus.
 
 ```bash
-tag=privileged-mcp-action-v0-candidate.2
+tag=privileged-mcp-action-v0-candidate.3
+source_digest="$(gh api "repos/Rul1an/assay/commits/$tag" --jq .sha)"
 gh release download "$tag" --repo Rul1an/assay \
   --pattern privileged-mcp-action-v0-clean-room.tar.gz \
   --pattern SHA256SUMS \
@@ -42,9 +46,14 @@ gh attestation verify privileged-mcp-action-v0-clean-room.tar.gz \
   --repo Rul1an/assay \
   --bundle attestation-bundle.json \
   --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml \
-  --source-digest 975ee0129a421925cad78b84ffc02144aa655679 \
-  --source-ref refs/tags/privileged-mcp-action-v0-candidate.2
+  --source-digest "$source_digest" \
+  --source-ref refs/heads/main
 ```
+
+The release controller runs only from `main`, validates
+[`candidate-release.json`](candidate-release.json) against the checked-out manifest, and creates
+the annotated tag after the pack, transformation check, and attestation succeed. Resolving the tag
+above independently confirms that the published release still names that attested source commit.
 
 Follow [`CONFORMANCE-PROTOCOL.md`](CONFORMANCE-PROTOCOL.md): implement before scoring, preserve the
 first run, disclose the materials read, and publish a machine-readable run record plus the completed

--- a/conformance/privileged-mcp-action-v0/candidate-release.json
+++ b/conformance/privileged-mcp-action-v0/candidate-release.json
@@ -1,0 +1,6 @@
+{
+  "schema": "assay.privileged_mcp_action.candidate_release.v0",
+  "tag": "privileged-mcp-action-v0-candidate.3",
+  "case_count": 14,
+  "corpus_digest": "sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342"
+}

--- a/conformance/privileged-mcp-action-v0/scripts/pack_format.py
+++ b/conformance/privileged-mcp-action-v0/scripts/pack_format.py
@@ -178,23 +178,42 @@ def rewrite_bundle_stream_identity(bundle: bytes, opaque_run_id: str) -> bytes:
 
 def clean_room_spec(spec: bytes) -> bytes:
     text = spec.decode("utf-8")
+    metadata_start = "- Conformance corpus:"
+    normative_start = "The key words MUST, MUST NOT, SHOULD, and MAY"
     start_heading = "## 8. Conformance corpus"
     end_heading = "## 9. Versioning and maturity"
+    changelog_heading = "## Changelog"
+    metadata = text.find(metadata_start)
+    normative = text.find(normative_start)
     start = text.find(start_heading)
     end = text.find(end_heading)
-    if start < 0 or end < 0 or end <= start:
+    changelog = text.find(changelog_heading)
+    if (
+        metadata < 0
+        or normative < 0
+        or normative <= metadata
+        or start < 0
+        or end < 0
+        or end <= start
+        or changelog < 0
+        or changelog <= end
+    ):
         raise ValueError(
-            "canonical spec must contain ordered sections "
-            f"{start_heading!r} and {end_heading!r}"
+            "canonical spec must contain the ordered metadata and section anchors"
         )
+    text = text[:metadata] + text[normative:]
+    start = text.find(start_heading)
+    end = text.find(end_heading)
+    changelog = text.find(changelog_heading)
     replacement = """\
 ## 8. Clean-room rendering note
 
-The canonical document's informative conformance-corpus section is omitted from this pack because it
-names answer-bearing corpus surfaces. Sections 1 through 7 and 9 onward are unchanged.
+The canonical document's corpus pointers, informative conformance-corpus section, and changelog are
+omitted from this pack because they name answer-bearing corpus surfaces. Normative Sections 1 through
+7, 9, and 10 are unchanged.
 
 """
-    return (text[:start] + replacement + text[end:]).encode()
+    return (text[:start] + replacement + text[end:changelog]).encode()
 
 
 def clean_room_descriptor(descriptor: bytes) -> bytes:

--- a/conformance/privileged-mcp-action-v0/scripts/validate_candidate_release.py
+++ b/conformance/privileged-mcp-action-v0/scripts/validate_candidate_release.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate that a clean-room candidate release names the current corpus."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+
+
+SCHEMA = "assay.privileged_mcp_action.candidate_release.v0"
+TAG = re.compile(r"^privileged-mcp-action-v0-candidate\.[1-9][0-9]*$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def manifest_corpus_digest(manifest: object) -> str:
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("vectors"), list):
+        raise ValueError("manifest must contain a vectors list")
+    digests = []
+    for vector in manifest["vectors"]:
+        if (
+            not isinstance(vector, dict)
+            or not isinstance(vector.get("sha256"), str)
+            or not DIGEST.fullmatch(vector["sha256"])
+        ):
+            raise ValueError("manifest vector must contain a sha256 digest")
+        digests.append(vector["sha256"] + "\n")
+    return "sha256:" + hashlib.sha256("".join(digests).encode()).hexdigest()
+
+
+def validate(candidate_path: Path, manifest_path: Path) -> dict[str, object]:
+    candidate = json.loads(candidate_path.read_text())
+    manifest = json.loads(manifest_path.read_text())
+    if not isinstance(candidate, dict) or set(candidate) != {
+        "schema",
+        "tag",
+        "case_count",
+        "corpus_digest",
+    }:
+        raise ValueError("candidate release must contain exactly the registered fields")
+    if candidate["schema"] != SCHEMA:
+        raise ValueError("unexpected candidate release schema")
+    if not isinstance(candidate["tag"], str) or not TAG.fullmatch(candidate["tag"]):
+        raise ValueError("invalid candidate release tag")
+    computed_digest = manifest_corpus_digest(manifest)
+    if manifest.get("corpus_digest") != computed_digest:
+        raise ValueError("manifest corpus digest does not match ordered vector digests")
+    if (
+        not isinstance(candidate["case_count"], int)
+        or isinstance(candidate["case_count"], bool)
+        or candidate["case_count"] != len(manifest["vectors"])
+    ):
+        raise ValueError("candidate case count does not match manifest")
+    if (
+        not isinstance(candidate["corpus_digest"], str)
+        or not DIGEST.fullmatch(candidate["corpus_digest"])
+        or candidate["corpus_digest"] != manifest["corpus_digest"]
+    ):
+        raise ValueError("candidate corpus digest does not match manifest")
+    return candidate
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        candidate = validate(args.candidate, args.manifest)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"candidate release validation failed: {error}", file=sys.stderr)
+        return 2
+    if args.github_output is not None:
+        with args.github_output.open("a") as output:
+            print(f"tag={candidate['tag']}", file=output)
+            print(f"case-count={candidate['case_count']}", file=output)
+            print(f"corpus-digest={candidate['corpus_digest']}", file=output)
+    print("candidate-release=valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -24,6 +24,13 @@ REPO_ROOT = CORPUS_DIR.parents[1]
 BUILD_SCRIPT = CORPUS_DIR / "scripts" / "build_clean_room_pack.py"
 SCORE_SCRIPT = CORPUS_DIR / "scripts" / "score_candidate.py"
 VALIDATE_SCRIPT = CORPUS_DIR / "scripts" / "validate_run_record.py"
+VALIDATE_CANDIDATE_RELEASE = (
+    CORPUS_DIR / "scripts" / "validate_candidate_release.py"
+)
+CANDIDATE_RELEASE = CORPUS_DIR / "candidate-release.json"
+RELEASE_WORKFLOW = (
+    REPO_ROOT / ".github/workflows/privileged-mcp-action-pack-release.yml"
+)
 
 def _head_commit() -> str:
     """Resolve HEAD, the way the conformance and pack-release workflows already do.
@@ -161,6 +168,18 @@ class CleanRoomPackTests(unittest.TestCase):
             self.assertNotIn("description", json.dumps(cases))
 
             manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+            packed_spec = files["privileged-mcp-action-v0/spec.md"].decode()
+            for forbidden in (
+                "## Changelog",
+                "MANIFEST.json",
+                "gen_vectors.py",
+                "#1840",
+                "13-vector",
+                "14 vectors",
+            ):
+                self.assertNotIn(forbidden, packed_spec)
+            for vector in manifest["vectors"]:
+                self.assertNotIn(vector["id"], packed_spec)
             source_hashes = {vector["sha256"] for vector in manifest["vectors"]}
             packed_hashes = {
                 sha256(files[f"privileged-mcp-action-v0/{case['file']}"])
@@ -194,6 +213,86 @@ class CleanRoomPackTests(unittest.TestCase):
                 b"bad-108",
             ):
                 self.assertNotIn(forbidden, public_inputs)
+
+    def test_candidate_release_is_bound_to_the_current_corpus(self) -> None:
+        candidate = json.loads(CANDIDATE_RELEASE.read_text())
+        manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+        readme = (CORPUS_DIR / "README.md").read_text()
+        protocol = (CORPUS_DIR / "CONFORMANCE-PROTOCOL.md").read_text()
+        workflow = RELEASE_WORKFLOW.read_text()
+
+        self.assertEqual(
+            candidate["schema"],
+            "assay.privileged_mcp_action.candidate_release.v0",
+        )
+        self.assertRegex(
+            candidate["tag"],
+            r"^privileged-mcp-action-v0-candidate\.[1-9][0-9]*$",
+        )
+        self.assertEqual(candidate["case_count"], len(manifest["vectors"]))
+        self.assertEqual(candidate["corpus_digest"], manifest["corpus_digest"])
+        self.assertIn(candidate["tag"], readme)
+        self.assertIn(candidate["tag"], protocol)
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn('tags:\n      - "privileged-mcp-action-v0-candidate.*"', workflow)
+        self.assertIn("ref: ${{ github.sha }}", workflow)
+        self.assertNotIn("ref: main", workflow)
+        self.assertIn(
+            "conformance/privileged-mcp-action-v0/candidate-release.json",
+            workflow,
+        )
+        self.assertIn("--source-ref refs/heads/main", readme)
+        self.assertIn("--source-ref refs/heads/main", protocol)
+
+    def test_candidate_release_validator_rejects_stale_corpus_bindings(self) -> None:
+        candidate = json.loads(CANDIDATE_RELEASE.read_text())
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "candidate-release.json"
+            for key, stale_value in (
+                ("case_count", candidate["case_count"] - 1),
+                ("corpus_digest", "sha256:" + "0" * 64),
+            ):
+                stale = dict(candidate)
+                stale[key] = stale_value
+                path.write_text(json.dumps(stale))
+                result = run(
+                    str(VALIDATE_CANDIDATE_RELEASE),
+                    "--candidate",
+                    str(path),
+                    "--manifest",
+                    str(CORPUS_DIR / "MANIFEST.json"),
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(
+                    f"candidate {'case count' if key == 'case_count' else 'corpus digest'} "
+                    "does not match manifest",
+                    result.stderr,
+                )
+
+    def test_candidate_release_validator_recomputes_manifest_digest(self) -> None:
+        manifest = json.loads((CORPUS_DIR / "MANIFEST.json").read_text())
+        manifest["vectors"][0]["sha256"] = "sha256:" + "0" * 64
+        with tempfile.TemporaryDirectory() as tmp:
+            candidate_path = Path(tmp) / "candidate-release.json"
+            manifest_path = Path(tmp) / "MANIFEST.json"
+            candidate_path.write_text(CANDIDATE_RELEASE.read_text())
+            manifest_path.write_text(json.dumps(manifest))
+            result = run(
+                str(VALIDATE_CANDIDATE_RELEASE),
+                "--candidate",
+                str(candidate_path),
+                "--manifest",
+                str(manifest_path),
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn(
+            "manifest corpus digest does not match ordered vector digests",
+            result.stderr,
+        )
 
     def test_archive_metadata_is_normalized(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- bind `privileged-mcp-action-v0-candidate.3` to the current 14-case manifest through a checked-in, validated candidate record
- replace tag-triggered publication with a singleton, main-dispatched release controller that builds, tests, transformation-checks, attests, and only then creates the annotated tag and prerelease
- pin checkout to the dispatch SHA so a partial publication remains retryable after `main` advances
- resolve release provenance through the tag's peeled source commit while keeping the conformance action pinned independently to the unchanged invoked scoring path
- remove corpus pointers and the non-normative changelog from `spec.md` in the clean-room pack so vector identities cannot become authorship inputs

This addresses JM-Lab's observation that #1840 points prospective reproducer authors at a superseded 13-case candidate. `candidate.2` remains unchanged historical input; this PR prepares but does not publish `candidate.3`.

## Verification on `a9c15771014242d559d24a99108cf06941ee0fba`

- `python3 -m unittest conformance/privileged-mcp-action-v0/tests/test_activation_kit.py` (24 passed)
- `cargo test -p assay-cli --test conformance_privileged_mcp_action` (2 passed)
- two exact-head clean-room builds are byte-identical (`sha256:252951ffd3080b559cc6d7a2144835b5ce693a5dc405ef8c61b236eb8dd4a9c0`)
- rendered pack contains 14 opaque cases, declares corpus digest `sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342`, and contains no changelog, vector names, generator, manifest, or issue pointer
- candidate validator recomputes the aggregate digest from ordered vector digests and rejects stale count, candidate digest, or manifest aggregate before any release mutation
- `python3 scripts/ci/check-public-artifact-sanitization.py --self-test`
- `python3 scripts/ci/check-public-artifact-sanitization.py`
- `actionlint .github/workflows/privileged-mcp-action-pack-release.yml`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push hooks including actionlint, workspace clippy with denied warnings, and the Linux compile gate

## Release sequence

After merge, dispatch the controller from `main`. It creates the annotated tag only after all local release checks and the attestation complete, then publishes the pack, `SHA256SUMS`, and the attestation bundle. The resulting release and downloaded assets still require post-publication verification before #1840 is repinned.

Repository-level immutable releases are currently disabled, so this PR deliberately does not claim that GitHub enforces asset or tag immutability. Enabling that policy requires a separate draft-first migration of every release workflow, including the software release line.

## Non-claims

This does not satisfy Gate 2, establish implementation independence, change profile semantics, change corpus bytes, or claim that `candidate.3` is already released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added candidate-release metadata validation for tags, case counts, and corpus digests.
  * Improved release publishing with immutable source verification and safer tag handling.
  * Updated clean-room pack generation to validate required specification anchors and exclusions.

* **Documentation**
  * Updated conformance instructions for candidate release 3, including attestation and source verification details.

* **Tests**
  * Added coverage for candidate-release integrity, stale metadata, digest mismatches, and deterministic pack contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->