### PR TITLE
fix(otel): harden bounded MCP span decoding

### DIFF
--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -874,10 +874,10 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
 fn valid_base64(value: &str) -> bool {
     use base64::engine::general_purpose::{STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD};
 
-    STANDARD.decode(value).is_ok()
-        || STANDARD_NO_PAD.decode(value).is_ok()
-        || URL_SAFE.decode(value).is_ok()
-        || URL_SAFE_NO_PAD.decode(value).is_ok()
+    let mut scratch = vec![0; base64::decoded_len_estimate(value.len())];
+    [&STANDARD, &STANDARD_NO_PAD, &URL_SAFE, &URL_SAFE_NO_PAD]
+        .into_iter()
+        .any(|engine| engine.decode_slice(value, &mut scratch).is_ok())
 }
 
 enum ListKind {

--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -636,13 +636,17 @@ impl<'de> Visitor<'de> for ValueIntSeed<'_, '_> {
     fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(8)?;
         charge_value(self.st, self.budget, 8)?;
-        Ok(Some(v))
+        integral_i64(v as f64).map(Some).ok_or_else(|| {
+            self.st
+                .borrow_mut()
+                .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue))
+        })
     }
 
     fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(8)?;
         charge_value(self.st, self.budget, 8)?;
-        i64::try_from(v).map(Some).map_err(|_| {
+        integral_i64(v as f64).map(Some).ok_or_else(|| {
             self.st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue))
@@ -694,6 +698,9 @@ fn integral_i64(value: f64) -> Option<i64> {
 /// Parse ProtoJSON's quoted decimal/exponent form without routing through binary64. Floating-point
 /// conversion can round a fractional or out-of-range decimal onto an integral boundary.
 fn parse_decimal_i64(value: &str) -> Option<i64> {
+    if !is_json_number(value) {
+        return None;
+    }
     let (negative, unsigned) = match value.as_bytes().first() {
         Some(b'-') => (true, &value[1..]),
         Some(b'+') | None => return None,

--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -1130,7 +1130,9 @@ impl<'de> Visitor<'de> for KvEntryValueKeySeed<'_, '_> {
         reject_value_scalar(self.st, self.budget, 8)
     }
     fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
-        reject_value_scalar(self.st, self.budget, 1)
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
+        Ok(String::new())
     }
     reject_container_at!(seq, ShapeSite::AttributeValue);
     reject_container_at!(map, ShapeSite::AttributeValue);

--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -9,6 +9,8 @@
 
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 
+use base64::Engine as _;
+
 use super::decode::{
     reject_container_at, reject_scalars_at, DecodedValue, KeySeed, Members, SkipSeed, SpanAttrs, St,
 };
@@ -90,6 +92,13 @@ struct AttributeEntrySeed<'a, 'c> {
 impl<'de> DeserializeSeed<'de> for AttributeEntrySeed<'_, '_> {
     type Value = (String, DecodedValue);
     fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
+        let mut state = self.st.borrow_mut();
+        *self.count += 1;
+        if *self.count > state.limits.max_attribute_count {
+            let max = state.limits.max_attribute_count;
+            return Err(state.limit(OtlpLimitDimension::AttributeCount, max));
+        }
+        drop(state);
         de.deserialize_any(self)
     }
 }
@@ -105,15 +114,7 @@ impl<'de> Visitor<'de> for AttributeEntrySeed<'_, '_> {
     reject_container_at!(seq, ShapeSite::AttributeEntry);
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        {
-            let mut state = self.st.borrow_mut();
-            *self.count += 1;
-            if *self.count > state.limits.max_attribute_count {
-                let max = state.limits.max_attribute_count;
-                return Err(state.limit(OtlpLimitDimension::AttributeCount, max));
-            }
-            state.enter(self.depth)?;
-        }
+        self.st.borrow_mut().enter(self.depth)?;
         let mut members = Members::new(ShapeSite::AttributeEntry);
         let mut key: Option<String> = None;
         let mut value: Option<DecodedValue> = None;
@@ -146,8 +147,9 @@ impl<'de> Visitor<'de> for AttributeEntrySeed<'_, '_> {
 }
 
 /// The `key` member of an attribute entry: the one string with its own dedicated byte ceiling,
-/// checked against the borrowed slice **before** the key is allocated, so an oversized key is
-/// never retained even transiently. Any non-string shape is a typed entry fault.
+/// checked before copying it into the domain observation. Serde may hold parser scratch for the
+/// token first; that allocation is bounded by the source ceiling. Any non-string shape is a typed
+/// entry fault.
 struct AttrKeySeed<'a> {
     st: St<'a>,
 }
@@ -221,8 +223,9 @@ impl<'de> Visitor<'de> for AttrKeySeed<'_> {
     }
 }
 
-/// A proto `AnyValue` object: exactly one recognized value member. A second member — duplicate
-/// or different — is a conflict; an unrecognized member is a shape fault.
+/// A proto `AnyValue` object. Exactly one recognized oneof member may be present. Empty values and
+/// unknown protobuf JSON fields are forward-compatible and decode as `Other`; a second recognized
+/// member is a conflict, while duplicate unknown fields still fail closed.
 struct AnyValueSeed<'a, 'b> {
     st: St<'a>,
     depth: u64,
@@ -243,90 +246,251 @@ impl<'de> Visitor<'de> for AnyValueSeed<'_, '_> {
         f.write_str("an AnyValue object")
     }
 
-    reject_scalars_at!(ShapeSite::AttributeValue);
     reject_container_at!(seq, ShapeSite::AttributeValue);
+
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_str<E: de::Error>(self, _: &str) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
+        Ok(DecodedValue::Other)
+    }
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
         let mut decoded: Option<DecodedValue> = None;
+        let mut members = Members::new(ShapeSite::AttributeValue);
         while let Some(member) = map.next_key_seed(KeySeed { st: self.st })? {
-            if decoded.is_some() {
+            let recognized = matches!(
+                member.as_str(),
+                "stringValue"
+                    | "intValue"
+                    | "doubleValue"
+                    | "boolValue"
+                    | "bytesValue"
+                    | "arrayValue"
+                    | "kvlistValue"
+            );
+            if !recognized {
+                // Unknown names are attacker content. Charge before duplicate detection so the
+                // value ceiling remains the first boundary crossed by the next list member.
+                charge_value(self.st, self.budget, member.len() as u64)?;
+            }
+            if recognized && decoded.is_some() {
                 return Err(self
                     .st
                     .borrow_mut()
                     .fail(OtlpIngestError::ConflictingAttributeValue));
             }
-            decoded = Some(match member.as_str() {
+            members.admit(self.st, &member)?;
+            let value = match member.as_str() {
                 "stringValue" => {
-                    let s = map.next_value_seed(ValueStrSeed {
+                    let Some(s) = map.next_value_seed(ValueStrSeed {
                         st: self.st,
                         budget: self.budget,
-                    })?;
+                    })?
+                    else {
+                        continue;
+                    };
                     DecodedValue::Str(s)
                 }
                 "intValue" => {
-                    let i = map.next_value_seed(ValueIntSeed {
-                        st: self.st,
-                        budget: self.budget,
-                    })?;
-                    DecodedValue::Int(i)
+                    if map
+                        .next_value_seed(ValueIntSeed {
+                            st: self.st,
+                            budget: self.budget,
+                        })?
+                        .is_none()
+                    {
+                        continue;
+                    }
+                    DecodedValue::Other
                 }
                 "doubleValue" => {
-                    map.next_value_seed(ValueScalarSeed {
-                        st: self.st,
-                        budget: self.budget,
-                        kind: ScalarKind::Number,
-                    })?;
+                    if map
+                        .next_value_seed(ValueScalarSeed {
+                            st: self.st,
+                            budget: self.budget,
+                            kind: ScalarKind::Number,
+                        })?
+                        .is_none()
+                    {
+                        continue;
+                    }
                     DecodedValue::Other
                 }
                 "boolValue" => {
-                    map.next_value_seed(ValueScalarSeed {
-                        st: self.st,
-                        budget: self.budget,
-                        kind: ScalarKind::Bool,
-                    })?;
+                    if map
+                        .next_value_seed(ValueScalarSeed {
+                            st: self.st,
+                            budget: self.budget,
+                            kind: ScalarKind::Bool,
+                        })?
+                        .is_none()
+                    {
+                        continue;
+                    }
                     DecodedValue::Other
                 }
                 "bytesValue" => {
-                    map.next_value_seed(ValueScalarSeed {
-                        st: self.st,
-                        budget: self.budget,
-                        kind: ScalarKind::Base64,
-                    })?;
+                    if map
+                        .next_value_seed(ValueScalarSeed {
+                            st: self.st,
+                            budget: self.budget,
+                            kind: ScalarKind::Base64,
+                        })?
+                        .is_none()
+                    {
+                        continue;
+                    }
                     DecodedValue::Other
                 }
                 "arrayValue" => {
-                    map.next_value_seed(ValueListSeed {
-                        st: self.st,
-                        depth: self.depth + 1,
-                        budget: self.budget,
-                        kind: ListKind::Array,
-                    })?;
+                    if map
+                        .next_value_seed(ValueListSeed {
+                            st: self.st,
+                            depth: self.depth + 1,
+                            budget: self.budget,
+                            kind: ListKind::Array,
+                        })?
+                        .is_none()
+                    {
+                        continue;
+                    }
                     DecodedValue::Other
                 }
                 "kvlistValue" => {
-                    map.next_value_seed(ValueListSeed {
-                        st: self.st,
-                        depth: self.depth + 1,
-                        budget: self.budget,
-                        kind: ListKind::Kv,
-                    })?;
+                    if map
+                        .next_value_seed(ValueListSeed {
+                            st: self.st,
+                            depth: self.depth + 1,
+                            budget: self.budget,
+                            kind: ListKind::Kv,
+                        })?
+                        .is_none()
+                    {
+                        continue;
+                    }
                     DecodedValue::Other
                 }
                 _ => {
-                    return Err(self
-                        .st
-                        .borrow_mut()
-                        .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+                    // OTLP protobuf JSON receivers ignore unknown fields. They still consume the
+                    // same depth/global/value budgets and reject duplicate members.
+                    map.next_value_seed(ValueSkipSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                    })?;
+                    continue;
                 }
-            });
+            };
+            decoded = Some(value);
         }
-        // An empty AnyValue object carries no value at all; failing closed beats inventing one.
-        decoded.ok_or_else(|| {
-            self.st
-                .borrow_mut()
-                .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue))
-        })
+        Ok(decoded.unwrap_or(DecodedValue::Other))
+    }
+}
+
+/// Skip a forward-compatible value subtree without retention while charging both the document
+/// and per-attribute budgets. Object member names are attacker-controlled here, so they count
+/// toward the value budget as well as the document-global decoded budget.
+struct ValueSkipSeed<'a, 'b> {
+    st: St<'a>,
+    depth: u64,
+    budget: &'b mut u64,
+}
+
+impl<'de> DeserializeSeed<'de> for ValueSkipSeed<'_, '_> {
+    type Value = ();
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<(), D::Error> {
+        de.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for ValueSkipSeed<'_, '_> {
+    type Value = ();
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a forward-compatible attribute value")
+    }
+
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)
+    }
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<(), E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)
+    }
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<(), E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)
+    }
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<(), E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)
+    }
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<(), E> {
+        let bytes = value.len() as u64;
+        self.st.borrow_mut().charge(bytes)?;
+        charge_value(self.st, self.budget, bytes)
+    }
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
+        while seq
+            .next_element_seed(ValueSkipSeed {
+                st: self.st,
+                depth: self.depth + 1,
+                budget: self.budget,
+            })?
+            .is_some()
+        {}
+        Ok(())
+    }
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
+        let mut members = Members::new(ShapeSite::AttributeValue);
+        while let Some(key) = map.next_key_seed(KeySeed { st: self.st })? {
+            charge_value(self.st, self.budget, key.len() as u64)?;
+            members.admit(self.st, &key)?;
+            map.next_value_seed(ValueSkipSeed {
+                st: self.st,
+                depth: self.depth + 1,
+                budget: self.budget,
+            })?;
+        }
+        Ok(())
     }
 }
 
@@ -337,62 +501,61 @@ struct ValueStrSeed<'a, 'b> {
 }
 
 impl<'de> DeserializeSeed<'de> for ValueStrSeed<'_, '_> {
-    type Value = String;
-    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<String, D::Error> {
+    type Value = Option<String>;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
         de.deserialize_any(self)
     }
 }
 
 impl<'de> Visitor<'de> for ValueStrSeed<'_, '_> {
-    type Value = String;
+    type Value = Option<String>;
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("a string value")
     }
 
-    fn visit_str<E: de::Error>(self, s: &str) -> Result<String, E> {
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(s.len() as u64)?;
         charge_value(self.st, self.budget, s.len() as u64)?;
-        Ok(s.to_owned())
+        Ok(Some(s.to_owned()))
     }
 
-    fn visit_bool<E: de::Error>(self, _: bool) -> Result<String, E> {
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_i64<E: de::Error>(self, _: i64) -> Result<String, E> {
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_u64<E: de::Error>(self, _: u64) -> Result<String, E> {
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_f64<E: de::Error>(self, _: f64) -> Result<String, E> {
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_unit<E: de::Error>(self) -> Result<String, E> {
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
+        Ok(None)
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<String, A::Error> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
-    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<String, A::Error> {
+    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
         Err(self
             .st
             .borrow_mut()
@@ -408,77 +571,92 @@ struct ValueIntSeed<'a, 'b> {
 }
 
 impl<'de> DeserializeSeed<'de> for ValueIntSeed<'_, '_> {
-    type Value = i64;
-    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<i64, D::Error> {
+    type Value = Option<i64>;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
         de.deserialize_any(self)
     }
 }
 
 impl<'de> Visitor<'de> for ValueIntSeed<'_, '_> {
-    type Value = i64;
+    type Value = Option<i64>;
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("an int64 value")
     }
 
-    fn visit_str<E: de::Error>(self, s: &str) -> Result<i64, E> {
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
         // A string-encoded int64 is a JSON string: it charges its observed UTF-8 length under
         // the shared charge model, never a fixed numeric width, and is charged before parsing.
         self.st.borrow_mut().charge(s.len() as u64)?;
         charge_value(self.st, self.budget, s.len() as u64)?;
-        s.parse::<i64>().map_err(|_| {
+        let parsed = s
+            .parse::<i64>()
+            .ok()
+            .or_else(|| s.parse::<f64>().ok().and_then(integral_i64));
+        parsed.map(Some).ok_or_else(|| {
             self.st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue))
         })
     }
 
-    fn visit_i64<E: de::Error>(self, v: i64) -> Result<i64, E> {
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(8)?;
         charge_value(self.st, self.budget, 8)?;
-        Ok(v)
+        Ok(Some(v))
     }
 
-    fn visit_u64<E: de::Error>(self, v: u64) -> Result<i64, E> {
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(8)?;
         charge_value(self.st, self.budget, 8)?;
-        i64::try_from(v).map_err(|_| {
+        i64::try_from(v).map(Some).map_err(|_| {
             self.st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue))
         })
     }
 
-    fn visit_bool<E: de::Error>(self, _: bool) -> Result<i64, E> {
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_f64<E: de::Error>(self, _: f64) -> Result<i64, E> {
+    fn visit_f64<E: de::Error>(self, value: f64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)?;
+        integral_i64(value).map(Some).ok_or_else(|| {
+            self.st
+                .borrow_mut()
+                .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue))
+        })
+    }
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
+        Ok(None)
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_unit<E: de::Error>(self) -> Result<i64, E> {
+    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<i64, A::Error> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
-    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<i64, A::Error> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
+}
+
+fn integral_i64(value: f64) -> Option<i64> {
+    const I64_UPPER_EXCLUSIVE: f64 = 9_223_372_036_854_775_808.0;
+    const I64_LOWER_INCLUSIVE: f64 = -9_223_372_036_854_775_808.0;
+    (value.is_finite()
+        && value.fract() == 0.0
+        && (I64_LOWER_INCLUSIVE..I64_UPPER_EXCLUSIVE).contains(&value))
+    .then_some(value as i64)
 }
 
 enum ScalarKind {
@@ -498,23 +676,24 @@ struct ValueScalarSeed<'a, 'b> {
 }
 
 impl<'de> DeserializeSeed<'de> for ValueScalarSeed<'_, '_> {
-    type Value = ();
-    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<(), D::Error> {
+    type Value = Option<()>;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
         de.deserialize_any(self)
     }
 }
 
 impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
-    type Value = ();
+    type Value = Option<()>;
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("a scalar AnyValue member")
     }
 
-    fn visit_bool<E: de::Error>(self, _: bool) -> Result<(), E> {
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
         if matches!(self.kind, ScalarKind::Bool) {
             self.st.borrow_mut().charge(1)?;
-            charge_value(self.st, self.budget, 1)
+            charge_value(self.st, self.budget, 1)?;
+            Ok(Some(()))
         } else {
             Err(self
                 .st
@@ -523,10 +702,11 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
         }
     }
 
-    fn visit_f64<E: de::Error>(self, _: f64) -> Result<(), E> {
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
         if matches!(self.kind, ScalarKind::Number) {
             self.st.borrow_mut().charge(8)?;
-            charge_value(self.st, self.budget, 8)
+            charge_value(self.st, self.budget, 8)?;
+            Ok(Some(()))
         } else {
             Err(self
                 .st
@@ -535,18 +715,26 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
         }
     }
 
-    fn visit_i64<E: de::Error>(self, v: i64) -> Result<(), E> {
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
         self.visit_f64(v as f64)
     }
 
-    fn visit_u64<E: de::Error>(self, v: u64) -> Result<(), E> {
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
         self.visit_f64(v as f64)
     }
 
-    fn visit_str<E: de::Error>(self, s: &str) -> Result<(), E> {
-        if matches!(self.kind, ScalarKind::Base64) {
-            self.st.borrow_mut().charge(s.len() as u64)?;
-            charge_value(self.st, self.budget, s.len() as u64)
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(s.len() as u64)?;
+        charge_value(self.st, self.budget, s.len() as u64)?;
+        let valid = match self.kind {
+            ScalarKind::Number => {
+                matches!(s, "NaN" | "Infinity" | "-Infinity") || s.parse::<f64>().is_ok()
+            }
+            ScalarKind::Base64 => valid_base64(s),
+            ScalarKind::Bool => false,
+        };
+        if valid {
+            Ok(Some(()))
         } else {
             Err(self
                 .st
@@ -555,24 +743,32 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
         }
     }
 
-    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
+        Ok(None)
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<(), A::Error> {
+    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<(), A::Error> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
+}
+
+fn valid_base64(value: &str) -> bool {
+    use base64::engine::general_purpose::{STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD};
+
+    STANDARD.decode(value).is_ok()
+        || STANDARD_NO_PAD.decode(value).is_ok()
+        || URL_SAFE.decode(value).is_ok()
+        || URL_SAFE_NO_PAD.decode(value).is_ok()
 }
 
 enum ListKind {
@@ -592,43 +788,84 @@ struct ValueListSeed<'a, 'b> {
 }
 
 impl<'de> DeserializeSeed<'de> for ValueListSeed<'_, '_> {
-    type Value = ();
-    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<(), D::Error> {
+    type Value = Option<()>;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
         de.deserialize_any(self)
     }
 }
 
 impl<'de> Visitor<'de> for ValueListSeed<'_, '_> {
-    type Value = ();
+    type Value = Option<()>;
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("an AnyValue list wrapper")
     }
 
-    reject_scalars_at!(ShapeSite::AttributeValue);
     reject_container_at!(seq, ShapeSite::AttributeValue);
 
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+    fn visit_str<E: de::Error>(self, _: &str) -> Result<Self::Value, E> {
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
         let mut members = Members::new(ShapeSite::AttributeValue);
         while let Some(member) = map.next_key_seed(KeySeed { st: self.st })? {
-            members.admit(self.st, &member)?;
             match member.as_str() {
-                "values" => map.next_value_seed(ValueElementsSeed {
-                    st: self.st,
-                    depth: self.depth + 1,
-                    budget: self.budget,
-                    kind: &self.kind,
-                })?,
+                "values" => {
+                    members.admit(self.st, &member)?;
+                    map.next_value_seed(ValueElementsSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                        kind: &self.kind,
+                    })?;
+                }
                 _ => {
-                    return Err(self
-                        .st
-                        .borrow_mut()
-                        .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+                    charge_value(self.st, self.budget, member.len() as u64)?;
+                    members.admit(self.st, &member)?;
+                    map.next_value_seed(ValueSkipSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                    })?;
                 }
             }
         }
-        Ok(())
+        Ok(Some(()))
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
+        Ok(None)
     }
 }
 
@@ -714,13 +951,14 @@ impl<'de> Visitor<'de> for KvEntrySeed<'_, '_> {
         self.st.borrow_mut().enter(self.depth)?;
         let mut members = Members::new(ShapeSite::AttributeValue);
         while let Some(member) = map.next_key_seed(KeySeed { st: self.st })? {
-            members.admit(self.st, &member)?;
             match member.as_str() {
                 "key" => {
+                    members.admit(self.st, &member)?;
                     let k = map.next_value_seed(KeySeed { st: self.st })?;
                     charge_value(self.st, self.budget, k.len() as u64)?;
                 }
                 "value" => {
+                    members.admit(self.st, &member)?;
                     map.next_value_seed(AnyValueSeed {
                         st: self.st,
                         depth: self.depth + 1,
@@ -728,10 +966,13 @@ impl<'de> Visitor<'de> for KvEntrySeed<'_, '_> {
                     })?;
                 }
                 _ => {
-                    return Err(self
-                        .st
-                        .borrow_mut()
-                        .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+                    charge_value(self.st, self.budget, member.len() as u64)?;
+                    members.admit(self.st, &member)?;
+                    map.next_value_seed(ValueSkipSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                    })?;
                 }
             }
         }

--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -12,7 +12,8 @@ use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use base64::Engine as _;
 
 use super::decode::{
-    reject_container_at, reject_scalars_at, DecodedValue, KeySeed, Members, SkipSeed, SpanAttrs, St,
+    reject_container_at, reject_non_null_scalars_at, reject_scalars_at, DecodedValue, KeySeed,
+    Members, SkipSeed, SpanAttrs, St,
 };
 use super::limits::{OtlpIngestError, OtlpLimitDimension, ShapeSite};
 
@@ -28,6 +29,43 @@ fn charge_value<E: de::Error>(st: St<'_>, budget: &mut u64, bytes: u64) -> Resul
         return Err(state.limit(OtlpLimitDimension::AttributeValueBytes, max));
     }
     Ok(())
+}
+
+fn reject_value_scalar<E: de::Error, T>(st: St<'_>, budget: &mut u64, bytes: u64) -> Result<T, E> {
+    st.borrow_mut().charge(bytes)?;
+    charge_value(st, budget, bytes)?;
+    Err(st
+        .borrow_mut()
+        .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+}
+
+macro_rules! reject_value_non_null_scalars {
+    () => {
+        fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+            reject_value_scalar(self.st, self.budget, 1)
+        }
+        fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+            reject_value_scalar(self.st, self.budget, 8)
+        }
+        fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+            reject_value_scalar(self.st, self.budget, 8)
+        }
+        fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+            reject_value_scalar(self.st, self.budget, 8)
+        }
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            reject_value_scalar(self.st, self.budget, value.len() as u64)
+        }
+    };
+}
+
+macro_rules! reject_value_scalars {
+    () => {
+        reject_value_non_null_scalars!();
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            reject_value_scalar(self.st, self.budget, 1)
+        }
+    };
 }
 
 /// An `attributes` list. In extract mode (span attributes) recognized MCP values are applied to
@@ -52,8 +90,13 @@ impl<'de> Visitor<'de> for AttributeListSeed<'_, '_> {
         f.write_str("an attribute list")
     }
 
-    reject_scalars_at!(ShapeSite::AttributeList);
+    reject_non_null_scalars_at!(ShapeSite::AttributeList);
     reject_container_at!(map, ShapeSite::AttributeList);
+
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(())
+    }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -122,7 +165,12 @@ impl<'de> Visitor<'de> for AttributeEntrySeed<'_, '_> {
         while let Some(member) = map.next_key_seed(KeySeed { st: self.st })? {
             members.admit(self.st, &member)?;
             match member.as_str() {
-                "key" => key = Some(map.next_value_seed(AttrKeySeed { st: self.st })?),
+                "key" => {
+                    key = Some(map.next_value_seed(AttrKeySeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                    })?)
+                }
                 "value" => {
                     value = Some(map.next_value_seed(AnyValueSeed {
                         st: self.st,
@@ -152,6 +200,7 @@ impl<'de> Visitor<'de> for AttributeEntrySeed<'_, '_> {
 /// entry fault.
 struct AttrKeySeed<'a> {
     st: St<'a>,
+    depth: u64,
 }
 
 impl<'de> DeserializeSeed<'de> for AttrKeySeed<'_> {
@@ -180,42 +229,49 @@ impl<'de> Visitor<'de> for AttrKeySeed<'_> {
     }
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<String, E> {
+        self.st.borrow_mut().charge(1)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeEntry)))
     }
     fn visit_i64<E: de::Error>(self, _: i64) -> Result<String, E> {
+        self.st.borrow_mut().charge(8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeEntry)))
     }
     fn visit_u64<E: de::Error>(self, _: u64) -> Result<String, E> {
+        self.st.borrow_mut().charge(8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeEntry)))
     }
     fn visit_f64<E: de::Error>(self, _: f64) -> Result<String, E> {
+        self.st.borrow_mut().charge(8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeEntry)))
     }
     fn visit_unit<E: de::Error>(self) -> Result<String, E> {
+        self.st.borrow_mut().charge(1)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeEntry)))
     }
     fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<String, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeEntry)))
     }
     fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<String, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
@@ -249,30 +305,40 @@ impl<'de> Visitor<'de> for AnyValueSeed<'_, '_> {
     reject_container_at!(seq, ShapeSite::AttributeValue);
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
     fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
     fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
     fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
-    fn visit_str<E: de::Error>(self, _: &str) -> Result<Self::Value, E> {
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(value.len() as u64)?;
+        charge_value(self.st, self.budget, value.len() as u64)?;
         Err(self
             .st
             .borrow_mut()
@@ -304,103 +370,62 @@ impl<'de> Visitor<'de> for AnyValueSeed<'_, '_> {
                 // value ceiling remains the first boundary crossed by the next list member.
                 charge_value(self.st, self.budget, member.len() as u64)?;
             }
-            if recognized && decoded.is_some() {
-                return Err(self
-                    .st
-                    .borrow_mut()
-                    .fail(OtlpIngestError::ConflictingAttributeValue));
-            }
             members.admit(self.st, &member)?;
             let value = match member.as_str() {
-                "stringValue" => {
-                    let Some(s) = map.next_value_seed(ValueStrSeed {
+                "stringValue" => map
+                    .next_value_seed(ValueStrSeed {
                         st: self.st,
+                        depth: self.depth + 1,
                         budget: self.budget,
                     })?
-                    else {
-                        continue;
-                    };
-                    DecodedValue::Str(s)
-                }
-                "intValue" => {
-                    if map
-                        .next_value_seed(ValueIntSeed {
-                            st: self.st,
-                            budget: self.budget,
-                        })?
-                        .is_none()
-                    {
-                        continue;
-                    }
-                    DecodedValue::Other
-                }
-                "doubleValue" => {
-                    if map
-                        .next_value_seed(ValueScalarSeed {
-                            st: self.st,
-                            budget: self.budget,
-                            kind: ScalarKind::Number,
-                        })?
-                        .is_none()
-                    {
-                        continue;
-                    }
-                    DecodedValue::Other
-                }
-                "boolValue" => {
-                    if map
-                        .next_value_seed(ValueScalarSeed {
-                            st: self.st,
-                            budget: self.budget,
-                            kind: ScalarKind::Bool,
-                        })?
-                        .is_none()
-                    {
-                        continue;
-                    }
-                    DecodedValue::Other
-                }
-                "bytesValue" => {
-                    if map
-                        .next_value_seed(ValueScalarSeed {
-                            st: self.st,
-                            budget: self.budget,
-                            kind: ScalarKind::Base64,
-                        })?
-                        .is_none()
-                    {
-                        continue;
-                    }
-                    DecodedValue::Other
-                }
-                "arrayValue" => {
-                    if map
-                        .next_value_seed(ValueListSeed {
-                            st: self.st,
-                            depth: self.depth + 1,
-                            budget: self.budget,
-                            kind: ListKind::Array,
-                        })?
-                        .is_none()
-                    {
-                        continue;
-                    }
-                    DecodedValue::Other
-                }
-                "kvlistValue" => {
-                    if map
-                        .next_value_seed(ValueListSeed {
-                            st: self.st,
-                            depth: self.depth + 1,
-                            budget: self.budget,
-                            kind: ListKind::Kv,
-                        })?
-                        .is_none()
-                    {
-                        continue;
-                    }
-                    DecodedValue::Other
-                }
+                    .map(DecodedValue::Str),
+                "intValue" => map
+                    .next_value_seed(ValueIntSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                    })?
+                    .map(|_| DecodedValue::Other),
+                "doubleValue" => map
+                    .next_value_seed(ValueScalarSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                        kind: ScalarKind::Number,
+                    })?
+                    .map(|_| DecodedValue::Other),
+                "boolValue" => map
+                    .next_value_seed(ValueScalarSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                        kind: ScalarKind::Bool,
+                    })?
+                    .map(|_| DecodedValue::Other),
+                "bytesValue" => map
+                    .next_value_seed(ValueScalarSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                        kind: ScalarKind::Base64,
+                    })?
+                    .map(|_| DecodedValue::Other),
+                "arrayValue" => map
+                    .next_value_seed(ValueListSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                        kind: ListKind::Array,
+                    })?
+                    .map(|_| DecodedValue::Other),
+                "kvlistValue" => map
+                    .next_value_seed(ValueListSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                        kind: ListKind::Kv,
+                    })?
+                    .map(|_| DecodedValue::Other),
                 _ => {
                     // OTLP protobuf JSON receivers ignore unknown fields. They still consume the
                     // same depth/global/value budgets and reject duplicate members.
@@ -409,10 +434,20 @@ impl<'de> Visitor<'de> for AnyValueSeed<'_, '_> {
                         depth: self.depth + 1,
                         budget: self.budget,
                     })?;
-                    continue;
+                    None
                 }
             };
-            decoded = Some(value);
+            if recognized {
+                if let Some(value) = value {
+                    if decoded.is_some() {
+                        return Err(self
+                            .st
+                            .borrow_mut()
+                            .fail(OtlpIngestError::ConflictingAttributeValue));
+                    }
+                    decoded = Some(value);
+                }
+            }
         }
         Ok(decoded.unwrap_or(DecodedValue::Other))
     }
@@ -497,6 +532,7 @@ impl<'de> Visitor<'de> for ValueSkipSeed<'_, '_> {
 /// A `stringValue`: charged to both the global and the per-value ceilings before retention.
 struct ValueStrSeed<'a, 'b> {
     st: St<'a>,
+    depth: u64,
     budget: &'b mut u64,
 }
 
@@ -521,28 +557,16 @@ impl<'de> Visitor<'de> for ValueStrSeed<'_, '_> {
     }
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+        reject_value_scalar(self.st, self.budget, 1)
     }
     fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+        reject_value_scalar(self.st, self.budget, 8)
     }
     fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+        reject_value_scalar(self.st, self.budget, 8)
     }
     fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+        reject_value_scalar(self.st, self.budget, 8)
     }
     fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(1)?;
@@ -550,12 +574,14 @@ impl<'de> Visitor<'de> for ValueStrSeed<'_, '_> {
         Ok(None)
     }
     fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
     fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
@@ -567,6 +593,7 @@ impl<'de> Visitor<'de> for ValueStrSeed<'_, '_> {
 /// accepted, matching lenient upstream decoders. Anything else is a shape fault.
 struct ValueIntSeed<'a, 'b> {
     st: St<'a>,
+    depth: u64,
     budget: &'b mut u64,
 }
 
@@ -589,10 +616,7 @@ impl<'de> Visitor<'de> for ValueIntSeed<'_, '_> {
         // the shared charge model, never a fixed numeric width, and is charged before parsing.
         self.st.borrow_mut().charge(s.len() as u64)?;
         charge_value(self.st, self.budget, s.len() as u64)?;
-        let parsed = s
-            .parse::<i64>()
-            .ok()
-            .or_else(|| s.parse::<f64>().ok().and_then(integral_i64));
+        let parsed = parse_decimal_i64(s);
         parsed.map(Some).ok_or_else(|| {
             self.st
                 .borrow_mut()
@@ -617,10 +641,7 @@ impl<'de> Visitor<'de> for ValueIntSeed<'_, '_> {
     }
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+        reject_value_scalar(self.st, self.budget, 1)
     }
     fn visit_f64<E: de::Error>(self, value: f64) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(8)?;
@@ -637,12 +658,14 @@ impl<'de> Visitor<'de> for ValueIntSeed<'_, '_> {
         Ok(None)
     }
     fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
     fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
@@ -659,18 +682,102 @@ fn integral_i64(value: f64) -> Option<i64> {
     .then_some(value as i64)
 }
 
+/// Parse ProtoJSON's quoted decimal/exponent form without routing through binary64. Floating-point
+/// conversion can round a fractional or out-of-range decimal onto an integral boundary.
+fn parse_decimal_i64(value: &str) -> Option<i64> {
+    let (negative, unsigned) = match value.as_bytes().first() {
+        Some(b'-') => (true, &value[1..]),
+        Some(b'+') | None => return None,
+        _ => (false, value),
+    };
+    let (mantissa, exponent) = match unsigned.find(['e', 'E']) {
+        Some(index) => {
+            let exponent_text = &unsigned[index + 1..];
+            if exponent_text.is_empty() || unsigned[index + 1..].contains(['e', 'E']) {
+                return None;
+            }
+            let exponent = exponent_text.parse::<i64>().ok()?;
+            (&unsigned[..index], exponent)
+        }
+        None => (unsigned, 0),
+    };
+    let (integer, fraction) = match mantissa.split_once('.') {
+        Some((integer, fraction)) if !integer.is_empty() && !fraction.is_empty() => {
+            (integer, fraction)
+        }
+        Some(_) => return None,
+        None if !mantissa.is_empty() => (mantissa, ""),
+        None => return None,
+    };
+    if !integer.bytes().all(|b| b.is_ascii_digit()) || !fraction.bytes().all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let mut digits = Vec::with_capacity(integer.len().saturating_add(fraction.len()));
+    digits.extend(integer.bytes());
+    digits.extend(fraction.bytes());
+    let scale = exponent.checked_sub(i64::try_from(fraction.len()).ok()?)?;
+    if scale < 0 {
+        let remove = usize::try_from(scale.unsigned_abs()).ok()?;
+        if remove > digits.len() {
+            return digits.iter().all(|digit| *digit == b'0').then_some(0);
+        }
+        let split = digits.len() - remove;
+        if !digits[split..].iter().all(|digit| *digit == b'0') {
+            return None;
+        }
+        digits.truncate(split);
+    }
+
+    let first_nonzero = digits.iter().position(|digit| *digit != b'0');
+    let Some(first_nonzero) = first_nonzero else {
+        return Some(0);
+    };
+    let significant = &digits[first_nonzero..];
+    let appended_zeros = usize::try_from(scale.max(0)).ok()?;
+    let effective_len = significant.len().checked_add(appended_zeros)?;
+    if effective_len > 19 {
+        return None;
+    }
+
+    let mut magnitude = 0_u64;
+    for digit in significant
+        .iter()
+        .copied()
+        .chain(std::iter::repeat_n(b'0', appended_zeros))
+    {
+        magnitude = magnitude
+            .checked_mul(10)?
+            .checked_add(u64::from(digit - b'0'))?;
+    }
+    if negative {
+        const MIN_MAGNITUDE: u64 = i64::MAX as u64 + 1;
+        if magnitude == MIN_MAGNITUDE {
+            Some(i64::MIN)
+        } else if magnitude <= i64::MAX as u64 {
+            Some(-(magnitude as i64))
+        } else {
+            None
+        }
+    } else {
+        i64::try_from(magnitude).ok()
+    }
+}
+
 enum ScalarKind {
     /// `doubleValue`: a JSON number.
     Number,
     /// `boolValue`: a JSON boolean.
     Bool,
-    /// `bytesValue`: base64 text, charged by its encoded length and never decoded.
+    /// `bytesValue`: base64 text, charged by encoded length and decoded transiently for validation.
     Base64,
 }
 
 /// A non-extracted scalar `AnyValue` member: validated for shape and charged, never retained.
 struct ValueScalarSeed<'a, 'b> {
     st: St<'a>,
+    depth: u64,
     budget: &'b mut u64,
     kind: ScalarKind,
 }
@@ -690,9 +797,9 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
     }
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
         if matches!(self.kind, ScalarKind::Bool) {
-            self.st.borrow_mut().charge(1)?;
-            charge_value(self.st, self.budget, 1)?;
             Ok(Some(()))
         } else {
             Err(self
@@ -703,9 +810,9 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
     }
 
     fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        charge_value(self.st, self.budget, 8)?;
         if matches!(self.kind, ScalarKind::Number) {
-            self.st.borrow_mut().charge(8)?;
-            charge_value(self.st, self.budget, 8)?;
             Ok(Some(()))
         } else {
             Err(self
@@ -749,12 +856,14 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
         Ok(None)
     }
     fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
     }
     fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
@@ -803,36 +912,7 @@ impl<'de> Visitor<'de> for ValueListSeed<'_, '_> {
 
     reject_container_at!(seq, ShapeSite::AttributeValue);
 
-    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
-    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
-    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
-    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
-    fn visit_str<E: de::Error>(self, _: &str) -> Result<Self::Value, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
-    }
+    reject_value_non_null_scalars!();
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -891,8 +971,14 @@ impl<'de> Visitor<'de> for ValueElementsSeed<'_, '_> {
         f.write_str("an AnyValue values array")
     }
 
-    reject_scalars_at!(ShapeSite::AttributeValue);
+    reject_value_non_null_scalars!();
     reject_container_at!(map, ShapeSite::AttributeValue);
+
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        charge_value(self.st, self.budget, 1)?;
+        Ok(())
+    }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -944,7 +1030,7 @@ impl<'de> Visitor<'de> for KvEntrySeed<'_, '_> {
         f.write_str("a kvlist entry object")
     }
 
-    reject_scalars_at!(ShapeSite::AttributeValue);
+    reject_value_scalars!();
     reject_container_at!(seq, ShapeSite::AttributeValue);
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {

--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -176,6 +176,7 @@ impl<'de> Visitor<'de> for AttributeEntrySeed<'_, '_> {
                         st: self.st,
                         depth: self.depth + 1,
                         budget: &mut budget,
+                        allow_null: true,
                     })?);
                 }
                 _ => map.next_value_seed(SkipSeed {
@@ -286,6 +287,7 @@ struct AnyValueSeed<'a, 'b> {
     st: St<'a>,
     depth: u64,
     budget: &'b mut u64,
+    allow_null: bool,
 }
 
 impl<'de> DeserializeSeed<'de> for AnyValueSeed<'_, '_> {
@@ -347,7 +349,14 @@ impl<'de> Visitor<'de> for AnyValueSeed<'_, '_> {
     fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
         self.st.borrow_mut().charge(1)?;
         charge_value(self.st, self.budget, 1)?;
-        Ok(DecodedValue::Other)
+        if self.allow_null {
+            Ok(DecodedValue::Other)
+        } else {
+            Err(self
+                .st
+                .borrow_mut()
+                .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)))
+        }
     }
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
@@ -765,6 +774,51 @@ fn parse_decimal_i64(value: &str) -> Option<i64> {
     }
 }
 
+/// Return whether `value` follows JSON's decimal-number grammar. ProtoJSON permits quoted
+/// floating-point numbers, but it does not widen that grammar to Rust's additional spellings.
+fn is_json_number(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = usize::from(bytes.first() == Some(&b'-'));
+    if index == bytes.len() {
+        return false;
+    }
+
+    match bytes[index] {
+        b'0' => index += 1,
+        b'1'..=b'9' => {
+            index += 1;
+            while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+                index += 1;
+            }
+        }
+        _ => return false,
+    }
+    if bytes.get(index) == Some(&b'.') {
+        index += 1;
+        let fraction_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if index == fraction_start {
+            return false;
+        }
+    }
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+        let exponent_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if index == exponent_start {
+            return false;
+        }
+    }
+    index == bytes.len()
+}
+
 enum ScalarKind {
     /// `doubleValue`: a JSON number.
     Number,
@@ -835,7 +889,8 @@ impl<'de> Visitor<'de> for ValueScalarSeed<'_, '_> {
         charge_value(self.st, self.budget, s.len() as u64)?;
         let valid = match self.kind {
             ScalarKind::Number => {
-                matches!(s, "NaN" | "Infinity" | "-Infinity") || s.parse::<f64>().is_ok()
+                matches!(s, "NaN" | "Infinity" | "-Infinity")
+                    || (is_json_number(s) && s.parse::<f64>().is_ok_and(|value| value.is_finite()))
             }
             ScalarKind::Base64 => valid_base64(s),
             ScalarKind::Bool => false,
@@ -989,6 +1044,7 @@ impl<'de> Visitor<'de> for ValueElementsSeed<'_, '_> {
                         st: self.st,
                         depth: self.depth + 1,
                         budget: self.budget,
+                        allow_null: false,
                     })?
                     .is_some()
                 {}
@@ -1049,6 +1105,7 @@ impl<'de> Visitor<'de> for KvEntrySeed<'_, '_> {
                         st: self.st,
                         depth: self.depth + 1,
                         budget: self.budget,
+                        allow_null: true,
                     })?;
                 }
                 _ => {

--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -185,9 +185,9 @@ impl<'de> Visitor<'de> for AttributeEntrySeed<'_, '_> {
                 })?,
             }
         }
-        match (key, value) {
-            (Some(key), Some(value)) => Ok((key, value)),
-            _ => Err(self
+        match key {
+            Some(key) => Ok((key, value.unwrap_or(DecodedValue::Other))),
+            None => Err(self
                 .st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape(ShapeSite::AttributeEntry))),

--- a/crates/assay-core/src/otel/mcp_ingest/attr.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/attr.rs
@@ -706,16 +706,15 @@ fn parse_decimal_i64(value: &str) -> Option<i64> {
         Some(b'+') | None => return None,
         _ => (false, value),
     };
-    let (mantissa, exponent) = match unsigned.find(['e', 'E']) {
+    let (mantissa, exponent_text) = match unsigned.find(['e', 'E']) {
         Some(index) => {
             let exponent_text = &unsigned[index + 1..];
             if exponent_text.is_empty() || unsigned[index + 1..].contains(['e', 'E']) {
                 return None;
             }
-            let exponent = exponent_text.parse::<i64>().ok()?;
-            (&unsigned[..index], exponent)
+            (&unsigned[..index], Some(exponent_text))
         }
-        None => (unsigned, 0),
+        None => (unsigned, None),
     };
     let (integer, fraction) = match mantissa.split_once('.') {
         Some((integer, fraction)) if !integer.is_empty() && !fraction.is_empty() => {
@@ -733,6 +732,10 @@ fn parse_decimal_i64(value: &str) -> Option<i64> {
     let mut digits = Vec::with_capacity(integer.len().saturating_add(fraction.len()));
     digits.extend(integer.bytes());
     digits.extend(fraction.bytes());
+    if digits.iter().all(|digit| *digit == b'0') {
+        return Some(0);
+    }
+    let exponent = exponent_text.map_or(Some(0), |text| text.parse::<i64>().ok())?;
     let scale = exponent.checked_sub(i64::try_from(fraction.len()).ok()?)?;
     if scale < 0 {
         let remove = usize::try_from(scale.unsigned_abs()).ok()?;
@@ -1057,14 +1060,19 @@ impl<'de> Visitor<'de> for ValueElementsSeed<'_, '_> {
                 {}
             }
             ListKind::Kv => {
-                while seq
-                    .next_element_seed(KvEntrySeed {
-                        st: self.st,
-                        depth: self.depth + 1,
-                        budget: self.budget,
-                    })?
-                    .is_some()
-                {}
+                let mut keys = std::collections::HashSet::new();
+                while let Some(key) = seq.next_element_seed(KvEntrySeed {
+                    st: self.st,
+                    depth: self.depth + 1,
+                    budget: self.budget,
+                })? {
+                    if !keys.insert(key) {
+                        return Err(self
+                            .st
+                            .borrow_mut()
+                            .fail(OtlpIngestError::DuplicateField(ShapeSite::AttributeValue)));
+                    }
+                }
             }
         }
         Ok(())
@@ -1079,15 +1087,64 @@ struct KvEntrySeed<'a, 'b> {
     budget: &'b mut u64,
 }
 
+/// The nested `KeyValue.key` string. Unlike an object member name, this is attacker content in
+/// the enclosing AnyValue, so both byte ceilings are checked before the list-local uniqueness
+/// set retains a bounded copy.
+struct KvEntryValueKeySeed<'a, 'b> {
+    st: St<'a>,
+    depth: u64,
+    budget: &'b mut u64,
+}
+
+impl<'de> DeserializeSeed<'de> for KvEntryValueKeySeed<'_, '_> {
+    type Value = String;
+
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
+        de.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for KvEntryValueKeySeed<'_, '_> {
+    type Value = String;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a nested KeyValue key string")
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<String, E> {
+        self.st.borrow_mut().charge(value.len() as u64)?;
+        charge_value(self.st, self.budget, value.len() as u64)?;
+        Ok(value.to_owned())
+    }
+
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        reject_value_scalar(self.st, self.budget, 1)
+    }
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        reject_value_scalar(self.st, self.budget, 8)
+    }
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        reject_value_scalar(self.st, self.budget, 8)
+    }
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        reject_value_scalar(self.st, self.budget, 8)
+    }
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        reject_value_scalar(self.st, self.budget, 1)
+    }
+    reject_container_at!(seq, ShapeSite::AttributeValue);
+    reject_container_at!(map, ShapeSite::AttributeValue);
+}
+
 impl<'de> DeserializeSeed<'de> for KvEntrySeed<'_, '_> {
-    type Value = ();
-    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<(), D::Error> {
+    type Value = String;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<String, D::Error> {
         de.deserialize_any(self)
     }
 }
 
 impl<'de> Visitor<'de> for KvEntrySeed<'_, '_> {
-    type Value = ();
+    type Value = String;
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("a kvlist entry object")
@@ -1096,15 +1153,19 @@ impl<'de> Visitor<'de> for KvEntrySeed<'_, '_> {
     reject_value_scalars!();
     reject_container_at!(seq, ShapeSite::AttributeValue);
 
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<String, A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
         let mut members = Members::new(ShapeSite::AttributeValue);
+        let mut key = None;
         while let Some(member) = map.next_key_seed(KeySeed { st: self.st })? {
             match member.as_str() {
                 "key" => {
                     members.admit(self.st, &member)?;
-                    let k = map.next_value_seed(KeySeed { st: self.st })?;
-                    charge_value(self.st, self.budget, k.len() as u64)?;
+                    key = Some(map.next_value_seed(KvEntryValueKeySeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        budget: self.budget,
+                    })?);
                 }
                 "value" => {
                     members.admit(self.st, &member)?;
@@ -1126,6 +1187,6 @@ impl<'de> Visitor<'de> for KvEntrySeed<'_, '_> {
                 }
             }
         }
-        Ok(())
+        Ok(key.unwrap_or_default())
     }
 }

--- a/crates/assay-core/src/otel/mcp_ingest/decode.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/decode.rs
@@ -700,6 +700,12 @@ impl<'de> Visitor<'de> for InstrumentationScopeSeed<'_> {
             ShapeSite::InstrumentationScope,
         )))
     }
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(value.len() as u64)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
     reject_container_at!(seq, ShapeSite::InstrumentationScope);
 
     fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {

--- a/crates/assay-core/src/otel/mcp_ingest/decode.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/decode.rs
@@ -16,6 +16,7 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::io::{BufReader, Read};
+use std::sync::Arc;
 
 use assay_common::limits::{LimitExceeded, LimitKind, LimitReader};
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
@@ -647,8 +648,9 @@ impl<'de> Visitor<'de> for ScopeSpansEntrySeed<'_, '_> {
             }
         }
         if let Some(scope) = scope {
+            let scope = Arc::new(scope);
             for span in &mut self.spans[first_span..] {
-                span.instrumentation_scope = Some(scope.clone());
+                span.instrumentation_scope = Some(Arc::clone(&scope));
             }
         }
         Ok(())

--- a/crates/assay-core/src/otel/mcp_ingest/decode.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/decode.rs
@@ -864,7 +864,8 @@ impl<'de> Visitor<'de> for SpansSeed<'_, '_> {
 
 /// Bounded raw values for attributes that may participate in the MCP projection. Type validation
 /// is deferred until the full list establishes whether the span is MCP-shaped; otherwise generic
-/// OTLP attributes on unrelated spans could manufacture MCP projection failures.
+/// OTLP attributes on unrelated spans could manufacture MCP projection failures. Resource URI and
+/// session ID act as identity markers here: their type is validated, then their value is dropped.
 #[derive(Default)]
 pub(super) struct SpanAttrs {
     mcp_marker_seen: bool,

--- a/crates/assay-core/src/otel/mcp_ingest/decode.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/decode.rs
@@ -26,9 +26,9 @@ use super::limits::{
     SpanField,
 };
 use super::observation::{
-    ErrorTypeObservation, McpResourceSpansObservation, McpSpanObservation, MethodObservation,
-    OperationObservation, RequestIdObservation, RpcResponseStatusObservation, SpanKind,
-    SpanProtocolVersion, StatusObservation, SEMCONV_PIN,
+    ErrorTypeObservation, InstrumentationScopeObservation, McpResourceSpansObservation,
+    McpSpanObservation, MethodObservation, OperationObservation, RequestIdObservation,
+    RpcResponseStatusObservation, SpanKind, SpanProtocolVersion, StatusObservation, SEMCONV_PIN,
 };
 use crate::mcp::era::{is_version_shaped, SUPPORTED_VERSIONS};
 
@@ -58,12 +58,15 @@ pub(crate) fn decode_mcp_resource_spans<R: Read>(
         state: &state,
     };
     let mut de = serde_json::Deserializer::from_reader(reader);
-    let outcome = (RootSeed { st: &state })
-        .deserialize(&mut de)
-        .and_then(|value| {
-            de.end()?;
-            Ok(value)
-        });
+    let outcome = (RootSeed {
+        st: &state,
+        depth: 1,
+    })
+    .deserialize(&mut de)
+    .and_then(|value| {
+        de.end()?;
+        Ok(value)
+    });
     match outcome {
         Ok(value) => Ok(value),
         Err(err) => Err(classify(state.into_inner().typed, &err)),
@@ -163,39 +166,51 @@ impl<R: Read> Read for TrackingReader<'_, R> {
 
 /// Reject every scalar shape with a typed site fault, so a wrong shape never falls through to a
 /// `serde_json` message.
-macro_rules! reject_scalars_at {
+macro_rules! reject_non_null_scalars_at {
     ($site:expr) => {
         fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+            self.st.borrow_mut().charge(1)?;
             Err(self
                 .st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape($site)))
         }
         fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+            self.st.borrow_mut().charge(8)?;
             Err(self
                 .st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape($site)))
         }
         fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+            self.st.borrow_mut().charge(8)?;
             Err(self
                 .st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape($site)))
         }
         fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+            self.st.borrow_mut().charge(8)?;
             Err(self
                 .st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape($site)))
         }
-        fn visit_str<E: de::Error>(self, _: &str) -> Result<Self::Value, E> {
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            self.st.borrow_mut().charge(value.len() as u64)?;
             Err(self
                 .st
                 .borrow_mut()
                 .fail(OtlpIngestError::UnexpectedShape($site)))
         }
+    };
+}
+
+macro_rules! reject_scalars_at {
+    ($site:expr) => {
+        reject_non_null_scalars_at!($site);
         fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            self.st.borrow_mut().charge(1)?;
             Err(self
                 .st
                 .borrow_mut()
@@ -208,6 +223,7 @@ macro_rules! reject_scalars_at {
 macro_rules! reject_container_at {
     (map, $site:expr) => {
         fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+            self.st.borrow_mut().enter(self.depth)?;
             Err(self
                 .st
                 .borrow_mut()
@@ -216,6 +232,7 @@ macro_rules! reject_container_at {
     };
     (seq, $site:expr) => {
         fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+            self.st.borrow_mut().enter(self.depth)?;
             Err(self
                 .st
                 .borrow_mut()
@@ -224,7 +241,7 @@ macro_rules! reject_container_at {
     };
 }
 
-pub(super) use {reject_container_at, reject_scalars_at};
+pub(super) use {reject_container_at, reject_non_null_scalars_at, reject_scalars_at};
 
 // --- Generic bounded skip -------------------------------------------------------------------
 
@@ -349,6 +366,7 @@ impl Members {
 /// Root object: `{"resourceSpans": [...]}` at depth 1.
 struct RootSeed<'a> {
     st: St<'a>,
+    depth: u64,
 }
 
 impl<'de> DeserializeSeed<'de> for RootSeed<'_> {
@@ -369,7 +387,7 @@ impl<'de> Visitor<'de> for RootSeed<'_> {
     reject_container_at!(seq, ShapeSite::Root);
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        self.st.borrow_mut().enter(1)?;
+        self.st.borrow_mut().enter(self.depth)?;
         let mut members = Members::new(ShapeSite::Root);
         let mut spans = Vec::new();
         while let Some(key) = map.next_key_seed(KeySeed { st: self.st })? {
@@ -414,8 +432,13 @@ impl<'de> Visitor<'de> for ResourceSpansSeed<'_, '_> {
         f.write_str("a resourceSpans array")
     }
 
-    reject_scalars_at!(ShapeSite::ResourceSpans);
+    reject_non_null_scalars_at!(ShapeSite::ResourceSpans);
     reject_container_at!(map, ShapeSite::ResourceSpans);
+
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(())
+    }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -500,8 +523,13 @@ impl<'de> Visitor<'de> for ResourceSeed<'_> {
         f.write_str("a resource object")
     }
 
-    reject_scalars_at!(ShapeSite::Resource);
+    reject_non_null_scalars_at!(ShapeSite::Resource);
     reject_container_at!(seq, ShapeSite::Resource);
+
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(())
+    }
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -547,8 +575,13 @@ impl<'de> Visitor<'de> for ScopeSpansSeed<'_, '_> {
         f.write_str("a scopeSpans array")
     }
 
-    reject_scalars_at!(ShapeSite::ScopeSpans);
+    reject_non_null_scalars_at!(ShapeSite::ScopeSpans);
     reject_container_at!(map, ShapeSite::ScopeSpans);
+
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(())
+    }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -564,7 +597,7 @@ impl<'de> Visitor<'de> for ScopeSpansSeed<'_, '_> {
     }
 }
 
-/// One scope entry: `{"scope": {...}, "spans": [...]}`; the scope itself is skipped.
+/// One scope entry: `{"scope": {...}, "spans": [...]}`.
 struct ScopeSpansEntrySeed<'a, 'v> {
     st: St<'a>,
     depth: u64,
@@ -591,9 +624,17 @@ impl<'de> Visitor<'de> for ScopeSpansEntrySeed<'_, '_> {
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
         let mut members = Members::new(ShapeSite::ScopeSpansEntry);
+        let first_span = self.spans.len();
+        let mut scope = None;
         while let Some(key) = map.next_key_seed(KeySeed { st: self.st })? {
             members.admit(self.st, &key)?;
             match key.as_str() {
+                "scope" => {
+                    scope = map.next_value_seed(InstrumentationScopeSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                    })?;
+                }
                 "spans" => map.next_value_seed(SpansSeed {
                     st: self.st,
                     depth: self.depth + 1,
@@ -605,7 +646,172 @@ impl<'de> Visitor<'de> for ScopeSpansEntrySeed<'_, '_> {
                 })?,
             }
         }
+        if let Some(scope) = scope {
+            for span in &mut self.spans[first_span..] {
+                span.instrumentation_scope = Some(scope.clone());
+            }
+        }
         Ok(())
+    }
+}
+
+struct InstrumentationScopeSeed<'a> {
+    st: St<'a>,
+    depth: u64,
+}
+
+impl<'de> DeserializeSeed<'de> for InstrumentationScopeSeed<'_> {
+    type Value = Option<InstrumentationScopeObservation>;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
+        de.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for InstrumentationScopeSeed<'_> {
+    type Value = Option<InstrumentationScopeObservation>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("an instrumentation scope object")
+    }
+
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+    reject_container_at!(seq, ShapeSite::InstrumentationScope);
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(None)
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
+        let mut members = Members::new(ShapeSite::InstrumentationScope);
+        let mut name = None;
+        let mut version = None;
+        while let Some(key) = map.next_key_seed(KeySeed { st: self.st })? {
+            members.admit(self.st, &key)?;
+            match key.as_str() {
+                "name" => {
+                    name = map.next_value_seed(OptionalScopeStringSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                    })?;
+                }
+                "version" => {
+                    version = map.next_value_seed(OptionalScopeStringSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                    })?;
+                }
+                "attributes" => {
+                    map.next_value_seed(AttributeListSeed {
+                        st: self.st,
+                        depth: self.depth + 1,
+                        extract: None,
+                    })?;
+                }
+                _ => map.next_value_seed(SkipSeed {
+                    st: self.st,
+                    depth: self.depth + 1,
+                })?,
+            }
+        }
+        if name.is_none() && version.is_none() {
+            Ok(None)
+        } else {
+            Ok(Some(InstrumentationScopeObservation { name, version }))
+        }
+    }
+}
+
+struct OptionalScopeStringSeed<'a> {
+    st: St<'a>,
+    depth: u64,
+}
+
+impl<'de> DeserializeSeed<'de> for OptionalScopeStringSeed<'_> {
+    type Value = Option<String>;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
+        de.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for OptionalScopeStringSeed<'_> {
+    type Value = Option<String>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("an instrumentation scope string")
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(value.len() as u64)?;
+        Ok((!value.is_empty()).then(|| value.to_owned()))
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(None)
+    }
+
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
+        Err(self.st.borrow_mut().fail(OtlpIngestError::UnexpectedShape(
+            ShapeSite::InstrumentationScope,
+        )))
     }
 }
 
@@ -630,8 +836,13 @@ impl<'de> Visitor<'de> for SpansSeed<'_, '_> {
         f.write_str("a spans array")
     }
 
-    reject_scalars_at!(ShapeSite::Spans);
+    reject_non_null_scalars_at!(ShapeSite::Spans);
     reject_container_at!(map, ShapeSite::Spans);
+
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(())
+    }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -836,6 +1047,7 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
         let mut members = Members::new(ShapeSite::Span);
         let mut trace_id: Option<String> = None;
         let mut span_id: Option<String> = None;
+        let mut parent_span_id: Option<String> = None;
         let mut kind = SpanKind::Unspecified;
         let mut attrs = SpanAttrs::default();
         let mut status = StatusObservation::Absent;
@@ -847,6 +1059,7 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
                         st: self.st,
                         hex_len: 32,
                         field: SpanField::TraceId,
+                        depth: self.depth + 1,
                     })?);
                 }
                 "spanId" => {
@@ -854,13 +1067,23 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
                         st: self.st,
                         hex_len: 16,
                         field: SpanField::SpanId,
+                        depth: self.depth + 1,
                     })?);
+                }
+                "parentSpanId" => {
+                    parent_span_id = map.next_value_seed(OptionalIdSeed {
+                        st: self.st,
+                        hex_len: 16,
+                        field: SpanField::ParentSpanId,
+                        depth: self.depth + 1,
+                    })?;
                 }
                 "kind" => {
                     kind = map.next_value_seed(EnumSeed {
                         st: self.st,
                         field: SpanField::Kind,
                         decode: decode_span_kind,
+                        depth: self.depth + 1,
                     })?;
                 }
                 "attributes" => {
@@ -902,6 +1125,8 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
         Ok(Some(McpSpanObservation {
             trace_id,
             span_id,
+            parent_span_id,
+            instrumentation_scope: None,
             kind,
             method: attrs.method,
             operation: attrs.operation,
@@ -915,6 +1140,93 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
     }
 }
 
+struct OptionalIdSeed<'a> {
+    st: St<'a>,
+    hex_len: usize,
+    field: SpanField,
+    depth: u64,
+}
+
+impl<'de> DeserializeSeed<'de> for OptionalIdSeed<'_> {
+    type Value = Option<String>;
+    fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
+        de.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for OptionalIdSeed<'_> {
+    type Value = Option<String>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("an optional hex identifier")
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(value.len() as u64)?;
+        if value.is_empty() {
+            return Ok(None);
+        }
+        if value.len() != self.hex_len
+            || !value.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || value.bytes().all(|byte| byte == b'0')
+        {
+            return Err(self
+                .st
+                .borrow_mut()
+                .fail(OtlpIngestError::MalformedSpanField(self.field)));
+        }
+        Ok(Some(value.to_ascii_lowercase()))
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(None)
+    }
+
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::MalformedSpanField(self.field)))
+    }
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::MalformedSpanField(self.field)))
+    }
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::MalformedSpanField(self.field)))
+    }
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(8)?;
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::MalformedSpanField(self.field)))
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::MalformedSpanField(self.field)))
+    }
+    fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<Self::Value, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
+        Err(self
+            .st
+            .borrow_mut()
+            .fail(OtlpIngestError::MalformedSpanField(self.field)))
+    }
+}
+
 /// A fixed-length hex identifier. OTLP/JSON hex ids are case-insensitive, so both cases are
 /// accepted and the retained id is normalized to lowercase — one span must never split into
 /// two identities by case. Anything else is a typed malformed-field fault that never carries
@@ -923,6 +1235,7 @@ struct IdSeed<'a> {
     st: St<'a>,
     hex_len: usize,
     field: SpanField,
+    depth: u64,
 }
 
 impl<'de> DeserializeSeed<'de> for IdSeed<'_> {
@@ -954,42 +1267,49 @@ impl<'de> Visitor<'de> for IdSeed<'_> {
     }
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<String, E> {
+        self.st.borrow_mut().charge(1)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_i64<E: de::Error>(self, _: i64) -> Result<String, E> {
+        self.st.borrow_mut().charge(8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_u64<E: de::Error>(self, _: u64) -> Result<String, E> {
+        self.st.borrow_mut().charge(8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_f64<E: de::Error>(self, _: f64) -> Result<String, E> {
+        self.st.borrow_mut().charge(8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_unit<E: de::Error>(self) -> Result<String, E> {
+        self.st.borrow_mut().charge(1)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<String, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<String, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
@@ -1024,6 +1344,7 @@ struct EnumSeed<'a, T> {
     st: St<'a>,
     field: SpanField,
     decode: fn(i32) -> T,
+    depth: u64,
 }
 
 impl<'de, T> DeserializeSeed<'de> for EnumSeed<'_, T> {
@@ -1063,18 +1384,21 @@ impl<'de, T> Visitor<'de> for EnumSeed<'_, T> {
     }
 
     fn visit_bool<E: de::Error>(self, _: bool) -> Result<T, E> {
+        self.st.borrow_mut().charge(1)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_f64<E: de::Error>(self, _: f64) -> Result<T, E> {
+        self.st.borrow_mut().charge(8)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
-    fn visit_str<E: de::Error>(self, _: &str) -> Result<T, E> {
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<T, E> {
+        self.st.borrow_mut().charge(value.len() as u64)?;
         Err(self
             .st
             .borrow_mut()
@@ -1085,12 +1409,14 @@ impl<'de, T> Visitor<'de> for EnumSeed<'_, T> {
         Ok((self.decode)(0))
     }
     fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<T, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<T, A::Error> {
+        self.st.borrow_mut().enter(self.depth)?;
         Err(self
             .st
             .borrow_mut()
@@ -1118,8 +1444,13 @@ impl<'de> Visitor<'de> for StatusSeed<'_> {
         f.write_str("a span status object")
     }
 
-    reject_scalars_at!(ShapeSite::Status);
+    reject_non_null_scalars_at!(ShapeSite::Status);
     reject_container_at!(seq, ShapeSite::Status);
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.st.borrow_mut().charge(1)?;
+        Ok(StatusObservation::Absent)
+    }
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
         self.st.borrow_mut().enter(self.depth)?;
@@ -1134,6 +1465,7 @@ impl<'de> Visitor<'de> for StatusSeed<'_> {
                         st: self.st,
                         field: SpanField::StatusCode,
                         decode: decode_status_code,
+                        depth: self.depth + 1,
                     })?;
                 }
                 _ => map.next_value_seed(SkipSeed {

--- a/crates/assay-core/src/otel/mcp_ingest/decode.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/decode.rs
@@ -2,9 +2,10 @@
 //! OTLP/JSON corpus.
 //!
 //! Untrusted bytes are decoded through `serde::de::DeserializeSeed` implementations rather than
-//! materialized into `serde_json::Value`: only the recognized structure is traversed, every
-//! ceiling in [`OtlpIngestLimits`] is charged before retention, and unknown subtrees are skipped
-//! under the same depth and decoded-byte ceilings without being kept.
+//! materialized into `serde_json::Value`: only the recognized structure is traversed. The source
+//! ceiling bounds serde's transient token scratch; traversal ceilings are charged before content
+//! enters the domain observation, and unknown subtrees are skipped under the same depth and
+//! decoded-byte ceilings without being kept.
 //!
 //! Typed errors cross the serde boundary by being stashed in shared [`DecodeState`] before a
 //! value-free placeholder `serde` error is raised; the entry point recovers the stashed error, so
@@ -14,7 +15,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashSet;
-use std::io::Read;
+use std::io::{BufReader, Read};
 
 use assay_common::limits::{LimitExceeded, LimitKind, LimitReader};
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
@@ -26,8 +27,8 @@ use super::limits::{
 };
 use super::observation::{
     ErrorTypeObservation, McpResourceSpansObservation, McpSpanObservation, MethodObservation,
-    OperationObservation, RequestIdObservation, SpanKind, SpanProtocolVersion, StatusObservation,
-    SEMCONV_PIN,
+    OperationObservation, RequestIdObservation, RpcResponseStatusObservation, SpanKind,
+    SpanProtocolVersion, StatusObservation, SEMCONV_PIN,
 };
 use crate::mcp::era::{is_version_shaped, SUPPORTED_VERSIONS};
 
@@ -46,8 +47,14 @@ pub(crate) fn decode_mcp_resource_spans<R: Read>(
         span_count: 0,
         typed: None,
     });
+    // Buffer inside the source limiter: serde_json requests bytes one at a time, while the
+    // BufReader batches underlying reads without prefetching past the configured source ceiling.
     let reader = TrackingReader {
-        inner: LimitReader::new(source, limits.max_source_bytes, LimitKind::SourceBytes),
+        inner: BufReader::new(LimitReader::new(
+            source,
+            limits.max_source_bytes,
+            LimitKind::SourceBytes,
+        )),
         state: &state,
     };
     let mut de = serde_json::Deserializer::from_reader(reader);
@@ -124,11 +131,11 @@ impl DecodeState {
 
 pub(super) type St<'a> = &'a RefCell<DecodeState>;
 
-/// Wraps the source-byte [`LimitReader`] so that read failures are stashed as typed errors
+/// Wraps the buffered source-byte [`LimitReader`] so read failures are stashed as typed errors
 /// before `serde_json` swallows the `io::Error`, whose typed cause is otherwise unreachable
-/// through the serde error chain.
+/// through the serde error chain. Genericity keeps buffering inside the limiter.
 struct TrackingReader<'a, R> {
-    inner: LimitReader<R>,
+    inner: R,
     state: St<'a>,
 }
 
@@ -632,7 +639,9 @@ impl<'de> Visitor<'de> for SpansSeed<'_, '_> {
             st: self.st,
             depth: self.depth + 1,
         })? {
-            self.spans.push(span);
+            if let Some(span) = span {
+                self.spans.push(span);
+            }
         }
         Ok(())
     }
@@ -640,85 +649,148 @@ impl<'de> Visitor<'de> for SpansSeed<'_, '_> {
 
 // --- Span decoding --------------------------------------------------------------------------
 
-/// Recognized MCP attribute values, accumulated while one span's attribute list is traversed.
+/// Bounded raw values for attributes that may participate in the MCP projection. Type validation
+/// is deferred until the full list establishes whether the span is MCP-shaped; otherwise generic
+/// OTLP attributes on unrelated spans could manufacture MCP projection failures.
 #[derive(Default)]
 pub(super) struct SpanAttrs {
+    mcp_marker_seen: bool,
+    method: Option<DecodedValue>,
+    operation: Option<DecodedValue>,
+    tool_name: Option<DecodedValue>,
+    request_id: Option<DecodedValue>,
+    protocol_version: Option<DecodedValue>,
+    resource_uri: Option<DecodedValue>,
+    session_id: Option<DecodedValue>,
+    error_type: Option<DecodedValue>,
+    rpc_response_status: Option<DecodedValue>,
+}
+
+impl SpanAttrs {
+    /// Retain one bounded candidate value. Duplicate keys were already rejected by the caller, so
+    /// each slot is set at most once.
+    pub(super) fn apply<E: de::Error>(
+        &mut self,
+        _st: St<'_>,
+        key: &str,
+        value: DecodedValue,
+    ) -> Result<(), E> {
+        match key {
+            "mcp.method.name" => {
+                self.mcp_marker_seen = true;
+                self.method = Some(value);
+            }
+            "mcp.protocol.version" => {
+                self.mcp_marker_seen = true;
+                self.protocol_version = Some(value);
+            }
+            "mcp.resource.uri" => {
+                self.mcp_marker_seen = true;
+                self.resource_uri = Some(value);
+            }
+            "mcp.session.id" => {
+                self.mcp_marker_seen = true;
+                self.session_id = Some(value);
+            }
+            "gen_ai.operation.name" => self.operation = Some(value),
+            "gen_ai.tool.name" => self.tool_name = Some(value),
+            "jsonrpc.request.id" => self.request_id = Some(value),
+            "error.type" => self.error_type = Some(value),
+            "rpc.response.status_code" => self.rpc_response_status = Some(value),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn project<E: de::Error>(self, st: St<'_>) -> Result<Option<ProjectedSpanAttrs>, E> {
+        let wrong = |which: RecognizedAttribute| -> E {
+            st.borrow_mut()
+                .fail(OtlpIngestError::RecognizedAttributeWrongType(which))
+        };
+        let Some(method_value) = self.method else {
+            if self.mcp_marker_seen {
+                return Err(st
+                    .borrow_mut()
+                    .fail(OtlpIngestError::MissingRequiredAttribute(
+                        RecognizedAttribute::MethodName,
+                    )));
+            }
+            return Ok(None);
+        };
+        let method = match method_value {
+            DecodedValue::Str(s) if s == "tools/call" => MethodObservation::ToolsCall,
+            DecodedValue::Str(_) => MethodObservation::OtherMethod,
+            DecodedValue::Other => return Err(wrong(RecognizedAttribute::MethodName)),
+        };
+        for (value, field) in [
+            (self.resource_uri, RecognizedAttribute::ResourceUri),
+            (self.session_id, RecognizedAttribute::SessionId),
+        ] {
+            if matches!(value, Some(DecodedValue::Other)) {
+                return Err(wrong(field));
+            }
+        }
+        let operation = match self.operation {
+            Some(DecodedValue::Str(s)) if s == "execute_tool" => OperationObservation::ExecuteTool,
+            Some(DecodedValue::Str(_)) => OperationObservation::OtherOperation,
+            Some(DecodedValue::Other) => return Err(wrong(RecognizedAttribute::OperationName)),
+            None => OperationObservation::Absent,
+        };
+        let tool_name = match self.tool_name {
+            Some(DecodedValue::Str(s)) => Some(s),
+            Some(DecodedValue::Other) => return Err(wrong(RecognizedAttribute::ToolName)),
+            None => None,
+        };
+        let request_id = match self.request_id {
+            Some(DecodedValue::Str(s)) => Some(RequestIdObservation::String(s)),
+            Some(DecodedValue::Other) => return Err(wrong(RecognizedAttribute::RequestId)),
+            None => None,
+        };
+        // Malformed is an observation state, not a decode failure: this is producer-self-reported
+        // telemetry and never substitutes for MCP transport evidence.
+        let protocol_version = match self.protocol_version {
+            Some(DecodedValue::Str(s)) if is_version_shaped(&s) => {
+                if SUPPORTED_VERSIONS.contains(&s.as_str()) {
+                    SpanProtocolVersion::PresentSupported(s)
+                } else {
+                    SpanProtocolVersion::PresentUnsupported(s)
+                }
+            }
+            Some(_) => SpanProtocolVersion::Malformed,
+            None => SpanProtocolVersion::Absent,
+        };
+        let error_type = match self.error_type {
+            Some(DecodedValue::Str(s)) => ErrorTypeObservation::Present(s),
+            Some(DecodedValue::Other) => return Err(wrong(RecognizedAttribute::ErrorType)),
+            None => ErrorTypeObservation::Absent,
+        };
+        let rpc_response_status = match self.rpc_response_status {
+            Some(DecodedValue::Str(s)) => RpcResponseStatusObservation::Present(s),
+            Some(DecodedValue::Other) => {
+                return Err(wrong(RecognizedAttribute::RpcResponseStatusCode))
+            }
+            None => RpcResponseStatusObservation::Absent,
+        };
+        Ok(Some(ProjectedSpanAttrs {
+            method,
+            operation,
+            tool_name,
+            request_id,
+            protocol_version,
+            error_type,
+            rpc_response_status,
+        }))
+    }
+}
+
+struct ProjectedSpanAttrs {
     method: MethodObservation,
     operation: OperationObservation,
     tool_name: Option<String>,
     request_id: Option<RequestIdObservation>,
     protocol_version: SpanProtocolVersion,
     error_type: ErrorTypeObservation,
-}
-
-impl SpanAttrs {
-    /// Apply one recognized attribute. Duplicate keys were already rejected by the caller, so
-    /// each field is set at most once.
-    pub(super) fn apply<E: de::Error>(
-        &mut self,
-        st: St<'_>,
-        key: &str,
-        value: DecodedValue,
-    ) -> Result<(), E> {
-        let wrong = |st: St<'_>, which: RecognizedAttribute| -> E {
-            st.borrow_mut()
-                .fail(OtlpIngestError::RecognizedAttributeWrongType(which))
-        };
-        match key {
-            "mcp.method.name" => {
-                self.method = match value {
-                    DecodedValue::Str(s) if s == "tools/call" => MethodObservation::ToolsCall,
-                    DecodedValue::Str(_) => MethodObservation::OtherMethod,
-                    _ => return Err(wrong(st, RecognizedAttribute::MethodName)),
-                };
-            }
-            "gen_ai.operation.name" => {
-                self.operation = match value {
-                    DecodedValue::Str(s) if s == "execute_tool" => {
-                        OperationObservation::ExecuteTool
-                    }
-                    DecodedValue::Str(_) => OperationObservation::OtherOperation,
-                    _ => return Err(wrong(st, RecognizedAttribute::OperationName)),
-                };
-            }
-            "gen_ai.tool.name" => {
-                self.tool_name = match value {
-                    DecodedValue::Str(s) => Some(s),
-                    _ => return Err(wrong(st, RecognizedAttribute::ToolName)),
-                };
-            }
-            "jsonrpc.request.id" => {
-                self.request_id = match value {
-                    DecodedValue::Str(s) => Some(RequestIdObservation::String(s)),
-                    DecodedValue::Int(i) => Some(RequestIdObservation::Integer(i)),
-                    _ => return Err(wrong(st, RecognizedAttribute::RequestId)),
-                };
-            }
-            "mcp.protocol.version" => {
-                // Malformed is a typed observation state, not a decode failure: the attribute is
-                // producer-self-reported, and an unreadable version is a fact to record, never a
-                // defect that suppresses the rest of the document.
-                self.protocol_version = match value {
-                    DecodedValue::Str(s) if is_version_shaped(&s) => {
-                        if SUPPORTED_VERSIONS.contains(&s.as_str()) {
-                            SpanProtocolVersion::PresentSupported(s)
-                        } else {
-                            SpanProtocolVersion::PresentUnsupported(s)
-                        }
-                    }
-                    _ => SpanProtocolVersion::Malformed,
-                };
-            }
-            "error.type" => {
-                self.error_type = match value {
-                    DecodedValue::Str(s) => ErrorTypeObservation::Present(s),
-                    _ => return Err(wrong(st, RecognizedAttribute::ErrorType)),
-                };
-            }
-            _ => {}
-        }
-        Ok(())
-    }
+    rpc_response_status: RpcResponseStatusObservation,
 }
 
 /// The value of one attribute after bounded decoding. Only the shapes the recognized MCP
@@ -726,7 +798,6 @@ impl SpanAttrs {
 /// retention.
 pub(super) enum DecodedValue {
     Str(String),
-    Int(i64),
     Other,
 }
 
@@ -737,14 +808,21 @@ struct SpanSeed<'a> {
 }
 
 impl<'de> DeserializeSeed<'de> for SpanSeed<'_> {
-    type Value = McpSpanObservation;
+    type Value = Option<McpSpanObservation>;
     fn deserialize<D: de::Deserializer<'de>>(self, de: D) -> Result<Self::Value, D::Error> {
+        let mut st = self.st.borrow_mut();
+        st.span_count += 1;
+        if st.span_count > st.limits.max_span_count {
+            let max = st.limits.max_span_count;
+            return Err(st.limit(OtlpLimitDimension::SpanCount, max));
+        }
+        drop(st);
         de.deserialize_any(self)
     }
 }
 
 impl<'de> Visitor<'de> for SpanSeed<'_> {
-    type Value = McpSpanObservation;
+    type Value = Option<McpSpanObservation>;
 
     fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("a span object")
@@ -754,15 +832,7 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
     reject_container_at!(seq, ShapeSite::Span);
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        {
-            let mut st = self.st.borrow_mut();
-            st.span_count += 1;
-            if st.span_count > st.limits.max_span_count {
-                let max = st.limits.max_span_count;
-                return Err(st.limit(OtlpLimitDimension::SpanCount, max));
-            }
-            st.enter(self.depth)?;
-        }
+        self.st.borrow_mut().enter(self.depth)?;
         let mut members = Members::new(ShapeSite::Span);
         let mut trace_id: Option<String> = None;
         let mut span_id: Option<String> = None;
@@ -824,7 +894,12 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
                 .borrow_mut()
                 .fail(OtlpIngestError::MissingRequiredSpanField(SpanField::SpanId))
         })?;
-        Ok(McpSpanObservation {
+        let Some(attrs) = attrs.project(self.st)? else {
+            // Mixed exports contain unrelated spans. Generic GenAI/RPC/error attributes alone do
+            // not establish MCP identity, so their projection rules do not apply here.
+            return Ok(None);
+        };
+        Ok(Some(McpSpanObservation {
             trace_id,
             span_id,
             kind,
@@ -835,7 +910,8 @@ impl<'de> Visitor<'de> for SpanSeed<'_> {
             protocol_version: attrs.protocol_version,
             status,
             error_type: attrs.error_type,
-        })
+            rpc_response_status: attrs.rpc_response_status,
+        }))
     }
 }
 
@@ -865,7 +941,10 @@ impl<'de> Visitor<'de> for IdSeed<'_> {
 
     fn visit_str<E: de::Error>(self, s: &str) -> Result<String, E> {
         self.st.borrow_mut().charge(s.len() as u64)?;
-        if s.len() != self.hex_len || !s.bytes().all(|b| b.is_ascii_hexdigit()) {
+        if s.len() != self.hex_len
+            || !s.bytes().all(|b| b.is_ascii_hexdigit())
+            || s.bytes().all(|b| b == b'0')
+        {
             return Err(self
                 .st
                 .borrow_mut()
@@ -918,33 +997,33 @@ impl<'de> Visitor<'de> for IdSeed<'_> {
     }
 }
 
-fn decode_span_kind(v: u64) -> Option<SpanKind> {
+fn decode_span_kind(v: i32) -> SpanKind {
     match v {
-        0 => Some(SpanKind::Unspecified),
-        1 => Some(SpanKind::Internal),
-        2 => Some(SpanKind::Server),
-        3 => Some(SpanKind::Client),
-        4 => Some(SpanKind::Producer),
-        5 => Some(SpanKind::Consumer),
-        _ => None,
+        0 => SpanKind::Unspecified,
+        1 => SpanKind::Internal,
+        2 => SpanKind::Server,
+        3 => SpanKind::Client,
+        4 => SpanKind::Producer,
+        5 => SpanKind::Consumer,
+        _ => SpanKind::Unknown,
     }
 }
 
-fn decode_status_code(v: u64) -> Option<StatusObservation> {
+fn decode_status_code(v: i32) -> StatusObservation {
     match v {
-        0 => Some(StatusObservation::Unset),
-        1 => Some(StatusObservation::Ok),
-        2 => Some(StatusObservation::Error),
-        _ => None,
+        0 => StatusObservation::Unset,
+        1 => StatusObservation::Ok,
+        2 => StatusObservation::Error,
+        _ => StatusObservation::Unknown,
     }
 }
 
-/// A closed proto enum encoded as a non-negative integer. Any other token, and any integer the
-/// pinned proto does not define, is a typed malformed-field fault.
+/// An open proto3 enum encoded as an `int32`. Future numbers, including negative values, map to
+/// the decoder's value-free unknown state; out-of-range numbers and wrong JSON types are malformed.
 struct EnumSeed<'a, T> {
     st: St<'a>,
     field: SpanField,
-    decode: fn(u64) -> Option<T>,
+    decode: fn(i32) -> T,
 }
 
 impl<'de, T> DeserializeSeed<'de> for EnumSeed<'_, T> {
@@ -963,16 +1042,19 @@ impl<'de, T> Visitor<'de> for EnumSeed<'_, T> {
 
     fn visit_u64<E: de::Error>(self, v: u64) -> Result<T, E> {
         self.st.borrow_mut().charge(8)?;
-        (self.decode)(v).ok_or_else(|| {
-            self.st
+        match i32::try_from(v) {
+            Ok(v) => Ok((self.decode)(v)),
+            Err(_) => Err(self
+                .st
                 .borrow_mut()
-                .fail(OtlpIngestError::MalformedSpanField(self.field))
-        })
+                .fail(OtlpIngestError::MalformedSpanField(self.field))),
+        }
     }
 
     fn visit_i64<E: de::Error>(self, v: i64) -> Result<T, E> {
-        match u64::try_from(v) {
-            Ok(v) => self.visit_u64(v),
+        self.st.borrow_mut().charge(8)?;
+        match i32::try_from(v) {
+            Ok(v) => Ok((self.decode)(v)),
             Err(_) => Err(self
                 .st
                 .borrow_mut()
@@ -999,10 +1081,8 @@ impl<'de, T> Visitor<'de> for EnumSeed<'_, T> {
             .fail(OtlpIngestError::MalformedSpanField(self.field)))
     }
     fn visit_unit<E: de::Error>(self) -> Result<T, E> {
-        Err(self
-            .st
-            .borrow_mut()
-            .fail(OtlpIngestError::MalformedSpanField(self.field)))
+        self.st.borrow_mut().charge(1)?;
+        Ok((self.decode)(0))
     }
     fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<T, A::Error> {
         Err(self

--- a/crates/assay-core/src/otel/mcp_ingest/limits.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/limits.rs
@@ -80,6 +80,7 @@ pub(crate) enum ShapeSite {
     Resource,
     ScopeSpans,
     ScopeSpansEntry,
+    InstrumentationScope,
     Spans,
     Span,
     AttributeList,
@@ -96,6 +97,7 @@ pub(crate) enum ShapeSite {
 pub(crate) enum SpanField {
     TraceId,
     SpanId,
+    ParentSpanId,
     Kind,
     StatusCode,
 }

--- a/crates/assay-core/src/otel/mcp_ingest/limits.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/limits.rs
@@ -9,11 +9,13 @@
 //! Every limit is inclusive: an input at exactly the limit is accepted, an input one past it is
 //! rejected. That boundary is load-bearing and each dimension has a test proving both sides.
 
-/// Ceilings applied before any untrusted content is retained.
+/// Independent ceilings for parser input and decoded observation retention.
 ///
 /// Dimensions are independent on purpose: a document can be small in source bytes while hostile
 /// in nesting depth, and declared metadata (`droppedAttributesCount` and friends) never
-/// substitutes for the observed counts these ceilings govern.
+/// substitutes for the observed counts these ceilings govern. `max_source_bytes` bounds the
+/// serde parser's transient token scratch; traversal limits are charged before content is copied
+/// into the domain observation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OtlpIngestLimits {
     /// Bytes taken from the source stream, before JSON decoding.
@@ -102,10 +104,13 @@ pub(crate) enum SpanField {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RecognizedAttribute {
     MethodName,
+    ResourceUri,
+    SessionId,
     OperationName,
     ToolName,
     RequestId,
     ErrorType,
+    RpcResponseStatusCode,
 }
 
 /// Typed, value-free rejection. No variant carries attacker-controlled bytes: limits carry the
@@ -139,6 +144,9 @@ pub(crate) enum OtlpIngestError {
     ConflictingAttributeValue,
     #[error("missing required span field {0:?}")]
     MissingRequiredSpanField(SpanField),
+    /// A required MCP semantic-convention attribute was absent from an otherwise MCP-shaped span.
+    #[error("missing required recognized attribute {0:?}")]
+    MissingRequiredAttribute(RecognizedAttribute),
     #[error("malformed span field {0:?}")]
     MalformedSpanField(SpanField),
     /// A recognized MCP attribute carried a value type the pinned semconv does not define for it.

--- a/crates/assay-core/src/otel/mcp_ingest/mod.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/mod.rs
@@ -4,9 +4,8 @@
 //! source/decode reader and a selective structured serde visitor over that pinned corpus:
 //!
 //! - [`decode::decode_mcp_resource_spans`] decodes an OTLP/JSON `resourceSpans` document under
-//!   the independent pre-retention ceilings in [`limits::OtlpIngestLimits`] (source bytes,
-//!   decoded bytes, nesting depth, span count, attribute count, attribute-key bytes,
-//!   attribute-value bytes).
+//!   independent ceilings in [`limits::OtlpIngestLimits`]. The source ceiling bounds bytes and
+//!   serde parser scratch; traversal ceilings apply before decoded content enters an observation.
 //! - Extraction is limited to the explicit MCP observation fields named in issue #1931, each
 //!   preserving upstream field provenance and the semconv pin
 //!   ([`observation::SEMCONV_PIN`]).

--- a/crates/assay-core/src/otel/mcp_ingest/observation.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/observation.rs
@@ -24,6 +24,12 @@ pub(crate) enum UpstreamField {
     TraceId,
     /// OTLP span `spanId`.
     SpanId,
+    /// OTLP span `parentSpanId`.
+    ParentSpanId,
+    /// OTLP instrumentation scope `name`.
+    InstrumentationScopeName,
+    /// OTLP instrumentation scope `version`.
+    InstrumentationScopeVersion,
     /// OTLP span `kind`.
     SpanKind,
     /// OTLP span `status.code`.
@@ -50,6 +56,9 @@ impl UpstreamField {
         match self {
             UpstreamField::TraceId => "traceId",
             UpstreamField::SpanId => "spanId",
+            UpstreamField::ParentSpanId => "parentSpanId",
+            UpstreamField::InstrumentationScopeName => "scope.name",
+            UpstreamField::InstrumentationScopeVersion => "scope.version",
             UpstreamField::SpanKind => "kind",
             UpstreamField::StatusCode => "status.code",
             UpstreamField::McpMethodName => "mcp.method.name",

--- a/crates/assay-core/src/otel/mcp_ingest/observation.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/observation.rs
@@ -147,6 +147,13 @@ pub(crate) enum SpanProtocolVersion {
     PresentUnsupported(String),
 }
 
+/// Bounded identity reported by the enclosing OTLP instrumentation scope.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct InstrumentationScopeObservation {
+    pub(crate) name: Option<String>,
+    pub(crate) version: Option<String>,
+}
+
 /// One decoded MCP-shaped span, carrying only the explicit observation fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct McpSpanObservation {
@@ -154,6 +161,9 @@ pub(crate) struct McpSpanObservation {
     pub(crate) trace_id: String,
     /// 16-char hex span id, validated case-insensitively and normalized to lowercase.
     pub(crate) span_id: String,
+    /// Optional 16-char parent span id, normalized to lowercase when present.
+    pub(crate) parent_span_id: Option<String>,
+    pub(crate) instrumentation_scope: Option<InstrumentationScopeObservation>,
     pub(crate) kind: SpanKind,
     pub(crate) method: MethodObservation,
     pub(crate) operation: OperationObservation,

--- a/crates/assay-core/src/otel/mcp_ingest/observation.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/observation.rs
@@ -38,6 +38,8 @@ pub(crate) enum UpstreamField {
     McpProtocolVersion,
     /// Stable general attribute `error.type` (used by the Development MCP document).
     ErrorType,
+    /// Semconv attribute `rpc.response.status_code`.
+    RpcResponseStatusCode,
 }
 
 impl UpstreamField {
@@ -54,11 +56,13 @@ impl UpstreamField {
             UpstreamField::JsonRpcRequestId => "jsonrpc.request.id",
             UpstreamField::McpProtocolVersion => "mcp.protocol.version",
             UpstreamField::ErrorType => "error.type",
+            UpstreamField::RpcResponseStatusCode => "rpc.response.status_code",
         }
     }
 }
 
-/// OTLP span kind, from the pinned `trace.proto` enum. Values outside 0..=5 are malformed.
+/// OTLP span kind, from the pinned `trace.proto` enum. Proto3 enums are open, so a future numeric
+/// value is retained only as the value-free `Unknown` state rather than mislabeled malformed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SpanKind {
     Unspecified,
@@ -67,16 +71,18 @@ pub(crate) enum SpanKind {
     Client,
     Producer,
     Consumer,
+    Unknown,
 }
 
-/// OTLP span status code, from the pinned `trace.proto` enum. Values outside 0..=2 are
-/// malformed. Absent status is the proto default and therefore ordinary.
+/// OTLP span status code, from the pinned `trace.proto` enum. Proto3 enums are open; values outside
+/// the pinned vocabulary become `Unknown`. Absent status is the proto default and ordinary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StatusObservation {
     Absent,
     Unset,
     Ok,
     Error,
+    Unknown,
 }
 
 /// What `mcp.method.name` said. Only the explicit tool-call method is recognized; any other
@@ -102,13 +108,21 @@ pub(crate) enum OperationObservation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RequestIdObservation {
     String(String),
-    Integer(i64),
 }
 
 /// What `error.type` said. Present values are bounded by the attribute-value ceiling before
 /// retention.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) enum ErrorTypeObservation {
+    #[default]
+    Absent,
+    Present(String),
+}
+
+/// What `rpc.response.status_code` said. The pinned semconv declares a string value; absence is
+/// ordinary when no JSON-RPC error code was reported.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) enum RpcResponseStatusObservation {
     #[default]
     Absent,
     Present(String),
@@ -149,6 +163,7 @@ pub(crate) struct McpSpanObservation {
     pub(crate) protocol_version: SpanProtocolVersion,
     pub(crate) status: StatusObservation,
     pub(crate) error_type: ErrorTypeObservation,
+    pub(crate) rpc_response_status: RpcResponseStatusObservation,
 }
 
 /// The decode result for one OTLP/JSON document: extracted spans plus the semconv pin they were

--- a/crates/assay-core/src/otel/mcp_ingest/observation.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/observation.rs
@@ -10,6 +10,8 @@
 //! the transport-level `EraResolution` contract: [`SpanProtocolVersion`] has no conflict state,
 //! because a span cannot manufacture the MCP-defined header/body conflict.
 
+use std::sync::Arc;
+
 /// The pinned semconv revision that defines the recognized attribute names. Matches the
 /// `semconv` entry in `tests/fixtures/otel-mcp-ingest-v0/upstream.lock.json`.
 pub(crate) const SEMCONV_PIN: &str =
@@ -163,7 +165,7 @@ pub(crate) struct McpSpanObservation {
     pub(crate) span_id: String,
     /// Optional 16-char parent span id, normalized to lowercase when present.
     pub(crate) parent_span_id: Option<String>,
-    pub(crate) instrumentation_scope: Option<InstrumentationScopeObservation>,
+    pub(crate) instrumentation_scope: Option<Arc<InstrumentationScopeObservation>>,
     pub(crate) kind: SpanKind,
     pub(crate) method: MethodObservation,
     pub(crate) operation: OperationObservation,

--- a/crates/assay-core/src/otel/mcp_ingest/tests.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/tests.rs
@@ -548,6 +548,24 @@ fn duplicate_nested_kvlist_keys_are_rejected() {
 }
 
 #[test]
+fn null_omitted_and_empty_nested_keys_share_the_proto_default() {
+    for key in [r#""key":null,"#, "", r#""key":"","#] {
+        let entry = format!(
+            r#"{{"key":"x","value":{{"kvlistValue":{{"values":[{{{key}"value":{{}}}}]}}}}}}"#
+        );
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("default-valued nested key must be accepted: {err:?}"));
+    }
+
+    let duplicates = r#"{"key":"x","value":{"kvlistValue":{"values":[{"key":null,"value":{}},{"value":{}},{"key":"","value":{}}]}}}"#;
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[duplicates.to_string()]), &corpus_limits())
+            .expect_err("all three forms are the same empty default key"),
+        OtlpIngestError::DuplicateField(ShapeSite::AttributeValue)
+    );
+}
+
+#[test]
 fn malformed_kvlist_keys_charge_value_budget_before_typed_shape_refusal() {
     let entry = r#"{"key":"x","value":{"kvlistValue":{"values":[{"key":true,"value":{}}]}}}"#;
 

--- a/crates/assay-core/src/otel/mcp_ingest/tests.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/tests.rs
@@ -1251,12 +1251,28 @@ fn protojson_int64_accepts_integral_number_and_exponent_forms() {
 }
 
 #[test]
+fn protojson_bare_int64_uses_binary64_interpretation() {
+    let rejected = format!(r#"{{"key":"x","value":{{"intValue":{}}}}}"#, i64::MAX);
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[rejected]), &corpus_limits())
+            .expect_err("bare i64::MAX rounds to the exclusive binary64 boundary"),
+        OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)
+    );
+
+    let accepted = format!(r#"{{"key":"x","value":{{"intValue":{}}}}}"#, i64::MIN);
+    decode_str(&doc_with_attrs(&[accepted]), &corpus_limits())
+        .expect("bare i64::MIN is exactly representable as binary64");
+}
+
+#[test]
 fn protojson_int64_string_conversion_is_exact() {
     for int_value in [
         r#""-9223372036854775809""#,
         r#""9223372036854775808""#,
         r#""9007199254740992.5""#,
         r#""-9.223372036854775809e18""#,
+        r#""01""#,
+        r#""-01""#,
     ] {
         let entry = format!(r#"{{"key":"x","value":{{"intValue":{int_value}}}}}"#);
         assert_eq!(

--- a/crates/assay-core/src/otel/mcp_ingest/tests.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/tests.rs
@@ -4,6 +4,7 @@
 //! limit+1 rejected), every hostile fixture locked in `upstream.lock.json` is rejected for its
 //! locked purpose, and every rejection path is swept for attacker-content echo.
 
+use std::cell::Cell;
 use std::io::Read;
 
 use super::decode::decode_mcp_resource_spans;
@@ -13,8 +14,8 @@ use super::limits::{
 };
 use super::observation::{
     ErrorTypeObservation, McpResourceSpansObservation, MethodObservation, OperationObservation,
-    RequestIdObservation, SpanKind, SpanProtocolVersion, StatusObservation, UpstreamField,
-    SEMCONV_PIN,
+    RequestIdObservation, RpcResponseStatusObservation, SpanKind, SpanProtocolVersion,
+    StatusObservation, UpstreamField, SEMCONV_PIN,
 };
 
 const FIXTURE_DIR: &str = concat!(
@@ -64,6 +65,12 @@ fn doc_with_attrs(attrs: &[String]) -> String {
     doc_with_spans(&[span_with_attrs(attrs)])
 }
 
+fn mcp_doc_with_attrs(attrs: &[String]) -> String {
+    let mut all = vec![attr_str("mcp.method.name", "tools/call")];
+    all.extend_from_slice(attrs);
+    doc_with_attrs(&all)
+}
+
 fn assert_limit(
     result: Result<McpResourceSpansObservation, OtlpIngestError>,
     dimension: OtlpLimitDimension,
@@ -73,6 +80,31 @@ fn assert_limit(
         result.expect_err("input past the ceiling must be rejected"),
         OtlpIngestError::LimitExceeded { dimension, limit }
     );
+}
+
+struct CountingReader<'a> {
+    bytes: &'a [u8],
+    reads: &'a Cell<usize>,
+}
+
+impl Read for CountingReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.reads.set(self.reads.get() + 1);
+        self.bytes.read(buf)
+    }
+}
+
+struct ByteCountingReader<'a> {
+    bytes: &'a [u8],
+    yielded: &'a Cell<usize>,
+}
+
+impl Read for ByteCountingReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.bytes.read(buf)?;
+        self.yielded.set(self.yielded.get() + n);
+        Ok(n)
+    }
 }
 
 // --- Corpus acceptance and extraction -------------------------------------------------------
@@ -100,6 +132,10 @@ fn client_fixture_decodes_and_extracts_explicit_fields() {
     );
     assert_eq!(span.status, StatusObservation::Ok);
     assert_eq!(span.error_type, ErrorTypeObservation::Absent);
+    assert_eq!(
+        span.rpc_response_status,
+        RpcResponseStatusObservation::Absent
+    );
 }
 
 #[test]
@@ -128,6 +164,10 @@ fn provenance_mapping_is_pinned() {
         (UpstreamField::JsonRpcRequestId, "jsonrpc.request.id"),
         (UpstreamField::McpProtocolVersion, "mcp.protocol.version"),
         (UpstreamField::ErrorType, "error.type"),
+        (
+            UpstreamField::RpcResponseStatusCode,
+            "rpc.response.status_code",
+        ),
     ];
     for (field, name) in expected {
         assert_eq!(field.upstream_name(), name);
@@ -183,6 +223,28 @@ fn source_bytes_exact_accepted_one_more_rejected() {
 }
 
 #[test]
+fn buffering_never_prefetches_beyond_the_source_ceiling_probe() {
+    let doc = format!(r#"{{"resourceSpans":[],"padding":"{}"}}"#, "x".repeat(4096));
+    let yielded = Cell::new(0);
+    let mut limits = corpus_limits();
+    limits.max_source_bytes = 64;
+    let reader = ByteCountingReader {
+        bytes: doc.as_bytes(),
+        yielded: &yielded,
+    };
+    assert_limit(
+        decode_mcp_resource_spans(reader, &limits),
+        OtlpLimitDimension::SourceBytes,
+        64,
+    );
+    assert!(
+        yielded.get() <= limits.max_source_bytes as usize + 1,
+        "buffering below the limiter prefetched {} source bytes",
+        yielded.get()
+    );
+}
+
+#[test]
 fn decoded_bytes_exact_accepted_one_more_rejected() {
     // Charge model: member-name strings charge their UTF-8 length; the empty string value
     // charges 0. `{"resourceSpans":[],"a":""}` charges 13 + 1 = 14 decoded bytes.
@@ -230,6 +292,26 @@ fn span_count_exact_accepted_one_more_rejected() {
 }
 
 #[test]
+fn span_count_precedes_shape_validation_for_every_list_element() {
+    let mut limits = corpus_limits();
+    limits.max_span_count = 1;
+    let doc = doc_with_spans(&[span_with_attrs(&[]), "0".into()]);
+    assert_limit(decode_str(&doc, &limits), OtlpLimitDimension::SpanCount, 1);
+}
+
+#[test]
+fn span_count_is_global_and_precedes_decoding_across_resource_groups() {
+    let mut limits = corpus_limits();
+    limits.max_span_count = 1;
+    let first = span_with_attrs(&[attr_str("mcp.method.name", "tools/call")]);
+    let malformed_second = r#"{"kind":{"deeply":"wrong"}}"#;
+    let doc = format!(
+        r#"{{"resourceSpans":[{{"scopeSpans":[{{"spans":[{first}]}}]}},{{"scopeSpans":[{{"spans":[{malformed_second}]}}]}}]}}"#
+    );
+    assert_limit(decode_str(&doc, &limits), OtlpLimitDimension::SpanCount, 1);
+}
+
+#[test]
 fn attribute_count_exact_accepted_one_more_rejected() {
     let mut limits = corpus_limits();
     limits.max_attribute_count = 3;
@@ -240,6 +322,23 @@ fn attribute_count_exact_accepted_one_more_rejected() {
         decode_str(&doc_with_attrs(&four), &limits),
         OtlpLimitDimension::AttributeCount,
         3,
+    );
+}
+
+#[test]
+fn attribute_count_precedes_entry_content_decoding() {
+    let mut limits = corpus_limits();
+    limits.max_attribute_count = 1;
+    let first = attr_str("mcp.method.name", "tools/call");
+    let malformed_second =
+        r#"{"key":{"not":"a string"},"value":{"arrayValue":{"values":[[[[]]]]}}}"#;
+    assert_limit(
+        decode_str(
+            &doc_with_attrs(&[first, malformed_second.to_string()]),
+            &limits,
+        ),
+        OtlpLimitDimension::AttributeCount,
+        1,
     );
 }
 
@@ -298,6 +397,28 @@ fn attribute_value_bytes_aggregate_across_nested_value() {
         OtlpLimitDimension::AttributeValueBytes,
         8,
     );
+}
+
+#[test]
+fn kvlist_keys_and_values_share_one_per_attribute_budget() {
+    let mut limits = corpus_limits();
+    limits.max_attribute_value_bytes = 6;
+    let exact = r#"{"key":"k","value":{"kvlistValue":{"values":[{"key":"aa","value":{"stringValue":"bbbb"}}]}}}"#;
+    decode_str(&doc_with_attrs(&[exact.to_string()]), &limits)
+        .expect("nested key and leaf value exactly at their shared ceiling");
+
+    let over = r#"{"key":"k","value":{"kvlistValue":{"values":[{"key":"aa","value":{"stringValue":"bbbbb"}}]}}}"#;
+    assert_limit(
+        decode_str(&doc_with_attrs(&[over.to_string()]), &limits),
+        OtlpLimitDimension::AttributeValueBytes,
+        6,
+    );
+
+    decode_str(
+        &doc_with_attrs(&[exact.to_string(), exact.replacen("\"k\"", "\"j\"", 1)]),
+        &limits,
+    )
+    .expect("per-value budget resets between separate attributes");
 }
 
 // --- Short reads and source truncation ------------------------------------------------------
@@ -610,33 +731,70 @@ fn missing_and_malformed_ids_are_typed() {
 }
 
 #[test]
-fn out_of_range_kind_and_status_are_typed() {
-    let bad_kind = format!(r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","kind":6}}"#);
-    assert_eq!(
-        decode_str(&doc_with_spans(&[bad_kind]), &corpus_limits()).expect_err("kind 6"),
-        OtlpIngestError::MalformedSpanField(SpanField::Kind)
+fn all_zero_trace_and_span_ids_are_invalid() {
+    for (span, field) in [
+        (
+            format!(r#"{{"traceId":"{}","spanId":"{SPAN_ID}"}}"#, "0".repeat(32)),
+            SpanField::TraceId,
+        ),
+        (
+            format!(
+                r#"{{"traceId":"{TRACE_ID}","spanId":"{}"}}"#,
+                "0".repeat(16)
+            ),
+            SpanField::SpanId,
+        ),
+    ] {
+        assert_eq!(
+            decode_str(&doc_with_spans(&[span]), &corpus_limits())
+                .expect_err("the pinned OTLP proto forbids all-zero ids"),
+            OtlpIngestError::MalformedSpanField(field)
+        );
+    }
+}
+
+#[test]
+fn future_kind_and_status_numbers_are_value_free_unknown_states() {
+    for (kind, status) in [(6, 3), (-1, -1)] {
+        let span = format!(
+            r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","kind":{kind},"attributes":[{}],"status":{{"code":{status}}}}}"#,
+            attr_str("mcp.method.name", "tools/call")
+        );
+        let obs = decode_str(&doc_with_spans(&[span]), &corpus_limits())
+            .expect("proto3 enum numbers are open within int32");
+        assert_eq!(obs.spans[0].kind, SpanKind::Unknown);
+        assert_eq!(obs.spans[0].status, StatusObservation::Unknown);
+    }
+
+    let too_large = format!(
+        r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","kind":2147483648,"attributes":[{}]}}"#,
+        attr_str("mcp.method.name", "tools/call")
     );
-    let bad_status =
-        format!(r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","status":{{"code":3}}}}"#);
     assert_eq!(
-        decode_str(&doc_with_spans(&[bad_status]), &corpus_limits()).expect_err("status 3"),
-        OtlpIngestError::MalformedSpanField(SpanField::StatusCode)
+        decode_str(&doc_with_spans(&[too_large]), &corpus_limits())
+            .expect_err("enum numbers remain int32"),
+        OtlpIngestError::MalformedSpanField(SpanField::Kind)
     );
 }
 
 #[test]
-fn span_without_attributes_or_status_is_ordinary() {
+fn span_without_required_mcp_method_is_filtered_as_unrelated() {
     let span = format!(r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}"}}"#);
     let obs = decode_str(&doc_with_spans(&[span]), &corpus_limits()).expect("bare span");
-    let span = &obs.spans[0];
-    assert_eq!(span.kind, SpanKind::Unspecified);
-    assert_eq!(span.method, MethodObservation::Absent);
-    assert_eq!(span.operation, OperationObservation::Absent);
-    assert_eq!(span.tool_name, None);
-    assert_eq!(span.request_id, None);
-    assert_eq!(span.protocol_version, SpanProtocolVersion::Absent);
-    assert_eq!(span.status, StatusObservation::Absent);
-    assert_eq!(span.error_type, ErrorTypeObservation::Absent);
+    assert!(
+        obs.spans.is_empty(),
+        "an unrelated OTLP span must not become an MCP observation"
+    );
+}
+
+#[test]
+fn mixed_otlp_input_retains_only_mcp_identified_spans() {
+    let unrelated = format!(r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}"}}"#);
+    let mcp = span_with_attrs(&[attr_str("mcp.method.name", "tools/call")]);
+    let obs =
+        decode_str(&doc_with_spans(&[unrelated, mcp]), &corpus_limits()).expect("mixed OTLP input");
+    assert_eq!(obs.spans.len(), 1);
+    assert_eq!(obs.spans[0].method, MethodObservation::ToolsCall);
 }
 
 #[test]
@@ -673,6 +831,16 @@ fn recognized_attribute_wrong_value_type_rejects_typed() {
             RecognizedAttribute::MethodName,
         ),
         (
+            "mcp.resource.uri",
+            r#"{"boolValue":true}"#,
+            RecognizedAttribute::ResourceUri,
+        ),
+        (
+            "mcp.session.id",
+            r#"{"intValue":"7"}"#,
+            RecognizedAttribute::SessionId,
+        ),
+        (
             "gen_ai.operation.name",
             r#"{"boolValue":true}"#,
             RecognizedAttribute::OperationName,
@@ -692,11 +860,21 @@ fn recognized_attribute_wrong_value_type_rejects_typed() {
             r#"{"boolValue":false}"#,
             RecognizedAttribute::ErrorType,
         ),
+        (
+            "rpc.response.status_code",
+            r#"{"intValue":"500"}"#,
+            RecognizedAttribute::RpcResponseStatusCode,
+        ),
     ];
     for (key, value, attribute) in cases {
         let entry = format!(r#"{{"key":"{key}","value":{value}}}"#);
+        let doc = if *key == "mcp.method.name" {
+            doc_with_attrs(&[entry])
+        } else {
+            mcp_doc_with_attrs(&[entry])
+        };
         assert_eq!(
-            decode_str(&doc_with_attrs(&[entry]), &corpus_limits()).expect_err("wrong type"),
+            decode_str(&doc, &corpus_limits()).expect_err("wrong type on an MCP span"),
             OtlpIngestError::RecognizedAttributeWrongType(*attribute),
             "attribute {attribute:?}"
         );
@@ -704,26 +882,217 @@ fn recognized_attribute_wrong_value_type_rejects_typed() {
 }
 
 #[test]
-fn integer_request_id_preserves_upstream_type() {
+fn unrelated_spans_do_not_apply_mcp_projection_type_rules() {
+    let entries = [
+        r#"{"key":"gen_ai.operation.name","value":{"boolValue":true}}"#.to_string(),
+        r#"{"key":"gen_ai.tool.name","value":{"intValue":"7"}}"#.to_string(),
+        r#"{"key":"jsonrpc.request.id","value":{"doubleValue":1.5}}"#.to_string(),
+        r#"{"key":"error.type","value":{"boolValue":false}}"#.to_string(),
+        r#"{"key":"rpc.response.status_code","value":{"intValue":"500"}}"#.to_string(),
+    ];
+    let obs = decode_str(&doc_with_attrs(&entries), &corpus_limits())
+        .expect("generic attributes on an unrelated span are not MCP projection faults");
+    assert!(obs.spans.is_empty());
+}
+
+#[test]
+fn integer_request_id_is_wrong_typed_for_the_pinned_semconv() {
     let entry = r#"{"key":"jsonrpc.request.id","value":{"intValue":"42"}}"#.to_string();
-    let obs = decode_str(&doc_with_attrs(&[entry]), &corpus_limits()).expect("int request id");
     assert_eq!(
-        obs.spans[0].request_id,
-        Some(RequestIdObservation::Integer(42))
+        decode_str(&mcp_doc_with_attrs(&[entry]), &corpus_limits())
+            .expect_err("the pinned semconv defines request id as string"),
+        OtlpIngestError::RecognizedAttributeWrongType(RecognizedAttribute::RequestId)
     );
 }
 
 #[test]
-fn error_status_and_error_type_are_extracted() {
+fn empty_and_unknown_anyvalue_members_are_forward_compatible() {
+    for value in [
+        r#"{}"#,
+        r#"{"stringValueStrindex":1}"#,
+        r#"{"futureValue":"ignored"}"#,
+    ] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{value}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .expect("OTLP permits empty AnyValue and ignores unknown protobuf JSON fields");
+    }
+
+    let recognized = r#"{"key":"mcp.method.name","value":{"stringValueStrindex":1}}"#;
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[recognized.to_string()]), &corpus_limits())
+            .expect_err("profile-only AnyValue is not a string MCP method"),
+        OtlpIngestError::RecognizedAttributeWrongType(RecognizedAttribute::MethodName)
+    );
+}
+
+#[test]
+fn unknown_anyvalue_content_remains_bounded_and_duplicate_strict() {
+    let mut limits = corpus_limits();
+    limits.max_attribute_value_bytes = 8;
+    let oversized = r#"{"key":"x","value":{"u":"123456789"}}"#.to_string();
+    assert_limit(
+        decode_str(&doc_with_attrs(&[oversized]), &limits),
+        OtlpLimitDimension::AttributeValueBytes,
+        8,
+    );
+
+    let duplicate = r#"{"key":"x","value":{"futureValue":1,"futureValue":2}}"#.to_string();
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[duplicate]), &corpus_limits())
+            .expect_err("duplicate unknown AnyValue member"),
+        OtlpIngestError::DuplicateField(ShapeSite::AttributeValue)
+    );
+}
+
+#[test]
+fn unknown_duplicate_key_is_charged_before_duplicate_rejection() {
+    let mut limits = corpus_limits();
+    limits.max_attribute_value_bytes = 2;
+    let entry = r#"{"key":"x","value":{"u":null,"u":null}}"#.to_string();
+    assert_limit(
+        decode_str(&doc_with_attrs(&[entry]), &limits),
+        OtlpLimitDimension::AttributeValueBytes,
+        2,
+    );
+}
+
+#[test]
+fn protojson_null_leaves_anyvalue_member_unset() {
+    for value in [
+        r#"{"stringValue":null}"#,
+        r#"{"intValue":null}"#,
+        r#"{"doubleValue":null}"#,
+        r#"{"boolValue":null}"#,
+        r#"{"bytesValue":null}"#,
+        r#"{"arrayValue":null}"#,
+        r#"{"kvlistValue":null}"#,
+        r#"{"stringValue":null,"intValue":"1"}"#,
+    ] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{value}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("ProtoJSON null must leave the member unset: {err:?}"));
+    }
+
+    let recognized = r#"{"key":"mcp.method.name","value":{"stringValue":null}}"#.to_string();
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[recognized]), &corpus_limits())
+            .expect_err("an unset AnyValue is not a string method"),
+        OtlpIngestError::RecognizedAttributeWrongType(RecognizedAttribute::MethodName)
+    );
+
+    let unset_value = r#"{"key":"unrecognized","value":null}"#.to_string();
+    decode_str(&doc_with_attrs(&[unset_value]), &corpus_limits())
+        .expect("a null message field leaves the AnyValue unset");
+}
+
+#[test]
+fn nested_protojson_unknown_fields_are_ignored_but_bounded() {
+    for value in [
+        r#"{"arrayValue":{"future":null,"values":[]}}"#,
+        r#"{"kvlistValue":{"future":null,"values":[]}}"#,
+        r#"{"kvlistValue":{"values":[{"key":"k","keyStrindex":1,"value":{}}]}}"#,
+    ] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{value}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("OTLP nested unknown field must be ignored: {err:?}"));
+    }
+
+    let mut limits = corpus_limits();
+    limits.max_attribute_value_bytes = 3;
+    let entry = r#"{"key":"x","value":{"arrayValue":{"u":"abc","values":[]}}}"#.to_string();
+    assert_limit(
+        decode_str(&doc_with_attrs(&[entry]), &limits),
+        OtlpLimitDimension::AttributeValueBytes,
+        3,
+    );
+}
+
+#[test]
+fn protojson_int64_accepts_integral_number_and_exponent_forms() {
+    for int_value in [r#""1e2""#, "1e2", "1.0"] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{{"intValue":{int_value}}}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("valid ProtoJSON int64 form {int_value}: {err:?}"));
+    }
+    for int_value in ["1.5", r#""1.5""#, r#""1e100""#] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{{"intValue":{int_value}}}}}"#);
+        assert_eq!(
+            decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+                .expect_err("non-integral or out-of-range int64 must reject"),
+            OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)
+        );
+    }
+}
+
+#[test]
+fn protojson_double_accepts_numeric_strings_and_named_values() {
+    for double_value in [r#""1e2""#, r#""NaN""#, r#""Infinity""#, r#""-Infinity""#] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{{"doubleValue":{double_value}}}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("valid ProtoJSON double form {double_value}: {err:?}"));
+    }
+}
+
+#[test]
+fn protojson_bytes_require_valid_standard_or_url_safe_base64() {
+    for bytes_value in ["YWJj", "YWI=", "YWI", "-_8=", "-_8"] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{{"bytesValue":"{bytes_value}"}}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("valid ProtoJSON base64 {bytes_value}: {err:?}"));
+    }
+    for bytes_value in ["not base64", "a", "ab===", "YWJj$"] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{{"bytesValue":"{bytes_value}"}}}}"#);
+        assert_eq!(
+            decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+                .expect_err("invalid ProtoJSON base64 must reject"),
+            OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)
+        );
+    }
+}
+
+#[test]
+fn protojson_null_enum_uses_the_default_zero_value() {
     let span = format!(
-        r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","attributes":[{}],"status":{{"code":2}}}}"#,
+        r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","kind":null,"attributes":[{}],"status":{{"code":null}}}}"#,
+        attr_str("mcp.method.name", "tools/call")
+    );
+    let obs = decode_str(&doc_with_spans(&[span]), &corpus_limits()).expect("enum null defaults");
+    assert_eq!(obs.spans[0].kind, SpanKind::Unspecified);
+    assert_eq!(obs.spans[0].status, StatusObservation::Unset);
+}
+
+#[test]
+fn source_reader_is_buffered_without_weakening_the_source_ceiling() {
+    let doc = doc_with_spans(&[]);
+    let reads = Cell::new(0);
+    let reader = CountingReader {
+        bytes: doc.as_bytes(),
+        reads: &reads,
+    };
+    decode_mcp_resource_spans(reader, &corpus_limits()).expect("small valid document");
+    assert!(
+        reads.get() <= 3,
+        "a small document should not require one underlying read per byte"
+    );
+}
+
+#[test]
+fn error_status_error_type_and_rpc_status_are_extracted() {
+    let span = format!(
+        r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","attributes":[{},{},{}],"status":{{"code":2}}}}"#,
+        attr_str("mcp.method.name", "tools/call"),
         attr_str("error.type", "timeout"),
+        attr_str("rpc.response.status_code", "-32602"),
     );
     let obs = decode_str(&doc_with_spans(&[span]), &corpus_limits()).expect("error span");
     assert_eq!(obs.spans[0].status, StatusObservation::Error);
     assert_eq!(
         obs.spans[0].error_type,
         ErrorTypeObservation::Present("timeout".into())
+    );
+    assert_eq!(
+        obs.spans[0].rpc_response_status,
+        RpcResponseStatusObservation::Present("-32602".into())
     );
 }
 
@@ -744,7 +1113,7 @@ fn protocol_version_states_are_typed_observations_not_failures() {
         ("2026-02-31", SpanProtocolVersion::Malformed),
     ];
     for (value, expected) in cases {
-        let doc = doc_with_attrs(&[attr_str("mcp.protocol.version", value)]);
+        let doc = mcp_doc_with_attrs(&[attr_str("mcp.protocol.version", value)]);
         let obs = decode_str(&doc, &corpus_limits()).expect("version states never fail decode");
         assert_eq!(&obs.spans[0].protocol_version, expected, "value {value:?}");
     }
@@ -753,11 +1122,38 @@ fn protocol_version_states_are_typed_observations_not_failures() {
 #[test]
 fn non_string_protocol_version_is_the_malformed_state() {
     let entry = r#"{"key":"mcp.protocol.version","value":{"intValue":"5"}}"#.to_string();
-    let obs = decode_str(&doc_with_attrs(&[entry]), &corpus_limits()).expect("typed state");
+    let obs = decode_str(&mcp_doc_with_attrs(&[entry]), &corpus_limits()).expect("typed state");
     assert_eq!(
         obs.spans[0].protocol_version,
         SpanProtocolVersion::Malformed
     );
+}
+
+#[test]
+fn protocol_version_without_required_mcp_method_fails_closed() {
+    assert_eq!(
+        decode_str(
+            &doc_with_attrs(&[attr_str("mcp.protocol.version", "2025-06-18")]),
+            &corpus_limits(),
+        )
+        .expect_err("an MCP-specific span without its required method"),
+        OtlpIngestError::MissingRequiredAttribute(RecognizedAttribute::MethodName)
+    );
+}
+
+#[test]
+fn any_pinned_mcp_marker_requires_the_semconv_method() {
+    for key in ["mcp.resource.uri", "mcp.session.id"] {
+        assert_eq!(
+            decode_str(
+                &doc_with_attrs(&[attr_str(key, "producer-reported")]),
+                &corpus_limits(),
+            )
+            .expect_err("an MCP-shaped span cannot disappear as unrelated"),
+            OtlpIngestError::MissingRequiredAttribute(RecognizedAttribute::MethodName),
+            "marker {key}"
+        );
+    }
 }
 
 #[test]
@@ -887,9 +1283,10 @@ fn uppercase_hex_ids_are_accepted_and_normalized_to_lowercase() {
     // OTLP JSON hex ids are case-insensitive; retained ids normalize to lowercase so one span
     // never splits into two identities by case.
     let span = format!(
-        r#"{{"traceId":"{}","spanId":"{}"}}"#,
+        r#"{{"traceId":"{}","spanId":"{}","attributes":[{}]}}"#,
         TRACE_ID.to_uppercase(),
-        SPAN_ID.to_uppercase()
+        SPAN_ID.to_uppercase(),
+        attr_str("mcp.method.name", "tools/call")
     );
     let obs = decode_str(&doc_with_spans(&[span]), &corpus_limits()).expect("uppercase hex");
     assert_eq!(obs.spans[0].trace_id, TRACE_ID);
@@ -913,4 +1310,19 @@ fn attribute_count_ceiling_is_per_list() {
         span_with_attrs(&[attr_str("g", "v"), attr_str("h", "v")]),
     );
     decode_str(&doc, &limits).expect("resource and span lists are counted independently");
+}
+
+#[test]
+fn attribute_count_precedes_shape_validation_for_every_list_element() {
+    let mut limits = corpus_limits();
+    limits.max_attribute_count = 1;
+    let span = format!(
+        r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","attributes":[{},0]}}"#,
+        attr_str("a", "v")
+    );
+    assert_limit(
+        decode_str(&doc_with_spans(&[span]), &limits),
+        OtlpLimitDimension::AttributeCount,
+        1,
+    );
 }

--- a/crates/assay-core/src/otel/mcp_ingest/tests.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/tests.rs
@@ -192,6 +192,25 @@ fn instrumentation_scope_storage_is_shared_across_its_spans() {
 }
 
 #[test]
+fn string_instrumentation_scope_is_typed_and_charged_before_shape_refusal() {
+    let oversized = "x".repeat(128);
+    let doc = format!(r#"{{"resourceSpans":[{{"scopeSpans":[{{"scope":"{oversized}"}}]}}]}}"#);
+
+    let mut bounded = corpus_limits();
+    bounded.max_decoded_bytes = 64;
+    assert_limit(
+        decode_str(&doc, &bounded),
+        OtlpLimitDimension::DecodedBytes,
+        64,
+    );
+
+    assert_eq!(
+        decode_str(&doc, &corpus_limits()).expect_err("scope must be an object"),
+        OtlpIngestError::UnexpectedShape(ShapeSite::InstrumentationScope)
+    );
+}
+
+#[test]
 fn absent_null_and_empty_parent_or_scope_identity_remain_absent() {
     for parent in ["", "null"] {
         let parent_field = if parent == "null" {
@@ -250,6 +269,9 @@ fn provenance_mapping_is_pinned() {
     let expected = [
         (UpstreamField::TraceId, "traceId"),
         (UpstreamField::SpanId, "spanId"),
+        (UpstreamField::ParentSpanId, "parentSpanId"),
+        (UpstreamField::InstrumentationScopeName, "scope.name"),
+        (UpstreamField::InstrumentationScopeVersion, "scope.version"),
         (UpstreamField::SpanKind, "kind"),
         (UpstreamField::StatusCode, "status.code"),
         (UpstreamField::McpMethodName, "mcp.method.name"),
@@ -513,6 +535,35 @@ fn kvlist_keys_and_values_share_one_per_attribute_budget() {
         &limits,
     )
     .expect("per-value budget resets between separate attributes");
+}
+
+#[test]
+fn duplicate_nested_kvlist_keys_are_rejected() {
+    let entry = r#"{"key":"x","value":{"kvlistValue":{"values":[{"key":"same","value":{}},{"key":"same","value":{}}]}}}"#;
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[entry.to_string()]), &corpus_limits())
+            .expect_err("nested KeyValueList keys must be unique"),
+        OtlpIngestError::DuplicateField(ShapeSite::AttributeValue)
+    );
+}
+
+#[test]
+fn malformed_kvlist_keys_charge_value_budget_before_typed_shape_refusal() {
+    let entry = r#"{"key":"x","value":{"kvlistValue":{"values":[{"key":true,"value":{}}]}}}"#;
+
+    let mut bounded = corpus_limits();
+    bounded.max_attribute_value_bytes = 0;
+    assert_limit(
+        decode_str(&doc_with_attrs(&[entry.to_string()]), &bounded),
+        OtlpLimitDimension::AttributeValueBytes,
+        0,
+    );
+
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[entry.to_string()]), &corpus_limits())
+            .expect_err("nested key must be a string"),
+        OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)
+    );
 }
 
 // --- Short reads and source truncation ------------------------------------------------------
@@ -1287,6 +1338,8 @@ fn protojson_int64_string_conversion_is_exact() {
         r#""-9223372036854775808""#,
         r#""9223372036854775807""#,
         r#""-9.223372036854775808e18""#,
+        r#""0e-9223372036854775809""#,
+        r#""0.0e-9223372036854775808""#,
     ] {
         let entry = format!(r#"{{"key":"x","value":{{"intValue":{int_value}}}}}"#);
         decode_str(&doc_with_attrs(&[entry]), &corpus_limits())

--- a/crates/assay-core/src/otel/mcp_ingest/tests.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/tests.rs
@@ -13,9 +13,9 @@ use super::limits::{
     SpanField,
 };
 use super::observation::{
-    ErrorTypeObservation, McpResourceSpansObservation, MethodObservation, OperationObservation,
-    RequestIdObservation, RpcResponseStatusObservation, SpanKind, SpanProtocolVersion,
-    StatusObservation, UpstreamField, SEMCONV_PIN,
+    ErrorTypeObservation, InstrumentationScopeObservation, McpResourceSpansObservation,
+    MethodObservation, OperationObservation, RequestIdObservation, RpcResponseStatusObservation,
+    SpanKind, SpanProtocolVersion, StatusObservation, UpstreamField, SEMCONV_PIN,
 };
 
 const FIXTURE_DIR: &str = concat!(
@@ -131,11 +131,64 @@ fn client_fixture_decodes_and_extracts_explicit_fields() {
         SpanProtocolVersion::PresentSupported("2024-11-05".into())
     );
     assert_eq!(span.status, StatusObservation::Ok);
+    assert_eq!(
+        span.instrumentation_scope,
+        Some(InstrumentationScopeObservation {
+            name: Some("mcp-fixture-generator".into()),
+            version: Some("1.0.0".into()),
+        })
+    );
     assert_eq!(span.error_type, ErrorTypeObservation::Absent);
     assert_eq!(
         span.rpc_response_status,
         RpcResponseStatusObservation::Absent
     );
+}
+
+#[test]
+fn parent_span_and_instrumentation_scope_are_retained_when_present() {
+    let parent = "A7AD6B7169203331";
+    let span = format!(
+        r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","parentSpanId":"{parent}","attributes":[{}]}}"#,
+        attr_str("mcp.method.name", "tools/call")
+    );
+    let doc = format!(
+        r#"{{"resourceSpans":[{{"scopeSpans":[{{"spans":[{span}],"scope":{{"version":"1.2.3","name":"fixture-scope"}}}}]}}]}}"#
+    );
+    let obs = decode_str(&doc, &corpus_limits()).expect("bounded parent and scope identity");
+    assert_eq!(obs.spans.len(), 1);
+    assert_eq!(
+        obs.spans[0].parent_span_id.as_deref(),
+        Some("a7ad6b7169203331")
+    );
+    assert_eq!(
+        obs.spans[0].instrumentation_scope,
+        Some(InstrumentationScopeObservation {
+            name: Some("fixture-scope".into()),
+            version: Some("1.2.3".into()),
+        })
+    );
+}
+
+#[test]
+fn absent_null_and_empty_parent_or_scope_identity_remain_absent() {
+    for parent in ["", "null"] {
+        let parent_field = if parent == "null" {
+            r#""parentSpanId":null,"#.to_string()
+        } else {
+            r#""parentSpanId":"","#.to_string()
+        };
+        let span = format!(
+            r#"{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}",{parent_field}"attributes":[{}]}}"#,
+            attr_str("mcp.method.name", "tools/call")
+        );
+        let doc = format!(
+            r#"{{"resourceSpans":[{{"scopeSpans":[{{"scope":{{"name":"","version":""}},"spans":[{span}]}}]}}]}}"#
+        );
+        let obs = decode_str(&doc, &corpus_limits()).expect("default-valued identities are absent");
+        assert_eq!(obs.spans[0].parent_span_id, None);
+        assert_eq!(obs.spans[0].instrumentation_scope, None);
+    }
 }
 
 #[test]
@@ -695,7 +748,7 @@ fn any_value_with_conflicting_members_rejects() {
     assert_eq!(
         decode_str(&doc_with_attrs(&[duplicate_variant]), &corpus_limits())
             .expect_err("duplicate value member"),
-        OtlpIngestError::ConflictingAttributeValue
+        OtlpIngestError::DuplicateField(ShapeSite::AttributeValue)
     );
 }
 
@@ -896,6 +949,59 @@ fn unrelated_spans_do_not_apply_mcp_projection_type_rules() {
 }
 
 #[test]
+fn mcp_projection_is_independent_of_attribute_order() {
+    let attrs = [
+        attr_str("gen_ai.tool.name", "read_file"),
+        attr_str("jsonrpc.request.id", "17"),
+        attr_str("mcp.method.name", "tools/call"),
+    ];
+    let obs = decode_str(&doc_with_attrs(&attrs), &corpus_limits())
+        .expect("candidate observations before the MCP marker are retained until classification");
+    assert_eq!(obs.spans.len(), 1);
+    assert_eq!(obs.spans[0].tool_name.as_deref(), Some("read_file"));
+    assert_eq!(
+        obs.spans[0].request_id,
+        Some(RequestIdObservation::String("17".into()))
+    );
+
+    let wrong_before_marker = [
+        r#"{"key":"gen_ai.tool.name","value":{"intValue":"7"}}"#.to_string(),
+        attr_str("mcp.method.name", "tools/call"),
+    ];
+    assert_eq!(
+        decode_str(&doc_with_attrs(&wrong_before_marker), &corpus_limits())
+            .expect_err("order must not hide a wrong-typed recognized observation"),
+        OtlpIngestError::RecognizedAttributeWrongType(RecognizedAttribute::ToolName)
+    );
+}
+
+#[test]
+fn unknown_mcp_prefixed_attribute_does_not_establish_identity() {
+    let attrs = [attr_str("mcp.future.extension", "value")];
+    let obs = decode_str(&doc_with_attrs(&attrs), &corpus_limits())
+        .expect("only exact pinned MCP markers establish identity");
+    assert!(obs.spans.is_empty());
+}
+
+#[test]
+fn wrong_typed_observation_error_is_value_free_after_mcp_identity_is_known() {
+    const MARKER: &str = "ZZ_ATTACKER_MARKER_ZZ";
+    let attrs = [
+        attr_str("x", MARKER),
+        r#"{"key":"gen_ai.tool.name","value":{"intValue":"1"}}"#.to_string(),
+        attr_str("mcp.method.name", "tools/call"),
+    ];
+    let err = decode_str(&doc_with_attrs(&attrs), &corpus_limits())
+        .expect_err("wrong-typed candidate remains a fault even when it precedes the marker");
+    assert_eq!(
+        err,
+        OtlpIngestError::RecognizedAttributeWrongType(RecognizedAttribute::ToolName)
+    );
+    assert!(!err.to_string().contains(MARKER));
+    assert!(!format!("{err:?}").contains(MARKER));
+}
+
+#[test]
 fn integer_request_id_is_wrong_typed_for_the_pinned_semconv() {
     let entry = r#"{"key":"jsonrpc.request.id","value":{"intValue":"42"}}"#.to_string();
     assert_eq!(
@@ -986,6 +1092,59 @@ fn protojson_null_leaves_anyvalue_member_unset() {
 }
 
 #[test]
+fn protojson_null_leaves_repeated_and_message_fields_unset() {
+    for doc in [
+        r#"{"resourceSpans":null}"#.to_string(),
+        r#"{"resourceSpans":[{"resource":null,"scopeSpans":null}]}"#.to_string(),
+        format!(
+            r#"{{"resourceSpans":[{{"scopeSpans":[{{"scope":null,"spans":[{{"traceId":"{TRACE_ID}","spanId":"{SPAN_ID}","attributes":[{}],"status":null}}]}}]}}]}}"#,
+            attr_str("mcp.method.name", "tools/call")
+        ),
+    ] {
+        decode_str(&doc, &corpus_limits())
+            .unwrap_or_else(|err| panic!("ProtoJSON null field must remain unset: {err:?}"));
+    }
+
+    for value in [
+        r#"{"arrayValue":{"values":null}}"#,
+        r#"{"kvlistValue":{"values":null}}"#,
+    ] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{value}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("ProtoJSON null repeated field must be empty: {err:?}"));
+    }
+}
+
+#[test]
+fn protojson_null_does_not_create_a_oneof_conflict() {
+    for value in [
+        r#"{"stringValue":"kept","intValue":null}"#,
+        r#"{"intValue":null,"stringValue":"kept"}"#,
+    ] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{value}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("a null oneof member remains unset: {err:?}"));
+    }
+}
+
+#[test]
+fn duplicate_anyvalue_member_precedes_oneof_conflict() {
+    let duplicate = r#"{"key":"x","value":{"stringValue":"a","stringValue":"b"}}"#.to_string();
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[duplicate]), &corpus_limits())
+            .expect_err("the same AnyValue member is duplicated"),
+        OtlpIngestError::DuplicateField(ShapeSite::AttributeValue)
+    );
+
+    let conflict = r#"{"key":"x","value":{"stringValue":"a","intValue":"1"}}"#.to_string();
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[conflict]), &corpus_limits())
+            .expect_err("two populated oneof members conflict"),
+        OtlpIngestError::ConflictingAttributeValue
+    );
+}
+
+#[test]
 fn nested_protojson_unknown_fields_are_ignored_but_bounded() {
     for value in [
         r#"{"arrayValue":{"future":null,"values":[]}}"#,
@@ -1020,6 +1179,85 @@ fn protojson_int64_accepts_integral_number_and_exponent_forms() {
             decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
                 .expect_err("non-integral or out-of-range int64 must reject"),
             OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)
+        );
+    }
+}
+
+#[test]
+fn protojson_int64_string_conversion_is_exact() {
+    for int_value in [
+        r#""-9223372036854775809""#,
+        r#""9223372036854775808""#,
+        r#""9007199254740992.5""#,
+        r#""-9.223372036854775809e18""#,
+    ] {
+        let entry = format!(r#"{{"key":"x","value":{{"intValue":{int_value}}}}}"#);
+        assert_eq!(
+            decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+                .expect_err("fractional or out-of-range decimal must not round into int64"),
+            OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue),
+            "accepted {int_value}"
+        );
+    }
+
+    for int_value in [
+        r#""-9223372036854775808""#,
+        r#""9223372036854775807""#,
+        r#""-9.223372036854775808e18""#,
+    ] {
+        let entry = format!(r#"{{"key":"x","value":{{"intValue":{int_value}}}}}"#);
+        decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+            .unwrap_or_else(|err| panic!("exact in-range int64 {int_value}: {err:?}"));
+    }
+}
+
+#[test]
+fn malformed_shapes_still_cross_their_resource_ceiling_first() {
+    let mut decoded = corpus_limits();
+    decoded.max_decoded_bytes = "resourceSpans".len() as u64 + 1;
+    assert_limit(
+        decode_str(r#"{"resourceSpans":"xx"}"#, &decoded),
+        OtlpLimitDimension::DecodedBytes,
+        decoded.max_decoded_bytes,
+    );
+
+    let mut value = corpus_limits();
+    value.max_attribute_value_bytes = 0;
+    let wrong_value = r#"{"key":"mcp.method.name","value":true}"#.to_string();
+    assert_limit(
+        decode_str(&doc_with_attrs(&[wrong_value]), &value),
+        OtlpLimitDimension::AttributeValueBytes,
+        0,
+    );
+
+    let mut depth = corpus_limits();
+    depth.max_nesting_depth = 1;
+    assert_limit(
+        decode_str(r#"{"resourceSpans":{}}"#, &depth),
+        OtlpLimitDimension::NestingDepth,
+        1,
+    );
+}
+
+#[test]
+fn malformed_anyvalue_scalars_are_charged_at_every_nested_layer() {
+    let values = [
+        r#"true"#,
+        r#"{"stringValue":true}"#,
+        r#"{"intValue":true}"#,
+        r#"{"doubleValue":true}"#,
+        r#"{"arrayValue":true}"#,
+        r#"{"arrayValue":{"values":true}}"#,
+        r#"{"kvlistValue":{"values":[true]}}"#,
+    ];
+    for value in values {
+        let mut limits = corpus_limits();
+        limits.max_attribute_value_bytes = 0;
+        let entry = format!(r#"{{"key":"x","value":{value}}}"#);
+        assert_limit(
+            decode_str(&doc_with_attrs(&[entry]), &limits),
+            OtlpLimitDimension::AttributeValueBytes,
+            0,
         );
     }
 }
@@ -1185,11 +1423,6 @@ fn rejection_errors_never_echo_attacker_content() {
         doc_with_attrs(&[
             attr_str(&format!("a{MARKER}"), "v"),
             attr_str(&format!("a{MARKER}"), "v"),
-        ]),
-        // Wrong-typed recognized attribute whose sibling carries the marker.
-        doc_with_attrs(&[
-            attr_str("x", MARKER),
-            r#"{"key":"gen_ai.tool.name","value":{"intValue":"1"}}"#.to_string(),
         ]),
         // Malformed id carrying the marker.
         doc_with_spans(&[format!(r#"{{"traceId":"{MARKER}","spanId":"{SPAN_ID}"}}"#)]),

--- a/crates/assay-core/src/otel/mcp_ingest/tests.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/tests.rs
@@ -6,6 +6,7 @@
 
 use std::cell::Cell;
 use std::io::Read;
+use std::sync::Arc;
 
 use super::decode::decode_mcp_resource_spans;
 use super::limits::{
@@ -133,10 +134,10 @@ fn client_fixture_decodes_and_extracts_explicit_fields() {
     assert_eq!(span.status, StatusObservation::Ok);
     assert_eq!(
         span.instrumentation_scope,
-        Some(InstrumentationScopeObservation {
+        Some(Arc::new(InstrumentationScopeObservation {
             name: Some("mcp-fixture-generator".into()),
             version: Some("1.0.0".into()),
-        })
+        }))
     );
     assert_eq!(span.error_type, ErrorTypeObservation::Absent);
     assert_eq!(
@@ -163,11 +164,31 @@ fn parent_span_and_instrumentation_scope_are_retained_when_present() {
     );
     assert_eq!(
         obs.spans[0].instrumentation_scope,
-        Some(InstrumentationScopeObservation {
+        Some(Arc::new(InstrumentationScopeObservation {
             name: Some("fixture-scope".into()),
             version: Some("1.2.3".into()),
-        })
+        }))
     );
+}
+
+#[test]
+fn instrumentation_scope_storage_is_shared_across_its_spans() {
+    let first = span_with_attrs(&[attr_str("mcp.method.name", "tools/call")]);
+    let second = first.replace(SPAN_ID, "b7ad6b7169203332");
+    let doc = format!(
+        r#"{{"resourceSpans":[{{"scopeSpans":[{{"scope":{{"name":"shared-scope","version":"1.0.0"}},"spans":[{first},{second}]}}]}}]}}"#
+    );
+    let obs = decode_str(&doc, &corpus_limits()).expect("shared instrumentation scope");
+    assert_eq!(obs.spans.len(), 2);
+    let first_scope = obs.spans[0]
+        .instrumentation_scope
+        .as_ref()
+        .expect("first span scope");
+    let second_scope = obs.spans[1]
+        .instrumentation_scope
+        .as_ref()
+        .expect("second span scope");
+    assert!(Arc::ptr_eq(first_scope, second_scope));
 }
 
 #[test]
@@ -1116,6 +1137,21 @@ fn protojson_null_leaves_repeated_and_message_fields_unset() {
 }
 
 #[test]
+fn protojson_null_is_rejected_inside_repeated_anyvalue_elements() {
+    for value in [
+        r#"{"arrayValue":{"values":[null]}}"#,
+        r#"{"kvlistValue":{"values":[null]}}"#,
+    ] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{value}}}"#);
+        assert_eq!(
+            decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+                .expect_err("ProtoJSON repeated elements cannot be null"),
+            OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue)
+        );
+    }
+}
+
+#[test]
 fn protojson_null_does_not_create_a_oneof_conflict() {
     for value in [
         r#"{"stringValue":"kept","intValue":null}"#,
@@ -1264,10 +1300,36 @@ fn malformed_anyvalue_scalars_are_charged_at_every_nested_layer() {
 
 #[test]
 fn protojson_double_accepts_numeric_strings_and_named_values() {
-    for double_value in [r#""1e2""#, r#""NaN""#, r#""Infinity""#, r#""-Infinity""#] {
+    for double_value in [
+        r#""1e2""#,
+        r#""-1.25e+2""#,
+        r#""0""#,
+        r#""NaN""#,
+        r#""Infinity""#,
+        r#""-Infinity""#,
+    ] {
         let entry = format!(r#"{{"key":"unrecognized","value":{{"doubleValue":{double_value}}}}}"#);
         decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
             .unwrap_or_else(|err| panic!("valid ProtoJSON double form {double_value}: {err:?}"));
+    }
+
+    for double_value in [
+        r#""inf""#,
+        r#""+infinity""#,
+        r#""nan""#,
+        r#"".5""#,
+        r#""5.""#,
+        r#""01""#,
+        r#""+1""#,
+        r#""1e999""#,
+    ] {
+        let entry = format!(r#"{{"key":"unrecognized","value":{{"doubleValue":{double_value}}}}}"#);
+        assert_eq!(
+            decode_str(&doc_with_attrs(&[entry]), &corpus_limits())
+                .expect_err("non-ProtoJSON double spelling must reject"),
+            OtlpIngestError::UnexpectedShape(ShapeSite::AttributeValue),
+            "accepted {double_value}"
+        );
     }
 }
 

--- a/crates/assay-core/src/otel/mcp_ingest/tests.rs
+++ b/crates/assay-core/src/otel/mcp_ingest/tests.rs
@@ -213,6 +213,26 @@ fn absent_null_and_empty_parent_or_scope_identity_remain_absent() {
 }
 
 #[test]
+fn either_scope_identity_field_is_retained_independently() {
+    for (scope, expected_name, expected_version) in [
+        (r#"{"name":"scope-only"}"#, Some("scope-only"), None),
+        (r#"{"version":"2.0.0"}"#, None, Some("2.0.0")),
+    ] {
+        let span = span_with_attrs(&[attr_str("mcp.method.name", "tools/call")]);
+        let doc = format!(
+            r#"{{"resourceSpans":[{{"scopeSpans":[{{"scope":{scope},"spans":[{span}]}}]}}]}}"#
+        );
+        let obs = decode_str(&doc, &corpus_limits()).expect("partial scope identity");
+        let observed = obs.spans[0]
+            .instrumentation_scope
+            .as_ref()
+            .expect("either scope field retains the scope");
+        assert_eq!(observed.name.as_deref(), expected_name);
+        assert_eq!(observed.version.as_deref(), expected_version);
+    }
+}
+
+#[test]
 fn server_fixture_decodes_as_server_kind() {
     let bytes = fixture_bytes("mcp_server_tools_call.json");
     let obs = decode_mcp_resource_spans(&bytes[..], &corpus_limits()).expect("benign corpus");
@@ -1110,6 +1130,17 @@ fn protojson_null_leaves_anyvalue_member_unset() {
     let unset_value = r#"{"key":"unrecognized","value":null}"#.to_string();
     decode_str(&doc_with_attrs(&[unset_value]), &corpus_limits())
         .expect("a null message field leaves the AnyValue unset");
+
+    let omitted_value = r#"{"key":"unrecognized"}"#.to_string();
+    decode_str(&doc_with_attrs(&[omitted_value]), &corpus_limits())
+        .expect("an omitted message field carries the same proto default");
+
+    let omitted_recognized = r#"{"key":"mcp.method.name"}"#.to_string();
+    assert_eq!(
+        decode_str(&doc_with_attrs(&[omitted_recognized]), &corpus_limits())
+            .expect_err("an unset recognized value is not a valid method"),
+        OtlpIngestError::RecognizedAttributeWrongType(RecognizedAttribute::MethodName)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: #1931
- Slice: Slice B hardening stacked onto #1944
- Builder: Codex
- Final head SHA: `67a47c2963ab8f5fcd2f35249b77c5e2ce898793`
- ADR invariants affected: bounded hostile ingest; observation versus conclusion separation; value-free refusal; no manufactured policy evidence

## Behavior

Aligns the bounded OTLP/JSON decoder with the pinned ProtoJSON and MCP semantic-convention surfaces. Every list element is counted before shape dispatch; buffering remains inside the source limiter; malformed values consume the relevant source, decoded, depth, and per-value budget before shape refusal; unknown subtrees stay bounded and duplicate-strict.

Recognized ProtoJSON message/repeated fields and AnyValue oneof members treat `null` as unset, while repeated AnyValue elements reject `null`. Omitted `KeyValue.value` has the same proto default as explicit null; a missing key remains the proto default. Nested `KeyValueList` keys are charged before their bounded temporary copy and enforced unique as required by the pinned OTLP proto.

Quoted int64 values use exact decimal conversion and JSON-number grammar. Exact zero is recognized before bounded exponent arithmetic, so exponent magnitude cannot wrongly reject a zero result. Bare int64 numbers follow ProtoJSON's binary64 coercion before integer range validation. Quoted doubles use JSON-number grammar plus finite-range conversion, with only exact ProtoJSON non-finite spellings accepted.

Base64 validation reuses one bounded scratch allocation. MCP projection is order-independent, but an unknown `mcp.*` key does not establish identity. The frozen Slice B output retains bounded `parentSpanId` observations and shares each bounded instrumentation-scope identity across its spans. Those fields now have explicit pinned provenance mappings. No conclusion layer is added.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- Standard OTel error/status fields never become policy-decision evidence.
- No reducer, CLI, receiver, policy integration, or span-version conflict semantics.

## Test Evidence

The red phase independently exposed null/oneof, exact quoted integer, bare-int64 binary64 coercion, quoted-number grammar, float grammar/range, malformed-budget, parent/scope, projection-order, unknown-marker, scope-fanout, repeated-null, omitted-message-default, nested-key resource ordering, string-scope classification, zero-exponent, provenance, and nested-key uniqueness and null-default defects.

Eight earlier applied removal/regression mutations had direct bite: exact decimal parsing; conflict-before-null; malformed-value charge; parent projection; pre-marker filtering; scope copy versus sharing; repeated-element null; strict float grammar. The final review corrections were each red before implementation. One earlier isolated mutation rerun exhausted disk while linking and is not counted.

One initial marker mutation changed an unexercised attribute and stayed green; it is explicitly not counted. The corrected marker mutation failed. The single-allocation base64 property is structurally reviewable rather than allocator-counted; accepted/rejected forms and the scratch bound are covered, but no allocation-counting oracle is claimed.

### GREEN

- `cargo test -p assay-core otel::mcp_ingest::tests`: 89 passed
- `cargo test -p assay-core`: 723 unit tests plus all integration/doc-test binaries passed; only intentional recording tests ignored
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p assay-core --all-targets -- -D warnings`: clean
- `git diff --check`: clean
- pre-push workspace clippy and Linux compile gate: passed

## Review Quorum

- [x] First non-building exact-head review on `67a47c2963ab8f5fcd2f35249b77c5e2ce898793`
- [x] Second independent exact-head review because bot reviews target superseded stacked heads
- [x] Every actionable finding fixed or technically disposed
- [x] Local proof targets this exact head SHA

Reviews on `f1e1bd22` and `c63b283f` found and drove the final corrections; they are retained as diagnostic evidence but do not count toward the final-head quorum. A new push invalidates all older approvals.

Stacked integration order: merge this PR into `claude/otel-mcp-ingest-slice-b`, then re-run and review #1944 on its resulting exact head before merging to `main`.
