### PR TITLE
fix(release): emit portable checksum sidecars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
               lightweight_only=true
             fi
 
-            if grep -E '^(crates/assay-mcp-server/|packaging/mcpb/|packaging/mcp-registry/|scripts/ci/build_mcpb_bundle\.sh$|scripts/ci/render_registry_server_json\.sh$|scripts/publish-mcpcentral\.sh$|\.github/workflows/release\.yml$)' "$changed_file" >/dev/null; then
+            if grep -E '^(crates/assay-mcp-server/|packaging/mcpb/|packaging/mcp-registry/|scripts/ci/(build_mcpb_bundle|write_sha256_sidecar)\.sh$|scripts/ci/render_registry_server_json\.sh$|scripts/publish-mcpcentral\.sh$|\.github/workflows/release\.yml$)' "$changed_file" >/dev/null; then
               mcp_registry_touched=true
             else
               mcp_registry_touched=false
@@ -378,6 +378,28 @@ jobs:
           persist-credentials: false
       - name: Check vendored pack files are in sync
         run: ./scripts/check-vendored-packs.sh
+
+  release-asset-contract:
+    name: Release asset contract (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - name: Verify portable checksum production and flat download layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/test-write-sha256-sidecar.sh
+          bash scripts/ci/test-release-assets.sh
 
   mcp-registry-foundation:
     name: MCP Registry foundation smoke
@@ -823,7 +845,7 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     if: always()
-    needs: [scope, deps-security, clippy, rustdoc, public-msrv, distribution-boundary, vendored-packs, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
+    needs: [scope, deps-security, clippy, rustdoc, public-msrv, distribution-boundary, vendored-packs, release-asset-contract, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
     steps:
       - name: Evaluate required job results
         env:
@@ -835,6 +857,7 @@ jobs:
           PUBLIC_MSRV_RESULT: ${{ needs.public-msrv.result }}
           DISTRIBUTION_BOUNDARY_RESULT: ${{ needs.distribution-boundary.result }}
           VENDORED_PACKS_RESULT: ${{ needs.vendored-packs.result }}
+          RELEASE_ASSET_CONTRACT_RESULT: ${{ needs.release-asset-contract.result }}
           MCP_REGISTRY_FOUNDATION_RESULT: ${{ needs.mcp-registry-foundation.result }}
           PERF_RESULT: ${{ needs.perf.result }}
           TEST_RESULT: ${{ needs.test.result }}
@@ -890,6 +913,7 @@ jobs:
             "public-msrv|${PUBLIC_MSRV_RESULT}|${code_gated_expectation}" \
             "distribution-boundary|${DISTRIBUTION_BOUNDARY_RESULT}|required" \
             "vendored-packs|${VENDORED_PACKS_RESULT}|required" \
+            "release-asset-contract|${RELEASE_ASSET_CONTRACT_RESULT}|required" \
             "mcp-registry-foundation|${MCP_REGISTRY_FOUNDATION_RESULT}|${registry_expectation}" \
             "perf|${PERF_RESULT}|${code_gated_expectation}" \
             "test|${TEST_RESULT}|${code_gated_expectation}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,6 @@ jobs:
           cp README.md LICENSE "dist/${ARCHIVE_NAME}/" 2>/dev/null || true
           cd dist
           tar -czvf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
-          shasum -a 256 "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
 
       - name: Package (Windows)
         if: matrix.archive == 'zip'
@@ -207,8 +206,15 @@ jobs:
           Copy-Item "target\${{ matrix.target }}\release\${{ matrix.artifact }}" "dist\${ARCHIVE_NAME}\"
           Copy-Item README.md, LICENSE "dist\${ARCHIVE_NAME}\" -ErrorAction SilentlyContinue
           Compress-Archive -Path "dist\${ARCHIVE_NAME}" -DestinationPath "dist\${ARCHIVE_NAME}.zip"
-          $hash = (Get-FileHash "dist\${ARCHIVE_NAME}.zip" -Algorithm SHA256).Hash.ToLower()
-          "${hash}  ${ARCHIVE_NAME}.zip" | Out-File -Encoding ASCII "dist\${ARCHIVE_NAME}.zip.sha256"
+
+      - name: Write archive checksum
+        shell: bash
+        env:
+          VERSION: ${{ needs.release-contract.outputs.version }}
+        run: |
+          set -euo pipefail
+          ARCHIVE_NAME="assay-${VERSION}-${{ matrix.target }}"
+          bash scripts/ci/write_sha256_sidecar.sh "dist/${ARCHIVE_NAME}.${{ matrix.archive }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -308,7 +314,7 @@ jobs:
           cp README.md LICENSE "dist/${ARCHIVE_NAME}/" 2>/dev/null || true
           cd dist
           tar -czvf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
-          shasum -a 256 "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
+          bash "${GITHUB_WORKSPACE}/scripts/ci/write_sha256_sidecar.sh" "${ARCHIVE_NAME}.tar.gz"
 
       - name: Upload assay-mcp-server artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -364,7 +370,7 @@ jobs:
           done < <(find . -name 'assay-sbom.json' -print)
 
           tar -czf "release/assay-${VERSION}-sbom-cyclonedx.tar.gz" -C release/sbom .
-          shasum -a 256 "release/assay-${VERSION}-sbom-cyclonedx.tar.gz" > "release/assay-${VERSION}-sbom-cyclonedx.tar.gz.sha256"
+          bash scripts/ci/write_sha256_sidecar.sh "release/assay-${VERSION}-sbom-cyclonedx.tar.gz"
           rm -rf release/sbom
 
       - name: Download all artifacts
@@ -493,7 +499,7 @@ jobs:
         run: |
           set -euo pipefail
           bash scripts/ci/release_attestation_enforce.sh
-          shasum -a 256 "${OUT_SUMMARY}" > "${OUT_SUMMARY}.sha256"
+          bash scripts/ci/write_sha256_sidecar.sh "${OUT_SUMMARY}"
 
       - name: Build release proof kit
         env:
@@ -507,7 +513,7 @@ jobs:
         run: |
           set -euo pipefail
           bash scripts/ci/release_proof_kit_build.sh
-          shasum -a 256 "${OUT_ARCHIVE}" > "${OUT_ARCHIVE}.sha256"
+          bash scripts/ci/write_sha256_sidecar.sh "${OUT_ARCHIVE}"
 
       - name: Check release asset preflight
         env:

--- a/scripts/ci/build_mcpb_bundle.sh
+++ b/scripts/ci/build_mcpb_bundle.sh
@@ -113,4 +113,4 @@ npx --yes "${MCPB_CLI_PACKAGE}" validate "$STAGE_DIR/manifest.json"
 
 mkdir -p "$(dirname "$OUTPUT")"
 npx --yes "${MCPB_CLI_PACKAGE}" pack "$STAGE_DIR" "$OUTPUT"
-shasum -a 256 "$OUTPUT" > "${OUTPUT}.sha256"
+bash "${SCRIPT_DIR}/write_sha256_sidecar.sh" "$OUTPUT"

--- a/scripts/ci/check-release-assets.sh
+++ b/scripts/ci/check-release-assets.sh
@@ -23,15 +23,6 @@ compute_sha256() {
   fi
 }
 
-basename_from_checksum_line() {
-  local line="$1"
-  line="${line#* }"
-  line="${line#"${line%%[![:space:]]*}"}"
-  line="${line#\\*}"
-  line="${line%$'\r'}"
-  basename "$line"
-}
-
 require_bin "$JQ_BIN"
 
 if [[ ! "$VERSION" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
@@ -104,13 +95,29 @@ for asset in "${checksum_targets[@]}"; do
     exit 1
   fi
 
-  checksum_line="$(head -n 1 "$checksum_path")"
-  expected_hash="$(awk '{print $1}' <<<"$checksum_line")"
-  checksum_target="$(basename_from_checksum_line "$checksum_line")"
+  if [[ "$(wc -l <"$checksum_path" | tr -d ' ')" != "1" ]] ||
+    [[ "$(tail -c 1 "$checksum_path" | od -An -tu1 | tr -d ' ')" != "10" ]] ||
+    LC_ALL=C grep -q $'\r' "$checksum_path"; then
+    echo "release checksum must contain exactly one LF-terminated line: $(basename "$checksum_path")" >&2
+    exit 1
+  fi
+
+  IFS= read -r checksum_line <"$checksum_path"
+  expected_hash="${checksum_line:0:64}"
+  separator="${checksum_line:64:2}"
+  checksum_target="${checksum_line:66}"
   actual_hash="$(compute_sha256 "$asset_path")"
 
   if [[ ! "$expected_hash" =~ ^[0-9a-f]{64}$ ]]; then
     echo "release checksum has invalid sha256 format: $(basename "$checksum_path")" >&2
+    exit 1
+  fi
+  if [[ "$separator" != "  " ]] ||
+    [[ -z "$checksum_target" ]] ||
+    [[ "$checksum_target" == *"/"* ]] ||
+    [[ "$checksum_target" == *"\\"* ]] ||
+    [[ "$checksum_target" =~ [[:cntrl:]] ]]; then
+    echo "release checksum must use two spaces and a basename-only target: $(basename "$checksum_path")" >&2
     exit 1
   fi
   if [[ "$checksum_target" != "$asset" ]]; then
@@ -121,6 +128,15 @@ for asset in "${checksum_targets[@]}"; do
     echo "release checksum mismatch for $asset" >&2
     exit 1
   fi
+
+  (
+    cd "$ASSETS_DIR"
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum -c "$(basename "$checksum_path")" >/dev/null
+    else
+      shasum -a 256 -c "$(basename "$checksum_path")" >/dev/null
+    fi
+  )
 done
 
 mcpb_asset="assay-mcp-server-${VERSION}-linux.mcpb"

--- a/scripts/ci/test-ci-gate-expectations.sh
+++ b/scripts/ci/test-ci-gate-expectations.sh
@@ -62,6 +62,10 @@ grep -q "PUBLIC_MSRV_RESULT" <<<"$GATE" \
   || fail "the gate does not inspect the public-msrv result"
 grep -q "RUSTDOC_RESULT" <<<"$GATE" \
   || fail "the gate does not inspect the rustdoc result"
+grep -q "RELEASE_ASSET_CONTRACT_RESULT" <<<"$GATE" \
+  || fail "the gate does not inspect the release-asset-contract result"
+grep -q "write_sha256_sidecar" "$WORKFLOW" \
+  || fail "checksum helper changes do not activate the MCP Registry foundation smoke"
 python3 - "$WORKFLOW" <<'PY' \
   || fail "the rustdoc lane does not actively cover assay-registry's public OIDC feature"
 import sys
@@ -100,6 +104,78 @@ mutated = [
 if required in rustdoc_commands(mutated):
     sys.exit(1)
 PY
+python3 - "$WORKFLOW" <<'PY' \
+  || fail "the release asset contract job does not actively run both contract tests"
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+
+
+def job_section(source, name):
+    start = source.index(f"  {name}:")
+    end = next(
+        (
+            index
+            for index in range(start + 1, len(source))
+            if source[index].startswith("  ")
+            and not source[index].startswith("    ")
+            and source[index].endswith(":")
+        ),
+        len(source),
+    )
+    return source[start:end]
+
+
+def active_commands(source):
+    return {
+        line.strip()
+        for line in job_section(source, "release-asset-contract")
+        if line.startswith("          ") and not line.lstrip().startswith("#")
+    }
+
+
+def validate_release_contract(source):
+    section = job_section(source, "release-asset-contract")
+    commands = active_commands(source)
+    if any(command not in commands for command in required):
+        raise ValueError("release asset contract command is not active")
+    for line in section:
+        key = line.strip().split(":", 1)[0]
+        if key in {"if", "continue-on-error"}:
+            raise ValueError(f"release asset contract may not use {key}")
+
+
+required = (
+    "bash scripts/ci/test-write-sha256-sidecar.sh",
+    "bash scripts/ci/test-release-assets.sh",
+)
+validate_release_contract(lines)
+
+# Pin the no-op failure mode: a commented command is documentation, not an
+# executed contract. The independent gate self-test must notice even though
+# the release-asset-contract job would still exit successfully.
+commented = [
+    line.replace(command, f"# {command}", 1) if line.strip() == command else line
+    for line in lines
+    for command in (required[0],)
+]
+mutations = [commented]
+
+# A present command can still be skipped or made non-blocking by step/job
+# controls. Both are fail-open for a required contract and must be rejected.
+step_at = lines.index(
+    "      - name: Verify portable checksum production and flat download layout"
+)
+for control in ("        if: false", "        continue-on-error: true"):
+    mutations.append(lines[: step_at + 1] + [control] + lines[step_at + 1 :])
+
+for mutated in mutations:
+    try:
+        validate_release_contract(mutated)
+    except ValueError:
+        continue
+    raise SystemExit("release asset contract bypass mutation passed")
+PY
 if sed -n '/^run_gate()/,/^}/p' "$0" | grep -qE '(PUBLIC_MSRV|RUSTDOC)_RESULT=success'; then
   fail "run_gate must not inject a successful MSRV or rustdoc result into every scenario"
 fi
@@ -109,7 +185,7 @@ import sys
 # A lane wired only into `needs:` still gates; a lane wired only into the triples does not exist to
 # the rollup at all. Both halves are checked: this one asserts the `needs:` membership, and the
 # `*_RESULT` greps above assert the gate actually reads the result.
-REQUIRED = ("public-msrv", "rustdoc")
+REQUIRED = ("public-msrv", "rustdoc", "release-asset-contract")
 
 lines = open(sys.argv[1]).read().splitlines()
 for index, line in enumerate(lines):
@@ -128,7 +204,7 @@ run_gate() {
   local expected="$1" name="$2"
   shift 2
   local out rc=0
-  out="$(env "$@" bash -c "$GATE" 2>&1)" || rc=$?
+  out="$(env RELEASE_ASSET_CONTRACT_RESULT=success "$@" bash -c "$GATE" 2>&1)" || rc=$?
   if [[ "$expected" == "pass" && $rc -ne 0 ]]; then
     echo "$out" >&2
     fail "$name: expected the gate to pass, it exited $rc"
@@ -198,7 +274,7 @@ grep -q "mcp-registry-foundation was skipped" <<<"$out" \
 echo "ok: mcp-registry-foundation skipped while touched fails the gate"
 
 # Unconditional jobs may never be skipped, whatever the scope says.
-for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS; do
+for job in DISTRIBUTION_BOUNDARY VENDORED_PACKS RELEASE_ASSET_CONTRACT; do
   out="$(run_gate fail "unconditional $job skipped" \
     SCOPE_RESULT=$ok LIGHTWEIGHT_ONLY=true DEPS_SECURITY_RESULT=skipped CLIPPY_RESULT=skipped RUSTDOC_RESULT=skipped \
     PUBLIC_MSRV_RESULT=skipped \

--- a/scripts/ci/test-release-assets.sh
+++ b/scripts/ci/test-release-assets.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 CHECK_SCRIPT="${REPO_ROOT}/scripts/ci/check-release-assets.sh"
+CHECKSUM_WRITER="${REPO_ROOT}/scripts/ci/write_sha256_sidecar.sh"
 VERSION="v9.9.9"
 SEMVER="${VERSION#v}"
 
@@ -20,7 +21,7 @@ write_asset() {
   local assets_dir="$1"
   local name="$2"
   printf 'fixture payload for %s\n' "$name" >"${assets_dir}/${name}"
-  printf '%s  %s\n' "$(compute_sha256 "${assets_dir}/${name}")" "$name" >"${assets_dir}/${name}.sha256"
+  bash "$CHECKSUM_WRITER" "${assets_dir}/${name}"
 }
 
 write_server_json() {
@@ -104,7 +105,7 @@ crlf_target="assay-${VERSION}-x86_64-pc-windows-msvc.zip"
 printf '%s  %s\r\n' \
   "$(compute_sha256 "${crlf_checksum_dir}/${crlf_target}")" \
   "$crlf_target" >"${crlf_checksum_dir}/${crlf_target}.sha256"
-expect_pass "$crlf_checksum_dir"
+expect_fail "crlf checksum" "$crlf_checksum_dir"
 
 embedded_cr_target_dir="${tmp_root}/embedded-cr-target"
 cp -R "$valid_dir" "$embedded_cr_target_dir"
@@ -113,6 +114,39 @@ printf '%s  %s\r%s\n' \
   "assay-${VERSION}-x86_64-pc-windows-msvc" \
   ".zip" >"${embedded_cr_target_dir}/${crlf_target}.sha256"
 expect_fail "embedded carriage return in checksum target" "$embedded_cr_target_dir"
+
+prefixed_target_dir="${tmp_root}/prefixed-target"
+cp -R "$valid_dir" "$prefixed_target_dir"
+printf '%s  release/%s\n' \
+  "$(compute_sha256 "${prefixed_target_dir}/${crlf_target}")" \
+  "$crlf_target" >"${prefixed_target_dir}/${crlf_target}.sha256"
+expect_fail "release-prefixed checksum target" "$prefixed_target_dir"
+
+absolute_target_dir="${tmp_root}/absolute-target"
+cp -R "$valid_dir" "$absolute_target_dir"
+printf '%s  /tmp/%s\n' \
+  "$(compute_sha256 "${absolute_target_dir}/${crlf_target}")" \
+  "$crlf_target" >"${absolute_target_dir}/${crlf_target}.sha256"
+expect_fail "absolute checksum target" "$absolute_target_dir"
+
+tab_separator_dir="${tmp_root}/tab-separator"
+cp -R "$valid_dir" "$tab_separator_dir"
+printf '%s\t%s\n' \
+  "$(compute_sha256 "${tab_separator_dir}/${crlf_target}")" \
+  "$crlf_target" >"${tab_separator_dir}/${crlf_target}.sha256"
+expect_fail "tab-separated checksum target" "$tab_separator_dir"
+
+missing_final_lf_dir="${tmp_root}/missing-final-lf"
+cp -R "$valid_dir" "$missing_final_lf_dir"
+printf '%s  %s' \
+  "$(compute_sha256 "${missing_final_lf_dir}/${crlf_target}")" \
+  "$crlf_target" >"${missing_final_lf_dir}/${crlf_target}.sha256"
+expect_fail "checksum without final lf" "$missing_final_lf_dir"
+
+extra_line_dir="${tmp_root}/extra-line"
+cp -R "$valid_dir" "$extra_line_dir"
+printf '\n' >>"${extra_line_dir}/${crlf_target}.sha256"
+expect_fail "checksum with extra line" "$extra_line_dir"
 
 missing_checksum_dir="${tmp_root}/missing-checksum"
 cp -R "$valid_dir" "$missing_checksum_dir"

--- a/scripts/ci/test-write-sha256-sidecar.sh
+++ b/scripts/ci/test-write-sha256-sidecar.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WRITER="${SCRIPT_DIR}/write_sha256_sidecar.sh"
+CI_WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
+RELEASE_WORKFLOW="${REPO_ROOT}/.github/workflows/release.yml"
+MCPB_BUILDER="${SCRIPT_DIR}/build_mcpb_bundle.sh"
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+release_dir="${tmp_root}/release"
+mkdir -p "$release_dir"
+asset="${release_dir}/assay-v9.9.9-release-proof-kit.tar.gz"
+printf 'release asset fixture\n' >"$asset"
+
+bash "$WRITER" "$asset"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  digest="$(sha256sum "$asset" | awk '{print $1}')"
+else
+  digest="$(shasum -a 256 "$asset" | awk '{print $1}')"
+fi
+
+printf '%s  %s\n' "$digest" "$(basename "$asset")" >"${tmp_root}/expected.sha256"
+cmp "${tmp_root}/expected.sha256" "${asset}.sha256"
+
+(
+  cd "$release_dir"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$(basename "${asset}.sha256")" >/dev/null
+  else
+    shasum -a 256 -c "$(basename "${asset}.sha256")" >/dev/null
+  fi
+)
+
+python3 - "$CI_WORKFLOW" "$RELEASE_WORKFLOW" "$MCPB_BUILDER" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+ci_path, release_path, mcpb_path = map(Path, sys.argv[1:])
+ci_text = ci_path.read_text()
+release_text = release_path.read_text()
+mcpb_text = mcpb_path.read_text()
+
+workflow_calls = (
+    'bash scripts/ci/write_sha256_sidecar.sh "dist/${ARCHIVE_NAME}.${{ matrix.archive }}"',
+    'bash "${GITHUB_WORKSPACE}/scripts/ci/write_sha256_sidecar.sh" "${ARCHIVE_NAME}.tar.gz"',
+    'bash scripts/ci/write_sha256_sidecar.sh "release/assay-${VERSION}-sbom-cyclonedx.tar.gz"',
+    'bash scripts/ci/write_sha256_sidecar.sh "${OUT_SUMMARY}"',
+    'bash scripts/ci/write_sha256_sidecar.sh "${OUT_ARCHIVE}"',
+)
+mcpb_call = 'bash "${SCRIPT_DIR}/write_sha256_sidecar.sh" "$OUTPUT"'
+legacy_writer = re.compile(
+    r"(shasum -a 256|sha256sum|Get-FileHash|Out-File).*[.]sha256"
+)
+
+
+def active_lines(text):
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def validate_wiring(workflow, mcpb):
+    workflow_active = active_lines(workflow)
+    mcpb_active = active_lines(mcpb)
+    for expected in workflow_calls:
+        if workflow_active.count(expected) != 1:
+            raise ValueError(f"missing or duplicate active release checksum call: {expected}")
+    if mcpb_active.count(mcpb_call) != 1:
+        raise ValueError("missing or duplicate active MCPB checksum call")
+    if any(legacy_writer.search(line) for line in workflow_active + mcpb_active):
+        raise ValueError("release checksum producer bypasses write_sha256_sidecar.sh")
+
+
+validate_wiring(release_text, mcpb_text)
+
+# Pin the original failure in the textual guard: a commented producer is not
+# an active producer even though a plain occurrence count still sees it.
+provenance_call = workflow_calls[3]
+mutated = release_text.replace(
+    f"          {provenance_call}",
+    f"          # {provenance_call}",
+    1,
+)
+try:
+    validate_wiring(mutated, mcpb_text)
+except ValueError:
+    pass
+else:
+    raise SystemExit("commented checksum producer passed the wiring contract")
+
+start = ci_text.index("  release-asset-contract:")
+remaining = ci_text[start + 1 :]
+next_job = re.search(r"^  [a-zA-Z0-9_-]+:$", remaining, re.MULTILINE)
+section = ci_text[start : start + 1 + next_job.start()] if next_job else ci_text[start:]
+matrix_contract = (
+    "name: Release asset contract (${{ matrix.os }})",
+    "runs-on: ${{ matrix.os }}",
+    "- ubuntu-latest",
+    "- windows-latest",
+)
+
+
+def validate_matrix(text):
+    active = active_lines(text)
+    for required in matrix_contract:
+        if active.count(required) != 1:
+            raise ValueError(f"release asset contract matrix is missing: {required}")
+    if any(line.split(":", 1)[0] == "exclude" for line in active):
+        raise ValueError("release asset contract matrix may not exclude an OS")
+
+
+validate_matrix(section)
+matrix_mutations = [
+    section.replace("          - windows-latest", "          # - windows-latest", 1),
+    section.replace(
+        "          - windows-latest",
+        "          - windows-latest\n        exclude:\n          - os: windows-latest",
+        1,
+    ),
+]
+for mutated in matrix_mutations:
+    try:
+        validate_matrix(mutated)
+    except ValueError:
+        continue
+    raise SystemExit("release asset contract matrix bypass mutation passed")
+PY
+
+echo "sha256 sidecar writer tests passed"

--- a/scripts/ci/write_sha256_sidecar.sh
+++ b/scripts/ci/write_sha256_sidecar.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: write_sha256_sidecar.sh <asset-path>" >&2
+  exit 2
+fi
+
+asset_path="$1"
+if [[ ! -f "$asset_path" ]]; then
+  echo "checksum asset is not a regular file: $asset_path" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  digest="$(sha256sum "$asset_path" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  digest="$(shasum -a 256 "$asset_path" | awk '{print $1}')"
+else
+  echo "sha256sum or shasum is required" >&2
+  exit 1
+fi
+
+asset_name="${asset_path##*/}"
+printf '%s  %s\n' "$digest" "$asset_name" >"${asset_path}.sha256"


### PR DESCRIPTION
## Summary

- generate all eleven release checksum sidecars through one LF-only, basename-only helper
- reject CRLF, path-prefixed, absolute, malformed, and multi-line sidecars before publication
- verify the actual flat download layout with the platform-native checksum verifier
- run the release asset contract on Ubuntu and Windows as part of required PR CI
- keep MCPB helper changes in the registry smoke scope

## Test evidence

- legacy preflight reproduced the defect: a CRLF Windows sidecar passed before the fix
- `bash scripts/ci/test-write-sha256-sidecar.sh`
- `bash scripts/ci/test-release-assets.sh`
- `bash scripts/ci/test-ci-gate-expectations.sh`
- `bash scripts/ci/mcp_registry_foundation_smoke.sh`
- ShellCheck and actionlint with the repository-documented `concurrency.queue` exception
- full pre-commit and pre-push hooks, including workspace clippy and the Linux compile gate

## Non-claims

- does not change primary binaries, platform archives, semantic provenance records, or attestation bundles
- the proof-kit archive changes because its copied provenance checksum sidecar becomes basename-only and LF-only
- does not rewrite previously published release assets

Fixes #1926