### PR TITLE
A doc link outlived the constant it pointed at

### DIFF
--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -34,9 +34,10 @@ const REAP_TIMEOUT: Duration = Duration::from_secs(10);
 ///
 /// The channel is bounded because the deadline bounds time, not memory. A child writing lines
 /// faster than the caller skips them fills an unbounded channel for the whole budget: measured at
-/// ~110 MB/s against `yes`, which is ~3.3 GB at [`DEFAULT_TIMEOUT`] and ~8 GB at
-/// [`CARGO_RUN_TIMEOUT`]. With a bound the reader thread stops draining stdout, the child blocks on
-/// its own pipe, and the test keeps control of the deadline.
+/// ~110 MB/s against `yes`, which is ~3.3 GB at [`DEFAULT_TIMEOUT`] and grows with any longer
+/// budget a caller sets through [`Conn::with_startup_timeout`]. With a bound the reader thread
+/// stops draining stdout, the child blocks on its own pipe, and the test keeps control of the
+/// deadline.
 ///
 /// The bound is large rather than minimal on purpose. Backpressure introduces a deadlock the
 /// unbounded channel could not have: a test that writes several requests before reading any could,


### PR DESCRIPTION
Follow-up to #1995, fixing something that PR left behind — by my own hand, so recording it plainly.

## What

`crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs:38` links to `[`CARGO_RUN_TIMEOUT`]`, a constant
that no longer exists. #1995's rebase removed it: #1986 had already replaced every `cargo run`
spawn in this crate's tests with the prebuilt `CARGO_BIN_EXE_assay-mcp-server`, so the constant had
no callers left and its stated justification — *"a server spawned through `cargo run`, which may
still have to build"* — had stopped being true.

The `READ_AHEAD_LINES` doc cited it for a worst-case memory figure. That sentence was rewritten
during the rebase but **the edit was never committed** — it went straight from editor to
`cargo fmt` and `git push`, which pushes commits, not the working tree. So the constant left and
the link stayed.

## Impact

None at build time. This is a `tests/` support module, no rustdoc lane resolves its intra-doc
links, and `Rustdoc (deny warnings)` was green on #1995. It is worth fixing anyway: a link to a
deleted item says "the reasoning is over there" and there is no over there.

## Fix

The figure is kept — it is a real measurement — and re-anchored to what still exists:
`DEFAULT_TIMEOUT` for the measured case, and `Conn::with_startup_timeout` for the longer budgets a
caller can still set.

## Verification

On this branch, clean tree, `rustc 1.96.0`, darwin 25.6.0:

| | |
|---|---|
| `rg CARGO_RUN_TIMEOUT crates/` | no matches |
| `cargo nextest run -p assay-mcp-server` | **287 passed**, 0 skipped |
| `cargo fmt --all --check` | clean |

## Note for #2002

#2002 also touches this module and is in flight. It does not modify this file in its own commit
(it takes `main`'s version wholesale), so this is a one-line rebase for it at worst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)