### PR TITLE
feat(mcp-server): type the correlation basis a tool-decision record retains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `assay.tool_decision_surface.v0` records now carry a typed `correlation`
+  basis: a valid W3C `traceparent` from `_meta` is retained verbatim as a
+  propagated claim, a broken carrier is typed `malformed_trace_context` with
+  its bytes dropped, and a stateless record is typed `none` — never silently.
+  Additive to the shipped v0 shape; records from producers up to and including
+  3.37.0 carry no `correlation` field (#1955).
+
 ## [3.37.0] - 2026-08-02
 
 ### Added

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -378,10 +378,7 @@ impl Server {
                                 rule_id: None,
                                 // SEP-414 (MCP 2026-07-28): trace context travels in `_meta`.
                                 // Validation and basis typing happen inside build_decision.
-                                traceparent: params
-                                    .get("_meta")
-                                    .and_then(|m| m.get("traceparent"))
-                                    .and_then(|v| v.as_str()),
+                                traceparent: crate::tool_decision::traceparent_from_params(&params),
                             });
                             tracing::info!(
                                 event = "tool_decision",

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -376,6 +376,12 @@ impl Server {
                                 effect,
                                 status: &status,
                                 rule_id: None,
+                                // SEP-414 (MCP 2026-07-28): trace context travels in `_meta`.
+                                // Validation and basis typing happen inside build_decision.
+                                traceparent: params
+                                    .get("_meta")
+                                    .and_then(|m| m.get("traceparent"))
+                                    .and_then(|v| v.as_str()),
                             });
                             tracing::info!(
                                 event = "tool_decision",

--- a/crates/assay-mcp-server/src/tool_decision.rs
+++ b/crates/assay-mcp-server/src/tool_decision.rs
@@ -331,11 +331,23 @@ fn is_valid_traceparent(tp: &str) -> bool {
                 .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
     };
     hex(version, 2)
+        && version != "ff" // forbidden by W3C Trace Context
         && hex(trace_id, 32)
         && hex(parent_id, 16)
         && hex(flags, 2)
         && trace_id.bytes().any(|b| b != b'0')
         && parent_id.bytes().any(|b| b != b'0')
+}
+
+/// Extract the `_meta.traceparent` carrier from `tools/call` params (SEP-414). `None` means no
+/// carrier was sent; `Some("")` means a carrier was sent but is not a JSON string — the empty
+/// string fails validation, so a non-string carrier is typed `malformed_trace_context`, never
+/// silently collapsed into `none` (an absent carrier and a broken one are different facts).
+pub fn traceparent_from_params(params: &Value) -> Option<&str> {
+    params
+        .get("_meta")
+        .and_then(|m| m.get("traceparent"))
+        .map(|v| v.as_str().unwrap_or(""))
 }
 
 /// The correlation basis of this record, typed. Three states, never silent (an absent carrier and

--- a/crates/assay-mcp-server/src/tool_decision.rs
+++ b/crates/assay-mcp-server/src/tool_decision.rs
@@ -89,6 +89,11 @@ pub struct ObservedCall<'a> {
     pub status: &'a str,
     /// Policy rule id if the decision named one; `None` falls back to a neutral marker.
     pub rule_id: Option<&'a str>,
+    /// Raw `_meta.traceparent` from the request (SEP-414), if the client sent one. The record
+    /// types it as a propagated claim; it is never an observed transport fact. `tracestate` and
+    /// `baggage` are deliberately not retained: their values are free-form and may carry data
+    /// the redaction rules cannot reason about.
+    pub traceparent: Option<&'a str>,
 }
 
 /// Outcome of running the rule-based privileged-action classifiers over one observed call. Total:
@@ -307,6 +312,57 @@ pub fn sanitize(input: &str) -> String {
         .collect()
 }
 
+/// A W3C `traceparent` (version-traceid-parentid-flags) with lowercase hex fields and non-zero
+/// trace-id/parent-id. Anything else is retained only as the fact "malformed", never as bytes.
+fn is_valid_traceparent(tp: &str) -> bool {
+    let mut parts = tp.split('-');
+    let (Some(version), Some(trace_id), Some(parent_id), Some(flags), None) = (
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+    ) else {
+        return false;
+    };
+    let hex = |s: &str, len: usize| {
+        s.len() == len
+            && s.bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    };
+    hex(version, 2)
+        && hex(trace_id, 32)
+        && hex(parent_id, 16)
+        && hex(flags, 2)
+        && trace_id.bytes().any(|b| b != b'0')
+        && parent_id.bytes().any(|b| b != b'0')
+}
+
+/// The correlation basis of this record, typed. Three states, never silent (an absent carrier and
+/// a malformed one are different facts): `propagated_trace_context` (valid `_meta.traceparent`
+/// retained — a producer-propagated claim, not an observed transport fact), `malformed_trace_context`
+/// (a carrier was sent but is not a valid traceparent; its bytes are not retained), `none` (the
+/// record is stateless, per MCP 2026-07-28). Grouping built on this basis inherits its class.
+fn correlation(traceparent: Option<&str>) -> Value {
+    match traceparent {
+        Some(tp) if is_valid_traceparent(tp) => json!({
+            "basis": "propagated_trace_context",
+            "traceparent": tp,
+            "source_class": "propagated"
+        }),
+        Some(_) => json!({
+            "basis": "malformed_trace_context",
+            "traceparent": Value::Null,
+            "source_class": Value::Null
+        }),
+        None => json!({
+            "basis": "none",
+            "traceparent": Value::Null,
+            "source_class": Value::Null
+        }),
+    }
+}
+
 /// Build a single observed tool-decision entry. Redaction and the asserted-vs-verified rule are
 /// applied here by construction; no caller can opt out of them.
 pub fn build_decision(call: &ObservedCall<'_>) -> Value {
@@ -349,7 +405,8 @@ pub fn build_decision(call: &ObservedCall<'_>) -> Value {
             "arguments_redacted": true,
             "credential_alias": Value::Null,
             "secret_material_stored": false
-        }
+        },
+        "correlation": correlation(call.traceparent)
     });
     if let Some(detail) = c.detail {
         decision["detail"] = Value::String(detail);

--- a/crates/assay-mcp-server/src/tool_decision/tests.rs
+++ b/crates/assay-mcp-server/src/tool_decision/tests.rs
@@ -8,6 +8,55 @@ fn call<'a>(tool: &'a str, args: &'a Value, effect: Effect, status: &'a str) -> 
         effect,
         status,
         rule_id: Some("r1"),
+        traceparent: None,
+    }
+}
+
+fn call_with_traceparent<'a>(args: &'a Value, traceparent: Option<&'a str>) -> ObservedCall<'a> {
+    ObservedCall {
+        traceparent,
+        ..call("github.add_deploy_key", args, Effect::Allow, "success")
+    }
+}
+
+#[test]
+fn valid_traceparent_is_retained_and_typed_as_propagated() {
+    let a = json!({});
+    let tp = "00-11111111111111111111111111111111-aaaaaaaaaaaaaaa1-01";
+    let d = build_decision(&call_with_traceparent(&a, Some(tp)));
+    assert_eq!(d["correlation"]["basis"], json!("propagated_trace_context"));
+    assert_eq!(d["correlation"]["traceparent"], json!(tp));
+    assert_eq!(d["correlation"]["source_class"], json!("propagated"));
+}
+
+#[test]
+fn absent_traceparent_is_typed_none_never_silent() {
+    let a = json!({});
+    let d = build_decision(&call_with_traceparent(&a, None));
+    assert_eq!(d["correlation"]["basis"], json!("none"));
+    assert_eq!(d["correlation"]["traceparent"], json!(null));
+    assert_eq!(d["correlation"]["source_class"], json!(null));
+}
+
+#[test]
+fn malformed_traceparent_is_typed_distinctly_and_not_retained() {
+    let a = json!({});
+    for bad in [
+        "not-a-traceparent",
+        "00-11111111111111111111111111111111-aaaaaaaaaaaaaaa1", // missing flags
+        "00-zzzz1111111111111111111111111111-aaaaaaaaaaaaaaa1-01", // non-hex
+        "00-00000000000000000000000000000000-aaaaaaaaaaaaaaa1-01", // all-zero trace-id
+        "00-11111111111111111111111111111111-0000000000000000-01", // all-zero parent-id
+        "00-1111\u{1b}]8;;evil\u{7}-aaaaaaaaaaaaaaa1-01",       // hostile bytes
+    ] {
+        let d = build_decision(&call_with_traceparent(&a, Some(bad)));
+        assert_eq!(
+            d["correlation"]["basis"],
+            json!("malformed_trace_context"),
+            "{bad}"
+        );
+        assert_eq!(d["correlation"]["traceparent"], json!(null), "{bad}");
+        assert_eq!(d["correlation"]["source_class"], json!(null), "{bad}");
     }
 }
 

--- a/crates/assay-mcp-server/src/tool_decision/tests.rs
+++ b/crates/assay-mcp-server/src/tool_decision/tests.rs
@@ -48,6 +48,8 @@ fn malformed_traceparent_is_typed_distinctly_and_not_retained() {
         "00-00000000000000000000000000000000-aaaaaaaaaaaaaaa1-01", // all-zero trace-id
         "00-11111111111111111111111111111111-0000000000000000-01", // all-zero parent-id
         "00-1111\u{1b}]8;;evil\u{7}-aaaaaaaaaaaaaaa1-01",       // hostile bytes
+        "ff-11111111111111111111111111111111-aaaaaaaaaaaaaaa1-01", // version ff forbidden by W3C
+        "", // present-but-non-string carrier is extracted as "" and must land here, not in "none"
     ] {
         let d = build_decision(&call_with_traceparent(&a, Some(bad)));
         assert_eq!(
@@ -58,6 +60,20 @@ fn malformed_traceparent_is_typed_distinctly_and_not_retained() {
         assert_eq!(d["correlation"]["traceparent"], json!(null), "{bad}");
         assert_eq!(d["correlation"]["source_class"], json!(null), "{bad}");
     }
+}
+
+#[test]
+fn traceparent_extraction_distinguishes_absent_from_non_string() {
+    let valid = "00-11111111111111111111111111111111-aaaaaaaaaaaaaaa1-01";
+    let with = json!({"name": "t", "_meta": {"traceparent": valid}});
+    assert_eq!(traceparent_from_params(&with), Some(valid));
+    // A present-but-non-string carrier is a malformed carrier, not an absent one.
+    let non_string = json!({"name": "t", "_meta": {"traceparent": 42}});
+    assert_eq!(traceparent_from_params(&non_string), Some(""));
+    let absent = json!({"name": "t"});
+    assert_eq!(traceparent_from_params(&absent), None);
+    let meta_not_object = json!({"name": "t", "_meta": 7});
+    assert_eq!(traceparent_from_params(&meta_not_object), None);
 }
 
 #[test]

--- a/crates/assay-mcp-server/tests/fixtures/side_effect/asserted.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/asserted.json
@@ -47,6 +47,11 @@
         "arguments_redacted": true,
         "credential_alias": "github-prod-admin",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "none",
+        "traceparent": null,
+        "source_class": null
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/side_effect/observed_confirmed.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/observed_confirmed.json
@@ -47,6 +47,11 @@
         "arguments_redacted": true,
         "credential_alias": "github-prod-admin",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "none",
+        "traceparent": null,
+        "source_class": null
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/side_effect/verified.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/verified.json
@@ -47,6 +47,11 @@
         "arguments_redacted": true,
         "credential_alias": "github-prod-admin",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "none",
+        "traceparent": null,
+        "source_class": null
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
@@ -41,6 +41,11 @@
         "arguments_redacted": true,
         "credential_alias": "github-prod-admin",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "propagated_trace_context",
+        "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        "source_class": "propagated"
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
@@ -40,6 +40,11 @@
         "arguments_redacted": true,
         "credential_alias": "github-prod-admin",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "propagated_trace_context",
+        "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        "source_class": "propagated"
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
@@ -39,7 +39,12 @@
         "credential_alias": "github-prod-admin",
         "secret_material_stored": false
       },
-      "detail": "missing_github_owner_or_repo"
+      "detail": "missing_github_owner_or_repo",
+      "correlation": {
+        "basis": "none",
+        "traceparent": null,
+        "source_class": null
+      }
     }
   ],
   "non_claims": [

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
@@ -44,6 +44,11 @@
         "sanitized_fields": [
           "tool.name"
         ]
+      },
+      "correlation": {
+        "basis": "malformed_trace_context",
+        "traceparent": null,
+        "source_class": null
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
@@ -40,6 +40,11 @@
         "arguments_redacted": true,
         "credential_alias": "slack-bot",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "none",
+        "traceparent": null,
+        "source_class": null
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
@@ -35,6 +35,11 @@
         "arguments_redacted": true,
         "credential_alias": null,
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "none",
+        "traceparent": null,
+        "source_class": null
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
@@ -40,6 +40,11 @@
         "arguments_redacted": true,
         "credential_alias": "workspace-admin",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "none",
+        "traceparent": null,
+        "source_class": null
       }
     }
   ],

--- a/crates/assay-mcp-server/tests/side_effect_fixtures.rs
+++ b/crates/assay-mcp-server/tests/side_effect_fixtures.rs
@@ -108,3 +108,44 @@ fn levels_are_from_the_pinned_set() {
         );
     }
 }
+
+#[test]
+fn side_effect_vectors_carry_a_typed_correlation_basis() {
+    // These fixtures declare the same `assay.tool_decision_surface.v0` schema as the
+    // tool_decisions vectors, so the correlation contract binds them too: basis is required,
+    // typed, and never silent (see tests/tool_decision_fixtures.rs for the full invariant).
+    for name in ["asserted.json", "observed_confirmed.json", "verified.json"] {
+        let v = fx(name);
+        for d in v["observed_tool_decisions"].as_array().expect("decisions") {
+            let corr = d.get("correlation").unwrap_or_else(|| {
+                panic!("{name}: every decision must carry a typed correlation basis")
+            });
+            let basis = corr["basis"].as_str().unwrap_or("");
+            assert!(
+                [
+                    "propagated_trace_context",
+                    "malformed_trace_context",
+                    "none"
+                ]
+                .contains(&basis),
+                "{name}: unknown correlation basis {basis:?}"
+            );
+            if basis == "propagated_trace_context" {
+                assert!(
+                    corr["traceparent"].is_string(),
+                    "{name}: propagated must retain traceparent"
+                );
+                assert_eq!(corr["source_class"].as_str(), Some("propagated"), "{name}");
+            } else {
+                assert!(
+                    corr["traceparent"].is_null(),
+                    "{name}: non-propagated must carry null"
+                );
+                assert!(
+                    corr["source_class"].is_null(),
+                    "{name}: non-propagated must carry null"
+                );
+            }
+        }
+    }
+}

--- a/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
+++ b/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
@@ -86,10 +86,13 @@ fn tool_decision_fixtures_hold_the_spec_invariants() {
                 "{name}: secret_material_stored must be false"
             );
 
-            // Correlation basis, when present, is typed and never silent: a traceparent is
+            // Correlation basis is required and typed, never silent: a traceparent is
             // retained exactly when the basis is propagated_trace_context, and a malformed
             // carrier keeps its bytes out of the record while staying distinct from `none`.
-            if let Some(corr) = d.get("correlation") {
+            {
+                let corr = d.get("correlation").unwrap_or_else(|| {
+                    panic!("{name}: every decision must carry a typed correlation basis")
+                });
                 let basis = corr["basis"].as_str().unwrap_or("");
                 assert!(
                     [

--- a/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
+++ b/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
@@ -86,6 +86,33 @@ fn tool_decision_fixtures_hold_the_spec_invariants() {
                 "{name}: secret_material_stored must be false"
             );
 
+            // Correlation basis, when present, is typed and never silent: a traceparent is
+            // retained exactly when the basis is propagated_trace_context, and a malformed
+            // carrier keeps its bytes out of the record while staying distinct from `none`.
+            if let Some(corr) = d.get("correlation") {
+                let basis = corr["basis"].as_str().unwrap_or("");
+                assert!(
+                    [
+                        "propagated_trace_context",
+                        "malformed_trace_context",
+                        "none"
+                    ]
+                    .contains(&basis),
+                    "{name}: unknown correlation basis {basis:?}"
+                );
+                let propagated = basis == "propagated_trace_context";
+                assert_eq!(
+                    corr["traceparent"].is_string(),
+                    propagated,
+                    "{name}: traceparent must be retained iff basis is propagated_trace_context"
+                );
+                assert_eq!(
+                    corr["source_class"].as_str(),
+                    propagated.then_some("propagated"),
+                    "{name}: source_class must be \"propagated\" iff basis is propagated, else null"
+                );
+            }
+
             // A classified privileged tool carries a derived required_scope (non-null string); an
             // unclassified tool carries null (read downstream as required_scope_unknown, not "none").
             let req = &d["action"]["required_scope"];

--- a/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
+++ b/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
@@ -104,16 +104,29 @@ fn tool_decision_fixtures_hold_the_spec_invariants() {
                     "{name}: unknown correlation basis {basis:?}"
                 );
                 let propagated = basis == "propagated_trace_context";
-                assert_eq!(
-                    corr["traceparent"].is_string(),
-                    propagated,
-                    "{name}: traceparent must be retained iff basis is propagated_trace_context"
-                );
-                assert_eq!(
-                    corr["source_class"].as_str(),
-                    propagated.then_some("propagated"),
-                    "{name}: source_class must be \"propagated\" iff basis is propagated, else null"
-                );
+                if propagated {
+                    assert!(
+                        corr["traceparent"].is_string(),
+                        "{name}: a propagated basis must retain the traceparent string"
+                    );
+                    assert_eq!(
+                        corr["source_class"].as_str(),
+                        Some("propagated"),
+                        "{name}: a propagated basis must carry source_class \"propagated\""
+                    );
+                } else {
+                    // JSON null exactly — a number or object here would be a shape drift the
+                    // is_string()/as_str() checks alone would wave through.
+                    assert!(
+                        corr["traceparent"].is_null(),
+                        "{name}: a non-propagated basis must carry traceparent null"
+                    );
+                    assert!(
+                        corr["source_class"].is_null(),
+                        "{name}: a non-propagated basis must carry source_class null — the \
+                         record retains no basis to classify"
+                    );
+                }
             }
 
             // A classified privileged tool carries a derived required_scope (non-null string); an

--- a/docs/reference/privileged-action-evidence.md
+++ b/docs/reference/privileged-action-evidence.md
@@ -39,7 +39,7 @@ observed tool call
 | `assay.enforcement_decision.v0` | the enforcing proxy's per-call allow or deny: decision, precedence-pinned reason, `fail_closed`, drift state, credential alias (never the token) | [mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) |
 | `assay.manifest_establish.v0` | the bounded pre-call re-list journey (establish path and run outcome), kept separate from the verdict | [mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) |
 | `assay.denied_call_observation.v0` | opt-in caller-visible proxy-deny observation, kept separate from `assay.enforcement_decision.v0` verdict records | [mcp-upstream-proxy-enforcement.md](mcp-upstream-proxy-enforcement.md) |
-| `assay.tool_decision_surface.v0` | per-call: server, classified action + projected target, decision, response, redaction | [tool-decision-surface.md](tool-decision-surface.md) |
+| `assay.tool_decision_surface.v0` | per-call: server, classified action + projected target, decision, response, redaction, correlation basis | [tool-decision-surface.md](tool-decision-surface.md) |
 | `assay.declared_tool_surface.v0` | declared/allowed privileged actions, for observed-vs-declared review | [declared-tool-surface.md](declared-tool-surface.md) |
 | `assay.tool_decision_truth.v0` | experimental declared-vs-observed policy-decision carrier, digest, verdict, and pack-row primitive | [tool-decision-truth.md](tool-decision-truth.md) |
 | `action.required_scope` (+ declared credentials) | the scope an action requires vs the alias's declared scope | [credential-scope.md](credential-scope.md) |

--- a/docs/reference/tool-decision-surface.md
+++ b/docs/reference/tool-decision-surface.md
@@ -186,11 +186,23 @@ basis it actually retains, in `correlation`:
 |---|---|
 | `propagated_trace_context` | the request carried a `traceparent` in `_meta` (SEP-414) that passes validation (four lowercase-hex fields `2-32-16-2`, non-zero trace/parent ids, version not `ff`); it is retained verbatim. `source_class: propagated` — a producer-propagated **claim**, never an observed transport fact. A covering, uniform trace-id can claim-support a grouping and a partitioned one can refute it; it cannot be lifted to proof. |
 | `malformed_trace_context` | a carrier was sent but does not pass that validation (wrong shape, non-hex, all-zero ids, hostile bytes, a non-string JSON value, or a future-version form this validator is deliberately stricter than W3C about). Its bytes are **not** retained. Distinct from `none` by design: a broken carrier and an absent carrier are different facts. |
-| `none` | the record is stateless; no carrier was sent, and the record's own `source_class` is null — it retains no basis to classify. Any grouping of such records rests on producer-minted envelope identity (e.g. a run id) and inherits `self_reported` class **from that envelope**, not from this record. |
+| `none` | the record is stateless; no carrier was sent, and the record's own `source_class` is null — it retains no basis to classify. Any grouping of such records rests on producer-minted envelope identity (e.g. a run id) — a producer assertion that lives outside this record's `correlation` field. |
+
+The `source_class` vocabulary of this record family is exactly `"propagated"` or JSON null; it
+deliberately borrows nothing from the gateway-evidence or tool-decision-truth source-class
+families (a different record family's vocabulary MUST NOT be used here). The consumer rule is a
+no-upgrade rule, not an ordering: a grouping claim over several records can never assert a
+stronger basis than any member retains, and a group containing a `none` or
+`malformed_trace_context` member cannot be grouped on trace context at all — that grouping claim
+is incomplete, not weakly supported.
 
 `tracestate` and `baggage` are deliberately not retained: their values are free-form and may carry
-data the redaction rules above cannot reason about. Consumers that group records across calls must
-carry the weakest `source_class` among the members' bases in any pooled verdict.
+data the redaction rules above cannot reason about.
+
+Era scoping: this server still negotiates only legacy handshakes (`2024-11-05` / `2025-11-25`);
+for such clients a `_meta.traceparent` is optional practice rather than SEP-414 conformance, so
+`basis: "none"` is the expected common case. The extraction does not gate on era: any client that
+does send the carrier gets it typed.
 
 ## Reason codes
 

--- a/docs/reference/tool-decision-surface.md
+++ b/docs/reference/tool-decision-surface.md
@@ -184,8 +184,8 @@ basis it actually retains, in `correlation`:
 
 | `basis` | meaning |
 |---|---|
-| `propagated_trace_context` | the request carried a valid W3C `traceparent` in `_meta` (SEP-414); it is retained verbatim. `source_class: propagated` — a producer-propagated **claim**, never an observed transport fact. A covering, uniform trace-id can claim-support a grouping and a partitioned one can refute it; it cannot be lifted to proof. |
-| `malformed_trace_context` | a carrier was sent but is not a valid `traceparent` (wrong shape, non-hex, all-zero ids, hostile bytes). Its bytes are **not** retained. Distinct from `none` by design: a broken carrier and an absent carrier are different facts. |
+| `propagated_trace_context` | the request carried a `traceparent` in `_meta` (SEP-414) that passes validation (four lowercase-hex fields `2-32-16-2`, non-zero trace/parent ids, version not `ff`); it is retained verbatim. `source_class: propagated` — a producer-propagated **claim**, never an observed transport fact. A covering, uniform trace-id can claim-support a grouping and a partitioned one can refute it; it cannot be lifted to proof. |
+| `malformed_trace_context` | a carrier was sent but does not pass that validation (wrong shape, non-hex, all-zero ids, hostile bytes, a non-string JSON value, or a future-version form this validator is deliberately stricter than W3C about). Its bytes are **not** retained. Distinct from `none` by design: a broken carrier and an absent carrier are different facts. |
 | `none` | the record is stateless; no carrier was sent. Any grouping of such records rests on producer-minted envelope identity (e.g. a run id) and inherits `self_reported` class from it. |
 
 `tracestate` and `baggage` are deliberately not retained: their values are free-form and may carry
@@ -208,4 +208,8 @@ Machine-readable, never parsed from prose: `classified_github_deploy_key`,
 - `slack_add_member_allow.json` — classified, allowed
 - `workspace_admin_allow.json` — classified, allowed (one concrete tool)
 - `unknown_tool_observed.json` — `observed_unknown_tool`, never clean
-- `redacted_and_sanitized.json` — secret alias only, control chars sanitized
+- `redacted_and_sanitized.json` — secret alias only, control chars sanitized; carries the
+  `malformed_trace_context` correlation state (carrier sent but invalid, bytes dropped)
+
+Every fixture carries a `correlation` object; between them the vectors cover all three basis
+states (`propagated_trace_context`, `malformed_trace_context`, `none`).

--- a/docs/reference/tool-decision-surface.md
+++ b/docs/reference/tool-decision-surface.md
@@ -108,6 +108,11 @@ complete tool observation" means "no observed tool use in this run" (see P58 cov
         "arguments_redacted": true,
         "credential_alias": "github-prod-admin",
         "secret_material_stored": false
+      },
+      "correlation": {
+        "basis": "propagated_trace_context",
+        "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        "source_class": "propagated"
       }
     }
   ],
@@ -170,6 +175,22 @@ labels; principal-like identifiers are hashed (see Redaction).
   hash invites offline brute force.
 - Hostile strings (terminal escapes, control characters) are sanitized before the record is written,
   the same discipline the evidence TUI/rendering already applies.
+
+## Correlation basis
+
+MCP 2026-07-28 removed protocol-level sessions (SEP-2567), so "these N records belong to one
+interaction" is no longer a transport fact a reader may assume. Each record therefore types the
+basis it actually retains, in `correlation`:
+
+| `basis` | meaning |
+|---|---|
+| `propagated_trace_context` | the request carried a valid W3C `traceparent` in `_meta` (SEP-414); it is retained verbatim. `source_class: propagated` — a producer-propagated **claim**, never an observed transport fact. A covering, uniform trace-id can claim-support a grouping and a partitioned one can refute it; it cannot be lifted to proof. |
+| `malformed_trace_context` | a carrier was sent but is not a valid `traceparent` (wrong shape, non-hex, all-zero ids, hostile bytes). Its bytes are **not** retained. Distinct from `none` by design: a broken carrier and an absent carrier are different facts. |
+| `none` | the record is stateless; no carrier was sent. Any grouping of such records rests on producer-minted envelope identity (e.g. a run id) and inherits `self_reported` class from it. |
+
+`tracestate` and `baggage` are deliberately not retained: their values are free-form and may carry
+data the redaction rules above cannot reason about. Consumers that group records across calls must
+carry the weakest `source_class` among the members' bases in any pooled verdict.
 
 ## Reason codes
 

--- a/docs/reference/tool-decision-surface.md
+++ b/docs/reference/tool-decision-surface.md
@@ -186,7 +186,7 @@ basis it actually retains, in `correlation`:
 |---|---|
 | `propagated_trace_context` | the request carried a `traceparent` in `_meta` (SEP-414) that passes validation (four lowercase-hex fields `2-32-16-2`, non-zero trace/parent ids, version not `ff`); it is retained verbatim. `source_class: propagated` — a producer-propagated **claim**, never an observed transport fact. A covering, uniform trace-id can claim-support a grouping and a partitioned one can refute it; it cannot be lifted to proof. |
 | `malformed_trace_context` | a carrier was sent but does not pass that validation (wrong shape, non-hex, all-zero ids, hostile bytes, a non-string JSON value, or a future-version form this validator is deliberately stricter than W3C about). Its bytes are **not** retained. Distinct from `none` by design: a broken carrier and an absent carrier are different facts. |
-| `none` | the record is stateless; no carrier was sent. Any grouping of such records rests on producer-minted envelope identity (e.g. a run id) and inherits `self_reported` class from it. |
+| `none` | the record is stateless; no carrier was sent, and the record's own `source_class` is null — it retains no basis to classify. Any grouping of such records rests on producer-minted envelope identity (e.g. a run id) and inherits `self_reported` class **from that envelope**, not from this record. |
 
 `tracestate` and `baggage` are deliberately not retained: their values are free-form and may carry
 data the redaction rules above cannot reason about. Consumers that group records across calls must


### PR DESCRIPTION
## What

MCP 2026-07-28 removed protocol-level sessions (SEP-2567) and documented W3C Trace Context keys in `_meta` (SEP-414). That means "these N records belong to one interaction" stopped being a transport fact a reader of retained records may assume — it became a claim whose basis must travel with the record.

Each `assay.tool_decision_surface.v0` decision now carries a typed `correlation` object:

| basis | meaning |
|---|---|
| `propagated_trace_context` | valid W3C `traceparent` from `_meta`, retained verbatim; `source_class: propagated` — a producer-propagated claim, never an observed transport fact |
| `malformed_trace_context` | a carrier was sent but is invalid (shape, non-hex, all-zero ids, hostile bytes); its bytes are **not** retained; deliberately distinct from absence |
| `none` | stateless record; grouping rests on producer-minted envelope identity and inherits `self_reported` class |

`tracestate`/`baggage` are deliberately not retained (free-form values the redaction rules cannot reason about).

## How

- `ObservedCall` gains `traceparent: Option<&str>`; the server extracts it from `params._meta` at the `tool_call_done` site.
- Validation and basis typing live inside `build_decision` — no caller can opt out, same discipline as redaction.
- TDD: the three behavioral tests were written first and confirmed failing (`valid_traceparent_is_retained_and_typed_as_propagated`, `absent_traceparent_is_typed_none_never_silent`, `malformed_traceparent_is_typed_distinctly_and_not_retained`), then the smallest passing change.
- Reference fixtures updated (one propagated, one none) + fixture-guard invariant: `traceparent` retained iff basis is propagated; `source_class` propagated iff basis is propagated.
- Spec doc `docs/reference/tool-decision-surface.md` gains the record-shape field and a `## Correlation basis` section.

## Non-claims

Additive to v0; no consumer keying on the existing shape breaks. This does not claim any producer propagates context wrongly, does not verify trace propagation, and does not introduce any grouping verdict — it only types what the record retains so a downstream grouping claim inherits an honest source class.

## Verification

- `cargo test -p assay-mcp-server` — all green (includes the 3 new behavioral tests + fixture guard)
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings` — clean
- `cargo fmt` — applied; pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tool-decision records now include correlation details for valid, missing, or malformed trace context.
  - Valid trace information is retained and classified as propagated; invalid values are safely discarded.

- **Documentation**
  - Added reference documentation describing correlation fields, trace-context handling, and grouping behavior.

- **Tests**
  - Expanded coverage for valid, absent, malformed, and untrusted trace context scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->