### PR TITLE
inputs.gates said which set was requested, not which set ran

### DIFF
--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -68,7 +68,9 @@ cleanup and checkout.
    `assay-runner-delegated-proof-pack-<run_id>` contains `manifest.json`,
    `subject-checksums.txt`, and `attestation-bundle.json`. Lane-check verifies
    the GitHub artifact attestation, the proof-pack subjects, the selected gate,
-   and the gated-path tree OIDs. During the transition, recording the workflow
+   the per-gate execution status recorded in the manifest, and the gated-path
+   tree OIDs. A pack in which any recorded gate is not `passed` is rejected,
+   so `gates=all` means five gates ran rather than that the label said so. During the transition, recording the workflow
    run URL, commit SHA, selected gate, and result in the PR body or a PR comment
    remains a compatibility fallback.
 4. Do not treat a delegated skip as success. In the delegated lane, exit `40`

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -69,8 +69,13 @@ cleanup and checkout.
    `subject-checksums.txt`, and `attestation-bundle.json`. Lane-check verifies
    the GitHub artifact attestation, the proof-pack subjects, the selected gate,
    the per-gate execution status recorded in the manifest, and the gated-path
-   tree OIDs. A pack in which any recorded gate is not `passed` is rejected,
-   so `gates=all` means five gates ran rather than that the label said so. During the transition, recording the workflow
+   tree OIDs. A pack in which any recorded gate is not `passed` is rejected.
+   Note what that does not cover: the *number* of gates is not verified, so a
+   pack labelled `gates=all` carrying fewer entries is accepted. Checking the
+   size would compare the verifier's copy of the selection against a pack built
+   at another ref, which deadlocks any change to the gate set. What guards the
+   size is review of the diff to `GATE_SELECTIONS`, which is content-addressed
+   and so forces a fresh dispatch when it changes. During the transition, recording the workflow
    run URL, commit SHA, selected gate, and result in the PR body or a PR comment
    remains a compatibility fallback.
 4. Do not treat a delegated skip as success. In the delegated lane, exit `40`

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -988,7 +988,7 @@ def content_tree_proof_accepts_head(
 
 
 @lru_cache(maxsize=1)
-def gate_selections() -> dict[str, tuple[str, ...]]:
+def _gate_selections_cached() -> tuple[tuple[str, tuple[str, ...]], ...]:
     """Which gate keys each `inputs.gates` label is supposed to produce.
 
     Imported from the producer rather than restated. The proof pack builder
@@ -1003,37 +1003,59 @@ def gate_selections() -> dict[str, tuple[str, ...]]:
 
     sibling = Path(__file__).resolve().parent / "assay_runner_delegated_proof_pack.py"
     spec = importlib.util.spec_from_file_location("_assay_proof_pack", sibling)
-    if spec is None or spec.loader is None:  # pragma: no cover - packaging fault
+    if spec is None or spec.loader is None:
         raise RuntimeError(f"cannot load {sibling}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return dict(module.GATE_SELECTIONS)
+    try:
+        spec.loader.exec_module(module)
+        selections = module.GATE_SELECTIONS
+    except (OSError, SyntaxError, AttributeError) as exc:
+        # spec_from_file_location does not stat, so a missing or broken sibling
+        # surfaces here rather than above. Fail closed with the path named: the
+        # bare FileNotFoundError this replaced said nothing about why lane-check
+        # needs a file it never used to read.
+        raise RuntimeError(f"cannot read GATE_SELECTIONS from {sibling}: {exc}") from exc
+    return tuple((k, tuple(v)) for k, v in selections.items())
+
+
+def gate_selections() -> dict[str, tuple[str, ...]]:
+    """A fresh copy per call; the cache holds an immutable one."""
+    return dict(_gate_selections_cached())
 
 
 def gate_execution_diagnostics(manifest: dict[str, object], label: str) -> tuple[str, ...]:
-    """Reject a proof whose gates did not all run and pass.
+    """Reject a proof whose recorded gates did not all pass.
 
     `inputs.gates` is a label. It says which set was requested, not which set
     executed: the workflow's `all` branch and the builder's `GATE_SELECTIONS`
-    are separate lists, so a gate can be dropped from the branch and the run
-    still reports success, with the pack recording that gate as `missing`.
-    Until this check existed nothing read those per-gate statuses, and such a
-    pack was credited as `gates=all`.
+    are separate lists, so a gate can be dropped from the branch while the run
+    still reports success and the pack records that gate as `missing`. Until
+    this check existed nothing read those per-gate statuses and such a pack was
+    credited as `gates=all`.
 
-    Fail closed on absence, which is the harder half. A signature cannot
-    guarantee that a record arrives, so a gate that is simply not in the array
-    must be rejected rather than ignored.
+    Every recorded gate must be `passed`. A duplicate key is a rejection rather
+    than a last-wins overwrite, because otherwise a `missing` entry followed by
+    a `passed` entry for the same gate reads as success.
+
+    **The size of the selection is deliberately not checked here.**
+    `assay-runner-lane-check.yml` checks out the PR base, so that a PR can never
+    run its own gatekeeper, while the pack is built by the delegated workflow at
+    the PR head. Comparing the recorded set against this process's
+    `GATE_SELECTIONS` would therefore compare two refs, and any PR that adds or
+    retires a gate would produce a pack its own verifier rejects — in both
+    directions, with no escape, since `assay_runner_delegated_proof_pack.py` is
+    `Gate.ALL` and so requires a delegated proof to change. Measured before this
+    was dropped. What guards the selection's size instead is that the builder
+    derives the array from `GATE_SELECTIONS` at its own head, and that file is
+    content-addressed: shrinking it forces a fresh dispatch and shows up in the
+    diff.
     """
-    diagnostics: list[str] = []
-    expected = gate_selections().get(label)
-    if expected is None:
-        return (f"proof manifest inputs.gates={label!r} is not a known selection",)
-
     raw = manifest.get("gates")
-    if not isinstance(raw, list):
-        return ("proof manifest missing gates array",)
+    if not isinstance(raw, list) or not raw:
+        return ("proof manifest has no gates array",)
 
-    recorded: dict[str, str] = {}
+    diagnostics: list[str] = []
+    seen: set[str] = set()
     for entry in raw:
         if not isinstance(entry, dict):
             diagnostics.append("proof manifest gates entry is not an object")
@@ -1042,17 +1064,13 @@ def gate_execution_diagnostics(manifest: dict[str, object], label: str) -> tuple
         if not name:
             diagnostics.append("proof manifest gates entry has no gate name")
             continue
-        recorded[name] = str(entry.get("status") or "")
-
-    for gate in expected:
-        status = recorded.get(gate)
-        if status is None:
-            diagnostics.append(f"proof manifest records no result for gate {gate!r}")
-        elif status != "passed":
-            diagnostics.append(f"proof manifest gate {gate!r} is {status!r}, expected 'passed'")
-
-    for gate in sorted(set(recorded) - set(expected)):
-        diagnostics.append(f"proof manifest records gate {gate!r}, which {label!r} does not select")
+        if name in seen:
+            diagnostics.append(f"proof manifest records gate {name!r} more than once")
+            continue
+        seen.add(name)
+        status = str(entry.get("status") or "")
+        if status != "passed":
+            diagnostics.append(f"proof manifest gate {name!r} is {status!r}, expected 'passed'")
 
     return tuple(diagnostics)
 
@@ -1919,6 +1937,7 @@ def self_test() -> None:
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
     _test_gating_rule_count_is_derived()
+    _test_gate_execution_is_verified()
     _test_gate_selections_match_the_workflow()
     _test_gating_map_is_current()
     _test_prefix_gated_surfaces_keep_their_coverage()
@@ -2000,6 +2019,74 @@ def _test_gating_rule_count_is_derived() -> None:
     assert gating_rule_count() == 14, gating_rule_count()
 
 
+def _test_gate_execution_is_verified() -> None:
+    """A proof is credited only when every recorded gate passed.
+
+    Committed rather than run by hand. An earlier revision of this check shipped
+    with nine cases exercised interactively and none of them here, and replacing
+    the function body with `return ()` left the suite green — the fix was
+    unprotected against its own removal.
+    """
+    full = [{"gate": g, "status": "passed"} for g in gate_selections()["all"]]
+
+    def diagnose(gates: object) -> tuple[str, ...]:
+        return gate_execution_diagnostics({"inputs": {"gates": "all"}, "gates": gates}, "all")
+
+    # Accepted: a complete run, and a narrower selection carrying only its own gate.
+    assert diagnose(full) == ()
+    assert diagnose([{"gate": "kernel-only", "status": "passed"}]) == ()
+
+    # Rejected: the reported case -- a gate the workflow never ran.
+    missing = [dict(e) for e in full]
+    missing[-1]["status"] = "missing"
+    assert "is 'missing'" in diagnose(missing)[0]
+
+    # Rejected: every other non-passing status the producer can record.
+    for status in ("failed", "incomplete", "skipped", ""):
+        one = [dict(e) for e in full]
+        one[0]["status"] = status
+        assert diagnose(one), f"{status!r} was accepted"
+
+    # Rejected: a duplicate key cannot launder a missing gate into a passed one.
+    name = full[0]["gate"]
+    for pair in (("missing", "passed"), ("passed", "missing")):
+        found = diagnose([{"gate": name, "status": s} for s in pair])
+        # Order-independent: which complaint lands first depends on which entry
+        # is out of order, and both orders must reject.
+        assert any("more than once" in d for d in found), (pair, found)
+
+    # Rejected: shapes that carry no usable result at all.
+    for shape in (None, {}, [], "all passed", [{"status": "passed"}], ["kernel-only"]):
+        assert diagnose(shape), f"{shape!r} was accepted"
+
+    # Rejected: a status that is not the string 'passed', however it is spelled.
+    for status in (True, 1, None, "PASSED", "passed ", ["passed"]):
+        one = [dict(e) for e in full]
+        one[0]["status"] = status
+        assert diagnose(one), f"{status!r} was accepted"
+
+
+# Which script each gate key runs, pinned rather than derived. The key and the
+# script name have no reliable relationship -- `gemini-google-genai-kernel-policy`
+# runs a script whose name contains neither "kernel" nor "policy" -- so a naming
+# rule cannot stand in for the mapping. Without this, a gate key can be rewired
+# to a weaker script with every check green, which is the one drift the parity
+# assertion below is supposed to see.
+GATE_SCRIPTS = {
+    "kernel-only": "runner-spike-kernel-only-three-run-determinism.sh",
+    "kernel-policy": "runner-spike-kernel-policy-three-run-determinism.sh",
+    "openai-agents-kernel-policy": (
+        "runner-spike-openai-agents-kernel-policy-three-run-determinism.sh"
+    ),
+    "openai-agents-hidden-write": (
+        "runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh"
+    ),
+    "gemini-google-genai-kernel-policy": (
+        "runner-spike-gemini-google-genai-three-run-determinism.sh"
+    ),
+}
+
+
 def _test_gate_selections_match_the_workflow() -> None:
     """`GATE_SELECTIONS` and the delegated workflow's case branch agree.
 
@@ -2012,20 +2099,38 @@ def _test_gate_selections_match_the_workflow() -> None:
 
     Parity rather than derivation: the branch is shell inside YAML, and parsing
     it to drive production would be a worse dependency than asserting on it.
+
+    Not caught, measured: a `run_gate` call left in place but wrapped in a
+    condition that never fires. The text still names the gate and the script,
+    so this reads it as running. Detecting that needs the pack's recorded
+    gates, which `gate_execution_diagnostics` checks separately -- a gate that
+    did not run is recorded `missing` there.
     """
     root = Path(__file__).resolve().parents[2]
     workflow = (root / DELEGATED_WORKFLOW_PATH).read_text(encoding="utf-8")
     selections = gate_selections()
     for label, expected in selections.items():
-        marker = f'\n            {label})\n' if label != "all" else '\n            all)\n'
+        marker = f"\n            {label})\n"
         start = workflow.find(marker)
         assert start != -1, f"no case branch for {label!r} in {DELEGATED_WORKFLOW_PATH}"
         end = workflow.find(";;", start)
         branch = workflow[start:end]
-        ran = tuple(re.findall(r'run_gate "([^"]+)"', branch))
-        assert ran == tuple(expected), (
-            f"{label!r}: workflow runs {ran}, GATE_SELECTIONS says {tuple(expected)}"
+        # Strip comments first. The regex is text matching, so a commented-out
+        # `run_gate` line otherwise counts as a gate that runs -- which is the
+        # natural way to disable one, and was invisible here until measured.
+        live = "\n".join(
+            line for line in branch.splitlines() if not line.lstrip().startswith("#")
         )
+        ran = tuple(re.findall(r'run_gate "([^"]+)"[^\n]*\n\s*"([^"]+)"', live))
+        assert tuple(k for k, _ in ran) == tuple(expected), (
+            f"{label!r}: workflow runs {tuple(k for k, _ in ran)}, "
+            f"GATE_SELECTIONS says {tuple(expected)}"
+        )
+        for key, script in ran:
+            stem = script.rsplit("/", 1)[-1]
+            assert GATE_SCRIPTS.get(key) == stem, (
+                f"{label!r}: gate {key!r} runs {stem!r}, pinned as {GATE_SCRIPTS.get(key)!r}"
+            )
 
 
 def _test_gating_map_is_current() -> None:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -987,6 +987,76 @@ def content_tree_proof_accepts_head(
     return compare_content_path_trees(manifest, current_trees)
 
 
+@lru_cache(maxsize=1)
+def gate_selections() -> dict[str, tuple[str, ...]]:
+    """Which gate keys each `inputs.gates` label is supposed to produce.
+
+    Imported from the producer rather than restated. The proof pack builder
+    already holds this mapping and uses it to decide which gates to collect; a
+    second copy here would be two answers to one question, and the consumer's
+    copy drifting silently is precisely the failure this verification exists to
+    catch.
+
+    Loaded by path from `__file__` so it has no cwd or `sys.path` precondition.
+    """
+    import importlib.util
+
+    sibling = Path(__file__).resolve().parent / "assay_runner_delegated_proof_pack.py"
+    spec = importlib.util.spec_from_file_location("_assay_proof_pack", sibling)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging fault
+        raise RuntimeError(f"cannot load {sibling}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return dict(module.GATE_SELECTIONS)
+
+
+def gate_execution_diagnostics(manifest: dict[str, object], label: str) -> tuple[str, ...]:
+    """Reject a proof whose gates did not all run and pass.
+
+    `inputs.gates` is a label. It says which set was requested, not which set
+    executed: the workflow's `all` branch and the builder's `GATE_SELECTIONS`
+    are separate lists, so a gate can be dropped from the branch and the run
+    still reports success, with the pack recording that gate as `missing`.
+    Until this check existed nothing read those per-gate statuses, and such a
+    pack was credited as `gates=all`.
+
+    Fail closed on absence, which is the harder half. A signature cannot
+    guarantee that a record arrives, so a gate that is simply not in the array
+    must be rejected rather than ignored.
+    """
+    diagnostics: list[str] = []
+    expected = gate_selections().get(label)
+    if expected is None:
+        return (f"proof manifest inputs.gates={label!r} is not a known selection",)
+
+    raw = manifest.get("gates")
+    if not isinstance(raw, list):
+        return ("proof manifest missing gates array",)
+
+    recorded: dict[str, str] = {}
+    for entry in raw:
+        if not isinstance(entry, dict):
+            diagnostics.append("proof manifest gates entry is not an object")
+            continue
+        name = str(entry.get("gate") or "")
+        if not name:
+            diagnostics.append("proof manifest gates entry has no gate name")
+            continue
+        recorded[name] = str(entry.get("status") or "")
+
+    for gate in expected:
+        status = recorded.get(gate)
+        if status is None:
+            diagnostics.append(f"proof manifest records no result for gate {gate!r}")
+        elif status != "passed":
+            diagnostics.append(f"proof manifest gate {gate!r} is {status!r}, expected 'passed'")
+
+    for gate in sorted(set(recorded) - set(expected)):
+        diagnostics.append(f"proof manifest records gate {gate!r}, which {label!r} does not select")
+
+    return tuple(diagnostics)
+
+
 def accepted_gates(expected: Gate) -> set[str]:
     if expected == Gate.KERNEL_ONLY:
         return {"kernel-only", "all"}
@@ -1428,6 +1498,8 @@ def validate_proof_manifest_semantics(
                 f"proof manifest inputs.gates={gate!r}, "
                 f"expected one of {sorted(accepted_gates(expected))!r}"
             )
+        else:
+            diagnostics.extend(gate_execution_diagnostics(manifest, gate))
         if inputs.get("build_ebpf") != "true":
             diagnostics.append("proof manifest inputs.build_ebpf must be 'true'")
 
@@ -1847,6 +1919,7 @@ def self_test() -> None:
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
     _test_gating_rule_count_is_derived()
+    _test_gate_selections_match_the_workflow()
     _test_gating_map_is_current()
     _test_prefix_gated_surfaces_keep_their_coverage()
     _test_declared_gate_surfaces_exist()
@@ -1925,6 +1998,34 @@ def _test_gating_rule_count_is_derived() -> None:
     the number goes stale. That is exactly how "eleven" survived.
     """
     assert gating_rule_count() == 14, gating_rule_count()
+
+
+def _test_gate_selections_match_the_workflow() -> None:
+    """`GATE_SELECTIONS` and the delegated workflow's case branch agree.
+
+    `gate_execution_diagnostics` rejects a proof whose recorded gates do not
+    match the selection, and it takes that selection from the pack builder. The
+    workflow's `case` branch is a third copy of the same mapping, and it is the
+    one that actually decides which scripts run. If it drifts, the builder
+    collects gates the workflow never ran -- which this verification would
+    report as a defective proof rather than as the drift it is.
+
+    Parity rather than derivation: the branch is shell inside YAML, and parsing
+    it to drive production would be a worse dependency than asserting on it.
+    """
+    root = Path(__file__).resolve().parents[2]
+    workflow = (root / DELEGATED_WORKFLOW_PATH).read_text(encoding="utf-8")
+    selections = gate_selections()
+    for label, expected in selections.items():
+        marker = f'\n            {label})\n' if label != "all" else '\n            all)\n'
+        start = workflow.find(marker)
+        assert start != -1, f"no case branch for {label!r} in {DELEGATED_WORKFLOW_PATH}"
+        end = workflow.find(";;", start)
+        branch = workflow[start:end]
+        ran = tuple(re.findall(r'run_gate "([^"]+)"', branch))
+        assert ran == tuple(expected), (
+            f"{label!r}: workflow runs {ran}, GATE_SELECTIONS says {tuple(expected)}"
+        )
 
 
 def _test_gating_map_is_current() -> None:
@@ -2083,6 +2184,9 @@ def _test_attested_proof_pack_helpers() -> None:
             "workflow_sha": "abc123",
         },
         "inputs": {"gates": "all", "build_ebpf": "true"},
+        "gates": [
+            {"gate": name, "status": "passed"} for name in gate_selections()["all"]
+        ],
         "content_provenance": {"path_trees": {}},
         "proof_pack": {
             "subjects": [


### PR DESCRIPTION
## Description

Closes #2017. `lane-check` credited a delegated proof on the label alone.

The proof pack records a status per gate — `passed`, `failed`, `skipped`,
`incomplete`, `missing` — and nothing in the verification path read it. The only
two reads were inside the pack builder's own `--self-test`.

**Reproduced against `origin/main` @ `9cd0b0e4`**: a manifest carrying
`gemini-google-genai-kernel-policy: missing` alongside four passed gates was
accepted as `gates=all`.

The route there is not exotic. Drop a `run_gate` call from the workflow's `all`
branch; that file is content-addressed, so a fresh dispatch is forced rather
than a stale proof reused; the remaining gates pass; the run concludes success;
the builder records the dropped gate as `missing`; and the proof is credited as
if five gates ran. A reviewer would have to notice the workflow diff.

## What changed

`gate_execution_diagnostics` requires every gate in the selection to be present
and `passed`, and rejects any gate the label does not select.

It fails closed on **absence**, which is the harder half and the part the issue
under-specified. Current attestation guidance is explicit that a signature
cannot guarantee a record arrives, only that it was not altered — so a gate
simply missing from the array has to be a rejection rather than a silence.

## Verification

Each case run separately against the real function:

| Case | Result |
|---|---|
| full `all` run, every gate passed | accept |
| `kernel-only` selection, its one gate passed | accept |
| one gate `missing` (the reported case) | **reject** |
| one gate absent from the array | **reject** |
| one gate `incomplete` | **reject** |
| one gate `skipped` (a skip is a failure in this lane) | **reject** |
| duplicate key: `missing` then `passed` for one gate | **reject** |
| `gates` array missing, or not a list | **reject** |

The real proof pack from run `31042268173` is accepted unchanged, so this
rejects overclaims without rejecting practice.

## Revised after adversarial review

Two lenses ran against the first revision. Every finding was reproduced against
`origin/main` before being acted on. Three changed the design:

**The check had no committed test.** Replacing `gate_execution_diagnostics` with
`return ()` left `--self-test` green. Nine cases had been exercised by hand and
none shipped, while the checklist claimed otherwise. They are now
`_test_gate_execution_is_verified`; neutralising the function fails the suite.

**Set equality is dropped, and had to be.** `assay-runner-lane-check.yml` checks
out the PR base — deliberately, so a PR can never run its own gatekeeper —
while the pack is built at the PR head. Comparing the recorded set against this
process's `GATE_SELECTIONS` compared two refs, so any PR adding or retiring a
gate produced a pack its own verifier rejected, in both directions, with no
escape: `assay_runner_delegated_proof_pack.py` is `Gate.ALL`. Measured before it
was dropped. What remains is the rule the issue asked for.

**The parity assertion saw only line deletion.** Its regex ran over raw text, so
a commented-out `run_gate` counted as running, and it captured only the key,
never the script.

| Workflow drift | Before | Now |
|---|---|---|
| `run_gate` line deleted | red | red |
| gate commented out | green | **red** |
| gate rewired to a weaker script | green | **red** |
| gate wrapped in a false condition | green | green — disclaimed |

The last is not caught by parity and says so in the docstring. It is caught from
the other side: a gate that does not run leaves no directory, `gate_status`
records `missing`, and the new check rejects it. Both halves verified.

## One rule, one function

There are three real copies of "which gates does `all` mean":

1. `GATE_SELECTIONS` in the pack builder — decides which gates get collected
2. the `case` branch in `runner-spike-delegated.yml` — decides which scripts run
3. a hardcoded status map in the builder's own `--self-test` (`:559-566`) —
   parity-guarded already, so not a silent-drift risk, but a copy

`gate_selections()` imports (1) by path from `__file__`, no cwd or `sys.path`
precondition. `_test_gate_selections_match_the_workflow` asserts (2) agrees,
and `GATE_SCRIPTS` pins each key to the script it runs.

`GATE_SCRIPTS` is pinned rather than derived because the key and the script name
have no reliable relationship — `gemini-google-genai-kernel-policy` runs a
script whose name contains neither "kernel" nor "policy". Retiring it is #2041.

## Scope

`Gate.NONE` — `scripts/ci/assay_runner_lane_check.py` is the proof consumer,
which runs on GitHub-hosted Ubuntu rather than the delegated host, and the
exemption in `classify_file` is explicit. No delegated dispatch required or
claimed. The check itself runs in `--self-test`, which is what the required
`lane-check/proof` status executes.

## Not addressed, filed rather than dropped

- **#2040 — the legacy path bypasses this entirely.** `run_check` computes
  `passed = attested.accepted or fallback_passed`, and the fallback never
  downloads a manifest. A pack that fails validation here falls through and is
  credited there. Pre-existing and deliberate (a transition fallback,
  `ci-lanes.md:75`), but closing it is a contract change for every PR and does
  not belong smuggled into this one. It is the more urgent of the two.
- **#2041 — Direction 2 of #2017.** Binding each gate key to the script path and
  digest as executed, which would retire `GATE_SCRIPTS`. The durable answer.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
