### PR TITLE
Count the strong join that was established, not the one declared

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mcp_tunnel_observed.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_tunnel_observed.rs
@@ -69,9 +69,22 @@ struct RequestBindingReport {
     request_envelope_canonicalization: Option<String>,
 }
 
+/// Counts what the artifact ESTABLISHED, never what it declared.
+///
+/// A reference declares `relationship` and `join_strength` itself. Counting a strong join on those
+/// fields alone would let a producer's own assertion arrive in the summary as an established one,
+/// which is the failure mode this command exists to catch. So a declared-strong reference only
+/// reaches `strong_same_request_instance` once its `request_envelope_digest` and canonicalization
+/// actually match the request instance.
+///
+/// A declared-strong reference that fails that match is NOT folded into `diagnostic_correlation`
+/// either: a diagnostic reference is a valid weaker join, while this is a claim the artifact made
+/// and did not substantiate. Laundering the second into the first would hide it. It gets its own
+/// bucket so the count of unsubstantiated claims is readable rather than inferred.
 #[derive(Debug, Serialize, Default)]
 struct JoinSummary {
     strong_same_request_instance: usize,
+    unsubstantiated_strong_claim: usize,
     diagnostic_correlation: usize,
 }
 
@@ -384,11 +397,16 @@ fn push_evidence_ref_checks(
             && join_strength.as_deref() == Some("strong");
 
         if is_strong_same_request {
-            join_summary.strong_same_request_instance += 1;
             let ok = ref_digest.as_deref() == request_digest
                 && ref_canonicalization.as_deref() == request_canonicalization
                 && request_digest.is_some()
                 && request_canonicalization.is_some();
+            // Count the established join, not the declared one.
+            if ok {
+                join_summary.strong_same_request_instance += 1;
+            } else {
+                join_summary.unsubstantiated_strong_claim += 1;
+            }
             checks.push(CheckReport {
                 id: "same_request_instance_strong_join",
                 ok,
@@ -506,6 +524,10 @@ fn print_table_report(report: &TunnelObservedReport) {
     println!(
         "Strong joins:        {}",
         report.join_summary.strong_same_request_instance
+    );
+    println!(
+        "Unsubstantiated:     {}",
+        report.join_summary.unsubstantiated_strong_claim
     );
     println!(
         "Diagnostic joins:    {}",

--- a/crates/assay-cli/tests/evidence_test/mcp_tunnel_observed.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_tunnel_observed.rs
@@ -196,4 +196,44 @@ fn verify_mcp_tunnel_observed_does_not_credit_a_bare_strong_declaration() {
     assert_eq!(report["ok"], false);
     assert_eq!(report["join_summary"]["strong_same_request_instance"], 0);
     assert_eq!(report["join_summary"]["unsubstantiated_strong_claim"], 1);
+    // One reference lands in exactly one bucket. Without this a regression that incremented both
+    // the unsubstantiated and the diagnostic counter would pass.
+    assert_eq!(report["join_summary"]["diagnostic_correlation"], 0);
+}
+
+/// The canonicalization case above only proves one of the two required binding fields rejects a
+/// strong join. This proves the other: digest mismatch while canonicalization matches.
+#[test]
+fn verify_mcp_tunnel_observed_rejects_strong_join_on_digest_mismatch_alone() {
+    let mut artifact = read_valid_tunnel();
+    artifact["evidence_refs"][0]["request_envelope_digest"] = Value::String(
+        "sha256:9999999999999999999999999999999999999999999999999999999999999999".to_string(),
+    );
+    let (_dir, path) = write_fixture(&artifact, "digest-mismatch-strong-join.tunnel.json");
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-tunnel-observed",
+            "--artifact",
+            path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert!(report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|check| check["id"] == "same_request_instance_strong_join" && check["ok"] == false));
+    assert_eq!(report["join_summary"]["strong_same_request_instance"], 0);
+    assert_eq!(report["join_summary"]["unsubstantiated_strong_claim"], 1);
+    assert_eq!(report["join_summary"]["diagnostic_correlation"], 0);
 }

--- a/crates/assay-cli/tests/evidence_test/mcp_tunnel_observed.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_tunnel_observed.rs
@@ -154,4 +154,46 @@ fn verify_mcp_tunnel_observed_rejects_mismatched_strong_join() {
         .unwrap()
         .iter()
         .any(|check| check["id"] == "same_request_instance_strong_join" && check["ok"] == false));
+
+    // The summary must report what was established, not what the reference declared. A
+    // declared-strong join whose digest does not match is not a strong join, and it is not a
+    // diagnostic one either: it is a claim the artifact failed to substantiate, and it says so.
+    assert_eq!(report["join_summary"]["strong_same_request_instance"], 0);
+    assert_eq!(report["join_summary"]["unsubstantiated_strong_claim"], 1);
+    assert_eq!(report["join_summary"]["diagnostic_correlation"], 0);
+}
+
+/// A reference can declare `same_request_instance` + `strong` and carry no binding fields at all.
+/// That is the cheapest possible way to assert a strong join, so it must not produce one.
+#[test]
+fn verify_mcp_tunnel_observed_does_not_credit_a_bare_strong_declaration() {
+    let mut artifact = read_valid_tunnel();
+    artifact["evidence_refs"][0] = serde_json::json!({
+        "kind": "mcp.execution_record",
+        "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "relationship": "same_request_instance",
+        "join_strength": "strong"
+    });
+    let (_dir, path) = write_fixture(&artifact, "bare-strong-declaration.tunnel.json");
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-tunnel-observed",
+            "--artifact",
+            path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["ok"], false);
+    assert_eq!(report["join_summary"]["strong_same_request_instance"], 0);
+    assert_eq!(report["join_summary"]["unsubstantiated_strong_claim"], 1);
 }

--- a/examples/mcp-tunnel-observed-evidence/README.md
+++ b/examples/mcp-tunnel-observed-evidence/README.md
@@ -75,6 +75,14 @@ joins or diagnostic correlation. Strong joins require a shared
 `request_envelope_digest` and `request_envelope_canonicalization`; route,
 upstream, request id, timestamp, or provider request id alone stay diagnostic.
 
+The join summary counts what a reference established, never what it declared. A
+reference that declares `same_request_instance` and `strong` but does not carry
+the matching digest and canonicalization is counted under
+`unsubstantiated_strong_claim`, not under `strong_same_request_instance` and not
+under `diagnostic_correlation`. A diagnostic reference is a valid weaker join,
+while an unsubstantiated one is a claim the artifact did not back up, and
+folding the second into the first would hide it.
+
 ## Map the substituted-upstream artifact
 
 ```bash

--- a/examples/mcp-tunnel-observed-evidence/README.md
+++ b/examples/mcp-tunnel-observed-evidence/README.md
@@ -70,8 +70,9 @@ assay evidence verify-mcp-tunnel-observed \
 
 This checker is the reference fixture path for the sample. It validates the
 bounded `assay.mcp.tunnel_observed.v0` shape, keeps raw payload/auth material
-out, and classifies `evidence_refs` as either strong `same_request_instance`
-joins or diagnostic correlation. Strong joins require a shared
+out, and classifies each of the `evidence_refs` as one of three things: an
+established strong `same_request_instance` join, an unsubstantiated strong
+claim, or diagnostic correlation. Strong joins require a shared
 `request_envelope_digest` and `request_envelope_canonicalization`; route,
 upstream, request id, timestamp, or provider request id alone stay diagnostic.
 


### PR DESCRIPTION
`verify-mcp-tunnel-observed` exists to stop a producer's own assertion reading as an observation. Its join summary did the opposite.

## The defect

`join_summary.strong_same_request_instance` incremented as soon as a reference declared `relationship: same_request_instance` and `join_strength: strong` — before, and independently of, the digest match:

```rust
if is_strong_same_request {
    join_summary.strong_same_request_instance += 1;   // on self-declared fields
    let ok = ref_digest == request_digest && ...;      // the actual check, after
```

The match did run, failed `same_request_instance_strong_join`, and correctly failed the report, so no verdict was wrong. But the summary still counted the reference as a strong join, and a reader scanning `Strong joins: 1` saw an established binding where the artifact had only claimed one.

This was found while reviewing an unrelated design, by reading the code rather than the docs.

## Why this is a fix and not a change of meaning

The documented contract was already correct. `examples/mcp-tunnel-observed-evidence/README.md`: "Strong joins require a shared `request_envelope_digest` and `request_envelope_canonicalization`." Only the counter disagreed with it.

## The third bucket

A declared-strong reference that fails the match is **not** folded into `diagnostic_correlation`. A diagnostic reference is a valid weaker join; an unsubstantiated one is a claim the artifact did not back up. Merging the second into the first would hide exactly the thing worth seeing, so it gets `unsubstantiated_strong_claim`, printed beside the others.

## Why it survived

The existing mismatch test asserted the failing check and never the counters. It now pins all three, and a second test covers the cheapest possible case: a reference declaring `same_request_instance` + `strong` while carrying no binding fields at all.

## Verification

| Gate | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, zero warnings |
| `cargo test -p assay-cli` | 604 passed, 0 failed |
| `cargo fmt --all --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evidence verification for strong same-request claims that lack matching digest or canonicalization data.
  * Such claims are now reported as unsubstantiated instead of being counted as confirmed or diagnostic joins.
  * Added validation to reject incomplete strong join declarations.

* **Documentation**
  * Clarified how strong and diagnostic MCP tunnel evidence joins are classified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->