### PR TITLE
An unknown key in an assertion is a typo, not a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- An `assertions:` entry carrying a key the type does not define is now rejected
+  at parse time, naming the offending key, instead of being dropped in silence.
+  Where the intended field had a default the dropped key left a check that could
+  not fail: the documented `max_calls: 0` "must NOT use a forbidden tool"
+  example inverted into "must be called at least once", because `max_calls` was
+  discarded and `min_calls` defaulted to 1. Rejection holds through the config
+  loader, which collects unknown keys elsewhere and outside strict mode only
+  warns about them. **This turns previously green configurations red, by design:
+  an unknown key in an assertion is either a typo or a feature that does not
+  exist** (#1961).
+- Every `assertions:` example in the documentation now loads. None of them did:
+  five of the seven documented types had no implementation, the two that existed
+  were shown with field names that did not, the architecture example nested them
+  under a top-level `policies:` block the loader refuses at `configVersion: 1`,
+  and the example labelled "must NOT use a forbidden tool" asserted the
+  opposite. The catalogue is rewritten from the enum, and a test now loads every
+  fenced example, requires every shipped variant to be documented, and requires
+  every type listed as unimplemented to actually be rejected (#1960).
 - An `assertions:` entry that cannot check anything no longer reports as a pass.
   Thirteen shapes evaluated to nothing or to a check that could not fail for any
   input — an `args_valid` without `test_args`, a `sequence_valid` written

--- a/crates/assay-core/src/agent_assertions/model.rs
+++ b/crates/assay-core/src/agent_assertions/model.rs
@@ -1,7 +1,28 @@
 use serde::{Deserialize, Serialize};
 
+/// An assertion carrying a key this enum does not define is rejected at parse time.
+///
+/// Without `deny_unknown_fields` serde drops the unrecognised key silently, and where the
+/// intended field has a default the assertion falls back to a shape that cannot fail. The
+/// documented `max_calls: 0` "must NOT use a forbidden tool" example is the worked case: the
+/// key is dropped, `min_calls` defaults to 1 in `matchers.rs`, and the assertion inverts into
+/// "must be called at least once" with no signal at any stage (#1961).
+///
+/// `deny_unknown_fields` is applied at the **container**, which is the only place serde accepts
+/// it — it is not a variant attribute, and the compiler rejects it as one. There is folklore
+/// that container-level rejection is unreliable on an internally-tagged enum (serde-rs/serde
+/// #2294, #1358). Those defects are about unit-like variants and `flatten`; every variant here
+/// is a struct variant with named fields and none flattens, and rejection was verified on this
+/// exact shape for the hardest case in it — `tool_blocklist`, whose fields are all defaulted, so
+/// nothing but the tag is required. A stray key there is rejected too. Nested free-form values
+/// (`policy`, `test_args`) are `serde_json::Value` and stay unconstrained, which is intended:
+/// the guard covers the assertion's own field vocabulary, not policy contents.
+///
+/// Keep the guard at the container. Per-variant allow-set validation was considered and is not
+/// needed here; the tests in `tests/assertions_unknown_fields.rs` pin the behaviour that makes
+/// it unnecessary, including the all-defaulted variant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum TraceAssertion {
     #[serde(rename = "trace_must_call_tool")]
     TraceMustCallTool {

--- a/crates/assay-core/tests/assertions_unknown_fields.rs
+++ b/crates/assay-core/tests/assertions_unknown_fields.rs
@@ -266,13 +266,65 @@ fn first_party_suites_still_load() {
         .and_then(|p| p.parent())
         .expect("repo root");
 
-    for name in ["tests/fp_suite.yaml", "tests/regex_compatibility.yaml"] {
+    // No `if !path.exists() { continue }`. A missing path would make this test pass without
+    // loading anything, and this test is the only thing standing behind the claim that no
+    // first-party config broke — absence reported as a pass, in the guard against exactly that.
+    let suites = ["tests/fp_suite.yaml", "tests/regex_compatibility.yaml"];
+    let mut loaded = 0;
+    for name in suites {
         let path = repo_root.join(name);
-        if !path.exists() {
-            continue;
-        }
+        assert!(
+            path.exists(),
+            "{name} not found at {}; this test's coverage would otherwise be silently empty",
+            path.display()
+        );
         assay_core::config::load_config(&path, false, false).unwrap_or_else(|e| {
             panic!("{name} no longer loads after the unknown-field guard: {e}")
         });
+        loaded += 1;
+    }
+    assert_eq!(
+        loaded,
+        suites.len(),
+        "not every first-party suite was exercised"
+    );
+}
+
+/// `docs/metrics/index.md` states that `trace_must_call_tool` counts an errored call, because
+/// `ToolCallRow` carries no status or error column. That is a claim about a struct, and the
+/// documentation test next door checks the *examples*, not the prose — so if the row ever gains
+/// an outcome column the sentence would quietly become false.
+///
+/// This makes it rot loudly instead, two ways. The literal below stops compiling if a field is
+/// added, which points a change at this test; and the field-name check catches a rename that
+/// still compiles. If either fires, the doc is now wrong and the assertion may have become able
+/// to distinguish success from failure — a real capability worth documenting rather than a test
+/// to delete.
+#[test]
+fn the_documented_reason_errored_calls_still_count_is_still_true() {
+    let row = serde_json::to_value(assay_core::storage::rows::ToolCallRow {
+        id: 1,
+        step_id: "s".into(),
+        episode_id: "e".into(),
+        tool_name: Some("t".into()),
+        call_index: Some(0),
+        args: None,
+        result: None,
+    })
+    .expect("ToolCallRow serializes");
+    let fields: Vec<&str> = row
+        .as_object()
+        .expect("ToolCallRow is a struct")
+        .keys()
+        .map(|k| k.as_str())
+        .collect();
+
+    for outcome_ish in ["status", "error", "ok", "success", "outcome", "failed"] {
+        assert!(
+            !fields.contains(&outcome_ish),
+            "ToolCallRow gained a `{outcome_ish}` field. `docs/metrics/index.md` says an errored \
+             call satisfies `trace_must_call_tool` because no such column exists; update the doc \
+             (and consider whether the assertion should now distinguish them). Fields: {fields:?}"
+        );
     }
 }

--- a/crates/assay-core/tests/assertions_unknown_fields.rs
+++ b/crates/assay-core/tests/assertions_unknown_fields.rs
@@ -1,0 +1,278 @@
+//! An unrecognised key inside an `assertions:` entry must be rejected, not dropped (#1961).
+//!
+//! Serde drops an unknown key silently by default. Where the field the author meant has a
+//! default, the assertion falls back to a shape that cannot fail — so a one-character typo
+//! turns a real check into a permanent pass with no signal at any stage. The documented
+//! `max_calls: 0` example is the worked case and inverts into its own opposite.
+//!
+//! These tests pin two things the fix depends on and one thing it must not break:
+//!
+//! 1. rejection reaches every variant, including `tool_blocklist`, whose fields are all
+//!    defaulted so nothing but the tag is required — the shape closest to the unit-like
+//!    variants that serde's known `deny_unknown_fields` defects are actually about;
+//! 2. rejection survives the real config-loading path, which wraps deserialization in
+//!    `serde_ignored` to collect unknown keys and, outside strict mode, only warns about
+//!    them. A guard that fires on a bare `from_str` but not through `load_config` would be
+//!    the check looking present while the CLI stayed permissive;
+//! 3. free-form values nested under `policy` and `test_args` stay unconstrained.
+
+use assay_core::agent_assertions::model::TraceAssertion;
+
+fn parse(yaml: &str) -> Result<TraceAssertion, serde_yaml::Error> {
+    serde_yaml::from_str(yaml)
+}
+
+/// Asserts rejection **and** that the message names the offending key.
+///
+/// A code-only assertion is too weak here: the whole point of the fix is that the author is
+/// told which key was wrong, because the common case is one character away from a real field.
+#[track_caller]
+fn assert_rejects_naming(yaml: &str, offending_key: &str, case: &str) {
+    match parse(yaml) {
+        Ok(v) => panic!("{case}: expected rejection, but parsed into {v:?}"),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains(offending_key),
+                "{case}: rejected, but the message does not name `{offending_key}`: {msg}"
+            );
+        }
+    }
+}
+
+#[track_caller]
+fn assert_accepts(yaml: &str, case: &str) {
+    if let Err(e) = parse(yaml) {
+        panic!("{case}: expected this to parse, got {e}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// One misspelling per variant. The variants with a defaulted field are where a
+// dropped key is dangerous; the all-required ones are covered so the guard is
+// not silently variant-dependent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trace_must_call_tool_rejects_unknown_key() {
+    assert_rejects_naming(
+        "type: trace_must_call_tool\ntool: delete_database\nmax_calls: 0\n",
+        "max_calls",
+        "trace_must_call_tool / the documented max_calls inversion",
+    );
+    assert_rejects_naming(
+        "type: trace_must_call_tool\ntool: web_search\nmin_call: 2\n",
+        "min_call",
+        "trace_must_call_tool / misspelled min_calls",
+    );
+    // The field name the documentation used for years.
+    assert_rejects_naming(
+        "type: trace_must_call_tool\ntool_name: web_search\n",
+        "tool_name",
+        "trace_must_call_tool / documented tool_name",
+    );
+}
+
+#[test]
+fn trace_must_not_call_tool_rejects_unknown_key() {
+    assert_rejects_naming(
+        "type: trace_must_not_call_tool\ntool: rm\nmax_calls: 0\n",
+        "max_calls",
+        "trace_must_not_call_tool / stray key",
+    );
+}
+
+#[test]
+fn trace_tool_sequence_rejects_unknown_key() {
+    assert_rejects_naming(
+        "type: trace_tool_sequence\nsequence: [a, b]\nallow_other_tool: true\n",
+        "allow_other_tool",
+        "trace_tool_sequence / misspelled allow_other_tools",
+    );
+    // `mode: loose` is what the architecture document wrote instead of the real field.
+    assert_rejects_naming(
+        "type: trace_tool_sequence\nsequence: [a, b]\nallow_other_tools: false\nmode: loose\n",
+        "mode",
+        "trace_tool_sequence / documented mode key",
+    );
+}
+
+#[test]
+fn trace_max_steps_rejects_unknown_key() {
+    assert_rejects_naming(
+        "type: trace_max_steps\nmax: 10\nsteps: 10\n",
+        "steps",
+        "trace_max_steps / stray key",
+    );
+}
+
+#[test]
+fn args_valid_rejects_unknown_key() {
+    assert_rejects_naming(
+        "type: args_valid\ntool: t\ntest_arg: {a: 1}\n",
+        "test_arg",
+        "args_valid / misspelled test_args",
+    );
+    assert_rejects_naming(
+        "type: args_valid\ntool: t\ntest_args: {a: 1}\nexpekt: pass\n",
+        "expekt",
+        "args_valid / misspelled expect",
+    );
+}
+
+#[test]
+fn sequence_valid_rejects_unknown_key() {
+    assert_rejects_naming(
+        "type: sequence_valid\ntest_trace_row: []\n",
+        "test_trace_row",
+        "sequence_valid / misspelled test_trace_raw",
+    );
+}
+
+/// The decisive variant: every field is defaulted, so only the tag is required. This is the
+/// shape closest to the unit-like variants that serde's `deny_unknown_fields` issues describe,
+/// and the one that would silently keep dropping keys if container-level rejection did not
+/// reach it.
+#[test]
+fn tool_blocklist_rejects_unknown_key_despite_having_no_required_field() {
+    assert_rejects_naming(
+        "type: tool_blocklist\nblocked: [rm]\n",
+        "blocked",
+        "tool_blocklist / `blocked` at the top level instead of inside policy",
+    );
+    assert_rejects_naming(
+        "type: tool_blocklist\ntest_tool_call: [rm]\n",
+        "test_tool_call",
+        "tool_blocklist / misspelled test_tool_calls",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls. Rejecting unknown keys must not narrow what a valid
+// assertion may say.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_variant_still_parses_in_its_documented_form() {
+    for (case, yaml) in [
+        (
+            "trace_must_call_tool",
+            "type: trace_must_call_tool\ntool: web_search\nmin_calls: 1\n",
+        ),
+        (
+            "trace_must_call_tool without min_calls",
+            "type: trace_must_call_tool\ntool: web_search\n",
+        ),
+        (
+            "trace_must_not_call_tool",
+            "type: trace_must_not_call_tool\ntool: delete_database\n",
+        ),
+        (
+            "trace_tool_sequence",
+            "type: trace_tool_sequence\nsequence: [search, summarize]\nallow_other_tools: true\n",
+        ),
+        ("trace_max_steps", "type: trace_max_steps\nmax: 10\n"),
+        (
+            "args_valid",
+            "type: args_valid\ntool: t\ntest_args: {percent: 10}\npolicy: {schema: {}}\nexpect: pass\n",
+        ),
+        (
+            "sequence_valid",
+            "type: sequence_valid\ntest_trace_raw: [{tool: a}]\npolicy: {regex: '^a$'}\nexpect: pass\n",
+        ),
+        (
+            "tool_blocklist",
+            "type: tool_blocklist\ntest_tool_calls: [rm]\npolicy: {blocked: [rm]}\nexpect: fail\n",
+        ),
+        ("tool_blocklist bare", "type: tool_blocklist\n"),
+    ] {
+        assert_accepts(yaml, case);
+    }
+}
+
+/// The guard covers an assertion's own field vocabulary, not the contents of the free-form
+/// values it carries. A policy or an argument object may hold any keys at all — constraining
+/// those is the policy schema's job, and tightening them here would break every real config.
+#[test]
+fn nested_free_form_values_stay_unconstrained() {
+    assert_accepts(
+        "type: args_valid\ntool: t\ntest_args: {anything: {nested: [1, 2]}, weird_key: true}\npolicy: {schema: {properties: {x: {type: number}}}, extra_policy_key: 1}\n",
+        "args_valid / free-form nested keys",
+    );
+    assert_accepts(
+        "type: tool_blocklist\npolicy: {blocked: [rm], unknown_policy_key: 1}\n",
+        "tool_blocklist / free-form policy keys",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The boundary that matters: the real config-loading path.
+// ---------------------------------------------------------------------------
+
+fn write_config(dir: &std::path::Path, assertion_block: &str) -> std::path::PathBuf {
+    let path = dir.join("eval.yaml");
+    std::fs::write(
+        &path,
+        format!(
+            "configVersion: 1\nsuite: unknown_field_probe\nmodel: dummy\ntests:\n  - id: t1\n    input: hello\n    assertions:\n{assertion_block}"
+        ),
+    )
+    .expect("write config");
+    path
+}
+
+/// `load_config` deserializes through `serde_ignored`, which exists to *collect* unknown keys
+/// rather than fail on them, and outside strict mode only prints a warning. If the guard were
+/// swallowed there, it would fire in unit tests and never in the CLI — the check looking
+/// present while every command stayed permissive.
+///
+/// Both modes are asserted: an unknown key inside an assertion is a hard error regardless of
+/// `strict`, because unlike a stray top-level key it cannot be a forward-compatible extension.
+#[test]
+fn load_config_rejects_an_unknown_key_inside_an_assertion() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = write_config(
+        tmp.path(),
+        "      - type: trace_must_call_tool\n        tool: delete_database\n        max_calls: 0\n",
+    );
+
+    for strict in [false, true] {
+        let err = assay_core::config::load_config(&path, false, strict)
+            .expect_err(&format!("strict={strict}: expected load_config to reject"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("max_calls"),
+            "strict={strict}: rejected but did not name the offending key: {msg}"
+        );
+    }
+}
+
+#[test]
+fn load_config_still_accepts_a_well_formed_assertion() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = write_config(
+        tmp.path(),
+        "      - type: trace_must_call_tool\n        tool: web_search\n        min_calls: 1\n",
+    );
+    assay_core::config::load_config(&path, false, false).expect("well-formed assertion must load");
+}
+
+/// The shipped suites are the check that this change does not break configurations that run
+/// today (#1961 acceptance: "No first-party fixture or generated config fails the new check").
+#[test]
+fn first_party_suites_still_load() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root");
+
+    for name in ["tests/fp_suite.yaml", "tests/regex_compatibility.yaml"] {
+        let path = repo_root.join(name);
+        if !path.exists() {
+            continue;
+        }
+        assay_core::config::load_config(&path, false, false).unwrap_or_else(|e| {
+            panic!("{name} no longer loads after the unknown-field guard: {e}")
+        });
+    }
+}

--- a/crates/assay-core/tests/docs_assertion_examples.rs
+++ b/crates/assay-core/tests/docs_assertion_examples.rs
@@ -1,0 +1,168 @@
+//! Every `assertions:` example in the documentation must load (#1960).
+//!
+//! `docs/metrics/index.md` and `docs/architecture/agents.md` document the inline assertion
+//! surface. Before this test, not one of their examples parsed: five of the seven documented
+//! types did not exist, the two that did were shown with field names that did not, and the
+//! example labelled "must NOT use a forbidden tool" inverted into "must be called at least
+//! once" once its field name was corrected.
+//!
+//! Review cannot keep prose and an enum in agreement — nothing failed when they diverged. This
+//! test is the mechanism that does: it extracts every fenced YAML block from those documents
+//! and pushes it through the same code a user's config goes through. A documented type or field
+//! that stops existing fails here.
+//!
+//! It also checks the reverse direction. A catalogue that silently omits shipped variants is a
+//! subtler version of the same defect, so every variant in the enum must appear in the
+//! catalogue, and every type the catalogue lists as unimplemented must in fact be rejected.
+
+use assay_core::agent_assertions::model::TraceAssertion;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root")
+        .to_path_buf()
+}
+
+const METRICS_DOC: &str = "docs/metrics/index.md";
+const AGENTS_DOC: &str = "docs/architecture/agents.md";
+
+/// Every variant of `TraceAssertion`, by its wire name. Adding a variant without documenting it
+/// fails `every_shipped_variant_is_documented` below.
+const SHIPPED_TYPES: &[&str] = &[
+    "trace_must_call_tool",
+    "trace_must_not_call_tool",
+    "trace_tool_sequence",
+    "trace_max_steps",
+    "args_valid",
+    "sequence_valid",
+    "tool_blocklist",
+];
+
+struct Block {
+    doc: &'static str,
+    line: usize,
+    body: String,
+}
+
+/// Extracts fenced ```yaml blocks with the line number of the opening fence, so a failure points
+/// at the source rather than at an anonymous snippet.
+fn yaml_blocks(doc: &'static str) -> Vec<Block> {
+    let text = std::fs::read_to_string(repo_root().join(doc))
+        .unwrap_or_else(|e| panic!("cannot read {doc}: {e}"));
+    let mut out = Vec::new();
+    let mut current: Option<(usize, Vec<&str>)> = None;
+
+    for (idx, line) in text.lines().enumerate() {
+        match current.take() {
+            None => {
+                if line.trim_start().starts_with("```yaml") {
+                    current = Some((idx + 1, Vec::new()));
+                }
+            }
+            Some((start, mut acc)) => {
+                if line.trim_start().starts_with("```") {
+                    out.push(Block {
+                        doc,
+                        line: start,
+                        body: acc.join("\n"),
+                    });
+                } else {
+                    acc.push(line);
+                    current = Some((start, acc));
+                }
+            }
+        }
+    }
+    assert!(
+        !out.is_empty(),
+        "{doc}: no fenced yaml blocks found — the extractor or the document moved"
+    );
+    out
+}
+
+/// A block is either one assertion or a whole config. Both are checked, through the path a user
+/// would actually take.
+fn check_block(b: &Block) {
+    let looks_like_config = b.body.contains("configVersion:") || b.body.contains("\ntests:");
+
+    if looks_like_config {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("eval.yaml");
+        std::fs::write(&path, &b.body).expect("write config");
+        if let Err(e) = assay_core::config::load_config(&path, false, false) {
+            panic!(
+                "{}:{} — documented config does not load: {e}\n---\n{}\n---",
+                b.doc, b.line, b.body
+            );
+        }
+        return;
+    }
+
+    // Otherwise it must be a single assertion. Anything else in a fenced yaml block on these
+    // pages is a documentation bug in its own right, so require the tag rather than skipping.
+    assert!(
+        b.body.contains("type:"),
+        "{}:{} — fenced yaml block is neither a config nor an assertion:\n{}",
+        b.doc,
+        b.line,
+        b.body
+    );
+    if let Err(e) = serde_yaml::from_str::<TraceAssertion>(&b.body) {
+        panic!(
+            "{}:{} — documented assertion does not parse: {e}\n---\n{}\n---",
+            b.doc, b.line, b.body
+        );
+    }
+}
+
+#[test]
+fn every_documented_assertion_example_parses() {
+    for doc in [METRICS_DOC, AGENTS_DOC] {
+        for block in yaml_blocks(doc) {
+            check_block(&block);
+        }
+    }
+}
+
+/// The other direction: the catalogue must not quietly omit shipped variants. Five of the seven
+/// were missing when this was filed, which is how the documented surface and the implemented one
+/// drifted far enough for none of the examples to work.
+#[test]
+fn every_shipped_variant_is_documented() {
+    let text = std::fs::read_to_string(repo_root().join(METRICS_DOC)).expect("read metrics doc");
+    for ty in SHIPPED_TYPES {
+        assert!(
+            text.contains(&format!("### `{ty}`")),
+            "{METRICS_DOC}: `{ty}` exists in TraceAssertion but has no section in the catalogue"
+        );
+    }
+}
+
+/// The "Not implemented" table is a claim about the parser, so it is checked against the parser.
+/// If one of these is ever built, this test fails and the table has to be updated with it.
+#[test]
+fn types_documented_as_unimplemented_are_actually_rejected() {
+    for ty in [
+        "trace_no_tool_call",
+        "trace_tool_args_match",
+        "trace_tool_args_schema",
+        "trace_tool_call_count",
+        "trace_no_tool_errors",
+    ] {
+        let yaml = format!("type: {ty}\n");
+        assert!(
+            serde_yaml::from_str::<TraceAssertion>(&yaml).is_err(),
+            "`{ty}` is listed as not implemented but the parser accepts it"
+        );
+        let text =
+            std::fs::read_to_string(repo_root().join(METRICS_DOC)).expect("read metrics doc");
+        assert!(
+            text.contains(&format!("`{ty}`")),
+            "{METRICS_DOC}: `{ty}` is rejected by the parser but is not listed under \
+             \"Not implemented\", so a reader has no way to learn what to write instead"
+        );
+    }
+}

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -98,37 +98,52 @@ Use `eval.yaml` to define behavioral gates for your agent.
 
 ### Example Configuration
 
+Assertions are declared on a test case, under `tests:`. A top-level `policies:` block is not
+valid at `configVersion: 1` and is refused at load.
+
 ```yaml
-version: 1
+configVersion: 1
 suite: my-agent-suite
 model: gpt-4
-policies:
-  agent_policy:
+tests:
+  - id: agent_behaviour
+    input: "What is the weather in Berlin?"
     assertions:
       # 1. Must use a specific tool
       - type: trace_must_call_tool
-        tool_name: web_search
+        tool: web_search
         min_calls: 1
 
       # 2. Must NOT use a forbidden tool
-      - type: trace_must_call_tool
-        tool_name: delete_database
-        max_calls: 0
+      - type: trace_must_not_call_tool
+        tool: delete_database
 
       # 3. Enforce a specific sequence of actions
       - type: trace_tool_sequence
         sequence:
           - web_search
           - summarize_results
-        mode: loose # allow other steps in between
+        allow_other_tools: true # allow other steps in between
+
+      # 4. Bound the episode length
+      - type: trace_max_steps
+        max: 10
 ```
+
+Assertion 2 is the only correct way to forbid a tool. Writing it as `trace_must_call_tool` with a
+count of zero does not express the opposite of assertion 1 — `min_calls` defaults to 1, so such a
+config asserts that the forbidden tool **must** be called.
 
 ### Supported Assertions
 
-*   `trace_must_call_tool`: Verify tool usage counts (min/max).
-*   `trace_tool_sequence`: Verify order of operations (`exact` or `loose` modes).
-*   `trace_no_tool_errors`: Ensure no tool calls resulted in errors.
-*   `trace_max_steps`: Limit the number of steps (prevent infinite loops).
+The full catalogue, with every field, is in [Assertion Types](../metrics/index.md). The four used
+above:
+
+*   `trace_must_call_tool`: require at least `min_calls` calls to a tool. There is no upper bound.
+*   `trace_must_not_call_tool`: require zero calls to a tool.
+*   `trace_tool_sequence`: require an order of operations; `allow_other_tools` is required and
+    decides whether other calls may appear in between.
+*   `trace_max_steps`: limit the number of steps (prevent infinite loops).
 
 ## 4. CI Integration
 

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -1,87 +1,161 @@
-# Assertion Types (V1)
+# Assertion Types
 
-In Assay v0.9.0+, behavioral checks are defined using **inline assertions** on the test case, rather than separate policy files.
+Behavioral checks are defined using **inline assertions** on the test case, rather than separate
+policy files.
 
-These assertions map to underlying metrics but provide a cleaner, schema-validated syntax.
+Every type and field below is taken from the executable enum
+(`crates/assay-core/src/agent_assertions/model.rs`). Every example on this page is deserialized
+into that enum by a test, so a type or field that stops existing fails CI rather than drifting
+into prose.
+
+An assertion carrying a key that is not listed here is **rejected at parse time**. An unknown key
+is either a typo or a feature that does not exist, and silently dropping it can turn a real check
+into one that cannot fail.
 
 ---
 
 ## Tool Assertions
 
 ### `trace_must_call_tool`
-Passes if the trace contains at least one successful call to the specified tool.
+
+Passes if the trace contains at least `min_calls` calls to the named tool. `min_calls` defaults
+to 1.
 
 ```yaml
 type: trace_must_call_tool
-tool_name: "get_weather"
+tool: get_weather
+min_calls: 1
 ```
 
-### `trace_no_tool_call`
-Passes if the trace contains **zero** calls to the specified tool. Replaces the legacy `tool_blocklist` policy.
+The count is over recorded tool calls. It does **not** distinguish a call that succeeded from one
+that errored: `ToolCallRow` (`crates/assay-core/src/storage/rows.rs`) carries no status or error
+column, so an errored call satisfies this assertion. There is no `max_calls` field — to express
+"must not be called", use `trace_must_not_call_tool` below.
+
+### `trace_must_not_call_tool`
+
+Passes if the trace contains **zero** calls to the named tool.
 
 ```yaml
-type: trace_no_tool_call
-tool_name: "delete_database"
+type: trace_must_not_call_tool
+tool: delete_database
 ```
 
-### `trace_tool_args_match`
-Passes if **every** call to the specified tool matches the provided argument values.
+This is the only way to express a forbidden tool. Do not attempt it with `trace_must_call_tool`
+and a count of zero.
+
+### `tool_blocklist`
+
+Checks a list of tool calls against a blocked list. Useful as a unit test of the policy itself,
+without a recorded episode.
 
 ```yaml
-type: trace_tool_args_match
-tool_name: "apply_discount"
-args:
+type: tool_blocklist
+test_tool_calls: [read_file, delete_database]
+policy:
+  blocked: [delete_database]
+expect: fail
+```
+
+`policy.blocked` must be present and non-empty; an absent or empty blocklist admits every call
+and is rejected as ineffective.
+
+---
+
+## Argument Assertions
+
+### `args_valid`
+
+Checks tool arguments against a policy. The policy may carry a JSON Schema, which covers both
+value matching and structural validation.
+
+```yaml
+type: args_valid
+tool: apply_discount
+policy:
+  schema:
+    properties:
+      percent: { type: number, maximum: 30 }
+      reason: { type: string }
+    required: [percent]
+test_args:
   percent: 10
-  code: "SUMMER"
+  reason: "Loyalty program"
+expect: pass
 ```
 
-### `trace_tool_args_schema`
-Passes if **every** call to the tool matches the provided JSON Schema.
-
-```yaml
-type: trace_tool_args_schema
-tool_name: "search"
-schema:
-  required: ["query"]
-  properties:
-    query: { type: "string", minLength: 3 }
-```
-
-### `trace_tool_call_count`
-Passes if the tool call count is within the specified range.
-
-```yaml
-type: trace_tool_call_count
-tool_name: "retry"
-min: 1
-max: 3
-```
-
-### `trace_no_tool_errors`
-Passes only if the trace contains zero tool execution errors (e.g., exceptions raised by the tool).
-
-```yaml
-type: trace_no_tool_errors
-```
+`expect` accepts `pass` or `fail` and nothing else; any other spelling is rejected rather than
+being read as its opposite.
 
 ---
 
 ## Sequence Assertions
 
 ### `trace_tool_sequence`
-Enforces a strict order of tool calls. Other tools can be called in between, but the specified sequence must appear in that relative order.
+
+Requires the named tools to appear in the given relative order. `allow_other_tools` is
+**required** — there is no default, and it decides whether other calls may appear in between.
 
 ```yaml
 type: trace_tool_sequence
-sequence: ["login", "view_balance", "logout"]
+sequence: [login, view_balance, logout]
+allow_other_tools: true
+```
+
+With `allow_other_tools: false` the sequence must match exactly. An empty `sequence` with
+`allow_other_tools: false` is the effective "no tool calls at all" constraint; an empty sequence
+with `allow_other_tools: true` constrains nothing and is rejected.
+
+### `sequence_valid`
+
+Checks a supplied trace against a sequence policy. Like `tool_blocklist`, this is a unit-test
+form that needs no recorded episode.
+
+```yaml
+type: sequence_valid
+test_trace_raw:
+  - tool: submit_payment
+    args: { iban: "DE00" }
+policy:
+  regex: '^submit_payment$'
+expect: pass
+```
+
+Supply the trace through `test_trace_raw`. The policy must carry a usable `regex`; a policy
+without one is universally permissive and is rejected.
+
+---
+
+## Step Assertions
+
+### `trace_max_steps`
+
+Passes if the episode used no more than `max` steps.
+
+```yaml
+type: trace_max_steps
+max: 10
 ```
 
 ---
 
-## Comparison Table
+## Not implemented
 
-| V1 Assertion | Legacy V0 Policy |
+These types have appeared in earlier drafts of this page. They are **not** in the enum and are
+rejected. The nearest shipped equivalent is given so a config can be written today:
+
+| Not implemented | Use instead |
 |---|---|
-| `trace_tool_args_match` | `args_valid` metric |
-| `trace_tool_sequence` | `sequence_valid` metric |
-| `trace_no_tool_call` | `tool_blocklist` metric |
+| `trace_no_tool_call` | `trace_must_not_call_tool` |
+| `trace_tool_args_match` | `args_valid` with a `policy.schema` |
+| `trace_tool_args_schema` | `args_valid` with a `policy.schema` |
+| `trace_tool_call_count` | `trace_must_call_tool` with `min_calls` — an upper bound is not expressible |
+| `trace_no_tool_errors` | nothing; recorded tool calls carry no outcome, so this cannot be evaluated |
+
+---
+
+## Relationship to the metric names
+
+`args_valid`, `sequence_valid`, and `tool_blocklist` are the names used both as assertion types
+here and as metric names on the `expected:` surface. They are the same checks reached two ways;
+the names do not diverge.


### PR DESCRIPTION
Closes #1961. Closes #1960.

⚠️ **Breaking by design** — see the release note below.

Serde drops an unrecognised key in silence. Where the field the author meant has a default, the assertion falls back to a shape that cannot fail, so a one-character typo turns a real check into a permanent pass with no signal at any stage.

The documented "must NOT use a forbidden tool" example was the worked case: `max_calls: 0` was discarded, `min_calls` defaulted to 1, and the assertion inverted into *"must be called at least once"*. The only reason that was not live is that `tool_name` — also wrong — failed loudly first. That is an accident of which fields happen to have defaults, not a safeguard.

## Why the container, and why that is enough

`deny_unknown_fields` is not a variant attribute; the compiler rejects it as one. So the choice was container-level or hand-rolled.

There is folklore that container-level rejection is unreliable on an internally-tagged enum (serde-rs/serde #2294, #1358). Those defects are about **unit-like variants** and **`flatten`** — every variant here is a struct variant with named fields and none flattens. Rejection was verified on the hardest shape in this enum: `tool_blocklist`, whose fields are all defaulted so nothing but the tag is required. A stray key there is rejected too, and that case has its own test because it is the one the folklore would have been right about.

Two things fall out for free that a hand-rolled allow-set would have needed code for: the message already names the offending key and lists the expected ones, and nested `policy` / `test_args` stay unconstrained — which is required, since policies legitimately carry arbitrary keys.

## The boundary that mattered

`load_config` deserializes through `serde_ignored`, whose whole job is to *collect* unknown keys rather than fail on them, and outside strict mode it only warns. A guard that fired on a bare `from_str` and was swallowed there would be the check looking present while every command stayed permissive. Rejection is asserted at that boundary in **both** strict and non-strict mode.

## The documentation is the other half

None of its examples parsed. Five of seven documented types had no implementation, the two that existed were shown with field names that did not, and the architecture example nested its assertions under a top-level `policies:` block the loader refuses at `configVersion: 1` — so it could not have loaded even with every field corrected. The catalogue also omitted five of the seven *shipped* variants, so the drift ran both ways.

Both documents are rewritten from the enum. Types that do not exist are listed with their nearest shipped equivalent rather than deleted, so a reader holding an old copy learns what to write instead.

Prose cannot be held to an enum by review — nothing failed when they diverged. A test now loads every fenced example through the path a user's config takes, requires every shipped variant to be documented, and requires every type listed as unimplemented to actually be rejected, so that table stays a claim about the parser rather than a note that rots.

## Verification

Mutation-verified: removing the attribute fails 7 of 12 parser tests; restoring `tool_name:` in one example produces `docs/metrics/index.md:24 — documented assertion does not parse: unknown field \`tool_name\`, expected \`tool\` or \`min_calls\``; renaming one variant's section heading fails the catalogue check.

`tests/fp_suite.yaml` and `tests/regex_compatibility.yaml` still load, and no template, example or demo config carries an `assertions:` block.

## Release note

An unknown key in an assertion is now a hard error where it was previously dropped. That is the point — it is either a typo or a feature that does not exist — but it turns previously green configurations red. No first-party fixture or generated config relies on one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)