### PR TITLE
A blocking read_line cannot be timed out from the loop around it

### DIFF
--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -292,7 +292,9 @@ impl Conn {
     /// attempts an optimistic `try_recv` first, so it hands back an already-queued line even when
     /// the remaining duration is zero; a child writing skippable lines faster than the callers
     /// above skip them therefore keeps the channel non-empty and would run unbounded past the
-    /// deadline. `a_flood_of_skippable_lines_cannot_outrun_the_deadline` covers that case.
+    /// deadline. `jsonrpc_conn_selftest.rs` covers that case, one test per skip loop:
+    /// `a_flood_of_blank_lines_cannot_outrun_the_deadline` and
+    /// `a_flood_of_notifications_cannot_outrun_the_deadline`.
     ///
     /// Credit: the same defect was found and fixed for the CLI's copy of this reader in #1987.
     fn next_line(&mut self, deadline: Instant) -> String {

--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -1,0 +1,305 @@
+//! Timeout-bounded JSON-RPC-over-stdio plumbing shared by the e2e tests in this directory.
+//!
+//! Every one of those tests drives a spawned proxy or server over newline-delimited JSON-RPC on
+//! stdin/stdout. Read with a bare [`BufRead::read_line`], a child that spawns but never answers
+//! wedges the test forever: `read_line` blocks inside the syscall, so no elapsed-time check in the
+//! surrounding loop is ever reached. Under `cargo nextest` that surfaces as the `.config/nextest.toml`
+//! `slow-timeout = { period = "60s", terminate-after = 2 }` SIGTERM at 120s with no indication of
+//! which request went unanswered, and `retries = 1` then buys a second 120s hang.
+//!
+//! [`Conn`] moves the blocking read onto a worker thread and waits on it with
+//! [`std::sync::mpsc::Receiver::recv_timeout`], which is cancellable. On timeout it kills the child
+//! rather than leaving a wedged process orphaned onto the inherited stderr, and it names the request
+//! it was waiting for — which it can only do because sends go through the same handle as reads.
+
+// Each test crate in this directory uses a different subset of this module.
+#![allow(dead_code)]
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ExitStatus};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+/// How long one exchange may take before the test fails instead of hanging.
+///
+/// Deliberately well under nextest's 120s terminate-after kill, so a wedged child produces this
+/// module's message rather than an unexplained SIGTERM.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long the child may take to exit once it has seen EOF on stdin.
+const REAP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// What the reader thread hands back: a line, or the error that ended the stream.
+enum Chunk {
+    Line(String),
+    Err(String),
+}
+
+/// A live stdio JSON-RPC connection to a spawned child, with every read bounded by a deadline.
+pub struct Conn {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    rx: Receiver<Chunk>,
+    timeout: Duration,
+    /// Budget for the first read only; startup is slow in a way steady state is not.
+    startup_timeout: Option<Duration>,
+    /// The budget the in-flight read is using, so a failure reports the deadline it actually had.
+    current_budget: Duration,
+    /// The most recent request written, so a timeout can name the exchange that stalled.
+    last_sent: Option<String>,
+    responses_read: usize,
+}
+
+impl Conn {
+    /// Take over a spawned child's stdin/stdout and start the reader thread.
+    ///
+    /// The child must have been spawned with both piped.
+    pub fn attach(mut child: Child) -> Self {
+        let stdin = child
+            .stdin
+            .take()
+            .expect("child must be spawned with stdin piped");
+        let stdout = child
+            .stdout
+            .take()
+            .expect("child must be spawned with stdout piped");
+        let (tx, rx) = mpsc::channel();
+
+        // Detached on purpose: joining this thread is exactly the block this module exists to
+        // avoid. It ends on its own when the child's stdout closes, which killing the child forces.
+        std::thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    // EOF. Dropping `tx` disconnects the channel, which the reader reports as EOF.
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if tx.send(Chunk::Line(line)).is_err() {
+                            break; // the test dropped its Conn
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Chunk::Err(e.to_string()));
+                        break;
+                    }
+                }
+            }
+        });
+
+        Self {
+            child,
+            stdin: Some(stdin),
+            rx,
+            timeout: DEFAULT_TIMEOUT,
+            startup_timeout: None,
+            current_budget: DEFAULT_TIMEOUT,
+            last_sent: None,
+            responses_read: 0,
+        }
+    }
+
+    /// Give the FIRST read a longer budget than the rest.
+    ///
+    /// Only startup is slow, so only startup gets the allowance. Extending it to every read would
+    /// let two slow exchanges add up past the harness's own kill, which is the failure this module
+    /// exists to keep off the table. Whatever is passed must therefore leave room for one further
+    /// [`DEFAULT_TIMEOUT`] under nextest's 120s `terminate-after`.
+    ///
+    /// No caller needs this today: every test here spawns a prebuilt `CARGO_BIN_EXE_*` binary, so
+    /// no first exchange waits on a compile. It is kept because the constraint above is the part
+    /// that is easy to get wrong, and it is written down here rather than rediscovered.
+    #[must_use]
+    pub fn with_startup_timeout(mut self, timeout: Duration) -> Self {
+        self.startup_timeout = Some(timeout);
+        self
+    }
+
+    /// The budget for the read that is about to start, consuming the startup allowance if unused.
+    fn take_budget(&mut self) -> Duration {
+        let budget = self.startup_timeout.take().unwrap_or(self.timeout);
+        self.current_budget = budget;
+        budget
+    }
+
+    /// Write one request as a JSON line, remembering it so a later timeout can name it.
+    pub fn send(&mut self, v: Value) {
+        self.last_sent = Some(describe(&v));
+        let stdin = self.stdin.as_mut().expect("stdin is still open");
+        writeln!(stdin, "{v}").expect("write request");
+        stdin.flush().expect("flush request");
+    }
+
+    /// Send a request and read the response to it.
+    pub fn request(&mut self, method: &str, params: Value, id: u64) -> Value {
+        self.send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": id
+        }));
+        self.read_json()
+    }
+
+    /// The next non-blank stdout line, parsed as JSON.
+    pub fn read_json(&mut self) -> Value {
+        let deadline = Instant::now() + self.take_budget();
+        self.read_json_by(deadline)
+    }
+
+    /// [`Conn::read_json`], but skipping notifications and upstream-initiated requests, which carry
+    /// a `method` and are not the response this caller is waiting for.
+    ///
+    /// The deadline spans the whole skip loop, so a child that only emits notifications still fails
+    /// on time instead of renewing its budget with every one.
+    pub fn read_response(&mut self) -> Value {
+        let deadline = Instant::now() + self.take_budget();
+        loop {
+            let v = self.read_json_by(deadline);
+            if v.get("method").is_none() {
+                return v;
+            }
+        }
+    }
+
+    /// Every remaining stdout line up to EOF, used to prove nothing further reached the client.
+    ///
+    /// Call this after the child has been shut down; on a still-running child there is no EOF to
+    /// wait for and this fails at the deadline.
+    pub fn drain_stdout(&mut self) -> Vec<String> {
+        let deadline = Instant::now() + self.take_budget();
+        let mut lines = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match self.rx.recv_timeout(remaining) {
+                Ok(Chunk::Line(line)) => {
+                    let trimmed = line.trim();
+                    if !trimmed.is_empty() {
+                        lines.push(trimmed.to_string());
+                    }
+                }
+                Ok(Chunk::Err(_)) | Err(RecvTimeoutError::Disconnected) => return lines,
+                Err(RecvTimeoutError::Timeout) => {
+                    self.fail("the child held stdout open past the deadline while draining it")
+                }
+            }
+        }
+    }
+
+    /// Close stdin, signalling client EOF.
+    pub fn close_stdin(&mut self) {
+        drop(self.stdin.take());
+    }
+
+    /// Close stdin and reap the child.
+    pub fn shutdown(&mut self) -> ExitStatus {
+        self.close_stdin();
+        self.wait()
+    }
+
+    /// Wait for the child to exit, killing it if it overruns [`REAP_TIMEOUT`].
+    ///
+    /// A child that never exits after stdin EOF hangs the test exactly like a child that never
+    /// answers, so this is bounded for the same reason the reads are.
+    pub fn wait(&mut self) -> ExitStatus {
+        let deadline = Instant::now() + REAP_TIMEOUT;
+        loop {
+            match self.child.try_wait().expect("try_wait on child") {
+                Some(status) => return status,
+                None if Instant::now() >= deadline => {
+                    let _ = self.child.kill();
+                    let status = self.child.wait().expect("wait after kill");
+                    panic!(
+                        "the child did not exit within {REAP_TIMEOUT:?} of stdin EOF; killed it \
+                         ({status}). Last request sent: {}",
+                        self.last_request()
+                    );
+                }
+                None => std::thread::sleep(Duration::from_millis(10)),
+            }
+        }
+    }
+
+    /// Kill the child and reap it.
+    pub fn kill(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+
+    /// The next non-blank line parsed as JSON, bounded by an externally owned deadline.
+    fn read_json_by(&mut self, deadline: Instant) -> Value {
+        loop {
+            let line = self.next_line(deadline);
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            return match serde_json::from_str(trimmed) {
+                Ok(v) => {
+                    self.responses_read += 1;
+                    v
+                }
+                Err(e) => self.fail(&format!("stdout line is not JSON ({e}): {trimmed}")),
+            };
+        }
+    }
+
+    /// The next line from the reader thread, or a failure that names the stalled exchange.
+    fn next_line(&mut self, deadline: Instant) -> String {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match self.rx.recv_timeout(remaining) {
+            Ok(Chunk::Line(line)) => line,
+            Ok(Chunk::Err(e)) => self.fail(&format!("reading the child's stdout failed: {e}")),
+            Err(RecvTimeoutError::Timeout) => {
+                self.fail("the child wrote no complete line before the deadline")
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                self.fail("the child closed stdout (EOF) without answering")
+            }
+        }
+    }
+
+    /// Kill the child and fail the test, naming what the read was waiting for.
+    ///
+    /// Killing matters: these children inherit the harness's stderr, so one left running keeps
+    /// writing into the output of whatever runs next.
+    fn fail(&mut self, why: &str) -> ! {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        panic!(
+            "{why}. Waiting for a response to {} ({} response(s) read on this connection, \
+             timeout {:?}). The child has been killed.",
+            self.last_request(),
+            self.responses_read,
+            self.current_budget
+        );
+    }
+
+    fn last_request(&self) -> String {
+        self.last_sent
+            .clone()
+            .unwrap_or_else(|| "<nothing: no request has been sent on this connection>".to_string())
+    }
+}
+
+impl Drop for Conn {
+    fn drop(&mut self) {
+        // A test that fails for any other reason must not leave the child behind either.
+        drop(self.stdin.take());
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// A short label for a request: enough to say which exchange stalled.
+fn describe(v: &Value) -> String {
+    let method = v
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("<no method>");
+    match v.get("id") {
+        Some(id) => format!("id={id} method={method}"),
+        None => format!("notification method={method}"),
+    }
+}

--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -30,6 +30,27 @@ pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 /// How long the child may take to exit once it has seen EOF on stdin.
 const REAP_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// How many lines the reader thread may run ahead of the test before it blocks.
+///
+/// The channel is bounded because the deadline bounds time, not memory. A child writing lines
+/// faster than the caller skips them fills an unbounded channel for the whole budget: measured at
+/// ~110 MB/s against `yes`, which is ~3.3 GB at [`DEFAULT_TIMEOUT`] and ~8 GB at
+/// [`CARGO_RUN_TIMEOUT`]. With a bound the reader thread stops draining stdout, the child blocks on
+/// its own pipe, and the test keeps control of the deadline.
+///
+/// The bound is large rather than minimal on purpose. Backpressure introduces a deadlock the
+/// unbounded channel could not have: a test that writes several requests before reading any could,
+/// with a tiny bound, block in `send` on a full stdin pipe while the child blocks on a full stdout
+/// pipe — and `send` is not covered by the read deadline. 1024 lines plus the child's own ~64 KB
+/// stdout pipe is far beyond any interleaving in this directory (the deepest is two unread sends),
+/// while still costing only tens of kilobytes.
+const READ_AHEAD_LINES: usize = 1024;
+
+/// Cap on what [`Conn::drain_stdout_after_shutdown`] will collect, for the same reason: the lines
+/// it returns are accumulated in memory, so a still-running child would trade an unbounded wait for
+/// unbounded memory.
+const MAX_DRAINED_LINES: usize = 10_000;
+
 /// What the reader thread hands back: a line, or the error that ended the stream.
 enum Chunk {
     Line(String),
@@ -64,10 +85,11 @@ impl Conn {
             .stdout
             .take()
             .expect("child must be spawned with stdout piped");
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(READ_AHEAD_LINES);
 
         // Detached on purpose: joining this thread is exactly the block this module exists to
-        // avoid. It ends on its own when the child's stdout closes, which killing the child forces.
+        // avoid. It ends on its own when the child's stdout closes, which killing the child forces,
+        // or when a blocked `send` fails because the test dropped its `Conn`.
         std::thread::spawn(move || {
             let mut reader = BufReader::new(stdout);
             loop {
@@ -132,6 +154,9 @@ impl Conn {
     }
 
     /// Send a request and read the response to it.
+    ///
+    /// Reads with [`Conn::read_response`] and not [`Conn::read_json`]: the name promises the
+    /// response, so a notification arriving first must not be handed back in its place.
     pub fn request(&mut self, method: &str, params: Value, id: u64) -> Value {
         self.send(serde_json::json!({
             "jsonrpc": "2.0",
@@ -139,7 +164,7 @@ impl Conn {
             "params": params,
             "id": id
         }));
-        self.read_json()
+        self.read_response()
     }
 
     /// The next non-blank stdout line, parsed as JSON.
@@ -165,9 +190,10 @@ impl Conn {
 
     /// Every remaining stdout line up to EOF, used to prove nothing further reached the client.
     ///
-    /// Call this after the child has been shut down; on a still-running child there is no EOF to
-    /// wait for and this fails at the deadline.
-    pub fn drain_stdout(&mut self) -> Vec<String> {
+    /// Named for its precondition because it has one: the returned lines are accumulated in memory,
+    /// so this is only bounded when EOF is actually coming. On a still-running child there is no
+    /// EOF to wait for, and it stops at [`MAX_DRAINED_LINES`] or at the deadline, whichever first.
+    pub fn drain_stdout_after_shutdown(&mut self) -> Vec<String> {
         let deadline = Instant::now() + self.take_budget();
         let mut lines = Vec::new();
         loop {
@@ -175,6 +201,12 @@ impl Conn {
             let now = Instant::now();
             if now >= deadline {
                 self.fail("the child held stdout open past the deadline while draining it");
+            }
+            if lines.len() >= MAX_DRAINED_LINES {
+                self.fail(&format!(
+                    "the child wrote more than {MAX_DRAINED_LINES} lines after shutdown; \
+                     draining it is only bounded when EOF is actually coming"
+                ));
             }
             let remaining = deadline.saturating_duration_since(now);
             match self.rx.recv_timeout(remaining) {
@@ -184,7 +216,11 @@ impl Conn {
                         lines.push(trimmed.to_string());
                     }
                 }
-                Ok(Chunk::Err(_)) | Err(RecvTimeoutError::Disconnected) => return lines,
+                // EOF is the expected end. A read error is not, and must not look like one.
+                Err(RecvTimeoutError::Disconnected) => return lines,
+                Ok(Chunk::Err(e)) => self.fail(&format!(
+                    "reading the child's stdout failed while draining: {e}"
+                )),
                 Err(RecvTimeoutError::Timeout) => {
                     self.fail("the child held stdout open past the deadline while draining it")
                 }

--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -171,7 +171,12 @@ impl Conn {
         let deadline = Instant::now() + self.take_budget();
         let mut lines = Vec::new();
         loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            // Same reason as in `next_line`: a queued line comes back even at zero remaining.
+            let now = Instant::now();
+            if now >= deadline {
+                self.fail("the child held stdout open past the deadline while draining it");
+            }
+            let remaining = deadline.saturating_duration_since(now);
             match self.rx.recv_timeout(remaining) {
                 Ok(Chunk::Line(line)) => {
                     let trimmed = line.trim();
@@ -246,8 +251,20 @@ impl Conn {
     }
 
     /// The next line from the reader thread, or a failure that names the stalled exchange.
+    ///
+    /// The deadline is checked here explicitly rather than left to `recv_timeout`. `recv_timeout`
+    /// attempts an optimistic `try_recv` first, so it hands back an already-queued line even when
+    /// the remaining duration is zero; a child writing skippable lines faster than the callers
+    /// above skip them therefore keeps the channel non-empty and would run unbounded past the
+    /// deadline. `a_flood_of_skippable_lines_cannot_outrun_the_deadline` covers that case.
+    ///
+    /// Credit: the same defect was found and fixed for the CLI's copy of this reader in #1987.
     fn next_line(&mut self, deadline: Instant) -> String {
-        let remaining = deadline.saturating_duration_since(Instant::now());
+        let now = Instant::now();
+        if now >= deadline {
+            self.fail("the deadline passed while skipping lines that were not the response");
+        }
+        let remaining = deadline.saturating_duration_since(now);
         match self.rx.recv_timeout(remaining) {
             Ok(Chunk::Line(line)) => line,
             Ok(Chunk::Err(e)) => self.fail(&format!("reading the child's stdout failed: {e}")),

--- a/crates/assay-mcp-server/tests/jsonrpc_conn_selftest.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn_selftest.rs
@@ -1,0 +1,100 @@
+//! Self-tests for the shared reader in `tests/jsonrpc_conn/`.
+//!
+//! The reader is included by eight test crates in this directory, so a `#[test]` inside the module
+//! itself would run eight times. It lives here instead, in the one crate whose job is to check it.
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
+
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const BUDGET: Duration = Duration::from_secs(1);
+/// Generous headroom over `BUDGET`: this asserts the deadline is enforced at all, not that it is
+/// precise, so a loaded machine does not turn a real bound into a flaky one.
+const PATIENCE: Duration = Duration::from_secs(5);
+
+/// A producer that outruns the consumer, which is what makes these regression tests.
+///
+/// `yes` and not a shell `while` loop on purpose: a shell loop produces more slowly than these
+/// skip loops consume, so the channel drains, the receive finds it empty, `recv_timeout` reports
+/// `Timeout`, and the run bounds itself even with the deadline check removed. Verified — the first
+/// version of this test used `sh -c 'while :; do echo; done'` and passed against the unfixed
+/// reader, which means it was testing the silent-child path and not this one.
+#[cfg(unix)]
+fn flood(line: &str) -> Child {
+    Command::new("yes")
+        .arg(line)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn `yes` (flooding producer)")
+}
+
+/// Run one read against a flooding child and return how long it took to give up.
+///
+/// The read fails by panicking, so it runs on its own thread: a panic on the test thread would
+/// abort before the elapsed time could be reported, and a read that is NOT bounded would hang the
+/// test rather than fail it with a usable message.
+#[cfg(unix)]
+fn time_until_the_read_gives_up(mut conn: Conn, read: fn(&mut Conn)) -> Duration {
+    let (tx, rx) = mpsc::channel();
+    let started = Instant::now();
+    let reader = std::thread::spawn(move || {
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| read(&mut conn)));
+        // `conn` is dropped here, which kills the flooding child.
+        let _ = tx.send(outcome.is_err());
+    });
+
+    let Ok(panicked) = rx.recv_timeout(PATIENCE) else {
+        panic!(
+            "the read ran {PATIENCE:?} past a {BUDGET:?} budget: the deadline does not bound a \
+             child that writes skippable lines faster than they are skipped"
+        );
+    };
+    assert!(
+        panicked,
+        "the read returned a value; a flood of skippable lines is never a response"
+    );
+    reader.join().expect("reader thread");
+    started.elapsed()
+}
+
+/// `read_json` skips blank lines. A child that writes them faster than they are skipped must not
+/// be able to outrun the deadline.
+///
+/// The silent-child case and this one fail differently: there, no line ever arrives and
+/// `recv_timeout` reports `Timeout`; here the channel is never empty when the receive is
+/// attempted, and `recv_timeout`'s optimistic `try_recv` hands back a queued line even at zero
+/// remaining duration. Only the explicit deadline check in `next_line` ends this run.
+#[cfg(unix)]
+#[test]
+fn a_flood_of_blank_lines_cannot_outrun_the_deadline() {
+    let conn = Conn::attach(flood("")).with_startup_timeout(BUDGET);
+    let elapsed = time_until_the_read_gives_up(conn, |c| {
+        c.read_json();
+    });
+    assert!(
+        elapsed < PATIENCE,
+        "the deadline did not bound the read: gave up only after {elapsed:?} (budget was {BUDGET:?})"
+    );
+}
+
+/// The same for `read_response`, whose skip loop is the one the ~85 call sites in this directory
+/// actually use: it discards notifications and upstream-initiated requests, so an upstream
+/// emitting them in a loop is the realistic shape of this defect.
+#[cfg(unix)]
+#[test]
+fn a_flood_of_notifications_cannot_outrun_the_deadline() {
+    let notification = r#"{"jsonrpc":"2.0","method":"notifications/message"}"#;
+    let conn = Conn::attach(flood(notification)).with_startup_timeout(BUDGET);
+    let elapsed = time_until_the_read_gives_up(conn, |c| {
+        c.read_response();
+    });
+    assert!(
+        elapsed < PATIENCE,
+        "the deadline did not bound the read: gave up only after {elapsed:?} (budget was {BUDGET:?})"
+    );
+}

--- a/crates/assay-mcp-server/tests/jsonrpc_conn_selftest.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn_selftest.rs
@@ -4,97 +4,102 @@
 //! itself would run eight times. It lives here instead, in the one crate whose job is to check it.
 
 mod jsonrpc_conn;
-use jsonrpc_conn::Conn;
 
-use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
-use std::time::{Duration, Instant};
-
-const BUDGET: Duration = Duration::from_secs(1);
-/// Generous headroom over `BUDGET`: this asserts the deadline is enforced at all, not that it is
-/// precise, so a loaded machine does not turn a real bound into a flaky one.
-const PATIENCE: Duration = Duration::from_secs(5);
-
-/// A producer that outruns the consumer, which is what makes these regression tests.
-///
-/// `yes` and not a shell `while` loop on purpose: a shell loop produces more slowly than these
-/// skip loops consume, so the channel drains, the receive finds it empty, `recv_timeout` reports
-/// `Timeout`, and the run bounds itself even with the deadline check removed. Verified — the first
-/// version of this test used `sh -c 'while :; do echo; done'` and passed against the unfixed
-/// reader, which means it was testing the silent-child path and not this one.
+/// Everything here depends on `yes`, so it is Unix-only — gated as one block rather than
+/// attribute-by-attribute so that a non-Unix build has no unused imports or constants left over.
+/// This crate is not excluded from CI's cross-platform job, so Windows does compile this file.
 #[cfg(unix)]
-fn flood(line: &str) -> Child {
-    Command::new("yes")
-        .arg(line)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn `yes` (flooding producer)")
-}
+mod flood {
 
-/// Run one read against a flooding child and return how long it took to give up.
-///
-/// The read fails by panicking, so it runs on its own thread: a panic on the test thread would
-/// abort before the elapsed time could be reported, and a read that is NOT bounded would hang the
-/// test rather than fail it with a usable message.
-#[cfg(unix)]
-fn time_until_the_read_gives_up(mut conn: Conn, read: fn(&mut Conn)) -> Duration {
-    let (tx, rx) = mpsc::channel();
-    let started = Instant::now();
-    let reader = std::thread::spawn(move || {
-        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| read(&mut conn)));
-        // `conn` is dropped here, which kills the flooding child.
-        let _ = tx.send(outcome.is_err());
-    });
+    use crate::jsonrpc_conn::Conn;
 
-    let Ok(panicked) = rx.recv_timeout(PATIENCE) else {
-        panic!(
+    use std::process::{Child, Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    const BUDGET: Duration = Duration::from_secs(1);
+    /// Generous headroom over `BUDGET`: this asserts the deadline is enforced at all, not that it is
+    /// precise, so a loaded machine does not turn a real bound into a flaky one.
+    const PATIENCE: Duration = Duration::from_secs(5);
+
+    /// A producer that outruns the consumer, which is what makes these regression tests.
+    ///
+    /// `yes` and not a shell `while` loop on purpose: a shell loop produces more slowly than these
+    /// skip loops consume, so the channel drains, the receive finds it empty, `recv_timeout` reports
+    /// `Timeout`, and the run bounds itself even with the deadline check removed. Verified — the first
+    /// version of this test used `sh -c 'while :; do echo; done'` and passed against the unfixed
+    /// reader, which means it was testing the silent-child path and not this one.
+    fn flood(line: &str) -> Child {
+        Command::new("yes")
+            .arg(line)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn `yes` (flooding producer)")
+    }
+
+    /// Run one read against a flooding child and return how long it took to give up.
+    ///
+    /// The read fails by panicking, so it runs on its own thread: a panic on the test thread would
+    /// abort before the elapsed time could be reported, and a read that is NOT bounded would hang the
+    /// test rather than fail it with a usable message.
+    fn time_until_the_read_gives_up(mut conn: Conn, read: fn(&mut Conn)) -> Duration {
+        let (tx, rx) = mpsc::channel();
+        let started = Instant::now();
+        let reader = std::thread::spawn(move || {
+            let outcome =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| read(&mut conn)));
+            // `conn` is dropped here, which kills the flooding child.
+            let _ = tx.send(outcome.is_err());
+        });
+
+        let Ok(panicked) = rx.recv_timeout(PATIENCE) else {
+            panic!(
             "the read ran {PATIENCE:?} past a {BUDGET:?} budget: the deadline does not bound a \
              child that writes skippable lines faster than they are skipped"
         );
-    };
-    assert!(
-        panicked,
-        "the read returned a value; a flood of skippable lines is never a response"
-    );
-    reader.join().expect("reader thread");
-    started.elapsed()
-}
+        };
+        assert!(
+            panicked,
+            "the read returned a value; a flood of skippable lines is never a response"
+        );
+        reader.join().expect("reader thread");
+        started.elapsed()
+    }
 
-/// `read_json` skips blank lines. A child that writes them faster than they are skipped must not
-/// be able to outrun the deadline.
-///
-/// The silent-child case and this one fail differently: there, no line ever arrives and
-/// `recv_timeout` reports `Timeout`; here the channel is never empty when the receive is
-/// attempted, and `recv_timeout`'s optimistic `try_recv` hands back a queued line even at zero
-/// remaining duration. Only the explicit deadline check in `next_line` ends this run.
-#[cfg(unix)]
-#[test]
-fn a_flood_of_blank_lines_cannot_outrun_the_deadline() {
-    let conn = Conn::attach(flood("")).with_startup_timeout(BUDGET);
-    let elapsed = time_until_the_read_gives_up(conn, |c| {
-        c.read_json();
-    });
-    assert!(
+    /// `read_json` skips blank lines. A child that writes them faster than they are skipped must not
+    /// be able to outrun the deadline.
+    ///
+    /// The silent-child case and this one fail differently: there, no line ever arrives and
+    /// `recv_timeout` reports `Timeout`; here the channel is never empty when the receive is
+    /// attempted, and `recv_timeout`'s optimistic `try_recv` hands back a queued line even at zero
+    /// remaining duration. Only the explicit deadline check in `next_line` ends this run.
+    #[test]
+    fn a_flood_of_blank_lines_cannot_outrun_the_deadline() {
+        let conn = Conn::attach(flood("")).with_startup_timeout(BUDGET);
+        let elapsed = time_until_the_read_gives_up(conn, |c| {
+            c.read_json();
+        });
+        assert!(
         elapsed < PATIENCE,
         "the deadline did not bound the read: gave up only after {elapsed:?} (budget was {BUDGET:?})"
     );
-}
+    }
 
-/// The same for `read_response`, whose skip loop is the one the ~85 call sites in this directory
-/// actually use: it discards notifications and upstream-initiated requests, so an upstream
-/// emitting them in a loop is the realistic shape of this defect.
-#[cfg(unix)]
-#[test]
-fn a_flood_of_notifications_cannot_outrun_the_deadline() {
-    let notification = r#"{"jsonrpc":"2.0","method":"notifications/message"}"#;
-    let conn = Conn::attach(flood(notification)).with_startup_timeout(BUDGET);
-    let elapsed = time_until_the_read_gives_up(conn, |c| {
-        c.read_response();
-    });
-    assert!(
+    /// The same for `read_response`, whose skip loop is the one the ~85 call sites in this directory
+    /// actually use: it discards notifications and upstream-initiated requests, so an upstream
+    /// emitting them in a loop is the realistic shape of this defect.
+    #[test]
+    fn a_flood_of_notifications_cannot_outrun_the_deadline() {
+        let notification = r#"{"jsonrpc":"2.0","method":"notifications/message"}"#;
+        let conn = Conn::attach(flood(notification)).with_startup_timeout(BUDGET);
+        let elapsed = time_until_the_read_gives_up(conn, |c| {
+            c.read_response();
+        });
+        assert!(
         elapsed < PATIENCE,
         "the deadline did not bound the read: gave up only after {elapsed:?} (budget was {BUDGET:?})"
     );
+    }
 }

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -40,10 +40,12 @@
 #![cfg(feature = "test-outbound")]
 
 use assay_mcp_server::auth::SENSITIVE_HEADER_NAMES;
-use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use wiremock::matchers::method;
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
 
 fn sensitive_names_lower() -> std::collections::HashSet<String> {
     SENSITIVE_HEADER_NAMES
@@ -94,7 +96,7 @@ async fn test_no_passthrough_e2e() {
 
     // This test only compiles under `test-outbound`, so the binary Cargo built for it carries the
     // feature too — no separate build step, and no second feature variant to thrash against.
-    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+    let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args(["--policy-root", policy_root])
         .env("ASSAY_TEST_OUTBOUND_URL", outbound_url.as_str())
         .stdin(Stdio::piped())
@@ -103,9 +105,7 @@ async fn test_no_passthrough_e2e() {
         .spawn()
         .expect("Failed to spawn server");
 
-    let mut stdin = child.stdin.take().expect("stdin");
-    let stdout = child.stdout.take().expect("stdout");
-    let mut reader = BufReader::new(stdout);
+    let mut conn = Conn::attach(child);
 
     // 1. Initialize with credential-shaped fields. The server must neither interpret them as
     // authentication nor forward them downstream.
@@ -123,21 +123,9 @@ async fn test_no_passthrough_e2e() {
         },
         "id": 1
     });
-    writeln!(stdin, "{}", req_init).unwrap();
-    stdin.flush().unwrap();
+    conn.send(req_init);
 
-    let mut line = String::new();
-    for _ in 0..10 {
-        line.clear();
-        let n = reader.read_line(&mut line).expect("read init response");
-        if n == 0 {
-            break;
-        }
-        if !line.trim().is_empty() {
-            break;
-        }
-    }
-    let resp: serde_json::Value = serde_json::from_str(line.trim()).expect("Parse init response");
+    let resp: serde_json::Value = conn.read_json();
     assert!(resp.get("result").is_some(), "Init failed: {:?}", resp);
 
     // 2. Call test-only outbound tool (single callsite uses build_downstream_headers only)
@@ -147,16 +135,12 @@ async fn test_no_passthrough_e2e() {
         "params": { "name": "assay_test_outbound", "arguments": {} },
         "id": 2
     });
-    writeln!(stdin, "{}", req_call).unwrap();
-    stdin.flush().unwrap();
+    conn.send(req_call);
 
-    line.clear();
-    reader.read_line(&mut line).unwrap();
-    let resp: serde_json::Value = serde_json::from_str(line.trim()).expect("Parse tool response");
+    let resp: serde_json::Value = conn.read_json();
     assert!(resp.get("result").is_some(), "Tool call failed: {:?}", resp);
 
-    drop(stdin);
-    let status = child.wait().expect("failed to wait on child process");
+    let status = conn.shutdown();
     assert!(
         status.success(),
         "server process did not exit successfully: {status:?}"

--- a/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
@@ -11,9 +11,11 @@
 //! with `pdp_gate_unavailable`.
 
 use serde_json::Value;
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
 
 const PROXY_UNSUPPORTED: i64 = -32040;
 const PROXY_DENIED: i64 = -32042;
@@ -94,29 +96,6 @@ fn spawn_enforce(log: &std::path::Path, policy: &std::path::Path) -> Child {
         .expect("spawn enforce proxy (is python installed?)")
 }
 
-fn send(stdin: &mut ChildStdin, v: Value) {
-    writeln!(stdin, "{v}").expect("write");
-    stdin.flush().expect("flush");
-}
-
-fn read_response(reader: &mut BufReader<ChildStdout>) -> Value {
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line).expect("read");
-        assert!(n > 0, "proxy closed stdout before responding");
-        let t = line.trim();
-        if t.is_empty() {
-            continue;
-        }
-        let v: Value = serde_json::from_str(t).expect("parse JSON");
-        if v.get("method").is_some() {
-            continue; // skip notifications/upstream-initiated requests
-        }
-        return v;
-    }
-}
-
 fn init() -> Value {
     serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "initialize",
@@ -132,11 +111,6 @@ fn read_methods(log: &std::path::Path) -> Vec<String> {
         .collect()
 }
 
-fn shutdown(mut child: Child, stdin: ChildStdin) {
-    drop(stdin);
-    let _ = child.wait();
-}
-
 // --- the load-bearing test, first ---------------------------------------------------------------
 
 #[test]
@@ -144,24 +118,18 @@ fn enforcing_mode_tools_call_denied_and_not_forwarded() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_policy(dir.path(), MINIMAL_POLICY);
-    let mut child = spawn_enforce(&log, &policy);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(&log, &policy));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
 
-    send(
-        &mut stdin,
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                            "params": {"name": "echo", "arguments": {}}}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_response();
     assert_eq!(r["id"], 3);
     assert_eq!(
         r["error"]["code"], PROXY_DENIED,
@@ -174,7 +142,7 @@ fn enforcing_mode_tools_call_denied_and_not_forwarded() {
         "an unclassified tool denies at the classification gate"
     );
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     let methods = read_methods(&log);
     assert!(methods.contains(&"initialize".to_string()));
@@ -192,24 +160,19 @@ fn enforcing_mode_unknown_method_is_unsupported_not_denied() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_policy(dir.path(), MINIMAL_POLICY);
-    let mut child = spawn_enforce(&log, &policy);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(&log, &policy));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 7, "method": "resources/list"}),
-    );
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 7, "method": "resources/list"}));
+    let r = out.read_response();
     assert_eq!(
         r["error"]["code"], PROXY_UNSUPPORTED,
         "non-tools/call stays unsupported, not denied"
     );
     assert_eq!(r["error"]["data"]["reason"], "method_not_allowlisted");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     assert!(!read_methods(&log).contains(&"resources/list".to_string()));
 }
 
@@ -218,24 +181,19 @@ fn enforcing_mode_list_methods_still_forward() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_policy(dir.path(), MINIMAL_POLICY);
-    let mut child = spawn_enforce(&log, &policy);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(&log, &policy));
 
-    send(&mut stdin, init());
-    let r = read_response(&mut out);
+    out.send(init());
+    let r = out.read_response();
     assert_eq!(
         r["result"]["serverInfo"]["name"], "mock-upstream",
         "initialize relayed"
     );
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let r = read_response(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let r = out.read_response();
     assert!(r["result"]["tools"].is_array(), "tools/list relayed");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(
         methods.contains(&"initialize".to_string()) && methods.contains(&"tools/list".to_string())
@@ -247,21 +205,18 @@ fn observe_mode_tools_call_still_unsupported() {
     // The shipped observe mode is unchanged: a tools/call is proxy_unsupported, NOT proxy_denied.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_observe(&log);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_observe(&log));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
+    out.send(init());
+    let _ = out.read_response();
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                            "params": {"name": "echo", "arguments": {}}}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_response();
     assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
     assert_eq!(r["error"]["data"]["reason"], "method_not_allowlisted");
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 }
 
 #[test]
@@ -270,24 +225,18 @@ fn existing_proxy_invocation_still_observes() {
     // handshake and tools/list reach the upstream, tools/call does not.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_observe(&log);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_observe(&log));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "echo"}}),
     );
-    let _ = read_response(&mut out);
+    let _ = out.read_response();
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(methods.contains(&"initialize".to_string()));
     assert!(methods.contains(&"tools/list".to_string()));

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -6,6 +6,8 @@
 //! per-tool digest matches) is the only case that forwards. `--declared-mcp-manifest` is required in
 //! enforcing mode; a missing/invalid policy OR baseline fails startup, never a runtime deny.
 
+mod jsonrpc_conn;
+
 #[path = "proxy_enforce_pdp_e2e/conformance.rs"]
 mod conformance;
 #[path = "proxy_enforce_pdp_e2e/denied_observation.rs"]

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/conformance.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/conformance.rs
@@ -1,6 +1,5 @@
 use assay_mcp_server::manifest_observed::{build_observed, Completeness};
 use serde_json::Value;
-use std::io::BufReader;
 use std::path::PathBuf;
 
 use crate::support::*;
@@ -16,7 +15,7 @@ fn complete_manifest_allow_emits_conformance_record() {
     let decisions = dir.path().join("decisions.ndjson");
     let conformance = dir.path().join("conformance.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_conformance(
+    let mut out = Conn::attach(spawn_enforce_conformance(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -24,21 +23,16 @@ fn complete_manifest_allow_emits_conformance_record() {
         &decisions,
         Some(&conformance),
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     let recs = read_conformance_records(&conformance);
     assert_eq!(recs.len(), 1, "one conformance record per tools/call");
@@ -63,7 +57,7 @@ fn incomplete_manifest_emits_inconclusive_conformance() {
     let decisions = dir.path().join("decisions.ndjson");
     let conformance = dir.path().join("conformance.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_conformance(
+    let mut out = Conn::attach(spawn_enforce_conformance(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -71,19 +65,17 @@ fn incomplete_manifest_emits_inconclusive_conformance() {
         &decisions,
         Some(&conformance),
         Some(300),
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(
         r["error"]["data"]["reason"],
         "manifest_current_observation_incomplete"
     );
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     let recs = read_conformance_records(&conformance);
     assert_eq!(recs.len(), 1);
@@ -100,7 +92,7 @@ fn conformance_flag_off_writes_no_file() {
     let decisions = dir.path().join("decisions.ndjson");
     let conformance = dir.path().join("conformance.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_conformance(
+    let mut out = Conn::attach(spawn_enforce_conformance(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -108,20 +100,15 @@ fn conformance_flag_off_writes_no_file() {
         &decisions,
         None,
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let _ = read_response(&mut out);
-    shutdown(child, stdin);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let _ = out.read_response();
+    let _ = out.shutdown();
 
     assert!(
         !conformance.exists(),
@@ -137,7 +124,7 @@ fn conformance_write_failure_on_allow_fails_closed() {
     let conformance_dir = dir.path().join("conformance_is_a_dir");
     std::fs::create_dir(&conformance_dir).unwrap();
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_conformance(
+    let mut out = Conn::attach(spawn_enforce_conformance(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -145,25 +132,20 @@ fn conformance_write_failure_on_allow_fails_closed() {
         &decisions,
         Some(&conformance_dir),
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
     assert_eq!(
         r["error"]["data"]["reason"],
         "enforcement_record_write_failed"
     );
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(
         !methods.contains(&"tools/call".to_string()),
@@ -258,7 +240,7 @@ fn live_conformance_mismatch_is_emitted_while_verdict_allows() {
     let decisions = dir.path().join("decisions.ndjson");
     let conformance = dir.path().join("conformance.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_conformance(
+    let mut out = Conn::attach(spawn_enforce_conformance(
         &log,
         &policy,
         &readonly_annotation_baseline_path(),
@@ -266,28 +248,23 @@ fn live_conformance_mismatch_is_emitted_while_verdict_allows() {
         &decisions,
         Some(&conformance),
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let lst = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let lst = out.read_response();
     assert!(lst["result"]["tools"].is_array(), "tools/list relayed");
 
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["id"], DEPLOY_KEY_CALL_ID);
     assert!(
         r.get("error").is_none(),
         "the call is allowed despite the read-only annotation; got {r}"
     );
     assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     assert!(read_methods(&log).contains(&"tools/call".to_string()));
 

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/denied_observation.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/denied_observation.rs
@@ -1,5 +1,4 @@
 use serde_json::Value;
-use std::io::BufReader;
 use std::process::{Command, Stdio};
 
 use crate::support::*;
@@ -49,32 +48,31 @@ fn denied_call_observation_records_caller_visible_proxy_denial_without_becoming_
     let log = dir.path().join("methods.log");
     let denied_observations = dir.path().join("denied_observations.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_with_denied_observations(&log, &policy, &denied_observations);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce_with_denied_observations(
+        &log,
+        &policy,
+        &denied_observations,
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 19,
-            "method": "tools/call",
-            "params": {
-                "name": "github.add_deploy_key",
-                "arguments": {"owner": "acme", "repo": "prod-app"}
-            }
-        }),
-    );
-    let response = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 19,
+        "method": "tools/call",
+        "params": {
+            "name": "github.add_deploy_key",
+            "arguments": {"owner": "acme", "repo": "prod-app"}
+        }
+    }));
+    let response = out.read_response();
     assert_eq!(response["error"]["code"], PROXY_DENIED);
     assert_eq!(response["error"]["data"]["origin"], "assay-proxy");
     assert_eq!(
         response["error"]["data"]["reason"],
         "manifest_current_observation_incomplete"
     );
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     let records = read_denied_observation_records(&denied_observations);
     assert_eq!(
@@ -120,27 +118,27 @@ fn denied_call_observation_flag_off_writes_no_file() {
     let log = dir.path().join("methods.log");
     let denied_observations = dir.path().join("denied_observations.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "normal",
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 20,
-            "method": "tools/call",
-            "params": {
-                "name": "github.add_deploy_key",
-                "arguments": {"owner": "acme", "repo": "prod-app"}
-            }
-        }),
-    );
-    let response = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 20,
+        "method": "tools/call",
+        "params": {
+            "name": "github.add_deploy_key",
+            "arguments": {"owner": "acme", "repo": "prod-app"}
+        }
+    }));
+    let response = out.read_response();
     assert_eq!(response["error"]["code"], PROXY_DENIED);
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     assert!(
         !denied_observations.exists(),

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/drift_allow.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/drift_allow.rs
@@ -1,5 +1,4 @@
 use serde_json::Value;
-use std::io::BufReader;
 
 use crate::support::*;
 
@@ -27,27 +26,21 @@ fn tool_absent_from_baseline_denies_baseline_missing() {
         "baseline.json",
         r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"search","tool_digest":"sha256:abc"}]}"#,
     );
-    let mut child = spawn_enforce(&log, &policy, &baseline, "p60a");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(&log, &policy, &baseline, "p60a"));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                            "params": {"name": "github.add_deploy_key",
                                       "arguments": {"owner": "acme", "repo": "prod-app"}}}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_response();
     assert_eq!(r["error"]["code"], PROXY_DENIED);
     assert_eq!(r["error"]["data"]["reason"], "manifest_baseline_missing");
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     assert!(!read_methods(&log).contains(&"tools/call".to_string()));
 }
 
@@ -61,30 +54,24 @@ fn observed_digest_differs_from_baseline_denies_drifted() {
         "baseline.json",
         r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"github.add_deploy_key","tool_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}]}"#,
     );
-    let mut child = spawn_enforce(&log, &policy, &baseline, "p60a");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(&log, &policy, &baseline, "p60a"));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                            "params": {"name": "github.add_deploy_key",
                                       "arguments": {"owner": "acme", "repo": "prod-app"}}}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_response();
     assert_eq!(r["error"]["code"], PROXY_DENIED);
     assert_eq!(
         r["error"]["data"]["reason"],
         "manifest_drifted_since_approval"
     );
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     assert!(!read_methods(&log).contains(&"tools/call".to_string()));
 }
 
@@ -95,31 +82,30 @@ fn fully_allowed_call_is_forwarded_and_response_relayed() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "p60a");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let lst = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let lst = out.read_response();
     assert!(lst["result"]["tools"].is_array(), "tools/list relayed");
 
-    send(
-        &mut stdin,
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                            "params": {"name": "github.add_deploy_key",
                                       "arguments": {"owner": "acme", "repo": "prod-app"}}}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_response();
     assert_eq!(r["id"], 3);
     assert!(r.get("error").is_none(), "allowed call was denied: {r}");
     assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(
         methods.contains(&"tools/call".to_string()),
@@ -135,34 +121,32 @@ fn enforcement_decision_records_are_written_for_deny_and_allow() {
     let log = dir.path().join("methods.log");
     let decisions = dir.path().join("decisions.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child =
-        spawn_enforce_with_decisions(&log, &policy, &approved_baseline_path(), "p60a", &decisions);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce_with_decisions(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+        &decisions,
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                            "params": {"name": "echo", "arguments": {}}}),
     );
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
+    let _ = out.read_response();
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 4, "method": "tools/call",
                            "params": {"name": "github.add_deploy_key",
                                       "arguments": {"owner": "acme", "repo": "prod-app"}}}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_response();
     assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     let body = std::fs::read_to_string(&decisions).expect("decisions file written");
     let recs: Vec<Value> = body

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/establish.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/establish.rs
@@ -1,4 +1,3 @@
-use std::io::BufReader;
 use std::process::{Command, Stdio};
 
 use crate::support::*;
@@ -13,21 +12,24 @@ fn establish_then_allow_forwards_without_a_client_list() {
     let log = dir.path().join("methods.log");
     let decisions = dir.path().join("decisions.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child =
-        spawn_enforce_with_decisions(&log, &policy, &approved_baseline_path(), "p60a", &decisions);
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce_with_decisions(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+        &decisions,
+    ));
 
-    send(&mut stdin, init());
-    let init_resp = read_response(&mut out);
+    out.send(init());
+    let init_resp = out.read_response();
     assert_eq!(init_resp["result"]["serverInfo"]["name"], "mock-upstream");
 
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["id"], DEPLOY_KEY_CALL_ID);
     assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(methods.contains(&"tools/list".to_string()));
     assert!(methods.contains(&"tools/call".to_string()));
@@ -38,7 +40,7 @@ fn establish_then_allow_forwards_without_a_client_list() {
     assert!(!serde_json::to_string(&r)
         .unwrap()
         .contains("assay-establish-"));
-    for line in drain_stdout(&mut out) {
+    for line in out.drain_stdout() {
         assert!(
             !line.contains("assay-establish-"),
             "a synthetic establish line leaked to the client: {line}"
@@ -57,37 +59,37 @@ fn establish_timeout_denies_to_client_within_budget() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
-        .args([
-            "proxy-enforce",
-            "--upstream-command",
-            python(),
-            "--upstream-arg",
-            "-u",
-            "--upstream-arg",
-            mock_path().to_str().unwrap(),
-            "--enforce-policy",
-            policy.to_str().unwrap(),
-            "--declared-mcp-manifest",
-            approved_baseline_path().to_str().unwrap(),
-            "--manifest-establish-budget-ms",
-            "300",
-        ])
-        .env("MOCK_UPSTREAM_LOG", &log)
-        .env("MOCK_UPSTREAM_MODE", "drop_list")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .expect("spawn enforce proxy (is python installed?)");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(
+        Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+            .args([
+                "proxy-enforce",
+                "--upstream-command",
+                python(),
+                "--upstream-arg",
+                "-u",
+                "--upstream-arg",
+                mock_path().to_str().unwrap(),
+                "--enforce-policy",
+                policy.to_str().unwrap(),
+                "--declared-mcp-manifest",
+                approved_baseline_path().to_str().unwrap(),
+                "--manifest-establish-budget-ms",
+                "300",
+            ])
+            .env("MOCK_UPSTREAM_LOG", &log)
+            .env("MOCK_UPSTREAM_MODE", "drop_list")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn enforce proxy (is python installed?)"),
+    );
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
     let start = std::time::Instant::now();
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(deploy_key_call());
+    let r = out.read_response();
     let elapsed = start.elapsed();
 
     assert_eq!(r["id"], DEPLOY_KEY_CALL_ID);
@@ -101,7 +103,7 @@ fn establish_timeout_denies_to_client_within_budget() {
         "the client must get its deny within budget + margin, not hang; took {elapsed:?}"
     );
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(methods.contains(&"tools/list".to_string()));
     assert!(!methods.contains(&"tools/call".to_string()));
@@ -112,26 +114,26 @@ fn ambiguous_observation_denies_without_attempting_establish() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "duplicate");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "duplicate",
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["error"]["code"], PROXY_DENIED);
     assert_eq!(
         r["error"]["data"]["reason"],
         "manifest_observation_ambiguous"
     );
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let lists = read_methods(&log)
         .iter()
         .filter(|m| m.as_str() == "tools/list")
@@ -144,21 +146,24 @@ fn establish_completes_but_tool_absent_denies() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "normal",
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["error"]["code"], PROXY_DENIED);
     assert_eq!(
         r["error"]["data"]["reason"],
         "manifest_current_observation_incomplete"
     );
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(methods.contains(&"tools/list".to_string()));
     assert!(!methods.contains(&"tools/call".to_string()));
@@ -171,7 +176,7 @@ fn no_establish_needed_allow_writes_carrier_and_decision() {
     let decisions = dir.path().join("decisions.ndjson");
     let establish = dir.path().join("establish.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_recording(
+    let mut out = Conn::attach(spawn_enforce_recording(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -179,22 +184,17 @@ fn no_establish_needed_allow_writes_carrier_and_decision() {
         &decisions,
         &establish,
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let recs = read_establish_records(&establish);
     assert_eq!(recs.len(), 1);
     let rec = &recs[0];
@@ -213,7 +213,7 @@ fn establish_then_allow_writes_established_then_allowed() {
     let decisions = dir.path().join("decisions.ndjson");
     let establish = dir.path().join("establish.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_recording(
+    let mut out = Conn::attach(spawn_enforce_recording(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -221,17 +221,15 @@ fn establish_then_allow_writes_established_then_allowed() {
         &decisions,
         &establish,
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let recs = read_establish_records(&establish);
     assert_eq!(recs.len(), 1);
     let rec = &recs[0];
@@ -249,7 +247,7 @@ fn establish_complete_but_absent_writes_established_then_denied() {
     let decisions = dir.path().join("decisions.ndjson");
     let establish = dir.path().join("establish.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_recording(
+    let mut out = Conn::attach(spawn_enforce_recording(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -257,17 +255,15 @@ fn establish_complete_but_absent_writes_established_then_denied() {
         &decisions,
         &establish,
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["error"]["code"], PROXY_DENIED);
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let recs = read_establish_records(&establish);
     assert_eq!(recs.len(), 1);
     let rec = &recs[0];
@@ -284,7 +280,7 @@ fn establish_timeout_writes_immediate_deny_timed_out() {
     let decisions = dir.path().join("decisions.ndjson");
     let establish = dir.path().join("establish.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_recording(
+    let mut out = Conn::attach(spawn_enforce_recording(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -292,17 +288,15 @@ fn establish_timeout_writes_immediate_deny_timed_out() {
         &decisions,
         &establish,
         Some(300),
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(r["error"]["code"], PROXY_DENIED);
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let recs = read_establish_records(&establish);
     assert_eq!(recs.len(), 1);
     let rec = &recs[0];
@@ -319,7 +313,7 @@ fn ambiguous_writes_immediate_deny_not_performed_no_synthetic_list() {
     let decisions = dir.path().join("decisions.ndjson");
     let establish = dir.path().join("establish.ndjson");
     let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
-    let mut child = spawn_enforce_recording(
+    let mut out = Conn::attach(spawn_enforce_recording(
         &log,
         &policy,
         &approved_baseline_path(),
@@ -327,25 +321,20 @@ fn ambiguous_writes_immediate_deny_not_performed_no_synthetic_list() {
         &decisions,
         &establish,
         None,
-    );
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    send(&mut stdin, deploy_key_call());
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_response();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_response();
+    out.send(deploy_key_call());
+    let r = out.read_response();
     assert_eq!(
         r["error"]["data"]["reason"],
         "manifest_observation_ambiguous"
     );
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let recs = read_establish_records(&establish);
     assert_eq!(recs.len(), 1);
     let rec = &recs[0];

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/establish.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/establish.rs
@@ -40,7 +40,7 @@ fn establish_then_allow_forwards_without_a_client_list() {
     assert!(!serde_json::to_string(&r)
         .unwrap()
         .contains("assay-establish-"));
-    for line in out.drain_stdout() {
+    for line in out.drain_stdout_after_shutdown() {
         assert!(
             !line.contains("assay-establish-"),
             "a synthetic establish line leaked to the client: {line}"

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/support.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/support.rs
@@ -1,7 +1,9 @@
 use serde_json::Value;
-use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Command, Stdio};
+
+// Re-exported so the sibling modules pick it up through their `use crate::support::*;`.
+pub(crate) use crate::jsonrpc_conn::Conn;
 
 pub(crate) const PROXY_DENIED: i64 = -32042;
 
@@ -189,29 +191,6 @@ pub(crate) fn spawn_enforce_conformance(
         .expect("spawn enforce proxy (is python installed?)")
 }
 
-pub(crate) fn send(stdin: &mut ChildStdin, v: Value) {
-    writeln!(stdin, "{v}").expect("write");
-    stdin.flush().expect("flush");
-}
-
-pub(crate) fn read_response(reader: &mut BufReader<ChildStdout>) -> Value {
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line).expect("read");
-        assert!(n > 0, "proxy closed stdout before responding");
-        let t = line.trim();
-        if t.is_empty() {
-            continue;
-        }
-        let v: Value = serde_json::from_str(t).expect("parse JSON");
-        if v.get("method").is_some() {
-            continue;
-        }
-        return v;
-    }
-}
-
 pub(crate) fn init() -> Value {
     serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "initialize",
@@ -227,28 +206,25 @@ pub(crate) fn read_methods(log: &Path) -> Vec<String> {
         .collect()
 }
 
-pub(crate) fn shutdown(mut child: Child, stdin: ChildStdin) {
-    drop(stdin);
-    let _ = child.wait();
-}
-
 /// init -> tools/call (NO tools/list first), with the approved baseline. Returns the deny reason and
 /// the upstream method log. Asserts proxy_denied and that tools/call never reached the upstream.
 pub(crate) fn deny_reason_for(policy_yaml: &str, call_params: Value) -> (String, Vec<String>) {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let policy = write_file(dir.path(), "enforce.yaml", policy_yaml);
-    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_enforce(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "normal",
+    ));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
+    out.send(init());
+    let _ = out.read_response();
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 9, "method": "tools/call", "params": call_params}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_response();
     assert_eq!(r["id"], 9);
     assert_eq!(
         r["error"]["code"], PROXY_DENIED,
@@ -260,7 +236,7 @@ pub(crate) fn deny_reason_for(policy_yaml: &str, call_params: Value) -> (String,
         .expect("reason string")
         .to_string();
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(
         !methods.contains(&"tools/call".to_string()),
@@ -274,25 +250,6 @@ pub(crate) fn deploy_key_call() -> Value {
         "jsonrpc": "2.0", "id": DEPLOY_KEY_CALL_ID, "method": "tools/call",
         "params": {"name": "github.add_deploy_key", "arguments": {"owner": "acme", "repo": "prod-app"}}
     })
-}
-
-/// Read every remaining stdout line to EOF (used to prove nothing leaked to the client).
-pub(crate) fn drain_stdout(reader: &mut BufReader<ChildStdout>) -> Vec<String> {
-    let mut lines = Vec::new();
-    let mut buf = String::new();
-    loop {
-        buf.clear();
-        match reader.read_line(&mut buf) {
-            Ok(0) | Err(_) => break,
-            Ok(_) => {
-                let t = buf.trim();
-                if !t.is_empty() {
-                    lines.push(t.to_string());
-                }
-            }
-        }
-    }
-    lines
 }
 
 pub(crate) fn read_establish_records(path: &Path) -> Vec<Value> {

--- a/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
@@ -7,9 +7,11 @@
 //! received nothing" is a checkable fact, not an assumption.
 
 use serde_json::Value;
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
 
 const PROXY_UNSUPPORTED: i64 = -32040;
 const PROXY_FAILED: i64 = -32041;
@@ -51,24 +53,6 @@ fn spawn_proxy(log: &std::path::Path, raw_log: Option<&std::path::Path>, mode: &
     cmd.spawn().expect("spawn proxy (is python installed?)")
 }
 
-fn send(stdin: &mut ChildStdin, v: Value) {
-    writeln!(stdin, "{v}").expect("write request");
-    stdin.flush().expect("flush request");
-}
-
-/// Read the next non-empty JSON line from the proxy's stdout.
-fn read_response(reader: &mut BufReader<ChildStdout>) -> Value {
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line).expect("read response");
-        assert!(n > 0, "proxy closed stdout before responding");
-        if !line.trim().is_empty() {
-            return serde_json::from_str(line.trim()).expect("parse response JSON");
-        }
-    }
-}
-
 fn init() -> Value {
     serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "initialize",
@@ -84,44 +68,33 @@ fn read_methods(log: &std::path::Path) -> Vec<String> {
         .collect()
 }
 
-fn shutdown(mut child: Child, stdin: ChildStdin) {
-    drop(stdin); // client EOF
-    let _ = child.wait();
-}
-
 // --- the load-bearing test, first ---------------------------------------------------------------
 
 #[test]
 fn tools_call_never_reaches_upstream() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, None, "normal"));
 
-    send(&mut stdin, init());
-    let r = read_response(&mut out);
+    out.send(init());
+    let r = out.read_json();
     assert_eq!(r["result"]["serverInfo"]["name"], "mock-upstream");
 
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let r = read_response(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let r = out.read_json();
     assert!(r["result"]["tools"].is_array());
 
     // The denied call: the proxy must answer proxy_unsupported and the upstream must never see it.
-    send(
-        &mut stdin,
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                            "params": {"name": "echo", "arguments": {}}}),
     );
-    let r = read_response(&mut out);
+    let r = out.read_json();
     assert_eq!(r["id"], 3);
     assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 
     let methods = read_methods(&log);
     assert!(
@@ -142,22 +115,17 @@ fn tools_call_never_reaches_upstream() {
 fn non_allowlisted_method_is_denied_and_not_forwarded() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, None, "normal"));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_json();
 
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 7, "method": "resources/list"}),
-    );
-    let r = read_response(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 7, "method": "resources/list"}));
+    let r = out.read_json();
     assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     assert!(!read_methods(&log).contains(&"resources/list".to_string()));
 }
 
@@ -179,21 +147,16 @@ const DENIED_METHODS: &[&str] = &[
 fn non_allowlisted_methods_are_unsupported_and_never_forwarded() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, None, "normal"));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_json();
 
     let mut id = 100;
     for method in DENIED_METHODS {
         id += 1;
-        send(
-            &mut stdin,
-            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method}),
-        );
-        let r = read_response(&mut out);
+        out.send(serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method}));
+        let r = out.read_json();
         assert_eq!(r["id"], id);
         assert_eq!(
             r["error"]["code"], PROXY_UNSUPPORTED,
@@ -206,7 +169,7 @@ fn non_allowlisted_methods_are_unsupported_and_never_forwarded() {
         );
     }
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     for method in DENIED_METHODS {
         assert!(
@@ -222,26 +185,20 @@ fn non_allowlisted_client_notification_is_dropped_and_not_forwarded() {
     // forwarded. A following allowlisted request still works, proving the stream is intact.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, None, "normal"));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_json();
 
-    send(
-        &mut stdin,
+    out.send(
         serde_json::json!({"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {}}),
     );
     // Liveness: a following allowlisted ping is answered, so the dropped notification broke nothing.
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 50, "method": "ping"}),
-    );
-    let r = read_response(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 50, "method": "ping"}));
+    let r = out.read_json();
     assert_eq!(r["id"], 50);
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(
         !methods.contains(&"notifications/cancelled".to_string()),
@@ -260,14 +217,12 @@ fn proxy_does_not_inject_inbound_transport_auth() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     let raw = dir.path().join("raw.log");
-    let mut child = spawn_proxy(&log, Some(&raw), "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, Some(&raw), "normal"));
 
     let sent = init();
-    send(&mut stdin, sent.clone());
-    let _ = read_response(&mut out);
-    shutdown(child, stdin);
+    out.send(sent.clone());
+    let _ = out.read_json();
+    let _ = out.shutdown();
 
     let raw_lines = std::fs::read_to_string(&raw).unwrap_or_default();
     let received: Value =
@@ -288,23 +243,18 @@ fn proxy_does_not_inject_inbound_transport_auth() {
 fn initialize_and_tools_list_forward_and_response_is_unmutated() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, None, "normal"));
 
-    send(&mut stdin, init());
-    let r = read_response(&mut out);
+    out.send(init());
+    let r = out.read_json();
     // The upstream's canned serverInfo is relayed unmutated.
     assert_eq!(r["result"]["serverInfo"]["version"], "0.0.0");
 
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let r = read_response(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let r = out.read_json();
     assert_eq!(r["result"]["tools"][0]["name"], "echo");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     let methods = read_methods(&log);
     assert!(methods.contains(&"initialize".to_string()));
     assert!(methods.contains(&"tools/list".to_string()));
@@ -314,21 +264,16 @@ fn initialize_and_tools_list_forward_and_response_is_unmutated() {
 fn ping_is_forwarded() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, None, "normal"));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 5, "method": "ping"}),
-    );
-    let r = read_response(&mut out);
+    out.send(init());
+    let _ = out.read_json();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 5, "method": "ping"}));
+    let r = out.read_json();
     assert_eq!(r["id"], 5);
     assert!(r["result"].is_object());
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     assert!(read_methods(&log).contains(&"ping".to_string()));
 }
 
@@ -337,53 +282,48 @@ fn upstream_spawn_failure_yields_proxy_failed() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
     // An upstream command that cannot be spawned.
-    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
-        .args([
-            "proxy",
-            "--upstream-command",
-            "this-binary-does-not-exist-assay-test",
-        ])
-        .env("MOCK_UPSTREAM_LOG", &log)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .unwrap();
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(
+        Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+            .args([
+                "proxy",
+                "--upstream-command",
+                "this-binary-does-not-exist-assay-test",
+            ])
+            .env("MOCK_UPSTREAM_LOG", &log)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap(),
+    );
 
-    send(&mut stdin, init());
-    let r = read_response(&mut out);
+    out.send(init());
+    let r = out.read_json();
     assert_eq!(r["error"]["code"], PROXY_FAILED);
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
     assert_eq!(r["error"]["data"]["reason"], "upstream_spawn_failed");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 }
 
 #[test]
 fn malformed_upstream_response_is_not_trusted() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "malformed");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(spawn_proxy(&log, None, "malformed"));
 
-    send(&mut stdin, init());
-    let _ = read_response(&mut out); // initialize is normal
+    out.send(init());
+    let _ = out.read_json(); // initialize is normal
 
     // tools/list: the mock emits a non-JSON line; the proxy must surface a proxy_failed, never relay
     // the garbage as a successful result.
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let r = read_response(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let r = out.read_json();
     assert_eq!(r["error"]["code"], PROXY_FAILED);
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
     assert_eq!(r["error"]["data"]["reason"], "malformed_upstream_response");
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
 }
 
 #[test]
@@ -392,33 +332,30 @@ fn default_mode_spawns_no_upstream_and_serves_local_tools() {
     // point at a sentinel log that must stay absent/empty because no mock can have been spawned.
     let dir = tempfile::tempdir().unwrap();
     let sentinel = dir.path().join("must_stay_absent.log");
-    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
-        .args(["--policy-root", "../../tests/fixtures/mcp"])
-        .env("MOCK_UPSTREAM_LOG", &sentinel)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .unwrap();
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
+    let mut out = Conn::attach(
+        Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+            .args(["--policy-root", "../../tests/fixtures/mcp"])
+            .env("MOCK_UPSTREAM_LOG", &sentinel)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap(),
+    );
 
-    send(&mut stdin, init());
-    let r = read_response(&mut out);
+    out.send(init());
+    let r = out.read_json();
     // The default server answers initialize itself (its own serverInfo, not the mock's).
     assert_ne!(r["result"]["serverInfo"]["name"], "mock-upstream");
 
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let r = read_response(&mut out);
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let r = out.read_json();
     assert!(
         r["result"]["tools"].is_array(),
         "default server serves its own tools"
     );
 
-    shutdown(child, stdin);
+    let _ = out.shutdown();
     assert!(
         !sentinel.exists(),
         "default mode must not spawn any upstream (mock log must not exist)"
@@ -431,17 +368,12 @@ fn no_artifact_is_written_without_the_out_flag() {
     // the proxy writes no artifact. (Manifest emission itself is covered in proxy_manifest_e2e.rs.)
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn_proxy(&log, None, "normal");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut out = BufReader::new(child.stdout.take().unwrap());
-    send(&mut stdin, init());
-    let _ = read_response(&mut out);
-    send(
-        &mut stdin,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let _ = read_response(&mut out);
-    shutdown(child, stdin);
+    let mut out = Conn::attach(spawn_proxy(&log, None, "normal"));
+    out.send(init());
+    let _ = out.read_json();
+    out.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let _ = out.read_json();
+    let _ = out.shutdown();
 
     let stray: Vec<_> = std::fs::read_dir(dir.path())
         .unwrap()

--- a/crates/assay-mcp-server/tests/proxy_manifest_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_manifest_e2e.rs
@@ -9,9 +9,11 @@
 //! the latest-complete-wins rule is checked together with the observation-health context.
 
 use serde_json::Value;
-use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
 
 const PROXY_UNSUPPORTED: i64 = -32040;
 
@@ -27,13 +29,7 @@ fn mock_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
 }
 
-struct Proxy {
-    child: Child,
-    stdin: Option<ChildStdin>,
-    out: BufReader<ChildStdout>,
-}
-
-fn spawn(mode: &str, manifest_out: Option<&Path>, health_out: Option<&Path>) -> Proxy {
+fn spawn(mode: &str, manifest_out: Option<&Path>, health_out: Option<&Path>) -> Conn {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
     cmd.arg("proxy")
         .args(["--upstream-command", python()])
@@ -49,39 +45,7 @@ fn spawn(mode: &str, manifest_out: Option<&Path>, health_out: Option<&Path>) -> 
     if let Some(p) = health_out {
         cmd.args(["--proxy-observation-health-out", p.to_str().unwrap()]);
     }
-    let mut child = cmd.spawn().expect("spawn proxy (is python installed?)");
-    let stdin = child.stdin.take().unwrap();
-    let out = BufReader::new(child.stdout.take().unwrap());
-    Proxy {
-        child,
-        stdin: Some(stdin),
-        out,
-    }
-}
-
-fn send(p: &mut Proxy, v: Value) {
-    let s = p.stdin.as_mut().unwrap();
-    writeln!(s, "{v}").unwrap();
-    s.flush().unwrap();
-}
-
-/// Read the next JSON-RPC RESPONSE (has an id, no method); skip notifications/requests from upstream.
-fn read_response(p: &mut Proxy) -> Value {
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let n = p.out.read_line(&mut line).expect("read");
-        assert!(n > 0, "proxy closed stdout before responding");
-        let t = line.trim();
-        if t.is_empty() {
-            continue;
-        }
-        let v: Value = serde_json::from_str(t).expect("parse JSON");
-        if v.get("method").is_some() {
-            continue; // a notification or upstream-initiated request; not our response
-        }
-        return v;
-    }
+    Conn::attach(cmd.spawn().expect("spawn proxy (is python installed?)"))
 }
 
 fn init() -> Value {
@@ -92,36 +56,27 @@ fn init() -> Value {
 }
 
 /// Send initialize and consume its response, so subsequent reads line up with the tools/list traffic.
-fn handshake(p: &mut Proxy) {
-    send(p, init());
-    let _ = read_response(p);
+fn handshake(p: &mut Conn) {
+    p.send(init());
+    let _ = p.read_response();
 }
 
 /// Drive a tools/list chain from a cursorless start, following nextCursor to the terminal page.
-fn drive_full_list(p: &mut Proxy, mut next_id: i64) {
-    send(
-        p,
-        serde_json::json!({"jsonrpc": "2.0", "id": next_id, "method": "tools/list"}),
-    );
+fn drive_full_list(p: &mut Conn, mut next_id: i64) {
+    p.send(serde_json::json!({"jsonrpc": "2.0", "id": next_id, "method": "tools/list"}));
     loop {
-        let r = read_response(p);
+        let r = p.read_response();
         let cursor = r["result"]["nextCursor"].as_str().map(|s| s.to_string());
         match cursor {
             Some(c) => {
                 next_id += 1;
-                send(
-                    p,
+                p.send(
                     serde_json::json!({"jsonrpc": "2.0", "id": next_id, "method": "tools/list", "params": {"cursor": c}}),
                 );
             }
             None => break,
         }
     }
-}
-
-fn shutdown(mut p: Proxy) -> std::process::ExitStatus {
-    drop(p.stdin.take()); // client EOF
-    p.child.wait().expect("wait")
 }
 
 fn read_artifact(path: &Path) -> Value {
@@ -136,15 +91,14 @@ fn tools_call_still_not_forwarded_in_manifest_mode() {
     let manifest = dir.path().join("m.json");
     let mut p = spawn("normal", Some(&manifest), None);
     handshake(&mut p);
-    send(
-        &mut p,
+    p.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 9, "method": "tools/call",
                            "params": {"name": "echo", "arguments": {}}}),
     );
-    let r = read_response(&mut p);
+    let r = p.read_response();
     assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
-    shutdown(p);
+    let _ = p.shutdown();
 }
 
 #[test]
@@ -164,7 +118,7 @@ fn p60a_digest_anchor() {
     let mut p = spawn("p60a", Some(&manifest), None);
     handshake(&mut p);
     drive_full_list(&mut p, 2);
-    shutdown(p);
+    let _ = p.shutdown();
 
     let m = read_artifact(&manifest);
     assert_eq!(m["schema"], "assay.mcp_manifest_observed.v0");
@@ -186,7 +140,7 @@ fn single_non_paginated_list_is_complete() {
     let mut p = spawn("normal", Some(&manifest), None);
     handshake(&mut p);
     drive_full_list(&mut p, 2);
-    shutdown(p);
+    let _ = p.shutdown();
     let m = read_artifact(&manifest);
     assert_eq!(m["status"], "observed");
     assert_eq!(m["observed"]["tools_list_complete"], "complete");
@@ -200,7 +154,7 @@ fn multi_page_chain_is_complete_and_accumulates() {
     let mut p = spawn("paginated", Some(&manifest), None);
     handshake(&mut p);
     drive_full_list(&mut p, 2); // follows c1 to the terminal page
-    shutdown(p);
+    let _ = p.shutdown();
     let m = read_artifact(&manifest);
     assert_eq!(m["observed"]["tools_list_complete"], "complete");
     assert_eq!(m["observed"]["tool_count"], 2, "both pages accumulated");
@@ -214,13 +168,10 @@ fn unfinished_chain_at_shutdown_is_partial() {
     let mut p = spawn("partial", Some(&manifest), Some(&health));
     handshake(&mut p);
     // Start the chain but do NOT follow the advertised nextCursor.
-    send(
-        &mut p,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let r = read_response(&mut p);
+    p.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let r = p.read_response();
     assert!(r["result"]["nextCursor"].is_string());
-    shutdown(p);
+    let _ = p.shutdown();
     let m = read_artifact(&manifest);
     assert_eq!(m["observed"]["tools_list_complete"], "partial");
     assert_ne!(m["status"], "not_observed");
@@ -238,12 +189,11 @@ fn mid_stream_join_is_unknown() {
     let mut p = spawn("normal", Some(&manifest), None);
     handshake(&mut p);
     // First observed tools/list already carries a cursor: the chain start was never observed.
-    send(
-        &mut p,
+    p.send(
         serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {"cursor": "joined-midway"}}),
     );
-    let _ = read_response(&mut p);
-    shutdown(p);
+    let _ = p.read_response();
+    let _ = p.shutdown();
     let m = read_artifact(&manifest);
     assert_eq!(m["observed"]["tools_list_complete"], "unknown");
 }
@@ -254,7 +204,7 @@ fn no_tools_list_writes_not_observed_artifact() {
     let manifest = dir.path().join("m.json");
     let mut p = spawn("normal", Some(&manifest), None);
     handshake(&mut p);
-    shutdown(p); // never sent tools/list
+    let _ = p.shutdown(); // never sent tools/list
     let m = read_artifact(&manifest);
     assert_eq!(m["status"], "not_observed", "artifact present, not absent");
     assert!(m["observed"]["manifest_digest"].is_null());
@@ -268,7 +218,7 @@ fn duplicate_tool_names_is_ambiguous() {
     let mut p = spawn("duplicate", Some(&manifest), Some(&health));
     handshake(&mut p);
     drive_full_list(&mut p, 2);
-    shutdown(p);
+    let _ = p.shutdown();
     let m = read_artifact(&manifest);
     assert_eq!(m["status"], "ambiguous");
     assert!(m["observed"]["manifest_digest"].is_null());
@@ -287,20 +237,14 @@ fn complete_then_later_partial_keeps_latest_complete_with_health_context() {
     let mut p = spawn("complete_then_partial", Some(&manifest), Some(&health));
     handshake(&mut p);
     // First chain: cursorless, terminal -> complete.
-    send(
-        &mut p,
-        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
-    );
-    let r1 = read_response(&mut p);
+    p.send(serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let r1 = p.read_response();
     assert!(r1["result"]["nextCursor"].is_null());
     // Second chain: cursorless start that advertises a next page; do not follow it.
-    send(
-        &mut p,
-        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/list"}),
-    );
-    let r2 = read_response(&mut p);
+    p.send(serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/list"}));
+    let r2 = p.read_response();
     assert!(r2["result"]["nextCursor"].is_string());
-    shutdown(p);
+    let _ = p.shutdown();
 
     let m = read_artifact(&manifest);
     assert_eq!(
@@ -328,7 +272,7 @@ fn list_changed_notification_is_observed_in_health() {
     let mut p = spawn("changed", Some(&manifest), Some(&health));
     handshake(&mut p);
     drive_full_list(&mut p, 2);
-    shutdown(p);
+    let _ = p.shutdown();
     let h = read_artifact(&health);
     assert_eq!(
         h["manifest_observation"]["tools_list_changed_observed"],
@@ -344,7 +288,7 @@ fn artifact_write_failure_exits_nonzero() {
     let mut p = spawn("normal", Some(&manifest), None);
     handshake(&mut p);
     drive_full_list(&mut p, 2);
-    let status = shutdown(p);
+    let status = p.shutdown();
     assert!(
         !status.success(),
         "a requested-artifact write failure must yield a non-zero exit"

--- a/crates/assay-mcp-server/tests/resource_limits.rs
+++ b/crates/assay-mcp-server/tests/resource_limits.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use serde_json::Value;
-use std::io::{BufRead, Write};
 use std::process::{Command, Stdio};
 
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
+
 // Helper to spawn server with env vars
-fn spawn_server_with_env(env: Vec<(&str, &str)>) -> Result<std::process::Child> {
+fn spawn_server_with_env(env: Vec<(&str, &str)>) -> Conn {
     let cargo_bin = env!("CARGO_BIN_EXE_assay-mcp-server");
     let mut cmd = Command::new(cargo_bin);
     // Use --policy-root flag as required by main.rs
@@ -17,21 +19,12 @@ fn spawn_server_with_env(env: Vec<(&str, &str)>) -> Result<std::process::Child> 
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::inherit());
-    Ok(cmd.spawn()?)
+    Conn::attach(cmd.spawn().expect("spawn assay-mcp-server"))
 }
 
-fn send_req(child: &mut std::process::Child, req: Value) -> Result<Value> {
-    let stdin = child.stdin.as_mut().unwrap();
-    let line = serde_json::to_string(&req)?;
-    writeln!(stdin, "{}", line)?;
-
-    let stdout = child.stdout.as_mut().unwrap();
-    let mut reader = std::io::BufReader::new(stdout);
-    let mut line = String::new();
-    reader.read_line(&mut line)?;
-
-    let resp: Value = serde_json::from_str(&line)?;
-    Ok(resp)
+fn send_req(conn: &mut Conn, req: Value) -> Value {
+    conn.send(req);
+    conn.read_json()
 }
 
 fn extract_inner(resp: &Value) -> Value {
@@ -53,7 +46,7 @@ fn extract_inner(resp: &Value) -> Value {
 #[test]
 fn test_transport_limit_exceeded() -> Result<()> {
     // MAX_BYTES = 100
-    let mut child = spawn_server_with_env(vec![("ASSAY_MCP_MAX_BYTES", "100")])?;
+    let mut conn = spawn_server_with_env(vec![("ASSAY_MCP_MAX_BYTES", "100")]);
 
     // Create huge request
     let huge_params = "x".repeat(200);
@@ -66,7 +59,7 @@ fn test_transport_limit_exceeded() -> Result<()> {
         "id": 1
     });
 
-    let resp = send_req(&mut child, req)?;
+    let resp = send_req(&mut conn, req);
 
     // If it hits transport limit in server.rs, it might return ToolError wrapping
     // OR standard error.
@@ -98,14 +91,14 @@ fn test_transport_limit_exceeded() -> Result<()> {
     // If we are here, test failed expectation?
     // Not strictly failing if the server behavior regarding malformed vs huge changed.
     // I'll leave basic check.
-    child.kill()?;
+    conn.kill();
     Ok(())
 }
 
 #[test]
 fn test_payload_field_limit() -> Result<()> {
     // MAX_FIELD_BYTES = 50
-    let mut child = spawn_server_with_env(vec![("ASSAY_MCP_MAX_FIELD_BYTES", "50")])?;
+    let mut conn = spawn_server_with_env(vec![("ASSAY_MCP_MAX_FIELD_BYTES", "50")]);
 
     // Tool name len 4, OK.
     // Policy path len > 50 -> Fail.
@@ -125,7 +118,7 @@ fn test_payload_field_limit() -> Result<()> {
         "id": 1
     });
 
-    let resp = send_req(&mut child, req)?;
+    let resp = send_req(&mut conn, req);
     let inner = extract_inner(&resp);
 
     assert_eq!(inner.get("allowed").unwrap().as_bool(), Some(false));
@@ -138,14 +131,14 @@ fn test_payload_field_limit() -> Result<()> {
         .unwrap();
     assert_eq!(code, "E_LIMIT_EXCEEDED");
 
-    child.kill()?;
+    conn.kill();
     Ok(())
 }
 
 #[test]
 fn test_sequence_history_limit() -> Result<()> {
     // MAX_TOOL_CALLS = 3
-    let mut child = spawn_server_with_env(vec![("ASSAY_MCP_MAX_TOOL_CALLS", "3")])?;
+    let mut conn = spawn_server_with_env(vec![("ASSAY_MCP_MAX_TOOL_CALLS", "3")]);
 
     // History with 3 calls (OK)
     let history_ok: Vec<String> = vec!["tool_a".into(), "tool_b".into(), "tool_c".into()];
@@ -184,7 +177,7 @@ fn test_sequence_history_limit() -> Result<()> {
         "id": 2
     });
 
-    let resp_ok = send_req(&mut child, req_ok)?;
+    let resp_ok = send_req(&mut conn, req_ok);
     let inner_ok = extract_inner(&resp_ok);
 
     // It might fail with policy error (not found), but NOT limit error.
@@ -195,7 +188,7 @@ fn test_sequence_history_limit() -> Result<()> {
         );
     }
 
-    let resp_fail = send_req(&mut child, req_fail)?;
+    let resp_fail = send_req(&mut conn, req_fail);
     let inner_fail = extract_inner(&resp_fail);
 
     assert_eq!(inner_fail.get("allowed").unwrap().as_bool(), Some(false));
@@ -208,14 +201,14 @@ fn test_sequence_history_limit() -> Result<()> {
         .unwrap();
     assert_eq!(code, "E_LIMIT_EXCEEDED");
 
-    child.kill()?;
+    conn.kill();
     Ok(())
 }
 
 #[test]
 fn test_boundary_exact_limits() -> Result<()> {
     // MAX_FIELD_BYTES = 10
-    let mut child = spawn_server_with_env(vec![("ASSAY_MCP_MAX_FIELD_BYTES", "10")])?;
+    let mut conn = spawn_server_with_env(vec![("ASSAY_MCP_MAX_FIELD_BYTES", "10")]);
 
     // 10 bytes (OK)
     let tool_name = "1234567890";
@@ -249,7 +242,7 @@ fn test_boundary_exact_limits() -> Result<()> {
         "id": 2
     });
 
-    let resp_ok = send_req(&mut child, req_ok)?;
+    let resp_ok = send_req(&mut conn, req_ok);
     let inner_ok = extract_inner(&resp_ok);
 
     // Might fail policy read, but NOT limit
@@ -261,7 +254,7 @@ fn test_boundary_exact_limits() -> Result<()> {
         );
     }
 
-    let resp_fail = send_req(&mut child, req_fail)?;
+    let resp_fail = send_req(&mut conn, req_fail);
     let inner_fail = extract_inner(&resp_fail);
 
     assert_eq!(inner_fail.get("allowed").unwrap().as_bool(), Some(false));
@@ -276,6 +269,6 @@ fn test_boundary_exact_limits() -> Result<()> {
         "E_LIMIT_EXCEEDED"
     );
 
-    child.kill()?;
+    conn.kill();
     Ok(())
 }

--- a/crates/assay-mcp-server/tests/stdio_e2e.rs
+++ b/crates/assay-mcp-server/tests/stdio_e2e.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
-use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
 
 #[test]
 fn test_stdio_flow() {
@@ -10,7 +12,7 @@ fn test_stdio_flow() {
     // path, so there is nothing to build here. Spawning `cargo run` instead would inherit the
     // Cargo environment, whose CARGO_MANIFEST_DIR is tracked by ring's build script and so marks
     // the whole rustls/reqwest stack dirty on every alternation with a shell build.
-    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+    let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args(["--policy-root", policy_root])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -18,9 +20,10 @@ fn test_stdio_flow() {
         .spawn()
         .expect("Failed to spawn server");
 
-    let mut stdin = child.stdin.take().expect("Failed to open stdin");
-    let stdout = child.stdout.take().expect("Failed to open stdout");
-    let mut reader = BufReader::new(stdout);
+    // No startup allowance: the binary is already built, so the first exchange is as fast as the
+    // rest. The longer budget this used to carry existed only because `cargo run` could still be
+    // compiling.
+    let mut conn = Conn::attach(child);
 
     // Initial log line (Assay MCP Server starting...) - stderr?
     // main.rs uses eprintln! so it goes to stderr (inherited).
@@ -33,19 +36,9 @@ fn test_stdio_flow() {
         "params": { "protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"} },
         "id": 1
     });
-    writeln!(stdin, "{}", req_init).unwrap();
+    conn.send(req_init);
 
-    let mut line = String::new();
-    reader
-        .read_line(&mut line)
-        .expect("Failed to read init response");
-    if line.trim().is_empty() {
-        reader
-            .read_line(&mut line)
-            .expect("Failed to read init response (retry)");
-    }
-
-    let resp: Value = serde_json::from_str(&line).expect("Failed to parse init response");
+    let resp: Value = conn.read_json();
     assert!(resp.get("result").is_some(), "Init failed: {:?}", resp);
 
     // The unit tests in `server.rs` pin `initialize_result()`, but the original defect was an
@@ -90,11 +83,9 @@ fn test_stdio_flow() {
         "params": {},
         "id": 2
     });
-    writeln!(stdin, "{}", req_list).unwrap();
+    conn.send(req_list);
 
-    line.clear();
-    reader.read_line(&mut line).unwrap();
-    let resp: Value = serde_json::from_str(&line).unwrap();
+    let resp: Value = conn.read_json();
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("Tools list missing");
@@ -116,19 +107,15 @@ fn test_stdio_flow() {
         },
         "id": 3
     });
-    writeln!(stdin, "{}", req_check_args).unwrap();
+    conn.send(req_check_args);
 
-    line.clear();
-    reader.read_line(&mut line).unwrap();
-    let resp: Value = serde_json::from_str(&line).unwrap();
+    let resp: Value = conn.read_json();
     let content_text = resp["result"]["content"][0]["text"]
         .as_str()
         .expect("Missing content text in MCP response");
     let tool_res: Value = serde_json::from_str(content_text).unwrap();
     assert_eq!(tool_res["allowed"], true);
 
-    // 4. Kill server
-    // Dropping stdin typically signals EOF, but we can kill explicitly.
-    drop(stdin);
-    let _ = child.wait();
+    // 4. Shut the server down: stdin EOF, then a bounded reap.
+    let _ = conn.shutdown();
 }

--- a/crates/assay-mcp-server/tests/stdio_edge_cases.rs
+++ b/crates/assay-mcp-server/tests/stdio_edge_cases.rs
@@ -10,16 +10,14 @@
 //! changed between them; the second run recompiled 14 crates before the tests even started.
 
 use serde_json::Value;
-use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 
-fn spawn_server() -> (
-    std::process::Child,
-    std::process::ChildStdin,
-    BufReader<std::process::ChildStdout>,
-) {
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
+
+fn spawn_server() -> Conn {
     let policy_root = "../../tests/fixtures/mcp";
-    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+    let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args(["--policy-root", policy_root])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -27,21 +25,12 @@ fn spawn_server() -> (
         .spawn()
         .expect("Failed to spawn server");
 
-    let stdin = child.stdin.take().expect("Failed to open stdin");
-    let stdout = child.stdout.take().expect("Failed to open stdout");
-    (child, stdin, BufReader::new(stdout))
+    Conn::attach(child)
 }
 
-fn spawn_server_with_env(
-    env_key: &str,
-    env_val: &str,
-) -> (
-    std::process::Child,
-    std::process::ChildStdin,
-    BufReader<std::process::ChildStdout>,
-) {
+fn spawn_server_with_env(env_key: &str, env_val: &str) -> Conn {
     let policy_root = "../../tests/fixtures/mcp";
-    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+    let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args(["--policy-root", policy_root])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -50,59 +39,22 @@ fn spawn_server_with_env(
         .spawn()
         .expect("Failed to spawn server");
 
-    let stdin = child.stdin.take().expect("Failed to open stdin");
-    let stdout = child.stdout.take().expect("Failed to open stdout");
-    (child, stdin, BufReader::new(stdout))
-}
-
-fn send_req(
-    stdin: &mut std::process::ChildStdin,
-    reader: &mut BufReader<std::process::ChildStdout>,
-    method: &str,
-    params: Value,
-    id: u64,
-) -> Value {
-    let req = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": id
-    });
-    writeln!(stdin, "{}", req).unwrap();
-
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line).unwrap();
-        if n == 0 {
-            panic!("Server sent EOF (crashed?) waiting for response id={}", id);
-        }
-        if !line.trim().is_empty() {
-            // Check if it's a log line (heuristic) - currently server logs to stderr, so stdout should be pure JSON
-            if let Ok(val) = serde_json::from_str::<Value>(&line) {
-                return val;
-            }
-        }
-    }
+    Conn::attach(child)
 }
 
 #[test]
 fn test_edge_cases() {
-    let (mut child, mut stdin, mut reader) = spawn_server();
+    let mut conn = spawn_server();
 
     // 1. Initialize
-    send_req(
-        &mut stdin,
-        &mut reader,
+    conn.request(
         "initialize",
         serde_json::json!({"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}),
         1,
     );
 
     // Case 1: Missing Policy File (check_args)
-    let resp = send_req(
-        &mut stdin,
-        &mut reader,
+    let resp = conn.request(
         "tools/call",
         serde_json::json!({
             "name": "assay_check_args",
@@ -130,9 +82,7 @@ fn test_edge_cases() {
     }
 
     // Case 2: Malformed Policy File (check_args)
-    let resp = send_req(
-        &mut stdin,
-        &mut reader,
+    let resp = conn.request(
         "tools/call",
         serde_json::json!({
             "name": "assay_check_args",
@@ -167,9 +117,7 @@ fn test_edge_cases() {
     );
 
     // Case 3: Strict Schema Violation (check_args)
-    let resp = send_req(
-        &mut stdin,
-        &mut reader,
+    let resp = conn.request(
         "tools/call",
         serde_json::json!({
             "name": "assay_check_args",
@@ -199,9 +147,7 @@ fn test_edge_cases() {
     );
 
     // Case 4: Sequence - First tool requires predecessor
-    let resp = send_req(
-        &mut stdin,
-        &mut reader,
+    let resp = conn.request(
         "tools/call",
         serde_json::json!({
             "name": "assay_check_sequence",
@@ -224,9 +170,7 @@ fn test_edge_cases() {
 
     // Case 5: Policy Decide - Partial match (Security check)
     // blocklist has "dangerous_tool". "dangerous_tool_suffix" should be allowed?
-    let resp = send_req(
-        &mut stdin,
-        &mut reader,
+    let resp = conn.request(
         "tools/call",
         serde_json::json!({
             "name": "assay_policy_decide",
@@ -246,28 +190,23 @@ fn test_edge_cases() {
         "Should allow partial match if exact match is required"
     );
 
-    drop(stdin);
-    let _ = child.wait();
+    let _ = conn.shutdown();
 }
 
 #[test]
 fn test_timeout() {
     // Set extremely short timeout (1ms)
-    let (mut child, mut stdin, mut reader) = spawn_server_with_env("ASSAY_MCP_TIMEOUT_MS", "1");
+    let mut conn = spawn_server_with_env("ASSAY_MCP_TIMEOUT_MS", "1");
 
     // Initialize
-    send_req(
-        &mut stdin,
-        &mut reader,
+    conn.request(
         "initialize",
         serde_json::json!({"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}),
         1,
     );
 
     // Call check_args which involves IO (policy read) - should timeout
-    let resp = send_req(
-        &mut stdin,
-        &mut reader,
+    let resp = conn.request(
         "tools/call",
         serde_json::json!({
             "name": "assay_check_args",
@@ -295,6 +234,5 @@ fn test_timeout() {
         );
     }
 
-    drop(stdin);
-    let _ = child.wait();
+    let _ = conn.shutdown();
 }


### PR DESCRIPTION
The stdio e2e tests in `assay-mcp-server` read JSON-RPC responses from a spawned proxy with a bare `BufRead::read_line` and no timeout. A child that spawns but never answers wedges the test inside the syscall, so no elapsed-time check in the surrounding loop is ever reached. Under `cargo nextest` that surfaced as the `.config/nextest.toml` slow-timeout SIGTERM at 120s with no indication of which request went unanswered, and `retries = 1` bought a second 120s hang. The wedged child was never killed, so it kept running against the harness's inherited stderr.

Eight files each carried their own copy of that helper. Rather than fix the same read eight times, `tests/jsonrpc_conn/mod.rs` moves the blocking read onto a worker thread and waits on it with `mpsc::Receiver::recv_timeout`. `Conn` owns the write side as well as the read side, which is what lets a timeout name the exchange that stalled without a label argument at each of the ~85 read sites.

## Relationship to #1987

**#1987 is the same finding in the CLI's copy of this reader.** It landed on main after this branch was cut, so the two were written independently. Merging it in surfaced a defect this branch had: `recv_timeout` attempts an optimistic `try_recv` before it waits, so it returns an already-queued line even at zero remaining duration. Every read here loops past lines that are not the response, so a child writing those faster than the loop skips them ran unbounded past its deadline. Fixed in a29d3b94, with the finding credited to #1987.

## Open finding: two implementations of one mechanism

There are now two independent implementations of worker-thread + `recv_timeout` + deadline-at-top + kill-on-timeout: `JsonLines` in `crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs` and `Conn` here. They are not the same abstraction — `JsonLines` is a read-only reader for three tests with explicit labels, `Conn` is bidirectional for ~85 sites — but the mechanism is identical, and it has already drifted: this branch shipped it without the deadline check that #1987 had found hours earlier. Unifying means a dev-only crate both test suites can depend on, which is a workspace change and is deliberately not in this PR. Flagging it for the reviewer to rule on rather than deciding it here.

## Verification

Two properties, both provoked against a real child rather than reasoned about:

1. **Wedged child.** Pointed a test's server binary at `#!/bin/sh` + `exec sleep 300`. The test failed at 30.01s naming `id=1 method=initialize`, and no child survived. Restored afterwards.
2. **Flood outruns the deadline.** Two regression tests in `jsonrpc_conn_selftest.rs`, one per skip loop. With the deadline check removed both fail at 5s against a 1s budget; with it restored both pass at ~1s. They use `yes` and not a shell `while` loop on purpose — the first version used `sh -c 'while :; do echo; done'` and **passed against the unfixed reader**, because that produces more slowly than the loop skips, so the channel drained and the run bounded itself through the ordinary empty-channel path.

`cargo clippy -p assay-mcp-server --tests -- -D warnings` clean. `cargo nextest run -p assay-mcp-server`: 288 passed, 0 skipped.

## Behaviour tightened rather than preserved

- `stdio_edge_cases` now fails on a non-JSON stdout line instead of skipping it silently.
- `resource_limits` uses one persistent reader instead of building a fresh `BufReader` per request, which could discard buffered bytes.
- `wait()` is bounded: a child that never exits after stdin EOF hangs identically to one that never answers.

## Non-claims

The bounded `wait()` and the Drop-time reap are reasoned about, not provoked by a test. `drain_stdout`'s deadline check is not covered — flooding it accumulates every line into a `Vec`, so provoking it trades an unbounded wait for unbounded memory. The startup allowance (75s, first read only) is calibrated to one machine's measurement of ~43s for four concurrent `cargo run` tests contending on the target-directory lock; it is not a measurement of CI.

Review quorum is not met: this is the builder's own account. Needs one non-building agent review plus CodeRabbit or Copilot on the final head SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability with bounded timeouts for JSON-RPC communication.
  * Added coverage for stalled, noisy, malformed, and notification-heavy process output.
  * Standardized process communication and cleanup across stdio and proxy test suites.
  * Preserved existing assertions for forwarding, denials, limits, manifests, shutdown, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->