### PR TITLE
An existence check on a measurement harness is not a freshness check

### DIFF
--- a/crates/assay-cli/benches/profile_store_harness.rs
+++ b/crates/assay-cli/benches/profile_store_harness.rs
@@ -52,17 +52,10 @@ fn selected_workloads() -> Vec<Workload> {
 }
 
 fn assay_bin() -> PathBuf {
-    if let Some(p) = option_env!("CARGO_BIN_EXE_assay") {
-        return PathBuf::from(p);
-    }
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let release = manifest.join("../../target/release/assay");
-    let debug = manifest.join("../../target/debug/assay");
-    if release.exists() {
-        release
-    } else {
-        debug
-    }
+    // Cargo sets CARGO_BIN_EXE_<name> for bench targets and builds that binary from the
+    // current source first, so this path cannot resolve to a stale artifact. The value is
+    // baked in at compile time, so it also holds when the bench binary is run directly.
+    PathBuf::from(env!("CARGO_BIN_EXE_assay"))
 }
 
 fn run_cmd(bin: &Path, cwd: &Path, args: &[String]) {

--- a/crates/assay-cli/benches/suite_run_worstcase.rs
+++ b/crates/assay-cli/benches/suite_run_worstcase.rs
@@ -1,7 +1,7 @@
 //! Criterion benchmark: suite run worstcase (runner → store → report, file-backed WAL).
 //! Generates enough writes so WAL/checkpointing can occur; for P0.3 regression.
 //! Run with: cargo bench -p assay-cli --bench suite_run_worstcase
-//! Requires: assay binary (cargo build --release or CARGO_BIN_EXE_assay when run via cargo bench).
+//! The assay binary is supplied by cargo via CARGO_BIN_EXE_assay; no prior build is needed.
 //!
 //! **Duration:** Each iteration runs a full `assay run` subprocess (12 episodes, file-backed DB).
 //! With QUICK=1 (10 samples, 300ms warm-up, 1s measurement): expect ~20–40s total. Not a hang.
@@ -15,18 +15,10 @@ use std::time::Duration;
 use tempfile::TempDir;
 
 fn assay_bin() -> PathBuf {
-    if let Some(p) = option_env!("CARGO_BIN_EXE_assay") {
-        return PathBuf::from(p);
-    }
-    // Fallback when not invoked by cargo bench: workspace target dir
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let release = manifest.join("../../target/release/assay");
-    let debug = manifest.join("../../target/debug/assay");
-    if release.exists() {
-        release
-    } else {
-        debug
-    }
+    // Cargo sets CARGO_BIN_EXE_<name> for bench targets and builds that binary from the
+    // current source first, so this path cannot resolve to a stale artifact. The value is
+    // baked in at compile time, so it also holds when the bench binary is run directly.
+    PathBuf::from(env!("CARGO_BIN_EXE_assay"))
 }
 
 /// Write minimal worstcase eval (12 tests, deterministic-only) and trace (12 episodes × 8 tool_calls, ~400B payload).

--- a/scripts/ci/exp-mcp-fragmented-ipi/cross_session/run_cross_session_decay.sh
+++ b/scripts/ci/exp-mcp-fragmented-ipi/cross_session/run_cross_session_decay.sh
@@ -33,6 +33,21 @@ case "$MODE" in
     ;;
 esac
 
+# drive_fragmented_ipi.py consumes these binaries without building them (see prebuilt_binary
+# there); freshness is this wrapper's job, so build rather than assume. Each is built only on
+# the path that reaches it: RUN_LIVE=1 drives $ASSAY_CMD instead of the local wrap binary, and
+# the sequence guard is spawned only when --sequence-policy-root is passed below.
+BUILD_PKGS=()
+if [[ "$RUN_LIVE" == "0" ]]; then
+  BUILD_PKGS+=(-p assay-cli)
+fi
+if [[ "$USE_SEQUENCE" == "1" ]]; then
+  BUILD_PKGS+=(-p assay-mcp-server)
+fi
+if (( ${#BUILD_PKGS[@]} > 0 )); then
+  cargo build -q "${BUILD_PKGS[@]}"
+fi
+
 SESSION_DIR="$OUT_DIR/sessions/${MODE}/decay_runs_${DECAY_RUNS}"
 STATE_FILE="$SESSION_DIR/state/session_guard_state.json"
 CONTROL_STATE_FILE="$SESSION_DIR/state/legit_control_state.json"

--- a/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
+++ b/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
@@ -53,33 +53,26 @@ def parse_tool_payload(response):
         return {"raw": text}
 
 
-def require_prebuilt(path, package):
-    """Check a binary this driver consumes but deliberately does not build.
-
-    Callers pass the fully constructed path rather than a binary name: keeping the join a
-    literal at the call site is what stops the path expression depending on a variable
-    (py/path-injection), and there are only ever two of them.
-
-    This is a presence test, NOT a freshness test: it cannot tell a current binary from one
-    left over from an older source tree. Freshness is owned by the wrapper scripts, which
-    build before invoking this driver -- run_baseline.sh, run_protected.sh and
-    cross_session/run_cross_session_decay.sh, plus the scripts/ci/test-exp-mcp-fragmented-ipi*
-    entry points above them. The build lives there rather than here because this driver is
-    re-invoked once per run and per session, and a no-op cargo freshness check costs ~3s each
-    time; doing it here would re-verify what the wrapper just verified, several times over.
-
-    The consequence is worth stating plainly, because these runs produce published numbers:
-    invoke this driver directly against a stale target/debug and it will produce a summary for
-    source that never ran. Enter through a wrapper.
-    """
-    if not path.exists():
-        raise FileNotFoundError(
-            f"Missing binary: {path}. This driver consumes a prebuilt binary and does not build "
-            f"one -- invoke it through its wrapper script (run_baseline.sh, run_protected.sh, "
-            f"cross_session/run_cross_session_decay.sh), or run "
-            f"`cargo build -p {package}` first."
-        )
-    return path
+# This driver consumes two prebuilt binaries -- target/debug/assay and
+# target/debug/assay-mcp-server -- and deliberately does not build either. The two checks below
+# are PRESENCE tests, NOT freshness tests: neither can tell a current binary from one left over
+# from an older source tree.
+#
+# Freshness is owned by the wrapper scripts, which build before invoking this driver:
+# run_baseline.sh, run_protected.sh and cross_session/run_cross_session_decay.sh, plus the
+# scripts/ci/test-exp-mcp-fragmented-ipi* entry points above them. The build lives there rather
+# than here because this driver is re-invoked once per run and per session, and a no-op cargo
+# freshness check costs ~3s each time; doing it here would re-verify what the wrapper just
+# verified, several times over.
+#
+# The consequence is worth stating plainly, because these runs produce published numbers:
+# invoke this driver directly against a stale target/debug and it will produce a summary for
+# source that never ran. Enter through a wrapper.
+#
+# The two checks are written out inline rather than shared through a helper on purpose. Routing
+# them through a function makes the path reach its check as a parameter, and CodeQL reports that
+# as py/path-injection off `--repo-root` (alert #701 on PR #1989). The duplication is two lines;
+# the rule that matters is this comment.
 
 
 def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_path, wrap_policy, run_live, mcp_host_cmd, mcp_host_args, assay_cmd):
@@ -96,7 +89,14 @@ def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_pa
         host_cmd = shlex.split(mcp_host_cmd)
         host_args = shlex.split(mcp_host_args or "")
     else:
-        wrap_cmd = [str(require_prebuilt(repo_root / "target/debug/assay", "assay-cli"))]
+        assay_bin = repo_root / "target/debug/assay"
+        if not assay_bin.exists():
+            raise FileNotFoundError(
+                f"Missing binary: {assay_bin}. This driver consumes a prebuilt binary and does "
+                f"not build one -- invoke it through a wrapper script, or run "
+                f"`cargo build -p assay-cli` first."
+            )
+        wrap_cmd = [str(assay_bin)]
         if env.get("EXPERIMENT_VARIANT") == "sink_failure":
             env["COMPAT_ROOT"] = str(fixture_root)
             env["COMPAT_AUDIT_LOG"] = str(tool_log_path)
@@ -120,7 +120,13 @@ def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_pa
 
 
 def spawn_sequence_guard(repo_root, policy_root):
-    bin_path = require_prebuilt(repo_root / "target/debug/assay-mcp-server", "assay-mcp-server")
+    bin_path = repo_root / "target/debug/assay-mcp-server"
+    if not bin_path.exists():
+        raise FileNotFoundError(
+            f"Missing binary: {bin_path}. This driver consumes a prebuilt binary and does not "
+            f"build one -- invoke it through a wrapper script, or run "
+            f"`cargo build -p assay-mcp-server` first."
+        )
     cmd = [str(bin_path), "--policy-root", str(policy_root)]
     return subprocess.Popen(cmd, cwd=repo_root, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 

--- a/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
+++ b/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
@@ -53,6 +53,32 @@ def parse_tool_payload(response):
         return {"raw": text}
 
 
+def prebuilt_binary(repo_root, name, package):
+    """Resolve a binary this driver consumes but deliberately does not build.
+
+    This is a presence test, NOT a freshness test: it cannot tell a current binary from one
+    left over from an older source tree. Freshness is owned by the wrapper scripts, which
+    build before invoking this driver -- run_baseline.sh, run_protected.sh and
+    cross_session/run_cross_session_decay.sh, plus the scripts/ci/test-exp-mcp-fragmented-ipi*
+    entry points above them. The build lives there rather than here because this driver is
+    re-invoked once per run and per session, and a no-op cargo freshness check costs ~3s each
+    time; doing it here would re-verify what the wrapper just verified, several times over.
+
+    The consequence is worth stating plainly, because these runs produce published numbers:
+    invoke this driver directly against a stale target/debug and it will produce a summary for
+    source that never ran. Enter through a wrapper.
+    """
+    path = repo_root / "target/debug" / name
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Missing binary: {path}. This driver consumes a prebuilt binary and does not build "
+            f"one -- invoke it through its wrapper script (run_baseline.sh, run_protected.sh, "
+            f"cross_session/run_cross_session_decay.sh), or run "
+            f"`cargo build -p {package}` first."
+        )
+    return path
+
+
 def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_path, wrap_policy, run_live, mcp_host_cmd, mcp_host_args, assay_cmd):
     env = dict(**__import__("os").environ)
     env["EXP_FIXTURE_ROOT"] = str(fixture_root)
@@ -67,10 +93,7 @@ def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_pa
         host_cmd = shlex.split(mcp_host_cmd)
         host_args = shlex.split(mcp_host_args or "")
     else:
-        assay_bin = repo_root / "target/debug/assay"
-        if not assay_bin.exists():
-            raise FileNotFoundError(f"Missing binary: {assay_bin}")
-        wrap_cmd = [str(assay_bin)]
+        wrap_cmd = [str(prebuilt_binary(repo_root, "assay", "assay-cli"))]
         if env.get("EXPERIMENT_VARIANT") == "sink_failure":
             env["COMPAT_ROOT"] = str(fixture_root)
             env["COMPAT_AUDIT_LOG"] = str(tool_log_path)
@@ -94,9 +117,7 @@ def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_pa
 
 
 def spawn_sequence_guard(repo_root, policy_root):
-    bin_path = repo_root / "target/debug/assay-mcp-server"
-    if not bin_path.exists():
-        raise FileNotFoundError(f"Missing binary: {bin_path}")
+    bin_path = prebuilt_binary(repo_root, "assay-mcp-server", "assay-mcp-server")
     cmd = [str(bin_path), "--policy-root", str(policy_root)]
     return subprocess.Popen(cmd, cwd=repo_root, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 

--- a/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
+++ b/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
@@ -53,8 +53,12 @@ def parse_tool_payload(response):
         return {"raw": text}
 
 
-def prebuilt_binary(repo_root, name, package):
-    """Resolve a binary this driver consumes but deliberately does not build.
+def require_prebuilt(path, package):
+    """Check a binary this driver consumes but deliberately does not build.
+
+    Callers pass the fully constructed path rather than a binary name: keeping the join a
+    literal at the call site is what stops the path expression depending on a variable
+    (py/path-injection), and there are only ever two of them.
 
     This is a presence test, NOT a freshness test: it cannot tell a current binary from one
     left over from an older source tree. Freshness is owned by the wrapper scripts, which
@@ -68,7 +72,6 @@ def prebuilt_binary(repo_root, name, package):
     invoke this driver directly against a stale target/debug and it will produce a summary for
     source that never ran. Enter through a wrapper.
     """
-    path = repo_root / "target/debug" / name
     if not path.exists():
         raise FileNotFoundError(
             f"Missing binary: {path}. This driver consumes a prebuilt binary and does not build "
@@ -93,7 +96,7 @@ def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_pa
         host_cmd = shlex.split(mcp_host_cmd)
         host_args = shlex.split(mcp_host_args or "")
     else:
-        wrap_cmd = [str(prebuilt_binary(repo_root, "assay", "assay-cli"))]
+        wrap_cmd = [str(require_prebuilt(repo_root / "target/debug/assay", "assay-cli"))]
         if env.get("EXPERIMENT_VARIANT") == "sink_failure":
             env["COMPAT_ROOT"] = str(fixture_root)
             env["COMPAT_AUDIT_LOG"] = str(tool_log_path)
@@ -117,7 +120,7 @@ def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_pa
 
 
 def spawn_sequence_guard(repo_root, policy_root):
-    bin_path = prebuilt_binary(repo_root, "assay-mcp-server", "assay-mcp-server")
+    bin_path = require_prebuilt(repo_root / "target/debug/assay-mcp-server", "assay-mcp-server")
     cmd = [str(bin_path), "--policy-root", str(policy_root)]
     return subprocess.Popen(cmd, cwd=repo_root, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 

--- a/scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh
+++ b/scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh
@@ -15,9 +15,6 @@ FIXTURE_ROOT="$ROOT/scripts/ci/fixtures/exp-mcp-fragmented-ipi"
 POLICY="$FIXTURE_ROOT/policies/baseline_wrap.yaml"
 mkdir -p "$OUT_DIR"
 
-test -x "$ROOT/target/debug/assay" || { echo "Missing $ROOT/target/debug/assay; build assay-cli first"; exit 1; }
-test -x "$ROOT/target/debug/assay-mcp-server" || { echo "Missing $ROOT/target/debug/assay-mcp-server; build assay-mcp-server first"; exit 1; }
-
 echo "ABLATION_MODE=$ABLATION_MODE"
 echo "RUN_LIVE=$RUN_LIVE"
 case "$RUN_LIVE" in
@@ -31,6 +28,17 @@ case "$RUN_LIVE" in
     exit 2
     ;;
 esac
+
+# Build rather than assert existence: an existence test passes against a stale artifact, and
+# these summaries get published in docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-*-RESULTS.md against
+# a git SHA, so a stale binary attributes a measurement to source that never ran it. Cargo
+# re-checks rather than rebuilds on an up-to-date tree, so callers that already build pay ~3s.
+# assay-cli only: RUN_LIVE=1 drives $ASSAY_CMD instead, and baseline never reaches the
+# assay-mcp-server sequence guard (drive_fragmented_ipi.py spawns it only for --mode protected
+# with --sequence-policy-root). --manifest-path because this script deliberately never cd's.
+if [[ "$RUN_LIVE" == "0" ]]; then
+  cargo build -q --manifest-path "$ROOT/Cargo.toml" -p assay-cli
+fi
 
 python3 "$ROOT/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py" \
   --repo-root "$ROOT" \

--- a/scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh
+++ b/scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh
@@ -19,9 +19,6 @@ SEQ_ROOT="$FIXTURE_ROOT/policies"
 SEQUENCE_POLICY_FILE="${SEQUENCE_POLICY_FILE:-fragmented_sequence.yaml}"
 mkdir -p "$OUT_DIR"
 
-test -x "$ROOT/target/debug/assay" || { echo "Missing $ROOT/target/debug/assay; build assay-cli first"; exit 1; }
-test -x "$ROOT/target/debug/assay-mcp-server" || { echo "Missing $ROOT/target/debug/assay-mcp-server; build assay-mcp-server first"; exit 1; }
-
 echo "ABLATION_MODE=$ABLATION_MODE"
 echo "RUN_LIVE=$RUN_LIVE"
 echo "SEQUENCE_SIDECAR=$SEQUENCE_SIDECAR"
@@ -43,6 +40,24 @@ case "$RUN_LIVE" in
     exit 2
     ;;
 esac
+
+# Build rather than assert existence: an existence test passes against a stale artifact, and
+# these summaries get published in docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-*-RESULTS.md against
+# a git SHA, so a stale binary attributes a measurement to source that never ran it. Cargo
+# re-checks rather than rebuilds on an up-to-date tree, so callers that already build pay ~3s.
+# Each package is built only on the path that reaches it: RUN_LIVE=1 drives $ASSAY_CMD instead
+# of the local wrap binary, and the assay-mcp-server sequence guard is spawned only when the
+# sidecar passes --sequence-policy-root. --manifest-path because this script never cd's.
+BUILD_PKGS=()
+if [[ "$RUN_LIVE" == "0" ]]; then
+  BUILD_PKGS+=(-p assay-cli)
+fi
+if [[ "$SEQUENCE_SIDECAR" == "1" ]]; then
+  BUILD_PKGS+=(-p assay-mcp-server)
+fi
+if (( ${#BUILD_PKGS[@]} > 0 )); then
+  cargo build -q --manifest-path "$ROOT/Cargo.toml" "${BUILD_PKGS[@]}"
+fi
 
 ATTACK_ARGS=(
   --repo-root "$ROOT"


### PR DESCRIPTION
Follow-up to #1980, which diagnosed this pattern in `crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs`: an existence check catches an absent binary but not a stale one, so the thing runs green against an artifact that no longer matches the source. Five sites were left out of that PR on scope. This closes them.

## Why the fragmented-IPI scripts are the sharper case

For a test, a stale binary produces a wrong pass/fail that the next real run corrects. These three scripts are not tests. They are the engine under nine `test-exp-mcp-fragmented-ipi*.sh` harnesses, the `ablation/` and `cross_session/` runners, and the rerun procedure in `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RERUN.md` — and their output is a number published in ten `docs/ops/EXPERIMENT-*-RESULTS.md` files against a git SHA (`EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md` records `Repo commit: 289a43ecc144` under "Run identity").

There the run *is* the artifact. A stale binary writes a measurement attributed to source that never ran it, and nothing downstream corrects it. So for these, "build it" was the only defensible option; documenting the caveat would have left a documented path from a stale artifact to a published figure.

Worth stating explicitly, because it cuts against the usual instinct: **no workflow references these scripts, and that makes deletion more wrong, not less.** They are live — driven by hand, as the rerun docs describe.

## Changes

| File | Change |
|---|---|
| `benches/suite_run_worstcase.rs`, `benches/profile_store_harness.rs` | `env!("CARGO_BIN_EXE_assay")`. The `option_env!` + `../../target/{release,debug}` fallback was dead code: cargo always sets that var for bench targets, so the fallback branch was unreachable. |
| `run_baseline.sh` | builds `assay-cli`; existence checks removed |
| `run_protected.sh` | builds `assay-cli`, plus `assay-mcp-server` when the sidecar is on |
| `cross_session/run_cross_session_decay.sh` | same, keyed on `USE_SEQUENCE`; gained the `RUN_LIVE` validation its siblings had |
| `drive_fragmented_ipi.py` | error message names the wrapper; a comment states plainly that its checks are presence tests, not freshness tests |
| `test-exp-mcp-fragmented-ipi-freshness.sh` | **new** — pins the invariant (see Verification) |

Two decisions that are deliberate rather than incidental:

**The driver does not build.** It is re-invoked once per run and per session — 4 times in a default cross-session run, 6 at `DECAY_RUNS=3` — so freshness is owned by the three wrapper scripts, which are the only things that execute it. The driver now says so rather than implying it verifies more than it does. Its checks are inline rather than shared through a helper because routing them through a function makes the path arrive as a parameter, which CodeQL reports as `py/path-injection` off `--repo-root` (alert #701, hit during this PR).

**`cargo` is pinned with both `--manifest-path` and `--target-dir "$ROOT/target"`.** The manifest path because two of the three scripts are deliberately cwd-agnostic. The target dir because the driver reads a hardcoded `repo_root/"target/debug"`, so without pinning, a `CARGO_TARGET_DIR` would send the build somewhere the driver never opens.

## What adversarial review changed

Two independent reviewers ran against an earlier head. They found the first version made its own version of this defect on two paths, and asserted several things that were not true. Recording it because the corrections are the substance of this PR, not footnotes:

- **`RUN_LIVE=1` built nothing for `assay-cli`.** I read `RUN_LIVE` as "someone else's assay" and gated the build on `RUN_LIVE=0`. It selects a real MCP host over the mock; every live rerun doc sets `ASSAY_CMD` to a `target/debug/assay` path, and `EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md` asks the operator by hand to "ensure `ASSAY_CMD` points to the freshly built `target/debug/assay`" — an obligation the script can discharge. With the sidecar on, that gate rebuilt `assay-mcp-server` while measuring it against whatever wrap binary was lying in `target/debug`.
- **`CARGO_TARGET_DIR` broke the invariant**, and `AGENTS.md:49` tells worktree owners to set it. Hence `--target-dir`.
- **`SKIP_CARGO_BUILD`**, a real knob plumbed through two entry points and a review gate, had been silently disabled.
- **Two numbers were wrong.** "~3s" for a warm cargo no-op is ~0.3s; the original was measured right after a build, which is the thermal contamination this repo has a standing note about. "6× per cross-session run" is 4 by default.
- **The bench comment claimed freshness it could not deliver.** It said the baked-in `CARGO_BIN_EXE` path "cannot resolve to a stale artifact … also when run directly". Both reviewers disproved that independently: under `cargo bench` it holds, but run the compiled bench binary directly and the path resolves while the artifact is as stale as the last bench left it. Presence sold as freshness, in the comment of a PR about not doing that.

A second round, on the build logic and on the test itself, found no blockers but four things worth fixing:

- The `ASSAY_CMD` warning fired on **four of seven** forms measured, including `"$ROOT/target/debug/assay --verbose"` - argv the driver explicitly supports and a review gate checks for - plus relative paths, `./` and symlinks. It compares by inode now, after stripping arguments. It also goes to stderr, because `ablation/run_variant.sh` redirects wrapper stdout into a log, so on the live ablation path the operator never saw it.
- `SKIP_CARGO_BUILD=1` said nothing about what it disabled, while being the only remaining route to a stale binary. It announces itself now.
- The cross-session rerun doc set `CARGO_NET_OFFLINE` as a one-shot prefix and then recorded `cargo_net_offline: True` in `build-info.json`. The wrapper's build does not inherit a one-shot prefix, so that field described a property the measured run no longer had - this PR's own defect class. Exported now.
- Two comments overstated their case. `--target-dir` is a workaround, not the right layer: the clean fix is handing the driver the resolved path, and the only reason not to is CodeQL alert #701. It costs a second target tree to anyone who set `CARGO_TARGET_DIR`. And the driver comment blamed entry points that do not build; every entry point reaching the driver does build, and the real reason to name the wrappers is that a person can run the driver directly.

One reviewer claim did not survive checking: that `tests/security_audit/` contains no hard-coded path. It contains three `./target/release/assay` references; the grep behind that finding only covered `target/debug`.

## Verification

The load-bearing claim is *freshness*, not presence, so that is what is tested. `test-exp-mcp-fragmented-ipi-freshness.sh` (new) carries 14 cases and 51 assertions over both halves of the invariant:

- **A-K** - the build decision for every wrapper and configuration: that `RUN_LIVE=1` still builds, that `CARGO_TARGET_DIR` cannot divert any of the three, that `SKIP_CARGO_BUILD` is honoured *and announced*, and that each wrapper's package set matches the flags it passes the driver. Each also asserts the wrapper's exit status - recording what cargo was *asked* while ignoring whether it succeeded is intent, not result.
- **L** - the other half: the driver's own path literals must fall under what the wrappers pin. Without this, pointing the driver at `target/release` leaves everything green.
- **M** - end-to-end: touch a source file, confirm the binary is rebuilt *and* that the run produced its summary.
- **N** - the warnings are accurate: no false alarm on the argv or relative forms of `ASSAY_CMD`, a real one on a foreign binary.

### The test was reviewed too, and it did not survive first contact

A mutation review ran 27 mutations against the first version and **13 came back green**. The rebuilt version catches all seven previously-missed mutations that were re-run, including pointing the driver at a different tree. What was wrong:

- Cases recorded what the wrapper *asked* cargo to do and ignored its exit status, so a build that could never succeed passed. Evidence of intent read as evidence of result - the same shape as the defect this PR closes.
- The end-to-end case was **inoperative on Linux**, the CI OS. `stat -f` is BSD; GNU reads it as `--file-system` and prints filesystem stats before failing on the format, so the fallback compared block counts that the build's own disk writes change. It reported "rebuilt" with identical mtimes against a build that could not succeed. GNU is tried first now - it fails cleanly on BSD, the reverse does not.
- `run_cross_session_decay.sh`'s build block was **unreachable**: its only case exited at validation before reaching it, so all seven mutations of that file - including deleting the build outright - were green.
- Assertions were substring greps over a joined command line, which both false-pass (`$ROOT/target` matching `$ROOT/target/x`) and false-fail (`assay-mcp-server` matching `--manifest-path` in a worktree named for that crate). The shim records one argument per line now.
- Earlier still, the assertion helpers were `A && B || C`, where a failing assert falls through and prints as a pass.

```
ref:       73930b80eb273530bac72fed098afbd9ab7b6051
tree:      clean
worktree:  /Users/roelschuurkes/assay/.claude/worktrees/trusting-albattani-8b0291
toolchain: cargo 1.96.0 (30a34c682 2026-05-25) / rustc 1.96.0 (ac68faa20 2026-05-25)
host:      Darwin 25.6.0 arm64
```

All ten harnesses pass on that head - the nine existing ones with their own assertions (`baseline_asr == 1.0`, `protected_tpr == 1.0`, `fnr == 0.0`, `fpr == 0.0`), plus the freshness test. Also green: `cargo fmt --check`, `cargo clippy -p assay-cli --benches -- -D warnings`, shellcheck, pre-push clippy and the linux compile gate. CI is 52 pass / 0 fail; CodeQL reports 0 open alerts.

Every marker the `review-exp-*.sh` slice gates grep for is still present, and `MCP_HOST_ARGS` is still never logged.

**What CI does and does not cover.** The `Criterion benches (store + suite)` job runs `cargo bench -p assay-cli --bench suite_run_worstcase`, so CI exercises that half of the bench change directly. `profile_store_harness.rs` is in no workflow. Neither are the three scripts nor the freshness test - which is why the local run above is the evidence for them, not CI green.

## Out of scope

A repo-wide sweep finds further sites with hard-coded `target/` paths outside this harness. They are not here, and not because of size: their output is a test pass/fail that the next run corrects rather than a published number, and most have no workflow caller at all — so the first question is whether they are still alive, not whether they check or build. That is a dead-code investigation and deserves its own PR. I am deliberately not quoting a count: the ones I produced were not reproducible under any criterion I could state, and this is not the PR in which to publish a number I cannot defend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
