### PR TITLE
Ask libtest for its tally, not the per-test line it splits in two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,47 +607,41 @@ jobs:
       # E6a.3 no-pass-through: E2E invariant test (requires test-outbound feature).
       #
       # Runs on every OS, because this is the only job that RUNS the test — the workspace runs
-      # above and below build it out, and the feature-enabled clippy step near the top of this
-      # file compiles it but executes nothing. That also means a missing or misspelled feature
-      # flag here would be silent: `cargo test` exits 0 when zero tests match. So assert the test
-      # actually executed rather than trusting the exit code.
+      # above and below build it out, and the feature-enabled clippy step in the `clippy` job
+      # type-checks it without ever producing a runnable binary. That also means a missing or
+      # misspelled feature flag here would be silent: `cargo test` exits 0 when zero tests match.
+      # So assert the test actually executed rather than trusting the exit code.
       - name: Test MCP no-pass-through E2E (E6a.3)
         shell: bash
         run: |
           set -euo pipefail
           cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
             2>&1 | tee "$RUNNER_TEMP/e6a3.log"
-          # Two questions. Every previous version of this guard folded them into one pattern and
-          # got one of them wrong: too strict and it called a passing test absent, too loose and
-          # it called a skipped test present. Pass-versus-fail is not among them — `set -o
-          # pipefail` settles that above, so a test that ran and failed never reaches here.
+          # `cargo test` exits 0 when zero tests match, so the exit code above proves nothing ran
+          # wrong — not that anything ran. This asserts execution, and it asks libtest's own tally
+          # for this binary rather than reading the per-test line.
           #
-          # The two are sequential, not independent: question 2 rescans the lines question 1
-          # matched. That is a known and deliberate compromise. Broadening question 1 to survive
-          # interleaved child output means arbitrary server stderr can end up inside the string
-          # question 2 searches, so a log line containing the word "ignored" can trip it. The
-          # alternative — anchoring question 2 to the status field — is more precise but inverts
-          # the failure direction: a shape it fails to anchor passes the guard, and the step goes
-          # green on an invariant nobody ran. Being noisily wrong beats being quietly wrong here,
-          # so this stays until someone has a form that is precise AND fails closed.
+          # Reading the per-test line is what five earlier versions of this guard did, and each
+          # got it wrong in one direction or the other. The reason is structural: libtest flushes
+          # `test NAME ... ` and its status separately, so anything this test's inherited server
+          # stderr writes in between lands on that line. Match the name loosely enough to survive
+          # that and you have taken arbitrary child output into the string you then search for a
+          # skip word; match it tightly and a split line reads as absence. The tally has neither
+          # problem — it is one line, written after the run, in a fixed shape.
           #
-          # 1. Did the runner report this test at all? Deliberately broad, because the shapes are
-          #    many: at --test-threads=1 libtest prints `test NAME ... ` before running, so this
-          #    test's own inherited stderr lands between the name and the status word; a
-          #    `- should panic` suffix or a module path shifts it further; nextest has its own
-          #    vocabulary entirely. Matching the name rather than the outcome survives all of them.
-          reported=$(grep -E '^test .*test_no_passthrough_e2e|^ *(PASS|FAIL|TRY|FLAKY|LEAK|SLOW|TIMEOUT).*test_no_passthrough_e2e([[:space:]]|$)' \
-            "$RUNNER_TEMP/e6a3.log" || true)
-          if [ -z "$reported" ]; then
-            echo "::error::E6a.3 no-pass-through test did not run, so the invariant was never exercised. Either the test-outbound gate is misconfigured, or the test is skipped under a runner that reports skips without naming them (nextest counts them and moves on)."
-            exit 1
-          fi
-          # 2. Was it reported as skipped? `#[ignore]` prints a result line and exits 0, so being
-          #    reported is not the same as having executed. This is the routine answer to a flaky
-          #    spawn-a-server test on the OS legs this step just added, and it has to be loud.
-          case "$reported" in
-            *ignored*)
-              echo "::error::E6a.3 no-pass-through test was reported as ignored, not executed. The invariant was never exercised."
+          # Default-deny: anything that is not positively "some passed, none failed, none ignored"
+          # is a failure, so a shape this does not recognise cannot certify the invariant. That
+          # includes nextest, which prints no such line; migrating this step means replacing this
+          # check, and it will go red until someone does rather than silently stop checking.
+          tally=$(awk '
+            /^[[:space:]]*Running[[:space:]].*no_passthrough_e2e/ { inblk = 1; next }
+            /^[[:space:]]*Running[[:space:]]/                     { inblk = 0 }
+            inblk && /^test result:/                              { print }
+          ' "$RUNNER_TEMP/e6a3.log")
+          case "$tally" in
+            "test result: ok. "[1-9]*" passed; 0 failed; 0 ignored;"*) ;;
+            *)
+              echo "::error::E6a.3 no-pass-through test did not execute, so the invariant was never exercised. libtest reported: ${tally:-<no result line for no_passthrough_e2e>}. Either the test-outbound gate is misconfigured, or the test is #[ignore]d, or this step no longer runs under libtest."
               exit 1
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,11 +613,12 @@ jobs:
       # So assert the test actually executed rather than trusting the exit code.
       - name: Test MCP no-pass-through E2E (E6a.3)
         shell: bash
-        # Load-bearing, and measured rather than assumed: on the runner cargo colours its own
-        # `Running` line (`ESC[1mESC[92m     RunningESC[0m tests/...`), which is the line the guard
-        # below keys its per-binary block on. Without this pin the block is never entered, the
-        # tally comes back empty, and the step fails a passing test. libtest's own lines are plain
-        # either way — this is about cargo's, not libtest's.
+        # Defence in depth, not the guarantee — the awk below strips colour itself, and was
+        # measured green against the real coloured log from the run that failed without it. What
+        # this pin buys is a readable log and one less thing to reason about. The colour is real
+        # though: `Swatinem/rust-cache` exports CARGO_TERM_COLOR=always into $GITHUB_ENV, so cargo
+        # writes `ESC[1mESC[92m     RunningESC[0m tests/...` in every job using that action.
+        # libtest's own lines are plain regardless; this only ever concerned cargo's.
         env:
           CARGO_TERM_COLOR: never
         run: |
@@ -625,36 +626,40 @@ jobs:
           cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
             2>&1 | tee "$RUNNER_TEMP/e6a3.log"
           # `cargo test` exits 0 when zero tests match, so the exit code above proves nothing ran
-          # wrong — not that anything ran. This asserts execution, and it asks libtest's own tally
-          # for this binary rather than reading the per-test line.
+          # wrong — not that anything ran. Two checks assert execution, and both must pass. Each
+          # can only add a failure, so neither can rescue the other into a false green.
           #
-          # Reading the per-test line is what five earlier versions of this guard did, and each
-          # got it wrong in one direction or the other. The reason is structural: libtest flushes
-          # `test NAME ... ` and its status separately, so anything this test's inherited server
-          # stderr writes in between lands on that line. Match the name loosely enough to survive
-          # that and you have taken arbitrary child output into the string you then search for a
-          # skip word; match it tightly and a split line reads as absence. The tally has neither
-          # problem — it is one line, written after the run, in a fixed shape.
+          # 1. A test by this NAME was reported. The tally in check 2 carries no test names, so on
+          #    its own it would accept any passing test the `no_passthrough` filter selects —
+          #    including a replacement that no longer proves the invariant. Presence only, never
+          #    the status word: libtest flushes `test NAME ... ` and its status separately, so this
+          #    test's inherited server stderr can land between them, and five earlier versions of
+          #    this guard died on exactly that. The name survives the split; the status does not.
+          if ! grep -qE '^test .*test_no_passthrough_e2e' "$RUNNER_TEMP/e6a3.log"; then
+            echo "::error::E6a.3: libtest reported no test named test_no_passthrough_e2e, so the invariant was never exercised. Either the test-outbound gate is misconfigured, or the test was renamed or removed."
+            exit 1
+          fi
+          # 2. That binary's own tally says everything ran and nothing was skipped. Default-deny,
+          #    so a shape this does not recognise cannot certify anything — including nextest,
+          #    which prints no such line, so migrating this step turns it red rather than quietly
+          #    stopping the check. `exit` after the first match keeps the value single-line: the
+          #    glob below is greedy across newlines, so a two-line tally could otherwise satisfy it
+          #    by taking the count from one line and the zeros from the next.
           #
-          # Default-deny: anything that is not positively "some passed, none failed, none ignored"
-          # is a failure, so a shape this does not recognise cannot certify the invariant. That
-          # includes nextest, which prints no such line; migrating this step means replacing this
-          # check, and it will go red until someone does rather than silently stop checking.
-          # Colour is stripped before matching rather than tolerated in the patterns. The pin above
-          # should already keep these lines plain; this is the second lock, because the failure it
-          # prevents is not symmetric. An escape ahead of `Running` that stops the block from
-          # OPENING just fails a passing test, but one that stops it from CLOSING hands this check
-          # the next binary's tally — the single way it could pass without the test running.
+          #    Colour is stripped here rather than relied on being absent upstream. Both awk rules
+          #    key on `Running`, and cargo colours every such line or none, so in practice an
+          #    escape stops the block opening and closing together and the result is an empty
+          #    tally — red, the safe direction. The strip removes even that noise.
           tally=$(awk '
             { gsub(/\033\[[0-9;]*m/, "") }
             /Running[[:space:]]+[^[:space:]]*no_passthrough_e2e/ { inblk = 1; next }
             /Running[[:space:]]/                                 { inblk = 0 }
-            inblk && /^test result:/                             { print }
+            inblk && /^test result:/                             { print; exit }
           ' "$RUNNER_TEMP/e6a3.log")
           case "$tally" in
             "test result: ok. "[1-9]*" passed; 0 failed; 0 ignored;"*) ;;
             *)
-              echo "::error::E6a.3 no-pass-through test did not execute, so the invariant was never exercised. libtest reported: ${tally:-<no result line for no_passthrough_e2e>}. Either the test-outbound gate is misconfigured, or the test is #[ignore]d, or this step no longer runs under libtest."
+              echo "::error::E6a.3 no-pass-through test did not execute, so the invariant was never exercised. libtest reported: ${tally:-<no result line for no_passthrough_e2e>}. Either the test is #[ignore]d, or this step no longer runs under libtest."
               exit 1
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,13 @@ jobs:
       # So assert the test actually executed rather than trusting the exit code.
       - name: Test MCP no-pass-through E2E (E6a.3)
         shell: bash
+        # Load-bearing, and measured rather than assumed: on the runner cargo colours its own
+        # `Running` line (`ESC[1mESC[92m     RunningESC[0m tests/...`), which is the line the guard
+        # below keys its per-binary block on. Without this pin the block is never entered, the
+        # tally comes back empty, and the step fails a passing test. libtest's own lines are plain
+        # either way — this is about cargo's, not libtest's.
+        env:
+          CARGO_TERM_COLOR: never
         run: |
           set -euo pipefail
           cargo test --locked -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough \
@@ -633,10 +640,16 @@ jobs:
           # is a failure, so a shape this does not recognise cannot certify the invariant. That
           # includes nextest, which prints no such line; migrating this step means replacing this
           # check, and it will go red until someone does rather than silently stop checking.
+          # Colour is stripped before matching rather than tolerated in the patterns. The pin above
+          # should already keep these lines plain; this is the second lock, because the failure it
+          # prevents is not symmetric. An escape ahead of `Running` that stops the block from
+          # OPENING just fails a passing test, but one that stops it from CLOSING hands this check
+          # the next binary's tally — the single way it could pass without the test running.
           tally=$(awk '
-            /^[[:space:]]*Running[[:space:]].*no_passthrough_e2e/ { inblk = 1; next }
-            /^[[:space:]]*Running[[:space:]]/                     { inblk = 0 }
-            inblk && /^test result:/                              { print }
+            { gsub(/\033\[[0-9;]*m/, "") }
+            /Running[[:space:]]+[^[:space:]]*no_passthrough_e2e/ { inblk = 1; next }
+            /Running[[:space:]]/                                 { inblk = 0 }
+            inblk && /^test result:/                             { print }
           ' "$RUNNER_TEMP/e6a3.log")
           case "$tally" in
             "test result: ok. "[1-9]*" passed; 0 failed; 0 ignored;"*) ;;

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -33,7 +33,8 @@
 //! *this* package — split-wave0-gates.yml does so for assay-core, assay-cli, assay-registry and
 //! assay-evidence, but never for assay-mcp-server. That includes
 //! `cargo clippy --workspace --all-targets` in CI, which is why a dedicated feature-enabled clippy
-//! step sits beside the test step, but it also includes both pre-push hooks
+//! step exists in that workflow's `clippy` job — a different job from the one that runs this test,
+//! and it only type-checks the file. Absence also covers both pre-push hooks
 //! (`scripts/precommit/cargo-clippy.sh`, `scripts/ci/check-linux.sh`) and a plain
 //! `cargo test -p assay-mcp-server`. A syntax or type error here passes every local check and only
 //! surfaces on CI. Run the documented command above before pushing changes to this file.

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -33,8 +33,8 @@
 //! *this* package — split-wave0-gates.yml does so for assay-core, assay-cli, assay-registry and
 //! assay-evidence, but never for assay-mcp-server. That includes
 //! `cargo clippy --workspace --all-targets` in CI, which is why a dedicated feature-enabled clippy
-//! step exists in that workflow's `clippy` job — a different job from the one that runs this test,
-//! and it only type-checks the file. Absence also covers both pre-push hooks
+//! step exists in ci.yml's `clippy` job — a different job from the one that runs this test, and it
+//! only type-checks the file. Absence also covers both pre-push hooks
 //! (`scripts/precommit/cargo-clippy.sh`, `scripts/ci/check-linux.sh`) and a plain
 //! `cargo test -p assay-mcp-server`. A syntax or type error here passes every local check and only
 //! surfaces on CI. Run the documented command above before pushing changes to this file.


### PR DESCRIPTION
Follow-up to #1986, which merged while its last commit was still in review. Six review rounds on that PR, and three more here, have all landed on the same guard: the one asserting that the E6a.3 credential no-pass-through test actually **executed**, since `cargo test` exits 0 when zero tests match and the test sits behind a feature gate.

## Why the previous form had to change

#1986's final commit declined to make the guard more precise, arguing that anchoring it would invert the failure direction. That is refuted by its own history — both forms extracted and run against a real `#[ignore]`d libtest log:

| form | anchored? | on an `#[ignore]`d test |
|---|---|---|
| `f5b35949` | no anchor at all | **green** — fail-open |
| `ef903dc3` | status-anchored | **red** — fail-closed |

Anchoring was tried there and failed closed. It also set itself a falsifiable exit condition — the compromise stays "until someone has a form that is precise AND fails closed" — and reviewers falsified it.

## What the guard does now

Two checks, both required, neither able to rescue the other into a green.

**1. A test by that name was reported.** `grep -qE '^test .*test_no_passthrough_e2e'` — presence only, never the status word. libtest flushes `test NAME ... ` and its status as separate writes, so this test's inherited server stderr can land between them. That split destroys the *status* field and leaves the *name* intact, which is the distinction five earlier versions missed.

**2. The binary's own tally says everything ran and nothing was skipped.** Default-deny: anything that is not positively "some passed, none failed, none ignored" fails, so an unrecognised shape cannot certify anything. `exit` after the first match keeps the value single-line, because the glob is greedy across newlines.

## What review found in the intermediate forms

A tally-only version — the first attempt here — had two false greens, both reproduced by a reviewer rather than reasoned about:

- **Deleting the test passed the guard.** Replacing `test_no_passthrough_e2e` with a do-nothing `no_passthrough_placeholder_does_nothing` went green, because the tally carries counts and never names. This was a regression against the form being replaced. Check 1 closes it.
- **A two-line tally satisfied the glob**, taking its count from one line and its zeros from the next. Latent behind file ordering that nothing asserts. `exit` closes it.

A second reviewer falsified a claim this branch had made about itself: `CARGO_TERM_COLOR: never` is **not** load-bearing. Driving the current guard against the real coloured log from the run that failed *without* the pin gives green — the awk strips colour itself. Remove the `gsub` instead and it goes red. The pin is defence in depth; the `gsub` is the guarantee. (The colour comes from `Swatinem/rust-cache` exporting `CARGO_TERM_COLOR=always` into `$GITHUB_ENV`.)

## Eight shapes, both directions

| shape | result |
|---|---|
| plain pass | green |
| split line at `--test-threads=1`, `ignored` in child stderr | green |
| coloured pass, and Windows `tests\` separator | green |
| test replaced by a differently-named passing test | **red** |
| two-line tally combining `1 ignored` with a later `0 ignored` | **red** |
| `#[ignore]`d | red |
| feature off, zero tests | red |
| nextest (prints no tally) | red — fail-closed |

Plus the two real logs from the original measurement. The guard block is extracted verbatim from the workflow and driven against them rather than retyped.

## Corrections to #1986's merged record

Two sentences there are false and are why the flaw looked unreachable:

- *"Hosted runners are multi-core so libtest emits the unsplit shape"* — it splits at `--test-threads=8` too; a reviewer reproduced it 7 times in 25 runs with a flooding child. What actually prevents it here is that the test reaps its child before returning.
- *"No `--test-threads=1` anywhere in the repo"* — `crates/assay-registry/docs/TRACEABILITY.md:221`. Another package's docs, so the conclusion survived; the sentence did not.

One framing in an earlier version of this description was sharper than its source: the merged text attached "the one round 3 already produced once" to *the outcome*, not to anchoring as its cause. The substantive rebuttal above stands on the measured table, not on that reading.

## Checks

- 288 tests pass with `--features test-outbound`; 287 without (the delta is the gated test)
- All pre-commit hooks pass, including the workflow linter
- `actionlint` reports one pre-existing `unexpected key "queue" for "concurrency"` on `ci.yml`, present on `main` as well — not introduced here
- No behavioural change to any test; this touches the CI guard and two comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)