### PR TITLE
docs(mcp): publish pinned protocol-era parity run

### DIFF
--- a/docs/mcp/protocol-era-parity.md
+++ b/docs/mcp/protocol-era-parity.md
@@ -43,9 +43,9 @@ The fixed corpus exercises these boundaries:
 | 2026 `complete` result without a non-null `inputRequests` or `requestState` | Terminal |
 | 2026 `complete` result with any non-null `inputRequests` or `requestState` | Incomplete because completion contradicts the continuation |
 | 2026 `input_required` with a string `requestState` or object `inputRequests`, and no malformed sibling | Valid but non-terminal |
-| 2026 `input_required` with neither such member, or with another top-level JSON type | Invalid rather than an ordinary unfinished call |
+| 2026 `input_required` with neither such member, or with a non-null member of another top-level JSON type | Invalid rather than an ordinary unfinished call; `null` is treated as absent |
 | 2026 result without `resultType` | Invalid once the era is known |
-| Present but unrecognized result token | Always incomplete; capabilities distinguish unrecognized from recognition-undeterminable |
+| Present but unrecognized result token | Incomplete when capabilities are readable, absent, or unavailable; malformed modern capabilities are invalid before recognition |
 | Unknown protocol era | No terminal conclusion |
 | Conflicting header and request-metadata eras | Refused distinctly from an unknown era |
 | Multi-hop interim flow | Separate records; no pairing or eventual completion is inferred |
@@ -68,6 +68,8 @@ request, or that an external side effect occurred.
   [`PIN.json`](https://github.com/Rul1an/assay/blob/5e2203e183c6630101f4c6d356cdd7c465ff1364/crates/assay-core/tests/fixtures/mcp-era-parity-v0/PIN.json)
 - Canonical MCP specification commit:
   [`5f5440bb26a62e2cf3440b92da5a667efa03b267`](https://github.com/modelcontextprotocol/modelcontextprotocol/commit/5f5440bb26a62e2cf3440b92da5a667efa03b267)
+- Upstream reference-lane definition and pins:
+  [`mcp-upstream-reference.yml`](https://github.com/Rul1an/assay/blob/5e2203e183c6630101f4c6d356cdd7c465ff1364/.github/workflows/mcp-upstream-reference.yml)
 
 Assay also runs a separate, pinned upstream reference lane for the official MCP conformance source
 and Rust SDK. That lane checks named upstream scenarios and source integrity. It does not represent

--- a/docs/mcp/protocol-era-parity.md
+++ b/docs/mcp/protocol-era-parity.md
@@ -40,10 +40,12 @@ The fixed corpus exercises these boundaries:
 |---|---|
 | Equivalent 2025 and 2026 calls | Same referenced profile baseline and equivalent result conclusion |
 | 2025 result without `resultType` | Terminal under the legacy compatibility rule |
-| 2026 result with `resultType: "complete"` | Terminal |
-| 2026 result with `resultType: "input_required"` | Valid but non-terminal; continuation evidence remains required |
+| 2026 `complete` result without a continuation member | Terminal |
+| 2026 `complete` result with `inputRequests` or `requestState` | Incomplete because completion contradicts the continuation |
+| 2026 `input_required` result with a well-shaped continuation member | Valid but non-terminal |
+| 2026 `input_required` result without a well-shaped continuation member | Invalid rather than an ordinary unfinished call |
 | 2026 result without `resultType` | Invalid once the era is known |
-| Present but unrecognized result token | Incomplete unless the request's capabilities establish recognition |
+| Present but unrecognized result token | Always incomplete; capabilities distinguish unrecognized from recognition-undeterminable |
 | Unknown protocol era | No terminal conclusion |
 | Conflicting header and request-metadata eras | Refused distinctly from an unknown era |
 | Multi-hop interim flow | Separate records; no pairing or eventual completion is inferred |

--- a/docs/mcp/protocol-era-parity.md
+++ b/docs/mcp/protocol-era-parity.md
@@ -1,0 +1,90 @@
+# MCP Protocol-Era Parity
+
+Assay carries an executable, exploratory corpus for one narrow compatibility question across MCP
+`2025-06-18` and `2026-07-28`:
+
+> When otherwise equivalent privileged tool calls use the result framing of different protocol
+> eras, does Assay preserve the same evidence interpretation without reading an interim result as
+> completed?
+
+The corpus keeps schema acceptance, wire observation, semantic conclusion, and the surrounding
+privileged-action evidence baseline separate. Those layers can disagree on purpose. A schema-valid
+message is evidence about its shape, not proof that a tool action completed or had an external
+effect.
+
+## Reproduce The Pinned Run
+
+The following snapshot includes all implementation slices behind this note:
+
+```bash
+git clone https://github.com/Rul1an/assay.git
+cd assay
+git checkout --detach 5e2203e183c6630101f4c6d356cdd7c465ff1364
+cargo test --locked -p assay-core mcp::era_parity_tests --lib
+```
+
+Expected result:
+
+```text
+test result: ok. 38 passed; 0 failed; 0 ignored
+```
+
+The schemas are vendored and digest-checked before use, so the test does not fetch a moving MCP
+schema. Cargo may still need to download Rust dependencies on a fresh machine.
+
+## What The Run Establishes
+
+The fixed corpus exercises these boundaries:
+
+| Case | Bounded conclusion |
+|---|---|
+| Equivalent 2025 and 2026 calls | Same referenced profile baseline and equivalent result conclusion |
+| 2025 result without `resultType` | Terminal under the legacy compatibility rule |
+| 2026 result with `resultType: "complete"` | Terminal |
+| 2026 result with `resultType: "input_required"` | Valid but non-terminal; continuation evidence remains required |
+| 2026 result without `resultType` | Invalid once the era is known |
+| Present but unrecognized result token | Incomplete unless the request's capabilities establish recognition |
+| Unknown protocol era | No terminal conclusion |
+| Conflicting header and request-metadata eras | Refused distinctly from an unknown era |
+| Multi-hop interim flow | Separate records; no pairing or eventual completion is inferred |
+| `traceparent` present or absent | Correlation only; no conclusion changes |
+
+The load-bearing parity check references the same frozen four-cell profile row for equivalent calls.
+It does not derive that profile row from the transcript. In particular, wire bytes do not establish
+that Assay recorded a policy decision, that a caller observed a denial, that an upstream accepted a
+request, or that an external side effect occurred.
+
+## Pinned Evidence
+
+- Assay implementation snapshot:
+  [`5e2203e183c6630101f4c6d356cdd7c465ff1364`](https://github.com/Rul1an/assay/commit/5e2203e183c6630101f4c6d356cdd7c465ff1364)
+- Corpus contract and maturity statement:
+  [`mcp-era-parity-v0/README.md`](https://github.com/Rul1an/assay/blob/5e2203e183c6630101f4c6d356cdd7c465ff1364/crates/assay-core/tests/fixtures/mcp-era-parity-v0/README.md)
+- Machine-readable vectors:
+  [`MANIFEST.json`](https://github.com/Rul1an/assay/blob/5e2203e183c6630101f4c6d356cdd7c465ff1364/crates/assay-core/tests/fixtures/mcp-era-parity-v0/MANIFEST.json)
+- MCP source pin and vendored schema digests:
+  [`PIN.json`](https://github.com/Rul1an/assay/blob/5e2203e183c6630101f4c6d356cdd7c465ff1364/crates/assay-core/tests/fixtures/mcp-era-parity-v0/PIN.json)
+- Canonical MCP specification commit:
+  [`5f5440bb26a62e2cf3440b92da5a667efa03b267`](https://github.com/modelcontextprotocol/modelcontextprotocol/commit/5f5440bb26a62e2cf3440b92da5a667efa03b267)
+
+Assay also runs a separate, pinned upstream reference lane for the official MCP conformance source
+and Rust SDK. That lane checks named upstream scenarios and source integrity. It does not represent
+Assay as an MCP client or server and does not turn this corpus into a broad conformance claim.
+
+## Claim Ceiling
+
+This run supports a bounded statement: Assay preserves the measured privileged-action evidence
+interpretation across the pinned 2025 and 2026 cases, and does not read the measured interim results
+as terminal.
+
+It does **not** establish:
+
+- general MCP protocol conformance;
+- SDK certification or interoperability across all implementations;
+- HTTP, OAuth, Tasks, Apps, session, or identity support;
+- eventual completion of an interim result;
+- upstream delivery or an external side effect;
+- a whole-action verdict, scalar trust score, or compliance claim.
+
+The corpus remains **exploratory**. It is intentionally lower-maturity than the frozen
+Privileged MCP Action conformance corpus and carries no independent reproduction request.

--- a/docs/mcp/protocol-era-parity.md
+++ b/docs/mcp/protocol-era-parity.md
@@ -69,7 +69,7 @@ request, or that an external side effect occurred.
 - Canonical MCP specification commit:
   [`5f5440bb26a62e2cf3440b92da5a667efa03b267`](https://github.com/modelcontextprotocol/modelcontextprotocol/commit/5f5440bb26a62e2cf3440b92da5a667efa03b267)
 - Upstream reference-lane definition and pins:
-  [`mcp-upstream-reference.yml`](https://github.com/Rul1an/assay/blob/5e2203e183c6630101f4c6d356cdd7c465ff1364/.github/workflows/mcp-upstream-reference.yml)
+  [`mcp-upstream-reference.yml`](https://github.com/Rul1an/assay/blob/f31f839e08b79205954aa5a85650295b06497eba/.github/workflows/mcp-upstream-reference.yml)
 
 Assay also runs a separate, pinned upstream reference lane for the official MCP conformance source
 and Rust SDK. That lane checks named upstream scenarios and source integrity. It does not represent

--- a/docs/mcp/protocol-era-parity.md
+++ b/docs/mcp/protocol-era-parity.md
@@ -40,10 +40,10 @@ The fixed corpus exercises these boundaries:
 |---|---|
 | Equivalent 2025 and 2026 calls | Same referenced profile baseline and equivalent result conclusion |
 | 2025 result without `resultType` | Terminal under the legacy compatibility rule |
-| 2026 `complete` result without a continuation member | Terminal |
-| 2026 `complete` result with `inputRequests` or `requestState` | Incomplete because completion contradicts the continuation |
-| 2026 `input_required` result with a well-shaped continuation member | Valid but non-terminal |
-| 2026 `input_required` result without a well-shaped continuation member | Invalid rather than an ordinary unfinished call |
+| 2026 `complete` result without a non-null `inputRequests` or `requestState` | Terminal |
+| 2026 `complete` result with any non-null `inputRequests` or `requestState` | Incomplete because completion contradicts the continuation |
+| 2026 `input_required` with a string `requestState` or object `inputRequests`, and no malformed sibling | Valid but non-terminal |
+| 2026 `input_required` with neither such member, or with another top-level JSON type | Invalid rather than an ordinary unfinished call |
 | 2026 result without `resultType` | Invalid once the era is known |
 | Present but unrecognized result token | Always incomplete; capabilities distinguish unrecognized from recognition-undeterminable |
 | Unknown protocol era | No terminal conclusion |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,7 @@ nav:
     - mcp/index.md
     - Quick Start: mcp/quickstart.md
     - Import Formats: mcp/import-formats.md
+    - Protocol-Era Parity: mcp/protocol-era-parity.md
     - Assay MCP Server: mcp/server.md
     - Self-Correcting Agents: mcp/self-correction.md
 


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: #1866
- Slice: 4 - launch note and reproducible parity run
- Builder: Codex
- Reviewers: Claude Code plan/read-only review plus a second independent non-building exact-head review; both reported zero actionable findings
- Final head SHA: `fed6af6f8c5139d86e654f2ae7eebccaa56762d0`
- ADR invariants affected: ADR-042 claim ceiling only; no profile, verifier, or protocol behavior changes

## Behavior

Adds a discoverable MCP Integration page and nav entry for the exploratory 2025/2026 era-parity corpus. The page gives one immutable reproduction command against merged implementation snapshot `5e2203e183c6630101f4c6d356cdd7c465ff1364`, reports its bounded 38/38 result, links the pinned corpus inputs, and states the claim ceiling beside the result.

No runtime behavior, public Rust API, corpus byte, profile vocabulary, or workflow changes.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

The note also explicitly does not claim general MCP conformance, SDK certification, eventual completion, upstream delivery, or external side effects. The exploratory corpus carries no independent reproduction request.

## Test Evidence

### RED

Not applicable to this docs-only discoverability slice. The implementation and behavioral red/green record is carried by slices 0-3 in #1866; this PR adds no production behavior.

### GREEN

On exact head `fed6af6f8c5139d86e654f2ae7eebccaa56762d0`:

- `cargo test --locked -p assay-core mcp::era_parity_tests --lib`: 38 passed, 0 failed
- `mkdocs build --strict` with `docs/requirements-ci.txt`: passed
- `python3 scripts/ci/check-public-artifact-sanitization.py`: passed
- all seven HTTPS source and proof links: HTTP 200
- generated page exists at `mcp/protocol-era-parity/index.html` with canonical `https://docs.getassay.dev/mcp/protocol-era-parity/`
- `git diff --check`: clean
- commit and pre-push hooks: green, including workspace clippy and Linux compile gate

Independent review of superseded head `713d0acf` found that the first table draft treated
`complete` and `input_required` as token-only conclusions and implied capabilities could promote an
unrecognized token. The correction head states the continuation conditions explicitly and keeps
every unrecognized token incomplete while capabilities only refine the reason.

Independent review of superseded head `c5e677d8` then found two remaining wording overclaims. The
next correction stated that explicit JSON `null` is absence and that continuation validity checks
only the top-level JSON type rather than a deeper schema. The canonical issue body was reconciled at
the same time so its slice states and result matrix no longer lag the PR.

Two independent reviews of superseded head `7dc5cb7a` found three final publication gaps. This head
states that malformed modern capabilities are invalid before token recognition, excludes JSON
`null` from malformed continuation types, and links the immutable upstream reference-lane workflow
whose pins support that bounded side claim.

The publication review then exercised that linked lane and found its SDK lock digest was computed
after resolving against the moving crates.io index. [#1937](https://github.com/Rul1an/assay/pull/1937)
merged as `f31f839e08b79205954aa5a85650295b06497eba`; it freezes and installs the reviewed dependency
closure. This head is rebased on that merge and pins the workflow proof link to it. The corpus and
reproduction checkout remain pinned to implementation snapshot `5e2203e183c6630101f4c6d356cdd7c465ff1364`
because those bytes, rather than the later workflow-only correction, are the measured subject.

On final head `fed6af6f8c5139d86e654f2ae7eebccaa56762d0`, Claude Code reviewed in
plan/read-only mode and a second independent non-building reviewer ran a separate exact-head review.
Both reported zero actionable findings. Claude's initial pinned-link P2 was dismissed after it was
shown to have compared against stale local `main`: both linked Assay commits are ancestors of
`origin/main`, and the links return HTTP 200. CodeRabbit reported `Review rate limited` and is not
counted. Per the user's explicit direction, the route-2 reviewers were started without an artificial
30-minute delay.

## Review Quorum

- [x] One non-building agent review
- [ ] CodeRabbit or Copilot review on this head SHA
- [x] Second non-building agent review linked under the user-authorized no-wait route-2 exception
- [x] Every actionable finding is fixed or has a technical disposition
- [x] Any delegated proof targets this exact head SHA (`lane-check/proof`: no delegated runner proof required)

## Residual Boundaries

The separate upstream reference lane remains reference-only: it does not represent Assay as an MCP client or server. Older generic MCP compatibility imports remain outside Slice 2's bounded-ingest claim and are not described as bounded here.

Closes #1866 after merge and final ledger reconciliation.
