### PR TITLE
Failing validation was no worse than never being validated

### DIFF
--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -68,7 +68,9 @@ cleanup and checkout.
    `assay-runner-delegated-proof-pack-<run_id>` contains `manifest.json`,
    `subject-checksums.txt`, and `attestation-bundle.json`. Lane-check verifies
    the GitHub artifact attestation, the proof-pack subjects, the selected gate,
-   and the gated-path tree OIDs. During the transition, recording the workflow
+   the per-gate execution status recorded in the manifest, and the gated-path
+   tree OIDs. A pack in which any recorded gate is not `passed` is rejected,
+   so `gates=all` means five gates ran rather than that the label said so. During the transition, recording the workflow
    run URL, commit SHA, selected gate, and result in the PR body or a PR comment
    remains a compatibility fallback.
 4. Do not treat a delegated skip as success. In the delegated lane, exit `40`

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -72,7 +72,10 @@ cleanup and checkout.
    tree OIDs. A pack in which any recorded gate is not `passed` is rejected,
    so `gates=all` means five gates ran rather than that the label said so. During the transition, recording the workflow
    run URL, commit SHA, selected gate, and result in the PR body or a PR comment
-   remains a compatibility fallback.
+   remains a compatibility fallback -- but only where no attested evidence was
+   available. A proof pack that was obtained and rejected on its contents is not
+   credited by the fallback, so failing verification is not equivalent to never
+   having been verified.
 4. Do not treat a delegated skip as success. In the delegated lane, exit `40`
    means the runner contract has drifted.
 5. Do not bypass required repository checks for runner-impacting changes.

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -118,6 +118,12 @@ class AttestedProofCheck:
     accepted: bool
     run: dict[str, object] | None
     diagnostics: tuple[str, ...]
+    # True when a proof pack was obtained and its contents were rejected, as
+    # opposed to no attested evidence being available at all. The legacy
+    # fallback exists for the second case; letting it cover the first is a
+    # downgrade, and would make failing validation no worse than never being
+    # validated.
+    evidence_rejected: bool = False
 
 
 @dataclass(frozen=True)
@@ -1541,6 +1547,7 @@ def find_valid_attested_proof(
     expected: Gate,
 ) -> AttestedProofCheck:
     diagnostics: list[str] = []
+    evidence_rejected = False
     for run_id in run_ids:
         try:
             run = dict(api.request("GET", f"/actions/runs/{run_id}"))
@@ -1560,6 +1567,7 @@ def find_valid_attested_proof(
         statement, statement_diagnostics = validate_attestation_statement(pack)
         if statement is None:
             diagnostics.extend(f"run {run_id}: {line}" for line in statement_diagnostics)
+            evidence_rejected = True
             continue
 
         semantic_diagnostics = validate_proof_manifest_semantics(
@@ -1571,24 +1579,28 @@ def find_valid_attested_proof(
         )
         if semantic_diagnostics:
             diagnostics.extend(f"run {run_id}: {line}" for line in semantic_diagnostics)
+            evidence_rejected = True
             continue
 
         predicate_diagnostics = validate_attestation_predicate(statement, pack.manifest, run, api)
         if predicate_diagnostics:
             diagnostics.extend(f"run {run_id}: {line}" for line in predicate_diagnostics)
+            evidence_rejected = True
             continue
 
         verification, verify_diagnostics = run_gh_attestation_verify(api, pack)
         if verification is None:
             diagnostics.extend(f"run {run_id}: {line}" for line in verify_diagnostics)
+            evidence_rejected = True
             continue
         claim_diagnostics = validate_gh_attestation_claims(verification, pack.manifest, api)
         if claim_diagnostics:
             diagnostics.extend(f"run {run_id}: {line}" for line in claim_diagnostics)
+            evidence_rejected = True
             continue
 
-        return AttestedProofCheck(True, run, tuple(diagnostics))
-    return AttestedProofCheck(False, None, tuple(diagnostics))
+        return AttestedProofCheck(True, run, tuple(diagnostics), evidence_rejected)
+    return AttestedProofCheck(False, None, tuple(diagnostics), evidence_rejected)
 
 
 def recorded_gate_ok(text: str, expected: Gate) -> bool:
@@ -1751,6 +1763,22 @@ def maybe_status(
         raise
 
 
+def fallback_applies(attested: AttestedProofCheck, eligible: bool) -> bool:
+    """Whether the legacy fallback may credit this PR.
+
+    No downgrade. The fallback exists for the case where no attested evidence is
+    available -- artifact retention expired, the attestation API unreachable, a
+    run predating the attested lane. It must not cover the case where a pack was
+    obtained and rejected on its contents, because then failing validation is no
+    worse than never being validated, and every strengthening of the attested
+    path widens the gap to the weaker one (#2040).
+
+    A function rather than an expression inside `run_check` so that a test can
+    exercise the decision the consumer actually makes.
+    """
+    return eligible and not attested.evidence_rejected
+
+
 def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) -> int:
     pr = load_pr(api, pr_number)
     classification = classify_files(pr.files)
@@ -1787,7 +1815,8 @@ def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) ->
     valid_run, run_diagnostics = find_valid_delegated_run(api, run_ids, pr.head_sha)
     sha_ok = text_mentions_head_sha(text, pr.head_sha)
     gate_ok = recorded_gate_ok(text, classification.gate)
-    fallback_passed = valid_run is not None and sha_ok and gate_ok
+    fallback_eligible = valid_run is not None and sha_ok and gate_ok
+    fallback_passed = fallback_applies(attested, fallback_eligible)
     passed = attested.accepted or fallback_passed
 
     details: list[str] = []
@@ -1825,6 +1854,12 @@ def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) ->
         status_description = f"legacy delegated proof accepted: gates={classification.gate.label}"
     else:
         status_description = f"delegated proof required: gates={classification.gate.label}"
+        if fallback_eligible and attested.evidence_rejected:
+            details.append(
+                "A recorded delegated run matches this head, but its attested proof\n"
+                "pack was rejected on its contents. The compatibility fallback is not\n"
+                "applied to a rejected pack -- see the attested diagnostics above."
+            )
     maybe_status(api, pr.head_sha, passed, status_description, status=status)
 
     if passed:
@@ -1937,6 +1972,7 @@ def self_test() -> None:
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
     _test_gating_rule_count_is_derived()
+    _test_rejected_evidence_does_not_fall_back()
     _test_gate_execution_is_verified()
     _test_gate_selections_match_the_workflow()
     _test_gating_map_is_current()
@@ -2017,6 +2053,33 @@ def _test_gating_rule_count_is_derived() -> None:
     the number goes stale. That is exactly how "eleven" survived.
     """
     assert gating_rule_count() == 14, gating_rule_count()
+
+
+def _test_rejected_evidence_does_not_fall_back() -> None:
+    """A rejected proof pack is not credited by the legacy path.
+
+    `run_check` accepts on `attested.accepted or fallback_passed`, and the
+    fallback never downloads a manifest -- it reads the run's conclusion and
+    greps the PR body for a gate name. Every check on the attested path was
+    therefore bypassable by having a recorded run, and the stronger that path
+    got, the wider the gap (#2040).
+
+    This calls `fallback_applies`, the function `run_check` uses, so removing
+    the rule fails here rather than leaving the suite green.
+    """
+    absent = AttestedProofCheck(False, None, ("run 1: could not download proof pack",))
+    rejected = AttestedProofCheck(
+        False, None, ("run 1: proof manifest gate 'x' is 'missing', expected 'passed'",), True
+    )
+    assert absent.evidence_rejected is False
+    assert rejected.evidence_rejected is True
+
+    # No attested evidence: the fallback keeps its purpose.
+    assert fallback_applies(absent, True) is True
+    assert fallback_applies(absent, False) is False
+    # Evidence obtained and rejected: no downgrade, whatever the PR body says.
+    assert fallback_applies(rejected, True) is False
+    assert fallback_applies(rejected, False) is False
 
 
 def _test_gate_execution_is_verified() -> None:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -988,7 +988,7 @@ def content_tree_proof_accepts_head(
 
 
 @lru_cache(maxsize=1)
-def gate_selections() -> dict[str, tuple[str, ...]]:
+def _gate_selections_cached() -> tuple[tuple[str, tuple[str, ...]], ...]:
     """Which gate keys each `inputs.gates` label is supposed to produce.
 
     Imported from the producer rather than restated. The proof pack builder
@@ -1003,37 +1003,59 @@ def gate_selections() -> dict[str, tuple[str, ...]]:
 
     sibling = Path(__file__).resolve().parent / "assay_runner_delegated_proof_pack.py"
     spec = importlib.util.spec_from_file_location("_assay_proof_pack", sibling)
-    if spec is None or spec.loader is None:  # pragma: no cover - packaging fault
+    if spec is None or spec.loader is None:
         raise RuntimeError(f"cannot load {sibling}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return dict(module.GATE_SELECTIONS)
+    try:
+        spec.loader.exec_module(module)
+        selections = module.GATE_SELECTIONS
+    except (OSError, SyntaxError, AttributeError) as exc:
+        # spec_from_file_location does not stat, so a missing or broken sibling
+        # surfaces here rather than above. Fail closed with the path named: the
+        # bare FileNotFoundError this replaced said nothing about why lane-check
+        # needs a file it never used to read.
+        raise RuntimeError(f"cannot read GATE_SELECTIONS from {sibling}: {exc}") from exc
+    return tuple((k, tuple(v)) for k, v in selections.items())
+
+
+def gate_selections() -> dict[str, tuple[str, ...]]:
+    """A fresh copy per call; the cache holds an immutable one."""
+    return dict(_gate_selections_cached())
 
 
 def gate_execution_diagnostics(manifest: dict[str, object], label: str) -> tuple[str, ...]:
-    """Reject a proof whose gates did not all run and pass.
+    """Reject a proof whose recorded gates did not all pass.
 
     `inputs.gates` is a label. It says which set was requested, not which set
     executed: the workflow's `all` branch and the builder's `GATE_SELECTIONS`
-    are separate lists, so a gate can be dropped from the branch and the run
-    still reports success, with the pack recording that gate as `missing`.
-    Until this check existed nothing read those per-gate statuses, and such a
-    pack was credited as `gates=all`.
+    are separate lists, so a gate can be dropped from the branch while the run
+    still reports success and the pack records that gate as `missing`. Until
+    this check existed nothing read those per-gate statuses and such a pack was
+    credited as `gates=all`.
 
-    Fail closed on absence, which is the harder half. A signature cannot
-    guarantee that a record arrives, so a gate that is simply not in the array
-    must be rejected rather than ignored.
+    Every recorded gate must be `passed`. A duplicate key is a rejection rather
+    than a last-wins overwrite, because otherwise a `missing` entry followed by
+    a `passed` entry for the same gate reads as success.
+
+    **The size of the selection is deliberately not checked here.**
+    `assay-runner-lane-check.yml` checks out the PR base, so that a PR can never
+    run its own gatekeeper, while the pack is built by the delegated workflow at
+    the PR head. Comparing the recorded set against this process's
+    `GATE_SELECTIONS` would therefore compare two refs, and any PR that adds or
+    retires a gate would produce a pack its own verifier rejects — in both
+    directions, with no escape, since `assay_runner_delegated_proof_pack.py` is
+    `Gate.ALL` and so requires a delegated proof to change. Measured before this
+    was dropped. What guards the selection's size instead is that the builder
+    derives the array from `GATE_SELECTIONS` at its own head, and that file is
+    content-addressed: shrinking it forces a fresh dispatch and shows up in the
+    diff.
     """
-    diagnostics: list[str] = []
-    expected = gate_selections().get(label)
-    if expected is None:
-        return (f"proof manifest inputs.gates={label!r} is not a known selection",)
-
     raw = manifest.get("gates")
-    if not isinstance(raw, list):
-        return ("proof manifest missing gates array",)
+    if not isinstance(raw, list) or not raw:
+        return ("proof manifest has no gates array",)
 
-    recorded: dict[str, str] = {}
+    diagnostics: list[str] = []
+    seen: set[str] = set()
     for entry in raw:
         if not isinstance(entry, dict):
             diagnostics.append("proof manifest gates entry is not an object")
@@ -1042,17 +1064,13 @@ def gate_execution_diagnostics(manifest: dict[str, object], label: str) -> tuple
         if not name:
             diagnostics.append("proof manifest gates entry has no gate name")
             continue
-        recorded[name] = str(entry.get("status") or "")
-
-    for gate in expected:
-        status = recorded.get(gate)
-        if status is None:
-            diagnostics.append(f"proof manifest records no result for gate {gate!r}")
-        elif status != "passed":
-            diagnostics.append(f"proof manifest gate {gate!r} is {status!r}, expected 'passed'")
-
-    for gate in sorted(set(recorded) - set(expected)):
-        diagnostics.append(f"proof manifest records gate {gate!r}, which {label!r} does not select")
+        if name in seen:
+            diagnostics.append(f"proof manifest records gate {name!r} more than once")
+            continue
+        seen.add(name)
+        status = str(entry.get("status") or "")
+        if status != "passed":
+            diagnostics.append(f"proof manifest gate {name!r} is {status!r}, expected 'passed'")
 
     return tuple(diagnostics)
 
@@ -1919,6 +1937,7 @@ def self_test() -> None:
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
     _test_gating_rule_count_is_derived()
+    _test_gate_execution_is_verified()
     _test_gate_selections_match_the_workflow()
     _test_gating_map_is_current()
     _test_prefix_gated_surfaces_keep_their_coverage()
@@ -2000,6 +2019,74 @@ def _test_gating_rule_count_is_derived() -> None:
     assert gating_rule_count() == 14, gating_rule_count()
 
 
+def _test_gate_execution_is_verified() -> None:
+    """A proof is credited only when every recorded gate passed.
+
+    Committed rather than run by hand. An earlier revision of this check shipped
+    with nine cases exercised interactively and none of them here, and replacing
+    the function body with `return ()` left the suite green — the fix was
+    unprotected against its own removal.
+    """
+    full = [{"gate": g, "status": "passed"} for g in gate_selections()["all"]]
+
+    def diagnose(gates: object) -> tuple[str, ...]:
+        return gate_execution_diagnostics({"inputs": {"gates": "all"}, "gates": gates}, "all")
+
+    # Accepted: a complete run, and a narrower selection carrying only its own gate.
+    assert diagnose(full) == ()
+    assert diagnose([{"gate": "kernel-only", "status": "passed"}]) == ()
+
+    # Rejected: the reported case -- a gate the workflow never ran.
+    missing = [dict(e) for e in full]
+    missing[-1]["status"] = "missing"
+    assert "is 'missing'" in diagnose(missing)[0]
+
+    # Rejected: every other non-passing status the producer can record.
+    for status in ("failed", "incomplete", "skipped", ""):
+        one = [dict(e) for e in full]
+        one[0]["status"] = status
+        assert diagnose(one), f"{status!r} was accepted"
+
+    # Rejected: a duplicate key cannot launder a missing gate into a passed one.
+    name = full[0]["gate"]
+    for pair in (("missing", "passed"), ("passed", "missing")):
+        found = diagnose([{"gate": name, "status": s} for s in pair])
+        # Order-independent: which complaint lands first depends on which entry
+        # is out of order, and both orders must reject.
+        assert any("more than once" in d for d in found), (pair, found)
+
+    # Rejected: shapes that carry no usable result at all.
+    for shape in (None, {}, [], "all passed", [{"status": "passed"}], ["kernel-only"]):
+        assert diagnose(shape), f"{shape!r} was accepted"
+
+    # Rejected: a status that is not the string 'passed', however it is spelled.
+    for status in (True, 1, None, "PASSED", "passed ", ["passed"]):
+        one = [dict(e) for e in full]
+        one[0]["status"] = status
+        assert diagnose(one), f"{status!r} was accepted"
+
+
+# Which script each gate key runs, pinned rather than derived. The key and the
+# script name have no reliable relationship -- `gemini-google-genai-kernel-policy`
+# runs a script whose name contains neither "kernel" nor "policy" -- so a naming
+# rule cannot stand in for the mapping. Without this, a gate key can be rewired
+# to a weaker script with every check green, which is the one drift the parity
+# assertion below is supposed to see.
+GATE_SCRIPTS = {
+    "kernel-only": "runner-spike-kernel-only-three-run-determinism.sh",
+    "kernel-policy": "runner-spike-kernel-policy-three-run-determinism.sh",
+    "openai-agents-kernel-policy": (
+        "runner-spike-openai-agents-kernel-policy-three-run-determinism.sh"
+    ),
+    "openai-agents-hidden-write": (
+        "runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh"
+    ),
+    "gemini-google-genai-kernel-policy": (
+        "runner-spike-gemini-google-genai-three-run-determinism.sh"
+    ),
+}
+
+
 def _test_gate_selections_match_the_workflow() -> None:
     """`GATE_SELECTIONS` and the delegated workflow's case branch agree.
 
@@ -2012,20 +2099,38 @@ def _test_gate_selections_match_the_workflow() -> None:
 
     Parity rather than derivation: the branch is shell inside YAML, and parsing
     it to drive production would be a worse dependency than asserting on it.
+
+    Not caught, measured: a `run_gate` call left in place but wrapped in a
+    condition that never fires. The text still names the gate and the script,
+    so this reads it as running. Detecting that needs the pack's recorded
+    gates, which `gate_execution_diagnostics` checks separately -- a gate that
+    did not run is recorded `missing` there.
     """
     root = Path(__file__).resolve().parents[2]
     workflow = (root / DELEGATED_WORKFLOW_PATH).read_text(encoding="utf-8")
     selections = gate_selections()
     for label, expected in selections.items():
-        marker = f'\n            {label})\n' if label != "all" else '\n            all)\n'
+        marker = f"\n            {label})\n"
         start = workflow.find(marker)
         assert start != -1, f"no case branch for {label!r} in {DELEGATED_WORKFLOW_PATH}"
         end = workflow.find(";;", start)
         branch = workflow[start:end]
-        ran = tuple(re.findall(r'run_gate "([^"]+)"', branch))
-        assert ran == tuple(expected), (
-            f"{label!r}: workflow runs {ran}, GATE_SELECTIONS says {tuple(expected)}"
+        # Strip comments first. The regex is text matching, so a commented-out
+        # `run_gate` line otherwise counts as a gate that runs -- which is the
+        # natural way to disable one, and was invisible here until measured.
+        live = "\n".join(
+            line for line in branch.splitlines() if not line.lstrip().startswith("#")
         )
+        ran = tuple(re.findall(r'run_gate "([^"]+)"[^\n]*\n\s*"([^"]+)"', live))
+        assert tuple(k for k, _ in ran) == tuple(expected), (
+            f"{label!r}: workflow runs {tuple(k for k, _ in ran)}, "
+            f"GATE_SELECTIONS says {tuple(expected)}"
+        )
+        for key, script in ran:
+            stem = script.rsplit("/", 1)[-1]
+            assert GATE_SCRIPTS.get(key) == stem, (
+                f"{label!r}: gate {key!r} runs {stem!r}, pinned as {GATE_SCRIPTS.get(key)!r}"
+            )
 
 
 def _test_gating_map_is_current() -> None:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -337,7 +337,7 @@ def read_zip_member(
     return bytes(body), None
 
 
-def load_proof_pack_zip(data: bytes) -> tuple[ProofPackArtifact | None, tuple[str, ...]]:
+def load_proof_pack_zip(data: bytes) -> tuple[ProofPackArtifact | None, tuple[str, ...], bool]:
     if len(data) > PROOF_PACK_ARCHIVE_MAX_BYTES:
         return None, (
             f"proof artifact archive size {len(data)} exceeds limit "
@@ -412,12 +412,12 @@ def download_proof_pack_artifact(
     try:
         response = api.request("GET", f"/actions/runs/{run_id}/artifacts")
     except TRANSIENT_REQUEST_ERRORS as exc:
-        return None, (f"run {run_id}: could not list artifacts ({exc})",)
+        return None, (f"run {run_id}: could not list artifacts ({exc})",), False
     if not isinstance(response, dict):
-        return None, (f"run {run_id}: artifacts response is not an object",)
+        return None, (f"run {run_id}: artifacts response is not an object",), False
     raw_artifacts = response.get("artifacts")
     if not isinstance(raw_artifacts, list):
-        return None, (f"run {run_id}: artifacts response missing artifacts list",)
+        return None, (f"run {run_id}: artifacts response missing artifacts list",), False
 
     expected_name = proof_pack_artifact_name(run_id)
     candidates = [
@@ -428,20 +428,24 @@ def download_proof_pack_artifact(
         and artifact.get("expired") is not True
     ]
     if not candidates:
-        return None, (f"run {run_id}: proof artifact {expected_name!r} not found or expired",)
+        return None, (f"run {run_id}: proof artifact {expected_name!r} not found or expired",), False
 
     artifact = dict(candidates[0])
     download_url = artifact.get("archive_download_url")
     if not isinstance(download_url, str) or not download_url:
-        return None, (f"run {run_id}: proof artifact missing archive_download_url",)
+        return None, (f"run {run_id}: proof artifact missing archive_download_url",), False
     try:
         data = api.download(download_url, max_bytes=PROOF_PACK_ARCHIVE_MAX_BYTES)
     except DownloadLimitExceeded as exc:
-        return None, (f"run {run_id}: proof artifact exceeds size limit ({exc})",)
+        return None, (f"run {run_id}: proof artifact exceeds size limit ({exc})",), False
     except TRANSIENT_REQUEST_ERRORS as exc:
-        return None, (f"run {run_id}: could not download proof artifact ({exc})",)
+        return None, (f"run {run_id}: could not download proof artifact ({exc})",), False
+    # Reaching here means the bytes arrived. Anything load_proof_pack_zip
+    # refuses is evidence obtained and rejected, not evidence unavailable --
+    # the distinction fallback_applies keys on. Returned as a flag rather
+    # than inferred from diagnostic wording, which is not a contract.
     pack, diagnostics = load_proof_pack_zip(data)
-    return pack, tuple(f"run {run_id}: {line}" for line in diagnostics)
+    return pack, tuple(f"run {run_id}: {line}" for line in diagnostics), True
 
 
 def decode_dsse_statement(bundle: dict[str, object]) -> tuple[dict[str, object] | None, tuple[str, ...]]:
@@ -1559,9 +1563,18 @@ def find_valid_attested_proof(
             diagnostics.append(basic)
             continue
 
-        pack, pack_diagnostics = download_proof_pack_artifact(api, run_id)
+        pack, pack_diagnostics, pack_downloaded = download_proof_pack_artifact(api, run_id)
         if pack is None:
             diagnostics.extend(pack_diagnostics)
+            # An artifact that downloaded but would not parse is evidence that
+            # was obtained and rejected, not evidence that was unavailable.
+            # `load_proof_pack_zip` refuses nine content shapes -- not a zip,
+            # missing members, unreadable or oversized members, undecodable
+            # JSON -- and bucketing those as absence left the cheapest bypass
+            # open: emit an unparsable pack and be credited by the path that
+            # parses nothing.
+            if pack_downloaded:
+                evidence_rejected = True
             continue
 
         statement, statement_diagnostics = validate_attestation_statement(pack)
@@ -1591,7 +1604,15 @@ def find_valid_attested_proof(
         verification, verify_diagnostics = run_gh_attestation_verify(api, pack)
         if verification is None:
             diagnostics.extend(f"run {run_id}: {line}" for line in verify_diagnostics)
-            evidence_rejected = True
+            # `gh` missing, unable to exec, or unable to reach the attestation
+            # API is verification that could not be performed -- the case the
+            # fallback exists for. Only a verdict counts as rejection.
+            if not any(
+                marker in line
+                for line in verify_diagnostics
+                for marker in ("not available", "could not run", "no such host", "Timeout")
+            ):
+                evidence_rejected = True
             continue
         claim_diagnostics = validate_gh_attestation_claims(verification, pack.manifest, api)
         if claim_diagnostics:
@@ -1845,6 +1866,12 @@ def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) ->
     elif fallback_passed and valid_run is not None:
         details.append(f"Matched legacy delegated run proof: {valid_run.get('html_url')}")
 
+    if fallback_eligible and attested.evidence_rejected:
+        details.append(
+            "A recorded delegated run matches this head, but its attested proof pack\n"
+            "was rejected on its contents. The compatibility fallback is not applied\n"
+            "to a rejected pack; see the attested diagnostics above."
+        )
     detail = "\n\n".join(details)
     body = comment_body(classification, pr, passed, detail)
     maybe_comment(api, pr.number, comments, body, comment=comment)
@@ -1854,12 +1881,7 @@ def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) ->
         status_description = f"legacy delegated proof accepted: gates={classification.gate.label}"
     else:
         status_description = f"delegated proof required: gates={classification.gate.label}"
-        if fallback_eligible and attested.evidence_rejected:
-            details.append(
-                "A recorded delegated run matches this head, but its attested proof\n"
-                "pack was rejected on its contents. The compatibility fallback is not\n"
-                "applied to a rejected pack -- see the attested diagnostics above."
-            )
+
     maybe_status(api, pr.head_sha, passed, status_description, status=status)
 
     if passed:
@@ -1972,6 +1994,7 @@ def self_test() -> None:
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
     _test_gating_rule_count_is_derived()
+    _test_evidence_rejection_is_constructed_not_only_decided()
     _test_rejected_evidence_does_not_fall_back()
     _test_gate_execution_is_verified()
     _test_gate_selections_match_the_workflow()
@@ -2053,6 +2076,76 @@ def _test_gating_rule_count_is_derived() -> None:
     the number goes stale. That is exactly how "eleven" survived.
     """
     assert gating_rule_count() == 14, gating_rule_count()
+
+
+def _test_evidence_rejection_is_constructed_not_only_decided() -> None:
+    """`evidence_rejected` is set by the sites that mean rejection.
+
+    An earlier revision tested `fallback_applies` alone, with the flag
+    hardcoded in the fixture. Every one of the five sites that set it -- and all
+    five at once -- could then be deleted with the suite green: the decision was
+    covered and its construction was not. This drives the real
+    `find_valid_attested_proof` so the classification itself is pinned.
+    """
+    manifest_bad = {
+        "schema": PROOF_PACK_SCHEMA,
+        "kind": PROOF_PACK_KIND,
+        "claim_ceiling": PROOF_PACK_CLAIM_CEILING,
+        "inputs": {"gates": "all", "build_ebpf": "true"},
+        "gates": [{"gate": "kernel-only", "status": "missing"}],
+        "source": {},
+    }
+    pr = PullRequest(
+        number=1, title="", body="", author_login="x", head_sha="abc123", files=()
+    )
+
+    class _Api:
+        repo = "Rul1an/assay"
+
+        def __init__(self, artifacts: object, blob: bytes = b"") -> None:
+            self._artifacts = artifacts
+            self._blob = blob
+
+        def download(self, url: str, max_bytes: int | None = None) -> bytes:
+            return self._blob
+
+        def request(self, method: str, path: str, payload: object = None) -> object:
+            if "/artifacts" in path:
+                return self._artifacts
+            return {
+                "name": DELEGATED_WORKFLOW_NAME,
+                "event": "workflow_dispatch",
+                "head_sha": "abc123",
+                "conclusion": "success",
+                "id": 1,
+                "html_url": "u",
+            }
+
+    present = {
+        "artifacts": [
+            {
+                "name": "assay-runner-delegated-proof-pack-1",
+                "archive_download_url": "x",
+                "size_in_bytes": 10,
+            }
+        ]
+    }
+
+    # Nothing to download is absence: the fallback keeps its purpose.
+    absent = find_valid_attested_proof(_Api({"artifacts": []}), ["1"], pr, Gate.ALL)
+    assert absent.accepted is False
+    assert absent.evidence_rejected is False, absent.diagnostics
+    assert fallback_applies(absent, True) is True
+
+    # Downloaded and unparsable is evidence obtained and rejected. This was the
+    # cheapest bypass: emit a pack that will not parse and be credited by the
+    # path that parses nothing.
+    broken = find_valid_attested_proof(
+        _Api(present, b"not a zip"), ["1"], pr, Gate.ALL
+    )
+    assert broken.accepted is False
+    assert broken.evidence_rejected is True, broken.diagnostics
+    assert fallback_applies(broken, True) is False
 
 
 def _test_rejected_evidence_does_not_fall_back() -> None:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -987,6 +987,76 @@ def content_tree_proof_accepts_head(
     return compare_content_path_trees(manifest, current_trees)
 
 
+@lru_cache(maxsize=1)
+def gate_selections() -> dict[str, tuple[str, ...]]:
+    """Which gate keys each `inputs.gates` label is supposed to produce.
+
+    Imported from the producer rather than restated. The proof pack builder
+    already holds this mapping and uses it to decide which gates to collect; a
+    second copy here would be two answers to one question, and the consumer's
+    copy drifting silently is precisely the failure this verification exists to
+    catch.
+
+    Loaded by path from `__file__` so it has no cwd or `sys.path` precondition.
+    """
+    import importlib.util
+
+    sibling = Path(__file__).resolve().parent / "assay_runner_delegated_proof_pack.py"
+    spec = importlib.util.spec_from_file_location("_assay_proof_pack", sibling)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging fault
+        raise RuntimeError(f"cannot load {sibling}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return dict(module.GATE_SELECTIONS)
+
+
+def gate_execution_diagnostics(manifest: dict[str, object], label: str) -> tuple[str, ...]:
+    """Reject a proof whose gates did not all run and pass.
+
+    `inputs.gates` is a label. It says which set was requested, not which set
+    executed: the workflow's `all` branch and the builder's `GATE_SELECTIONS`
+    are separate lists, so a gate can be dropped from the branch and the run
+    still reports success, with the pack recording that gate as `missing`.
+    Until this check existed nothing read those per-gate statuses, and such a
+    pack was credited as `gates=all`.
+
+    Fail closed on absence, which is the harder half. A signature cannot
+    guarantee that a record arrives, so a gate that is simply not in the array
+    must be rejected rather than ignored.
+    """
+    diagnostics: list[str] = []
+    expected = gate_selections().get(label)
+    if expected is None:
+        return (f"proof manifest inputs.gates={label!r} is not a known selection",)
+
+    raw = manifest.get("gates")
+    if not isinstance(raw, list):
+        return ("proof manifest missing gates array",)
+
+    recorded: dict[str, str] = {}
+    for entry in raw:
+        if not isinstance(entry, dict):
+            diagnostics.append("proof manifest gates entry is not an object")
+            continue
+        name = str(entry.get("gate") or "")
+        if not name:
+            diagnostics.append("proof manifest gates entry has no gate name")
+            continue
+        recorded[name] = str(entry.get("status") or "")
+
+    for gate in expected:
+        status = recorded.get(gate)
+        if status is None:
+            diagnostics.append(f"proof manifest records no result for gate {gate!r}")
+        elif status != "passed":
+            diagnostics.append(f"proof manifest gate {gate!r} is {status!r}, expected 'passed'")
+
+    for gate in sorted(set(recorded) - set(expected)):
+        diagnostics.append(f"proof manifest records gate {gate!r}, which {label!r} does not select")
+
+    return tuple(diagnostics)
+
+
 def accepted_gates(expected: Gate) -> set[str]:
     if expected == Gate.KERNEL_ONLY:
         return {"kernel-only", "all"}
@@ -1428,6 +1498,8 @@ def validate_proof_manifest_semantics(
                 f"proof manifest inputs.gates={gate!r}, "
                 f"expected one of {sorted(accepted_gates(expected))!r}"
             )
+        else:
+            diagnostics.extend(gate_execution_diagnostics(manifest, gate))
         if inputs.get("build_ebpf") != "true":
             diagnostics.append("proof manifest inputs.build_ebpf must be 'true'")
 
@@ -1847,6 +1919,7 @@ def self_test() -> None:
     assert uncovered_content_provenance_files(["crates/assay-runner-core/src/lib.rs"]) == ()
     assert uncovered_content_provenance_files(["Cargo.lock"]) == ("Cargo.lock",)
     _test_gating_rule_count_is_derived()
+    _test_gate_selections_match_the_workflow()
     _test_gating_map_is_current()
     _test_prefix_gated_surfaces_keep_their_coverage()
     _test_declared_gate_surfaces_exist()
@@ -1925,6 +1998,34 @@ def _test_gating_rule_count_is_derived() -> None:
     the number goes stale. That is exactly how "eleven" survived.
     """
     assert gating_rule_count() == 14, gating_rule_count()
+
+
+def _test_gate_selections_match_the_workflow() -> None:
+    """`GATE_SELECTIONS` and the delegated workflow's case branch agree.
+
+    `gate_execution_diagnostics` rejects a proof whose recorded gates do not
+    match the selection, and it takes that selection from the pack builder. The
+    workflow's `case` branch is a third copy of the same mapping, and it is the
+    one that actually decides which scripts run. If it drifts, the builder
+    collects gates the workflow never ran -- which this verification would
+    report as a defective proof rather than as the drift it is.
+
+    Parity rather than derivation: the branch is shell inside YAML, and parsing
+    it to drive production would be a worse dependency than asserting on it.
+    """
+    root = Path(__file__).resolve().parents[2]
+    workflow = (root / DELEGATED_WORKFLOW_PATH).read_text(encoding="utf-8")
+    selections = gate_selections()
+    for label, expected in selections.items():
+        marker = f'\n            {label})\n' if label != "all" else '\n            all)\n'
+        start = workflow.find(marker)
+        assert start != -1, f"no case branch for {label!r} in {DELEGATED_WORKFLOW_PATH}"
+        end = workflow.find(";;", start)
+        branch = workflow[start:end]
+        ran = tuple(re.findall(r'run_gate "([^"]+)"', branch))
+        assert ran == tuple(expected), (
+            f"{label!r}: workflow runs {ran}, GATE_SELECTIONS says {tuple(expected)}"
+        )
 
 
 def _test_gating_map_is_current() -> None:
@@ -2083,6 +2184,9 @@ def _test_attested_proof_pack_helpers() -> None:
             "workflow_sha": "abc123",
         },
         "inputs": {"gates": "all", "build_ebpf": "true"},
+        "gates": [
+            {"gate": name, "status": "passed"} for name in gate_selections()["all"]
+        ],
         "content_provenance": {"path_trees": {}},
         "proof_pack": {
             "subjects": [


### PR DESCRIPTION
## Description

Closes #2040. **Stacked on #2038** — that PR added the per-gate execution check
this one stops being bypassable. Merge #2038 first.

`run_check` credits a PR on `attested.accepted or fallback_passed`, and the
fallback never downloads a manifest. `find_valid_delegated_run` reads the run's
name, event, head SHA and conclusion; `recorded_gate_ok` greps the PR body for a
gate name. Every check on the attested path — attestation statement, manifest
semantics, predicate, `gh attestation verify`, claims, and as of #2038 the
per-gate execution status — was bypassable by having a recorded run.

The perverse part is the ordering: a pack that **fails** validation falls
through to the branch that **never** validates. A rejected proof and an absent
proof reach the same verdict, and every strengthening of the attested path
widens the gap to the weaker one.

## Approach

The current consumer-side answer to this shape is a no-downgrade policy —
pnpm's `trustPolicy: no-downgrade` fails when a package's evidence level weakens
between versions, and exists because the 2025 s1ngularity attack shipped
versions lacking the provenance attestations their predecessors had. The
principle transfers: do not accept weaker evidence than was available.

Applied here, the distinction that matters is *why* the attested path failed.

`AttestedProofCheck` carries `evidence_rejected`, set at the five failure sites
that occur after a pack has been obtained and parsed — statement, semantics,
predicate, verify, claims — and not at the three that mean no evidence was
available: unreadable run, wrong workflow or conclusion, pack not downloadable.

`fallback_applies` returns `False` for the first class.

## The fallback keeps its purpose

`ci-lanes.md:75` describes it as a compatibility path for the transition.
Retention expiry, an unreachable attestation API, and runs predating the
attested lane all still reach it. What it loses is the case where evidence was
available and rejected.

| Situation | Fallback |
|---|---|
| no attested evidence, run recorded | applies |
| no attested evidence, nothing recorded | no |
| **pack obtained and rejected, run recorded** | **no** (was: yes) |
| pack obtained and rejected, nothing recorded | no |

## Verification

`fallback_applies` is a function rather than an expression inside `run_check`,
so `_test_rejected_evidence_does_not_fall_back` exercises what the consumer
actually calls.

**Verified to bite:** replacing the rule with `return eligible` fails the suite.
An earlier draft of this PR asserted on a copy of the expression and stayed
green after the rule was removed — the same shape as the missing coverage
#2038's review found, so it is worth naming rather than quietly fixing.

## Diagnostics

When the fallback is suppressed, the commit status says so. A maintainer reading
a red `lane-check/proof` is pointed at the attested diagnostics rather than left
wondering why a recorded run did not count.

## Scope

`Gate.NONE` — `scripts/ci/assay_runner_lane_check.py` is the proof consumer,
which runs on GitHub-hosted Ubuntu. No delegated dispatch required or claimed.

## Not addressed

#2041 — binding each gate key to the script path and digest as executed. Larger:
it changes the producer (`Gate.ALL`, so a delegated run) and the manifest shape.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
