### PR TITLE
One $defs preparation, agreed on by every path that compiles a tool-schema map

### DIFF
--- a/crates/assay-cli/src/cli/commands/coverage/legacy.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/legacy.rs
@@ -106,8 +106,10 @@ pub(super) async fn cmd_coverage_legacy(args: CoverageArgs) -> Result<i32> {
 
     let mut trace_records = Vec::new();
 
-    // Prepare for validation
-    policy_v2.compile_all_schemas();
+    // Prepare for validation; a policy whose schemas cannot compile has no coverage story.
+    policy_v2
+        .try_compile_all_schemas()
+        .map_err(|error| anyhow::anyhow!("policy schemas failed to compile: {error}"))?;
     let mut state = assay_core::mcp::policy::PolicyState::default();
 
     let mut violations = Vec::new();

--- a/crates/assay-cli/src/cli/commands/policy/migrate.rs
+++ b/crates/assay-cli/src/cli/commands/policy/migrate.rs
@@ -10,7 +10,9 @@ pub async fn run(args: PolicyMigrateArgs) -> Result<i32> {
     policy.migrate_constraints_to_schemas();
 
     // Ensure schemas compile after migration
-    policy.compile_all_schemas();
+    policy
+        .try_compile_all_schemas()
+        .map_err(|error| anyhow::anyhow!("migrated policy schemas failed to compile: {error}"))?;
 
     // Serialize to YAML
     let yaml = serde_yaml::to_string(&policy).context("failed to serialize migrated policy")?;

--- a/crates/assay-cli/src/cli/commands/policy/validate.rs
+++ b/crates/assay-cli/src/cli/commands/policy/validate.rs
@@ -12,7 +12,9 @@ pub async fn run(args: PolicyValidateArgs) -> Result<i32> {
         .with_context(|| format!("failed to load policy {}", args.input.display()))?;
 
     // Force schema compilation so failures happen here (not at runtime).
-    policy.compile_all_schemas();
+    policy
+        .try_compile_all_schemas()
+        .map_err(|error| anyhow::anyhow!("policy schemas failed to compile: {error}"))?;
 
     eprintln!("✔ Policy OK: {}", args.input.display());
     Ok(exit_codes::OK)

--- a/crates/assay-core/src/mcp/policy/engine.rs
+++ b/crates/assay-core/src/mcp/policy/engine.rs
@@ -42,7 +42,32 @@ pub(super) fn evaluate_with_metadata(
     }
 
     let compiled = policy.compiled_schemas();
-    if let Some(validator) = compiled.get(tool_name) {
+    if let Some(compile_result) = compiled.get(tool_name) {
+        let validator = match compile_result {
+            Ok(validator) => validator,
+            // A declared schema that fails to prepare or compile is a malformed constraint on
+            // THIS tool. Fail closed for the tool rather than aborting the server: the operator
+            // declared an intent to constrain it, so its calls must not pass unvalidated, and a
+            // proxy panic over user-authored policy input is the larger blast radius (#1952).
+            Err(error) => {
+                let reason = format!("Declared schema failed to prepare or compile: {error}");
+                return finalize_evaluation(
+                    policy,
+                    metadata,
+                    PolicyDecision::Deny {
+                        tool: tool_name.to_string(),
+                        code: "E_SCHEMA_COMPILE".to_string(),
+                        reason: reason.clone(),
+                        contract: serde_json::json!({
+                            "status": "deny",
+                            "error_code": "E_SCHEMA_COMPILE",
+                            "tool": tool_name,
+                            "message": reason,
+                        }),
+                    },
+                );
+            }
+        };
         if let Some(decision) = schema_violation_decision(tool_name, args, validator.as_ref()) {
             return finalize_evaluation(policy, metadata, decision);
         }

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -95,7 +95,7 @@ impl McpPolicy {
     }
 
     #[deprecated(
-        note = "panics on a policy whose schemas fail to prepare or compile; use                 try_compile_all_schemas and handle the error"
+        note = "panics on a policy whose schemas fail to prepare or compile; use try_compile_all_schemas and handle the error"
     )]
     pub fn compile_all_schemas(&self) -> HashMap<String, Arc<jsonschema::Validator>> {
         self.try_compile_all_schemas()

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -64,13 +64,42 @@ impl McpPolicy {
         schema::migrate_constraints_to_schemas(self);
     }
 
-    fn compiled_schemas(&self) -> &HashMap<String, Arc<jsonschema::Validator>> {
+    fn compiled_schemas(&self) -> &types::CompiledSchemas {
         self.compiled
             .get_or_init(|| schema::compile_all_schemas(self))
     }
 
+    /// Compile every tool schema, failing with a message that names every broken tool. This is the
+    /// load-time validation surface: callers that want a policy rejected up front (`assay policy
+    /// validate`, migration) use this, while the enforcement path holds the same per-tool errors
+    /// and denies the affected tool's calls with `E_SCHEMA_COMPILE` instead of aborting.
+    pub fn try_compile_all_schemas(
+        &self,
+    ) -> Result<HashMap<String, Arc<jsonschema::Validator>>, String> {
+        let mut compiled = HashMap::new();
+        let mut errors: Vec<String> = Vec::new();
+        for (tool, result) in schema::compile_all_schemas(self) {
+            match result {
+                Ok(validator) => {
+                    compiled.insert(tool, validator);
+                }
+                Err(error) => errors.push(format!("tool '{tool}': {error}")),
+            }
+        }
+        if errors.is_empty() {
+            Ok(compiled)
+        } else {
+            errors.sort();
+            Err(errors.join("; "))
+        }
+    }
+
+    #[deprecated(
+        note = "panics on a policy whose schemas fail to prepare or compile; use                 try_compile_all_schemas and handle the error"
+    )]
     pub fn compile_all_schemas(&self) -> HashMap<String, Arc<jsonschema::Validator>> {
-        schema::compile_all_schemas(self)
+        self.try_compile_all_schemas()
+            .unwrap_or_else(|error| panic!("Failed to compile JSON schemas: {error}"))
     }
 
     pub fn policy_digest(&self) -> Option<String> {

--- a/crates/assay-core/src/mcp/policy/schema.rs
+++ b/crates/assay-core/src/mcp/policy/schema.rs
@@ -10,7 +10,11 @@ use std::sync::Arc;
 /// entry: `compile_all_schemas` records the same malformed declaration as a per-tool error that the
 /// enforcement engine denies with `E_SCHEMA_COMPILE`.
 pub(super) fn check_tool_args(policy: &McpPolicy, tool_name: &str, args: &Value) -> ArgsCheck {
-    if !policy.schemas.contains_key(tool_name) {
+    // `$defs` is the shared-definitions entry, consumed by preparation; it is never a tool. Without
+    // this, a call to a tool literally named "$defs" would compile the definitions map as a schema
+    // (which asserts nothing and accepts everything) while the load-time compiler produces no
+    // validator for it: exactly the cross-path drift this module exists to prevent.
+    if tool_name == "$defs" || !policy.schemas.contains_key(tool_name) {
         return ArgsCheck::NoSchema;
     }
     let schemas = Value::Object(policy.schemas.clone().into_iter().collect());
@@ -175,6 +179,14 @@ mod tests {
         assert_eq!(
             check_tool_args(&policy, "$weird", &json!({})),
             ArgsCheck::Valid
+        );
+        policy
+            .schemas
+            .insert("$defs".to_string(), json!({"shared": {"type": "string"}}));
+        assert_eq!(
+            check_tool_args(&policy, "$defs", &json!({})),
+            ArgsCheck::NoSchema,
+            "$defs is consumed by preparation and is never itself a checkable tool"
         );
         let compiled = compile_all_schemas(&policy);
         assert!(

--- a/crates/assay-core/src/mcp/policy/schema.rs
+++ b/crates/assay-core/src/mcp/policy/schema.rs
@@ -3,11 +3,12 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Defensively validate `args` against the declared per-tool schema WITHOUT panicking. Unlike
-/// [`compile_all_schemas`] (which fail-closes by panicking at load time), this is for the experimental
-/// verdict gate, where a malformed declared schema is a classification input (it maps to `invalid`), not
-/// an abort. Preparation is shared with the load-time compiler so `$defs` merge and collision semantics
-/// cannot drift between the two paths.
+/// Defensively validate `args` against the declared per-tool schema. This is for the experimental
+/// verdict gate, where a malformed declared schema is a classification input (it maps to `invalid`).
+/// Preparation is shared with [`compile_all_schemas`] so `$defs` merge and collision semantics cannot
+/// drift between the two paths, and both treat exactly the `"$defs"` key as the shared-definitions
+/// entry: `compile_all_schemas` records the same malformed declaration as a per-tool error that the
+/// enforcement engine denies with `E_SCHEMA_COMPILE`.
 pub(super) fn check_tool_args(policy: &McpPolicy, tool_name: &str, args: &Value) -> ArgsCheck {
     if !policy.schemas.contains_key(tool_name) {
         return ArgsCheck::NoSchema;
@@ -40,32 +41,36 @@ pub(super) fn migrate_constraints_to_schemas(policy: &mut McpPolicy) {
     }
 }
 
-pub(super) fn compile_all_schemas(
-    policy: &McpPolicy,
-) -> HashMap<String, Arc<jsonschema::Validator>> {
+/// Compile every tool schema, recording per-tool preparation and compile errors instead of
+/// panicking. Preparation could not fail before #1948; it now fails on a shared/tool-local `$defs`
+/// collision or a non-mapping `$defs`, and this map is materialized lazily from the enforcement
+/// path (`compiled_schemas()` is a `OnceLock`), so a panic here would abort the proxy on the first
+/// enforcement decision over user-authored policy input. A broken declared schema is a per-tool
+/// fail-closed condition (`E_SCHEMA_COMPILE` at evaluation, mirroring `PolicyState::compile` and
+/// `check_tool_args`), not a server abort.
+///
+/// Skips exactly the `"$defs"` key, matching `prepare_schema_map`: `$defs` is consumed by the
+/// merge and is never itself a tool. Any other `$`-prefixed name is an ordinary (if ill-advised)
+/// tool name on every path, so the two compilers cannot disagree about which keys are tools.
+pub(super) fn compile_all_schemas(policy: &McpPolicy) -> super::types::CompiledSchemas {
     let schemas = Value::Object(policy.schemas.clone().into_iter().collect());
     let mut compiled = HashMap::new();
     for tool_name in policy.schemas.keys() {
-        if tool_name.starts_with('$') {
+        if tool_name == "$defs" {
             continue;
         }
-        let schema_to_compile = crate::policy_engine::prepare_tool_schema(&schemas, tool_name)
-            .unwrap_or_else(|error| {
-                panic!("Failed to prepare JSON schema for tool '{tool_name}': {error}")
-            });
-        match crate::policy_engine::compile_schema(&schema_to_compile) {
-            Ok(validator) => {
-                compiled.insert(tool_name.clone(), Arc::new(validator));
-            }
-            Err(e) => {
-                tracing::error!("Failed to compile schema for tool {}: {}", tool_name, e);
-                // Fail securely: do not allow tools with broken schemas to load.
-                panic!(
-                    "Failed to compile JSON schema for tool '{}': {}",
-                    tool_name, e
-                );
-            }
+        let result = crate::policy_engine::prepare_tool_schema(&schemas, tool_name)
+            .and_then(|schema| crate::policy_engine::compile_schema(&schema))
+            .map(Arc::new);
+        if let Err(error) = &result {
+            tracing::error!(
+                "Schema for tool '{}' failed to prepare or compile; its calls will be denied \
+                 (E_SCHEMA_COMPILE): {}",
+                tool_name,
+                error
+            );
         }
+        compiled.insert(tool_name.clone(), result);
     }
     compiled
 }
@@ -122,7 +127,61 @@ mod tests {
             check_tool_args(&policy, "lookup", &json!({"name": "item", "count": 1})),
             ArgsCheck::Valid
         );
-        assert!(policy.compile_all_schemas().contains_key("lookup"));
+        assert!(policy
+            .try_compile_all_schemas()
+            .expect("merged schemas compile")
+            .contains_key("lookup"));
+    }
+
+    /// #1952: a `$defs` collision is a per-tool compile error and a load-time `Err`, never a
+    /// panic. The proxy reaches `compile_all_schemas` lazily from the enforcement path, so a
+    /// panic here would abort the server on the first enforcement decision.
+    #[test]
+    fn mcp_compilation_records_collision_as_error_instead_of_panicking() {
+        let mut policy = McpPolicy::default();
+        policy
+            .schemas
+            .insert("$defs".to_string(), json!({"id": {"type": "string"}}));
+        policy.schemas.insert(
+            "lookup".to_string(),
+            json!({"$defs": {"id": {"type": "integer"}}, "$ref": "#/$defs/id"}),
+        );
+        policy
+            .schemas
+            .insert("healthy".to_string(), json!({"type": "object"}));
+
+        let compiled = compile_all_schemas(&policy);
+        assert!(compiled["lookup"].is_err(), "collision is a per-tool error");
+        assert!(compiled["healthy"].is_ok(), "healthy tools still compile");
+        assert!(!compiled.contains_key("$defs"), "$defs is never a tool");
+
+        let error = policy
+            .try_compile_all_schemas()
+            .expect_err("load-time surface names the broken tool");
+        assert!(error.contains("lookup"), "{error}");
+        assert!(error.contains("overlap"), "{error}");
+    }
+
+    /// The two compile paths must agree about which keys are tools. `compile_all_schemas` used
+    /// to skip every `$`-prefixed key while `check_tool_args` special-cased only `"$defs"`, so a
+    /// tool named `$weird` was checkable on one path and invisible on the other (#1952).
+    #[test]
+    fn dollar_prefixed_tool_names_are_tools_on_both_paths() {
+        let mut policy = McpPolicy::default();
+        policy
+            .schemas
+            .insert("$weird".to_string(), json!({"type": "object"}));
+
+        assert_eq!(
+            check_tool_args(&policy, "$weird", &json!({})),
+            ArgsCheck::Valid
+        );
+        let compiled = compile_all_schemas(&policy);
+        assert!(
+            compiled.contains_key("$weird"),
+            "load-time compiler sees the same tool set as check_tool_args"
+        );
+        assert!(compiled["$weird"].is_ok());
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/policy/types.rs
+++ b/crates/assay-core/src/mcp/policy/types.rs
@@ -6,6 +6,11 @@ use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, OnceLock};
 
+/// Per-tool compile results, materialized once per policy. `Err` carries the preparation or
+/// compile failure for that tool; the enforcement engine denies such a tool's calls with
+/// `E_SCHEMA_COMPILE` instead of aborting (#1952).
+pub(crate) type CompiledSchemas = HashMap<String, Result<Arc<jsonschema::Validator>, String>>;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct McpPolicy {
     #[serde(default)]
@@ -60,7 +65,7 @@ pub struct McpPolicy {
 
     /// Compiled schemas (lazy, thread-safe, shared across clones)
     #[serde(skip)]
-    pub(crate) compiled: Arc<OnceLock<HashMap<String, Arc<jsonschema::Validator>>>>,
+    pub(crate) compiled: Arc<OnceLock<CompiledSchemas>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/assay-core/src/model/tests/mod.rs
+++ b/crates/assay-core/src/model/tests/mod.rs
@@ -1581,3 +1581,53 @@ fn args_policy_oracles_agree() {
         );
     }
 }
+
+/// #1951: the validation layer, the vacuity rule, and the runtime metric reason about the SAME
+/// prepared map. A shared-$defs `$ref` shape validates (it used to fail as unresolvable because
+/// validation compiled tool schemas verbatim), and a collision is a loud validation error rather
+/// than a config that reads as effective and then validates nothing at runtime.
+#[test]
+fn tool_output_valid_shared_defs_validate_and_collisions_are_loud() {
+    let supported = crate::model::Expected::ToolOutputValid {
+        schemas: Some(serde_json::json!({
+            "$defs": {"NonEmpty": {"type": "string", "minLength": 1}},
+            "exec": {"$ref": "#/$defs/NonEmpty"}
+        })),
+    };
+    crate::model::validation::validate_expected_for_execution(&supported)
+        .expect("shared $defs with a resolvable ref is a supported, effective config");
+
+    let colliding = crate::model::Expected::ToolOutputValid {
+        schemas: Some(serde_json::json!({
+            "$defs": {"X": {"type": "string"}},
+            "exec": {"$defs": {"X": {}}}
+        })),
+    };
+    let err = crate::model::validation::validate_expected_for_execution(&colliding)
+        .expect_err("a $defs collision is a preparation failure, not an effective schema");
+    assert!(err.to_string().contains("overlap"), "{err:#}");
+
+    let non_mapping = crate::model::Expected::ToolOutputValid {
+        schemas: Some(serde_json::json!({
+            "$defs": ["not", "a", "mapping"],
+            "exec": {"type": "object"}
+        })),
+    };
+    let err = crate::model::validation::validate_expected_for_execution(&non_mapping)
+        .expect_err("a non-mapping $defs is a preparation failure");
+    assert!(err.to_string().contains("mapping"), "{err:#}");
+}
+
+/// A map whose only entry is `$defs` still asserts nothing after preparation: the merge consumes
+/// the entry and leaves no tool schema behind, so the vacuity diagnosis fires, not a compile error.
+#[test]
+fn tool_output_valid_defs_only_map_is_vacuous() {
+    let defs_only = crate::model::Expected::ToolOutputValid {
+        schemas: Some(serde_json::json!({
+            "$defs": {"NonEmpty": {"type": "string", "minLength": 1}}
+        })),
+    };
+    let err = crate::model::validation::validate_expected_for_execution(&defs_only)
+        .expect_err("definitions without any tool schema assert nothing");
+    assert!(err.to_string().contains("nothing"), "{err:#}");
+}

--- a/crates/assay-core/src/model/validation.rs
+++ b/crates/assay-core/src/model/validation.rs
@@ -188,34 +188,21 @@ fn structured_controls_assert(root: &serde_json::Map<String, serde_json::Value>)
 }
 
 fn schema_map_asserts_nothing(value: &serde_json::Value) -> bool {
-    value.as_object().is_some_and(|schemas| {
-        let shared_defs = schemas.get("$defs").and_then(serde_json::Value::as_object);
+    if !value.is_object() {
+        return false;
+    }
+    // Delegate the $defs merge to the one preparation implementation instead of hand-rolling a
+    // copy of it here; two approximations of the same merge drift (#1951). A map that fails to
+    // prepare (a $defs collision, a non-mapping $defs) is NOT classified as vacuous: preparation
+    // failure is a malformed config with its own loud diagnosis at the validation and runtime
+    // layers, and claiming vacuity (or effectiveness) for it here would mask that.
+    let Ok(prepared) = crate::policy_engine::prepare_schema_map(value) else {
+        return false;
+    };
+    prepared.as_object().is_some_and(|schemas| {
         schemas
             .iter()
-            .filter(|(tool, _)| tool.as_str() != "$defs")
-            .all(|(_, schema)| {
-                let mut materialized = schema.clone();
-                if let (Some(shared_defs), Some(schema)) =
-                    (shared_defs, materialized.as_object_mut())
-                {
-                    match schema.get_mut("$defs") {
-                        Some(serde_json::Value::Object(local_defs)) => {
-                            if shared_defs.keys().any(|name| local_defs.contains_key(name)) {
-                                return false;
-                            }
-                            local_defs.extend(shared_defs.clone());
-                        }
-                        Some(_) => return false,
-                        None => {
-                            schema.insert(
-                                "$defs".to_string(),
-                                serde_json::Value::Object(shared_defs.clone()),
-                            );
-                        }
-                    }
-                }
-                schema_asserts_nothing(&materialized)
-            })
+            .all(|(_, schema)| schema_asserts_nothing(schema))
     })
 }
 
@@ -563,7 +550,15 @@ fn validate_static_inputs(e: &Expected) -> anyhow::Result<()> {
         } => validate_args_policy_value(schema)?,
         Expected::ToolOutputValid {
             schemas: Some(schema),
-        } => validate_schema_map(schema, false, true)?,
+        } => {
+            // Prepare BEFORE validating, exactly as the structured args path does above, so a
+            // shared-$defs collision or a non-mapping $defs is a loud config error here rather
+            // than a silently vacuous schema at evaluation time (#1951). Validation, the vacuity
+            // rule, and the runtime metric all reason about the SAME prepared map.
+            let prepared = crate::policy_engine::prepare_schema_map(schema)
+                .map_err(|e| anyhow::anyhow!("tool_output_valid schemas: {e}"))?;
+            validate_schema_map(&prepared, false, true)?
+        }
         Expected::ArgsValid {
             policy: Some(path),
             schema: None,

--- a/crates/assay-core/src/policy_engine.rs
+++ b/crates/assay-core/src/policy_engine.rs
@@ -121,7 +121,13 @@ pub struct PolicyState {
 /// Root `$defs` are merged into each object-valued tool schema and therefore compile under that
 /// schema's declared dialect. A shared definition may not replace a tool-local definition with the
 /// same name. With only boolean tools, the otherwise-unscoped definitions use the default dialect.
-pub(crate) fn prepare_schema_map(policy: &Value) -> Result<Value, String> {
+///
+/// This is the ONE preparation semantics for `$defs` in a tool-schema map. Every consumer that
+/// compiles or reasons about such a map (the MCP proxy's load-time compiler, `check_tool_args`,
+/// the `tool_output_valid` metric, and config-validation vacuity checks) must go through it, or a
+/// `$defs` entry means different things on different paths. The returned map contains only tool
+/// entries: `$defs` is consumed by the merge and is never itself a tool schema.
+pub fn prepare_schema_map(policy: &Value) -> Result<Value, String> {
     let Some(schemas) = policy.as_object() else {
         return Ok(policy.clone());
     };
@@ -149,7 +155,7 @@ fn shared_defs(
     })
 }
 
-pub(crate) fn prepare_tool_schema(policy: &Value, tool: &str) -> Result<Value, String> {
+pub fn prepare_tool_schema(policy: &Value, tool: &str) -> Result<Value, String> {
     let schemas = policy
         .as_object()
         .ok_or_else(|| "policy must be a tool-name-to-schema mapping".to_string())?;

--- a/crates/assay-core/tests/jsonschema_semantics_probe.rs
+++ b/crates/assay-core/tests/jsonschema_semantics_probe.rs
@@ -1,0 +1,80 @@
+//! Empirical pins for the jsonschema-crate semantics both #1951 and #1952 rest on.
+use serde_json::json;
+
+#[test]
+fn unresolvable_local_ref_fails_at_build_time() {
+    let schema = json!({"$ref": "#/$defs/Missing"});
+    let result = jsonschema::validator_for(&schema);
+    assert!(result.is_err(), "expected build-time error, got Ok");
+}
+
+#[test]
+fn bare_defs_object_accepts_everything() {
+    let schema = json!({"$defs": {"X": {"type": "string"}}});
+    let validator = jsonschema::validator_for(&schema).expect("compiles");
+    assert!(validator.is_valid(&json!(42)));
+    assert!(validator.is_valid(&json!({"anything": true})));
+}
+
+#[test]
+fn ref_with_merged_defs_resolves_and_validates() {
+    let schema = json!({"$defs": {"NonEmpty": {"type": "string", "minLength": 1}}, "$ref": "#/$defs/NonEmpty"});
+    let validator = jsonschema::validator_for(&schema).expect("compiles");
+    assert!(validator.is_valid(&json!("ok")));
+    assert!(!validator.is_valid(&json!("")));
+    assert!(!validator.is_valid(&json!(7)));
+}
+
+/// #1952 end to end: a policy carrying a shared/tool-local `$defs` collision loads, and the first
+/// enforcement decision on the broken tool is a fail-closed deny, not a process abort. Healthy
+/// tools in the same policy keep evaluating normally.
+mod collision_policy_enforcement {
+    use assay_core::mcp::policy::{McpPolicy, PolicyDecision, PolicyState};
+    use serde_json::json;
+
+    fn collision_policy() -> McpPolicy {
+        let mut policy = McpPolicy::default();
+        policy
+            .schemas
+            .insert("$defs".to_string(), json!({"id": {"type": "string"}}));
+        policy.schemas.insert(
+            "lookup".to_string(),
+            json!({"$defs": {"id": {"type": "integer"}}, "$ref": "#/$defs/id"}),
+        );
+        policy.schemas.insert(
+            "healthy".to_string(),
+            json!({"type": "object", "required": ["name"], "properties": {"name": {"type": "string"}}}),
+        );
+        policy
+    }
+
+    #[test]
+    fn broken_tool_is_denied_fail_closed_instead_of_panicking() {
+        let policy = collision_policy();
+        let mut state = PolicyState::default();
+
+        let decision = policy.evaluate("lookup", &json!({"anything": 1}), &mut state, None);
+        match decision {
+            PolicyDecision::Deny { code, tool, .. } => {
+                assert_eq!(code, "E_SCHEMA_COMPILE");
+                assert_eq!(tool, "lookup");
+            }
+            other => panic!("expected fail-closed deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn healthy_tools_keep_evaluating_beside_a_broken_one() {
+        let policy = collision_policy();
+        let mut state = PolicyState::default();
+
+        let allowed = policy.evaluate("healthy", &json!({"name": "x"}), &mut state, None);
+        assert!(matches!(allowed, PolicyDecision::Allow));
+
+        let rejected = policy.evaluate("healthy", &json!({}), &mut state, None);
+        assert!(
+            matches!(rejected, PolicyDecision::Deny { ref code, .. } if code == "E_ARG_SCHEMA"),
+            "schema violations still classify normally: {rejected:?}"
+        );
+    }
+}

--- a/crates/assay-metrics/src/tool_output_valid.rs
+++ b/crates/assay-metrics/src/tool_output_valid.rs
@@ -30,17 +30,29 @@ impl Metric for ToolOutputValidMetric {
 
         // Validate that schemas is a JSON object; return a config error otherwise
         // to prevent false negatives from silently skipping all tool validation.
-        let schemas_obj = schemas_value.as_object().ok_or_else(|| {
-            anyhow::anyhow!(
+        if !schemas_value.is_object() {
+            anyhow::bail!(
                 "config error: 'schemas' for ToolOutputValid must be a JSON object \
                  mapping tool names to JSON Schemas"
-            )
-        })?;
+            );
+        }
+
+        // Prepare the map with the same `$defs` semantics as the args path (shared `$defs`
+        // merged into each tool schema, collisions refused) BEFORE compiling anything. Without
+        // this, a `$defs` entry compiled as if it were a tool's schema, a `$ref` into shared
+        // definitions failed as unresolvable, and a colliding map compiled to a schema that
+        // validates nothing while the vacuity check upstream had modelled the merge and
+        // accepted the config as effective (#1951).
+        let prepared = assay_core::policy_engine::prepare_schema_map(schemas_value)
+            .map_err(|e| anyhow::anyhow!("config error: tool_output_valid schemas: {}", e))?;
+        let prepared_obj = prepared
+            .as_object()
+            .expect("prepare_schema_map returns an object for object input");
 
         // Pre-compile all schemas once per evaluate() call rather than inside the
         // per-call loop, so traces with many calls to the same tool don't recompile.
         let mut compiled_schemas: HashMap<&str, jsonschema::Validator> = HashMap::new();
-        for (tool_name, schema) in schemas_obj {
+        for (tool_name, schema) in prepared_obj {
             let compiled = crate::schema_support::compile(schema).map_err(|e| {
                 anyhow::anyhow!(
                     "config error: invalid output schema for tool '{}': {}",
@@ -276,6 +288,107 @@ mod tests {
                 .contains("external JSON Schema retrieval is disabled"),
             "refusal must come from the explicit retriever: {err:#}"
         );
+    }
+
+    /// #1951, the modelled-but-unsupported shape: shared `$defs` with a `$ref` into it used to
+    /// fail as an unresolvable reference because the metric never merged. Prepared, it validates.
+    #[tokio::test]
+    async fn shared_defs_are_merged_so_refs_resolve() {
+        let metric = ToolOutputValidMetric;
+        let expected = Expected::ToolOutputValid {
+            schemas: Some(serde_json::json!({
+                "$defs": {"NonEmpty": {"type": "string", "minLength": 1}},
+                "exec": {"$ref": "#/$defs/NonEmpty"}
+            })),
+        };
+
+        let ok = metric
+            .evaluate(
+                &test_case(),
+                &expected,
+                &resp_with_result("exec", serde_json::json!("out")),
+            )
+            .await
+            .unwrap();
+        assert!(ok.passed, "resolvable ref validates the output");
+
+        let bad = metric
+            .evaluate(
+                &test_case(),
+                &expected,
+                &resp_with_result("exec", serde_json::json!("")),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !bad.passed,
+            "the merged schema actually constrains: {bad:?}"
+        );
+    }
+
+    /// #1951, the silent no-op: a shared/tool-local `$defs` collision used to compile the tool
+    /// schema verbatim to `{"$defs":{...}}`, which accepts any output. It is a loud config error.
+    #[tokio::test]
+    async fn colliding_defs_are_a_config_error_not_a_silent_accept() {
+        let metric = ToolOutputValidMetric;
+        let expected = Expected::ToolOutputValid {
+            schemas: Some(serde_json::json!({
+                "$defs": {"X": {"type": "string"}},
+                "exec": {"$defs": {"X": {}}}
+            })),
+        };
+
+        let err = metric
+            .evaluate(
+                &test_case(),
+                &expected,
+                &resp_with_result("exec", serde_json::json!({"anything": true})),
+            )
+            .await
+            .expect_err("a collision is a preparation failure, never an accepting schema");
+        assert!(err.to_string().contains("overlap"), "{err:#}");
+    }
+
+    /// `$defs` is consumed by the merge; it is never compiled as if it were a tool's schema, and
+    /// a trace calling a tool literally named `$defs` simply has no schema to check against.
+    #[tokio::test]
+    async fn defs_entry_is_not_a_tool_schema() {
+        let metric = ToolOutputValidMetric;
+        let expected = Expected::ToolOutputValid {
+            schemas: Some(serde_json::json!({
+                "$defs": {"NonEmpty": {"type": "string", "minLength": 1}},
+                "exec": {"$ref": "#/$defs/NonEmpty"}
+            })),
+        };
+        let resp = resp_with_result("$defs", serde_json::json!("anything"));
+        let result = metric
+            .evaluate(&test_case(), &expected, &resp)
+            .await
+            .unwrap();
+        assert!(
+            result.passed,
+            "no schema for a tool named $defs after preparation"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_mapping_defs_is_a_config_error() {
+        let metric = ToolOutputValidMetric;
+        let expected = Expected::ToolOutputValid {
+            schemas: Some(serde_json::json!({
+                "$defs": ["not", "a", "mapping"],
+                "exec": {"type": "object"}
+            })),
+        };
+        let err = metric
+            .evaluate(
+                &test_case(),
+                &expected,
+                &resp_with_result("exec", serde_json::json!({})),
+            )
+            .await
+            .expect_err("non-mapping $defs is a preparation failure");
+        assert!(err.to_string().contains("mapping"), "{err:#}");
     }
 
     #[tokio::test]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "hex",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "chrono",
  "libc",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "anyhow",
  "assay-canonical",


### PR DESCRIPTION
Fixes #1951. Fixes #1952.

Both bugs are one defect surfacing twice: the `$defs` preparation semantics from #1948 (shared definitions merged into each tool schema, collisions refused) lived in `prepare_schema_map`, was applied on some paths, modelled by hand on others, and absent on the rest. Every divergence was a bug with a different face.

## #1951 — the metric never prepared

`tool_output_valid` iterated the schema map verbatim: it compiled a `$defs` entry as if it were a tool's schema, a `$ref` into shared definitions failed as unresolvable, and a colliding map compiled the tool schema to `{"$defs":{...}}` — which asserts nothing and accepts every output. The vacuity check upstream *modelled* the merge and refused collisions, so exactly the configs it accepted as effective could validate nothing at runtime. That is the "no-op schema accepted" case #1948 set out to eliminate, surviving on a neighbouring path.

The metric now prepares through the same `prepare_schema_map` (made `pub`) as the args path. A preparation failure is a loud config error; the shared-`$defs`-plus-`$ref` shape now works end to end.

## #1952 — the proxy panicked

`compile_all_schemas` unwrapped preparation errors, and it is materialized lazily from the enforcement path (`OnceLock`), so a policy carrying a collision aborted the server on the **first enforcement decision**. It now records a per-tool `Err`, and the engine denies that tool's calls fail-closed with `E_SCHEMA_COMPILE` — mirroring what `check_tool_args` and `PolicyState::compile` already did. Healthy tools beside a broken one keep evaluating.

Public API: `compile_all_schemas` keeps its signature but is `#[deprecated]` in favour of `try_compile_all_schemas`, which names every broken tool. `assay policy validate`, `migrate` and `coverage` surface that error instead of relying on the panic, so load-time still fails loudly where loud failure is wanted.

Also fixed from the issue's addendum: the load-time compiler skipped every `$`-prefixed key while `check_tool_args` special-cased only `"$defs"`. Both now treat exactly `"$defs"` as the shared-definitions entry, and the doc comment claiming the paths cannot drift is now true.

## The drift is structurally gone

`schema_map_asserts_nothing` delegated its hand-rolled merge copy to `prepare_schema_map`, and `ToolOutputValid` validation prepares before compiling, exactly as the structured args path already did. One preparation, four consumers: load-time compiler, `check_tool_args`, the metric, and config validation.

## Semantics pinned, not assumed

`tests/jsonschema_semantics_probe.rs` pins the jsonschema-crate (0.49, draft 2020-12) behaviour both fixes rest on: an unresolvable local ref fails at build time, a bare `$defs` object accepts everything (`$defs` is not an assertion keyword), merged definitions resolve. End-to-end tests pin the enforcement behaviour the issue found unpinned: collision policy loads, broken tool denied `E_SCHEMA_COMPILE`, healthy tools unaffected.

## Verification

| Gate | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, zero warnings |
| `cargo test -p assay-core -p assay-metrics -p assay-cli` | 1797 passed, 0 failed |
| `cargo test -p assay-mcp-server` | 281 passed, 0 failed |
| `cargo fmt --all --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)