### PR TITLE
A disclosed truncation carries the cap it was measured against

### DIFF
--- a/crates/assay-evidence/src/lint/engine.rs
+++ b/crates/assay-evidence/src/lint/engine.rs
@@ -103,6 +103,8 @@ pub fn lint_bundle_with_options<R: Read>(
             verified: true,
             findings,
             summary,
+            truncated,
+            truncated_count,
         },
         pack_meta,
     })

--- a/crates/assay-evidence/src/lint/engine.rs
+++ b/crates/assay-evidence/src/lint/engine.rs
@@ -105,6 +105,7 @@ pub fn lint_bundle_with_options<R: Read>(
             summary,
             truncated,
             truncated_count,
+            applied_cap: max_results,
         },
         pack_meta,
     })

--- a/crates/assay-evidence/src/lint/mod.rs
+++ b/crates/assay-evidence/src/lint/mod.rs
@@ -118,6 +118,16 @@ pub struct LintReport {
     pub verified: bool,
     pub findings: Vec<LintFinding>,
     pub summary: LintSummary,
+    /// Whether `max_results` dropped findings this run.
+    ///
+    /// This lives on the report rather than only in the pack metadata because truncation applies to
+    /// every run, and pack metadata is absent whenever no packs are configured. Carried there alone,
+    /// a default-path run could drop findings and present as if it had none to drop, which is the
+    /// one thing a lint report must never do quietly. `summary` is computed after truncation, so it
+    /// describes what survived and this flag is what says so.
+    pub truncated: bool,
+    /// How many findings were dropped. Zero when `truncated` is false.
+    pub truncated_count: usize,
 }
 
 impl LintReport {

--- a/crates/assay-evidence/src/lint/mod.rs
+++ b/crates/assay-evidence/src/lint/mod.rs
@@ -128,6 +128,11 @@ pub struct LintReport {
     pub truncated: bool,
     /// How many findings were dropped. Zero when `truncated` is false.
     pub truncated_count: usize,
+    /// The `max_results` cap that was in force this run. A disclosed truncation is only actionable
+    /// if a consumer can see the bound it was truncated to, not just how many findings fell past it
+    /// (the review point on OWASP agentic-skills #49): `truncated_count` says how many were
+    /// dropped, `applied_cap` says the ceiling they were dropped against.
+    pub applied_cap: usize,
 }
 
 impl LintReport {

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -348,22 +348,21 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     // A capped run succeeded; it reported less than it found. Flipping this would assert a failure
     // that did not happen.
     //
-    // Where the cap should be disclosed is genuinely unsettled in SARIF, and the honest answer is
-    // that the format has no home for it. Appendix I ("Detecting incomplete result sets",
-    // informative) lists three conditions, and all three describe a tool that failed to *analyse*:
-    // `executionSuccessful` false, an `error`-level notification meaning the tool "was unable to
-    // execute every analysis rule on every analysis target", or `results` being null. A reporting
-    // cap is none of those. It is a serialisation policy chosen before the run, and the tool did
-    // analyse everything.
+    // The cap itself is the deeper problem, and it is worth stating here rather than only in a
+    // commit message. Section 3.14.23 is normative: outside the failed-to-start cases, `results`
+    // "SHALL be present and SHALL contain all results detected by the tool". A configured
+    // `max_results` therefore puts this producer out of conformance whenever it fires. The cap
+    // exists because downstream consumers impose upload limits, so this is a real tension and not
+    // an oversight, but it is a tension the format resolves against us. An earlier version of this
+    // comment claimed SARIF had no home for a reporting cap; that was wrong, and the correction is
+    // that SARIF has a position instead of a gap.
     //
-    // So this emits in both places and claims neither as normative. `run.properties` is the honest
-    // machine-readable home, because a property bag is what the format leaves for conditions it
-    // does not model. The notification is a human-readable aid at `warning`, which deliberately
-    // does not meet Appendix I's `error` gate: raising it to `error` would be worse than silence,
-    // since section 3.20.21 makes an error-level notification mean the run itself failed, which
-    // would contradict the `executionSuccessful: true` directly above and overstate a cap into a
-    // failure. A consumer keying strictly on Appendix I will therefore not see this, and that is a
-    // gap in the format rather than something this producer can close on its own.
+    // Until the cap goes, disclose it in both available places and claim neither as a blessing.
+    // `run.properties` is the machine-readable carrier. The notification is a human-readable aid at
+    // `warning`, which 3.58.6 defines as covering the case where "the analysis might be incomplete
+    // but the results that were generated are probably valid". It stays below Appendix I's `error`
+    // gate deliberately: 3.20.21 makes an error-level notification mean the run failed, and a cap
+    // is not a failed run.
     let mut invocation = json!({
         "executionSuccessful": true
     });

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -318,15 +318,19 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     }
 
     // Build run.properties
+    //
+    // Truncation is read off the report rather than the pack metadata. Both carry it and both are
+    // set from the same values, but pack metadata is absent whenever no packs are configured, so
+    // keying on it meant a default-path run disclosed nothing here at all.
     let mut run_props = serde_json::Map::new();
     if let Some(ref meta) = options.pack_meta {
         if let Some(ref disclaimer) = meta.disclaimer {
             run_props.insert("disclaimer".into(), json!(disclaimer));
         }
-        if meta.truncated {
-            run_props.insert("truncated".into(), json!(true));
-            run_props.insert("truncatedCount".into(), json!(meta.truncated_count));
-        }
+    }
+    if report.truncated {
+        run_props.insert("truncated".into(), json!(true));
+        run_props.insert("truncatedCount".into(), json!(report.truncated_count));
     }
 
     let automation_id = format!(
@@ -338,18 +342,28 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     // Note: workingDirectory is intentionally omitted to avoid leaking local paths
     // (e.g., /Users/... or /home/...). GitHub Code Scanning doesn't require it.
     //
-    // `executionSuccessful` stays true on a truncated run, and that is the spec reading rather than
-    // a convenience. SARIF 2.1.0 section 3.20.14 defines it as the tool having "run to completion
-    // without encountering fatal errors that prevented it from analyzing the full set of specified
-    // targets". Truncation caps what is *reported*, not what was analyzed, so flipping this would
-    // tell a consumer the analysis was cut short when it was not.
+    // `executionSuccessful` stays true on a truncated run. SARIF 2.1.0 section 3.20.14 defines it
+    // as true "if the engineering system that started the process knows that the analysis tool
+    // succeeded", and its own example pairs `executionSuccessful: true` with a non-zero exit code.
+    // A capped run succeeded; it reported less than it found. Flipping this would assert a failure
+    // that did not happen.
     //
-    // The condition still has to reach a consumer somewhere it will look. Appendix I, "Detecting
-    // incomplete result sets", names exactly two places a consumer examines, and the other one is
-    // `toolExecutionNotifications`: conditions to weigh when judging whether the result set is
-    // complete. Truncation is that, so it goes there. Carrying it only in `run.properties`, as this
-    // producer did before, meant the notice existed but sat somewhere no generic consumer reads,
-    // which for a tool that argues a partial scan must not read as a clean one was the wrong place.
+    // Where the cap should be disclosed is genuinely unsettled in SARIF, and the honest answer is
+    // that the format has no home for it. Appendix I ("Detecting incomplete result sets",
+    // informative) lists three conditions, and all three describe a tool that failed to *analyse*:
+    // `executionSuccessful` false, an `error`-level notification meaning the tool "was unable to
+    // execute every analysis rule on every analysis target", or `results` being null. A reporting
+    // cap is none of those. It is a serialisation policy chosen before the run, and the tool did
+    // analyse everything.
+    //
+    // So this emits in both places and claims neither as normative. `run.properties` is the honest
+    // machine-readable home, because a property bag is what the format leaves for conditions it
+    // does not model. The notification is a human-readable aid at `warning`, which deliberately
+    // does not meet Appendix I's `error` gate: raising it to `error` would be worse than silence,
+    // since section 3.20.21 makes an error-level notification mean the run itself failed, which
+    // would contradict the `executionSuccessful: true` directly above and overstate a cap into a
+    // failure. A consumer keying strictly on Appendix I will therefore not see this, and that is a
+    // gap in the format rather than something this producer can close on its own.
     let mut invocation = json!({
         "executionSuccessful": true
     });

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -337,9 +337,40 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     // Build invocations
     // Note: workingDirectory is intentionally omitted to avoid leaking local paths
     // (e.g., /Users/... or /home/...). GitHub Code Scanning doesn't require it.
-    let invocation = json!({
+    //
+    // `executionSuccessful` stays true on a truncated run, and that is the spec reading rather than
+    // a convenience. SARIF 2.1.0 section 3.20.14 defines it as the tool having "run to completion
+    // without encountering fatal errors that prevented it from analyzing the full set of specified
+    // targets". Truncation caps what is *reported*, not what was analyzed, so flipping this would
+    // tell a consumer the analysis was cut short when it was not.
+    //
+    // The condition still has to reach a consumer somewhere it will look. Appendix I, "Detecting
+    // incomplete result sets", names exactly two places a consumer examines, and the other one is
+    // `toolExecutionNotifications`: conditions to weigh when judging whether the result set is
+    // complete. Truncation is that, so it goes there. Carrying it only in `run.properties`, as this
+    // producer did before, meant the notice existed but sat somewhere no generic consumer reads,
+    // which for a tool that argues a partial scan must not read as a clean one was the wrong place.
+    let mut invocation = json!({
         "executionSuccessful": true
     });
+    if report.truncated {
+        invocation.as_object_mut().unwrap().insert(
+            "toolExecutionNotifications".into(),
+            json!([{
+                "descriptor": { "id": "ASSAY-LINT-TRUNCATED" },
+                "level": "warning",
+                "message": {
+                    "text": format!(
+                        "Result set is incomplete: {} finding(s) were dropped by the max_results \
+                         cap. The findings reported here are the highest severity that survived \
+                         the cap; absence of a lower-severity finding does not mean it was absent \
+                         from the bundle.",
+                        report.truncated_count
+                    )
+                }
+            }]),
+        );
+    }
 
     // Build tool.driver
     let mut driver = json!({

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -331,6 +331,9 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     if report.truncated {
         run_props.insert("truncated".into(), json!(true));
         run_props.insert("truncatedCount".into(), json!(report.truncated_count));
+        // The cap the count was measured against. Without it a consumer sees how many findings
+        // fell past the bound but not what the bound was (OWASP agentic-skills #49 review point).
+        run_props.insert("appliedCap".into(), json!(report.applied_cap));
     }
 
     let automation_id = format!(
@@ -374,12 +377,19 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
                 "level": "warning",
                 "message": {
                     "text": format!(
-                        "Result set is incomplete: {} finding(s) were dropped by the max_results \
-                         cap. The findings reported here are the highest severity that survived \
-                         the cap; absence of a lower-severity finding does not mean it was absent \
-                         from the bundle.",
-                        report.truncated_count
+                        "Result set is incomplete: {} finding(s) were dropped by a max_results \
+                         cap of {}. The findings reported here are the highest severity that \
+                         survived the cap; absence of a lower-severity finding does not mean it \
+                         was absent from the bundle.",
+                        report.truncated_count, report.applied_cap
                     )
+                },
+                // The configured limit and the suppressed count as separate machine-readable
+                // fields, so a consumer reconstructs both the ceiling and how many fell past it
+                // without parsing the message text.
+                "properties": {
+                    "appliedCap": report.applied_cap,
+                    "droppedCount": report.truncated_count
                 }
             }]),
         );

--- a/crates/assay-evidence/tests/lint_truncation_disclosure.rs
+++ b/crates/assay-evidence/tests/lint_truncation_disclosure.rs
@@ -5,10 +5,14 @@
 //! findings and present as though it had none to drop. For a tool whose own position is that a
 //! partial scan must not read as a clean one, that was the wrong silence to keep.
 //!
-//! The SARIF half is about placement rather than presence. `run.properties.truncated` is a vendor
-//! extension; SARIF 2.1.0 Appendix I, "Detecting incomplete result sets", names the two places a
-//! consumer actually examines, and `invocations[].toolExecutionNotifications` is the one that
-//! carries conditions bearing on completeness.
+//! The SARIF half is about reach, and about not overclaiming what the format supports. SARIF 2.1.0
+//! has no construct for a reporting cap: Appendix I ("Detecting incomplete result sets",
+//! informative) lists three conditions and every one describes a tool that failed to *analyse*, not
+//! one that reported less than it found. So the cap is disclosed twice and neither is claimed as
+//! normative. `run.properties` is the machine-readable home, now emitted on every path rather than
+//! only when packs are configured. The notification is a human-readable aid at `warning`, which
+//! deliberately misses Appendix I's `error` gate, because per 3.20.21 an error-level notification
+//! means the run failed and a cap is not a failure.
 
 use assay_evidence::bundle::BundleWriter;
 use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions};
@@ -80,10 +84,12 @@ fn an_untruncated_run_reports_no_truncation() {
     assert_eq!(report.truncated_count, 0);
 }
 
-/// Placement, not presence. A generic consumer reads Appendix I's two indicators, so the notice has
-/// to be one of them rather than a vendor property it has no reason to know about.
+/// The notification exists and carries the count. This does NOT claim Appendix I coverage: at
+/// `warning` it sits below that appendix's `error` gate, deliberately, since `error` would mean the
+/// run failed. What it pins is that the notice is emitted and is legible to a consumer that reads
+/// notifications rather than only Appendix I's three conditions.
 #[test]
-fn truncation_reaches_sarif_where_a_consumer_examines_completeness() {
+fn truncation_is_announced_in_a_tool_execution_notification() {
     let bundle = bundle_with_many_findings(10);
     let report = lint_capped(&bundle, Some(3));
     let sarif = to_sarif(&report);
@@ -109,9 +115,9 @@ fn truncation_reaches_sarif_where_a_consumer_examines_completeness() {
 }
 
 /// The spec reading, pinned so it cannot be "fixed" into a plausible mistake later. SARIF 2.1.0
-/// 3.20.14 ties `executionSuccessful` to whether the tool analyzed the full set of specified
-/// targets. Truncation caps what is reported, not what was analyzed, so this stays true and the
-/// completeness signal travels in the notification instead.
+/// 3.20.14 makes `executionSuccessful` true when the engineering system knows the tool succeeded,
+/// and its own example pairs true with a non-zero exit code. A capped run succeeded; it reported
+/// less than it found.
 #[test]
 fn truncation_does_not_claim_the_analysis_failed() {
     let bundle = bundle_with_many_findings(10);
@@ -135,5 +141,38 @@ fn an_untruncated_run_carries_no_notification() {
             .get("toolExecutionNotifications")
             .is_none(),
         "a complete run must not carry an incompleteness notice, or the notice means nothing"
+    );
+}
+
+/// The machine-readable half, which was the actual regression: `run.properties` used to be gated on
+/// pack metadata, so a default-path run disclosed nothing there.
+#[test]
+fn truncation_reaches_run_properties_without_packs() {
+    let bundle = bundle_with_many_findings(10);
+    let report = lint_capped(&bundle, Some(3));
+    let sarif = to_sarif(&report);
+
+    let props = &sarif["runs"][0]["properties"];
+    assert_eq!(
+        props["truncated"], true,
+        "no packs were configured: {props}"
+    );
+    assert_eq!(props["truncatedCount"], report.truncated_count);
+}
+
+/// Appendix I's notification condition gates on `level == "error"`, and 3.20.21 makes that mean the
+/// run failed. A cap is not a failure, so this must stay below that gate. Pinned because raising it
+/// looks like a fix and would contradict `executionSuccessful` three lines away.
+#[test]
+fn the_truncation_notice_does_not_assert_a_failed_run() {
+    let bundle = bundle_with_many_findings(10);
+    let report = lint_capped(&bundle, Some(3));
+    let sarif = to_sarif(&report);
+
+    let level = &sarif["runs"][0]["invocations"][0]["toolExecutionNotifications"][0]["level"];
+    assert_eq!(level, "warning");
+    assert_ne!(
+        level, "error",
+        "error would declare the run failed (3.20.21)"
     );
 }

--- a/crates/assay-evidence/tests/lint_truncation_disclosure.rs
+++ b/crates/assay-evidence/tests/lint_truncation_disclosure.rs
@@ -112,6 +112,18 @@ fn truncation_is_announced_in_a_tool_execution_notification() {
         text.contains(&report.truncated_count.to_string()),
         "the notice must carry how many were dropped: {text}"
     );
+    // OWASP agentic-skills #49 review point: a disclosed truncation is only actionable if the
+    // consumer can see the ceiling, not just the overflow. The cap travels as a machine-readable
+    // field and in the message, so a consumer reconstructs both without parsing prose.
+    assert!(
+        text.contains(&report.applied_cap.to_string()),
+        "the notice must name the cap the count was measured against: {text}"
+    );
+    assert_eq!(notifications[0]["properties"]["appliedCap"], 3);
+    assert_eq!(
+        notifications[0]["properties"]["droppedCount"],
+        report.truncated_count
+    );
 }
 
 /// The spec reading, pinned so it cannot be "fixed" into a plausible mistake later. SARIF 2.1.0
@@ -158,6 +170,10 @@ fn truncation_reaches_run_properties_without_packs() {
         "no packs were configured: {props}"
     );
     assert_eq!(props["truncatedCount"], report.truncated_count);
+    assert_eq!(
+        props["appliedCap"], 3,
+        "the run properties carry the configured ceiling, not only the overflow: {props}"
+    );
 }
 
 /// Appendix I's notification condition gates on `level == "error"`, and 3.20.21 makes that mean the

--- a/crates/assay-evidence/tests/lint_truncation_disclosure.rs
+++ b/crates/assay-evidence/tests/lint_truncation_disclosure.rs
@@ -1,0 +1,139 @@
+//! A truncated lint run has to say so, on every path and where a consumer looks.
+//!
+//! `max_results` applies to every run, but the truncation flags used to be recorded only in the
+//! pack metadata, which is absent whenever no packs are configured. On that path a run could drop
+//! findings and present as though it had none to drop. For a tool whose own position is that a
+//! partial scan must not read as a clean one, that was the wrong silence to keep.
+//!
+//! The SARIF half is about placement rather than presence. `run.properties.truncated` is a vendor
+//! extension; SARIF 2.1.0 Appendix I, "Detecting incomplete result sets", names the two places a
+//! consumer actually examines, and `invocations[].toolExecutionNotifications` is the one that
+//! carries conditions bearing on completeness.
+
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions};
+use assay_evidence::lint::sarif::to_sarif;
+use assay_evidence::types::EvidenceEvent;
+use assay_evidence::VerifyLimits;
+use chrono::{TimeZone, Utc};
+use std::io::Cursor;
+
+/// Events that each trip a built-in rule, so findings outnumber a small cap.
+fn bundle_with_many_findings(n: u64) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    for seq in 0..n {
+        let mut event = EvidenceEvent::new(
+            "assay.net.connect",
+            "urn:assay:test",
+            "run_truncation",
+            seq,
+            serde_json::json!({"url": "https://api.example.com"}),
+        );
+        event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+        event = event.with_subject(format!(
+            "https://api.example.com?api_key=sk-{seq:016}abcdef"
+        ));
+        writer.add_event(event);
+    }
+    writer.finish().unwrap();
+    buffer
+}
+
+fn lint_capped(bundle: &[u8], max_results: Option<usize>) -> assay_evidence::lint::LintReport {
+    lint_bundle_with_options(
+        Cursor::new(bundle),
+        VerifyLimits::default(),
+        LintOptions {
+            packs: Vec::new(),
+            max_results,
+            bundle_path: None,
+        },
+    )
+    .expect("lint should succeed")
+    .report
+}
+
+/// The root case: no packs configured, so nothing else could have carried this.
+#[test]
+fn a_truncated_default_path_run_records_it_on_the_report() {
+    let bundle = bundle_with_many_findings(10);
+    let report = lint_capped(&bundle, Some(3));
+
+    assert!(
+        report.truncated,
+        "a run that dropped findings must say so even with no packs configured"
+    );
+    assert_eq!(report.findings.len(), 3, "the cap still applies");
+    assert!(
+        report.truncated_count > 0,
+        "the count of dropped findings must be reported, not just the fact"
+    );
+}
+
+#[test]
+fn an_untruncated_run_reports_no_truncation() {
+    let bundle = bundle_with_many_findings(3);
+    let report = lint_capped(&bundle, Some(5000));
+
+    assert!(!report.truncated, "nothing was dropped");
+    assert_eq!(report.truncated_count, 0);
+}
+
+/// Placement, not presence. A generic consumer reads Appendix I's two indicators, so the notice has
+/// to be one of them rather than a vendor property it has no reason to know about.
+#[test]
+fn truncation_reaches_sarif_where_a_consumer_examines_completeness() {
+    let bundle = bundle_with_many_findings(10);
+    let report = lint_capped(&bundle, Some(3));
+    let sarif = to_sarif(&report);
+
+    let invocation = &sarif["runs"][0]["invocations"][0];
+    let notifications = invocation["toolExecutionNotifications"]
+        .as_array()
+        .expect("a truncated run must carry a tool execution notification");
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0]["descriptor"]["id"], "ASSAY-LINT-TRUNCATED");
+    assert_eq!(notifications[0]["level"], "warning");
+    let text = notifications[0]["message"]["text"]
+        .as_str()
+        .expect("message text");
+    assert!(
+        text.contains("incomplete"),
+        "the notice must name the condition in the consumer's vocabulary: {text}"
+    );
+    assert!(
+        text.contains(&report.truncated_count.to_string()),
+        "the notice must carry how many were dropped: {text}"
+    );
+}
+
+/// The spec reading, pinned so it cannot be "fixed" into a plausible mistake later. SARIF 2.1.0
+/// 3.20.14 ties `executionSuccessful` to whether the tool analyzed the full set of specified
+/// targets. Truncation caps what is reported, not what was analyzed, so this stays true and the
+/// completeness signal travels in the notification instead.
+#[test]
+fn truncation_does_not_claim_the_analysis_failed() {
+    let bundle = bundle_with_many_findings(10);
+    let report = lint_capped(&bundle, Some(3));
+    let sarif = to_sarif(&report);
+
+    assert_eq!(
+        sarif["runs"][0]["invocations"][0]["executionSuccessful"], true,
+        "a capped report is still a completed analysis"
+    );
+}
+
+#[test]
+fn an_untruncated_run_carries_no_notification() {
+    let bundle = bundle_with_many_findings(3);
+    let report = lint_capped(&bundle, Some(5000));
+    let sarif = to_sarif(&report);
+
+    assert!(
+        sarif["runs"][0]["invocations"][0]
+            .get("toolExecutionNotifications")
+            .is_none(),
+        "a complete run must not carry an incompleteness notice, or the notice means nothing"
+    );
+}


### PR DESCRIPTION
Lands the SARIF truncation-disclosure work, and closes the one gap a reviewer named on it.

## Background

On OWASP [www-project-agentic-skills-top-10#49](https://github.com/OWASP/www-project-agentic-skills-top-10/pull/49) this lint producer became the worked example of the emitter side of a rule the PR states for consumers: an incomplete scan must not read as a clean one. The disclosure fix (three commits here) made a truncated run say so, in both places SARIF 2.1.0 Appendix I tells a consumer to look. Those commits had only ever landed on an unmerged branch; this brings them to main.

## The gap this closes

The disclosure named **how many** findings were dropped, not the **ceiling** they were dropped against. A consumer could see the overflow and not the bound. `applied_cap` now travels on `LintReport` beside `truncated_count`, and both carriers report it:

- `invocations[].toolExecutionNotifications[]`: the message names the cap, and `properties.appliedCap` / `properties.droppedCount` are separate machine-readable fields.
- `run.properties`: `appliedCap` beside the existing `truncated` / `truncatedCount`.

So a consumer reconstructs both the ceiling and the overflow without parsing prose.

## What does not change

Conformance. A capped run is still non-conformant on `results` per §3.14.23; `executionSuccessful` still stays `true` per §3.20.14 (the analysis completed, the report was capped); the notification stays at `warning`, below Appendix I's `error` gate. This makes the disclosure of the cap complete, it does not bless the cap.

## Verification

| Gate | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo test -p assay-evidence` | 610 passed, 0 failed |
| `cargo fmt --all --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)