### PR TITLE
fix(test): a deadline checked around a blocking read is not a timeout

### DIFF
--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -105,10 +105,23 @@ impl JsonLines {
     ///
     /// `what` names the thing being awaited, so a timeout points at the request that went
     /// unanswered instead of reporting a bare "timeout".
+    ///
+    /// The deadline is checked explicitly at the top of each iteration and not left to
+    /// `recv_timeout` alone. `recv_timeout` attempts an optimistic `try_recv` first, so it returns
+    /// an already-queued line even when the remaining duration is zero; a child that writes
+    /// non-JSON faster than this loop skips it therefore keeps the channel non-empty and runs
+    /// unbounded past the deadline. `json_lines_deadline_holds_against_a_flood_of_non_json_lines`
+    /// covers that case.
     fn next_json(&mut self, timeout: Duration, what: &str) -> anyhow::Result<Value> {
         let deadline = Instant::now() + timeout;
         loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            let now = Instant::now();
+            if now >= deadline {
+                anyhow::bail!(
+                    "timed out after {timeout:?} waiting for {what}: no JSON response line arrived"
+                );
+            }
+            let remaining = deadline.saturating_duration_since(now);
             let line = match self.rx.recv_timeout(remaining) {
                 Ok(Ok(line)) => line,
                 Ok(Err(err)) => {
@@ -150,6 +163,51 @@ fn read_json_line(
         let _ = child.kill();
         let _ = child.wait();
     })
+}
+
+/// A child that floods stdout with non-JSON must not be able to outrun the deadline.
+///
+/// The silent-child case and this one fail differently: there, no line ever arrives and
+/// `recv_timeout` reports `Timeout`; here lines arrive faster than they are skipped, so the
+/// channel is never empty when the receive is attempted, and `recv_timeout`'s optimistic
+/// `try_recv` hands back a queued line even at zero remaining duration. Only the explicit deadline
+/// check in `next_json` ends this run.
+///
+/// `yes` and not a shell `while` loop on purpose: a shell loop produces more slowly than this
+/// consumer skips, so the channel drains, the receive finds it empty, and the run bounds itself
+/// even without the deadline check. Reproducing the defect needs a producer that outruns the
+/// consumer, which is what makes this a regression test rather than a test that happens to pass.
+#[cfg(unix)]
+#[test]
+fn json_lines_deadline_holds_against_a_flood_of_non_json_lines() -> anyhow::Result<()> {
+    let timeout = Duration::from_secs(1);
+    let mut child = Command::new("yes")
+        .arg("not-json")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let mut lines = JsonLines::new(child.stdout.take().expect("stdout"));
+
+    let start = Instant::now();
+    let err = lines
+        .next_json(timeout, "a response that never comes")
+        .expect_err("a flood of non-JSON lines must not satisfy the read");
+    let elapsed = start.elapsed();
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // Generous headroom over the 1s deadline: this asserts the deadline is enforced at all, not
+    // that it is precise, so a loaded CI machine does not turn a real bound into a flaky one.
+    assert!(
+        elapsed < timeout * 5,
+        "the deadline did not bound the read: gave up only after {elapsed:?} (timeout was {timeout:?})"
+    );
+    assert!(
+        err.to_string().contains("timed out"),
+        "expected a timeout failure, got: {err}"
+    );
+    Ok(())
 }
 
 fn wait_child_with_timeout(child: &mut Child, timeout: Duration) -> anyhow::Result<ExitStatus> {

--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -1,11 +1,16 @@
 use anyhow::Context;
 
 use serde_json::{json, Value};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
+
+/// How long a single JSON-RPC response may take before the proxy is declared wedged.
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn exe_name(name: &str) -> String {
     if cfg!(windows) {
@@ -55,31 +60,96 @@ fn send_line(stdin: &mut dyn Write, v: &Value) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Read one JSON line from stdout with timeout (best-effort).
-fn read_json_line(
-    reader: &mut BufReader<std::process::ChildStdout>,
-    timeout: Duration,
-) -> anyhow::Result<Value> {
-    let start = Instant::now();
-    loop {
-        if start.elapsed() > timeout {
-            anyhow::bail!("timeout waiting for response");
-        }
-        let mut line = String::new();
-        let n = reader.read_line(&mut line)?;
-        if n == 0 {
-            anyhow::bail!("EOF from proxy");
-        }
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        // Ignore log lines if any
-        if !line.starts_with('{') {
-            continue;
-        }
-        return Ok(serde_json::from_str::<Value>(line)?);
+/// Line reader for the proxy's stdout whose timeout survives a proxy that never answers.
+///
+/// `BufRead::read_line` blocks until a newline, EOF, or error, so a deadline checked around it is
+/// only ever evaluated once a line has already arrived. The blocking read therefore runs on a
+/// worker thread and the test waits on a channel instead, which bounds the wait whether or not the
+/// proxy writes anything. (A read timeout on the pipe itself would do as well, but `ChildStdout`
+/// is not a socket, so that needs platform-specific code on both Unix and Windows.)
+///
+/// The worker exits on EOF, on a read error, or once the receiver is gone. If the proxy is wedged
+/// it stays parked in `read_line`; killing the child closes the pipe and releases it, which is why
+/// [`read_json_line`] kills on timeout rather than leaving the process behind.
+struct JsonLines {
+    rx: mpsc::Receiver<io::Result<String>>,
+}
+
+impl JsonLines {
+    fn new(stdout: ChildStdout) -> Self {
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    // EOF: dropping `tx` is what reports it to the receiver.
+                    Ok(0) => break,
+                    // A send error means the test has moved on; stop reading.
+                    Ok(_) => {
+                        if tx.send(Ok(line)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        let _ = tx.send(Err(err));
+                        break;
+                    }
+                }
+            }
+        });
+        Self { rx }
     }
+
+    /// Wait up to `timeout` for the next JSON line.
+    ///
+    /// `what` names the thing being awaited, so a timeout points at the request that went
+    /// unanswered instead of reporting a bare "timeout".
+    fn next_json(&mut self, timeout: Duration, what: &str) -> anyhow::Result<Value> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let line = match self.rx.recv_timeout(remaining) {
+                Ok(Ok(line)) => line,
+                Ok(Err(err)) => {
+                    return Err(anyhow::Error::new(err)
+                        .context(format!("read error while waiting for {what}")))
+                }
+                Err(RecvTimeoutError::Timeout) => anyhow::bail!(
+                    "timed out after {timeout:?} waiting for {what}: the proxy wrote no response line"
+                ),
+                Err(RecvTimeoutError::Disconnected) => {
+                    anyhow::bail!("EOF from proxy while waiting for {what}")
+                }
+            };
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            // Ignore log lines if any
+            if !line.starts_with('{') {
+                continue;
+            }
+            return serde_json::from_str::<Value>(line)
+                .with_context(|| format!("malformed JSON line while waiting for {what}: {line}"));
+        }
+    }
+}
+
+/// Read one JSON line from the proxy, killing it if the response does not arrive in time.
+///
+/// A timed-out read means the proxy is wedged, and leaving it running orphans it (and the server
+/// it wrapped) onto the inherited stderr for as long as the test binary lives.
+fn read_json_line(
+    child: &mut Child,
+    lines: &mut JsonLines,
+    timeout: Duration,
+    what: &str,
+) -> anyhow::Result<Value> {
+    lines.next_json(timeout, what).inspect_err(|_| {
+        let _ = child.kill();
+        let _ = child.wait();
+    })
 }
 
 fn wait_child_with_timeout(child: &mut Child, timeout: Duration) -> anyhow::Result<ExitStatus> {
@@ -220,7 +290,7 @@ enforcement:
 
     let mut stdin = child.stdin.take().expect("stdin");
     let stdout = child.stdout.take().expect("stdout");
-    let mut reader = BufReader::new(stdout);
+    let mut lines = JsonLines::new(stdout);
     let secret = "ghp_assay_fixture_DO_NOT_LEAK_0123456789";
 
     // Both calls carry the same token-like argument. The first resolves its policy and is actually
@@ -245,12 +315,22 @@ enforcement:
     };
 
     send_line(&mut stdin, &call("token-log-allowed", "read-file.yaml"))?;
-    let allowed_resp = read_json_line(&mut reader, Duration::from_secs(5))?;
+    let allowed_resp = read_json_line(
+        &mut child,
+        &mut lines,
+        RESPONSE_TIMEOUT,
+        "the tools/call response to request token-log-allowed (the normal, policy-resolving path)",
+    )?;
     send_line(
         &mut stdin,
         &call("token-log-missing", "does-not-exist.yaml"),
     )?;
-    let error_resp = read_json_line(&mut reader, Duration::from_secs(5))?;
+    let error_resp = read_json_line(
+        &mut child,
+        &mut lines,
+        RESPONSE_TIMEOUT,
+        "the tools/call response to request token-log-missing (the unresolvable-policy path)",
+    )?;
     drop(stdin);
     let status = wait_child_with_timeout(&mut child, Duration::from_secs(5))?;
     assert!(status.success(), "proxy exited with status {status}");
@@ -377,7 +457,7 @@ enforcement:
 
     let mut stdin = child.stdin.take().expect("stdin");
     let stdout = child.stdout.take().expect("stdout");
-    let mut reader = BufReader::new(stdout);
+    let mut lines = JsonLines::new(stdout);
 
     // tools/call -> "skill_check" should match *kill* and be denied by proxy
     let req = json!({
@@ -388,7 +468,12 @@ enforcement:
     });
 
     send_line(&mut stdin, &req)?;
-    let resp = read_json_line(&mut reader, Duration::from_secs(5))?;
+    let resp = read_json_line(
+        &mut child,
+        &mut lines,
+        RESPONSE_TIMEOUT,
+        "the tools/call response to the denied skill_check request",
+    )?;
 
     // Accept both transitional codes (old/new) while you converge
     let code = extract_error_code(&resp).unwrap_or_default();
@@ -460,7 +545,7 @@ enforcement:
 
     let mut stdin = child.stdin.take().expect("stdin");
     let stdout = child.stdout.take().expect("stdout");
-    let mut reader = BufReader::new(stdout);
+    let mut lines = JsonLines::new(stdout);
 
     // Violating path -> should be denied by schema
     let req = json!({
@@ -471,7 +556,12 @@ enforcement:
     });
 
     send_line(&mut stdin, &req)?;
-    let resp = read_json_line(&mut reader, Duration::from_secs(5))?;
+    let resp = read_json_line(
+        &mut child,
+        &mut lines,
+        RESPONSE_TIMEOUT,
+        "the tools/call response to the schema-violating read_file request",
+    )?;
 
     let code = extract_error_code(&resp).unwrap_or_default();
     assert!(


### PR DESCRIPTION
## Description

`read_json_line` in `crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs` checked `start.elapsed()` *before* calling `BufRead::read_line`, so the deadline was only ever evaluated once a line had already arrived — exactly the case where it is not needed. Callers passed `Duration::from_secs(5)` believing it bounded the wait; against a server that spawns but never answers, the read blocked and the timeout never fired.

The fix moves the blocking read onto a worker thread and waits with `mpsc::Receiver::recv_timeout`. A read timeout on the pipe itself would work too, but `ChildStdout` is not a socket, so that needs platform-specific code on both Unix and Windows; the thread plus channel is std-only and behaves the same on both.

Three details worth review attention:

- The deadline is checked explicitly at the top of each iteration, so a child flooding stdout with non-JSON cannot outrun it. Computing the deadline once is not sufficient on its own: `recv_timeout` attempts an optimistic `try_recv` before consulting the clock, so it hands back an already-queued line even at zero remaining duration. `json_lines_deadline_holds_against_a_flood_of_non_json_lines` covers this. (This bullet previously claimed the single deadline gave the property by itself. That was wrong, and it was caught in review on `f67385eb`; see the review thread.)
- Callers now pass what they are waiting for. The OWASP MCP01 test reads two responses off one stream, and `"timeout waiting for response"` could not distinguish them.
- A timed-out read kills the child. That releases the worker parked in `read_line`, and stops a wedged proxy from being orphaned onto the inherited stderr for the life of the test binary.

This is pre-existing and was not introduced by #1980, but that PR made it matter more: it establishes `owasp_mcp01_token_args_do_not_leak_to_proxy_logs` as the one test in the file that depends on the server answering at all.

## Type of Change
- [x] Bug fix

## Verification

All measurements on `20f170020154dd2ad83c361dbbe60752c3075128`, worktree `nifty-tesla-53fc6b`, `rustc 1.96.0-aarch64-apple-darwin`, binaries built from that tree into that worktree's own `target/`. The counterfactual below was measured on `f67385eb` against `f67385eb~1`, and that is stated where it applies.

**Counterfactual — the pre-fix code, same tree, same fake server.** `crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs` restored from `f67385eb~1` with the server pointed at a script that spawns, accepts its arguments and never writes (`#!/bin/sh` + `exec sleep 30`):

```
exit=143 (SIGTERM), elapsed 300s — no failure, no message
```

Unbounded, not merely slow: the `sleep` exits after 30s, but the `assay mcp wrap` parent holds the stdout pipe open, so `read_line` never sees EOF. Under nextest that is a SIGTERM at 120s with no message, and `retries = 1` buys a second one.

**Fixed code, same fake server:**

```
test owasp_mcp01_token_args_do_not_leak_to_proxy_logs ... FAILED
Error: timed out after 5s waiting for the tools/call response to request
token-log-allowed (the normal, policy-resolving path): the proxy wrote no response line

test result: FAILED. finished in 5.02s
```

Under nextest: `FL+LK [5.220s]`, whole run 11.4s including the `retries = 1` re-run. The `LK` (leaked handle) is the synthetic `sleep 30` grandchild ignoring stdin and surviving the kill of its parent while still holding the inherited stderr; nextest reports it inside its grace window rather than hanging. The real `assay-mcp-server` exits on stdin EOF, so this is a property of the deliberately hostile fake server, not of the change.

**Flood case (added in `20f17002` after review).** A child writing non-JSON faster than the loop skips it, driven by `yes not-json`:

```
test json_lines_deadline_holds_against_a_flood_of_non_json_lines ... ok
test result: ok. finished in 1.06s
```

Without the explicit deadline check the same test runs past 40s against its 1s deadline. Worth noting for reviewers: an earlier version of this test used a shell `while` loop as the producer and passed against the broken code in 1.00s, because a shell loop produces more slowly than the consumer skips, so the channel drains and the receive bounds itself. Reproducing the defect requires a producer that outruns the consumer, and the test carries that reasoning in a comment.

**Real server, test restored:**

- `cargo nextest run -p assay-cli --test e2e_mcp_wrap_assert_cmd` — 3 passed, 0.135s
- `cargo test -p assay-cli` — 606 passed, 0 failed across all test binaries
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p assay-cli --tests -- -D warnings` — clean
- `git diff --check` — clean

- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Ran a demo suite — not applicable; this changes no production behavior

## Non-claims

- Test-only change. No production code is touched, so no evidence-ingestion, evidence-verification, or MCP-authorization behavior changes and ADR-042/043 boundaries are not engaged.
- The workspace suite was not run; the affected-crate suite was.
- This does not fix the sibling readers in `crates/assay-mcp-server/tests/` (`proxy_enforce_e2e.rs:102`, `stdio_edge_cases.rs:81`, `no_passthrough_e2e.rs:118`, `stdio_e2e.rs:52`, `proxy_forwarding_e2e.rs:64`, `proxy_manifest_e2e.rs:73`, `proxy_enforce_pdp_e2e/support.rs:201`, `resource_limits.rs:31`). Those have no timeout at all — strictly worse against a non-answering server, but a different file set and a larger change than this one. Tracked separately.

## Review

The builder's self-review does not count. This needs the quorum on the final head SHA per AGENTS.md.

Round 1 on `f67385eb`: one review found a blocking timeout hole, confirmed and fixed in `20f17002`. CodeRabbit declared a rate limit on that head and left no findings, which is not a review. The advance to `20f17002` introduces new changes, so neither carries to the current head.

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly — no documented behavior changed.
- [x] I have added tests to cover my changes — the change is to test infrastructure; it is verified by the counterfactual above rather than by a new test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

