### PR TITLE
Ask Cargo for the binary these tests already had

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,15 +591,27 @@ jobs:
       # Linux: Test everything except eBPF and integration tests
       - name: Test Workspace (Linux)
         if: runner.os == 'Linux'
-        # no_passthrough_e2e shells out to a feature-enabled cargo build/run and has
-        # a dedicated step below. Skipping it here avoids duplicating that heavy build
-        # inside the already-large workspace test job on hosted Ubuntu runners.
-        run: cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it -- --skip test_no_passthrough_e2e
+        # no_passthrough_e2e is gated on `test-outbound` and so compiles to nothing here; it has a
+        # dedicated step below. It used to need an explicit --skip because it compiled everywhere
+        # and shelled out to its own feature-enabled cargo build.
+        run: cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it
 
-      # E6a.3 no-pass-through: E2E invariant test (requires test-outbound feature)
+      # E6a.3 no-pass-through: E2E invariant test (requires test-outbound feature).
+      #
+      # Runs on every OS, because this is now the only job that compiles the test at all — the
+      # workspace runs above and below build it out. That also means a missing or misspelled
+      # feature flag here would be silent: `cargo test` exits 0 when zero tests match. So assert
+      # the test actually executed rather than trusting the exit code.
       - name: Test MCP no-pass-through E2E (E6a.3)
-        if: runner.os == 'Linux'
-        run: cargo test -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
+            2>&1 | tee "$RUNNER_TEMP/e6a3.log"
+          grep -qF 'test_no_passthrough_e2e ... ok' "$RUNNER_TEMP/e6a3.log" || {
+            echo "::error::E6a.3 no-pass-through test did not run. The test-outbound gate is misconfigured, so the invariant was never exercised."
+            exit 1
+          }
 
       # Non-Linux: Exclude OS-specific crates (assay-monitor, assay-cli)
       # Windows/macOS automatically use bundled sqlite via cfg() in Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,17 +612,28 @@ jobs:
       # the test actually executed rather than trusting the exit code.
       - name: Test MCP no-pass-through E2E (E6a.3)
         shell: bash
+        # The guard below reads the log with anchored patterns, and a colour escape sits between
+        # the anchor and the status word. Runners are not TTYs so cargo defaults to plain output,
+        # but split-wave0-gates.yml sets CARGO_TERM_COLOR: always at workflow level — pinning it
+        # here means copying this step somewhere else cannot silently disarm half the pattern.
+        env:
+          CARGO_TERM_COLOR: never
         run: |
           set -euo pipefail
           cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
             2>&1 | tee "$RUNNER_TEMP/e6a3.log"
-          # This guard answers one question only: did the test run at all. Whether it passed is
+          # This guard answers one question only: did the test execute. Whether it passed is
           # already settled above, by the exit code under `set -o pipefail` — a test that ran and
-          # failed never reaches this line. Keeping the two apart is what lets the pattern match a
-          # result line in any shape without enumerating which shapes mean success, which is where
-          # the earlier version went wrong: it matched nextest's plain PASS and so would have
-          # reported "did not run" for a test that passed after a retry or while leaking.
-          grep -qE 'test test_no_passthrough_e2e \.\.\.|^ *(PASS|FAIL|TRY|FLAKY|LEAK|SLOW|TIMEOUT).*test_no_passthrough_e2e' \
+          # failed never reaches this line. That separation is what lets the pattern accept any
+          # runner's vocabulary rather than enumerating which words mean success.
+          #
+          # "Executed" is the load-bearing word, and it is narrower than "was mentioned". libtest
+          # prints `... ignored` for a skipped test and exits 0, so the arm below requires a
+          # terminal status: `ok` and `FAILED` both mean it ran, `ignored` means it did not. That
+          # matters most on the OS legs this step added — `#[cfg_attr(windows, ignore)]` is the
+          # routine answer to a flaky spawn-a-server test, and it must turn this step red rather
+          # than let it certify an invariant nobody checked.
+          grep -qE 'test test_no_passthrough_e2e \.\.\. (ok|FAILED)|^ *(PASS|FAIL|TRY|FLAKY|LEAK|SLOW|TIMEOUT).*test_no_passthrough_e2e([[:space:]]|$)' \
             "$RUNNER_TEMP/e6a3.log" || {
             echo "::error::E6a.3 no-pass-through test did not run. The test-outbound gate is misconfigured, so the invariant was never exercised."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,32 +612,35 @@ jobs:
       # the test actually executed rather than trusting the exit code.
       - name: Test MCP no-pass-through E2E (E6a.3)
         shell: bash
-        # The guard below reads the log with anchored patterns, and a colour escape sits between
-        # the anchor and the status word. Runners are not TTYs so cargo defaults to plain output,
-        # but split-wave0-gates.yml sets CARGO_TERM_COLOR: always at workflow level — pinning it
-        # here means copying this step somewhere else cannot silently disarm half the pattern.
-        env:
-          CARGO_TERM_COLOR: never
         run: |
           set -euo pipefail
           cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
             2>&1 | tee "$RUNNER_TEMP/e6a3.log"
-          # This guard answers one question only: did the test execute. Whether it passed is
-          # already settled above, by the exit code under `set -o pipefail` — a test that ran and
-          # failed never reaches this line. That separation is what lets the pattern accept any
-          # runner's vocabulary rather than enumerating which words mean success.
+          # Two questions, asked separately. Every previous version of this guard asked them with
+          # one pattern and got one of them wrong: too strict and it called a passing test absent,
+          # too loose and it called a skipped test present. Pass-versus-fail is not among them —
+          # `set -o pipefail` settles that above, so a test that ran and failed never reaches here.
           #
-          # "Executed" is the load-bearing word, and it is narrower than "was mentioned". libtest
-          # prints `... ignored` for a skipped test and exits 0, so the arm below requires a
-          # terminal status: `ok` and `FAILED` both mean it ran, `ignored` means it did not. That
-          # matters most on the OS legs this step added — `#[cfg_attr(windows, ignore)]` is the
-          # routine answer to a flaky spawn-a-server test, and it must turn this step red rather
-          # than let it certify an invariant nobody checked.
-          grep -qE 'test test_no_passthrough_e2e \.\.\. (ok|FAILED)|^ *(PASS|FAIL|TRY|FLAKY|LEAK|SLOW|TIMEOUT).*test_no_passthrough_e2e([[:space:]]|$)' \
-            "$RUNNER_TEMP/e6a3.log" || {
+          # 1. Did the runner report this test at all? Deliberately broad, because the shapes are
+          #    many: at --test-threads=1 libtest prints `test NAME ... ` before running, so this
+          #    test's own inherited stderr lands between the name and the status word; a
+          #    `- should panic` suffix or a module path shifts it further; nextest has its own
+          #    vocabulary entirely. Matching the name rather than the outcome survives all of them.
+          reported=$(grep -E '^test .*test_no_passthrough_e2e|^ *(PASS|FAIL|TRY|FLAKY|LEAK|SLOW|TIMEOUT).*test_no_passthrough_e2e([[:space:]]|$)' \
+            "$RUNNER_TEMP/e6a3.log" || true)
+          if [ -z "$reported" ]; then
             echo "::error::E6a.3 no-pass-through test did not run. The test-outbound gate is misconfigured, so the invariant was never exercised."
             exit 1
-          }
+          fi
+          # 2. Was it reported as skipped? `#[ignore]` prints a result line and exits 0, so being
+          #    reported is not the same as having executed. This is the routine answer to a flaky
+          #    spawn-a-server test on the OS legs this step just added, and it has to be loud.
+          case "$reported" in
+            *ignored*)
+              echo "::error::E6a.3 no-pass-through test was reported as ignored, not executed. The invariant was never exercised."
+              exit 1
+              ;;
+          esac
 
       # Non-Linux: Exclude OS-specific crates (assay-monitor, assay-cli)
       # Windows/macOS automatically use bundled sqlite via cfg() in Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,10 @@ jobs:
       # invisible to the sweep above: cfg strips it to an empty crate and clippy lints nothing.
       # no_passthrough_e2e.rs is gated on `test-outbound` and would otherwise be the one test in
       # the workspace that no lint job ever sees.
-      - run: cargo clippy -p assay-mcp-server --all-targets --features test-outbound -- -D warnings
+      # The deny list matches split-wave0-gates.yml, which carries no --all-features either, so this
+      # step is the only place the gated file meets `clippy::todo` and `clippy::unimplemented`.
+      # Denying only `-D warnings` here would leave a placeholder legal in exactly one test file.
+      - run: cargo clippy -p assay-mcp-server --all-targets --features test-outbound -- -D warnings -D clippy::todo -D clippy::unimplemented
 
   rustdoc:
     name: Rustdoc (deny warnings)
@@ -613,9 +616,13 @@ jobs:
           set -euo pipefail
           cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
             2>&1 | tee "$RUNNER_TEMP/e6a3.log"
-          # Matches libtest's line today and nextest's if this ever migrates, because a guard that
-          # reads "the test did not run" while the test is passing is worse than no guard.
-          grep -qE 'test_no_passthrough_e2e \.\.\. ok|^ *PASS .*test_no_passthrough_e2e' \
+          # This guard answers one question only: did the test run at all. Whether it passed is
+          # already settled above, by the exit code under `set -o pipefail` — a test that ran and
+          # failed never reaches this line. Keeping the two apart is what lets the pattern match a
+          # result line in any shape without enumerating which shapes mean success, which is where
+          # the earlier version went wrong: it matched nextest's plain PASS and so would have
+          # reported "did not run" for a test that passed after a retry or while leaking.
+          grep -qE 'test test_no_passthrough_e2e \.\.\.|^ *(PASS|FAIL|TRY|FLAKY|LEAK|SLOW|TIMEOUT).*test_no_passthrough_e2e' \
             "$RUNNER_TEMP/e6a3.log" || {
             echo "::error::E6a.3 no-pass-through test did not run. The test-outbound gate is misconfigured, so the invariant was never exercised."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,11 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # `--all-targets` does not imply `--all-features`, so any test file gated behind a feature is
+      # invisible to the sweep above: cfg strips it to an empty crate and clippy lints nothing.
+      # no_passthrough_e2e.rs is gated on `test-outbound` and would otherwise be the one test in
+      # the workspace that no lint job ever sees.
+      - run: cargo clippy -p assay-mcp-server --all-targets --features test-outbound -- -D warnings
 
   rustdoc:
     name: Rustdoc (deny warnings)
@@ -606,9 +611,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo test -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
+          cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
             2>&1 | tee "$RUNNER_TEMP/e6a3.log"
-          grep -qF 'test_no_passthrough_e2e ... ok' "$RUNNER_TEMP/e6a3.log" || {
+          # Matches libtest's line today and nextest's if this ever migrates, because a guard that
+          # reads "the test did not run" while the test is passing is worse than no guard.
+          grep -qE 'test_no_passthrough_e2e \.\.\. ok|^ *PASS .*test_no_passthrough_e2e' \
+            "$RUNNER_TEMP/e6a3.log" || {
             echo "::error::E6a.3 no-pass-through test did not run. The test-outbound gate is misconfigured, so the invariant was never exercised."
             exit 1
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,20 +606,30 @@ jobs:
 
       # E6a.3 no-pass-through: E2E invariant test (requires test-outbound feature).
       #
-      # Runs on every OS, because this is now the only job that compiles the test at all — the
-      # workspace runs above and below build it out. That also means a missing or misspelled
-      # feature flag here would be silent: `cargo test` exits 0 when zero tests match. So assert
-      # the test actually executed rather than trusting the exit code.
+      # Runs on every OS, because this is the only job that RUNS the test — the workspace runs
+      # above and below build it out, and the feature-enabled clippy step near the top of this
+      # file compiles it but executes nothing. That also means a missing or misspelled feature
+      # flag here would be silent: `cargo test` exits 0 when zero tests match. So assert the test
+      # actually executed rather than trusting the exit code.
       - name: Test MCP no-pass-through E2E (E6a.3)
         shell: bash
         run: |
           set -euo pipefail
           cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
             2>&1 | tee "$RUNNER_TEMP/e6a3.log"
-          # Two questions, asked separately. Every previous version of this guard asked them with
-          # one pattern and got one of them wrong: too strict and it called a passing test absent,
-          # too loose and it called a skipped test present. Pass-versus-fail is not among them —
-          # `set -o pipefail` settles that above, so a test that ran and failed never reaches here.
+          # Two questions. Every previous version of this guard folded them into one pattern and
+          # got one of them wrong: too strict and it called a passing test absent, too loose and
+          # it called a skipped test present. Pass-versus-fail is not among them — `set -o
+          # pipefail` settles that above, so a test that ran and failed never reaches here.
+          #
+          # The two are sequential, not independent: question 2 rescans the lines question 1
+          # matched. That is a known and deliberate compromise. Broadening question 1 to survive
+          # interleaved child output means arbitrary server stderr can end up inside the string
+          # question 2 searches, so a log line containing the word "ignored" can trip it. The
+          # alternative — anchoring question 2 to the status field — is more precise but inverts
+          # the failure direction: a shape it fails to anchor passes the guard, and the step goes
+          # green on an invariant nobody ran. Being noisily wrong beats being quietly wrong here,
+          # so this stays until someone has a form that is precise AND fails closed.
           #
           # 1. Did the runner report this test at all? Deliberately broad, because the shapes are
           #    many: at --test-threads=1 libtest prints `test NAME ... ` before running, so this
@@ -629,7 +639,7 @@ jobs:
           reported=$(grep -E '^test .*test_no_passthrough_e2e|^ *(PASS|FAIL|TRY|FLAKY|LEAK|SLOW|TIMEOUT).*test_no_passthrough_e2e([[:space:]]|$)' \
             "$RUNNER_TEMP/e6a3.log" || true)
           if [ -z "$reported" ]; then
-            echo "::error::E6a.3 no-pass-through test did not run. The test-outbound gate is misconfigured, so the invariant was never exercised."
+            echo "::error::E6a.3 no-pass-through test did not run, so the invariant was never exercised. Either the test-outbound gate is misconfigured, or the test is skipped under a runner that reports skips without naming them (nextest counts them and moves on)."
             exit 1
           fi
           # 2. Was it reported as skipped? `#[ignore]` prints a result line and exits 0, so being

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -29,7 +29,9 @@
 //! the test actually ran; see the E6a.3 step in .github/workflows/ci.yml.
 //!
 //! Absence has a cost worth knowing before you edit this file: no gate that omits
-//! `--features test-outbound` compiles it, and none of them carry `--all-features`. That includes
+//! `--features test-outbound` compiles it, and no gate anywhere passes `--all-features` for
+//! *this* package — split-wave0-gates.yml does so for assay-core, assay-cli, assay-registry and
+//! assay-evidence, but never for assay-mcp-server. That includes
 //! `cargo clippy --workspace --all-targets` in CI, which is why a dedicated feature-enabled clippy
 //! step sits beside the test step, but it also includes both pre-push hooks
 //! (`scripts/precommit/cargo-clippy.sh`, `scripts/ci/check-linux.sh`) and a plain

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -5,12 +5,19 @@
 //! trigger the test-only outbound call, then assert the mock received no sensitive headers or
 //! sentinel values. Run with: cargo test -p assay-mcp-server --features test-outbound no_passthrough
 //!
-//! This file is gated on `test-outbound`, and that gate is what makes `CARGO_BIN_EXE` safe to
-//! trust here. The variable is a fixed path — `target/debug/assay-mcp-server` — not a per-feature
-//! one, and its contents are whichever variant Cargo last uplifted, so the path alone guarantees
-//! nothing. What does guarantee it is that Cargo uplifts the matching variant in the same
-//! invocation that builds and runs this test, and the gate ensures the only invocations that run
-//! it are ones that asked for the feature.
+//! This file is gated on `test-outbound` because `CARGO_BIN_EXE_assay-mcp-server` names one
+//! uplift slot, not a per-feature one — `target/debug/assay-mcp-server` for the usual dev build,
+//! relocated by `--target` or a non-dev profile and suffixed `.exe` on Windows — and its contents
+//! are whichever variant Cargo last put there. The gate is what makes the invocation that runs
+//! this test also be one that asked for the feature, so the variant Cargo uplifts on the way in
+//! is the one the test needs.
+//!
+//! That is narrower than it may read, and the narrowness was measured rather than assumed: Cargo
+//! releases the build lock when compilation finishes, before test binaries execute, so a
+//! concurrent `cargo build -p assay-mcp-server` in another shell can re-uplift the feature-less
+//! variant mid-run. Reproduced; the test then fails on `received.len() == 1` below, because a
+//! binary without the feature has no `assay_test_outbound` to call. It fails closed, never green,
+//! but it is a real flake if you build this crate in a second terminal while this test runs.
 //!
 //! Previously the file compiled unconditionally and shelled out to `cargo build --features
 //! test-outbound`, whose inherited CARGO_MANIFEST_DIR dirtied the shared stack like every other
@@ -19,9 +26,15 @@
 //!
 //! Gating trades a rebuild for an absence, which is the more dangerous failure: `cargo test` exits
 //! 0 when zero tests match. So the CI job that owns this invariant enables the feature and asserts
-//! the test actually ran; see the E6a.3 step in .github/workflows/ci.yml. Because the gate also
-//! hides this file from `cargo clippy --workspace --all-targets`, which carries no `--all-features`,
-//! there is a dedicated feature-enabled clippy step alongside it.
+//! the test actually ran; see the E6a.3 step in .github/workflows/ci.yml.
+//!
+//! Absence has a cost worth knowing before you edit this file: no gate that omits
+//! `--features test-outbound` compiles it, and none of them carry `--all-features`. That includes
+//! `cargo clippy --workspace --all-targets` in CI, which is why a dedicated feature-enabled clippy
+//! step sits beside the test step, but it also includes both pre-push hooks
+//! (`scripts/precommit/cargo-clippy.sh`, `scripts/ci/check-linux.sh`) and a plain
+//! `cargo test -p assay-mcp-server`. A syntax or type error here passes every local check and only
+//! surfaces on CI. Run the documented command above before pushing changes to this file.
 #![cfg(feature = "test-outbound")]
 
 use assay_mcp_server::auth::SENSITIVE_HEADER_NAMES;

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -6,13 +6,17 @@
 //! sentinel values. Run with: cargo test -p assay-mcp-server --features test-outbound no_passthrough
 //!
 //! This file is gated on `test-outbound` so that it runs against the binary Cargo built for this
-//! test target, which is the only way to be sure the two agree about the feature. Previously it
-//! compiled unconditionally and shelled out to `cargo build --features test-outbound`, which meant
-//! a plain `cargo nextest run -p assay-mcp-server` built the whole dependency stack a second time
-//! under a different feature set — the two variants overwrite each other's artifacts, so each run
-//! undid the last. The gate makes absence the failure mode instead of a silent rebuild, so every
-//! CI job that is expected to exercise this invariant enables the feature and asserts the test
-//! actually ran; see the E6a.3 steps in .github/workflows/ci.yml.
+//! test target. That is the whole reason for the gate: `CARGO_BIN_EXE_assay-mcp-server` points at
+//! whatever feature set this test target was built with, so the two can only be guaranteed to
+//! agree if the test compiles under the feature too. Previously the file compiled unconditionally
+//! and shelled out to `cargo build --features test-outbound`, whose inherited CARGO_MANIFEST_DIR
+//! dirtied the shared stack like every other nested Cargo here.
+//!
+//! Gating trades a rebuild for an absence, which is the more dangerous failure: `cargo test` exits
+//! 0 when zero tests match. So the CI job that owns this invariant enables the feature and asserts
+//! the test actually ran; see the E6a.3 step in .github/workflows/ci.yml. Because the gate also
+//! hides this file from `cargo clippy --workspace --all-targets`, which carries no `--all-features`,
+//! there is a dedicated feature-enabled clippy step alongside it.
 #![cfg(feature = "test-outbound")]
 
 use assay_mcp_server::auth::SENSITIVE_HEADER_NAMES;

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -4,6 +4,16 @@
 //! must never appear on any Assay-originated outbound HTTP request. We send a sentinel field,
 //! trigger the test-only outbound call, then assert the mock received no sensitive headers or
 //! sentinel values. Run with: cargo test -p assay-mcp-server --features test-outbound no_passthrough
+//!
+//! This file is gated on `test-outbound` so that it runs against the binary Cargo built for this
+//! test target, which is the only way to be sure the two agree about the feature. Previously it
+//! compiled unconditionally and shelled out to `cargo build --features test-outbound`, which meant
+//! a plain `cargo nextest run -p assay-mcp-server` built the whole dependency stack a second time
+//! under a different feature set — the two variants overwrite each other's artifacts, so each run
+//! undid the last. The gate makes absence the failure mode instead of a silent rebuild, so every
+//! CI job that is expected to exercise this invariant enables the feature and asserts the test
+//! actually ran; see the E6a.3 steps in .github/workflows/ci.yml.
+#![cfg(feature = "test-outbound")]
 
 use assay_mcp_server::auth::SENSITIVE_HEADER_NAMES;
 use std::io::{BufRead, BufReader, Write};
@@ -58,30 +68,10 @@ async fn test_no_passthrough_e2e() {
     let policy_root = "../../tests/fixtures/mcp";
     let outbound_url = mock_server.uri();
 
-    let status = Command::new("cargo")
-        .args([
-            "build",
-            "-p",
-            "assay-mcp-server",
-            "--features",
-            "test-outbound",
-        ])
-        .status()
-        .expect("Failed to build server");
-    assert!(status.success(), "Build with test-outbound must succeed");
-
-    let mut child = Command::new("cargo")
-        .args([
-            "run",
-            "-q",
-            "-p",
-            "assay-mcp-server",
-            "--features",
-            "test-outbound",
-            "--",
-            "--policy-root",
-            policy_root,
-        ])
+    // This test only compiles under `test-outbound`, so the binary Cargo built for it carries the
+    // feature too — no separate build step, and no second feature variant to thrash against.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(["--policy-root", policy_root])
         .env("ASSAY_TEST_OUTBOUND_URL", outbound_url.as_str())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -5,12 +5,17 @@
 //! trigger the test-only outbound call, then assert the mock received no sensitive headers or
 //! sentinel values. Run with: cargo test -p assay-mcp-server --features test-outbound no_passthrough
 //!
-//! This file is gated on `test-outbound` so that it runs against the binary Cargo built for this
-//! test target. That is the whole reason for the gate: `CARGO_BIN_EXE_assay-mcp-server` points at
-//! whatever feature set this test target was built with, so the two can only be guaranteed to
-//! agree if the test compiles under the feature too. Previously the file compiled unconditionally
-//! and shelled out to `cargo build --features test-outbound`, whose inherited CARGO_MANIFEST_DIR
-//! dirtied the shared stack like every other nested Cargo here.
+//! This file is gated on `test-outbound`, and that gate is what makes `CARGO_BIN_EXE` safe to
+//! trust here. The variable is a fixed path — `target/debug/assay-mcp-server` — not a per-feature
+//! one, and its contents are whichever variant Cargo last uplifted, so the path alone guarantees
+//! nothing. What does guarantee it is that Cargo uplifts the matching variant in the same
+//! invocation that builds and runs this test, and the gate ensures the only invocations that run
+//! it are ones that asked for the feature.
+//!
+//! Previously the file compiled unconditionally and shelled out to `cargo build --features
+//! test-outbound`, whose inherited CARGO_MANIFEST_DIR dirtied the shared stack like every other
+//! nested Cargo here. Note the dependency stack itself never had two variants to thrash between:
+//! `test-outbound = []` enables no dependency features, so only this crate's own units differ.
 //!
 //! Gating trades a rebuild for an absence, which is the more dangerous failure: `cargo test` exits
 //! 0 when zero tests match. So the CI job that owns this invariant enables the feature and asserts

--- a/crates/assay-mcp-server/tests/stdio_e2e.rs
+++ b/crates/assay-mcp-server/tests/stdio_e2e.rs
@@ -6,24 +6,13 @@ use std::process::{Command, Stdio};
 fn test_stdio_flow() {
     let policy_root = "../../tests/fixtures/mcp"; // Relative to crates/assay-mcp-server CWD
 
-    // Ensure binary is built
-    let status = Command::new("cargo")
-        .args(["build", "-p", "assay-mcp-server"])
-        .status()
-        .expect("Failed to build server");
-    assert!(status.success());
-
-    // Spawn server
-    let mut child = Command::new("cargo")
-        .args([
-            "run",
-            "-q",
-            "-p",
-            "assay-mcp-server",
-            "--",
-            "--policy-root",
-            policy_root,
-        ])
+    // Cargo builds this crate's bin target before running its integration tests and hands us the
+    // path, so there is nothing to build here. Spawning `cargo run` instead would (a) inherit the
+    // Cargo environment, whose CARGO_MANIFEST_DIR is tracked by ring's build script and so marks
+    // the whole rustls/reqwest stack dirty on every alternation with a shell build, and (b) make
+    // the server a grandchild, leaving `child.kill()` reaping Cargo and orphaning the server.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(["--policy-root", policy_root])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())

--- a/crates/assay-mcp-server/tests/stdio_e2e.rs
+++ b/crates/assay-mcp-server/tests/stdio_e2e.rs
@@ -7,10 +7,9 @@ fn test_stdio_flow() {
     let policy_root = "../../tests/fixtures/mcp"; // Relative to crates/assay-mcp-server CWD
 
     // Cargo builds this crate's bin target before running its integration tests and hands us the
-    // path, so there is nothing to build here. Spawning `cargo run` instead would (a) inherit the
+    // path, so there is nothing to build here. Spawning `cargo run` instead would inherit the
     // Cargo environment, whose CARGO_MANIFEST_DIR is tracked by ring's build script and so marks
-    // the whole rustls/reqwest stack dirty on every alternation with a shell build, and (b) make
-    // the server a grandchild, leaving `child.kill()` reaping Cargo and orphaning the server.
+    // the whole rustls/reqwest stack dirty on every alternation with a shell build.
     let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args(["--policy-root", policy_root])
         .stdin(Stdio::piped())

--- a/crates/assay-mcp-server/tests/stdio_edge_cases.rs
+++ b/crates/assay-mcp-server/tests/stdio_edge_cases.rs
@@ -4,8 +4,7 @@
 //! `CARGO_BIN_EXE_assay-mcp-server`, rather than shelling out to `cargo run`. A nested Cargo
 //! inherits this process's CARGO_MANIFEST_DIR, which ring's build script tracks, so it marks the
 //! rustls/reqwest stack dirty every time it alternates with a shell build — measured at ~62s per
-//! test against a 120s nextest kill budget. It also made the server a grandchild of Cargo, so
-//! `child.kill()` reaped Cargo and left the server running.
+//! test against a 120s nextest kill budget.
 
 use serde_json::Value;
 use std::io::{BufRead, BufReader, Write};

--- a/crates/assay-mcp-server/tests/stdio_edge_cases.rs
+++ b/crates/assay-mcp-server/tests/stdio_edge_cases.rs
@@ -3,8 +3,11 @@
 //! Both spawn helpers below run the binary Cargo already built for this test target, via
 //! `CARGO_BIN_EXE_assay-mcp-server`, rather than shelling out to `cargo run`. A nested Cargo
 //! inherits this process's CARGO_MANIFEST_DIR, which ring's build script tracks, so it marks the
-//! rustls/reqwest stack dirty every time it alternates with a shell build — measured at ~62s per
-//! test against a 120s nextest kill budget.
+//! rustls/reqwest stack dirty every time it alternates with a shell build — 62.5s to 63.9s per
+//! test, against the 120s kill budget `.config/nextest.toml` sets via
+//! `slow-timeout = { period = "60s", terminate-after = 2 }`. Measured on 0799ab8b, rustc 1.96.0,
+//! aarch64-apple-darwin, two back-to-back `cargo nextest run -p assay-mcp-server` with nothing
+//! changed between them; the second run recompiled 14 crates before the tests even started.
 
 use serde_json::Value;
 use std::io::{BufRead, BufReader, Write};

--- a/crates/assay-mcp-server/tests/stdio_edge_cases.rs
+++ b/crates/assay-mcp-server/tests/stdio_edge_cases.rs
@@ -1,3 +1,12 @@
+//! Edge-case coverage for the stdio transport.
+//!
+//! Both spawn helpers below run the binary Cargo already built for this test target, via
+//! `CARGO_BIN_EXE_assay-mcp-server`, rather than shelling out to `cargo run`. A nested Cargo
+//! inherits this process's CARGO_MANIFEST_DIR, which ring's build script tracks, so it marks the
+//! rustls/reqwest stack dirty every time it alternates with a shell build — measured at ~62s per
+//! test against a 120s nextest kill budget. It also made the server a grandchild of Cargo, so
+//! `child.kill()` reaped Cargo and left the server running.
+
 use serde_json::Value;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
@@ -8,16 +17,8 @@ fn spawn_server() -> (
     BufReader<std::process::ChildStdout>,
 ) {
     let policy_root = "../../tests/fixtures/mcp";
-    let mut child = Command::new("cargo")
-        .args([
-            "run",
-            "-q",
-            "-p",
-            "assay-mcp-server",
-            "--",
-            "--policy-root",
-            policy_root,
-        ])
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(["--policy-root", policy_root])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -38,16 +39,8 @@ fn spawn_server_with_env(
     BufReader<std::process::ChildStdout>,
 ) {
     let policy_root = "../../tests/fixtures/mcp";
-    let mut child = Command::new("cargo")
-        .args([
-            "run",
-            "-q",
-            "-p",
-            "assay-mcp-server",
-            "--",
-            "--policy-root",
-            policy_root,
-        ])
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(["--policy-root", policy_root])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
Six integration tests in `assay-mcp-server` shelled out to `cargo build` / `cargo run -p assay-mcp-server` to get a server to talk to. Cargo already builds this crate's bin target before running its integration tests and hands over the path in `CARGO_BIN_EXE_assay-mcp-server` — `resource_limits.rs`, in the same directory, has been using it all along.

The nested invocation inherited this process's Cargo environment, whose `CARGO_MANIFEST_DIR` is tracked by `ring`'s build script, so it marked the rustls/reqwest stack dirty every time it alternated with a shell build.

## Measurement

`cargo nextest run -p assay-mcp-server --no-fail-fast`, twice back to back with nothing changed between. Cold `target/` warmed with a shell `--no-run` first. Before: `0799ab8b`. After: this branch. rustc/cargo 1.96.0, `aarch64-apple-darwin`.

| | before run 1 | before run 2 | after run 1 | after run 2 |
|---|---|---|---|---|
| wall | 73.0 s | 39.4 s | **4.9 s** | **3.7 s** |
| **crates recompiled by nextest** | 0 | **14** | **0** | **0** |
| `stdio_e2e::test_stdio_flow` | 62.879 s | 15.857 s | 0.051 s | 0.037 s |
| `stdio_edge_cases::test_edge_cases` | 62.554 s | 15.667 s | 0.093 s | 0.055 s |
| `stdio_edge_cases::test_timeout` | 62.586 s | 15.714 s | 0.060 s | 0.026 s |
| `no_passthrough_e2e` | 63.925 s | 16.472 s | 0.10 s (feature job) | — |

Read the wall figures with one caveat: the plain run has 285 tests after and 286 before, because `no_passthrough_e2e` is now gated and moves to its own job. Some of the wall delta is therefore absence rather than speed. That confound was measured and is small — the fourth test costs 0.06–0.07 s with the feature on — so the magnitude holds, but the two effects are not separated in the table.

The 14 are `ring`, `rustls`, `rustls-webpki`, `tokio-rustls`, `rustls-platform-verifier`, `hyper-rustls`, both `reqwest` majors, `object_store`, `assay-evidence`, `assay-adapter-api`, `assay-core`, `assay-metrics`, `assay-mcp-server`.

For scale: the next-slowest test in the crate is 5.4 s and everything else is ≤ 0.36 s. These four were essentially the entire runtime of a 286-test suite.

`.config/nextest.toml` sets `slow-timeout = { period = "60s", terminate-after = 2 }`, so 62 s on this machine was already past half the kill budget, with `retries = 1` buying a second full attempt on a slower runner.

## Why `no_passthrough_e2e` is gated

`CARGO_BIN_EXE_assay-mcp-server` resolves to whatever feature set the test target was built with. A test that needs a `test-outbound` binary can only be sure it gets one if it compiles under that feature itself. That is the whole reason for the gate.

## The gate needed a guard

Gating converts a rebuild into a silent absence. `cargo test` exits 0 when zero tests match, so a misspelled feature flag would be green. The E6a.3 CI step now asserts the test actually ran, and runs on every OS because it is the only job that compiles the test at all.

Verified with a negative control — same command, feature omitted:

```
running 0 tests
cargo exit code: 0
guard verdict: fails, as it should
```

## The gate also cost a lint, which is restored

`cargo clippy --workspace --all-targets` carries no `--all-features`, and `--all-targets` does not imply it, so cfg strips the gated file to an empty crate and the sweep lints nothing. A dedicated feature-enabled clippy step restores it. Demonstrated rather than assumed: injecting an unused-variable violation into `test_no_passthrough_e2e` passes the existing sweep and fails the new step.

## Adversarial review

An independent review of `ea152602` found three defects, all fixed in `a76e2e77`:

- The `child.kill()` benefit claimed in the comments and commit message **does not exist** in any file this PR touches — all three use `drop(stdin); child.wait()`. The claim is removed rather than reworded.
- The claim that two feature variants "overwrite each other's artifacts" is **wrong**. `test-outbound = []` enables no dependency features, so the stack has one fingerprint under both, and this PR's own Windows job shows the two test binaries coexisting under distinct hashes. The measured cost is fully explained by the `CARGO_MANIFEST_DIR` mechanism, which does reproduce.
- The lint-coverage regression above.

Plus two smaller ones: the guard's grep was bound to libtest's exact line and would have reported "the test did not run" while it passed if the step were ever migrated to nextest (it now matches either format, and still fails on absence and on a FAIL line); and E6a.3 gained `--locked` to match the workspace step beside it.

## Scope note

This does not fix the same pathology in `assay-cli`. `golden_runner.rs` still spawns `cargo run --bin assay` with the inherited environment, inside the same Linux `cargo test --workspace` step, so the thrash survives one crate over. #1980 addresses that crate; see the comment there about `golden_runner` specifically, which spawns assay-cli's *own* bin and so has the same escape available as these tests did.

## Checks

- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`, clean with and without the feature
- 285 tests pass in 1.87 s
- All pre-commit hooks pass, including the actionlint workflow lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test execution across platforms.
  * Added coverage for outbound and no-pass-through behavior using prebuilt server binaries.
  * Strengthened test validation to detect cases where tests fail to run.
  * Preserved existing standard input/output and edge-case coverage.

* **Chores**
  * Added explicit Clippy checks for the server’s outbound-testing configuration.
  * Streamlined automated test workflows for more reliable and consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->