### PR TITLE
docs(readme): state the corpus the pack actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ is a composition and verification contract over evidence records that already ex
 privileged MCP tool call decided, what was observed of its effect, and what stays unproven. It adds
 no new envelope and no aggregate verdict.
 
-It ships with a [13-vector conformance corpus](conformance/privileged-mcp-action-v0)
-(5 accept, 8 reject) whose digest is a **candidate**: it is not called reproduced until a non-author
+It ships with a [14-vector conformance corpus](conformance/privileged-mcp-action-v0)
+(5 accept, 9 reject) whose digest is a **candidate**: it is not called reproduced until a non-author
 implementation derives the expected outcomes from the specification text alone.
 
 **That reproduction is open, and the invitation is real:


### PR DESCRIPTION
`README.md:170-171` said 13 vectors, 5 accept and 8 reject. `MANIFEST.json` carries
14, split 5 and 9.

This is the second time this pointer has been wrong. JM-Lab reported the stale
13-case count, the release was corrected on 2026-07-29, and the README was not
swept with it. It is the first thing a prospective reproducer reads, and it now
disagrees with the pack they are being asked to reproduce.

## Sweep

I did not assume this was the only instance. Six other mentions of thirteen
survive, and all six are correct where they stand:

| Location | Why it stays |
|---|---|
| `conformance/.../README.md:34` | describes `candidate.2` as superseded historical input |
| `docs/profiles/.../v0.md:304` | changelog entry dated 2026-07-24, describing the profile as it stood |
| `docs/profiles/.../v0.md:309` | states that a pack released against the 13-vector digest is superseded |
| `ADR-043:211` | a measurement pinned to `a867173b` and true at that commit |
| `test_activation_kit.py:177-178` | asserts the 13→14 transformation, so both strings are load-bearing |
| `score_candidate.py:49` | a comment documenting how the corpus grew to fourteen while a constant said thirteen |

Rewriting any of those would replace a historical record with a current one,
which is a different defect.

## Verification

Branched from `212bfe57`, worktree `scratchpad/readmefix`. The replacement numbers
were counted out of `MANIFEST.json` at this head rather than taken from prose:

```
MANIFEST: 14 vectors, 5 accept, 9 reject
```

`pre-commit` over `README.md` passes (merge conflicts, end-of-file, trailing
whitespace, typos, `cargo fmt --check`). Docs-only: no behaviour, no code paths,
and no change to the corpus or its digest. Staged by explicit path.