### PR TITLE
fix(core): reject unparsable `expected:` blocks instead of silently passing

### DIFF
--- a/crates/assay-cli/src/templates.rs
+++ b/crates/assay-cli/src/templates.rs
@@ -14,6 +14,7 @@ tests:
       prompt: "ci_schema"
     expected:
       type: json_schema
+      json_schema: "{}"
       schema_file: "schemas/ci_answer.schema.json"
   - id: "ci_smoke_semantic"
     input:

--- a/crates/assay-cli/tests/contract_init_ci.rs
+++ b/crates/assay-cli/tests/contract_init_ci.rs
@@ -73,6 +73,37 @@ fn test_init_ci_contract() {
     );
 }
 
+/// The generated scaffold must actually LOAD, not merely contain the right substrings.
+///
+/// Regression guard: `CI_EVAL_YAML` once emitted `type: json_schema` without the
+/// required `json_schema` field. The old parser silently degraded that to a vacuous
+/// always-passing test, so every text assertion above still held while
+/// `assay run --config ci-eval.yaml` was broken. Grepping the template cannot catch
+/// that class of defect; parsing it can.
+#[test]
+fn contract_init_ci_scaffold_is_loadable() {
+    let temp = tempfile::tempdir().unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(temp.path())
+        .arg("init")
+        .arg("--ci")
+        .assert()
+        .success();
+
+    // `validate` exercises the same loader as `run`/`ci`, and reports a diagnostic
+    // instead of the bare exit code those commands emit on a config error.
+    Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(temp.path())
+        .arg("validate")
+        .arg("--config")
+        .arg("ci-eval.yaml")
+        .assert()
+        .success();
+}
+
 #[test]
 fn test_init_preset_and_pack_alias_contract() {
     let temp = tempdir().unwrap();

--- a/crates/assay-cli/tests/exit_codes/core.rs
+++ b/crates/assay-cli/tests/exit_codes/core.rs
@@ -474,9 +474,10 @@ tests:
     assert_eq!(run["reason_code"], "E_CFG_PARSE");
 }
 
-/// `assay validate` sweeps a suite for always-green tests without running it.
+/// An explicitly-written empty assertion is a HARD ERROR, and it must be caught on
+/// the paths that decide outcomes — `run` and `ci`, not just `validate`.
 #[test]
-fn contract_validate_flags_vacuous_expected() {
+fn contract_run_rejects_explicitly_empty_assertion() {
     let dir = tempdir().unwrap();
     fs::write(
         dir.path().join("assay.yaml"),
@@ -492,6 +493,37 @@ tests:
     )
     .unwrap();
 
+    Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .assert()
+        .code(2);
+
+    let run = read_run_json(dir.path());
+    assert_eq!(run["reason_code"], "E_CFG_PARSE");
+}
+
+/// A test that omits `expected:` AND has no `assertions:` asserts nothing, but the
+/// omission itself is a documented, legitimate shape — so `assay validate` sweeps for
+/// it as a WARNING (exit 0), not an error.
+#[test]
+fn contract_validate_warns_on_test_with_no_assertion() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        r#"suite: vacuous
+model: dummy
+tests:
+  - id: always_green
+    input: hello
+"#,
+    )
+    .unwrap();
+
     let out = Command::cargo_bin("assay")
         .unwrap()
         .current_dir(dir.path())
@@ -501,20 +533,21 @@ tests:
         .arg("--format")
         .arg("json")
         .assert()
-        .code(2)
+        .code(0)
         .get_output()
         .clone();
 
     let report: Value = serde_json::from_slice(&out.stdout).expect("validate json");
-    let codes: Vec<&str> = report["diagnostics"]
-        .as_array()
-        .expect("diagnostics array")
+    let diags = report["diagnostics"].as_array().expect("diagnostics array");
+    let vacuous: Vec<&Value> = diags
         .iter()
-        .filter_map(|d| d["code"].as_str())
+        .filter(|d| d["code"] == "W_CFG_VACUOUS_EXPECTED")
         .collect();
-    assert!(
-        codes.contains(&"E_CFG_VACUOUS_EXPECTED"),
-        "expected E_CFG_VACUOUS_EXPECTED, got {:?}",
-        codes
+    assert_eq!(
+        vacuous.len(),
+        1,
+        "expected one vacuous warning, got {:?}",
+        diags
     );
+    assert_eq!(vacuous[0]["severity"], "warn");
 }

--- a/crates/assay-cli/tests/exit_codes/core.rs
+++ b/crates/assay-cli/tests/exit_codes/core.rs
@@ -374,3 +374,147 @@ fn contract_run_default_text_keeps_stdout_clean() {
         String::from_utf8_lossy(&out.stdout)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Vacuous / unparsable `expected:` blocks
+//
+// A YAML typo in `expected:` used to fall back to `Expected::default()` — an
+// empty `must_contain`, which passes for any response. These pin the three
+// silent paths to the default as config errors (exit 2), end to end.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_run_rejects_unparsable_expected_object() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        r#"suite: typo
+model: dummy
+tests:
+  - id: t1
+    input: hello
+    expected:
+      must_contains: ["hello"]
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .assert()
+        .code(2);
+
+    let run = read_run_json(dir.path());
+    assert_eq!(run["reason_code"], "E_CFG_PARSE");
+}
+
+#[test]
+fn contract_run_rejects_unrecognized_expected_list_entry() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        r#"suite: typo
+model: dummy
+tests:
+  - id: t1
+    input: hello
+    expected:
+      - must_contains: ["hello"]
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .assert()
+        .code(2);
+
+    let run = read_run_json(dir.path());
+    assert_eq!(run["reason_code"], "E_CFG_PARSE");
+}
+
+#[test]
+fn contract_run_rejects_multi_element_expected_list() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        r#"suite: multi
+model: dummy
+tests:
+  - id: t1
+    input: hello
+    expected:
+      - must_contain: "hello"
+      - must_contain: "world"
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .assert()
+        .code(2);
+
+    let run = read_run_json(dir.path());
+    assert_eq!(run["reason_code"], "E_CFG_PARSE");
+}
+
+/// `assay validate` sweeps a suite for always-green tests without running it.
+#[test]
+fn contract_validate_flags_vacuous_expected() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        r#"suite: vacuous
+model: dummy
+tests:
+  - id: always_green
+    input: hello
+    expected:
+      type: must_contain
+      must_contain: []
+"#,
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("validate")
+        .arg("--config")
+        .arg("assay.yaml")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .code(2)
+        .get_output()
+        .clone();
+
+    let report: Value = serde_json::from_slice(&out.stdout).expect("validate json");
+    let codes: Vec<&str> = report["diagnostics"]
+        .as_array()
+        .expect("diagnostics array")
+        .iter()
+        .filter_map(|d| d["code"].as_str())
+        .collect();
+    assert!(
+        codes.contains(&"E_CFG_VACUOUS_EXPECTED"),
+        "expected E_CFG_VACUOUS_EXPECTED, got {:?}",
+        codes
+    );
+}

--- a/crates/assay-core/src/errors/diagnostic.rs
+++ b/crates/assay-core/src/errors/diagnostic.rs
@@ -89,6 +89,8 @@ pub mod codes {
     // Errors (Exit 2)
     pub const E_CFG_PARSE: &str = "E_CFG_PARSE";
     pub const E_CFG_SCHEMA: &str = "E_CFG_SCHEMA";
+    /// A test whose `expected:` asserts nothing and therefore always passes.
+    pub const E_CFG_VACUOUS_EXPECTED: &str = "E_CFG_VACUOUS_EXPECTED";
     pub const E_PATH_NOT_FOUND: &str = "E_PATH_NOT_FOUND";
     pub const E_TRACE_MISS: &str = "E_TRACE_MISS";
     pub const E_TRACE_INVALID: &str = "E_TRACE_INVALID";

--- a/crates/assay-core/src/errors/diagnostic.rs
+++ b/crates/assay-core/src/errors/diagnostic.rs
@@ -89,8 +89,6 @@ pub mod codes {
     // Errors (Exit 2)
     pub const E_CFG_PARSE: &str = "E_CFG_PARSE";
     pub const E_CFG_SCHEMA: &str = "E_CFG_SCHEMA";
-    /// A test whose `expected:` asserts nothing and therefore always passes.
-    pub const E_CFG_VACUOUS_EXPECTED: &str = "E_CFG_VACUOUS_EXPECTED";
     pub const E_PATH_NOT_FOUND: &str = "E_PATH_NOT_FOUND";
     pub const E_TRACE_MISS: &str = "E_TRACE_MISS";
     pub const E_TRACE_INVALID: &str = "E_TRACE_INVALID";
@@ -100,6 +98,10 @@ pub mod codes {
     pub const E_POLICY_VIOLATION: &str = "E_POLICY_VIOLATION";
 
     // Warnings (Exit 0)
+    /// A test that asserts nothing: no `expected:` block and no `assertions:`, so it
+    /// passes for any response. An `expected:` block written out as empty is rejected
+    /// at parse time as `E_CFG_PARSE` instead.
+    pub const W_CFG_VACUOUS_EXPECTED: &str = "W_CFG_VACUOUS_EXPECTED";
     pub const W_BASE_FINGERPRINT: &str = "W_BASE_FINGERPRINT";
     pub const W_CACHE_CONFUSION: &str = "W_CACHE_CONFUSION";
 }

--- a/crates/assay-core/src/model/serde.rs
+++ b/crates/assay-core/src/model/serde.rs
@@ -1,7 +1,157 @@
 use crate::on_error::ErrorPolicy;
+use serde::de::Error as _;
 use serde::Deserialize;
 
 use super::types::{Expected, TestCase, TestInput};
+
+/// Legacy (pre-`type:`-tagged) keys an `expected:` block may still be written with.
+///
+/// This surface is frozen: new metrics are only reachable through the tagged form
+/// (`type: <metric>`). It is listed here so error messages can name the accepted
+/// alternatives instead of leaving the author to guess.
+const LEGACY_EXPECTED_KEYS: [&str; 4] = ["$ref", "must_contain", "sequence", "schema"];
+
+/// Describe a JSON value's shape for error messages.
+fn value_kind(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "a boolean",
+        serde_json::Value::Number(_) => "a number",
+        serde_json::Value::String(_) => "a string",
+        serde_json::Value::Array(_) => "a list",
+        serde_json::Value::Object(_) => "a mapping",
+    }
+}
+
+/// Parse a single `expected:` entry into an [`Expected`].
+///
+/// Resolution order is strict V1 (`type:`-tagged) first, then the frozen legacy
+/// heuristics in [`LEGACY_EXPECTED_KEYS`].
+///
+/// An entry matching neither is an error and **never** falls back to
+/// `Expected::default()`. That default is an empty `must_contain`, which the
+/// `must_contain` metric passes unconditionally, so a silent fallback turns a
+/// misspelled key into a test that always reports green.
+///
+/// The same function serves both the scalar and the list position. Keeping one
+/// implementation is deliberate: the two positions previously diverged (the list
+/// branch applied legacy heuristics, the scalar branch did not), which made
+/// `expected: {must_contain: [...]}` silently vacuous while the list-wrapped form
+/// of the same YAML worked.
+fn parse_expected_entry(item: &serde_json::Value) -> Result<Expected, String> {
+    // 1. Strict V1 (tagged).
+    let strict_err = match serde_json::from_value::<Expected>(item.clone()) {
+        Ok(exp) => return Ok(exp),
+        Err(e) => e,
+    };
+
+    let Some(obj) = item.as_object() else {
+        return Err(format!(
+            "`expected:` must be a mapping (or a list of one mapping), found {}",
+            value_kind(item)
+        ));
+    };
+
+    // A block that carries `type:` is asking for the tagged form; report why the
+    // tagged parse failed rather than the generic "unrecognized keys" message.
+    if obj.contains_key("type") {
+        return Err(format!("invalid `expected:` block: {}", strict_err));
+    }
+
+    // 2. Legacy heuristics.
+    let mut parsed = None;
+    let mut matched_keys = Vec::new();
+
+    if let Some(r) = obj.get("$ref") {
+        parsed = Some(Expected::Reference {
+            path: r.as_str().unwrap_or("").to_string(),
+        });
+        matched_keys.push("$ref");
+    }
+
+    // Don't chain else-ifs, check all to detect ambiguity
+    if let Some(mc) = obj.get("must_contain") {
+        let val = if mc.is_string() {
+            vec![mc.as_str().unwrap().to_string()]
+        } else {
+            serde_json::from_value(mc.clone()).unwrap_or_default()
+        };
+        // Last match wins for parsed, but we warn below
+        if parsed.is_none() {
+            parsed = Some(Expected::MustContain { must_contain: val });
+        }
+        matched_keys.push("must_contain");
+    }
+
+    if obj.get("sequence").is_some() {
+        if parsed.is_none() {
+            parsed = Some(Expected::SequenceValid {
+                policy: None,
+                sequence: serde_json::from_value(obj.get("sequence").unwrap().clone()).ok(),
+                rules: None,
+            });
+        }
+        matched_keys.push("sequence");
+    }
+
+    if obj.get("schema").is_some() {
+        if parsed.is_none() {
+            parsed = Some(Expected::ArgsValid {
+                policy: None,
+                schema: obj.get("schema").cloned(),
+            });
+        }
+        matched_keys.push("schema");
+    }
+
+    if matched_keys.len() > 1 {
+        eprintln!(
+            "WARN: Ambiguous legacy expected block. Found keys: {:?}. Using first match.",
+            matched_keys
+        );
+    }
+
+    parsed.ok_or_else(|| {
+        let found: Vec<&str> = obj.keys().map(String::as_str).collect();
+        format!(
+            "unrecognized `expected:` block, found key(s) {:?}. Use the tagged form \
+             (e.g. `type: must_contain` with `must_contain: [...]`) or one of the legacy \
+             keys {:?}",
+            found, LEGACY_EXPECTED_KEYS
+        )
+    })
+}
+
+/// Parse the whole `expected:` value (scalar or list form) for one test case.
+///
+/// Multi-element lists are rejected. `TestCase::expected` holds exactly one
+/// [`Expected`]; the previous code kept element 0 and dropped the rest without a
+/// word, so a two-assertion block enforced half of what it claimed. Supporting
+/// them properly would mean making `expected` a collection, which changes the
+/// metric-dispatch contract everywhere it is matched on; until that happens the
+/// honest behaviour is to refuse the input and name the fix. Single-element lists
+/// stay accepted for legacy compatibility.
+fn parse_expected_value(test_id: &str, val: &serde_json::Value) -> Result<Expected, String> {
+    let Some(arr) = val.as_array() else {
+        return parse_expected_entry(val).map_err(|e| format!("test '{}': {}", test_id, e));
+    };
+
+    match arr.len() {
+        0 => Err(format!(
+            "test '{}': `expected:` is an empty list, which asserts nothing. \
+             Remove the key or give it an assertion.",
+            test_id
+        )),
+        1 => parse_expected_entry(&arr[0])
+            .map_err(|e| format!("test '{}': `expected:` entry 0 is invalid: {}", test_id, e)),
+        n => Err(format!(
+            "test '{}': `expected:` has {} entries but only one is supported \
+             (earlier versions silently dropped all but the first). \
+             Split them into separate tests, or move the extra checks to `assertions:`.",
+            test_id, n
+        )),
+    }
+}
 
 impl<'de> Deserialize<'de> for TestCase {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -24,91 +174,17 @@ impl<'de> Deserialize<'de> for TestCase {
         }
 
         let raw = RawTestCase::deserialize(deserializer)?;
-        let mut expected_main = Expected::default();
         let extra_assertions = raw.assertions.unwrap_or_default();
 
-        if let Some(val) = raw.expected {
-            if let Some(arr) = val.as_array() {
-                // Legacy list format
-                for (i, item) in arr.iter().enumerate() {
-                    // Try to parse as Expected
-                    // Try to parse as Expected (Strict V1)
-                    if let Ok(exp) = serde_json::from_value::<Expected>(item.clone()) {
-                        if i == 0 {
-                            expected_main = exp;
-                        }
-                    } else if let Some(obj) = item.as_object() {
-                        // Try Legacy Heuristics
-                        let mut parsed = None;
-                        let mut matched_keys = Vec::new();
-
-                        if let Some(r) = obj.get("$ref") {
-                            parsed = Some(Expected::Reference {
-                                path: r.as_str().unwrap_or("").to_string(),
-                            });
-                            matched_keys.push("$ref");
-                        }
-
-                        // Don't chain else-ifs, check all to detect ambiguity
-                        if let Some(mc) = obj.get("must_contain") {
-                            let val = if mc.is_string() {
-                                vec![mc.as_str().unwrap().to_string()]
-                            } else {
-                                serde_json::from_value(mc.clone()).unwrap_or_default()
-                            };
-                            // Last match wins for parsed, but we warn below
-                            if parsed.is_none() {
-                                parsed = Some(Expected::MustContain { must_contain: val });
-                            }
-                            matched_keys.push("must_contain");
-                        }
-
-                        if obj.get("sequence").is_some() {
-                            if parsed.is_none() {
-                                parsed = Some(Expected::SequenceValid {
-                                    policy: None,
-                                    sequence: serde_json::from_value(
-                                        obj.get("sequence").unwrap().clone(),
-                                    )
-                                    .ok(),
-                                    rules: None,
-                                });
-                            }
-                            matched_keys.push("sequence");
-                        }
-
-                        if obj.get("schema").is_some() {
-                            if parsed.is_none() {
-                                parsed = Some(Expected::ArgsValid {
-                                    policy: None,
-                                    schema: obj.get("schema").cloned(),
-                                });
-                            }
-                            matched_keys.push("schema");
-                        }
-
-                        if matched_keys.len() > 1 {
-                            eprintln!(
-                                "WARN: Ambiguous legacy expected block. Found keys: {:?}. Using first match.",
-                                matched_keys
-                            );
-                        }
-
-                        if let Some(p) = parsed {
-                            if i == 0 {
-                                expected_main = p;
-                            }
-                            // else: drop or move to assertions (out of scope for quick fix, primary policy is priority)
-                        }
-                    }
-                }
-            } else {
-                // Try V1 single object
-                if let Ok(exp) = serde_json::from_value(val.clone()) {
-                    expected_main = exp;
-                }
-            }
-        }
+        // A missing `expected:` key stays permissive: a test may carry its checks in
+        // `assertions:` instead. It resolves to the vacuous default, which the
+        // `E_CFG_VACUOUS_EXPECTED` rule in `assay validate` reports when the test has
+        // no assertions either. A present-but-unparsable key is a different matter and
+        // is a hard error below.
+        let expected_main = match &raw.expected {
+            Some(val) => parse_expected_value(&raw.id, val).map_err(D::Error::custom)?,
+            None => Expected::default(),
+        };
 
         Ok(TestCase {
             id: raw.id,

--- a/crates/assay-core/src/model/serde.rs
+++ b/crates/assay-core/src/model/serde.rs
@@ -41,7 +41,7 @@ fn value_kind(v: &serde_json::Value) -> &'static str {
 fn parse_expected_entry(item: &serde_json::Value) -> Result<Expected, String> {
     // 1. Strict V1 (tagged).
     let strict_err = match serde_json::from_value::<Expected>(item.clone()) {
-        Ok(exp) => return Ok(exp),
+        Ok(exp) => return reject_vacuous(exp),
         Err(e) => e,
     };
 
@@ -52,29 +52,42 @@ fn parse_expected_entry(item: &serde_json::Value) -> Result<Expected, String> {
         ));
     };
 
-    // A block that carries `type:` is asking for the tagged form; report why the
-    // tagged parse failed rather than the generic "unrecognized keys" message.
-    if obj.contains_key("type") {
-        return Err(format!("invalid `expected:` block: {}", strict_err));
-    }
-
     // 2. Legacy heuristics.
+    //
+    // These run even when the block carries a `type:` key. A tagged block whose
+    // VALUE shape is legacy — `{type: must_contain, must_contain: "hello"}`, where
+    // the scalar string is the legacy spelling of a one-element list — fails the
+    // strict parse but is a perfectly good assertion, and rejecting it would turn
+    // working suites into config errors. Only when no legacy key matches at all do
+    // we fall back to reporting why the strict parse failed.
     let mut parsed = None;
     let mut matched_keys = Vec::new();
 
     if let Some(r) = obj.get("$ref") {
+        let path = r
+            .as_str()
+            .ok_or_else(|| format!("`$ref` must be a string, found {}", value_kind(r)))?;
         parsed = Some(Expected::Reference {
-            path: r.as_str().unwrap_or("").to_string(),
+            path: path.to_string(),
         });
         matched_keys.push("$ref");
     }
 
     // Don't chain else-ifs, check all to detect ambiguity
     if let Some(mc) = obj.get("must_contain") {
-        let val = if mc.is_string() {
-            vec![mc.as_str().unwrap().to_string()]
+        // No `unwrap_or_default()` here: an unparsable value used to collapse to an
+        // empty vec, i.e. an assertion that passes for any response — the very bug
+        // this module exists to prevent.
+        let val: Vec<String> = if let Some(s) = mc.as_str() {
+            vec![s.to_string()]
         } else {
-            serde_json::from_value(mc.clone()).unwrap_or_default()
+            serde_json::from_value(mc.clone()).map_err(|e| {
+                format!(
+                    "`must_contain` must be a string or a list of strings, found {}: {}",
+                    value_kind(mc),
+                    e
+                )
+            })?
         };
         // Last match wins for parsed, but we warn below
         if parsed.is_none() {
@@ -83,11 +96,21 @@ fn parse_expected_entry(item: &serde_json::Value) -> Result<Expected, String> {
         matched_keys.push("must_contain");
     }
 
-    if obj.get("sequence").is_some() {
+    if let Some(seq) = obj.get("sequence") {
         if parsed.is_none() {
+            // Previously `.ok()`, which turned a bad value into `sequence: None`.
+            // `sequence_valid` passes unconditionally when it has neither a sequence
+            // nor rules, so that silently produced an always-green test.
+            let sequence: Vec<String> = serde_json::from_value(seq.clone()).map_err(|e| {
+                format!(
+                    "`sequence` must be a list of strings, found {}: {}",
+                    value_kind(seq),
+                    e
+                )
+            })?;
             parsed = Some(Expected::SequenceValid {
                 policy: None,
-                sequence: serde_json::from_value(obj.get("sequence").unwrap().clone()).ok(),
+                sequence: Some(sequence),
                 rules: None,
             });
         }
@@ -111,15 +134,51 @@ fn parse_expected_entry(item: &serde_json::Value) -> Result<Expected, String> {
         );
     }
 
-    parsed.ok_or_else(|| {
-        let found: Vec<&str> = obj.keys().map(String::as_str).collect();
-        format!(
-            "unrecognized `expected:` block, found key(s) {:?}. Use the tagged form \
-             (e.g. `type: must_contain` with `must_contain: [...]`) or one of the legacy \
-             keys {:?}",
-            found, LEGACY_EXPECTED_KEYS
-        )
-    })
+    if let Some(p) = parsed {
+        return reject_vacuous(p);
+    }
+
+    // 3. Nothing matched. A block that carries `type:` was asking for the tagged
+    // form, so report why that parse failed rather than listing legacy keys it
+    // never wanted.
+    if obj.contains_key("type") {
+        return Err(format!("invalid `expected:` block: {}", strict_err));
+    }
+
+    let found: Vec<&str> = obj.keys().map(String::as_str).collect();
+    Err(format!(
+        "unrecognized `expected:` block, found key(s) {:?}. Use the tagged form \
+         (e.g. `type: must_contain` with `must_contain: [...]`) or one of the legacy \
+         keys {:?}",
+        found, LEGACY_EXPECTED_KEYS
+    ))
+}
+
+/// Reject an `expected:` block that was written out in full but asserts nothing.
+///
+/// An empty `must_contain` / `must_not_contain` gives the metric no substring to
+/// look for, so it passes for any response. Catching it here rather than only in
+/// `assay validate` matters: this path runs for every command that loads a config,
+/// including `assay run` and `assay ci`, which are the gates that decide outcomes.
+///
+/// This applies only to an assertion the author actually wrote. Omitting `expected:`
+/// altogether stays permissive — see the note in the `TestCase` deserializer — and
+/// is reported as a warning by the `W_CFG_VACUOUS_EXPECTED` rule instead.
+fn reject_vacuous(exp: Expected) -> Result<Expected, String> {
+    let field = match &exp {
+        Expected::MustContain { must_contain } if must_contain.is_empty() => "must_contain",
+        Expected::MustNotContain { must_not_contain } if must_not_contain.is_empty() => {
+            "must_not_contain"
+        }
+        _ => return Ok(exp),
+    };
+
+    Err(format!(
+        "`{}` is empty, so this test would pass for any response. \
+         Give it at least one entry, or remove the `expected:` block and put the \
+         test's checks in `assertions:`.",
+        field
+    ))
 }
 
 /// Parse the whole `expected:` value (scalar or list form) for one test case.
@@ -178,7 +237,7 @@ impl<'de> Deserialize<'de> for TestCase {
 
         // A missing `expected:` key stays permissive: a test may carry its checks in
         // `assertions:` instead. It resolves to the vacuous default, which the
-        // `E_CFG_VACUOUS_EXPECTED` rule in `assay validate` reports when the test has
+        // `W_CFG_VACUOUS_EXPECTED` rule in `assay validate` reports when the test has
         // no assertions either. A present-but-unparsable key is a different matter and
         // is a hard error below.
         let expected_main = match &raw.expected {

--- a/crates/assay-core/src/model/tests/mod.rs
+++ b/crates/assay-core/src/model/tests/mod.rs
@@ -14,7 +14,25 @@ fn test_string_input_deserialize() {
 }
 
 #[test]
-fn test_legacy_list_expected() {
+fn test_legacy_list_expected_single_entry() {
+    let yaml = r#"
+            id: test1
+            input: "test"
+            expected:
+              - must_contain: "Paris"
+        "#;
+    let tc: TestCase = serde_yaml::from_str(yaml).expect("failed to parse");
+    if let Expected::MustContain { must_contain } = tc.expected {
+        assert_eq!(must_contain, vec!["Paris"]);
+    } else {
+        panic!("Expected MustContain, got {:?}", tc.expected);
+    }
+}
+
+/// A multi-element `expected:` list used to keep element 0 and drop the rest in
+/// silence, so a two-assertion block enforced half of what it claimed.
+#[test]
+fn test_multi_element_expected_list_is_rejected() {
     let yaml = r#"
             id: test1
             input: "test"
@@ -22,11 +40,124 @@ fn test_legacy_list_expected() {
               - must_contain: "Paris"
               - must_not_contain: "London"
         "#;
+    let err = serde_yaml::from_str::<TestCase>(yaml)
+        .expect_err("multi-element expected list must not parse");
+    let msg = err.to_string();
+    assert!(msg.contains("test1"), "message must name the test: {}", msg);
+    assert!(
+        msg.contains("2 entries"),
+        "message must name the entry count: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_empty_expected_list_is_rejected() {
+    let yaml = r#"
+            id: test1
+            input: "test"
+            expected: []
+        "#;
+    let err =
+        serde_yaml::from_str::<TestCase>(yaml).expect_err("empty expected list must not parse");
+    assert!(err.to_string().contains("empty list"), "{}", err);
+}
+
+/// The headline regression: a typo in a key used to fall back to
+/// `Expected::default()` (an empty `must_contain`), which passes unconditionally.
+#[test]
+fn test_unparsable_expected_object_is_hard_error() {
+    let yaml = r#"
+            id: typo_test
+            input: "test"
+            expected:
+              must_contains: ["Paris"]
+        "#;
+    let err = serde_yaml::from_str::<TestCase>(yaml)
+        .expect_err("unrecognized expected block must not parse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("typo_test"),
+        "message must name the test: {}",
+        msg
+    );
+    assert!(
+        msg.contains("must_contains"),
+        "message must name the offending key: {}",
+        msg
+    );
+}
+
+/// Same typo, but inside a list entry: the other silent path to the default.
+#[test]
+fn test_unrecognized_expected_list_entry_is_hard_error() {
+    let yaml = r#"
+            id: typo_list
+            input: "test"
+            expected:
+              - must_contains: ["Paris"]
+        "#;
+    let err = serde_yaml::from_str::<TestCase>(yaml)
+        .expect_err("unrecognized expected list entry must not parse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("typo_list") && msg.contains("must_contains"),
+        "message must name test and key: {}",
+        msg
+    );
+}
+
+/// A block that opts into the tagged form gets the underlying serde error, not the
+/// generic "unrecognized keys" message. Here `pattern` is misspelled, so the field
+/// is missing as far as serde is concerned.
+#[test]
+fn test_tagged_expected_reports_underlying_error() {
+    let yaml = r#"
+            id: bad_tagged
+            input: "test"
+            expected:
+              type: regex_match
+              pattten: "^hi"
+        "#;
+    let err = serde_yaml::from_str::<TestCase>(yaml)
+        .expect_err("tagged block with a missing field must not parse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("bad_tagged") && msg.contains("pattern"),
+        "message must name the test and the missing field: {}",
+        msg
+    );
+}
+
+/// Untagged single mappings are read with the same legacy heuristics as list
+/// entries. Before the fix, this shape silently became an empty `must_contain`.
+#[test]
+fn test_untagged_single_object_uses_legacy_heuristics() {
+    let yaml = r#"
+            id: test1
+            input: "test"
+            expected:
+              must_contain: ["Paris"]
+        "#;
     let tc: TestCase = serde_yaml::from_str(yaml).expect("failed to parse");
-    if let Expected::MustContain { must_contain } = tc.expected {
-        assert_eq!(must_contain, vec!["Paris"]);
-    } else {
-        panic!("Expected MustContain, got {:?}", tc.expected);
+    match tc.expected {
+        Expected::MustContain { must_contain } => assert_eq!(must_contain, vec!["Paris"]),
+        other => panic!("Expected MustContain, got {:?}", other),
+    }
+}
+
+/// (d) A missing `expected:` key stays permissive: `assertions:` may carry the
+/// checks. `assay validate` reports the case where neither is present.
+#[test]
+fn test_missing_expected_key_still_parses() {
+    let yaml = r#"
+            id: test1
+            input: "test"
+        "#;
+    let tc: TestCase = serde_yaml::from_str(yaml).expect("missing expected must stay permissive");
+    match tc.expected {
+        Expected::MustContain { must_contain } => assert!(must_contain.is_empty()),
+        other => panic!("Expected default MustContain, got {:?}", other),
     }
 }
 

--- a/crates/assay-core/src/model/tests/mod.rs
+++ b/crates/assay-core/src/model/tests/mod.rs
@@ -107,9 +107,126 @@ fn test_unrecognized_expected_list_entry_is_hard_error() {
     );
 }
 
-/// A block that opts into the tagged form gets the underlying serde error, not the
-/// generic "unrecognized keys" message. Here `pattern` is misspelled, so the field
-/// is missing as far as serde is concerned.
+/// A tagged block whose VALUE shape is legacy must still parse. The strict parse
+/// fails (a scalar is not a list), but the legacy heuristics understand it, and
+/// rejecting it would turn working suites into config errors.
+#[test]
+fn test_tagged_block_with_legacy_scalar_value_still_parses() {
+    let yaml = r#"
+            id: tagged_scalar
+            input: "test"
+            expected:
+              - type: must_contain
+                must_contain: "hello"
+        "#;
+    let tc: TestCase = serde_yaml::from_str(yaml).expect("tagged block with scalar must parse");
+    match tc.expected {
+        Expected::MustContain { must_contain } => assert_eq!(must_contain, vec!["hello"]),
+        other => panic!("Expected MustContain, got {:?}", other),
+    }
+}
+
+/// `type: sequence` is not an `Expected` variant (the variant is `sequence_valid`),
+/// but it is the shape documented in the migration guide, and the legacy `sequence`
+/// key resolves it. It must keep working.
+#[test]
+fn test_legacy_type_sequence_still_parses() {
+    let yaml = r#"
+            id: legacy_seq
+            input: "test"
+            expected:
+              - type: sequence
+                sequence: ["Search", "Create"]
+        "#;
+    let tc: TestCase = serde_yaml::from_str(yaml).expect("legacy type: sequence must parse");
+    match tc.expected {
+        Expected::SequenceValid { sequence, .. } => {
+            assert_eq!(
+                sequence,
+                Some(vec!["Search".to_string(), "Create".to_string()])
+            );
+        }
+        other => panic!("Expected SequenceValid, got {:?}", other),
+    }
+}
+
+/// An unparsable `sequence` value used to become `sequence: None` via `.ok()`, and
+/// `sequence_valid` passes unconditionally with neither sequence nor rules — an
+/// always-green test that no validate rule caught.
+#[test]
+fn test_unparsable_sequence_value_is_hard_error() {
+    let yaml = r#"
+            id: bad_seq
+            input: "test"
+            expected:
+              sequence: 42
+        "#;
+    let err = serde_yaml::from_str::<TestCase>(yaml).expect_err("bad sequence must not parse");
+    assert!(
+        err.to_string().contains("`sequence` must be a list"),
+        "{}",
+        err
+    );
+}
+
+/// An unparsable `must_contain` value used to collapse to an empty vec via
+/// `unwrap_or_default()`, which passes for any response.
+#[test]
+fn test_unparsable_must_contain_value_is_hard_error() {
+    let yaml = r#"
+            id: bad_mc
+            input: "test"
+            expected:
+              must_contain: {oops: 1}
+        "#;
+    let err = serde_yaml::from_str::<TestCase>(yaml).expect_err("bad must_contain must not parse");
+    assert!(
+        err.to_string().contains("`must_contain` must be a string"),
+        "{}",
+        err
+    );
+}
+
+/// An assertion written out as empty passes for any response. Rejecting it at parse
+/// time means every command that loads a config catches it, including `run` and `ci`.
+#[test]
+fn test_explicit_empty_must_contain_is_hard_error() {
+    let yaml = r#"
+            id: vacuous
+            input: "test"
+            expected:
+              type: must_contain
+              must_contain: []
+        "#;
+    let err =
+        serde_yaml::from_str::<TestCase>(yaml).expect_err("empty must_contain must not parse");
+    assert!(
+        err.to_string().contains("would pass for any response"),
+        "{}",
+        err
+    );
+}
+
+#[test]
+fn test_explicit_empty_must_not_contain_is_hard_error() {
+    let yaml = r#"
+            id: vacuous
+            input: "test"
+            expected:
+              type: must_not_contain
+              must_not_contain: []
+        "#;
+    let err =
+        serde_yaml::from_str::<TestCase>(yaml).expect_err("empty must_not_contain must not parse");
+    assert!(
+        err.to_string().contains("would pass for any response"),
+        "{}",
+        err
+    );
+}
+
+/// A block that opts into the tagged form and matches NO legacy key gets the
+/// underlying serde error, not the generic "unrecognized keys" message.
 #[test]
 fn test_tagged_expected_reports_underlying_error() {
     let yaml = r#"
@@ -144,6 +261,34 @@ fn test_untagged_single_object_uses_legacy_heuristics() {
         Expected::MustContain { must_contain } => assert_eq!(must_contain, vec!["Paris"]),
         other => panic!("Expected MustContain, got {:?}", other),
     }
+}
+
+/// Writers must not emit a config the parser rejects.
+///
+/// A test that omits `expected:` holds the vacuous default. Serializing it verbatim
+/// would write `must_contain: []`, which is now a hard parse error — so `assay migrate`
+/// would produce files that no longer load. `skip_serializing_if` prevents that; this
+/// test pins the round-trip.
+#[test]
+fn test_omitted_expected_round_trips_through_serialization() {
+    let yaml = r#"
+            id: assertions_only
+            input: "test"
+            assertions:
+              - type: trace_must_call_tool
+                tool: Search
+        "#;
+    let tc: TestCase = serde_yaml::from_str(yaml).expect("failed to parse");
+
+    let written = serde_yaml::to_string(&tc).expect("serialize");
+    assert!(
+        !written.contains("must_contain"),
+        "vacuous default must not be materialised into config: {}",
+        written
+    );
+
+    let reparsed: TestCase = serde_yaml::from_str(&written).expect("writer output must load again");
+    assert_eq!(reparsed.id, "assertions_only");
 }
 
 /// (d) A missing `expected:` key stays permissive: `assertions:` may carry the

--- a/crates/assay-core/src/model/types.rs
+++ b/crates/assay-core/src/model/types.rs
@@ -204,6 +204,15 @@ pub struct PinnedTool {
 }
 
 impl Default for Expected {
+    /// NOTE: this default is **vacuous** — an empty `must_contain` makes the
+    /// `must_contain` metric pass unconditionally, because it has no substring to
+    /// look for. It exists only so `TestCase` can derive `Default` and so a test
+    /// whose checks live in `assertions:` can omit `expected:` entirely.
+    ///
+    /// It must never be used as a parse fallback: an `expected:` block that fails
+    /// to parse is a hard config error (see `model::serde`), and a test that ends
+    /// up holding this value with no assertions is reported by the
+    /// `E_CFG_VACUOUS_EXPECTED` rule in `assay validate`.
     fn default() -> Self {
         Expected::MustContain {
             must_contain: vec![],

--- a/crates/assay-core/src/model/types.rs
+++ b/crates/assay-core/src/model/types.rs
@@ -65,6 +65,9 @@ pub struct ThresholdingSettings {
 pub struct TestCase {
     pub id: String,
     pub input: TestInput,
+    /// Skipped on serialize when vacuous: writers such as `assay migrate` must not
+    /// materialise an empty `must_contain` that the parser would then reject.
+    #[serde(skip_serializing_if = "crate::model::validation::is_vacuous_expected")]
     pub expected: Expected,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assertions: Option<Vec<crate::agent_assertions::model::TraceAssertion>>,
@@ -212,7 +215,7 @@ impl Default for Expected {
     /// It must never be used as a parse fallback: an `expected:` block that fails
     /// to parse is a hard config error (see `model::serde`), and a test that ends
     /// up holding this value with no assertions is reported by the
-    /// `E_CFG_VACUOUS_EXPECTED` rule in `assay validate`.
+    /// `W_CFG_VACUOUS_EXPECTED` rule in `assay validate`.
     fn default() -> Self {
         Expected::MustContain {
             must_contain: vec![],

--- a/crates/assay-core/src/model/validation.rs
+++ b/crates/assay-core/src/model/validation.rs
@@ -18,6 +18,20 @@ pub(crate) fn is_default_settings(s: &Settings) -> bool {
     s == &Settings::default()
 }
 
+/// True when `expected` asserts nothing (an empty `must_contain`/`must_not_contain`).
+///
+/// Used to skip serializing the vacuous default. Without this, a writer such as
+/// `assay migrate` would materialise `expected: {type: must_contain, must_contain: []}`
+/// into the config for every test that legitimately omitted the key — a shape the
+/// parser now rejects, so the tool's own output would no longer load.
+pub(crate) fn is_vacuous_expected(e: &Expected) -> bool {
+    match e {
+        Expected::MustContain { must_contain } => must_contain.is_empty(),
+        Expected::MustNotContain { must_not_contain } => must_not_contain.is_empty(),
+        _ => false,
+    }
+}
+
 pub(crate) fn default_one() -> u32 {
     1
 }

--- a/crates/assay-core/src/validate/mod.rs
+++ b/crates/assay-core/src/validate/mod.rs
@@ -65,7 +65,7 @@ pub async fn validate(
         return Ok(ValidateReport { diagnostics: diags });
     }
 
-    // 1b. Vacuous assertions (E_CFG_VACUOUS_EXPECTED)
+    // 1b. Vacuous assertions (W_CFG_VACUOUS_EXPECTED)
     diags.extend(check_vacuous_expected(cfg));
 
     // 2. Load Trace & Baseline for deeper checks
@@ -279,15 +279,21 @@ pub async fn validate(
     Ok(ValidateReport { diagnostics: diags })
 }
 
-/// Flag tests whose `expected:` block asserts nothing and therefore always passes.
+/// Warn about tests that assert nothing and therefore always pass.
 ///
-/// An empty `must_contain` / `must_not_contain` gives the metric no substring to look
-/// for, so it returns `pass(1.0)` for any response whatsoever. The same shape is what a
-/// test with no `expected:` key at all resolves to, via `Expected::default()`.
+/// By the time a config has loaded, an empty `must_contain` / `must_not_contain` can
+/// only have come from an OMITTED `expected:` key resolving to `Expected::default()`.
+/// An assertion the author actually wrote out as empty is rejected at parse time (see
+/// `model::serde::reject_vacuous`), which is a hard error and reaches every command
+/// that loads a config, including `assay run` and `assay ci`.
 ///
-/// Tests that carry `assertions:` are exempt: for those, omitting `expected:` is the
-/// documented way to let trace assertions do the checking, and the empty default is
-/// then a placeholder rather than a claim.
+/// That split is deliberate. Omitting `expected:` is a documented, legitimate shape —
+/// a test may carry its checks in `assertions:` — so making it an error here would
+/// contradict the permissive parse and break configs the tool itself writes. It is
+/// still worth reporting when such a test has no assertions either, because then it
+/// really does assert nothing; hence a warning rather than an error.
+///
+/// Tests that carry `assertions:` are exempt.
 ///
 /// This check reads only the config, so `assay validate` can sweep a suite for
 /// always-green tests without running it.
@@ -310,20 +316,20 @@ fn check_vacuous_expected(cfg: &EvalConfig) -> Vec<Diagnostic> {
 
         diags.push(
             Diagnostic::new(
-                codes::E_CFG_VACUOUS_EXPECTED,
+                codes::W_CFG_VACUOUS_EXPECTED,
                 format!(
-                    "Test '{}' asserts nothing: `{}` is empty, so this test passes for any response",
-                    tc.id, field
+                    "Test '{}' asserts nothing: it has no `expected:` block and no `assertions:`, so it passes for any response",
+                    tc.id
                 ),
             )
+            .with_severity("warn")
             .with_source("config")
             .with_context(serde_json::json!({
                 "test_id": tc.id,
                 "field": field,
             }))
-            .with_fix_step(format!("Give `{}` at least one entry", field))
-            .with_fix_step("Or replace the expected block with a metric that checks something")
-            .with_fix_step("Or move the test's checks to `assertions:`"),
+            .with_fix_step("Add an `expected:` block that checks something")
+            .with_fix_step("Or give the test `assertions:`"),
         );
     }
 
@@ -456,8 +462,11 @@ mod vacuous_expected_tests {
         );
         let diags = check_vacuous_expected(&cfg);
         assert_eq!(diags.len(), 1);
-        assert_eq!(diags[0].code, codes::E_CFG_VACUOUS_EXPECTED);
-        assert_eq!(diags[0].severity, "error");
+        assert_eq!(diags[0].code, codes::W_CFG_VACUOUS_EXPECTED);
+        // Warning, not error: by this point the shape can only have come from an
+        // omitted `expected:` key, which the parser deliberately permits. An
+        // explicitly-written empty assertion never gets this far.
+        assert_eq!(diags[0].severity, "warn");
         assert!(diags[0].message.contains("t1"), "{}", diags[0].message);
     }
 
@@ -525,6 +534,6 @@ mod vacuous_expected_tests {
 
         let report = validate(&cfg, &opts, &resolver).await.expect("validate");
         assert_eq!(report.diagnostics.len(), 1);
-        assert_eq!(report.diagnostics[0].code, codes::E_CFG_VACUOUS_EXPECTED);
+        assert_eq!(report.diagnostics[0].code, codes::W_CFG_VACUOUS_EXPECTED);
     }
 }

--- a/crates/assay-core/src/validate/mod.rs
+++ b/crates/assay-core/src/validate/mod.rs
@@ -58,10 +58,15 @@ pub async fn validate(
         }
     }
 
-    // Return early if basic files missing to avoid noise
+    // Return early if basic files missing to avoid noise. The vacuous-expected scan is
+    // still reported: it is a pure config check that needs neither trace nor baseline.
     if !diags.is_empty() {
+        diags.extend(check_vacuous_expected(cfg));
         return Ok(ValidateReport { diagnostics: diags });
     }
+
+    // 1b. Vacuous assertions (E_CFG_VACUOUS_EXPECTED)
+    diags.extend(check_vacuous_expected(cfg));
 
     // 2. Load Trace & Baseline for deeper checks
     let trace_client = if let Some(path) = &opts.trace_file {
@@ -274,6 +279,57 @@ pub async fn validate(
     Ok(ValidateReport { diagnostics: diags })
 }
 
+/// Flag tests whose `expected:` block asserts nothing and therefore always passes.
+///
+/// An empty `must_contain` / `must_not_contain` gives the metric no substring to look
+/// for, so it returns `pass(1.0)` for any response whatsoever. The same shape is what a
+/// test with no `expected:` key at all resolves to, via `Expected::default()`.
+///
+/// Tests that carry `assertions:` are exempt: for those, omitting `expected:` is the
+/// documented way to let trace assertions do the checking, and the empty default is
+/// then a placeholder rather than a claim.
+///
+/// This check reads only the config, so `assay validate` can sweep a suite for
+/// always-green tests without running it.
+fn check_vacuous_expected(cfg: &EvalConfig) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+
+    for tc in &cfg.tests {
+        let has_assertions = tc.assertions.as_ref().is_some_and(|a| !a.is_empty());
+        if has_assertions {
+            continue;
+        }
+
+        let field = match &tc.expected {
+            Expected::MustContain { must_contain } if must_contain.is_empty() => "must_contain",
+            Expected::MustNotContain { must_not_contain } if must_not_contain.is_empty() => {
+                "must_not_contain"
+            }
+            _ => continue,
+        };
+
+        diags.push(
+            Diagnostic::new(
+                codes::E_CFG_VACUOUS_EXPECTED,
+                format!(
+                    "Test '{}' asserts nothing: `{}` is empty, so this test passes for any response",
+                    tc.id, field
+                ),
+            )
+            .with_source("config")
+            .with_context(serde_json::json!({
+                "test_id": tc.id,
+                "field": field,
+            }))
+            .with_fix_step(format!("Give `{}` at least one entry", field))
+            .with_fix_step("Or replace the expected block with a metric that checks something")
+            .with_fix_step("Or move the test's checks to `assertions:`"),
+        );
+    }
+
+    diags
+}
+
 fn validate_strict_requirements(
     tc: &crate::model::TestCase,
     resp: &crate::model::LlmResponse,
@@ -359,5 +415,116 @@ fn check_embedding_dims(
                 );
             }
         }
+    }
+}
+#[cfg(test)]
+mod vacuous_expected_tests {
+    use super::*;
+    use crate::agent_assertions::model::TraceAssertion;
+    use crate::model::{Settings, TestCase, TestInput};
+
+    fn cfg_with(expected: Expected, assertions: Option<Vec<TraceAssertion>>) -> EvalConfig {
+        EvalConfig {
+            version: 1,
+            suite: "s".into(),
+            model: "dummy".into(),
+            settings: Settings::default(),
+            thresholds: Default::default(),
+            otel: Default::default(),
+            tests: vec![TestCase {
+                id: "t1".into(),
+                input: TestInput {
+                    prompt: "hi".into(),
+                    context: None,
+                },
+                expected,
+                assertions,
+                on_error: None,
+                tags: vec![],
+                metadata: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn flags_empty_must_contain() {
+        let cfg = cfg_with(
+            Expected::MustContain {
+                must_contain: vec![],
+            },
+            None,
+        );
+        let diags = check_vacuous_expected(&cfg);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code, codes::E_CFG_VACUOUS_EXPECTED);
+        assert_eq!(diags[0].severity, "error");
+        assert!(diags[0].message.contains("t1"), "{}", diags[0].message);
+    }
+
+    #[test]
+    fn flags_empty_must_not_contain() {
+        let cfg = cfg_with(
+            Expected::MustNotContain {
+                must_not_contain: vec![],
+            },
+            None,
+        );
+        let diags = check_vacuous_expected(&cfg);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].context["field"], "must_not_contain");
+    }
+
+    /// A missing `expected:` key resolves to the vacuous default, so the same rule
+    /// covers it — this is what keeps the permissive parse honest.
+    #[test]
+    fn flags_default_expected_from_missing_key() {
+        let cfg = cfg_with(Expected::default(), None);
+        assert_eq!(check_vacuous_expected(&cfg).len(), 1);
+    }
+
+    #[test]
+    fn does_not_flag_populated_must_contain() {
+        let cfg = cfg_with(
+            Expected::MustContain {
+                must_contain: vec!["Paris".into()],
+            },
+            None,
+        );
+        assert!(check_vacuous_expected(&cfg).is_empty());
+    }
+
+    /// Assertion-carrying tests legitimately omit `expected:`.
+    #[test]
+    fn does_not_flag_when_assertions_present() {
+        let cfg = cfg_with(
+            Expected::default(),
+            Some(vec![TraceAssertion::TraceMustCallTool {
+                tool: "search".into(),
+                min_calls: None,
+            }]),
+        );
+        assert!(check_vacuous_expected(&cfg).is_empty());
+    }
+
+    /// The sweep must work with no trace file and no baseline — that is the point of
+    /// being able to check a suite without running it.
+    #[tokio::test]
+    async fn validate_reports_vacuous_without_trace_file() {
+        let cfg = cfg_with(
+            Expected::MustContain {
+                must_contain: vec![],
+            },
+            None,
+        );
+        let opts = ValidateOptions {
+            trace_file: None,
+            baseline_file: None,
+            replay_strict: false,
+        };
+        let resolver = PathResolver::new(Path::new("eval.yaml"));
+
+        let report = validate(&cfg, &opts, &resolver).await.expect("validate");
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(report.diagnostics[0].code, codes::E_CFG_VACUOUS_EXPECTED);
     }
 }

--- a/demo/walkthrough_tmp/ci-eval.yaml
+++ b/demo/walkthrough_tmp/ci-eval.yaml
@@ -14,6 +14,7 @@ tests:
       prompt: "ci_schema"
     expected:
       type: json_schema
+      json_schema: "{}"
       schema_file: "schemas/ci_answer.schema.json"
   - id: "ci_smoke_semantic"
     input:

--- a/docs/reference/config/eval-yaml.md
+++ b/docs/reference/config/eval-yaml.md
@@ -39,8 +39,8 @@ Each test in the `tests` list defines a scenario and its validation rules.
   input:
     prompt: "..."
   expected:
-    type: json_match
-    # ...
+    type: must_contain
+    must_contain: ["..."]
   assertions: []
 ```
 
@@ -60,9 +60,14 @@ Defines the **output** validation (the final answer).
 | Type | Description |
 |---|---|
 | `must_contain` | List of substrings that must appear in the response. |
+| `must_not_contain` | List of substrings that must NOT appear in the response. |
 | `regex_match` | Regex pattern the response must match. |
-| `json_match` | Validates response against a JSON schema. |
-| `exact_match` | Full string equality check. |
+| `json_schema` | Validates the response against a JSON schema. |
+| `semantic_similarity_to` | Embedding similarity against a reference answer. |
+
+An `expected:` block must assert something. An empty `must_contain`/`must_not_contain`
+passes for any response, so it is rejected as a config error. A test may omit
+`expected:` entirely when its checks live in `assertions:`.
 
 ### `assertions`
 

--- a/examples/demo/assay-safe.yaml
+++ b/examples/demo/assay-safe.yaml
@@ -6,4 +6,5 @@ tests:
   - id: "placeholder-smoke"
     input: "ignore"
     expected:
-      must_contain: []
+      type: must_contain
+      must_contain: ["passed"]

--- a/examples/demo/common-mistake/assay.yaml
+++ b/examples/demo/common-mistake/assay.yaml
@@ -4,9 +4,12 @@ model: "dummy"
 
 
 
-# Minimal stub so validate can load config; no traces required for policy validation.
+# Minimal smoke test so validate can load the config; no traces required for policy
+# validation. It asserts against the dummy model's fixed response so it is a real check
+# rather than an always-green placeholder.
 tests:
   - id: "placeholder-smoke"
     input: "ignore"
     expected:
-      must_contain: []
+      type: must_contain
+      must_contain: ["passed"]

--- a/tests/fixtures/migrate-zoo/04_legacy_syntax.yaml
+++ b/tests/fixtures/migrate-zoo/04_legacy_syntax.yaml
@@ -1,4 +1,8 @@
 # Test: Legacy sequence syntax (list of strings instead of list of objects)
+#
+# A single-entry legacy list is still accepted. Multi-entry `expected:` lists are
+# rejected: only the first entry was ever evaluated, so the rest were dropped in
+# silence. Checks that used to share one list now live in separate tests.
 configVersion: 1
 suite: legacy_test
 model: dummy
@@ -9,4 +13,10 @@ tests:
        prompt: "Do things"
     expected:
        - must_contain: "Paris"
-       - must_not_contain: "London"
+  # `must_not_contain` has no legacy heuristic, so it uses the tagged form.
+  - id: legacy_sequence_negative
+    input:
+       prompt: "Do things"
+    expected:
+       type: must_not_contain
+       must_not_contain: ["London"]


### PR DESCRIPTION
## The bug

A YAML typo in a test's `expected:` block produced a test that **always passed**.

`impl Default for Expected` returns `MustContain { must_contain: vec![] }`, and `MustContainMetric` iterates that empty vec and returns `pass(1.0)`. Three paths in `model/serde.rs` reached that default in silence — an `expected:` object that failed to parse, a list entry matching neither the strict nor the legacy form, and a multi-element list whose elements after the first were dropped without a word.

## Two commits

`607d4a86` stopped the silent fallback. Adversarial review then found it had landed the detector without repairing what the detector caught, and had introduced a regression of its own. `b382e729` fixes that. Every finding below was reproduced against the built binary.

## What `b382e729` fixes

**A regression introduced by the first commit.** `parse_expected_entry` returned the strict serde error as soon as a block carried a `type:` key, before the legacy heuristics ran. The old code fell straight from strict-failure into those heuristics. So a tagged block with a legacy *value* shape went from a working assertion to a whole-suite config error:

```yaml
- {type: must_contain, must_contain: "hello"}   # scalar = legacy spelling of a 1-element list
- {type: sequence, sequence: [Search, Create]}  # the form documented in migration.md
```

The heuristics now run first; the strict error is reported only when no legacy key matched.

**Silent fallbacks the first commit moved without auditing.** It relocated the legacy heuristic block verbatim, carrying along the same swallow-the-error pattern its own thesis condemns:

| | was | now |
|---|---|---|
| `must_contain: {oops: 1}` | `unwrap_or_default()` → empty vec → passes for any response | hard error |
| `sequence: 42` | `.ok()` → `sequence: None` → `sequence_valid` passes unconditionally | hard error |
| `$ref: 42` | `unwrap_or("")` | hard error |

The `sequence` case was the worst: `assay run` reported `status: pass, score: 1.0` and `assay validate` reported "Validation OK".

**Vacuous assertions are now caught where it matters.** An `expected:` block written out as empty is rejected at **parse** time, so every command that loads a config catches it — including `run` and `ci`. The first commit's rule lived only in `validate()`, which neither command calls, and which is not what the workflow `assay init --ci` generates for users runs.

An **omitted** `expected:` key stays permissive, because a test may legitimately carry its checks in `assertions:`. When such a test has no assertions either, it is a **warning**: `W_CFG_VACUOUS_EXPECTED` (renamed from `E_CFG_` to match the repo's `W_` convention for exit-0 diagnostics).

That split also resolves an exit-code inconsistency the review surfaced. `validate()` has four call sites, not one, and only two reach `decide_exit`. The first commit's error-severity diagnostic therefore produced **1** from `assay doctor` and **0** from `assay doctor --format json` while claiming to be an exit-2 config error. Hard errors now flow through the pre-existing `E_CFG_PARSE` path instead.

**Self-inflicted breakage the first commit shipped.**

- `templates.rs::CI_EVAL_YAML` emitted `type: json_schema` without the required `json_schema` field, so `assay init --ci` produced a project `assay run` refused to load. The old parser degraded that to a vacuous always-green test, which is why it went unnoticed — the repo-root `ci-eval.yaml` had already been hand-patched while the generator drifted. `contract_init_ci` only grepped the generated file's text; it now loads the scaffold through the real loader.
- `examples/demo/assay-safe.yaml` and `common-mistake/assay.yaml` used `must_contain: []` as a deliberate stub, and `.github/workflows/assay-security.yml` gates on validating the first. (Latent: that workflow pins a released binary, so it would have gone red only after publish.) Both now assert against the dummy model's fixed response.

**Round-trip.** `TestCase.expected` is skipped on serialize when vacuous. Without it, `assay migrate` would materialise `must_contain: []` into every test that omitted the key — output its own parser now rejects.

**Docs.** `eval-yaml.md` documented `json_match` and `exact_match`; neither is an `Expected` variant, so both were silently vacuous before and hard-fail now.

## Behaviour changes for existing suites

Suites relying on a silently-vacuous `expected:` now fail to load. That is the point. Specifically:

- `- must_not_contain: "x"` in list form has no legacy heuristic (the legacy key set is frozen at `$ref`, `must_contain`, `sequence`, `schema`), so it is a hard error naming the tagged form rather than a silent always-pass.
- An untagged single mapping such as `{must_contain: [...]}` is now read with the same heuristics as a list entry, so it actually checks.
- Multi-element `expected:` lists are rejected. Only element 0 was ever evaluated. `TestCase.expected` holds one `Expected` and is matched on across metric dispatch, validate, doctor and config/resolve, so supporting a collection is a contract change beyond this fix.

## Why a missing `expected:` key stays permissive

Omitting `expected:` is a legitimate shape: a test may carry its checks in `assertions:`, and several existing contract tests use a bare `input:` with no expected block. Making the missing key an error would reject valid configs — and would reject the output `assay migrate` itself writes.

The distinction that matters to a user is not *"was the key written?"* but *"does this test assert anything?"*. So the two cases are split by what the parser can actually observe: an assertion written out as empty is a hard error at parse time; an omitted key is permissive, with a warning when the test has no assertions either. The permissiveness is deliberate and documented at both ends rather than emergent from a missing `else` branch.

## Known gap

A typo *inside* a tagged block (`type: must_contain` with `must_contaisn:`) still parses, because `Expected` lacks `deny_unknown_fields` and `serde_ignored` cannot see into `expected:` — the hand-written `Deserialize` consumes the subtree as an opaque `Value`. It surfaces as an empty `must_contain`, which is now a parse error, so the always-green outcome is gone; only the message is generic. Closing it properly has a wider blast radius and is left as a follow-up.

`assay migrate` still cannot load multi-element legacy lists — the one shape being deprecated is the one it refuses. Restoring the legacy heuristics recovers everything else it was documented to handle. Tracked as a follow-up rather than expanded here.

## Tests

Parser: unparsable object, unrecognized list entry, multi-element list, empty list, tagged-error passthrough, untagged heuristics, permissive missing key, tagged-with-legacy-scalar, `type: sequence`, unparsable `sequence`, unparsable `must_contain`, explicit empty `must_contain`/`must_not_contain`, and a serialize→reparse round-trip.

CLI contracts: exit 2 / `E_CFG_PARSE` through the real binary for each parse path including the explicit-empty case on `assay run`; `W_CFG_VACUOUS_EXPECTED` as a warning at exit 0 from `assay validate`; and the `init --ci` scaffold loaded through the real loader.

Verified: `cargo test --workspace` (201 suites, 0 failures), `cargo clippy --workspace --all-targets -D warnings` via pre-push, `cargo fmt --check`.

## Review

Reviewed by three independent adversarial agents spawned by the builder's orchestrator, each running read-only on head `607d4a86` with a distinct lens (validate call-site blast radius, parser semantics and round-trip, shipped docs and generated YAML). Two built the parent commit for a true A/B. All three returned do-not-merge; their findings are what `b382e729` implements. Load-bearing claims were re-verified by the builder before acting, and one claim — that `migrate` output fails `validate` — was checked and downgraded: `migrate` does materialise the vacuous default, but assertion-carrying tests are exempt, so it did not by itself produce a validate failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
