### PR TITLE
A deny the upstream never sees is not an e2e test

### DIFF
--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -39,20 +39,14 @@ fn assay_bin() -> PathBuf {
 /// such as `assay-core` that an mtime comparison against `assay-mcp-server/src`
 /// would miss. On an already-current tree this is a no-op freshness check.
 ///
-/// What this does and does not buy, because the difference is easy to overstate:
-/// it guarantees the binary these tests spawn is built from the current source.
-/// It does *not* make the tests fail when it would not be. Only
-/// `owasp_mcp01_token_args_do_not_leak_to_proxy_logs` depends on the server
-/// answering at all; `e2e_wrap_denies_wildcard_contains` and
-/// `e2e_wrap_denies_schema_violation` assert verdicts the proxy reaches before
-/// dispatching upstream. They pass against anything that spawns and then exits
-/// when its stdin closes — `/usr/bin/true` included, so the upstream need not
-/// speak the protocol, or read a byte, to satisfy them. (#1981 added an
-/// exit-status assert, which does make a server that hangs past five seconds
-/// fail them; that bounds how the upstream *terminates*, not what it answers.)
-/// Detecting a wrong server in those two needs an assertion only a correct
-/// server can satisfy, which is a change to what they test rather than to how
-/// the binary is found, and is what #1988 is for.
+/// Building the current binary is only half of it: a test also has to *notice*
+/// when the wrong one is on the other end. It used not to. The deny fixtures
+/// asserted verdicts the proxy reaches before dispatching upstream, so they
+/// passed against anything spawnable, `/usr/bin/true` included — the upstream
+/// needed neither to speak the protocol nor to read a byte. Every test in this
+/// file now makes the wrapped server answer for itself, the deny fixtures via
+/// [`assert_upstream_is_the_real_server`], which is where that argument is
+/// written down. A stale or wrong binary now fails here.
 ///
 /// Panics (never skips) if the build fails: a skipped e2e test that reads as
 /// green is a worse failure than a loud one.
@@ -412,6 +406,119 @@ fn extract_tool_payload(resp: &Value) -> anyhow::Result<Value> {
         .with_context(|| format!("result.content[0].text is not JSON: {text}"))
 }
 
+/// Request id of the upstream probe the two deny fixtures send after their deny.
+const UPSTREAM_PROBE_ID: &str = "upstream-probe";
+
+/// Policy the probe asks the wrapped server to evaluate, relative to its `--policy-root`.
+const PROBE_INNER_POLICY: &str = "probe-inner.yaml";
+
+/// Write the policy the upstream probe evaluates into the wrapped server's `--policy-root`.
+///
+/// Both deny fixtures already created this directory and passed it to the server, but left it
+/// empty and never made the server read anything out of it. The probe gives that argument a job:
+/// resolving this file is work only the real server does.
+fn write_probe_inner_policy(policy_root: &Path) -> anyhow::Result<()> {
+    std::fs::write(
+        policy_root.join(PROBE_INNER_POLICY),
+        r#"
+version: "2.0"
+name: "upstream-probe-inner"
+tools:
+  allow: ["read_file"]
+enforcement:
+  unconstrained_tools: allow
+"#,
+    )?;
+    Ok(())
+}
+
+/// Assert that the process on the far side of the proxy is a working `assay-mcp-server`.
+///
+/// Call this from a deny fixture *after* reading its deny response, on the same proxy process. It
+/// sends one call the fixture's policy allows, so the proxy forwards it, and the answer can only
+/// come from upstream.
+///
+/// Two things are checked, and they are not the same thing:
+///
+/// 1. **The response is the probe's.** The proxy answers a denied call itself and skips the
+///    forward, so a correct proxy produces exactly one frame for it. Were it forwarded instead,
+///    the server would answer it — the denied names here are ones the server does not implement,
+///    and it replies `Unknown tool: <name>` rather than staying silent — and because the server
+///    writes to a single ordered pipe, that frame would necessarily arrive before the probe's.
+///    Reading the very next frame and finding the probe's id is therefore evidence the denied call
+///    was never dispatched, which is the property a proxy deny is actually for and which asserting
+///    on the deny response alone cannot show. It rests on this server answering unknown tools; an
+///    upstream that received the call and said nothing would not be caught.
+///
+/// 2. **The payload is a real policy verdict.** The server resolves [`PROBE_INNER_POLICY`] under
+///    its `--policy-root`, evaluates the arguments against it, and reports `allowed` in the text
+///    block. Nothing but `assay-mcp-server` produces that.
+///
+/// Together these are what makes the fixtures' `e2e`, and their spawn of a real server, honest.
+/// Before this, both asserted only verdicts `assay mcp wrap` reaches *before* dispatching
+/// upstream, so they passed against any spawnable executable, `/usr/bin/true` included.
+///
+/// Established by mutation rather than by argument, since an argument is what an earlier revision
+/// of this file got wrong. Against the real test binary: renaming the server's `assay_check_args`
+/// arm fails both fixtures on (2), and making the server exit immediately fails them on the read;
+/// removing the proxy's skip-the-forward on a blocked call fails them on (1), and on nothing else
+/// in this file. Substituting a fake at the binary's *path* proves nothing either way — the nested
+/// build in [`assay_mcp_server_bin`] restores the real binary before the test spawns it — so the
+/// stand-in upstreams (`sh -c 'sleep 30'`, `/bin/cat`, `/usr/bin/true`) were driven through this
+/// exact request sequence out-of-band: none satisfies (2). `cat` is the interesting one, since it
+/// echoes the request and so does carry the probe's id, but has no `result.content[0].text`.
+fn assert_upstream_is_the_real_server(
+    child: &mut Child,
+    stdin: &mut dyn Write,
+    lines: &mut JsonLines,
+) -> anyhow::Result<()> {
+    send_line(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": UPSTREAM_PROBE_ID,
+            "method": "tools/call",
+            "params": {
+                "name": "assay_check_args",
+                "arguments": {
+                    "tool": "read_file",
+                    "arguments": { "path": "/workspace/report.md" },
+                    "policy": PROBE_INNER_POLICY
+                }
+            }
+        }),
+    )?;
+    let resp = read_json_line(
+        child,
+        lines,
+        RESPONSE_TIMEOUT,
+        "the wrapped assay-mcp-server's answer to the allowed upstream probe",
+    )?;
+
+    assert_eq!(
+        resp.get("id").and_then(|v| v.as_str()),
+        Some(UPSTREAM_PROBE_ID),
+        "expected the next frame to answer the probe; a frame for the denied call means the proxy \
+         forwarded it upstream instead of blocking it. resp={resp}"
+    );
+
+    let payload = extract_tool_payload(&resp)?;
+    assert_eq!(
+        payload.get("allowed"),
+        Some(&Value::Bool(true)),
+        "expected the wrapped assay-mcp-server to evaluate {PROBE_INNER_POLICY} and allow the \
+         probe; got payload={payload} from resp={resp}"
+    );
+    assert_eq!(
+        resp.get("result")
+            .and_then(|r| r.get("isError"))
+            .and_then(|v| v.as_bool()),
+        Some(false),
+        "expected a non-error result from upstream, got {resp}"
+    );
+    Ok(())
+}
+
 /// Mask the fixture's token-like argument in an assertion's failure message.
 ///
 /// Only the rendered text is masked; every assertion still compares against the raw value, so a
@@ -614,8 +721,12 @@ fn e2e_wrap_denies_wildcard_contains() -> anyhow::Result<()> {
     let policy_path = tmp.path().join("proxy-policy.yaml");
     let policy_root = tmp.path().join("policy-root");
     std::fs::create_dir_all(&policy_root)?;
+    write_probe_inner_policy(&policy_root)?;
 
-    // Proxy policy: wildcard deny *kill*
+    // Proxy policy: wildcard deny *kill*. `assay_check_args` needs no entry of its own: `allow:
+    // ["*"]` covers it, it matches none of the deny patterns, and `unconstrained_tools: allow`
+    // lets it through without a schema — so the upstream probe below runs against the fixture's
+    // policy unchanged.
     std::fs::write(
         &policy_path,
         r#"
@@ -674,6 +785,10 @@ enforcement:
         "expected deny-ish error_code, got '{code}'. resp={resp}"
     );
 
+    // The deny above is reached before the proxy dispatches upstream, so on its own it says
+    // nothing about what is on the other end. Make the wrapped server answer for itself.
+    assert_upstream_is_the_real_server(&mut child, &mut stdin, &mut lines)?;
+
     // Close stdin and reap the proxy instead of killing it: a kill only reaches the `assay`
     // parent, orphaning the wrapped assay-mcp-server, which then races TempDir teardown and fails
     // its own --policy-root canonicalization on a directory that has just been deleted.
@@ -692,15 +807,25 @@ fn e2e_wrap_denies_schema_violation() -> anyhow::Result<()> {
     let policy_path = tmp.path().join("proxy-policy.yaml");
     let policy_root = tmp.path().join("policy-root");
     std::fs::create_dir_all(&policy_root)?;
+    write_probe_inner_policy(&policy_root)?;
 
-    // Proxy policy: schema for read_file must be /workspace/*
+    // Proxy policy: schema for read_file must be /workspace/*.
+    //
+    // `assay_check_args` is admitted alongside it purely to carry the upstream probe. It needs
+    // both an allowlist entry and a schema: `unconstrained_tools: deny` denies an allowed tool
+    // that has no schema of its own. The probe cannot instead be a `tools/list`, which this
+    // policy denies — the proxy evaluates every request, and a method that names no tool
+    // evaluates as the empty name, which is not in the allowlist.
+    //
+    // This leaves the deny under test untouched: `read_file` keeps the same schema, and
+    // `/etc/passwd` still fails the same `pattern` and reports the same E_ARG_SCHEMA below.
     std::fs::write(
         &policy_path,
         r#"
 version: "2.0"
 name: "e2e-schema"
 tools:
-  allow: ["read_file"]
+  allow: ["read_file", "assay_check_args"]
 schemas:
   read_file:
     type: object
@@ -712,6 +837,16 @@ schemas:
         minLength: 1
         maxLength: 4096
     required: ["path"]
+  assay_check_args:
+    type: object
+    properties:
+      tool:
+        type: string
+        minLength: 1
+      policy:
+        type: string
+        minLength: 1
+    required: ["tool", "arguments", "policy"]
 enforcement:
   unconstrained_tools: deny
 "#,
@@ -758,6 +893,10 @@ enforcement:
         code == "E_ARG_SCHEMA" || code == "MCP_ARG_CONSTRAINT",
         "expected schema/constraint error_code, got '{code}'. resp={resp}"
     );
+
+    // The deny above is reached before the proxy dispatches upstream, so on its own it says
+    // nothing about what is on the other end. Make the wrapped server answer for itself.
+    assert_upstream_is_the_real_server(&mut child, &mut stdin, &mut lines)?;
 
     // Close stdin and reap the proxy instead of killing it: a kill only reaches the `assay`
     // parent, orphaning the wrapped assay-mcp-server, which then races TempDir teardown and fails


### PR DESCRIPTION
Rebased onto `main` now that #1980 has merged: this is a **single commit**, and the three #1980
commits it previously carried are gone.

## Description

`e2e_wrap_denies_wildcard_contains` and `e2e_wrap_denies_schema_violation` spawned
`assay-mcp-server` and never used it. Both assert verdicts `assay mcp wrap` reaches *before*
dispatching upstream, so their real boundary was "anything spawnable" — `/usr/bin/true` passed
them. They detected an *absent* upstream, never a wrong or stale one. #1980 made the binary they
spawn guaranteed-current and said in the same doc comment that this does not close the gap; that
comment pointed here.

Two options were on the table: give them an assertion only a correct server can satisfy, or accept
they are proxy-policy tests, rename them, and stop spawning a server they never use.

**This takes the first.** Not primarily for the name. The property they are reaching for — *a
denied call must not reach the upstream* — is real, is end-to-end, and this file is the only place
covering it. Renaming down would discard it rather than fix it, and would not even remove the
spawn, since the proxy must spawn something; it would trade a real server for a stub.

The deciding detail was in the fixtures rather than the names: **both already created a
`--policy-root`, passed it to the server, then left it empty and never made the server read
anything out of it.** The scaffolding for a real upstream was there, unused. So the fix gives that
argument a job. After the deny, each fixture sends one call its own policy allows; the proxy
forwards it, and the wrapped server has to resolve a policy out of that root and answer.

### What the probe checks

Two independent things:

1. **The next frame is the probe's.** The proxy answers a denied call itself and skips the forward.
   Had it forwarded instead, the server would have answered it — the denied names are ones the
   server does not implement, and it replies `Unknown tool: <name>` rather than staying silent —
   and on a single ordered pipe that frame necessarily precedes the probe's. So reading the very
   next frame and finding the probe's id is evidence the denied call was never dispatched. That is
   the property a proxy deny exists for, and asserting on the deny response alone cannot show it.
   It rests on this server answering unknown tools; an upstream that received the call and said
   nothing would not be caught, and the doc comment says so.
2. **The payload is a real policy verdict** — resolved from `--policy-root` and reported as
   `allowed`. Nothing but `assay-mcp-server` produces it.

### Fixture changes, and why they do not weaken anything

The schema fixture admits `assay_check_args` alongside `read_file` to carry the probe, with a
schema of its own because `unconstrained_tools: deny` denies an allowed tool that has none.
`read_file` keeps its schema; `/etc/passwd` still fails the same `pattern` and still reports the
same `E_ARG_SCHEMA`. The wildcard fixture needs no policy change at all.

The probe cannot instead be a `tools/list`: the proxy evaluates policy against **every** request,
and a method naming no tool evaluates as the *empty* tool name, which the schema fixture's
allowlist rejects (`E_TOOL_NOT_ALLOWED`, `tool: ""`). Measured, not assumed.

No existing assertion is weakened and there is no skip path.

### What this PR no longer contains

An earlier revision also rewrote `read_json_line` to be able to time out, because the version it
was based on could not. #1980 landed its own fix for that — `JsonLines`, with an explicit deadline
check against `recv_timeout`'s optimistic `try_recv` and a dedicated regression test, which is
better than what this PR had. That work is dropped here and the probe calls the existing helper
instead. Two implementations of one rule drift; this one now has a single owner.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor

## Verification

Measurements on `93c1bf12`, clean working tree, worktree `.claude/worktrees/kind-gould-c0bc7f`,
`rustc 1.96.0 (ac68faa20 2026-05-25)` (the pinned toolchain), darwin 25.6.0. Re-measured after the
rebase, because the reader underneath these fixtures changed.

Established by mutation against the real test binary, not by argument — an argument is what an
earlier revision of this file got wrong twice:

| mutation | result |
|---|---|
| server drops its `assay_check_args` dispatch arm | both fixtures **FAIL** on the payload |
| server exits immediately | both **FAIL** on the read |
| proxy forwards a blocked call anyway | both **FAIL** on the frame id — and nothing else in the file does |
| unmutated | `cargo nextest run -p assay-cli`: **606 passed**, 1 skipped |

`cargo clippy -p assay-cli --tests --all-features -- -D warnings` clean; `cargo fmt --all --check`
clean.

### A note for anyone re-checking this

Substituting a fake at `target/debug/assay-mcp-server` proves nothing either way: the nested Cargo
build from #1980 **restores the real binary** before the test spawns it. An attempt at it "passed"
against `/usr/bin/true` — including `owasp_mcp01_...`, which genuinely depends on the server, and
that impossibility is what exposed the mistake. The stand-in upstreams (`sh -c 'sleep 30'`,
`/bin/cat`, `/usr/bin/true`) were driven through the identical request sequence out-of-band
instead; none satisfies check 2. `cat` is the interesting one: it echoes the request, so it does
carry the probe's id, but has no `result.content[0].text`. This is recorded in the code so the next
person does not lose the same hour.

- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Ran a demo suite — not applicable; this is test infrastructure

Not an ADR-042/043 slice: it changes no evidence ingestion, no evidence verification, and no MCP
authorization behaviour — only what the tests over `assay mcp wrap` assert.

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. — no docs describe these fixtures; the rationale lives in doc comments beside the assertions.
- [x] I have added tests to cover my changes. — the change *is* to tests; its properties are established by the mutation table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)