### PR TITLE
chore(deps): bump rustls-pki-types to 1.15.1 and tokio-stream to 0.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5412,9 +5412,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",


### PR DESCRIPTION
Combines #1964 and #1966 onto a maintainer branch. Closes #1964. Closes #1966.

## Why not just merge the Dependabot PRs

A `Cargo.lock` change classifies as `gates=all`, so both needed a delegated proof — and neither could get one. Dependabot's `pull_request` token is read-only by design, so `lane-check/proof` was never even posted, leaving both permanently `BLOCKED` with zero failing checks.

The repo already decided how that is handled. [`dependabot-lane-flow.md`](docs/reference/runner/dependabot-lane-flow.md) reserves the dispatch and the proof comment for a maintainer, and [`ci-lanes.md`](docs/reference/runner/ci-lanes.md) lists auto-dispatching the self-hosted runner from a Dependabot PR as needing a separate security design review — the delegated lane runs the workflow definition *from the dispatched ref*, and the helper's own assertion says "dispatching on a ref carrying untrusted changes stays forbidden".

A maintainer branch is a trusted ref, so it can be proven the ordinary way.

## The lockfile is Dependabot's, not a regeneration

Worth stating, because the first attempt was wrong. `cargo update -p <crate> --precise <version>` re-resolved the graph and **downgraded `windows-sys` from 0.61.2 to 0.60.2 and 0.52.0 across six entries** — a regression wearing a bump's clothes.

Dependabot's own lockfiles differ from `main` only in the target crate's version and checksum, so those two diffs were applied directly instead.

Verified:

```
-version = "1.15.0"    +version = "1.15.1"     (rustls-pki-types)
-checksum = "764899a…" +checksum = "2f492502…"
-version = "0.1.18"    +version = "0.1.19"     (tokio-stream)
-checksum = "32da4980…" +checksum = "a3d06f0b…"

windows-sys lines touched: 0
```

Four changed lines, nothing else.

## Note on `fuzz/Cargo.lock`

Not touched here, and it is already inconsistent: it carries `rustls-pki-types 1.15.1` while `main` carried 1.15.0, and has no `tokio-stream` entry at all. That drift is #1996's subject, not this PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)