### PR TITLE
One rule, one function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,24 @@ The failure mode this catches is not arithmetic but attribution: the number is r
 ref, artifact, or build it describes is not. Name the artifact too when a generated form exists, since
 a correct reading of a generated layer is still the wrong layer.
 
+### One rule, one function
+
+When the same rule has to be answered in two places — a load-time check and an execution-time check, a
+display normaliser and a matching normaliser, a validator and the thing it validates against — make
+one side call the other, or extract the single function both use. Do not write the rule twice.
+
+The failure mode is drift, and it is silent: the second implementation starts as a faithful
+approximation and diverges one edit at a time, so both sides keep passing their own tests while
+disagreeing about a real input. PR #1948 spent five independent review rounds on exactly this, and
+each round fixed one divergence while introducing another. What held was making the second site
+mirror the first structurally and pinning them together with a test that asserts both answer the same
+for the same input.
+
+Where the two genuinely cannot share code, the fallback is that parity test — one test over a table of
+inputs asserting agreement, not two separate test suites that never meet. Prefer one function; treat
+the parity test as the compromise it is. `lycorp-jp/sim-use` states the same rule for its normalisers,
+so that display and round-trip "can never drift apart".
+
 ## Tool Boundaries
 
 - Codex owns programme-ledger coordination, CI triage, PR sequencing, and merge-state reconciliation.


### PR DESCRIPTION
## Description

Records a verification rule we have already paid for twice, so the next reviewer reaches for it before round five.

When the same rule has to be answered in two places — a load-time check and an execution-time check, a display normaliser and a matching normaliser — one side should call the other, or both should call one extracted function. Writing it twice produces drift, and the drift is silent: the second implementation starts as a faithful approximation and diverges one edit at a time, so both sides keep passing their own tests while disagreeing about a real input.

PR #1948 spent five independent review rounds on exactly this. A load-time vacuity check was a second, approximate implementation of the execution-time effectiveness rule in `validate_args_policy_value`, and every round fixed one divergence while introducing another (`enforcement` counted on key presence where execution required `"deny"`; the allow-list universality test used `all` where execution used `any`). What finally held was making the load-time side mirror the execution rule structurally and pinning the two together with a parity test.

The rule therefore also names its fallback honestly: where two sites genuinely cannot share code, add one parity test over a table of inputs asserting they agree — not two separate suites that never meet. One function is the goal; the parity test is the compromise.

Lands as a subsection under Verification, beside Measurement provenance, in the same shape those rules already use (state the rule, then name the failure mode it catches).

## Type of Change
- [x] Documentation update

## Verification

Documentation only — no code, no public surface, no dependency-manifest change.

- [x] Pre-commit hooks pass (merge conflicts, end-of-file, trailing whitespace, typos, `cargo fmt --check`, MCP registry token hygiene)
- [x] Rendered and re-read in context: heading level and voice match the surrounding Verification subsections
- [ ] `cargo check` / `cargo test` — not applicable, no Rust touched
- [ ] Demo suite — not applicable

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes — not applicable to a documentation rule.

## Non-claims

This records a rule; it does not audit the codebase against it. No existing duplicate-rule site is fixed or identified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development guidance encouraging centralized implementations for shared rules.
  * Documented parity testing as a fallback when shared code is impractical.
  * Added context on preventing behavioral drift across duplicated logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->