### PR TITLE
test(otel): Slice A post-merge hardening — hash-before-parse pins, bounded no-decoder claim

### DIFF
--- a/crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/README.md
+++ b/crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/README.md
@@ -7,7 +7,7 @@ convention testing in Assay.
 ## Purpose
 
 - **Test-only input corpus**: Locked reference fixtures for future OTLP/JSON MCP ingest work
-- **No production decoder**: `assay-core` contains no serde models or parsers for OTLP (Slice A scope)
+- **No production decoder for this corpus**: Slice A adds no production decoder for this MCP-shaped OTLP/JSON corpus (pre-existing `trace::otel_ingest` models are out of this corpus's scope and unchanged)
 - **Hermetic validator**: Integration tests use a typed, test-only validator with strict lock checking
 - **Future work**: Slice B+ will add `assay evidence inspect-otel-mcp` for semantic validation
 
@@ -38,7 +38,7 @@ Hostile fixtures are **locked inputs only** -- Slice B will define rejection sem
 - Exporter: `@opentelemetry/exporter-trace-otlp-http@0.221.0`
 - Proto files: 4 vendored `.proto` files from `opentelemetry-proto v1.11.0` with SHA-256
 - MCP semconv: `semantic-conventions-genai` commit 434c91dc, `docs/gen-ai/mcp.md` with SHA-256
-- Generator: `package.json`, `package-lock.json`, `generate.js`, `check-runtime.cjs` with SHA-256
+- Generator: `package.json`, `package-lock.json`, `generate.js`, `check-runtime.cjs`, `.node-version` with SHA-256
 - Runtime pair: `node_version` (22.16.0) and `npm_version` (10.9.2) in lock
 - Corpus: Every fixture with sidecar, hash, byte count, span kind, MCP method
 

--- a/crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/upstream.lock.json
+++ b/crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/upstream.lock.json
@@ -106,6 +106,6 @@
     }
   ],
   "provenance": {
-    "note": "Locally generated test fixtures using official OpenTelemetry SDK and OTLP HTTP exporter. Not external deployment evidence. No production decoder in assay-core."
+    "note": "Locally generated test fixtures using official OpenTelemetry SDK and OTLP HTTP exporter. Not external deployment evidence. Slice A adds no production decoder for this MCP-shaped OTLP/JSON corpus."
   }
 }

--- a/crates/assay-core/tests/otel_corpus_mutation.rs
+++ b/crates/assay-core/tests/otel_corpus_mutation.rs
@@ -1121,7 +1121,7 @@ fn test_provenance_note_with_contradictory_suffix() {
         serde_json::from_str(&fs::read_to_string(&lock_path).unwrap()).unwrap();
     // Append a contradictory suffix -- old substring check would pass this
     lock["provenance"]["note"] = serde_json::json!(
-        "Locally generated test fixtures using official OpenTelemetry SDK and OTLP HTTP exporter. Not external deployment evidence. No production decoder in assay-core. HOWEVER this is actually production data."
+        "Locally generated test fixtures using official OpenTelemetry SDK and OTLP HTTP exporter. Not external deployment evidence. Slice A adds no production decoder for this MCP-shaped OTLP/JSON corpus. HOWEVER this is actually production data."
     );
     fs::write(&lock_path, serde_json::to_vec_pretty(&lock).unwrap()).unwrap();
 
@@ -1829,6 +1829,34 @@ fn test_package_lock_malformed_is_parse_error() {
 
     let result = validate_corpus_at_path(&corpus);
     assert_eq!(result, Err(ValidationError::GeneratorParseError));
+}
+
+/// Regression pin: hash-before-parse classification for generator/package.json.
+/// Malformed bytes WITHOUT a matching governed digest must be typed as the
+/// hash claim (GeneratorHashMismatch), not the parse claim: the byte-integrity
+/// decision precedes parsing, so an untrusted edit is reported as tamper first.
+#[test]
+fn test_package_json_malformed_without_hash_update_is_hash_mismatch() {
+    let (_tmp, corpus) = copy_corpus_to_temp();
+    let pkg_path = corpus.join("generator/package.json");
+
+    fs::write(&pkg_path, b"{ \"packageManager\": ").unwrap();
+
+    let result = validate_corpus_at_path(&corpus);
+    assert_eq!(result, Err(ValidationError::GeneratorHashMismatch));
+}
+
+/// Regression pin: hash-before-parse classification for
+/// generator/package-lock.json, same construction as above.
+#[test]
+fn test_package_lock_malformed_without_hash_update_is_hash_mismatch() {
+    let (_tmp, corpus) = copy_corpus_to_temp();
+    let pkg_lock_path = corpus.join("generator/package-lock.json");
+
+    fs::write(&pkg_lock_path, b"{ \"packages\": [ oops").unwrap();
+
+    let result = validate_corpus_at_path(&corpus);
+    assert_eq!(result, Err(ValidationError::GeneratorHashMismatch));
 }
 
 /// Proves duplicate object keys in generator/package.json are structurally

--- a/crates/assay-core/tests/support/otel_validator.rs
+++ b/crates/assay-core/tests/support/otel_validator.rs
@@ -95,7 +95,7 @@ const EXPECTED_HOSTILE: &[(&str, &str)] = &[
 ];
 
 /// Exact provenance note (no substring acceptance).
-const EXPECTED_PROVENANCE_NOTE: &str = "Locally generated test fixtures using official OpenTelemetry SDK and OTLP HTTP exporter. Not external deployment evidence. No production decoder in assay-core.";
+const EXPECTED_PROVENANCE_NOTE: &str = "Locally generated test fixtures using official OpenTelemetry SDK and OTLP HTTP exporter. Not external deployment evidence. Slice A adds no production decoder for this MCP-shaped OTLP/JSON corpus.";
 
 /// Exact span name for all benign fixtures.
 const EXPECTED_SPAN_NAME: &str = "tools/call read_file";


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: #1931 (kept open; this PR does not close it)
- Slice: A, post-merge audit hardening (no Slice B work)
- Builder: Claude Code
- Base: `main` at `4bdb94452cc466921b047bcb2a8163f836b89414` (the #1940 squash merge)
- Final head SHA: `1d70b8568a41c10dc37bc1de01a222463276492e`
- ADR invariants affected: none; regression pins and claim narrowing only

## Behavior

No validator behavior change. Three post-merge audit findings from #1931:

1. **Hash-before-parse regression pins.** Two new mutations write malformed `generator/package.json` / `generator/package-lock.json` WITHOUT updating the governed digests and assert exact `GeneratorHashMismatch`: byte-integrity classification precedes parsing, so an untrusted edit is reported as tamper first. Bite proven by a trap-guaranteed temporary mutation moving strict parsing before both hash decisions: both pins turned red with `Err(GeneratorParseError)`, then passed on the restored code (restoration and index cleanliness verified).
2. **Bounded no-decoder claim.** The repository-wide "No production decoder in assay-core" sentence was false (`trace::otel_ingest::OtelSpan` exists). It is replaced with the exact bounded statement "Slice A adds no production decoder for this MCP-shaped OTLP/JSON corpus" in the fixture README, the `upstream.lock.json` provenance note, and `EXPECTED_PROVENANCE_NOTE` (kept byte-equal, verified). The superset-note mutation test payload follows the new sentence so it remains a true prefix superset. The external-deployment non-claim is unchanged.
3. **README inventory completeness.** `.node-version` added to the README's generator SHA-256 inventory, matching the validator's `node_version_sha256` binding.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No new decoder, receiver, reducer, CLI, or public API (Slice B untouched)
- [x] No claim that assay-core has no OTLP model or parser; only the corpus-bounded Slice A statement
- [x] No external deployment evidence; provenance non-claim unchanged
- [x] No fixture payload byte changes (verified: only README and the lock's note line changed under the fixture tree)

## Test Evidence

Exact head `1d70b8568a41c10dc37bc1de01a222463276492e`, all with unpiped exact exit statuses:

- 138 targeted Rust tests: 107 mutation, 15 hermetic, 4 contract, 1 ingest, 10 projection, 1 TDT projection
- Bite proof: pins red (cargo exit 101, `Err(GeneratorParseError)`) under the temporary parse-before-hash mutation, green (exit 0) on restored code; validator file restored byte-identical, index clean
- `cargo fmt --all -- --check` = 0; `cargo clippy -p assay-core --all-targets -- -D warnings` = 0; `git diff --check` = 0
- Public-string grep: zero occurrences of "No production decoder in assay-core" remain in `crates/`
- Provenance note byte-equality between `EXPECTED_PROVENANCE_NOTE` and the lock verified
- GitHub CI and exact-head review state remain the final merge proof

Part of #1931; later bounded-reader, reducer, and CLI slices remain separate.
