### PR TITLE
Four gated paths are not content-addressed, and the docs named one

### DIFF
--- a/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
+++ b/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
@@ -194,7 +194,7 @@ That is deliberate rebuild avoidance, and it is guarded: four gated paths sit
 outside the content-provenance prefixes and are therefore not provable by tree
 OID at all.
 
-```
+```text
 Cargo.toml
 Cargo.lock
 crates/assay-cli/src/cgroup.rs

--- a/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
+++ b/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
@@ -148,6 +148,65 @@ Reason: this host is the environment where Linux, cgroup v2, Node 22, and the
 eBPF artifact are expected to exist. If a delegated script skips, the runner or
 workflow has drifted from its contract.
 
+This is enforced, not left to discipline. `run_gate` records any non-zero
+status as a failed gate and returns it under `set -euo pipefail`, so exit `40`
+fails the job like any other failure. Note that not every gate script has such
+a guard; the ones that do are the ones checking host prerequisites.
+
+## Lane-Check Interaction Failures
+
+A delegated run can pass and still leave the PR blocked. These four are the
+recurring causes; all four are consumer-side, none is visible in this
+workflow's own logs.
+
+**The proof binds to the dispatched ref, not to the PR.** The proof pack
+records `--head-sha "$GITHUB_SHA"`, which is the head of whatever ref you
+picked in the Run-workflow dropdown. There is no `expected_head_sha` input on
+this workflow; that input exists only on `assay-runner-lane-check.yml`.
+Dispatching against `main` while reviewing a PR produces a valid, attested,
+useless proof pack: lane-check compares the recorded head SHA against the PR
+head and rejects it. Always select the PR branch as the ref, and dispatch only
+after the branch holds the final candidate commit, since a later push
+invalidates the proof.
+
+**A red `lane-check` job is not a red `lane-check/proof`.** The Actions job is
+named `lane-check`; the required commit status is named `lane-check/proof`, and
+branch protection on `main` requires the status. A job that fails before
+reaching the status-posting step leaves the status stale or absent, which
+blocks the merge without producing a matching red job on the current head. When
+a merge is blocked and the job looks green, read the commit status directly.
+
+**Fork and Dependabot PRs cannot post the status from the PR event.** Posting
+needs `statuses: write`. On `pull_request` events from a fork or from
+Dependabot the token is read-only by GitHub policy, so the status cannot be
+written no matter how the workflow is configured. This is not a bug to fix in
+the workflow: lane-check degrades to a warning in exactly this case and in no
+other, because a 403 from a privileged dispatch context is misconfiguration
+rather than policy. Refresh the status through a `workflow_dispatch` of
+`Assay-Runner Lane Check` with the PR number. Run that dispatch from a trusted
+ref, never from a ref carrying the untrusted changes.
+
+**Content-identical trees may reuse an earlier proof, except on four paths.**
+Lane-check compares the gated-path tree OIDs recorded in the manifest against
+the current PR head, over every `content_provenance_path`, unconditionally. If
+all of them are unchanged, a proof produced on an earlier commit is accepted.
+That is deliberate rebuild avoidance, and it is guarded: four gated paths sit
+outside the content-provenance prefixes and are therefore not provable by tree
+OID at all.
+
+```
+Cargo.toml
+Cargo.lock
+crates/assay-cli/src/cgroup.rs
+crates/assay-cli/src/cli/commands/runner_spike.rs
+```
+
+A PR touching any of them cannot reuse a proof from a different head;
+lane-check rejects it and a fresh dispatch is required. The residual limit is
+narrower than it first appears: tree OIDs cover source content, not host state,
+so the current-state verification rule above still governs kernel, toolchain
+and dependency drift on the delegated host.
+
 ## Workflow Lifecycle Notes
 
 The workflow uses two jobs:

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -108,7 +108,7 @@ delegated host actually exercised.
 Four gated paths sit outside the `content_provenance_paths` prefixes and are
 therefore not provable by tree OID at all:
 
-```
+```text
 Cargo.toml
 Cargo.lock
 crates/assay-cli/src/cgroup.rs

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -72,7 +72,12 @@ cleanup and checkout.
    run URL, commit SHA, selected gate, and result in the PR body or a PR comment
    remains a compatibility fallback.
 4. Do not treat a delegated skip as success. In the delegated lane, exit `40`
-   means the runner contract has drifted.
+   means the runner contract has drifted. Gate scripts that guard on host
+   prerequisites exit `40`; `run_gate` in the delegated workflow records any
+   non-zero status as a failed gate and returns it under `set -euo pipefail`,
+   so a skip fails the job and cannot reach the proof pack as a pass. See the
+   *Skip Semantics* section of the
+   [delegated runbook](../../ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md).
 5. Do not bypass required repository checks for runner-impacting changes.
 
 If a runner-impacting PR cannot get a delegated run because the host is
@@ -99,6 +104,24 @@ identical tree OIDs for every content-provenance path in
 without another delegated run. This does not claim anything about unrelated
 repository state; it only preserves the proof for the gated content the
 delegated host actually exercised.
+
+Four gated paths sit outside the `content_provenance_paths` prefixes and are
+therefore not provable by tree OID at all:
+
+```
+Cargo.toml
+Cargo.lock
+crates/assay-cli/src/cgroup.rs
+crates/assay-cli/src/cli/commands/runner_spike.rs
+```
+
+`crates/assay-cli` is deliberately outside those prefixes; only the runner
+crates, monitor, ebpf and xtask are covered. A PR touching any of the four
+cannot reuse a proof produced on a different head, and lane-check rejects the
+reuse rather than accepting it silently. The set is derived from
+`assay_runner_gated_paths.json` rather than restated, and
+`--self-test` asserts it, so adding a gated path fails until its coverage is
+decided.
 
 The workflow keeps `pull-requests: write` while the transition comment channel
 exists. Empirically, `issues: write` plus `pull-requests: read` is not enough to

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1745,19 +1745,25 @@ def self_test() -> None:
 
 
 def _test_content_provenance_coverage_is_decided() -> None:
-    """Every gated path is either content-addressed or knowingly not.
+    """Every gated path and gated prefix is content-addressed or knowingly not.
 
     This asserts the set derived from `assay_runner_gated_paths.json` rather
-    than restating it, so adding a gate path fails here until someone answers
-    whether it belongs under a `content_provenance_paths` prefix. A path that
-    is not content-addressed cannot be proven by tree OID, so any change to it
-    forces a fresh delegated dispatch instead of proof reuse.
+    than restating it, so adding gated coverage fails here until someone
+    answers whether it belongs under a `content_provenance_paths` prefix. A
+    path that is not content-addressed cannot be proven by tree OID, so any
+    change to it forces a fresh delegated dispatch instead of proof reuse.
+
+    Both axes are checked. Gating arrives either as an exact entry in
+    `all_gate_paths` or as an `all_gate_prefixes` entry that gates everything
+    beneath it, and a prefix added without matching content provenance is the
+    same silent drift as a path added without it.
 
     `crates/assay-cli` is deliberately outside the content-provenance
     prefixes: only the runner crates, monitor, ebpf and xtask are covered.
     """
     config = load_gated_path_config()
-    assert sorted(uncovered_content_provenance_files(config.all_gate_paths)) == [
+    gated = sorted(set(config.all_gate_paths) | set(config.all_gate_prefixes))
+    assert sorted(uncovered_content_provenance_files(gated)) == [
         "Cargo.lock",
         "Cargo.toml",
         "crates/assay-cli/src/cgroup.rs",

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1699,6 +1699,7 @@ def self_test() -> None:
     assert not recorded_gate_ok("- gate: kernel-only", Gate.OPENAI_AGENTS_KERNEL_POLICY)
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
+    _test_content_provenance_coverage_is_decided()
     _test_content_tree_comparison()
 
     valid_run = {
@@ -1741,6 +1742,27 @@ def self_test() -> None:
     # touching the classifier itself, including any future PR that
     # might silently re-introduce a spike dependency.
     _assert_assay_cli_does_not_consume_spike()
+
+
+def _test_content_provenance_coverage_is_decided() -> None:
+    """Every gated path is either content-addressed or knowingly not.
+
+    This asserts the set derived from `assay_runner_gated_paths.json` rather
+    than restating it, so adding a gate path fails here until someone answers
+    whether it belongs under a `content_provenance_paths` prefix. A path that
+    is not content-addressed cannot be proven by tree OID, so any change to it
+    forces a fresh delegated dispatch instead of proof reuse.
+
+    `crates/assay-cli` is deliberately outside the content-provenance
+    prefixes: only the runner crates, monitor, ebpf and xtask are covered.
+    """
+    config = load_gated_path_config()
+    assert sorted(uncovered_content_provenance_files(config.all_gate_paths)) == [
+        "Cargo.lock",
+        "Cargo.toml",
+        "crates/assay-cli/src/cgroup.rs",
+        "crates/assay-cli/src/cli/commands/runner_spike.rs",
+    ]
 
 
 def _test_content_tree_comparison() -> None:


### PR DESCRIPTION
## Description

`content_provenance_paths` in `scripts/ci/assay_runner_gated_paths.json` covers the
runner crates, monitor, ebpf and xtask. It does not cover `crates/assay-cli`. Four
gated paths therefore cannot be proven by tree OID:

```
Cargo.toml
Cargo.lock
crates/assay-cli/src/cgroup.rs
crates/assay-cli/src/cli/commands/runner_spike.rs
```

The behaviour around them is already correct. `uncovered_content_provenance_files`
is consumed at `assay_runner_lane_check.py:826` and rejects proof reuse for those
paths when the proof head differs from the PR head. What was missing is smaller and
duller: nothing forced the coverage question to be answered when a gated path is
added, and no document named the set. The two documents that discuss proof reuse
mentioned neither.

Four changes, all Gate.NONE.

**1. An invariant, not a constant** (`scripts/ci/assay_runner_lane_check.py`)

`_test_content_provenance_coverage_is_decided` asserts the set *derived* from
`assay_runner_gated_paths.json` rather than restating it. Adding a gated path fails
the self-test until someone decides whether it belongs under a content-provenance
prefix.

A hardcoded `NO_CONTENT_ADDRESS_GATE_PATHS` constant was the obvious shape and is
deliberately not what landed. It would be a third home for a rule that already lives
in the JSON manifest and in `content_provenance_covers_path`, and it would move in
lockstep with itself, so it could never fail.

**2. `ci-lanes.md` names the four paths** next to the proof-reuse rule, with the
reason `crates/assay-cli` sits outside the prefixes.

**3. The delegated runbook gains a Lane-Check Interaction Failures section.**

Four consumer-side causes of a delegated run that passes while the PR stays blocked,
none of them visible in the delegated workflow's own logs: the proof binding to the
dispatched ref rather than the PR, the `lane-check` job versus the `lane-check/proof`
required status, read-only tokens on fork and Dependabot `pull_request` events, and
proof reuse on content-identical trees.

A grep of the runbook for `head_sha|fork|dependabot|lane-check|expected_head|status`
previously returned two incidental hits and nothing normative.

**4. The exit-40 rule in `ci-lanes.md` now says why it holds.**

`run_gate` returns any non-zero status under `set -euo pipefail`, so a skip fails the
job and cannot reach the proof pack as a pass. The rule was already enforced; it read
as convention. The wording says "gate scripts that guard on host prerequisites"
rather than "the gate scripts", because four of the nine three-run-determinism
scripts carry the guard and five do not.

## Type of Change

- [x] Documentation update
- [x] Test coverage (self-test invariant)

## Verification

- [x] `python3 scripts/ci/assay_runner_lane_check.py --self-test` passes
- [x] **Negative control**: adding an uncovered path to `all_gate_paths` in
      `assay_runner_gated_paths.json` fails the self-test with `AssertionError`.
      The manifest was restored; `git diff` on it is empty.
- [x] Full pre-commit suite green, including the `Assay-Runner lane-check self-test`
      hook that runs the new invariant
- [x] All three changed files classify as `Gate.NONE` via `classify_file`
- [x] The new relative link from `ci-lanes.md` resolves to an existing file

No delegated run was dispatched and none is claimed. `cargo` targets are unaffected;
no Rust source changed.

## Related

Companion to #2017, which reports the finding this work did not fix: the proof pack
records a per-gate status array that no consumer reads. That is a behaviour change to
`lane-check` and belongs in its own PR.

Scope deliberately excluded: the choice between "runbook is normative" and "code is
normative" for delegated-proof freshness. This PR records current behaviour and makes
no claim about which should govern.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that delegated gate exit status `40` and prerequisite-check failures are treated as failed gates.
  - Documented troubleshooting guidance for dispatched references, required commit statuses, fork and Dependabot permissions, and proof reuse.
  - Identified four gated paths that always require a fresh proof when changed.
  - Clarified that content-identical trees may allow proof reuse only when no fresh-proof paths are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->