### PR TITLE
Type evidence diff's format argument

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/diff.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/diff.rs
@@ -1,8 +1,16 @@
 use anyhow::{Context, Result};
 use assay_evidence::diff::engine::diff_bundles;
 use assay_evidence::VerifyLimits;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::fs::File;
+
+/// The shapes `evidence diff` can emit. A type rather than a string, so the match over it is
+/// exhaustive and no spelling can reach it that the parser did not accept.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum DiffFormat {
+    Human,
+    Json,
+}
 
 #[derive(Debug, Args, Clone)]
 pub struct DiffArgs {
@@ -15,8 +23,8 @@ pub struct DiffArgs {
     pub candidate: Option<std::path::PathBuf>,
 
     /// Output format: human or json
-    #[arg(long, default_value = "human", value_parser = ["human", "json"])]
-    pub format: String,
+    #[arg(long, default_value = "human")]
+    pub format: DiffFormat,
 
     /// Baseline directory (look for {dir}/{key}.tar.gz)
     #[arg(long)]
@@ -51,11 +59,11 @@ pub fn cmd_diff(args: DiffArgs) -> Result<i32> {
     let limits = VerifyLimits::default();
     let report = diff_bundles(baseline_file, candidate_file, limits)?;
 
-    match args.format.as_str() {
-        "json" => {
+    match args.format {
+        DiffFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&report)?);
         }
-        _ => {
+        DiffFormat::Human => {
             eprintln!("Assay Evidence Diff");
             eprintln!("===================");
             eprintln!(


### PR DESCRIPTION
Second slice of #2039, following the recipe established in #2042.

`evidence diff --format` was a validated string: clap rejected an unrecognized value, but the type stayed `String`, so the match at `diff.rs:54` still needed a `_` arm kept in step with the parser by hand.

`DiffFormat { Human, Json }` makes the parser list and the match arms one declaration. The match is exhaustive over the type and the catch-all is gone.

## Behaviour

`--format human|json` unchanged, an unrecognized value still exits 2 with the accepted set, and `format_value_parser` passes untouched — it asserts the help line still advertises `human` and `json`, which is the property that would break if the enum and its `--help` output ever diverged.

## Remaining

`explain`, `profile show`, `mcp discover`, `sandbox --profile-format` and `coverage` carry the same shape. Kept separate so a behaviour regression in one is attributable to one.

Note the correction recorded on #2039: enabling `clippy::wildcard_enum_match_arm` workspace-wide is the wrong step — 99 warnings, of which only 12 are on the CLI boundary and 49 are internal domain matches in assay-core where a catch-all is correct. The lint should be scoped to `cli::args` and `cli::commands` once these arguments are typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)