### PR TITLE
A finished plan that still tells an agent to execute it

### DIFF
--- a/docs/superpowers/plans/2026-06-27-hotspot-loc-under-600-refactor.md
+++ b/docs/superpowers/plans/2026-06-27-hotspot-loc-under-600-refactor.md
@@ -1,5 +1,22 @@
 # Hotspot LOC Under 600 Refactor Implementation Plan
 
+> **STATUS: COMPLETE. Do not execute this plan.** Every hotspot it targets was split before this
+> note was written. Measured on `main` at `1619cad9`, plan figure vs current:
+>
+> | plan | now | file |
+> |---:|---:|---|
+> | 1630 | 35 | `crates/assay-mcp-server/src/proxy/enforce.rs` |
+> | 1565 | 24 | `crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs` |
+> | 1398 | 34 | `crates/assay-core/src/mcp/tool_decision_truth.rs` |
+> | 1390 | 321 | `crates/assay-mcp-server/src/proxy/mod.rs` |
+> | 1311 | 209 | `crates/assay-registry/src/supply_chain.rs` |
+> | 860 | 87 | `crates/assay-cli/src/cli/commands/supply_chain_conformance.rs` |
+>
+> The document is kept as the record of what was planned on `fcfdb8e1`, alongside its predecessor
+> `2026-06-05-assay-wave53-hotspot-top2-9-refactor.md`. The directive below tells an agentic worker
+> to implement it task-by-task; that directive is now spent, and this note sits above it so it is
+> read first.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Bring every current handwritten Rust hotspot at or above 600 LOC below 600 LOC, excluding generated files, while preserving behavior, public APIs, wire contracts, CLI output, and security invariants.


### PR DESCRIPTION
`docs/superpowers/plans/2026-06-27-hotspot-loc-under-600-refactor.md` reached `main` by accident — a `git add -A docs/` while preparing #2006, landing through #2008 — and every hotspot it targets had already been split.

Two problems with leaving it as-is:

1. It reads as pending work.
2. Its second line is `**For agentic workers:** … implement this plan task-by-task`. The first thing anyone acting on that directory would do is start a job that is finished.

## Why a note rather than a revert

`docs/superpowers/plans/2026-06-05-assay-wave53-hotspot-top2-9-refactor.md` — the same class of document, an earlier wave of the same work — is already tracked here, and no sibling plan carries a status marker. That directory is a record of plans, not a queue. Removing one member of a series while its predecessor stays would be the worse inconsistency.

## The measurement, so a reader can check it

| plan | now | file |
|---:|---:|---|
| 1630 | 35 | `crates/assay-mcp-server/src/proxy/enforce.rs` |
| 1565 | 24 | `crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs` |
| 1398 | 34 | `crates/assay-core/src/mcp/tool_decision_truth.rs` |
| 1390 | 321 | `crates/assay-mcp-server/src/proxy/mod.rs` |
| 1311 | 209 | `crates/assay-registry/src/supply_chain.rs` |
| 860 | 87 | `crates/assay-cli/src/cli/commands/supply_chain_conformance.rs` |

The note carries the numbers rather than the word "done", and sits **above** the execute-this-plan directive — a status line below the instruction is read too late.

## Not in this change

No sibling plan is touched. Whether completed plans should carry a status marker as a convention is a real question this PR does not answer; it puts one document ahead of the convention rather than changing it.

The accidental entry is corrected on the record in a comment on #2007, whose body claimed the file had been deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the refactor plan with a completion notice and current line-count details for the affected files.
  * Added references to the measurement source and predecessor plan.
  * Clarified that the remaining implementation note is no longer actionable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->