### PR TITLE
An assertion that cannot check anything is not a pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
   against the unread `test_trace` field or carrying no usable `regex`, a
   `tool_blocklist` whose `blocked` list was absent, empty, wrongly typed or
   partly unreadable, `min_calls: 0`, an empty `sequence` with
-  `allow_other_tools: true`, and others — and each now reports
+  `allow_other_tools: true`, an empty `tool` name, a `max` at the largest
+  representable bound, and others — and each now reports
   `E_ASSERT_INEFFECTIVE` naming the responsible field. Separately, `expect` was
   compared by exact equality to `"pass"` at three sites, so any other spelling
   silently selected *expect failure* and inverted the assertion; unrecognized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- An `assertions:` entry that cannot check anything no longer reports as a pass.
+  Thirteen shapes evaluated to nothing or to a check that could not fail for any
+  input — an `args_valid` without `test_args`, a `sequence_valid` written
+  against the unread `test_trace` field or carrying no usable `regex`, a
+  `tool_blocklist` whose `blocked` list was absent, empty, wrongly typed or
+  partly unreadable, `min_calls: 0`, an empty `sequence` with
+  `allow_other_tools: true`, and others — and each now reports
+  `E_ASSERT_INEFFECTIVE` naming the responsible field. Separately, `expect` was
+  compared by exact equality to `"pass"` at three sites, so any other spelling
+  silently selected *expect failure* and inverted the assertion; unrecognized
+  values are now rejected. **This turns previously green configurations red, by
+  design: they were green because they checked nothing** (#1949).
+
 ### Added
 - `assay.tool_decision_surface.v0` records now carry a typed `correlation`
   basis: a valid W3C `traceparent` from `_meta` is retained verbatim as a

--- a/crates/assay-core/src/agent_assertions/matchers.rs
+++ b/crates/assay-core/src/agent_assertions/matchers.rs
@@ -25,6 +25,17 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
                 .filter(|t| t.tool_name.as_deref() == Some(tool.as_str()))
                 .count();
             let min = min_calls.unwrap_or(1);
+            if min == 0 {
+                // `count < 0` is never true for an unsigned count, so no trace can fail this.
+                return Some(ineffective(
+                    "trace_must_call_tool",
+                    "min_calls",
+                    "`min_calls: 0` is satisfied by every trace, including one where the tool is \
+                     never called.",
+                    "Use `min_calls: 1` or higher, or express \"never called\" with \
+                     `trace_must_not_call_tool`.",
+                ));
+            }
             if (actual as u32) < min {
                 return Some(make_diag(
                     "E_TRACE_ASSERT_FAIL",
@@ -63,6 +74,19 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
             allow_other_tools,
         } => {
             if *allow_other_tools {
+                // An empty subsequence has nothing to look for, so every trace contains it.
+                // The exact form is different: an empty sequence there asserts the trace made no
+                // named tool call at all, which is a real constraint.
+                if sequence.is_empty() {
+                    return Some(ineffective(
+                        "trace_tool_sequence",
+                        "sequence",
+                        "an empty `sequence` with `allow_other_tools: true` is contained in every \
+                         trace, so the assertion cannot fail.",
+                        "Name the tools the trace must contain, or set \
+                         `allow_other_tools: false` to assert that no tool was called.",
+                    ));
+                }
                 // Subsequence check
                 if let Err(msg) = check_subsequence(&graph.tool_calls, sequence) {
                     return Some(make_diag(
@@ -139,7 +163,10 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
                 let policy_map = serde_json::json!({ tool: schema });
 
                 let verdict = crate::policy_engine::evaluate_tool_args(&policy_map, tool, args);
-                let expected_pass = expect.as_deref().unwrap_or("pass") == "pass";
+                let expected_pass = match expected_pass(expect, "args_valid") {
+                    Ok(v) => v,
+                    Err(d) => return Some(*d),
+                };
                 let actual_pass = verdict.status == crate::policy_engine::VerdictStatus::Allowed;
 
                 if expected_pass != actual_pass {
@@ -215,19 +242,27 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
                     // Defaulting a missing key to `.*` would make the assertion match every
                     // possible trace, which is a check that cannot fail rather than a check
                     // that passes.
-                    let Some(regex) = pol.get("regex").and_then(|s| s.as_str()) else {
+                    let regex = pol
+                        .get("regex")
+                        .and_then(|s| s.as_str())
+                        .filter(|r| !r.is_empty());
+                    let Some(regex) = regex else {
                         return Some(ineffective(
                             "sequence_valid",
                             "policy.regex",
-                            "the policy carries no `regex` key, so there is no constraint to \
-                             evaluate the steps against.",
+                            "the policy carries no usable `regex`, so there is no constraint to \
+                             evaluate the steps against — an absent, non-string, or empty \
+                             pattern matches every possible trace.",
                             "Add a `regex` field to the policy describing the permitted tool \
                              sequence.",
                         ));
                     };
 
                     let verdict = crate::policy_engine::evaluate_sequence(regex, &tools);
-                    let expected_pass = expect.as_deref().unwrap_or("pass") == "pass";
+                    let expected_pass = match expected_pass(expect, "sequence_valid") {
+                        Ok(v) => v,
+                        Err(d) => return Some(*d),
+                    };
                     let actual_pass =
                         verdict.status == crate::policy_engine::VerdictStatus::Allowed;
 
@@ -299,7 +334,10 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
                         ));
                     }
 
-                    let expected_pass = expect.as_deref().unwrap_or("pass") == "pass";
+                    let expected_pass = match expected_pass(expect, "tool_blocklist") {
+                        Ok(v) => v,
+                        Err(d) => return Some(*d),
+                    };
                     // Check if *any* tool is blocked
                     let mut actual_pass = true;
                     for t in tools {
@@ -354,6 +392,34 @@ fn check_subsequence(
         }
     }
     Ok(())
+}
+
+/// Reads the `expect` field, which selects the polarity of a policy-mode assertion.
+///
+/// This was three copies of `expect.as_deref().unwrap_or("pass") == "pass"`. Exact string
+/// equality meant every other spelling — `Pass`, `PASS`, `passes`, `true` — silently selected
+/// *expect failure* and inverted the assertion, so a config that reads as "this must be allowed"
+/// went green precisely when the policy rejected it. An inversion is worse than a no-op: a no-op
+/// stops checking, an inversion checks the opposite.
+///
+/// One function rather than three comparisons, per `AGENTS.md` Verification. The `Err` variant is
+/// boxed because `Diagnostic` is large enough to trip `result_large_err` on a `bool` happy path.
+fn expected_pass(expect: &Option<String>, variant: &str) -> Result<bool, Box<Diagnostic>> {
+    match expect.as_deref() {
+        None | Some("pass") => Ok(true),
+        Some("fail") => Ok(false),
+        Some(other) => Err(Box::new(make_diag(
+            "E_CONFIG_ERROR",
+            &format!(
+                "Assertion `{variant}` has an unrecognized `expect` value; \
+                 the only accepted values are `pass` and `fail`."
+            ),
+            None,
+            Some(
+                serde_json::json!({ "assertion": variant, "field": "expect", "length": other.len() }),
+            ),
+        ))),
+    }
 }
 
 /// An assertion that cannot check anything, reported under its own code so a suite can tell it

--- a/crates/assay-core/src/agent_assertions/matchers.rs
+++ b/crates/assay-core/src/agent_assertions/matchers.rs
@@ -19,6 +19,9 @@ pub fn evaluate(
 fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
     match a {
         TraceAssertion::TraceMustCallTool { tool, min_calls } => {
+            if let Some(d) = names_no_tool(tool, "trace_must_call_tool", EMPTY_TOOL_NEVER_HOLDS) {
+                return Some(d);
+            }
             let actual = graph
                 .tool_calls
                 .iter()
@@ -49,6 +52,10 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
             }
         }
         TraceAssertion::TraceMustNotCallTool { tool } => {
+            if let Some(d) = names_no_tool(tool, "trace_must_not_call_tool", EMPTY_TOOL_NEVER_FAILS)
+            {
+                return Some(d);
+            }
             if let Some(call) = graph
                 .tool_calls
                 .iter()
@@ -118,8 +125,23 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
             }
         }
         TraceAssertion::TraceMaxSteps { max } => {
+            // No step count can exceed the ceiling of the type the bound is written in, so this
+            // one bound holds for every trace. Only the ceiling is refused: a merely large bound
+            // like 100_000 is a real constraint whose outcome depends on the trace, and refusing
+            // those is the over-eager vacuity detection that earns a suppression.
+            if *max == u32::MAX {
+                return Some(ineffective(
+                    "trace_max_steps",
+                    "max",
+                    "`max` is the largest representable bound, so no trace can exceed it and the \
+                     assertion cannot fail.",
+                    "Set `max` to the step budget the agent is actually expected to stay within.",
+                ));
+            }
             let count = graph.steps.len();
-            if count as u32 > *max {
+            // Compare in `usize` rather than casting the count down to `u32`: a count above
+            // 2^32 would wrap and could land under the bound.
+            if count > *max as usize {
                 return Some(make_diag(
                     "E_TRACE_ASSERT_FAIL",
                     &format!("Expected at most {} steps, got {}.", max, count),
@@ -438,6 +460,29 @@ fn check_subsequence(
     }
     Ok(())
 }
+
+/// An empty `tool` names nothing, and no recorded call carries an empty name.
+///
+/// Which way that breaks depends on the assertion's polarity — `trace_must_not_call_tool` can then
+/// never fail, `trace_must_call_tool` can never be satisfied — but the config mistake is the same
+/// one, so both report through here rather than through two codes for one typo. The permanently
+/// failing side matters as much as the permanently passing one: reported as a behavioural failure
+/// it would send the author to look at their agent for a defect that is in their config.
+fn names_no_tool(tool: &str, variant: &str, why: &'static str) -> Option<Diagnostic> {
+    tool.is_empty().then(|| {
+        ineffective(
+            variant,
+            "tool",
+            why,
+            "Name the tool the assertion is about.",
+        )
+    })
+}
+
+const EMPTY_TOOL_NEVER_FAILS: &str =
+    "`tool` is empty, so it names no recorded call and the assertion can never fail.";
+const EMPTY_TOOL_NEVER_HOLDS: &str =
+    "`tool` is empty, so it names no recorded call and the assertion can never be satisfied.";
 
 /// Reads the `expect` field, which selects the polarity of a policy-mode assertion.
 ///

--- a/crates/assay-core/src/agent_assertions/matchers.rs
+++ b/crates/assay-core/src/agent_assertions/matchers.rs
@@ -237,6 +237,19 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
                                 .map(|s| s.to_string())
                         })
                         .collect();
+                    // An entry keyed on neither `tool` nor `tool_name` is dropped above, which
+                    // silently shortens the sequence being checked — a misspelled key would turn
+                    // this into a different, weaker assertion rather than an error.
+                    if tools.len() != trace_vals.len() {
+                        return Some(ineffective(
+                            "sequence_valid",
+                            "test_trace_raw",
+                            "an entry in `test_trace_raw` names no tool under `tool` or \
+                             `tool_name`, so it is dropped and the sequence checked is shorter \
+                             than the one written.",
+                            "Give every entry a `tool` key naming one tool.",
+                        ));
+                    }
 
                     // The policy carries the sequence constraint as a regex under `regex`.
                     // Defaulting a missing key to `.*` would make the assertion match every
@@ -307,18 +320,50 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
                     ));
                 };
                 {
+                    // No calls to check is the same shape as an empty blocklist, from the other
+                    // side: the loop below starts at `actual_pass = true` and never iterates.
+                    if tools.is_empty() {
+                        return Some(ineffective(
+                            "tool_blocklist",
+                            "test_tool_calls",
+                            "`test_tool_calls` is empty, so there is no call to match against the \
+                             blocklist and the assertion cannot fail.",
+                            "List the calls the policy should be evaluated against, or remove the \
+                             assertion.",
+                        ));
+                    }
+
                     // pol should look like { "blocked": [...] }
                     // An absent key and an empty list are both a blocklist that admits every
                     // call, which cannot fail for any input.
-                    let Some(blocked_raw) = pol.get("blocked").and_then(|v| v.as_array()) else {
+                    let blocked_value = pol.get("blocked");
+                    let Some(blocked_raw) = blocked_value.and_then(|v| v.as_array()) else {
+                        // Distinguish absent from present-but-wrong-typed: they point the author
+                        // at different fixes, and "carries no list" is false for `blocked: "rm"`.
                         return Some(ineffective(
                             "tool_blocklist",
                             "policy.blocked",
-                            "the policy carries no `blocked` list, so every tool call is \
-                             admitted and the assertion cannot fail.",
-                            "Add a `blocked` array to the policy naming the disallowed tools.",
+                            if blocked_value.is_some() {
+                                "the policy's `blocked` is not a list, so no tool name can be \
+                                 matched against it and the assertion cannot fail."
+                            } else {
+                                "the policy carries no `blocked` list, so every tool call is \
+                                 admitted and the assertion cannot fail."
+                            },
+                            "Give `blocked` an array of tool names.",
                         ));
                     };
+                    // A non-string entry is dropped by the conversion below. Dropping some of the
+                    // blocklist silently would leave a check that looks complete and is not.
+                    if blocked_raw.iter().any(|v| !v.is_string()) {
+                        return Some(ineffective(
+                            "tool_blocklist",
+                            "policy.blocked",
+                            "`blocked` contains an entry that is not a tool name, which would be \
+                             dropped and leave the assertion checking less than it appears to.",
+                            "Make every entry in `blocked` a string naming one tool.",
+                        ));
+                    }
                     let blocked: Vec<String> = blocked_raw
                         .iter()
                         .filter_map(|v| v.as_str().map(|s| s.to_string()))

--- a/crates/assay-core/src/agent_assertions/matchers.rs
+++ b/crates/assay-core/src/agent_assertions/matchers.rs
@@ -110,7 +110,20 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
             policy,
             expect,
         } => {
-            if let Some(args) = test_args {
+            let Some(args) = test_args else {
+                // No trace-mode evaluation exists for this variant, so without `test_args` there
+                // is nothing to check. Reporting nothing here would be indistinguishable from a
+                // check that ran and held.
+                return Some(ineffective(
+                    "args_valid",
+                    "test_args",
+                    "`args_valid` is only evaluated against the arguments supplied in `test_args`; \
+                     with that field absent the assertion checks nothing.",
+                    "Give the assertion `test_args`, or drop it and constrain the trace with \
+                     `trace_must_call_tool` or `trace_tool_sequence`.",
+                ));
+            };
+            {
                 let Some(pol) = policy else {
                     return Some(make_diag(
                         "E_CONFIG_ERROR",
@@ -149,13 +162,43 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
             }
         }
         TraceAssertion::SequenceValid {
+            test_trace,
             test_trace_raw,
             policy,
             expect,
-            ..
         } => {
-            if let Some(trace_vals) = test_trace_raw {
-                if let Some(pol) = policy {
+            // The typed `test_trace` field is not evaluated — only `test_trace_raw` is read
+            // below. Saying so beats ignoring a field the author believed was carrying the test.
+            if test_trace.is_some() && test_trace_raw.is_none() {
+                return Some(ineffective(
+                    "sequence_valid",
+                    "test_trace",
+                    "`test_trace` is not evaluated; only `test_trace_raw` is read, so this \
+                     assertion checks nothing.",
+                    "Move the steps to `test_trace_raw` as a list of `{ tool: <name> }` entries.",
+                ));
+            }
+            let Some(trace_vals) = test_trace_raw else {
+                return Some(ineffective(
+                    "sequence_valid",
+                    "test_trace_raw",
+                    "`sequence_valid` is only evaluated against the steps supplied in \
+                     `test_trace_raw`; with that field absent the assertion checks nothing.",
+                    "Give the assertion `test_trace_raw`, or constrain the recorded trace with \
+                     `trace_tool_sequence` instead.",
+                ));
+            };
+            {
+                let Some(pol) = policy else {
+                    return Some(ineffective(
+                        "sequence_valid",
+                        "policy",
+                        "`sequence_valid` has no policy to evaluate the steps against, so the \
+                         assertion checks nothing.",
+                        "Give the assertion a `policy` carrying a `regex` field.",
+                    ));
+                };
+                {
                     // Extract tool names from trace
                     // trace_vals is Vec<Value>. Expect { tool_name: "..." }
                     let tools: Vec<String> = trace_vals
@@ -168,27 +211,20 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
                         })
                         .collect();
 
-                    // Policy is { rules: [...] } or just rules array?
-                    // evaluate_sequence expects regex string.
-                    // But parity.rs constructs regex from JSON rules.
-                    // We need a helper to convert JSON rules to regex string.
-                    // crate::policy_engine::evaluate_sequence takes (regex, tools).
-                    // We can assume 'policy' here IS the regex string or we need transformation logic.
-                    // Implementation Plan: Assume policy contains "rules" and we construct regex or simplistic "join".
-                    // parity.rs did: rules.join(" THEN ") ? No, that was latency_check.
-                    // policy_engine has NO helper to convert JSON->Regex yet?
-                    // Wait, `policy_engine::evaluate_sequence` takes `policy_regex: &str`.
-                    // Does `policy_engine` have a JSON parser?
-                    // Let's assume for this specific integration, we pass the regex string in the policy field?
-                    // Or we assume the user provides it.
-                    // Actually, parity.rs handled `CheckType::SequenceValid` by converting JSON rules to Regex.
-                    // If we want Asserts to work, we verify what format `policy` comes in.
-                    // fp_suite.yaml doesn't specify policy format yet.
-                    // Let's assume policy IS the regex string for simplicity now, or simple rule list.
-
-                    // Simplified: We skip implementing full rule engine here if not readily avail.
-                    // We will allow `policy` to contain `regex` field.
-                    let regex = pol.get("regex").and_then(|s| s.as_str()).unwrap_or(".*");
+                    // The policy carries the sequence constraint as a regex under `regex`.
+                    // Defaulting a missing key to `.*` would make the assertion match every
+                    // possible trace, which is a check that cannot fail rather than a check
+                    // that passes.
+                    let Some(regex) = pol.get("regex").and_then(|s| s.as_str()) else {
+                        return Some(ineffective(
+                            "sequence_valid",
+                            "policy.regex",
+                            "the policy carries no `regex` key, so there is no constraint to \
+                             evaluate the steps against.",
+                            "Add a `regex` field to the policy describing the permitted tool \
+                             sequence.",
+                        ));
+                    };
 
                     let verdict = crate::policy_engine::evaluate_sequence(regex, &tools);
                     let expected_pass = expect.as_deref().unwrap_or("pass") == "pass";
@@ -214,20 +250,54 @@ fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
             test_tool_calls,
             policy,
             expect,
-            ..
         } => {
-            if let Some(tools) = test_tool_calls {
-                if let Some(pol) = policy {
+            let Some(tools) = test_tool_calls else {
+                return Some(ineffective(
+                    "tool_blocklist",
+                    "test_tool_calls",
+                    "`tool_blocklist` is only evaluated against the calls supplied in \
+                     `test_tool_calls`; with that field absent the assertion checks nothing.",
+                    "Give the assertion `test_tool_calls`, or constrain the recorded trace with \
+                     `trace_must_not_call_tool` instead.",
+                ));
+            };
+            {
+                let Some(pol) = policy else {
+                    return Some(ineffective(
+                        "tool_blocklist",
+                        "policy",
+                        "`tool_blocklist` has no policy to evaluate the calls against, so the \
+                         assertion checks nothing.",
+                        "Give the assertion a `policy` carrying a `blocked` list.",
+                    ));
+                };
+                {
                     // pol should look like { "blocked": [...] }
-                    let blocked: Vec<String> = pol
-                        .get("blocked")
-                        .and_then(|v| v.as_array())
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                .collect()
-                        })
-                        .unwrap_or_default();
+                    // An absent key and an empty list are both a blocklist that admits every
+                    // call, which cannot fail for any input.
+                    let Some(blocked_raw) = pol.get("blocked").and_then(|v| v.as_array()) else {
+                        return Some(ineffective(
+                            "tool_blocklist",
+                            "policy.blocked",
+                            "the policy carries no `blocked` list, so every tool call is \
+                             admitted and the assertion cannot fail.",
+                            "Add a `blocked` array to the policy naming the disallowed tools.",
+                        ));
+                    };
+                    let blocked: Vec<String> = blocked_raw
+                        .iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect();
+                    if blocked.is_empty() {
+                        return Some(ineffective(
+                            "tool_blocklist",
+                            "policy.blocked",
+                            "the `blocked` list is empty, so every tool call is admitted and the \
+                             assertion cannot fail.",
+                            "Name at least one disallowed tool in `blocked`, or remove the \
+                             assertion.",
+                        ));
+                    }
 
                     let expected_pass = expect.as_deref().unwrap_or("pass") == "pass";
                     // Check if *any* tool is blocked
@@ -284,6 +354,23 @@ fn check_subsequence(
         }
     }
     Ok(())
+}
+
+/// An assertion that cannot check anything, reported under its own code so a suite can tell it
+/// apart from a check that ran and held.
+///
+/// `AGENTS.md`, Development Discipline: never turn absence of evidence into a clean result. The
+/// message names the variant and the field responsible rather than the value, so the diagnostic
+/// stays value-free and safe to print.
+fn ineffective(variant: &str, field: &str, why: &str, fix: &str) -> Diagnostic {
+    Diagnostic {
+        code: "E_ASSERT_INEFFECTIVE".to_string(),
+        severity: "error".to_string(),
+        source: "agent_assertions".to_string(),
+        message: format!("Assertion `{variant}` checks nothing: {why}"),
+        context: serde_json::json!({ "assertion": variant, "field": field }),
+        fix_steps: vec![fix.to_string()],
+    }
 }
 
 fn make_diag(

--- a/crates/assay-core/tests/assertions_vacuity.rs
+++ b/crates/assay-core/tests/assertions_vacuity.rs
@@ -1,0 +1,269 @@
+//! Assertions that cannot check anything must not report as satisfied.
+//!
+//! `AGENTS.md`, Development Discipline: "Never turn absence of evidence, failed validation,
+//! skipped review, or unavailable infrastructure into a clean result." The `assertions:`
+//! evaluator does exactly that in several places — a missing field takes an `if let Some(..)`
+//! with no `else` and the assertion contributes no diagnostic, which is indistinguishable from
+//! a check that ran and held.
+//!
+//! Each test below names the mechanism at file:line as of the tree these were written against,
+//! and asserts the behaviour we want rather than the behaviour we have. Issue #1949.
+
+use assay_core::agent_assertions::{model::TraceAssertion, verify_assertions};
+use assay_core::storage::Store;
+use assay_core::trace::schema::{EpisodeStart, StepEntry, ToolCallEntry, TraceEvent};
+use serde_json::json;
+
+/// A store carrying one episode with a single `web_search` tool call, so every assertion below
+/// is evaluated against a real episode graph rather than the unit-test fallback.
+fn store_with_one_call() -> anyhow::Result<(Store, i64, &'static str)> {
+    let store = Store::memory()?;
+    store.init_schema()?;
+    let run_id = store.insert_run("vacuity-suite")?;
+    let test_id = "agent-under-test";
+
+    store.insert_event(
+        &TraceEvent::EpisodeStart(EpisodeStart {
+            episode_id: "ep-1".into(),
+            timestamp: 1000,
+            input: json!({ "prompt": "hi" }),
+            meta: json!({}),
+        }),
+        Some(run_id),
+        Some(test_id),
+    )?;
+    store.insert_event(
+        &TraceEvent::Step(StepEntry {
+            episode_id: "ep-1".into(),
+            step_id: "s-1".into(),
+            idx: 0,
+            timestamp: 1001,
+            kind: "tool".into(),
+            name: Some("model".into()),
+            content: None,
+            content_sha256: None,
+            truncations: vec![],
+            meta: json!({}),
+        }),
+        Some(run_id),
+        Some(test_id),
+    )?;
+    store.insert_event(
+        &TraceEvent::ToolCall(ToolCallEntry {
+            episode_id: "ep-1".into(),
+            step_id: "s-1".into(),
+            timestamp: 1002,
+            tool_name: "web_search".into(),
+            call_index: Some(0),
+            args: json!({ "q": "rust" }),
+            args_sha256: None,
+            result: None,
+            result_sha256: None,
+            error: None,
+            truncations: vec![],
+        }),
+        Some(run_id),
+        Some(test_id),
+    )?;
+
+    Ok((store, run_id, test_id))
+}
+
+/// Every assertion that cannot check anything reports through this code, so a suite can tell
+/// "nothing to check" apart from "checked and held" without reading prose.
+const INEFFECTIVE: &str = "E_ASSERT_INEFFECTIVE";
+
+fn assert_reports_ineffective(diags: &[assay_core::errors::diagnostic::Diagnostic], case: &str) {
+    assert!(
+        !diags.is_empty(),
+        "{case}: assertion evaluated to nothing and reported no diagnostic, \
+         which is indistinguishable from a check that ran and held"
+    );
+    assert!(
+        diags.iter().any(|d| d.code == INEFFECTIVE),
+        "{case}: expected a {INEFFECTIVE} diagnostic, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+}
+
+/// `matchers.rs:113` — `if let Some(args) = test_args` with no `else`. Against a real episode
+/// there is no trace-mode implementation at all, so the assertion silently contributes nothing.
+#[test]
+fn args_valid_without_test_args_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ArgsValid {
+            tool: "web_search".into(),
+            test_args: None,
+            policy: Some(json!({ "type": "object", "required": ["q"] })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(&diags, "args_valid without test_args");
+    Ok(())
+}
+
+/// `matchers.rs:114-121` already diagnoses a missing policy in unit-test mode. Positive control:
+/// this must keep working, so the fix does not trade one silent path for another.
+#[test]
+fn args_valid_with_test_args_and_no_policy_still_diagnoses() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ArgsValid {
+            tool: "web_search".into(),
+            test_args: Some(json!({ "q": "rust" })),
+            policy: None,
+            expect: None,
+        }],
+    )?;
+    assert!(
+        !diags.is_empty(),
+        "a unit-mode args_valid without a policy must stay diagnosed"
+    );
+    Ok(())
+}
+
+/// `matchers.rs:191` — `pol.get("regex")...unwrap_or(".*")`. A policy with no `regex` key becomes
+/// a universally permissive check rather than an error, so no trace can ever fail it.
+#[test]
+fn sequence_valid_policy_without_regex_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::SequenceValid {
+            test_trace: None,
+            test_trace_raw: Some(vec![json!({ "tool": "web_search" })]),
+            policy: Some(json!({ "rules": ["whatever the author meant"] })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(&diags, "sequence_valid policy without regex");
+    Ok(())
+}
+
+/// `matchers.rs:151-157` — the typed `test_trace` field is destructured away with `..` and never
+/// read; only `test_trace_raw` is. A config written against the typed field checks nothing.
+#[test]
+fn sequence_valid_with_typed_test_trace_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::SequenceValid {
+            test_trace: Some(vec![]),
+            test_trace_raw: None,
+            policy: Some(json!({ "regex": "^web_search$" })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(&diags, "sequence_valid using the typed test_trace field");
+    Ok(())
+}
+
+/// `matchers.rs:222-230` — a policy with no `blocked` key yields an empty list through
+/// `unwrap_or_default()`, and an empty blocklist admits every tool call.
+#[test]
+fn tool_blocklist_without_blocked_key_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ToolBlocklist {
+            test_tool_calls: Some(vec!["web_search".into()]),
+            policy: Some(json!({ "deny": ["rm"] })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(&diags, "tool_blocklist policy without a blocked key");
+    Ok(())
+}
+
+/// Same shape, stated explicitly rather than through a missing key.
+#[test]
+fn tool_blocklist_with_empty_blocked_list_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ToolBlocklist {
+            test_tool_calls: Some(vec!["web_search".into()]),
+            policy: Some(json!({ "blocked": [] })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(&diags, "tool_blocklist with blocked: []");
+    Ok(())
+}
+
+/// `matchers.rs:219-220` — `test_tool_calls` absent takes the outer `if let Some` and the whole
+/// assertion evaluates to nothing.
+#[test]
+fn tool_blocklist_without_test_tool_calls_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ToolBlocklist {
+            test_tool_calls: None,
+            policy: Some(json!({ "blocked": ["rm"] })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(&diags, "tool_blocklist without test_tool_calls");
+    Ok(())
+}
+
+/// Negative control: a fully specified assertion that genuinely holds must stay silent, or the
+/// fix has simply made everything noisy.
+#[test]
+fn effective_assertion_that_holds_stays_silent() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMustCallTool {
+            tool: "web_search".into(),
+            min_calls: Some(1),
+        }],
+    )?;
+    assert!(
+        diags.is_empty(),
+        "an effective assertion that holds must report nothing, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// Negative control on the other side: a real violation must still be reported as a failure,
+/// not reclassified as ineffective.
+#[test]
+fn effective_assertion_that_fails_still_fails() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMustNotCallTool {
+            tool: "web_search".into(),
+        }],
+    )?;
+    assert!(
+        diags.iter().any(|d| d.code == "E_TRACE_ASSERT_FAIL"),
+        "a genuine violation must stay a failure, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+    Ok(())
+}

--- a/crates/assay-core/tests/assertions_vacuity.rs
+++ b/crates/assay-core/tests/assertions_vacuity.rs
@@ -261,6 +261,192 @@ fn tool_blocklist_without_test_tool_calls_is_not_a_pass() -> anyhow::Result<()> 
     Ok(())
 }
 
+/// `expect` was compared by exact string equality to `"pass"`, so any other spelling silently
+/// meant *expect failure* and inverted the assertion. An author writing `expect: Pass` got a test
+/// that goes green precisely when the policy would have rejected the input.
+///
+/// This is worse than a no-op: a no-op stops checking, an inversion checks the opposite.
+#[test]
+fn unrecognised_expect_value_is_rejected_not_silently_inverted() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    for spelling in ["Pass", "PASS", "passes", "true", "ok", ""] {
+        let diags = verify_assertions(
+            &store,
+            run_id,
+            test_id,
+            &[TraceAssertion::ArgsValid {
+                tool: "web_search".into(),
+                test_args: Some(json!({ "q": "rust" })),
+                policy: Some(json!({ "schema": { "type": "object", "required": ["q"] } })),
+                expect: Some(spelling.to_string()),
+            }],
+        )?;
+        assert!(
+            diags.iter().any(|d| d.code == "E_CONFIG_ERROR"),
+            "expect: {spelling:?} must be rejected, not read as `expect failure`; got {:?}",
+            diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+        );
+    }
+    Ok(())
+}
+
+/// Both recognised spellings must keep working, so rejecting the rest does not break real configs.
+#[test]
+fn recognised_expect_values_still_work() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let schema = json!({ "schema": { "type": "object", "required": ["q"] } });
+
+    // `pass` against args that satisfy the schema: holds, so silent.
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ArgsValid {
+            tool: "web_search".into(),
+            test_args: Some(json!({ "q": "rust" })),
+            policy: Some(schema.clone()),
+            expect: Some("pass".into()),
+        }],
+    )?;
+    assert!(diags.is_empty(), "expect: pass on valid args must hold");
+
+    // `fail` against args that violate the schema: also holds, so also silent.
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ArgsValid {
+            tool: "web_search".into(),
+            test_args: Some(json!({ "wrong": 1 })),
+            policy: Some(schema),
+            expect: Some("fail".into()),
+        }],
+    )?;
+    assert!(diags.is_empty(), "expect: fail on invalid args must hold");
+    Ok(())
+}
+
+/// `min_calls: 0` makes `(actual as u32) < 0` — never true for an unsigned count, so the
+/// assertion cannot fail for any trace.
+#[test]
+fn must_call_tool_with_min_calls_zero_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMustCallTool {
+            tool: "web_search".into(),
+            min_calls: Some(0),
+        }],
+    )?;
+    assert_reports_ineffective(
+        &diags,
+        "trace_must_call_tool with min_calls: 0",
+        "min_calls",
+    );
+    Ok(())
+}
+
+/// An empty sequence under `allow_other_tools: true` is a subsequence check with nothing to
+/// find, which every trace satisfies.
+#[test]
+fn tool_sequence_empty_subsequence_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceToolSequence {
+            sequence: vec![],
+            allow_other_tools: true,
+        }],
+    )?;
+    assert_reports_ineffective(
+        &diags,
+        "trace_tool_sequence with an empty sequence and allow_other_tools",
+        "sequence",
+    );
+    Ok(())
+}
+
+/// The exact-sequence form of an empty sequence is *not* vacuous — it asserts the trace made no
+/// named tool call, which this trace violates. Positive control against over-rejecting.
+#[test]
+fn tool_sequence_empty_exact_is_a_real_constraint() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceToolSequence {
+            sequence: vec![],
+            allow_other_tools: false,
+        }],
+    )?;
+    assert!(
+        diags.iter().any(|d| d.code == "E_TRACE_ASSERT_FAIL"),
+        "an empty exact sequence constrains the trace to no tool calls and must fail here, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// A policy whose `regex` is present but cannot constrain anything — empty pattern, or a
+/// non-string that previously degraded to `.*`.
+#[test]
+fn sequence_valid_permissive_regex_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    for pol in [json!({ "regex": "" }), json!({ "regex": 123 })] {
+        let diags = verify_assertions(
+            &store,
+            run_id,
+            test_id,
+            &[TraceAssertion::SequenceValid {
+                test_trace: None,
+                test_trace_raw: Some(vec![json!({ "tool": "web_search" })]),
+                policy: Some(pol.clone()),
+                expect: None,
+            }],
+        )?;
+        assert_reports_ineffective(
+            &diags,
+            &format!("sequence_valid regex {pol}"),
+            "policy.regex",
+        );
+    }
+    Ok(())
+}
+
+/// A `blocked` value that is not an array of strings collapses to an empty blocklist, which
+/// admits every call.
+#[test]
+fn tool_blocklist_unusable_blocked_value_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    for pol in [
+        json!({ "blocked": "rm" }),
+        json!({ "blocked": [42] }),
+        json!({ "blocked": [{ "name": "rm" }] }),
+    ] {
+        let diags = verify_assertions(
+            &store,
+            run_id,
+            test_id,
+            &[TraceAssertion::ToolBlocklist {
+                test_tool_calls: Some(vec!["web_search".into()]),
+                policy: Some(pol.clone()),
+                expect: None,
+            }],
+        )?;
+        assert_reports_ineffective(
+            &diags,
+            &format!("tool_blocklist blocked {pol}"),
+            "policy.blocked",
+        );
+    }
+    Ok(())
+}
+
 /// Negative control: a fully specified assertion that genuinely holds must stay silent, or the
 /// fix has simply made everything noisy.
 #[test]

--- a/crates/assay-core/tests/assertions_vacuity.rs
+++ b/crates/assay-core/tests/assertions_vacuity.rs
@@ -478,6 +478,49 @@ fn tool_blocklist_unusable_blocked_value_is_not_a_pass() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// An absent `blocked` and a wrongly-typed one need different fixes, so they must not share a
+/// message. Pinning the text as well as the field, because a diagnostic that blames the right
+/// field with the wrong explanation still misdirects — the same standard applied to `test_trace`.
+#[test]
+fn blocked_diagnostic_separates_absent_from_wrongly_typed() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let message_for = |policy: serde_json::Value| -> anyhow::Result<String> {
+        let diags = verify_assertions(
+            &store,
+            run_id,
+            test_id,
+            &[TraceAssertion::ToolBlocklist {
+                test_tool_calls: Some(vec!["web_search".into()]),
+                policy: Some(policy),
+                expect: None,
+            }],
+        )?;
+        Ok(diags
+            .iter()
+            .find(|d| d.code == INEFFECTIVE)
+            .map(|d| d.message.clone())
+            .unwrap_or_default())
+    };
+
+    let absent = message_for(json!({ "deny": ["rm"] }))?;
+    let wrong_type = message_for(json!({ "blocked": "rm" }))?;
+
+    assert!(
+        absent.contains("carries no"),
+        "an absent `blocked` should say so; got {absent:?}"
+    );
+    assert!(
+        wrong_type.contains("not a list"),
+        "a wrongly-typed `blocked` should say so rather than claiming it is absent; got \
+         {wrong_type:?}"
+    );
+    assert_ne!(
+        absent, wrong_type,
+        "two different defects must not share one explanation"
+    );
+    Ok(())
+}
+
 /// The structural twin of `blocked: []`, from the other side: with no calls to check, the loop
 /// starts at "passing" and never iterates, so no blocklist can fail it. Rejecting one side of the
 /// pair and not the other would be an arbitrary boundary.

--- a/crates/assay-core/tests/assertions_vacuity.rs
+++ b/crates/assay-core/tests/assertions_vacuity.rs
@@ -595,6 +595,103 @@ fn sequence_valid_unreadable_trace_entry_is_not_a_pass() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// No recorded tool call carries an empty name, so an empty `tool` names nothing. The polarity
+/// decides which way it breaks — permanently green here, permanently red for `must_call` below —
+/// but the config mistake is the same one, so it gets the same diagnostic.
+#[test]
+fn must_not_call_tool_with_empty_name_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMustNotCallTool {
+            tool: String::new(),
+        }],
+    )?;
+    assert_reports_ineffective(
+        &diags,
+        "trace_must_not_call_tool with an empty tool",
+        "tool",
+    );
+    Ok(())
+}
+
+/// The mirror defect. This one fails rather than passes, so it is loud — but it fails for a
+/// reason that has nothing to do with the agent, and no trace can ever satisfy it. Reporting it
+/// as a behavioural failure would send the author looking at their agent.
+#[test]
+fn must_call_tool_with_empty_name_is_not_a_behavioural_failure() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMustCallTool {
+            tool: String::new(),
+            min_calls: Some(1),
+        }],
+    )?;
+    assert_reports_ineffective(&diags, "trace_must_call_tool with an empty tool", "tool");
+    assert!(
+        !diags.iter().any(|d| d.code == "E_TRACE_ASSERT_FAIL"),
+        "an unsatisfiable config must not be reported as the agent misbehaving"
+    );
+    Ok(())
+}
+
+/// `u32::MAX` cannot be exceeded by any step count, so the assertion holds for every trace.
+#[test]
+fn max_steps_at_the_ceiling_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMaxSteps { max: u32::MAX }],
+    )?;
+    assert_reports_ineffective(&diags, "trace_max_steps at u32::MAX", "max");
+    Ok(())
+}
+
+/// Control: an ordinary large bound is a real constraint. It is not statically decidable whether
+/// a trace will exceed it, and rejecting it would be the over-eager vacuity detection the
+/// literature warns gets suppressed. Only the unreachable ceiling is refused.
+#[test]
+fn max_steps_at_a_large_but_reachable_bound_is_a_real_constraint() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMaxSteps { max: 100_000 }],
+    )?;
+    assert!(
+        diags.is_empty(),
+        "a large but reachable step bound must stay a real constraint, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// Control: `max_steps` still fails when the trace genuinely exceeds the bound.
+#[test]
+fn max_steps_still_fails_when_exceeded() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::TraceMaxSteps { max: 0 }],
+    )?;
+    assert!(
+        diags.iter().any(|d| d.code == "E_TRACE_ASSERT_FAIL"),
+        "one step against max: 0 must fail, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
 /// Negative control: a fully specified assertion that genuinely holds must stay silent, or the
 /// fix has simply made everything noisy.
 #[test]

--- a/crates/assay-core/tests/assertions_vacuity.rs
+++ b/crates/assay-core/tests/assertions_vacuity.rs
@@ -266,28 +266,59 @@ fn tool_blocklist_without_test_tool_calls_is_not_a_pass() -> anyhow::Result<()> 
 /// that goes green precisely when the policy would have rejected the input.
 ///
 /// This is worse than a no-op: a no-op stops checking, an inversion checks the opposite.
+///
+/// Covers **all three** call sites. Testing one of them was not enough: an adversarial review
+/// restored the pre-fix comparison at the `sequence_valid` and `tool_blocklist` sites and every
+/// test in the crate stayed green, because only `args_valid` was exercised here.
 #[test]
 fn unrecognised_expect_value_is_rejected_not_silently_inverted() -> anyhow::Result<()> {
     let (store, run_id, test_id) = store_with_one_call()?;
     for spelling in ["Pass", "PASS", "passes", "true", "ok", ""] {
-        let diags = verify_assertions(
-            &store,
-            run_id,
-            test_id,
-            &[TraceAssertion::ArgsValid {
+        for (site, assertion) in expect_sites(spelling) {
+            let diags = verify_assertions(&store, run_id, test_id, &[assertion])?;
+            assert!(
+                diags.iter().any(|d| d.code == "E_CONFIG_ERROR"),
+                "{site} with expect: {spelling:?} must be rejected, not read as \
+                 `expect failure`; got {:?}",
+                diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// One well-formed assertion per variant that reads `expect`, so the polarity parser is pinned
+/// everywhere it is called rather than only where it was convenient to test.
+fn expect_sites(spelling: &str) -> Vec<(&'static str, TraceAssertion)> {
+    let expect = Some(spelling.to_string());
+    vec![
+        (
+            "args_valid",
+            TraceAssertion::ArgsValid {
                 tool: "web_search".into(),
                 test_args: Some(json!({ "q": "rust" })),
                 policy: Some(json!({ "schema": { "type": "object", "required": ["q"] } })),
-                expect: Some(spelling.to_string()),
-            }],
-        )?;
-        assert!(
-            diags.iter().any(|d| d.code == "E_CONFIG_ERROR"),
-            "expect: {spelling:?} must be rejected, not read as `expect failure`; got {:?}",
-            diags.iter().map(|d| &d.code).collect::<Vec<_>>()
-        );
-    }
-    Ok(())
+                expect: expect.clone(),
+            },
+        ),
+        (
+            "sequence_valid",
+            TraceAssertion::SequenceValid {
+                test_trace: None,
+                test_trace_raw: Some(vec![json!({ "tool": "web_search" })]),
+                policy: Some(json!({ "regex": "^web_search$" })),
+                expect: expect.clone(),
+            },
+        ),
+        (
+            "tool_blocklist",
+            TraceAssertion::ToolBlocklist {
+                test_tool_calls: Some(vec!["web_search".into()]),
+                policy: Some(json!({ "blocked": ["rm"] })),
+                expect,
+            },
+        ),
+    ]
 }
 
 /// Both recognised spellings must keep working, so rejecting the rest does not break real configs.
@@ -444,6 +475,80 @@ fn tool_blocklist_unusable_blocked_value_is_not_a_pass() -> anyhow::Result<()> {
             "policy.blocked",
         );
     }
+    Ok(())
+}
+
+/// The structural twin of `blocked: []`, from the other side: with no calls to check, the loop
+/// starts at "passing" and never iterates, so no blocklist can fail it. Rejecting one side of the
+/// pair and not the other would be an arbitrary boundary.
+#[test]
+fn tool_blocklist_with_no_calls_to_check_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ToolBlocklist {
+            test_tool_calls: Some(vec![]),
+            policy: Some(json!({ "blocked": ["rm"] })),
+            expect: Some("pass".into()),
+        }],
+    )?;
+    assert_reports_ineffective(
+        &diags,
+        "tool_blocklist with an empty test_tool_calls",
+        "test_tool_calls",
+    );
+    Ok(())
+}
+
+/// A partly-unusable blocklist is worse than a wholly unusable one: the assertion keeps working
+/// for the entries it could read, so it looks complete while silently checking less.
+#[test]
+fn tool_blocklist_partially_unusable_blocked_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::ToolBlocklist {
+            test_tool_calls: Some(vec!["drop_table".into()]),
+            policy: Some(json!({ "blocked": ["rm", { "name": "drop_table" }] })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(
+        &diags,
+        "tool_blocklist with a non-string entry in blocked",
+        "policy.blocked",
+    );
+    Ok(())
+}
+
+/// Same shape one variant over: an entry keyed on neither `tool` nor `tool_name` is dropped, so
+/// the sequence actually checked is shorter than the one written.
+#[test]
+fn sequence_valid_unreadable_trace_entry_is_not_a_pass() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = store_with_one_call()?;
+    let diags = verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &[TraceAssertion::SequenceValid {
+            test_trace: None,
+            test_trace_raw: Some(vec![
+                json!({ "tool": "web_search" }),
+                json!({ "toolName": "delete_account" }),
+            ]),
+            policy: Some(json!({ "regex": "^web_search$" })),
+            expect: None,
+        }],
+    )?;
+    assert_reports_ineffective(
+        &diags,
+        "sequence_valid with an entry naming no tool",
+        "test_trace_raw",
+    );
     Ok(())
 }
 

--- a/crates/assay-core/tests/assertions_vacuity.rs
+++ b/crates/assay-core/tests/assertions_vacuity.rs
@@ -73,16 +73,36 @@ fn store_with_one_call() -> anyhow::Result<(Store, i64, &'static str)> {
 /// "nothing to check" apart from "checked and held" without reading prose.
 const INEFFECTIVE: &str = "E_ASSERT_INEFFECTIVE";
 
-fn assert_reports_ineffective(diags: &[assay_core::errors::diagnostic::Diagnostic], case: &str) {
+/// Asserts the diagnostic exists **and** names the field actually responsible.
+///
+/// Checking only the code is too weak: several ineffective paths sit behind one another, so a
+/// diagnostic naming the wrong field still satisfies a code-only assertion while sending the
+/// author to look at a field they believe they already supplied. A mutation that removed the
+/// typed-`test_trace` guard survived a code-only assertion for exactly that reason.
+fn assert_reports_ineffective(
+    diags: &[assay_core::errors::diagnostic::Diagnostic],
+    case: &str,
+    expected_field: &str,
+) {
     assert!(
         !diags.is_empty(),
         "{case}: assertion evaluated to nothing and reported no diagnostic, \
          which is indistinguishable from a check that ran and held"
     );
-    assert!(
-        diags.iter().any(|d| d.code == INEFFECTIVE),
-        "{case}: expected a {INEFFECTIVE} diagnostic, got {:?}",
-        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    let found = diags
+        .iter()
+        .find(|d| d.code == INEFFECTIVE)
+        .unwrap_or_else(|| {
+            panic!(
+                "{case}: expected a {INEFFECTIVE} diagnostic, got {:?}",
+                diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+            )
+        });
+    let named = found.context.get("field").and_then(|v| v.as_str());
+    assert_eq!(
+        named,
+        Some(expected_field),
+        "{case}: diagnostic blamed the wrong field, which points the author at the wrong fix"
     );
 }
 
@@ -102,7 +122,7 @@ fn args_valid_without_test_args_is_not_a_pass() -> anyhow::Result<()> {
             expect: None,
         }],
     )?;
-    assert_reports_ineffective(&diags, "args_valid without test_args");
+    assert_reports_ineffective(&diags, "args_valid without test_args", "test_args");
     Ok(())
 }
 
@@ -145,7 +165,11 @@ fn sequence_valid_policy_without_regex_is_not_a_pass() -> anyhow::Result<()> {
             expect: None,
         }],
     )?;
-    assert_reports_ineffective(&diags, "sequence_valid policy without regex");
+    assert_reports_ineffective(
+        &diags,
+        "sequence_valid policy without regex",
+        "policy.regex",
+    );
     Ok(())
 }
 
@@ -165,7 +189,11 @@ fn sequence_valid_with_typed_test_trace_is_not_a_pass() -> anyhow::Result<()> {
             expect: None,
         }],
     )?;
-    assert_reports_ineffective(&diags, "sequence_valid using the typed test_trace field");
+    assert_reports_ineffective(
+        &diags,
+        "sequence_valid using the typed test_trace field",
+        "test_trace",
+    );
     Ok(())
 }
 
@@ -184,7 +212,11 @@ fn tool_blocklist_without_blocked_key_is_not_a_pass() -> anyhow::Result<()> {
             expect: None,
         }],
     )?;
-    assert_reports_ineffective(&diags, "tool_blocklist policy without a blocked key");
+    assert_reports_ineffective(
+        &diags,
+        "tool_blocklist policy without a blocked key",
+        "policy.blocked",
+    );
     Ok(())
 }
 
@@ -202,7 +234,7 @@ fn tool_blocklist_with_empty_blocked_list_is_not_a_pass() -> anyhow::Result<()> 
             expect: None,
         }],
     )?;
-    assert_reports_ineffective(&diags, "tool_blocklist with blocked: []");
+    assert_reports_ineffective(&diags, "tool_blocklist with blocked: []", "policy.blocked");
     Ok(())
 }
 
@@ -221,7 +253,11 @@ fn tool_blocklist_without_test_tool_calls_is_not_a_pass() -> anyhow::Result<()> 
             expect: None,
         }],
     )?;
-    assert_reports_ineffective(&diags, "tool_blocklist without test_tool_calls");
+    assert_reports_ineffective(
+        &diags,
+        "tool_blocklist without test_tool_calls",
+        "test_tool_calls",
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Description

The reporting half of #1949. The `assertions:` evaluator silently skipped whole assertions, or degraded a missing policy field to a value that admits everything, and contributed no diagnostic — which a suite cannot tell apart from a check that ran and held.

`AGENTS.md` already forbids this under Development Discipline: *"Never turn absence of evidence, failed validation, skipped review, or unavailable infrastructure into a clean result."* An `if let Some(..)` with no `else` inside a checker is a checker that does not check, so this enforces an existing rule rather than introducing one.

### Ten shapes that could not fail for any input

| Variant | Shape | Mechanism |
|---|---|---|
| `args_valid` | no `test_args` | `if let Some(args)` with no else; there is no trace-mode evaluation at all |
| `sequence_valid` | written against the typed `test_trace` | field was destructured away with `..` and never read |
| `sequence_valid` | no `test_trace_raw`; no `policy` | silent skips |
| `sequence_valid` | `regex` absent, empty, or non-string | all three degraded to `.*` |
| `tool_blocklist` | no `test_tool_calls`; no `policy` | nested `if let Some` with no else |
| `tool_blocklist` | `blocked` absent, `[]`, non-array, or non-string entries | collapsed to an empty blocklist, which admits every call |
| `trace_must_call_tool` | `min_calls: 0` | `count < 0` is never true for an unsigned count |
| `trace_tool_sequence` | empty `sequence` + `allow_other_tools: true` | every trace contains the empty subsequence |

Each now reports `E_ASSERT_INEFFECTIVE`, naming the variant and the responsible field, value-free, with a fix step. A non-empty diagnostics list sets `TestStatus::Fail` (`runner_next/assertions.rs:19-20`), so this is fail-closed.

### And one inversion, which is worse than any no-op

`expect` was compared by exact string equality to `"pass"` at three sites. Every other spelling — `Pass`, `PASS`, `passes`, `true` — silently selected *expect failure*, so a config reading "this must be allowed" went green precisely when the policy rejected it. A no-op stops checking; an inversion checks the opposite. The three comparisons are now one `expected_pass` parser accepting `pass` and `fail` and rejecting the rest as a config error — one function rather than three comparisons, per the rule added in #1957.

### What is deliberately not changed

An empty `sequence` with `allow_other_tools: false` stays a real constraint — it asserts the trace made no named tool call — and a control test pins that distinction so the fix does not over-reject.

## Type of Change
- [x] Bug fix

## Verification

Worktree `/private/tmp/assay-1949-vacuous`, own `CARGO_TARGET_DIR`, branch head `a48f6ae1`.

- [x] Sixteen tests in `crates/assay-core/tests/assertions_vacuity.rs` — ten for the shapes above, plus **four controls**: a unit-mode `args_valid` missing its policy stays diagnosed under its existing code; an effective assertion that holds stays silent; a genuine violation stays a failure rather than being reclassified; an empty exact sequence stays a real constraint. Every new test failed before its change and passes after.
- [x] `cargo test -p assay-core` — **1154 passed, 0 failed**
- [x] `cargo clippy -p assay-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] **Mutation tested, seven bites, all killed.** One survived on the first pass: removing the typed-`test_trace` guard left every test green, because the case fell through to the `test_trace_raw` check which also returns `E_ASSERT_INEFFECTIVE`. The assertion only checked the code, not which field was blamed — and that difference is the whole value of the diagnostic. `933001c3` strengthens it to pin the `field`, and the bite now fails.
- [ ] Demo suite — not applicable

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly — no user-facing docs describe these shapes; two existing docs mismatches are recorded as follow-ups below rather than fixed here.
- [x] I have added tests to cover my changes.

## Follow-ups, deliberately out of scope

Found during an exhaustive walk of the seven variants against their evaluator, recorded so they are not lost:

- `TraceAssertion` has no `deny_unknown_fields`, so a misspelled `test_args` / `min_calls` is dropped at parse time and turns a real check into a no-op. Parse-time change with a compatibility decision attached.
- `evaluate_sequence` uses `is_match`, which is unanchored: `regex: "search"` is satisfied by any superstring. A semantics question, not vacuity.
- Fallback 1 in `agent_assertions/mod.rs` fires on **any** store error, including ambiguous-episode and SQL errors, and is checked before Fallback 2 — so a unit-test-shaped list never consults a recorded trace.
- `docs/architecture/agents.md:114-116` advertises `max_calls: 0`; the field does not exist and is silently ignored.
- `docs/metrics/index.md:12` promises `trace_must_call_tool` counts a **successful** call; `ToolCallRow` has no status column, so errored calls count.
- Layers 2 and 3 of the design note on #1949: an exercised/not-exercised status, and narrow static rejection reusing `validate_args_policy_value` rather than approximating it.

## Non-claims

This does not make the `assertions:` surface complete or safe — it removes ten shapes that could not fail and one that failed backwards. It does not address configuration-level vacuity that only a trace can reveal, which is what layer 2 is for. Verified on one tree; no claim about other branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear diagnostics for ineffective assertion configurations, including missing inputs, empty sequences, zero call minimums, and unusable policies.
  * Invalid expectation values now report configuration errors instead of silently reversing pass/fail behavior.
  * Sequence checks now require a valid policy pattern before evaluation.
  * Assertion inputs are validated explicitly to prevent misleading successful results.

* **Tests**
  * Added comprehensive coverage for invalid, ineffective, passing, and failing assertion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->