### PR TITLE
ci(rustdoc): gate on cargo doc with warnings denied, and clear the nine that had accumulated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,52 @@ jobs:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
+  rustdoc:
+    name: Rustdoc (deny warnings)
+    needs: [scope]
+    if: needs.scope.outputs.lightweight_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Install Linux deps (for build scripts)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev || {
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y \
+              -o Acquire::Retries=10 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 \
+              -o Acquire::CompressionTypes::Order::=gz \
+              -o Acquire::ForceIPv4=true \
+              -o Acquire::Languages=none
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
+          }
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Clippy above never sees rustdoc's lints: broken intra-doc links, unclosed HTML tags in doc
+      # comments and bare URLs are diagnosed by rustdoc alone, and they are warn-by-default, so
+      # nothing failed while a crate's documentation quietly stopped building. `assay-evidence`
+      # carried a `redundant explicit link target` that survived exactly this way.
+      #
+      # Deliberately default features, not `--all-features`: this mirrors the doc surface a
+      # consumer gets, and it keeps the lane from depending on optional features whose deps
+      # (tui, ebpf, test-outbound) are not what this job exists to check. A doc link that only
+      # resolves under a feature therefore must not be written as a link — see
+      # `crates/assay-mcp-server/src/auth/sensitive_headers.rs`.
+      #
+      # `--no-deps` keeps the failure surface to this workspace; a warning in a third-party crate
+      # is not ours to fix and must not be able to redden this gate.
+      - run: cargo doc --workspace --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+
   public-msrv:
     name: Public crates MSRV
     needs: [scope]
@@ -774,7 +820,7 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     if: always()
-    needs: [scope, deps-security, clippy, public-msrv, distribution-boundary, vendored-packs, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
+    needs: [scope, deps-security, clippy, rustdoc, public-msrv, distribution-boundary, vendored-packs, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
     steps:
       - name: Evaluate required job results
         env:
@@ -782,6 +828,7 @@ jobs:
           LIGHTWEIGHT_ONLY: ${{ needs.scope.outputs.lightweight_only }}
           DEPS_SECURITY_RESULT: ${{ needs.deps-security.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
+          RUSTDOC_RESULT: ${{ needs.rustdoc.result }}
           PUBLIC_MSRV_RESULT: ${{ needs.public-msrv.result }}
           DISTRIBUTION_BOUNDARY_RESULT: ${{ needs.distribution-boundary.result }}
           VENDORED_PACKS_RESULT: ${{ needs.vendored-packs.result }}
@@ -836,6 +883,7 @@ jobs:
             "scope|${SCOPE_RESULT}|required" \
             "deps-security|${DEPS_SECURITY_RESULT}|${code_gated_expectation}" \
             "clippy|${CLIPPY_RESULT}|${code_gated_expectation}" \
+            "rustdoc|${RUSTDOC_RESULT}|${code_gated_expectation}" \
             "public-msrv|${PUBLIC_MSRV_RESULT}|${code_gated_expectation}" \
             "distribution-boundary|${DISTRIBUTION_BOUNDARY_RESULT}|required" \
             "vendored-packs|${VENDORED_PACKS_RESULT}|required" \

--- a/crates/assay-cli/src/cli/args/trust_basis.rs
+++ b/crates/assay-cli/src/cli/args/trust_basis.rs
@@ -62,7 +62,7 @@ pub struct TrustBasisAssertArgs {
     #[arg(long, short = 'i', value_name = "TRUST_BASIS")]
     pub input: PathBuf,
 
-    /// Required claim level, formatted as <claim-id>=<level>
+    /// Required claim level, formatted as `<claim-id>=<level>`
     #[arg(long = "require", value_name = "CLAIM=LEVEL", required = true)]
     pub requirements: Vec<String>,
 

--- a/crates/assay-cli/src/cli/commands/profile_types.rs
+++ b/crates/assay-cli/src/cli/commands/profile_types.rs
@@ -175,7 +175,7 @@ pub fn stability_smoothed(runs_seen: u32, total_runs: u32, alpha: f64) -> f64 {
 /// z=1.96 gives ~95% confidence; z=1.645 gives ~90%.
 ///
 /// Formula: (p + z²/2n - z√(p(1-p)/n + z²/4n²)) / (1 + z²/n)
-/// Reference: https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval
+/// Reference: <https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval>
 pub fn stability_wilson_lower(runs_seen: u32, total_runs: u32, z: f64) -> f64 {
     if total_runs == 0 {
         return 0.0;

--- a/crates/assay-cli/src/profile/events.rs
+++ b/crates/assay-cli/src/profile/events.rs
@@ -13,7 +13,7 @@ pub enum ProfileEvent {
         scrubbed: bool,
     },
 
-    /// Command execution observed (argv[0])
+    /// Command execution observed (`argv[0]`)
     ExecObserved { argv0: String },
 
     /// Filesystem operation observed

--- a/crates/assay-cli/src/templates.rs
+++ b/crates/assay-cli/src/templates.rs
@@ -60,7 +60,7 @@ pub const HELLO_TRACES_JSONL: &str = r#"{"schema_version": 1, "type": "assay.tra
 /// This template uses `assay-action` to install the CLI, then runs `assay ci`
 /// directly for the eval-based gate, and finally uploads SARIF results to GitHub Code Scanning.
 /// Canonical marketplace slug: `Rul1an/assay-action@v2`.
-/// See: https://github.com/Rul1an/assay-action
+/// See: <https://github.com/Rul1an/assay-action>
 pub const CI_WORKFLOW_YML: &str = r#"name: Assay Gate
 on:
   push:

--- a/crates/assay-core/src/mcp/trust_policy.rs
+++ b/crates/assay-core/src/mcp/trust_policy.rs
@@ -30,7 +30,7 @@ pub struct TrustPolicy {
 /// A trusted key with metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrustedKey {
-    /// SHA-256 of SPKI bytes: sha256:<hex>
+    /// SHA-256 of SPKI bytes: `sha256:<hex>`
     pub key_id: String,
 
     /// Path to public key file (SPKI PEM).

--- a/crates/assay-core/src/report/summary/types.rs
+++ b/crates/assay-core/src/report/summary/types.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Serde helpers: serialize Option<u64> as JSON string or null to avoid precision loss (u64 > 2^53 in JS).
+/// Serde helpers: serialize `Option<u64>` as JSON string or null to avoid precision loss (u64 > 2^53 in JS).
 mod serde_seed {
     use serde::{Deserialize, Deserializer, Serializer};
 

--- a/crates/assay-core/src/runtime/authorizer.rs
+++ b/crates/assay-core/src/runtime/authorizer.rs
@@ -188,7 +188,7 @@ impl Authorizer {
         authorizer_internal::run::authorize_and_consume_impl(self, mandate, tool_call)
     }
 
-    /// Like [`authorize_and_consume`] but with an explicit `now` timestamp.
+    /// Like [`Self::authorize_and_consume`] but with an explicit `now` timestamp.
     /// Use this in tests to avoid flaky clock-dependent assertions.
     pub fn authorize_at(
         &self,

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -1,4 +1,4 @@
-//! Trust Card (T1b): deterministic render layer over [`TrustBasis`](crate::TrustBasis).
+//! Trust Card (T1b): deterministic render layer over [`TrustBasis`].
 //!
 //! Semantics come only from `generate_trust_basis`; this module maps and serializes.
 

--- a/crates/assay-mcp-server/src/auth/sensitive_headers.rs
+++ b/crates/assay-mcp-server/src/auth/sensitive_headers.rs
@@ -7,7 +7,8 @@
 //! **PR packet (review/sign-off):**
 //! 1. **Header set (denylist):** [SENSITIVE_HEADER_NAMES] — comparison is case-insensitive.
 //! 2. **Outbound callsites:** (a) JWKS in [crate::auth::jwks] — no request-derived headers.
-//!    (b) Test-only outbound in [crate::tools::test_outbound] — uses [build_downstream_headers] only.
+//!    (b) Test-only outbound in `crate::tools::test_outbound` (behind feature `test-outbound`, so
+//!    it is not linkable from a default doc build) — uses [build_downstream_headers] only.
 //! 3. **E2E proof:** `tests/no_passthrough_e2e.rs` — inbound auth in initialize, then outbound call;
 //!    assert mock received no sensitive header names (audit-grade failure message on leak).
 

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -60,18 +60,25 @@ grep -q "MCP_REGISTRY_TOUCHED" <<<"$GATE" \
   || fail "the gate does not read mcp_registry_touched; three scope outputs decide whether a job should run"
 grep -q "PUBLIC_MSRV_RESULT" <<<"$GATE" \
   || fail "the gate does not inspect the public-msrv result"
-if sed -n '/^run_gate()/,/^}/p' "$0" | grep -q 'PUBLIC_MSRV_RESULT=success'; then
-  fail "run_gate must not inject a successful MSRV result into every scenario"
+grep -q "RUSTDOC_RESULT" <<<"$GATE" \
+  || fail "the gate does not inspect the rustdoc result"
+if sed -n '/^run_gate()/,/^}/p' "$0" | grep -qE '(PUBLIC_MSRV|RUSTDOC)_RESULT=success'; then
+  fail "run_gate must not inject a successful MSRV or rustdoc result into every scenario"
 fi
-python3 - "$WORKFLOW" <<'PY' || fail "the required CI rollup does not need public-msrv"
+python3 - "$WORKFLOW" <<'PY' || fail "the required CI rollup does not need every lane listed in REQUIRED"
 import sys
+
+# A lane wired only into `needs:` still gates; a lane wired only into the triples does not exist to
+# the rollup at all. Both halves are checked: this one asserts the `needs:` membership, and the
+# `*_RESULT` greps above assert the gate actually reads the result.
+REQUIRED = ("public-msrv", "rustdoc")
 
 lines = open(sys.argv[1]).read().splitlines()
 for index, line in enumerate(lines):
     if line == "  ci:":
         for candidate in lines[index + 1 : index + 10]:
             if candidate.strip().startswith("needs:"):
-                if "public-msrv" not in candidate:
+                if any(name not in candidate for name in REQUIRED):
                     sys.exit(1)
                 sys.exit(0)
         break
@@ -99,7 +106,7 @@ ok="success"
 
 # A full run with every job green.
 run_gate pass "everything green" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -108,7 +115,7 @@ echo "ok: a complete green run passes"
 
 # A docs-only run: the four code-gated jobs are legitimately scoped out.
 run_gate pass "lightweight scoped out" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped RUSTDOC_RESULT=skipped \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
   PUBLIC_MSRV_RESULT=skipped \
@@ -117,9 +124,9 @@ echo "ok: a documentation-only run passes with its jobs scoped out"
 
 # The defect: a code-bearing run where a job that should have executed did not. Before this change
 # every one of these was green.
-for job in DEPS_SECURITY CLIPPY PUBLIC_MSRV PERF TEST; do
+for job in DEPS_SECURITY CLIPPY RUSTDOC PUBLIC_MSRV PERF TEST; do
   out="$(run_gate fail "silently skipped $job" \
-    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
     PUBLIC_MSRV_RESULT=$ok \
     DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
     MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -132,7 +139,7 @@ echo "ok: a code-gated job that silently did not run fails the gate, and is name
 
 # The eBPF case the audit called sharpest: the `== 'true'` form disarms on a typo.
 out="$(run_gate fail "ebpf required but skipped" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -143,7 +150,7 @@ echo "ok: ebpf-smoke-ubuntu skipped while required fails the gate"
 
 # The output the gate did not read at all until now.
 out="$(run_gate fail "registry touched but skipped" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -155,7 +162,7 @@ echo "ok: mcp-registry-foundation skipped while touched fails the gate"
 # Unconditional jobs may never be skipped, whatever the scope says.
 for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS; do
   out="$(run_gate fail "unconditional $job skipped" \
-    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped RUSTDOC_RESULT=skipped \
     PUBLIC_MSRV_RESULT=skipped \
     DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
     MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
@@ -168,13 +175,13 @@ echo "ok: a job with no condition may not be skipped even on a docs-only run"
 
 # Failure still fails, and scope failing takes the basis for every other judgement with it.
 run_gate fail "a job failed" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=failure \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=failure RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
   EBPF_SMOKE_REQUIRED=false EBPF_SMOKE_UBUNTU_RESULT=skipped MCP_REGISTRY_TOUCHED=false >/dev/null
 run_gate fail "scope itself skipped" \
-  SCOPE_RESULT=skipped LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  SCOPE_RESULT=skipped LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped RUSTDOC_RESULT=skipped \
   PUBLIC_MSRV_RESULT=skipped \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
@@ -183,7 +190,7 @@ echo "ok: an outright failure fails, and a skipped scope fails"
 
 for result in failure ""; do
   out="$(run_gate fail "public-msrv result ${result:-empty}" \
-    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+    SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
     PUBLIC_MSRV_RESULT="$result" \
     DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
     MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -196,7 +203,7 @@ echo "ok: a failed or missing public-msrv result fails closed and names the job"
 # An empty scope output is the typo signature: `'' == 'true'` is false, so the job silently never
 # runs. Treating empty as "not required" would reproduce the defect through the fix.
 out="$(run_gate fail "empty lightweight_only with skipped code jobs" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY= DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped RUSTDOC_RESULT=skipped \
   PUBLIC_MSRV_RESULT=skipped \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=skipped TEST_RESULT=skipped \
@@ -210,7 +217,7 @@ echo "ok: an empty lightweight_only is treated as the strict case, not the permi
 # gate only got `lightweight_only` right and left both of these failing open, which is the defect
 # it was written to close, surviving in the fix.
 out="$(run_gate fail "empty ebpf_smoke_required with the job skipped" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -219,7 +226,7 @@ grep -q "ebpf-smoke-ubuntu was skipped" <<<"$out" \
   || fail "an empty ebpf_smoke_required must be strict, got: $out"
 
 out="$(run_gate fail "empty mcp_registry_touched with the job skipped" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -230,7 +237,7 @@ grep -q "mcp-registry-foundation was skipped" <<<"$out" \
 # A wrong-case value is the same class as empty: GitHub compares these outputs as strings, so
 # `TRUE` is not `true` and the job silently never runs.
 out="$(run_gate fail "wrong-case ebpf_smoke_required" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=$ok PERF_RESULT=$ok TEST_RESULT=$ok \
@@ -241,7 +248,7 @@ echo "ok: empty or wrong-case == 'true' outputs are strict, so a disarmed job ca
 
 # And the legitimate relaxations still work: an explicit false scopes the job out.
 run_gate pass "explicit false relaxes both" \
-  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok \
+  SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=false DEPS_SECURITY_RESULT=$ok CLIPPY_RESULT=$ok RUSTDOC_RESULT=$ok \
   PUBLIC_MSRV_RESULT=$ok \
   DISTRIBUTION_BOUNDARY_RESULT=$ok VENDORED_PACKS_RESULT=$ok \
   MCP_REGISTRY_FOUNDATION_RESULT=skipped PERF_RESULT=$ok TEST_RESULT=$ok \


### PR DESCRIPTION
## Why

`cargo doc -p assay-evidence --no-deps` emitted a `redundant explicit link target` on `crates/assay-evidence/src/trust_card.rs:1`, and under `RUSTDOCFLAGS="-D warnings"` that stopped the crate documenting at all. It was present on `main` and deliberately kept out of #1915, whose head was being held stable for review.

The warning survived because nothing in CI ran `cargo doc` with warnings denied. Clippy never sees rustdoc's lints: broken intra-doc links, unclosed HTML tags in doc comments and bare URLs are diagnosed by rustdoc alone and are all warn-by-default. So a crate's documentation could break with no check noticing.

A lane is only worth adding if it lands green, so a warn-level workspace pass came first. It found **nine** warnings across three crates, all invisible for exactly that reason.

## Commits

| | |
|---|---|
| `c3d77ac5` | `docs(evidence)` — the `trust_card.rs` fix on its own, so it can be read against #1915 in isolation |
| `cfba6dec` | `ci(rustdoc)` — the lane, the eight other fixes, and the gate-contract update |

## The two that carried real information

Most were `<hex>`, `<u64>`, `<claim-id>=<level>` and `argv[0]` being read as HTML tags and reference links by rustdoc's Markdown renderer, plus two bare URLs. Two were not cosmetic:

- **`authorize_and_consume`** (`crates/assay-core/src/runtime/authorizer.rs:191`) had been a dead link since it was written. Intra-doc links in a method's docs resolve in *module* scope, not `impl` scope, so the bare name never resolved to the sibling inherent method. Now `Self::`-qualified and live.
- **`crate::tools::test_outbound`** (`crates/assay-mcp-server/src/auth/sensitive_headers.rs:10`) points at a `#[cfg(feature = "test-outbound")]` module, so it can never resolve in a default doc build. That block is the security-invariant PR packet listing the outbound callsites a reviewer is meant to check, and one of its two references did not navigate anywhere. Written as code text with the gate stated, rather than a link that only works under a feature.

`--require`'s text in `crates/assay-cli/src/cli/args/trust_basis.rs` is also clap `--help` output. Backticking it matches the convention the line directly above it already uses; rendered help was checked.

## The lane

Mirrors `clippy`, and is wired into the aggregate `ci` gate with its own result variable and expectation triple — so it blocks without a branch-protection change.

- **Default features, not `--all-features`.** That is the doc surface a consumer actually gets, and it keeps the lane off optional deps (tui, ebpf, test-outbound) it has no business building. A link that only resolves under a feature therefore must not be written as a link — hence the `test_outbound` fix above.
- **`--no-deps`** keeps a third-party crate's warning from being able to redden this gate.

## The gate contract caught the wiring twice

`scripts/ci/test-ci-gate-expectations.sh` extracts the gate's `run:` body out of `ci.yml` and executes it verbatim, so the thing under test is the thing that ships. It failed immediately on an unbound `RUSTDOC_RESULT` under `set -u`.

Adding the fixture alone would have left the new lane less protected than every other code-gated job, so `rustdoc` also joins the silently-skipped loop. Mutation-checked: with the `rustdoc` triple removed from the gate, the contract fails with `silently skipped RUSTDOC: expected the gate to fail, it passed`. The case is load-bearing, not decorative.

## Verification

All on the final tree, cold `target/`:

| Check | Result |
|---|---|
| `RUSTDOCFLAGS="-D warnings" cargo doc -p assay-evidence --no-deps` | exit 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, zero warnings |
| `cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it` | exit 0 — 2786 passed, 0 failed, 197 suites |
| `bash scripts/ci/test-ci-gate-expectations.sh` | exit 0, 11/11 |
| Pre-commit + pre-push (fmt, typos, actionlint, shellcheck, gate contract, linux compile gate) | passed |

## Not fixed here

`cargo doc --workspace` still warns about an output filename collision at `target/doc/assay/index.html` between the `assay` lib in `assay-it` and the `assay` bin in `assay-cli` ([cargo#6313](https://github.com/rust-lang/cargo/issues/6313)). It is a *cargo* diagnostic, so `RUSTDOCFLAGS` cannot promote it and it will not redden this lane — but one of those two doc trees does clobber the other. Its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)