### PR TITLE
The gated file became a stub, and the gate stayed on the stub

### DIFF
--- a/scripts/ci/assay_runner_gated_paths.json
+++ b/scripts/ci/assay_runner_gated_paths.json
@@ -6,14 +6,14 @@
     "crates/assay-runner-linux/",
     "crates/assay-monitor/",
     "crates/assay-ebpf/",
-    "crates/assay-xtask/"
+    "crates/assay-xtask/",
+    "crates/assay-cli/src/cli/commands/runner_spike/"
   ],
   "all_gate_paths": [
     ".github/workflows/runner-spike-delegated.yml",
     ".github/workflows/runner-spike-sdk.yml",
     ".github/actions/canonical-ebpf-build/action.yml",
     "crates/assay-cli/src/cli/commands/runner_spike.rs",
-    "crates/assay-cli/src/cgroup.rs",
     "Cargo.toml",
     "Cargo.lock",
     "scripts/ci/assay_runner_delegated_proof_pack.py",

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1757,8 +1757,14 @@ def _test_declared_gate_surfaces_exist() -> None:
     moved (#2020).
 
     The surface list is read from `assay_runner_gated_paths.json` and matched
-    against `git ls-files` with the production `starts` helper; nothing here
-    restates the manifest.
+    against `git ls-files`; nothing here restates the manifest.
+
+    Each kind is matched the way `classify_file` consumes it: `all_gate_paths`
+    by exact membership (`path in gated_paths.all_gate_paths`) and
+    `all_gate_prefixes` through the production `starts` helper. Matching an
+    exact declaration by descent instead would accept a directory name as
+    live while `classify_file` gates nothing under it, since `git ls-files`
+    never yields a directory.
 
     Bounded on purpose: this proves no declared surface is dead. It does not
     prove the gated set is the right set. Most gating lives in `classify_file`
@@ -1767,14 +1773,20 @@ def _test_declared_gate_surfaces_exist() -> None:
     """
     config = load_gated_path_config()
     root = Path(__file__).resolve().parents[2]
-    tracked = subprocess.check_output(
-        ["git", "-C", str(root), "ls-files", "-z"], text=True
-    ).split("\0")
-    surfaces = (*config.all_gate_paths, *config.all_gate_prefixes)
+    tracked = {
+        path
+        for path in subprocess.check_output(
+            ["git", "-C", str(root), "ls-files", "-z"], text=True
+        ).split("\0")
+        if path
+    }
     dead = sorted(
-        surface
-        for surface in surfaces
-        if not any(starts(path, surface) for path in tracked if path)
+        [path for path in config.all_gate_paths if path not in tracked]
+        + [
+            prefix
+            for prefix in config.all_gate_prefixes
+            if not any(starts(path, prefix) for path in tracked)
+        ]
     )
     assert not dead, f"declared gate surfaces matching no tracked file: {dead}"
 

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1699,6 +1699,7 @@ def self_test() -> None:
     assert not recorded_gate_ok("- gate: kernel-only", Gate.OPENAI_AGENTS_KERNEL_POLICY)
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
+    _test_declared_gate_surfaces_exist()
     _test_content_tree_comparison()
 
     valid_run = {
@@ -1741,6 +1742,41 @@ def self_test() -> None:
     # touching the classifier itself, including any future PR that
     # might silently re-introduce a spike dependency.
     _assert_assay_cli_does_not_consume_spike()
+
+
+def _test_declared_gate_surfaces_exist() -> None:
+    """Every declared gate surface matches at least one tracked file.
+
+    `all_gate_paths` matches exactly and `all_gate_prefixes` matches by
+    descent, so a file that moves stops being gated without producing any
+    diagnostic: the stale entry matches nothing, the new location matches no
+    rule, and the entry still reads as coverage. That is how
+    `crates/assay-cli/src/cli/commands/runner_spike.rs` came to gate a 17-line
+    module facade while the eight files holding the behaviour were ungated,
+    and how `crates/assay-cli/src/cgroup.rs` stayed declared after the file
+    moved (#2020).
+
+    The surface list is read from `assay_runner_gated_paths.json` and matched
+    against `git ls-files` with the production `starts` helper; nothing here
+    restates the manifest.
+
+    Bounded on purpose: this proves no declared surface is dead. It does not
+    prove the gated set is the right set. Most gating lives in `classify_file`
+    rather than the manifest, and which of the two is the source of truth is
+    open in #2020.
+    """
+    config = load_gated_path_config()
+    root = Path(__file__).resolve().parents[2]
+    tracked = subprocess.check_output(
+        ["git", "-C", str(root), "ls-files", "-z"], text=True
+    ).split("\0")
+    surfaces = (*config.all_gate_paths, *config.all_gate_prefixes)
+    dead = sorted(
+        surface
+        for surface in surfaces
+        if not any(starts(path, surface) for path in tracked if path)
+    )
+    assert not dead, f"declared gate surfaces matching no tracked file: {dead}"
 
 
 def _test_content_tree_comparison() -> None:


### PR DESCRIPTION
## Description

Closes the live coverage hole in #2020.

`all_gate_paths` matches by exact path. The Wave53 module split moved the
runner-spike behaviour into `crates/assay-cli/src/cli/commands/runner_spike/`
and left the manifest entry on the file that stayed behind. That file is now a
17-line `mod` facade:

| Before this PR | |
|---|---|
| `…/runner_spike.rs` (17-line facade) | `Gate.ALL` |
| `…/runner_spike/{args,cgroup,exit_status,implementation,logs,phases,redaction,spec}.rs` | `Gate.NONE` |

So a PR rewriting cgroup placement or phase sequencing required no delegated
proof, while a PR touching the `mod` declarations required a full `gates=all`
dispatch. The same refactor also moved `crates/assay-cli/src/cgroup.rs`, whose
manifest entry stayed and has been gating a path that does not exist.

**Changes**

- `all_gate_prefixes` gains `crates/assay-cli/src/cli/commands/runner_spike/`,
  so the module is gated by descent and survives the next file move.
- The dead `crates/assay-cli/src/cgroup.rs` entry is removed. The surviving
  `cgroup.rs` is in `crates/assay-runner-linux/`, already covered by prefix.
- `_test_declared_gate_surfaces_exist` asserts that every entry in
  `all_gate_paths` and `all_gate_prefixes` matches at least one `git ls-files`
  path, using the production `starts` helper. The surface list is read from the
  manifest and matched against the tree; nothing restates it.

## Type of Change

- [x] Bug fix (CI lane coverage)
- [x] Test coverage

## Verification

Four axes, each run separately, manifest restored between runs:

| Mutation | Self-test |
|---|---|
| dead exact path (`crates/assay-cli/src/cgroup.rs`) — the bug above | **red** |
| dead prefix (`crates/assay-gone/`) | **red** |
| live path added (`README.md`) | green — so it discriminates |
| **gated file moved, entry left behind** | **red** |

The fourth reproduces the real failure end to end rather than asserting a list:
`git mv` the gated file away, leave the manifest untouched, and the check goes
red. The first three only manipulate the manifest.

Also verified:

- [x] All eight `runner_spike/` files now classify `Gate.ALL` (was `Gate.NONE`)
- [x] Baseline `--self-test` passes; full pre-commit suite green
- [x] The hook fires on this change — `.pre-commit-config.yaml` covers both
      `assay_runner_lane_check.py` and `assay_runner_gated_paths.json`, and
      `assay-runner-lane-check.yml` runs `--self-test` on every `pull_request`

## Delegated proof required

**This PR is `Gate.ALL`.** It touches `scripts/ci/assay_runner_gated_paths.json`,
which classifies as *"runner workflow, CLI, cgroup, or workspace dependency
surface requires gates=all"*. It needs a `Runner Spike Delegated` dispatch with
`gates=all` **on this branch**, after the final candidate commit — not on `main`,
per the runbook's dispatch procedure.

Not dispatched here: that workflow runs destructive cleanup on the dedicated
`assay-bpf-runner` host, and host availability is not something this change can
determine.

## Bounded claim

This proves no *declared* gate surface is dead. It does **not** prove the gated
set is the right set.

Most gating lives in `classify_file`, which decides from eleven rules and reads
the manifest in two of them. Derived over all tracked files, 26 are gated but
not content-addressed — `runner-fixtures/**` and `tests/fixtures/runner-spike/**`
among them. This PR raises that to 34, because the eight newly-gated module
files are also outside `content_provenance_paths`. That is fail-closed (those
PRs cannot reuse a proof from another head), but it is the trade-off #2020 asks
someone to decide on.

Which artifact is the source of truth for gating stays open in #2020.

## Related

- Closes the urgent half of #2020
- #2018 was closed rather than patched: it tried to pin this property by
  deriving the gated surface from the manifest, which is the wrong artifact.
  Three adversarial review lenses found its documentation claims false.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] Documentation — none needed; no documented behaviour changes. The lane
      contract already says this surface requires `gates=all`; it simply was
      not true of the files that hold it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-detection coverage for runner-related components.
  * Removed an outdated path from gated validation checks.
  * Added safeguards that identify stale or unmatched path declarations, helping ensure changes are evaluated by the appropriate checks.
  * These updates improve the consistency and reliability of automated validation for runner-related changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->