### PR TITLE
docs(mcp): make protocol-era parity discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Generate one from observed behaviour with `assay init --from-trace trace.jsonl`,
 ## Learn more
 
 - [MCP Quickstart](examples/mcp-quickstart/) · [Editor MCP recipe](docs/guides/editor-mcp-recipe.md) — policy-enforcing MCP in Cursor / Claude Code / Codex
+- [MCP 2025/2026 protocol-era parity](https://docs.getassay.dev/mcp/protocol-era-parity/) — pinned `resultType` and interim-result compatibility corpus
 - [Coding-agent governance](docs/guides/coding-agent-governance.md) · [OpenTelemetry & Langfuse](docs/guides/otel-langfuse.md) — observed runs → evidence
 - [Evidence Receipts in Action](docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) — Promptfoo / OpenFeature / CycloneDX receipt families
 - [CI Guide](docs/guides/github-action.md) · [Evidence Store](docs/guides/evidence-store-aws-s3.md) (S3 / B2 / MinIO)

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -161,6 +161,14 @@ MCP standardizes **how** agents communicate. Assay validates **what** they commu
 
     [:octicons-arrow-right-24: Quick Start](quickstart.md)
 
+-   :material-compare-horizontal:{ .lg .middle } __MCP 2025/2026 Protocol-Era Parity__
+
+    ---
+
+    Reproduce the pinned `resultType` and interim-result compatibility corpus.
+
+    [:octicons-arrow-right-24: Protocol-Era Parity](protocol-era-parity.md)
+
 -   :material-server:{ .lg .middle } __Assay MCP Wrapper__
 
     ---

--- a/docs/mcp/protocol-era-parity.md
+++ b/docs/mcp/protocol-era-parity.md
@@ -1,3 +1,8 @@
+---
+title: MCP 2025/2026 Protocol-Era Parity
+description: Reproduce Assay's pinned MCP 2025-06-18 and 2026-07-28 resultType parity corpus for complete, input_required, and interim tool results.
+---
+
 # MCP Protocol-Era Parity
 
 Assay carries an executable, exploratory corpus for one narrow compatibility question across MCP

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {% if page and page.meta and page.meta.description %}
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="{{ page.meta.title or page.title }} - {{ config.site_name }}">
+    <meta property="og:description" content="{{ page.meta.description }}">
+    <meta property="og:url" content="{{ page.canonical_url }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ page.meta.title or page.title }} - {{ config.site_name }}">
+    <meta name="twitter:description" content="{{ page.meta.description }}">
+  {% endif %}
+{% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -4,11 +4,11 @@
   {{ super() }}
   {% if page and page.meta and page.meta.description %}
     <meta property="og:type" content="article">
-    <meta property="og:title" content="{{ page.meta.title or page.title }} - {{ config.site_name }}">
-    <meta property="og:description" content="{{ page.meta.description }}">
-    <meta property="og:url" content="{{ page.canonical_url }}">
+    <meta property="og:title" content="{{ (page.meta.title or page.title) | e }} - {{ config.site_name | e }}">
+    <meta property="og:description" content="{{ page.meta.description | e }}">
+    <meta property="og:url" content="{{ page.canonical_url | e }}">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ page.meta.title or page.title }} - {{ config.site_name }}">
-    <meta name="twitter:description" content="{{ page.meta.description }}">
+    <meta name="twitter:title" content="{{ (page.meta.title or page.title) | e }} - {{ config.site_name | e }}">
+    <meta name="twitter:description" content="{{ page.meta.description | e }}">
   {% endif %}
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+  {{ super() }}
   {% if page and page.meta and page.meta.description %}
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{ page.meta.title or page.title }} - {{ config.site_name }}">

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://docs.getassay.dev/sitemap.xml

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://docs.getassay.dev/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ markdown_extensions:
   - def_list
   - footnotes
   - md_in_html
+  - meta
   - toc:
       permalink: true
   - pymdownx.arithmatex:


### PR DESCRIPTION
## Summary

- add page-specific search and social metadata for the pinned MCP 2025/2026 parity run
- add body-level entry points from the MCP landing page and README
- preserve inherited MkDocs head content while adding bounded social metadata

## Evidence

- `mkdocs build --strict`
- rendered canonical, description, Open Graph, and Twitter metadata inspected
- sitemap contains the canonical parity URL
- built-in search index contains five parity-page entries
- `python3 scripts/ci/check-public-artifact-sanitization.py`
- `python3 scripts/ci/check-claims-boundary.py`
- `git diff --check`

## Review dispositions

- the override calls `super()` so future theme/plugin head content is preserved and explicitly escapes dynamic social metadata attributes
- an explicit `robots.txt` sitemap hint was removed after review showed that MkDocs also lists non-navigation internal pages; this PR does not newly advertise that unfiltered inventory

## Claim ceiling

This improves discovery of the existing exploratory corpus. It does not claim general MCP conformance, certification, SDK interoperability, external effects, or independent reproduction.