### PR TITLE
Snapshot the gated surface, because every derived key lost information

### DIFF
--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -631,6 +631,72 @@ def load_gated_path_config() -> GatedPathConfig:
     )
 
 
+def derive_gating_inventory() -> tuple[tuple[str, str, int, int], ...]:
+    """Derive the whole gating contract from `classify_file` over `git ls-files`.
+
+    One row per (gate, rule): the gate label, the rule text without its leading
+    path, how many tracked files the rule gates, and how many of those are not
+    content-addressed.
+
+    Derived, never declared. `classify_file` is the source of truth for gating:
+    it holds eleven rules and reads `assay_runner_gated_paths.json` in two of
+    them. The manifest stays because `content_provenance_paths` is a cross-tool
+    contract that `.github/actions/canonical-ebpf-build` also reads, but it is
+    not the gating contract and cannot become one — the reasons for most rules
+    are prose, and JSON has nowhere to put them.
+    """
+    config = load_gated_path_config()
+    root = Path(__file__).resolve().parents[2]
+    tracked = [
+        path
+        for path in subprocess.check_output(
+            ["git", "-C", str(root), "ls-files", "-z"], text=True
+        ).split("\0")
+        if path
+    ]
+    totals: dict[tuple[str, str], int] = {}
+    uncovered: dict[tuple[str, str], int] = {}
+    for path in tracked:
+        gate, reason = classify_file(path)
+        if gate is Gate.NONE:
+            continue
+        rule = reason.split(": ", 1)[1] if reason and ": " in reason else str(reason)
+        key = (gate.label, rule)
+        totals[key] = totals.get(key, 0) + 1
+        if not content_provenance_covers_path(path, config):
+            uncovered[key] = uncovered.get(key, 0) + 1
+    return tuple(
+        (gate, rule, totals[(gate, rule)], uncovered.get((gate, rule), 0))
+        for gate, rule in sorted(totals)
+    )
+
+
+def explain_gating() -> int:
+    """Print the derived gating contract.
+
+    Answers "what is gated, by which rule, and can it reuse a delegated proof"
+    without reading this file, so nobody has to infer the contract from the
+    manifest's partial view again.
+    """
+    rows = derive_gating_inventory()
+    print("Gating contract, derived from classify_file over git ls-files.")
+    print("classify_file is the source of truth; assay_runner_gated_paths.json")
+    print("carries only what other tools consume.")
+    print()
+    print(f"{'gate':<30} {'files':>5} {'uncov':>5}  rule")
+    for gate, rule, total, uncov in rows:
+        print(f"{gate:<30} {total:>5} {uncov:>5}  {rule}")
+    total_uncovered = sum(row[3] for row in rows)
+    print()
+    print(
+        f"{total_uncovered} gated files sit outside content_provenance_paths. A PR "
+        "touching one\ncannot reuse a delegated proof from another head, so it "
+        "always needs a fresh\ndispatch. That is fail-closed, and it is the cost "
+        "side of the coverage set."
+    )
+    return 0
+
+
 def classify_file(path: str) -> tuple[Gate, str | None]:
     gated_paths = load_gated_path_config()
     docs_runner_prefixes = (
@@ -1700,6 +1766,8 @@ def self_test() -> None:
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
     _test_declared_gate_surfaces_exist()
+    _test_uncovered_gating_rules_are_known()
+    _test_prefix_gated_surfaces_keep_their_coverage()
     _test_content_tree_comparison()
 
     valid_run = {
@@ -1742,6 +1810,60 @@ def self_test() -> None:
     # touching the classifier itself, including any future PR that
     # might silently re-introduce a spike dependency.
     _assert_assay_cli_does_not_consume_spike()
+
+
+def _test_uncovered_gating_rules_are_known() -> None:
+    """Which rules gate files that cannot be content-addressed is a known set.
+
+    A gated file outside `content_provenance_paths` can never reuse a delegated
+    proof from another head. That is fail-closed and correct, but it is a cost,
+    and a new rule that quietly adds one should be a decision rather than a
+    surprise. This asserts the rules, not the files, so adding a fixture under
+    an existing rule does not churn while a new uncovered surface does fail.
+
+    Derived from `classify_file` over `git ls-files`, which is where gating is
+    decided. Deriving it from the manifest instead would see two of the eleven
+    rules, which is the error #2018 shipped and was closed for.
+    """
+    uncovered_rules = sorted(
+        f"{gate}: {rule}" for gate, rule, _, uncov in derive_gating_inventory() if uncov
+    )
+    assert uncovered_rules == [
+        "all: Gemini google-genai fixture requires gates=all",
+        "all: ambiguous runner fixture surface defaults to gates=all",
+        "all: runner workflow, CLI, cgroup, or workspace dependency surface requires gates=all",
+        "all: shared runner/eBPF/monitor/xtask code requires gates=all",
+        "kernel-only: kernel-only fixture requires gates=kernel-only",
+        "kernel-policy: policy fixture requires gates=kernel-policy",
+        "openai-agents-kernel-policy: OpenAI Agents fixture requires gates=openai-agents-kernel-policy",
+    ], uncovered_rules
+
+
+def _test_prefix_gated_surfaces_keep_their_coverage() -> None:
+    """Which prefix-gated surfaces are content-addressed is a known set.
+
+    Separate subject from `_test_uncovered_gating_rules_are_known`, which pins
+    rules. This pins prefixes, because coverage can be withdrawn from a whole
+    crate without changing the rule set: the six prefixes share one rule, so
+    dropping `crates/assay-monitor` from `content_provenance_paths` leaves that
+    rule already-uncovered and the rule-level assertion green.
+
+    Stable against file churn — it reads prefixes, not files.
+
+    Still not claimed, on purpose: a `content_provenance_paths` entry that
+    covers only exact `all_gate_paths` members can still be withdrawn without
+    failing anything here, and neither test notices a shrinking file count
+    inside a rule that is already partly uncovered.
+    """
+    config = load_gated_path_config()
+    uncovered = sorted(
+        prefix
+        for prefix in config.all_gate_prefixes
+        if not content_provenance_covers_path(prefix, config)
+    )
+    assert uncovered == [
+        "crates/assay-cli/src/cli/commands/runner_spike/",
+    ], uncovered
 
 
 def _test_declared_gate_surfaces_exist() -> None:
@@ -2557,6 +2679,7 @@ def _assert_assay_cli_does_not_consume_spike() -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--explain-gating", action="store_true")
     parser.add_argument("--resolve-pr-from-event", action="store_true")
     parser.add_argument("--pr-number", type=int, default=int(os.environ.get("PR_NUMBER", "0") or "0"))
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
@@ -2568,6 +2691,9 @@ def main() -> int:
         self_test()
         print("self-test ok")
         return 0
+
+    if args.explain_gating:
+        return explain_gating()
 
     token = os.environ.get("GITHUB_TOKEN", "")
     if not token:


### PR DESCRIPTION
## Description

Resolves direction 2 of #2020, the half #2022 left open: whether the manifest or
the classifier is the source of truth for gating, and how a reader gets a
complete answer.

**This PR was rewritten after adversarial review refuted its first mechanism.**
The history is the argument, so it is stated rather than buried.

## Why the obvious mechanisms do not work

Three attempts pinned the gated surface with a *derived key*. Each was refuted
by demonstration, not by argument:

| Attempt | Key | Refuted by |
|---|---|---|
| #2018 | the manifest fields | saw 2 of 14 rules; published "four gated paths" when it was 26 |
| this PR, v1 | the set of rule strings | one entry added to `all_gate_paths` → green; a new `classify_file` branch reusing a neighbouring rule's wording → **43 new uncovered files, green** |
| this PR, v1 | the set of uncovered prefixes | ungating `.github/workflows/runner-spike-delegated.yml` → green; ungating `crates/assay-monitor/` → green; widening the exemption set → green |

The pattern is not three bugs. **Any key coarse enough to absorb a legitimate
addition also absorbs a silent removal.** Both v1 tests are removed rather than
patched a fourth time.

## What this ships instead

A snapshot, where "nothing changed" is the invariant — the shape this repository
already uses for derived artifacts that go stale quietly. `check-aee-seal-fixture-drift.sh`
commits its fixtures, regenerates into scratch, diffs, and prints the
regeneration command plus a note that a vanished entry belongs deleted rather
than restored. This follows it exactly.

- **`--emit-gating-map`** writes `scripts/ci/assay_runner_gating_map.txt`: 115
  gated files with their required gate, derived from `classify_file` over
  `git ls-files`.
- **`check-runner-gating-map-drift.sh`** regenerates and diffs, wired as a
  pre-commit hook over the emitter, the manifest, the map, and itself.

Churn is deliberate. A gated file appearing or disappearing *is* a change to the
gated surface, and the diff is where that decision gets reviewed.

### Verification

Every mutation that defeated the previous three attempts, each run separately
and reverted:

| Mutation | Before | Now |
|---|---|---|
| new uncovered path in `all_gate_paths` | green | **red** |
| new rule reusing an existing reason string (+43 uncovered files) | green | **red** |
| `runner-spike-delegated.yml` ungated | green | **red** |
| whole crate ungated via prefix removal | green | **red** |
| exemption widened, gate silently removed | green | **red** |

## The decision, now actually implemented

**`classify_file` is the source of truth for gating.**

v1 asserted this in a docstring inside the file that already won, and changed the
manifest not at all — so a reader opening `assay_runner_gated_paths.json` saw
exactly what they saw before. #2020 asked for the manifest to *stop presenting
itself as the gated-path contract*, which requires touching the manifest.

It now carries `_source_of_truth`, naming `classify_file`, stating that the file
is not the gating contract, and pointing at `--explain-gating` and the map.

The manifest stays because `content_provenance_paths` is read by
`.github/actions/canonical-ebpf-build/action.yml` and
`assay_runner_delegated_proof_pack.py`. Its two *gating* fields are read by
nothing outside `assay_runner_lane_check.py` — so the cross-tool argument
justifies keeping the coverage field in JSON and says nothing about the gating
fields. Those stay because moving all 14 rules into a data table would make
first-match-wins ordering an implicit contract in a JSON array and turn a
fail-closed classifier into a table interpreter, which is a real regression
surface for no gain now that the complete answer is derivable.

An earlier draft justified this with "JSON has nowhere to put prose". That is
false — a rule entry can carry a `note` field — and it has been dropped.

## Corrections, all from adversarial review

- **"eleven rules" was wrong in three places.** `classify_file` has 14 gating
  rules and 17 returns. The number came from #2020 unchecked.
- **`docs/superpowers/plans/2026-07-03-runner-delegated-proof-layer2.md`** said
  the manifest "is the single source for gated prefixes". The repo was shipping
  the opposite answer to the question this PR settles.
- **`ci-lanes.md`** now names the source of truth and points at
  `--explain-gating`, which nothing in the repo referenced.
- **`--explain-gating` no longer claims** the manifest "carries only what other
  tools consume": its two rules declare **74 of the 115** gated files. It also
  labels its own partiality — "12 of 14 gating rules match at least one tracked
  file" — instead of reporting the exercised contract as the contract.
- **The rule key** is taken by stripping the known path prefix rather than
  splitting on the first `": "`, which a path containing `": "` corrupted into a
  phantom rule.

## Known and not fixed

Two dead rules, found while counting, left for a separate issue: the proof-pack
collector rule is shadowed by the `all_gate_paths` entry for the same file, and
the `runner-fixtures` catch-all matches nothing today. Both are harmless — the
shadowing rule assigns the same gate — but a rule whose reason can never be
shown is worth removing deliberately.

The map does not catch a *new* file that should be gated and is not. Nothing can,
without knowing intent.

## Delegated proof required

**This PR is `Gate.ALL`** — it touches `scripts/ci/assay_runner_gated_paths.json`.
A `Runner Spike Delegated` dispatch with `gates=all` on this branch is required.

## Related

Closes #2020. Direction 1 landed in #2022 (`f696298`); this is direction 2.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
