### PR TITLE
A suite that carried assertions was swept without reading them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ All notable changes to this project will be documented in this file.
   opposite. The catalogue is rewritten from the enum, and a test now loads every
   fenced example, requires every shipped variant to be documented, and requires
   every type listed as unimplemented to actually be rejected (#1960).
+- `assay validate` now sweeps `assertions:` instead of stepping over them. The
+  exemption tested whether a test carried a **non-empty** assertion list, not an
+  **effective** one, and nothing examined the assertions afterwards — so a single
+  assertion that could not fail cleared both gates at once: the `expected:` check
+  was skipped because assertions existed, and the assertions were never looked
+  at. A suite could be swept clean while asserting nothing. Effectiveness is
+  decided by the same code the evaluator runs, so there is one definition of
+  "cannot fail" rather than a static one and a runtime one that drift. An
+  unrecognized `expect` spelling — which selected *expect failure* and inverted
+  the assertion — is now caught in the same sweep (#1949).
 - An `assertions:` entry that cannot check anything no longer reports as a pass.
   Thirteen shapes evaluated to nothing or to a check that could not fail for any
   input — an `args_valid` without `test_args`, a `sequence_valid` written

--- a/crates/assay-core/src/agent_assertions/matchers.rs
+++ b/crates/assay-core/src/agent_assertions/matchers.rs
@@ -16,6 +16,39 @@ pub fn evaluate(
     Ok(out)
 }
 
+/// Why this assertion cannot check anything, decided from the configuration alone.
+///
+/// `Some` means no trace could ever make the assertion fail, so running it would report a pass
+/// that carries no information. `None` means the assertion constrains something; whether it then
+/// holds is a question about a trace and is not answered here.
+///
+/// This lets a static sweep — `assay validate`, which reads a config without running it — reach
+/// the same conclusions the evaluator reaches, **without a second definition of "cannot fail"**.
+/// Two implementations of one rule drift; the fix for that is one implementation with two callers.
+/// So this runs the real checker against an empty episode and keeps only the diagnostics that were
+/// decided before any trace was consulted.
+///
+/// That filter is exact rather than approximate, and the reason is a property of the checker:
+/// every `E_ASSERT_INEFFECTIVE` and `E_CONFIG_ERROR` in `check_one` is returned from a branch that
+/// reads only the assertion's own fields, and every branch that reads the graph returns a
+/// different code (`E_TRACE_ASSERT_FAIL`, `E_POLICY_ASSERT_FAIL`).
+/// `validate::vacuous_expected_tests::does_not_flag_an_assertion_that_merely_fails_for_a_trace`
+/// pins that split, so a future check that broke it fails there rather than silently making the
+/// sweep reject working configurations.
+///
+/// The cost of the reuse is that a valid `args_valid` compiles its schema here as well as at
+/// evaluation. In a static sweep that is acceptable and arguably the point: a schema that cannot
+/// compile is worth learning about from `assay validate` rather than from a run.
+pub fn ineffective_reason(a: &TraceAssertion) -> Option<Diagnostic> {
+    let no_trace = EpisodeGraph {
+        episode_id: "static_config_sweep".into(),
+        steps: vec![],
+        tool_calls: vec![],
+    };
+    check_one(&no_trace, a)
+        .filter(|d| d.code == "E_ASSERT_INEFFECTIVE" || d.code == "E_CONFIG_ERROR")
+}
+
 fn check_one(graph: &EpisodeGraph, a: &TraceAssertion) -> Option<Diagnostic> {
     match a {
         TraceAssertion::TraceMustCallTool { tool, min_calls } => {

--- a/crates/assay-core/src/agent_assertions/matchers.rs
+++ b/crates/assay-core/src/agent_assertions/matchers.rs
@@ -37,8 +37,11 @@ pub fn evaluate(
 /// sweep reject working configurations.
 ///
 /// The cost of the reuse is that a valid `args_valid` compiles its schema here as well as at
-/// evaluation. In a static sweep that is acceptable and arguably the point: a schema that cannot
-/// compile is worth learning about from `assay validate` rather than from a run.
+/// evaluation, and the result is then discarded. In a static sweep that cost is acceptable, but
+/// it buys nothing: a schema that cannot compile produces an evaluation-decided code, which this
+/// filter drops, so the sweep stays silent about it. That is deliberate — a broken schema is not
+/// an assertion that cannot fail — but it is a boundary rather than a feature, and
+/// `a_schema_that_cannot_compile_neither_panics_nor_is_swept` pins it so nobody has to rediscover it.
 pub fn ineffective_reason(a: &TraceAssertion) -> Option<Diagnostic> {
     let no_trace = EpisodeGraph {
         episode_id: "static_config_sweep".into(),

--- a/crates/assay-core/src/validate/mod.rs
+++ b/crates/assay-core/src/validate/mod.rs
@@ -291,7 +291,17 @@ pub async fn validate(
 /// still worth reporting when such a test has no assertions either, because then it
 /// really does assert nothing; hence a warning rather than an error.
 ///
-/// Tests that carry `assertions:` are exempt.
+/// Tests that carry `assertions:` are not exempt — they are swept too.
+///
+/// The exemption used to test for a **non-empty** `assertions:` list rather than an **effective**
+/// one, and nothing looked at the assertions afterwards. One assertion that could not fail
+/// therefore cleared both gates in a single move: the `expected:` check was skipped because
+/// assertions existed, and the assertions were never examined. Reporting a suite as swept while
+/// stepping over the case the sweep exists to find is the failure this function is meant to
+/// prevent, one layer up.
+///
+/// Effectiveness is decided by `agent_assertions::matchers::ineffective_reason`, which is the same
+/// code the evaluator runs. Nothing here re-states what "cannot fail" means.
 ///
 /// This check reads only the config, so `assay validate` can sweep a suite for
 /// always-green tests without running it.
@@ -299,7 +309,29 @@ fn check_vacuous_expected(cfg: &EvalConfig) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
 
     for tc in &cfg.tests {
-        let has_assertions = tc.assertions.as_ref().is_some_and(|a| !a.is_empty());
+        let assertions = tc.assertions.as_deref().unwrap_or_default();
+        let has_assertions = !assertions.is_empty();
+
+        // An assertion that cannot fail is reported here rather than only when a run reaches it,
+        // so a suite can be swept for always-green tests without executing anything.
+        for (index, assertion) in assertions.iter().enumerate() {
+            let Some(mut reason) = crate::agent_assertions::matchers::ineffective_reason(assertion)
+            else {
+                continue;
+            };
+            // Keep the evaluator's own context — it names the variant and the responsible field —
+            // and add where in the suite it was found, which is what a sweep has to supply.
+            if let Some(obj) = reason.context.as_object_mut() {
+                obj.insert("test_id".into(), serde_json::json!(tc.id));
+                obj.insert("assertion_index".into(), serde_json::json!(index));
+            }
+            diags.push(
+                reason.with_fix_step(
+                    "Or remove the assertion, so the test does not appear to check it",
+                ),
+            );
+        }
+
         if has_assertions {
             continue;
         }
@@ -512,6 +544,168 @@ mod vacuous_expected_tests {
             }]),
         );
         assert!(check_vacuous_expected(&cfg).is_empty());
+    }
+
+    /// The case the exemption used to step over: a test carrying one assertion that cannot fail.
+    ///
+    /// Before this check, the non-empty `assertions:` list suppressed the `expected:` warning and
+    /// nothing looked at the assertion, so the suite swept clean while asserting nothing.
+    #[test]
+    fn flags_an_assertion_that_cannot_fail() {
+        let cfg = cfg_with(
+            Expected::default(),
+            Some(vec![TraceAssertion::TraceMustCallTool {
+                tool: "search".into(),
+                min_calls: Some(0),
+            }]),
+        );
+        let diags = check_vacuous_expected(&cfg);
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].code, "E_ASSERT_INEFFECTIVE");
+        assert_eq!(diags[0].severity, "error");
+        assert_eq!(diags[0].context["field"], "min_calls");
+        assert_eq!(diags[0].context["test_id"], "t1");
+        assert_eq!(diags[0].context["assertion_index"], 0);
+    }
+
+    /// One per variant. A sweep that reached only the variants convenient to write would be the
+    /// same partial-coverage problem it exists to report.
+    #[test]
+    fn flags_a_vacuous_shape_of_every_variant() {
+        let cases: Vec<(&str, TraceAssertion)> = vec![
+            (
+                "tool",
+                TraceAssertion::TraceMustCallTool {
+                    tool: String::new(),
+                    min_calls: None,
+                },
+            ),
+            (
+                "tool",
+                TraceAssertion::TraceMustNotCallTool {
+                    tool: String::new(),
+                },
+            ),
+            (
+                "sequence",
+                TraceAssertion::TraceToolSequence {
+                    sequence: vec![],
+                    allow_other_tools: true,
+                },
+            ),
+            ("max", TraceAssertion::TraceMaxSteps { max: u32::MAX }),
+            (
+                "test_args",
+                TraceAssertion::ArgsValid {
+                    tool: "t".into(),
+                    test_args: None,
+                    policy: None,
+                    expect: None,
+                },
+            ),
+            (
+                "test_trace_raw",
+                TraceAssertion::SequenceValid {
+                    test_trace: None,
+                    test_trace_raw: None,
+                    policy: None,
+                    expect: None,
+                },
+            ),
+            (
+                "test_tool_calls",
+                TraceAssertion::ToolBlocklist {
+                    test_tool_calls: None,
+                    policy: None,
+                    expect: None,
+                },
+            ),
+        ];
+
+        for (field, assertion) in cases {
+            let cfg = cfg_with(Expected::default(), Some(vec![assertion.clone()]));
+            let diags = check_vacuous_expected(&cfg);
+            assert_eq!(diags.len(), 1, "{assertion:?} produced {diags:?}");
+            assert_eq!(
+                diags[0].context["field"], field,
+                "{assertion:?} blamed the wrong field: {}",
+                diags[0].message
+            );
+        }
+    }
+
+    /// An unrecognized `expect` spelling silently selected *expect failure* and inverted the
+    /// assertion. That is worse than a no-op — a no-op stops checking, an inversion checks the
+    /// opposite — so the static sweep has to reach it too, not only the evaluator.
+    #[test]
+    fn flags_an_unrecognized_expect_spelling() {
+        let cfg = cfg_with(
+            Expected::default(),
+            Some(vec![TraceAssertion::ArgsValid {
+                tool: "t".into(),
+                test_args: Some(serde_json::json!({})),
+                policy: Some(serde_json::json!({ "schema": {} })),
+                expect: Some("Pass".into()),
+            }]),
+        );
+        let diags = check_vacuous_expected(&cfg);
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].code, "E_CONFIG_ERROR");
+        assert!(diags[0].message.contains("expect"), "{}", diags[0].message);
+    }
+
+    /// The invariant the static sweep rests on: it must reject configurations that cannot check
+    /// anything, and **only** those. An assertion that constrains something and would simply not
+    /// hold for a given trace is not a config defect, and reporting it here would make
+    /// `assay validate` refuse working suites — the over-eager detection that earns a suppression
+    /// and takes the real findings down with it.
+    ///
+    /// Each case below fails when evaluated against an empty episode, which is exactly the input
+    /// the sweep uses internally. If a future check answered one of these from the configuration,
+    /// this test fails rather than the sweep quietly growing false positives.
+    #[test]
+    fn does_not_flag_an_assertion_that_merely_fails_for_a_trace() {
+        for assertion in [
+            // Requires three calls; an empty episode has none.
+            TraceAssertion::TraceMustCallTool {
+                tool: "search".into(),
+                min_calls: Some(3),
+            },
+            // Requires this order; an empty episode has no calls at all.
+            TraceAssertion::TraceToolSequence {
+                sequence: vec!["a".into(), "b".into()],
+                allow_other_tools: true,
+            },
+            // Exact-sequence form, likewise unsatisfied by an empty episode.
+            TraceAssertion::TraceToolSequence {
+                sequence: vec!["a".into()],
+                allow_other_tools: false,
+            },
+            // A well-formed policy the supplied arguments violate: a real failure, not a
+            // configuration that checks nothing.
+            TraceAssertion::ArgsValid {
+                tool: "t".into(),
+                test_args: Some(serde_json::json!({ "percent": 90 })),
+                policy: Some(serde_json::json!({
+                    "schema": { "properties": { "percent": { "type": "number", "maximum": 30 } } }
+                })),
+                expect: Some("pass".into()),
+            },
+            // A blocked call that is actually made, expected to pass: fails, and should.
+            TraceAssertion::ToolBlocklist {
+                test_tool_calls: Some(vec!["rm".into()]),
+                policy: Some(serde_json::json!({ "blocked": ["rm"] })),
+                expect: Some("pass".into()),
+            },
+        ] {
+            let cfg = cfg_with(Expected::default(), Some(vec![assertion.clone()]));
+            let diags = check_vacuous_expected(&cfg);
+            assert!(
+                diags.is_empty(),
+                "the static sweep rejected a configuration that merely fails for a trace: \
+                 {assertion:?} -> {diags:?}"
+            );
+        }
     }
 
     /// The sweep must work with no trace file and no baseline — that is the point of

--- a/crates/assay-core/src/validate/mod.rs
+++ b/crates/assay-core/src/validate/mod.rs
@@ -708,6 +708,58 @@ mod vacuous_expected_tests {
         }
     }
 
+    /// The sweep reaches the schema compiler from a caller that did not exist before, so a
+    /// schema that cannot compile now has a new way to be encountered. A panic here would take
+    /// down `assay validate` on the one input it most needs to survive: a config someone is
+    /// trying to fix.
+    ///
+    /// It returns, and it says nothing. That was worth measuring rather than assuming, because
+    /// an earlier version of the doc comment on `ineffective_reason` claimed the opposite — that
+    /// the schema compilation the sweep performs would surface a broken schema early. It does
+    /// not: the resulting diagnostic carries an evaluation-decided code, which the filter drops.
+    /// Both are pinned here so the boundary is stated rather than rediscovered.
+    #[test]
+    fn a_schema_that_cannot_compile_neither_panics_nor_is_swept() {
+        for (case, policy) in [
+            (
+                "type is not a schema keyword value",
+                serde_json::json!({ "schema": { "type": 42 } }),
+            ),
+            (
+                "properties is not an object",
+                serde_json::json!({ "schema": { "properties": "not-an-object" } }),
+            ),
+            (
+                "required is not an array",
+                serde_json::json!({ "schema": { "required": 7 } }),
+            ),
+            (
+                "external ref, which the hermetic compiler refuses",
+                serde_json::json!({ "schema": { "$ref": "https://example.invalid/s.json" } }),
+            ),
+        ] {
+            let cfg = cfg_with(
+                Expected::default(),
+                Some(vec![TraceAssertion::ArgsValid {
+                    tool: "t".into(),
+                    test_args: Some(serde_json::json!({ "a": 1 })),
+                    policy: Some(policy),
+                    expect: Some("pass".into()),
+                }]),
+            );
+            // The assertion is that this returns rather than unwinding.
+            let diags = check_vacuous_expected(&cfg);
+            assert!(
+                diags.is_empty(),
+                "{case}: the sweep reported {diags:?}. An uncompilable schema is a broken \
+                 assertion, not one that cannot fail, and widening the sweep to catch it would \
+                 cost the narrowness `does_not_flag_an_assertion_that_merely_fails_for_a_trace` \
+                 protects. If this is now wanted, it belongs in a schema-validity check with its \
+                 own diagnostic, not in the vacuity filter."
+            );
+        }
+    }
+
     /// The sweep must work with no trace file and no baseline — that is the point of
     /// being able to check a suite without running it.
     #[tokio::test]


### PR DESCRIPTION
Item 2 of #1949.

`check_vacuous_expected` exists so `assay validate` can sweep a suite for always-green tests without running it. It tested whether a test carried a **non-empty** `assertions:` list and skipped it — non-empty, not effective — and nothing examined the assertions afterwards.

So one assertion that could not fail cleared both gates in a single move: the `expected:` check was skipped because assertions existed, and the assertions were never looked at. The sweep reported a suite as clean while stepping over exactly the case it exists to find.

## One definition of "cannot fail", not two

The obvious fix — have the sweep call the evaluator's effectiveness logic — was not available: `check_one` takes an `&EpisodeGraph`. Following it literally would have produced a second implementation of "cannot fail", which is the drift this repo has a rule against.

So the checks were mapped first. Every ineffectiveness check in `matchers.rs` is a pure function of the assertion's own fields: the `ArgsValid`, `SequenceValid` and `ToolBlocklist` arms touch the graph zero times, and in the other four arms every guard sits ahead of the first graph read.

`matchers::ineffective_reason(&TraceAssertion) -> Option<Diagnostic>` therefore runs the *real* checker against an empty episode and keeps only the diagnostics decided before any trace was consulted. The static sweep reaches the evaluator's conclusions by running the evaluator, not by restating it.

The filter is exact rather than approximate, for a structural reason: every `E_ASSERT_INEFFECTIVE` and `E_CONFIG_ERROR` is returned from a branch reading only configuration, while every branch that reads the graph returns a different code.

## The invariant

`does_not_flag_an_assertion_that_merely_fails_for_a_trace` pins that split. An assertion that constrains something and simply does not hold is not a config defect, and reporting it here would make `assay validate` refuse working suites — the over-eager detection that earns a suppression and takes the real findings down with it.

An unrecognized `expect` spelling comes along, and matters more than the vacuous shapes: a no-op stops checking, an inversion checks the opposite.

## Verification

Verified by mutation, in both directions:

- restoring the blind skip → **three tests fail**, so the sweep is load-bearing;
- widening the filter to admit every diagnostic → **the invariant test fails**, so the filter is what prevents false positives rather than an accident of the inputs.

The pre-existing `does_not_flag_when_assertions_present` passes unchanged as the positive control.

Rejecting at load for every command (item 1) is the remaining decision, and is now cheaper: the predicate it needs exists and is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)