### PR TITLE
Check the canonicalizer against RFC 8785, not against itself

### DIFF
--- a/crates/assay-canonical/tests/rfc8785_conformance.rs
+++ b/crates/assay-canonical/tests/rfc8785_conformance.rs
@@ -1,0 +1,183 @@
+//! RFC 8785 (JCS) conformance for this crate's canonicalizer.
+//!
+//! Every content id, mandate id and bundle run root in the workspace is a sha256 over the bytes
+//! this crate emits. If those bytes diverge from RFC 8785 on any edge case, the digests are
+//! irreproducible by any other implementation — and reproducibility by another implementation is
+//! the entire property independent verification rests on. A divergence would not fail any
+//! existing test: the reference producer and the reference verifier would simply agree with each
+//! other, which is exactly the failure this corpus exists to make visible.
+//!
+//! `serde_jcs` is pinned to an exact version in `Cargo.toml` because its byte output moves those
+//! digests. That pin protects against an unnoticed upgrade; it says nothing about whether the
+//! pinned version is correct. This does.
+//!
+//! Expected bytes were cross-validated against an independent implementation in another language,
+//! built from the primitives RFC 8785 defers to (see `_about.expected_provenance` in the vector
+//! file). When adding a vector, derive its expectation from the RFC or from a second conforming
+//! implementation — never from this crate, or the check becomes a snapshot of whatever we already
+//! do and stops being a conformance check at all.
+
+use std::collections::BTreeMap;
+
+#[derive(serde::Deserialize)]
+struct Vector {
+    input: String,
+    expected: String,
+    #[allow(dead_code)]
+    pins: String,
+}
+
+fn vectors() -> BTreeMap<String, Vector> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/vectors/rfc8785.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    let mut all: BTreeMap<String, serde_json::Value> =
+        serde_json::from_str(&raw).expect("vector file is not valid JSON");
+    all.remove("_about");
+
+    all.into_iter()
+        .map(|(name, v)| {
+            let vector: Vector = serde_json::from_value(v)
+                .unwrap_or_else(|e| panic!("vector `{name}` has the wrong shape: {e}"));
+            (name, vector)
+        })
+        .collect()
+}
+
+#[test]
+fn canonical_bytes_match_rfc8785_for_every_vector() {
+    let vectors = vectors();
+    assert!(
+        vectors.len() >= 31,
+        "the corpus shrank to {} vectors; removing coverage here is a silent loss of the \
+         cross-implementation guarantee",
+        vectors.len()
+    );
+
+    let mut failures = Vec::new();
+    for (name, v) in &vectors {
+        let value: serde_json::Value = match serde_json::from_str(&v.input) {
+            Ok(value) => value,
+            Err(e) => {
+                failures.push(format!("[{name}] input is not parseable JSON: {e}"));
+                continue;
+            }
+        };
+        match assay_canonical::jcs::to_vec(&value) {
+            Err(e) => failures.push(format!("[{name}] canonicalization failed: {e}")),
+            Ok(bytes) => {
+                let got = String::from_utf8(bytes).expect("JCS output must be UTF-8");
+                if got != v.expected {
+                    failures.push(format!(
+                        "[{name}]\n     got: {got:?}\n  wanted: {:?}\n    pins: {}",
+                        v.expected, v.pins
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} RFC 8785 vectors diverged:\n\n{}\n\nA divergence here means digests produced by \
+         this crate cannot be reproduced by a conforming implementation in another language.",
+        failures.len(),
+        vectors.len(),
+        failures.join("\n\n")
+    );
+}
+
+/// Canonicalization must be a function of the value, not of the text it was parsed from. Two
+/// different spellings of the same JSON value have to produce identical bytes, or a producer and
+/// a verifier that formatted their input differently would compute different content ids for the
+/// same data.
+#[test]
+fn distinct_spellings_of_one_value_canonicalize_identically() {
+    for (case, a, b) in [
+        ("trailing zero", r#"{"a":4.50}"#, r#"{"a":4.5}"#),
+        ("integral float", r#"{"a":1.0}"#, r#"{"a":1}"#),
+        ("exponent form", r#"{"a":2e-3}"#, r#"{"a":0.002}"#),
+        ("signed zero", r#"{"a":-0}"#, r#"{"a":0}"#),
+        ("key order", r#"{"b":1,"a":2}"#, r#"{"a":2,"b":1}"#),
+        ("whitespace", "{\"a\": 1,\n \"b\": 2}", r#"{"a":1,"b":2}"#),
+        (
+            "past double precision",
+            r#"{"a":9007199254740993}"#,
+            r#"{"a":9007199254740992}"#,
+        ),
+    ] {
+        let canon = |src: &str| {
+            let v: serde_json::Value = serde_json::from_str(src).expect("parse");
+            String::from_utf8(assay_canonical::jcs::to_vec(&v).expect("canonicalize"))
+                .expect("utf8")
+        };
+        assert_eq!(canon(a), canon(b), "{case}: {a} and {b} must agree");
+    }
+}
+
+/// Production values reach the canonicalizer as Rust structs, not as parsed `Value`s, and a `u64`
+/// takes a different serde route in each case. RFC 8785 numbers are doubles, so a `u64` above
+/// 2^53 loses precision either way — but the two routes must lose it *identically*, or the same
+/// data would produce different digests depending only on how it was constructed.
+///
+/// Today no canonicalized field carries an integer near that boundary (the `u64`s in the evidence
+/// types are counters and sequence numbers). This test is what makes that a bounded fact rather
+/// than a hope: if a future field does cross it, the loss is at least consistent.
+#[test]
+fn integers_canonicalize_identically_from_a_struct_and_from_a_parsed_value() {
+    #[derive(serde::Serialize)]
+    struct Wrapper {
+        a: u64,
+    }
+
+    for n in [
+        42u64,
+        9_007_199_254_740_992, // 2^53, the last exactly-representable integer
+        9_007_199_254_740_993, // one past it
+        18_446_744_073_709_551_615, // u64::MAX
+    ] {
+        let from_struct = String::from_utf8(
+            assay_canonical::jcs::to_vec(&Wrapper { a: n }).expect("canonicalize"),
+        )
+        .expect("utf8");
+        let value: serde_json::Value =
+            serde_json::from_str(&format!("{{\"a\":{n}}}")).expect("parse");
+        let from_value =
+            String::from_utf8(assay_canonical::jcs::to_vec(&value).expect("canonicalize"))
+                .expect("utf8");
+
+        assert_eq!(
+            from_struct, from_value,
+            "{n} canonicalizes differently depending on whether it arrived as a Rust integer or \
+             as parsed JSON, so the digest would depend on the construction path"
+        );
+    }
+}
+
+/// The two properties most likely to be broken by swapping the canonicalizer, stated as their own
+/// test so a failure names the cause rather than appearing as one row in a table.
+#[test]
+fn the_two_properties_a_replacement_would_break() {
+    let canon = |src: &str| {
+        let v: serde_json::Value = serde_json::from_str(src).expect("parse");
+        String::from_utf8(assay_canonical::jcs::to_vec(&v).expect("canonicalize")).expect("utf8")
+    };
+
+    // UTF-16 code-unit ordering. A non-BMP key begins with a leading surrogate (0xD800), which is
+    // below U+E000 in UTF-16 and above it in both code-point and UTF-8 byte order. Every other
+    // ordering vector in the corpus passes under all three rules; only this one separates them.
+    let ordered = canon(r#"{"𐀀":1,"":2}"#);
+    assert!(
+        ordered.starts_with("{\"\u{10000}\""),
+        "keys are not ordered by UTF-16 code unit — the non-BMP key must come first, got {ordered:?}"
+    );
+
+    // No Unicode normalization. If a canonicalizer applied NFC, these two keys would collapse into
+    // one and the object would silently lose a member.
+    let unnormalized = canon("{\"\u{e9}\":1,\"e\u{301}\":2}");
+    assert!(
+        unnormalized.matches(":").count() == 2,
+        "a key was lost — the canonicalizer appears to apply Unicode normalization, which RFC 8785 \
+         does not: {unnormalized:?}"
+    );
+}

--- a/crates/assay-canonical/tests/rfc8785_conformance.rs
+++ b/crates/assay-canonical/tests/rfc8785_conformance.rs
@@ -16,6 +16,13 @@
 //! file). When adding a vector, derive its expectation from the RFC or from a second conforming
 //! implementation — never from this crate, or the check becomes a snapshot of whatever we already
 //! do and stops being a conformance check at all.
+//!
+//! **To confirm this corpus still bites**, swap `serde_jcs::to_vec` for `serde_json::to_vec` in
+//! `src/jcs.rs` and run this file. At least 8 vectors must fail, and
+//! `keyorder_utf16_vs_codepoint` must be among them — `serde_json::Map` also sorts, so it is the
+//! only ordering vector here where code-unit, code-point and byte order disagree. A corpus that
+//! survives that substitution is measuring nothing, and the property is written here rather than
+//! left in a pull request description so it stays checkable rather than remembered.
 
 use std::collections::BTreeMap;
 
@@ -100,11 +107,11 @@ fn distinct_spellings_of_one_value_canonicalize_identically() {
         ("signed zero", r#"{"a":-0}"#, r#"{"a":0}"#),
         ("key order", r#"{"b":1,"a":2}"#, r#"{"a":2,"b":1}"#),
         ("whitespace", "{\"a\": 1,\n \"b\": 2}", r#"{"a":1,"b":2}"#),
-        (
-            "past double precision",
-            r#"{"a":9007199254740993}"#,
-            r#"{"a":9007199254740992}"#,
-        ),
+        // `9007199254740993` vs `...992` deliberately does NOT belong here. Those are two
+        // different integers that happen to round to one double, not one value spelled two ways,
+        // and the collapse is precision loss rather than canonicalization. It is covered by
+        // `integers_canonicalize_identically_from_a_struct_and_from_a_parsed_value`, where the
+        // framing is right and a future divergence would send the reader to the correct cause.
     ] {
         let canon = |src: &str| {
             let v: serde_json::Value = serde_json::from_str(src).expect("parse");

--- a/crates/assay-canonical/tests/vectors/rfc8785.json
+++ b/crates/assay-canonical/tests/vectors/rfc8785.json
@@ -1,0 +1,163 @@
+{
+  "_about": {
+    "what": "RFC 8785 (JCS) conformance vectors for assay-canonical.",
+    "why": "Content ids, mandate ids and the bundle run root are all sha256 over these bytes. A canonicalization that diverges from RFC 8785 on any edge case makes those digests irreproducible by any other implementation, which is the property independent verification depends on.",
+    "expected_provenance": "Cross-validated against an independent implementation written in JavaScript, built from the primitives RFC 8785 defers to: ECMAScript Number::toString for numbers (RFC 8785 section 3.2.2.3), ECMAScript JSON string escaping (3.2.2.2), and Array.prototype.sort for key order, which compares by UTF-16 code unit (3.2.3). Both implementations agreed on all 31 vectors on 2026-08-04. Regenerate expectations by re-deriving from the RFC or another conforming implementation, never from this crate, or the check becomes circular.",
+    "fields": "input is the JSON source text. expected is the exact canonical output. pins states the property the vector exists to hold."
+  },
+  "empty_containers": {
+    "input": "{\"o\":{},\"a\":[],\"s\":\"\"}",
+    "expected": "{\"a\":[],\"o\":{},\"s\":\"\"}",
+    "pins": "Empty object, array and string have no whitespace and no separators."
+  },
+  "keyorder_ascii_case": {
+    "input": "{\"b\":1,\"A\":2,\"a\":3,\"B\":4}",
+    "expected": "{\"A\":2,\"B\":4,\"a\":3,\"b\":1}",
+    "pins": "Uppercase sorts before lowercase; ordering is by code unit, not case-insensitive or locale-aware."
+  },
+  "keyorder_digits_vs_letters": {
+    "input": "{\"1\":1,\"a\":2,\"_\":3,\"A\":4}",
+    "expected": "{\"1\":1,\"A\":4,\"_\":3,\"a\":2}",
+    "pins": "Digits, then uppercase, then underscore, then lowercase: ASCII code-unit order."
+  },
+  "keyorder_latin1": {
+    "input": "{\"\\u00e9\":1,\"z\":2,\"a\":3}",
+    "expected": "{\"a\":3,\"z\":2,\"\u00e9\":1}",
+    "pins": "A Latin-1 key sorts after all ASCII keys."
+  },
+  "keyorder_prefix": {
+    "input": "{\"ab\":1,\"a\":2,\"abc\":3}",
+    "expected": "{\"a\":2,\"ab\":1,\"abc\":3}",
+    "pins": "A shorter key sorts before a longer key that extends it."
+  },
+  "keyorder_utf16_vs_codepoint": {
+    "input": "{\"\\ud800\\udc00\":\"non-bmp U+10000\",\"\\ue000\":\"bmp U+E000\"}",
+    "expected": "{\"\ud800\udc00\":\"non-bmp U+10000\",\"\ue000\":\"bmp U+E000\"}",
+    "pins": "DECISIVE: sorting is by UTF-16 code unit, so a non-BMP key (leading surrogate 0xD800) sorts BEFORE U+E000. Code-point order and UTF-8 byte order both give the opposite. An implementation that sorts by either is wrong here and nowhere else in this file."
+  },
+  "nested_structure": {
+    "input": "{\"z\":{\"b\":[1,{\"y\":2,\"x\":3}],\"a\":null},\"A\":[]}",
+    "expected": "{\"A\":[],\"z\":{\"a\":null,\"b\":[1,{\"x\":3,\"y\":2}]}}",
+    "pins": "Ordering applies at every object depth, and array order is never changed."
+  },
+  "nfc_precomposed_vs_decomposed": {
+    "input": "{\"\\u00e9\":\"precomposed\",\"e\\u0301\":\"decomposed\"}",
+    "expected": "{\"e\u0301\":\"decomposed\",\"\u00e9\":\"precomposed\"}",
+    "pins": "JCS applies NO Unicode normalization: precomposed and decomposed forms stay two distinct keys. An implementation that normalizes would collapse them and silently change the digest."
+  },
+  "num_1e20": {
+    "input": "{\"a\":1e20}",
+    "expected": "{\"a\":100000000000000000000}",
+    "pins": "One below that boundary, so it must render in full, all twenty-one digits."
+  },
+  "num_1e21_boundary": {
+    "input": "{\"a\":1e21}",
+    "expected": "{\"a\":1e+21}",
+    "pins": "The ES6 boundary: at 1e21 the representation switches to exponent form."
+  },
+  "num_1e_minus_6": {
+    "input": "{\"a\":1e-6}",
+    "expected": "{\"a\":0.000001}",
+    "pins": "One above it, so plain decimal."
+  },
+  "num_1e_minus_7": {
+    "input": "{\"a\":1e-7}",
+    "expected": "{\"a\":1e-7}",
+    "pins": "The small-magnitude boundary: at 1e-7 the representation switches to exponent form."
+  },
+  "num_2pow53": {
+    "input": "{\"a\":9007199254740992}",
+    "expected": "{\"a\":9007199254740992}",
+    "pins": "The largest integer a double represents exactly."
+  },
+  "num_2pow53_plus1": {
+    "input": "{\"a\":9007199254740993}",
+    "expected": "{\"a\":9007199254740992}",
+    "pins": "One past it: rounds to the same double, so both inputs must canonicalize identically."
+  },
+  "num_big_exponent": {
+    "input": "{\"a\":1E30}",
+    "expected": "{\"a\":1e+30}",
+    "pins": "Exponent form carries the sign: 1e+30, not 1E30 or 1e30."
+  },
+  "num_i64_min": {
+    "input": "{\"a\":-9223372036854775808}",
+    "expected": "{\"a\":-9223372036854776000}",
+    "pins": "Same, on the negative side."
+  },
+  "num_integral_float": {
+    "input": "{\"a\":1.0}",
+    "expected": "{\"a\":1}",
+    "pins": "1.0 and 1 are the same double and must produce the same bytes."
+  },
+  "num_negative_zero": {
+    "input": "{\"a\":-0}",
+    "expected": "{\"a\":0}",
+    "pins": "Negative zero canonicalizes to 0. A signed zero would make two equal values hash differently."
+  },
+  "num_point_one": {
+    "input": "{\"a\":0.1}",
+    "expected": "{\"a\":0.1}",
+    "pins": "The classic non-representable decimal must round-trip to the shortest form."
+  },
+  "num_precision_loss": {
+    "input": "{\"a\":333333333.33333329}",
+    "expected": "{\"a\":333333333.3333333}",
+    "pins": "RFC 8785's own precision example: the input has more digits than a double can hold."
+  },
+  "num_small_exponent": {
+    "input": "{\"a\":2e-3}",
+    "expected": "{\"a\":0.002}",
+    "pins": "2e-3 renders as the plain decimal 0.002, not in exponent form."
+  },
+  "num_sum_artifact": {
+    "input": "{\"a\":0.30000000000000004}",
+    "expected": "{\"a\":0.30000000000000004}",
+    "pins": "A value whose shortest representation needs all seventeen significant digits."
+  },
+  "num_tiny": {
+    "input": "{\"a\":1e-27}",
+    "expected": "{\"a\":1e-27}",
+    "pins": "Below the plain-decimal threshold, so exponent form with a bare negative exponent."
+  },
+  "num_trailing_zero": {
+    "input": "{\"a\":4.50}",
+    "expected": "{\"a\":4.5}",
+    "pins": "4.50 is not a distinct value from 4.5; ES6 Number::toString drops the trailing zero."
+  },
+  "num_u64_max": {
+    "input": "{\"a\":18446744073709551615}",
+    "expected": "{\"a\":18446744073709552000}",
+    "pins": "An integer beyond the double range loses precision by design; RFC 8785 numbers are doubles."
+  },
+  "rfc8785_appendix_mixed": {
+    "input": "{\"numbers\":[333333333.33333329,1E30,4.50,2e-3,0.000000000000000000000000001],\"string\":\"\\u20ac$\\u000F\\u000aA'\\u0042\\u0022\\u005c\\\\\\\"\\/\",\"literals\":[null,true,false]}",
+    "expected": "{\"literals\":[null,true,false],\"numbers\":[333333333.3333333,1e+30,4.5,0.002,1e-27],\"string\":\"\u20ac$\\u000f\\nA'B\\\"\\\\\\\\\\\"/\"}",
+    "pins": "The composite example from RFC 8785 itself: number reformatting, escaping, and key reordering in one value."
+  },
+  "string_backslash_quote": {
+    "input": "{\"a\":\"q\\\"b\\\\c\"}",
+    "expected": "{\"a\":\"q\\\"b\\\\c\"}",
+    "pins": "Quote and backslash are escaped, and nothing else is."
+  },
+  "string_control_chars": {
+    "input": "{\"a\":\"\\u0000\\u0001\\u001f\\b\\f\\n\\r\\t\"}",
+    "expected": "{\"a\":\"\\u0000\\u0001\\u001f\\b\\f\\n\\r\\t\"}",
+    "pins": "Control characters use the short escapes where they exist and the six-character form otherwise."
+  },
+  "string_del_and_high_ascii": {
+    "input": "{\"a\":\"\\u007f\\u0080\"}",
+    "expected": "{\"a\":\"\u007f\u0080\"}",
+    "pins": "DEL and U+0080 are emitted literally; only C0 controls, quote and backslash are escaped."
+  },
+  "string_high_unicode": {
+    "input": "{\"a\":\"\\ud83d\\ude00 emoji\"}",
+    "expected": "{\"a\":\"\ud83d\ude00 emoji\"}",
+    "pins": "A non-BMP character is emitted as literal UTF-8, not as an escaped surrogate pair."
+  },
+  "string_solidus": {
+    "input": "{\"a\":\"a/b\"}",
+    "expected": "{\"a\":\"a/b\"}",
+    "pins": "The solidus is NOT escaped."
+  }
+}


### PR DESCRIPTION
Every content id, mandate id and bundle run root is a sha256 over the bytes `assay-canonical` emits. Nothing checked those bytes against the standard they claim to follow.

A divergence would not have failed any existing test: the reference producer and the reference verifier would have gone on agreeing with each other, and only an independent implementation would ever have noticed — which is the one property the evidence contract rests on. `serde_jcs` is pinned to an exact version because its output moves those digests; that pin catches an unnoticed upgrade, it says nothing about whether the pinned version is right.

## What this adds

31 edge-case vectors, each carrying a `pins` line stating the property it exists to hold, and four tests over them.

Expected bytes were **cross-validated against an independent implementation in another language**, built from the primitives RFC 8785 defers to: ECMAScript `Number::toString` for numbers (§3.2.2.3), ECMAScript JSON escaping for strings (§3.2.2.2), and UTF-16 code-unit key ordering (§3.2.3). All 31 agree byte-for-byte.

Coverage includes number reformatting (`4.50` → `4.5`, `-0` → `0`, `1.0` → `1`), both ES6 exponent boundaries (`1e20` in full, `1e21` in exponent form; `1e-6` plain, `1e-7` exponent), the RFC's own precision example, and the absence of Unicode normalization.

## The decisive vector

`keyorder_utf16_vs_codepoint`. Almost any implementation looks correct on ordinary keys — including one that sorts by code point or by UTF-8 bytes, since `serde_json::Map` also sorts. Only a non-BMP key meeting one in `U+E000..U+FFFF` separates the three orderings.

Two further properties are pinned because a canonicalizer swap could break them silently: distinct spellings of one value must agree, and an integer must canonicalize identically whether it arrived as a Rust integer or as parsed JSON.

## Verification

Verified by mutation rather than by observing green: substituting plain `serde_json` for the pinned canonicalizer fails **8 of the 31** vectors and all four tests — and the only ordering vector among those 8 is the decisive one, which is the corpus confirming its own claim about itself.

`serde_json`'s `arbitrary_precision` feature is not enabled anywhere in the workspace, so that emission path cannot occur.

Expectations must never be regenerated from this crate; the vector file's `_about.expected_provenance` says so, because a corpus derived from the code under test is a snapshot rather than a conformance check.

**No production code changes, so no digest moves.** Groundwork for #1979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)