### PR TITLE
Make the lint report and summary #[non_exhaustive]

### DIFF
--- a/crates/assay-evidence/src/lint/mod.rs
+++ b/crates/assay-evidence/src/lint/mod.rs
@@ -103,7 +103,10 @@ impl LintFinding {
     }
 }
 
+/// `#[non_exhaustive]`: constructed only inside this crate (`compute_summary`), and a new severity
+/// bucket should be an additive change, not a breaking one for a downstream that reads it.
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct LintSummary {
     pub total: usize,
     pub errors: usize,
@@ -111,7 +114,13 @@ pub struct LintSummary {
     pub infos: usize,
 }
 
+/// `#[non_exhaustive]`: this report grows as new disclosure fields are added (`truncated`,
+/// `truncated_count`, `applied_cap` arrived incrementally, and more will), and it is constructed
+/// only inside this crate. Marking it non-exhaustive stops each such addition from being a
+/// breaking change for a downstream that constructs or exhaustively destructures it; consumers
+/// read fields and must accept that unlisted ones may exist. Raised on Rul1an/assay#1962.
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct LintReport {
     pub tool_version: String,
     pub bundle_meta: Manifest,

--- a/crates/assay-evidence/src/lint/mod.rs
+++ b/crates/assay-evidence/src/lint/mod.rs
@@ -103,8 +103,10 @@ impl LintFinding {
     }
 }
 
-/// `#[non_exhaustive]`: constructed only inside this crate (`compute_summary`), and a new severity
-/// bucket should be an additive change, not a breaking one for a downstream that reads it.
+/// A lint run's finding counts by severity.
+///
+/// Non-exhaustive: this type may gain fields in future releases, so construct it through this
+/// crate rather than a struct literal, and match it with `..`.
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct LintSummary {
@@ -114,11 +116,11 @@ pub struct LintSummary {
     pub infos: usize,
 }
 
-/// `#[non_exhaustive]`: this report grows as new disclosure fields are added (`truncated`,
-/// `truncated_count`, `applied_cap` arrived incrementally, and more will), and it is constructed
-/// only inside this crate. Marking it non-exhaustive stops each such addition from being a
-/// breaking change for a downstream that constructs or exhaustively destructures it; consumers
-/// read fields and must accept that unlisted ones may exist. Raised on Rul1an/assay#1962.
+/// The result of a lint run: the verified bundle, its findings, and disclosure fields describing
+/// how complete the run was.
+///
+/// Non-exhaustive: this type may gain fields in future releases, so construct it through this
+/// crate rather than a struct literal, and match it with `..`.
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct LintReport {


### PR DESCRIPTION
Follow-up to Copilot's semver note on #1962.

## What

`LintReport` and `LintSummary` are now `#[non_exhaustive]`. `LintReport` grows as disclosure fields are added — `truncated`, `truncated_count`, `applied_cap` arrived one at a time and more will — and each addition is a breaking change for a downstream that constructs the struct with a literal or destructures it exhaustively. `#[non_exhaustive]` makes future additions additive instead. `LintSummary` gets it on the same reasoning: a new severity bucket should not be a break.

Scoped to the two types constructed only inside this crate (`engine.rs`). In-crate construction is unaffected. `LintFinding` is left exhaustive: it has external pack construction sites and a `new()` constructor, so non_exhaustive there is a separate, larger decision.

## The deferral was wrong, and here is the proof

The reply on #1962 said this had to wait for a coordinated major bump, because `struct_now_non_exhaustive` is a major lint that would fail the Wave 0 semver gate. That was based on assuming the gate baselines near the current version. It does not: it baselines against `9cc23b4c` (v2.18.0) while the workspace is at 3.37.0. cargo-semver-checks sees a major change already present and authorizes breaking changes against that baseline.

Verified by running the gate exactly as CI does:

```
cargo semver-checks check-release -p assay-evidence --baseline-rev 9cc23b4c684be7cfd81f170c4f66d59903dd76eb
  Checking assay-evidence v2.18.0 -> v3.37.0 (major change)
  Summary no semver update required
  exit 0
```

## Verification

| Gate | Result |
|---|---|
| `cargo semver-checks check-release -p assay-evidence --baseline-rev 9cc23b4c…` | exit 0, no update required |
| `cargo clippy -p assay-evidence --all-targets -- -D warnings` | 0 warnings |
| `cargo test -p assay-evidence` | 610 passed, 0 failed |
| `cargo fmt --all --check` | clean |

Closes the follow-up spawned from #1962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that lint summary and report structures may evolve over time.
  * Improved guidance around constructing and using lint result data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->