### PR TITLE
Ask Cargo for the assay-mcp-server binary, and share the env strip that makes it cheap

### DIFF
--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -254,11 +254,15 @@ jobs:
               echo "- cargo nextest run -p assay-cli --all-features"
               echo "- cargo hack check -p assay-cli --each-feature --exclude-features experimental (touched crate)"
             } >> "$GITHUB_STEP_SUMMARY"
-            # Pre-warm only, no longer a correctness requirement: the e2e wrap
-            # tests build assay-mcp-server themselves, which is the only place
-            # that can also reject a stale artifact. Kept because nextest applies
-            # slow-timeout 60s x2 per test (.config/nextest.toml) and a cold
-            # compile inside that budget dies by SIGTERM without a useful message.
+            # Pre-warm only, not a correctness requirement: the e2e wrap tests
+            # build assay-mcp-server themselves, which is the only place that can
+            # also reject a stale artifact. Kept because nextest applies
+            # slow-timeout 60s x2 per test (.config/nextest.toml), so a cold
+            # compile inside a test dies by SIGTERM with no useful message.
+            # This only works because every test in the crate that shells out to
+            # Cargo strips the inherited Cargo environment (tests/common/mod.rs);
+            # when one of them did not, it re-dirtied these units from inside the
+            # nextest run below and the pre-warm bought nothing.
             cargo build -p assay-mcp-server
             cargo check -p assay-cli --no-default-features
             cargo check -p assay-cli --no-default-features --features sim

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -245,6 +245,7 @@ jobs:
             {
               echo ""
               echo "### assay-cli"
+              echo "- cargo build -p assay-mcp-server (pre-warm for the assay-cli e2e wrap tests)"
               echo "- cargo check -p assay-cli --no-default-features"
               echo "- cargo check -p assay-cli --no-default-features --features sim"
               echo "- cargo check -p assay-cli --no-default-features --features tui"
@@ -253,10 +254,12 @@ jobs:
               echo "- cargo nextest run -p assay-cli --all-features"
               echo "- cargo hack check -p assay-cli --each-feature --exclude-features experimental (touched crate)"
             } >> "$GITHUB_STEP_SUMMARY"
-            # No `cargo build -p assay-mcp-server` here: the assay-cli e2e wrap
-            # tests build that binary themselves, so the dependency lives in the
-            # test rather than in this workflow, where it could not detect a
-            # stale artifact anyway.
+            # Pre-warm only, no longer a correctness requirement: the e2e wrap
+            # tests build assay-mcp-server themselves, which is the only place
+            # that can also reject a stale artifact. Kept because nextest applies
+            # slow-timeout 60s x2 per test (.config/nextest.toml) and a cold
+            # compile inside that budget dies by SIGTERM without a useful message.
+            cargo build -p assay-mcp-server
             cargo check -p assay-cli --no-default-features
             cargo check -p assay-cli --no-default-features --features sim
             cargo check -p assay-cli --no-default-features --features tui

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -245,7 +245,6 @@ jobs:
             {
               echo ""
               echo "### assay-cli"
-              echo "- cargo build -p assay-mcp-server (required by assay-cli e2e wrap tests)"
               echo "- cargo check -p assay-cli --no-default-features"
               echo "- cargo check -p assay-cli --no-default-features --features sim"
               echo "- cargo check -p assay-cli --no-default-features --features tui"
@@ -254,7 +253,10 @@ jobs:
               echo "- cargo nextest run -p assay-cli --all-features"
               echo "- cargo hack check -p assay-cli --each-feature --exclude-features experimental (touched crate)"
             } >> "$GITHUB_STEP_SUMMARY"
-            cargo build -p assay-mcp-server
+            # No `cargo build -p assay-mcp-server` here: the assay-cli e2e wrap
+            # tests build that binary themselves, so the dependency lives in the
+            # test rather than in this workflow, where it could not detect a
+            # stale artifact anyway.
             cargo check -p assay-cli --no-default-features
             cargo check -p assay-cli --no-default-features --features sim
             cargo check -p assay-cli --no-default-features --features tui

--- a/crates/assay-cli/tests/common/mod.rs
+++ b/crates/assay-cli/tests/common/mod.rs
@@ -1,0 +1,68 @@
+//! Shared plumbing for tests in this crate that invoke Cargo as a subprocess.
+//!
+//! Two integration tests here shell out to Cargo — `e2e_mcp_wrap_assert_cmd`
+//! builds `assay-mcp-server`, and `golden_runner` runs `assay`. They must do it
+//! the same way, and not because duplication is untidy: when only one of them
+//! strips the inherited Cargo environment, the two invocations disagree about
+//! the fingerprint of every unit they share, and each run undoes the other's
+//! work. Measured on this crate, alternating cost ~15s per test on every
+//! `cargo nextest run -p assay-cli` after the first, with which test paid it
+//! decided by scheduling order.
+
+use std::process::Command;
+
+/// The Cargo that built this test, rather than whichever one is on `PATH`.
+///
+/// Baked in at compile time, so a nested build uses the toolchain pinned by
+/// `rust-toolchain.toml` instead of resolving through the rustup shim, which
+/// can select a different one.
+pub fn cargo_bin() -> &'static str {
+    option_env!("CARGO").unwrap_or("cargo")
+}
+
+/// Remove the per-crate variables Cargo injects into *this* test process, so a
+/// nested Cargo invocation sees the environment a plain shell would give it.
+///
+/// Build scripts track these variables, so leaving them in place marks units
+/// dirty in both directions: flipping `CARGO_MANIFEST_DIR` between unset (a
+/// shell `cargo build`) and `crates/assay-cli` (inherited here) rebuilds
+/// `ring`'s build script and cascades through the rustls/reqwest stack into
+/// `assay-evidence`, `assay-adapter-api`, `assay-core`, `assay-metrics` and
+/// `assay-mcp-server` — 14 crates, ~15s, every alternation.
+///
+/// The list states an intent rather than a complete set. It removes what
+/// identifies *this crate* to a child process; several arms never fire under
+/// `cargo test` or `cargo nextest` today and are matched defensively.
+/// `CARGO_BIN_EXE_*` is matched by prefix because nextest sets it at runtime
+/// even though cargo does not.
+///
+/// Three deliberate exclusions, none of them oversights:
+///   - configuration the *user* set (`CARGO_HOME`, `CARGO_TARGET_DIR`,
+///     `CARGO_NET_OFFLINE`, `RUSTFLAGS`): a shell would pass these through too,
+///     and dropping them would change where the build writes or whether it may
+///     reach the network;
+///   - `CARGO` itself, which the nested invocation overwrites anyway;
+///   - the dynamic-library search path (`LD_LIBRARY_PATH`, and nextest's
+///     `NEXTEST_DYLD_FALLBACK_LIBRARY_PATH`): no build-script fingerprint tracks
+///     it, so it costs nothing, and removing it could break linking.
+pub fn strip_cargo_crate_env(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        let Some(key) = key.to_str() else { continue };
+        let injected = key.starts_with("CARGO_PKG_")
+            || key.starts_with("CARGO_BIN_EXE_")
+            || matches!(
+                key,
+                "CARGO_MANIFEST_DIR"
+                    | "CARGO_MANIFEST_PATH"
+                    | "CARGO_MANIFEST_LINKS"
+                    | "CARGO_CRATE_NAME"
+                    | "CARGO_BIN_NAME"
+                    | "CARGO_PRIMARY_PACKAGE"
+                    | "CARGO_TARGET_TMPDIR"
+                    | "OUT_DIR"
+            );
+        if injected {
+            cmd.env_remove(key);
+        }
+    }
+}

--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -21,19 +21,29 @@ fn assay_bin() -> PathBuf {
 /// Cargo only injects `CARGO_BIN_EXE_*` for bins declared in the *same* package,
 /// and `assay-mcp-server` is a separate workspace member — so there is no env var
 /// to read here. The previous approach guessed at `<workspace>/target/debug/
-/// assay-mcp-server` and asserted the path existed, which is wrong in both
-/// directions: it fails on a tree that has simply never built the server (reading
-/// as a test failure rather than a missing build step), and it silently *passes*
-/// against a stale binary left over from an older tree, so the e2e suite reads
-/// green while exercising code that no longer exists.
+/// assay-mcp-server` and asserted the path existed, which fails on a tree that
+/// has never built the server, reading as a test failure rather than as a
+/// missing build step. It also could not tell a current binary from a stale one
+/// left over by an older tree.
 ///
 /// Instead, ask Cargo to build it and to report where it put it. Cargo owns the
 /// staleness computation, so this also covers changes in transitive dependencies
 /// such as `assay-core` that an mtime comparison against `assay-mcp-server/src`
 /// would miss. On an already-current tree this is a no-op freshness check.
 ///
+/// What this does and does not buy, because the difference is easy to overstate:
+/// it guarantees the binary these tests spawn is built from the current source.
+/// It does *not* make the tests fail when it would not be. Only
+/// `owasp_mcp01_token_args_do_not_leak_to_proxy_logs` depends on the server
+/// answering at all; `e2e_wrap_denies_wildcard_contains` and
+/// `e2e_wrap_denies_schema_violation` assert verdicts the proxy reaches before
+/// dispatching upstream, and pass against any executable that holds the pipe
+/// open. Detecting a wrong server in those two needs an assertion only a correct
+/// server can satisfy, which is a change to what they test, not to how the
+/// binary is found.
+///
 /// Panics (never skips) if the build fails: a skipped e2e test that reads as
-/// green is precisely the failure mode this replaces.
+/// green is a worse failure than a loud one.
 fn assay_mcp_server_bin() -> PathBuf {
     static BIN: OnceLock<PathBuf> = OnceLock::new();
     BIN.get_or_init(|| build_assay_mcp_server().expect("build assay-mcp-server for e2e wrap tests"))
@@ -43,16 +53,28 @@ fn assay_mcp_server_bin() -> PathBuf {
 /// Remove the per-crate variables Cargo injects into *this* test process, so the
 /// nested build sees the environment a plain shell `cargo build` would give it.
 ///
-/// Without this the nested build is not just noisy, it is slow on every run:
-/// dependency build scripts track these variables, and `ring` in particular goes
-/// dirty when `CARGO_MANIFEST_DIR` flips between unset (shell) and
-/// `crates/assay-cli` (inherited here). That drags the whole rustls/reqwest stack
-/// with it — ~13s of rebuild per alternation, in both directions.
+/// Without this the nested build is not merely noisy, it is slow on every run:
+/// build scripts track these variables, so flipping `CARGO_MANIFEST_DIR` between
+/// unset (shell) and `crates/assay-cli` (inherited here) marks units dirty in
+/// both directions. Measured on this workspace, the alternation rebuilds
+/// `assay-evidence`, `assay-adapter-api`, `assay-core`, `assay-metrics` and
+/// `assay-mcp-server`, plus `ring`'s build script and the rustls/reqwest stack
+/// above it: ~15s each way, on every run. With the strip, both directions are
+/// a sub-second freshness check.
 ///
-/// Variables the *user* set to configure Cargo (`CARGO_HOME`, `CARGO_TARGET_DIR`,
-/// `CARGO_NET_OFFLINE`, `RUSTFLAGS`, ...) are deliberately left alone: a shell
-/// would pass those through too, and dropping them would change where the build
-/// writes or whether it may reach the network.
+/// The list below is the set Cargo documents as per-crate injections, not the
+/// set observed in any one runner — several never appear under `cargo test` or
+/// `cargo nextest` today and are matched defensively. `CARGO_BIN_EXE_*` is set
+/// at runtime by nextest but not by cargo, which is why it is matched by prefix
+/// rather than assumed absent.
+///
+/// Two deliberate exclusions. Variables the *user* set to configure Cargo
+/// (`CARGO_HOME`, `CARGO_TARGET_DIR`, `CARGO_NET_OFFLINE`, `RUSTFLAGS`, ...) stay:
+/// a shell would pass those through too, and dropping them would change where
+/// the build writes or whether it may reach the network. The dynamic-library
+/// search path Cargo injects (`LD_LIBRARY_PATH`, and nextest's
+/// `NEXTEST_DYLD_FALLBACK_LIBRARY_PATH`) also stays: no build-script fingerprint
+/// tracks it, so it costs nothing, and removing it could break linking.
 fn strip_cargo_crate_env(cmd: &mut Command) {
     for (key, _) in std::env::vars_os() {
         let Some(key) = key.to_str() else { continue };
@@ -75,6 +97,60 @@ fn strip_cargo_crate_env(cmd: &mut Command) {
     }
 }
 
+/// Where the parent build put its artifacts: the cross-compilation target triple
+/// if there is one, and the profile directory.
+///
+/// Build the nested binary into the same place, so `cargo test --release` does
+/// not trigger a second full dependency build in the other profile.
+///
+/// `CARGO_BIN_EXE_assay` is `<target-dir>/<profile-dir>/assay`, or
+/// `<target-dir>/<triple>/<profile-dir>/assay` when the parent passed `--target`.
+/// Reading the parent directory name alone cannot tell those apart — under
+/// `--target` it still yields `debug`, and the nested build would then quietly
+/// produce a *host* binary, in a different artifact tree from the one under
+/// test. Stripping the target directory shows which shape it is.
+///
+/// Falls back to the profile-dir-only reading when the layout is not
+/// recognisable (a `build.target-dir` redirect, say). That is the pre-existing
+/// behaviour and is correct whenever `--target` is absent, which is every
+/// invocation in this repo today.
+fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
+    let bin_exe = Path::new(env!("CARGO_BIN_EXE_assay"));
+    let dir_name = |p: Option<&Path>| {
+        p.and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(str::to_owned)
+    };
+    // `debug` is the fallback rather than an error: a wrong profile costs build
+    // time, and there is no reading of this path that should fail a test.
+    let profile_only = || {
+        (
+            None,
+            dir_name(bin_exe.parent()).unwrap_or_else(|| "debug".into()),
+        )
+    };
+
+    let target_dir = match std::env::var_os("CARGO_TARGET_DIR") {
+        Some(d) => PathBuf::from(d),
+        None => workspace_root.join("target"),
+    };
+    let Ok(rel) = bin_exe.strip_prefix(&target_dir) else {
+        return profile_only();
+    };
+
+    // rel is `<profile>/assay` or `<triple>/<profile>/assay`.
+    let mut components: Vec<_> = rel
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+    components.pop(); // the file name
+    match components[..] {
+        [profile] => (None, profile.to_owned()),
+        [triple, profile] => (Some(triple.to_owned()), profile.to_owned()),
+        _ => profile_only(),
+    }
+}
+
 fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {
     // crates/assay-cli -> crates -> workspace root
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -82,16 +158,7 @@ fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {
         .and_then(|p| p.parent())
         .context("failed to resolve workspace root from CARGO_MANIFEST_DIR")?;
 
-    // Build into the same profile directory the test itself was built into, so a
-    // `cargo test --release` run does not trigger a second full dependency build.
-    // `CARGO_BIN_EXE_assay` is `<target-dir>/<profile-dir>/assay`; the profile dir
-    // and the profile name coincide for every profile except dev, whose directory
-    // is `debug`.
-    let profile_dir = Path::new(env!("CARGO_BIN_EXE_assay"))
-        .parent()
-        .and_then(|p| p.file_name())
-        .and_then(|p| p.to_str())
-        .context("failed to resolve profile directory from CARGO_BIN_EXE_assay")?;
+    let (target_triple, profile_dir) = target_and_profile(workspace_root);
 
     let cargo = option_env!("CARGO").unwrap_or("cargo");
     let mut cmd = Command::new(cargo);
@@ -101,9 +168,16 @@ fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {
         "assay-mcp-server",
         "--bin",
         "assay-mcp-server",
+        // The parent resolved the graph already; a test has no business editing
+        // Cargo.lock. `cargo test --locked` (ci.yml) would otherwise not extend
+        // its guarantee to the build this test performs.
+        "--locked",
     ]);
+    if let Some(triple) = &target_triple {
+        cmd.args(["--target", triple]);
+    }
     if profile_dir != "debug" {
-        cmd.args(["--profile", profile_dir]);
+        cmd.args(["--profile", &profile_dir]);
     }
     // json on stdout for the artifact path, human-readable diagnostics on stderr.
     cmd.arg("--message-format=json-render-diagnostics");

--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -4,46 +4,140 @@ use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
-fn exe_name(name: &str) -> String {
-    if cfg!(windows) {
-        format!("{name}.exe")
-    } else {
-        name.to_string()
+/// Path to the `assay` binary under test.
+///
+/// `assay` is a bin target of this package, so Cargo injects the path at compile
+/// time and guarantees the binary is built and current before the test runs.
+fn assay_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_assay"))
+}
+
+/// Path to a freshly built `assay-mcp-server` binary.
+///
+/// Cargo only injects `CARGO_BIN_EXE_*` for bins declared in the *same* package,
+/// and `assay-mcp-server` is a separate workspace member — so there is no env var
+/// to read here. The previous approach guessed at `<workspace>/target/debug/
+/// assay-mcp-server` and asserted the path existed, which is wrong in both
+/// directions: it fails on a tree that has simply never built the server (reading
+/// as a test failure rather than a missing build step), and it silently *passes*
+/// against a stale binary left over from an older tree, so the e2e suite reads
+/// green while exercising code that no longer exists.
+///
+/// Instead, ask Cargo to build it and to report where it put it. Cargo owns the
+/// staleness computation, so this also covers changes in transitive dependencies
+/// such as `assay-core` that an mtime comparison against `assay-mcp-server/src`
+/// would miss. On an already-current tree this is a no-op freshness check.
+///
+/// Panics (never skips) if the build fails: a skipped e2e test that reads as
+/// green is precisely the failure mode this replaces.
+fn assay_mcp_server_bin() -> PathBuf {
+    static BIN: OnceLock<PathBuf> = OnceLock::new();
+    BIN.get_or_init(|| build_assay_mcp_server().expect("build assay-mcp-server for e2e wrap tests"))
+        .clone()
+}
+
+/// Remove the per-crate variables Cargo injects into *this* test process, so the
+/// nested build sees the environment a plain shell `cargo build` would give it.
+///
+/// Without this the nested build is not just noisy, it is slow on every run:
+/// dependency build scripts track these variables, and `ring` in particular goes
+/// dirty when `CARGO_MANIFEST_DIR` flips between unset (shell) and
+/// `crates/assay-cli` (inherited here). That drags the whole rustls/reqwest stack
+/// with it — ~13s of rebuild per alternation, in both directions.
+///
+/// Variables the *user* set to configure Cargo (`CARGO_HOME`, `CARGO_TARGET_DIR`,
+/// `CARGO_NET_OFFLINE`, `RUSTFLAGS`, ...) are deliberately left alone: a shell
+/// would pass those through too, and dropping them would change where the build
+/// writes or whether it may reach the network.
+fn strip_cargo_crate_env(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        let Some(key) = key.to_str() else { continue };
+        let injected = key.starts_with("CARGO_PKG_")
+            || key.starts_with("CARGO_BIN_EXE_")
+            || matches!(
+                key,
+                "CARGO_MANIFEST_DIR"
+                    | "CARGO_MANIFEST_PATH"
+                    | "CARGO_MANIFEST_LINKS"
+                    | "CARGO_CRATE_NAME"
+                    | "CARGO_BIN_NAME"
+                    | "CARGO_PRIMARY_PACKAGE"
+                    | "CARGO_TARGET_TMPDIR"
+                    | "OUT_DIR"
+            );
+        if injected {
+            cmd.env_remove(key);
+        }
     }
 }
 
-/// Try to locate a built binary without relying on PATH.
-///
-/// Priority:
-/// 1) Cargo-injected env var: CARGO_BIN_EXE_<name> (with '-' sometimes '_' in env var)
-/// 2) {CARGO_TARGET_DIR}/debug/<name>
-/// 3) <workspace_root>/target/debug/<name>
-fn bin_path(bin: &str) -> anyhow::Result<PathBuf> {
-    // Cargo typically uses underscores in env var keys for hyphenated bin names
-    let env_key_underscore = format!("CARGO_BIN_EXE_{}", bin.replace('-', "_"));
-    let env_key_hyphen = format!("CARGO_BIN_EXE_{bin}");
+fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {
+    // crates/assay-cli -> crates -> workspace root
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .context("failed to resolve workspace root from CARGO_MANIFEST_DIR")?;
 
-    if let Ok(p) = std::env::var(&env_key_underscore).or_else(|_| std::env::var(&env_key_hyphen)) {
-        return Ok(PathBuf::from(p));
+    // Build into the same profile directory the test itself was built into, so a
+    // `cargo test --release` run does not trigger a second full dependency build.
+    // `CARGO_BIN_EXE_assay` is `<target-dir>/<profile-dir>/assay`; the profile dir
+    // and the profile name coincide for every profile except dev, whose directory
+    // is `debug`.
+    let profile_dir = Path::new(env!("CARGO_BIN_EXE_assay"))
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|p| p.to_str())
+        .context("failed to resolve profile directory from CARGO_BIN_EXE_assay")?;
+
+    let cargo = option_env!("CARGO").unwrap_or("cargo");
+    let mut cmd = Command::new(cargo);
+    cmd.current_dir(workspace_root).args([
+        "build",
+        "-p",
+        "assay-mcp-server",
+        "--bin",
+        "assay-mcp-server",
+    ]);
+    if profile_dir != "debug" {
+        cmd.args(["--profile", profile_dir]);
+    }
+    // json on stdout for the artifact path, human-readable diagnostics on stderr.
+    cmd.arg("--message-format=json-render-diagnostics");
+    strip_cargo_crate_env(&mut cmd);
+
+    let out = cmd
+        .output()
+        .with_context(|| format!("failed to run `{cargo} build -p assay-mcp-server`"))?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "`cargo build -p assay-mcp-server` failed with status {}.\n\
+             The e2e wrap tests drive the real server binary; run it yourself to \
+             see the errors:\n    cargo build -p assay-mcp-server\n--- cargo stderr ---\n{}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 
-    let target_dir = if let Ok(td) = std::env::var("CARGO_TARGET_DIR") {
-        PathBuf::from(td)
-    } else {
-        // crates/assay-cli -> crates -> workspace root
-        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let workspace_root = manifest
-            .parent()
-            .and_then(|p| p.parent())
-            .context("failed to resolve workspace root from CARGO_MANIFEST_DIR")?;
-        workspace_root.join("target")
-    };
+    // Take the `executable` of the bin artifact. Cargo emits this for fresh
+    // (already up-to-date) units too, so it is authoritative either way.
+    let executable = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|msg| {
+            msg["reason"] == "compiler-artifact" && msg["target"]["name"] == "assay-mcp-server"
+        })
+        .filter_map(|msg| msg["executable"].as_str().map(PathBuf::from))
+        .next_back()
+        .context(
+            "`cargo build -p assay-mcp-server` reported no bin artifact; \
+             has the `assay-mcp-server` bin target been renamed or removed?",
+        )?;
 
-    let candidate = target_dir.join("debug").join(exe_name(bin));
-    Ok(candidate)
+    Ok(executable)
 }
 
 /// Write one JSON line to stdin (newline delimited JSON-RPC).
@@ -127,10 +221,8 @@ fn extract_error_code(resp: &Value) -> Option<String> {
 
 #[test]
 fn owasp_mcp01_token_args_do_not_leak_to_proxy_logs() -> anyhow::Result<()> {
-    let assay = bin_path("assay")?;
-    let server = bin_path("assay-mcp-server")?;
-    assert!(assay.exists(), "missing binary: {}", assay.display());
-    assert!(server.exists(), "missing binary: {}", server.display());
+    let assay = assay_bin();
+    let server = assay_mcp_server_bin();
 
     let tmp = TempDir::new()?;
     let policy_path = tmp.path().join("proxy-policy.yaml");
@@ -220,13 +312,8 @@ enforcement:
 
 #[test]
 fn e2e_wrap_denies_wildcard_contains() -> anyhow::Result<()> {
-    // Ensure binaries exist (nice error if not built)
-    let assay = bin_path("assay")?;
-    let server = bin_path("assay-mcp-server")?;
-
-    // In CI: run `cargo build --workspace` before tests so these exist.
-    assert!(assay.exists(), "missing binary: {}", assay.display());
-    assert!(server.exists(), "missing binary: {}", server.display());
+    let assay = assay_bin();
+    let server = assay_mcp_server_bin();
 
     let tmp = TempDir::new()?;
     let policy_path = tmp.path().join("proxy-policy.yaml");
@@ -294,10 +381,8 @@ enforcement:
 
 #[test]
 fn e2e_wrap_denies_schema_violation() -> anyhow::Result<()> {
-    let assay = bin_path("assay")?;
-    let server = bin_path("assay-mcp-server")?;
-    assert!(assay.exists(), "missing binary: {}", assay.display());
-    assert!(server.exists(), "missing binary: {}", server.display());
+    let assay = assay_bin();
+    let server = assay_mcp_server_bin();
 
     let tmp = TempDir::new()?;
     let policy_path = tmp.path().join("proxy-policy.yaml");

--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -45,10 +45,14 @@ fn assay_bin() -> PathBuf {
 /// `owasp_mcp01_token_args_do_not_leak_to_proxy_logs` depends on the server
 /// answering at all; `e2e_wrap_denies_wildcard_contains` and
 /// `e2e_wrap_denies_schema_violation` assert verdicts the proxy reaches before
-/// dispatching upstream, and pass against anything spawnable — `/usr/bin/true`
-/// included, so not even holding the pipe open is required. Detecting a wrong
-/// server in those two needs an assertion only a correct server can satisfy,
-/// which is a change to what they test, not to how the binary is found.
+/// dispatching upstream. They pass against anything that spawns and then exits
+/// when its stdin closes — `/usr/bin/true` included, so the upstream need not
+/// speak the protocol, or read a byte, to satisfy them. (#1981 added an
+/// exit-status assert, which does make a server that hangs past five seconds
+/// fail them; that bounds how the upstream *terminates*, not what it answers.)
+/// Detecting a wrong server in those two needs an assertion only a correct
+/// server can satisfy, which is a change to what they test rather than to how
+/// the binary is found, and is what #1988 is for.
 ///
 /// Panics (never skips) if the build fails: a skipped e2e test that reads as
 /// green is a worse failure than a loud one.

--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -8,6 +8,9 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
+mod common;
+use common::{cargo_bin, strip_cargo_crate_env};
+
 /// Path to the `assay` binary under test.
 ///
 /// `assay` is a bin target of this package, so Cargo injects the path at compile
@@ -37,10 +40,10 @@ fn assay_bin() -> PathBuf {
 /// `owasp_mcp01_token_args_do_not_leak_to_proxy_logs` depends on the server
 /// answering at all; `e2e_wrap_denies_wildcard_contains` and
 /// `e2e_wrap_denies_schema_violation` assert verdicts the proxy reaches before
-/// dispatching upstream, and pass against any executable that holds the pipe
-/// open. Detecting a wrong server in those two needs an assertion only a correct
-/// server can satisfy, which is a change to what they test, not to how the
-/// binary is found.
+/// dispatching upstream, and pass against anything spawnable — `/usr/bin/true`
+/// included, so not even holding the pipe open is required. Detecting a wrong
+/// server in those two needs an assertion only a correct server can satisfy,
+/// which is a change to what they test, not to how the binary is found.
 ///
 /// Panics (never skips) if the build fails: a skipped e2e test that reads as
 /// green is a worse failure than a loud one.
@@ -48,53 +51,6 @@ fn assay_mcp_server_bin() -> PathBuf {
     static BIN: OnceLock<PathBuf> = OnceLock::new();
     BIN.get_or_init(|| build_assay_mcp_server().expect("build assay-mcp-server for e2e wrap tests"))
         .clone()
-}
-
-/// Remove the per-crate variables Cargo injects into *this* test process, so the
-/// nested build sees the environment a plain shell `cargo build` would give it.
-///
-/// Without this the nested build is not merely noisy, it is slow on every run:
-/// build scripts track these variables, so flipping `CARGO_MANIFEST_DIR` between
-/// unset (shell) and `crates/assay-cli` (inherited here) marks units dirty in
-/// both directions. Measured on this workspace, the alternation rebuilds
-/// `assay-evidence`, `assay-adapter-api`, `assay-core`, `assay-metrics` and
-/// `assay-mcp-server`, plus `ring`'s build script and the rustls/reqwest stack
-/// above it: ~15s each way, on every run. With the strip, both directions are
-/// a sub-second freshness check.
-///
-/// The list below is the set Cargo documents as per-crate injections, not the
-/// set observed in any one runner — several never appear under `cargo test` or
-/// `cargo nextest` today and are matched defensively. `CARGO_BIN_EXE_*` is set
-/// at runtime by nextest but not by cargo, which is why it is matched by prefix
-/// rather than assumed absent.
-///
-/// Two deliberate exclusions. Variables the *user* set to configure Cargo
-/// (`CARGO_HOME`, `CARGO_TARGET_DIR`, `CARGO_NET_OFFLINE`, `RUSTFLAGS`, ...) stay:
-/// a shell would pass those through too, and dropping them would change where
-/// the build writes or whether it may reach the network. The dynamic-library
-/// search path Cargo injects (`LD_LIBRARY_PATH`, and nextest's
-/// `NEXTEST_DYLD_FALLBACK_LIBRARY_PATH`) also stays: no build-script fingerprint
-/// tracks it, so it costs nothing, and removing it could break linking.
-fn strip_cargo_crate_env(cmd: &mut Command) {
-    for (key, _) in std::env::vars_os() {
-        let Some(key) = key.to_str() else { continue };
-        let injected = key.starts_with("CARGO_PKG_")
-            || key.starts_with("CARGO_BIN_EXE_")
-            || matches!(
-                key,
-                "CARGO_MANIFEST_DIR"
-                    | "CARGO_MANIFEST_PATH"
-                    | "CARGO_MANIFEST_LINKS"
-                    | "CARGO_CRATE_NAME"
-                    | "CARGO_BIN_NAME"
-                    | "CARGO_PRIMARY_PACKAGE"
-                    | "CARGO_TARGET_TMPDIR"
-                    | "OUT_DIR"
-            );
-        if injected {
-            cmd.env_remove(key);
-        }
-    }
 }
 
 /// Where the parent build put its artifacts: the cross-compilation target triple
@@ -110,12 +66,21 @@ fn strip_cargo_crate_env(cmd: &mut Command) {
 /// produce a *host* binary, in a different artifact tree from the one under
 /// test. Stripping the target directory shows which shape it is.
 ///
-/// Falls back to the profile-dir-only reading when the layout is not
-/// recognisable (a `build.target-dir` redirect, say). That is the pre-existing
-/// behaviour and is correct whenever `--target` is absent, which is every
-/// invocation in this repo today.
+/// Both paths are canonicalised before comparing, because `strip_prefix` is
+/// lexical. `CARGO_TARGET_DIR` may be relative — AGENTS.md mandates a per-worktree
+/// target dir, so that is not exotic — and Cargo may canonicalise a symlinked one
+/// (on macOS, `/tmp` is `/private/tmp`), leaving the env var not a literal prefix
+/// of the path Cargo reports. Without this, both cases fall through to the
+/// profile-only reading and drop the triple.
+///
+/// Falls back to the profile-dir-only reading when the layout is still not
+/// recognisable. That is only correct when `--target` is absent — which is every
+/// invocation in this repo today — so the fallback carries a real, narrow risk:
+/// it would build a host binary while the test runs a cross-compiled one, where
+/// the code this replaced would have failed loudly with a missing binary. Made
+/// as narrow as canonicalising can make it, and called out rather than hidden.
 fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
-    let bin_exe = Path::new(env!("CARGO_BIN_EXE_assay"));
+    let bin_exe_raw = Path::new(env!("CARGO_BIN_EXE_assay"));
     let dir_name = |p: Option<&Path>| {
         p.and_then(|p| p.file_name())
             .and_then(|n| n.to_str())
@@ -126,7 +91,7 @@ fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
     let profile_only = || {
         (
             None,
-            dir_name(bin_exe.parent()).unwrap_or_else(|| "debug".into()),
+            dir_name(bin_exe_raw.parent()).unwrap_or_else(|| "debug".into()),
         )
     };
 
@@ -134,6 +99,10 @@ fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
         Some(d) => PathBuf::from(d),
         None => workspace_root.join("target"),
     };
+    // Canonicalising needs the paths to exist. They do: the binary is what Cargo
+    // just built, and the target dir contains it. Fall back rather than fail.
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let (bin_exe, target_dir) = (canon(bin_exe_raw), canon(&target_dir));
     let Ok(rel) = bin_exe.strip_prefix(&target_dir) else {
         return profile_only();
     };
@@ -160,7 +129,7 @@ fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {
 
     let (target_triple, profile_dir) = target_and_profile(workspace_root);
 
-    let cargo = option_env!("CARGO").unwrap_or("cargo");
+    let cargo = cargo_bin();
     let mut cmd = Command::new(cargo);
     cmd.current_dir(workspace_root).args([
         "build",

--- a/crates/assay-cli/tests/golden_runner.rs
+++ b/crates/assay-cli/tests/golden_runner.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 use std::process::Command;
 
+mod common;
+use common::{cargo_bin, strip_cargo_crate_env};
+
 #[test]
 fn test_golden_harness() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
@@ -8,11 +11,19 @@ fn test_golden_harness() {
 
     // Build binary first usually, but for test we can use cargo run?
     // Better to use the binary if available. But cargo run is easiest for dev/CI.
-
-    let output = Command::new("cargo")
+    //
+    // This must strip the inherited Cargo environment for the same reason
+    // e2e_mcp_wrap_assert_cmd does, and it is not optional politeness: both run
+    // inside one `cargo nextest run -p assay-cli`, so if only one of them strips,
+    // each undoes the other's work and every test that shells out to Cargo pays a
+    // ~15s rebuild on every run after the first. See tests/common/mod.rs.
+    let mut cmd = Command::new(cargo_bin());
+    strip_cargo_crate_env(&mut cmd);
+    let output = cmd
         .args([
             "run",
             "--quiet",
+            "--locked",
             "--bin",
             "assay",
             "--",

--- a/crates/assay-cli/tests/mcp_wrap_state_window_out.rs
+++ b/crates/assay-cli/tests/mcp_wrap_state_window_out.rs
@@ -1,40 +1,9 @@
 #![allow(deprecated)]
 
-use anyhow::Context;
 use assert_cmd::Command;
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tempfile::TempDir;
-
-fn exe_name(name: &str) -> String {
-    if cfg!(windows) {
-        format!("{name}.exe")
-    } else {
-        name.to_string()
-    }
-}
-
-fn bin_path(bin: &str) -> anyhow::Result<PathBuf> {
-    let env_key_underscore = format!("CARGO_BIN_EXE_{}", bin.replace('-', "_"));
-    let env_key_hyphen = format!("CARGO_BIN_EXE_{bin}");
-
-    if let Ok(p) = std::env::var(&env_key_underscore).or_else(|_| std::env::var(&env_key_hyphen)) {
-        return Ok(PathBuf::from(p));
-    }
-
-    let target_dir = if let Ok(td) = std::env::var("CARGO_TARGET_DIR") {
-        PathBuf::from(td)
-    } else {
-        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let workspace_root = manifest
-            .parent()
-            .and_then(|p| p.parent())
-            .context("failed to resolve workspace root from CARGO_MANIFEST_DIR")?;
-        workspace_root.join("target")
-    };
-
-    Ok(target_dir.join("debug").join(exe_name(bin)))
-}
 
 fn read_json(path: &Path) -> Value {
     let content = std::fs::read_to_string(path).expect("state window report should exist");
@@ -43,8 +12,8 @@ fn read_json(path: &Path) -> Value {
 
 #[test]
 fn mcp_wrap_state_window_out_writes_valid_v1_report() -> anyhow::Result<()> {
-    let assay = bin_path("assay")?;
-    assert!(assay.exists(), "missing binary: {}", assay.display());
+    // `assay` is a bin of this package, so Cargo builds it and injects the path.
+    let assay = env!("CARGO_BIN_EXE_assay");
 
     let tmp = TempDir::new()?;
     let policy_path = tmp.path().join("proxy-policy.yaml");
@@ -62,7 +31,7 @@ enforcement:
 "#,
     )?;
 
-    Command::new(&assay)
+    Command::new(assay)
         .args([
             "mcp",
             "wrap",


### PR DESCRIPTION
## Description

`crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs` resolved the `assay-mcp-server` binary through a `bin_path` helper that tried `CARGO_BIN_EXE_<name>` and then fell back to a hand-built `<workspace>/target/debug/<name>`. Cargo only injects `CARGO_BIN_EXE_*` for bins declared in the **same package**: `assay` is a bin of `assay-cli` so it was covered, but `assay-mcp-server` is a separate workspace member and so always took the fallback, checked only with `assert!(path.exists())`.

That has two costs. On a tree that has never built the server, all three tests fail with `missing binary: .../target/debug/assay-mcp-server`, which reads as a test failure rather than a missing build step. And the check cannot tell a current binary from a stale one left over by an older tree.

This PR replaces the guess: ask Cargo to build the binary and to report where it put it, reading `executable` from the `compiler-artifact` line of `--message-format=json`. Cargo emits that field for `"fresh": true` units too, so it is authoritative without reconstructing `target/<profile>/<name>` by hand. Cargo also owns the staleness computation, which covers transitive changes in `assay-core` that an mtime comparison against `assay-mcp-server/src` would miss — the reason this is not implemented as an mtime check. `artifact = "bin"` dependencies were not an option: still unstable, and `rust-toolchain.toml` pins stable 1.96.0.

A failed build panics with the exact `cargo build -p assay-mcp-server` command plus the compiler errors. There is no skip path.

### What this buys, and what it does not

Stated precisely, because an earlier revision of this PR overstated it and an adversarial review was right to refuse it.

**It does** guarantee the binary these tests spawn is built from current source, and it removes the misleading `missing binary:` failure.

**It does not** make the tests fail when the binary would have been stale. Two of the three assert verdicts that `assay mcp wrap` reaches *before* dispatching upstream. Replacing the server with `#!/bin/sh; sleep 30` and running both fixtures returns `E_TOOL_DENIED` and `E_ARG_SCHEMA` unchanged — the exact codes they assert. Any executable that holds the pipe open passes them. Only `owasp_mcp01_token_args_do_not_leak_to_proxy_logs` depends on the server answering at all.

Giving the other two an assertion only a correct server can satisfy is a change to *what they test*, not to *how the binary is found*, and is deliberately out of scope here. It belongs with the separate work already open on that file's `owasp_mcp01` fixture.

### Adjacent cleanups

- `assay` now resolves through `env!("CARGO_BIN_EXE_assay")`, a compile-time guarantee that makes the existence assert unnecessary and matches how every other test in the workspace names a binary. That also lets the duplicate `bin_path` in `mcp_wrap_state_window_out.rs` — which used it for `assay` alone — be deleted rather than shared, so no second definition is left to drift.
- The `cargo build -p assay-mcp-server` step in `split-wave0-gates.yml` is kept, but as a pre-warm rather than a correctness requirement, and with a corrected comment. `.config/nextest.toml` sets `slow-timeout = { period = "60s", terminate-after = 2 }`, so a cold compile inside a test dies by SIGTERM with no useful message. **An earlier revision of this PR justified the step this way while it did not actually work** — see the review history below.

### The nested build strips Cargo's per-crate environment

Worth review attention: not obvious, and load-bearing for build time. The first working revision cost ~15s on **every** run, with nothing changed. `CARGO_LOG=cargo::core::compiler::fingerprint=info` named it:

```
dirty: EnvVarChanged { name: "CARGO_MANIFEST_DIR", old_value: None, new_value: Some(".../crates/assay-cli") }
```

Cargo injects per-crate variables into the test process; a spawned build inherits them; build scripts track them. Flipping `CARGO_MANIFEST_DIR` between *unset* (shell `cargo build`) and *`crates/assay-cli`* (nested) marks units dirty **in both directions**. Observed rebuilding: `assay-evidence`, `assay-adapter-api`, `assay-core`, `assay-metrics`, `assay-mcp-server`, plus `ring`'s build script and the rustls/reqwest stack above it. `strip_cargo_crate_env` removes Cargo's per-crate injections and deliberately preserves both user configuration (`CARGO_HOME`, `CARGO_TARGET_DIR`, `CARGO_NET_OFFLINE`, `RUSTFLAGS`) and the dylib search path. Steady state is sub-second and neither direction recompiles. Note that this alone was *not* sufficient: see the review history.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor

## Verification

All measurements taken on commit `240c247ed6b832246facc7736740b2aad192a785`, clean working tree (`git status --porcelain` empty), worktree `.claude/worktrees/friendly-torvalds-f5cfff`, `rustc 1.96.0 (ac68faa20 2026-05-25)` (the pinned toolchain), darwin 25.6.0.

Restated on this head deliberately. An earlier revision of this table cited `18933f0e`, whose tree differs from this one by 366 lines *in the file this PR is about*, and reported 605 tests where this head has 606 — main's `json_lines_deadline_holds_against_a_flood_of_non_json_lines` arrived via the merge. Under AGENTS.md's measurement-provenance rule that was a number describing a tree nobody is merging.

| Property | Result on `240c247e` |
|---|---|
| `cargo nextest run -p assay-cli --all-features` | **606 passed**, 1 skipped |
| Same command again, back to back | 606 passed twice; 2.12s and 2.21s wall; wrap tests 0.64-0.89s, `golden_runner` 0.68s |
| Shell `cargo build -p assay-mcp-server --locked` straight after | **0 crates recompiled** |
| `cargo clippy -p assay-cli --tests --all-features -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| Binary rebuilt when source changed | mtime advanced; tests passed |
| Binary rebuilt when deleted | tests passed; binary present again |
| Build failure is loud | test **FAILED** naming `cargo build -p assay-mcp-server` and the compiler error at file:line — no skip, no green |
| Merged-in work from #1981 and #1987 | `json_lines_deadline_holds_…` and the strengthened `owasp_mcp01` both run and pass |

Profile and target derivation, verified against real Cargo output rather than reasoned about (the previous revision got this wrong precisely because it was only reasoned about):

| parent invocation | `CARGO_BIN_EXE_*` | derived |
|---|---|---|
| default | `target/debug/x` | `(None, "debug")` |
| `--release` | `target/release/x` | `(None, "release")` |
| `--target <triple>` | `target/<triple>/debug/x` | `(Some(triple), "debug")` |
| `--target <triple> --release` | `target/<triple>/release/x` | `(Some(triple), "release")` |
| `CARGO_TARGET_DIR` | `alt/debug/x` | `(None, "debug")` |
| `CARGO_TARGET_DIR` + `--target` | `alt/<triple>/debug/x` | `(Some(triple), "debug")` |

- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Ran a demo suite — not applicable; this is test infrastructure

This is not an ADR-042/043 slice — it touches neither evidence ingestion, evidence verification, nor MCP authorization — so the default template is used rather than `adr-boundary.md`.

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. — no docs describe this helper; the rationale lives in doc comments on the functions themselves.
- [x] I have added tests to cover my changes. — the change *is* to tests; the properties it adds are verified in the tables above rather than by new test cases.

## Review history

This PR was reviewed adversarially twice, and both rounds refuted something. The measurements below are the point, not the narrative: each revision's claims were checked by substituting fake binaries and by replaying the CI command order, not by re-reading the code.

**Round 1, on `6ff611f6`** — the central claim was refuted. The commit said staleness could no longer pass silently. Two of the three tests never reach the upstream: `assay mcp wrap` denies first, so they pass against anything spawnable. Withdrawn in `d37ec351`, in both the doc comment and this body.

**Round 2, on `d37ec351`** — found that `d37ec351` had *regressed CI*, and that the pre-warm bullet above was false as written. `crates/assay-cli/tests/golden_runner.rs` ran a bare `Command::new("cargo")` with the Cargo environment inherited — including the `CARGO_MANIFEST_DIR` this PR identifies as the dirtying variable — inside the same `cargo nextest run -p assay-cli`, concurrently with the wrap tests. It re-dirtied what they had just built. The pre-warm therefore bought nothing, and a multi-crate rebuild sat inside nextest's 120s budget.

Same command twice, nothing changed in between:

| | on `d37ec351` (regressed) | on `18933f0e` (fixed) |
|---|---|---|
| wrap tests, run 1 | 0.68 / 0.94 / 1.02s | 1.27 / 1.39 / 1.47s |
| wrap tests, run 2 | **14.9 / 15.0 / 15.1s** | **0.71 / 0.81 / 0.94s** |
| wrap tests, run 3 | — | 0.73 / 0.84 / 0.90s |
| `golden_runner` | 21.9s → 34.1s | 10.4s → 0.77s |
| shell `cargo build -p assay-mcp-server` after | **14 crates** | **0 crates** |
| whole crate suite | 19.7s | **2.1s** |

The fix is AGENTS.md's own rule rather than a larger timeout: one rule, one function. "How a test in this crate invokes Cargo" now lives once in `crates/assay-cli/tests/common/mod.rs`, and both callers use it. `golden_runner` was paying this alternation against shell builds before this branch existed, so sharing the strip fixes a pre-existing defect too — which is why the whole-suite number moves as much as it does.

Also from round 2: `target_and_profile` now canonicalises before comparing, because `strip_prefix` is lexical and a relative or symlinked `CARGO_TARGET_DIR` (which AGENTS.md's per-worktree target dir makes likely) would drop the triple and silently build a host binary where the replaced code failed loudly. And "holds the pipe open" became "anything spawnable" — `/usr/bin/true` passes both deny fixtures, so the original phrasing described a sufficient condition as the boundary. Both reviews reached that independently.

**Round 3, on `2df30187`** (the merge commit) — confirmed nothing from #1981 or #1987 was lost, by running their behaviours rather than looking for their symbols, and blocked on the body rather than the code: a stale SHA, four statements the merge had falsified, and a wrong premise in one disposition. All corrected.

**Round 4, on `ae5456e7`** — CodeRabbit found that the canonicalise in `d37ec351` fixed the symlinked `CARGO_TARGET_DIR` but not the relative one. Correct, and fixed in `240c247e` by taking `target_directory` from `cargo metadata` instead of reading the env var. Its other finding on this head — that build failures print no compiler errors because `json-render-diagnostics` sends them to stdout — was refuted by injecting a syntax error and reading the panic; that format renders diagnostics as text on stderr.

Reviews recorded on earlier heads do not carry to `240c247e`.

### Findings accepted rather than fixed

Recorded because a finding with no disposition is worse than one that is declined:

- **The two deny fixtures still pass against a wrong server.** Fixing that means giving them an assertion only a correct server can satisfy, which changes *what they test*. Deliberately out of scope here. #1988 does it — an allowed call that must round-trip to upstream, plus a frame-ordering check that the denied call was never dispatched — but **#1988 is still open and none of it is in this head**; both fixtures were re-checked on `bb4ef64c` and neither has a round-trip or ordering assertion. Note that #1981, which *is* in this head, added an exit-status assert, so an upstream that hangs past five seconds now fails them; that bounds how the upstream terminates, not what it answers. `/usr/bin/true` still passes both.
- **`read_json_line` cannot time out.** Its elapsed check ran before the blocking `read_line`, so a server that never answered blocked until nextest SIGTERMed the test. **Resolved by #1987, which is merged and is in this head** via the merge commit below — not by #1988, as an earlier revision of this section said. The read now runs on a worker thread behind `recv_timeout`, with an explicit deadline check ahead of it so a flood of non-JSON lines cannot run past the deadline; `json_lines_deadline_holds_against_a_flood_of_non_json_lines` covers that and passes here.
- **Six other tests still invoke Cargo without the strip**, in `assay-mcp-server`'s test files. Fixed by #1986 — which drops the nested Cargo invocation entirely for `env!("CARGO_BIN_EXE_assay-mcp-server")`, so no shared strip is needed — and still declined here, but **the reason given in an earlier revision of this section was wrong** and is corrected: they are not a separate invocation. `ci.yml:597` runs `cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it`, which builds both crates' test binaries in one run, so those six can dirty the units these tests depend on. Measured cost when that alternation is induced: the three wrap tests report 101.8 / 102.2 / 102.3s, because their nested builds serialize on the build-directory lock and each test's duration absorbs the whole serialized build — 85% of nextest's 120s kill. The shipped CI order in `split-wave0-gates.yml` does not trigger it, and the alternation predates this branch (`golden_runner` already had it), but three more tests now pay it. The decline still stands on scope: sharing across crates needs a `publish = false` test-support crate, which is a workspace-shape decision rather than something to smuggle into this PR. It should not wait long.
- **Five sites hard-code `target/debug/<bin>`** — `scripts/ci/exp-mcp-fragmented-ipi/{run_baseline.sh,run_protected.sh,drive_fragmented_ipi.py}` and two `assay-cli` benches. Not referenced by any workflow, so not live, but the diagnosis in this PR applies to them verbatim. Fixed by #1989, which also covers a sixth site in `cross_session/run_cross_session_decay.sh`.
- **`e2e_wrap_denies_*` orphan the spawned server** when they kill the proxy. Pre-existing, low.
- **With a stale `Cargo.lock`, the nested build reaches the network** inside a test. Only reachable when the test binary runs without a preceding cargo resolve, which no supported invocation does.

## Note for reviewers

This branch now contains `main`, merged in at `2df30187`. While the PR was open, main landed #1981 (OWASP MCP01 redaction asserted on the wrong path) and #1987 (a deadline checked around a blocking read is not a timeout), both against `main` and therefore both built on the `bin_path` path guess that this PR deletes. That conflicted, and an earlier revision of this section said the PR did not conflict and could merge as-is; it did conflict, in exactly that file.

The resolution took main's version of the file as the base and reapplied this branch's binary resolution on top, rather than hunk by hunk. `git diff origin/main...bb4ef64c` on that file reduces to the import/helper block and the three call sites; every other byte matches `main`, which is a complete accounting because #1981 and #1987 touched only that file. Both merged-in behaviours were re-verified by running them, not by looking for their symbols.

#1988 stacks on top of this and must not merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability when launching the CLI and MCP server.
  * Prevented stale build artifacts and inherited build settings from causing failures or unnecessary rebuilds.
  * Added reproducible, locked build and test invocations.

* **Tests**
  * Updated MCP wrapping and golden tests to use Cargo-managed executable paths and build outputs.
  * Added shared utilities for consistent subprocess setup and more reliable test execution.
  * Improved server pre-warming to help avoid timeout-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




