### PR TITLE
chore(release): 3.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.37.0] - 2026-08-02
+
+### Added
+- Observe the MCP protocol era on import and carry it through wire-profile
+  normalization, with an era-parity corpus pinning how protocol-era results are
+  concluded. The event shape is unchanged (#1929, #1934, #1935).
+- Bounded MCP OTLP/JSON decoder with pre-retention ceilings, so an oversized or
+  deeply nested payload is refused before it is retained rather than after
+  (#1931, #1944).
+
+### Fixed
+- Reject vacuous and ambiguous `expected` assertions. An `args_valid` policy
+  that asserts nothing now fails at config load instead of passing every
+  response, and shared JSON Schema `$defs` are prepared once for the preflight,
+  cached, one-shot and MCP paths so they cannot drift apart. JSON Schema is
+  compiled hermetically: an external `$ref` is refused by an explicit denying
+  retriever, with jsonschema's default features off as a second layer. Only
+  same-document and embedded references are supported (#1948).
+- Separate immutable MCP replay from live drift in CI (#1947).
+- ProtoJSON ingest correctness: int64 coercion, omitted-message defaults and
+  nested null key defaults now follow the spec.
+
+### Notes
+- Not a general schema satisfiability solver. `expected` is judged vacuous only
+  for policies the rule fully understands; anything else keeps its specific
+  diagnosis ("not enforced by this evaluator", "must be a list").
+
 ## [3.36.0] - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "aya",
  "chrono",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.36.0"
+version = "3.37.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"


### PR DESCRIPTION
Minor bump. Main carries four `feat` commits since v3.36.0, so this is 3.37.0 rather than a patch.

**Contents** — protocol-era observation on import and through wire-profile normalization with an era-parity corpus (#1929, #1934, #1935), the bounded MCP OTLP/JSON decoder with pre-retention ceilings (#1931, #1944), the vacuous/ambiguous `expected` rejection and hermetic JSON Schema compilation (#1948), and the immutable-replay/live-drift split in CI (#1947).

**Release-prep discipline** — `Cargo.lock` was updated by version line only and verified with `cargo check --workspace --locked --offline`, so no unrelated dependency re-resolves into the release diff. No new workspace crate is introduced, so the OIDC trusted-publishing path is unaffected.

Touches the workspace dependency surface, so lane-check requires `gates=all`; the delegated proof follows on this exact head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release notes for version 3.37.0, covering improved MCP protocol support, validation, schema handling, telemetry decoding, and ProtoJSON ingestion.
* **Chores**
  * Updated the application version to 3.37.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->