### PR TITLE
A documented example output was tracked as a source change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ benchmark_results/
 *.log
 junit.xml
 sarif.json
+enforcement.sarif
 run.json
 summary.json
 otel.jsonl


### PR DESCRIPTION
## What

`examples/privileged-action-gate/README.md` tells the reader to run `./sarif.sh enforcement.sarif`, so every reader of that example leaves an untracked `enforcement.sarif` in the worktree. No `.sarif` is tracked anywhere in this repository, and the neighbouring run outputs — `junit.xml`, `sarif.json`, `run.json`, `summary.json`, `otel.jsonl` — are already ignored by bare filename. This one was missed.

Ignored by the same bare-filename convention rather than a broad `*.sarif`, which would silently swallow a future tracked fixture.

## Also in this change

Deletes the stale `codex/release-3.38.0` branch, local and remote. **Recovery SHA: `dd2b3c3ae0f85a98b102ff90ef79f92d8dc2b178`.**

`git cherry` reported its three commits as unlanded. That is patch-id noise from surrounding context, not real divergence — verified at file level instead:

- `.github/workflows/release.yml` byte-identical to `origin/main`
- `fuzz/Cargo.lock` byte-identical to `origin/main`
- `Cargo.toml`, `CHANGELOG.md` and `fuzz/Cargo.lock` all read `3.38.0` on `main`
- `git diff origin/main <tip>` restricted to the five files those commits touched is empty

## Not in this change

One untracked file is deliberately left alone: `docs/superpowers/plans/2026-06-27-hotspot-loc-under-600-refactor.md`. Sibling plan docs *are* tracked under `docs/superpowers/plans/`, so this is either an uncommitted plan or a leftover — that is an author call, not a cleanup call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)