### PR TITLE
chore(release): prepare v3.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,31 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.36.0] - 2026-07-29
+
+### Added
+- Bind new `evidence-bundle/v1` attestations to the SHA-256 digest of the exact bundle archive.
+  Signature verification now returns an explicitly artifact-unmatched state; only
+  `verify_attestation_for_bundle` can establish that the signed subject and predicate match a
+  verified bundle. The legacy v0 predicate identifier remains available for compatibility, while
+  new attestations use the separately versioned v1 contract.
+- Publish `privileged-mcp-action-v0-candidate.3`, a deterministic 14-case clean-room conformance
+  pack with checksums and GitHub artifact attestation. This improves the independent-reproduction
+  surface; it does not itself satisfy the non-author reproduction gate.
+
 ### Changed
 - Declare Rust 1.89 as the MSRV for all public crates and enforce that floor against the locked
-  workspace graph and all Linux-host targets in required CI. The policy becomes part of published
-  crate metadata with the first release after 3.35.0. Repository development remains pinned to
-  Rust 1.96, and the eBPF nightly remains a separate internal build toolchain.
+  workspace graph and all Linux-host targets in required CI. Repository development remains pinned
+  to Rust 1.96, and the eBPF nightly remains a separate internal build toolchain.
 - The stdio MCP server now negotiates its two tested legacy handshake revisions. Requests for
   `2024-11-05` or `2025-11-25` receive that exact revision; other string values receive the
   latest supported legacy revision, `2025-11-25`. Missing or structurally incomplete initialize
   parameters fail with JSON-RPC invalid params. This does not claim MCP `2026-07-28` support: the
   modern `server/discover` and per-request metadata contract remains separate.
+- Evidence verification no longer retains the decompressed event stream after it has been
+  validated, reducing peak memory without changing the verified result.
+
+### Fixed
 - **Fail-closed correction (bundle verification, migration-visible).** The verifier now rejects
   every bundle `BundleWriter` refuses to emit. Five shapes previously verified: an empty bundle, an
   inconsistent `source` across events, a `source` that is not a URI, and a blank line in
@@ -23,6 +38,10 @@ All notable changes to this project will be documented in this file.
   this repository is affected; all 26 in the tree were checked before the change. Third-party
   producers targeting the format should compare against `StreamRule`, now public at
   `assay_evidence::bundle::StreamRule`.
+- Refuse IPv6 CIDR policy rules before monitor attachment instead of silently applying only the
+  supported IPv4 subset.
+- Pin, audit and consume the evidence fuzz lockfile through its own CI lifecycle, and require
+  warning-free public rustdoc including the stable `assay-registry/oidc` feature surface.
 
 ## [3.35.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Bind new `evidence-bundle/v1` attestations to the SHA-256 digest of the exact bundle archive.
-  Signature verification now returns an explicitly artifact-unmatched state; only
+  The new `verify_envelope_signature` API returns an explicitly artifact-unmatched state; the
+  deprecated `verify_envelope` compatibility shim keeps its published 3.x signature. Only
   `verify_attestation_for_bundle` can establish that the signed subject and predicate match a
-  verified bundle. The legacy v0 predicate identifier remains available for compatibility, while
-  new attestations use the separately versioned v1 contract.
-- Publish `privileged-mcp-action-v0-candidate.3`, a deterministic 14-case clean-room conformance
-  pack with checksums and GitHub artifact attestation. This improves the independent-reproduction
-  surface; it does not itself satisfy the non-author reproduction gate.
+  verified bundle. Existing v0 attestations must be re-issued, and `assay evidence attest` now
+  refuses caller-supplied `--predicate` data because every v1 predicate field is derived from the
+  verified archive.
+- Separately publish `privileged-mcp-action-v0-candidate.3` as a conformance prerelease: a
+  deterministic 14-case clean-room pack with checksums and GitHub artifact attestation. This
+  improves the independent-reproduction surface; it does not itself satisfy the non-author
+  reproduction gate.
 
 ### Changed
 - Declare Rust 1.89 as the MSRV for all public crates and enforce that floor against the locked
@@ -25,8 +28,9 @@ All notable changes to this project will be documented in this file.
   latest supported legacy revision, `2025-11-25`. Missing or structurally incomplete initialize
   parameters fail with JSON-RPC invalid params. This does not claim MCP `2026-07-28` support: the
   modern `server/discover` and per-request metadata contract remains separate.
-- Evidence verification no longer retains the decompressed event stream after it has been
-  validated, reducing peak memory without changing the verified result.
+- Verify-only bundle paths no longer retain the decompressed event stream after validating it,
+  reducing peak memory without changing the verified result. Reader APIs that expose events still
+  retain that content for their callers.
 
 ### Fixed
 - **Fail-closed correction (bundle verification, migration-visible).** The verifier now rejects

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "aya",
  "chrono",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.35.0"
+version = "3.36.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -76,14 +76,14 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.35.0" }
-assay-common = { path = "crates/assay-common", version = "3.35.0", default-features = false }
+assay-core = { path = "crates/assay-core", version = "3.36.0" }
+assay-common = { path = "crates/assay-common", version = "3.36.0", default-features = false }
 assay-monitor = { path = "crates/assay-monitor", version = "3.19.1" }
 assay-metrics = { path = "crates/assay-metrics", version = "3.19.1" }
 assay-policy = { path = "crates/assay-policy", version = "3.19.1" }
 assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.19.1" }
 assay-canonical = { path = "crates/assay-canonical", version = "3.19.1" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.35.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.36.0" }
 assay-sim = { path = "crates/assay-sim", version = "3.19.1" }
 assay-registry = { path = "crates/assay-registry", version = "3.19.1" }
 assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.19.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ codegen-units = 1
 # Internal crates
 assay-core = { path = "crates/assay-core", version = "3.36.0" }
 assay-common = { path = "crates/assay-common", version = "3.36.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.19.1" }
+assay-monitor = { path = "crates/assay-monitor", version = "3.36.0" }
 assay-metrics = { path = "crates/assay-metrics", version = "3.19.1" }
 assay-policy = { path = "crates/assay-policy", version = "3.19.1" }
 assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.19.1" }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,11 +1,11 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-07-27, `v3.35.0` release line):** this line
-> adds the open `privileged-mcp-action/v0` profile, corpus, importer and verifier,
-> and accepts ADR-043 after bounded ingest, the explicit stdio-auth boundary,
-> and evidence-verifier fuzz/property coverage landed. The same line makes named
-> sandbox policy loading fail before execution when requested composition cannot
-> be enforced. Assay-Runner remains on the shared workspace version but adds no
+> **Status sync (2026-07-29, `v3.36.0` release line):** this line
+> binds new evidence attestations to exact archive bytes, separates signature
+> verification from artifact matching, aligns verifier acceptance with the
+> writer contract, negotiates the two tested legacy MCP revisions, refuses
+> unsupported IPv6 CIDR monitor policies, and publishes Rust 1.89 as the public
+> crate MSRV. Assay-Runner remains on the shared workspace version but adds no
 > new runtime or eBPF semantics beyond the cgroup attribution shipped in
 > `v3.34.0`.
 > The current execution posture remains trigger-led: keep Assay-Runner

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ Install Assay on your system.
     ```
 
     **Note:** The crate is named `assay-cli`, but the binary is `assay`.
-    The Rust 1.89 MSRV policy takes effect with the first release after 3.35.0;
+    Releases starting with 3.36.0 declare Rust 1.89 as their MSRV;
     earlier releases did not declare an MSRV. `--locked` uses the lockfile shipped
     with the release selected by Cargo. Builds from source (~2 minutes). See
     [Rust support](../reference/rust-support.md).
@@ -52,7 +52,7 @@ assay --version
 
 Expected output:
 ```
-assay 3.4.0
+assay 3.36.0
 ```
 
 ---

--- a/docs/reference/rust-support.md
+++ b/docs/reference/rust-support.md
@@ -7,8 +7,8 @@ toolchain used to develop the full workspace.
 
 The public crate set defined by `scripts/ci/check-public-crate-policy.sh` supports Rust **1.89.0**
 in the checked-in source tree. Each public package exposes `rust-version = "1.89"` through Cargo
-metadata. This becomes a published-crate guarantee with the first release after 3.35.0; published
-releases through 3.35.0 did not declare an MSRV.
+metadata. Releases starting with 3.36.0 carry that published-crate guarantee; releases through
+3.35.0 did not declare an MSRV.
 
 CI checks every public workspace package, its default feature set, and all targets available on
 the Linux CI host with Rust 1.89.0 against the workspace `Cargo.lock`. That build is the

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "hex",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "chrono",
  "libc",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "anyhow",
  "assay-canonical",


### PR DESCRIPTION
## Summary

- advance the workspace release line to `3.36.0`
- publish the artifact-bound attestation, verifier, MCP, monitor, MSRV and CI changes since `v3.35.0`
- keep Assay-Runner on the shared version without claiming new runtime or eBPF semantics
- preserve the separate `privileged-mcp-action` prerelease channel and its independent-reproduction claim ceiling

## Verification

- `RBENV_VERSION=3.3.12 EXPECTED_RELEASE=v3.36.0 CHECK_VM=1 HARNESS_DIR=/Users/roelschuurkes/Assay-Harness bash scripts/ci/check-assay-version-line.sh`
- `ASSAY_PUBLIC_MSRV=1.89.0 bash scripts/ci/check-msrv-policy.sh`
- `bash scripts/ci/check-public-crate-policy.sh`
- `RBENV_VERSION=3.3.12 bash scripts/ci/test-release-channel-separation.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `mkdocs build --strict`
- package construction passed for `assay-common`, `assay-registry` and `assay-canonical`; downstream local packaging correctly waits for unpublished `assay-common 3.36.0`, which the release publisher handles in dependency order

## Release boundary

This is a minor release. It adds public attestation state and matching APIs and makes migration-visible fail-closed corrections. It does not add MCP `2026-07-28` support, new Runner/eBPF semantics, a whole-action verdict, a scalar trust score, or completion of Gate 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence attestations now bind to the exact archive being verified.
  * Added a privileged MCP clean-room conformance pack candidate.
* **Bug Fixes**
  * Verification now clearly reports when an artifact does not match its evidence.
  * Unsupported IPv6 CIDR monitor policies are rejected before monitoring begins.
  * Improved legacy MCP handshake negotiation and invalid-parameter errors.
  * Evidence verification uses less peak memory.
* **Documentation**
  * Updated installation and Rust support guidance for version 3.36.0 and Rust 1.89.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->