### PR TITLE
ci(rustdoc): cover registry OIDC documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,15 +257,18 @@ jobs:
       # nothing failed while a crate's documentation quietly stopped building. `assay-evidence`
       # carried a `redundant explicit link target` that survived exactly this way.
       #
-      # Deliberately default features, not `--all-features`: this mirrors the doc surface a
-      # consumer gets, and it keeps the lane from depending on optional features whose deps
-      # (tui, ebpf, test-outbound) are not what this job exists to check. A doc link that only
-      # resolves under a feature therefore must not be written as a link — see
-      # `crates/assay-mcp-server/src/auth/sensitive_headers.rs`.
+      # The workspace pass covers every default documentation surface. `--all-features` is too
+      # broad here because it also enables platform-specific, experimental, and test-only
+      # surfaces. Stable public opt-in features still need explicit coverage: assay-registry's
+      # OIDC API is absent from its default feature set, so document that supported surface in a
+      # second pass. A doc link that only resolves under a test feature must still be written as
+      # code text — see `crates/assay-mcp-server/src/auth/sensitive_headers.rs`.
       #
       # `--no-deps` keeps the failure surface to this workspace; a warning in a third-party crate
       # is not ours to fix and must not be able to redden this gate.
-      - run: cargo doc --workspace --no-deps
+      - run: |
+          cargo doc --workspace --no-deps
+          cargo doc -p assay-registry --features oidc --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/crates/assay-registry/src/auth.rs
+++ b/crates/assay-registry/src/auth.rs
@@ -123,7 +123,7 @@ impl OidcProvider {
     /// - `ACTIONS_ID_TOKEN_REQUEST_TOKEN`: Token to authenticate request
     ///
     /// Optional:
-    /// - `ASSAY_REGISTRY_URL`: Custom registry URL (default: https://registry.getassay.dev/v1)
+    /// - `ASSAY_REGISTRY_URL`: Custom registry URL (default: <https://registry.getassay.dev/v1>)
     pub fn from_github_actions() -> RegistryResult<Self> {
         auth_next::oidc::from_github_actions()
     }

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -62,6 +62,44 @@ grep -q "PUBLIC_MSRV_RESULT" <<<"$GATE" \
   || fail "the gate does not inspect the public-msrv result"
 grep -q "RUSTDOC_RESULT" <<<"$GATE" \
   || fail "the gate does not inspect the rustdoc result"
+python3 - "$WORKFLOW" <<'PY' \
+  || fail "the rustdoc lane does not actively cover assay-registry's public OIDC feature"
+import sys
+
+required = "cargo doc -p assay-registry --features oidc --no-deps"
+lines = open(sys.argv[1]).read().splitlines()
+
+
+def rustdoc_commands(source):
+    start = source.index("  rustdoc:")
+    end = next(
+        (
+            index
+            for index in range(start + 1, len(source))
+            if source[index].startswith("  ")
+            and not source[index].startswith("    ")
+            and source[index].endswith(":")
+        ),
+        len(source),
+    )
+    return {
+        line.strip()
+        for line in source[start:end]
+        if line.startswith("          ") and not line.lstrip().startswith("#")
+    }
+
+
+if required not in rustdoc_commands(lines):
+    sys.exit(1)
+
+# Pin the failure mode: a commented command is documentation, not an executed gate.
+mutated = [
+    line.replace(required, f"# {required}", 1) if line.strip() == required else line
+    for line in lines
+]
+if required in rustdoc_commands(mutated):
+    sys.exit(1)
+PY
 if sed -n '/^run_gate()/,/^}/p' "$0" | grep -qE '(PUBLIC_MSRV|RUSTDOC)_RESULT=success'; then
   fail "run_gate must not inject a successful MSRV or rustdoc result into every scenario"
 fi


### PR DESCRIPTION
## Summary

- extend the required rustdoc lane from workspace-default docs to the public `assay-registry/oidc` feature surface
- fix the bare registry URL that proves the feature-gated surface was not covered
- pin the explicit OIDC doc command in the CI gate contract test

`--workspace --all-features` is deliberately not used: it also enables platform-specific, experimental, and test-only surfaces. This PR adds the one stable public opt-in surface that the default workspace pass cannot see.

## Verification

- red on merged `main`: `RUSTDOCFLAGS="-D warnings" cargo doc -p assay-registry --features oidc --no-deps` fails at `auth.rs:126`
- green after the fix: workspace-default rustdoc and registry OIDC rustdoc
- contract mutation: removing the OIDC command makes `test-ci-gate-expectations.sh` fail with the named missing-surface diagnostic
- `cargo clippy -p assay-registry --features oidc --all-targets -- -D warnings`
- full pre-commit file set, including actionlint and the CI gate contract
- `cargo fmt --all -- --check`
- `git diff --check`

## Release impact

This closes the public-feature documentation gap found after #1923 and is a prerequisite for the planned `v3.36.0` release. It does not change runtime behavior or release artifacts.