### PR TITLE
One DSSE PAE, because two of them are two definitions of a signature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,10 +131,17 @@ Leaf crates (no internal dependencies): `assay-common`, `assay-canonical`, `assa
 
 No circular dependencies. All dependencies flow in one direction.
 
-`assay-evidence -> assay-common` carries only the bounded-ingest primitive
-(`assay_common::limits::LimitReader`, ADR-043 §1), shared with the replay verifier in
-`assay-core` so both apply one ceiling mechanism. Limit *vocabularies* stay domain-local:
-`VerifyLimits` describes an evidence bundle and does not travel.
+`assay-evidence -> assay-common` carries two shared primitives, and the test for admitting one
+is the same in both cases: a mechanism whose second implementation would silently mean something
+different. The bounded-ingest primitive (`assay_common::limits::LimitReader`, ADR-043 §1) is
+shared with the replay verifier in `assay-core` so both apply one ceiling. `assay_common::dsse`
+holds the DSSE Pre-Authentication Encoding for the same reason: PAE defines what a signature
+covers, so two constructions of it are two definitions of what a signature means, and both
+`assay-evidence`'s mandate signing and `assay-core`'s MCP signing call it.
+
+Vocabularies still stay domain-local. `VerifyLimits` describes an evidence bundle and does not
+travel; neither does a payload type or a key policy. What travels is the construction, never the
+domain's reading of it.
 
 ## assay-sim (Attack Simulation)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,10 @@ holds the DSSE Pre-Authentication Encoding for the same reason: PAE defines what
 covers, so two constructions of it are two definitions of what a signature means, and both
 `assay-evidence`'s mandate signing and `assay-core`'s MCP signing call it.
 
+`assay-registry` carries four PAE copies of its own and is deliberately not folded in: it is a
+leaf crate with no internal dependencies, so sharing would give it a new edge, which is an
+architecture decision rather than a refactor. The shared module says so in its own docs.
+
 Vocabularies still stay domain-local. `VerifyLimits` describes an evidence bundle and does not
 travel; neither does a payload type or a key policy. What travels is the construction, never the
 domain's reading of it.

--- a/crates/assay-common/src/dsse.rs
+++ b/crates/assay-common/src/dsse.rs
@@ -1,0 +1,91 @@
+//! DSSE Pre-Authentication Encoding, in one place.
+//!
+//! std-only, like [`crate::limits`]: it allocates.
+//!
+//! PAE is what a DSSE signature is actually taken over, so two implementations
+//! of it are two definitions of what a signature means. They had been
+//! byte-identical, which is the state a drift starts from rather than a defence
+//! against one: nothing failed if one of them gained a space, a different length
+//! encoding, or a non-ASCII payload type handled another way, until a signature
+//! made by one side stopped verifying on the other.
+//!
+//! There were two copies before this module, in `assay-evidence`'s mandate
+//! signing and in `assay-core`'s MCP signing, and a third was about to be
+//! written for a run-end seal. Both now call this.
+
+use std::string::ToString;
+use std::vec::Vec;
+
+/// Build the DSSE Pre-Authentication Encoding.
+///
+/// ```text
+/// PAE(type, payload) = "DSSEv1" SP LEN(type) SP type SP LEN(payload) SP payload
+/// ```
+///
+/// Lengths are the byte lengths of the UTF-8 `payload_type` and of the raw
+/// `payload`, rendered in decimal ASCII. The payload is appended verbatim: it is
+/// never re-canonicalized here, because a caller that signs re-serialized bytes
+/// signs something the verifier does not hold.
+///
+/// ```
+/// # use assay_common::dsse::build_pae;
+/// assert_eq!(
+///     build_pae("application/vnd.in-toto+json", b"{}"),
+///     b"DSSEv1 28 application/vnd.in-toto+json 2 {}".to_vec()
+/// );
+/// ```
+pub fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
+    let type_len = payload_type.len().to_string();
+    let payload_len = payload.len().to_string();
+
+    let mut pae = Vec::new();
+    pae.extend_from_slice(b"DSSEv1 ");
+    pae.extend_from_slice(type_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_type.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload);
+    pae
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_pae;
+
+    #[test]
+    fn empty_payload_and_type_still_carry_their_separators() {
+        assert_eq!(build_pae("", b""), b"DSSEv1 0  0 ".to_vec());
+    }
+
+    /// The lengths are byte lengths, not character counts. A multi-byte payload
+    /// type is where the two diverge, and a verifier reading character counts
+    /// would accept a different framing for the same bytes.
+    #[test]
+    fn lengths_count_bytes_rather_than_characters() {
+        let ty = "café/json"; // 9 chars, 10 bytes
+        assert_eq!(ty.chars().count(), 9);
+        let pae = build_pae(ty, b"x");
+        assert!(
+            pae.starts_with(b"DSSEv1 10 "),
+            "type length must be the byte length: {:?}",
+            std::str::from_utf8(&pae[..14]).unwrap()
+        );
+    }
+
+    /// A payload carrying the separator byte must not be able to restructure the
+    /// encoding, which is the property the length prefixes exist for.
+    #[test]
+    fn payload_containing_spaces_does_not_reframe_the_encoding() {
+        let pae = build_pae("t", b"a b c");
+        assert_eq!(pae, b"DSSEv1 1 t 5 a b c".to_vec());
+    }
+
+    /// Raw bytes are appended verbatim, including bytes that are not valid UTF-8.
+    #[test]
+    fn payload_is_not_required_to_be_utf8() {
+        let pae = build_pae("t", &[0xff, 0xfe]);
+        assert_eq!(pae, b"DSSEv1 1 t 2 \xff\xfe".to_vec());
+    }
+}

--- a/crates/assay-common/src/dsse.rs
+++ b/crates/assay-common/src/dsse.rs
@@ -1,17 +1,23 @@
-//! DSSE Pre-Authentication Encoding, in one place.
+//! DSSE Pre-Authentication Encoding, for the crates that share this one.
 //!
 //! std-only, like [`crate::limits`]: it allocates.
 //!
 //! PAE is what a DSSE signature is actually taken over, so two implementations
-//! of it are two definitions of what a signature means. They had been
-//! byte-identical, which is the state a drift starts from rather than a defence
-//! against one: nothing failed if one of them gained a space, a different length
-//! encoding, or a non-ASCII payload type handled another way, until a signature
-//! made by one side stopped verifying on the other.
+//! of it are two definitions of what a signature covers. Byte-identical copies
+//! are where a drift starts rather than a defence against one: nothing fails if
+//! one gains a space, renders a length differently, or handles a non-ASCII
+//! payload type another way, until a signature made by one side stops verifying
+//! on the other.
 //!
-//! There were two copies before this module, in `assay-evidence`'s mandate
-//! signing and in `assay-core`'s MCP signing, and a third was about to be
-//! written for a run-end seal. Both now call this.
+//! Scope, stated exactly because an earlier version of this comment claimed the
+//! workspace had two copies and it has six. `assay-evidence`'s mandate signing
+//! and `assay-core`'s MCP signing call this. `assay-registry` carries four more
+//! of its own, in `dsse`, `sigstore_bundle`, `supply_chain::provenance` and
+//! `verify_internal::dsse`, and they are not consolidated here: that crate has
+//! no internal dependencies at all, so folding them in means giving a leaf crate
+//! a new edge, which is an architecture decision rather than a refactor. This
+//! module is one construction for the crates that already share it, not one for
+//! the workspace.
 
 use std::string::ToString;
 use std::vec::Vec;
@@ -67,10 +73,13 @@ mod tests {
         let ty = "café/json"; // 9 chars, 10 bytes
         assert_eq!(ty.chars().count(), 9);
         let pae = build_pae(ty, b"x");
+        // The diagnostic must not decode: a fixed-width slice of a PAE carrying a
+        // multi-byte payload type can land mid-codepoint, and a panicking failure
+        // message hides the assertion it was written to explain.
         assert!(
             pae.starts_with(b"DSSEv1 10 "),
-            "type length must be the byte length: {:?}",
-            std::str::from_utf8(&pae[..14]).unwrap()
+            "type length must be the byte length, got prefix {:?}",
+            &pae[..pae.len().min(14)]
         );
     }
 

--- a/crates/assay-common/src/lib.rs
+++ b/crates/assay-common/src/lib.rs
@@ -10,6 +10,11 @@ pub mod exports;
 /// Bounded ingest primitive (ADR-043 §1). std-only: it is an `io::Read` adapter.
 pub mod limits;
 
+/// DSSE Pre-Authentication Encoding. std-only: it allocates. Shared because two
+/// implementations of PAE are two definitions of what a signature covers.
+#[cfg(feature = "std")]
+pub mod dsse;
+
 pub const EVENT_OPENAT: u32 = 1;
 pub const EVENT_CONNECT: u32 = 2;
 pub const EVENT_FORK: u32 = 3;

--- a/crates/assay-core/src/mcp/signing.rs
+++ b/crates/assay-core/src/mcp/signing.rs
@@ -119,23 +119,10 @@ fn key_to_spki_der(key: &VerifyingKey) -> Result<Vec<u8>> {
 
 /// Build DSSE Pre-Authentication Encoding (PAE).
 ///
-/// ```text
-/// PAE(type, payload) = "DSSEv1" SP LEN(type) SP type SP LEN(payload) SP payload
-/// ```
+/// Delegates to [`assay_common::dsse::build_pae`], which `assay-evidence` also
+/// calls. PAE defines what a signature covers, so one construction serves both.
 fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
-    let type_len = payload_type.len().to_string();
-    let payload_len = payload.len().to_string();
-
-    let mut pae = Vec::new();
-    pae.extend_from_slice(b"DSSEv1 ");
-    pae.extend_from_slice(type_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_type.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload);
-    pae
+    assay_common::dsse::build_pae(payload_type, payload)
 }
 
 /// Remove x-assay-sig field from tool JSON.

--- a/crates/assay-evidence/src/mandate/signing.rs
+++ b/crates/assay-evidence/src/mandate/signing.rs
@@ -114,23 +114,12 @@ fn key_to_spki_der(key: &VerifyingKey) -> Result<Vec<u8>> {
 
 /// Build DSSE Pre-Authentication Encoding (PAE).
 ///
-/// ```text
-/// PAE(type, payload) = "DSSEv1" SP LEN(type) SP type SP LEN(payload) SP payload
-/// ```
+/// Delegates to [`assay_common::dsse::build_pae`]. PAE defines what a signature
+/// covers, so this crate and `assay-core` must not carry separate constructions
+/// of it; they did, byte-identically, which is where a drift starts rather than
+/// where it is prevented.
 pub(crate) fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
-    let type_len = payload_type.len().to_string();
-    let payload_len = payload.len().to_string();
-
-    let mut pae = Vec::new();
-    pae.extend_from_slice(b"DSSEv1 ");
-    pae.extend_from_slice(type_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_type.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload);
-    pae
+    assay_common::dsse::build_pae(payload_type, payload)
 }
 
 /// Sign a mandate.


### PR DESCRIPTION
## Why

PAE is what a DSSE signature is taken over, so a second construction of it is a second answer to what a signature covers. `assay-evidence`'s mandate signing and `assay-core`'s MCP signing each carried one, **byte-identical**.

Byte-identical is where a drift starts, not a defence against one. Nothing fails if one side gains a space, renders a length differently, or handles a non-ASCII payload type another way — until a signature made by one stops verifying on the other.

## Scope, stated exactly

An earlier version of this description said the workspace had two copies and that this fixed it before a third appeared. **That was wrong, and review caught it.** The workspace has six. `assay-registry` carries four of its own, in `dsse`, `sigstore_bundle`, `supply_chain::provenance` and `verify_internal::dsse`. The claim came from a grep truncated at five results.

So this PR is scoped honestly rather than rescoped: `assay_common::dsse::build_pae` is one construction **for the two crates that already depend on `assay-common`**, not one for the workspace. `assay-registry` stays out deliberately — it is a leaf crate with no internal dependencies, so folding it in gives it a new edge, which is an architecture decision and not a refactor to make in passing. The module docs and `CLAUDE.md` both say so.

## What changes

Both call sites delegate. The module lives in `assay-common` because both crates already depend on it, and is std-gated for the same reason `limits` is: it allocates.

Tests pin properties the two copies happened to share and neither stated:

- lengths are **byte** lengths, not character counts — where a multi-byte payload type would have split them
- a payload containing the separator byte cannot restructure the encoding, which is what the length prefixes are for
- the payload is appended verbatim, including bytes that are not valid UTF-8

## Review fixes

- The count and scope above.
- Removed a roadmap sentence about a future seal from public rustdoc.
- Fixed a test whose *failure diagnostic* sliced a fixed 14 bytes of a PAE carrying a multi-byte payload type and decoded them: on failure that panics mid-codepoint and hides the assertion it exists to explain. Both reviewers caught this independently.

## Gates

| | |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 warnings |
| `cargo test -p assay-common -p assay-evidence -p assay-core` | 1787 passed, 0 failed |
| `cargo fmt --all` | clean |

No behaviour change: the emitted bytes are identical, which the existing signing tests cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)