### PR TITLE
feat(mcp): bound wire-profile normalization

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
@@ -410,6 +410,35 @@ mod tests {
     }
 
     #[test]
+    fn deny_import_accepts_an_observed_jsonrpc_error_without_deriving_from_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(dir.path(), "dec.ndjson", &[decision("deny")]);
+        let transcript = r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}},{"response":{"jsonrpc":"2.0","id":1,"error":{"code":-32042,"message":"ATTACKER_SENTINEL"}}}]}"#;
+        let mut import = args(dir.path(), decisions);
+        import.mcp_transcript = Some(write_transcript(
+            dir.path(),
+            "deny-transcript.json",
+            transcript,
+        ));
+        import.mcp_format = Some(PrivilegedMcpTranscriptFormat::StreamableHttp);
+
+        assert_eq!(
+            cmd_privileged_mcp_action(import.clone()).unwrap(),
+            exit_codes::OK
+        );
+        let reader = BundleReader::open(File::open(&import.bundle_out).unwrap()).unwrap();
+        let events = reader.events_vec().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].payload, decision("deny"));
+        assert!(
+            !serde_json::to_string(&events)
+                .unwrap()
+                .contains("ATTACKER_SENTINEL"),
+            "the optional wire observation must not become producer evidence"
+        );
+    }
+
+    #[test]
     fn transcript_and_format_must_be_supplied_together() {
         let dir = tempfile::tempdir().unwrap();
         let decisions = write_ndjson(dir.path(), "dec.ndjson", &[profile_allow_decision()]);

--- a/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
@@ -10,10 +10,12 @@
 
 use crate::exit_codes;
 use anyhow::{bail, Context, Result};
+use assay_core::mcp::ingest::{parse_mcp_transcript_bounded, McpTranscriptLimits};
+use assay_core::mcp::McpInputFormat;
 use assay_evidence::bundle::BundleWriter;
 use assay_evidence::types::{EvidenceEvent, ProducerMeta};
 use chrono::{DateTime, Utc};
-use clap::Args;
+use clap::{Args, ValueEnum};
 use serde_json::Value;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -36,6 +38,14 @@ pub struct PrivilegedMcpActionArgs {
     #[arg(long, value_name = "PATH")]
     pub manifest_establish: Option<PathBuf>,
 
+    /// Optional MCP transcript to validate beside the producer-authored profile carriers
+    #[arg(long, value_name = "PATH", requires = "mcp_format")]
+    pub mcp_transcript: Option<PathBuf>,
+
+    /// Input format of --mcp-transcript
+    #[arg(long, value_enum, requires = "mcp_transcript")]
+    pub mcp_format: Option<PrivilegedMcpTranscriptFormat>,
+
     /// Output Assay evidence bundle path (.tar.gz)
     #[arg(long, alias = "out", value_name = "PATH")]
     pub bundle_out: PathBuf,
@@ -49,10 +59,19 @@ pub struct PrivilegedMcpActionArgs {
     pub import_time: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum PrivilegedMcpTranscriptFormat {
+    Inspector,
+    Jsonrpc,
+    StreamableHttp,
+    HttpSse,
+}
+
 pub fn cmd_privileged_mcp_action(args: PrivilegedMcpActionArgs) -> Result<i32> {
     if args.run_id.contains(':') {
         bail!("run_id cannot contain ':' because event ids use run_id:seq");
     }
+    validate_optional_mcp_transcript(&args)?;
     let import_time = parse_import_time(args.import_time.as_deref())?;
     let producer = ProducerMeta {
         name: "assay-cli".to_string(),
@@ -94,6 +113,26 @@ pub fn cmd_privileged_mcp_action(args: PrivilegedMcpActionArgs) -> Result<i32> {
         args.bundle_out.display()
     );
     Ok(exit_codes::OK)
+}
+
+fn validate_optional_mcp_transcript(args: &PrivilegedMcpActionArgs) -> Result<()> {
+    let (path, format) = match (&args.mcp_transcript, args.mcp_format) {
+        (None, None) => return Ok(()),
+        (Some(_), None) => bail!("--mcp-transcript requires --mcp-format"),
+        (None, Some(_)) => bail!("--mcp-format requires --mcp-transcript"),
+        (Some(path), Some(format)) => (path, format),
+    };
+    let file = File::open(path)
+        .with_context(|| format!("failed to open MCP transcript {}", path.display()))?;
+    let format = match format {
+        PrivilegedMcpTranscriptFormat::Inspector => McpInputFormat::Inspector,
+        PrivilegedMcpTranscriptFormat::Jsonrpc => McpInputFormat::JsonRpc,
+        PrivilegedMcpTranscriptFormat::StreamableHttp => McpInputFormat::StreamableHttp,
+        PrivilegedMcpTranscriptFormat::HttpSse => McpInputFormat::HttpSse,
+    };
+    parse_mcp_transcript_bounded(file, format, McpTranscriptLimits::default())
+        .map_err(|error| anyhow::anyhow!("MCP transcript validation failed: {error}"))?;
+    Ok(())
 }
 
 /// Read one NDJSON file into `(schema, payload)` pairs, byte-faithful.
@@ -142,6 +181,8 @@ mod tests {
     use assay_evidence::bundle::BundleReader;
     use serde_json::json;
 
+    const NOTIFICATION: &str = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{}}"#;
+
     fn decision(decision: &str) -> Value {
         json!({
             "schema": "assay.enforcement_decision.v0",
@@ -173,6 +214,8 @@ mod tests {
             decisions,
             denied_observations: None,
             manifest_establish: None,
+            mcp_transcript: None,
+            mcp_format: None,
             bundle_out: dir.join("out.bundle.tar.gz"),
             run_id: DEFAULT_RUN_ID.to_string(),
             import_time: Some("2026-07-24T00:00:00Z".to_string()),
@@ -240,5 +283,146 @@ mod tests {
         let decisions = write_ndjson(dir.path(), "dec.ndjson", &[]);
         let err = cmd_privileged_mcp_action(args(dir.path(), decisions)).unwrap_err();
         assert!(err.to_string().contains("nothing to import"));
+    }
+
+    fn profile_allow_decision() -> Value {
+        json!({
+            "schema": "assay.enforcement_decision.v0",
+            "caller": {"id": "ci-agent"},
+            "tool": {
+                "name": "github.add_deploy_key",
+                "action_class": "github_deploy_key"
+            },
+            "action": {
+                "verb": "create",
+                "resource_type": "github_deploy_key",
+                "target": {
+                    "provider": "github",
+                    "owner": "acme",
+                    "repo": "prod-app"
+                },
+                "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+            },
+            "decision": "allow",
+            "reason": "allow",
+            "fail_closed": false,
+            "drift_state": "satisfied",
+            "credential_alias": "gh-deploy",
+            "non_claims": [
+                "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+                "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+                "credential referenced by alias only, never the token or declared scopes",
+                "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+                "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+            ]
+        })
+    }
+
+    fn expected_allow_report() -> Value {
+        json!({
+            "schema": "assay.privileged_mcp_action.verify.report.v0",
+            "profile": "privileged-mcp-action/v0",
+            "bundle_integrity": "pass",
+            "verdict": "valid",
+            "claims": {
+                "policy_decision_recorded": {
+                    "status": "confirmed",
+                    "source_class": "producer_reported"
+                },
+                "caller_visible_denial": {"status": "incomplete"},
+                "upstream_delivery": {"status": "incomplete"},
+                "external_side_effect": {"status": "incomplete"}
+            },
+            "findings": [],
+            "non_claims": [
+                "allow does not prove upstream delivery",
+                "deny does not establish maliciousness",
+                "caller-visible denial does not prove external side-effect absence",
+                "bundle integrity does not upgrade source class"
+            ]
+        })
+    }
+
+    fn write_transcript(dir: &Path, name: &str, text: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, text).unwrap();
+        path
+    }
+
+    #[test]
+    fn wire_era_forms_round_trip_to_the_same_frozen_profile_report() {
+        use super::super::verify_privileged_mcp_action::verify_bundle_report;
+
+        let vectors = [
+            (
+                "legacy-missing",
+                r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2025-06-18"}},"entries":[{"request":{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{}}}},{"response":{"jsonrpc":"2.0","id":1,"result":{"content":[]}}}]}"#,
+            ),
+            (
+                "modern-complete",
+                r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}},{"response":{"jsonrpc":"2.0","id":1,"result":{"content":[],"resultType":"complete"}}}]}"#,
+            ),
+            (
+                "modern-input-required",
+                r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}},{"response":{"jsonrpc":"2.0","id":1,"result":{"resultType":"input_required","inputRequests":{"elicitation":{"method":"elicitation/create","params":{"message":"m","requestedSchema":{"type":"object","properties":{}}}}}}}}]}"#,
+            ),
+        ];
+
+        for (name, transcript) in vectors {
+            let dir = tempfile::tempdir().unwrap();
+            let decisions = write_ndjson(dir.path(), "dec.ndjson", &[profile_allow_decision()]);
+            let mut import = args(dir.path(), decisions);
+            import.mcp_transcript =
+                Some(write_transcript(dir.path(), "transcript.json", transcript));
+            import.mcp_format = Some(PrivilegedMcpTranscriptFormat::StreamableHttp);
+            cmd_privileged_mcp_action(import.clone())
+                .unwrap_or_else(|error| panic!("{name}: {error:#}"));
+            let report = verify_bundle_report(&import.bundle_out).unwrap();
+            assert_eq!(
+                serde_json::to_value(report).unwrap(),
+                expected_allow_report(),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_wire_input_is_refused_before_a_bundle_is_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(dir.path(), "dec.ndjson", &[profile_allow_decision()]);
+        let mut import = args(dir.path(), decisions);
+        import.mcp_transcript = Some(write_transcript(
+            dir.path(),
+            "transcript.json",
+            r#"{"ATTACKER_SENTINEL":"#,
+        ));
+        import.mcp_format = Some(PrivilegedMcpTranscriptFormat::StreamableHttp);
+        let error = cmd_privileged_mcp_action(import.clone()).unwrap_err();
+        assert!(error.to_string().contains("MCP transcript is invalid"));
+        assert!(!format!("{error:?}").contains("ATTACKER_SENTINEL"));
+        assert!(!import.bundle_out.exists());
+    }
+
+    #[test]
+    fn transcript_and_format_must_be_supplied_together() {
+        let dir = tempfile::tempdir().unwrap();
+        let decisions = write_ndjson(dir.path(), "dec.ndjson", &[profile_allow_decision()]);
+        let mut transcript_only = args(dir.path(), decisions.clone());
+        transcript_only.mcp_transcript = Some(write_transcript(
+            dir.path(),
+            "transcript.json",
+            NOTIFICATION,
+        ));
+        assert!(cmd_privileged_mcp_action(transcript_only)
+            .unwrap_err()
+            .to_string()
+            .contains("--mcp-format"));
+
+        let mut format_only = args(dir.path(), decisions);
+        format_only.mcp_format = Some(PrivilegedMcpTranscriptFormat::Jsonrpc);
+        assert!(cmd_privileged_mcp_action(format_only)
+            .unwrap_err()
+            .to_string()
+            .contains("--mcp-transcript"));
     }
 }

--- a/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
@@ -387,6 +387,89 @@ mod tests {
     }
 
     #[test]
+    fn every_cli_transcript_format_reaches_its_parser_and_preserves_the_profile() {
+        use super::super::verify_privileged_mcp_action::verify_bundle_report;
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "github.add_deploy_key",
+                "arguments": {},
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        });
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [], "resultType": "complete"}
+        });
+        let header = json!({"MCP-Protocol-Version": "2026-07-28"});
+        let vectors = [
+            (
+                "inspector",
+                json!({"events": [request.clone(), response.clone()]}).to_string(),
+                PrivilegedMcpTranscriptFormat::Inspector,
+            ),
+            (
+                "jsonrpc",
+                format!("{request}\n{response}\n"),
+                PrivilegedMcpTranscriptFormat::Jsonrpc,
+            ),
+            (
+                "streamable-http",
+                json!({
+                    "transport": "streamable-http",
+                    "transport_context": {"headers": header.clone()},
+                    "entries": [
+                        {"request": request.clone()},
+                        {"response": response.clone()}
+                    ]
+                })
+                .to_string(),
+                PrivilegedMcpTranscriptFormat::StreamableHttp,
+            ),
+            (
+                "http-sse",
+                json!({
+                    "transport": "http-sse",
+                    "transport_context": {"headers": header},
+                    "entries": [
+                        {"sse": {"event": "message", "data": request}},
+                        {"sse": {"event": "message", "data": response}}
+                    ]
+                })
+                .to_string(),
+                PrivilegedMcpTranscriptFormat::HttpSse,
+            ),
+        ];
+
+        for (name, transcript, format) in vectors {
+            let dir = tempfile::tempdir().unwrap();
+            let decisions = write_ndjson(dir.path(), "dec.ndjson", &[profile_allow_decision()]);
+            let mut import = args(dir.path(), decisions);
+            import.mcp_transcript = Some(write_transcript(
+                dir.path(),
+                &format!("{name}.json"),
+                &transcript,
+            ));
+            import.mcp_format = Some(format);
+            cmd_privileged_mcp_action(import.clone())
+                .unwrap_or_else(|error| panic!("{name}: {error:#}"));
+            let report = verify_bundle_report(&import.bundle_out).unwrap();
+            assert_eq!(
+                serde_json::to_value(report).unwrap(),
+                expected_allow_report(),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
     fn malformed_wire_input_is_refused_before_a_bundle_is_written() {
         let dir = tempfile::tempdir().unwrap();
         let decisions = write_ndjson(dir.path(), "dec.ndjson", &[profile_allow_decision()]);

--- a/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs
@@ -38,7 +38,7 @@ pub struct PrivilegedMcpActionArgs {
     #[arg(long, value_name = "PATH")]
     pub manifest_establish: Option<PathBuf>,
 
-    /// Optional MCP transcript to validate beside the producer-authored profile carriers
+    /// Optional MCP transcript to inspect beside the producer-authored profile carriers
     #[arg(long, value_name = "PATH", requires = "mcp_format")]
     pub mcp_transcript: Option<PathBuf>,
 
@@ -71,7 +71,7 @@ pub fn cmd_privileged_mcp_action(args: PrivilegedMcpActionArgs) -> Result<i32> {
     if args.run_id.contains(':') {
         bail!("run_id cannot contain ':' because event ids use run_id:seq");
     }
-    validate_optional_mcp_transcript(&args)?;
+    inspect_optional_mcp_transcript(&args)?;
     let import_time = parse_import_time(args.import_time.as_deref())?;
     let producer = ProducerMeta {
         name: "assay-cli".to_string(),
@@ -115,7 +115,7 @@ pub fn cmd_privileged_mcp_action(args: PrivilegedMcpActionArgs) -> Result<i32> {
     Ok(exit_codes::OK)
 }
 
-fn validate_optional_mcp_transcript(args: &PrivilegedMcpActionArgs) -> Result<()> {
+fn inspect_optional_mcp_transcript(args: &PrivilegedMcpActionArgs) -> Result<()> {
     let (path, format) = match (&args.mcp_transcript, args.mcp_format) {
         (None, None) => return Ok(()),
         (Some(_), None) => bail!("--mcp-transcript requires --mcp-format"),
@@ -131,7 +131,7 @@ fn validate_optional_mcp_transcript(args: &PrivilegedMcpActionArgs) -> Result<()
         PrivilegedMcpTranscriptFormat::HttpSse => McpInputFormat::HttpSse,
     };
     parse_mcp_transcript_bounded(file, format, McpTranscriptLimits::default())
-        .map_err(|error| anyhow::anyhow!("MCP transcript validation failed: {error}"))?;
+        .map_err(|error| anyhow::anyhow!("MCP transcript ingest failed: {error}"))?;
     Ok(())
 }
 
@@ -398,6 +398,12 @@ mod tests {
         ));
         import.mcp_format = Some(PrivilegedMcpTranscriptFormat::StreamableHttp);
         let error = cmd_privileged_mcp_action(import.clone()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .starts_with("MCP transcript ingest failed:"),
+            "{error:#}"
+        );
         assert!(error.to_string().contains("MCP transcript is invalid"));
         assert!(!format!("{error:?}").contains("ATTACKER_SENTINEL"));
         assert!(!import.bundle_out.exists());

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -637,6 +637,11 @@ pub(crate) struct ParsedMcpEvent {
     pub(crate) event: McpEvent,
     /// Read by the bounded conclusion layer before the public event projection drops it.
     pub(crate) context: McpEraContext,
+    /// A valid JSON-RPC error response has no result whose terminality can be concluded.
+    ///
+    /// Kept as an observation on the internal sidecar so the bounded ingest gate can refuse the
+    /// incomplete reading without treating a protocol-valid error response as malformed.
+    pub(crate) is_error_response: bool,
 }
 
 /// The protocol versions this build has era rules for, newest last. This is a statement about

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -513,10 +513,6 @@ pub(crate) enum CapabilityObservation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-// Targeted rather than module-wide, so a future dead item in this file is still reported.
-// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
-// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
-#[allow(dead_code)]
 pub(crate) enum IncompleteReason {
     EraUnknown(UnknownReason),
     /// The token is unreadable to this build, and nothing is outstanding that could still cover it.
@@ -546,10 +542,6 @@ pub(crate) enum IncompleteReason {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-// Targeted rather than module-wide, so a future dead item in this file is still reported.
-// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
-// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
-#[allow(dead_code)]
 pub(crate) enum InvalidReason {
     EraConflicting {
         header: String,
@@ -593,10 +585,6 @@ pub(crate) enum InvalidReason {
 /// category error here: "no objection" and "valid but unfinished" are different answers and only
 /// the second belongs to a result.
 #[derive(Debug, Clone, PartialEq, Eq)]
-// Targeted rather than module-wide, so a future dead item in this file is still reported.
-// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
-// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
-#[allow(dead_code)]
 pub(crate) enum RequestAssessment {
     Valid,
     Incomplete(IncompleteReason),
@@ -607,10 +595,6 @@ pub(crate) enum RequestAssessment {
 /// contradicted, and a missing required field are three different findings, and `input_required`
 /// is valid while not being terminal.
 #[derive(Debug, Clone, PartialEq, Eq)]
-// Targeted rather than module-wide, so a future dead item in this file is still reported.
-// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
-// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
-#[allow(dead_code)]
 pub(crate) enum ResultConclusion {
     Terminal,
     NonTerminal,
@@ -651,8 +635,7 @@ pub(crate) struct McpEraContext {
 #[derive(Debug, Clone)]
 pub(crate) struct ParsedMcpEvent {
     pub(crate) event: McpEvent,
-    /// Read by tests and by the slice-2 conclusion layer; nothing in production consumes it yet.
-    #[allow(dead_code)]
+    /// Read by the bounded conclusion layer before the public event projection drops it.
     pub(crate) context: McpEraContext,
 }
 
@@ -760,10 +743,6 @@ fn requires_result_type(version: &str) -> bool {
 /// The two MUSTs sit next to each other in the schema: a server implementing this version MUST
 /// include `resultType`, and a client receiving a result from an earlier-version server MUST treat
 /// the absent field as `"complete"`. Same observation, opposite conclusions.
-// Targeted rather than module-wide, so a future dead item in this file is still reported.
-// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
-// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
-#[allow(dead_code)]
 pub(crate) fn conclude(
     era: &EraResolution,
     observed: &ResultObservation,
@@ -878,10 +857,6 @@ pub(crate) fn conclude(
 /// the metadata arm and left the header arm, so a malformed header still resolved to an unknown
 /// era and then to "no objection". Both now land on `Invalid`, because more evidence does not make
 /// an unreadable value readable.
-// Targeted rather than module-wide, so a future dead item in this file is still reported.
-// `expect` would be stricter but is unfulfilled here: the tests use these under `--all-targets`,
-// so the lint does not fire and `expect` itself errors. Removed by the slice-2 conclusion layer.
-#[allow(dead_code)]
 pub(crate) fn conclude_request(
     era: &EraResolution,
     metadata: &RequestMetadata,

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -639,8 +639,8 @@ pub(crate) struct ParsedMcpEvent {
     pub(crate) context: McpEraContext,
     /// A valid JSON-RPC error response has no result whose terminality can be concluded.
     ///
-    /// Kept as an observation on the internal sidecar so the bounded ingest gate can refuse the
-    /// incomplete reading without treating a protocol-valid error response as malformed.
+    /// Kept as an observation on the internal sidecar so bounded ingest can distinguish it from
+    /// silent absence and accept it without inventing a result conclusion or producer decision.
     pub(crate) is_error_response: bool,
 }
 

--- a/crates/assay-core/src/mcp/era.rs
+++ b/crates/assay-core/src/mcp/era.rs
@@ -352,6 +352,11 @@ pub(crate) enum MessageShapeError {
     /// response, so it consumed an outstanding id and freed it for reuse without answering anything.
     #[error("a JSON-RPC response must carry exactly one of result or error")]
     NotExactlyOneResponseBody,
+    /// `error` is not merely a discriminator. Accepting a null, scalar, or object without the two
+    /// required members would let the bounded gate treat an unreadable body as a valid error
+    /// response and skip result conclusion.
+    #[error("a JSON-RPC error response must carry an integer code and string message")]
+    MalformedErrorBody,
 }
 
 /// Classify by the two fields JSON-RPC uses.
@@ -381,6 +386,26 @@ pub(crate) fn classify_message(
         let has_error = v.get("error").is_some();
         if has_result == has_error {
             return Err(MessageShapeError::NotExactlyOneResponseBody);
+        }
+        if has_error {
+            let Some(error) = v.get("error").and_then(serde_json::Value::as_object) else {
+                return Err(MessageShapeError::MalformedErrorBody);
+            };
+            let integer_code = error
+                .get("code")
+                .and_then(serde_json::Value::as_i64)
+                .is_some()
+                || error
+                    .get("code")
+                    .and_then(serde_json::Value::as_u64)
+                    .is_some();
+            let string_message = error
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .is_some();
+            if !integer_code || !string_message {
+                return Err(MessageShapeError::MalformedErrorBody);
+            }
         }
         return Ok(MessageKind::Response);
     };

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -1,9 +1,11 @@
 //! Resource-bounded ingest for untrusted MCP transcript bytes.
 //!
 //! This layer owns the cost of reaching the existing MCP parser and refuses typed conclusion states
-//! that cannot support a clean reading. It does not derive a policy decision or change the public
-//! [`McpEvent`] shape. When a caller supplies the transcript as an optional companion input, a
-//! refusal can veto that import but can never author or alter the producer's evidence.
+//! that cannot support a clean reading. A valid JSON-RPC error response is accepted as an observed
+//! protocol outcome, but never treated as a result or as terminality evidence. This layer does not
+//! derive a policy decision or change the public [`McpEvent`] shape. When a caller supplies the
+//! transcript as an optional companion input, a refusal can veto that import but can never author or
+//! alter the producer's evidence.
 
 use super::era::{conclude, conclude_request, RequestAssessment, ResultConclusion};
 use super::parser::parse_mcp_transcript_detailed;
@@ -65,9 +67,10 @@ pub enum McpTranscriptIngestError {
 
 /// Read and parse one transcript under explicit limits, refusing unusable conclusion states.
 ///
-/// `Terminal` and `NonTerminal` results are both accepted. `Incomplete` and `Invalid` request or
-/// result states are mapped to value-free ingest errors; no policy decision or profile carrier is
-/// derived from them.
+/// `Terminal` and `NonTerminal` results are both accepted. A valid JSON-RPC error response has no
+/// result conclusion and is accepted without being promoted to one. `Incomplete` and `Invalid`
+/// request or result states are mapped to value-free ingest errors; no policy decision or profile
+/// carrier is derived from them.
 pub fn parse_mcp_transcript_bounded<R: Read>(
     reader: R,
     format: McpInputFormat,
@@ -90,6 +93,12 @@ pub fn parse_mcp_transcript_bounded<R: Read>(
     let parsed = parse_mcp_transcript_detailed(&text, format)
         .map_err(|_| McpTranscriptIngestError::InvalidTranscript)?;
     for entry in &parsed {
+        if entry.is_error_response {
+            // The parser has already established a valid JSON-RPC error-response shape. It carries
+            // no MCP result whose terminality can be read. Keep that distinction explicit:
+            // accepting it must not synthesize a result conclusion or a producer decision.
+            continue;
+        }
         if let Some(metadata) = &entry.context.request_metadata {
             match conclude_request(
                 &entry.context.era,
@@ -119,9 +128,6 @@ pub fn parse_mcp_transcript_bounded<R: Read>(
                     return Err(McpTranscriptIngestError::ConclusionInvalid)
                 }
             }
-        }
-        if entry.is_error_response {
-            return Err(McpTranscriptIngestError::ConclusionIncomplete);
         }
     }
     Ok(parsed.into_iter().map(|entry| entry.event).collect())
@@ -713,15 +719,20 @@ mod tests {
     }
 
     #[test]
-    fn modern_error_response_cannot_bypass_the_conclusion_gate() {
-        let error = parse_mcp_transcript_bounded(
-            Cursor::new(modern_transport_error()),
+    fn modern_error_response_is_observed_without_becoming_a_result_conclusion() {
+        let transcript = modern_transport_error();
+        let parsed =
+            parse_mcp_transcript_detailed(&transcript, McpInputFormat::StreamableHttp).unwrap();
+        assert!(
+            parsed.iter().any(|entry| entry.is_error_response),
+            "the bounded gate must not accept an error response by failing to observe it"
+        );
+        assert!(parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
             McpInputFormat::StreamableHttp,
             limits(),
         )
-        .unwrap_err();
-        assert_eq!(error.to_string(), "MCP transcript conclusion is incomplete");
-        assert!(!format!("{error:?}").contains("ATTACKER_SENTINEL"));
+        .is_ok());
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -10,6 +10,7 @@ use std::io::Read;
 
 /// Domain-local ceilings for one MCP transcript.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct McpTranscriptLimits {
     /// Maximum bytes read from the source before UTF-8 materialization.
     pub max_source_bytes: u64,
@@ -34,6 +35,7 @@ impl Default for McpTranscriptLimits {
 
 /// A typed, value-free refusal at the MCP transcript boundary.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum McpTranscriptIngestError {
     #[error("MCP transcript exceeded source-byte limit of {limit}")]
     SourceBytes { limit: u64 },

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -2,7 +2,8 @@
 //!
 //! This layer owns the cost of reaching the existing MCP parser and refuses typed conclusion states
 //! that cannot support a clean reading. It does not derive a policy decision or change the public
-//! [`McpEvent`] shape.
+//! [`McpEvent`] shape. When a caller supplies the transcript as an optional companion input, a
+//! refusal can veto that import but can never author or alter the producer's evidence.
 
 use super::era::{conclude, conclude_request, RequestAssessment, ResultConclusion};
 use super::parser::parse_mcp_transcript_detailed;
@@ -80,7 +81,7 @@ pub fn parse_mcp_transcript_bounded<R: Read>(
         }
         return Err(McpTranscriptIngestError::ReadFailed);
     }
-    check_json_depth(&bytes, limits.max_json_depth)?;
+    check_json_depth(&bytes, format, limits.max_json_depth)?;
     if format == McpInputFormat::JsonRpc {
         check_jsonl_lines(&bytes, limits.max_line_bytes)?;
     }
@@ -119,6 +120,9 @@ pub fn parse_mcp_transcript_bounded<R: Read>(
                 }
             }
         }
+        if entry.is_error_response {
+            return Err(McpTranscriptIngestError::ConclusionIncomplete);
+        }
     }
     Ok(parsed.into_iter().map(|entry| entry.event).collect())
 }
@@ -134,7 +138,11 @@ fn check_jsonl_lines(bytes: &[u8], max_line_bytes: u64) -> Result<(), McpTranscr
     Ok(())
 }
 
-fn check_json_depth(bytes: &[u8], max_json_depth: usize) -> Result<(), McpTranscriptIngestError> {
+fn check_json_depth(
+    bytes: &[u8],
+    format: McpInputFormat,
+    max_json_depth: usize,
+) -> Result<(), McpTranscriptIngestError> {
     let mut depth = 0usize;
     let mut in_string = false;
     let mut escaped = false;
@@ -144,6 +152,9 @@ fn check_json_depth(bytes: &[u8], max_json_depth: usize) -> Result<(), McpTransc
             // one row cannot hide structural depth on later rows from the resource guard.
             in_string = false;
             escaped = false;
+            if format == McpInputFormat::JsonRpc {
+                depth = 0;
+            }
             continue;
         }
         if in_string {
@@ -405,6 +416,10 @@ mod tests {
         )
     }
 
+    fn modern_transport_error() -> String {
+        r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"example.tool","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}},{"response":{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"ATTACKER_SENTINEL"}}}]}"#.to_string()
+    }
+
     fn limits() -> McpTranscriptLimits {
         McpTranscriptLimits {
             max_source_bytes: 4096,
@@ -642,6 +657,17 @@ mod tests {
     }
 
     #[test]
+    fn unbalanced_jsonl_depth_does_not_carry_into_the_next_line() {
+        let transcript = format!("{{\"open\":{{\n{NOTIFICATION}");
+        let mut bounded = limits();
+        bounded.max_json_depth = 2;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(transcript), McpInputFormat::JsonRpc, bounded)
+                .unwrap_err();
+        assert!(matches!(error, McpTranscriptIngestError::InvalidTranscript));
+    }
+
+    #[test]
     fn diagnostics_do_not_echo_attacker_controlled_input() {
         let input = br#"{"ATTACKER_SENTINEL":"#;
         let error =
@@ -687,7 +713,19 @@ mod tests {
     }
 
     #[test]
-    fn modern_input_required_with_continuation_remains_accepted_and_nonterminal() {
+    fn modern_error_response_cannot_bypass_the_conclusion_gate() {
+        let error = parse_mcp_transcript_bounded(
+            Cursor::new(modern_transport_error()),
+            McpInputFormat::StreamableHttp,
+            limits(),
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "MCP transcript conclusion is incomplete");
+        assert!(!format!("{error:?}").contains("ATTACKER_SENTINEL"));
+    }
+
+    #[test]
+    fn valid_modern_input_required_with_continuation_is_accepted() {
         let transcript =
             modern_transport(r#"{"resultType":"input_required","requestState":"opaque"}"#);
         assert!(parse_mcp_transcript_bounded(

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -52,9 +52,6 @@ pub enum McpTranscriptIngestError {
 }
 
 /// Read and parse one transcript under explicit limits.
-///
-/// The initial implementation is intentionally incomplete so the limit tests below fail before
-/// the production guards are added.
 pub fn parse_mcp_transcript_bounded<R: Read>(
     reader: R,
     format: McpInputFormat,
@@ -93,6 +90,13 @@ fn check_json_depth(bytes: &[u8], max_json_depth: usize) -> Result<(), McpTransc
     let mut in_string = false;
     let mut escaped = false;
     for &byte in bytes {
+        if byte == b'\n' {
+            // Raw newlines cannot occur inside JSON strings. Recover here so malformed JSONL on
+            // one row cannot hide structural depth on later rows from the resource guard.
+            in_string = false;
+            escaped = false;
+            continue;
+        }
         if in_string {
             if escaped {
                 escaped = false;
@@ -566,6 +570,20 @@ mod tests {
             bounded,
         )
         .is_ok());
+    }
+
+    #[test]
+    fn unterminated_jsonl_string_cannot_mask_depth_on_the_next_line() {
+        let transcript = "{\"text\":\"unterminated\n[[[]]]";
+        let mut bounded = limits();
+        bounded.max_json_depth = 2;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(transcript), McpInputFormat::JsonRpc, bounded)
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::JsonDepth { limit: 2 }
+        ));
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -1,9 +1,12 @@
 //! Resource-bounded ingest for untrusted MCP transcript bytes.
 //!
-//! This layer owns only the cost of reaching the existing MCP parser. It does not reinterpret
-//! protocol observations, derive a policy decision, or change the public [`McpEvent`] shape.
+//! This layer owns the cost of reaching the existing MCP parser and refuses typed conclusion states
+//! that cannot support a clean reading. It does not derive a policy decision or change the public
+//! [`McpEvent`] shape.
 
-use super::{parse_mcp_transcript, McpEvent, McpInputFormat};
+use super::era::{conclude, conclude_request, RequestAssessment, ResultConclusion};
+use super::parser::parse_mcp_transcript_detailed;
+use super::{McpEvent, McpInputFormat};
 use assay_common::limits::{LimitExceeded, LimitKind, LimitReader};
 use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use std::io::Read;
@@ -51,9 +54,19 @@ pub enum McpTranscriptIngestError {
     ReadFailed,
     #[error("MCP transcript is invalid")]
     InvalidTranscript,
+    /// At least one request or result needs evidence this transcript does not provide.
+    #[error("MCP transcript conclusion is incomplete")]
+    ConclusionIncomplete,
+    /// At least one request or result carries a protocol-invalid observation.
+    #[error("MCP transcript conclusion is invalid")]
+    ConclusionInvalid,
 }
 
-/// Read and parse one transcript under explicit limits.
+/// Read and parse one transcript under explicit limits, refusing unusable conclusion states.
+///
+/// `Terminal` and `NonTerminal` results are both accepted. `Incomplete` and `Invalid` request or
+/// result states are mapped to value-free ingest errors; no policy decision or profile carrier is
+/// derived from them.
 pub fn parse_mcp_transcript_bounded<R: Read>(
     reader: R,
     format: McpInputFormat,
@@ -73,7 +86,41 @@ pub fn parse_mcp_transcript_bounded<R: Read>(
     }
     let text = String::from_utf8(bytes).map_err(|_| McpTranscriptIngestError::InvalidUtf8)?;
     check_event_count(text.as_bytes(), format, limits.max_events)?;
-    parse_mcp_transcript(&text, format).map_err(|_| McpTranscriptIngestError::InvalidTranscript)
+    let parsed = parse_mcp_transcript_detailed(&text, format)
+        .map_err(|_| McpTranscriptIngestError::InvalidTranscript)?;
+    for entry in &parsed {
+        if let Some(metadata) = &entry.context.request_metadata {
+            match conclude_request(
+                &entry.context.era,
+                metadata,
+                entry.context.capability_observation.as_ref(),
+            ) {
+                RequestAssessment::Valid => {}
+                RequestAssessment::Incomplete(_) => {
+                    return Err(McpTranscriptIngestError::ConclusionIncomplete)
+                }
+                RequestAssessment::Invalid(_) => {
+                    return Err(McpTranscriptIngestError::ConclusionInvalid)
+                }
+            }
+        }
+        if let Some(result) = &entry.context.result_observation {
+            match conclude(
+                &entry.context.era,
+                result,
+                entry.context.capability_observation.as_ref(),
+            ) {
+                ResultConclusion::Terminal | ResultConclusion::NonTerminal => {}
+                ResultConclusion::Incomplete(_) => {
+                    return Err(McpTranscriptIngestError::ConclusionIncomplete)
+                }
+                ResultConclusion::Invalid(_) => {
+                    return Err(McpTranscriptIngestError::ConclusionInvalid)
+                }
+            }
+        }
+    }
+    Ok(parsed.into_iter().map(|entry| entry.event).collect())
 }
 
 fn check_jsonl_lines(bytes: &[u8], max_line_bytes: u64) -> Result<(), McpTranscriptIngestError> {
@@ -352,6 +399,12 @@ mod tests {
 
     const NOTIFICATION: &str = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{}}"#;
 
+    fn modern_transport(result: &str) -> String {
+        format!(
+            r#"{{"transport":"streamable-http","transport_context":{{"headers":{{"MCP-Protocol-Version":"2026-07-28"}}}},"entries":[{{"request":{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"example.tool","arguments":{{}},"_meta":{{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{{}}}}}}}}}},{{"response":{{"jsonrpc":"2.0","id":1,"result":{result}}}}}]}}"#
+        )
+    }
+
     fn limits() -> McpTranscriptLimits {
         McpTranscriptLimits {
             max_source_bytes: 4096,
@@ -597,5 +650,51 @@ mod tests {
         assert!(matches!(error, McpTranscriptIngestError::InvalidTranscript));
         assert!(!error.to_string().contains("ATTACKER_SENTINEL"));
         assert!(!format!("{error:?}").contains("ATTACKER_SENTINEL"));
+    }
+
+    #[test]
+    fn unresolved_request_era_is_refused_after_bounded_parsing() {
+        let request = r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"example.tool","arguments":{}}}"#;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(request), McpInputFormat::JsonRpc, limits())
+                .unwrap_err();
+        assert_eq!(error.to_string(), "MCP transcript conclusion is incomplete");
+    }
+
+    #[test]
+    fn modern_result_without_result_type_is_refused_after_bounded_parsing() {
+        let transcript = modern_transport(r#"{"content":[]}"#);
+        let error = parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::StreamableHttp,
+            limits(),
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "MCP transcript conclusion is invalid");
+    }
+
+    #[test]
+    fn unrecognized_modern_result_is_not_promoted_to_a_clean_reading() {
+        let transcript = modern_transport(r#"{"content":[],"resultType":"future-state"}"#);
+        let error = parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::StreamableHttp,
+            limits(),
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "MCP transcript conclusion is incomplete");
+        assert!(!format!("{error:?}").contains("future-state"));
+    }
+
+    #[test]
+    fn modern_input_required_with_continuation_remains_accepted_and_nonterminal() {
+        let transcript =
+            modern_transport(r#"{"resultType":"input_required","requestState":"opaque"}"#);
+        assert!(parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::StreamableHttp,
+            limits(),
+        )
+        .is_ok());
     }
 }

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -8,7 +8,7 @@
 //! alter the producer's evidence.
 
 use super::era::{conclude, conclude_request, RequestAssessment, ResultConclusion};
-use super::parser::parse_mcp_transcript_detailed;
+use super::parser::{parse_mcp_transcript_detailed_with_depth, EmbeddedJsonDepthExceeded};
 use super::{McpEvent, McpInputFormat};
 use assay_common::limits::{LimitExceeded, LimitKind, LimitReader};
 use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor};
@@ -90,8 +90,16 @@ pub fn parse_mcp_transcript_bounded<R: Read>(
     }
     let text = String::from_utf8(bytes).map_err(|_| McpTranscriptIngestError::InvalidUtf8)?;
     check_event_count(text.as_bytes(), format, limits.max_events)?;
-    let parsed = parse_mcp_transcript_detailed(&text, format)
-        .map_err(|_| McpTranscriptIngestError::InvalidTranscript)?;
+    let parsed = parse_mcp_transcript_detailed_with_depth(&text, format, limits.max_json_depth)
+        .map_err(|error| {
+            if error.downcast_ref::<EmbeddedJsonDepthExceeded>().is_some() {
+                McpTranscriptIngestError::JsonDepth {
+                    limit: limits.max_json_depth,
+                }
+            } else {
+                McpTranscriptIngestError::InvalidTranscript
+            }
+        })?;
     for entry in &parsed {
         if entry.is_error_response {
             // The parser has already established a valid JSON-RPC error-response shape. It carries
@@ -149,43 +157,10 @@ fn check_json_depth(
     format: McpInputFormat,
     max_json_depth: usize,
 ) -> Result<(), McpTranscriptIngestError> {
-    let mut depth = 0usize;
-    let mut in_string = false;
-    let mut escaped = false;
-    for &byte in bytes {
-        if byte == b'\n' {
-            // Raw newlines cannot occur inside JSON strings. Recover here so malformed JSONL on
-            // one row cannot hide structural depth on later rows from the resource guard.
-            in_string = false;
-            escaped = false;
-            if format == McpInputFormat::JsonRpc {
-                depth = 0;
-            }
-            continue;
-        }
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if byte == b'\\' {
-                escaped = true;
-            } else if byte == b'"' {
-                in_string = false;
-            }
-            continue;
-        }
-        match byte {
-            b'"' => in_string = true,
-            b'{' | b'[' => {
-                depth += 1;
-                if depth > max_json_depth {
-                    return Err(McpTranscriptIngestError::JsonDepth {
-                        limit: max_json_depth,
-                    });
-                }
-            }
-            b'}' | b']' => depth = depth.saturating_sub(1),
-            _ => {}
-        }
+    if super::json_depth::exceeds_limit(bytes, max_json_depth, format == McpInputFormat::JsonRpc) {
+        return Err(McpTranscriptIngestError::JsonDepth {
+            limit: max_json_depth,
+        });
     }
     Ok(())
 }
@@ -412,6 +387,7 @@ fn drain_map<'de, A: MapAccess<'de>>(mut map: A) -> Result<(), A::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::parser::parse_mcp_transcript_detailed;
     use std::io::{Cursor, Read};
 
     const NOTIFICATION: &str = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{}}"#;
@@ -638,6 +614,182 @@ mod tests {
             error,
             McpTranscriptIngestError::JsonDepth { limit: 2 }
         ));
+    }
+
+    #[test]
+    fn sse_string_payload_obeys_the_same_json_depth_limit() {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "example.tool",
+                "arguments": {"one": {"two": {"three": true}}},
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        });
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [], "resultType": "complete"}
+        });
+        let transcript = serde_json::json!({
+            "transport": "http-sse",
+            "transport_context": {
+                "headers": {"MCP-Protocol-Version": "2026-07-28"}
+            },
+            "entries": [
+                {"sse": {"event": "message", "data": request.to_string()}},
+                {"sse": {"event": "message", "data": response.to_string()}}
+            ]
+        })
+        .to_string();
+        let mut exact = limits();
+        exact.max_json_depth = 5;
+        assert!(parse_mcp_transcript_bounded(
+            Cursor::new(transcript.as_bytes()),
+            McpInputFormat::HttpSse,
+            exact,
+        )
+        .is_ok());
+
+        let mut over = exact;
+        over.max_json_depth = 4;
+
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(transcript), McpInputFormat::HttpSse, over)
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::JsonDepth { limit: 4 }
+        ));
+    }
+
+    #[test]
+    fn framed_json_depth_accumulates_across_newlines() {
+        let transcript = r#"{
+  "transport": "streamable-http",
+  "transport_context": {
+    "headers": {
+      "MCP-Protocol-Version": "2026-07-28"
+    }
+  },
+  "entries": [
+    {
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+          "name": "example.tool",
+          "arguments": {},
+          "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {}
+          }
+        }
+      }
+    }
+  ]
+}"#;
+        let mut bounded = limits();
+        bounded.max_json_depth = 1;
+
+        let error = parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::StreamableHttp,
+            bounded,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::JsonDepth { limit: 1 }
+        ));
+    }
+
+    #[test]
+    fn every_jsonrpc_message_shape_requires_the_2_0_marker() {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "example.tool",
+                "arguments": {},
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        });
+        let shapes = [
+            ("request", request.clone(), false),
+            (
+                "notification",
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/progress",
+                    "params": {}
+                }),
+                false,
+            ),
+            (
+                "success response",
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"content": [], "resultType": "complete"}
+                }),
+                true,
+            ),
+            (
+                "error response",
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32603, "message": "refused"}
+                }),
+                true,
+            ),
+        ];
+        let markers = [
+            ("missing", None),
+            ("non-string", Some(serde_json::json!(7))),
+            ("wrong", Some(serde_json::json!("1.0"))),
+        ];
+
+        for (shape_name, shape, needs_request) in shapes {
+            for (marker_name, marker) in &markers {
+                let mut malformed = shape.clone();
+                let object = malformed.as_object_mut().unwrap();
+                match marker {
+                    Some(value) => {
+                        object.insert("jsonrpc".to_string(), value.clone());
+                    }
+                    None => {
+                        object.remove("jsonrpc");
+                    }
+                }
+                let transcript = if needs_request {
+                    format!("{request}\n{malformed}\n")
+                } else {
+                    format!("{malformed}\n")
+                };
+                let error = parse_mcp_transcript_bounded(
+                    Cursor::new(transcript),
+                    McpInputFormat::JsonRpc,
+                    limits(),
+                )
+                .unwrap_err();
+                assert!(
+                    matches!(error, McpTranscriptIngestError::InvalidTranscript),
+                    "{shape_name} with {marker_name} marker returned {error:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -422,8 +422,14 @@ mod tests {
         )
     }
 
+    fn modern_transport_with_error(error: &str) -> String {
+        format!(
+            r#"{{"transport":"streamable-http","transport_context":{{"headers":{{"MCP-Protocol-Version":"2026-07-28"}}}},"entries":[{{"request":{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"example.tool","arguments":{{}},"_meta":{{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{{}}}}}}}}}},{{"response":{{"jsonrpc":"2.0","id":1,"error":{error}}}}}]}}"#
+        )
+    }
+
     fn modern_transport_error() -> String {
-        r#"{"transport":"streamable-http","transport_context":{"headers":{"MCP-Protocol-Version":"2026-07-28"}},"entries":[{"request":{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"example.tool","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}},{"response":{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"ATTACKER_SENTINEL"}}}]}"#.to_string()
+        modern_transport_with_error(r#"{"code":-32603,"message":"ATTACKER_SENTINEL"}"#)
     }
 
     fn limits() -> McpTranscriptLimits {
@@ -723,9 +729,13 @@ mod tests {
         let transcript = modern_transport_error();
         let parsed =
             parse_mcp_transcript_detailed(&transcript, McpInputFormat::StreamableHttp).unwrap();
+        let error_entry = parsed
+            .iter()
+            .find(|entry| entry.is_error_response)
+            .expect("the parser must observe the JSON-RPC error response");
         assert!(
-            parsed.iter().any(|entry| entry.is_error_response),
-            "the bounded gate must not accept an error response by failing to observe it"
+            error_entry.context.result_observation.is_none(),
+            "an error response must not acquire an MCP result conclusion"
         );
         assert!(parse_mcp_transcript_bounded(
             Cursor::new(transcript),
@@ -733,6 +743,31 @@ mod tests {
             limits(),
         )
         .is_ok());
+    }
+
+    #[test]
+    fn malformed_error_members_are_refused_before_error_acceptance() {
+        for malformed in [
+            "null",
+            "7",
+            r#""denied""#,
+            r#"{"message":"missing code"}"#,
+            r#"{"code":-32603}"#,
+            r#"{"code":1.0,"message":"decimal code"}"#,
+            r#"{"code":1.5,"message":"float code"}"#,
+            r#"{"code":-32603,"message":7}"#,
+        ] {
+            let error = parse_mcp_transcript_bounded(
+                Cursor::new(modern_transport_with_error(malformed)),
+                McpInputFormat::StreamableHttp,
+                limits(),
+            )
+            .unwrap_err();
+            assert!(
+                matches!(error, McpTranscriptIngestError::InvalidTranscript),
+                "malformed error member must be a transcript refusal, got {error:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/ingest.rs
+++ b/crates/assay-core/src/mcp/ingest.rs
@@ -1,0 +1,581 @@
+//! Resource-bounded ingest for untrusted MCP transcript bytes.
+//!
+//! This layer owns only the cost of reaching the existing MCP parser. It does not reinterpret
+//! protocol observations, derive a policy decision, or change the public [`McpEvent`] shape.
+
+use super::{parse_mcp_transcript, McpEvent, McpInputFormat};
+use assay_common::limits::{LimitExceeded, LimitKind, LimitReader};
+use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use std::io::Read;
+
+/// Domain-local ceilings for one MCP transcript.
+#[derive(Debug, Clone, Copy)]
+pub struct McpTranscriptLimits {
+    /// Maximum bytes read from the source before UTF-8 materialization.
+    pub max_source_bytes: u64,
+    /// Maximum bytes in one JSON-RPC JSONL line.
+    pub max_line_bytes: u64,
+    /// Maximum messages or transport entries in one transcript.
+    pub max_events: usize,
+    /// Maximum structural JSON nesting depth.
+    pub max_json_depth: usize,
+}
+
+impl Default for McpTranscriptLimits {
+    fn default() -> Self {
+        Self {
+            max_source_bytes: 16 * 1024 * 1024,
+            max_line_bytes: 1024 * 1024,
+            max_events: 100_000,
+            max_json_depth: 64,
+        }
+    }
+}
+
+/// A typed, value-free refusal at the MCP transcript boundary.
+#[derive(Debug, thiserror::Error)]
+pub enum McpTranscriptIngestError {
+    #[error("MCP transcript exceeded source-byte limit of {limit}")]
+    SourceBytes { limit: u64 },
+    #[error("MCP transcript JSONL line exceeded byte limit of {limit}")]
+    LineBytes { limit: u64 },
+    #[error("MCP transcript event count exceeded limit of {limit}")]
+    Events { limit: usize },
+    #[error("MCP transcript JSON nesting exceeded depth limit of {limit}")]
+    JsonDepth { limit: usize },
+    #[error("MCP transcript is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("MCP transcript could not be read")]
+    ReadFailed,
+    #[error("MCP transcript is invalid")]
+    InvalidTranscript,
+}
+
+/// Read and parse one transcript under explicit limits.
+///
+/// The initial implementation is intentionally incomplete so the limit tests below fail before
+/// the production guards are added.
+pub fn parse_mcp_transcript_bounded<R: Read>(
+    reader: R,
+    format: McpInputFormat,
+    limits: McpTranscriptLimits,
+) -> Result<Vec<McpEvent>, McpTranscriptIngestError> {
+    let mut reader = LimitReader::new(reader, limits.max_source_bytes, LimitKind::SourceBytes);
+    let mut bytes = Vec::new();
+    if let Err(error) = reader.read_to_end(&mut bytes) {
+        if let Some(LimitExceeded { limit, .. }) = LimitExceeded::from_io(&error) {
+            return Err(McpTranscriptIngestError::SourceBytes { limit });
+        }
+        return Err(McpTranscriptIngestError::ReadFailed);
+    }
+    check_json_depth(&bytes, limits.max_json_depth)?;
+    if format == McpInputFormat::JsonRpc {
+        check_jsonl_lines(&bytes, limits.max_line_bytes)?;
+    }
+    let text = String::from_utf8(bytes).map_err(|_| McpTranscriptIngestError::InvalidUtf8)?;
+    check_event_count(text.as_bytes(), format, limits.max_events)?;
+    parse_mcp_transcript(&text, format).map_err(|_| McpTranscriptIngestError::InvalidTranscript)
+}
+
+fn check_jsonl_lines(bytes: &[u8], max_line_bytes: u64) -> Result<(), McpTranscriptIngestError> {
+    for line in bytes.split(|byte| *byte == b'\n') {
+        if line.len() as u64 > max_line_bytes {
+            return Err(McpTranscriptIngestError::LineBytes {
+                limit: max_line_bytes,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_json_depth(bytes: &[u8], max_json_depth: usize) -> Result<(), McpTranscriptIngestError> {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for &byte in bytes {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > max_json_depth {
+                    return Err(McpTranscriptIngestError::JsonDepth {
+                        limit: max_json_depth,
+                    });
+                }
+            }
+            b'}' | b']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn check_event_count(
+    bytes: &[u8],
+    format: McpInputFormat,
+    max_events: usize,
+) -> Result<(), McpTranscriptIngestError> {
+    let count = match format {
+        McpInputFormat::JsonRpc => {
+            let count = bytes
+                .split(|byte| *byte == b'\n')
+                .filter(|line| !line.iter().all(u8::is_ascii_whitespace))
+                .count();
+            if count > max_events {
+                CountOutcome::OverLimit
+            } else {
+                CountOutcome::WithinLimit
+            }
+        }
+        McpInputFormat::Inspector => count_container_array(bytes, "events", true, max_events)?,
+        McpInputFormat::StreamableHttp | McpInputFormat::HttpSse => {
+            count_container_array(bytes, "entries", false, max_events)?
+        }
+    };
+    match count {
+        CountOutcome::WithinLimit => Ok(()),
+        CountOutcome::OverLimit => Err(McpTranscriptIngestError::Events { limit: max_events }),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CountOutcome {
+    WithinLimit,
+    OverLimit,
+}
+
+fn count_container_array(
+    bytes: &[u8],
+    array_key: &'static str,
+    root_array_is_target: bool,
+    max_events: usize,
+) -> Result<CountOutcome, McpTranscriptIngestError> {
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    deserializer
+        .deserialize_any(ContainerVisitor {
+            array_key,
+            root_array_is_target,
+            max_events,
+        })
+        .map_err(|_| McpTranscriptIngestError::InvalidTranscript)
+}
+
+struct ContainerVisitor {
+    array_key: &'static str,
+    root_array_is_target: bool,
+    max_events: usize,
+}
+
+impl<'de> Visitor<'de> for ContainerVisitor {
+    type Value = CountOutcome;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an MCP transcript container")
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, sequence: A) -> Result<Self::Value, A::Error> {
+        if self.root_array_is_target {
+            CountSeed {
+                max_events: self.max_events,
+            }
+            .count(sequence)
+        } else {
+            drain_sequence(sequence)?;
+            Ok(CountOutcome::WithinLimit)
+        }
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut outcome = CountOutcome::WithinLimit;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == self.array_key {
+                let observed = map.next_value_seed(CountSeed {
+                    max_events: self.max_events,
+                })?;
+                if observed == CountOutcome::OverLimit {
+                    return Ok(observed);
+                }
+                outcome = observed;
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        Ok(outcome)
+    }
+
+    fn visit_bool<E: serde::de::Error>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_str<E: serde::de::Error>(self, _value: &str) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_string<E: serde::de::Error>(self, _value: String) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+}
+
+struct CountSeed {
+    max_events: usize,
+}
+
+impl CountSeed {
+    fn count<'de, A: SeqAccess<'de>>(&self, mut sequence: A) -> Result<CountOutcome, A::Error> {
+        let mut count = 0usize;
+        while sequence.next_element::<IgnoredAny>()?.is_some() {
+            count += 1;
+            if count > self.max_events {
+                return Ok(CountOutcome::OverLimit);
+            }
+        }
+        Ok(CountOutcome::WithinLimit)
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for CountSeed {
+    type Value = CountOutcome;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_any(CountValueVisitor {
+            max_events: self.max_events,
+        })
+    }
+}
+
+struct CountValueVisitor {
+    max_events: usize,
+}
+
+impl<'de> Visitor<'de> for CountValueVisitor {
+    type Value = CountOutcome;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an event array")
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, sequence: A) -> Result<Self::Value, A::Error> {
+        CountSeed {
+            max_events: self.max_events,
+        }
+        .count(sequence)
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+        drain_map(map)?;
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_bool<E: serde::de::Error>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_str<E: serde::de::Error>(self, _value: &str) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_string<E: serde::de::Error>(self, _value: String) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(CountOutcome::WithinLimit)
+    }
+}
+
+fn drain_sequence<'de, A: SeqAccess<'de>>(mut sequence: A) -> Result<(), A::Error> {
+    while sequence.next_element::<IgnoredAny>()?.is_some() {}
+    Ok(())
+}
+
+fn drain_map<'de, A: MapAccess<'de>>(mut map: A) -> Result<(), A::Error> {
+    while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Read};
+
+    const NOTIFICATION: &str = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{}}"#;
+
+    fn limits() -> McpTranscriptLimits {
+        McpTranscriptLimits {
+            max_source_bytes: 4096,
+            max_line_bytes: 4096,
+            max_events: 8,
+            max_json_depth: 16,
+        }
+    }
+
+    fn assert_source_limit(error: McpTranscriptIngestError, limit: u64) {
+        assert!(
+            matches!(error, McpTranscriptIngestError::SourceBytes { limit: got } if got == limit),
+            "expected source-byte refusal at {limit}, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn source_limit_is_inclusive_and_one_more_byte_is_refused() {
+        let bytes = NOTIFICATION.as_bytes();
+        let mut exact = limits();
+        exact.max_source_bytes = bytes.len() as u64;
+        assert_eq!(
+            parse_mcp_transcript_bounded(Cursor::new(bytes), McpInputFormat::JsonRpc, exact)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let mut over = exact;
+        over.max_source_bytes -= 1;
+        let error = parse_mcp_transcript_bounded(Cursor::new(bytes), McpInputFormat::JsonRpc, over)
+            .unwrap_err();
+        assert_source_limit(error, over.max_source_bytes);
+    }
+
+    #[test]
+    fn short_non_seekable_reads_cannot_walk_past_the_source_limit() {
+        struct OneByteAtATime(Cursor<Vec<u8>>);
+        impl Read for OneByteAtATime {
+            fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+                if output.is_empty() {
+                    return Ok(0);
+                }
+                self.0.read(&mut output[..1])
+            }
+        }
+
+        let bytes = NOTIFICATION.as_bytes().to_vec();
+        let mut exact = limits();
+        exact.max_source_bytes = bytes.len() as u64;
+        assert!(parse_mcp_transcript_bounded(
+            OneByteAtATime(Cursor::new(bytes.clone())),
+            McpInputFormat::JsonRpc,
+            exact,
+        )
+        .is_ok());
+
+        let mut over = exact;
+        over.max_source_bytes -= 1;
+        let error = parse_mcp_transcript_bounded(
+            OneByteAtATime(Cursor::new(bytes)),
+            McpInputFormat::JsonRpc,
+            over,
+        )
+        .unwrap_err();
+        assert_source_limit(error, over.max_source_bytes);
+    }
+
+    #[test]
+    fn source_limit_fires_before_invalid_utf8_is_materialized() {
+        let input = [b'{', b'}', 0xff];
+        let mut bounded = limits();
+        bounded.max_source_bytes = 2;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(input), McpInputFormat::Inspector, bounded)
+                .unwrap_err();
+        assert_source_limit(error, 2);
+    }
+
+    #[test]
+    fn jsonl_line_limit_is_inclusive_and_one_more_byte_is_refused() {
+        let mut exact = limits();
+        exact.max_line_bytes = NOTIFICATION.len() as u64;
+        assert!(parse_mcp_transcript_bounded(
+            Cursor::new(NOTIFICATION),
+            McpInputFormat::JsonRpc,
+            exact,
+        )
+        .is_ok());
+
+        let mut over = exact;
+        over.max_line_bytes -= 1;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(NOTIFICATION), McpInputFormat::JsonRpc, over)
+                .unwrap_err();
+        assert!(
+            matches!(error, McpTranscriptIngestError::LineBytes { limit } if limit == over.max_line_bytes)
+        );
+    }
+
+    #[test]
+    fn jsonl_line_limit_fires_before_invalid_json_is_parsed() {
+        let mut bounded = limits();
+        bounded.max_line_bytes = 3;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new("not-json"), McpInputFormat::JsonRpc, bounded)
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::LineBytes { limit: 3 }
+        ));
+    }
+
+    #[test]
+    fn jsonrpc_event_limit_is_applied_before_the_parser_builds_the_event_vector() {
+        let transcript = format!("{NOTIFICATION}\n{NOTIFICATION}");
+        let mut exact = limits();
+        exact.max_events = 2;
+        assert_eq!(
+            parse_mcp_transcript_bounded(Cursor::new(&transcript), McpInputFormat::JsonRpc, exact,)
+                .unwrap()
+                .len(),
+            2
+        );
+
+        let mut over = exact;
+        over.max_events = 1;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(&transcript), McpInputFormat::JsonRpc, over)
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::Events { limit: 1 }
+        ));
+
+        let malformed_second = format!("{NOTIFICATION}\nnot-json");
+        let error = parse_mcp_transcript_bounded(
+            Cursor::new(malformed_second),
+            McpInputFormat::JsonRpc,
+            over,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, McpTranscriptIngestError::Events { limit: 1 }),
+            "event ceiling must decide before a later row reaches the semantic parser"
+        );
+    }
+
+    #[test]
+    fn inspector_event_limit_is_applied_to_the_events_array() {
+        let transcript = format!(r#"{{"events":[{NOTIFICATION},{NOTIFICATION}]}}"#);
+        let mut bounded = limits();
+        bounded.max_events = 1;
+        let error = parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::Inspector,
+            bounded,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::Events { limit: 1 }
+        ));
+    }
+
+    #[test]
+    fn transport_event_limit_is_applied_to_the_entries_array() {
+        let entry = format!(r#"{{"request":{NOTIFICATION}}}"#);
+        let transcript =
+            format!(r#"{{"transport":"streamable-http","entries":[{entry},{entry}]}}"#);
+        let mut bounded = limits();
+        bounded.max_events = 1;
+        let error = parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::StreamableHttp,
+            bounded,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::Events { limit: 1 }
+        ));
+    }
+
+    #[test]
+    fn json_depth_limit_is_inclusive_and_one_more_level_is_refused() {
+        let transcript =
+            r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{"outer":{"leaf":1}}}"#;
+        let mut exact = limits();
+        exact.max_json_depth = 3;
+        assert!(parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::JsonRpc,
+            exact,
+        )
+        .is_ok());
+
+        let mut over = exact;
+        over.max_json_depth = 2;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(transcript), McpInputFormat::JsonRpc, over)
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            McpTranscriptIngestError::JsonDepth { limit: 2 }
+        ));
+    }
+
+    #[test]
+    fn braces_inside_strings_do_not_consume_json_depth_budget() {
+        let transcript =
+            r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{"text":"{{[[}}]]"}}"#;
+        let mut bounded = limits();
+        bounded.max_json_depth = 2;
+        assert!(parse_mcp_transcript_bounded(
+            Cursor::new(transcript),
+            McpInputFormat::JsonRpc,
+            bounded,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn diagnostics_do_not_echo_attacker_controlled_input() {
+        let input = br#"{"ATTACKER_SENTINEL":"#;
+        let error =
+            parse_mcp_transcript_bounded(Cursor::new(input), McpInputFormat::Inspector, limits())
+                .unwrap_err();
+        assert!(matches!(error, McpTranscriptIngestError::InvalidTranscript));
+        assert!(!error.to_string().contains("ATTACKER_SENTINEL"));
+        assert!(!format!("{error:?}").contains("ATTACKER_SENTINEL"));
+    }
+}

--- a/crates/assay-core/src/mcp/json_depth.rs
+++ b/crates/assay-core/src/mcp/json_depth.rs
@@ -1,0 +1,43 @@
+/// Return whether JSON structure exceeds `max_depth` before full deserialization.
+///
+/// JSONL treats each physical line as a separate document. Framed inputs and embedded SSE payloads
+/// are single documents and must retain their structural depth across newlines.
+pub(crate) fn exceeds_limit(bytes: &[u8], max_depth: usize, reset_at_newline: bool) -> bool {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for &byte in bytes {
+        if byte == b'\n' {
+            // Raw newlines cannot occur inside JSON strings. Recover here so malformed JSONL on one
+            // row cannot hide structural depth on later rows from the resource guard.
+            in_string = false;
+            escaped = false;
+            if reset_at_newline {
+                depth = 0;
+            }
+            continue;
+        }
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > max_depth {
+                    return true;
+                }
+            }
+            b'}' | b']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    false
+}

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -9,6 +9,7 @@ pub use g3_auth_context::AuthContextProjection;
 pub mod identity;
 pub mod ingest;
 pub mod jcs;
+pub(crate) mod json_depth;
 pub mod jsonrpc;
 pub mod lifecycle;
 pub mod mapper_v2;

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -7,6 +7,7 @@ pub mod g3_auth_context;
 
 pub use g3_auth_context::AuthContextProjection;
 pub mod identity;
+pub mod ingest;
 pub mod jcs;
 pub mod jsonrpc;
 pub mod lifecycle;

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -45,7 +45,7 @@ pub(crate) fn parse_mcp_transcript_detailed(
             // The capability set travels on the same arm as the request metadata and for the same
             // reason: it is stated by a request and nowhere else. A response gets it by correlation
             // below, never by reading its own bytes.
-            let (request_metadata, result_observation, capability_observation) =
+            let (request_metadata, result_observation, capability_observation, is_error_response) =
                 match payload_raw(&event.payload) {
                     // The same classifier the parser used. A shape it rejects never reaches here,
                     // because `parse_events_with_envelopes` runs first and refuses it, so the error
@@ -55,12 +55,15 @@ pub(crate) fn parse_mcp_transcript_detailed(
                             Some(observe_request_metadata(raw)),
                             None,
                             observe_client_capabilities(raw),
+                            false,
                         ),
-                        Ok(MessageKind::Notification { .. }) => (None, None, None),
-                        Ok(MessageKind::Response) => (None, observe_result(raw), None),
-                        Err(_) => (None, None, None),
+                        Ok(MessageKind::Notification { .. }) => (None, None, None, false),
+                        Ok(MessageKind::Response) => {
+                            (None, observe_result(raw), None, raw.get("error").is_some())
+                        }
+                        Err(_) => (None, None, None, false),
                     },
-                    None => (None, None, None),
+                    None => (None, None, None, false),
                 };
             // Unframed formats have one whole-input observation and no entries to index. A framed
             // input that does not resolve to an entry is a mapping the parser cannot vouch for,
@@ -92,6 +95,7 @@ pub(crate) fn parse_mcp_transcript_detailed(
                     result_observation,
                     capability_observation,
                 },
+                is_error_response,
             }
         })
         .collect();

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -4,6 +4,7 @@ use crate::mcp::era::{
     EnvelopeObservation, McpEraContext, MessageKind, ParsedMcpEvent, RequestMetadata,
 };
 use crate::mcp::era::{CorrelationId, DuplicateAwareSink, EraResolution, SeenMembers, UniqueValue};
+use crate::mcp::json_depth;
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -28,7 +29,26 @@ pub(crate) fn parse_mcp_transcript_detailed(
     text: &str,
     format: McpInputFormat,
 ) -> Result<Vec<ParsedMcpEvent>> {
-    let (events, envelopes) = parse_events_with_envelopes(text, format)?;
+    parse_mcp_transcript_detailed_internal(text, format, None)
+}
+
+/// Bounded internal parse. The outer transcript has already passed its depth scan; this limit is
+/// carried to JSON stored inside SSE `data` strings, which is a separate document whose structure
+/// is invisible to the outer scan.
+pub(crate) fn parse_mcp_transcript_detailed_with_depth(
+    text: &str,
+    format: McpInputFormat,
+    max_json_depth: usize,
+) -> Result<Vec<ParsedMcpEvent>> {
+    parse_mcp_transcript_detailed_internal(text, format, Some(max_json_depth))
+}
+
+fn parse_mcp_transcript_detailed_internal(
+    text: &str,
+    format: McpInputFormat,
+    max_embedded_json_depth: Option<usize>,
+) -> Result<Vec<ParsedMcpEvent>> {
+    let (events, envelopes) = parse_events_with_envelopes(text, format, max_embedded_json_depth)?;
     let framed = is_framed(format);
     let parsed: Vec<ParsedMcpEvent> = events
         .into_iter()
@@ -223,6 +243,7 @@ fn payload_raw(payload: &McpPayload) -> Option<&serde_json::Value> {
 fn parse_events_with_envelopes(
     text: &str,
     format: McpInputFormat,
+    max_embedded_json_depth: Option<usize>,
 ) -> Result<(Vec<McpEvent>, Vec<EnvelopeObservation>)> {
     let (events, envelopes) = match format {
         McpInputFormat::JsonRpc => (parse_jsonrpc_jsonl(text)?, Vec::new()),
@@ -232,10 +253,15 @@ fn parse_events_with_envelopes(
             "streamable-http",
             "streamable-http transcript",
             false,
+            max_embedded_json_depth,
         )?,
-        McpInputFormat::HttpSse => {
-            parse_transport_transcript_detailed(text, "http-sse", "http-sse transcript", true)?
-        }
+        McpInputFormat::HttpSse => parse_transport_transcript_detailed(
+            text,
+            "http-sse",
+            "http-sse transcript",
+            true,
+            max_embedded_json_depth,
+        )?,
     };
     // No global id gate here. The old one keyed on the public `String` rendering, so a number `1`
     // and a string `"1"` collided; it refused any reuse anywhere in the transcript, so a legal reuse
@@ -308,6 +334,7 @@ fn parse_transport_transcript_detailed(
     expected_transport: &str,
     source_label: &str,
     allow_endpoint_event: bool,
+    max_embedded_json_depth: Option<usize>,
 ) -> Result<(Vec<McpEvent>, Vec<EnvelopeObservation>)> {
     let transcript: TransportTranscript =
         serde_json::from_str(text).with_context(|| format!("invalid {}", source_label))?;
@@ -378,7 +405,9 @@ fn parse_transport_transcript_detailed(
         }
 
         if let Some(sse) = entry.sse {
-            if let Some(jsonrpc) = extract_jsonrpc_from_sse(&sse, allow_endpoint_event)? {
+            if let Some(jsonrpc) =
+                extract_jsonrpc_from_sse(&sse, allow_endpoint_event, max_embedded_json_depth)?
+            {
                 out.push(parse_jsonrpc_message(
                     jsonrpc,
                     source_line,
@@ -401,6 +430,13 @@ fn parse_jsonrpc_message(
     if !v.is_object() {
         bail!(
             "MCP event at source line {} must be a JSON object",
+            source_line
+        );
+    }
+
+    if v.get("jsonrpc").and_then(serde_json::Value::as_str) != Some("2.0") {
+        bail!(
+            "MCP event at source line {} must carry JSON-RPC version 2.0",
             source_line
         );
     }
@@ -661,6 +697,7 @@ fn reject_unusable_id_shape(raw_id: Option<&serde_json::Value>, source_line: u64
 fn extract_jsonrpc_from_sse(
     sse: &TransportSseEnvelope,
     allow_endpoint_event: bool,
+    max_embedded_json_depth: Option<usize>,
 ) -> Result<Option<serde_json::Value>> {
     let event_name = sse.event.as_deref().unwrap_or("message");
     if event_name == "endpoint" && allow_endpoint_event {
@@ -671,8 +708,12 @@ fn extract_jsonrpc_from_sse(
         return Ok(None);
     }
 
-    extract_jsonrpc_like_value(&sse.data.0)
+    extract_jsonrpc_like_value(&sse.data.0, max_embedded_json_depth)
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("embedded SSE JSON exceeds its depth limit")]
+pub(crate) struct EmbeddedJsonDepthExceeded;
 
 /// Pull a JSON-RPC-looking value out of an SSE `data` payload.
 ///
@@ -681,7 +722,10 @@ fn extract_jsonrpc_from_sse(
 /// carries a duplicate member, which is refused. The two are told apart by
 /// `serde_json::error::Category`, not by reading the message: a visitor's `Error::custom` classifies
 /// as `Data` while malformed bytes classify as `Syntax`, so the distinction is typed.
-fn extract_jsonrpc_like_value(value: &serde_json::Value) -> Result<Option<serde_json::Value>> {
+fn extract_jsonrpc_like_value(
+    value: &serde_json::Value,
+    max_embedded_json_depth: Option<usize>,
+) -> Result<Option<serde_json::Value>> {
     match value {
         serde_json::Value::Object(map)
             if map.contains_key("method")
@@ -695,13 +739,22 @@ fn extract_jsonrpc_like_value(value: &serde_json::Value) -> Result<Option<serde_
         // same one, so it goes through the same duplicate-aware boundary rather than a plain
         // `Value`. Without this an SSE frame carrying its payload as a string was the one path that
         // kept a duplicate member.
-        serde_json::Value::String(text) => match serde_json::from_str::<UniqueValue>(text) {
-            Ok(UniqueValue(parsed)) => extract_jsonrpc_like_value(&parsed),
-            Err(e) if e.classify() == serde_json::error::Category::Data => {
-                Err(anyhow::Error::new(e).context("invalid SSE data payload"))
+        serde_json::Value::String(text) => {
+            if max_embedded_json_depth
+                .is_some_and(|limit| json_depth::exceeds_limit(text.as_bytes(), limit, false))
+            {
+                return Err(EmbeddedJsonDepthExceeded.into());
             }
-            Err(_) => Ok(None),
-        },
+            match serde_json::from_str::<UniqueValue>(text) {
+                Ok(UniqueValue(parsed)) => {
+                    extract_jsonrpc_like_value(&parsed, max_embedded_json_depth)
+                }
+                Err(e) if e.classify() == serde_json::error::Category::Data => {
+                    Err(anyhow::Error::new(e).context("invalid SSE data payload"))
+                }
+                Err(_) => Ok(None),
+            }
+        }
         _ => Ok(None),
     }
 }


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: #1866
- Slice: 2, wire-to-profile normalizer and bounded CLI import path
- Builder: Codex
- Reviewers: Claude Code plus an independent non-building reviewer; CodeRabbit/Copilot if available
- Final head SHA: `70b3725902112cac796394b5f49f659bc075bbea`
- ADR invariants affected: ADR-043 section 1 bounded ingest; MCP 2026 era conclusion boundary

## Behavior

`assay evidence import privileged-mcp-action` can inspect an optional MCP transcript beside a real,
producer-authored decision carrier. The transcript is bounded before materialization by source,
JSONL-line, event-count, and JSON-depth ceilings. The bounded parser consumes Slice 1's internal
request/result conclusions: `Terminal` and `NonTerminal` are accepted, while `Incomplete` and
`Invalid` are refused with value-free ingest errors before any bundle is written.

A valid JSON-RPC error response is explicitly observed but carries no MCP result whose terminality
can be concluded. It is accepted as a protocol response without being promoted to a result,
terminality claim, or producer decision. The shared message classifier first requires the `error`
member to be an object with an integer `code` and string `message`; null, scalar, partial, and
floating-code bodies are refused value-free before they can take this route. This keeps a
producer-authored deny carrier importable beside its valid error response. An end-to-end test pins
that the transcript error text never enters the bundle and that the sole event remains the
producer's deny carrier.

JSONL depth accounting resets per record, so malformed structure on one line cannot misclassify the
next line's resource use.

The same depth ceiling now follows JSON stored inside an SSE `data` string. That string is a second
JSON document whose structural tokens are invisible to the outer transcript scan; the bounded
parser applies the shared scanner before deserializing it. Framed input keeps depth across physical
newlines, while only JSONL resets per record. Every parsed request, notification, success response,
and error response must also carry the exact JSON-RPC `"2.0"` marker.

The wire input never mints or changes an enforcement decision or profile carrier. Legacy missing
`resultType`, modern `complete`, and modern valid `input_required` all round-trip to the same frozen
four-cell profile report.

All four public CLI transcript-format variants now pass through their mapped parser in one
end-to-end test and reproduce that same frozen report. This closes the review gap where only the
Streamable HTTP mapping had reached the importer.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

The bounded claim is limited to the new privileged MCP action importer. The older generic
`import` and `trace import-mcp` compatibility commands still materialize with `read_to_string` and
are not made bounded by this PR; migrating them is separate follow-up work.

## Test Evidence

### RED

Before the conclusion binding:

```text
cargo test -p assay-core mcp::ingest::tests --lib
13 passed, 3 failed
```

The unresolved request era, missing modern `resultType`, and unrecognized modern token each returned
`Ok(Vec<McpEvent>)`. The valid `input_required` control remained green.

During review, a blanket refusal of JSON-RPC error responses made both the focused error-response
test and the end-to-end producer-deny import fail with `ConclusionIncomplete`. That disposition was
rejected because it made the optional wire input unusable beside the deny carrier it most naturally
accompanies.

Claude's subsequent review found that key presence alone treated null, scalar, partial, and
floating-code error bodies as valid. The new malformed-body test failed before the shared message
classifier validated the required JSON-RPC error members. The accepted-error test also lacked an
assertion that the entry acquired no result observation.

An independent exact-head review then found three remaining boundary gaps. Embedded JSON in an SSE
string bypassed the outer depth scan; every message shape accepted missing, non-string, or non-2.0
JSON-RPC markers; and framed multiline depth accumulation lacked discriminating coverage. The SSE
and marker tests failed before the fix. The framed test was green against the correct code and failed
when the newline reset was deliberately made unconditional.

### GREEN

- focused bounded ingest: 22/22
- full `assay-core` library: 634/634
- full `assay-cli`: 394 passed, 1 generator ignored, 0 failed
- privileged MCP importer: 10/10
- `cargo clippy -p assay-core -p assay-cli --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p assay-core --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push workspace clippy and Linux compile gate

Mutation proof:

- removing the parser's explicit error-response observation makes the focused observation test fail;
- removing the error-body shape guard makes the malformed-body test fail;
- assigning a result observation to an accepted error response makes its focused test fail;
- removing the JSONL per-record depth reset makes the line-isolation test fail;
- routing the JSON-RPC CLI variant through the Inspector parser makes the four-format importer test
  fail on the JSON-RPC case;
- before the fix, embedded SSE nesting at limit plus one and twelve invalid
  marker/message-shape pairs passed their parser paths;
- resetting framed depth at every physical newline makes the multiline framed test fail.

## Review Quorum

- [ ] Two non-building agent reviews on this exact head, unless a current CodeRabbit/Copilot review is available
- [ ] Every actionable finding is fixed or has a recorded technical disposition
- [ ] All required checks are green on this exact head
