### PR TITLE
Stop pointing the ledger line at a finished programme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,18 @@ this contract.
 ## Canonical State
 
 - Repository truth is the checked-in code and documentation.
-- The public execution ledger for the active programme is
-  [issue #1866](https://github.com/Rul1an/assay/issues/1866). Keep the number to this one line;
-  everywhere else the contract names the role, so the next programme costs one edit here rather than
-  one in every section. Nothing enforces that, so it is an instruction and not a guarantee.
+- The public execution ledger for the active programme is named on this line. **No programme is
+  active.** The previous one, [issue #1866](https://github.com/Rul1an/assay/issues/1866), closed on
+  2026-08-01; name the new ledger here when one opens, and say so plainly here when none is. Keep
+  the number to this one line; everywhere else the contract names the role, so the next programme
+  costs one edit here rather than one in every section. Nothing enforces that, so it is an
+  instruction and not a guarantee — and the way it fails is quiet: the line kept pointing at a
+  finished programme, which reads as an active ledger and sends handoffs to a closed issue.
 - Agent chats, local plans, memories, and unpushed branches are not authoritative project state.
-- Every handoff records the branch, PR, exact head SHA, verification, reviews, non-claims, and open
-  findings in the ledger.
+- Every handoff for a programme slice records the branch, PR, exact head SHA, verification, reviews,
+  non-claims, and open findings in that programme's ledger. Work outside a programme — a standalone
+  fix, a documentation change — has no ledger to record to, and inventing one or appending to a
+  closed one is worse than the omission.
 
 ## ADR-042/043 Scope
 


### PR DESCRIPTION
## Description

`AGENTS.md` names the public execution ledger for the active programme on a single line, deliberately, so a new programme costs one edit there rather than one per section. That line still named [issue #1866](https://github.com/Rul1an/assay/issues/1866), which **closed on 2026-08-01** with "Programme complete — all slices are merged and the final publication is verified."

So the contract has been directing handoffs to a closed ledger for a programme that ended, and there is no open issue currently serving that role.

The failure is quiet by construction: a stale pointer reads exactly like a live one, and the existing sentence already admits "nothing enforces that, so it is an instruction and not a guarantee". This change makes the empty state sayable — the line now states plainly that no programme is active, so the next reader sees an empty slot instead of a dead link that looks alive.

It also closes a second gap the same trip surfaced. The handoff rule said every handoff records to "the ledger", which has no answer for work that is not a programme slice — a standalone fix, a documentation change. The rule now scopes itself to programme slices and says what to do otherwise, because appending to a closed ledger to satisfy the letter of the rule is worse than the omission.

Found while looking for the house style of a ledger entry, which is how the closure was noticed at all.

## Type of Change
- [x] Documentation update

## Verification

Documentation only — no code, no public surface, no dependency-manifest change.

- [x] Pre-commit hooks pass (merge conflicts, end-of-file, trailing whitespace, typos, `cargo fmt --check`, MCP registry token hygiene)
- [x] Issue state checked against the API rather than assumed: `#1866 CLOSED, closed 2026-08-01T08:22:26Z`
- [x] No open issue currently acts as a programme ledger (`gh issue list --state open`)
- [ ] `cargo check` / `cargo test` — not applicable, no Rust touched
- [ ] Demo suite — not applicable

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes — not applicable to a documentation rule.

## Non-claims

This does not open a new programme or nominate a new ledger; it records that none is active. It does not backfill handoff records for work merged while the pointer was stale, and does not audit how long the pointer had been stale beyond the close date above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)