### PR TITLE
One PAE for assay-registry, and a test copy kept on purpose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,13 @@ holds the DSSE Pre-Authentication Encoding for the same reason: PAE defines what
 covers, so two constructions of it are two definitions of what a signature means, and both
 `assay-evidence`'s mandate signing and `assay-core`'s MCP signing call it.
 
-`assay-registry` carries four PAE copies of its own and is deliberately not folded in: it is a
-leaf crate with no internal dependencies, so sharing would give it a new edge, which is an
-architecture decision rather than a refactor. The shared module says so in its own docs.
+`assay-registry` keeps its own PAE in `assay_registry::pae` and is deliberately not folded in: it
+is a leaf crate with no internal dependencies, so sharing would give it a new edge, which is an
+architecture decision rather than a refactor. It had three production copies, collapsed into that
+one module; an earlier version of this paragraph said four, which counted a test helper in
+`sigstore_bundle` that is intentionally left standing. That helper builds a PAE, signs it, and
+asserts the production verifier accepts it, so it is an independent construction rather than a
+duplicate: sharing it would leave the tests signing with the same code they verify with.
 
 Vocabularies still stay domain-local. `VerifyLimits` describes an evidence bundle and does not
 travel; neither does a payload type or a key policy. What travels is the construction, never the

--- a/crates/assay-common/src/dsse.rs
+++ b/crates/assay-common/src/dsse.rs
@@ -9,15 +9,15 @@
 //! payload type another way, until a signature made by one side stops verifying
 //! on the other.
 //!
-//! Scope, stated exactly because an earlier version of this comment claimed the
-//! workspace had two copies and it has six. `assay-evidence`'s mandate signing
-//! and `assay-core`'s MCP signing call this. `assay-registry` carries four more
-//! of its own, in `dsse`, `sigstore_bundle`, `supply_chain::provenance` and
-//! `verify_internal::dsse`, and they are not consolidated here: that crate has
-//! no internal dependencies at all, so folding them in means giving a leaf crate
-//! a new edge, which is an architecture decision rather than a refactor. This
-//! module is one construction for the crates that already share it, not one for
-//! the workspace.
+//! Scope, stated exactly because an earlier version of this comment miscounted
+//! twice. `assay-evidence`'s mandate signing and `assay-core`'s MCP signing call
+//! this. `assay-registry` keeps its own in `assay_registry::pae`, collapsed there
+//! from three production copies, and is not folded in here: that crate has no
+//! internal dependencies at all, so giving a leaf crate its first edge is an
+//! architecture decision rather than a refactor. It also keeps one PAE in its
+//! `sigstore_bundle` tests on purpose, as an independent construction that would
+//! catch this one drifting. So this module is one construction for the crates
+//! that already share it, not one for the workspace.
 
 use std::string::ToString;
 use std::vec::Vec;
@@ -44,7 +44,13 @@ pub fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
     let type_len = payload_type.len().to_string();
     let payload_len = payload.len().to_string();
 
-    let mut pae = Vec::new();
+    // Preallocated: the exact size is known, and PAE is built for every signature
+    // and every verification. `dsse::dsse_pae` carried this before the collapse
+    // and the shared one dropped it, which is the kind of regression a
+    // consolidation is otherwise free of.
+    let mut pae = Vec::with_capacity(
+        7 + type_len.len() + 1 + payload_type.len() + 1 + payload_len.len() + 1 + payload.len(),
+    );
     pae.extend_from_slice(b"DSSEv1 ");
     pae.extend_from_slice(type_len.as_bytes());
     pae.push(b' ');

--- a/crates/assay-registry/src/dsse.rs
+++ b/crates/assay-registry/src/dsse.rs
@@ -57,17 +57,10 @@ struct SignatureIn {
 /// Build the DSSE v1 Pre-Authentication Encoding:
 /// `"DSSEv1" SP LEN(payloadType) SP payloadType SP LEN(payload) SP payload`, where SP is a single ASCII
 /// space and LEN is the ASCII-decimal byte length. The signature is computed over exactly these bytes.
+/// Delegates to [`crate::pae::build_pae`]. See that module for why one
+/// construction serves this crate.
 fn dsse_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
-    let mut pae = Vec::with_capacity(payload.len() + payload_type.len() + 32);
-    pae.extend_from_slice(b"DSSEv1 ");
-    pae.extend_from_slice(payload_type.len().to_string().as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_type.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload.len().to_string().as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload);
-    pae
+    crate::pae::build_pae(payload_type, payload)
 }
 
 /// Verify a DSSE envelope over an in-toto Statement, fully offline, using the public key in `leaf_der`.

--- a/crates/assay-registry/src/lib.rs
+++ b/crates/assay-registry/src/lib.rs
@@ -50,6 +50,10 @@ pub mod cache;
 pub mod canonicalize;
 pub mod client;
 mod digest;
+/// One DSSE PAE for this crate; see the module docs for why it is not shared
+/// with `assay-common` yet.
+pub(crate) mod pae;
+
 pub mod dsse;
 pub mod error;
 pub mod lockfile;

--- a/crates/assay-registry/src/pae.rs
+++ b/crates/assay-registry/src/pae.rs
@@ -33,7 +33,13 @@ pub(crate) fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
     let type_len = payload_type.len().to_string();
     let payload_len = payload.len().to_string();
 
-    let mut pae = Vec::new();
+    // Preallocated: the exact size is known, and PAE is built for every signature
+    // and every verification. `dsse::dsse_pae` carried this before the collapse
+    // and the shared one dropped it, which is the kind of regression a
+    // consolidation is otherwise free of.
+    let mut pae = Vec::with_capacity(
+        7 + type_len.len() + 1 + payload_type.len() + 1 + payload_len.len() + 1 + payload.len(),
+    );
     pae.extend_from_slice(b"DSSEv1 ");
     pae.extend_from_slice(type_len.as_bytes());
     pae.push(b' ');

--- a/crates/assay-registry/src/pae.rs
+++ b/crates/assay-registry/src/pae.rs
@@ -1,0 +1,83 @@
+//! DSSE Pre-Authentication Encoding, once for this crate.
+//!
+//! PAE is what a DSSE signature is taken over, so a second construction of it is
+//! a second answer to what a signature covers. This crate had three, in `dsse`,
+//! `supply_chain::provenance` and `verify::verify_internal::dsse`, all
+//! behaviourally identical. Identical is where a drift starts rather than a
+//! defence against one: nothing fails if one gains a space, renders a length
+//! differently, or handles a non-ASCII payload type another way, until a
+//! signature made by one path stops verifying on another.
+//!
+//! Why here and not `assay_common::dsse`, which holds the same construction for
+//! `assay-evidence` and `assay-core`: this crate has no internal dependencies at
+//! all, and giving a leaf crate its first edge is an architecture decision
+//! rather than a refactor. Sharing across that line is worth doing and is worth
+//! deciding on its own terms; nothing about it needs to block collapsing three
+//! copies into one inside a crate that already builds without it.
+
+/// Build the DSSE Pre-Authentication Encoding.
+///
+/// ```text
+/// PAE(type, payload) = "DSSEv1" SP LEN(type) SP type SP LEN(payload) SP payload
+/// ```
+///
+/// Lengths are the byte lengths of the UTF-8 `payload_type` and of the raw
+/// `payload`, in decimal ASCII. DSSE v1.0.0 defines the type input as a byte
+/// sequence, `PAE(UTF8(PAYLOAD_TYPE), SERIALIZED_BODY)`; taking `&str` here is
+/// deliberately stricter, since a payload type that is not valid UTF-8 cannot be
+/// constructed rather than being encoded and rejected later.
+///
+/// The payload is appended verbatim and never re-serialized: a caller that signs
+/// re-canonicalized bytes signs something the verifier does not hold.
+pub(crate) fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
+    let type_len = payload_type.len().to_string();
+    let payload_len = payload.len().to_string();
+
+    let mut pae = Vec::new();
+    pae.extend_from_slice(b"DSSEv1 ");
+    pae.extend_from_slice(type_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_type.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload);
+    pae
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_pae;
+
+    /// The vector from the DSSE specification's own worked example shape: the
+    /// lengths bracket each field, so nothing inside either can restructure the
+    /// encoding.
+    #[test]
+    fn separators_are_bracketed_by_lengths() {
+        assert_eq!(build_pae("t", b"a b c"), b"DSSEv1 1 t 5 a b c".to_vec());
+    }
+
+    /// Lengths are byte lengths, not character counts. A multi-byte payload type
+    /// is where the two readings diverge, and this crate signs pack and bundle
+    /// media types that are ASCII today and need not stay that way.
+    #[test]
+    fn lengths_count_bytes_rather_than_characters() {
+        let ty = "café/json";
+        assert_eq!(ty.chars().count(), 9);
+        assert_eq!(ty.len(), 10);
+        assert!(build_pae(ty, b"x").starts_with(b"DSSEv1 10 "));
+    }
+
+    #[test]
+    fn payload_need_not_be_utf8() {
+        assert_eq!(
+            build_pae("t", &[0xff, 0xfe]),
+            b"DSSEv1 1 t 2 \xff\xfe".to_vec()
+        );
+    }
+
+    #[test]
+    fn empty_type_and_payload_keep_their_separators() {
+        assert_eq!(build_pae("", b""), b"DSSEv1 0  0 ".to_vec());
+    }
+}

--- a/crates/assay-registry/src/sigstore_bundle.rs
+++ b/crates/assay-registry/src/sigstore_bundle.rs
@@ -297,6 +297,15 @@ mod tests {
     }
 
     /// DSSE v1 PAE (mirrors the dsse module; tests build their own signed bytes).
+    /// Deliberately not delegated to `crate::pae::build_pae`, unlike the three
+    /// production copies this crate collapsed into it.
+    ///
+    /// These tests build a PAE here, sign it, and assert the production verifier
+    /// accepts the result. That makes this an independent construction rather
+    /// than a duplicate: if the shared one drifted, the signature would stop
+    /// verifying and these tests would fail, which is the whole point. Sharing
+    /// it would leave the tests signing with the same code they verify with, and
+    /// a PAE bug would agree with itself and pass.
     fn pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
         let mut p = Vec::new();
         p.extend_from_slice(b"DSSEv1 ");

--- a/crates/assay-registry/src/supply_chain/provenance.rs
+++ b/crates/assay-registry/src/supply_chain/provenance.rs
@@ -30,17 +30,9 @@ struct InTotoSubject {
 
 // ---- Verification --------------------------------------------------------------------------------
 
+/// Delegates to [`crate::pae::build_pae`].
 pub(super) fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
-    let mut pae = Vec::new();
-    pae.extend_from_slice(b"DSSEv1 ");
-    pae.extend_from_slice(payload_type.len().to_string().as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_type.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload.len().to_string().as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload);
-    pae
+    crate::pae::build_pae(payload_type, payload)
 }
 
 /// Verify a DSSE envelope's signatures against the pinned trust store. Distinguishes "no trusted key

--- a/crates/assay-registry/src/verify_internal/dsse.rs
+++ b/crates/assay-registry/src/verify_internal/dsse.rs
@@ -14,20 +14,9 @@ use crate::types::DsseEnvelope;
 use super::super::PAYLOAD_TYPE_PACK_V1;
 use super::digest::canonicalize_for_dsse_impl;
 
+/// Delegates to [`crate::pae::build_pae`].
 pub(crate) fn build_pae_impl(payload_type: &str, payload: &[u8]) -> Vec<u8> {
-    let type_len = payload_type.len().to_string();
-    let payload_len = payload.len().to_string();
-
-    let mut pae = Vec::new();
-    pae.extend_from_slice(b"DSSEv1 ");
-    pae.extend_from_slice(type_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_type.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload);
-    pae
+    crate::pae::build_pae(payload_type, payload)
 }
 
 pub(crate) fn verify_dsse_signature_bytes_impl(


### PR DESCRIPTION
Follow-up to #1967, which shared a DSSE PAE between `assay-evidence` and `assay-core` and recorded that `assay-registry` carried more of its own.

## What changes

Three production constructions — in `dsse`, `supply_chain::provenance` and `verify::verify_internal::dsse` — all behaviourally identical, now call `assay_registry::pae::build_pae`.

Identical is where a drift starts, not a defence against one: nothing fails if one gains a space, renders a length differently, or handles a non-ASCII payload type another way, until a signature made by one path stops verifying on another.

## Two corrections to what #1967 recorded

Both counting errors of the same kind, and both are fixed in `CLAUDE.md` here:

- It said **four** copies. There are **three**; the fourth is a test helper.
- It implied `verify_internal` already offered a crate-wide home. It does not — that module is private to `verify.rs`, so its `pub(crate)` helper was never reachable from the other two.

## The test copy stays, deliberately

This is the part worth reading. The `sigstore_bundle` tests build a PAE, sign it, and assert the **production verifier** accepts the result. That makes it an *independent construction*, not a duplicate: if the shared PAE drifted, the signature would stop verifying and those tests would fail, which is exactly the point.

Delegating it would leave the tests signing with the same code they verify with, and a PAE bug would agree with itself and pass. Both the helper and `CLAUDE.md` now say so, since it otherwise reads as an oversight a future cleanup would "fix".

## Still not shared with `assay_common::dsse`

`assay-registry` has no internal dependencies at all, and giving a leaf crate its first edge is a decision to take on its own terms rather than in passing.

Worth recording for whoever takes it: **the portability objection is empirically void.** The release workflow builds `assay-cli` for `x86_64-pc-windows-msvc`, and `assay-cli` already depends on both `assay-common` and `assay-registry`, so `assay-common` (with `nix` behind its `std` feature) already compiles for Windows on every release.

## Spec note

DSSE v1.0.0 defines the type input as a byte sequence, `PAE(UTF8(PAYLOAD_TYPE), SERIALIZED_BODY)`. Taking `&str` is deliberately stricter — a payload type that is not valid UTF-8 cannot be constructed, rather than being encoded and rejected later — and the module says so.

## Gates

| | |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 warnings |
| `cargo test -p assay-registry` | 348 passed, 0 failed |
| `cargo fmt --all` | clean |

No behaviour change: the emitted bytes are identical, and the signing tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared DSSE Pre-Authentication Encoding support with correct handling of UTF-8 lengths, binary payloads, empty values, and embedded spaces.
* **Bug Fixes**
  * Standardized DSSE signing and verification behavior across supported workflows.
  * Preserved existing output compatibility while improving consistency.
* **Documentation**
  * Expanded guidance on DSSE implementation boundaries and independent test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->