### PR TITLE
SEP-2828: settle step 5's checkable half, and publish the pairing reproduction

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -280,7 +280,11 @@ fn push_result_commitment_checks(
         .and_then(|d| {
             d.get("resultCommitment")
                 .or_else(|| d.get("result_commitment"))
-        });
+        })
+        // `Value::get` yields `Some(&Value::Null)` for a key present with an explicit null. A null
+        // commits to nothing, so it is the same as no key at all; without this filter a refused
+        // outcome would be failed for carrying a commitment it does not have.
+        .filter(|commitment| !commitment.is_null());
 
     let Some(commitment) = commitment else {
         // Absence is only meaningful for `refused`, which by definition has no result.
@@ -311,7 +315,25 @@ fn push_result_commitment_checks(
     let reference = commitment.get("ref").and_then(Value::as_str);
 
     match (projection, reference) {
-        (Some(projection), _) => {
+        // A commitment is one shape or the other. Carrying both leaves which one binds the result
+        // undecided, so it is a producer defect rather than a licence to pick the first match.
+        (Some(_), Some(_)) => {
+            checks.push(CheckReport {
+                id: "result_commitment_shape_recognized",
+                ok: false,
+                detail: "resultCommitment carries both `projection` and `ref`; a commitment is \
+                         one shape or the other"
+                    .to_string(),
+            });
+            Some(ResultCommitmentReport {
+                kind: "ambiguous",
+                projection_digest,
+                ref_digest: string_at(commitment, &["digest"]),
+                embedded_digest: None,
+                recomputed_projection_digest: None,
+            })
+        }
+        (Some(projection), None) => {
             let recomputed = format!(
                 "sha256:{}",
                 hex::encode(Sha256::digest(projection.as_bytes()))
@@ -330,15 +352,20 @@ fn push_result_commitment_checks(
             Some(ResultCommitmentReport {
                 kind: "args_projection",
                 projection_digest,
+                ref_digest: None,
                 embedded_digest: embedded,
                 recomputed_projection_digest: Some(recomputed),
             })
         }
         (None, Some(_)) => {
             extra_claims.push("result_commitment_ref_not_dereferenced");
+            // An ArgsRef's `digest` addresses referenced content. It is not a digest over a
+            // projection string, so it does not go in `projection_digest`: a reader keying on that
+            // field by name would compare two different quantities.
             Some(ResultCommitmentReport {
                 kind: "args_ref",
-                projection_digest: string_at(commitment, &["digest"]),
+                projection_digest: None,
+                ref_digest: string_at(commitment, &["digest"]),
                 embedded_digest: None,
                 recomputed_projection_digest: None,
             })
@@ -352,6 +379,7 @@ fn push_result_commitment_checks(
             Some(ResultCommitmentReport {
                 kind: "unrecognized",
                 projection_digest: None,
+                ref_digest: None,
                 embedded_digest: None,
                 recomputed_projection_digest: None,
             })

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -9,7 +9,7 @@ mod report;
 
 use report::{
     print_table_report, AttestationReport, BackLinkReport, BindingReport, CheckReport,
-    DecisionReport, OutcomeReport, PairingReport, VerificationScope,
+    DecisionReport, OutcomeReport, PairingReport, ResultCommitmentReport, VerificationScope,
 };
 
 #[derive(Debug, Args, Clone)]
@@ -134,6 +134,8 @@ fn build_report(
     let expectation = binding_expectation(binding_input, &decision_backlink, fallback_projection)?;
 
     let mut checks = Vec::new();
+    let mut extra_claims: Vec<&'static str> = Vec::new();
+    let mut result_commitment = None;
     // Fail-closed: named projection requested but the binding block could not be resolved is
     // non-conformant, never a silent fall-back to hashing the whole envelope. The check id is the
     // stable reason code (invalid `_meta` vs missing `authorization_binding`).
@@ -182,6 +184,10 @@ fn build_report(
             outcome.and_then(outcome_status).as_deref(),
             &["executed", "refused", "errored"],
         ));
+        if let Some(outcome) = outcome {
+            result_commitment =
+                push_result_commitment_checks(&mut checks, &mut extra_claims, outcome);
+        }
     } else {
         checks.push(CheckReport {
             id: "outcome_absent",
@@ -201,6 +207,7 @@ fn build_report(
             status: outcome_status(outcome),
             completed_at: string_at(outcome, &["outcomeDerived", "completedAt"]),
             decision_digest: outcome_decision_digest(outcome),
+            result_commitment,
             backlink,
             signature_present: outcome.get("signature").and_then(Value::as_str).is_some(),
         }),
@@ -228,7 +235,11 @@ fn build_report(
         decision: decision_report,
         outcome: outcome_report,
         checks,
-        claims_not_made: claims_not_made(&expectation),
+        claims_not_made: {
+            let mut claims = claims_not_made(&expectation);
+            claims.extend(extra_claims);
+            claims
+        },
     })
 }
 
@@ -245,6 +256,107 @@ fn claims_not_made(expectation: &BindingExpectation) -> Vec<&'static str> {
         claims.push("fallback_nonce_freshness_or_uniqueness");
     }
     claims
+}
+
+/// SEP-2828 verification-algorithm step 5, split into the half a record-only consumer can settle
+/// and the half it cannot.
+///
+/// An `ArgsProjection` commits `projectionDigest` as sha256 over the UTF-8 bytes of the
+/// `projection` string, so a consumer holding nothing but the record recomputes it in full. An
+/// `ArgsRef` addresses content this verifier never fetches. Neither shape says whether the
+/// committed value is what the tool actually returned; that needs the runtime result, which a
+/// record consumer does not have. The first half is now checked. The second is *declared* rather
+/// than left to a reader's assumption, which is the point: an undeclared gap in coverage reads as
+/// coverage.
+fn push_result_commitment_checks(
+    checks: &mut Vec<CheckReport>,
+    extra_claims: &mut Vec<&'static str>,
+    outcome: &Value,
+) -> Option<ResultCommitmentReport> {
+    let status = outcome_status(outcome);
+    let commitment = outcome
+        .get("outcomeDerived")
+        .or_else(|| outcome.get("outcome_derived"))
+        .and_then(|d| {
+            d.get("resultCommitment")
+                .or_else(|| d.get("result_commitment"))
+        });
+
+    let Some(commitment) = commitment else {
+        // Absence is only meaningful for `refused`, which by definition has no result.
+        if status.as_deref() == Some("refused") {
+            checks.push(CheckReport {
+                id: "result_commitment_absent_for_refused",
+                ok: true,
+                detail: "refused outcome carries no resultCommitment".to_string(),
+            });
+        }
+        return None;
+    };
+
+    if status.as_deref() == Some("refused") {
+        checks.push(CheckReport {
+            id: "result_commitment_absent_for_refused",
+            ok: false,
+            detail: "refused outcome carries a resultCommitment; a refusal has no result"
+                .to_string(),
+        });
+    }
+
+    // The committed value is never compared against a runtime result, in either shape.
+    extra_claims.push("result_commitment_payload_binding");
+
+    let projection = commitment.get("projection").and_then(Value::as_str);
+    let projection_digest = string_at(commitment, &["projectionDigest"]);
+    let reference = commitment.get("ref").and_then(Value::as_str);
+
+    match (projection, reference) {
+        (Some(projection), _) => {
+            let recomputed = format!(
+                "sha256:{}",
+                hex::encode(Sha256::digest(projection.as_bytes()))
+            );
+            checks.push(check_eq(
+                "result_commitment_projection_digest_match",
+                projection_digest.as_deref(),
+                Some(recomputed.as_str()),
+                "projectionDigest matches sha256 over the projection string bytes",
+            ));
+            // The RECOMMENDED hash-only-identity form embeds a digest of the withheld value. It is
+            // surfaced so a reader can see what was committed to, and explicitly not checked.
+            let embedded = serde_json::from_str::<Value>(projection)
+                .ok()
+                .and_then(|p| string_at(&p, &["digest"]));
+            Some(ResultCommitmentReport {
+                kind: "args_projection",
+                projection_digest,
+                embedded_digest: embedded,
+                recomputed_projection_digest: Some(recomputed),
+            })
+        }
+        (None, Some(_)) => {
+            extra_claims.push("result_commitment_ref_not_dereferenced");
+            Some(ResultCommitmentReport {
+                kind: "args_ref",
+                projection_digest: string_at(commitment, &["digest"]),
+                embedded_digest: None,
+                recomputed_projection_digest: None,
+            })
+        }
+        (None, None) => {
+            checks.push(CheckReport {
+                id: "result_commitment_shape_recognized",
+                ok: false,
+                detail: "resultCommitment is neither an ArgsProjection nor an ArgsRef".to_string(),
+            });
+            Some(ResultCommitmentReport {
+                kind: "unrecognized",
+                projection_digest: None,
+                embedded_digest: None,
+                recomputed_projection_digest: None,
+            })
+        }
+    }
 }
 
 fn binding_expectation(

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records/report.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records/report.rs
@@ -61,6 +61,9 @@ pub(super) struct OutcomeReport {
 pub(super) struct ResultCommitmentReport {
     pub(super) kind: &'static str,
     pub(super) projection_digest: Option<String>,
+    /// An `ArgsRef`'s `digest`, which addresses referenced content rather than a projection
+    /// string. Kept separate so a consumer keying on a field name never compares the two.
+    pub(super) ref_digest: Option<String>,
     pub(super) embedded_digest: Option<String>,
     pub(super) recomputed_projection_digest: Option<String>,
 }

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records/report.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records/report.rs
@@ -49,8 +49,20 @@ pub(super) struct OutcomeReport {
     pub(super) status: Option<String>,
     pub(super) completed_at: Option<String>,
     pub(super) decision_digest: Option<String>,
+    pub(super) result_commitment: Option<ResultCommitmentReport>,
     pub(super) backlink: BackLinkReport,
     pub(super) signature_present: bool,
+}
+
+/// What the outcome record commits to about the result, and how much of that a record-only
+/// consumer settled. `embedded_digest` is surfaced but never checked: it binds a value this
+/// verifier never sees.
+#[derive(Debug, Serialize)]
+pub(super) struct ResultCommitmentReport {
+    pub(super) kind: &'static str,
+    pub(super) projection_digest: Option<String>,
+    pub(super) embedded_digest: Option<String>,
+    pub(super) recomputed_projection_digest: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records/fixtures.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records/fixtures.rs
@@ -127,6 +127,55 @@ pub(super) fn outcome_json_with_backlink(
     )
 }
 
+/// sha256 over raw UTF-8 bytes. SEP-2828 defines `projectionDigest` over the bytes of the
+/// `projection` string itself, so this is deliberately not `jcs_digest_json`, which canonicalizes
+/// a value first.
+pub(super) fn sha256_of_str(value: &str) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(value.as_bytes())))
+}
+
+/// The RECOMMENDED hash-only-identity commitment: a projection whose content is the JCS encoding
+/// of `{"digest": ...}`, committing to a result the record never carries.
+pub(super) fn hash_only_projection() -> String {
+    r#"{"digest":"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf"}"#
+        .to_string()
+}
+
+pub(super) fn outcome_json_with_commitment(
+    digest: &str,
+    decision_digest: &str,
+    status: &str,
+    commitment: &str,
+) -> String {
+    let nonce = binding_nonce();
+    let receipt_nonce = fixture_value("outcome-receipt");
+    format!(
+        r#"{{
+  "version": 1,
+  "alg": "ES256",
+  "backLink": {{
+    "attestationDigest": "{digest}",
+    "attestationNonce": "{nonce}"
+  }},
+  "outcomeDerived": {{
+    "status": "{status}",
+    "completedAt": "2026-06-01T00:00:02Z",
+    "decisionDigest": "{decision_digest}",
+    "resultCommitment": {commitment}
+  }},
+  "receiptAsserted": {{
+    "iss": "server",
+    "sub": "agent:test",
+    "iat": "2026-06-01T00:00:02Z",
+    "nonce": "{receipt_nonce}",
+    "secretVersion": "test",
+    "alg": "ES256"
+  }},
+  "signature": "outcome-sig"
+}}"#
+    )
+}
+
 pub(super) fn request_envelope_json() -> &'static str {
     r#"{
   "name": "tools/call",

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records/verify.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records/verify.rs
@@ -470,7 +470,12 @@ fn verify_mcp_records_declares_unfetched_result_commitment_ref() {
     );
 
     assert_eq!(report["ok"], true);
-    assert_eq!(report["outcome"]["result_commitment"]["kind"], "args_ref");
+    let commitment = &report["outcome"]["result_commitment"];
+    assert_eq!(commitment["kind"], "args_ref");
+    // An ArgsRef's digest addresses referenced content, so it must not surface as a projection
+    // digest: a consumer keying on that field name would be comparing two different quantities.
+    assert_eq!(commitment["ref_digest"], "sha256:abc");
+    assert_eq!(commitment["projection_digest"], Value::Null);
     let claims = claims(&report);
     assert!(claims.contains(&"result_commitment_ref_not_dereferenced".to_string()));
     assert!(claims.contains(&"result_commitment_payload_binding".to_string()));
@@ -564,4 +569,44 @@ fn claims(report: &Value) -> Vec<String> {
         .iter()
         .map(|v| v.as_str().unwrap().to_string())
         .collect()
+}
+
+/// `Value::get` yields `Some(&Value::Null)` for a key present with an explicit null, so an
+/// explicit null must be filtered to absent or a refusal is failed for a commitment it does not
+/// carry.
+#[test]
+fn verify_mcp_records_treats_explicit_null_commitment_as_absent() {
+    let report = run_with_commitment("refused", "null");
+
+    assert_eq!(report["ok"], true);
+    assert!(check_ok(&report, "result_commitment_absent_for_refused"));
+    assert_eq!(report["outcome"]["result_commitment"], Value::Null);
+}
+
+#[test]
+fn verify_mcp_records_treats_explicit_null_commitment_as_absent_when_executed() {
+    let report = run_with_commitment("executed", "null");
+
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["outcome"]["result_commitment"], Value::Null);
+    assert!(!claims(&report).contains(&"result_commitment_payload_binding".to_string()));
+}
+
+/// A commitment is an ArgsProjection or an ArgsRef. Carrying both leaves which one binds the
+/// result undecided, so picking the first match would be a guess.
+#[test]
+fn verify_mcp_records_fails_on_commitment_carrying_both_shapes() {
+    let projection = hash_only_projection();
+    let report = run_with_commitment(
+        "executed",
+        &format!(
+            r#"{{"projection": {}, "projectionDigest": "{}", "ref": "https://example.test/r", "digest": "sha256:abc"}}"#,
+            serde_json::to_string(&projection).unwrap(),
+            sha256_of_str(&projection)
+        ),
+    );
+
+    assert_eq!(report["ok"], false);
+    assert!(!check_ok(&report, "result_commitment_shape_recognized"));
+    assert_eq!(report["outcome"]["result_commitment"]["kind"], "ambiguous");
 }

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records/verify.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records/verify.rs
@@ -6,8 +6,8 @@ use tempfile::tempdir;
 
 use super::fixtures::{
     attestation_digest, attestation_json, binding_nonce, decision_json, decision_json_with_value,
-    jcs_digest_json, outcome_json, outcome_json_with_backlink, request_envelope_json,
-    substituted_binding_nonce,
+    hash_only_projection, jcs_digest_json, outcome_json, outcome_json_with_backlink,
+    outcome_json_with_commitment, request_envelope_json, sha256_of_str, substituted_binding_nonce,
 };
 
 #[test]
@@ -409,4 +409,159 @@ fn verify_mcp_records_fails_on_unknown_decision_enum() {
         .stdout(predicate::str::contains(
             "defer is not one of allow, block, escalate",
         ));
+}
+
+/// SEP-2828 verification step 5. An `ArgsProjection` is fully checkable by a record-only consumer:
+/// `projectionDigest` is sha256 over the bytes of the `projection` string, so nothing external is
+/// needed. What the projection *commits to* is a different question, and stays declared-not-claimed.
+#[test]
+fn verify_mcp_records_recomputes_result_commitment_projection_digest() {
+    let report = run_with_commitment("executed", &{
+        let projection = hash_only_projection();
+        let digest = sha256_of_str(&projection);
+        format!(
+            r#"{{"projection": {}, "projectionDigest": "{}"}}"#,
+            serde_json::to_string(&projection).unwrap(),
+            digest
+        )
+    });
+
+    assert_eq!(report["ok"], true);
+    assert!(check_ok(
+        &report,
+        "result_commitment_projection_digest_match"
+    ));
+    let commitment = &report["outcome"]["result_commitment"];
+    assert_eq!(commitment["kind"], "args_projection");
+    assert_eq!(
+        commitment["embedded_digest"],
+        "sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf"
+    );
+    // The committed value is never compared against a runtime result, and says so.
+    assert!(claims(&report).contains(&"result_commitment_payload_binding".to_string()));
+}
+
+#[test]
+fn verify_mcp_records_fails_on_result_commitment_projection_digest_mismatch() {
+    let projection = hash_only_projection();
+    let report = run_with_commitment(
+        "executed",
+        &format!(
+            r#"{{"projection": {}, "projectionDigest": "sha256:{}"}}"#,
+            serde_json::to_string(&projection).unwrap(),
+            "0".repeat(64)
+        ),
+    );
+
+    assert_eq!(report["ok"], false);
+    assert!(!check_ok(
+        &report,
+        "result_commitment_projection_digest_match"
+    ));
+}
+
+/// An `ArgsRef` addresses content this verifier never fetches. That is not a silent pass: the
+/// undereferenced reference is named in `claims_not_made`.
+#[test]
+fn verify_mcp_records_declares_unfetched_result_commitment_ref() {
+    let report = run_with_commitment(
+        "executed",
+        r#"{"ref": "https://example.test/result", "digest": "sha256:abc", "canonicalization": "jcs"}"#,
+    );
+
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["outcome"]["result_commitment"]["kind"], "args_ref");
+    let claims = claims(&report);
+    assert!(claims.contains(&"result_commitment_ref_not_dereferenced".to_string()));
+    assert!(claims.contains(&"result_commitment_payload_binding".to_string()));
+}
+
+/// A refusal has no result, so a commitment on a refused outcome is a producer defect.
+#[test]
+fn verify_mcp_records_fails_when_refused_outcome_carries_a_result_commitment() {
+    let projection = hash_only_projection();
+    let report = run_with_commitment(
+        "refused",
+        &format!(
+            r#"{{"projection": {}, "projectionDigest": "{}"}}"#,
+            serde_json::to_string(&projection).unwrap(),
+            sha256_of_str(&projection)
+        ),
+    );
+
+    assert_eq!(report["ok"], false);
+    assert!(!check_ok(&report, "result_commitment_absent_for_refused"));
+}
+
+#[test]
+fn verify_mcp_records_reports_absent_commitment_for_refused_outcome() {
+    let attestation_digest = attestation_digest();
+    let decision_body = decision_json(&attestation_digest);
+    let decision_digest = jcs_digest_json(&decision_body);
+    let nonce = binding_nonce();
+    let outcome_body = outcome_json_with_backlink(&attestation_digest, &nonce, &decision_digest)
+        .replace("\"status\": \"executed\"", "\"status\": \"refused\"");
+    let report = run_report(&decision_body, &outcome_body);
+
+    assert_eq!(report["ok"], true);
+    assert!(check_ok(&report, "result_commitment_absent_for_refused"));
+    assert_eq!(report["outcome"]["result_commitment"], Value::Null);
+}
+
+fn run_with_commitment(status: &str, commitment: &str) -> Value {
+    let attestation_digest = attestation_digest();
+    let decision_body = decision_json(&attestation_digest);
+    let decision_digest = jcs_digest_json(&decision_body);
+    let outcome_body =
+        outcome_json_with_commitment(&attestation_digest, &decision_digest, status, commitment);
+    run_report(&decision_body, &outcome_body)
+}
+
+fn run_report(decision_body: &str, outcome_body: &str) -> Value {
+    let dir = tempdir().unwrap();
+    let attestation = dir.path().join("attestation.json");
+    let decision = dir.path().join("decision.json");
+    let outcome = dir.path().join("outcome.json");
+    fs::write(&attestation, attestation_json()).unwrap();
+    fs::write(&decision, decision_body).unwrap();
+    fs::write(&outcome, outcome_body).unwrap();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--attestation",
+            attestation.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--outcome",
+            outcome.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap()
+}
+
+fn check_ok(report: &Value, id: &str) -> bool {
+    report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["id"] == id)
+        .map(|c| c["ok"] == true)
+        .unwrap_or(false)
+}
+
+fn claims(report: &Value) -> Vec<String> {
+    report["claims_not_made"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect()
 }

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -1,0 +1,100 @@
+# Interop record: SEP-2828 `decision_pairing_v0`
+
+Assay verifies MCP server-side execution records as an independent consumer. This is the record of
+running that verifier against the upstream conformance vectors, so the claim is checkable rather
+than asserted.
+
+**Result: 6 of the 7 normative cases reproduced. 1 not reproduced, for a reason documented below.**
+
+Re-run it yourself:
+
+```bash
+cargo build -p assay-cli --release
+scripts/interop/reproduce-sep2828-decision-pairing.sh
+```
+
+The vectors are published by [vaaraio/vaara](https://github.com/vaaraio/vaara) under
+AGPL-3.0-or-later. The script fetches them at run time and never vendors them into this MIT
+repository. Nothing upstream is executed: the upstream checker is read but not run, and every
+verdict below is computed by `assay` from the wire bytes.
+
+## Why this record exists
+
+Assay's position is that undeclared coverage reads as coverage, so a verifier should publish both
+what it checked and what it did not. That applies to Assay first. "Assay reproduces these vectors"
+is a claim about this project's own software, and a producer asserting its own conformance is
+exactly the shape Assay argues is insufficient. Hence a re-runnable script and a written scope,
+rather than a sentence in a README.
+
+## What was reproduced
+
+| Case | Expected | Assay |
+|---|---|---|
+| `valid_pair_allow_executed` | paired | Check A and Check B both hold |
+| `decision_only_escalate` | no outcome required | decision-only report, no pairing asserted |
+| `substituted_attestation_backlink` | Check A fails | outcome attestation digest mismatch, pairing refused |
+| `substituted_pairing_nonce` | Check A fails | attestation digest holds, nonce mismatch, pairing refused |
+| `substituted_decision_under_shared_attestation` | Check A holds, Check B fails | back-links match, `outcomeDerived.decisionDigest` does not |
+| `supersession_equal_decidedat_tie` | `ambiguous` | `ambiguous`, reason `supersession_ambiguous_missing_sequence` |
+| `fallback_envelope_binding` | binding holds | not reproduced, see below |
+
+Two of these are worth calling out as good corpus design. `substituted_pairing_nonce` and
+`substituted_decision_under_shared_attestation` are the cases that separate an implementation which
+actually distinguishes instance binding from content binding from one that merely compares
+back-links. A corpus that only carried the happy path and a single tampered record would not tell
+those apart.
+
+Supersession is a separate command, `assay evidence verify-mcp-supersession`, because it reasons
+over a set of decisions sharing one back-link rather than over a decision and outcome pair.
+
+## What Assay does not check
+
+Declared rather than left to inference:
+
+- **Signatures and issuer trust.** Assay verifies no signatures and resolves no keys, so
+  `decision_signature_ok` and `receipt_signature_ok` are neither confirmed nor contradicted here.
+  Reported as `signature_verification` and `issuer_key_trust` in `claims_not_made`.
+- **Result payload binding.** The result commitment's own integrity is checked, since an
+  `ArgsProjection` commits `projectionDigest` over the bytes of its `projection` string. Whether
+  the committed value is what the tool returned needs the runtime result, which a record consumer
+  does not hold. Reported as `result_commitment_payload_binding`.
+- **Runtime effect.** A reproduced verdict says the records bind to each other as specified. It
+  does not say the recorded action occurred. Reported as `runtime_side_effect_truth`.
+
+## The case that was not reproduced
+
+`fallback_envelope_binding` is the no-attestation path, where the back-link digest is taken over a
+named, versioned projection of the request envelope rather than over an attestation.
+
+Both implementations do the versioning right. Each names its projection, and each binds that name
+into the digest pre-image, so a mismatch between two different projections is visible rather than
+silent. Assay computes `assay.fallback_projection.v0`; the vectors carry
+`tools_call_params_plus_meta_authorization_binding_v1`.
+
+Assay does not implement the upstream projection version, and reconstructing it from the published
+specification text turned out not to be possible. The text declares the allowlist exactly, the
+`tools/call` `name` and `arguments` plus the named binding block, which fixes *which* fields enter
+the pre-image. It does not fix the *shape* of the object the digest is taken over, and the shape is
+part of the bytes. Five readings of the published prose were tried before the reference checker's
+source settled it.
+
+That is a general property rather than a complaint about one profile, and it is raised as such in
+the venue where the rule is being written, on the SCITT Canonical Payload Binding draft:
+[action-state-group/scitt-payload-binding#5](https://github.com/action-state-group/scitt-payload-binding/issues/5).
+Short version: an identifier that travels is necessary but not sufficient. It has to resolve to a
+published pre-image construction, or it names a shape only its author can build.
+
+The practical consequence is worth stating because it is the part that bites. A pre-image built
+from a good-faith reading of the specification produces a digest mismatch, which is the same signal
+the binding raises for a tampered record. A careful second implementer therefore concludes the
+artifact is bad rather than that their pre-image is wrong.
+
+## Provenance
+
+| | |
+|---|---|
+| Run | 2026-08-02 |
+| Assay | `assay-cli` 3.34.0, release profile |
+| Verifier commands | `assay evidence verify-mcp-records`, `assay evidence verify-mcp-supersession` |
+| Upstream vectors | `tests/vectors/decision_pairing_v0/normative`, fetched from `main` |
+| Method | upstream JSON read; upstream checker read, not executed; all verdicts computed by `assay` |

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -58,6 +58,11 @@ Declared rather than left to inference:
   `ArgsProjection` commits `projectionDigest` over the bytes of its `projection` string. Whether
   the committed value is what the tool returned needs the runtime result, which a record consumer
   does not hold. Reported as `result_commitment_payload_binding`.
+- **`ArgsRef` dereferencing.** Only the recomputable half of a commitment is verified. An
+  `ArgsRef` addresses content by URI, and this verifier fetches nothing, so its `digest` is
+  reported as `ref_digest` and never checked against anything. Reported as
+  `result_commitment_ref_not_dereferenced`. The embedded digest of the hash-only-identity
+  `ArgsProjection` form is surfaced on the same terms: shown, not checked.
 - **Runtime effect.** A reproduced verdict says the records bind to each other as specified. It
   does not say the recorded action occurred. Reported as `runtime_side_effect_truth`.
 
@@ -93,8 +98,18 @@ artifact is bad rather than that their pre-image is wrong.
 
 | | |
 |---|---|
-| Run | 2026-08-02 |
-| Assay | `assay-cli` 3.34.0, release profile |
+| Run | 2026-08-03 |
+| Assay | `assay-cli` 3.37.0, release profile |
 | Verifier commands | `assay evidence verify-mcp-records`, `assay evidence verify-mcp-supersession` |
-| Upstream vectors | `tests/vectors/decision_pairing_v0/normative`, fetched from `main` |
+| Upstream vectors | `tests/vectors/decision_pairing_v0/normative` at `519d3df8749bc0adbd79b28d0fb3d19142ababc7` |
 | Method | upstream JSON read; upstream checker read, not executed; all verdicts computed by `assay` |
+
+The upstream revision is pinned rather than tracked from `main`, because a record whose inputs can
+move is not a record. Drift shows up as a fetch failure instead of as a quietly different number.
+`ASSAY_INTEROP_REV` re-runs the comparison against another commit. The script prints the revision
+and the versions of `assay`, `curl` and `python3` it used, and fails closed on a bad fetch or an
+unexpected tool exit rather than reporting either as a comparison result.
+
+The comparison is per check, not per case. Each row above pins the specific check ids that must
+pass and must fail, so a case that reaches the right overall verdict for the wrong reason is
+reported as a divergence.

--- a/scripts/interop/reproduce-sep2828-decision-pairing.sh
+++ b/scripts/interop/reproduce-sep2828-decision-pairing.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Reproduce the upstream SEP-2828 decision/outcome pairing conformance vectors with Assay's
+# independent consumer verifier, and print how each case compares.
+#
+# The vectors are published by vaaraio/vaara under AGPL-3.0-or-later. They are FETCHED at run time
+# and never vendored into this MIT repository. Nothing from upstream is executed: the upstream
+# checker is not run, only its committed JSON is read, and every verdict below is computed by
+# `assay` from the wire bytes.
+#
+# Usage:  scripts/interop/reproduce-sep2828-decision-pairing.sh [path-to-assay-binary]
+# Exit:   0 when the comparison matches the recorded result in
+#         docs/interop/sep2828-decision-pairing-v0.md, 1 when it has drifted.
+set -euo pipefail
+
+ASSAY="${1:-./target/release/assay}"
+UPSTREAM="https://raw.githubusercontent.com/vaaraio/vaara/main/tests/vectors/decision_pairing_v0/normative"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+if ! command -v "$ASSAY" >/dev/null 2>&1 && [ ! -x "$ASSAY" ]; then
+  echo "assay binary not found at '$ASSAY'. Build it with: cargo build -p assay-cli --release" >&2
+  exit 2
+fi
+
+fetch() { # case, file
+  curl -sfL "$UPSTREAM/$1/$2" -o "$WORK/$2" 2>/dev/null
+}
+
+pass=0
+diverge=0
+
+pairing() { # case, expected_ok, note
+  local case="$1" want="$2" note="$3"
+  mkdir -p "$WORK" && rm -f "$WORK"/*.json
+  fetch "$case" attestation.json || true
+  fetch "$case" decision.json
+  local args=(evidence verify-mcp-records --attestation "$WORK/attestation.json" \
+              --decision "$WORK/decision.json" --format json)
+  if fetch "$case" receipt.json; then
+    args+=(--outcome "$WORK/receipt.json")
+  fi
+  # A correctly-failing case exits 2 by design, so the exit code is not an error here.
+  local out got
+  out="$("$ASSAY" "${args[@]}" 2>/dev/null || true)"
+  got="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["ok"])')"
+  report "$case" "$want" "$got" "$note"
+}
+
+report() { # case, want, got, note
+  if [ "$2" = "$3" ]; then
+    printf '  %-46s reproduced   (%s)\n' "$1" "$4"
+    pass=$((pass + 1))
+  else
+    printf '  %-46s DIVERGES     want=%s got=%s  (%s)\n' "$1" "$2" "$3" "$4"
+    diverge=$((diverge + 1))
+  fi
+}
+
+echo "SEP-2828 decision_pairing_v0, reproduced by Assay as an independent consumer"
+echo "Vectors: vaaraio/vaara (AGPL-3.0-or-later), fetched, not vendored, not executed"
+echo
+
+pairing valid_pair_allow_executed                    True  "Check A and Check B both hold"
+pairing decision_only_escalate                       True  "decision with no outcome yet"
+pairing substituted_attestation_backlink             False "Check A fails on the attestation digest"
+pairing substituted_pairing_nonce                    False "Check A fails on the nonce"
+pairing substituted_decision_under_shared_attestation False "Check A holds, Check B fails"
+
+# Supersession is a separate command: it reasons over a set of decisions sharing one back-link,
+# not over a decision/outcome pair.
+rm -f "$WORK"/*.json
+fetch supersession_equal_decidedat_tie decision_a.json
+fetch supersession_equal_decidedat_tie decision_b.json
+python3 -c '
+import json,sys
+a=json.load(open(sys.argv[1])); b=json.load(open(sys.argv[2]))
+json.dump([a,b],open(sys.argv[3],"w"))' "$WORK/decision_a.json" "$WORK/decision_b.json" "$WORK/pair.json"
+supersession_out="$("$ASSAY" evidence verify-mcp-supersession --decisions "$WORK/pair.json" --format json 2>/dev/null || true)"
+verdict="$(printf '%s' "$supersession_out" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["groups"][0]["verdict"])')"
+report supersession_equal_decidedat_tie ambiguous "$verdict" "equal decidedAt, no ordering field"
+
+# The fallback case is a known, documented divergence: Assay implements its own named projection
+# (assay.fallback_projection.v0) and the upstream projection's pre-image cannot be reconstructed
+# from the published specification text. See docs/interop/sep2828-decision-pairing-v0.md.
+printf '  %-46s not reproduced (see the record: projection pre-image)\n' fallback_envelope_binding
+
+echo
+echo "reproduced: $pass   diverged: $diverge   documented non-reproduction: 1"
+if [ "$diverge" -ne 0 ]; then
+  echo "Result differs from the recorded 6 of 7. Update docs/interop/sep2828-decision-pairing-v0.md." >&2
+  exit 1
+fi

--- a/scripts/interop/reproduce-sep2828-decision-pairing.sh
+++ b/scripts/interop/reproduce-sep2828-decision-pairing.sh
@@ -7,87 +7,152 @@
 # checker is not run, only its committed JSON is read, and every verdict below is computed by
 # `assay` from the wire bytes.
 #
+# The upstream revision is PINNED. A reproduction record whose inputs can move is not a record, so
+# the default is an immutable commit and a drift shows up as a fetch failure rather than as a
+# silently different result. Point ASSAY_INTEROP_REV at another commit to re-run against it.
+#
 # Usage:  scripts/interop/reproduce-sep2828-decision-pairing.sh [path-to-assay-binary]
-# Exit:   0 when the comparison matches the recorded result in
-#         docs/interop/sep2828-decision-pairing-v0.md, 1 when it has drifted.
+# Exit:   0 when every case matches the result recorded in
+#         docs/interop/sep2828-decision-pairing-v0.md, 1 when it has drifted, 2 on a setup or
+#         fetch failure. A fetch or tool failure is never reported as a comparison result.
 set -euo pipefail
 
 ASSAY="${1:-./target/release/assay}"
-UPSTREAM="https://raw.githubusercontent.com/vaaraio/vaara/main/tests/vectors/decision_pairing_v0/normative"
+REV="${ASSAY_INTEROP_REV:-519d3df8749bc0adbd79b28d0fb3d19142ababc7}"
+UPSTREAM="https://raw.githubusercontent.com/vaaraio/vaara/${REV}/tests/vectors/decision_pairing_v0/normative"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-if ! command -v "$ASSAY" >/dev/null 2>&1 && [ ! -x "$ASSAY" ]; then
-  echo "assay binary not found at '$ASSAY'. Build it with: cargo build -p assay-cli --release" >&2
-  exit 2
-fi
+die() { echo "$*" >&2; exit 2; }
 
-fetch() { # case, file
-  curl -sfL "$UPSTREAM/$1/$2" -o "$WORK/$2" 2>/dev/null
-}
+[ -x "$ASSAY" ] || command -v "$ASSAY" >/dev/null 2>&1 \
+  || die "assay binary not found at '$ASSAY'. Build it with: cargo build -p assay-cli --release"
+command -v curl >/dev/null 2>&1 || die "curl is required"
+command -v python3 >/dev/null 2>&1 || die "python3 is required"
+
+echo "SEP-2828 decision_pairing_v0, reproduced by Assay as an independent consumer"
+echo "Vectors: vaaraio/vaara (AGPL-3.0-or-later), fetched, not vendored, not executed"
+echo "Upstream revision: ${REV}"
+echo "Toolchain:         $("$ASSAY" --version 2>/dev/null || echo 'assay ?')"
+echo "                   $(curl --version 2>/dev/null | head -1 | cut -d' ' -f1-2)"
+echo "                   $(python3 --version 2>&1)"
+echo
 
 pass=0
 diverge=0
 
-pairing() { # case, expected_ok, note
-  local case="$1" want="$2" note="$3"
-  mkdir -p "$WORK" && rm -f "$WORK"/*.json
-  fetch "$case" attestation.json || true
-  fetch "$case" decision.json
-  local args=(evidence verify-mcp-records --attestation "$WORK/attestation.json" \
-              --decision "$WORK/decision.json" --format json)
-  if fetch "$case" receipt.json; then
-    args+=(--outcome "$WORK/receipt.json")
-  fi
-  # A correctly-failing case exits 2 by design, so the exit code is not an error here.
-  local out got
-  out="$("$ASSAY" "${args[@]}" 2>/dev/null || true)"
-  got="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["ok"])')"
-  report "$case" "$want" "$got" "$note"
+# A missing or empty fetch is a setup failure, never an absent optional input.
+fetch() { # case, file
+  curl -sfL --max-time 30 "$UPSTREAM/$1/$2" -o "$WORK/$2" || return 1
+  [ -s "$WORK/$2" ] || die "empty response for $1/$2 at $REV"
 }
 
-report() { # case, want, got, note
-  if [ "$2" = "$3" ]; then
-    printf '  %-46s reproduced   (%s)\n' "$1" "$4"
+# Runs the verifier and echoes the ids of the checks that passed and failed. Exit code 2 means a
+# case was correctly refused, so only a code outside {0,2} is a tool failure.
+run_pairing() { # case, has_receipt
+  local case="$1" has_receipt="$2" rc=0 out
+  local args=(evidence verify-mcp-records --decision "$WORK/decision.json" --format json)
+  if [ -s "$WORK/attestation.json" ]; then
+    args=(evidence verify-mcp-records --attestation "$WORK/attestation.json" \
+          --decision "$WORK/decision.json" --format json)
+  fi
+  [ "$has_receipt" = yes ] && args+=(--outcome "$WORK/receipt.json")
+  out="$("$ASSAY" "${args[@]}" 2>/dev/null)" || rc=$?
+  case "$rc" in
+    0|2) ;;
+    *) die "assay exited $rc on $case" ;;
+  esac
+  printf '%s' "$out"
+}
+
+# Compares against the check ids each upstream case pins, not just the overall boolean, so a case
+# that fails for the wrong reason is a divergence rather than a match.
+compare() { # case, report_json, expect_ok, must_pass (csv), must_fail (csv), note
+  local case="$1" verdict
+  verdict="$(printf '%s' "$2" | python3 -c '
+import json,sys
+r=json.load(sys.stdin)
+want_ok, must_pass, must_fail = sys.argv[1]=="true", sys.argv[2], sys.argv[3]
+checks={c["id"]: c["ok"] for c in r["checks"]}
+bad=[]
+if r["ok"] is not want_ok: bad.append("ok=%s" % r["ok"])
+for cid in [c for c in must_pass.split(",") if c]:
+    if checks.get(cid) is not True: bad.append("%s not passing" % cid)
+for cid in [c for c in must_fail.split(",") if c]:
+    if checks.get(cid) is not False: bad.append("%s not failing" % cid)
+print("ok" if not bad else "; ".join(bad))
+' "$3" "$4" "$5")"
+  if [ "$verdict" = ok ]; then
+    printf '  %-46s reproduced   (%s)\n' "$case" "$6"
     pass=$((pass + 1))
   else
-    printf '  %-46s DIVERGES     want=%s got=%s  (%s)\n' "$1" "$2" "$3" "$4"
+    printf '  %-46s DIVERGES     %s  (%s)\n' "$case" "$verdict" "$6"
     diverge=$((diverge + 1))
   fi
 }
 
-echo "SEP-2828 decision_pairing_v0, reproduced by Assay as an independent consumer"
-echo "Vectors: vaaraio/vaara (AGPL-3.0-or-later), fetched, not vendored, not executed"
-echo
+case_run() { # case, has_attestation, has_receipt, expect_ok, must_pass, must_fail, note
+  rm -f "$WORK"/*.json
+  [ "$2" = yes ] && fetch "$1" attestation.json
+  fetch "$1" decision.json
+  [ "$3" = yes ] && fetch "$1" receipt.json
+  compare "$1" "$(run_pairing "$1" "$3")" "$4" "$5" "$6" "$7"
+}
 
-pairing valid_pair_allow_executed                    True  "Check A and Check B both hold"
-pairing decision_only_escalate                       True  "decision with no outcome yet"
-pairing substituted_attestation_backlink             False "Check A fails on the attestation digest"
-pairing substituted_pairing_nonce                    False "Check A fails on the nonce"
-pairing substituted_decision_under_shared_attestation False "Check A holds, Check B fails"
+case_run valid_pair_allow_executed yes yes true \
+  decision_outcome_backlink_match,outcome_decision_digest_match,result_commitment_projection_digest_match \
+  "" "Check A and Check B both hold"
+
+case_run decision_only_escalate yes no true \
+  decision_attestation_digest_match,outcome_absent "" "decision with no outcome yet"
+
+case_run substituted_attestation_backlink yes yes false \
+  decision_attestation_digest_match \
+  outcome_attestation_digest_match,decision_outcome_backlink_match \
+  "Check A fails on the attestation digest"
+
+case_run substituted_pairing_nonce yes yes false \
+  outcome_attestation_digest_match \
+  outcome_attestation_nonce_match,decision_outcome_backlink_match \
+  "Check A fails on the nonce, digest still matches"
+
+case_run substituted_decision_under_shared_attestation yes yes false \
+  decision_outcome_backlink_match outcome_decision_digest_match \
+  "Check A holds, Check B fails"
 
 # Supersession is a separate command: it reasons over a set of decisions sharing one back-link,
-# not over a decision/outcome pair.
+# not over a decision and outcome pair. The reason code is compared, not only the verdict, so a
+# tie broken for the wrong reason would not read as a match.
 rm -f "$WORK"/*.json
 fetch supersession_equal_decidedat_tie decision_a.json
 fetch supersession_equal_decidedat_tie decision_b.json
 python3 -c '
 import json,sys
-a=json.load(open(sys.argv[1])); b=json.load(open(sys.argv[2]))
-json.dump([a,b],open(sys.argv[3],"w"))' "$WORK/decision_a.json" "$WORK/decision_b.json" "$WORK/pair.json"
-supersession_out="$("$ASSAY" evidence verify-mcp-supersession --decisions "$WORK/pair.json" --format json 2>/dev/null || true)"
-verdict="$(printf '%s' "$supersession_out" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["groups"][0]["verdict"])')"
-report supersession_equal_decidedat_tie ambiguous "$verdict" "equal decidedAt, no ordering field"
+json.dump([json.load(open(sys.argv[1])), json.load(open(sys.argv[2]))], open(sys.argv[3],"w"))' \
+  "$WORK/decision_a.json" "$WORK/decision_b.json" "$WORK/pair.json"
+sup_rc=0
+sup_out="$("$ASSAY" evidence verify-mcp-supersession --decisions "$WORK/pair.json" --format json 2>/dev/null)" || sup_rc=$?
+case "$sup_rc" in 0|2) ;; *) die "assay exited $sup_rc on supersession" ;; esac
+sup_verdict="$(printf '%s' "$sup_out" | python3 -c '
+import json,sys
+g=json.load(sys.stdin)["groups"][0]
+print("%s/%s" % (g["verdict"], g["reason_code"]))')"
+if [ "$sup_verdict" = "ambiguous/supersession_ambiguous_missing_sequence" ]; then
+  printf '  %-46s reproduced   (%s)\n' supersession_equal_decidedat_tie "equal decidedAt, no ordering field"
+  pass=$((pass + 1))
+else
+  printf '  %-46s DIVERGES     got=%s\n' supersession_equal_decidedat_tie "$sup_verdict"
+  diverge=$((diverge + 1))
+fi
 
-# The fallback case is a known, documented divergence: Assay implements its own named projection
+# The fallback case is a documented non-reproduction: Assay implements its own named projection
 # (assay.fallback_projection.v0) and the upstream projection's pre-image cannot be reconstructed
 # from the published specification text. See docs/interop/sep2828-decision-pairing-v0.md.
-printf '  %-46s not reproduced (see the record: projection pre-image)\n' fallback_envelope_binding
+printf '  %-46s not reproduced (upstream projection pre-image, see the record)\n' fallback_envelope_binding
 
 echo
 echo "reproduced: $pass   diverged: $diverge   documented non-reproduction: 1"
-if [ "$diverge" -ne 0 ]; then
+if [ "$diverge" -ne 0 ] || [ "$pass" -ne 6 ]; then
   echo "Result differs from the recorded 6 of 7. Update docs/interop/sep2828-decision-pairing-v0.md." >&2
   exit 1
 fi


### PR DESCRIPTION
Two changes, one argument: a verifier should publish both what it checked and what it did not, and that applies to this project first.

## 1. `verify-mcp-records` now settles the checkable half of SEP-2828 step 5

The command covered steps 2, 3, 4 and 6 of the verification algorithm and was silent on step 5, the result commitment. Silence was the defect. `claims_not_made` listed `payload_or_result_disclosure`, which is about disclosure, so a reader had no way to tell the commitment was never looked at.

Step 5 splits along what a record-only consumer can actually settle:

- an `ArgsProjection` commits `projectionDigest` as sha256 over the UTF-8 bytes of the `projection` string, so it is recomputable from the record alone. That is now a real check.
- an `ArgsRef` addresses content this verifier never fetches, and neither shape says whether the committed value is what the tool returned. Both are now named in `claims_not_made` instead of left to inference.

Also reports the embedded digest of the recommended hash-only-identity form without checking it, since it binds a value this verifier never sees, and fails a `refused` outcome that carries a commitment.

Five new tests. Validated against the upstream vectors, whose receipts carry that projection shape.

## 2. The reproduction is now a re-runnable record, not a claim

```bash
scripts/interop/reproduce-sep2828-decision-pairing.sh
```

Fetches the upstream normative vectors at run time and computes every verdict with `assay` from the wire bytes. The vectors are AGPL-3.0-or-later and are never vendored into this MIT tree; the upstream checker is read but not executed.

Six of seven reproduce, including the two cases that actually separate instance binding from content binding. The seventh is the no-attestation fallback: both sides name and bind their projection version correctly, but the upstream pre-image cannot be reconstructed from the published specification text, because the allowlist fixes which fields enter the pre-image and not the shape of the object hashed. That is a general property, so it is raised where the rule is being written rather than as a complaint about one profile: action-state-group/scitt-payload-binding#5.

`docs/interop/sep2828-decision-pairing-v0.md` carries the scorecard, the scope, and the provenance.

## Verification

| Gate | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, zero warnings |
| `cargo test -p assay-cli` | 571 passed, 0 failed |
| `cargo fmt --all --check` | clean |
| `scripts/interop/reproduce-sep2828-decision-pairing.sh` | 6 reproduced, 0 diverged, exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)