### PR TITLE
Ask Cargo for the target directory too, instead of reading the env var

### DIFF
--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -60,101 +60,99 @@ fn assay_mcp_server_bin() -> PathBuf {
 /// if there is one, and the profile directory.
 ///
 /// Build the nested binary into the same place, so `cargo test --release` does
-/// not trigger a second full dependency build in the other profile.
+/// not trigger a second full dependency build in the other profile, and a
+/// cross-compiled parent does not get a host binary on the other end of the pipe.
 ///
-/// `CARGO_BIN_EXE_assay` is `<target-dir>/<profile-dir>/assay`, or
-/// `<target-dir>/<triple>/<profile-dir>/assay` when the parent passed `--target`.
-/// Reading the parent directory name alone cannot tell those apart — under
-/// `--target` it still yields `debug`, and the nested build would then quietly
-/// produce a *host* binary, in a different artifact tree from the one under
-/// test. Stripping the target directory shows which shape it is.
+/// The artifact root comes from `CARGO_TARGET_TMPDIR`, which Cargo sets to
+/// `<target-dir>/[<triple>/]tmp` for integration tests. Its parent is therefore
+/// exactly the directory holding the profile directories: absolute, and — the
+/// property that matters here — independent of any current working directory.
 ///
-/// The target directory comes from `cargo metadata`, not from reading
-/// `CARGO_TARGET_DIR`, and both paths are canonicalised before comparing, because
-/// `strip_prefix` is lexical. Two ways the env var alone gets this wrong, both
-/// verified against real Cargo output: a *relative* value is resolved by Cargo
-/// against the directory cargo was invoked from, not the package root a test runs
-/// in, so `target/wt` would canonicalise here to `crates/assay-cli/target/wt` and
-/// never match; and a symlinked one may be reported canonicalised by Cargo (on
-/// macOS `/tmp` is `/private/tmp`) while the env var still holds the symlink. A
-/// `build.target-dir` in `.cargo/config.toml` is invisible to the env var
-/// entirely. Each of those silently dropped the triple.
+/// Two earlier attempts got this wrong in opposite directions, so the reason is
+/// worth writing down. Reading `CARGO_TARGET_DIR` and canonicalising it resolves
+/// a relative value against *this test's* cwd, the package root. Asking
+/// `cargo metadata` resolves it against whatever cwd that call is made from.
+/// Each is correct only when the parent cargo happened to be invoked from the
+/// matching directory, and each silently drops the triple when it was not —
+/// building a host binary while the test runs a cross-compiled one, which is the
+/// exact failure this function exists to prevent. `CARGO_TARGET_TMPDIR` carries
+/// no such precondition, and it also reflects `--target-dir`, a per-invocation
+/// flag that `cargo metadata` cannot see at all.
 ///
-/// Falls back to the profile-dir-only reading if even that does not line up.
-/// That reading is correct whenever `--target` is absent, which is every
-/// invocation in this repo today, and wrong only under `--target`, where it
-/// would build a host binary while the test runs a cross-compiled one. The
-/// fallback is therefore stated rather than hidden — but asking Cargo removes
-/// the cases that actually reached it.
-fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
-    let bin_exe_raw = Path::new(env!("CARGO_BIN_EXE_assay"));
-    let dir_name = |p: Option<&Path>| {
-        p.and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            .map(str::to_owned)
-    };
+/// Whether the last component of that root is a triple is settled against
+/// `rustc --print target-list`, not by pattern-matching a directory name. The
+/// only false positive is a target directory named exactly like a rustc target.
+fn target_and_profile() -> (Option<String>, String) {
+    let bin_exe = Path::new(env!("CARGO_BIN_EXE_assay"));
     // `debug` is the fallback rather than an error: a wrong profile costs build
-    // time, and there is no reading of this path that should fail a test.
+    // time, and no reading of this path should turn into a test failure.
     let profile_only = || {
         (
             None,
-            dir_name(bin_exe_raw.parent()).unwrap_or_else(|| "debug".into()),
+            bin_exe
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .unwrap_or("debug")
+                .to_owned(),
         )
     };
 
-    // Ask Cargo where the target directory is, rather than reading the env var
-    // and hoping. A relative `CARGO_TARGET_DIR` is resolved by Cargo against the
-    // directory *cargo* was invoked from, which is not the package root a test
-    // runs in — so reading it here and canonicalising against our own cwd turns
-    // `target/wt` into `crates/assay-cli/target/wt` and the prefix never matches.
-    // `cargo metadata` reports an absolute `target_directory` and settles it,
-    // including a `build.target-dir` set in config.toml, which the env var alone
-    // never sees. It is one extra process per test binary, inside the cached
-    // build, and this is a file about not guessing at Cargo's layout.
-    let target_dir =
-        resolved_target_dir(workspace_root).unwrap_or_else(|| workspace_root.join("target"));
-    // Canonicalising needs the paths to exist. They do: the binary is what Cargo
-    // just built, and the target dir contains it. Fall back rather than fail.
+    let Some(artifact_root) = Path::new(env!("CARGO_TARGET_TMPDIR")).parent() else {
+        return profile_only();
+    };
+    // Both paths come from Cargo in the same run, so they already agree;
+    // canonicalise anyway rather than let a lexical mismatch drop the triple.
     let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
-    let (bin_exe, target_dir) = (canon(bin_exe_raw), canon(&target_dir));
-    let Ok(rel) = bin_exe.strip_prefix(&target_dir) else {
+    let (canon_bin, canon_root) = (canon(bin_exe), canon(artifact_root));
+    let Ok(rel) = canon_bin.strip_prefix(&canon_root) else {
         return profile_only();
     };
 
-    // rel is `<profile>/assay` or `<triple>/<profile>/assay`.
+    // `rel` is `<profile>/assay`: the artifact root has already absorbed the triple.
     let mut components: Vec<_> = rel
         .components()
         .filter_map(|c| c.as_os_str().to_str())
         .collect();
     components.pop(); // the file name
-    match components[..] {
-        [profile] => (None, profile.to_owned()),
-        [triple, profile] => (Some(triple.to_owned()), profile.to_owned()),
-        _ => profile_only(),
-    }
+    let [profile] = components[..] else {
+        return profile_only();
+    };
+
+    let triple = artifact_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .filter(|n| is_rustc_target(n))
+        .map(str::to_owned);
+    (triple, profile.to_owned())
 }
 
-/// Cargo's own answer for where build artifacts go, absolute and already
-/// accounting for `CARGO_TARGET_DIR` and `build.target-dir`.
-///
-/// Returns `None` rather than failing: a wrong target directory costs a rebuild
-/// in the wrong place, and no reading of this should turn into a test failure.
-fn resolved_target_dir(workspace_root: &Path) -> Option<PathBuf> {
-    let mut cmd = Command::new(cargo_bin());
-    cmd.current_dir(workspace_root).args([
-        "metadata",
-        "--format-version",
-        "1",
-        "--no-deps",
-        "--offline",
-    ]);
-    strip_cargo_crate_env(&mut cmd);
-    let out = cmd.output().ok()?;
-    if !out.status.success() {
-        return None;
+/// Whether `name` is a target triple rustc knows, rather than someone's choice of
+/// directory name. One `rustc --print target-list` per test process, and only
+/// when the name could plausibly be a triple at all.
+fn is_rustc_target(name: &str) -> bool {
+    if !name.contains('-') {
+        return false;
     }
-    let meta: Value = serde_json::from_slice(&out.stdout).ok()?;
-    meta.get("target_directory")?.as_str().map(PathBuf::from)
+    static TARGETS: OnceLock<Vec<String>> = OnceLock::new();
+    TARGETS
+        .get_or_init(|| {
+            let rustc = option_env!("RUSTC").unwrap_or("rustc");
+            Command::new(rustc)
+                .args(["--print", "target-list"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| {
+                    String::from_utf8_lossy(&o.stdout)
+                        .lines()
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default()
+        })
+        .iter()
+        .any(|t| t == name)
 }
 
 fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {
@@ -164,7 +162,7 @@ fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {
         .and_then(|p| p.parent())
         .context("failed to resolve workspace root from CARGO_MANIFEST_DIR")?;
 
-    let (target_triple, profile_dir) = target_and_profile(workspace_root);
+    let (target_triple, profile_dir) = target_and_profile();
 
     let cargo = cargo_bin();
     let mut cmd = Command::new(cargo);
@@ -496,8 +494,10 @@ enforcement:
 /// of this file got wrong. Against the real test binary: renaming the server's `assay_check_args`
 /// arm fails both fixtures on (2), and making the server exit immediately fails them on the read;
 /// removing the proxy's skip-the-forward on a blocked call fails them on (1), and on nothing else
-/// in this file. Substituting a fake at the binary's *path* proves nothing either way — the nested
-/// build in [`assay_mcp_server_bin`] restores the real binary before the test spawns it — so the
+/// in this file. Substituting a fake at the binary's *path* works only if its mtime is preserved:
+/// [`assay_mcp_server_bin`] asks Cargo, and Cargo's freshness check reads the fingerprint rather
+/// than the artifact, so a same-mtime fake survives and a naive `cp` is silently overwritten. That
+/// is a trap for the next person mutation-testing this file, which is why the
 /// stand-in upstreams (`sh -c 'sleep 30'`, `/bin/cat`, `/usr/bin/true`) were driven through this
 /// exact request sequence out-of-band: none satisfies (2). `cat` is the interesting one, since it
 /// echoes the request and so does carry the probe's id, but has no `result.content[0].text`.

--- a/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
+++ b/crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs
@@ -75,19 +75,23 @@ fn assay_mcp_server_bin() -> PathBuf {
 /// produce a *host* binary, in a different artifact tree from the one under
 /// test. Stripping the target directory shows which shape it is.
 ///
-/// Both paths are canonicalised before comparing, because `strip_prefix` is
-/// lexical. `CARGO_TARGET_DIR` may be relative — AGENTS.md mandates a per-worktree
-/// target dir, so that is not exotic — and Cargo may canonicalise a symlinked one
-/// (on macOS, `/tmp` is `/private/tmp`), leaving the env var not a literal prefix
-/// of the path Cargo reports. Without this, both cases fall through to the
-/// profile-only reading and drop the triple.
+/// The target directory comes from `cargo metadata`, not from reading
+/// `CARGO_TARGET_DIR`, and both paths are canonicalised before comparing, because
+/// `strip_prefix` is lexical. Two ways the env var alone gets this wrong, both
+/// verified against real Cargo output: a *relative* value is resolved by Cargo
+/// against the directory cargo was invoked from, not the package root a test runs
+/// in, so `target/wt` would canonicalise here to `crates/assay-cli/target/wt` and
+/// never match; and a symlinked one may be reported canonicalised by Cargo (on
+/// macOS `/tmp` is `/private/tmp`) while the env var still holds the symlink. A
+/// `build.target-dir` in `.cargo/config.toml` is invisible to the env var
+/// entirely. Each of those silently dropped the triple.
 ///
-/// Falls back to the profile-dir-only reading when the layout is still not
-/// recognisable. That is only correct when `--target` is absent — which is every
-/// invocation in this repo today — so the fallback carries a real, narrow risk:
-/// it would build a host binary while the test runs a cross-compiled one, where
-/// the code this replaced would have failed loudly with a missing binary. Made
-/// as narrow as canonicalising can make it, and called out rather than hidden.
+/// Falls back to the profile-dir-only reading if even that does not line up.
+/// That reading is correct whenever `--target` is absent, which is every
+/// invocation in this repo today, and wrong only under `--target`, where it
+/// would build a host binary while the test runs a cross-compiled one. The
+/// fallback is therefore stated rather than hidden — but asking Cargo removes
+/// the cases that actually reached it.
 fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
     let bin_exe_raw = Path::new(env!("CARGO_BIN_EXE_assay"));
     let dir_name = |p: Option<&Path>| {
@@ -104,10 +108,17 @@ fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
         )
     };
 
-    let target_dir = match std::env::var_os("CARGO_TARGET_DIR") {
-        Some(d) => PathBuf::from(d),
-        None => workspace_root.join("target"),
-    };
+    // Ask Cargo where the target directory is, rather than reading the env var
+    // and hoping. A relative `CARGO_TARGET_DIR` is resolved by Cargo against the
+    // directory *cargo* was invoked from, which is not the package root a test
+    // runs in — so reading it here and canonicalising against our own cwd turns
+    // `target/wt` into `crates/assay-cli/target/wt` and the prefix never matches.
+    // `cargo metadata` reports an absolute `target_directory` and settles it,
+    // including a `build.target-dir` set in config.toml, which the env var alone
+    // never sees. It is one extra process per test binary, inside the cached
+    // build, and this is a file about not guessing at Cargo's layout.
+    let target_dir =
+        resolved_target_dir(workspace_root).unwrap_or_else(|| workspace_root.join("target"));
     // Canonicalising needs the paths to exist. They do: the binary is what Cargo
     // just built, and the target dir contains it. Fall back rather than fail.
     let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
@@ -127,6 +138,29 @@ fn target_and_profile(workspace_root: &Path) -> (Option<String>, String) {
         [triple, profile] => (Some(triple.to_owned()), profile.to_owned()),
         _ => profile_only(),
     }
+}
+
+/// Cargo's own answer for where build artifacts go, absolute and already
+/// accounting for `CARGO_TARGET_DIR` and `build.target-dir`.
+///
+/// Returns `None` rather than failing: a wrong target directory costs a rebuild
+/// in the wrong place, and no reading of this should turn into a test failure.
+fn resolved_target_dir(workspace_root: &Path) -> Option<PathBuf> {
+    let mut cmd = Command::new(cargo_bin());
+    cmd.current_dir(workspace_root).args([
+        "metadata",
+        "--format-version",
+        "1",
+        "--no-deps",
+        "--offline",
+    ]);
+    strip_cargo_crate_env(&mut cmd);
+    let out = cmd.output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let meta: Value = serde_json::from_slice(&out.stdout).ok()?;
+    meta.get("target_directory")?.as_str().map(PathBuf::from)
 }
 
 fn build_assay_mcp_server() -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
## Description

Follow-up to #1980, which merged while this fix was still in review, so it never reached `main`.

#1980 made the e2e wrap tests ask Cargo to build `assay-mcp-server` instead of guessing `target/debug/…`, and derived the profile directory — plus any `--target` triple — by stripping the target directory from `CARGO_BIN_EXE_assay`. Getting *that* stripping right took three attempts, and the first two are worth recording because they failed in opposite directions:

1. **Read `CARGO_TARGET_DIR` and canonicalise it** (#1980). Canonicalising resolves a relative value against *this test's* cwd, the package root. Wrong whenever the parent cargo ran from the workspace root.
2. **Ask `cargo metadata`** (the previous commit here). It resolves a relative value against whatever cwd *that call* uses — the workspace root. So it fixed case 1 and broke the mirror image: correct from the workspace root, wrong from a member directory, where the code it replaced had been correct. An adversarial review reproduced it with a real cross-compiled build and a nested build landing host-arch in the wrong tree.

Both were the same mistake: a source with an invocation-directory precondition, used where no such precondition holds.

**`CARGO_TARGET_TMPDIR` has none.** Cargo sets it to `<target-dir>/[<triple>/]tmp` for every integration test, so its parent is exactly the directory holding the profile directories — absolute, and cwd-independent. It also reflects `--target-dir`, a per-invocation flag `cargo metadata` cannot see and which *both* earlier versions dropped the triple on. That flag is the most idiomatic way to satisfy AGENTS.md's per-worktree target directory, so it is not an exotic case.

Whether the root's last component is a triple is settled against `rustc --print target-list` rather than by pattern-matching a directory name. The `cargo metadata` subprocess is gone; the rustc one runs only when the name could be a triple at all.

This is latent, not live: no workflow here passes `--target` to `cargo test`, and CI sets no `CARGO_TARGET_DIR`. It is a silent-wrong-result path — the class #1980 existed to remove.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Verification

Measured on `a4a88f6d6634ec90da4764699fdbef6bc9c1c633`, clean working tree, worktree `.claude/worktrees/friendly-torvalds-f5cfff`, `rustc 1.96.0 (ac68faa20 2026-05-25)` (pinned), darwin 25.6.0. Restated on this head rather than an earlier one: the branch has been rebuilt twice under review, and an earlier revision of this body cited a tree that is not what merges.

Derivation against real Cargo output — eight configurations, each an actual `cargo test` invocation, not a simulation:

| configuration | derived | `main` | `cargo metadata` attempt |
|---|---|---|---|
| default | `(None, "debug")` | ✓ | ✓ |
| `--release` | `(None, "release")` | ✓ | ✓ |
| `--target` | `(Some(<triple>), "debug")` | ✓ | ✓ |
| `--target --release` | `(Some(<triple>), "release")` | ✓ | ✓ |
| absolute `CARGO_TARGET_DIR` + `--target` | `(Some(<triple>), "debug")` | ✓ | ✓ |
| relative `CARGO_TARGET_DIR` from root + `--target` | `(Some(<triple>), "debug")` | ✗ | ✓ |
| **`--target-dir` + `--target`** | `(Some(<triple>), "debug")` | ✗ | ✗ |
| **relative `CARGO_TARGET_DIR` from a member dir + `--target`** | `(Some(<triple>), "debug")` | ✓ | ✗ |

| Property | Result on `a4a88f6d6634ec90da4764699fdbef6bc9c1c633` |
|---|---|
| `cargo nextest run -p assay-cli --all-features` | **606 passed**, 1 skipped |
| Same again, back to back | 606 passed; 2.33s then 2.47s wall |
| Shell `cargo build -p assay-mcp-server --locked` straight after | **0 crates recompiled** — the #1980 cache alternation is not reintroduced |
| `cargo clippy -p assay-cli --tests --all-features -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |

- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Ran a demo suite — not applicable; test infrastructure

## Also corrected

The note on `assert_upstream_is_the_real_server` (from #1988, merged into this branch) said that substituting a fake at the binary's path proves nothing, because the nested build restores the real binary first. It does not restore it when the fake preserves its mtime: Cargo's freshness check reads the fingerprint, not the artifact. The reviewer used precisely that to confirm the deny fixtures now fail against a wrong-but-spawnable upstream (`/usr/bin/true` and `/bin/cat` both fail; the real binary passes). The old wording would send the next person mutation-testing this file down a dead end.

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. — the rationale lives in the doc comment on `target_and_profile`, which this PR rewrites to describe what it now actually does, including why the two earlier sources were wrong.
- [x] I have added tests to cover my changes. — this is test infrastructure; the property is verified by the derivation table above.

## Review

Reviewed adversarially on `17e8b8d8`, which returned BLOCK and refuted the `cargo metadata` approach outright. This head is the response: the source is replaced, the two configurations that review found broken are now verified correct, the false sentence it found in the `assert_upstream_is_the_real_server` note is fixed, and this body is restated against the head that merges. That review does not carry to `a4a88f6d6634ec90da4764699fdbef6bc9c1c633`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
