### PR TITLE
feat(mcp): observe the protocol era on import without touching the event shape

### DIFF
--- a/crates/assay-cli/tests/mcp_id_correlation_errors.rs
+++ b/crates/assay-cli/tests/mcp_id_correlation_errors.rs
@@ -59,8 +59,16 @@ fn contract_import_rejects_duplicate_tool_call_request_ids() {
         .failure();
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    // The semantic phrase only. The old message named the offending id, which is input-chosen data
+    // the parser no longer echoes, and the full diagnostic also carries a source line that moves
+    // whenever a fixture gains a line. Pinning either would make this test fail on changes that are
+    // not about the refusal.
     assert!(
-        stderr.contains("duplicate tools/call request id"),
-        "missing duplicate-id diagnostic: {stderr}"
+        stderr.contains("two outstanding JSON-RPC requests share an id"),
+        "missing outstanding-id diagnostic: {stderr}"
+    );
+    assert!(
+        !stderr.contains("dup-1"),
+        "the refusal must not echo the id: {stderr}"
     );
 }

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -151,10 +151,32 @@ pub(crate) enum CorrelationId {
 /// `None` for an absent or unusable id. `normalize_jsonrpc_id` already refuses booleans, arrays and
 /// objects at the parser boundary, so only the two valid shapes reach this.
 pub(crate) fn correlation_id(v: &serde_json::Value) -> Option<CorrelationId> {
-    match v.get("id") {
-        Some(serde_json::Value::String(s)) => Some(CorrelationId::Str(s.clone())),
-        Some(serde_json::Value::Number(n)) => Some(CorrelationId::Num(n.to_string())),
+    v.get("id").and_then(accept_id)
+}
+
+/// The one place that decides whether an id is usable, and what key it becomes.
+///
+/// MCP restricts `RequestId` to a string or an integer. A fractional number is not an id, and
+/// neither is one spelled with an exponent: `1.0` and `1e0` both parse as floats, so neither is an
+/// integer even though the second equals one. Accepting them would give two spellings of one call
+/// two different keys, or one key to two different calls, depending on which side rendered.
+///
+/// `CorrelationId::Num` therefore only ever comes from an accepted integer.
+pub(crate) fn accept_id(v: &serde_json::Value) -> Option<CorrelationId> {
+    match v {
+        serde_json::Value::String(s) => Some(CorrelationId::Str(s.clone())),
+        serde_json::Value::Number(n) if n.is_i64() || n.is_u64() => {
+            Some(CorrelationId::Num(n.to_string()))
+        }
         _ => None,
+    }
+}
+
+/// The text an accepted id renders to for the public `McpEvent::jsonrpc_id` field.
+pub(crate) fn accepted_id_text(id: &CorrelationId) -> String {
+    match id {
+        CorrelationId::Str(s) => s.clone(),
+        CorrelationId::Num(n) => n.clone(),
     }
 }
 

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -35,37 +35,64 @@ pub(crate) enum EnvelopeObservation {
     Malformed,
 }
 
-/// Which JSON-RPC message shape this is.
+/// Which JSON-RPC message shape this is, carrying the method so that nothing has to read it a
+/// second time.
 ///
 /// The distinction is load-bearing rather than tidy. `RequestParams._meta` is required and carries
 /// the protocol version; `NotificationParams._meta` is optional and is a different type that does
 /// not carry it. Treating a notification as a request therefore invents a fault: a
 /// `notifications/progress` under 2026 with no `_meta` is correct, and would be reported as missing
 /// required metadata.
+///
+/// The method travels inside the variant on purpose. Two callers each reaching for `method` with
+/// their own `as_str()` is how the discriminants drifted apart before: the parser read one thing and
+/// the era axes another, and a shape only one of them rejected fell through the gap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MessageKind {
-    Request,
-    Notification,
+pub(crate) enum MessageKind<'a> {
+    Request { method: &'a str },
+    Notification { method: &'a str },
     Response,
 }
 
-/// Classify by the two fields JSON-RPC uses. A notification is a request object *without* an `id`
-/// member, so absence is the discriminant and nothing about the value is.
+/// A message shape that cannot be classified at all.
 ///
-/// An explicit `"id": null` is therefore a request, not a notification. `RequestId` is `string |
-/// number`, so a null id is an invalid request id rather than an absent one, and treating it as a
-/// notification drops the required 2026 request metadata for any message that writes one. That is a
-/// fail-open reachable by a single token. The invalid id is a JSON-RPC validity question this slice
-/// does not own; what it owns is that the metadata requirement still applies.
-pub(crate) fn classify_message(v: &serde_json::Value) -> MessageKind {
-    match v.get("method").and_then(|m| m.as_str()) {
-        Some(_) if v.get("id").is_some() => MessageKind::Request,
-        Some(_) => MessageKind::Notification,
-        None => MessageKind::Response,
-    }
+/// Value-free: the offending value is chosen by the input, and naming its type is all a reader can
+/// act on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum MessageShapeError {
+    #[error("JSON-RPC method must be a string")]
+    NonStringMethod,
 }
 
-/// What a request carried in `params._meta`. Typed rather than `Option<String>` so that a missing
+/// Classify by the two fields JSON-RPC uses.
+///
+/// A notification is a request object *without* an `id` member, so absence is the discriminant and
+/// nothing about the value is. An explicit `"id": null` is therefore a request, not a notification:
+/// `RequestId` is `string | number`, which makes a null id an invalid request id rather than an
+/// absent one, and calling it a notification drops the required 2026 request metadata for any
+/// message that writes that one token.
+///
+/// A present `method` that is not a string is a malformed message shape rather than a message of
+/// some other kind. Answering `Response` for it, which is what folding through `as_str()` does,
+/// silently drops the request-metadata requirement the same way. The id vocabulary is settled
+/// separately by `normalize_jsonrpc_id`, which refuses booleans, arrays and objects.
+pub(crate) fn classify_message(
+    v: &serde_json::Value,
+) -> Result<MessageKind<'_>, MessageShapeError> {
+    let Some(method) = v.get("method") else {
+        return Ok(MessageKind::Response);
+    };
+    let Some(method) = method.as_str() else {
+        return Err(MessageShapeError::NonStringMethod);
+    };
+    Ok(if v.get("id").is_some() {
+        MessageKind::Request { method }
+    } else {
+        MessageKind::Notification { method }
+    })
+}
+
+/// What a request carried in `params._meta`./// What a request carried in `params._meta`. Typed rather than `Option<String>` so that a missing
 /// field and an unreadable one stay different findings: one is silence, the other is a malformed
 /// signal, and they have different remediations.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -47,7 +47,7 @@ pub(crate) enum EnvelopeObservation {
 /// enumerations that missed a member. RFC 8259 says names SHOULD be unique and RFC 7493 requires it,
 /// so refusing outright cannot go stale. Value-free: the diagnostic names neither the key nor either
 /// value.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct UniqueValue(pub(crate) serde_json::Value);
 
 impl<'de> serde::Deserialize<'de> for UniqueValue {
@@ -135,17 +135,84 @@ impl<'de> serde::Deserialize<'de> for UniqueValue {
 /// unknown member passed while the claim said every duplicate is refused. A manual `visit_map` that
 /// runs this on every key closes it inside the same pass, with no second read of the input.
 #[derive(Default)]
-pub(crate) struct SeenMembers(Vec<String>);
+pub(crate) struct SeenMembers(std::collections::HashSet<String>);
 
 impl SeenMembers {
+    /// Set membership rather than a linear scan. Keys are attacker-chosen and need not repeat, so a
+    /// scan is quadratic in the number of *unique* members, which is the cheap shape for an input to
+    /// have. The existing input ceiling is the outer budget; this keeps the inner cost linear.
     pub(crate) fn insert<E: serde::de::Error>(&mut self, key: &str) -> Result<(), E> {
-        if self.0.iter().any(|k| k == key) {
+        if !self.0.insert(key.to_string()) {
             return Err(serde::de::Error::custom(
                 "JSON object contains a duplicate member",
             ));
         }
-        self.0.push(key.to_string());
         Ok(())
+    }
+}
+
+/// Walk a value for duplicate members without building it.
+///
+/// `IgnoredAny` skips a subtree entirely, so a duplicate inside an unknown member escaped the rule
+/// while the claim said every duplicate is refused. This visits the same ground and keeps nothing,
+/// so an ignored subtree is still read for duplicates and still costs no tree.
+pub(crate) struct DuplicateAwareSink;
+
+impl<'de> serde::Deserialize<'de> for DuplicateAwareSink {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = DuplicateAwareSink;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("any JSON value with unique object members")
+            }
+            fn visit_unit<E>(self) -> Result<DuplicateAwareSink, E> {
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_none<E>(self) -> Result<DuplicateAwareSink, E> {
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_some<D: serde::Deserializer<'de>>(
+                self,
+                d: D,
+            ) -> Result<DuplicateAwareSink, D::Error> {
+                <DuplicateAwareSink as serde::Deserialize>::deserialize(d)
+            }
+            fn visit_bool<E>(self, _: bool) -> Result<DuplicateAwareSink, E> {
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_i64<E>(self, _: i64) -> Result<DuplicateAwareSink, E> {
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_u64<E>(self, _: u64) -> Result<DuplicateAwareSink, E> {
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_f64<E>(self, _: f64) -> Result<DuplicateAwareSink, E> {
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_str<E>(self, _: &str) -> Result<DuplicateAwareSink, E> {
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<DuplicateAwareSink, A::Error> {
+                while seq.next_element::<DuplicateAwareSink>()?.is_some() {}
+                Ok(DuplicateAwareSink)
+            }
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<DuplicateAwareSink, A::Error> {
+                let mut seen = SeenMembers::default();
+                while let Some(key) = map.next_key::<String>()? {
+                    seen.insert::<A::Error>(&key)?;
+                    map.next_value::<DuplicateAwareSink>()?;
+                }
+                Ok(DuplicateAwareSink)
+            }
+        }
+        deserializer.deserialize_any(V)
     }
 }
 
@@ -157,8 +224,8 @@ impl SeenMembers {
 /// request, took its era, and a missing `resultType` under a borrowed legacy era could read
 /// `Terminal`.
 ///
-/// The number is kept as its canonical text rather than parsed, so two spellings of one number
-/// become one key. The variant, not the text, carries the type distinction.
+/// A number key is the exact text of an integer this build could represent without loss. The variant,
+/// not the text, carries the type distinction, so a string is never a number however it is spelled.
 /// Crate-private: the public field is unchanged, byte and API compatible.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum CorrelationId {
@@ -166,32 +233,48 @@ pub(crate) enum CorrelationId {
     Num(String),
 }
 
+/// Whether an id is usable at all, which is a different question from whether it can correlate.
+///
+/// MCP restricts `RequestId` to a string or a number, so those are the shapes a request or a success
+/// response may carry. Nothing here decides correlation: see [`correlation_id`].
+pub(crate) fn id_is_acceptable(v: &serde_json::Value) -> bool {
+    matches!(
+        v,
+        serde_json::Value::String(_) | serde_json::Value::Number(_)
+    )
+}
+
 /// Read the correlation key from a message's raw JSON.
 ///
-/// `None` for an absent or unusable id. [`accept_id`] owns the vocabulary; the parser's shape
+/// `None` for an absent or unusable id. This function owns the correlation vocabulary; the parser's shape
 /// diagnostics for booleans, arrays and objects are more specific messages for a subset of the same
 /// refusal.
 pub(crate) fn correlation_id(v: &serde_json::Value) -> Option<CorrelationId> {
-    v.get("id").and_then(accept_id)
+    v.get("id").and_then(correlation_key)
 }
 
 /// The one place that decides whether an id is usable, and what key it becomes.
 ///
-/// The pinned 2026 schema says `RequestId = string | number`, and this function is the only place
-/// that decides it. An earlier head read "integer" out of a prose overview and refused fractional
-/// and exponent-spelled ids as protocol-invalid. They are not: JSON-RPC says fractional ids SHOULD
-/// NOT be used, which is advice to a sender rather than a rule a receiver may enforce as invalidity.
+/// The correlation key for an id, or `None` when this build cannot key on it safely.
 ///
-/// Two numeric ids are the same id when they are the same number, so the key is the canonical text
-/// serde renders: `1e0` and `1.0` both become `1.0` and correlate, while `1` stays `1`. That last
-/// pair is a bounded non-claim rather than a decision — `1` and `1.0` are numerically equal and
-/// JSON-RPC does not say whether they name one call — and this build treats them as distinct keys.
+/// A string keys on itself, exactly. A number keys on its exact text only when it is representable as
+/// an `i64` or a `u64`; every other JSON number is ingestible and simply does not correlate.
 ///
-/// `CorrelationId::Num` therefore only ever comes from an accepted integer.
-pub(crate) fn accept_id(v: &serde_json::Value) -> Option<CorrelationId> {
+/// That asymmetry is the point. Upstream does not define whether `1`, `1.0` and `1e0` name one call,
+/// and its own prose and schema disagree about whether an id may be fractional at all. Meanwhile
+/// serde_json parses any non-integer number through `f64`, so `9007199254740993.0` has already become
+/// `9007199254740992.0` before a key could be built, and two different ids would land on one call.
+///
+/// Correlating on a value that may be wrong is worse than not correlating: a false pairing hands a
+/// response the era of a call it did not answer, which can license a terminal reading. Declining to
+/// key leaves the response with the era its own envelope resolved, which is incomplete and true. A
+/// later sidecar that keeps the raw lexeme can widen the subset; nothing here forecloses that.
+pub(crate) fn correlation_key(v: &serde_json::Value) -> Option<CorrelationId> {
     match v {
         serde_json::Value::String(s) => Some(CorrelationId::Str(s.clone())),
-        serde_json::Value::Number(n) => Some(CorrelationId::Num(n.to_string())),
+        serde_json::Value::Number(n) if n.is_i64() || n.is_u64() => {
+            Some(CorrelationId::Num(n.to_string()))
+        }
         _ => None,
     }
 }
@@ -285,7 +368,7 @@ pub(crate) enum MessageShapeError {
 /// [`REQUEST_ONLY_METHODS`] classifies as requests whatever their id member does, so a request-only
 /// method cannot shed the requirement by omitting one.
 ///
-/// The id vocabulary is not settled here. [`accept_id`] owns it; the parser adds more specific shape
+/// The id vocabulary is not settled here. [`correlation_id`] owns it; the parser adds more specific shape
 /// diagnostics for booleans, arrays and objects, which are a subset of the same refusal.
 pub(crate) fn classify_message(
     v: &serde_json::Value,

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -108,12 +108,17 @@ impl<'de> serde::Deserialize<'de> for UniqueValue {
             ) -> Result<UniqueValue, A::Error> {
                 let mut out = serde_json::Map::new();
                 while let Some(key) = map.next_key::<String>()? {
-                    let UniqueValue(value) = map.next_value()?;
-                    if out.insert(key, value).is_some() {
+                    // Membership is checked on the key alone, before `next_value` materializes
+                    // whatever the duplicate carries. Reading it first means a hostile input pays
+                    // for a value that is only going to be refused, and the value may be an
+                    // arbitrarily large subtree.
+                    if out.contains_key(&key) {
                         return Err(serde::de::Error::custom(
                             "JSON object contains a duplicate member",
                         ));
                     }
+                    let UniqueValue(value) = map.next_value()?;
+                    out.insert(key, value);
                 }
                 Ok(UniqueValue(serde_json::Value::Object(out)))
             }

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -77,8 +77,12 @@ pub(crate) enum ResultObservation {
     InputRequired,
     /// `ResultType` is an open union and the handling rule is a SHOULD, so conforming verifiers
     /// may legitimately differ here.
-    Unrecognized(String),
-    /// The field is present and is not a token at all: a number, an object, an empty string.
+    ///
+    /// Value-free by design. The token is attacker-chosen, so echoing it hands a channel into
+    /// every log that ingests the finding while telling a reader nothing they can act on: the
+    /// actionable fact is that this build has no rule for it, not which bytes it was.
+    Unrecognized,
+    /// The field is present and is not a token at all: a number, an object, an array.
     /// Distinct from `Missing`, and the distinction is load-bearing on the legacy arm, where an
     /// absent field MUST be read as `"complete"` and an unreadable one must not inherit that.
     Malformed,
@@ -91,7 +95,7 @@ pub(crate) enum ResultObservation {
 #[allow(dead_code)]
 pub(crate) enum IncompleteReason {
     EraUnknown(UnknownReason),
-    UnrecognizedResultType(String),
+    UnrecognizedResultType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -295,8 +299,8 @@ pub(crate) fn conclude(era: &EraResolution, observed: &ResultObservation) -> Res
     match observed {
         ResultObservation::Complete => ResultConclusion::Terminal,
         ResultObservation::InputRequired => ResultConclusion::NonTerminal,
-        ResultObservation::Unrecognized(token) => {
-            ResultConclusion::Incomplete(IncompleteReason::UnrecognizedResultType(token.clone()))
+        ResultObservation::Unrecognized => {
+            ResultConclusion::Incomplete(IncompleteReason::UnrecognizedResultType)
         }
         // Checked before the era, because an unreadable field is not an absent one and must not
         // reach the backward-compatibility rule that reads absence as completion.
@@ -359,25 +363,6 @@ pub(crate) fn conclude_request(
 }
 
 /// The `_meta` key the protocol version travels under on a request.
-/// How much of an unrecognized token is kept. The two defined tokens are 8 and 14 bytes, so this
-/// is generous for anything a future revision might name while still bounding what one record can
-/// cost.
-pub(crate) const MAX_TOKEN_BYTES: usize = 64;
-
-/// Truncate on a character boundary, since cutting a UTF-8 string at a byte index panics.
-fn bounded_token(token: &str) -> String {
-    if token.len() <= MAX_TOKEN_BYTES {
-        return token.to_string();
-    }
-    let cut = token
-        .char_indices()
-        .map(|(i, _)| i)
-        .take_while(|i| *i <= MAX_TOKEN_BYTES)
-        .last()
-        .unwrap_or(0);
-    token[..cut].to_string()
-}
-
 pub(crate) const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
 
 /// The transport header carrying the same value.
@@ -460,8 +445,9 @@ pub(crate) fn observe_request_metadata(raw: &serde_json::Value) -> RequestMetada
     let Some(meta) = raw.get("params").and_then(|p| p.get("_meta")) else {
         return RequestMetadata::Absent;
     };
-    // `_meta` is an object by schema. A scalar or array here is a signal that arrived and failed,
-    // and `Value::get` on a non-object answers `None`, which would report it as silence.
+    // `_meta` is an object by schema, so a scalar or array is a signal that arrived and failed.
+    // The guard is explicit because `Value::get` on a non-object answers `None`, which the arm
+    // below would have read as the version simply being absent.
     if !meta.is_object() {
         return RequestMetadata::Malformed;
     }
@@ -490,9 +476,10 @@ pub(crate) fn observe_result(raw: &serde_json::Value) -> Option<ResultObservatio
         Some(v) => match v.as_str() {
             Some("complete") => ResultObservation::Complete,
             Some("input_required") => ResultObservation::InputRequired,
-            // `ResultType` is an open string union, so any string is syntactically a token. An
-            // empty one is unrecognized rather than unreadable; only a non-string is malformed.
-            Some(other) => ResultObservation::Unrecognized(bounded_token(other)),
+            // `ResultType` is an open string union, so any string is syntactically a token,
+            // including an empty one. Unrecognized is a statement about this build's rules, so it
+            // carries no value; only a non-string is unreadable.
+            Some(_) => ResultObservation::Unrecognized,
             None => ResultObservation::Malformed,
         },
     })

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -92,7 +92,7 @@ pub(crate) fn classify_message(
     })
 }
 
-/// What a request carried in `params._meta`./// What a request carried in `params._meta`. Typed rather than `Option<String>` so that a missing
+/// What a request carried in `params._meta`. Typed rather than `Option<String>` so that a missing
 /// field and an unreadable one stay different findings: one is silence, the other is a malformed
 /// signal, and they have different remediations.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -179,8 +179,8 @@ pub(crate) const SUPPORTED_VERSIONS: &[&str] = &[
 /// Ordering against [`RESULT_TYPE_SINCE`] is lexicographic, and lexicographic ordering is date
 /// ordering only once the value is a date. Ten bytes and two dashes is not enough: `2026-99-99`
 /// would pass a shape-only check and be reported as a version this build merely does not support,
-/// which blames the reader for a record that is wrong. Validated as a real calendar date, leap
-/// years included, so `2026-02-31` is malformed rather than unsupported.
+/// which blames the reader for a record that is wrong. The value is validated as a real calendar
+/// date, leap years included, so `2026-02-31` is malformed rather than unsupported.
 fn is_version_shaped(v: &str) -> bool {
     let b = v.as_bytes();
     if b.len() != 10 || b[4] != b'-' || b[7] != b'-' {

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -366,18 +366,26 @@ pub(crate) const PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
 /// reason `Malformed` exists, so this reads the slot itself.
 pub(crate) fn observe_header(headers: Option<&serde_json::Value>) -> Option<EnvelopeObservation> {
     let map = headers?.as_object()?;
-    let mut matches = map
+    let mut found: Option<&str> = None;
+    let mut any = false;
+    for (_, value) in map
         .iter()
-        .filter(|(k, _)| k.to_ascii_lowercase() == PROTOCOL_VERSION_HEADER);
-    let (_, value) = matches.next()?;
-    // Two spellings of one header is not a value to pick from. `find` would have taken whichever
-    // came first in map order, which is a silent choice between two disagreeing signals.
-    if matches.next().is_some() {
-        return Some(EnvelopeObservation::Malformed);
+        .filter(|(k, _)| k.to_ascii_lowercase() == PROTOCOL_VERSION_HEADER)
+    {
+        any = true;
+        match value.as_str() {
+            // Two spellings carrying the same value agree, and agreement is not a choice. Only a
+            // disagreement is: `find` would have silently taken whichever came first in map order.
+            Some(v) if !v.is_empty() && found.is_none_or(|prev| prev == v) => found = Some(v),
+            _ => return Some(EnvelopeObservation::Malformed),
+        }
     }
-    Some(match value.as_str() {
-        Some(v) if !v.is_empty() => EnvelopeObservation::Present(v.to_string()),
-        _ => EnvelopeObservation::Malformed,
+    if !any {
+        return None;
+    }
+    Some(match found {
+        Some(v) => EnvelopeObservation::Present(v.to_string()),
+        None => EnvelopeObservation::Malformed,
     })
 }
 

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -136,10 +136,10 @@ impl<'de> serde::Deserialize<'de> for UniqueValue {
 /// request, took its era, and a missing `resultType` under a borrowed legacy era could read
 /// `Terminal`.
 ///
-/// The number is kept as its canonical text rather than parsed, because JSON-RPC does not constrain
-/// an id to an integer and two spellings of one number are the same id. The variant, not the text,
-/// carries the type distinction. Crate-private: the public field is unchanged, byte and API
-/// compatible.
+/// The number is kept as its canonical text rather than parsed. MCP restricts `RequestId` to a
+/// string or an integer, so an accepted number is already an integer by the time it becomes a key,
+/// and the text is its canonical rendering. The variant, not the text, carries the type distinction.
+/// Crate-private: the public field is unchanged, byte and API compatible.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum CorrelationId {
     Str(String),
@@ -148,18 +148,20 @@ pub(crate) enum CorrelationId {
 
 /// Read the correlation key from a message's raw JSON.
 ///
-/// `None` for an absent or unusable id. `normalize_jsonrpc_id` already refuses booleans, arrays and
-/// objects at the parser boundary, so only the two valid shapes reach this.
+/// `None` for an absent or unusable id. [`accept_id`] owns the vocabulary; the parser's shape
+/// diagnostics for booleans, arrays and objects are more specific messages for a subset of the same
+/// refusal.
 pub(crate) fn correlation_id(v: &serde_json::Value) -> Option<CorrelationId> {
     v.get("id").and_then(accept_id)
 }
 
 /// The one place that decides whether an id is usable, and what key it becomes.
 ///
-/// MCP restricts `RequestId` to a string or an integer. A fractional number is not an id, and
-/// neither is one spelled with an exponent: `1.0` and `1e0` both parse as floats, so neither is an
-/// integer even though the second equals one. Accepting them would give two spellings of one call
-/// two different keys, or one key to two different calls, depending on which side rendered.
+/// MCP restricts `RequestId` to a string or an integer, and this function is the only place that
+/// decides it. A fractional number is not an id, and neither is one spelled with an exponent: `1.0`
+/// and `1e0` both parse as floats, so neither is an integer even though the second equals one.
+/// Accepting them would give two spellings of one call two different keys, or one key to two
+/// different calls, depending on which side rendered.
 ///
 /// `CorrelationId::Num` therefore only ever comes from an accepted integer.
 pub(crate) fn accept_id(v: &serde_json::Value) -> Option<CorrelationId> {
@@ -172,13 +174,15 @@ pub(crate) fn accept_id(v: &serde_json::Value) -> Option<CorrelationId> {
     }
 }
 
-/// The text an accepted id renders to for the public `McpEvent::jsonrpc_id` field.
-pub(crate) fn accepted_id_text(id: &CorrelationId) -> String {
-    match id {
-        CorrelationId::Str(s) => s.clone(),
-        CorrelationId::Num(n) => n.clone(),
-    }
-}
+/// Methods this build gives request semantics to.
+///
+/// `tools/call` is `CallToolRequest` and `tools/list` is `ListToolsRequest`, and a request MUST carry
+/// an id. Without this, a request-only method could shed the id requirement simply by omitting the
+/// member, and with it the required 2026 `RequestParams._meta`, because notification metadata is
+/// optional. The list is deliberately the methods the parser already gives request payloads to
+/// rather than every method in the specification: an extension method with an unknown name stays a
+/// notification, so this refuses what is known to be a request instead of guessing about the rest.
+pub(crate) const REQUEST_ONLY_METHODS: &[&str] = &["tools/call", "tools/list"];
 
 /// Which JSON-RPC message shape this is, carrying the method so that nothing has to read it a
 /// second time.
@@ -219,14 +223,18 @@ pub(crate) enum MessageShapeError {
 ///
 /// A notification is a request object *without* an `id` member, so absence is the discriminant and
 /// nothing about the value is. An explicit `"id": null` is therefore a request, not a notification:
-/// `RequestId` is `string | number`, which makes a null id an invalid request id rather than an
-/// absent one, and calling it a notification drops the required 2026 request metadata for any
-/// message that writes that one token.
+/// MCP restricts `RequestId` to a string or an integer, which makes a null id an invalid request id
+/// rather than an absent one, and calling it a notification drops the required 2026 request metadata
+/// for any message that writes that one token.
 ///
 /// A present `method` that is not a string is a malformed message shape rather than a message of
 /// some other kind. Answering `Response` for it, which is what folding through `as_str()` does,
-/// silently drops the request-metadata requirement the same way. The id vocabulary is settled
-/// separately by `normalize_jsonrpc_id`, which refuses booleans, arrays and objects.
+/// silently drops the request-metadata requirement the same way. Absence is not the only way in:
+/// [`REQUEST_ONLY_METHODS`] classifies as requests whatever their id member does, so a request-only
+/// method cannot shed the requirement by omitting one.
+///
+/// The id vocabulary is not settled here. [`accept_id`] owns it; the parser adds more specific shape
+/// diagnostics for booleans, arrays and objects, which are a subset of the same refusal.
 pub(crate) fn classify_message(
     v: &serde_json::Value,
 ) -> Result<MessageKind<'_>, MessageShapeError> {
@@ -244,11 +252,13 @@ pub(crate) fn classify_message(
     let Some(method) = method.as_str() else {
         return Err(MessageShapeError::NonStringMethod);
     };
-    Ok(if v.get("id").is_some() {
-        MessageKind::Request { method }
-    } else {
-        MessageKind::Notification { method }
-    })
+    Ok(
+        if v.get("id").is_some() || REQUEST_ONLY_METHODS.contains(&method) {
+            MessageKind::Request { method }
+        } else {
+            MessageKind::Notification { method }
+        },
+    )
 }
 
 /// What a request carried in `params._meta`. Typed rather than `Option<String>` so that a missing

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -1,0 +1,449 @@
+//! Protocol-era observation and resolution for imported MCP transcripts.
+//!
+//! Everything here is `pub(crate)`. The ledger calls this internal normalizer vocabulary, and it
+//! stays that way until a public normalizer API is deliberately designed: `McpEvent` is a public,
+//! constructible, non-`#[non_exhaustive]` struct, so adding fields to it would break downstream
+//! struct literals and exhaustive destructuring for a shape that is still being worked out. The
+//! era travels in a sidecar instead, and `parse_mcp_transcript` keeps returning `Vec<McpEvent>`.
+//!
+//! Three axes, deliberately not one. `EnvelopeObservation` is what the transport framing carried.
+//! `EraResolution` is what the era turned out to be once every signal was read. `ResultObservation`
+//! is what a response said about its own completeness. A format with no transport envelope has not
+//! lost the era, because the 2026 request carries its own required
+//! `_meta["io.modelcontextprotocol/protocolVersion"]`, and a header that disagrees with that field
+//! is a third fact with the spec's own MUST behind it.
+
+use super::types::McpEvent;
+
+/// The protocol version that introduced `resultType` and the required request metadata. Compared
+/// against, never keyed on: the rule is that no field is named after an era, not that no boundary
+/// may be stated.
+pub(crate) const RESULT_TYPE_SINCE: &str = "2026-07-28";
+
+/// What the transport framing carried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EnvelopeObservation {
+    /// The input format has no transport envelope, so there is nothing to be missing. Bare
+    /// JSON-RPC and Inspector exports land here: neither reaches `parse_transport_transcript`.
+    /// This describes Assay's current adapters, not the formats in principle.
+    NotApplicable,
+    Absent,
+    Present(String),
+    /// The framing carried something in the header slot that could not be read as a version:
+    /// a number, an object, an empty string. Distinct from `Absent`, which is silence, because a
+    /// signal that arrived and failed is a different finding with a different remediation.
+    Malformed,
+}
+
+/// What a request carried in `params._meta`. Typed rather than `Option<String>` so that a missing
+/// field and an unreadable one stay different findings: one is silence, the other is a malformed
+/// signal, and they have different remediations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RequestMetadata {
+    Absent,
+    Present(String),
+    /// Present but not a string, or not a usable version.
+    Malformed,
+}
+
+/// Why an era could not be resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum UnknownReason {
+    NoSignal,
+    /// A well-formed version this build does not know how to read.
+    UnsupportedVersion(String),
+    MalformedSignal,
+}
+
+/// What the era turned out to be once every available signal was read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EraResolution {
+    Known(String),
+    Unknown(UnknownReason),
+    /// Header and request metadata disagree. For the HTTP transport the metadata value MUST match
+    /// the `MCP-Protocol-Version` header, and a server MUST otherwise answer 400, so this is a
+    /// defined fault rather than something to resolve toward either side.
+    Conflicting {
+        header: String,
+        body: String,
+    },
+}
+
+/// What a response said about its own completeness, before any era was applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResultObservation {
+    Missing,
+    Complete,
+    InputRequired,
+    /// `ResultType` is an open union and the handling rule is a SHOULD, so conforming verifiers
+    /// may legitimately differ here.
+    Unrecognized(String),
+    /// The field is present and is not a token at all: a number, an object, an empty string.
+    /// Distinct from `Missing`, and the distinction is load-bearing on the legacy arm, where an
+    /// absent field MUST be read as `"complete"` and an unreadable one must not inherit that.
+    Malformed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+// Targeted rather than module-wide, so a future dead item in this file is still reported.
+// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
+// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
+#[allow(dead_code)]
+pub(crate) enum IncompleteReason {
+    EraUnknown(UnknownReason),
+    UnrecognizedResultType(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+// Targeted rather than module-wide, so a future dead item in this file is still reported.
+// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
+// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
+#[allow(dead_code)]
+pub(crate) enum InvalidReason {
+    EraConflicting {
+        header: String,
+        body: String,
+    },
+    MissingResultType,
+    MissingRequestMetadata,
+    MalformedRequestMetadata,
+    /// A version signal arrived and could not be read. Invalid rather than incomplete: more
+    /// evidence does not make an unreadable value readable.
+    MalformedEraSignal,
+    /// `resultType` is present and unreadable. Never folded into the absent-means-complete rule.
+    MalformedResultType,
+}
+
+/// What a request is worth on its own terms. A request has no result, so `NonTerminal` would be a
+/// category error here: "no objection" and "valid but unfinished" are different answers and only
+/// the second belongs to a result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+// Targeted rather than module-wide, so a future dead item in this file is still reported.
+// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
+// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
+#[allow(dead_code)]
+pub(crate) enum RequestAssessment {
+    Valid,
+    Incomplete(IncompleteReason),
+    Invalid(InvalidReason),
+}
+
+/// What a response licenses under a resolved era. Deliberately not a boolean: unknown,
+/// contradicted, and a missing required field are three different findings, and `input_required`
+/// is valid while not being terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+// Targeted rather than module-wide, so a future dead item in this file is still reported.
+// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
+// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
+#[allow(dead_code)]
+pub(crate) enum ResultConclusion {
+    Terminal,
+    NonTerminal,
+    Incomplete(IncompleteReason),
+    Invalid(InvalidReason),
+}
+
+/// The era sidecar for one parsed event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct McpEraContext {
+    pub(crate) envelope: EnvelopeObservation,
+    pub(crate) era: EraResolution,
+    pub(crate) request_metadata: Option<RequestMetadata>,
+    pub(crate) result_observation: Option<ResultObservation>,
+}
+
+/// One event and what was observed about its era, kept apart so the public event shape is
+/// unchanged.
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedMcpEvent {
+    pub(crate) event: McpEvent,
+    /// Read by tests and by the slice-2 conclusion layer; nothing in production consumes it yet.
+    #[allow(dead_code)]
+    pub(crate) context: McpEraContext,
+}
+
+/// The protocol versions this build has era rules for, newest last. This is a statement about
+/// what the reader knows, not about which versions exist: a well-formed version outside this set
+/// is `UnsupportedVersion`, which is a gap in the reader rather than a fault in the record.
+/// Enumerated from the specification repository's `schema/` directory.
+pub(crate) const SUPPORTED_VERSIONS: &[&str] = &[
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+    "2025-11-25",
+    RESULT_TYPE_SINCE,
+];
+
+/// Whether a string is a usable protocol version, which is an ISO calendar date.
+///
+/// Ordering against [`RESULT_TYPE_SINCE`] is lexicographic, and lexicographic ordering is date
+/// ordering only once the value is a date. Ten bytes and two dashes is not enough: `2026-99-99`
+/// would pass a shape-only check and be reported as a version this build merely does not support,
+/// which blames the reader for a record that is wrong. Day-of-month is bounded at 31 rather than
+/// Validated as a real calendar date, leap years included, so `2026-02-31` is malformed rather
+/// than a version this build merely does not support.
+fn is_version_shaped(v: &str) -> bool {
+    let b = v.as_bytes();
+    if b.len() != 10 || b[4] != b'-' || b[7] != b'-' {
+        return false;
+    }
+    if !b
+        .iter()
+        .enumerate()
+        .all(|(i, c)| matches!(i, 4 | 7) || c.is_ascii_digit())
+    {
+        return false;
+    }
+    let num = |from: usize, to: usize| v[from..to].parse::<u32>().unwrap_or(0);
+    let (year, month, day) = (num(0, 4), num(5, 7), num(8, 10));
+    if !matches!(month, 1..=12) || day == 0 {
+        return false;
+    }
+    let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let days = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        _ if leap => 29,
+        _ => 28,
+    };
+    day <= days
+}
+
+/// Classify a version already known to be shaped like one.
+fn classify(version: &str) -> EraResolution {
+    if SUPPORTED_VERSIONS.contains(&version) {
+        EraResolution::Known(version.to_string())
+    } else {
+        EraResolution::Unknown(UnknownReason::UnsupportedVersion(version.to_string()))
+    }
+}
+
+/// Resolve the era from the two signals a request can carry.
+///
+/// The order is the rule, and an earlier version of this function documented an order it did not
+/// implement. Unreadable is settled first, because two values that are not both versions cannot be
+/// said to disagree about a version: comparing them would report a contradiction where the real
+/// finding is that one of them is not a version at all. Only then is a disagreement settled, and
+/// only then is a single surviving value classified.
+pub(crate) fn resolve_era(
+    envelope: &EnvelopeObservation,
+    metadata: &RequestMetadata,
+) -> EraResolution {
+    let malformed = EraResolution::Unknown(UnknownReason::MalformedSignal);
+    let header = match envelope {
+        EnvelopeObservation::Present(v) => Some(v.as_str()),
+        EnvelopeObservation::Absent | EnvelopeObservation::NotApplicable => None,
+        EnvelopeObservation::Malformed => return malformed,
+    };
+    let body = match metadata {
+        RequestMetadata::Present(v) => Some(v.as_str()),
+        RequestMetadata::Absent => None,
+        RequestMetadata::Malformed => return malformed,
+    };
+    if [header, body]
+        .into_iter()
+        .flatten()
+        .any(|v| !is_version_shaped(v))
+    {
+        return malformed;
+    }
+    match (header, body) {
+        (Some(h), Some(b)) if h != b => EraResolution::Conflicting {
+            header: h.to_string(),
+            body: b.to_string(),
+        },
+        (Some(v), _) | (None, Some(v)) => classify(v),
+        (None, None) => EraResolution::Unknown(UnknownReason::NoSignal),
+    }
+}
+
+/// Whether a resolved version is one where `resultType` and the request metadata are required.
+fn requires_result_type(version: &str) -> bool {
+    version >= RESULT_TYPE_SINCE
+}
+
+/// Read a response observation under a resolved era.
+///
+/// The two MUSTs sit next to each other in the schema: a server implementing this version MUST
+/// include `resultType`, and a client receiving a result from an earlier-version server MUST treat
+/// the absent field as `"complete"`. Same observation, opposite conclusions.
+// Targeted rather than module-wide, so a future dead item in this file is still reported.
+// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
+// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
+#[allow(dead_code)]
+pub(crate) fn conclude(era: &EraResolution, observed: &ResultObservation) -> ResultConclusion {
+    let version = match era {
+        EraResolution::Known(v) => v,
+        EraResolution::Unknown(UnknownReason::MalformedSignal) => {
+            return ResultConclusion::Invalid(InvalidReason::MalformedEraSignal)
+        }
+        EraResolution::Unknown(reason) => {
+            return ResultConclusion::Incomplete(IncompleteReason::EraUnknown(reason.clone()))
+        }
+        EraResolution::Conflicting { header, body } => {
+            return ResultConclusion::Invalid(InvalidReason::EraConflicting {
+                header: header.clone(),
+                body: body.clone(),
+            })
+        }
+    };
+    match observed {
+        ResultObservation::Complete => ResultConclusion::Terminal,
+        ResultObservation::InputRequired => ResultConclusion::NonTerminal,
+        ResultObservation::Unrecognized(token) => {
+            ResultConclusion::Incomplete(IncompleteReason::UnrecognizedResultType(token.clone()))
+        }
+        // Checked before the era, because an unreadable field is not an absent one and must not
+        // reach the backward-compatibility rule that reads absence as completion.
+        ResultObservation::Malformed => {
+            ResultConclusion::Invalid(InvalidReason::MalformedResultType)
+        }
+        ResultObservation::Missing => {
+            if requires_result_type(version) {
+                ResultConclusion::Invalid(InvalidReason::MissingResultType)
+            } else {
+                ResultConclusion::Terminal
+            }
+        }
+    }
+}
+
+/// Read a request under the resolved era. `RequestParams._meta` and the version inside it are both
+/// required from the version that introduced them, with no `?` in the schema.
+///
+/// Every unreadable signal is a fault here, whichever side it arrived on. An earlier version fixed
+/// the metadata arm and left the header arm, so a malformed header still resolved to an unknown
+/// era and then to "no objection". Both now land on `Invalid`, because more evidence does not make
+/// an unreadable value readable.
+// Targeted rather than module-wide, so a future dead item in this file is still reported.
+// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
+// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
+#[allow(dead_code)]
+pub(crate) fn conclude_request(
+    era: &EraResolution,
+    metadata: &RequestMetadata,
+) -> RequestAssessment {
+    if matches!(metadata, RequestMetadata::Malformed) {
+        return RequestAssessment::Invalid(InvalidReason::MalformedRequestMetadata);
+    }
+    match era {
+        // A refused or aborted request is exactly the case with no response, so leaving the
+        // contradiction to the response side loses it. Reporting it from both axes is a
+        // deduplication problem for the consumer, which has the call id to do it with.
+        EraResolution::Conflicting { header, body } => {
+            RequestAssessment::Invalid(InvalidReason::EraConflicting {
+                header: header.clone(),
+                body: body.clone(),
+            })
+        }
+        EraResolution::Unknown(UnknownReason::MalformedSignal) => {
+            RequestAssessment::Invalid(InvalidReason::MalformedEraSignal)
+        }
+        EraResolution::Unknown(reason) => {
+            RequestAssessment::Incomplete(IncompleteReason::EraUnknown(reason.clone()))
+        }
+        EraResolution::Known(version) if !requires_result_type(version) => RequestAssessment::Valid,
+        EraResolution::Known(_) => match metadata {
+            RequestMetadata::Present(_) => RequestAssessment::Valid,
+            RequestMetadata::Absent => {
+                RequestAssessment::Invalid(InvalidReason::MissingRequestMetadata)
+            }
+            RequestMetadata::Malformed => unreachable!("handled above"),
+        },
+    }
+}
+
+/// The `_meta` key the protocol version travels under on a request.
+pub(crate) const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+
+/// The transport header carrying the same value.
+pub(crate) const PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+
+/// Read one header slot as an observation rather than as an `Option`.
+///
+/// The existing case-insensitive header helper answers `None` for a value that is present and not
+/// a string, which reports silence where a signal arrived and failed. That difference is the whole
+/// reason `Malformed` exists, so this reads the slot itself.
+pub(crate) fn observe_header(headers: Option<&serde_json::Value>) -> Option<EnvelopeObservation> {
+    let map = headers?.as_object()?;
+    let mut matches = map
+        .iter()
+        .filter(|(k, _)| k.to_ascii_lowercase() == PROTOCOL_VERSION_HEADER);
+    let (_, value) = matches.next()?;
+    // Two spellings of one header is not a value to pick from. `find` would have taken whichever
+    // came first in map order, which is a silent choice between two disagreeing signals.
+    if matches.next().is_some() {
+        return Some(EnvelopeObservation::Malformed);
+    }
+    Some(match value.as_str() {
+        Some(v) if !v.is_empty() => EnvelopeObservation::Present(v.to_string()),
+        _ => EnvelopeObservation::Malformed,
+    })
+}
+
+/// Fold every header slot a transcript carried into one observation.
+///
+/// Agreement is `Present`; anything else is `Malformed`. Two levels of one transcript stating
+/// different versions is not a signal to choose between, and this slice does not invent a
+/// resolution rule the specification does not give.
+pub(crate) fn fold_envelope(
+    observations: Vec<EnvelopeObservation>,
+    framed: bool,
+) -> EnvelopeObservation {
+    if observations.is_empty() {
+        return if framed {
+            EnvelopeObservation::Absent
+        } else {
+            EnvelopeObservation::NotApplicable
+        };
+    }
+    let mut seen: Option<&str> = None;
+    for o in &observations {
+        match o {
+            EnvelopeObservation::Present(v) => match seen {
+                Some(prev) if prev != v => return EnvelopeObservation::Malformed,
+                _ => seen = Some(v),
+            },
+            _ => return EnvelopeObservation::Malformed,
+        }
+    }
+    seen.map(|v| EnvelopeObservation::Present(v.to_string()))
+        .unwrap_or(EnvelopeObservation::Malformed)
+}
+
+/// Read `params._meta` as an observation.
+pub(crate) fn observe_request_metadata(raw: &serde_json::Value) -> RequestMetadata {
+    let Some(meta) = raw.get("params").and_then(|p| p.get("_meta")) else {
+        return RequestMetadata::Absent;
+    };
+    // `_meta` is an object by schema. A scalar or array here is a signal that arrived and failed,
+    // and `Value::get` on a non-object answers `None`, which would report it as silence.
+    if !meta.is_object() {
+        return RequestMetadata::Malformed;
+    }
+    match meta.get(PROTOCOL_VERSION_META_KEY) {
+        None => RequestMetadata::Absent,
+        Some(v) => match v.as_str() {
+            Some(s) if !s.is_empty() => RequestMetadata::Present(s.to_string()),
+            _ => RequestMetadata::Malformed,
+        },
+    }
+}
+
+/// Read `result.resultType` as an observation. A present, non-string value is `Malformed` rather
+/// than absent, so it can never reach the rule that reads absence as completion.
+pub(crate) fn observe_result(raw: &serde_json::Value) -> Option<ResultObservation> {
+    let result = raw.get("result")?;
+    Some(match result.get("resultType") {
+        None => ResultObservation::Missing,
+        Some(v) => match v.as_str() {
+            Some("complete") => ResultObservation::Complete,
+            Some("input_required") => ResultObservation::InputRequired,
+            Some(other) if !other.is_empty() => ResultObservation::Unrecognized(other.to_string()),
+            _ => ResultObservation::Malformed,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -179,9 +179,8 @@ pub(crate) const SUPPORTED_VERSIONS: &[&str] = &[
 /// Ordering against [`RESULT_TYPE_SINCE`] is lexicographic, and lexicographic ordering is date
 /// ordering only once the value is a date. Ten bytes and two dashes is not enough: `2026-99-99`
 /// would pass a shape-only check and be reported as a version this build merely does not support,
-/// which blames the reader for a record that is wrong. Day-of-month is bounded at 31 rather than
-/// Validated as a real calendar date, leap years included, so `2026-02-31` is malformed rather
-/// than a version this build merely does not support.
+/// which blames the reader for a record that is wrong. Validated as a real calendar date, leap
+/// years included, so `2026-02-31` is malformed rather than unsupported.
 fn is_version_shaped(v: &str) -> bool {
     let b = v.as_bytes();
     if b.len() != 10 || b[4] != b'-' || b[7] != b'-' {
@@ -365,7 +364,12 @@ pub(crate) const PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
 /// a string, which reports silence where a signal arrived and failed. That difference is the whole
 /// reason `Malformed` exists, so this reads the slot itself.
 pub(crate) fn observe_header(headers: Option<&serde_json::Value>) -> Option<EnvelopeObservation> {
-    let map = headers?.as_object()?;
+    let headers = headers?;
+    // A headers node that is not an object is a signal that arrived and failed. `as_object`
+    // answering `None` would drop the slot entirely and report silence instead.
+    let Some(map) = headers.as_object() else {
+        return Some(EnvelopeObservation::Malformed);
+    };
     let mut found: Option<&str> = None;
     let mut any = false;
     for (_, value) in map
@@ -374,9 +378,16 @@ pub(crate) fn observe_header(headers: Option<&serde_json::Value>) -> Option<Enve
     {
         any = true;
         match value.as_str() {
+            // Shape is checked here rather than downstream so that `Present` can only ever hold a
+            // value already accepted as a version. A rejected one is reported as `Malformed` and
+            // its bytes are not retained, which is what stops an oversized header from being
+            // cloned into every entry's sidecar.
+            //
             // Two spellings carrying the same value agree, and agreement is not a choice. Only a
             // disagreement is: `find` would have silently taken whichever came first in map order.
-            Some(v) if !v.is_empty() && found.is_none_or(|prev| prev == v) => found = Some(v),
+            Some(v) if is_version_shaped(v) && found.is_none_or(|prev| prev == v) => {
+                found = Some(v)
+            }
             _ => return Some(EnvelopeObservation::Malformed),
         }
     }
@@ -432,7 +443,8 @@ pub(crate) fn observe_request_metadata(raw: &serde_json::Value) -> RequestMetada
     match meta.get(PROTOCOL_VERSION_META_KEY) {
         None => RequestMetadata::Absent,
         Some(v) => match v.as_str() {
-            Some(s) if !s.is_empty() => RequestMetadata::Present(s.to_string()),
+            // Same bound as the header: only an accepted version is retained.
+            Some(s) if is_version_shaped(s) => RequestMetadata::Present(s.to_string()),
             _ => RequestMetadata::Malformed,
         },
     }

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -128,6 +128,36 @@ impl<'de> serde::Deserialize<'de> for UniqueValue {
     }
 }
 
+/// A correlation key that keeps the id's JSON type.
+///
+/// `McpEvent::jsonrpc_id` is a `String` on a public, published struct, and it renders JSON number
+/// `1` and JSON string `"1"` identically. Those are different JSON-RPC ids, so keying correlation on
+/// that rendering paired a response with a call it did not answer: it consumed the wrong outstanding
+/// request, took its era, and a missing `resultType` under a borrowed legacy era could read
+/// `Terminal`.
+///
+/// The number is kept as its canonical text rather than parsed, because JSON-RPC does not constrain
+/// an id to an integer and two spellings of one number are the same id. The variant, not the text,
+/// carries the type distinction. Crate-private: the public field is unchanged, byte and API
+/// compatible.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum CorrelationId {
+    Str(String),
+    Num(String),
+}
+
+/// Read the correlation key from a message's raw JSON.
+///
+/// `None` for an absent or unusable id. `normalize_jsonrpc_id` already refuses booleans, arrays and
+/// objects at the parser boundary, so only the two valid shapes reach this.
+pub(crate) fn correlation_id(v: &serde_json::Value) -> Option<CorrelationId> {
+    match v.get("id") {
+        Some(serde_json::Value::String(s)) => Some(CorrelationId::Str(s.clone())),
+        Some(serde_json::Value::Number(n)) => Some(CorrelationId::Num(n.to_string())),
+        _ => None,
+    }
+}
+
 /// Which JSON-RPC message shape this is, carrying the method so that nothing has to read it a
 /// second time.
 ///

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -35,6 +35,33 @@ pub(crate) enum EnvelopeObservation {
     Malformed,
 }
 
+/// Which JSON-RPC message shape this is.
+///
+/// The distinction is load-bearing rather than tidy. `RequestParams._meta` is required and carries
+/// the protocol version; `NotificationParams._meta` is optional and is a different type that does
+/// not carry it. Treating a notification as a request therefore invents a fault: a
+/// `notifications/progress` under 2026 with no `_meta` is correct, and would be reported as missing
+/// required metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MessageKind {
+    Request,
+    Notification,
+    Response,
+}
+
+/// Classify by the two fields JSON-RPC uses: a notification is a request shape without an `id`.
+///
+/// An explicit `"id": null` counts as a notification. It is not a usable request id, and the
+/// alternative is to hold a message with no addressable identity to a requirement whose whole
+/// purpose is to describe an addressed request.
+pub(crate) fn classify_message(v: &serde_json::Value) -> MessageKind {
+    match v.get("method").and_then(|m| m.as_str()) {
+        Some(_) if v.get("id").is_some_and(|id| !id.is_null()) => MessageKind::Request,
+        Some(_) => MessageKind::Notification,
+        None => MessageKind::Response,
+    }
+}
+
 /// What a request carried in `params._meta`. Typed rather than `Option<String>` so that a missing
 /// field and an unreadable one stay different findings: one is silence, the other is a malformed
 /// signal, and they have different remediations.

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -128,6 +128,27 @@ impl<'de> serde::Deserialize<'de> for UniqueValue {
     }
 }
 
+/// Track the member names of one object and refuse a repeat.
+///
+/// `UniqueValue` covers free-form values, but a struct deserialized by serde's derive is a different
+/// path: it detects a repeated *known* field and ignores unknown ones entirely, so a duplicate
+/// unknown member passed while the claim said every duplicate is refused. A manual `visit_map` that
+/// runs this on every key closes it inside the same pass, with no second read of the input.
+#[derive(Default)]
+pub(crate) struct SeenMembers(Vec<String>);
+
+impl SeenMembers {
+    pub(crate) fn insert<E: serde::de::Error>(&mut self, key: &str) -> Result<(), E> {
+        if self.0.iter().any(|k| k == key) {
+            return Err(serde::de::Error::custom(
+                "JSON object contains a duplicate member",
+            ));
+        }
+        self.0.push(key.to_string());
+        Ok(())
+    }
+}
+
 /// A correlation key that keeps the id's JSON type.
 ///
 /// `McpEvent::jsonrpc_id` is a `String` on a public, published struct, and it renders JSON number
@@ -136,9 +157,8 @@ impl<'de> serde::Deserialize<'de> for UniqueValue {
 /// request, took its era, and a missing `resultType` under a borrowed legacy era could read
 /// `Terminal`.
 ///
-/// The number is kept as its canonical text rather than parsed. MCP restricts `RequestId` to a
-/// string or an integer, so an accepted number is already an integer by the time it becomes a key,
-/// and the text is its canonical rendering. The variant, not the text, carries the type distinction.
+/// The number is kept as its canonical text rather than parsed, so two spellings of one number
+/// become one key. The variant, not the text, carries the type distinction.
 /// Crate-private: the public field is unchanged, byte and API compatible.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum CorrelationId {
@@ -157,32 +177,64 @@ pub(crate) fn correlation_id(v: &serde_json::Value) -> Option<CorrelationId> {
 
 /// The one place that decides whether an id is usable, and what key it becomes.
 ///
-/// MCP restricts `RequestId` to a string or an integer, and this function is the only place that
-/// decides it. A fractional number is not an id, and neither is one spelled with an exponent: `1.0`
-/// and `1e0` both parse as floats, so neither is an integer even though the second equals one.
-/// Accepting them would give two spellings of one call two different keys, or one key to two
-/// different calls, depending on which side rendered.
+/// The pinned 2026 schema says `RequestId = string | number`, and this function is the only place
+/// that decides it. An earlier head read "integer" out of a prose overview and refused fractional
+/// and exponent-spelled ids as protocol-invalid. They are not: JSON-RPC says fractional ids SHOULD
+/// NOT be used, which is advice to a sender rather than a rule a receiver may enforce as invalidity.
+///
+/// Two numeric ids are the same id when they are the same number, so the key is the canonical text
+/// serde renders: `1e0` and `1.0` both become `1.0` and correlate, while `1` stays `1`. That last
+/// pair is a bounded non-claim rather than a decision — `1` and `1.0` are numerically equal and
+/// JSON-RPC does not say whether they name one call — and this build treats them as distinct keys.
 ///
 /// `CorrelationId::Num` therefore only ever comes from an accepted integer.
 pub(crate) fn accept_id(v: &serde_json::Value) -> Option<CorrelationId> {
     match v {
         serde_json::Value::String(s) => Some(CorrelationId::Str(s.clone())),
-        serde_json::Value::Number(n) if n.is_i64() || n.is_u64() => {
-            Some(CorrelationId::Num(n.to_string()))
-        }
+        serde_json::Value::Number(n) => Some(CorrelationId::Num(n.to_string())),
         _ => None,
     }
 }
 
 /// Methods this build gives request semantics to.
 ///
-/// `tools/call` is `CallToolRequest` and `tools/list` is `ListToolsRequest`, and a request MUST carry
-/// an id. Without this, a request-only method could shed the id requirement simply by omitting the
-/// member, and with it the required 2026 `RequestParams._meta`, because notification metadata is
-/// optional. The list is deliberately the methods the parser already gives request payloads to
-/// rather than every method in the specification: an extension method with an unknown name stays a
-/// notification, so this refuses what is known to be a request instead of guessing about the rest.
-pub(crate) const REQUEST_ONLY_METHODS: &[&str] = &["tools/call", "tools/list"];
+/// A request MUST carry an id, so without this a request method could shed the requirement simply by
+/// omitting the member, and with it the required 2026 `RequestParams._meta`, because notification
+/// metadata is optional.
+///
+/// The set is the request methods of every revision this build recognizes, not only the two the
+/// parser gives payloads to. An earlier head listed those two, which left `prompts/get` and the rest
+/// evading the rule for exactly the same reason `tools/call` had. Collected from the `Request`
+/// interfaces of `schema/{2024-11-05,2025-03-26,2025-06-18,2025-11-25,2026-07-28}` at spec commit
+/// `5f5440bb`, which is what the ledger names as the source of truth.
+///
+/// Methods that left the protocol stay in: a transcript from an older revision is still a transcript,
+/// and a request in it is still a request. A name that is in none of them stays a notification, so an
+/// unknown extension is unaffected.
+pub(crate) const REQUEST_ONLY_METHODS: &[&str] = &[
+    "completion/complete",
+    "elicitation/create",
+    "initialize",
+    "logging/setLevel",
+    "ping",
+    "prompts/get",
+    "prompts/list",
+    "resources/list",
+    "resources/read",
+    "resources/subscribe",
+    "resources/templates/list",
+    "resources/unsubscribe",
+    "roots/list",
+    "sampling/createMessage",
+    "server/discover",
+    "subscriptions/listen",
+    "tasks/cancel",
+    "tasks/get",
+    "tasks/list",
+    "tasks/result",
+    "tools/call",
+    "tools/list",
+];
 
 /// Which JSON-RPC message shape this is, carrying the method so that nothing has to read it a
 /// second time.
@@ -223,7 +275,7 @@ pub(crate) enum MessageShapeError {
 ///
 /// A notification is a request object *without* an `id` member, so absence is the discriminant and
 /// nothing about the value is. An explicit `"id": null` is therefore a request, not a notification:
-/// MCP restricts `RequestId` to a string or an integer, which makes a null id an invalid request id
+/// MCP restricts `RequestId` to a string or a number, which makes a null id an invalid request id
 /// rather than an absent one, and calling it a notification drops the required 2026 request metadata
 /// for any message that writes that one token.
 ///

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -442,7 +442,18 @@ pub(crate) fn fold_envelope(
 
 /// Read `params._meta` as an observation.
 pub(crate) fn observe_request_metadata(raw: &serde_json::Value) -> RequestMetadata {
-    let Some(meta) = raw.get("params").and_then(|p| p.get("_meta")) else {
+    let Some(params) = raw.get("params") else {
+        return RequestMetadata::Absent;
+    };
+    // The fourth container, and the one this rule was still not applied to. `params` is an object
+    // by schema, and reaching through a scalar or array with `Value::get` answers `None`, which
+    // reads a container that arrived and failed as silence. Under a legacy era that difference
+    // decides the verdict: `Absent` is only a fault from 2026 on, so a deviant `params` came back
+    // `Valid`, while `Malformed` is a fault whatever the era turned out to be.
+    if !params.is_object() {
+        return RequestMetadata::Malformed;
+    }
+    let Some(meta) = params.get("_meta") else {
         return RequestMetadata::Absent;
     };
     // `_meta` is an object by schema, so a scalar or array is a signal that arrived and failed.

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -49,14 +49,17 @@ pub(crate) enum MessageKind {
     Response,
 }
 
-/// Classify by the two fields JSON-RPC uses: a notification is a request shape without an `id`.
+/// Classify by the two fields JSON-RPC uses. A notification is a request object *without* an `id`
+/// member, so absence is the discriminant and nothing about the value is.
 ///
-/// An explicit `"id": null` counts as a notification. It is not a usable request id, and the
-/// alternative is to hold a message with no addressable identity to a requirement whose whole
-/// purpose is to describe an addressed request.
+/// An explicit `"id": null` is therefore a request, not a notification. `RequestId` is `string |
+/// number`, so a null id is an invalid request id rather than an absent one, and treating it as a
+/// notification drops the required 2026 request metadata for any message that writes one. That is a
+/// fail-open reachable by a single token. The invalid id is a JSON-RPC validity question this slice
+/// does not own; what it owns is that the metadata requirement still applies.
 pub(crate) fn classify_message(v: &serde_json::Value) -> MessageKind {
     match v.get("method").and_then(|m| m.as_str()) {
-        Some(_) if v.get("id").is_some_and(|id| !id.is_null()) => MessageKind::Request,
+        Some(_) if v.get("id").is_some() => MessageKind::Request,
         Some(_) => MessageKind::Notification,
         None => MessageKind::Response,
     }

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -271,6 +271,12 @@ fn requires_result_type(version: &str) -> bool {
 // so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
 #[allow(dead_code)]
 pub(crate) fn conclude(era: &EraResolution, observed: &ResultObservation) -> ResultConclusion {
+    // Checked before the era, for the same reason `conclude_request` checks its metadata first: an
+    // unreadable field is a fault whatever the era turned out to be, and reading the era first
+    // downgrades it to whatever the era's own gap was.
+    if matches!(observed, ResultObservation::Malformed) {
+        return ResultConclusion::Invalid(InvalidReason::MalformedResultType);
+    }
     let version = match era {
         EraResolution::Known(v) => v,
         EraResolution::Unknown(UnknownReason::MalformedSignal) => {
@@ -353,6 +359,25 @@ pub(crate) fn conclude_request(
 }
 
 /// The `_meta` key the protocol version travels under on a request.
+/// How much of an unrecognized token is kept. The two defined tokens are 8 and 14 bytes, so this
+/// is generous for anything a future revision might name while still bounding what one record can
+/// cost.
+pub(crate) const MAX_TOKEN_BYTES: usize = 64;
+
+/// Truncate on a character boundary, since cutting a UTF-8 string at a byte index panics.
+fn bounded_token(token: &str) -> String {
+    if token.len() <= MAX_TOKEN_BYTES {
+        return token.to_string();
+    }
+    let cut = token
+        .char_indices()
+        .map(|(i, _)| i)
+        .take_while(|i| *i <= MAX_TOKEN_BYTES)
+        .last()
+        .unwrap_or(0);
+    token[..cut].to_string()
+}
+
 pub(crate) const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
 
 /// The transport header carrying the same value.
@@ -454,13 +479,21 @@ pub(crate) fn observe_request_metadata(raw: &serde_json::Value) -> RequestMetada
 /// than absent, so it can never reach the rule that reads absence as completion.
 pub(crate) fn observe_result(raw: &serde_json::Value) -> Option<ResultObservation> {
     let result = raw.get("result")?;
+    // A `result` that is not an object cannot be missing a field. `Value::get` answers `None` on a
+    // scalar, array or null, which reported it as `Missing` and let the backward-compatibility rule
+    // read it as a completed action.
+    if !result.is_object() {
+        return Some(ResultObservation::Malformed);
+    }
     Some(match result.get("resultType") {
         None => ResultObservation::Missing,
         Some(v) => match v.as_str() {
             Some("complete") => ResultObservation::Complete,
             Some("input_required") => ResultObservation::InputRequired,
-            Some(other) if !other.is_empty() => ResultObservation::Unrecognized(other.to_string()),
-            _ => ResultObservation::Malformed,
+            // `ResultType` is an open string union, so any string is syntactically a token. An
+            // empty one is unrecognized rather than unreadable; only a non-string is malformed.
+            Some(other) => ResultObservation::Unrecognized(bounded_token(other)),
+            None => ResultObservation::Malformed,
         },
     })
 }

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -35,6 +35,94 @@ pub(crate) enum EnvelopeObservation {
     Malformed,
 }
 
+/// A `serde_json::Value` that refuses duplicate object members as it is built.
+///
+/// `serde_json` collapses duplicate members last-value-wins, so by the time any guard reads the tree
+/// the evidence that two were sent is already gone. A post-collapse check cannot recover it and a
+/// second full deserialization would double what a hostile input costs, so the refusal belongs in the
+/// one pass that builds the tree.
+///
+/// The rule is every duplicate rather than a list of security-significant names. A name list goes
+/// stale the moment a significant key is added, and this file has already been through several
+/// enumerations that missed a member. RFC 8259 says names SHOULD be unique and RFC 7493 requires it,
+/// so refusing outright cannot go stale. Value-free: the diagnostic names neither the key nor either
+/// value.
+#[derive(Debug, Clone)]
+pub(crate) struct UniqueValue(pub(crate) serde_json::Value);
+
+impl<'de> serde::Deserialize<'de> for UniqueValue {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = UniqueValue;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("any JSON value with unique object members")
+            }
+
+            fn visit_unit<E>(self) -> Result<UniqueValue, E> {
+                Ok(UniqueValue(serde_json::Value::Null))
+            }
+            fn visit_none<E>(self) -> Result<UniqueValue, E> {
+                Ok(UniqueValue(serde_json::Value::Null))
+            }
+            fn visit_some<D: serde::Deserializer<'de>>(
+                self,
+                d: D,
+            ) -> Result<UniqueValue, D::Error> {
+                <UniqueValue as serde::Deserialize>::deserialize(d)
+            }
+            fn visit_bool<E>(self, v: bool) -> Result<UniqueValue, E> {
+                Ok(UniqueValue(v.into()))
+            }
+            fn visit_i64<E>(self, v: i64) -> Result<UniqueValue, E> {
+                Ok(UniqueValue(v.into()))
+            }
+            fn visit_u64<E>(self, v: u64) -> Result<UniqueValue, E> {
+                Ok(UniqueValue(v.into()))
+            }
+            fn visit_f64<E>(self, v: f64) -> Result<UniqueValue, E> {
+                Ok(UniqueValue(
+                    serde_json::Number::from_f64(v).map_or(serde_json::Value::Null, Into::into),
+                ))
+            }
+            fn visit_str<E>(self, v: &str) -> Result<UniqueValue, E> {
+                Ok(UniqueValue(v.into()))
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<UniqueValue, A::Error> {
+                let mut out = Vec::new();
+                while let Some(UniqueValue(v)) = seq.next_element()? {
+                    out.push(v);
+                }
+                Ok(UniqueValue(serde_json::Value::Array(out)))
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<UniqueValue, A::Error> {
+                let mut out = serde_json::Map::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    let UniqueValue(value) = map.next_value()?;
+                    if out.insert(key, value).is_some() {
+                        return Err(serde::de::Error::custom(
+                            "JSON object contains a duplicate member",
+                        ));
+                    }
+                }
+                Ok(UniqueValue(serde_json::Value::Object(out)))
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
 /// Which JSON-RPC message shape this is, carrying the method so that nothing has to read it a
 /// second time.
 ///
@@ -422,8 +510,10 @@ pub(crate) fn conclude_request(
 /// The `_meta` key the protocol version travels under on a request.
 pub(crate) const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
 
-/// The transport header carrying the same value.
-pub(crate) const PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+/// The transport header carrying the same value. Compared with `eq_ignore_ascii_case`, so the
+/// casing here is documentation rather than a value the comparison depends on, and no allocation is
+/// made per key of an attacker-supplied header map.
+pub(crate) const PROTOCOL_VERSION_HEADER: &str = "MCP-Protocol-Version";
 
 /// Read one header slot as an observation rather than as an `Option`.
 ///
@@ -441,7 +531,7 @@ pub(crate) fn observe_header(headers: Option<&serde_json::Value>) -> Option<Enve
     let mut any = false;
     for (_, value) in map
         .iter()
-        .filter(|(k, _)| k.to_ascii_lowercase() == PROTOCOL_VERSION_HEADER)
+        .filter(|(k, _)| k.eq_ignore_ascii_case(PROTOCOL_VERSION_HEADER))
     {
         any = true;
         match value.as_str() {

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -155,6 +155,12 @@ pub(crate) enum MessageKind<'a> {
 pub(crate) enum MessageShapeError {
     #[error("JSON-RPC method must be a string")]
     NonStringMethod,
+    /// A no-method object is a response, and a response carries a result or an error, never both and
+    /// never neither. Both licensed completion: the result axis read `result`, saw `complete`, and a
+    /// 2026 era concluded `Terminal` on a protocol-invalid message. Neither was correlated as a
+    /// response, so it consumed an outstanding id and freed it for reuse without answering anything.
+    #[error("a JSON-RPC response must carry exactly one of result or error")]
+    NotExactlyOneResponseBody,
 }
 
 /// Classify by the two fields JSON-RPC uses.
@@ -173,6 +179,14 @@ pub(crate) fn classify_message(
     v: &serde_json::Value,
 ) -> Result<MessageKind<'_>, MessageShapeError> {
     let Some(method) = v.get("method") else {
+        // Exactly one of the two, checked here so no axis ever reads a shape that is not a response.
+        // The `method` branch below is untouched: a hybrid carrying `method` and `result` stays a
+        // request, which is a separate rule with its own tests.
+        let has_result = v.get("result").is_some();
+        let has_error = v.get("error").is_some();
+        if has_result == has_error {
+            return Err(MessageShapeError::NotExactlyOneResponseBody);
+        }
         return Ok(MessageKind::Response);
     };
     let Some(method) = method.as_str() else {

--- a/crates/assay-core/src/mcp/era/tests.rs
+++ b/crates/assay-core/src/mcp/era/tests.rs
@@ -448,3 +448,34 @@ fn composite_a_malformed_result_type_before_2026_is_not_complete() {
         ResultConclusion::Invalid(InvalidReason::MalformedResultType)
     );
 }
+
+/// An unreadable `resultType` is a fault whatever the era turned out to be. Reading the era first
+/// downgraded it to whatever the era's own gap was, so a malformed field under an unknown era came
+/// back `Incomplete` instead of `Invalid`.
+#[test]
+fn a_malformed_result_survives_an_unknown_era() {
+    for era in [
+        EraResolution::Unknown(UnknownReason::NoSignal),
+        EraResolution::Unknown(UnknownReason::UnsupportedVersion("2031-01-01".into())),
+    ] {
+        assert_eq!(
+            conclude(&era, &ResultObservation::Malformed),
+            ResultConclusion::Invalid(InvalidReason::MalformedResultType)
+        );
+    }
+}
+
+/// A token longer than the bound keeps only its prefix, so the retained value is a diagnostic and
+/// not a faithful record. Stated here so the truncation is a decision rather than a surprise.
+#[test]
+fn an_over_long_token_is_truncated_on_a_character_boundary() {
+    let token = "é".repeat(200);
+    let ResultObservation::Unrecognized(kept) = observe_result(&serde_json::json!({
+        "result": {"resultType": token}
+    }))
+    .expect("a result") else {
+        panic!("expected an unrecognized token")
+    };
+    assert!(kept.len() <= MAX_TOKEN_BYTES);
+    assert!(token.starts_with(&kept), "the prefix is kept intact");
+}

--- a/crates/assay-core/src/mcp/era/tests.rs
+++ b/crates/assay-core/src/mcp/era/tests.rs
@@ -1,0 +1,450 @@
+//! One behaviour class per test. Nothing here is composite: a test that walks a table proves only
+//! its first failing row, so each row is its own test and each bites on its own assertion.
+
+use super::*;
+
+const V2026: &str = RESULT_TYPE_SINCE;
+const V2025: &str = "2025-06-18";
+
+// --- Era resolution ----------------------------------------------------------------------------
+
+#[test]
+fn no_signal_anywhere_is_unknown_no_signal() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::NotApplicable,
+            &RequestMetadata::Absent
+        ),
+        EraResolution::Unknown(UnknownReason::NoSignal)
+    );
+}
+
+/// The correction that matters most: an unframed format with body metadata has a known era. An
+/// umbrella refusal on `NotApplicable` would ceiling valid evidence for a signal the format was
+/// never required to carry.
+#[test]
+fn body_metadata_alone_resolves_the_era() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::NotApplicable,
+            &RequestMetadata::Present(V2026.into())
+        ),
+        EraResolution::Known(V2026.into())
+    );
+}
+
+#[test]
+fn a_header_alone_resolves_the_era() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present(V2025.into()),
+            &RequestMetadata::Absent
+        ),
+        EraResolution::Known(V2025.into())
+    );
+}
+
+#[test]
+fn agreeing_signals_resolve_to_known() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present(V2026.into()),
+            &RequestMetadata::Present(V2026.into())
+        ),
+        EraResolution::Known(V2026.into())
+    );
+}
+
+/// The spec's own rule, not one this design invented.
+#[test]
+fn disagreeing_signals_resolve_to_conflicting() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present(V2025.into()),
+            &RequestMetadata::Present(V2026.into())
+        ),
+        EraResolution::Conflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        }
+    );
+}
+
+/// A well-formed date this build has no rules for. Distinct from silence: the signal arrived and
+/// was readable, and the gap is in the reader.
+#[test]
+fn a_wellformed_but_unsupported_version_is_unsupported_not_missing() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present("2031-01-01".into()),
+            &RequestMetadata::Absent
+        ),
+        EraResolution::Unknown(UnknownReason::UnsupportedVersion("2031-01-01".into()))
+    );
+}
+
+/// Lexicographic comparison against `RESULT_TYPE_SINCE` is only sound once the value is known to
+/// be a version at all, so an unusable one must be caught before any ordering is attempted.
+#[test]
+fn a_malformed_signal_is_malformed_not_unsupported() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::NotApplicable,
+            &RequestMetadata::Malformed
+        ),
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+}
+
+// --- Reading a response under the era ----------------------------------------------------------
+
+/// The positive case. Without it an implementation that refuses every modern result passes the
+/// rest of this file.
+#[test]
+fn complete_at_2026_is_terminal() {
+    assert_eq!(
+        conclude(
+            &EraResolution::Known(V2026.into()),
+            &ResultObservation::Complete
+        ),
+        ResultConclusion::Terminal
+    );
+}
+
+/// Valid, and not finished. The distinction a boolean cannot carry.
+#[test]
+fn input_required_is_valid_but_not_terminal() {
+    assert_eq!(
+        conclude(
+            &EraResolution::Known(V2026.into()),
+            &ResultObservation::InputRequired
+        ),
+        ResultConclusion::NonTerminal
+    );
+}
+
+#[test]
+fn an_unrecognized_token_is_incomplete_not_invalid() {
+    assert_eq!(
+        conclude(
+            &EraResolution::Known(V2026.into()),
+            &ResultObservation::Unrecognized("banana".into())
+        ),
+        ResultConclusion::Incomplete(IncompleteReason::UnrecognizedResultType("banana".into()))
+    );
+}
+
+#[test]
+fn missing_result_type_at_2026_is_invalid() {
+    assert_eq!(
+        conclude(
+            &EraResolution::Known(V2026.into()),
+            &ResultObservation::Missing
+        ),
+        ResultConclusion::Invalid(InvalidReason::MissingResultType)
+    );
+}
+
+/// The other arm of the same pair, as its own test so it is reached even when the first fails.
+#[test]
+fn missing_result_type_before_2026_is_terminal() {
+    assert_eq!(
+        conclude(
+            &EraResolution::Known(V2025.into()),
+            &ResultObservation::Missing
+        ),
+        ResultConclusion::Terminal
+    );
+}
+
+#[test]
+fn an_unknown_era_blocks_as_incomplete() {
+    assert_eq!(
+        conclude(
+            &EraResolution::Unknown(UnknownReason::NoSignal),
+            &ResultObservation::Complete
+        ),
+        ResultConclusion::Incomplete(IncompleteReason::EraUnknown(UnknownReason::NoSignal))
+    );
+}
+
+/// Contradiction is not silence: unknown may become conclusive with more evidence, this will not.
+#[test]
+fn a_conflicting_era_blocks_as_invalid() {
+    assert_eq!(
+        conclude(
+            &EraResolution::Conflicting {
+                header: V2025.into(),
+                body: V2026.into()
+            },
+            &ResultObservation::Complete
+        ),
+        ResultConclusion::Invalid(InvalidReason::EraConflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        })
+    );
+}
+
+// --- Reading a request under the era -----------------------------------------------------------
+
+/// `RequestParams._meta` and the version inside it are both required at 2026, with no `?`, so a
+/// request that resolves to that era and carries neither is a fault on its own terms.
+#[test]
+fn a_2026_request_without_metadata_is_invalid() {
+    assert_eq!(
+        conclude_request(
+            &EraResolution::Known(V2026.into()),
+            &RequestMetadata::Absent
+        ),
+        RequestAssessment::Invalid(InvalidReason::MissingRequestMetadata)
+    );
+}
+
+/// Missing and unreadable are different findings, which is why the observation is typed.
+#[test]
+fn a_2026_request_with_malformed_metadata_is_invalid_for_a_different_reason() {
+    assert_eq!(
+        conclude_request(
+            &EraResolution::Known(V2026.into()),
+            &RequestMetadata::Malformed
+        ),
+        RequestAssessment::Invalid(InvalidReason::MalformedRequestMetadata)
+    );
+}
+
+/// Before the field existed its absence is not a fault, so the rule must not become blanket.
+#[test]
+fn a_legacy_request_without_metadata_is_not_invalid() {
+    assert_eq!(
+        conclude_request(
+            &EraResolution::Known(V2025.into()),
+            &RequestMetadata::Absent
+        ),
+        RequestAssessment::Valid
+    );
+}
+
+#[test]
+fn a_2026_request_carrying_metadata_is_not_invalid() {
+    assert_eq!(
+        conclude_request(
+            &EraResolution::Known(V2026.into()),
+            &RequestMetadata::Present(V2026.into())
+        ),
+        RequestAssessment::Valid
+    );
+}
+
+/// A signal that arrived and is not a version. Found by mutation: with only the `Malformed`
+/// observation covered, deleting the shape check left every test green, because that path reaches
+/// `MalformedSignal` through the observation rather than through the check. Lexicographic
+/// comparison against `RESULT_TYPE_SINCE` is date comparison only once the value is known to be a
+/// date, so the check has to be the thing under test.
+#[test]
+fn a_present_signal_that_is_not_a_version_is_malformed() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present("not-a-date".into()),
+            &RequestMetadata::Absent
+        ),
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+}
+
+/// The trap the shape check exists for: a string that sorts above `RESULT_TYPE_SINCE` without
+/// being a date at all. Unguarded it would classify as a version and compare successfully.
+#[test]
+fn a_non_version_that_sorts_high_is_still_malformed() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::NotApplicable,
+            &RequestMetadata::Present("9999-not-a-date".into())
+        ),
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+}
+
+// --- Composite: the chain a caller actually walks ----------------------------------------------
+//
+// The tests above call `conclude_request` with an era handed to it directly. That can assert on a
+// pair the resolver never produces, which is how a unit-green implementation fails open in use.
+// These walk resolve-then-conclude, and they are the ones that decide.
+
+/// A 2026 header with unreadable metadata. `resolve_era` cannot return `Known` here, so the
+/// request-side fault has to survive an unresolved era or it is lost. Malformed metadata is a
+/// fault whenever it appears: unlike absence, it does not depend on which version is in force.
+#[test]
+fn composite_malformed_metadata_under_a_2026_header_is_invalid() {
+    let envelope = EnvelopeObservation::Present(V2026.into());
+    let metadata = RequestMetadata::Malformed;
+    let era = resolve_era(&envelope, &metadata);
+    assert_eq!(
+        conclude_request(&era, &metadata),
+        RequestAssessment::Invalid(InvalidReason::MalformedRequestMetadata)
+    );
+}
+
+/// A contradicted request with no response at all. Not double counting is the aggregator's job:
+/// a refused or aborted request is exactly the case that never produces a response, so leaving the
+/// fault to the response side loses it entirely.
+#[test]
+fn composite_a_conflicting_request_without_a_response_is_invalid() {
+    let envelope = EnvelopeObservation::Present(V2025.into());
+    let metadata = RequestMetadata::Present(V2026.into());
+    let era = resolve_era(&envelope, &metadata);
+    assert_eq!(
+        conclude_request(&era, &metadata),
+        RequestAssessment::Invalid(InvalidReason::EraConflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        })
+    );
+}
+
+/// Unreadable beats contradicted. Two values that are not both versions cannot be said to
+/// disagree about a version, so shape has to be settled before any comparison.
+#[test]
+fn composite_a_malformed_header_against_a_valid_body_is_malformed_not_conflicting() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present("not-a-date".into()),
+            &RequestMetadata::Present(V2026.into())
+        ),
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+}
+
+#[test]
+fn composite_a_malformed_body_against_a_valid_header_is_malformed_not_conflicting() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present(V2026.into()),
+            &RequestMetadata::Present("not-a-date".into())
+        ),
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+}
+
+#[test]
+fn composite_two_malformed_signals_are_malformed() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present("nope".into()),
+            &RequestMetadata::Present("also-nope".into())
+        ),
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+}
+
+/// A header that arrived and could not be read at all. Without this variant the wiring would have
+/// to call it absent, which is a different fact with a different conclusion.
+#[test]
+fn a_malformed_header_is_representable_and_malformed() {
+    assert_eq!(
+        resolve_era(&EnvelopeObservation::Malformed, &RequestMetadata::Absent),
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+}
+
+/// Ten bytes and two dashes is not a date. An impossible month must not pass as a version this
+/// build merely does not support, because that reports a reader gap where the record is wrong.
+#[test]
+fn an_impossible_date_is_malformed_not_unsupported() {
+    for bad in ["2026-99-99", "2026-13-01", "2026-00-10", "2026-01-32"] {
+        assert_eq!(
+            resolve_era(
+                &EnvelopeObservation::Present(bad.into()),
+                &RequestMetadata::Absent
+            ),
+            EraResolution::Unknown(UnknownReason::MalformedSignal),
+            "{bad}"
+        );
+    }
+}
+
+/// The twin of the metadata case, and the one an earlier fix missed. A malformed header resolves
+/// to an unknown era, and reading the era alone then answers "no objection" for the one input that
+/// is broken. Walks the real chain rather than stopping at `resolve_era`.
+#[test]
+fn composite_a_malformed_header_makes_the_request_invalid() {
+    let envelope = EnvelopeObservation::Malformed;
+    let metadata = RequestMetadata::Absent;
+    let era = resolve_era(&envelope, &metadata);
+    assert_eq!(era, EraResolution::Unknown(UnknownReason::MalformedSignal));
+    assert_eq!(
+        conclude_request(&era, &metadata),
+        RequestAssessment::Invalid(InvalidReason::MalformedEraSignal)
+    );
+}
+
+/// The same signal on the response axis. Unreadable is invalid on both, because more evidence does
+/// not make an unreadable value readable.
+#[test]
+fn composite_a_malformed_signal_makes_the_result_invalid() {
+    let era = resolve_era(
+        &EnvelopeObservation::Present("2026-02-31".into()),
+        &RequestMetadata::Absent,
+    );
+    assert_eq!(
+        conclude(&era, &ResultObservation::Complete),
+        ResultConclusion::Invalid(InvalidReason::MalformedEraSignal)
+    );
+}
+
+/// A date that is shaped right, in range per field, and does not exist. February never has 31
+/// days, so this is not a version this build fails to support: it is not a version.
+#[test]
+fn an_impossible_day_of_month_is_malformed_not_unsupported() {
+    for bad in ["2026-02-31", "2026-02-30", "2026-04-31", "2025-02-29"] {
+        assert_eq!(
+            resolve_era(
+                &EnvelopeObservation::Present(bad.into()),
+                &RequestMetadata::Absent
+            ),
+            EraResolution::Unknown(UnknownReason::MalformedSignal),
+            "{bad}"
+        );
+    }
+}
+
+/// The leap-year arm, so the rule is not simply "February is 28".
+#[test]
+fn a_leap_day_is_a_wellformed_date() {
+    assert_eq!(
+        resolve_era(
+            &EnvelopeObservation::Present("2024-02-29".into()),
+            &RequestMetadata::Absent
+        ),
+        EraResolution::Unknown(UnknownReason::UnsupportedVersion("2024-02-29".into()))
+    );
+}
+
+/// An unreadable `resultType` under a 2026 era.
+#[test]
+fn composite_a_malformed_result_type_at_2026_is_invalid() {
+    let era = resolve_era(
+        &EnvelopeObservation::Present(V2026.into()),
+        &RequestMetadata::Present(V2026.into()),
+    );
+    assert_eq!(
+        conclude(&era, &ResultObservation::Malformed),
+        ResultConclusion::Invalid(InvalidReason::MalformedResultType)
+    );
+}
+
+/// The arm that matters more. Under a legacy era an absent `resultType` MUST be read as complete,
+/// and an unreadable one must not inherit that reading: it is not absent, it is broken. Without
+/// this a malformed field silently becomes a completed action.
+#[test]
+fn composite_a_malformed_result_type_before_2026_is_not_complete() {
+    let era = resolve_era(
+        &EnvelopeObservation::Present(V2025.into()),
+        &RequestMetadata::Absent,
+    );
+    assert_eq!(era, EraResolution::Known(V2025.into()));
+    assert_eq!(
+        conclude(&era, &ResultObservation::Malformed),
+        ResultConclusion::Invalid(InvalidReason::MalformedResultType)
+    );
+}

--- a/crates/assay-core/src/mcp/era/tests.rs
+++ b/crates/assay-core/src/mcp/era/tests.rs
@@ -464,3 +464,21 @@ fn a_malformed_result_survives_an_unknown_era() {
         );
     }
 }
+
+/// The ASCII-digit half of the shape check, which no test reached: `"not-a-date"` dies on the
+/// dash anchors and `"9999-not-a-date"` on the length, both before the digits are looked at.
+/// Without it these are retained as `UnsupportedVersion`, which blames the reader and keeps
+/// attacker-chosen bytes in the sidecar.
+#[test]
+fn a_non_numeric_date_shape_is_malformed_not_unsupported() {
+    for bad in ["abcd-01-01", "20ab-01-01", "+123-01-01", "  12-01-01"] {
+        assert_eq!(
+            resolve_era(
+                &EnvelopeObservation::Present(bad.into()),
+                &RequestMetadata::Absent
+            ),
+            EraResolution::Unknown(UnknownReason::MalformedSignal),
+            "{bad}"
+        );
+    }
+}

--- a/crates/assay-core/src/mcp/era/tests.rs
+++ b/crates/assay-core/src/mcp/era/tests.rs
@@ -128,9 +128,9 @@ fn an_unrecognized_token_is_incomplete_not_invalid() {
     assert_eq!(
         conclude(
             &EraResolution::Known(V2026.into()),
-            &ResultObservation::Unrecognized("banana".into())
+            &ResultObservation::Unrecognized
         ),
-        ResultConclusion::Incomplete(IncompleteReason::UnrecognizedResultType("banana".into()))
+        ResultConclusion::Incomplete(IncompleteReason::UnrecognizedResultType)
     );
 }
 
@@ -463,19 +463,4 @@ fn a_malformed_result_survives_an_unknown_era() {
             ResultConclusion::Invalid(InvalidReason::MalformedResultType)
         );
     }
-}
-
-/// A token longer than the bound keeps only its prefix, so the retained value is a diagnostic and
-/// not a faithful record. Stated here so the truncation is a decision rather than a surprise.
-#[test]
-fn an_over_long_token_is_truncated_on_a_character_boundary() {
-    let token = "é".repeat(200);
-    let ResultObservation::Unrecognized(kept) = observe_result(&serde_json::json!({
-        "result": {"resultType": token}
-    }))
-    .expect("a result") else {
-        panic!("expected an unrecognized token")
-    };
-    assert!(kept.len() <= MAX_TOKEN_BYTES);
-    assert!(token.starts_with(&kept), "the prefix is kept intact");
 }

--- a/crates/assay-core/src/mcp/mapper_v2.rs
+++ b/crates/assay-core/src/mcp/mapper_v2.rs
@@ -1,7 +1,26 @@
+use crate::mcp::era::{correlation_id, CorrelationId};
 use crate::mcp::types::*;
 use crate::trace::schema::{EpisodeEnd, EpisodeStart, StepEntry, ToolCallEntry, TraceEvent};
 use serde_json::json;
 use std::collections::HashMap;
+
+/// The correlation key for one event, read from its retained raw JSON.
+///
+/// `McpEvent::jsonrpc_id` is a public `String` and cannot distinguish a JSON number from a JSON
+/// string, so the mapper derives the same typed key the parser uses rather than a second rendering
+/// of it. Two readers of one identity is how this drifted apart in the first place.
+fn payload_correlation_id(payload: &McpPayload) -> Option<CorrelationId> {
+    let raw = match payload {
+        McpPayload::SessionStart { raw }
+        | McpPayload::ToolsListRequest { raw }
+        | McpPayload::ToolsListResponse { raw, .. }
+        | McpPayload::ToolCallRequest { raw, .. }
+        | McpPayload::ToolCallResponse { raw, .. }
+        | McpPayload::SessionEnd { raw, .. }
+        | McpPayload::Other { raw, .. } => raw,
+    };
+    correlation_id(raw)
+}
 
 /// Map normalized MCP events to Assay V2 trace events (JSONL).
 pub fn mcp_events_to_v2_trace(
@@ -82,7 +101,12 @@ pub fn mcp_events_to_v2_trace(
     // The `ToolCallEntry` needs the `args` from the Request.
 
     // Map: id -> (StepId, ToolName, Args, Timestamp)
-    let mut pending_calls: HashMap<String, (String, String, serde_json::Value, u64)> =
+    // The same crate-private typed key the parser correlates on. Keying on the public
+    // `McpEvent::jsonrpc_id` rendered JSON number `1` and JSON string `"1"` identically, so the
+    // second request overwrote the first and a numeric response was attached to the string call.
+    // A number the correlator declines to key does not pair here either, rather than pairing on a
+    // rendering that cannot tell two ids apart.
+    let mut pending_calls: HashMap<CorrelationId, (String, String, serde_json::Value, u64)> =
         HashMap::new();
 
     let mut idx: i64 = 0;
@@ -93,6 +117,9 @@ pub fn mcp_events_to_v2_trace(
         if let Some(ts) = e.timestamp_ms {
             last_ts = last_ts.max(ts);
         }
+
+        // Read before the match, which consumes the payload.
+        let correlation = payload_correlation_id(&e.payload);
 
         match e.payload {
             McpPayload::ToolsListRequest { .. } => {
@@ -144,8 +171,8 @@ pub fn mcp_events_to_v2_trace(
                     meta: json!({ "jsonrpc_id": e.jsonrpc_id }),
                 }));
 
-                // Buffer for correlation if ID present
-                if let Some(id) = e.jsonrpc_id {
+                // Buffer for correlation if the id can be keyed
+                if let Some(id) = correlation.clone() {
                     pending_calls.insert(
                         id,
                         (step_id.clone(), name.clone(), arguments.clone(), last_ts),
@@ -174,7 +201,7 @@ pub fn mcp_events_to_v2_trace(
                 result, is_error, ..
             } => {
                 // Try to find matching Request
-                if let Some(id) = e.jsonrpc_id.clone() {
+                if let Some(id) = correlation {
                     if let Some((step_id, name, args, _req_ts)) = pending_calls.remove(&id) {
                         // Found match! Emit complete ToolCall
                         out.push(TraceEvent::ToolCall(ToolCallEntry {

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod decision;
+pub(crate) mod era;
 pub mod g3_auth_context;
 
 pub use g3_auth_context::AuthContextProjection;

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -1,13 +1,12 @@
 use crate::mcp::era::{
-    accept_id, classify_message, correlation_id, fold_envelope, observe_header,
+    classify_message, correlation_id, fold_envelope, id_is_acceptable, observe_header,
     observe_request_metadata, observe_result, resolve_era, EnvelopeObservation, McpEraContext,
     MessageKind, ParsedMcpEvent, RequestMetadata,
 };
-use crate::mcp::era::{CorrelationId, EraResolution, SeenMembers, UniqueValue};
+use crate::mcp::era::{CorrelationId, DuplicateAwareSink, EraResolution, SeenMembers, UniqueValue};
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use std::collections::HashSet;
 
 /// Parse MCP transcript file contents into normalized McpEvents.
 /// Public surface, unchanged. Projects the events out of the detailed parse and drops the era
@@ -202,7 +201,11 @@ fn parse_events_with_envelopes(
             parse_transport_transcript_detailed(text, "http-sse", "http-sse transcript", true)?
         }
     };
-    validate_mcp_events(&events)?;
+    // No global id gate here. The old one keyed on the public `String` rendering, so a number `1`
+    // and a string `"1"` collided; it refused any reuse anywhere in the transcript, so a legal reuse
+    // after a response was rejected; and it only saw `ToolCallRequest`. It also ran before
+    // correlation, which made it the de facto lifetime authority without owning the typed key.
+    // `correlate_calls` is that authority now, on the typed outstanding map.
     Ok((events, envelopes))
 }
 
@@ -572,18 +575,17 @@ fn auth_param_visible(header_value: &str, param_name: &str) -> bool {
 /// The existing type diagnostics for booleans, arrays and objects are kept: they are more specific
 /// than "not a string or a number" and downstream tests pin them.
 fn require_acceptable_id(raw_id: Option<&serde_json::Value>, source_line: u64) -> Result<String> {
-    // One match, one clone. The previous shape cloned the id inside `normalize_jsonrpc_id`, dropped
-    // that copy, cloned again into a `CorrelationId`, and cloned a third time into the public text —
-    // three transient copies of an attacker-controlled string on the hostile-input path, for a value
-    // that in the refusing case is discarded immediately.
+    // Acceptance and correlation are different questions, so this asks only the first. One clone,
+    // on the accepting path; the refusing path copies nothing.
     reject_unusable_id_shape(raw_id, source_line)?;
-    // Through `accept_id`, not a second copy of its rule. Re-deciding the vocabulary here is what
-    // made the mutation on `accept_id` stop biting: two readers of one rule, which is the drift that
-    // already produced the method discriminant and the correlation key defects on this branch. One
-    // clone still, since `accept_id` builds the key and destructuring moves the string out of it.
-    match raw_id.and_then(accept_id) {
-        Some(CorrelationId::Str(id) | CorrelationId::Num(id)) => Ok(id),
-        None => bail!(
+    // Acceptance is broader than correlation and is decided here: the schema allows a string or any
+    // number, so any of those is an acceptable id even when `correlation_id` declines to key it.
+    // Re-deciding the *correlation* rule here is what once made its mutation stop biting, so this
+    // asks only about acceptance and leaves keying to the one function that owns it.
+    match raw_id.filter(|v| id_is_acceptable(v)) {
+        Some(serde_json::Value::String(id)) => Ok(id.clone()),
+        Some(serde_json::Value::Number(id)) => Ok(id.to_string()),
+        _ => bail!(
             "JSON-RPC id on source line {} must be a string or a number",
             source_line
         ),
@@ -618,26 +620,6 @@ fn reject_unusable_id_shape(raw_id: Option<&serde_json::Value>, source_line: u64
             )
         }
     }
-}
-
-fn validate_mcp_events(events: &[McpEvent]) -> Result<()> {
-    let mut seen_tool_call_request_ids = HashSet::new();
-
-    for event in events {
-        if matches!(&event.payload, McpPayload::ToolCallRequest { .. }) {
-            if let Some(id) = &event.jsonrpc_id {
-                if !seen_tool_call_request_ids.insert(id.clone()) {
-                    bail!(
-                        "duplicate tools/call request id {:?} at source line {}",
-                        id,
-                        event.source_line
-                    );
-                }
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn extract_jsonrpc_from_sse(
@@ -777,7 +759,7 @@ impl<'de> Deserialize<'de> for TransportTranscript {
                         "headers" => out.headers = Some(map.next_value()?),
                         "entries" => out.entries = map.next_value()?,
                         _ => {
-                            map.next_value::<serde::de::IgnoredAny>()?;
+                            map.next_value::<DuplicateAwareSink>()?;
                         }
                     }
                 }
@@ -823,9 +805,19 @@ impl<'de> Deserialize<'de> for TransportTranscriptEntry {
                         "headers" => out.headers = Some(map.next_value()?),
                         "request" => out.request = Some(map.next_value()?),
                         "response" => out.response = Some(map.next_value()?),
-                        "sse" => out.sse = map.next_value()?,
+                        // Symmetric with the other slots: an explicitly written null is a slot
+                        // that arrived and failed, not an absent one. Folding it to absent let it
+                        // vanish silently beside a valid request.
+                        "sse" => match map.next_value::<Option<TransportSseEnvelope>>()? {
+                            Some(envelope) => out.sse = Some(envelope),
+                            None => {
+                                return Err(serde::de::Error::custom(
+                                    "sse slot is present and null",
+                                ))
+                            }
+                        },
                         _ => {
-                            map.next_value::<serde::de::IgnoredAny>()?;
+                            map.next_value::<DuplicateAwareSink>()?;
                         }
                     }
                 }
@@ -836,14 +828,57 @@ impl<'de> Deserialize<'de> for TransportTranscriptEntry {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default)]
 struct TransportSseEnvelope {
-    #[serde(default)]
     event: Option<String>,
     #[allow(dead_code)]
-    #[serde(default)]
     id: Option<String>,
     data: UniqueValue,
+}
+
+/// Duplicate-aware like the transcript and the entry. The derive would have let a repeated unknown
+/// member through, and `data` is where an SSE frame carries its whole JSON-RPC message.
+impl<'de> Deserialize<'de> for TransportSseEnvelope {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = TransportSseEnvelope;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("an SSE envelope with unique members")
+            }
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<TransportSseEnvelope, A::Error> {
+                let mut out = TransportSseEnvelope::default();
+                let mut seen = SeenMembers::default();
+                // A hand-written `Deserialize` inherits none of the derive's field obligations. The
+                // derive made `data` required; initializing from `Default` and never checking let a
+                // frame with no data produce zero events instead of a refusal, which is a malformed
+                // frame disappearing silently.
+                let mut saw_data = false;
+                while let Some(key) = map.next_key::<String>()? {
+                    seen.insert::<A::Error>(&key)?;
+                    match key.as_str() {
+                        "event" => out.event = map.next_value()?,
+                        "id" => out.id = map.next_value()?,
+                        "data" => {
+                            out.data = map.next_value()?;
+                            saw_data = true;
+                        }
+                        _ => {
+                            map.next_value::<DuplicateAwareSink>()?;
+                        }
+                    }
+                }
+                if !saw_data {
+                    return Err(serde::de::Error::missing_field("data"));
+                }
+                Ok(out)
+            }
+        }
+        d.deserialize_map(V)
+    }
 }
 
 #[cfg(test)]

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -33,11 +33,21 @@ pub(crate) fn parse_mcp_transcript_detailed(
         .into_iter()
         .map(|event| {
             // Observations are taken by reference before the event moves, so no payload is cloned.
-            let raw = payload_raw(&event.payload);
-            let request_metadata = raw
-                .filter(|r| r.get("method").and_then(|m| m.as_str()).is_some())
-                .map(observe_request_metadata);
-            let result_observation = raw.and_then(observe_result);
+            //
+            // One discriminant decides both axes, and it is the same one `parse_jsonrpc_message`
+            // classified the payload with. Reading `result` unconditionally gave a hybrid message
+            // — a valid string `method` alongside a `result` — both request metadata and a result
+            // observation, which is a result conclusion about an event the parser had already
+            // called a request. A request has no result to observe, and that is now structural:
+            // the two axes are produced by one match, so neither can be reached from the other's
+            // arm.
+            let (request_metadata, result_observation) = match payload_raw(&event.payload) {
+                Some(raw) if request_method(raw).is_some() => {
+                    (Some(observe_request_metadata(raw)), None)
+                }
+                Some(raw) => (None, observe_result(raw)),
+                None => (None, None),
+            };
             // Unframed formats have one whole-input observation and no entries to index. A framed
             // input that does not resolve to an entry is a mapping the parser cannot vouch for,
             // and a plausible-but-wrong attribution is worse than an unusable one.
@@ -68,9 +78,43 @@ pub(crate) fn parse_mcp_transcript_detailed(
         .collect())
 }
 
-/// The headers map inside a `transport_context` value.
-fn header_map(ctx: &serde_json::Value) -> Option<&serde_json::Value> {
-    ctx.get("headers")
+/// The JSON-RPC `method` of a message, if it has one.
+///
+/// The single discriminant between a request and a response. `parse_jsonrpc_message` branches on
+/// it to build the payload and the era observations follow the same answer, so one message cannot
+/// be a request on one axis and a response on the other.
+fn request_method(v: &serde_json::Value) -> Option<&str> {
+    v.get("method").and_then(|m| m.as_str())
+}
+
+/// Read the header slot inside a `transport_context` as an observation.
+///
+/// A container that is present and not an object is a signal that arrived and failed, not silence.
+/// `Value::get` answers `None` for a scalar, an array or a null, which made a deviant container
+/// indistinguishable from no container at all: at transcript level the whole transcript read as
+/// `Absent`, and at entry level the entry silently inherited whatever valid default the transcript
+/// had set. Both are a fold toward "nothing was wrong" on the evidence that something was.
+fn observe_transport_context(ctx: Option<&serde_json::Value>) -> Option<EnvelopeObservation> {
+    let ctx = ctx?;
+    let Some(map) = ctx.as_object() else {
+        return Some(EnvelopeObservation::Malformed);
+    };
+    // A readable container with no `headers` key is silence rather than a defect: it arrived, it
+    // was legible, and it carried no header slot. Only an unreadable one is a finding.
+    observe_header(map.get("headers"))
+}
+
+/// Deserialize an optional free-form slot so that an explicit `null` stays *present*.
+///
+/// `Option<Value>` maps JSON `null` onto `None`, the same answer as a missing key, and for these
+/// slots that difference is exactly the finding: a container that was written and cannot be read
+/// is a malformed envelope, a container that was never written is silence. `default` still covers
+/// the missing key, so only a key that is actually in the document reaches this.
+fn present_slot<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde_json::Value::deserialize(deserializer).map(Some)
 }
 
 /// Which formats carry transport framing at all. `Inspector` reads an events array straight into
@@ -192,7 +236,7 @@ fn parse_transport_transcript_detailed(
     }
 
     let mut transcript_slots = Vec::new();
-    if let Some(o) = observe_header(transcript.transport_context.as_ref().and_then(header_map)) {
+    if let Some(o) = observe_transport_context(transcript.transport_context.as_ref()) {
         transcript_slots.push(o);
     }
     if let Some(o) = observe_header(transcript.headers.as_ref()) {
@@ -203,7 +247,7 @@ fn parse_transport_transcript_detailed(
     let mut out = Vec::new();
     for (idx, entry) in transcript.entries.into_iter().enumerate() {
         let mut slots = transcript_slots.clone();
-        if let Some(o) = observe_header(entry.transport_context.as_ref().and_then(header_map)) {
+        if let Some(o) = observe_transport_context(entry.transport_context.as_ref()) {
             slots.push(o);
         }
         if let Some(o) = observe_header(entry.headers.as_ref()) {
@@ -278,14 +322,10 @@ fn parse_jsonrpc_message(
     // JSON-RPC ID extraction
     let id_str = normalize_jsonrpc_id(v.get("id"), source_line)?;
 
-    // Check for JSON-RPC Request (has method)
-    let method = v
-        .get("method")
-        .and_then(|m| m.as_str())
-        .map(|s| s.to_string());
-
-    let payload = if let Some(method) = method {
-        match method.as_str() {
+    // Check for JSON-RPC Request (has method). The era observations read the same discriminant,
+    // so a message classified as a request here is a request on both axes.
+    let payload = if let Some(method) = request_method(&v) {
+        match method {
             "tools/list" => McpPayload::ToolsListRequest { raw: v.clone() },
             "tools/call" => {
                 let params = v.get("params").cloned().unwrap_or(serde_json::Value::Null);
@@ -596,10 +636,10 @@ fn parse_tools_list_result(v: &serde_json::Value) -> Result<Vec<McpToolDef>> {
 struct TransportTranscript {
     transport: Option<String>,
     #[allow(dead_code)]
-    #[serde(default)]
+    #[serde(default, deserialize_with = "present_slot")]
     transport_context: Option<serde_json::Value>,
     #[allow(dead_code)]
-    #[serde(default)]
+    #[serde(default, deserialize_with = "present_slot")]
     headers: Option<serde_json::Value>,
     #[serde(default)]
     entries: Vec<TransportTranscriptEntry>,
@@ -610,10 +650,10 @@ struct TransportTranscriptEntry {
     #[serde(default)]
     timestamp_ms: Option<u64>,
     #[allow(dead_code)]
-    #[serde(default)]
+    #[serde(default, deserialize_with = "present_slot")]
     transport_context: Option<serde_json::Value>,
     #[allow(dead_code)]
-    #[serde(default)]
+    #[serde(default, deserialize_with = "present_slot")]
     headers: Option<serde_json::Value>,
     #[serde(default)]
     request: Option<serde_json::Value>,

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -3,7 +3,7 @@ use crate::mcp::era::{
     observe_request_metadata, observe_result, resolve_era, EnvelopeObservation, McpEraContext,
     MessageKind, ParsedMcpEvent, RequestMetadata,
 };
-use crate::mcp::era::{CorrelationId, EraResolution, UniqueValue};
+use crate::mcp::era::{CorrelationId, EraResolution, SeenMembers, UniqueValue};
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -162,19 +162,6 @@ fn observe_transport_context(ctx: Option<&serde_json::Value>) -> Option<Envelope
     // A readable container with no `headers` key is silence rather than a defect: it arrived, it
     // was legible, and it carried no header slot. Only an unreadable one is a finding.
     observe_header(map.get("headers"))
-}
-
-/// Deserialize an optional free-form slot so that an explicit `null` stays *present*.
-///
-/// `Option<Value>` maps JSON `null` onto `None`, the same answer as a missing key, and for these
-/// slots that difference is exactly the finding: a container that was written and cannot be read
-/// is a malformed envelope, a container that was never written is silence. `default` still covers
-/// the missing key, so only a key that is actually in the document reaches this.
-fn present_slot<'de, D>(deserializer: D) -> Result<Option<UniqueValue>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    UniqueValue::deserialize(deserializer).map(Some)
 }
 
 /// Which formats carry transport framing at all. `Inspector` reads an events array straight into
@@ -583,7 +570,7 @@ fn auth_param_visible(header_value: &str, param_name: &str) -> bool {
 /// Accept the id a request or a success response must carry, or refuse value-free.
 ///
 /// The existing type diagnostics for booleans, arrays and objects are kept: they are more specific
-/// than "not a string or an integer" and downstream tests pin them.
+/// than "not a string or a number" and downstream tests pin them.
 fn require_acceptable_id(raw_id: Option<&serde_json::Value>, source_line: u64) -> Result<String> {
     // One match, one clone. The previous shape cloned the id inside `normalize_jsonrpc_id`, dropped
     // that copy, cloned again into a `CorrelationId`, and cloned a third time into the public text —
@@ -597,7 +584,7 @@ fn require_acceptable_id(raw_id: Option<&serde_json::Value>, source_line: u64) -
     match raw_id.and_then(accept_id) {
         Some(CorrelationId::Str(id) | CorrelationId::Num(id)) => Ok(id),
         None => bail!(
-            "JSON-RPC id on source line {} must be a string or an integer",
+            "JSON-RPC id on source line {} must be a string or a number",
             source_line
         ),
     }
@@ -754,35 +741,99 @@ fn parse_tools_list_result(v: &serde_json::Value) -> Result<Vec<McpToolDef>> {
     Ok(out)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default)]
 struct TransportTranscript {
     transport: Option<String>,
     #[allow(dead_code)]
-    #[serde(default, deserialize_with = "present_slot")]
     transport_context: Option<UniqueValue>,
     #[allow(dead_code)]
-    #[serde(default, deserialize_with = "present_slot")]
     headers: Option<UniqueValue>,
-    #[serde(default)]
     entries: Vec<TransportTranscriptEntry>,
 }
 
-#[derive(Debug, Deserialize)]
+/// Hand-written so every member name passes through [`SeenMembers`], including the unknown ones the
+/// derive discards without looking at. Assigning `Some(..)` on each arm keeps the property the
+/// deleted `present_slot` helper carried: an explicitly written `null` stays present rather than
+/// folding to absent, which is what let a broken entry inherit a valid transcript default.
+impl<'de> Deserialize<'de> for TransportTranscript {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = TransportTranscript;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a transport transcript with unique members")
+            }
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<TransportTranscript, A::Error> {
+                let mut out = TransportTranscript::default();
+                let mut seen = SeenMembers::default();
+                while let Some(key) = map.next_key::<String>()? {
+                    seen.insert::<A::Error>(&key)?;
+                    match key.as_str() {
+                        "transport" => out.transport = map.next_value()?,
+                        "transport_context" => out.transport_context = Some(map.next_value()?),
+                        "headers" => out.headers = Some(map.next_value()?),
+                        "entries" => out.entries = map.next_value()?,
+                        _ => {
+                            map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(out)
+            }
+        }
+        d.deserialize_map(V)
+    }
+}
+
+#[derive(Debug, Default)]
 struct TransportTranscriptEntry {
-    #[serde(default)]
     timestamp_ms: Option<u64>,
     #[allow(dead_code)]
-    #[serde(default, deserialize_with = "present_slot")]
     transport_context: Option<UniqueValue>,
     #[allow(dead_code)]
-    #[serde(default, deserialize_with = "present_slot")]
     headers: Option<UniqueValue>,
-    #[serde(default)]
     request: Option<UniqueValue>,
-    #[serde(default)]
     response: Option<UniqueValue>,
-    #[serde(default)]
     sse: Option<TransportSseEnvelope>,
+}
+
+/// Same reason as the transcript above.
+impl<'de> Deserialize<'de> for TransportTranscriptEntry {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = TransportTranscriptEntry;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a transport transcript entry with unique members")
+            }
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<TransportTranscriptEntry, A::Error> {
+                let mut out = TransportTranscriptEntry::default();
+                let mut seen = SeenMembers::default();
+                while let Some(key) = map.next_key::<String>()? {
+                    seen.insert::<A::Error>(&key)?;
+                    match key.as_str() {
+                        "timestamp_ms" => out.timestamp_ms = map.next_value()?,
+                        "transport_context" => out.transport_context = Some(map.next_value()?),
+                        "headers" => out.headers = Some(map.next_value()?),
+                        "request" => out.request = Some(map.next_value()?),
+                        "response" => out.response = Some(map.next_value()?),
+                        "sse" => out.sse = map.next_value()?,
+                        _ => {
+                            map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(out)
+            }
+        }
+        d.deserialize_map(V)
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -1,5 +1,5 @@
 use crate::mcp::era::{
-    accept_id, accepted_id_text, classify_message, correlation_id, fold_envelope, observe_header,
+    accept_id, classify_message, correlation_id, fold_envelope, observe_header,
     observe_request_metadata, observe_result, resolve_era, EnvelopeObservation, McpEraContext,
     MessageKind, ParsedMcpEvent, RequestMetadata,
 };
@@ -585,9 +585,17 @@ fn auth_param_visible(header_value: &str, param_name: &str) -> bool {
 /// The existing type diagnostics for booleans, arrays and objects are kept: they are more specific
 /// than "not a string or an integer" and downstream tests pin them.
 fn require_acceptable_id(raw_id: Option<&serde_json::Value>, source_line: u64) -> Result<String> {
-    normalize_jsonrpc_id(raw_id, source_line)?;
+    // One match, one clone. The previous shape cloned the id inside `normalize_jsonrpc_id`, dropped
+    // that copy, cloned again into a `CorrelationId`, and cloned a third time into the public text —
+    // three transient copies of an attacker-controlled string on the hostile-input path, for a value
+    // that in the refusing case is discarded immediately.
+    reject_unusable_id_shape(raw_id, source_line)?;
+    // Through `accept_id`, not a second copy of its rule. Re-deciding the vocabulary here is what
+    // made the mutation on `accept_id` stop biting: two readers of one rule, which is the drift that
+    // already produced the method discriminant and the correlation key defects on this branch. One
+    // clone still, since `accept_id` builds the key and destructuring moves the string out of it.
     match raw_id.and_then(accept_id) {
-        Some(id) => Ok(accepted_id_text(&id)),
+        Some(CorrelationId::Str(id) | CorrelationId::Num(id)) => Ok(id),
         None => bail!(
             "JSON-RPC id on source line {} must be a string or an integer",
             source_line
@@ -595,14 +603,15 @@ fn require_acceptable_id(raw_id: Option<&serde_json::Value>, source_line: u64) -
     }
 }
 
-fn normalize_jsonrpc_id(
-    raw_id: Option<&serde_json::Value>,
-    source_line: u64,
-) -> Result<Option<String>> {
+/// The more specific type diagnostics, kept because they name the fault better than "not a string or
+/// an integer" and downstream tests pin them. Returns nothing: the accepted value is produced by the
+/// single match in [`require_acceptable_id`], so this no longer clones one to throw it away.
+fn reject_unusable_id_shape(raw_id: Option<&serde_json::Value>, source_line: u64) -> Result<()> {
     match raw_id {
-        None | Some(serde_json::Value::Null) => Ok(None),
-        Some(serde_json::Value::String(id)) => Ok(Some(id.clone())),
-        Some(serde_json::Value::Number(id)) => Ok(Some(id.to_string())),
+        None
+        | Some(serde_json::Value::Null)
+        | Some(serde_json::Value::String(_))
+        | Some(serde_json::Value::Number(_)) => Ok(()),
         Some(serde_json::Value::Bool(_)) => {
             bail!(
                 "JSON-RPC id on source line {} must not be a boolean",

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -1,7 +1,7 @@
 use crate::mcp::era::{
-    classify_message, correlation_id, fold_envelope, observe_header, observe_request_metadata,
-    observe_result, resolve_era, EnvelopeObservation, McpEraContext, MessageKind, ParsedMcpEvent,
-    RequestMetadata,
+    accept_id, accepted_id_text, classify_message, correlation_id, fold_envelope, observe_header,
+    observe_request_metadata, observe_result, resolve_era, EnvelopeObservation, McpEraContext,
+    MessageKind, ParsedMcpEvent, RequestMetadata,
 };
 use crate::mcp::era::{CorrelationId, EraResolution, UniqueValue};
 use crate::mcp::types::*;
@@ -381,15 +381,31 @@ fn parse_jsonrpc_message(
 
     let ts_ms = timestamp_ms_override.or_else(|| extract_ts_ms(&v));
 
-    // JSON-RPC ID extraction
-    let id_str = normalize_jsonrpc_id(v.get("id"), source_line)?;
-
     // One classification for the whole crate. A present non-string `method` is a malformed message
     // shape, not a message of another kind, and it is refused here: that is a JSON-RPC shape
     // refusal rather than an era-state refusal, so it does not weaken the rule that every era
     // observation parses. The message is value-free.
     let kind = classify_message(&v)
         .map_err(|e| anyhow::anyhow!("MCP event at source line {}: {}", source_line, e))?;
+
+    // Classification first, then the id its kind requires. The shapes differ: a notification has
+    // no id by definition, a request and a success response must name the call they are part of,
+    // and an error response is how a peer reports a request it could not parse, so it may have no
+    // usable id at all and simply correlates with nothing. Normalizing before classifying cannot
+    // apply any of that, because it does not yet know what it is looking at.
+    let raw_id = v.get("id");
+    let id_str = match kind {
+        MessageKind::Notification { .. } => None,
+        MessageKind::Request { .. } => Some(require_acceptable_id(raw_id, source_line)?),
+        MessageKind::Response => {
+            let is_error = v.get("error").is_some();
+            match raw_id {
+                // An invalid-request error response may carry no usable id.
+                None | Some(serde_json::Value::Null) if is_error => None,
+                _ => Some(require_acceptable_id(raw_id, source_line)?),
+            }
+        }
+    };
     let payload =
         if let MessageKind::Request { method } | MessageKind::Notification { method } = kind {
             match method {
@@ -562,6 +578,21 @@ fn auth_param_visible(header_value: &str, param_name: &str) -> bool {
     lower
         .match_indices(&needle)
         .any(|(idx, _)| idx == 0 || matches!(lower.as_bytes()[idx - 1], b' ' | b',' | b'\t'))
+}
+
+/// Accept the id a request or a success response must carry, or refuse value-free.
+///
+/// The existing type diagnostics for booleans, arrays and objects are kept: they are more specific
+/// than "not a string or an integer" and downstream tests pin them.
+fn require_acceptable_id(raw_id: Option<&serde_json::Value>, source_line: u64) -> Result<String> {
+    normalize_jsonrpc_id(raw_id, source_line)?;
+    match raw_id.and_then(accept_id) {
+        Some(id) => Ok(accepted_id_text(&id)),
+        None => bail!(
+            "JSON-RPC id on source line {} must be a string or an integer",
+            source_line
+        ),
+    }
 }
 
 fn normalize_jsonrpc_id(

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -34,16 +34,12 @@ pub(crate) fn parse_mcp_transcript_detailed(
         .map(|event| {
             // Observations are taken by reference before the event moves, so no payload is cloned.
             //
-            // One discriminant decides both axes, and it is the same one `parse_jsonrpc_message`
-            // classified the payload with. Reading `result` unconditionally gave a hybrid message
-            // — a valid string `method` alongside a `result` — both request metadata and a result
-            // observation, which is a result conclusion about an event the parser had already
-            // called a request. A request has no result to observe, and that is now structural:
-            // the two axes are produced by one match, so neither can be reached from the other's
-            // arm.
             // One classification decides both axes, so neither can be reached from the other's
-            // arm. A notification carries `method` like a request but its `_meta` is optional and a
-            // different type, so holding it to the request requirement invents a fault.
+            // arm. Reading `result` unconditionally gave a hybrid message, a valid string `method`
+            // alongside a `result`, both request metadata and a result observation: a result
+            // conclusion about an event the parser had already called a request. And a notification
+            // carries `method` like a request while its `_meta` is optional and a different type,
+            // so holding it to the request requirement invents a fault in the other direction.
             let (request_metadata, result_observation) = match payload_raw(&event.payload) {
                 // The same classifier the parser used. A shape it rejects never reaches here,
                 // because `parse_events_with_envelopes` runs first and refuses it, so the error arm
@@ -86,8 +82,6 @@ pub(crate) fn parse_mcp_transcript_detailed(
         .collect())
 }
 
-/// The JSON-RPC `method` of a message, if it has one.
-///
 /// Read the header slot inside a `transport_context` as an observation.
 ///
 /// A container that is present and not an object is a signal that arrived and failed, not silence.

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -1,10 +1,150 @@
+use crate::mcp::era::{
+    fold_envelope, observe_header, observe_request_metadata, observe_result, resolve_era,
+    EnvelopeObservation, McpEraContext, ParsedMcpEvent, RequestMetadata,
+};
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::collections::HashSet;
 
 /// Parse MCP transcript file contents into normalized McpEvents.
+/// Public surface, unchanged. Projects the events out of the detailed parse and drops the era
+/// sidecar, so downstream `McpEvent` consumers see exactly what they saw before this slice.
 pub fn parse_mcp_transcript(text: &str, format: McpInputFormat) -> Result<Vec<McpEvent>> {
+    Ok(parse_mcp_transcript_detailed(text, format)?
+        .into_iter()
+        .map(|parsed| parsed.event)
+        .collect())
+}
+
+/// Internal parse that keeps what the public event shape cannot carry.
+///
+/// The envelope is folded per entry, from the transcript-level slots each entry starts with plus
+/// its own, so a later deviant entry cannot reach back and contaminate an earlier correct one. The
+/// request and result signals are per message and are read from the payload's retained raw JSON,
+/// before any projection can lose them.
+pub(crate) fn parse_mcp_transcript_detailed(
+    text: &str,
+    format: McpInputFormat,
+) -> Result<Vec<ParsedMcpEvent>> {
+    let events = parse_events(text, format)?;
+    let framed = is_framed(format);
+    let envelopes = observe_envelopes(text, format);
+    Ok(events
+        .into_iter()
+        .map(|event| {
+            let raw = payload_raw(&event.payload).cloned();
+            let raw = raw.as_ref();
+            // A response carries no request metadata, so it gets no observation rather than an
+            // "absent" one, which would be a claim about a field that does not apply to it.
+            // The same discriminant `parse_jsonrpc_message` uses: a valid string `method`. Keying
+            // on the absence of `result`/`error` instead would drop the observation for a
+            // malformed hybrid that carries both, which is exactly the shape worth observing.
+            let request_metadata = raw
+                .filter(|r| r.get("method").and_then(|m| m.as_str()).is_some())
+                .map(observe_request_metadata);
+            // Transport entries number from one; every other format has a single whole-input
+            // observation, so index 0 serves them all.
+            // Unframed formats have one whole-input observation and no entries to index, so
+            // index 0 is their answer. A framed input that does not resolve to an entry is a
+            // mapping the parser cannot vouch for, and a plausible-but-wrong attribution is worse
+            // than an unusable one, so it fails closed rather than borrowing another entry's.
+            let envelope = if framed {
+                envelopes
+                    .get(event.source_line.saturating_sub(1) as usize)
+                    .cloned()
+                    .unwrap_or(EnvelopeObservation::Malformed)
+            } else {
+                envelopes
+                    .first()
+                    .cloned()
+                    .unwrap_or(EnvelopeObservation::NotApplicable)
+            };
+            let era = resolve_era(
+                &envelope,
+                request_metadata
+                    .as_ref()
+                    .unwrap_or(&RequestMetadata::Absent),
+            );
+            ParsedMcpEvent {
+                event,
+                context: McpEraContext {
+                    envelope,
+                    era,
+                    request_metadata,
+                    result_observation: raw.and_then(observe_result),
+                },
+            }
+        })
+        .collect())
+}
+
+fn payload_raw(payload: &McpPayload) -> Option<&serde_json::Value> {
+    match payload {
+        McpPayload::SessionStart { raw }
+        | McpPayload::ToolsListRequest { raw }
+        | McpPayload::ToolsListResponse { raw, .. }
+        | McpPayload::ToolCallRequest { raw, .. }
+        | McpPayload::ToolCallResponse { raw, .. }
+        | McpPayload::SessionEnd { raw, .. }
+        | McpPayload::Other { raw, .. } => Some(raw),
+    }
+}
+
+/// Every header slot one object carries: the nested `transport_context.headers` and the direct
+/// `headers` field that both the transcript and each entry also have.
+fn header_slots(node: Option<&serde_json::Value>, into: &mut Vec<EnvelopeObservation>) {
+    let Some(node) = node else { return };
+    for headers in [
+        node.get("transport_context").and_then(|c| c.get("headers")),
+        node.get("headers"),
+    ] {
+        if let Some(o) = observe_header(headers) {
+            into.push(o);
+        }
+    }
+}
+
+/// One envelope observation per entry, so a later deviant entry cannot retroactively contaminate
+/// an earlier correct one. The transcript-level slots are the default each entry starts from.
+/// Which formats carry transport framing at all. `Inspector` reads an events array straight into
+/// `parse_jsonrpc_message` and never reaches `parse_transport_transcript`, so it has no envelope.
+fn is_framed(format: McpInputFormat) -> bool {
+    matches!(
+        format,
+        McpInputFormat::StreamableHttp | McpInputFormat::HttpSse
+    )
+}
+
+fn observe_envelopes(text: &str, format: McpInputFormat) -> Vec<EnvelopeObservation> {
+    let framed = is_framed(format);
+    if !framed {
+        return vec![EnvelopeObservation::NotApplicable];
+    }
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(text) else {
+        return vec![EnvelopeObservation::Absent];
+    };
+    let mut transcript_slots = Vec::new();
+    header_slots(Some(&doc), &mut transcript_slots);
+    let entries = doc
+        .get("entries")
+        .and_then(|e| e.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if entries.is_empty() {
+        return vec![fold_envelope(transcript_slots, framed)];
+    }
+    entries
+        .iter()
+        .map(|entry| {
+            let mut slots = transcript_slots.clone();
+            header_slots(Some(entry), &mut slots);
+            fold_envelope(slots, framed)
+        })
+        .collect()
+}
+
+fn parse_events(text: &str, format: McpInputFormat) -> Result<Vec<McpEvent>> {
     let events = match format {
         McpInputFormat::JsonRpc => parse_jsonrpc_jsonl(text),
         McpInputFormat::Inspector => parse_inspector_best_effort(text),
@@ -518,3 +658,6 @@ struct TransportSseEnvelope {
     id: Option<String>,
     data: serde_json::Value,
 }
+
+#[cfg(test)]
+mod era_wiring_tests;

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -81,7 +81,7 @@ pub(crate) fn parse_mcp_transcript_detailed(
             }
         })
         .collect();
-    Ok(correlate_calls(parsed))
+    correlate_calls(parsed)
 }
 
 /// Give a response the era its own call resolved to.
@@ -96,29 +96,39 @@ pub(crate) fn parse_mcp_transcript_detailed(
 /// validates for duplicates. A response with no matching request keeps the era it resolved on its
 /// own, so this adds authority rather than removing it. Multi-hop calls spread across separate
 /// records stay out of scope: that needs a call-scoped identity this slice does not define.
-fn correlate_calls(mut parsed: Vec<ParsedMcpEvent>) -> Vec<ParsedMcpEvent> {
-    let request_eras: std::collections::HashMap<String, EraResolution> = parsed
-        .iter()
-        .filter(|p| p.context.request_metadata.is_some())
-        .filter_map(|p| {
-            p.event
-                .jsonrpc_id
-                .clone()
-                .map(|id| (id, p.context.era.clone()))
-        })
-        .collect();
+fn correlate_calls(mut parsed: Vec<ParsedMcpEvent>) -> Result<Vec<ParsedMcpEvent>> {
+    // Source order, not a map built up front. A global map is last-wins, so a response could take
+    // the era of a request that had not happened yet: with an id reused after the response, the
+    // contradiction on the call being answered was replaced by the clean era of the next call.
+    // Requests are outstanding until a response consumes them.
+    let mut outstanding: std::collections::HashMap<String, EraResolution> =
+        std::collections::HashMap::new();
     for p in &mut parsed {
-        if p.context.result_observation.is_none() {
-            continue;
-        }
-        let Some(id) = p.event.jsonrpc_id.as_ref() else {
+        let Some(id) = p.event.jsonrpc_id.clone() else {
             continue;
         };
-        if let Some(era) = request_eras.get(id) {
-            p.context.era = era.clone();
+        if p.context.request_metadata.is_some() {
+            // Two calls outstanding on one id makes the correlation ambiguous, and choosing either
+            // is a silent choice between two calls. Reuse *after* a response is legal and is what
+            // the removal below permits.
+            if outstanding
+                .insert(id.clone(), p.context.era.clone())
+                .is_some()
+            {
+                bail!(
+                    "two outstanding JSON-RPC requests share an id at source line {}",
+                    p.event.source_line
+                );
+            }
+        } else if p.context.result_observation.is_some() {
+            // An orphan response keeps the era it resolved on its own, so correlation adds
+            // authority rather than removing it.
+            if let Some(era) = outstanding.remove(&id) {
+                p.context.era = era;
+            }
         }
     }
-    parsed
+    Ok(parsed)
 }
 
 /// Read the header slot inside a `transport_context` as an observation.
@@ -326,7 +336,7 @@ fn parse_transport_transcript_detailed(
         }
 
         if let Some(sse) = entry.sse {
-            if let Some(jsonrpc) = extract_jsonrpc_from_sse(&sse, allow_endpoint_event) {
+            if let Some(jsonrpc) = extract_jsonrpc_from_sse(&sse, allow_endpoint_event)? {
                 out.push(parse_jsonrpc_message(
                     jsonrpc,
                     source_line,
@@ -590,20 +600,27 @@ fn validate_mcp_events(events: &[McpEvent]) -> Result<()> {
 fn extract_jsonrpc_from_sse(
     sse: &TransportSseEnvelope,
     allow_endpoint_event: bool,
-) -> Option<serde_json::Value> {
+) -> Result<Option<serde_json::Value>> {
     let event_name = sse.event.as_deref().unwrap_or("message");
     if event_name == "endpoint" && allow_endpoint_event {
-        return None;
+        return Ok(None);
     }
 
     if event_name != "message" {
-        return None;
+        return Ok(None);
     }
 
-    extract_jsonrpc_like_value(&sse.data)
+    extract_jsonrpc_like_value(&sse.data.0)
 }
 
-fn extract_jsonrpc_like_value(value: &serde_json::Value) -> Option<serde_json::Value> {
+/// Pull a JSON-RPC-looking value out of an SSE `data` payload.
+///
+/// `Ok(None)` means the payload is not JSON-RPC-shaped, which is tolerated: an SSE stream carries
+/// keepalives and endpoint frames alongside messages. An `Err` means the payload *is* JSON and
+/// carries a duplicate member, which is refused. The two are told apart by
+/// `serde_json::error::Category`, not by reading the message: a visitor's `Error::custom` classifies
+/// as `Data` while malformed bytes classify as `Syntax`, so the distinction is typed.
+fn extract_jsonrpc_like_value(value: &serde_json::Value) -> Result<Option<serde_json::Value>> {
     match value {
         serde_json::Value::Object(map)
             if map.contains_key("method")
@@ -611,12 +628,20 @@ fn extract_jsonrpc_like_value(value: &serde_json::Value) -> Option<serde_json::V
                 || map.contains_key("error")
                 || map.contains_key("jsonrpc") =>
         {
-            Some(value.clone())
+            Ok(Some(value.clone()))
         }
-        serde_json::Value::String(text) => serde_json::from_str::<serde_json::Value>(text)
-            .ok()
-            .and_then(|parsed| extract_jsonrpc_like_value(&parsed)),
-        _ => None,
+        // The embedded string is a *different* input from the transcript, not a second pass over the
+        // same one, so it goes through the same duplicate-aware boundary rather than a plain
+        // `Value`. Without this an SSE frame carrying its payload as a string was the one path that
+        // kept a duplicate member.
+        serde_json::Value::String(text) => match serde_json::from_str::<UniqueValue>(text) {
+            Ok(UniqueValue(parsed)) => extract_jsonrpc_like_value(&parsed),
+            Err(e) if e.classify() == serde_json::error::Category::Data => {
+                Err(anyhow::Error::new(e).context("invalid SSE data payload"))
+            }
+            Err(_) => Ok(None),
+        },
+        _ => Ok(None),
     }
 }
 
@@ -711,7 +736,7 @@ struct TransportSseEnvelope {
     #[allow(dead_code)]
     #[serde(default)]
     id: Option<String>,
-    data: serde_json::Value,
+    data: UniqueValue,
 }
 
 #[cfg(test)]

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -2,6 +2,7 @@ use crate::mcp::era::{
     classify_message, fold_envelope, observe_header, observe_request_metadata, observe_result,
     resolve_era, EnvelopeObservation, McpEraContext, MessageKind, ParsedMcpEvent, RequestMetadata,
 };
+use crate::mcp::era::{EraResolution, UniqueValue};
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -29,7 +30,7 @@ pub(crate) fn parse_mcp_transcript_detailed(
 ) -> Result<Vec<ParsedMcpEvent>> {
     let (events, envelopes) = parse_events_with_envelopes(text, format)?;
     let framed = is_framed(format);
-    Ok(events
+    let parsed: Vec<ParsedMcpEvent> = events
         .into_iter()
         .map(|event| {
             // Observations are taken by reference before the event moves, so no payload is cloned.
@@ -79,7 +80,45 @@ pub(crate) fn parse_mcp_transcript_detailed(
                 },
             }
         })
-        .collect())
+        .collect();
+    Ok(correlate_calls(parsed))
+}
+
+/// Give a response the era its own call resolved to.
+///
+/// The era resolves from two signals that both live on a request: the transport header and
+/// `params._meta`. A response carries neither, so it fell back to the header alone. A request whose
+/// header and body disagree is `Conflicting`, while its response resolved to `Known` from the header
+/// and a missing `resultType` under a legacy era is `Terminal` — so a contradicted call could still
+/// conclude that the action completed. The contradiction has to travel to the result.
+///
+/// Correlation is by JSON-RPC id within one transcript, which the parser already establishes and
+/// validates for duplicates. A response with no matching request keeps the era it resolved on its
+/// own, so this adds authority rather than removing it. Multi-hop calls spread across separate
+/// records stay out of scope: that needs a call-scoped identity this slice does not define.
+fn correlate_calls(mut parsed: Vec<ParsedMcpEvent>) -> Vec<ParsedMcpEvent> {
+    let request_eras: std::collections::HashMap<String, EraResolution> = parsed
+        .iter()
+        .filter(|p| p.context.request_metadata.is_some())
+        .filter_map(|p| {
+            p.event
+                .jsonrpc_id
+                .clone()
+                .map(|id| (id, p.context.era.clone()))
+        })
+        .collect();
+    for p in &mut parsed {
+        if p.context.result_observation.is_none() {
+            continue;
+        }
+        let Some(id) = p.event.jsonrpc_id.as_ref() else {
+            continue;
+        };
+        if let Some(era) = request_eras.get(id) {
+            p.context.era = era.clone();
+        }
+    }
+    parsed
 }
 
 /// Read the header slot inside a `transport_context` as an observation.
@@ -105,11 +144,11 @@ fn observe_transport_context(ctx: Option<&serde_json::Value>) -> Option<Envelope
 /// slots that difference is exactly the finding: a container that was written and cannot be read
 /// is a malformed envelope, a container that was never written is silence. `default` still covers
 /// the missing key, so only a key that is actually in the document reaches this.
-fn present_slot<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+fn present_slot<'de, D>(deserializer: D) -> Result<Option<UniqueValue>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    serde_json::Value::deserialize(deserializer).map(Some)
+    UniqueValue::deserialize(deserializer).map(Some)
 }
 
 /// Which formats carry transport framing at all. `Inspector` reads an events array straight into
@@ -163,7 +202,7 @@ fn parse_jsonrpc_jsonl(text: &str) -> Result<Vec<McpEvent>> {
             continue;
         }
 
-        let v: serde_json::Value = serde_json::from_str(line)
+        let UniqueValue(v) = serde_json::from_str::<UniqueValue>(line)
             .with_context(|| format!("invalid JSON on line {}", lineno + 1))?;
 
         let event = parse_jsonrpc_message(
@@ -179,7 +218,8 @@ fn parse_jsonrpc_jsonl(text: &str) -> Result<Vec<McpEvent>> {
 }
 
 fn parse_inspector_best_effort(text: &str) -> Result<Vec<McpEvent>> {
-    let v: serde_json::Value = serde_json::from_str(text).context("invalid inspector JSON")?;
+    let UniqueValue(v) =
+        serde_json::from_str::<UniqueValue>(text).context("invalid inspector JSON")?;
 
     // Handle Inspector export variations:
     // 1. Array of events
@@ -231,10 +271,11 @@ fn parse_transport_transcript_detailed(
     }
 
     let mut transcript_slots = Vec::new();
-    if let Some(o) = observe_transport_context(transcript.transport_context.as_ref()) {
+    if let Some(o) = observe_transport_context(transcript.transport_context.as_ref().map(|u| &u.0))
+    {
         transcript_slots.push(o);
     }
-    if let Some(o) = observe_header(transcript.headers.as_ref()) {
+    if let Some(o) = observe_header(transcript.headers.as_ref().map(|u| &u.0)) {
         transcript_slots.push(o);
     }
 
@@ -242,10 +283,10 @@ fn parse_transport_transcript_detailed(
     let mut out = Vec::new();
     for (idx, entry) in transcript.entries.into_iter().enumerate() {
         let mut slots = transcript_slots.clone();
-        if let Some(o) = observe_transport_context(entry.transport_context.as_ref()) {
+        if let Some(o) = observe_transport_context(entry.transport_context.as_ref().map(|u| &u.0)) {
             slots.push(o);
         }
-        if let Some(o) = observe_header(entry.headers.as_ref()) {
+        if let Some(o) = observe_header(entry.headers.as_ref().map(|u| &u.0)) {
             slots.push(o);
         }
         envelopes.push(fold_envelope(slots, true));
@@ -262,7 +303,7 @@ fn parse_transport_transcript_detailed(
             );
         }
 
-        if let Some(request) = entry.request {
+        if let Some(UniqueValue(request)) = entry.request {
             out.push(parse_jsonrpc_message(
                 request,
                 source_line,
@@ -274,7 +315,7 @@ fn parse_transport_transcript_detailed(
 
         let auth_discovery = parse_transport_auth_discovery(&entry);
 
-        if let Some(response) = entry.response {
+        if let Some(UniqueValue(response)) = entry.response {
             out.push(parse_jsonrpc_message(
                 response,
                 source_line,
@@ -397,12 +438,12 @@ fn parse_transport_auth_discovery(entry: &TransportTranscriptEntry) -> McpAuthor
     let header_value = entry
         .transport_context
         .as_ref()
-        .and_then(|value| find_header_case_insensitive(value, "www-authenticate"))
+        .and_then(|value| find_header_case_insensitive(&value.0, "www-authenticate"))
         .or_else(|| {
             entry
                 .headers
                 .as_ref()
-                .and_then(|value| find_header_case_insensitive(value, "www-authenticate"))
+                .and_then(|value| find_header_case_insensitive(&value.0, "www-authenticate"))
         });
 
     let Some(www_authenticate) = header_value else {
@@ -429,12 +470,12 @@ fn extract_http_status(entry: &TransportTranscriptEntry) -> Option<u16> {
     entry
         .transport_context
         .as_ref()
-        .and_then(extract_http_status_from_value)
+        .and_then(|v| extract_http_status_from_value(&v.0))
         .or_else(|| {
             entry
                 .headers
                 .as_ref()
-                .and_then(extract_http_status_from_value)
+                .and_then(|v| extract_http_status_from_value(&v.0))
         })
 }
 
@@ -637,10 +678,10 @@ struct TransportTranscript {
     transport: Option<String>,
     #[allow(dead_code)]
     #[serde(default, deserialize_with = "present_slot")]
-    transport_context: Option<serde_json::Value>,
+    transport_context: Option<UniqueValue>,
     #[allow(dead_code)]
     #[serde(default, deserialize_with = "present_slot")]
-    headers: Option<serde_json::Value>,
+    headers: Option<UniqueValue>,
     #[serde(default)]
     entries: Vec<TransportTranscriptEntry>,
 }
@@ -651,14 +692,14 @@ struct TransportTranscriptEntry {
     timestamp_ms: Option<u64>,
     #[allow(dead_code)]
     #[serde(default, deserialize_with = "present_slot")]
-    transport_context: Option<serde_json::Value>,
+    transport_context: Option<UniqueValue>,
     #[allow(dead_code)]
     #[serde(default, deserialize_with = "present_slot")]
-    headers: Option<serde_json::Value>,
+    headers: Option<UniqueValue>,
     #[serde(default)]
-    request: Option<serde_json::Value>,
+    request: Option<UniqueValue>,
     #[serde(default)]
-    response: Option<serde_json::Value>,
+    response: Option<UniqueValue>,
     #[serde(default)]
     sse: Option<TransportSseEnvelope>,
 }

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -45,10 +45,14 @@ pub(crate) fn parse_mcp_transcript_detailed(
             // arm. A notification carries `method` like a request but its `_meta` is optional and a
             // different type, so holding it to the request requirement invents a fault.
             let (request_metadata, result_observation) = match payload_raw(&event.payload) {
+                // The same classifier the parser used. A shape it rejects never reaches here,
+                // because `parse_events_with_envelopes` runs first and refuses it, so the error arm
+                // is a state this pass cannot observe rather than one it tolerates.
                 Some(raw) => match classify_message(raw) {
-                    MessageKind::Request => (Some(observe_request_metadata(raw)), None),
-                    MessageKind::Notification => (None, None),
-                    MessageKind::Response => (None, observe_result(raw)),
+                    Ok(MessageKind::Request { .. }) => (Some(observe_request_metadata(raw)), None),
+                    Ok(MessageKind::Notification { .. }) => (None, None),
+                    Ok(MessageKind::Response) => (None, observe_result(raw)),
+                    Err(_) => (None, None),
                 },
                 None => (None, None),
             };
@@ -84,13 +88,6 @@ pub(crate) fn parse_mcp_transcript_detailed(
 
 /// The JSON-RPC `method` of a message, if it has one.
 ///
-/// The single discriminant between a request and a response. `parse_jsonrpc_message` branches on
-/// it to build the payload and the era observations follow the same answer, so one message cannot
-/// be a request on one axis and a response on the other.
-fn request_method(v: &serde_json::Value) -> Option<&str> {
-    v.get("method").and_then(|m| m.as_str())
-}
-
 /// Read the header slot inside a `transport_context` as an observation.
 ///
 /// A container that is present and not an object is a signal that arrived and failed, not silence.
@@ -326,59 +323,64 @@ fn parse_jsonrpc_message(
     // JSON-RPC ID extraction
     let id_str = normalize_jsonrpc_id(v.get("id"), source_line)?;
 
-    // Check for JSON-RPC Request (has method). The era observations read the same discriminant,
-    // so a message classified as a request here is a request on both axes.
-    let payload = if let Some(method) = request_method(&v) {
-        match method {
-            "tools/list" => McpPayload::ToolsListRequest { raw: v.clone() },
-            "tools/call" => {
-                let params = v.get("params").cloned().unwrap_or(serde_json::Value::Null);
-                let name = params
-                    .get("name")
-                    .and_then(|x| x.as_str())
-                    .unwrap_or("unknown_tool")
-                    .to_string();
-                let arguments = params
-                    .get("arguments")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                McpPayload::ToolCallRequest {
-                    name,
-                    arguments,
-                    raw: v.clone(),
+    // One classification for the whole crate. A present non-string `method` is a malformed message
+    // shape, not a message of another kind, and it is refused here: that is a JSON-RPC shape
+    // refusal rather than an era-state refusal, so it does not weaken the rule that every era
+    // observation parses. The message is value-free.
+    let kind = classify_message(&v)
+        .map_err(|e| anyhow::anyhow!("MCP event at source line {}: {}", source_line, e))?;
+    let payload =
+        if let MessageKind::Request { method } | MessageKind::Notification { method } = kind {
+            match method {
+                "tools/list" => McpPayload::ToolsListRequest { raw: v.clone() },
+                "tools/call" => {
+                    let params = v.get("params").cloned().unwrap_or(serde_json::Value::Null);
+                    let name = params
+                        .get("name")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("unknown_tool")
+                        .to_string();
+                    let arguments = params
+                        .get("arguments")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    McpPayload::ToolCallRequest {
+                        name,
+                        arguments,
+                        raw: v.clone(),
+                    }
                 }
+                // Add other standard MCP methods mapping here if needed
+                _ => McpPayload::Other { raw: v.clone() },
             }
-            // Add other standard MCP methods mapping here if needed
-            _ => McpPayload::Other { raw: v.clone() },
-        }
-    } else {
-        // Response (result or error)
-        if v.get("result").is_some() {
-            if looks_like_tools_list_result(&v) {
-                let tools = parse_tools_list_result(&v)?;
-                McpPayload::ToolsListResponse {
-                    tools,
+        } else {
+            // Response (result or error)
+            if v.get("result").is_some() {
+                if looks_like_tools_list_result(&v) {
+                    let tools = parse_tools_list_result(&v)?;
+                    McpPayload::ToolsListResponse {
+                        tools,
+                        raw: v.clone(),
+                    }
+                } else {
+                    McpPayload::ToolCallResponse {
+                        result: v.get("result").cloned().unwrap_or(serde_json::Value::Null),
+                        is_error: false,
+                        raw: v.clone(),
+                    }
+                }
+            } else if v.get("error").is_some() {
+                McpPayload::ToolCallResponse {
+                    result: v.get("error").cloned().unwrap_or(serde_json::Value::Null),
+                    is_error: true,
                     raw: v.clone(),
                 }
             } else {
-                McpPayload::ToolCallResponse {
-                    result: v.get("result").cloned().unwrap_or(serde_json::Value::Null),
-                    is_error: false,
-                    raw: v.clone(),
-                }
+                // Maybe it's not JSON-RPC, or it's a notification/special event
+                // Check for known "Session" markers if any (ad-hoc)
+                McpPayload::Other { raw: v.clone() }
             }
-        } else if v.get("error").is_some() {
-            McpPayload::ToolCallResponse {
-                result: v.get("error").cloned().unwrap_or(serde_json::Value::Null),
-                is_error: true,
-                raw: v.clone(),
-            }
-        } else {
-            // Maybe it's not JSON-RPC, or it's a notification/special event
-            // Check for known "Session" markers if any (ad-hoc)
-            McpPayload::Other { raw: v.clone() }
-        }
-    };
+        };
 
     Ok(McpEvent {
         source_line,

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -27,38 +27,27 @@ pub(crate) fn parse_mcp_transcript_detailed(
     text: &str,
     format: McpInputFormat,
 ) -> Result<Vec<ParsedMcpEvent>> {
-    let events = parse_events(text, format)?;
+    let (events, envelopes) = parse_events_with_envelopes(text, format)?;
     let framed = is_framed(format);
-    let envelopes = observe_envelopes(text, format);
     Ok(events
         .into_iter()
         .map(|event| {
-            let raw = payload_raw(&event.payload).cloned();
-            let raw = raw.as_ref();
-            // A response carries no request metadata, so it gets no observation rather than an
-            // "absent" one, which would be a claim about a field that does not apply to it.
-            // The same discriminant `parse_jsonrpc_message` uses: a valid string `method`. Keying
-            // on the absence of `result`/`error` instead would drop the observation for a
-            // malformed hybrid that carries both, which is exactly the shape worth observing.
+            // Observations are taken by reference before the event moves, so no payload is cloned.
+            let raw = payload_raw(&event.payload);
             let request_metadata = raw
                 .filter(|r| r.get("method").and_then(|m| m.as_str()).is_some())
                 .map(observe_request_metadata);
-            // Transport entries number from one; every other format has a single whole-input
-            // observation, so index 0 serves them all.
-            // Unframed formats have one whole-input observation and no entries to index, so
-            // index 0 is their answer. A framed input that does not resolve to an entry is a
-            // mapping the parser cannot vouch for, and a plausible-but-wrong attribution is worse
-            // than an unusable one, so it fails closed rather than borrowing another entry's.
+            let result_observation = raw.and_then(observe_result);
+            // Unframed formats have one whole-input observation and no entries to index. A framed
+            // input that does not resolve to an entry is a mapping the parser cannot vouch for,
+            // and a plausible-but-wrong attribution is worse than an unusable one.
             let envelope = if framed {
                 envelopes
                     .get(event.source_line.saturating_sub(1) as usize)
                     .cloned()
                     .unwrap_or(EnvelopeObservation::Malformed)
             } else {
-                envelopes
-                    .first()
-                    .cloned()
-                    .unwrap_or(EnvelopeObservation::NotApplicable)
+                EnvelopeObservation::NotApplicable
             };
             let era = resolve_era(
                 &envelope,
@@ -72,11 +61,25 @@ pub(crate) fn parse_mcp_transcript_detailed(
                     envelope,
                     era,
                     request_metadata,
-                    result_observation: raw.and_then(observe_result),
+                    result_observation,
                 },
             }
         })
         .collect())
+}
+
+/// The headers map inside a `transport_context` value.
+fn header_map(ctx: &serde_json::Value) -> Option<&serde_json::Value> {
+    ctx.get("headers")
+}
+
+/// Which formats carry transport framing at all. `Inspector` reads an events array straight into
+/// `parse_jsonrpc_message` and never reaches `parse_transport_transcript`, so it has no envelope.
+fn is_framed(format: McpInputFormat) -> bool {
+    matches!(
+        format,
+        McpInputFormat::StreamableHttp | McpInputFormat::HttpSse
+    )
 }
 
 fn payload_raw(payload: &McpPayload) -> Option<&serde_json::Value> {
@@ -91,68 +94,25 @@ fn payload_raw(payload: &McpPayload) -> Option<&serde_json::Value> {
     }
 }
 
-/// Every header slot one object carries: the nested `transport_context.headers` and the direct
-/// `headers` field that both the transcript and each entry also have.
-fn header_slots(node: Option<&serde_json::Value>, into: &mut Vec<EnvelopeObservation>) {
-    let Some(node) = node else { return };
-    for headers in [
-        node.get("transport_context").and_then(|c| c.get("headers")),
-        node.get("headers"),
-    ] {
-        if let Some(o) = observe_header(headers) {
-            into.push(o);
+fn parse_events_with_envelopes(
+    text: &str,
+    format: McpInputFormat,
+) -> Result<(Vec<McpEvent>, Vec<EnvelopeObservation>)> {
+    let (events, envelopes) = match format {
+        McpInputFormat::JsonRpc => (parse_jsonrpc_jsonl(text)?, Vec::new()),
+        McpInputFormat::Inspector => (parse_inspector_best_effort(text)?, Vec::new()),
+        McpInputFormat::StreamableHttp => parse_transport_transcript_detailed(
+            text,
+            "streamable-http",
+            "streamable-http transcript",
+            false,
+        )?,
+        McpInputFormat::HttpSse => {
+            parse_transport_transcript_detailed(text, "http-sse", "http-sse transcript", true)?
         }
-    }
-}
-
-/// One envelope observation per entry, so a later deviant entry cannot retroactively contaminate
-/// an earlier correct one. The transcript-level slots are the default each entry starts from.
-/// Which formats carry transport framing at all. `Inspector` reads an events array straight into
-/// `parse_jsonrpc_message` and never reaches `parse_transport_transcript`, so it has no envelope.
-fn is_framed(format: McpInputFormat) -> bool {
-    matches!(
-        format,
-        McpInputFormat::StreamableHttp | McpInputFormat::HttpSse
-    )
-}
-
-fn observe_envelopes(text: &str, format: McpInputFormat) -> Vec<EnvelopeObservation> {
-    let framed = is_framed(format);
-    if !framed {
-        return vec![EnvelopeObservation::NotApplicable];
-    }
-    let Ok(doc) = serde_json::from_str::<serde_json::Value>(text) else {
-        return vec![EnvelopeObservation::Absent];
     };
-    let mut transcript_slots = Vec::new();
-    header_slots(Some(&doc), &mut transcript_slots);
-    let entries = doc
-        .get("entries")
-        .and_then(|e| e.as_array())
-        .cloned()
-        .unwrap_or_default();
-    if entries.is_empty() {
-        return vec![fold_envelope(transcript_slots, framed)];
-    }
-    entries
-        .iter()
-        .map(|entry| {
-            let mut slots = transcript_slots.clone();
-            header_slots(Some(entry), &mut slots);
-            fold_envelope(slots, framed)
-        })
-        .collect()
-}
-
-fn parse_events(text: &str, format: McpInputFormat) -> Result<Vec<McpEvent>> {
-    let events = match format {
-        McpInputFormat::JsonRpc => parse_jsonrpc_jsonl(text),
-        McpInputFormat::Inspector => parse_inspector_best_effort(text),
-        McpInputFormat::StreamableHttp => parse_streamable_http_transcript(text),
-        McpInputFormat::HttpSse => parse_http_sse_transcript(text),
-    }?;
     validate_mcp_events(&events)?;
-    Ok(events)
+    Ok((events, envelopes))
 }
 
 fn parse_jsonrpc_jsonl(text: &str) -> Result<Vec<McpEvent>> {
@@ -207,20 +167,17 @@ fn parse_inspector_best_effort(text: &str) -> Result<Vec<McpEvent>> {
     Ok(out)
 }
 
-fn parse_streamable_http_transcript(text: &str) -> Result<Vec<McpEvent>> {
-    parse_transport_transcript(text, "streamable-http", "streamable-http transcript", false)
-}
-
-fn parse_http_sse_transcript(text: &str) -> Result<Vec<McpEvent>> {
-    parse_transport_transcript(text, "http-sse", "http-sse transcript", true)
-}
-
-fn parse_transport_transcript(
+/// The transport parse, returning the per-entry envelope observations it already had in hand.
+///
+/// Deserializing the text a second time to read the headers would double the peak memory a hostile
+/// transcript can cost, on the one path that exists to read untrusted input, so the observations
+/// are taken from the same `TransportTranscript` the events come from.
+fn parse_transport_transcript_detailed(
     text: &str,
     expected_transport: &str,
     source_label: &str,
     allow_endpoint_event: bool,
-) -> Result<Vec<McpEvent>> {
+) -> Result<(Vec<McpEvent>, Vec<EnvelopeObservation>)> {
     let transcript: TransportTranscript =
         serde_json::from_str(text).with_context(|| format!("invalid {}", source_label))?;
 
@@ -234,8 +191,25 @@ fn parse_transport_transcript(
         );
     }
 
+    let mut transcript_slots = Vec::new();
+    if let Some(o) = observe_header(transcript.transport_context.as_ref().and_then(header_map)) {
+        transcript_slots.push(o);
+    }
+    if let Some(o) = observe_header(transcript.headers.as_ref()) {
+        transcript_slots.push(o);
+    }
+
+    let mut envelopes = Vec::new();
     let mut out = Vec::new();
     for (idx, entry) in transcript.entries.into_iter().enumerate() {
+        let mut slots = transcript_slots.clone();
+        if let Some(o) = observe_header(entry.transport_context.as_ref().and_then(header_map)) {
+            slots.push(o);
+        }
+        if let Some(o) = observe_header(entry.headers.as_ref()) {
+            slots.push(o);
+        }
+        envelopes.push(fold_envelope(slots, true));
         let source_line = (idx + 1) as u64;
         let present = usize::from(entry.request.is_some())
             + usize::from(entry.response.is_some())
@@ -283,7 +257,7 @@ fn parse_transport_transcript(
         }
     }
 
-    Ok(out)
+    Ok((out, envelopes))
 }
 
 fn parse_jsonrpc_message(

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -1,6 +1,6 @@
 use crate::mcp::era::{
-    fold_envelope, observe_header, observe_request_metadata, observe_result, resolve_era,
-    EnvelopeObservation, McpEraContext, ParsedMcpEvent, RequestMetadata,
+    classify_message, fold_envelope, observe_header, observe_request_metadata, observe_result,
+    resolve_era, EnvelopeObservation, McpEraContext, MessageKind, ParsedMcpEvent, RequestMetadata,
 };
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
@@ -41,11 +41,15 @@ pub(crate) fn parse_mcp_transcript_detailed(
             // called a request. A request has no result to observe, and that is now structural:
             // the two axes are produced by one match, so neither can be reached from the other's
             // arm.
+            // One classification decides both axes, so neither can be reached from the other's
+            // arm. A notification carries `method` like a request but its `_meta` is optional and a
+            // different type, so holding it to the request requirement invents a fault.
             let (request_metadata, result_observation) = match payload_raw(&event.payload) {
-                Some(raw) if request_method(raw).is_some() => {
-                    (Some(observe_request_metadata(raw)), None)
-                }
-                Some(raw) => (None, observe_result(raw)),
+                Some(raw) => match classify_message(raw) {
+                    MessageKind::Request => (Some(observe_request_metadata(raw)), None),
+                    MessageKind::Notification => (None, None),
+                    MessageKind::Response => (None, observe_result(raw)),
+                },
                 None => (None, None),
             };
             // Unframed formats have one whole-input observation and no entries to index. A framed

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -107,25 +107,37 @@ fn correlate_calls(mut parsed: Vec<ParsedMcpEvent>) -> Result<Vec<ParsedMcpEvent
         let Some(id) = p.event.jsonrpc_id.clone() else {
             continue;
         };
-        if p.context.request_metadata.is_some() {
-            // Two calls outstanding on one id makes the correlation ambiguous, and choosing either
-            // is a silent choice between two calls. Reuse *after* a response is legal and is what
-            // the removal below permits.
-            if outstanding
-                .insert(id.clone(), p.context.era.clone())
-                .is_some()
-            {
-                bail!(
-                    "two outstanding JSON-RPC requests share an id at source line {}",
-                    p.event.source_line
-                );
+        // The shared classifier is the authority, not the presence of an observation. An error
+        // response deliberately has no result observation, since the `resultType` requirement is
+        // about `result`, so keying off that observation made an error response invisible here: it
+        // inherited nothing and consumed nothing, and a legal sequential reuse of its id then
+        // tripped the two-outstanding refusal.
+        let kind = payload_raw(&p.event.payload)
+            .map(classify_message)
+            .and_then(Result::ok);
+        match kind {
+            Some(MessageKind::Request { .. }) => {
+                // Two calls outstanding on one id makes the correlation ambiguous, and choosing
+                // either is a silent choice between two calls. Reuse after a response is legal and
+                // is what the removal below permits.
+                if outstanding
+                    .insert(id.clone(), p.context.era.clone())
+                    .is_some()
+                {
+                    bail!(
+                        "two outstanding JSON-RPC requests share an id at source line {}",
+                        p.event.source_line
+                    );
+                }
             }
-        } else if p.context.result_observation.is_some() {
-            // An orphan response keeps the era it resolved on its own, so correlation adds
-            // authority rather than removing it.
-            if let Some(era) = outstanding.remove(&id) {
-                p.context.era = era;
+            Some(MessageKind::Response) => {
+                // An orphan response keeps the era it resolved on its own, so correlation adds
+                // authority rather than removing it.
+                if let Some(era) = outstanding.remove(&id) {
+                    p.context.era = era;
+                }
             }
+            Some(MessageKind::Notification { .. }) | None => {}
         }
     }
     Ok(parsed)

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -1,8 +1,9 @@
 use crate::mcp::era::{
-    classify_message, fold_envelope, observe_header, observe_request_metadata, observe_result,
-    resolve_era, EnvelopeObservation, McpEraContext, MessageKind, ParsedMcpEvent, RequestMetadata,
+    classify_message, correlation_id, fold_envelope, observe_header, observe_request_metadata,
+    observe_result, resolve_era, EnvelopeObservation, McpEraContext, MessageKind, ParsedMcpEvent,
+    RequestMetadata,
 };
-use crate::mcp::era::{EraResolution, UniqueValue};
+use crate::mcp::era::{CorrelationId, EraResolution, UniqueValue};
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -101,10 +102,15 @@ fn correlate_calls(mut parsed: Vec<ParsedMcpEvent>) -> Result<Vec<ParsedMcpEvent
     // the era of a request that had not happened yet: with an id reused after the response, the
     // contradiction on the call being answered was replaced by the clean era of the next call.
     // Requests are outstanding until a response consumes them.
-    let mut outstanding: std::collections::HashMap<String, EraResolution> =
+    let mut outstanding: std::collections::HashMap<CorrelationId, EraResolution> =
         std::collections::HashMap::new();
     for p in &mut parsed {
-        let Some(id) = p.event.jsonrpc_id.clone() else {
+        // The typed key, not the public `String` rendering: that renders JSON `1` and `"1"`
+        // identically, and they are different ids.
+        let Some(raw) = payload_raw(&p.event.payload) else {
+            continue;
+        };
+        let Some(id) = correlation_id(raw) else {
             continue;
         };
         // The shared classifier is the authority, not the presence of an observation. An error
@@ -112,9 +118,7 @@ fn correlate_calls(mut parsed: Vec<ParsedMcpEvent>) -> Result<Vec<ParsedMcpEvent
         // about `result`, so keying off that observation made an error response invisible here: it
         // inherited nothing and consumed nothing, and a legal sequential reuse of its id then
         // tripped the two-outstanding refusal.
-        let kind = payload_raw(&p.event.payload)
-            .map(classify_message)
-            .and_then(Result::ok);
+        let kind = classify_message(raw).ok();
         match kind {
             Some(MessageKind::Request { .. }) => {
                 // Two calls outstanding on one id makes the correlation ambiguous, and choosing

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -244,7 +244,7 @@ fn every_result_type_shape_reaches_the_axis() {
 /// field inherit the absent-means-complete rule.
 #[test]
 fn a_non_string_result_type_is_malformed() {
-    for bad in [json!(1), json!({}), json!([]), json!(null), json!("")] {
+    for bad in [json!(1), json!({}), json!([]), json!(null)] {
         assert_eq!(
             observed(Some(bad.clone())),
             ResultObservation::Malformed,
@@ -491,5 +491,56 @@ fn a_non_object_headers_node_is_malformed_not_absent() {
             EnvelopeObservation::Malformed,
             "{doc}"
         );
+    }
+}
+
+/// A `result` that is not an object cannot be missing a field. Reading it as `Missing` let the
+/// backward-compatibility rule turn `"result": null` into a completed action under a legacy era.
+#[test]
+fn a_non_object_result_is_malformed_not_missing() {
+    for bad in [json!(null), json!(7), json!([]), json!("done")] {
+        let message = json!({"jsonrpc": "2.0", "id": "call-1", "result": bad});
+        let input = framed(Some(headers(json!(V2025))), None, message);
+        let observed = detailed(&input, McpInputFormat::StreamableHttp)
+            .into_iter()
+            .find_map(|e| e.context.result_observation)
+            .expect("a response event");
+        assert_eq!(observed, ResultObservation::Malformed, "{bad}");
+    }
+}
+
+/// `ResultType` is an open string union, so an empty string is syntactically a token. Unrecognized
+/// rather than unreadable, which is a different finding with a different conclusion.
+#[test]
+fn an_empty_result_type_is_unrecognized_not_malformed() {
+    let input = framed(Some(headers(json!(V2026))), None, response(Some(json!(""))));
+    let observed = detailed(&input, McpInputFormat::StreamableHttp)
+        .into_iter()
+        .find_map(|e| e.context.result_observation)
+        .expect("a response event");
+    assert_eq!(observed, ResultObservation::Unrecognized(String::new()));
+}
+
+/// An attacker-chosen token was retained in full, once per event. The third retention site, after
+/// the header and the request metadata.
+#[test]
+fn an_oversized_result_token_is_bounded() {
+    let huge = "z".repeat(1024 * 1024);
+    let input = framed(
+        Some(headers(json!(V2026))),
+        None,
+        response(Some(json!(huge))),
+    );
+    let observed = detailed(&input, McpInputFormat::StreamableHttp)
+        .into_iter()
+        .find_map(|e| e.context.result_observation)
+        .expect("a response event");
+    match observed {
+        ResultObservation::Unrecognized(token) => assert!(
+            token.len() <= 64,
+            "retained {} bytes of an attacker-chosen token",
+            token.len()
+        ),
+        other => panic!("expected an unrecognized token, got {other:?}"),
     }
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -710,8 +710,14 @@ fn composite_a_deviant_params_under_a_legacy_era_is_invalid() {
         event.context.era,
         EraResolution::Unknown(UnknownReason::MalformedSignal)
     );
+    let observed = event
+        .context
+        .request_metadata
+        .as_ref()
+        .expect("a request reports metadata");
+    assert_eq!(observed, &RequestMetadata::Malformed);
     assert_eq!(
-        conclude_request(&event.context.era, &RequestMetadata::Malformed),
+        conclude_request(&event.context.era, observed),
         RequestAssessment::Invalid(InvalidReason::MalformedRequestMetadata)
     );
 }
@@ -772,18 +778,24 @@ fn a_notification_is_not_held_to_the_request_metadata_requirement() {
     assert_eq!(event.context.result_observation, None);
 }
 
-/// An explicit `"id": null` is not a usable request id, so it is a notification rather than a
-/// request with a broken one.
+/// A notification is a request object *without* an `id` member, so absence is the discriminant and
+/// the value is not. An explicit `"id": null` is a request with an invalid id, and calling it a
+/// notification drops the required 2026 metadata for any message that writes one token.
 #[test]
-fn an_explicit_null_id_is_a_notification() {
-    let message = json!({"jsonrpc": "2.0", "id": null, "method": "notifications/progress",
-                         "params": {}});
+fn an_explicit_null_id_is_a_request_not_a_notification() {
+    let message = json!({"jsonrpc": "2.0", "id": null, "method": "tools/call",
+                         "params": {"name": "Calculator", "arguments": {}}});
     let input = framed(Some(headers(json!(V2026))), None, message);
+    let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
     assert_eq!(
-        detailed(&input, McpInputFormat::StreamableHttp)[0]
-            .context
-            .request_metadata,
-        None
+        event.context.request_metadata,
+        Some(Absent),
+        "the metadata axis still applies"
+    );
+    let observed = event.context.request_metadata.as_ref().unwrap();
+    assert_eq!(
+        conclude_request(&event.context.era, observed),
+        RequestAssessment::Invalid(InvalidReason::MissingRequestMetadata)
     );
 }
 

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -920,3 +920,127 @@ fn the_sidecar_axes_follow_the_shared_classifier() {
         }
     }
 }
+
+// --- Call correlation: a response inherits its call's era ---------------------------------------
+
+/// The gap this closes. The era resolves from signals that live on a request, so a response carries
+/// none of its own and falls back to the transcript header. A request whose header and body
+/// disagree is `Conflicting`, but its response resolved to `Known(2025)` from the header alone, and
+/// a missing `resultType` at 2025 is `Terminal`. So a contradicted call could still conclude that
+/// the action completed. The request's era must reach the correlated response.
+#[test]
+fn a_response_inherits_the_conflicting_era_of_its_call() {
+    let request = json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
+                         "params": {"name": "Calculator", "arguments": {},
+                                    "_meta": meta(json!(V2026))}});
+    let response = json!({"jsonrpc": "2.0", "id": "call-1", "result": {"content": []}});
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": V2025}},
+        "entries": [
+            {"timestamp_ms": 1000, "request": request},
+            {"timestamp_ms": 1001, "response": response}
+        ]
+    });
+    let events = detailed(&doc.to_string(), McpInputFormat::StreamableHttp);
+    let req_event = &events[0];
+    let resp_event = &events[1];
+    assert_eq!(
+        req_event.context.era,
+        EraResolution::Conflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        },
+        "the request itself is contradicted"
+    );
+    assert_eq!(
+        resp_event.context.era,
+        EraResolution::Conflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        },
+        "the response must inherit its call's era"
+    );
+    let observed = resp_event
+        .context
+        .result_observation
+        .as_ref()
+        .expect("a response reports a result");
+    assert_eq!(observed, &ResultObservation::Missing);
+    assert_eq!(
+        conclude(&resp_event.context.era, observed),
+        ResultConclusion::Invalid(InvalidReason::EraConflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        }),
+        "a contradicted call cannot conclude that the action completed"
+    );
+}
+
+/// A response with no matching request keeps the era it resolved on its own, so correlation adds
+/// authority rather than removing it.
+#[test]
+fn an_uncorrelated_response_keeps_its_own_era() {
+    let response = json!({"jsonrpc": "2.0", "id": "orphan", "result": {"content": []}});
+    let input = framed(Some(headers(json!(V2025))), None, response);
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .era,
+        EraResolution::Known(V2025.into())
+    );
+}
+
+// --- Duplicate members ---------------------------------------------------------------------------
+
+/// `serde_json` collapses duplicate members last-value-wins, so by the time any guard reads the
+/// tree the evidence that two were sent is gone. Refused at the boundary instead, value-free.
+#[test]
+fn duplicate_members_are_refused_at_the_boundary() {
+    let cases = [
+        (
+            "resultType",
+            r#"{"transport":"streamable-http","entries":[{"response":{"jsonrpc":"2.0","id":"c","result":{"content":[],"resultType":"complete","resultType":"input_required"}}}]}"#,
+        ),
+        (
+            "params._meta protocolVersion",
+            r#"{"transport":"streamable-http","entries":[{"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-06-18","io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}}]}"#,
+        ),
+        (
+            "MCP-Protocol-Version header",
+            r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2025-06-18","MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#,
+        ),
+    ];
+    for (label, raw) in cases {
+        let err = parse_mcp_transcript(raw, McpInputFormat::StreamableHttp)
+            .expect_err(&format!("must refuse a duplicate {label}"));
+        // The whole chain, because `main` prints `{e:?}` and that is what an operator sees. The
+        // outermost context names the input; the cause names why.
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("duplicate member"),
+            "unexpected message for {label}: {rendered}"
+        );
+        assert!(
+            !rendered.contains("2026-07-28") && !rendered.contains("input_required"),
+            "refusal echoed an input value for {label}: {rendered}"
+        );
+    }
+}
+
+/// A duplicate on a bare JSON-RPC line is refused on the same basis.
+#[test]
+fn a_duplicate_member_on_a_jsonrpc_line_is_refused() {
+    let line =
+        r#"{"jsonrpc":"2.0","id":"c","method":"tools/call","method":"tools/list","params":{}}"#;
+    let err = parse_mcp_transcript(line, McpInputFormat::JsonRpc).expect_err("must refuse");
+    assert!(format!("{err:?}").contains("duplicate member"), "{err:?}");
+}
+
+/// Distinct members that merely look alike are not duplicates, so the rule does not become a ban on
+/// similar keys.
+#[test]
+fn distinct_members_are_not_duplicates() {
+    let raw = r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28","X-Other":"2025-06-18"}},"entries":[{"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
+    assert!(parse_mcp_transcript(raw, McpInputFormat::StreamableHttp).is_ok());
+}

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -3,11 +3,11 @@
 //! unit-green implementation can still get wrong.
 
 use super::*;
+use crate::mcp::era::{classify_message, conclude_request, RequestAssessment, UnknownReason};
 use crate::mcp::era::{
     conclude, EnvelopeObservation, EraResolution, IncompleteReason, InvalidReason, ParsedMcpEvent,
     RequestMetadata, RequestMetadata::*, ResultConclusion, ResultObservation,
 };
-use crate::mcp::era::{conclude_request, RequestAssessment, UnknownReason};
 use serde_json::{json, Value};
 
 const V2026: &str = "2026-07-28";
@@ -814,4 +814,100 @@ fn a_request_still_reports_the_metadata_axis() {
             .request_metadata,
         Some(Present(V2026.into()))
     );
+}
+
+// --- Message shape: one classifier, and the shapes it refuses ----------------------------------
+
+/// A present non-string `method` is a malformed message shape, not a message of another kind.
+/// Folding it through `as_str()` answered `Response`, which dropped the required 2026
+/// request-metadata check for anything that writes one wrong-typed field. The refusal is a JSON-RPC
+/// shape refusal rather than an era-state refusal, so it does not weaken the rule that every era
+/// observation parses.
+#[test]
+fn a_non_string_method_is_refused_at_parse_time() {
+    for bad in [json!(7), json!({}), json!([]), json!(null), json!(true)] {
+        let message = json!({"jsonrpc": "2.0", "id": "call-1", "method": bad,
+                             "params": {"name": "Calculator", "arguments": {}}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
+            .expect_err(&format!("must refuse method {bad}"));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("method must be a string"),
+            "unexpected message for {bad}: {rendered}"
+        );
+        // Value-free: the offending value is input-chosen and naming its type is all a reader can
+        // act on.
+        assert!(
+            !rendered.contains("7") && !rendered.contains("true"),
+            "refusal echoed the value: {rendered}"
+        );
+    }
+}
+
+/// The controls, so the refusal did not become a blanket rule. Each valid shape parses and lands on
+/// exactly the axes its kind licenses.
+#[test]
+fn each_valid_shape_lands_on_its_own_axes() {
+    let request = json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
+                         "params": {"name": "Calculator", "arguments": {}}});
+    let notification = json!({"jsonrpc": "2.0", "method": "notifications/progress",
+                              "params": {"progressToken": "t", "progress": 1}});
+    let response = json!({"jsonrpc": "2.0", "id": "call-1",
+                          "result": {"content": [], "resultType": "complete"}});
+    for (label, message, meta_axis, result_axis) in [
+        ("request", request, true, false),
+        ("notification", notification, false, false),
+        ("response", response, false, true),
+    ] {
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
+        assert_eq!(
+            event.context.request_metadata.is_some(),
+            meta_axis,
+            "{label} metadata axis"
+        );
+        assert_eq!(
+            event.context.result_observation.is_some(),
+            result_axis,
+            "{label} result axis"
+        );
+    }
+}
+
+/// The parser and the sidecar must not merely agree today, they must be reading the same answer.
+/// Two callers each reaching for `method` with their own `as_str()` is how the discriminants drifted
+/// apart before, so this asserts the axis assignment against `classify_message` itself rather than
+/// against a second copy of the rule.
+#[test]
+fn the_sidecar_axes_follow_the_shared_classifier() {
+    let shapes = [
+        json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
+               "params": {"name": "Calculator", "arguments": {}}}),
+        json!({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}),
+        json!({"jsonrpc": "2.0", "id": null, "method": "tools/call",
+               "params": {"name": "Calculator", "arguments": {}}}),
+        json!({"jsonrpc": "2.0", "id": "call-1", "method": "", "params": {}}),
+        json!({"jsonrpc": "2.0", "id": "call-1", "result": {"content": [], "resultType": "complete"}}),
+        json!({"jsonrpc": "2.0", "id": "call-1", "error": {"code": -1, "message": "x"}}),
+        json!({"jsonrpc": "2.0", "params": {}}),
+    ];
+    for shape in shapes {
+        let expected = classify_message(&shape).expect("a classifiable shape");
+        let input = framed(Some(headers(json!(V2026))), None, shape.clone());
+        let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
+        let (meta, result) = (
+            event.context.request_metadata.is_some(),
+            event.context.result_observation.is_some(),
+        );
+        match expected {
+            MessageKind::Request { .. } => assert_eq!((meta, result), (true, false), "{shape}"),
+            MessageKind::Notification { .. } => {
+                assert_eq!((meta, result), (false, false), "{shape}")
+            }
+            // An error response has no `result` to observe, so the result axis is licensed but
+            // empty; what matters is that the metadata axis stays off.
+            MessageKind::Response => assert!(!meta, "{shape}"),
+        }
+    }
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -397,21 +397,104 @@ fn a_non_object_meta_is_malformed() {
     }
 }
 
-/// A malformed hybrid: a valid string `method` alongside a `result`. The parser calls this a
-/// request, so the metadata observation has to follow the same rule. Keying on the absence of
-/// `result` would drop the observation for exactly the shape worth observing.
+/// The invariant stated once over every shape that reaches the parser:
+/// the two axes are mutually exclusive because one discriminant produces both. A message is a
+/// request or a response, never a request for the payload and a response for the sidecar.
 #[test]
-fn a_hybrid_with_method_and_result_still_reports_request_metadata() {
-    let hybrid = json!({
+fn no_event_ever_carries_both_axes() {
+    let hybrid_result = json!({
         "jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
         "params": {"name": "Calculator", "arguments": {}, "_meta": meta(json!(V2026))},
-        "result": {"content": []}
+        "result": {"content": [], "resultType": "complete"}
     });
+    let hybrid_error = json!({
+        "jsonrpc": "2.0", "id": "call-2", "method": "tools/list",
+        "error": {"code": -32000, "message": "boom"}
+    });
+    let hybrid_unreadable_result = json!({
+        "jsonrpc": "2.0", "id": "call-3", "method": "notifications/initialized",
+        "result": null
+    });
+    for message in [
+        req(Some(meta(json!(V2026)))),
+        response(Some(json!("complete"))),
+        hybrid_result,
+        hybrid_error,
+        hybrid_unreadable_result,
+    ] {
+        let parsed = detailed(&message.to_string(), McpInputFormat::JsonRpc);
+        let context = &parsed[0].context;
+        assert!(
+            context.request_metadata.is_none() || context.result_observation.is_none(),
+            "both axes populated for {message}: {context:?}"
+        );
+        // A message with a string `method` is a request on both axes, whatever else it carries.
+        assert_eq!(
+            context.request_metadata.is_some(),
+            message.get("method").and_then(Value::as_str).is_some(),
+            "the request axis must follow the payload discriminant for {message}"
+        );
+    }
+}
+
+/// A `transport_context` that is present and not an object is a signal that arrived and failed.
+/// `Value::get` answered `None` for it, which is the same answer as no container at all, so the
+/// whole transcript read as `Absent` on the evidence that its framing was deviant.
+#[test]
+fn a_non_object_transport_context_is_malformed_not_absent() {
+    for bad in [json!(7), json!("2026-07-28"), json!([]), json!(null)] {
+        let input = framed(Some(bad.clone()), None, req(None));
+        assert_eq!(
+            detailed(&input, McpInputFormat::StreamableHttp)[0]
+                .context
+                .envelope,
+            EnvelopeObservation::Malformed,
+            "{bad}"
+        );
+    }
+}
+
+/// The same shape one level down, where dropping the slot is worse: the entry silently inherits a
+/// valid transcript default and its own broken signal disappears.
+#[test]
+fn a_non_object_entry_transport_context_does_not_inherit_the_transcript_default() {
+    for bad in [json!(7), json!("2026-07-28"), json!([]), json!(null)] {
+        let input = framed(Some(headers(json!(V2026))), Some(bad.clone()), req(None));
+        assert_eq!(
+            detailed(&input, McpInputFormat::StreamableHttp)[0]
+                .context
+                .envelope,
+            EnvelopeObservation::Malformed,
+            "{bad}"
+        );
+    }
+}
+
+/// The distinction the fix rests on, from the other side: a container that is readable and simply
+/// carries no header slot is silence, not a defect. Folding it to `Malformed` would report a
+/// finding on every transcript whose `transport_context` holds anything else.
+#[test]
+fn a_readable_transport_context_without_headers_stays_absent() {
+    let input = framed(Some(json!({"status": 200})), None, req(None));
     assert_eq!(
-        detailed(&hybrid.to_string(), McpInputFormat::JsonRpc)[0]
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
             .context
-            .request_metadata,
-        Some(Present(V2026.into()))
+            .envelope,
+        EnvelopeObservation::Absent
+    );
+}
+
+/// An explicit `null` in a slot is a key that was written, not a key that was omitted. `Option<T>`
+/// folds both onto `None`, so the slots are deserialized to keep the difference.
+#[test]
+fn an_explicit_null_headers_slot_is_malformed_not_absent() {
+    let doc = json!({"transport": "streamable-http", "headers": null,
+                     "entries": [{"timestamp_ms": 1000, "request": req(None)}]});
+    assert_eq!(
+        detailed(&doc.to_string(), McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Malformed
     );
 }
 
@@ -573,4 +656,20 @@ fn composite_an_unknown_token_is_incomplete_and_value_free() {
         !format!("{conclusion:?}").contains("banana"),
         "the token must not travel: {conclusion:?}"
     );
+}
+
+/// The hybrid fixture, both axes on one message. A valid string `method` makes this a request, so
+/// the metadata observation follows that discriminant and no result observation is taken: keying
+/// the metadata on the absence of `result` would drop it for exactly the shape worth observing,
+/// and reading the `result` anyway would hand slice 2 a result conclusion about a request.
+#[test]
+fn a_hybrid_reports_request_metadata_and_no_result_observation() {
+    let hybrid = json!({
+        "jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
+        "params": {"name": "Calculator", "arguments": {}, "_meta": meta(json!(V2026))},
+        "result": {"content": []}
+    });
+    let event = &detailed(&hybrid.to_string(), McpInputFormat::JsonRpc)[0];
+    assert_eq!(event.context.request_metadata, Some(Present(V2026.into())));
+    assert_eq!(event.context.result_observation, None);
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -779,24 +779,29 @@ fn a_notification_is_not_held_to_the_request_metadata_requirement() {
 }
 
 /// A notification is a request object *without* an `id` member, so absence is the discriminant and
-/// the value is not. An explicit `"id": null` is a request with an invalid id, and calling it a
-/// notification drops the required 2026 metadata for any message that writes one token.
+/// the value is not. An explicit `"id": null` is therefore a request shape, and because a request
+/// must name the call it belongs to, an unusable id is refused rather than quietly downgraded to a
+/// notification. Downgrading would have dropped the required 2026 metadata check for any message
+/// that writes one token.
 #[test]
-fn an_explicit_null_id_is_a_request_not_a_notification() {
+fn an_explicit_null_id_is_a_refused_request_not_a_notification() {
     let message = json!({"jsonrpc": "2.0", "id": null, "method": "tools/call",
                          "params": {"name": "Calculator", "arguments": {}}});
     let input = framed(Some(headers(json!(V2026))), None, message);
-    let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
-    assert_eq!(
-        event.context.request_metadata,
-        Some(Absent),
-        "the metadata axis still applies"
+    let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
+        .expect_err("a request with a null id is refused");
+    assert!(
+        format!("{err:?}").contains("must be a string or an integer"),
+        "{err:?}"
     );
-    let observed = event.context.request_metadata.as_ref().unwrap();
-    assert_eq!(
-        conclude_request(&event.context.era, observed),
-        RequestAssessment::Invalid(InvalidReason::MissingRequestMetadata)
-    );
+    // The same token on a notification is not a refusal, which is what makes this a statement about
+    // request shape rather than about `null`.
+    let notification = json!({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}});
+    assert!(parse_mcp_transcript(
+        &framed(Some(headers(json!(V2026))), None, notification),
+        McpInputFormat::StreamableHttp
+    )
+    .is_ok());
 }
 
 /// The positive control: a request still reports the axis, so the notification rule did not turn it
@@ -894,8 +899,6 @@ fn the_sidecar_axes_follow_the_shared_classifier() {
         json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
                "params": {"name": "Calculator", "arguments": {}}}),
         json!({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}),
-        json!({"jsonrpc": "2.0", "id": null, "method": "tools/call",
-               "params": {"name": "Calculator", "arguments": {}}}),
         json!({"jsonrpc": "2.0", "id": "call-1", "method": "", "params": {}}),
         json!({"jsonrpc": "2.0", "id": "call-1", "result": {"content": [], "resultType": "complete"}}),
         json!({"jsonrpc": "2.0", "id": "call-1", "error": {"code": -1, "message": "x"}}),
@@ -1393,5 +1396,108 @@ fn outstanding_ids_are_tracked_per_typed_key() {
     assert!(
         !rendered.contains("notifications/x"),
         "refusal echoed input: {rendered}"
+    );
+}
+
+// --- RequestId shape: classify first, then accept the id its kind requires ----------------------
+
+/// MCP restricts `RequestId` to string or integer. A request must carry one, and `1.0` and the
+/// lexically-float `1e0` are not integers even though one of them equals an integer.
+#[test]
+fn a_request_id_must_be_a_string_or_an_integer() {
+    for bad in [json!(1.0), json!(1e0), json!(null)] {
+        let message = json!({"jsonrpc": "2.0", "id": bad, "method": "tools/call",
+                             "params": {"name": "Calculator", "arguments": {}}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
+            .expect_err(&format!("must refuse request id {bad}"));
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("must be a string or an integer"),
+            "unexpected for {bad}: {rendered}"
+        );
+        assert!(
+            !rendered.contains("1.0") && !rendered.contains("Calculator"),
+            "refusal echoed input for {bad}: {rendered}"
+        );
+    }
+}
+
+/// A request with no `id` member at all is a notification, which is a different shape and not a
+/// refusal. The absent case is only a fault for something that classified as a request.
+#[test]
+fn a_notification_may_have_no_id() {
+    let message = json!({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}});
+    let input = framed(Some(headers(json!(V2026))), None, message);
+    assert!(parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_ok());
+}
+
+/// A success response answers a call, so it must name which one.
+#[test]
+fn a_success_response_must_carry_an_acceptable_id() {
+    for bad in [Some(json!(null)), Some(json!(2.5)), None] {
+        let mut message = json!({"jsonrpc": "2.0", "result": {"content": [],
+                                                              "resultType": "complete"}});
+        if let Some(id) = &bad {
+            message["id"] = id.clone();
+        }
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        assert!(
+            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_err(),
+            "must refuse a success response with id {bad:?}"
+        );
+    }
+}
+
+/// An error response is how a peer reports a request it could not even parse, so it may have no
+/// usable id. It stays ingestible and simply correlates with nothing.
+#[test]
+fn an_invalid_request_error_response_may_have_no_usable_id() {
+    for id in [Some(json!(null)), None] {
+        let mut message = json!({"jsonrpc": "2.0",
+                                 "error": {"code": -32600, "message": "Invalid Request"}});
+        if let Some(id) = &id {
+            message["id"] = id.clone();
+        }
+        let input = framed(Some(headers(json!(V2025))), None, message);
+        let events = detailed(&input, McpInputFormat::StreamableHttp);
+        assert_eq!(events.len(), 1, "must remain ingestible for id {id:?}");
+        assert_eq!(
+            events[0].context.era,
+            EraResolution::Known(V2025.into()),
+            "and stay uncorrelated, keeping its own era"
+        );
+    }
+}
+
+/// Negative and large integers are integers.
+#[test]
+fn negative_and_large_integers_are_accepted_ids() {
+    for id in [json!(-1), json!(i64::MIN), json!(u64::MAX)] {
+        let request = json!({"jsonrpc": "2.0", "id": id, "method": "notifications/x",
+                             "params": {}});
+        let response = json!({"jsonrpc": "2.0", "id": id, "result": {"content": []}});
+        let events = detailed(
+            &two_entry_doc((request, V2025), (response, V2026)),
+            McpInputFormat::StreamableHttp,
+        );
+        assert_eq!(
+            events[1].context.era,
+            EraResolution::Known(V2025.into()),
+            "id {id} must be accepted and correlate"
+        );
+    }
+}
+
+/// The end-to-end property the whole contract exists for: an id this build will not accept must
+/// never let a response borrow a legacy era and read `Terminal`.
+#[test]
+fn an_unacceptable_response_id_can_never_license_terminal() {
+    let request = json!({"jsonrpc": "2.0", "id": 1, "method": "notifications/x", "params": {}});
+    let response = json!({"jsonrpc": "2.0", "id": 1.0, "result": {"content": []}});
+    let doc = two_entry_doc((request, V2025), (response, V2025));
+    assert!(
+        parse_mcp_transcript(&doc, McpInputFormat::StreamableHttp).is_err(),
+        "a float response id is refused rather than silently correlated"
     );
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -1,0 +1,415 @@
+//! Parser-level wiring for the era axes. The pure functions are tested in `mcp::era`; these prove
+//! the signals actually reach them from real transcript shapes, which is the half that a
+//! unit-green implementation can still get wrong.
+
+use super::*;
+use crate::mcp::era::{
+    EnvelopeObservation, ParsedMcpEvent, RequestMetadata, RequestMetadata::*, ResultObservation,
+};
+use serde_json::{json, Value};
+
+const V2026: &str = "2026-07-28";
+const V2025: &str = "2025-06-18";
+
+fn detailed(input: &str, format: McpInputFormat) -> Vec<ParsedMcpEvent> {
+    parse_mcp_transcript_detailed(input, format).expect("transcript parses")
+}
+
+fn req(meta: Option<Value>) -> Value {
+    let mut params = json!({"name": "Calculator", "arguments": {}});
+    if let Some(m) = meta {
+        params["_meta"] = m;
+    }
+    json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call", "params": params})
+}
+
+fn meta(version: Value) -> Value {
+    json!({"io.modelcontextprotocol/protocolVersion": version})
+}
+
+/// `transport_context` is a free-form `Value`, so every shape below is a real transcript.
+fn framed(ctx: Option<Value>, entry_ctx: Option<Value>, message: Value) -> String {
+    let key = if message.get("result").is_some() {
+        "response"
+    } else {
+        "request"
+    };
+    let mut entry = json!({"timestamp_ms": 1000, key: message});
+    if let Some(c) = entry_ctx {
+        entry["transport_context"] = c;
+    }
+    let mut doc = json!({"transport": "streamable-http", "entries": [entry]});
+    if let Some(c) = ctx {
+        doc["transport_context"] = c;
+    }
+    doc.to_string()
+}
+
+fn headers(version: Value) -> Value {
+    json!({"headers": {"MCP-Protocol-Version": version}})
+}
+
+// --- Envelope, read from both levels -----------------------------------------------------------
+
+/// The existing fixtures carry the header at transcript level, so this is the shape that must work
+/// or the whole corpus reads as `Absent`.
+#[test]
+fn a_transcript_level_header_is_observed() {
+    let input = framed(Some(headers(json!(V2026))), None, req(None));
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Present(V2026.into())
+    );
+}
+
+#[test]
+fn an_entry_level_header_is_observed() {
+    let input = framed(None, Some(headers(json!(V2026))), req(None));
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Present(V2026.into())
+    );
+}
+
+#[test]
+fn two_levels_agreeing_are_present() {
+    let input = framed(
+        Some(headers(json!(V2026))),
+        Some(headers(json!(V2026))),
+        req(None),
+    );
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Present(V2026.into())
+    );
+}
+
+/// Fail-closed. Two levels of the same transcript stating different versions is not a signal to
+/// pick from, and `Malformed` is enough for this slice: it blocks a conclusion without inventing a
+/// resolution rule the spec does not give.
+#[test]
+fn two_levels_disagreeing_are_malformed() {
+    let input = framed(
+        Some(headers(json!(V2025))),
+        Some(headers(json!(V2026))),
+        req(None),
+    );
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Malformed
+    );
+}
+
+/// The reason the existing header helper cannot be reused unchanged: it turns a non-string into
+/// `None`, which would report silence where a signal arrived and failed.
+#[test]
+fn a_non_string_header_is_malformed_not_absent() {
+    for bad in [
+        json!(2026),
+        json!({"v": V2026}),
+        json!([V2026]),
+        json!(null),
+    ] {
+        let input = framed(Some(headers(bad.clone())), None, req(None));
+        assert_eq!(
+            detailed(&input, McpInputFormat::StreamableHttp)[0]
+                .context
+                .envelope,
+            EnvelopeObservation::Malformed,
+            "{bad}"
+        );
+    }
+}
+
+#[test]
+fn an_empty_header_is_malformed() {
+    let input = framed(Some(headers(json!(""))), None, req(None));
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Malformed
+    );
+}
+
+#[test]
+fn a_framed_transcript_with_no_header_is_absent() {
+    let input = framed(None, None, req(None));
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Absent
+    );
+}
+
+#[test]
+fn unframed_formats_are_not_applicable() {
+    for (input, format) in [
+        (req(None).to_string(), McpInputFormat::JsonRpc),
+        (
+            json!({"events": [req(None)]}).to_string(),
+            McpInputFormat::Inspector,
+        ),
+    ] {
+        assert_eq!(
+            detailed(&input, format)[0].context.envelope,
+            EnvelopeObservation::NotApplicable
+        );
+    }
+}
+
+// --- Request metadata --------------------------------------------------------------------------
+
+#[test]
+fn a_request_metadata_version_is_read_from_params_meta() {
+    let input = req(Some(meta(json!(V2026)))).to_string();
+    assert_eq!(
+        detailed(&input, McpInputFormat::JsonRpc)[0]
+            .context
+            .request_metadata,
+        Some(Present(V2026.into()))
+    );
+}
+
+#[test]
+fn a_request_without_meta_reports_absent_metadata() {
+    let input = req(None).to_string();
+    assert_eq!(
+        detailed(&input, McpInputFormat::JsonRpc)[0]
+            .context
+            .request_metadata,
+        Some(Absent)
+    );
+}
+
+#[test]
+fn a_non_string_metadata_version_is_malformed() {
+    for bad in [json!(7), json!({}), json!([]), json!("")] {
+        let input = req(Some(meta(bad.clone()))).to_string();
+        assert_eq!(
+            detailed(&input, McpInputFormat::JsonRpc)[0]
+                .context
+                .request_metadata,
+            Some(RequestMetadata::Malformed),
+            "{bad}"
+        );
+    }
+}
+
+// --- Result observation --------------------------------------------------------------------------
+
+fn response(result_type: Option<Value>) -> Value {
+    let mut r = json!({"content": []});
+    if let Some(t) = result_type {
+        r["resultType"] = t;
+    }
+    json!({"jsonrpc": "2.0", "id": "call-1", "result": r})
+}
+
+fn observed(result_type: Option<Value>) -> ResultObservation {
+    let input = framed(Some(headers(json!(V2026))), None, response(result_type));
+    detailed(&input, McpInputFormat::StreamableHttp)
+        .into_iter()
+        .find_map(|e| e.context.result_observation)
+        .expect("a response event")
+}
+
+#[test]
+fn every_result_type_shape_reaches_the_axis() {
+    assert_eq!(observed(None), ResultObservation::Missing);
+    assert_eq!(
+        observed(Some(json!("complete"))),
+        ResultObservation::Complete
+    );
+    assert_eq!(
+        observed(Some(json!("input_required"))),
+        ResultObservation::InputRequired
+    );
+    assert_eq!(
+        observed(Some(json!("banana"))),
+        ResultObservation::Unrecognized("banana".into())
+    );
+}
+
+/// The shapes that must not become `Missing` or a token, since either would let an unreadable
+/// field inherit the absent-means-complete rule.
+#[test]
+fn a_non_string_result_type_is_malformed() {
+    for bad in [json!(1), json!({}), json!([]), json!(null), json!("")] {
+        assert_eq!(
+            observed(Some(bad.clone())),
+            ResultObservation::Malformed,
+            "{bad}"
+        );
+    }
+}
+
+/// A request has no result to observe.
+#[test]
+fn a_request_has_no_result_observation() {
+    let input = framed(Some(headers(json!(V2026))), None, req(None));
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .result_observation,
+        None
+    );
+}
+
+// --- The parser does not refuse ----------------------------------------------------------------
+
+/// Every malformed shape above is an observable protocol defect, not an unparsable transcript.
+/// Refusing here would conflate the two and would break `mcp_import_smoke.rs`.
+#[test]
+fn malformed_observations_never_fail_the_parse() {
+    let cases = [
+        framed(Some(headers(json!(2026))), None, req(None)),
+        framed(
+            Some(headers(json!(V2025))),
+            Some(headers(json!(V2026))),
+            req(None),
+        ),
+        req(Some(meta(json!(7)))).to_string(),
+        framed(Some(headers(json!(V2026))), None, response(Some(json!(1)))),
+    ];
+    for (i, input) in cases.iter().enumerate() {
+        let format = if input.contains("\"transport\"") {
+            McpInputFormat::StreamableHttp
+        } else {
+            McpInputFormat::JsonRpc
+        };
+        assert!(
+            parse_mcp_transcript_detailed(input, format).is_ok(),
+            "case {i}"
+        );
+        assert!(parse_mcp_transcript(input, format).is_ok(), "case {i}");
+    }
+}
+
+// --- Per-entry scope, and the slots that were being ignored -------------------------------------
+
+/// A later deviant entry must not reach back and contaminate an earlier correct one. The first
+/// implementation folded every entry into one transcript-wide observation and copied it to all.
+#[test]
+fn a_deviant_entry_does_not_contaminate_the_others() {
+    let doc = json!({
+        "transport": "streamable-http",
+        "entries": [
+            {"timestamp_ms": 1000, "request": req(None)},
+            {"timestamp_ms": 1001, "transport_context": headers(json!(2026)),
+             "request": {"jsonrpc": "2.0", "id": "call-2", "method": "tools/call",
+                         "params": {"name": "Calculator", "arguments": {}}}}
+        ]
+    });
+    let mut ctx = json!({"headers": {"MCP-Protocol-Version": V2026}});
+    let mut doc = doc;
+    doc["transport_context"] = std::mem::take(&mut ctx);
+    let parsed = detailed(&doc.to_string(), McpInputFormat::StreamableHttp);
+    assert_eq!(
+        parsed[0].context.envelope,
+        EnvelopeObservation::Present(V2026.into()),
+        "the clean entry keeps the transcript default"
+    );
+    assert_eq!(
+        parsed[1].context.envelope,
+        EnvelopeObservation::Malformed,
+        "only the deviant entry is malformed"
+    );
+}
+
+/// The direct `headers` field exists on both the transcript and each entry, beside the nested
+/// `transport_context.headers`. Reading only the nested one drops half the surface.
+#[test]
+fn a_direct_headers_field_is_read_at_both_levels() {
+    for doc in [
+        json!({"transport": "streamable-http",
+               "headers": {"MCP-Protocol-Version": V2026},
+               "entries": [{"timestamp_ms": 1000, "request": req(None)}]}),
+        json!({"transport": "streamable-http",
+               "entries": [{"timestamp_ms": 1000,
+                            "headers": {"MCP-Protocol-Version": V2026},
+                            "request": req(None)}]}),
+    ] {
+        assert_eq!(
+            detailed(&doc.to_string(), McpInputFormat::StreamableHttp)[0]
+                .context
+                .envelope,
+            EnvelopeObservation::Present(V2026.into())
+        );
+    }
+}
+
+/// Two spellings of one header is not a value to choose between.
+#[test]
+fn duplicate_case_variants_of_the_header_are_malformed() {
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {
+            "MCP-Protocol-Version": V2026,
+            "mcp-protocol-version": V2025
+        }},
+        "entries": [{"timestamp_ms": 1000, "request": req(None)}]
+    });
+    assert_eq!(
+        detailed(&doc.to_string(), McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Malformed
+    );
+}
+
+/// A response has no request metadata to observe, so the field is absent rather than reported as
+/// an absent version. The comment said so before the code did.
+#[test]
+fn a_response_reports_no_request_metadata() {
+    let input = framed(Some(headers(json!(V2026))), None, response(None));
+    let parsed = detailed(&input, McpInputFormat::StreamableHttp);
+    let response_event = parsed
+        .iter()
+        .find(|e| e.context.result_observation.is_some())
+        .expect("a response event");
+    assert_eq!(response_event.context.request_metadata, None);
+}
+
+/// `_meta` is an object by schema. A scalar there is a signal that arrived and failed, and
+/// `Value::get` on a non-object answers `None`, which would have reported it as silence.
+#[test]
+fn a_non_object_meta_is_malformed() {
+    for bad in [json!("2026-07-28"), json!(7), json!([]), json!(null)] {
+        let input = req(Some(bad.clone())).to_string();
+        assert_eq!(
+            detailed(&input, McpInputFormat::JsonRpc)[0]
+                .context
+                .request_metadata,
+            Some(RequestMetadata::Malformed),
+            "{bad}"
+        );
+    }
+}
+
+/// A malformed hybrid: a valid string `method` alongside a `result`. The parser calls this a
+/// request, so the metadata observation has to follow the same rule. Keying on the absence of
+/// `result` would drop the observation for exactly the shape worth observing.
+#[test]
+fn a_hybrid_with_method_and_result_still_reports_request_metadata() {
+    let hybrid = json!({
+        "jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
+        "params": {"name": "Calculator", "arguments": {}, "_meta": meta(json!(V2026))},
+        "result": {"content": []}
+    });
+    assert_eq!(
+        detailed(&hybrid.to_string(), McpInputFormat::JsonRpc)[0]
+            .context
+            .request_metadata,
+        Some(Present(V2026.into()))
+    );
+}

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -413,3 +413,23 @@ fn a_hybrid_with_method_and_result_still_reports_request_metadata() {
         Some(Present(V2026.into()))
     );
 }
+
+/// Two spellings of the header carrying the same value agree, and agreement is not a choice. An
+/// earlier version failed closed on the duplicate itself rather than on a disagreement.
+#[test]
+fn duplicate_case_variants_agreeing_are_present() {
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {
+            "MCP-Protocol-Version": V2026,
+            "mcp-protocol-version": V2026
+        }},
+        "entries": [{"timestamp_ms": 1000, "request": req(None)}]
+    });
+    assert_eq!(
+        detailed(&doc.to_string(), McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Present(V2026.into())
+    );
+}

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -1313,9 +1313,11 @@ fn two_entry_doc(first: (Value, &str), second: (Value, &str)) -> String {
     .to_string()
 }
 
-/// `normalize_jsonrpc_id` renders JSON number `1` and JSON string `"1"` as the same Rust `String`,
-/// so correlation paired them. The response consumed a call it did not answer and took its era, and
-/// a missing `resultType` under that borrowed legacy era could read `Terminal`.
+/// `McpEvent::jsonrpc_id` renders JSON number `1` and JSON string `"1"` as the same `String`, and
+/// correlation once keyed on that rendering, so it paired them. The response consumed a call it did
+/// not answer and took its era, and a missing `resultType` under that borrowed legacy era could read
+/// `Terminal`. The helper that produced the rendering has since been replaced; the public field it
+/// fed has not, which is why the key is derived from the raw JSON instead.
 #[test]
 fn a_numeric_id_does_not_correlate_with_a_string_id() {
     let request = json!({"jsonrpc": "2.0", "id": 1, "method": "notifications/x", "params": {}});

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -31,10 +31,14 @@ fn meta(version: Value) -> Value {
 
 /// `transport_context` is a free-form `Value`, so every shape below is a real transcript.
 fn framed(ctx: Option<Value>, entry_ctx: Option<Value>, message: Value) -> String {
-    let key = if message.get("result").is_some() {
-        "response"
-    } else {
+    // The same discriminant `classify_message` uses: a message with a string `method` is a request
+    // or a notification, anything else is a response. Keying on `result` alone put an error-only
+    // response in the request slot, and the parser classified it as a response regardless because it
+    // carries no `method`, so the harness was wrong without any assertion noticing.
+    let key = if message.get("method").and_then(Value::as_str).is_some() {
         "request"
+    } else {
+        "response"
     };
     let mut entry = json!({"timestamp_ms": 1000, key: message});
     if let Some(c) = entry_ctx {
@@ -416,12 +420,20 @@ fn no_event_ever_carries_both_axes() {
         "jsonrpc": "2.0", "id": "call-3", "method": "notifications/initialized",
         "result": null
     });
+    // A real notification: a string `method` and no `id`, and not a request-only name. Without it
+    // the matrix could not tell "is a request" from "has a method", so the invariant below was
+    // satisfied by a rule that is not the one the parser follows.
+    let notification = json!({
+        "jsonrpc": "2.0", "method": "notifications/progress",
+        "params": {"progressToken": "t", "progress": 1}
+    });
     for message in [
         req(Some(meta(json!(V2026)))),
         response(Some(json!("complete"))),
         hybrid_result,
         hybrid_error,
         hybrid_unreadable_result,
+        notification,
     ] {
         let parsed = detailed(&message.to_string(), McpInputFormat::JsonRpc);
         let context = &parsed[0].context;
@@ -429,10 +441,14 @@ fn no_event_ever_carries_both_axes() {
             context.request_metadata.is_none() || context.result_observation.is_none(),
             "both axes populated for {message}: {context:?}"
         );
-        // A message with a string `method` is a request on both axes, whatever else it carries.
+        // The expectation comes from the shared classifier, not from a second reading of the shape.
+        // "Has a string method" is not the rule: a method with no `id` is a notification unless the
+        // name is request-only, and a notification carries no request-metadata axis at all.
+        let expects_request_axis =
+            matches!(classify_message(&message), Ok(MessageKind::Request { .. }));
         assert_eq!(
             context.request_metadata.is_some(),
-            message.get("method").and_then(Value::as_str).is_some(),
+            expects_request_axis,
             "the request axis must follow the payload discriminant for {message}"
         );
     }
@@ -1869,4 +1885,44 @@ fn an_sse_frame_without_data_is_refused() {
         format!("{err:?}").contains("data"),
         "refused for the wrong reason: {err:?}"
     );
+}
+
+/// The fixture helper must place a message in the slot its kind belongs to. Keying on `result`
+/// alone put an error-only response under `request`, which the parser then classified as a response
+/// anyway because it carries no `method` — so the harness was wrong without any assertion falling
+/// over. A helper that lies quietly is the kind of thing later tests build on.
+#[test]
+fn the_framed_helper_places_messages_by_their_kind() {
+    let cases = [
+        (
+            "error-only response",
+            json!({"jsonrpc": "2.0", "id": "c", "error": {"code": -1, "message": "x"}}),
+            "response",
+        ),
+        (
+            "success response",
+            json!({"jsonrpc": "2.0", "id": "c", "result": {"content": []}}),
+            "response",
+        ),
+        (
+            "request",
+            json!({"jsonrpc": "2.0", "id": "c", "method": "tools/call",
+                   "params": {"name": "C", "arguments": {}}}),
+            "request",
+        ),
+        (
+            "notification",
+            json!({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}),
+            "request",
+        ),
+    ];
+    for (label, message, slot) in cases {
+        let doc: Value =
+            serde_json::from_str(&framed(None, None, message)).expect("the helper emits JSON");
+        let entry = &doc["entries"][0];
+        assert!(
+            entry.get(slot).is_some(),
+            "{label} belongs in the {slot} slot: {entry}"
+        );
+    }
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -31,11 +31,13 @@ fn meta(version: Value) -> Value {
 
 /// `transport_context` is a free-form `Value`, so every shape below is a real transcript.
 fn framed(ctx: Option<Value>, entry_ctx: Option<Value>, message: Value) -> String {
-    // The same discriminant `classify_message` uses: a message with a string `method` is a request
-    // or a notification, anything else is a response. Keying on `result` alone put an error-only
-    // response in the request slot, and the parser classified it as a response regardless because it
-    // carries no `method`, so the harness was wrong without any assertion noticing.
-    let key = if message.get("method").and_then(Value::as_str).is_some() {
+    // Which wrapper slot the message belongs in, keyed on the presence of a `method` member and
+    // nothing about its value. This is the wrapper's own question, not the classifier's: a present
+    // but non-string `method` is a malformed message shape that `classify_message` refuses, and the
+    // refusal has to happen on a message the transcript placed as a request. Keying on `as_str` sent
+    // exactly that fixture into the response slot, so the malformed-method test was exercising a path
+    // its own comment did not describe. `two_entry_doc` keys the same way.
+    let key = if message.get("method").is_some() {
         "request"
     } else {
         "response"
@@ -1913,6 +1915,16 @@ fn the_framed_helper_places_messages_by_their_kind() {
         (
             "notification",
             json!({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}),
+            "request",
+        ),
+        // A present but non-string `method` is a malformed message shape, and the wrapper has no
+        // business deciding that: it belongs in the request slot, where `classify_message` refuses
+        // it. Keying the wrapper on `as_str` put exactly this fixture in the response slot, so the
+        // existing malformed-method test was exercising a path its own comment did not describe.
+        (
+            "non-string method",
+            json!({"jsonrpc": "2.0", "id": "c", "method": 7,
+                   "params": {"name": "C", "arguments": {}}}),
             "request",
         ),
     ];

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -1155,3 +1155,60 @@ fn sequential_id_reuse_after_a_response_is_allowed() {
     });
     assert!(parse_mcp_transcript(&doc.to_string(), McpInputFormat::StreamableHttp).is_ok());
 }
+
+/// An error response is a response. It deliberately has no result observation, since the
+/// `resultType` requirement is about `result`, so keying correlation off that observation made it
+/// invisible: it inherited nothing and consumed nothing.
+#[test]
+fn an_error_response_inherits_the_era_of_its_call() {
+    let request = json!({"jsonrpc": "2.0", "id": "err", "method": "notifications/x",
+                         "params": {"_meta": meta(json!(V2026))}});
+    let error = json!({"jsonrpc": "2.0", "id": "err",
+                       "error": {"code": -32000, "message": "boom"}});
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": V2025}},
+        "entries": [
+            {"timestamp_ms": 1000, "request": request},
+            {"timestamp_ms": 1001, "response": error}
+        ]
+    });
+    let events = detailed(&doc.to_string(), McpInputFormat::StreamableHttp);
+    assert_eq!(
+        events[1].context.era,
+        EraResolution::Conflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        },
+        "an error response must inherit its call's era"
+    );
+    assert_eq!(
+        events[1].context.result_observation, None,
+        "and still reports no result observation, since it carries no result"
+    );
+}
+
+/// Consuming the outstanding id is the other half. Without it the id stayed outstanding and a legal
+/// sequential reuse tripped the two-outstanding refusal.
+#[test]
+fn an_error_response_frees_the_id_for_sequential_reuse() {
+    let mk_req = || {
+        json!({"jsonrpc": "2.0", "id": "err", "method": "notifications/x",
+                           "params": {}})
+    };
+    let error = json!({"jsonrpc": "2.0", "id": "err",
+                       "error": {"code": -32000, "message": "boom"}});
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": V2025}},
+        "entries": [
+            {"timestamp_ms": 1000, "request": mk_req()},
+            {"timestamp_ms": 1001, "response": error},
+            {"timestamp_ms": 1002, "request": mk_req()}
+        ]
+    });
+    assert!(
+        parse_mcp_transcript(&doc.to_string(), McpInputFormat::StreamableHttp).is_ok(),
+        "an error response must consume the outstanding id"
+    );
+}

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -722,8 +722,17 @@ fn composite_a_deviant_params_at_2026_is_invalid_for_the_container_not_the_era()
     let message = json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call", "params": []});
     let input = framed(Some(headers(json!(V2026))), None, message);
     let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
+    // Read from the context rather than handed in: feeding `Malformed` here would keep the
+    // assertion green after the guard that produces it was removed, which is the whole thing this
+    // composite exists to catch.
+    let observed = event
+        .context
+        .request_metadata
+        .as_ref()
+        .expect("a request reports metadata");
+    assert_eq!(observed, &RequestMetadata::Malformed);
     assert_eq!(
-        conclude_request(&event.context.era, &RequestMetadata::Malformed),
+        conclude_request(&event.context.era, observed),
         RequestAssessment::Invalid(InvalidReason::MalformedRequestMetadata)
     );
 }
@@ -743,5 +752,54 @@ fn an_explicit_null_entry_headers_slot_does_not_inherit_the_transcript_default()
             .context
             .envelope,
         EnvelopeObservation::Malformed
+    );
+}
+
+/// A real notification under 2026 with no `_meta`. `NotificationParams._meta` is optional and is a
+/// different type that does not carry the protocol version, so the request requirement does not
+/// apply and reporting it would invent a fault.
+#[test]
+fn a_notification_is_not_held_to_the_request_metadata_requirement() {
+    let notification = json!({"jsonrpc": "2.0", "method": "notifications/progress",
+                              "params": {"progressToken": "t", "progress": 1}});
+    let input = framed(Some(headers(json!(V2026))), None, notification);
+    let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
+    assert_eq!(event.context.era, EraResolution::Known(V2026.into()));
+    assert_eq!(
+        event.context.request_metadata, None,
+        "a notification has no request-metadata axis"
+    );
+    assert_eq!(event.context.result_observation, None);
+}
+
+/// An explicit `"id": null` is not a usable request id, so it is a notification rather than a
+/// request with a broken one.
+#[test]
+fn an_explicit_null_id_is_a_notification() {
+    let message = json!({"jsonrpc": "2.0", "id": null, "method": "notifications/progress",
+                         "params": {}});
+    let input = framed(Some(headers(json!(V2026))), None, message);
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .request_metadata,
+        None
+    );
+}
+
+/// The positive control: a request still reports the axis, so the notification rule did not turn it
+/// off for everything with a `method`.
+#[test]
+fn a_request_still_reports_the_metadata_axis() {
+    let input = framed(
+        Some(headers(json!(V2026))),
+        None,
+        req(Some(meta(json!(V2026)))),
+    );
+    assert_eq!(
+        detailed(&input, McpInputFormat::StreamableHttp)[0]
+            .context
+            .request_metadata,
+        Some(Present(V2026.into()))
     );
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -831,16 +831,25 @@ fn a_non_string_method_is_refused_at_parse_time() {
         let input = framed(Some(headers(json!(V2026))), None, message);
         let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
             .expect_err(&format!("must refuse method {bad}"));
+        // Split the located prefix from the diagnostic and assert each half for what it is.
+        // Searching the whole string for the offending value cannot work: `!contains("7")` also
+        // matches a source line numbered 7, and for `{}`, `[]`, `null` the search has nothing to
+        // find, so it passes while proving nothing. Pinning the diagnostic to one exact constant is
+        // the value-free property itself, since a constant cannot carry an input-chosen value.
         let rendered = err.to_string();
+        let (prefix, diagnostic) = rendered
+            .split_once(": ")
+            .unwrap_or_else(|| panic!("expected a located diagnostic for {bad}: {rendered}"));
+        let line = prefix
+            .strip_prefix("MCP event at source line ")
+            .unwrap_or_else(|| panic!("unexpected prefix for {bad}: {prefix}"));
         assert!(
-            rendered.contains("method must be a string"),
-            "unexpected message for {bad}: {rendered}"
+            !line.is_empty() && line.bytes().all(|c| c.is_ascii_digit()),
+            "source line is not a number for {bad}: {line}"
         );
-        // Value-free: the offending value is input-chosen and naming its type is all a reader can
-        // act on.
-        assert!(
-            !rendered.contains("7") && !rendered.contains("true"),
-            "refusal echoed the value: {rendered}"
+        assert_eq!(
+            diagnostic, "JSON-RPC method must be a string",
+            "the diagnostic must be exactly this constant, for {bad}"
         );
     }
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -1242,8 +1242,8 @@ fn a_response_carrying_both_result_and_error_is_refused() {
 }
 
 /// Neither, with an id, was correlated as a response: it consumed the outstanding id and then let a
-/// sequential reuse through. `notifications/x` keeps the pre-existing `tools/call` duplicate-id gate
-/// from masking the subject.
+/// sequential reuse through. The transcript-wide gate that once shadowed this is gone, so the
+/// outstanding map is what these observe.
 #[test]
 fn a_no_method_object_with_neither_result_nor_error_is_refused() {
     let request = json!({"jsonrpc": "2.0", "id": "n", "method": "notifications/x", "params": {}});
@@ -1569,83 +1569,7 @@ fn an_acceptable_integer_id_does_license_terminal_under_a_legacy_era() {
 
 // --- RequestId is string or number, per the pinned schema ---------------------------------------
 
-/// The pinned 2026 schema says `RequestId = string | number`, and #1866 names that schema the source
-/// of truth. An earlier head read "integer" from a prose overview and refused fractional and
-/// exponent-spelled ids as protocol-invalid. They are not: JSON-RPC says fractional ids SHOULD NOT be
-/// used, which is advice to senders and not a rule a receiver may enforce as invalidity.
-#[test]
-fn a_fractional_request_id_is_accepted_and_correlates() {
-    let raw = r#"{"transport":"streamable-http","entries":[
-        {"transport_context":{"headers":{"MCP-Protocol-Version":"2025-06-18"}},
-         "request":{"jsonrpc":"2.0","id":1.5,"method":"notifications/x","params":{}}},
-        {"transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},
-         "response":{"jsonrpc":"2.0","id":1.5,"result":{"content":[]}}}]}"#;
-    let events = detailed(raw, McpInputFormat::StreamableHttp);
-    assert_eq!(
-        events[1].context.era,
-        EraResolution::Known(V2025.into()),
-        "a fractional id correlates to its own call"
-    );
-}
-
-/// The exponent spelling reaches the parser only as text, and it is the same number as `1.0`, so it
-/// must correlate with it rather than be refused.
-#[test]
-fn an_exponent_spelled_id_correlates_with_its_decimal_form() {
-    let raw = r#"{"transport":"streamable-http","entries":[
-        {"transport_context":{"headers":{"MCP-Protocol-Version":"2025-06-18"}},
-         "request":{"jsonrpc":"2.0","id":1e0,"method":"notifications/x","params":{}}},
-        {"transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},
-         "response":{"jsonrpc":"2.0","id":1.0,"result":{"content":[]}}}]}"#;
-    assert!(raw.contains("1e0"), "the fixture must carry the spelling");
-    let events = detailed(raw, McpInputFormat::StreamableHttp);
-    assert_eq!(events[1].context.era, EraResolution::Known(V2025.into()));
-}
-
 // --- Every known request method, not just the two with payloads ---------------------------------
-
-/// The set must cover the request methods of every revision this build recognizes, not only the two
-/// the parser gives payloads to. A `prompts/get` without an id was a notification, and shed the
-/// required 2026 request metadata exactly as `tools/call` did.
-#[test]
-fn known_non_tool_requests_without_an_id_are_refused() {
-    for method in [
-        "server/discover",
-        "completion/complete",
-        "prompts/get",
-        "resources/read",
-        "subscriptions/listen",
-        "initialize",
-        "ping",
-        "sampling/createMessage",
-        "tasks/get",
-        "roots/list",
-    ] {
-        let message = json!({"jsonrpc": "2.0", "method": method, "params": {}});
-        let input = framed(Some(headers(json!(V2026))), None, message);
-        assert!(
-            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_err(),
-            "{method} without an id must be refused"
-        );
-    }
-}
-
-/// The control that keeps the set from swallowing notifications and extensions.
-#[test]
-fn notifications_and_extensions_remain_id_less() {
-    for method in [
-        "notifications/progress",
-        "notifications/cancelled",
-        "x-vendor/telemetry",
-    ] {
-        let message = json!({"jsonrpc": "2.0", "method": method, "params": {}});
-        let input = framed(Some(headers(json!(V2026))), None, message);
-        assert!(
-            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_ok(),
-            "{method} must remain ingestible without an id"
-        );
-    }
-}
 
 // --- The duplicate boundary reaches the derived structs too -------------------------------------
 
@@ -1666,4 +1590,281 @@ fn duplicate_members_on_an_entry_are_refused() {
     let err = parse_mcp_transcript(raw, McpInputFormat::StreamableHttp)
         .expect_err("a duplicate on an entry is refused");
     assert!(format!("{err:?}").contains("duplicate member"), "{err:?}");
+}
+
+// --- Numeric ids correlate on value, not on spelling --------------------------------------------
+
+fn raw_pair(req_id: &str, req_ver: &str, resp_id: &str, resp_ver: &str) -> String {
+    format!(
+        r#"{{"transport":"streamable-http","entries":[
+        {{"transport_context":{{"headers":{{"MCP-Protocol-Version":"{req_ver}"}}}},
+         "request":{{"jsonrpc":"2.0","id":{req_id},"method":"notifications/x","params":{{}}}}}},
+        {{"transport_context":{{"headers":{{"MCP-Protocol-Version":"{resp_ver}"}}}},
+         "response":{{"jsonrpc":"2.0","id":{resp_id},"result":{{"content":[]}}}}}}]}}"#
+    )
+}
+
+/// Only ids this build can key on without loss correlate. A string keys on itself; a number keys on
+/// its exact text when it is an `i64` or `u64`. Every other JSON number stays ingestible and does not
+/// correlate, because serde has already put it through `f64` and two different ids can land on one
+/// value. A false pairing hands a response the era of a call it did not answer; declining to key
+/// leaves it with its own envelope's era, which is incomplete and true.
+#[test]
+fn exactly_representable_integer_ids_correlate() {
+    for id in ["1", "0", "-1", "9007199254740993"] {
+        let events = detailed(
+            &raw_pair(id, V2025, id, V2026),
+            McpInputFormat::StreamableHttp,
+        );
+        assert_eq!(
+            events[1].context.era,
+            EraResolution::Known(V2025.into()),
+            "id {id} must correlate to its own call"
+        );
+    }
+}
+
+/// A number that cannot be keyed without loss keeps its own era rather than borrowing one.
+#[test]
+fn a_non_representable_number_id_does_not_correlate() {
+    for id in ["1.0", "1e0", "1.5", "-0.0"] {
+        let events = detailed(
+            &raw_pair(id, V2025, id, V2026),
+            McpInputFormat::StreamableHttp,
+        );
+        assert_eq!(
+            events[1].context.era,
+            EraResolution::Known(V2026.into()),
+            "id {id} must not correlate, and keeps its own envelope era"
+        );
+    }
+}
+
+/// The two decimal spellings either side of 2^53 both parse to the same double, so keying on them
+/// would put two different ids on one call. Neither correlates, so neither can.
+#[test]
+fn decimal_ids_beyond_two_to_the_53_never_land_on_one_call() {
+    let events = detailed(
+        &raw_pair("9007199254740992.0", V2025, "9007199254740993.0", V2026),
+        McpInputFormat::StreamableHttp,
+    );
+    assert_eq!(events[1].context.era, EraResolution::Known(V2026.into()));
+}
+
+/// A string is not a number however it is spelled.
+#[test]
+fn a_string_id_never_correlates_with_a_numeric_one() {
+    let events = detailed(
+        &raw_pair("1", V2025, "\"1\"", V2026),
+        McpInputFormat::StreamableHttp,
+    );
+    assert_eq!(events[1].context.era, EraResolution::Known(V2026.into()));
+}
+
+/// The two integers either side of 2^53 are different ids. An `f64` key collapses them, which would
+/// let one call answer another's response.
+#[test]
+fn integers_beyond_two_to_the_53_never_collide() {
+    let events = detailed(
+        &raw_pair("9007199254740992", V2025, "9007199254740993", V2026),
+        McpInputFormat::StreamableHttp,
+    );
+    assert_eq!(
+        events[1].context.era,
+        EraResolution::Known(V2026.into()),
+        "9007199254740992 and ...93 are different ids"
+    );
+}
+
+// --- Lifetime is owned by the typed outstanding map, on real request payloads ------------------
+
+fn tools_call(id: &str) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"tools/call","params":{{"name":"C","arguments":{{}}}}}}"#
+    )
+}
+
+fn jsonrpc_lines(lines: &[String]) -> String {
+    lines.join("\n")
+}
+
+/// A number `1` and a string `"1"` are different ids, so both may be in flight. The old global gate
+/// keyed on the public `String` rendering and refused this.
+#[test]
+fn a_numeric_and_a_string_tools_call_id_may_both_be_outstanding() {
+    let input = jsonrpc_lines(&[tools_call("1"), tools_call("\"1\"")]);
+    assert!(
+        parse_mcp_transcript(&input, McpInputFormat::JsonRpc).is_ok(),
+        "number 1 and string \"1\" are different calls"
+    );
+}
+
+/// Reuse after the response is legal. The old gate refused any reuse anywhere in the transcript.
+#[test]
+fn a_tools_call_id_may_be_reused_after_its_response() {
+    let response = r#"{"jsonrpc":"2.0","id":1,"result":{"content":[]}}"#.to_string();
+    let input = jsonrpc_lines(&[tools_call("1"), response, tools_call("1")]);
+    assert!(
+        parse_mcp_transcript(&input, McpInputFormat::JsonRpc).is_ok(),
+        "an id is free once its call has been answered"
+    );
+}
+
+/// And the case the refusal exists for still refuses, value-free.
+#[test]
+fn two_outstanding_tools_calls_on_one_id_are_refused() {
+    let input = jsonrpc_lines(&[tools_call("1"), tools_call("1")]);
+    let err = parse_mcp_transcript(&input, McpInputFormat::JsonRpc)
+        .expect_err("one id, two calls in flight");
+    let rendered = format!("{err:?}");
+    assert!(rendered.contains("outstanding"), "unexpected: {rendered}");
+    assert!(
+        !rendered.contains("\"C\""),
+        "refusal echoed input: {rendered}"
+    );
+}
+
+// --- The duplicate claim must reach every subtree ------------------------------------------------
+
+#[test]
+fn a_duplicate_inside_an_unknown_transcript_subtree_is_refused() {
+    let raw = r#"{"transport":"streamable-http","junk":{"a":1,"a":2},"entries":[{"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
+    assert!(
+        format!(
+            "{:?}",
+            parse_mcp_transcript(raw, McpInputFormat::StreamableHttp).unwrap_err()
+        )
+        .contains("duplicate member"),
+        "a duplicate inside an ignored subtree must still be refused"
+    );
+}
+
+#[test]
+fn a_duplicate_inside_an_unknown_entry_subtree_is_refused() {
+    let raw = r#"{"transport":"streamable-http","entries":[{"junk":{"b":1,"b":2},"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
+    assert!(
+        format!(
+            "{:?}",
+            parse_mcp_transcript(raw, McpInputFormat::StreamableHttp).unwrap_err()
+        )
+        .contains("duplicate member"),
+        "an ignored entry subtree must still be duplicate-aware"
+    );
+}
+
+#[test]
+fn duplicate_members_on_the_sse_envelope_are_refused() {
+    for raw in [
+        r#"{"transport":"http-sse","entries":[{"sse":{"event":"message","event":"other","data":{}}}]}"#,
+        r#"{"transport":"http-sse","entries":[{"sse":{"event":"message","junk":{"c":1,"c":2},"data":{}}}]}"#,
+    ] {
+        assert!(
+            format!(
+                "{:?}",
+                parse_mcp_transcript(raw, McpInputFormat::HttpSse).unwrap_err()
+            )
+            .contains("duplicate member"),
+            "SSE envelope must be duplicate-aware: {raw}"
+        );
+    }
+}
+
+/// `sse` written as an explicit null is a slot that arrived and failed, like `headers` and
+/// `transport_context`. Folding it to absent lets it disappear silently beside a valid request.
+#[test]
+fn an_explicit_null_sse_slot_is_malformed_not_absent() {
+    for raw in [
+        r#"{"transport":"http-sse","entries":[{"sse":null}]}"#,
+        r#"{"transport":"http-sse","entries":[{"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}},"sse":null}]}"#,
+    ] {
+        let err = parse_mcp_transcript(raw, McpInputFormat::HttpSse).expect_err(&format!(
+            "an explicit null sse slot must not fold to absent: {raw}"
+        ));
+        // Asserting only `is_err()` proved nothing: mutation showed that removing the null handling
+        // still refuses, because deserializing `null` into the envelope fails on its own. The reason
+        // is what distinguishes a slot that arrived and failed from a shape that would not parse.
+        assert!(
+            format!("{err:?}").contains("sse slot is present and null"),
+            "refused for the wrong reason: {err:?}"
+        );
+    }
+}
+
+/// The whole set, not a sample. Every request method of every revision this build recognizes must be
+/// refused without an id, because each one is a request and a request MUST carry one. A sample would
+/// leave the untested members free to regress silently, which is how the set came to hold two names.
+///
+/// Collected from the `Request` interfaces of
+/// `schema/{2024-11-05,2025-03-26,2025-06-18,2025-11-25,2026-07-28}` at spec commit `5f5440bb`.
+#[test]
+fn every_known_request_method_requires_an_id() {
+    let expected = [
+        "completion/complete",
+        "elicitation/create",
+        "initialize",
+        "logging/setLevel",
+        "ping",
+        "prompts/get",
+        "prompts/list",
+        "resources/list",
+        "resources/read",
+        "resources/subscribe",
+        "resources/templates/list",
+        "resources/unsubscribe",
+        "roots/list",
+        "sampling/createMessage",
+        "server/discover",
+        "subscriptions/listen",
+        "tasks/cancel",
+        "tasks/get",
+        "tasks/list",
+        "tasks/result",
+        "tools/call",
+        "tools/list",
+    ];
+    // The table and the constant must be the same set, so adding one without the other fails here
+    // rather than in a transcript.
+    let mut declared: Vec<&str> = crate::mcp::era::REQUEST_ONLY_METHODS.to_vec();
+    let mut listed: Vec<&str> = expected.to_vec();
+    declared.sort_unstable();
+    listed.sort_unstable();
+    assert_eq!(declared, listed, "the table and the constant have drifted");
+
+    for method in expected {
+        let message = json!({"jsonrpc": "2.0", "method": method, "params": {}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        assert!(
+            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_err(),
+            "{method} without an id must be refused"
+        );
+    }
+}
+
+/// And a name in none of the five revisions stays a notification, so the set does not swallow
+/// extensions.
+#[test]
+fn an_unknown_extension_method_stays_a_notification() {
+    for method in ["x-vendor/telemetry", "experimental/whatever", "vendor.ping"] {
+        let message = json!({"jsonrpc": "2.0", "method": method, "params": {}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        assert!(
+            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_ok(),
+            "{method} must remain ingestible without an id"
+        );
+    }
+}
+
+/// `data` is what an SSE frame carries. The derive made it required; the manual visitor I wrote to
+/// make the envelope duplicate-aware initialized from `Default` and never checked, so a frame with
+/// no `data` produced zero events instead of a refusal. A malformed frame disappearing silently is
+/// the failure mode this whole slice is built against.
+#[test]
+fn an_sse_frame_without_data_is_refused() {
+    let raw = r#"{"transport":"http-sse","entries":[{"sse":{"event":"message"}}]}"#;
+    let err = parse_mcp_transcript(raw, McpInputFormat::HttpSse)
+        .expect_err("an SSE frame with no data must be refused");
+    assert!(
+        format!("{err:?}").contains("data"),
+        "refused for the wrong reason: {err:?}"
+    );
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -899,7 +899,8 @@ fn the_sidecar_axes_follow_the_shared_classifier() {
         json!({"jsonrpc": "2.0", "id": "call-1", "method": "", "params": {}}),
         json!({"jsonrpc": "2.0", "id": "call-1", "result": {"content": [], "resultType": "complete"}}),
         json!({"jsonrpc": "2.0", "id": "call-1", "error": {"code": -1, "message": "x"}}),
-        json!({"jsonrpc": "2.0", "params": {}}),
+        // A no-method object with neither `result` nor `error` is refused as a message shape now,
+        // so it is not a classifiable input and belongs in the refusal test instead.
     ];
     for shape in shapes {
         let expected = classify_message(&shape).expect("a classifiable shape");
@@ -1211,4 +1212,80 @@ fn an_error_response_frees_the_id_for_sequential_reuse() {
         parse_mcp_transcript(&doc.to_string(), McpInputFormat::StreamableHttp).is_ok(),
         "an error response must consume the outstanding id"
     );
+}
+
+// --- A response is exactly one of result or error ------------------------------------------------
+
+/// Both at once is protocol-invalid, and it licensed completion: `observe_result` reads `result`,
+/// sees `complete`, and a 2026 era concludes `Terminal`. The shape has to be refused before any
+/// axis reads it.
+#[test]
+fn a_response_carrying_both_result_and_error_is_refused() {
+    let both = json!({"jsonrpc": "2.0", "id": "c",
+                      "result": {"content": [], "resultType": "complete"},
+                      "error": {"code": -32000, "message": "boom"}});
+    let input = framed(Some(headers(json!(V2026))), None, both);
+    let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
+        .expect_err("must refuse both result and error");
+    let rendered = format!("{err:?}");
+    assert!(
+        rendered.contains("exactly one of result or error"),
+        "unexpected message: {rendered}"
+    );
+    assert!(
+        !rendered.contains("complete") && !rendered.contains("boom"),
+        "refusal echoed an input value: {rendered}"
+    );
+}
+
+/// Neither, with an id, was correlated as a response: it consumed the outstanding id and then let a
+/// sequential reuse through. `notifications/x` keeps the pre-existing `tools/call` duplicate-id gate
+/// from masking the subject.
+#[test]
+fn a_no_method_object_with_neither_result_nor_error_is_refused() {
+    let request = json!({"jsonrpc": "2.0", "id": "n", "method": "notifications/x", "params": {}});
+    let neither = json!({"jsonrpc": "2.0", "id": "n"});
+    let doc = json!({
+        "transport": "streamable-http",
+        "entries": [
+            {"timestamp_ms": 1000, "request": request},
+            {"timestamp_ms": 1001, "response": neither}
+        ]
+    });
+    let err = parse_mcp_transcript(&doc.to_string(), McpInputFormat::StreamableHttp)
+        .expect_err("must refuse a response that is neither");
+    assert!(
+        format!("{err:?}").contains("exactly one of result or error"),
+        "unexpected message: {err:?}"
+    );
+}
+
+/// The controls. A valid success response and a valid error response both still correlate, so the
+/// rule refuses the two invalid shapes and nothing else.
+#[test]
+fn valid_success_and_error_responses_still_correlate() {
+    for response in [
+        json!({"jsonrpc": "2.0", "id": "ok", "result": {"content": [], "resultType": "complete"}}),
+        json!({"jsonrpc": "2.0", "id": "ok", "error": {"code": -1, "message": "x"}}),
+    ] {
+        let request = json!({"jsonrpc": "2.0", "id": "ok", "method": "notifications/x",
+                             "params": {"_meta": meta(json!(V2026))}});
+        let doc = json!({
+            "transport": "streamable-http",
+            "transport_context": {"headers": {"MCP-Protocol-Version": V2025}},
+            "entries": [
+                {"timestamp_ms": 1000, "request": request},
+                {"timestamp_ms": 1001, "response": response.clone()}
+            ]
+        });
+        let events = detailed(&doc.to_string(), McpInputFormat::StreamableHttp);
+        assert_eq!(
+            events[1].context.era,
+            EraResolution::Conflicting {
+                header: V2025.into(),
+                body: V2026.into()
+            },
+            "must still inherit for {response}"
+        );
+    }
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -7,6 +7,7 @@ use crate::mcp::era::{
     conclude, EnvelopeObservation, EraResolution, IncompleteReason, InvalidReason, ParsedMcpEvent,
     RequestMetadata, RequestMetadata::*, ResultConclusion, ResultObservation,
 };
+use crate::mcp::era::{conclude_request, RequestAssessment, UnknownReason};
 use serde_json::{json, Value};
 
 const V2026: &str = "2026-07-28";
@@ -437,9 +438,9 @@ fn no_event_ever_carries_both_axes() {
     }
 }
 
-/// A `transport_context` that is present and not an object is a signal that arrived and failed.
-/// `Value::get` answered `None` for it, which is the same answer as no container at all, so the
-/// whole transcript read as `Absent` on the evidence that its framing was deviant.
+/// A present non-object `transport_context` was naively read as `Absent`, because `Value::get`
+/// returned `None` for it, which is the same answer as no container at all. The fixed path reports
+/// `Malformed`, preserving the evidence that framing was present but unreadable.
 #[test]
 fn a_non_object_transport_context_is_malformed_not_absent() {
     for bad in [json!(7), json!("2026-07-28"), json!([]), json!(null)] {
@@ -672,4 +673,75 @@ fn a_hybrid_reports_request_metadata_and_no_result_observation() {
     let event = &detailed(&hybrid.to_string(), McpInputFormat::JsonRpc)[0];
     assert_eq!(event.context.request_metadata, Some(Present(V2026.into())));
     assert_eq!(event.context.result_observation, None);
+}
+
+/// The fourth container. `params` is an object by schema, and reaching through a scalar with
+/// `Value::get` answers `None`, which reads a container that arrived and failed as silence.
+#[test]
+fn a_non_object_params_is_malformed_not_absent() {
+    for bad in [
+        json!(7),
+        json!("x"),
+        json!([]),
+        json!(null),
+        json!([{"_meta": {}}]),
+    ] {
+        let message = json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call",
+                             "params": bad});
+        assert_eq!(
+            detailed(&message.to_string(), McpInputFormat::JsonRpc)[0]
+                .context
+                .request_metadata,
+            Some(RequestMetadata::Malformed),
+            "{bad}"
+        );
+    }
+}
+
+/// The whole chain under a legacy era, which is where the difference decides the verdict. `Absent`
+/// is only a fault from 2026 on, so a deviant container came back `Valid`: no objection recorded
+/// against a request whose parameters could not be read.
+#[test]
+fn composite_a_deviant_params_under_a_legacy_era_is_invalid() {
+    let message = json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call", "params": 7});
+    let input = framed(Some(headers(json!(V2025))), None, message);
+    let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
+    assert_eq!(
+        event.context.era,
+        EraResolution::Unknown(UnknownReason::MalformedSignal)
+    );
+    assert_eq!(
+        conclude_request(&event.context.era, &RequestMetadata::Malformed),
+        RequestAssessment::Invalid(InvalidReason::MalformedRequestMetadata)
+    );
+}
+
+/// The same chain at 2026, so the rule is not satisfied by the era alone.
+#[test]
+fn composite_a_deviant_params_at_2026_is_invalid_for_the_container_not_the_era() {
+    let message = json!({"jsonrpc": "2.0", "id": "call-1", "method": "tools/call", "params": []});
+    let input = framed(Some(headers(json!(V2026))), None, message);
+    let event = &detailed(&input, McpInputFormat::StreamableHttp)[0];
+    assert_eq!(
+        conclude_request(&event.context.era, &RequestMetadata::Malformed),
+        RequestAssessment::Invalid(InvalidReason::MalformedRequestMetadata)
+    );
+}
+
+/// An entry that writes its own `headers` slot as an explicit `null` must not inherit the valid
+/// transcript default. Mutation showed this was the one of the four `present_slot` sites no test
+/// pinned, and it is the site where dropping the slot silently borrows another entry's evidence.
+#[test]
+fn an_explicit_null_entry_headers_slot_does_not_inherit_the_transcript_default() {
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": V2026}},
+        "entries": [{"timestamp_ms": 1000, "headers": null, "request": req(None)}]
+    });
+    assert_eq!(
+        detailed(&doc.to_string(), McpInputFormat::StreamableHttp)[0]
+            .context
+            .envelope,
+        EnvelopeObservation::Malformed
+    );
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -1401,11 +1401,15 @@ fn outstanding_ids_are_tracked_per_typed_key() {
 
 // --- RequestId shape: classify first, then accept the id its kind requires ----------------------
 
-/// MCP restricts `RequestId` to string or integer. A request must carry one, and `1.0` and the
-/// lexically-float `1e0` are not integers even though one of them equals an integer.
+/// MCP restricts `RequestId` to a string or an integer. A request must carry one, and neither a
+/// fractional number nor a null is one.
+///
+/// `1e0` is not in this loop: `json!` evaluates it to the same `f64` as `json!(1.0)`, so including it
+/// would test one case twice. The exponent spelling only survives as text, and
+/// `a_lexically_exponent_id_is_refused_from_raw_text` owns it.
 #[test]
 fn a_request_id_must_be_a_string_or_an_integer() {
-    for bad in [json!(1.0), json!(1e0), json!(null)] {
+    for bad in [json!(1.0), json!(null)] {
         let message = json!({"jsonrpc": "2.0", "id": bad, "method": "tools/call",
                              "params": {"name": "Calculator", "arguments": {}}});
         let input = framed(Some(headers(json!(V2026))), None, message);
@@ -1499,5 +1503,86 @@ fn an_unacceptable_response_id_can_never_license_terminal() {
     assert!(
         parse_mcp_transcript(&doc, McpInputFormat::StreamableHttp).is_err(),
         "a float response id is refused rather than silently correlated"
+    );
+}
+
+// --- Request-only methods cannot become notifications by omitting an id -------------------------
+
+/// `tools/call` is `CallToolRequest`. Treating every method-bearing object without an `id` as a
+/// notification let a request-only method shed the id requirement, and with it the required 2026
+/// `RequestParams._meta`, since notification metadata is optional. End to end under 2026 with no
+/// `_meta` at all.
+#[test]
+fn a_request_only_method_without_an_id_is_refused() {
+    for method in ["tools/call", "tools/list"] {
+        let message = json!({"jsonrpc": "2.0", "method": method,
+                             "params": {"name": "Calculator", "arguments": {}}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
+            .expect_err(&format!("{method} without an id must be refused"));
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("must be a string or an integer"),
+            "unexpected for {method}: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Calculator"),
+            "refusal echoed input: {rendered}"
+        );
+    }
+}
+
+/// The positive control that keeps this from becoming a ban on notifications. A real notification,
+/// and an extension method that is not one of the known request-only names, both stay ingestible
+/// without an id.
+#[test]
+fn real_and_extension_notifications_still_need_no_id() {
+    for method in ["notifications/progress", "x-vendor/telemetry"] {
+        let message = json!({"jsonrpc": "2.0", "method": method, "params": {}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        assert!(
+            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_ok(),
+            "{method} must remain ingestible without an id"
+        );
+    }
+}
+
+/// The exponent form has to arrive as text: `json!(1e0)` builds the same `f64` as `json!(1.0)`, so a
+/// macro-built loop tests one case twice and proves nothing about the spelling.
+#[test]
+fn a_lexically_exponent_id_is_refused_from_raw_text() {
+    let raw = r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":1e0,"method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
+    assert!(
+        raw.contains("1e0"),
+        "the fixture must carry the exponent spelling"
+    );
+    let err = parse_mcp_transcript(raw, McpInputFormat::StreamableHttp)
+        .expect_err("an exponent-spelled id is not an integer");
+    assert!(
+        format!("{err:?}").contains("must be a string or an integer"),
+        "{err:?}"
+    );
+}
+
+/// The positive half of the security claim. Without it an implementation that refuses every id
+/// satisfies "an unacceptable id can never license Terminal" trivially.
+#[test]
+fn an_acceptable_integer_id_does_license_terminal_under_a_legacy_era() {
+    let request = json!({"jsonrpc": "2.0", "id": 1, "method": "notifications/x", "params": {}});
+    let response = json!({"jsonrpc": "2.0", "id": 1, "result": {"content": []}});
+    let events = detailed(
+        &two_entry_doc((request, V2025), (response, V2025)),
+        McpInputFormat::StreamableHttp,
+    );
+    let observed = events[1]
+        .context
+        .result_observation
+        .as_ref()
+        .expect("a response reports a result");
+    assert_eq!(observed, &ResultObservation::Missing);
+    assert_eq!(
+        conclude(&events[1].context.era, observed),
+        ResultConclusion::Terminal,
+        "a legacy era with an absent resultType is Terminal, which is the state the refusal protects"
     );
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -433,3 +433,63 @@ fn duplicate_case_variants_agreeing_are_present() {
         EnvelopeObservation::Present(V2026.into())
     );
 }
+
+/// An oversized header value must not be retained, let alone once per entry. An observation only
+/// ever holds a value it has already accepted as a version, so a rejected one costs the enum
+/// discriminant and nothing more, however large the input was.
+#[test]
+fn an_oversized_header_is_not_retained_per_entry() {
+    let huge = "x".repeat(1024 * 1024);
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": huge}},
+        "entries": [
+            {"timestamp_ms": 1000, "request": req(None)},
+            {"timestamp_ms": 1001,
+             "request": {"jsonrpc": "2.0", "id": "call-2", "method": "tools/call",
+                         "params": {"name": "Calculator", "arguments": {}}}}
+        ]
+    });
+    let parsed = detailed(&doc.to_string(), McpInputFormat::StreamableHttp);
+    assert_eq!(parsed.len(), 2);
+    for (i, event) in parsed.iter().enumerate() {
+        assert_eq!(
+            event.context.envelope,
+            EnvelopeObservation::Malformed,
+            "entry {i} must not carry the value"
+        );
+    }
+}
+
+/// The same bound on the body signal.
+#[test]
+fn an_oversized_metadata_version_is_not_retained() {
+    let huge = "x".repeat(1024 * 1024);
+    let input = req(Some(meta(json!(huge)))).to_string();
+    assert_eq!(
+        detailed(&input, McpInputFormat::JsonRpc)[0]
+            .context
+            .request_metadata,
+        Some(RequestMetadata::Malformed)
+    );
+}
+
+/// A `headers` node that is not an object is a signal that arrived and failed. `as_object`
+/// answering `None` would have dropped the slot and reported silence.
+#[test]
+fn a_non_object_headers_node_is_malformed_not_absent() {
+    for doc in [
+        json!({"transport": "streamable-http", "headers": 7,
+               "entries": [{"timestamp_ms": 1000, "request": req(None)}]}),
+        json!({"transport": "streamable-http", "transport_context": {"headers": 7},
+               "entries": [{"timestamp_ms": 1000, "request": req(None)}]}),
+    ] {
+        assert_eq!(
+            detailed(&doc.to_string(), McpInputFormat::StreamableHttp)[0]
+                .context
+                .envelope,
+            EnvelopeObservation::Malformed,
+            "{doc}"
+        );
+    }
+}

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -791,7 +791,7 @@ fn an_explicit_null_id_is_a_refused_request_not_a_notification() {
     let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
         .expect_err("a request with a null id is refused");
     assert!(
-        format!("{err:?}").contains("must be a string or an integer"),
+        format!("{err:?}").contains("must be a string or a number"),
         "{err:?}"
     );
     // The same token on a notification is not a refusal, which is what makes this a statement about
@@ -1401,30 +1401,25 @@ fn outstanding_ids_are_tracked_per_typed_key() {
 
 // --- RequestId shape: classify first, then accept the id its kind requires ----------------------
 
-/// MCP restricts `RequestId` to a string or an integer. A request must carry one, and neither a
-/// fractional number nor a null is one.
-///
-/// `1e0` is not in this loop: `json!` evaluates it to the same `f64` as `json!(1.0)`, so including it
-/// would test one case twice. The exponent spelling only survives as text, and
-/// `a_lexically_exponent_id_is_refused_from_raw_text` owns it.
+/// The pinned schema says `RequestId = string | number`, so a fractional id is valid and only a null
+/// is not. An earlier head refused `1.0` here on an integer-only reading taken from prose rather than
+/// from the schema the ledger names as the source of truth.
 #[test]
-fn a_request_id_must_be_a_string_or_an_integer() {
-    for bad in [json!(1.0), json!(null)] {
-        let message = json!({"jsonrpc": "2.0", "id": bad, "method": "tools/call",
-                             "params": {"name": "Calculator", "arguments": {}}});
-        let input = framed(Some(headers(json!(V2026))), None, message);
-        let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
-            .expect_err(&format!("must refuse request id {bad}"));
-        let rendered = format!("{err:?}");
-        assert!(
-            rendered.contains("must be a string or an integer"),
-            "unexpected for {bad}: {rendered}"
-        );
-        assert!(
-            !rendered.contains("1.0") && !rendered.contains("Calculator"),
-            "refusal echoed input for {bad}: {rendered}"
-        );
-    }
+fn a_null_request_id_is_refused() {
+    let message = json!({"jsonrpc": "2.0", "id": null, "method": "tools/call",
+                         "params": {"name": "Calculator", "arguments": {}}});
+    let input = framed(Some(headers(json!(V2026))), None, message);
+    let err = parse_mcp_transcript(&input, McpInputFormat::StreamableHttp)
+        .expect_err("must refuse a null request id");
+    let rendered = format!("{err:?}");
+    assert!(
+        rendered.contains("must be a string or a number"),
+        "unexpected: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Calculator"),
+        "refusal echoed input: {rendered}"
+    );
 }
 
 /// A request with no `id` member at all is a notification, which is a different shape and not a
@@ -1436,10 +1431,11 @@ fn a_notification_may_have_no_id() {
     assert!(parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_ok());
 }
 
-/// A success response answers a call, so it must name which one.
+/// A success response answers a call, so it must name which one. A fractional id names one, so only
+/// an absent or null id is a fault here.
 #[test]
 fn a_success_response_must_carry_an_acceptable_id() {
-    for bad in [Some(json!(null)), Some(json!(2.5)), None] {
+    for bad in [Some(json!(null)), None] {
         let mut message = json!({"jsonrpc": "2.0", "result": {"content": [],
                                                               "resultType": "complete"}});
         if let Some(id) = &bad {
@@ -1494,15 +1490,16 @@ fn negative_and_large_integers_are_accepted_ids() {
 }
 
 /// The end-to-end property the whole contract exists for: an id this build will not accept must
-/// never let a response borrow a legacy era and read `Terminal`.
+/// never let a response borrow a legacy era and read `Terminal`. A null id is the unacceptable case
+/// now that the number domain is whole.
 #[test]
 fn an_unacceptable_response_id_can_never_license_terminal() {
     let request = json!({"jsonrpc": "2.0", "id": 1, "method": "notifications/x", "params": {}});
-    let response = json!({"jsonrpc": "2.0", "id": 1.0, "result": {"content": []}});
+    let response = json!({"jsonrpc": "2.0", "id": null, "result": {"content": []}});
     let doc = two_entry_doc((request, V2025), (response, V2025));
     assert!(
         parse_mcp_transcript(&doc, McpInputFormat::StreamableHttp).is_err(),
-        "a float response id is refused rather than silently correlated"
+        "a null response id is refused rather than silently correlated"
     );
 }
 
@@ -1522,7 +1519,7 @@ fn a_request_only_method_without_an_id_is_refused() {
             .expect_err(&format!("{method} without an id must be refused"));
         let rendered = format!("{err:?}");
         assert!(
-            rendered.contains("must be a string or an integer"),
+            rendered.contains("must be a string or a number"),
             "unexpected for {method}: {rendered}"
         );
         assert!(
@@ -1547,23 +1544,6 @@ fn real_and_extension_notifications_still_need_no_id() {
     }
 }
 
-/// The exponent form has to arrive as text: `json!(1e0)` builds the same `f64` as `json!(1.0)`, so a
-/// macro-built loop tests one case twice and proves nothing about the spelling.
-#[test]
-fn a_lexically_exponent_id_is_refused_from_raw_text() {
-    let raw = r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":1e0,"method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
-    assert!(
-        raw.contains("1e0"),
-        "the fixture must carry the exponent spelling"
-    );
-    let err = parse_mcp_transcript(raw, McpInputFormat::StreamableHttp)
-        .expect_err("an exponent-spelled id is not an integer");
-    assert!(
-        format!("{err:?}").contains("must be a string or an integer"),
-        "{err:?}"
-    );
-}
-
 /// The positive half of the security claim. Without it an implementation that refuses every id
 /// satisfies "an unacceptable id can never license Terminal" trivially.
 #[test]
@@ -1585,4 +1565,105 @@ fn an_acceptable_integer_id_does_license_terminal_under_a_legacy_era() {
         ResultConclusion::Terminal,
         "a legacy era with an absent resultType is Terminal, which is the state the refusal protects"
     );
+}
+
+// --- RequestId is string or number, per the pinned schema ---------------------------------------
+
+/// The pinned 2026 schema says `RequestId = string | number`, and #1866 names that schema the source
+/// of truth. An earlier head read "integer" from a prose overview and refused fractional and
+/// exponent-spelled ids as protocol-invalid. They are not: JSON-RPC says fractional ids SHOULD NOT be
+/// used, which is advice to senders and not a rule a receiver may enforce as invalidity.
+#[test]
+fn a_fractional_request_id_is_accepted_and_correlates() {
+    let raw = r#"{"transport":"streamable-http","entries":[
+        {"transport_context":{"headers":{"MCP-Protocol-Version":"2025-06-18"}},
+         "request":{"jsonrpc":"2.0","id":1.5,"method":"notifications/x","params":{}}},
+        {"transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},
+         "response":{"jsonrpc":"2.0","id":1.5,"result":{"content":[]}}}]}"#;
+    let events = detailed(raw, McpInputFormat::StreamableHttp);
+    assert_eq!(
+        events[1].context.era,
+        EraResolution::Known(V2025.into()),
+        "a fractional id correlates to its own call"
+    );
+}
+
+/// The exponent spelling reaches the parser only as text, and it is the same number as `1.0`, so it
+/// must correlate with it rather than be refused.
+#[test]
+fn an_exponent_spelled_id_correlates_with_its_decimal_form() {
+    let raw = r#"{"transport":"streamable-http","entries":[
+        {"transport_context":{"headers":{"MCP-Protocol-Version":"2025-06-18"}},
+         "request":{"jsonrpc":"2.0","id":1e0,"method":"notifications/x","params":{}}},
+        {"transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},
+         "response":{"jsonrpc":"2.0","id":1.0,"result":{"content":[]}}}]}"#;
+    assert!(raw.contains("1e0"), "the fixture must carry the spelling");
+    let events = detailed(raw, McpInputFormat::StreamableHttp);
+    assert_eq!(events[1].context.era, EraResolution::Known(V2025.into()));
+}
+
+// --- Every known request method, not just the two with payloads ---------------------------------
+
+/// The set must cover the request methods of every revision this build recognizes, not only the two
+/// the parser gives payloads to. A `prompts/get` without an id was a notification, and shed the
+/// required 2026 request metadata exactly as `tools/call` did.
+#[test]
+fn known_non_tool_requests_without_an_id_are_refused() {
+    for method in [
+        "server/discover",
+        "completion/complete",
+        "prompts/get",
+        "resources/read",
+        "subscriptions/listen",
+        "initialize",
+        "ping",
+        "sampling/createMessage",
+        "tasks/get",
+        "roots/list",
+    ] {
+        let message = json!({"jsonrpc": "2.0", "method": method, "params": {}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        assert!(
+            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_err(),
+            "{method} without an id must be refused"
+        );
+    }
+}
+
+/// The control that keeps the set from swallowing notifications and extensions.
+#[test]
+fn notifications_and_extensions_remain_id_less() {
+    for method in [
+        "notifications/progress",
+        "notifications/cancelled",
+        "x-vendor/telemetry",
+    ] {
+        let message = json!({"jsonrpc": "2.0", "method": method, "params": {}});
+        let input = framed(Some(headers(json!(V2026))), None, message);
+        assert!(
+            parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).is_ok(),
+            "{method} must remain ingestible without an id"
+        );
+    }
+}
+
+// --- The duplicate boundary reaches the derived structs too -------------------------------------
+
+/// `UniqueValue` covers the free-form slots, but the transcript and entry themselves are derived
+/// structs, and serde's derive ignores unknown keys entirely — so a duplicate unknown member at
+/// either level passed while the claim said every duplicate is refused.
+#[test]
+fn duplicate_members_on_the_transcript_wrapper_are_refused() {
+    let raw = r#"{"transport":"streamable-http","x":1,"x":2,"entries":[{"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
+    let err = parse_mcp_transcript(raw, McpInputFormat::StreamableHttp)
+        .expect_err("a duplicate on the transcript wrapper is refused");
+    assert!(format!("{err:?}").contains("duplicate member"), "{err:?}");
+}
+
+#[test]
+fn duplicate_members_on_an_entry_are_refused() {
+    let raw = r#"{"transport":"streamable-http","entries":[{"y":1,"y":2,"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
+    let err = parse_mcp_transcript(raw, McpInputFormat::StreamableHttp)
+        .expect_err("a duplicate on an entry is refused");
+    assert!(format!("{err:?}").contains("duplicate member"), "{err:?}");
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -1044,3 +1044,114 @@ fn distinct_members_are_not_duplicates() {
     let raw = r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28","X-Other":"2025-06-18"}},"entries":[{"request":{"jsonrpc":"2.0","id":"c","method":"tools/call","params":{"name":"C","arguments":{}}}}]}"#;
     assert!(parse_mcp_transcript(raw, McpInputFormat::StreamableHttp).is_ok());
 }
+
+// --- SSE data goes through the same boundary ----------------------------------------------------
+
+/// `TransportSseEnvelope.data` was a plain `Value`, so an SSE frame bypassed the duplicate-aware
+/// boundary entirely: both the structured form and the JSON-string form kept only the last member.
+#[test]
+fn duplicate_members_in_sse_data_are_refused() {
+    let structured = r#"{"transport":"http-sse","entries":[{"sse":{"event":"message","data":{"jsonrpc":"2.0","id":"c","result":{"content":[],"resultType":"complete","resultType":"input_required"}}}}]}"#;
+    let as_string = r#"{"transport":"http-sse","entries":[{"sse":{"event":"message","data":"{\"jsonrpc\":\"2.0\",\"id\":\"c\",\"result\":{\"content\":[],\"resultType\":\"complete\",\"resultType\":\"input_required\"}}"}}]}"#;
+    for (label, raw) in [("structured", structured), ("json string", as_string)] {
+        let err = parse_mcp_transcript(raw, McpInputFormat::HttpSse)
+            .expect_err(&format!("must refuse a duplicate in {label} SSE data"));
+        assert!(
+            format!("{err:?}").contains("duplicate member"),
+            "unexpected message for {label}: {err:?}"
+        );
+    }
+}
+
+// --- Correlation runs in source order ------------------------------------------------------------
+
+/// The global map was last-wins, so a response could inherit the era of a *later* request. Here the
+/// first request is contradicted, its response has no `resultType`, and a second request reuses the
+/// id with a clean era. The response must keep the contradiction of the call it answered.
+#[test]
+fn a_response_takes_the_era_of_the_request_that_preceded_it() {
+    let conflicted = json!({"jsonrpc": "2.0", "id": "reused", "method": "notifications/x",
+                            "params": {"_meta": meta(json!(V2026))}});
+    let response = json!({"jsonrpc": "2.0", "id": "reused", "result": {"content": []}});
+    let clean = json!({"jsonrpc": "2.0", "id": "reused", "method": "notifications/x",
+                       "params": {"_meta": meta(json!(V2025))}});
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": V2025}},
+        "entries": [
+            {"timestamp_ms": 1000, "request": conflicted},
+            {"timestamp_ms": 1001, "response": response},
+            {"timestamp_ms": 1002, "request": clean}
+        ]
+    });
+    let events = detailed(&doc.to_string(), McpInputFormat::StreamableHttp);
+    assert_eq!(
+        events[1].context.era,
+        EraResolution::Conflicting {
+            header: V2025.into(),
+            body: V2026.into()
+        },
+        "the response must not inherit a later request's era"
+    );
+}
+
+/// A response arriving before any request keeps the era it resolved on its own.
+#[test]
+fn a_response_before_any_request_stays_self_resolved() {
+    let response = json!({"jsonrpc": "2.0", "id": "early", "result": {"content": []}});
+    let request = json!({"jsonrpc": "2.0", "id": "early", "method": "notifications/x",
+                         "params": {"_meta": meta(json!(V2026))}});
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": V2025}},
+        "entries": [
+            {"timestamp_ms": 1000, "response": response},
+            {"timestamp_ms": 1001, "request": request}
+        ]
+    });
+    let events = detailed(&doc.to_string(), McpInputFormat::StreamableHttp);
+    assert_eq!(events[0].context.era, EraResolution::Known(V2025.into()));
+}
+
+/// Two requests outstanding on one id makes the correlation ambiguous, and choosing either is a
+/// silent choice between two calls. Refused on the same basis as a duplicate member.
+#[test]
+fn two_outstanding_requests_on_one_id_are_refused() {
+    let first = json!({"jsonrpc": "2.0", "id": "dup", "method": "notifications/x", "params": {}});
+    let second = json!({"jsonrpc": "2.0", "id": "dup", "method": "notifications/x", "params": {}});
+    let doc = json!({
+        "transport": "streamable-http",
+        "entries": [
+            {"timestamp_ms": 1000, "request": first},
+            {"timestamp_ms": 1001, "request": second}
+        ]
+    });
+    let err = parse_mcp_transcript(&doc.to_string(), McpInputFormat::StreamableHttp)
+        .expect_err("must refuse two outstanding requests on one id");
+    assert!(
+        format!("{err:?}").contains("outstanding"),
+        "unexpected message: {err:?}"
+    );
+}
+
+/// Reusing an id *after* its response has been seen is legal, so the refusal must not become a ban
+/// on reuse.
+#[test]
+fn sequential_id_reuse_after_a_response_is_allowed() {
+    let mk_req = || {
+        json!({"jsonrpc": "2.0", "id": "seq", "method": "notifications/x",
+                           "params": {}})
+    };
+    let mk_resp = || json!({"jsonrpc": "2.0", "id": "seq", "result": {"content": []}});
+    let doc = json!({
+        "transport": "streamable-http",
+        "transport_context": {"headers": {"MCP-Protocol-Version": V2025}},
+        "entries": [
+            {"timestamp_ms": 1000, "request": mk_req()},
+            {"timestamp_ms": 1001, "response": mk_resp()},
+            {"timestamp_ms": 1002, "request": mk_req()},
+            {"timestamp_ms": 1003, "response": mk_resp()}
+        ]
+    });
+    assert!(parse_mcp_transcript(&doc.to_string(), McpInputFormat::StreamableHttp).is_ok());
+}

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -4,7 +4,8 @@
 
 use super::*;
 use crate::mcp::era::{
-    EnvelopeObservation, ParsedMcpEvent, RequestMetadata, RequestMetadata::*, ResultObservation,
+    conclude, EnvelopeObservation, EraResolution, IncompleteReason, InvalidReason, ParsedMcpEvent,
+    RequestMetadata, RequestMetadata::*, ResultConclusion, ResultObservation,
 };
 use serde_json::{json, Value};
 
@@ -236,7 +237,7 @@ fn every_result_type_shape_reaches_the_axis() {
     );
     assert_eq!(
         observed(Some(json!("banana"))),
-        ResultObservation::Unrecognized("banana".into())
+        ResultObservation::Unrecognized
     );
 }
 
@@ -518,29 +519,58 @@ fn an_empty_result_type_is_unrecognized_not_malformed() {
         .into_iter()
         .find_map(|e| e.context.result_observation)
         .expect("a response event");
-    assert_eq!(observed, ResultObservation::Unrecognized(String::new()));
+    assert_eq!(observed, ResultObservation::Unrecognized);
 }
 
-/// An attacker-chosen token was retained in full, once per event. The third retention site, after
-/// the header and the request metadata.
+/// The whole chain on the shape that was silently completing: a legacy-era transcript whose
+/// response carries `"result": null`. Parser observation through to conclusion, permanently, so
+/// this cannot regress through either half alone.
 #[test]
-fn an_oversized_result_token_is_bounded() {
-    let huge = "z".repeat(1024 * 1024);
+fn composite_a_null_result_under_a_legacy_era_is_invalid() {
+    let message = json!({"jsonrpc": "2.0", "id": "call-1", "result": null});
+    let input = framed(Some(headers(json!(V2025))), None, message);
+    let parsed = detailed(&input, McpInputFormat::StreamableHttp);
+    let event = parsed
+        .iter()
+        .find(|e| e.context.result_observation.is_some())
+        .expect("a response event");
+    assert_eq!(event.context.era, EraResolution::Known(V2025.into()));
+    assert_eq!(
+        event.context.result_observation,
+        Some(ResultObservation::Malformed)
+    );
+    assert_eq!(
+        conclude(
+            &event.context.era,
+            event.context.result_observation.as_ref().unwrap()
+        ),
+        ResultConclusion::Invalid(InvalidReason::MalformedResultType)
+    );
+}
+
+/// An unrecognized token reaches the conclusion without carrying the token.
+#[test]
+fn composite_an_unknown_token_is_incomplete_and_value_free() {
     let input = framed(
         Some(headers(json!(V2026))),
         None,
-        response(Some(json!(huge))),
+        response(Some(json!("banana"))),
     );
-    let observed = detailed(&input, McpInputFormat::StreamableHttp)
-        .into_iter()
-        .find_map(|e| e.context.result_observation)
+    let parsed = detailed(&input, McpInputFormat::StreamableHttp);
+    let event = parsed
+        .iter()
+        .find(|e| e.context.result_observation.is_some())
         .expect("a response event");
-    match observed {
-        ResultObservation::Unrecognized(token) => assert!(
-            token.len() <= 64,
-            "retained {} bytes of an attacker-chosen token",
-            token.len()
-        ),
-        other => panic!("expected an unrecognized token, got {other:?}"),
-    }
+    let conclusion = conclude(
+        &event.context.era,
+        event.context.result_observation.as_ref().unwrap(),
+    );
+    assert_eq!(
+        conclusion,
+        ResultConclusion::Incomplete(IncompleteReason::UnrecognizedResultType)
+    );
+    assert!(
+        !format!("{conclusion:?}").contains("banana"),
+        "the token must not travel: {conclusion:?}"
+    );
 }

--- a/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
+++ b/crates/assay-core/src/mcp/parser/era_wiring_tests.rs
@@ -1289,3 +1289,109 @@ fn valid_success_and_error_responses_still_correlate() {
         );
     }
 }
+
+// --- Correlation keys preserve the id's JSON type ------------------------------------------------
+
+/// Per-entry headers, so each message resolves its own era and the one a response ends up with says
+/// which call it was paired to.
+fn two_entry_doc(first: (Value, &str), second: (Value, &str)) -> String {
+    let entry = |m: Value, v: &str, ts: u64| {
+        let key = if m.get("method").is_some() {
+            "request"
+        } else {
+            "response"
+        };
+        json!({"timestamp_ms": ts, "transport_context": headers(json!(v)), key: m})
+    };
+    json!({
+        "transport": "streamable-http",
+        "entries": [entry(first.0, first.1, 1000), entry(second.0, second.1, 1001)]
+    })
+    .to_string()
+}
+
+/// `normalize_jsonrpc_id` renders JSON number `1` and JSON string `"1"` as the same Rust `String`,
+/// so correlation paired them. The response consumed a call it did not answer and took its era, and
+/// a missing `resultType` under that borrowed legacy era could read `Terminal`.
+#[test]
+fn a_numeric_id_does_not_correlate_with_a_string_id() {
+    let request = json!({"jsonrpc": "2.0", "id": 1, "method": "notifications/x", "params": {}});
+    let response = json!({"jsonrpc": "2.0", "id": "1", "result": {"content": []}});
+    let events = detailed(
+        &two_entry_doc((request, V2025), (response, V2026)),
+        McpInputFormat::StreamableHttp,
+    );
+    assert_eq!(
+        events[1].context.era,
+        EraResolution::Known(V2026.into()),
+        "the response must stay orphaned and keep its own era"
+    );
+    let observed = events[1]
+        .context
+        .result_observation
+        .as_ref()
+        .expect("a response reports a result");
+    assert_eq!(
+        conclude(&events[1].context.era, observed),
+        ResultConclusion::Invalid(InvalidReason::MissingResultType)
+    );
+}
+
+/// The other direction, so the rule is symmetric rather than an accident of which side renders.
+#[test]
+fn a_string_id_does_not_correlate_with_a_numeric_id() {
+    let request = json!({"jsonrpc": "2.0", "id": "1", "method": "notifications/x", "params": {}});
+    let response = json!({"jsonrpc": "2.0", "id": 1, "result": {"content": []}});
+    let events = detailed(
+        &two_entry_doc((request, V2025), (response, V2026)),
+        McpInputFormat::StreamableHttp,
+    );
+    assert_eq!(events[1].context.era, EraResolution::Known(V2026.into()));
+}
+
+/// The positive controls. Same type and same value still correlate, so type-preservation did not
+/// turn correlation off.
+#[test]
+fn same_typed_ids_still_correlate() {
+    for id in [json!(1), json!("1")] {
+        let request = json!({"jsonrpc": "2.0", "id": id, "method": "notifications/x",
+                             "params": {}});
+        let response = json!({"jsonrpc": "2.0", "id": id, "result": {"content": []}});
+        let events = detailed(
+            &two_entry_doc((request, V2025), (response, V2026)),
+            McpInputFormat::StreamableHttp,
+        );
+        assert_eq!(
+            events[1].context.era,
+            EraResolution::Known(V2025.into()),
+            "id {id} must correlate to its own call"
+        );
+    }
+}
+
+/// Outstanding tracking is per typed key. A numeric `1` and a string `"1"` are different calls and
+/// may both be in flight; two numeric `1`s are the ambiguous case the refusal exists for.
+#[test]
+fn outstanding_ids_are_tracked_per_typed_key() {
+    let numeric = json!({"jsonrpc": "2.0", "id": 1, "method": "notifications/x", "params": {}});
+    let stringy = json!({"jsonrpc": "2.0", "id": "1", "method": "notifications/x", "params": {}});
+    assert!(
+        parse_mcp_transcript(
+            &two_entry_doc((numeric.clone(), V2025), (stringy, V2025)),
+            McpInputFormat::StreamableHttp
+        )
+        .is_ok(),
+        "a numeric and a string id are different calls"
+    );
+    let err = parse_mcp_transcript(
+        &two_entry_doc((numeric.clone(), V2025), (numeric, V2025)),
+        McpInputFormat::StreamableHttp,
+    )
+    .expect_err("two numeric 1s are one id twice");
+    let rendered = format!("{err:?}");
+    assert!(rendered.contains("outstanding"), "unexpected: {rendered}");
+    assert!(
+        !rendered.contains("notifications/x"),
+        "refusal echoed input: {rendered}"
+    );
+}

--- a/crates/assay-core/tests/mcp_id_correlation.rs
+++ b/crates/assay-core/tests/mcp_id_correlation.rs
@@ -44,22 +44,46 @@ fn contract_numeric_id_canonicalizes_and_correlates() {
 }
 
 #[test]
-fn contract_null_id_normalizes_to_none_and_does_not_correlate() {
-    let events = parse_mcp_transcript(
+fn contract_null_id_on_a_request_fails_hard() {
+    // MCP restricts `RequestId` to a string or an integer, and a request has to name the call it
+    // belongs to. This transcript used to parse with both ids normalized to `None`, which meant a
+    // request with no usable identity was ingested and silently correlated with nothing.
+    let err = parse_mcp_transcript(
         r#"
 {"timestamp_ms":1000,"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"NullId","arguments":{"x":1}}}
-{"timestamp_ms":1001,"jsonrpc":"2.0","id":null,"result":{"ok":true}}
 "#,
         McpInputFormat::JsonRpc,
     )
-    .unwrap();
+    .expect_err("a request with a null id is refused");
+    let rendered = format!("{err:?}");
+    assert!(
+        rendered.contains("must be a string or an integer"),
+        "{rendered}"
+    );
+    assert!(
+        !rendered.contains("NullId"),
+        "refusal echoed input: {rendered}"
+    );
+}
 
+#[test]
+fn contract_null_id_on_an_error_response_remains_ingestible() {
+    // The control that keeps the rule from becoming a blanket ban on `null`. An error response is
+    // how a peer reports a request it could not parse, so it may have no usable id at all. It stays
+    // ingestible and correlates with nothing.
+    let events = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .expect("an invalid-request error response is ingestible");
+
+    assert_eq!(events.len(), 1);
     assert_eq!(events[0].jsonrpc_id, None);
-    assert_eq!(events[1].jsonrpc_id, None);
 
-    let trace = mcp_events_to_v2_trace(events, "null-id".into(), None, None);
+    let trace = mcp_events_to_v2_trace(events, "null-id-error".into(), None, None);
     assert_no_jsonrpc_id_literal_null(&trace);
-    assert_tool_call(&trace, "NullId", json!({"x": 1}), None, None);
 }
 
 #[test]
@@ -78,23 +102,21 @@ fn contract_missing_request_id_does_not_correlate() {
 }
 
 #[test]
-fn contract_missing_response_id_remains_unmatched() {
-    let events = parse_mcp_transcript(
+fn contract_missing_success_response_id_fails_hard() {
+    // A success response answers a call, so it must say which one. This used to be ingested and
+    // reported as `timeout/no_response` against the pending request, which reads as evidence about
+    // the call rather than as a defect in the record.
+    let err = parse_mcp_transcript(
         r#"
 {"timestamp_ms":1000,"jsonrpc":"2.0","id":"req-1","method":"tools/call","params":{"name":"MissingResponseId","arguments":{"x":1}}}
 {"timestamp_ms":1001,"jsonrpc":"2.0","result":{"ok":true}}
 "#,
         McpInputFormat::JsonRpc,
     )
-    .unwrap();
-
-    let trace = mcp_events_to_v2_trace(events, "missing-response-id".into(), None, None);
-    assert_tool_call(
-        &trace,
-        "MissingResponseId",
-        json!({"x": 1}),
-        None,
-        Some("timeout/no_response"),
+    .expect_err("a success response with no id is refused");
+    assert!(
+        format!("{err:?}").contains("must be a string or an integer"),
+        "{err:?}"
     );
 }
 

--- a/crates/assay-core/tests/mcp_id_correlation.rs
+++ b/crates/assay-core/tests/mcp_id_correlation.rs
@@ -87,18 +87,39 @@ fn contract_null_id_on_an_error_response_remains_ingestible() {
 }
 
 #[test]
-fn contract_missing_request_id_does_not_correlate() {
-    let events = parse_mcp_transcript(
+fn contract_request_only_method_without_an_id_fails_hard() {
+    // This transcript used to be accepted and normalized as a tool call. `tools/call` is
+    // `CallToolRequest` and a request MUST carry a string or integer id, so treating a method-bearing
+    // object without an `id` member as a notification let a request-only method shed the id
+    // requirement — and with it the required 2026 `RequestParams._meta`, since notification metadata
+    // is optional.
+    let err = parse_mcp_transcript(
         r#"
 {"timestamp_ms":1000,"jsonrpc":"2.0","method":"tools/call","params":{"name":"MissingRequestId","arguments":{"x":1}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .expect_err("a request-only method without an id is refused");
+    assert!(
+        format!("{err:?}").contains("must be a string or an integer"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn contract_an_orphan_response_does_not_correlate() {
+    // The property the previous test was really about, without needing a malformed request to
+    // demonstrate it: a well-formed response whose call is simply not in the transcript.
+    let events = parse_mcp_transcript(
+        r#"
 {"timestamp_ms":1001,"jsonrpc":"2.0","id":"ghost","result":{"ok":true}}
 "#,
         McpInputFormat::JsonRpc,
     )
-    .unwrap();
+    .expect("an orphan response is ingestible");
 
-    let trace = mcp_events_to_v2_trace(events, "missing-request-id".into(), None, None);
-    assert_tool_call(&trace, "MissingRequestId", json!({"x": 1}), None, None);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].jsonrpc_id.as_deref(), Some("ghost"));
 }
 
 #[test]

--- a/crates/assay-core/tests/mcp_id_correlation.rs
+++ b/crates/assay-core/tests/mcp_id_correlation.rs
@@ -45,7 +45,7 @@ fn contract_numeric_id_canonicalizes_and_correlates() {
 
 #[test]
 fn contract_null_id_on_a_request_fails_hard() {
-    // MCP restricts `RequestId` to a string or an integer, and a request has to name the call it
+    // MCP restricts `RequestId` to a string or a number, and a request has to name the call it
     // belongs to. This transcript used to parse with both ids normalized to `None`, which meant a
     // request with no usable identity was ingested and silently correlated with nothing.
     let err = parse_mcp_transcript(
@@ -57,7 +57,7 @@ fn contract_null_id_on_a_request_fails_hard() {
     .expect_err("a request with a null id is refused");
     let rendered = format!("{err:?}");
     assert!(
-        rendered.contains("must be a string or an integer"),
+        rendered.contains("must be a string or a number"),
         "{rendered}"
     );
     assert!(
@@ -101,7 +101,7 @@ fn contract_request_only_method_without_an_id_fails_hard() {
     )
     .expect_err("a request-only method without an id is refused");
     assert!(
-        format!("{err:?}").contains("must be a string or an integer"),
+        format!("{err:?}").contains("must be a string or a number"),
         "{err:?}"
     );
 }
@@ -136,7 +136,7 @@ fn contract_missing_success_response_id_fails_hard() {
     )
     .expect_err("a success response with no id is refused");
     assert!(
-        format!("{err:?}").contains("must be a string or an integer"),
+        format!("{err:?}").contains("must be a string or a number"),
         "{err:?}"
     );
 }

--- a/crates/assay-core/tests/mcp_id_correlation.rs
+++ b/crates/assay-core/tests/mcp_id_correlation.rs
@@ -89,7 +89,7 @@ fn contract_null_id_on_an_error_response_remains_ingestible() {
 #[test]
 fn contract_request_only_method_without_an_id_fails_hard() {
     // This transcript used to be accepted and normalized as a tool call. `tools/call` is
-    // `CallToolRequest` and a request MUST carry a string or integer id, so treating a method-bearing
+    // `CallToolRequest` and a request MUST carry an id, so treating a method-bearing
     // object without an `id` member as a notification let a request-only method shed the id
     // requirement — and with it the required 2026 `RequestParams._meta`, since notification metadata
     // is optional.
@@ -163,7 +163,10 @@ fn contract_mismatch_ids_leave_response_orphan_and_request_pending() {
 }
 
 #[test]
-fn contract_duplicate_request_ids_fail_hard() {
+fn contract_two_outstanding_request_ids_fail_hard() {
+    // Still fail-hard, and now from the authority that owns call lifetime rather than from a global
+    // gate that ran before correlation. The diagnostic no longer echoes the id: it is input-chosen,
+    // and naming it told a reader nothing they could act on.
     let err = parse_mcp_transcript(
         r#"
 {"timestamp_ms":1000,"jsonrpc":"2.0","id":"dup-1","method":"tools/call","params":{"name":"First","arguments":{"x":1}}}
@@ -173,11 +176,43 @@ fn contract_duplicate_request_ids_fail_hard() {
     )
     .unwrap_err();
 
+    let rendered = format!("{err:?}");
     assert!(
-        err.to_string()
-            .contains("duplicate tools/call request id \"dup-1\""),
-        "unexpected error: {err}"
+        rendered.contains("outstanding"),
+        "unexpected error: {rendered}"
     );
+    assert!(
+        !rendered.contains("dup-1"),
+        "refusal echoed the id: {rendered}"
+    );
+}
+
+#[test]
+fn contract_a_request_id_may_be_reused_after_its_response() {
+    // The old gate refused this. An id names a call in flight, and once the call is answered the id
+    // is free; JSON-RPC has no rule against reuse and long transcripts rely on it.
+    parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"reused","method":"tools/call","params":{"name":"First","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"reused","result":{"ok":true}}
+{"timestamp_ms":1002,"jsonrpc":"2.0","id":"reused","method":"tools/call","params":{"name":"Second","arguments":{"x":2}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .expect("an id is free once its call has been answered");
+}
+
+#[test]
+fn contract_a_numeric_and_a_string_id_are_different_calls() {
+    // The old gate keyed on the public `String` rendering, which made these one id.
+    parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"Numeric","arguments":{}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"Stringy","arguments":{}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .expect("number 1 and string \"1\" are different ids");
 }
 
 #[test]
@@ -314,4 +349,69 @@ fn assert_no_jsonrpc_id_literal_null(trace: &[TraceEvent]) {
             );
         }
     }
+}
+
+/// Pairs observed in the emitted trace, as `(tool_name, result)`.
+fn tool_call_pairs(input: &str) -> Vec<(String, String)> {
+    let events = parse_mcp_transcript(input, McpInputFormat::JsonRpc).expect("parse");
+    mcp_events_to_v2_trace(events, "typed-ids".into(), None, None)
+        .into_iter()
+        .filter_map(|e| match e {
+            TraceEvent::ToolCall(c) => Some((
+                c.tool_name,
+                c.result.map(|r| r.to_string()).unwrap_or_default(),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The parser tells a JSON number `1` from a JSON string `"1"`, but the trace mapper keyed on the
+/// public `String` rendering, so the second request overwrote the first and a numeric response was
+/// attached to the string request.
+#[test]
+fn contract_typed_ids_stay_distinct_through_the_trace_mapper() {
+    let pairs = tool_call_pairs(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"Stringy","arguments":{"owner":"string"}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"Numeric","arguments":{"owner":"numeric"}}}
+{"timestamp_ms":1002,"jsonrpc":"2.0","id":1,"result":{"owner":"numeric-response"}}
+"#,
+    );
+    let numeric = pairs
+        .iter()
+        .find(|(name, _)| name == "Numeric")
+        .expect("the numeric call");
+    assert!(
+        numeric.1.contains("numeric-response"),
+        "the numeric response belongs to the numeric call: {pairs:?}"
+    );
+    let stringy = pairs
+        .iter()
+        .find(|(name, _)| name == "Stringy")
+        .expect("the string call");
+    assert!(
+        !stringy.1.contains("numeric-response"),
+        "the string call must not receive the numeric response: {pairs:?}"
+    );
+}
+
+/// A number the correlator declines to key must not be paired through the public string rendering
+/// either. Both sides render as `1.5`, so a rendering-keyed map would pair them.
+#[test]
+fn contract_a_non_correlatable_numeric_id_is_never_paired() {
+    let pairs = tool_call_pairs(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":1.5,"method":"tools/call","params":{"name":"Fractional","arguments":{"owner":"req"}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":1.5,"result":{"owner":"resp"}}
+"#,
+    );
+    let call = pairs
+        .iter()
+        .find(|(name, _)| name == "Fractional")
+        .expect("the fractional call");
+    assert!(
+        !call.1.contains("resp"),
+        "an id the correlator will not key must not pair: {pairs:?}"
+    );
 }

--- a/crates/assay-core/tests/mcp_import_smoke.rs
+++ b/crates/assay-core/tests/mcp_import_smoke.rs
@@ -37,10 +37,16 @@ fn test_mcp_correlation_and_prompt() {
 #[test]
 fn test_determinism_line_fallback() {
     // P0.3: No timestamps, rely on line order.
+    //
+    // Each request carries a unique id because `tools/list` and `tools/call` are requests and MCP
+    // requires a string or integer id on one. The fixture previously omitted them, which is what let
+    // a request-only method be read as a notification and shed both the id requirement and the
+    // required 2026 request metadata. This test is about deterministic line fallback, not about
+    // ingesting protocol-invalid requests, and the ids change nothing it asserts.
     let input = r#"
-{"jsonrpc":"2.0", "method":"tools/list"}
-{"jsonrpc":"2.0", "method":"tools/call", "params":{"name":"A", "arguments":{}}}
-{"jsonrpc":"2.0", "method":"tools/call", "params":{"name":"B", "arguments":{}}}
+{"jsonrpc":"2.0", "id":"list-1", "method":"tools/list"}
+{"jsonrpc":"2.0", "id":"call-a", "method":"tools/call", "params":{"name":"A", "arguments":{}}}
+{"jsonrpc":"2.0", "id":"call-b", "method":"tools/call", "params":{"name":"B", "arguments":{}}}
 "#;
 
     let events = parse_mcp_transcript(input, McpInputFormat::JsonRpc).unwrap();


### PR DESCRIPTION
Slice 0 of #1866. `transport_context` did not survive import at all, so nothing downstream could tell
a 2026 transcript from a 2025 one, and a result with no `resultType` read the same either way.

This body describes the branch as it stands. It replaces a per-head correction log that had accreted
across sixteen heads, several of whose verification lines had gone stale in place. The history is in
the commits and in #1866; keeping a contradictory summary next to it was worse than keeping none.

## Three axes, not one field

| Axis | Question |
|---|---|
| `EnvelopeObservation` | what the transport framing carried |
| `EraResolution` | what the era turned out to be once every signal was read |
| `ResultObservation` | what a response said about its own completeness |

A format with no transport envelope has not lost the era: the 2026 request carries its own required
`_meta["io.modelcontextprotocol/protocolVersion"]`, so bare JSON-RPC and Inspector resolve from the
body. An earlier design refused on the missing envelope and would have ceilinged that evidence.

Conclusions are typed rather than boolean. Unknown, contradicted and a missing required field are
three findings, and `input_required` is valid while not being terminal. Requests and responses get
separate verdict types, since a request has no result and "no objection" is not "valid but unfinished".

## Order is the contract

Format capability, then unreadable, then contradiction, then classification, and absence read last
under the resolved era. Each step exists because the alternative fails silently: a format that cannot
carry the signal must never be asked whether one is missing, and two values that are not both versions
cannot be said to disagree about a version.

The schema settles the last step. A missing `resultType` is a violation at 2026 and prescribed as
`"complete"` before it, so the same observation has opposite conclusions and the era decides which.

## Call correlation

A response carries no era signal of its own, so it takes the era of the call it answers, correlated on
a crate-private typed key derived from the payload's raw JSON. Without this a request whose header and
body disagreed was `Conflicting` while its response resolved to `Known` from the header alone, and a
missing `resultType` under that legacy era read `Terminal`: a contradicted call concluding that the
action completed.

The typed outstanding map is the sole call-lifetime authority. Correlation runs in source order, a
response consumes the request that preceded it, an orphan response keeps the era it resolved on its
own, and two calls outstanding on one id are refused. `mcp_events_to_v2_trace` derives the same key, so
the public `String` rendering is nowhere in the correlation path.

**Acceptance and correlation are separate questions.** Any string or number the serde boundary can
represent is an acceptable id. Only a string, or an integer exactly representable as `i64`/`u64`,
becomes a correlation key; every other number is ingestible and correlates with nothing, keeping the
era its own envelope resolved. serde parses every non-integer through `f64`, so `9007199254740993.0`
has already become `...92.0` before this code sees it — a property of the parse that no downstream key
design recovers. False correlation hands a response the era of a call it did not answer and can license
a terminal reading; declining to key is incomplete and true.

## What refuses, and where

A malformed **era observation** never refuses. `Malformed` on any axis parses and the conclusion layer
classifies it. That is what the ordering contract protects.

A malformed **JSON-RPC message shape** refuses at the parser boundary, value-free: a present non-string
`method`, an id that is a boolean, array or object, a request-only method with no id, a response that
is neither a result nor an error, an SSE frame with no `data`, and any duplicate object member.

Duplicate members are refused as the tree is built, because `serde_json` collapses them last-value-wins
and a post-collapse check cannot recover the evidence. The rule is every duplicate rather than a list
of significant names: a name list goes stale the moment a significant key is added, and this branch
shipped three enumerations that missed a member. `DuplicateAwareSink` walks unknown subtrees so the
claim holds where it is made.

Request-only methods cannot become notifications by omitting an id. Twenty-two names across the five
revisions this build recognizes are pinned exhaustively, and the table is compared against the constant
first so drift fails in the test rather than in a transcript. An unknown extension method stays a
notification.

## No public API change

`McpEvent` keeps its five fields and `parse_mcp_transcript` still returns `Vec<McpEvent>`, projected
out of an internal detailed parse. `crates/assay-core/src/mcp/types.rs` is byte-identical to
`origin/main` and the diff adds no `pub` item. The whole vocabulary is `pub(crate)`: the crate is
published, and adding fields to a constructible, non-`#[non_exhaustive]` struct would break downstream
struct literals for a shape still being worked out.

The conclusion functions and reason enums carry a per-item `#[allow(dead_code)]` because slice 2 is
their only production consumer. Targeted rather than module-wide, so a future dead item is still
reported; `#[expect]` is unfulfilled here because the tests use them under `--all-targets`.

## Test files changed, and why

Two of the three MCP integration tests are changed on this PR. Earlier versions of this body said all
three were byte-unchanged from `main`, which was not true then either.

- `mcp_import_smoke.rs`: 9 insertions, 3 deletions. Its three request-only lines had no ids, which is
  exactly the defect that a request-only method may omit one, so the fixture encoded it. The
  line-order and Step-order assertions are untouched; the test is about deterministic line fallback.
- `mcp_id_correlation.rs`: the duplicate-id diagnostic echoed the id, which is input-chosen data this
  slice bans everywhere else. Reuse after a response, number-versus-string, and typed ids through the
  trace mapper are pinned as the cases they are.
- `mcp_transport_compat.rs`: **byte-unchanged, and the only one.** It is the negative control.

## Verification on `f71c3dce`

Base `3e657ed0`, worktree `scratchpad/slice0`.

- `cargo test -p assay-core`: 752 passed, 0 failed, 5 ignored, measured on `c3dcb365`
- focused MCP suite: 326 passed, 0 failed, measured on `2df6a658`
- `mcp_id_correlation` 18, `mcp_import_smoke` 2, `mcp_transport_compat` 9
- `cargo clippy -p assay-core --all-targets -- -D warnings`: nothing
- `cargo fmt --all -- --check` and `git diff --check`: clean
- `cargo doc --document-private-items` with warnings denied: one unresolved link, `VerifyLimits` in
  `crates/assay-core/src/replay/bundle/limits.rs`. It is present on `origin/main` and lives in a
  directory this branch does not touch, so it is pre-existing rather than introduced here.

Guards are mutation-tested rather than assumed. Removing each takes tests down: integer ids ceasing to
correlate 6, any number correlating 3, ignored subtrees unscanned 2, sse null handling 2, one method
dropped from the constant 2, the params container guard 3, the shape pre-check 6, day-of-month 3,
per-entry envelope folding 4.

**CI on `6479bc6d` found one stale assertion, and `270d95f8` fixes it.** Ubuntu job 90932659745:
`crates/assay-cli/tests/mcp_id_correlation_errors.rs:63` still expected
`duplicate tools/call request id`, the message of the global gate this branch deleted. Not a parser
regression — the refusal fires and the boolean-id control is green. The assertion now pins
`two outstanding JSON-RPC requests share an id`, taken verbatim from `parser.rs:131`, and nothing else:
not the id, which the parser deliberately no longer echoes, and not the source line, which moves
whenever a fixture gains one. A second assertion pins that the id is absent from stderr.

It was missed because the sweep for the old gate's message covered `assay-core` and not the CLI crate,
which asserts on the same parser through the binary's stderr. A message is part of a contract wherever
it is read, not only where it is produced.

**Three heads sit on top of the measured runs, and none is claimed green locally.** `6b86c1e6` adds a
comment; `6479bc6d` corrects the fixture wrapper and adds a non-string-method control. From `2df6a658`
onward, compile and test processes on this host are being killed without diagnostic output under memory
and IO pressure, so neither the `6479bc6d` nor the `270d95f8` test compile completed, with no partial output to
report. Required CI on the exact head is the proof for both, not a local run. The local pre-commit hook was skipped for the same reason and
that is recorded in the commit body; `cargo fmt --all -- --check` and `git diff --check` were run
directly and are clean.

One further environmental note, because the 752 number deserves its conditions. The `752 passed / 0 failed`
run was green as measured. A later doc-only rerun of the same suite reported one failure,
`tests::benchmark_combined_checks` in `latency_check.rs`, which asserts on `start.elapsed()`. It was
running alongside a workspace clippy with the disk at 99 percent, and the same test fails identically
on the unmodified base with this branch's changes stashed. It is a property of the machine under
parallel load, not of this branch, and the head `6b86c1e6` adds only a comment on top of `c3dcb365`.

Two of the mutation results measured 0 red on a first pass, and neither time was the guard untested. Once the
replacement anchor had not matched the formatted source, so nothing was mutated; once the test asserted
only `is_err()`, which the mutant also satisfies for a different reason. A mutation that changes more
than the guard, or an assertion that any refusal satisfies, looks identical to coverage.

## Out of scope

Multi-hop calls spread across separate records: correlation is by JSON-RPC id within one transcript,
and a call-scoped identity across records is not defined here.

Duplicate refusal covers what reaches this crate's MCP entry points. It is not a claim that every JSON
path in the workspace is duplicate-aware.

The conclusion layer that consumes these axes is slice 2. Nothing in production reads the sidecar yet.

## Rebased onto `128d4c79`

`main` moved while this PR was in review (docs PR #1932), and branch protection has
`required_status_checks.strict = true`, so the PR was `MERGEABLE` but `BEHIND`. Rebased onto current
`origin/main`; the previous head was `270d95f8`.

**Conflict-free, and the content is provably untouched.** All 26 commits replayed with no conflict, and
the patch this branch produces against its base is byte-identical before and after: 4512 lines, same
checksum. No content edit, no refactor, no squash. The base moves and the change does not.

Every prior review and CI result is invalidated by the new head. Exact-head review and required CI on
`f71c3dce` are what stand now, and CI is the proof: nothing on this head is locally verified beyond
`cargo fmt --all -- --check` and `git diff --check`, since focused runs on this host are still being
killed under memory and IO pressure.

