### PR TITLE
An exit code decided by spelling is not a decision

### DIFF
--- a/crates/assay-cli/src/cli/helpers.rs
+++ b/crates/assay-cli/src/cli/helpers.rs
@@ -1,5 +1,5 @@
 use crate::exit_codes;
-use assay_core::errors::diagnostic::Diagnostic;
+use assay_core::errors::diagnostic::{exit_class, Diagnostic, ExitClass};
 use std::path::{Path, PathBuf};
 
 pub fn normalize_severity(s: &str) -> &'static str {
@@ -24,25 +24,122 @@ pub fn infer_policy_path(assay_yaml: &Path) -> Option<PathBuf> {
     Some(PathBuf::from(p))
 }
 
+/// The process exit code for a set of diagnostics.
+///
+/// The class of each code comes from the registry that defines it. This function used to infer the
+/// class by matching code prefixes, which made a code's spelling load-bearing for exit semantics
+/// and had already drifted: `E_TRACE_MISS` and `E_PATH_NOT_FOUND` describe one missing-trace
+/// condition and exited 1 and 2 respectively.
 pub fn decide_exit(diags: &[Diagnostic]) -> i32 {
-    let has_error = diags
-        .iter()
-        .any(|d| normalize_severity(&d.severity) == "error");
-    if !has_error {
-        return exit_codes::OK;
+    let mut saw_error = false;
+    let mut saw_config = false;
+
+    for d in diags {
+        if normalize_severity(&d.severity) != "error" {
+            continue;
+        }
+        saw_error = true;
+        match exit_class(&d.code) {
+            ExitClass::Config => saw_config = true,
+            // An unregistered code is not evidence of a config fault. `assay_core::validate`
+            // forwards policy-engine verdict codes verbatim (`E_ARG_SCHEMA` and friends), and those
+            // describe a test outcome. Registering them is #2027; until then they land here, which
+            // is the same exit code the prefix match gave them.
+            ExitClass::Test | ExitClass::Unregistered => {}
+        }
     }
 
-    let is_config_like = diags.iter().any(|d| {
-        normalize_severity(&d.severity) == "error"
-            && (d.code.starts_with("E_CFG_")
-                || d.code.starts_with("E_PATH_")
-                || d.code.starts_with("E_TRACE_SCHEMA")
-                || d.code.starts_with("E_BASE_MISMATCH"))
-    });
-
-    if is_config_like {
+    if !saw_error {
+        return exit_codes::OK;
+    }
+    if saw_config {
         exit_codes::CONFIG_ERROR
     } else {
         exit_codes::TEST_FAILED
+    }
+}
+
+#[cfg(test)]
+mod decide_exit_tests {
+    use super::*;
+    use assay_core::errors::diagnostic::{codes, ERROR_EXIT_CLASSES};
+
+    fn err(code: &str) -> Diagnostic {
+        Diagnostic::new(code, "test")
+    }
+
+    /// The defect this function was rewritten for: one missing-trace condition is reported under
+    /// two codes depending on which lookup found it, and they used to exit 1 and 2.
+    #[test]
+    fn missing_trace_exits_the_same_under_either_code() {
+        assert_eq!(
+            decide_exit(&[err(codes::E_TRACE_MISS)]),
+            decide_exit(&[err(codes::E_PATH_NOT_FOUND)]),
+        );
+    }
+
+    /// The four codes the prefix list missed. Each is declared an error in the registry and each
+    /// used to exit 1.
+    #[test]
+    fn codes_the_prefix_list_missed_now_exit_config() {
+        for code in [
+            codes::E_TRACE_MISS,
+            codes::E_TRACE_INVALID,
+            codes::E_REPLAY_STRICT_MISSING,
+            codes::E_EMB_DIMS,
+        ] {
+            assert_eq!(
+                decide_exit(&[err(code)]),
+                exit_codes::CONFIG_ERROR,
+                "{code} is a registered error code and must not exit as a test failure",
+            );
+        }
+    }
+
+    #[test]
+    fn every_registered_error_code_exits_config() {
+        for (code, _) in ERROR_EXIT_CLASSES {
+            assert_eq!(
+                decide_exit(&[err(code)]),
+                exit_codes::CONFIG_ERROR,
+                "{code}",
+            );
+        }
+    }
+
+    /// Policy-engine verdict codes reach `validate` unregistered. They describe a test outcome, and
+    /// this is the exit code they had before the rewrite.
+    #[test]
+    fn unregistered_code_exits_test_failure() {
+        assert_eq!(decide_exit(&[err("E_ARG_SCHEMA")]), exit_codes::TEST_FAILED);
+        assert_eq!(decide_exit(&[err("E_UNKNOWN")]), exit_codes::TEST_FAILED);
+    }
+
+    /// A config fault anywhere in the set decides, matching the previous `any` semantics.
+    #[test]
+    fn one_config_code_among_test_codes_decides() {
+        let diags = vec![err("E_ARG_SCHEMA"), err(codes::E_CFG_PARSE)];
+        assert_eq!(decide_exit(&diags), exit_codes::CONFIG_ERROR);
+    }
+
+    #[test]
+    fn warnings_and_empty_sets_exit_ok() {
+        assert_eq!(decide_exit(&[]), exit_codes::OK);
+        let warn = err(codes::W_CFG_VACUOUS_EXPECTED).with_severity("warn");
+        assert_eq!(decide_exit(&[warn]), exit_codes::OK);
+    }
+
+    /// `E_TRACE_SCHEMA` was one of the four prefixes and has never named a code. Nothing may depend
+    /// on it, and a code that merely starts with a config-looking prefix is no longer special.
+    #[test]
+    fn spelling_no_longer_decides() {
+        assert_eq!(
+            decide_exit(&[err("E_TRACE_SCHEMA")]),
+            exit_codes::TEST_FAILED
+        );
+        assert_eq!(
+            decide_exit(&[err("E_CFG_INVENTED")]),
+            exit_codes::TEST_FAILED
+        );
     }
 }

--- a/crates/assay-core/src/errors/diagnostic.rs
+++ b/crates/assay-core/src/errors/diagnostic.rs
@@ -100,7 +100,8 @@ impl std::error::Error for Diagnostic {}
 
 // Common error codes
 pub mod codes {
-    // Errors (Exit 2)
+    // Errors. Their exit class is declared once, in `ERROR_EXIT_CLASSES` below — not here, and
+    // never by how a code is spelled.
     pub const E_CFG_PARSE: &str = "E_CFG_PARSE";
     pub const E_CFG_SCHEMA: &str = "E_CFG_SCHEMA";
     pub const E_PATH_NOT_FOUND: &str = "E_PATH_NOT_FOUND";
@@ -111,13 +112,124 @@ pub mod codes {
     pub const E_EMB_DIMS: &str = "E_EMB_DIMS";
     pub const E_POLICY_VIOLATION: &str = "E_POLICY_VIOLATION";
 
-    // Warnings (Exit 0)
+    // Warnings. These carry `severity: "warn"`, which is what keeps a run of them at exit 0, so
+    // they are deliberately absent from `ERROR_EXIT_CLASSES`.
     /// A test that asserts nothing: no `expected:` block and no `assertions:`, so it
     /// passes for any response. An `expected:` block written out as empty is rejected
     /// at parse time as `E_CFG_PARSE` instead.
     pub const W_CFG_VACUOUS_EXPECTED: &str = "W_CFG_VACUOUS_EXPECTED";
     pub const W_BASE_FINGERPRINT: &str = "W_BASE_FINGERPRINT";
     pub const W_CACHE_CONFUSION: &str = "W_CACHE_CONFUSION";
+}
+
+/// How an error diagnostic classifies for process exit.
+///
+/// The registry owns this. An exit decision must never be inferred from how a code is spelled: the
+/// CLI used to match code prefixes, and that list had drifted until `E_TRACE_MISS` exited 1 while
+/// `E_PATH_NOT_FOUND` exited 2 for the same missing-trace condition, and a fourth prefix
+/// (`E_TRACE_SCHEMA`) matched no code that has ever existed.
+///
+/// The variants name a class, not an exit number. Which number a class maps to belongs to whichever
+/// binary is exiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitClass {
+    /// The run could not be evaluated as specified: config, paths, traces, baselines, embeddings.
+    Config,
+    /// The subject under test failed a check.
+    Test,
+    /// Not a code in [`codes`]. This is a variant rather than a default so that an unclassified
+    /// code is a state a caller can see and test for, instead of the silent result of no match.
+    Unregistered,
+}
+
+/// The exit class of every registered error code — the single place the `// Errors (Exit 2)`
+/// comment above used to state in prose.
+///
+/// Warning codes are absent by design: severity already decides that a run of warnings exits 0, so
+/// a warning never reaches a class lookup.
+pub const ERROR_EXIT_CLASSES: &[(&str, ExitClass)] = &[
+    (codes::E_CFG_PARSE, ExitClass::Config),
+    (codes::E_CFG_SCHEMA, ExitClass::Config),
+    (codes::E_PATH_NOT_FOUND, ExitClass::Config),
+    (codes::E_TRACE_MISS, ExitClass::Config),
+    (codes::E_TRACE_INVALID, ExitClass::Config),
+    (codes::E_BASE_MISMATCH, ExitClass::Config),
+    (codes::E_REPLAY_STRICT_MISSING, ExitClass::Config),
+    (codes::E_EMB_DIMS, ExitClass::Config),
+    // Currently constructed nowhere. Classified per the registry's own declaration rather than per
+    // what the name suggests; whether a policy violation is a config or a test outcome is a
+    // question for the registry ADR, not for this table.
+    (codes::E_POLICY_VIOLATION, ExitClass::Config),
+];
+
+/// The exit class of `code`, or [`ExitClass::Unregistered`] when the registry does not know it.
+///
+/// Codes reach this from outside the registry — `assay_core::validate` forwards policy-engine
+/// verdict codes verbatim, and an unexpected trace error is reported as a bare `E_UNKNOWN`. Those
+/// are unregistered rather than misclassified, and the caller decides what that means.
+pub fn exit_class(code: &str) -> ExitClass {
+    ERROR_EXIT_CLASSES
+        .iter()
+        .find(|(registered, _)| *registered == code)
+        .map(|(_, class)| *class)
+        .unwrap_or(ExitClass::Unregistered)
+}
+
+#[cfg(test)]
+mod exit_class_tests {
+    use super::*;
+
+    #[test]
+    fn unknown_codes_are_unregistered_not_defaulted() {
+        assert_eq!(exit_class("E_UNKNOWN"), ExitClass::Unregistered);
+        assert_eq!(exit_class("E_ARG_SCHEMA"), ExitClass::Unregistered);
+        // Never a code, only ever a prefix in the CLI's old match.
+        assert_eq!(exit_class("E_TRACE_SCHEMA"), ExitClass::Unregistered);
+    }
+
+    #[test]
+    fn no_code_is_classified_twice() {
+        let mut seen: Vec<&str> = ERROR_EXIT_CLASSES.iter().map(|(c, _)| *c).collect();
+        let before = seen.len();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(seen.len(), before, "duplicate entry in ERROR_EXIT_CLASSES");
+    }
+
+    /// Pins every error constant to a class. A tenth constant added to `codes` without an entry
+    /// here is not caught — the table is `&str`-keyed, so nothing forces exhaustiveness at compile
+    /// time. Making that impossible needs the code enum tracked in #2028; this test holds the nine
+    /// that exist today.
+    #[test]
+    fn every_error_constant_has_a_class() {
+        for code in [
+            codes::E_CFG_PARSE,
+            codes::E_CFG_SCHEMA,
+            codes::E_PATH_NOT_FOUND,
+            codes::E_TRACE_MISS,
+            codes::E_TRACE_INVALID,
+            codes::E_BASE_MISMATCH,
+            codes::E_REPLAY_STRICT_MISSING,
+            codes::E_EMB_DIMS,
+            codes::E_POLICY_VIOLATION,
+        ] {
+            assert_eq!(
+                exit_class(code),
+                ExitClass::Config,
+                "{code} is unclassified"
+            );
+        }
+    }
+
+    /// Warning codes are deliberately absent: severity decides that a run of warnings exits 0, so a
+    /// warning never reaches a class lookup. If one ever did, unregistered is the honest answer.
+    #[test]
+    fn warning_codes_are_not_in_the_table() {
+        assert_eq!(
+            exit_class(codes::W_CFG_VACUOUS_EXPECTED),
+            ExitClass::Unregistered
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #2024.

## The defect

`decide_exit` decided the process exit code by prefix-matching the diagnostic code string:

```rust
d.code.starts_with("E_CFG_") || d.code.starts_with("E_PATH_")
    || d.code.starts_with("E_TRACE_SCHEMA") || d.code.starts_with("E_BASE_MISMATCH")
```

`assay validate` returns that directly, and `assay fix` runs it over the same report. So a code's *spelling* was load-bearing for exit semantics, and the list had drifted away from the registry it was reproducing.

A missing trace file reaches `validate` as `E_PATH_NOT_FOUND` on one path and as `E_TRACE_MISS` on another — the latter via `TraceClient::complete` (`providers/trace.rs:36`) returning a `Diagnostic` that `try_map_error` downcasts back out unchanged (`errors/mod.rs:247`). The first matched `E_PATH_` and exited 2; the second matched nothing and exited 1. One condition, two exit codes, decided by which lookup found it.

Four registered codes contradicted the registry's own `// Errors (Exit 2)` declaration this way:

| code | emitted at | exit before | declared |
|---|---|---|---|
| `E_TRACE_MISS` | `providers/trace.rs:37` | 1 | 2 |
| `E_TRACE_INVALID` | `validate/mod.rs:76` | 1 | 2 |
| `E_REPLAY_STRICT_MISSING` | `validate/mod.rs:409` | 1 | 2 |
| `E_EMB_DIMS` | `validate/mod.rs:443` | 1 | 2 |

And `E_TRACE_SCHEMA`, the third prefix, has never named a code — checked across every revision of the errors module, not just today's tree.

## The change

The registry declares the class; the CLI reads it.

`ExitClass` names a class rather than a number, so assay-core does not learn assay-cli's exit codes — the same shape as the existing `RunErrorKind` → `ReasonCode` mapping. `Unregistered` is a variant rather than a silent fallback: `assay_core::validate` forwards policy-engine verdict codes verbatim (`E_ARG_SCHEMA` and friends) and reports an unexpected trace error as a bare `E_UNKNOWN`, and those genuinely describe test outcomes. They keep exactly the exit code the prefix match gave them.

The `// Errors (Exit 2)` comment above the constants is replaced by a pointer to the table. Leaving a prose declaration next to the real one is how this drifted in the first place.

## Behaviour change

The four codes above now exit 2 instead of 1 from `assay validate` and `assay fix`. Nothing asserted the old values: there were no tests on `decide_exit` at all, and `SPEC-PR-Gate-Outputs-v1` governs `assay ci`/`assay run`, not `validate`. The full `assay-cli` suite (433 + 27 + 50 + …) and `assay-core` (829) pass unchanged.

## Verification

The tests were checked against the defect rather than against themselves: restoring the prefix logic under the new tests fails four of seven, and the three that still pass are exactly the behaviour-preservation cases (`unregistered_code_exits_test_failure`, `one_config_code_among_test_codes_decides`, `warnings_and_empty_sets_exit_ok`). A test suite that stays green when the bug returns would not have been worth adding.

## Deliberately not in scope

- Compile-time exhaustiveness. The table is `&str`-keyed, so a tenth constant added to `codes` without an entry is not caught. `every_error_constant_has_a_class` pins the nine that exist and says so in its doc comment; making it impossible needs the code enum in #2028.
- `E_UNKNOWN` and the policy verdict codes are still unregistered — that is #2027.
- `normalize_severity` still downgrades an unrecognized severity to `note`, which can turn a failing run into exit 0. Same file, separate defect, #2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)