### PR TITLE
A format argument that accepts anything produces an empty artifact

### DIFF
--- a/crates/assay-cli/src/cli/args/coverage.rs
+++ b/crates/assay-cli/src/cli/args/coverage.rs
@@ -44,7 +44,7 @@ pub struct CoverageArgs {
     /// - `--format md|json` for `--input` mode
     /// - `--input` mode: json|md (text aliases to json; markdown/github alias to md)
     /// - legacy mode: text|json|markdown|github
-    #[arg(long, default_value = "text")]
+    #[arg(long, default_value = "text", value_parser = ["text", "json", "md", "markdown", "github"])]
     pub format: String,
 
     /// Number of top routes to include in markdown output (default: 10).

--- a/crates/assay-cli/src/cli/args/mcp.rs
+++ b/crates/assay-cli/src/cli/args/mcp.rs
@@ -137,7 +137,7 @@ pub struct DiscoverArgs {
     pub local: bool,
 
     /// Output format (table, json, yaml)
-    #[clap(long, default_value = "table")]
+    #[clap(long, default_value = "table", value_parser = ["table", "json", "yaml"])]
     pub format: String,
 
     /// Write output to file

--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -207,7 +207,7 @@ pub struct SandboxArgs {
     pub profile: Option<PathBuf>,
 
     /// Profile output format: yaml | json (default: yaml)
-    #[arg(long, default_value = "yaml")]
+    #[arg(long, default_value = "yaml", value_parser = ["yaml", "json"])]
     pub profile_format: String,
 
     /// Optional path for human-readable profile report

--- a/crates/assay-cli/src/cli/commands/evidence/diff.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/diff.rs
@@ -15,7 +15,7 @@ pub struct DiffArgs {
     pub candidate: Option<std::path::PathBuf>,
 
     /// Output format: human or json
-    #[arg(long, default_value = "human")]
+    #[arg(long, default_value = "human", value_parser = ["human", "json"])]
     pub format: String,
 
     /// Baseline directory (look for {dir}/{key}.tar.gz)

--- a/crates/assay-cli/src/cli/commands/evidence/lint.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/lint.rs
@@ -17,7 +17,7 @@ pub struct LintArgs {
     pub bundle: Option<std::path::PathBuf>,
 
     /// Output format: json, sarif, or text
-    #[arg(long, default_value = "text")]
+    #[arg(long, default_value = "text", value_parser = ["json", "sarif", "text"])]
     pub format: String,
 
     /// Fail (exit 1) if findings at or above this severity exist

--- a/crates/assay-cli/src/cli/commands/explain.rs
+++ b/crates/assay-cli/src/cli/commands/explain.rs
@@ -28,7 +28,7 @@ pub struct ExplainArgs {
     pub policy: PathBuf,
 
     /// Output format: terminal, markdown, html, json
-    #[arg(short, long, default_value = "terminal")]
+    #[arg(short, long, default_value = "terminal", value_parser = ["terminal", "markdown", "md", "html", "json"])]
     pub format: String,
 
     /// Output file (default: stdout)

--- a/crates/assay-cli/src/cli/commands/profile_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/profile_next/mod.rs
@@ -90,7 +90,7 @@ pub struct ShowArgs {
     pub profile: PathBuf,
 
     /// Output format: summary, yaml, json
-    #[arg(long, default_value = "summary")]
+    #[arg(long, default_value = "summary", value_parser = ["summary", "json", "yaml"])]
     pub format: String,
 
     /// Show top N entries per category

--- a/crates/assay-cli/tests/format_value_parser.rs
+++ b/crates/assay-cli/tests/format_value_parser.rs
@@ -1,0 +1,138 @@
+//! Every `--format` argument must reject a value outside its documented set.
+//!
+//! Before this was enforced, each of these arguments was a bare `String` that clap accepted any
+//! value for, and the command's `match` fell through to a `_` arm. In `evidence lint`, `evidence
+//! diff` and `coverage` the structured branches write to stdout while the fallback writes only to
+//! stderr, so a typo'd format produced an empty artifact with an unchanged exit code.
+
+use std::process::Command;
+
+fn help_for(args: &[&str]) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(args)
+        .arg("--help")
+        .output()
+        .expect("failed to run assay");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// One option's help text, joined across the lines clap wraps it over.
+///
+/// An option with a short flag (`explain -f, --format`) puts its description on the following
+/// line, so matching a single line finds the flag and misses everything said about it.
+fn option_block(help: &str, flag: &str) -> String {
+    let lines: Vec<&str> = help.lines().collect();
+    let start = lines
+        .iter()
+        .position(|l| l.contains(flag))
+        .unwrap_or_else(|| panic!("no {flag} in help"));
+    let mut block = lines[start].trim().to_string();
+    for line in &lines[start + 1..] {
+        let t = line.trim();
+        // A new option starts the next block; a blank line ends the section.
+        if t.is_empty() || t.starts_with('-') {
+            break;
+        }
+        block.push(' ');
+        block.push_str(t);
+    }
+    block
+}
+
+/// The accepted set of every format argument, as the CLI advertises it.
+///
+/// Each set is the union of the command's explicit match arms and its default, because in four of
+/// these the default is only reachable through the fallback arm and would otherwise be rejected by
+/// its own parser.
+const FORMAT_ARGS: &[(&[&str], &str, &[&str])] = &[
+    (
+        &["evidence", "lint"],
+        "--format",
+        &["json", "sarif", "text"],
+    ),
+    (&["evidence", "diff"], "--format", &["human", "json"]),
+    (
+        &["explain"],
+        "--format",
+        &["terminal", "markdown", "md", "html", "json"],
+    ),
+    (
+        &["profile", "show"],
+        "--format",
+        &["summary", "json", "yaml"],
+    ),
+    (&["mcp", "discover"], "--format", &["table", "json", "yaml"]),
+    (&["sandbox"], "--profile-format", &["yaml", "json"]),
+    (
+        &["coverage"],
+        "--format",
+        &["text", "json", "md", "markdown", "github"],
+    ),
+];
+
+#[test]
+fn every_format_argument_advertises_its_accepted_values() {
+    for (cmd, flag, values) in FORMAT_ARGS {
+        let help = help_for(cmd);
+        let line = option_block(&help, flag);
+        assert!(
+            line.contains("[possible values:"),
+            "`assay {} {flag}` accepts any string: {line}",
+            cmd.join(" "),
+        );
+        for v in *values {
+            assert!(
+                line.contains(v),
+                "`assay {} {flag}` no longer accepts `{v}`: {line}",
+                cmd.join(" "),
+            );
+        }
+    }
+}
+
+/// The default must be inside its own accepted set. Four of these defaults (`text`, `human`,
+/// `summary`, `table`) have no match arm of their own and are only reachable through the fallback,
+/// so a parser derived from the arms alone would reject the command's own default.
+#[test]
+fn every_default_is_an_accepted_value() {
+    for (cmd, flag, values) in FORMAT_ARGS {
+        let help = help_for(cmd);
+        let line = option_block(&help, flag);
+        let default = line
+            .split("[default: ")
+            .nth(1)
+            .and_then(|s| s.split(']').next())
+            .unwrap_or_else(|| panic!("`assay {} {flag}` has no default", cmd.join(" ")));
+        assert!(
+            values.contains(&default),
+            "`assay {} {flag}` defaults to `{default}`, which is not in its own accepted set {values:?}",
+            cmd.join(" "),
+        );
+    }
+}
+
+#[test]
+fn an_unrecognized_format_is_rejected_rather_than_reinterpreted() {
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(["evidence", "lint", "/dev/null", "--format", "jsonn"])
+        .output()
+        .expect("failed to run assay");
+
+    assert!(
+        !out.status.success(),
+        "a typo'd --format exited successfully",
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "rejected run still wrote to stdout, which is where the artifact would go",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("invalid value 'jsonn'") && stderr.contains("possible values"),
+        "the error does not name the value or the accepted set: {stderr}",
+    );
+}


### PR DESCRIPTION
Closes #2034.

## The defect

Seven `--format` arguments were bare `String`s with no validation, and every command matching on one had a silent `_` arm. A typo did not fail — it selected a different output shape.

In `evidence lint`, `evidence diff` and `coverage`, the structured branches write to **stdout** and the fallback writes only to **stderr**. Counted directly: `lint.rs:100-132` (json and sarif) has 2 `println!` and 0 `eprintln!`; `lint.rs:133-219` (the fallback) has 0 and 17.

```bash
assay evidence lint bundle.tar.gz --format jsonn > report.json   # empty file
```

The exit code was unaffected: the format match closes at `lint.rs:220` and the `--fail-on` threshold is computed after it at `:223`. A CI step got its usual exit code and an empty artifact. For `--format sarif`, the same typo yielded an empty file where a SARIF upload expects a document.

`sandbox --profile-format jsonn` was worse than empty — `sandbox/profile.rs:31-32` wrote YAML into the file the user named, and `:41` then derived the evidence path from the raw format string, so the record described bytes that were not on disk.

## The change

Each argument carries the union of its match arms and its default:

| command | accepted set |
|---|---|
| `evidence lint` | json, sarif, text |
| `evidence diff` | human, json |
| `explain` | terminal, markdown, md, html, json |
| `profile show` | summary, json, yaml |
| `mcp discover` | table, json, yaml |
| `sandbox --profile-format` | yaml, json |
| `coverage` | text, json, md, markdown, github |

**The default is the part that needs care.** `text`, `human`, `summary` and `table` have no match arm of their own — they are only reachable *through* the fallback being removed. A parser derived from the arms alone would reject each command's own default. `explain` keeps `md`, an accepted alias its doc comment never mentioned.

The repo already knew how to do this: `coverage`'s `--input` mode rejects an unknown format and names the accepted set (`coverage/generate.rs:162-169`). This applies the same rule to the arguments that lacked it. A side benefit is that `--help` now lists the accepted values, which `docs/AIcontext/entry-points.md:239` does not.

## Behaviour change

A previously-accepted value now exits 2 with clap's usage error, including a did-you-mean:

```
error: invalid value 'jsonn' for '--format <FORMAT>'
  [possible values: json, sarif, text]
  tip: a similar value exists: 'json'
```

No test or workflow passed an out-of-set value — the only `--format` values in `.github/workflows/`, `scripts/` and `crates/assay-cli/tests/` are `json`, `md`, `sarif` and `text`, all inside their sets. (`--format=tar` in `mcp-upstream-reference.yml` is `git archive`, not this CLI.) The full `assay-cli` suite passes with zero failing suites.

## Verification

The tests were checked against the defect. Removing one `value_parser` fails two of the three, and the end-to-end test then reports the binary proceeding to bundle verification instead of rejecting the format — which is exactly the old behaviour.

One test exists because the first version of it was wrong rather than the code: `explain` has a short flag, so clap wraps its description onto the next line and a per-line match found the flag while missing everything said about it. `option_block` joins an option's wrapped lines.

## Not in scope

Three commands decide format with `if format == "json"` rather than a match — `evidence/mod.rs:300`, `baseline.rs:12,16` and `doctor/implementation.rs:14,41`. They have documented sets too and are unvalidated, but a binary choice does not produce the empty-artifact failure this issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI format options now clearly restrict input to supported values across coverage, MCP discovery, sandbox profiles, evidence, explanations, and profile views.
  * Supported formats and defaults are reported in command-line help.

* **Bug Fixes**
  * Invalid format values are rejected with clear errors listing valid alternatives.
  * Invalid requests no longer produce output artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->