### PR TITLE
ci(mcp): pin official conformance reference

### DIFF
--- a/.github/workflows/mcp-upstream-reference.yml
+++ b/.github/workflows/mcp-upstream-reference.yml
@@ -1,0 +1,166 @@
+name: MCP upstream reference
+
+# This lane runs the official conformance project against an official SDK. It
+# is a reference point for Assay's transcript semantics, not an Assay client or
+# server conformance claim.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/mcp-upstream-reference.yml"
+      - "scripts/ci/test-mcp-upstream-reference-contract.sh"
+      - "scripts/ci/test_verify_mcp_upstream_reference.py"
+      - "scripts/ci/verify-mcp-upstream-reference.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/mcp-upstream-reference.yml"
+      - "scripts/ci/test-mcp-upstream-reference-contract.sh"
+      - "scripts/ci/test_verify_mcp_upstream_reference.py"
+      - "scripts/ci/verify-mcp-upstream-reference.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-upstream-reference-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CONFORMANCE_COMMIT: "49103de6ed70804e940637bf3e9e29e4a3f54e64"
+  CONFORMANCE_ARCHIVE_SHA256: "e48c96369788414b05c6d3cf4a7233d01ff6e6a88e8f8943d586ae3dda1b87fe"
+  CONFORMANCE_LOCK_SHA256: "161aef794720d2393a6a3db64e9751f2d52730b49f662e84b23363df5c1196e1"
+  RUST_SDK_COMMIT: "3240b6e7828ed4146041d32dd0ce4ced7c04e411"
+  RUST_SDK_ARCHIVE_SHA256: "4ce506ce729ad4ed2b28de6bad157eda83247a2d298924c7590c0fc938e4351c"
+  RUST_SDK_LOCK_SHA256: "f4b9fd48cb9598f9658f00a9cc6f176739e97e45045e90b34e8bb4563937bc48"
+  MCP_SPEC_VERSION: "2026-07-28"
+  NODE_VERSION: "24.18.0"
+
+jobs:
+  focused-reference:
+    name: Official Rust SDK focused reference
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Check out Assay
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Run local workflow contract tests
+        run: bash scripts/ci/test-mcp-upstream-reference-contract.sh
+
+      - name: Fetch and verify the official conformance source
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_dir=/tmp/mcp-conformance
+          git init "$source_dir"
+          git -C "$source_dir" remote add origin \
+            https://github.com/modelcontextprotocol/conformance.git
+          git -C "$source_dir" fetch --depth=1 origin "$CONFORMANCE_COMMIT"
+          git -C "$source_dir" checkout --detach FETCH_HEAD
+          test "$(git -C "$source_dir" rev-parse HEAD)" = "$CONFORMANCE_COMMIT"
+          actual_archive="$(
+            git -C "$source_dir" archive --format=tar HEAD | sha256sum | cut -d' ' -f1
+          )"
+          actual_lock="$(sha256sum "$source_dir/package-lock.json" | cut -d' ' -f1)"
+          test "$actual_archive" = "$CONFORMANCE_ARCHIVE_SHA256"
+          test "$actual_lock" = "$CONFORMANCE_LOCK_SHA256"
+
+      - name: Fetch and lock the official Rust SDK source
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdk_dir="$RUNNER_TEMP/mcp-rust-sdk"
+          git init "$sdk_dir"
+          git -C "$sdk_dir" remote add origin \
+            https://github.com/modelcontextprotocol/rust-sdk.git
+          git -C "$sdk_dir" fetch --depth=1 origin "$RUST_SDK_COMMIT"
+          git -C "$sdk_dir" checkout --detach FETCH_HEAD
+          test "$(git -C "$sdk_dir" rev-parse HEAD)" = "$RUST_SDK_COMMIT"
+          actual_sdk_archive="$(
+            git -C "$sdk_dir" archive --format=tar HEAD | sha256sum | cut -d' ' -f1
+          )"
+          test "$actual_sdk_archive" = "$RUST_SDK_ARCHIVE_SHA256"
+          cargo generate-lockfile --manifest-path "$sdk_dir/Cargo.toml"
+          actual_sdk_lock="$(sha256sum "$sdk_dir/Cargo.lock" | cut -d' ' -f1)"
+          test "$actual_sdk_lock" = "$RUST_SDK_LOCK_SHA256"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+
+      - name: Install the pinned conformance build
+        working-directory: /tmp/mcp-conformance
+        run: npm ci
+
+      - name: Run the focused official reference scenarios
+        working-directory: /tmp/mcp-conformance
+        shell: bash
+        run: |
+          set -euo pipefail
+          results="$RUNNER_TEMP/mcp-reference-results"
+          sdk_dir="$RUNNER_TEMP/mcp-rust-sdk"
+          sdk="rust-sdk@${RUST_SDK_COMMIT}"
+
+          npm start -- sdk "$sdk" \
+            --path "$sdk_dir" \
+            --build-cmd "cargo build --locked -p mcp-conformance" \
+            --mode client \
+            --scenario sep-2322-client-request-state \
+            --spec-version "$MCP_SPEC_VERSION" \
+            --output "$results"
+
+          npm start -- sdk "$sdk" \
+            --path "$sdk_dir" \
+            --mode server \
+            --scenario input-required-result-result-type \
+            --spec-version "$MCP_SPEC_VERSION" \
+            --skip-build \
+            --output "$results"
+
+          npm start -- sdk "$sdk" \
+            --path "$sdk_dir" \
+            --mode server \
+            --scenario input-required-result-request-state \
+            --spec-version "$MCP_SPEC_VERSION" \
+            --skip-build \
+            --output "$results"
+
+      - name: Verify named check records
+        run: |
+          python3 scripts/ci/verify-mcp-upstream-reference.py \
+            "$RUNNER_TEMP/mcp-reference-results"
+
+      - name: Record pins and scope
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          {
+            echo "## MCP upstream reference"
+            echo ""
+            echo "- conformance commit: \`${CONFORMANCE_COMMIT}\`"
+            echo "- conformance archive SHA-256: \`${CONFORMANCE_ARCHIVE_SHA256}\`"
+            echo "- conformance lock SHA-256: \`${CONFORMANCE_LOCK_SHA256}\`"
+            echo "- Rust SDK commit: \`${RUST_SDK_COMMIT}\`"
+            echo "- Rust SDK archive SHA-256: \`${RUST_SDK_ARCHIVE_SHA256}\`"
+            echo "- Rust SDK lock SHA-256: \`${RUST_SDK_LOCK_SHA256}\`"
+            echo "- protocol version: \`${MCP_SPEC_VERSION}\`"
+            echo "- Node.js: \`${NODE_VERSION}\`"
+            echo ""
+            echo "**Upstream reference only:** this run does not claim that Assay is"
+            echo "an MCP client or server, or that Assay passes the upstream suite."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload reference check records
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mcp-upstream-reference-checks
+          path: ${{ runner.temp }}/mcp-reference-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/scripts/ci/test-mcp-upstream-reference-contract.sh
+++ b/scripts/ci/test-mcp-upstream-reference-contract.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/mcp-upstream-reference.yml"
+VALIDATOR="${ROOT}/scripts/ci/verify-mcp-upstream-reference.py"
+VALIDATOR_TEST="${ROOT}/scripts/ci/test_verify_mcp_upstream_reference.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$WORKFLOW" ]] || fail "missing upstream reference workflow"
+[[ -f "$VALIDATOR" ]] || fail "missing upstream result validator"
+[[ -f "$VALIDATOR_TEST" ]] || fail "missing validator regression tests"
+
+pin() {
+  local needle="$1" message="$2"
+  grep -F -- "$needle" "$WORKFLOW" >/dev/null || fail "$message"
+}
+
+pin "49103de6ed70804e940637bf3e9e29e4a3f54e64" \
+  "workflow must pin the conformance source commit"
+pin "e48c96369788414b05c6d3cf4a7233d01ff6e6a88e8f8943d586ae3dda1b87fe" \
+  "workflow must verify the source archive digest"
+pin "161aef794720d2393a6a3db64e9751f2d52730b49f662e84b23363df5c1196e1" \
+  "workflow must verify the package-lock digest"
+pin "3240b6e7828ed4146041d32dd0ce4ced7c04e411" \
+  "workflow must pin the Rust SDK reference"
+pin "4ce506ce729ad4ed2b28de6bad157eda83247a2d298924c7590c0fc938e4351c" \
+  "workflow must verify the Rust SDK source archive"
+pin "f4b9fd48cb9598f9658f00a9cc6f176739e97e45045e90b34e8bb4563937bc48" \
+  "workflow must verify the Rust SDK dependency lock"
+pin 'NODE_VERSION: "24.18.0"' "workflow must pin the Node runtime"
+pin "node-version: \"\${{ env.NODE_VERSION }}\"" \
+  "workflow must install the pinned Node version"
+pin "npm ci" "workflow must install the pinned lock"
+pin "sep-2322-client-request-state" "workflow must run the client scenario"
+pin "input-required-result-result-type" \
+  "workflow must run the explicit resultType server scenario"
+pin "input-required-result-request-state" \
+  "workflow must run the requestState server control"
+pin "verify-mcp-upstream-reference.py" \
+  "workflow must validate named check records"
+pin "Upstream reference only" \
+  "workflow must state its conformance non-claim"
+pin "fetch --depth=1 origin \"\$CONFORMANCE_COMMIT\"" \
+  "workflow must fetch the pinned conformance commit"
+pin "test \"\$actual_archive\" = \"\$CONFORMANCE_ARCHIVE_SHA256\"" \
+  "workflow must verify the conformance archive pin"
+pin "test \"\$actual_lock\" = \"\$CONFORMANCE_LOCK_SHA256\"" \
+  "workflow must verify the conformance lock pin"
+pin "fetch --depth=1 origin \"\$RUST_SDK_COMMIT\"" \
+  "workflow must fetch the pinned Rust SDK commit"
+pin "test \"\$actual_sdk_archive\" = \"\$RUST_SDK_ARCHIVE_SHA256\"" \
+  "workflow must verify the Rust SDK archive pin"
+pin 'cargo generate-lockfile' \
+  "workflow must materialize the reviewed Rust SDK lock"
+pin "test \"\$actual_sdk_lock\" = \"\$RUST_SDK_LOCK_SHA256\"" \
+  "workflow must verify the Rust SDK lock pin"
+pin "--path \"\$sdk_dir\"" \
+  "workflow must execute the verified Rust SDK checkout"
+pin '--build-cmd "cargo build --locked -p mcp-conformance"' \
+  "workflow must build the Rust SDK with its verified lock"
+
+grep -Eq 'uses: actions/checkout@[0-9a-f]{40}' "$WORKFLOW" \
+  || fail "checkout action must be SHA-pinned"
+grep -Eq 'uses: actions/setup-node@[0-9a-f]{40}' "$WORKFLOW" \
+  || fail "setup-node action must be SHA-pinned"
+grep -Eq 'uses: actions/upload-artifact@[0-9a-f]{40}' "$WORKFLOW" \
+  || fail "upload-artifact action must be SHA-pinned"
+
+if grep -Eq 'continue-on-error:[[:space:]]*true' "$WORKFLOW"; then
+  fail "the reference run must not turn a failed check into success"
+fi
+
+python3 -m unittest "$VALIDATOR_TEST"
+
+echo "ok: MCP upstream reference workflow contract"

--- a/scripts/ci/test_verify_mcp_upstream_reference.py
+++ b/scripts/ci/test_verify_mcp_upstream_reference.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("verify-mcp-upstream-reference.py")
+SPEC = importlib.util.spec_from_file_location("mcp_upstream_reference", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class UpstreamReferenceValidatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.results = Path(self.temp.name)
+        self.paths: dict[str, Path] = {}
+        for scenario, check_ids in MODULE.EXPECTED.items():
+            prefix = "" if scenario.startswith("sep-2322-client") else "server-"
+            path = self.results / f"{prefix}{scenario}-2026-07-31" / "checks.json"
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                json.dumps(
+                    [
+                        {"id": check_id, "status": "SUCCESS"}
+                        for check_id in sorted(check_ids)
+                    ]
+                    + [{"id": "wire-schema-observation", "status": "INFO"}]
+                ),
+                encoding="utf-8",
+            )
+            self.paths[scenario] = path
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write_result_type_checks(self, status: str, *, duplicate: bool = False) -> None:
+        checks = [
+            {"id": "sep-2322-result-type-included", "status": status},
+            {"id": "wire-schema-valid", "status": "SUCCESS"},
+        ]
+        if duplicate:
+            checks.insert(1, checks[0].copy())
+        self.paths["input-required-result-result-type"].write_text(
+            json.dumps(checks),
+            encoding="utf-8",
+        )
+
+    def test_clean_focused_result_set_is_accepted(self) -> None:
+        summary = MODULE.validate(self.results)
+        self.assertEqual(set(summary), set(MODULE.EXPECTED))
+
+    def test_missing_scenario_is_refused(self) -> None:
+        self.paths["input-required-result-result-type"].unlink()
+        with self.assertRaisesRegex(MODULE.ValidationError, "exactly one"):
+            MODULE.validate(self.results)
+
+    def test_duplicate_scenario_output_is_refused(self) -> None:
+        source = self.paths["input-required-result-result-type"]
+        duplicate = (
+            self.results
+            / "server-input-required-result-result-type-later"
+            / "checks.json"
+        )
+        duplicate.parent.mkdir()
+        duplicate.write_bytes(source.read_bytes())
+        with self.assertRaisesRegex(MODULE.ValidationError, "found 2"):
+            MODULE.validate(self.results)
+
+    def test_missing_named_check_is_refused(self) -> None:
+        path = self.paths["input-required-result-result-type"]
+        path.write_text("[]", encoding="utf-8")
+        with self.assertRaisesRegex(MODULE.ValidationError, "exactly once"):
+            MODULE.validate(self.results)
+
+    def test_missing_wire_schema_check_is_refused(self) -> None:
+        path = self.paths["input-required-result-result-type"]
+        path.write_text(
+            json.dumps(
+                [{"id": "sep-2322-result-type-included", "status": "SUCCESS"}]
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(MODULE.ValidationError, "wire-schema-valid"):
+            MODULE.validate(self.results)
+
+    def test_failure_status_is_refused(self) -> None:
+        self.write_result_type_checks("FAILURE")
+        with self.assertRaisesRegex(MODULE.ValidationError, "non-success"):
+            MODULE.validate(self.results)
+
+    def test_warning_status_is_refused(self) -> None:
+        self.write_result_type_checks("WARNING")
+        with self.assertRaisesRegex(MODULE.ValidationError, "non-success"):
+            MODULE.validate(self.results)
+
+    def test_expected_info_status_is_refused(self) -> None:
+        self.write_result_type_checks("INFO")
+        with self.assertRaisesRegex(MODULE.ValidationError, "must be SUCCESS"):
+            MODULE.validate(self.results)
+
+    def test_expected_skipped_status_is_refused(self) -> None:
+        self.write_result_type_checks("SKIPPED")
+        with self.assertRaisesRegex(MODULE.ValidationError, "non-success"):
+            MODULE.validate(self.results)
+
+    def test_duplicate_named_check_is_refused(self) -> None:
+        self.write_result_type_checks("SUCCESS", duplicate=True)
+        with self.assertRaisesRegex(MODULE.ValidationError, "exactly once"):
+            MODULE.validate(self.results)
+
+    def test_malformed_json_is_refused(self) -> None:
+        self.paths["input-required-result-result-type"].write_text(
+            "{", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(MODULE.ValidationError, "unreadable"):
+            MODULE.validate(self.results)
+
+    def test_unexpected_result_file_is_refused(self) -> None:
+        path = self.results / "unrelated-scenario" / "checks.json"
+        path.parent.mkdir()
+        path.write_text("[]", encoding="utf-8")
+        with self.assertRaisesRegex(MODULE.ValidationError, "unexpected"):
+            MODULE.validate(self.results)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/verify-mcp-upstream-reference.py
+++ b/scripts/ci/verify-mcp-upstream-reference.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate the focused MCP upstream-reference result set.
+
+The conformance CLI's exit code is useful but not sufficient for this lane:
+an inapplicable scenario may be skipped successfully, and a future scenario
+rename could leave no evidence for the behavior this lane names. This script
+therefore requires one result file per selected scenario and the exact
+SEP-2322 check IDs that carry those behaviors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED: dict[str, frozenset[str]] = {
+    "sep-2322-client-request-state": frozenset(
+        {
+            "sep-2322-client-request-state-echoed",
+            "sep-2322-client-jsonrpc-id-different",
+            "sep-2322-client-no-state-omitted",
+            "sep-2322-client-parallel-isolation",
+            "sep-2322-default-result-type-complete",
+        }
+    ),
+    "input-required-result-result-type": frozenset(
+        {
+            "sep-2322-result-type-included",
+            "wire-schema-valid",
+        }
+    ),
+    "input-required-result-request-state": frozenset(
+        {
+            "sep-2322-request-state-incomplete",
+            "sep-2322-request-state-complete",
+            "wire-schema-valid",
+        }
+    ),
+}
+
+ALLOWED_STATUSES = frozenset({"SUCCESS", "INFO"})
+
+
+class ValidationError(ValueError):
+    """The result set does not prove the focused reference run."""
+
+
+def _scenario_for(path: Path) -> str | None:
+    parent = path.parent.name
+    for scenario in EXPECTED:
+        if parent.startswith(f"{scenario}-") or parent.startswith(
+            f"server-{scenario}-"
+        ):
+            return scenario
+    return None
+
+
+def _load_checks(path: Path) -> list[dict[str, Any]]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValidationError(f"{path}: unreadable checks JSON: {error}") from error
+
+    if not isinstance(document, list):
+        raise ValidationError(f"{path}: checks document must be an array")
+
+    checks: list[dict[str, Any]] = []
+    for index, item in enumerate(document):
+        if not isinstance(item, dict):
+            raise ValidationError(f"{path}: check {index} must be an object")
+        check_id = item.get("id")
+        status = item.get("status")
+        if not isinstance(check_id, str) or not check_id:
+            raise ValidationError(f"{path}: check {index} has no string id")
+        if status not in ALLOWED_STATUSES:
+            raise ValidationError(
+                f"{path}: check {check_id!r} has non-success status {status!r}"
+            )
+        checks.append(item)
+    return checks
+
+
+def validate(results: Path) -> dict[str, int]:
+    if not results.is_dir():
+        raise ValidationError(f"results directory does not exist: {results}")
+
+    found: dict[str, list[Path]] = {scenario: [] for scenario in EXPECTED}
+    for checks_path in sorted(results.rglob("checks.json")):
+        scenario = _scenario_for(checks_path)
+        if scenario is None:
+            raise ValidationError(
+                f"unexpected checks file outside the focused scenarios: {checks_path}"
+            )
+        found[scenario].append(checks_path)
+
+    summary: dict[str, int] = {}
+    for scenario, expected_ids in EXPECTED.items():
+        paths = found[scenario]
+        if len(paths) != 1:
+            raise ValidationError(
+                f"{scenario}: expected exactly one checks.json, found {len(paths)}"
+            )
+
+        checks = _load_checks(paths[0])
+        for expected_id in expected_ids:
+            matching = [item for item in checks if item["id"] == expected_id]
+            if len(matching) != 1:
+                raise ValidationError(
+                    f"{scenario}: expected check {expected_id!r} exactly once, "
+                    f"found {len(matching)}"
+                )
+            if matching[0]["status"] != "SUCCESS":
+                raise ValidationError(
+                    f"{scenario}: expected check {expected_id!r} must be SUCCESS, "
+                    f"found {matching[0]['status']!r}"
+                )
+        summary[scenario] = len(checks)
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results", type=Path)
+    args = parser.parse_args()
+
+    try:
+        summary = validate(args.results)
+    except ValidationError as error:
+        print(f"FAIL: {error}")
+        return 1
+
+    print("MCP upstream reference checks verified:")
+    for scenario, count in summary.items():
+        print(f"- {scenario}: {count} check records")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a pinned upstream MCP conformance reference lane for the focused 2026-07-28 `requestState` and `resultType` behaviors.

The lane:
- verifies the official conformance source archive and npm lock before installation;
- verifies the official Rust SDK source archive and a reviewed Cargo lock digest before a `--locked` build;
- uses exact Node.js `24.18.0`;
- runs one client scenario and two server scenarios;
- requires the named SEP-2322 and wire-schema checks exactly once with status `SUCCESS`;
- archives the raw reference records and prints every pin.

## Scope

This is **upstream reference only**. It does not claim that Assay is an MCP client or server, that Assay passes the upstream conformance suite, or that the run proves authentication or action outcomes.

## Pins

- conformance commit: `49103de6ed70804e940637bf3e9e29e4a3f54e64`
- conformance archive SHA-256: `e48c96369788414b05c6d3cf4a7233d01ff6e6a88e8f8943d586ae3dda1b87fe`
- conformance lock SHA-256: `161aef794720d2393a6a3db64e9751f2d52730b49f662e84b23363df5c1196e1`
- Rust SDK commit: `3240b6e7828ed4146041d32dd0ce4ced7c04e411`
- Rust SDK archive SHA-256: `4ce506ce729ad4ed2b28de6bad157eda83247a2d298924c7590c0fc938e4351c`
- Rust SDK lock SHA-256: `f4b9fd48cb9598f9658f00a9cc6f176739e97e45045e90b34e8bb4563937bc48`
- protocol: `2026-07-28`
- Node.js: `24.18.0`

## Verification

- red-first workflow contract: missing SDK archive pin refused
- red-first result validation: required `INFO` check accepted before the fix
- validator unit tests: 12/12
- workflow contract: pass
- `actionlint`: pass
- `zizmor --min-confidence high`: no findings
- `shellcheck`: pass
- conformance source and lock digests reproduced locally
- Rust SDK source digest reproduced from a clean archive
- Rust SDK lock reproduced byte-identically from two clean source trees
- `cargo build --locked -p mcp-conformance`: pass
- exact source installs/builds under Node.js `24.18.0`
- focused scenarios confirmed present at the pinned source
- pre-push workspace clippy and Linux compile gate: pass

The actual Rust SDK scenario execution is delegated to this PR's GitHub lane and must be green on the final head before merge.

Closes the Slice 3 implementation portion of #1866.
