### PR TITLE
test(aee): add seal-first Assay AEE fixture spike

### DIFF
--- a/docs/experiments/aee-assay-spike-2026-08.md
+++ b/docs/experiments/aee-assay-spike-2026-08.md
@@ -37,11 +37,17 @@ The fixture also carries synthetic substrate, catch-policy, corpus, network-post
 ## Run
 
 ```bash
+set -euo pipefail
+
 python3 scripts/experiments/aee_spike_emit.py --variants
 python3 scripts/experiments/aee_spike_check.py scripts/experiments/fixtures/aee/statement-valid.json
 for f in scripts/experiments/fixtures/aee/negative-controls/*.json; do
   python3 scripts/experiments/aee_spike_check.py --expect-invalid "$f"
 done
+python3 -m py_compile \
+  scripts/experiments/aee_spike_lib.py \
+  scripts/experiments/aee_spike_emit.py \
+  scripts/experiments/aee_spike_check.py
 ```
 
 ## What the checker validates

--- a/docs/experiments/aee-assay-spike-2026-08.md
+++ b/docs/experiments/aee-assay-spike-2026-08.md
@@ -32,7 +32,7 @@ The fixture also carries synthetic substrate, catch-policy, corpus, network-post
 
 - `scripts/experiments/aee_spike_emit.py` emits the valid statement and optional negative controls.
 - `scripts/experiments/aee_spike_check.py` checks the fixture statement invariants.
-- `scripts/experiments/fixtures/aee/` contains the Assay-shaped source fixtures and emitted AEE-shaped statements.
+- `scripts/experiments/fixtures/aee/` contains the Assay-shaped source fixtures. The emitter writes generated AEE-shaped statements into this directory.
 
 ## Run
 

--- a/docs/experiments/aee-assay-spike-2026-08.md
+++ b/docs/experiments/aee-assay-spike-2026-08.md
@@ -32,7 +32,7 @@ The fixture also carries synthetic substrate, catch-policy, corpus, network-post
 
 - `scripts/experiments/aee_spike_emit.py` emits the valid statement and optional negative controls.
 - `scripts/experiments/aee_spike_check.py` checks the fixture statement invariants.
-- `scripts/experiments/fixtures/aee/` contains the Assay-shaped source fixtures. The emitter writes generated AEE-shaped statements into this directory.
+- `scripts/experiments/fixtures/aee/` contains the Assay-shaped source fixtures and emitted AEE-shaped statements.
 
 ## Run
 
@@ -40,9 +40,14 @@ The fixture also carries synthetic substrate, catch-policy, corpus, network-post
 set -euo pipefail
 
 python3 scripts/experiments/aee_spike_emit.py --variants
-python3 scripts/experiments/aee_spike_check.py scripts/experiments/fixtures/aee/statement-valid.json
-for f in scripts/experiments/fixtures/aee/negative-controls/*.json; do
-  python3 scripts/experiments/aee_spike_check.py --expect-invalid "$f"
+python3 scripts/experiments/aee_spike_check.py valid
+for name in \
+  artifact-labelled-substrate \
+  defective-unreferenced-seal \
+  missing-seal \
+  reconstructed-priced-intercepted \
+  run-population-overclaim; do
+  python3 scripts/experiments/aee_spike_check.py --expect-invalid "$name"
 done
 python3 -m py_compile \
   scripts/experiments/aee_spike_lib.py \
@@ -60,7 +65,7 @@ This checker is intentionally not a general AEE verifier. It validates the spike
 - run-binding recomputation using AEE v0.7 binding version 2 inputs;
 - fixture signature verification for carried observation records;
 - `batchRoot` recomputation over carried records;
-- substrate rows carry arming, sealed, and interception coverage;
+- substrate rows carry arming and sealed coverage, and caught/intercepted substrate rows carry interception coverage;
 - every carried covering-kind record is constrained even when no row references it;
 - pinned rows match `expectedPayloads` commitments;
 - negative controls fail for the expected reason.

--- a/docs/experiments/aee-assay-spike-2026-08.md
+++ b/docs/experiments/aee-assay-spike-2026-08.md
@@ -1,0 +1,95 @@
+# Assay -> AEE v0.7 fixture spike
+
+Status: non-production experiment.
+
+This experiment tests whether Assay's current runtime/proxy evidence carriers can be shaped into an Adversarial Execution Evidence (AEE) v0.7 statement for a two-vantage substrate under one operator.
+
+It deliberately builds the seal first. The first useful result is not production AEE support; it is the boundary statement that Assay can synthesize an AEE-shaped fixture seal, while production Assay does not yet emit a substrate-signed post-run seal over still-armed, drop accounting, observed labels, and observed attacks.
+
+## Pinned external input
+
+- AEE PR: `in-toto/attestation#570`
+- AEE PR head used for this spike: `c0c4da67defdf0f186f162e7ecb3f9527b6a94f8`
+- AEE predicate version: `0.7`
+- Local SHA-256 of `spec/predicates/adversarial-execution-evidence.md` from that head: `fda0f5f7885d56feb93194cfa604f57c060c12677f77fa5579888b15dc1d1a2d`
+
+The predicate is still under vetting. Any field or validity rule can change before acceptance.
+
+## Assay surfaces used
+
+The fixture maps two existing Assay evidence surfaces:
+
+1. `assay.denied_call_observation.v0`
+   - Used as the source for the proxy interception payload.
+   - Preserves the existing boundary: this is a caller-visible observation, not a policy verdict and not proof of upstream side effect.
+2. `assay.enforcement_health.v1`
+   - Used as the source for the Landlock TCP-connect blocked-probe payload.
+   - Preserves the existing boundary: this proves a blocked probe in the fixture, not complete run population.
+
+The fixture also carries synthetic substrate, catch-policy, corpus, network-posture, arming, and sealed records. Those synthetic records are the spike mechanism, not current production Assay output.
+
+## Files
+
+- `scripts/experiments/aee_spike_emit.py` emits the valid statement and optional negative controls.
+- `scripts/experiments/aee_spike_check.py` checks the fixture statement invariants.
+- `scripts/experiments/fixtures/aee/` contains the Assay-shaped source fixtures and emitted AEE-shaped statements.
+
+## Run
+
+```bash
+python3 scripts/experiments/aee_spike_emit.py --variants
+python3 scripts/experiments/aee_spike_check.py scripts/experiments/fixtures/aee/statement-valid.json
+for f in scripts/experiments/fixtures/aee/negative-controls/*.json; do
+  python3 scripts/experiments/aee_spike_check.py --expect-invalid "$f"
+done
+```
+
+## What the checker validates
+
+This checker is intentionally not a general AEE verifier. It validates the spike properties needed for the Assay mapping:
+
+- exactly one subject;
+- corpus manifest digest recomputation;
+- observation vocabulary digest recomputation;
+- run-binding recomputation using AEE v0.7 binding version 2 inputs;
+- fixture signature verification for carried observation records;
+- `batchRoot` recomputation over carried records;
+- substrate rows carry arming, sealed, and interception coverage;
+- every carried covering-kind record is constrained even when no row references it;
+- pinned rows match `expectedPayloads` commitments;
+- negative controls fail for the expected reason.
+
+## Negative controls
+
+The emitted negative controls cover the current spike risks:
+
+1. `statement-missing-seal.json`
+   - Expected failure: substrate rows lack required sealed coverage.
+2. `statement-defective-unreferenced-seal.json`
+   - Expected failure: a carried but unreferenced covering-kind seal still violates constraints.
+3. `statement-artifact-labelled-substrate.json`
+   - Expected failure: a substrate row with no observation references cannot be credited.
+4. `statement-reconstructed-priced-intercepted.json`
+   - Expected failure: a row claiming `intercepted` is covered by a weaker `reconstructed` record.
+5. `statement-run-population-overclaim.json`
+   - Expected failure: the spike must not claim no sibling runs existed.
+
+## Non-claims
+
+This experiment does not claim:
+
+- production AEE support;
+- stable support before the AEE predicate is accepted;
+- complete run population;
+- agent safety;
+- independent substrate operation when one fixture key signs both collection paths;
+- that production Assay emits substrate-signed sealed records;
+- that ProtoJSON or generated bindings are canonical evidence.
+
+## Initial finding
+
+The fixture supports the expected first finding:
+
+> Assay can synthesize AEE-shaped evidence for a two-vantage run only if it has an AEE sealed record. Current Assay carriers provide attach/probe/count and proxy-observation facts, but not yet a substrate-signed post-run seal over still-armed, drop-count/drop-bound, observed-set, and observed-attacks.
+
+The next useful work is to decide whether that seal belongs as a production Assay primitive, and whether one AEE `substrate` descriptor is sufficient for the proxy plus Landlock two-vantage case without losing important collection-path semantics.

--- a/scripts/experiments/aee_spike_check.py
+++ b/scripts/experiments/aee_spike_check.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Any
 
 from aee_spike_lib import (
     AEE_PREDICATE_TYPE,
@@ -25,6 +26,9 @@ from aee_spike_lib import (
     read_json,
     sign_payload,
 )
+
+ROOT = Path(__file__).resolve().parent
+FIXTURES = ROOT / "fixtures" / "aee"
 
 def recompute_run_binding(statement: dict[str, Any]) -> str:
     subject = statement["subject"][0]
@@ -183,7 +187,7 @@ def main() -> int:
     parser.add_argument("--expect-invalid", action="store_true", help="Exit 0 only when validation fails")
     args = parser.parse_args()
 
-    errors = validate(read_json(args.statement))
+    errors = validate(read_json(args.statement, base_dir=FIXTURES))
     if args.expect_invalid:
         if errors:
             print(f"invalid as expected: {args.statement}")

--- a/scripts/experiments/aee_spike_check.py
+++ b/scripts/experiments/aee_spike_check.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Check the fixture-only Assay -> AEE v0.7 spike statement.
+
+This is not a general AEE verifier. It validates the spike invariants that are
+useful for Assay: digest integrity, run binding, batch root, covering-kind
+constraints, substrate coverage, and the known negative controls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+AEE_PREDICATE_TYPE = "https://in-toto.io/attestation/adversarial-execution-evidence/v0.7"
+PAYLOAD_TYPE = "application/vnd.assay.aee-spike.observation.v0+json"
+FIXTURE_KEY_ID = "assay-aee-spike-fixture-key-v0"
+FIXTURE_KEY = b"assay-aee-spike-fixture-key-v0-not-production"
+VALID_RESULTS = ["fail", "degraded", "pass_indirect", "pass"]
+VALID_BASIS = {"substrate", "artifact"}
+VALID_METHOD = {"intercepted", "reconstructed"}
+VALID_ATTRIBUTION = {"pinned", "paired"}
+COVERING_KINDS = {"interception", "arming", "sealed", "examination"}
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def digest_json(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def dsse_pae(payload_type: str, payload: bytes) -> bytes:
+    return b"DSSEv1 " + str(len(payload_type)).encode("ascii") + b" " + payload_type.encode("utf-8") + b" " + str(len(payload)).encode("ascii") + b" " + payload
+
+
+def sign_payload(payload_type: str, payload: bytes) -> str:
+    return base64.b64encode(hmac.new(FIXTURE_KEY, dsse_pae(payload_type, payload), hashlib.sha256).digest()).decode("ascii")
+
+
+def merkle_root(leaves: list[dict[str, Any]]) -> str:
+    if not leaves:
+        return ""
+    layer = [hashlib.sha256(b"\x00" + canonical_bytes(leaf)).digest() for leaf in leaves]
+    while len(layer) > 1:
+        next_layer: list[bytes] = []
+        for idx in range(0, len(layer), 2):
+            if idx + 1 == len(layer):
+                next_layer.append(layer[idx])
+            else:
+                next_layer.append(hashlib.sha256(b"\x01" + layer[idx] + layer[idx + 1]).digest())
+        layer = next_layer
+    return layer[0].hex()
+
+
+def load_statement(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def decode_record(record: dict[str, Any]) -> tuple[dict[str, Any], bytes]:
+    payload_bytes = base64.b64decode(record["payload"])
+    payload = json.loads(payload_bytes.decode("utf-8"))
+    return payload, payload_bytes
+
+
+def recompute_run_binding(statement: dict[str, Any]) -> str:
+    subject = statement["subject"][0]
+    env = statement["predicate"]["observationEnvironment"]
+    network_posture = env["networkPosture"]
+    preimage = {
+        "aeeBindingVersion": "2",
+        "catchPolicy": env["catchPolicy"]["digest"]["sha256"],
+        "corpus": env["corpus"]["digest"]["sha256"],
+        "networkPosture": digest_json(network_posture),
+        "observationVocabulary": env["observationVocabulary"]["digest"]["sha256"],
+        "runEntropy": env["runEntropy"]["digest"]["sha256"],
+        "subject": subject["digest"]["sha256"],
+        "substrate": env["substrate"]["digest"]["sha256"],
+    }
+    return digest_json(preimage)
+
+
+def expected_result(predicate: dict[str, Any]) -> str:
+    vocab = predicate["observationEnvironment"]["observationVocabulary"]
+    labels = set(vocab["labels"])
+    caught = set(vocab["caught"])
+    rows = predicate["attackResults"]
+    if any(
+        row.get("containmentObserved") in caught
+        or row.get("containmentObserved") not in labels
+        or row.get("basis") not in VALID_BASIS
+        or row.get("method") not in VALID_METHOD
+        or row.get("attribution") not in VALID_ATTRIBUTION
+        for row in rows
+    ):
+        return "fail"
+    if predicate["coverage"].get("outOfScope") or predicate["coverage"].get("routedElsewhere"):
+        return "degraded"
+    if any(row.get("basis") != "substrate" or row.get("method") != "intercepted" for row in rows):
+        return "pass_indirect"
+    return "pass"
+
+
+def validate(statement: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if statement.get("_type") != "https://in-toto.io/Statement/v1":
+        errors.append("statement _type is not in-toto Statement/v1")
+    if statement.get("predicateType") != AEE_PREDICATE_TYPE:
+        errors.append("predicateType is not AEE v0.7")
+    if len(statement.get("subject", [])) != 1:
+        errors.append("statement must carry exactly one subject")
+
+    predicate = statement.get("predicate", {})
+    env = predicate.get("observationEnvironment", {})
+    corpus = env.get("corpus", {})
+    vocab = env.get("observationVocabulary", {})
+    records = predicate.get("observationRecords", [])
+    rows = predicate.get("attackResults", [])
+
+    if corpus.get("digest", {}).get("sha256") != digest_json(corpus.get("manifest")):
+        errors.append("corpus digest does not recompute")
+    if vocab.get("digest", {}).get("sha256") != digest_json({"caught": vocab.get("caught"), "labels": vocab.get("labels")}):
+        errors.append("observation vocabulary digest does not recompute")
+    if records and predicate.get("batchRoot") != merkle_root(records):
+        errors.append("batchRoot does not recompute")
+    if predicate.get("result") != expected_result(predicate):
+        errors.append("result does not recompute")
+
+    run_binding = None
+    if any(row.get("basis") == "substrate" for row in rows):
+        try:
+            run_binding = recompute_run_binding(statement)
+        except KeyError as exc:
+            errors.append(f"run binding cannot be derived: missing {exc}")
+
+    payloads: list[dict[str, Any]] = []
+    for idx, record in enumerate(records):
+        try:
+            payload, payload_bytes = decode_record(record)
+            payloads.append(payload)
+        except Exception as exc:  # noqa: BLE001 - checker reports all fixture faults.
+            errors.append(f"record {idx} payload cannot be decoded: {exc}")
+            payloads.append({})
+            continue
+        if record.get("payloadType") != PAYLOAD_TYPE:
+            errors.append(f"record {idx} payloadType is not the fixture +json type")
+        signatures = record.get("signatures", [])
+        if not signatures:
+            errors.append(f"record {idx} has no fixture signature")
+        elif signatures[0].get("keyid") != FIXTURE_KEY_ID or signatures[0].get("sig") != sign_payload(record["payloadType"], payload_bytes):
+            errors.append(f"record {idx} fixture signature does not verify")
+        if run_binding and payload.get("aeeRunBinding") != run_binding:
+            errors.append(f"record {idx} aeeRunBinding mismatch")
+
+    seal_indexes = [idx for idx, payload in enumerate(payloads) if payload.get("aeeKind") == "sealed"]
+    if any(row.get("basis") == "substrate" for row in rows) and not seal_indexes:
+        errors.append("substrate row lacks required sealed coverage")
+
+    for idx, payload in enumerate(payloads):
+        kind = payload.get("aeeKind")
+        if kind in COVERING_KINDS:
+            if kind == "sealed":
+                if payload.get("aeeStillArmed") is not True:
+                    errors.append(f"sealed record {idx} is not still armed")
+                if payload.get("aeeDropCount") != 0 or payload.get("aeeDropBound") != 0:
+                    errors.append(f"sealed record {idx} has non-zero or inconsistent drop accounting")
+                observed_set = sorted({row.get("containmentObserved") for row in rows if row.get("containmentObserved") in set(vocab.get("caught", []))})
+                if payload.get("aeeObservedSet") != observed_set:
+                    errors.append(f"sealed record {idx} aeeObservedSet mismatch")
+            if payload.get("aeeMethod") not in VALID_METHOD and kind != "arming":
+                errors.append(f"record {idx} has invalid aeeMethod")
+
+    referenced_interceptions: set[int] = set()
+    for row_idx, row in enumerate(rows):
+        refs = row.get("observationRefs", [])
+        if row.get("basis") == "substrate" and not refs:
+            errors.append(f"substrate row {row_idx} has empty observationRefs")
+        for ref in refs:
+            if not isinstance(ref, int) or ref < 0 or ref >= len(records):
+                errors.append(f"row {row_idx} has out-of-range observationRefs index {ref}")
+        ref_payloads = [payloads[ref] for ref in refs if isinstance(ref, int) and 0 <= ref < len(payloads)]
+        ref_kinds = {payload.get("aeeKind") for payload in ref_payloads}
+        if row.get("basis") == "substrate":
+            if row.get("containmentObserved") in set(vocab.get("caught", [])) and row.get("method") == "intercepted" and "interception" not in ref_kinds:
+                errors.append(f"caught substrate row {row_idx} lacks interception coverage")
+            if "arming" not in ref_kinds:
+                errors.append(f"substrate row {row_idx} lacks arming coverage")
+            if "sealed" not in ref_kinds:
+                errors.append(f"substrate row {row_idx} lacks sealed coverage")
+            methods = [payload.get("aeeMethod") for payload in ref_payloads if payload.get("aeeKind") in {"interception", "sealed", "examination"}]
+            if row.get("method") == "intercepted" and "reconstructed" in methods:
+                errors.append(f"row {row_idx} claims intercepted but covering record is reconstructed")
+        if row.get("attribution") == "pinned":
+            expected = corpus.get("manifest", {}).get("expectedPayloads", {}).get(row.get("attackId"), [])
+            interception_payloads = [payload for payload in ref_payloads if payload.get("aeeKind") == "interception"]
+            if not interception_payloads:
+                errors.append(f"pinned row {row_idx} lacks interception record")
+            elif not any(payload.get("aeePayloadCommitment") in expected for payload in interception_payloads):
+                errors.append(f"pinned row {row_idx} payload commitment not in corpus expectedPayloads")
+            for ref in refs:
+                if 0 <= ref < len(payloads) and payloads[ref].get("aeeKind") == "interception":
+                    referenced_interceptions.add(ref)
+
+    for idx, payload in enumerate(payloads):
+        if payload.get("aeeKind") == "interception" and idx not in referenced_interceptions:
+            errors.append(f"interception record {idx} is not resolved by a caught row")
+
+    if predicate.get("_ext", {}).get("assaySpike", {}).get("invalidClaim") == "no sibling runs existed":
+        errors.append("run population overclaim: AEE/Assay spike must not claim no sibling runs existed")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("statement", type=Path, help="AEE spike statement JSON to check")
+    parser.add_argument("--expect-invalid", action="store_true", help="Exit 0 only when validation fails")
+    args = parser.parse_args()
+
+    errors = validate(load_statement(args.statement))
+    if args.expect_invalid:
+        if errors:
+            print(f"invalid as expected: {args.statement}")
+            for error in errors:
+                print(f"- {error}")
+            return 0
+        print(f"expected invalid but passed: {args.statement}")
+        return 1
+    if errors:
+        print(f"invalid: {args.statement}")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print(f"valid fixture statement: {args.statement}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/aee_spike_check.py
+++ b/scripts/experiments/aee_spike_check.py
@@ -9,7 +9,6 @@ constraints, substrate coverage, and the known negative controls.
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
 from typing import Any
 
 from aee_spike_lib import (
@@ -17,34 +16,17 @@ from aee_spike_lib import (
     COVERING_KINDS,
     FIXTURE_KEY_ID,
     PAYLOAD_TYPE,
+    STATEMENT_PATHS,
     VALID_ATTRIBUTION,
     VALID_BASIS,
     VALID_METHOD,
     decode_record,
     digest_json,
     merkle_root,
-    read_json,
+    read_statement_fixture,
+    run_binding_from_statement,
     sign_payload,
 )
-
-ROOT = Path(__file__).resolve().parent
-FIXTURES = ROOT / "fixtures" / "aee"
-
-def recompute_run_binding(statement: dict[str, Any]) -> str:
-    subject = statement["subject"][0]
-    env = statement["predicate"]["observationEnvironment"]
-    network_posture = env["networkPosture"]
-    preimage = {
-        "aeeBindingVersion": "2",
-        "catchPolicy": env["catchPolicy"]["digest"]["sha256"],
-        "corpus": env["corpus"]["digest"]["sha256"],
-        "networkPosture": digest_json(network_posture),
-        "observationVocabulary": env["observationVocabulary"]["digest"]["sha256"],
-        "runEntropy": env["runEntropy"]["digest"]["sha256"],
-        "subject": subject["digest"]["sha256"],
-        "substrate": env["substrate"]["digest"]["sha256"],
-    }
-    return digest_json(preimage)
 
 
 def expected_result(predicate: dict[str, Any]) -> str:
@@ -96,9 +78,9 @@ def validate(statement: dict[str, Any]) -> list[str]:
     run_binding = None
     if any(row.get("basis") == "substrate" for row in rows):
         try:
-            run_binding = recompute_run_binding(statement)
-        except KeyError as exc:
-            errors.append(f"run binding cannot be derived: missing {exc}")
+            run_binding = run_binding_from_statement(statement)
+        except (KeyError, IndexError, TypeError) as exc:
+            errors.append(f"run binding cannot be derived: malformed statement: {exc}")
 
     payloads: list[dict[str, Any]] = []
     for idx, record in enumerate(records):
@@ -195,11 +177,14 @@ def validate(statement: dict[str, Any]) -> list[str]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("statement", type=Path, help="AEE spike statement JSON to check")
+    parser.add_argument("statement", choices=sorted(STATEMENT_PATHS), help="Named emitted fixture statement to check")
     parser.add_argument("--expect-invalid", action="store_true", help="Exit 0 only when validation fails")
     args = parser.parse_args()
 
-    errors = validate(read_json(args.statement, base_dir=FIXTURES))
+    try:
+        errors = validate(read_statement_fixture(args.statement))
+    except Exception as exc:  # noqa: BLE001 - malformed fixture input is invalid, not a traceback.
+        errors = [f"malformed statement: {exc}"]
     if args.expect_invalid:
         if errors:
             print(f"invalid as expected: {args.statement}")

--- a/scripts/experiments/aee_spike_check.py
+++ b/scripts/experiments/aee_spike_check.py
@@ -131,9 +131,21 @@ def validate(statement: dict[str, Any]) -> list[str]:
                     errors.append(f"sealed record {idx} is not still armed")
                 if payload.get("aeeDropCount") != 0 or payload.get("aeeDropBound") != 0:
                     errors.append(f"sealed record {idx} has non-zero or inconsistent drop accounting")
-                observed_set = sorted({row.get("containmentObserved") for row in rows if row.get("containmentObserved") in set(vocab.get("caught", []))})
+                caught_labels = set(vocab.get("caught", []))
+                observed_set = sorted({
+                    row.get("containmentObserved")
+                    for row in rows
+                    if row.get("containmentObserved") in caught_labels
+                })
                 if payload.get("aeeObservedSet") != observed_set:
                     errors.append(f"sealed record {idx} aeeObservedSet mismatch")
+                observed_attacks = sorted({
+                    row.get("attackId")
+                    for row in rows
+                    if row.get("containmentObserved") in caught_labels
+                })
+                if payload.get("aeeObservedAttacks") != observed_attacks:
+                    errors.append(f"sealed record {idx} aeeObservedAttacks mismatch")
             if payload.get("aeeMethod") not in VALID_METHOD and kind != "arming":
                 errors.append(f"record {idx} has invalid aeeMethod")
 

--- a/scripts/experiments/aee_spike_check.py
+++ b/scripts/experiments/aee_spike_check.py
@@ -9,65 +9,23 @@ constraints, substrate coverage, and the known negative controls.
 from __future__ import annotations
 
 import argparse
-import base64
-import hashlib
-import hmac
-import json
 from pathlib import Path
 from typing import Any
 
-AEE_PREDICATE_TYPE = "https://in-toto.io/attestation/adversarial-execution-evidence/v0.7"
-PAYLOAD_TYPE = "application/vnd.assay.aee-spike.observation.v0+json"
-FIXTURE_KEY_ID = "assay-aee-spike-fixture-key-v0"
-FIXTURE_KEY = b"assay-aee-spike-fixture-key-v0-not-production"
-VALID_RESULTS = ["fail", "degraded", "pass_indirect", "pass"]
-VALID_BASIS = {"substrate", "artifact"}
-VALID_METHOD = {"intercepted", "reconstructed"}
-VALID_ATTRIBUTION = {"pinned", "paired"}
-COVERING_KINDS = {"interception", "arming", "sealed", "examination"}
-
-
-def canonical_bytes(value: Any) -> bytes:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-
-
-def digest_json(value: Any) -> str:
-    return hashlib.sha256(canonical_bytes(value)).hexdigest()
-
-
-def dsse_pae(payload_type: str, payload: bytes) -> bytes:
-    return b"DSSEv1 " + str(len(payload_type)).encode("ascii") + b" " + payload_type.encode("utf-8") + b" " + str(len(payload)).encode("ascii") + b" " + payload
-
-
-def sign_payload(payload_type: str, payload: bytes) -> str:
-    return base64.b64encode(hmac.new(FIXTURE_KEY, dsse_pae(payload_type, payload), hashlib.sha256).digest()).decode("ascii")
-
-
-def merkle_root(leaves: list[dict[str, Any]]) -> str:
-    if not leaves:
-        return ""
-    layer = [hashlib.sha256(b"\x00" + canonical_bytes(leaf)).digest() for leaf in leaves]
-    while len(layer) > 1:
-        next_layer: list[bytes] = []
-        for idx in range(0, len(layer), 2):
-            if idx + 1 == len(layer):
-                next_layer.append(layer[idx])
-            else:
-                next_layer.append(hashlib.sha256(b"\x01" + layer[idx] + layer[idx + 1]).digest())
-        layer = next_layer
-    return layer[0].hex()
-
-
-def load_statement(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def decode_record(record: dict[str, Any]) -> tuple[dict[str, Any], bytes]:
-    payload_bytes = base64.b64decode(record["payload"])
-    payload = json.loads(payload_bytes.decode("utf-8"))
-    return payload, payload_bytes
-
+from aee_spike_lib import (
+    AEE_PREDICATE_TYPE,
+    COVERING_KINDS,
+    FIXTURE_KEY_ID,
+    PAYLOAD_TYPE,
+    VALID_ATTRIBUTION,
+    VALID_BASIS,
+    VALID_METHOD,
+    decode_record,
+    digest_json,
+    merkle_root,
+    read_json,
+    sign_payload,
+)
 
 def recompute_run_binding(statement: dict[str, Any]) -> str:
     subject = statement["subject"][0]
@@ -223,7 +181,7 @@ def main() -> int:
     parser.add_argument("--expect-invalid", action="store_true", help="Exit 0 only when validation fails")
     args = parser.parse_args()
 
-    errors = validate(load_statement(args.statement))
+    errors = validate(read_json(args.statement))
     if args.expect_invalid:
         if errors:
             print(f"invalid as expected: {args.statement}")

--- a/scripts/experiments/aee_spike_check.py
+++ b/scripts/experiments/aee_spike_check.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Any
 
 from aee_spike_lib import (
     AEE_PREDICATE_TYPE,
@@ -169,8 +168,11 @@ def validate(statement: dict[str, Any]) -> list[str]:
         if payload.get("aeeKind") == "interception" and idx not in referenced_interceptions:
             errors.append(f"interception record {idx} is not resolved by a caught row")
 
-    if predicate.get("_ext", {}).get("assaySpike", {}).get("invalidClaim") == "no sibling runs existed":
+    invalid_claim = predicate.get("_ext", {}).get("assaySpike", {}).get("invalidClaim")
+    if invalid_claim == "no sibling runs existed":
         errors.append("run population overclaim: AEE/Assay spike must not claim no sibling runs existed")
+    elif invalid_claim == "artifact-produced observation overclaimed as substrate":
+        errors.append("artifact/proxy observation overclaim: substrate basis requires substrate coverage")
 
     return errors
 

--- a/scripts/experiments/aee_spike_emit.py
+++ b/scripts/experiments/aee_spike_emit.py
@@ -10,87 +10,26 @@ carriers do not emit an AEE-compatible substrate-signed sealed record.
 from __future__ import annotations
 
 import argparse
-import base64
 import copy
-import hashlib
-import hmac
-import json
 from pathlib import Path
 from typing import Any
 
-AEE_PR_HEAD = "c0c4da67defdf0f186f162e7ecb3f9527b6a94f8"
-AEE_SPEC_SHA256 = "fda0f5f7885d56feb93194cfa604f57c060c12677f77fa5579888b15dc1d1a2d"
-AEE_PREDICATE_TYPE = "https://in-toto.io/attestation/adversarial-execution-evidence/v0.7"
-AEE_VERSION = "0.7"
-PAYLOAD_TYPE = "application/vnd.assay.aee-spike.observation.v0+json"
-FIXTURE_KEY_ID = "assay-aee-spike-fixture-key-v0"
-FIXTURE_KEY = b"assay-aee-spike-fixture-key-v0-not-production"
+from aee_spike_lib import (
+    AEE_PR_HEAD,
+    AEE_SPEC_SHA256,
+    AEE_PREDICATE_TYPE,
+    AEE_VERSION,
+    decode_payload,
+    digest_json,
+    merkle_root,
+    observation_record,
+    read_json,
+    write_json,
+)
 
 ROOT = Path(__file__).resolve().parent
 FIXTURES = ROOT / "fixtures" / "aee"
 DEFAULT_OUT = ROOT / "fixtures" / "aee" / "statement-valid.json"
-
-
-def canonical_bytes(value: Any) -> bytes:
-    """Return deterministic JSON bytes close to the JCS shape used by AEE.
-
-    The fixture uses ASCII-only member names/values and safe integers. This is
-    not a general RFC 8785 implementation; the checker keeps the same helper so
-    the spike has one rule in one function rather than parallel approximations.
-    """
-
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-
-
-def sha256_hex_bytes(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
-
-
-def digest_json(value: Any) -> str:
-    return sha256_hex_bytes(canonical_bytes(value))
-
-
-def read_json(path: Path) -> Any:
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def dsse_pae(payload_type: str, payload: bytes) -> bytes:
-    return b"DSSEv1 " + str(len(payload_type)).encode("ascii") + b" " + payload_type.encode("utf-8") + b" " + str(len(payload)).encode("ascii") + b" " + payload
-
-
-def sign_payload(payload_type: str, payload: bytes) -> str:
-    """Deterministic fixture-only signature, not a production DSSE algorithm."""
-
-    return base64.b64encode(hmac.new(FIXTURE_KEY, dsse_pae(payload_type, payload), hashlib.sha256).digest()).decode("ascii")
-
-
-def observation_record(payload: dict[str, Any], seq: int) -> dict[str, Any]:
-    payload_bytes = canonical_bytes(payload)
-    return {
-        "payload": base64.b64encode(payload_bytes).decode("ascii"),
-        "payloadType": PAYLOAD_TYPE,
-        "signatures": [{"keyid": FIXTURE_KEY_ID, "sig": sign_payload(PAYLOAD_TYPE, payload_bytes)}],
-        "seq": seq,
-    }
-
-
-def merkle_root(leaves: list[dict[str, Any]]) -> str:
-    """RFC6962-style SHA-256 Merkle root over canonical observation records."""
-
-    if not leaves:
-        return ""
-    layer = [hashlib.sha256(b"\x00" + canonical_bytes(leaf)).digest() for leaf in leaves]
-    while len(layer) > 1:
-        next_layer: list[bytes] = []
-        for idx in range(0, len(layer), 2):
-            if idx + 1 == len(layer):
-                next_layer.append(layer[idx])
-            else:
-                next_layer.append(hashlib.sha256(b"\x01" + layer[idx] + layer[idx + 1]).digest())
-        layer = next_layer
-    return layer[0].hex()
-
 
 def build_statement() -> dict[str, Any]:
     corpus_manifest = read_json(FIXTURES / "corpus-manifest.json")
@@ -299,11 +238,7 @@ def write_variant(path: Path, statement: dict[str, Any], variant: str) -> None:
         predicate["_ext"]["assaySpike"]["invalidClaim"] = "no sibling runs existed"
     else:
         raise ValueError(f"unknown variant: {variant}")
-    path.write_text(json.dumps(mutated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-
-def decode_payload(record: dict[str, Any]) -> dict[str, Any]:
-    return json.loads(base64.b64decode(record["payload"]).decode("utf-8"))
+    write_json(path, mutated)
 
 
 def main() -> int:
@@ -313,8 +248,7 @@ def main() -> int:
     args = parser.parse_args()
 
     statement = build_statement()
-    args.out.parent.mkdir(parents=True, exist_ok=True)
-    args.out.write_text(json.dumps(statement, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_json(args.out, statement)
 
     if args.variants:
         variants_dir = args.out.parent / "negative-controls"

--- a/scripts/experiments/aee_spike_emit.py
+++ b/scripts/experiments/aee_spike_emit.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import argparse
 import copy
-from pathlib import Path
 from typing import Any
 
 from aee_spike_lib import (
@@ -23,20 +22,27 @@ from aee_spike_lib import (
     digest_json,
     merkle_root,
     observation_record,
-    read_json,
-    write_json,
+    read_source_fixture,
+    run_binding_from_statement,
+    run_binding_input_from_statement,
+    write_statement_fixture,
 )
 
-ROOT = Path(__file__).resolve().parent
-FIXTURES = ROOT / "fixtures" / "aee"
-DEFAULT_OUT = ROOT / "fixtures" / "aee" / "statement-valid.json"
+VARIANT_NAMES = [
+    "missing-seal",
+    "defective-unreferenced-seal",
+    "artifact-labelled-substrate",
+    "reconstructed-priced-intercepted",
+    "run-population-overclaim",
+]
+
 
 def build_statement() -> dict[str, Any]:
-    corpus_manifest = read_json(FIXTURES / "corpus-manifest.json", base_dir=FIXTURES)
-    substrate_descriptor = read_json(FIXTURES / "substrate-descriptor.json", base_dir=FIXTURES)
-    catch_policy = read_json(FIXTURES / "catch-policy.json", base_dir=FIXTURES)
-    proxy_observation = read_json(FIXTURES / "proxy-deny-observation.json", base_dir=FIXTURES)
-    enforcement_health = read_json(FIXTURES / "enforcement-health-v1-active-probe.json", base_dir=FIXTURES)
+    corpus_manifest = read_source_fixture("corpus-manifest")
+    substrate_descriptor = read_source_fixture("substrate-descriptor")
+    catch_policy = read_source_fixture("catch-policy")
+    proxy_observation = read_source_fixture("proxy-deny-observation")
+    enforcement_health = read_source_fixture("enforcement-health-v1-active-probe")
 
     subject = {
         "name": "assay-aee-spike-fixture-subject",
@@ -70,17 +76,45 @@ def build_statement() -> dict[str, Any]:
         "manifest": corpus_manifest,
     }
 
-    run_binding_input = {
-        "aeeBindingVersion": "2",
-        "catchPolicy": catch_policy_descriptor["digest"]["sha256"],
-        "corpus": corpus["digest"]["sha256"],
-        "networkPosture": digest_json(network_posture),
-        "observationVocabulary": observation_vocabulary["digest"]["sha256"],
-        "runEntropy": run_entropy["digest"]["sha256"],
-        "subject": subject["digest"]["sha256"],
-        "substrate": substrate["digest"]["sha256"],
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [subject],
+        "predicateType": AEE_PREDICATE_TYPE,
+        "predicate": {
+            "result": "fail",
+            "observationEnvironment": {
+                "substrate": substrate,
+                "corpus": corpus,
+                "catchPolicy": catch_policy_descriptor,
+                "networkPosture": network_posture,
+                "observationVocabulary": observation_vocabulary,
+                "runEntropy": run_entropy,
+            },
+            "coverage": {"assessedClasses": ["MCP", "NET"], "outOfScope": {}, "routedElsewhere": {}},
+            "attackResults": [
+                {
+                    "attackId": "MCP-PROXY-DENY-001",
+                    "containmentObserved": "proxy_denied",
+                    "basis": "substrate",
+                    "method": "intercepted",
+                    "attribution": "pinned",
+                    "actualLayer": "proxy",
+                    "observationRefs": [0, 1, 2],
+                },
+                {
+                    "attackId": "NET-CONNECT-BLOCK-001",
+                    "containmentObserved": "connect_blocked",
+                    "basis": "substrate",
+                    "method": "intercepted",
+                    "attribution": "pinned",
+                    "actualLayer": "landlock",
+                    "observationRefs": [3, 1, 2],
+                },
+            ],
+        },
     }
-    run_binding = digest_json(run_binding_input)
+    run_binding_input = run_binding_input_from_statement(statement)
+    run_binding = run_binding_from_statement(statement)
 
     proxy_commitment = proxy_observation["caller_visible_response_digest"].removeprefix("sha256:")
     network_commitment = enforcement_health["probe"]["payload_commitment"].removeprefix("sha256:")
@@ -140,41 +174,8 @@ def build_statement() -> dict[str, Any]:
         observation_record(network_payload, 4),
     ]
 
-    statement = {
-        "_type": "https://in-toto.io/Statement/v1",
-        "subject": [subject],
-        "predicateType": AEE_PREDICATE_TYPE,
-        "predicate": {
-            "result": "fail",
-            "observationEnvironment": {
-                "substrate": substrate,
-                "corpus": corpus,
-                "catchPolicy": catch_policy_descriptor,
-                "networkPosture": network_posture,
-                "observationVocabulary": observation_vocabulary,
-                "runEntropy": run_entropy,
-            },
-            "coverage": {"assessedClasses": ["MCP", "NET"], "outOfScope": {}, "routedElsewhere": {}},
-            "attackResults": [
-                {
-                    "attackId": "MCP-PROXY-DENY-001",
-                    "containmentObserved": "proxy_denied",
-                    "basis": "substrate",
-                    "method": "intercepted",
-                    "attribution": "pinned",
-                    "actualLayer": "proxy",
-                    "observationRefs": [0, 1, 2],
-                },
-                {
-                    "attackId": "NET-CONNECT-BLOCK-001",
-                    "containmentObserved": "connect_blocked",
-                    "basis": "substrate",
-                    "method": "intercepted",
-                    "attribution": "pinned",
-                    "actualLayer": "landlock",
-                    "observationRefs": [3, 1, 2],
-                },
-            ],
+    statement["predicate"].update(
+        {
             "observationRecords": records,
             "batchRoot": merkle_root(records),
             "doesNotAssert": [
@@ -195,12 +196,12 @@ def build_statement() -> dict[str, Any]:
                     "nonProduction": True,
                 }
             },
-        },
-    }
+        }
+    )
     return statement
 
 
-def write_variant(path: Path, statement: dict[str, Any], variant: str) -> None:
+def write_variant(statement: dict[str, Any], variant: str) -> None:
     mutated = copy.deepcopy(statement)
     predicate = mutated["predicate"]
     if variant == "missing-seal":
@@ -252,33 +253,24 @@ def write_variant(path: Path, statement: dict[str, Any], variant: str) -> None:
         predicate["_ext"]["assaySpike"]["invalidClaim"] = "no sibling runs existed"
     else:
         raise ValueError(f"unknown variant: {variant}")
-    write_json(path, mutated, base_dir=FIXTURES)
+    write_statement_fixture(variant, mutated)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="Path for the valid emitted statement")
     parser.add_argument("--variants", action="store_true", help="Also emit intentionally invalid negative-control statements")
     args = parser.parse_args()
 
     statement = build_statement()
-    write_json(args.out, statement, base_dir=FIXTURES)
+    valid_path = write_statement_fixture("valid", statement)
 
     if args.variants:
-        variants_dir = args.out.parent / "negative-controls"
-        variants_dir.mkdir(parents=True, exist_ok=True)
-        for name in [
-            "missing-seal",
-            "defective-unreferenced-seal",
-            "artifact-labelled-substrate",
-            "reconstructed-priced-intercepted",
-            "run-population-overclaim",
-        ]:
-            write_variant(variants_dir / f"statement-{name}.json", statement, name)
+        for name in VARIANT_NAMES:
+            write_variant(statement, name)
 
-    print(f"wrote {args.out}")
+    print(f"wrote {valid_path}")
     if args.variants:
-        print(f"wrote negative controls under {args.out.parent / 'negative-controls'}")
+        print("wrote negative controls under scripts/experiments/fixtures/aee/negative-controls")
     return 0
 
 

--- a/scripts/experiments/aee_spike_emit.py
+++ b/scripts/experiments/aee_spike_emit.py
@@ -204,9 +204,17 @@ def write_variant(path: Path, statement: dict[str, Any], variant: str) -> None:
     mutated = copy.deepcopy(statement)
     predicate = mutated["predicate"]
     if variant == "missing-seal":
-        predicate["observationRecords"] = [r for r in predicate["observationRecords"] if decode_payload(r)["aeeKind"] != "sealed"]
-        for row in predicate["attackResults"]:
-            row["observationRefs"] = [idx for idx in row["observationRefs"] if idx != 2]
+        # Original records are [proxy, arming, sealed, network]. Drop only the
+        # seal and reindex the network interception so this negative control
+        # isolates the missing-seal failure instead of also creating an
+        # out-of-range reference.
+        predicate["observationRecords"] = [
+            predicate["observationRecords"][0],
+            predicate["observationRecords"][1],
+            predicate["observationRecords"][3],
+        ]
+        predicate["attackResults"][0]["observationRefs"] = [0, 1]
+        predicate["attackResults"][1]["observationRefs"] = [2, 1]
         predicate["batchRoot"] = merkle_root(predicate["observationRecords"])
     elif variant == "defective-unreferenced-seal":
         bad_payload = {
@@ -225,8 +233,14 @@ def write_variant(path: Path, statement: dict[str, Any], variant: str) -> None:
         predicate["observationRecords"].append(observation_record(bad_payload, 5))
         predicate["batchRoot"] = merkle_root(predicate["observationRecords"])
     elif variant == "artifact-labelled-substrate":
+        # The valid fixture row is already substrate-backed. To exercise the
+        # intended overclaim boundary, strip its substrate coverage and mark the
+        # producer-side claim being attempted: an artifact/proxy-produced
+        # observation being priced as substrate evidence.
         predicate["attackResults"][0]["basis"] = "substrate"
+        predicate["attackResults"][0]["method"] = "intercepted"
         predicate["attackResults"][0]["observationRefs"] = []
+        predicate["_ext"]["assaySpike"]["invalidClaim"] = "artifact-produced observation overclaimed as substrate"
     elif variant == "reconstructed-priced-intercepted":
         predicate["attackResults"][0]["method"] = "intercepted"
         payload = decode_payload(predicate["observationRecords"][0])

--- a/scripts/experiments/aee_spike_emit.py
+++ b/scripts/experiments/aee_spike_emit.py
@@ -32,11 +32,11 @@ FIXTURES = ROOT / "fixtures" / "aee"
 DEFAULT_OUT = ROOT / "fixtures" / "aee" / "statement-valid.json"
 
 def build_statement() -> dict[str, Any]:
-    corpus_manifest = read_json(FIXTURES / "corpus-manifest.json")
-    substrate_descriptor = read_json(FIXTURES / "substrate-descriptor.json")
-    catch_policy = read_json(FIXTURES / "catch-policy.json")
-    proxy_observation = read_json(FIXTURES / "proxy-deny-observation.json")
-    enforcement_health = read_json(FIXTURES / "enforcement-health-v1-active-probe.json")
+    corpus_manifest = read_json(FIXTURES / "corpus-manifest.json", base_dir=FIXTURES)
+    substrate_descriptor = read_json(FIXTURES / "substrate-descriptor.json", base_dir=FIXTURES)
+    catch_policy = read_json(FIXTURES / "catch-policy.json", base_dir=FIXTURES)
+    proxy_observation = read_json(FIXTURES / "proxy-deny-observation.json", base_dir=FIXTURES)
+    enforcement_health = read_json(FIXTURES / "enforcement-health-v1-active-probe.json", base_dir=FIXTURES)
 
     subject = {
         "name": "assay-aee-spike-fixture-subject",
@@ -252,7 +252,7 @@ def write_variant(path: Path, statement: dict[str, Any], variant: str) -> None:
         predicate["_ext"]["assaySpike"]["invalidClaim"] = "no sibling runs existed"
     else:
         raise ValueError(f"unknown variant: {variant}")
-    write_json(path, mutated)
+    write_json(path, mutated, base_dir=FIXTURES)
 
 
 def main() -> int:
@@ -262,7 +262,7 @@ def main() -> int:
     args = parser.parse_args()
 
     statement = build_statement()
-    write_json(args.out, statement)
+    write_json(args.out, statement, base_dir=FIXTURES)
 
     if args.variants:
         variants_dir = args.out.parent / "negative-controls"

--- a/scripts/experiments/aee_spike_emit.py
+++ b/scripts/experiments/aee_spike_emit.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Emit a fixture-only Assay -> AEE v0.7 spike statement.
+
+This script intentionally lives outside production crates. It tests the AEE
+field shape against Assay evidence carriers and makes the missing production
+primitive explicit: Assay can synthesize this fixture seal, but current Assay
+carriers do not emit an AEE-compatible substrate-signed sealed record.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import copy
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+AEE_PR_HEAD = "c0c4da67defdf0f186f162e7ecb3f9527b6a94f8"
+AEE_SPEC_SHA256 = "fda0f5f7885d56feb93194cfa604f57c060c12677f77fa5579888b15dc1d1a2d"
+AEE_PREDICATE_TYPE = "https://in-toto.io/attestation/adversarial-execution-evidence/v0.7"
+AEE_VERSION = "0.7"
+PAYLOAD_TYPE = "application/vnd.assay.aee-spike.observation.v0+json"
+FIXTURE_KEY_ID = "assay-aee-spike-fixture-key-v0"
+FIXTURE_KEY = b"assay-aee-spike-fixture-key-v0-not-production"
+
+ROOT = Path(__file__).resolve().parent
+FIXTURES = ROOT / "fixtures" / "aee"
+DEFAULT_OUT = ROOT / "fixtures" / "aee" / "statement-valid.json"
+
+
+def canonical_bytes(value: Any) -> bytes:
+    """Return deterministic JSON bytes close to the JCS shape used by AEE.
+
+    The fixture uses ASCII-only member names/values and safe integers. This is
+    not a general RFC 8785 implementation; the checker keeps the same helper so
+    the spike has one rule in one function rather than parallel approximations.
+    """
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_hex_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def digest_json(value: Any) -> str:
+    return sha256_hex_bytes(canonical_bytes(value))
+
+
+def read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def dsse_pae(payload_type: str, payload: bytes) -> bytes:
+    return b"DSSEv1 " + str(len(payload_type)).encode("ascii") + b" " + payload_type.encode("utf-8") + b" " + str(len(payload)).encode("ascii") + b" " + payload
+
+
+def sign_payload(payload_type: str, payload: bytes) -> str:
+    """Deterministic fixture-only signature, not a production DSSE algorithm."""
+
+    return base64.b64encode(hmac.new(FIXTURE_KEY, dsse_pae(payload_type, payload), hashlib.sha256).digest()).decode("ascii")
+
+
+def observation_record(payload: dict[str, Any], seq: int) -> dict[str, Any]:
+    payload_bytes = canonical_bytes(payload)
+    return {
+        "payload": base64.b64encode(payload_bytes).decode("ascii"),
+        "payloadType": PAYLOAD_TYPE,
+        "signatures": [{"keyid": FIXTURE_KEY_ID, "sig": sign_payload(PAYLOAD_TYPE, payload_bytes)}],
+        "seq": seq,
+    }
+
+
+def merkle_root(leaves: list[dict[str, Any]]) -> str:
+    """RFC6962-style SHA-256 Merkle root over canonical observation records."""
+
+    if not leaves:
+        return ""
+    layer = [hashlib.sha256(b"\x00" + canonical_bytes(leaf)).digest() for leaf in leaves]
+    while len(layer) > 1:
+        next_layer: list[bytes] = []
+        for idx in range(0, len(layer), 2):
+            if idx + 1 == len(layer):
+                next_layer.append(layer[idx])
+            else:
+                next_layer.append(hashlib.sha256(b"\x01" + layer[idx] + layer[idx + 1]).digest())
+        layer = next_layer
+    return layer[0].hex()
+
+
+def build_statement() -> dict[str, Any]:
+    corpus_manifest = read_json(FIXTURES / "corpus-manifest.json")
+    substrate_descriptor = read_json(FIXTURES / "substrate-descriptor.json")
+    catch_policy = read_json(FIXTURES / "catch-policy.json")
+    proxy_observation = read_json(FIXTURES / "proxy-deny-observation.json")
+    enforcement_health = read_json(FIXTURES / "enforcement-health-v1-active-probe.json")
+
+    subject = {
+        "name": "assay-aee-spike-fixture-subject",
+        "digest": {"sha256": digest_json({"fixture": "assay-aee-spike-subject", "version": 1})},
+    }
+    substrate = {
+        "name": "assay-runtime-substrate-spike",
+        "digest": {"sha256": digest_json(substrate_descriptor)},
+    }
+    catch_policy_descriptor = {
+        "name": "assay-aee-spike-catch-policy",
+        "digest": {"sha256": digest_json(catch_policy)},
+    }
+    network_posture = {
+        "posture": "sinkhole",
+        "digest": {"sha256": digest_json({"landlock": enforcement_health["landlock"], "scope": enforcement_health["scope"]})},
+    }
+    observation_vocabulary = {
+        "labels": ["connect_blocked", "no_connect_block", "no_proxy_denial", "proxy_denied"],
+        "caught": ["connect_blocked", "proxy_denied"],
+    }
+    observation_vocabulary["digest"] = {"sha256": digest_json({"caught": observation_vocabulary["caught"], "labels": observation_vocabulary["labels"]})}
+    run_entropy = {
+        "digest": {"sha256": digest_json({"fixtureRun": "assay-aee-spike-2026-08-04T00:00:00Z", "operator": "assay-spike-fixture"})}
+    }
+
+    corpus = {
+        "name": "assay-aee-spike-corpus",
+        "uri": "pkg:assay/aee-spike-corpus@2026-08-04",
+        "digest": {"sha256": digest_json(corpus_manifest)},
+        "manifest": corpus_manifest,
+    }
+
+    run_binding_input = {
+        "aeeBindingVersion": "2",
+        "catchPolicy": catch_policy_descriptor["digest"]["sha256"],
+        "corpus": corpus["digest"]["sha256"],
+        "networkPosture": digest_json(network_posture),
+        "observationVocabulary": observation_vocabulary["digest"]["sha256"],
+        "runEntropy": run_entropy["digest"]["sha256"],
+        "subject": subject["digest"]["sha256"],
+        "substrate": substrate["digest"]["sha256"],
+    }
+    run_binding = digest_json(run_binding_input)
+
+    proxy_commitment = proxy_observation["caller_visible_response_digest"].removeprefix("sha256:")
+    network_commitment = enforcement_health["probe"]["payload_commitment"].removeprefix("sha256:")
+
+    arming_payload = {
+        "aeeKind": "arming",
+        "aeeVersion": AEE_VERSION,
+        "aeeBindingVersion": "2",
+        "aeeRunBinding": run_binding,
+        "armedAt": "2026-08-04T00:00:00Z",
+        "aeePostureDigest": network_posture["digest"]["sha256"],
+        "aeeAssessedAttacks": ["MCP-PROXY-DENY-001", "NET-CONNECT-BLOCK-001"],
+        "aeeChainScope": ["subject", "substrate"],
+        "fixtureSource": "synthetic arming record; not emitted by production Assay",
+    }
+    proxy_payload = {
+        "aeeKind": "interception",
+        "aeeVersion": AEE_VERSION,
+        "aeeRunBinding": run_binding,
+        "aeeMethod": "intercepted",
+        "aeePayloadCommitment": proxy_commitment,
+        "layer": "proxy",
+        "schema": proxy_observation["schema"],
+        "fixtureSource": "derived from assay.denied_call_observation.v0 fixture",
+    }
+    network_payload = {
+        "aeeKind": "interception",
+        "aeeVersion": AEE_VERSION,
+        "aeeRunBinding": run_binding,
+        "aeeMethod": "intercepted",
+        "aeePayloadCommitment": network_commitment,
+        "layer": "landlock",
+        "schema": f"{enforcement_health['schema']}.probe",
+        "fixtureSource": "derived from assay.enforcement_health.v1 active probe fixture",
+    }
+
+    # The seal's aeeObservedSet is computed over the carried interception labels
+    # and attacks. It is a fixture stand-in for the production primitive Assay lacks.
+    sealed_payload = {
+        "aeeKind": "sealed",
+        "aeeVersion": AEE_VERSION,
+        "aeeRunBinding": run_binding,
+        "aeeMethod": "intercepted",
+        "aeePostureDigest": network_posture["digest"]["sha256"],
+        "aeeStillArmed": True,
+        "aeeDropCount": 0,
+        "aeeDropBound": 0,
+        "aeeObservedSet": ["connect_blocked", "proxy_denied"],
+        "aeeObservedAttacks": ["MCP-PROXY-DENY-001", "NET-CONNECT-BLOCK-001"],
+        "fixtureSource": "synthetic sealed record; current Assay does not emit this production primitive",
+    }
+
+    records = [
+        observation_record(proxy_payload, 1),
+        observation_record(arming_payload, 2),
+        observation_record(sealed_payload, 3),
+        observation_record(network_payload, 4),
+    ]
+
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [subject],
+        "predicateType": AEE_PREDICATE_TYPE,
+        "predicate": {
+            "result": "fail",
+            "observationEnvironment": {
+                "substrate": substrate,
+                "corpus": corpus,
+                "catchPolicy": catch_policy_descriptor,
+                "networkPosture": network_posture,
+                "observationVocabulary": observation_vocabulary,
+                "runEntropy": run_entropy,
+            },
+            "coverage": {"assessedClasses": ["MCP", "NET"], "outOfScope": {}, "routedElsewhere": {}},
+            "attackResults": [
+                {
+                    "attackId": "MCP-PROXY-DENY-001",
+                    "containmentObserved": "proxy_denied",
+                    "basis": "substrate",
+                    "method": "intercepted",
+                    "attribution": "pinned",
+                    "actualLayer": "proxy",
+                    "observationRefs": [0, 1, 2],
+                },
+                {
+                    "attackId": "NET-CONNECT-BLOCK-001",
+                    "containmentObserved": "connect_blocked",
+                    "basis": "substrate",
+                    "method": "intercepted",
+                    "attribution": "pinned",
+                    "actualLayer": "landlock",
+                    "observationRefs": [3, 1, 2],
+                },
+            ],
+            "observationRecords": records,
+            "batchRoot": merkle_root(records),
+            "doesNotAssert": [
+                "production AEE support",
+                "stable AEE support before in-toto predicate acceptance",
+                "complete run population",
+                "agent safety",
+                "independent substrate operation when one fixture key signs both paths",
+                "that production Assay emits substrate-signed sealed records",
+                "that ProtoJSON or generated bindings are canonical evidence",
+            ],
+            "issuedAt": "2026-08-04T00:00:00Z",
+            "_ext": {
+                "assaySpike": {
+                    "aeePrHead": AEE_PR_HEAD,
+                    "aeeSpecSha256": AEE_SPEC_SHA256,
+                    "runBindingInput": run_binding_input,
+                    "nonProduction": True,
+                }
+            },
+        },
+    }
+    return statement
+
+
+def write_variant(path: Path, statement: dict[str, Any], variant: str) -> None:
+    mutated = copy.deepcopy(statement)
+    predicate = mutated["predicate"]
+    if variant == "missing-seal":
+        predicate["observationRecords"] = [r for r in predicate["observationRecords"] if decode_payload(r)["aeeKind"] != "sealed"]
+        for row in predicate["attackResults"]:
+            row["observationRefs"] = [idx for idx in row["observationRefs"] if idx != 2]
+        predicate["batchRoot"] = merkle_root(predicate["observationRecords"])
+    elif variant == "defective-unreferenced-seal":
+        bad_payload = {
+            "aeeKind": "sealed",
+            "aeeVersion": AEE_VERSION,
+            "aeeRunBinding": predicate["_ext"]["assaySpike"]["runBindingInput"]["subject"],
+            "aeeMethod": "intercepted",
+            "aeePostureDigest": "0" * 64,
+            "aeeStillArmed": False,
+            "aeeDropCount": 1,
+            "aeeDropBound": 0,
+            "aeeObservedSet": ["proxy_denied"],
+            "aeeObservedAttacks": ["MCP-PROXY-DENY-001"],
+            "fixtureSource": "intentionally defective unreferenced seal",
+        }
+        predicate["observationRecords"].append(observation_record(bad_payload, 5))
+        predicate["batchRoot"] = merkle_root(predicate["observationRecords"])
+    elif variant == "artifact-labelled-substrate":
+        predicate["attackResults"][0]["basis"] = "substrate"
+        predicate["attackResults"][0]["observationRefs"] = []
+    elif variant == "reconstructed-priced-intercepted":
+        predicate["attackResults"][0]["method"] = "intercepted"
+        payload = decode_payload(predicate["observationRecords"][0])
+        payload["aeeMethod"] = "reconstructed"
+        predicate["observationRecords"][0] = observation_record(payload, 1)
+        predicate["batchRoot"] = merkle_root(predicate["observationRecords"])
+    elif variant == "run-population-overclaim":
+        predicate["doesNotAssert"] = [claim for claim in predicate["doesNotAssert"] if claim != "complete run population"]
+        predicate["_ext"]["assaySpike"]["invalidClaim"] = "no sibling runs existed"
+    else:
+        raise ValueError(f"unknown variant: {variant}")
+    path.write_text(json.dumps(mutated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def decode_payload(record: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(base64.b64decode(record["payload"]).decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="Path for the valid emitted statement")
+    parser.add_argument("--variants", action="store_true", help="Also emit intentionally invalid negative-control statements")
+    args = parser.parse_args()
+
+    statement = build_statement()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(statement, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.variants:
+        variants_dir = args.out.parent / "negative-controls"
+        variants_dir.mkdir(parents=True, exist_ok=True)
+        for name in [
+            "missing-seal",
+            "defective-unreferenced-seal",
+            "artifact-labelled-substrate",
+            "reconstructed-priced-intercepted",
+            "run-population-overclaim",
+        ]:
+            write_variant(variants_dir / f"statement-{name}.json", statement, name)
+
+    print(f"wrote {args.out}")
+    if args.variants:
+        print(f"wrote negative controls under {args.out.parent / 'negative-controls'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/aee_spike_lib.py
+++ b/scripts/experiments/aee_spike_lib.py
@@ -45,18 +45,35 @@ def digest_json(value: Any) -> str:
     return hashlib.sha256(canonical_bytes(value)).hexdigest()
 
 
-def read_json(path: Path) -> Any:
-    with path.open("r", encoding="utf-8") as handle:
+def _resolve_under(path: Path, *, base_dir: Path | None) -> Path:
+    """Resolve a fixture path and optionally require it to stay under base_dir."""
+
+    resolved = path.resolve()
+    if base_dir is None:
+        return resolved
+    base = base_dir.resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"path must stay under {base}") from exc
+    return resolved
+
+
+def read_json(path: Path, *, base_dir: Path | None = None) -> Any:
+    resolved = _resolve_under(path, base_dir=base_dir)
+    with resolved.open("r", encoding="utf-8") as handle:
         return json.load(handle)
 
 
-def write_json(path: Path, value: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+def write_json(path: Path, value: Any, *, base_dir: Path | None = None) -> None:
+    resolved = _resolve_under(path, base_dir=base_dir)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def dsse_pae(payload_type: str, payload: bytes) -> bytes:
-    return b"DSSEv1 " + str(len(payload_type)).encode("ascii") + b" " + payload_type.encode("utf-8") + b" " + str(len(payload)).encode("ascii") + b" " + payload
+    payload_type_bytes = payload_type.encode("utf-8")
+    return b"DSSEv1 " + str(len(payload_type_bytes)).encode("ascii") + b" " + payload_type_bytes + b" " + str(len(payload)).encode("ascii") + b" " + payload
 
 
 def sign_payload(payload_type: str, payload: bytes) -> str:

--- a/scripts/experiments/aee_spike_lib.py
+++ b/scripts/experiments/aee_spike_lib.py
@@ -1,0 +1,107 @@
+"""Shared helpers for the fixture-only Assay -> AEE v0.7 spike.
+
+This module is intentionally narrow. It is not a general AEE verifier or a
+production signing library; it keeps the experiment's deterministic JSON,
+fixture signature, and RFC6962-style Merkle rules in one place so the emitter
+and checker cannot drift.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+AEE_PR_HEAD = "c0c4da67defdf0f186f162e7ecb3f9527b6a94f8"
+AEE_SPEC_SHA256 = "fda0f5f7885d56feb93194cfa604f57c060c12677f77fa5579888b15dc1d1a2d"
+AEE_PREDICATE_TYPE = "https://in-toto.io/attestation/adversarial-execution-evidence/v0.7"
+AEE_VERSION = "0.7"
+PAYLOAD_TYPE = "application/vnd.assay.aee-spike.observation.v0+json"
+FIXTURE_KEY_ID = "assay-aee-spike-fixture-key-v0"
+FIXTURE_KEY = b"assay-aee-spike-fixture-key-v0-not-production"
+
+VALID_RESULTS = ["fail", "degraded", "pass_indirect", "pass"]
+VALID_BASIS = {"substrate", "artifact"}
+VALID_METHOD = {"intercepted", "reconstructed"}
+VALID_ATTRIBUTION = {"pinned", "paired"}
+COVERING_KINDS = {"interception", "arming", "sealed", "examination"}
+
+
+def canonical_bytes(value: Any) -> bytes:
+    """Return deterministic JSON bytes close to the JCS shape used by AEE.
+
+    The fixture uses ASCII-only member names/values and safe integers. This is
+    not a general RFC 8785 implementation; the experiment keeps this single
+    helper as the shared rule for all local digests and fixture signatures.
+    """
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def digest_json(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def dsse_pae(payload_type: str, payload: bytes) -> bytes:
+    return b"DSSEv1 " + str(len(payload_type)).encode("ascii") + b" " + payload_type.encode("utf-8") + b" " + str(len(payload)).encode("ascii") + b" " + payload
+
+
+def sign_payload(payload_type: str, payload: bytes) -> str:
+    """Return a deterministic fixture-only signature.
+
+    This is intentionally HMAC over DSSE PAE so the fixture is self-contained in
+    Python's standard library. It is not a production DSSE signature algorithm.
+    """
+
+    return base64.b64encode(hmac.new(FIXTURE_KEY, dsse_pae(payload_type, payload), hashlib.sha256).digest()).decode("ascii")
+
+
+def observation_record(payload: dict[str, Any], seq: int) -> dict[str, Any]:
+    payload_bytes = canonical_bytes(payload)
+    return {
+        "payload": base64.b64encode(payload_bytes).decode("ascii"),
+        "payloadType": PAYLOAD_TYPE,
+        "signatures": [{"keyid": FIXTURE_KEY_ID, "sig": sign_payload(PAYLOAD_TYPE, payload_bytes)}],
+        "seq": seq,
+    }
+
+
+def decode_record(record: dict[str, Any]) -> tuple[dict[str, Any], bytes]:
+    payload_bytes = base64.b64decode(record["payload"])
+    payload = json.loads(payload_bytes.decode("utf-8"))
+    return payload, payload_bytes
+
+
+def decode_payload(record: dict[str, Any]) -> dict[str, Any]:
+    payload, _ = decode_record(record)
+    return payload
+
+
+def merkle_root(leaves: list[dict[str, Any]]) -> str:
+    """RFC6962-style SHA-256 Merkle root over canonical observation records."""
+
+    if not leaves:
+        return ""
+    layer = [hashlib.sha256(b"\x00" + canonical_bytes(leaf)).digest() for leaf in leaves]
+    while len(layer) > 1:
+        next_layer: list[bytes] = []
+        for idx in range(0, len(layer), 2):
+            if idx + 1 == len(layer):
+                next_layer.append(layer[idx])
+            else:
+                next_layer.append(hashlib.sha256(b"\x01" + layer[idx] + layer[idx + 1]).digest())
+        layer = next_layer
+    return layer[0].hex()

--- a/scripts/experiments/aee_spike_lib.py
+++ b/scripts/experiments/aee_spike_lib.py
@@ -2,8 +2,8 @@
 
 This module is intentionally narrow. It is not a general AEE verifier or a
 production signing library; it keeps the experiment's deterministic JSON,
-fixture signature, and RFC6962-style Merkle rules in one place so the emitter
-and checker cannot drift.
+fixture signature, run-binding, and RFC6962-style Merkle rules in one place so
+emitter and checker cannot drift.
 """
 
 from __future__ import annotations
@@ -29,6 +29,27 @@ VALID_METHOD = {"intercepted", "reconstructed"}
 VALID_ATTRIBUTION = {"pinned", "paired"}
 COVERING_KINDS = {"interception", "arming", "sealed", "examination"}
 
+EXPERIMENT_ROOT = Path(__file__).resolve().parent
+FIXTURES = EXPERIMENT_ROOT / "fixtures" / "aee"
+NEGATIVE_CONTROLS = FIXTURES / "negative-controls"
+
+SOURCE_FIXTURE_PATHS = {
+    "catch-policy": FIXTURES / "catch-policy.json",
+    "corpus-manifest": FIXTURES / "corpus-manifest.json",
+    "enforcement-health-v1-active-probe": FIXTURES / "enforcement-health-v1-active-probe.json",
+    "proxy-deny-observation": FIXTURES / "proxy-deny-observation.json",
+    "substrate-descriptor": FIXTURES / "substrate-descriptor.json",
+}
+
+STATEMENT_PATHS = {
+    "valid": FIXTURES / "statement-valid.json",
+    "artifact-labelled-substrate": NEGATIVE_CONTROLS / "statement-artifact-labelled-substrate.json",
+    "defective-unreferenced-seal": NEGATIVE_CONTROLS / "statement-defective-unreferenced-seal.json",
+    "missing-seal": NEGATIVE_CONTROLS / "statement-missing-seal.json",
+    "reconstructed-priced-intercepted": NEGATIVE_CONTROLS / "statement-reconstructed-priced-intercepted.json",
+    "run-population-overclaim": NEGATIVE_CONTROLS / "statement-run-population-overclaim.json",
+}
+
 
 def canonical_bytes(value: Any) -> bytes:
     """Return deterministic JSON bytes close to the JCS shape used by AEE.
@@ -45,30 +66,24 @@ def digest_json(value: Any) -> str:
     return hashlib.sha256(canonical_bytes(value)).hexdigest()
 
 
-def _resolve_under(path: Path, *, base_dir: Path | None) -> Path:
-    """Resolve a fixture path and optionally require it to stay under base_dir."""
-
-    resolved = path.resolve()
-    if base_dir is None:
-        return resolved
-    base = base_dir.resolve()
-    try:
-        resolved.relative_to(base)
-    except ValueError as exc:
-        raise ValueError(f"path must stay under {base}") from exc
-    return resolved
+def read_source_fixture(name: str) -> Any:
+    return _read_known_json(SOURCE_FIXTURE_PATHS[name])
 
 
-def read_json(path: Path, *, base_dir: Path | None = None) -> Any:
-    resolved = _resolve_under(path, base_dir=base_dir)
-    with resolved.open("r", encoding="utf-8") as handle:
+def read_statement_fixture(name: str) -> Any:
+    return _read_known_json(STATEMENT_PATHS[name])
+
+
+def write_statement_fixture(name: str, value: Any) -> Path:
+    path = STATEMENT_PATHS[name]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_known_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
-
-
-def write_json(path: Path, value: Any, *, base_dir: Path | None = None) -> None:
-    resolved = _resolve_under(path, base_dir=base_dir)
-    resolved.parent.mkdir(parents=True, exist_ok=True)
-    resolved.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def dsse_pae(payload_type: str, payload: bytes) -> bytes:
@@ -122,3 +137,23 @@ def merkle_root(leaves: list[dict[str, Any]]) -> str:
                 next_layer.append(hashlib.sha256(b"\x01" + layer[idx] + layer[idx + 1]).digest())
         layer = next_layer
     return layer[0].hex()
+
+
+def run_binding_input_from_statement(statement: dict[str, Any]) -> dict[str, str]:
+    subject = statement["subject"][0]
+    env = statement["predicate"]["observationEnvironment"]
+    network_posture = env["networkPosture"]
+    return {
+        "aeeBindingVersion": "2",
+        "catchPolicy": env["catchPolicy"]["digest"]["sha256"],
+        "corpus": env["corpus"]["digest"]["sha256"],
+        "networkPosture": digest_json(network_posture),
+        "observationVocabulary": env["observationVocabulary"]["digest"]["sha256"],
+        "runEntropy": env["runEntropy"]["digest"]["sha256"],
+        "subject": subject["digest"]["sha256"],
+        "substrate": env["substrate"]["digest"]["sha256"],
+    }
+
+
+def run_binding_from_statement(statement: dict[str, Any]) -> str:
+    return digest_json(run_binding_input_from_statement(statement))

--- a/scripts/experiments/fixtures/aee/catch-policy.json
+++ b/scripts/experiments/fixtures/aee/catch-policy.json
@@ -1,0 +1,19 @@
+{
+  "schema": "assay.aee_spike.catch_policy.v0",
+  "domains": {
+    "proxy_deny_tool_call": {
+      "tool": "github.add_deploy_key",
+      "decision": "deny",
+      "reason": "fixture policy denies privileged deploy-key creation"
+    },
+    "network_connect_block": {
+      "mechanism": "landlock",
+      "scope": "tcp_connect_landlock_port",
+      "blockedPort": 443
+    }
+  },
+  "nonClaims": [
+    "not an Assay production policy format",
+    "not a stable AEE policy vocabulary"
+  ]
+}

--- a/scripts/experiments/fixtures/aee/corpus-manifest.json
+++ b/scripts/experiments/fixtures/aee/corpus-manifest.json
@@ -1,0 +1,10 @@
+{
+  "classes": {
+    "MCP": ["MCP-PROXY-DENY-001"],
+    "NET": ["NET-CONNECT-BLOCK-001"]
+  },
+  "expectedPayloads": {
+    "MCP-PROXY-DENY-001": ["2f8d481ee9191e503eb4837b8c048f8be196b9884a2b33aa01850a7018e54bc7"],
+    "NET-CONNECT-BLOCK-001": ["6d7cd7972edaa93427805b63e1836aabedbceec4e80b90b89389ff69853c9c15"]
+  }
+}

--- a/scripts/experiments/fixtures/aee/enforcement-health-v1-active-probe.json
+++ b/scripts/experiments/fixtures/aee/enforcement-health-v1-active-probe.json
@@ -1,0 +1,27 @@
+{
+  "schema": "assay.enforcement_health.v1",
+  "status": "active",
+  "mechanism": "landlock",
+  "scope": "tcp_connect_landlock_port",
+  "policy_semantics": {
+    "default": "deny",
+    "allowed": []
+  },
+  "failure": null,
+  "landlock": {
+    "abi": 6,
+    "restrict_self_confirmed": true,
+    "ruleset_applied": true
+  },
+  "probe": {
+    "kind": "tcp_connect_block",
+    "target": "fixture.invalid:443",
+    "blocked_before_listener_reached": true,
+    "payload_commitment": "sha256:6d7cd7972edaa93427805b63e1836aabedbceec4e80b90b89389ff69853c9c15"
+  },
+  "non_claims": [
+    "probe proves one denied connect was blocked",
+    "does not prove complete run population",
+    "does not prove an AEE substrate-signed seal exists in production Assay"
+  ]
+}

--- a/scripts/experiments/fixtures/aee/enforcement-health-v1-active-probe.json
+++ b/scripts/experiments/fixtures/aee/enforcement-health-v1-active-probe.json
@@ -1,27 +1,29 @@
 {
-  "schema": "assay.enforcement_health.v1",
-  "status": "active",
-  "mechanism": "landlock",
-  "scope": "tcp_connect_landlock_port",
-  "policy_semantics": {
-    "default": "deny",
-    "allowed": []
-  },
+  "claims": [
+    "probe proves one denied connect was blocked"
+  ],
   "failure": null,
   "landlock": {
     "abi": 6,
     "restrict_self_confirmed": true,
     "ruleset_applied": true
   },
-  "probe": {
-    "kind": "tcp_connect_block",
-    "target": "fixture.invalid:443",
-    "blocked_before_listener_reached": true,
-    "payload_commitment": "sha256:6d7cd7972edaa93427805b63e1836aabedbceec4e80b90b89389ff69853c9c15"
-  },
+  "mechanism": "landlock",
   "non_claims": [
-    "probe proves one denied connect was blocked",
     "does not prove complete run population",
     "does not prove an AEE substrate-signed seal exists in production Assay"
-  ]
+  ],
+  "policy_semantics": {
+    "allowed": [],
+    "default": "deny"
+  },
+  "probe": {
+    "blocked_before_listener_reached": true,
+    "kind": "tcp_connect_block",
+    "payload_commitment": "sha256:6d7cd7972edaa93427805b63e1836aabedbceec4e80b90b89389ff69853c9c15",
+    "target": "fixture.invalid:443"
+  },
+  "schema": "assay.enforcement_health.v1",
+  "scope": "tcp_connect_landlock_port",
+  "status": "active"
 }

--- a/scripts/experiments/fixtures/aee/proxy-deny-observation.json
+++ b/scripts/experiments/fixtures/aee/proxy-deny-observation.json
@@ -1,0 +1,18 @@
+{
+  "schema": "assay.denied_call_observation.v0",
+  "call": {
+    "tool_name": "github.add_deploy_key",
+    "target_digest": "sha256:2f8d481ee9191e503eb4837b8c048f8be196b9884a2b33aa01850a7018e54bc7"
+  },
+  "caller_visible_error": {
+    "code": -32042,
+    "origin": "assay-proxy",
+    "reason": "policy denied fixture deploy-key request"
+  },
+  "caller_visible_response_digest": "sha256:2f8d481ee9191e503eb4837b8c048f8be196b9884a2b33aa01850a7018e54bc7",
+  "non_claims": [
+    "observation only, not a policy verdict",
+    "does not assert upstream side effect",
+    "does not assert maliciousness or whole-action trust"
+  ]
+}

--- a/scripts/experiments/fixtures/aee/proxy-deny-observation.json
+++ b/scripts/experiments/fixtures/aee/proxy-deny-observation.json
@@ -1,8 +1,7 @@
 {
-  "schema": "assay.denied_call_observation.v0",
   "call": {
-    "tool_name": "github.add_deploy_key",
-    "target_digest": "sha256:2f8d481ee9191e503eb4837b8c048f8be196b9884a2b33aa01850a7018e54bc7"
+    "target_digest": "sha256:8a29d0d8e2f08b9298de4f618642895d6dcb9f6d9e33f4baf4c1f8fe9fb66f23",
+    "tool_name": "github.add_deploy_key"
   },
   "caller_visible_error": {
     "code": -32042,
@@ -14,5 +13,6 @@
     "observation only, not a policy verdict",
     "does not assert upstream side effect",
     "does not assert maliciousness or whole-action trust"
-  ]
+  ],
+  "schema": "assay.denied_call_observation.v0"
 }

--- a/scripts/experiments/fixtures/aee/substrate-descriptor.json
+++ b/scripts/experiments/fixtures/aee/substrate-descriptor.json
@@ -1,0 +1,13 @@
+{
+  "name": "assay-runtime-substrate-spike",
+  "collectionPaths": [
+    "json-rpc-proxy",
+    "landlock-tcp-connect"
+  ],
+  "operator": "assay-spike-fixture",
+  "nonClaims": [
+    "fixture substrate descriptor only",
+    "not a production substrate attestation",
+    "one operator signs both collection paths in this spike"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a non-production, fixture-backed Assay -> AEE v0.7 spike under `docs/experiments/` and `scripts/experiments/`.

The spike builds the AEE seal first, then emits and checks an AEE-shaped statement for a two-vantage Assay substrate fixture:

- proxy denial via `assay.denied_call_observation.v0`
- Landlock TCP-connect blocked probe via `assay.enforcement_health.v1`
- synthetic AEE arming, interception, and sealed records
- deterministic fixture-only signatures and batch root
- negative controls for missing/defective coverage and forbidden overclaims

## Motivation

The AEE v0.7 discussion asks for an implementation-backed challenge: build the seal first, then a run that emits and consumes against current AEE head.

This spike tests the AEE field shape against Assay's real evidence boundaries without claiming production support.

## Changes

- Add experiment note:
  - `docs/experiments/aee-assay-spike-2026-08.md`
- Add fixture scripts:
  - `scripts/experiments/aee_spike_lib.py`
  - `scripts/experiments/aee_spike_emit.py`
  - `scripts/experiments/aee_spike_check.py`
- Add source fixtures:
  - catch policy
  - corpus manifest
  - substrate descriptor
  - proxy denial observation
  - enforcement health v1 active probe

## Tests

Ran locally in the sandbox:

```bash
python3 scripts/experiments/aee_spike_emit.py --variants
python3 scripts/experiments/aee_spike_check.py scripts/experiments/fixtures/aee/statement-valid.json
for f in scripts/experiments/fixtures/aee/negative-controls/*.json; do
  python3 scripts/experiments/aee_spike_check.py --expect-invalid "$f"
done
python3 -m py_compile scripts/experiments/aee_spike_lib.py scripts/experiments/aee_spike_emit.py scripts/experiments/aee_spike_check.py
```

Observed result:

- valid fixture statement passed
- all negative controls failed as expected
- Python compile check passed

## Risks

- This is intentionally not a general AEE verifier.
- The AEE predicate is still under vetting, so field names and validity rules can change.
- The fixture uses deterministic HMAC-over-DSSE-PAE as a test-only stand-in, not production DSSE signing.

## Non-claims

This PR does not claim:

- production AEE support
- stable AEE support before predicate acceptance
- complete run population
- agent safety
- independent substrate operation when one fixture key signs both paths
- that production Assay emits substrate-signed sealed records
- that ProtoJSON or generated bindings are canonical evidence

## Rollout / Rollback

No production rollout. This adds isolated experiment files only.

Rollback is deleting the added experiment note, scripts, and fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fixture-only experiment for converting Assay evidence into AEE v0.7 statements.
  * Added tooling to generate, validate, sign, and verify evidence statements.
  * Added negative-test variants for missing seals, mislabeled artifacts, interception mismatches, and unsupported claims.
  * Added fixtures covering policy enforcement, network blocking, proxy-denied actions, corpus mappings, and runtime metadata.

* **Documentation**
  * Documented execution steps, validation rules, negative controls, limitations, and initial findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->