### PR TITLE
Type coverage --format, the one argument two commands read differently

### DIFF
--- a/crates/assay-cli/src/cli/args/coverage.rs
+++ b/crates/assay-cli/src/cli/args/coverage.rs
@@ -1,5 +1,28 @@
 use std::path::PathBuf;
 
+/// The spellings `coverage --format` accepts.
+///
+/// This is the argument's surface, not an output kind. `coverage` is two commands behind one
+/// name, and the two honour different sets, so each mode narrows this to its own output type at
+/// the boundary rather than matching on the spelling. Without that split a single enum over the
+/// union would move the ambiguity into the type and make it look settled.
+///
+/// `github` is an alias of `markdown` because both modes already render markdown for it, so
+/// collapsing the spelling changes nothing. `md` keeps a variant of its own for the opposite
+/// reason: legacy mode has to refuse it by name, and an alias does not survive parsing.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CoverageFormat {
+    #[default]
+    Text,
+    Json,
+    // No doc comment on a variant: clap renders per-value help as a bulleted list and drops the
+    // inline `[possible values: ...]`, which would make this the one format argument in the CLI
+    // whose help is laid out differently. The reasoning lives on the enum instead.
+    Md,
+    #[value(alias = "github")]
+    Markdown,
+}
+
 #[derive(clap::Args, Debug, Clone)]
 pub struct CoverageArgs {
     /// Path to JSONL tool/decision events for coverage_report_v1 generation.
@@ -40,12 +63,11 @@ pub struct CoverageArgs {
     #[arg(long)]
     pub export_baseline: Option<PathBuf>,
 
-    /// Output format.
-    /// - `--format md|json` for `--input` mode
-    /// - `--input` mode: json|md (text aliases to json; markdown/github alias to md)
-    /// - legacy mode: text|json|markdown|github
-    #[arg(long, default_value = "text", value_parser = ["text", "json", "md", "markdown", "github"])]
-    pub format: String,
+    /// Output format. With `--input`: `json` or `md`, and `text` names the canonical JSON.
+    /// Without it: `text`, `json` or `markdown`, and `md` is rejected in favour of `markdown`.
+    /// `github` is accepted as an alias of `markdown`.
+    #[arg(long, default_value = "text")]
+    pub format: CoverageFormat,
 
     /// Number of top routes to include in markdown output (default: 10).
     #[arg(long = "routes-top", default_value_t = 10)]

--- a/crates/assay-cli/src/cli/commands/coverage/generate.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/generate.rs
@@ -78,13 +78,7 @@ pub(super) async fn cmd_coverage_generate(args: &CoverageArgs) -> Result<i32> {
         Err(code) => return Ok(code),
     };
 
-    let output_format = match parse_generate_output_format(&args.format) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Measurement error: {e}");
-            return Ok(EXIT_CONFIG_ERROR);
-        }
-    };
+    let output_format = CoverageOutputFormat::narrow(args.format);
 
     let primary_format = if args.out_md.is_some() {
         CoverageOutputFormat::Json
@@ -157,14 +151,4 @@ async fn load_declared_tools(args: &CoverageArgs) -> std::result::Result<Vec<Str
     }
 
     Ok(declared.into_iter().collect())
-}
-
-fn parse_generate_output_format(raw: &str) -> std::result::Result<CoverageOutputFormat, String> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "json" | "text" => Ok(CoverageOutputFormat::Json),
-        "md" | "markdown" | "github" => Ok(CoverageOutputFormat::Markdown),
-        other => Err(format!(
-            "--format must be one of: json|md for --input mode (got '{other}')"
-        )),
-    }
 }

--- a/crates/assay-cli/src/cli/commands/coverage/legacy.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/legacy.rs
@@ -1,8 +1,12 @@
 use super::io::{print_markdown_report, print_text_report};
+use super::LegacyOutputFormat;
 use crate::cli::args::CoverageArgs;
 use anyhow::{Context, Result};
 
-pub(super) async fn cmd_coverage_legacy(args: CoverageArgs) -> Result<i32> {
+pub(super) async fn cmd_coverage_legacy(
+    args: CoverageArgs,
+    output: LegacyOutputFormat,
+) -> Result<i32> {
     let trace_file = match args.trace_file.as_ref() {
         Some(path) => path,
         None => {
@@ -224,18 +228,14 @@ pub(super) async fn cmd_coverage_legacy(args: CoverageArgs) -> Result<i32> {
     report.policy_warnings = warnings;
 
     // 5. Output
-    match args.format.as_str() {
-        "json" => {
+    match output {
+        LegacyOutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&report)?);
         }
-        "markdown" => {
+        LegacyOutputFormat::Markdown => {
             print_markdown_report(&report);
         }
-        "github" => {
-            print_markdown_report(&report);
-        }
-        _ => {
-            // text
+        LegacyOutputFormat::Text => {
             print_text_report(&report);
         }
     }

--- a/crates/assay-cli/src/cli/commands/coverage/mod.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/mod.rs
@@ -1,4 +1,4 @@
-use crate::cli::args::CoverageArgs;
+use crate::cli::args::{CoverageArgs, CoverageFormat};
 use anyhow::Result;
 use std::path::Path;
 
@@ -13,6 +13,44 @@ mod schema;
 pub(crate) enum CoverageOutputFormat {
     Json,
     Markdown,
+}
+
+impl CoverageOutputFormat {
+    /// What `--input` mode makes of a spelling. It has no text output, so `text` names the
+    /// canonical JSON report here; that is why the argument's shared default is accepted at all.
+    pub(crate) fn narrow(format: CoverageFormat) -> Self {
+        match format {
+            CoverageFormat::Text | CoverageFormat::Json => Self::Json,
+            CoverageFormat::Md | CoverageFormat::Markdown => Self::Markdown,
+        }
+    }
+}
+
+/// The shapes legacy mode can print.
+///
+/// Narrowed from `CoverageFormat` before the renderer is reached, so no arm downstream has to
+/// answer for a spelling this mode does not honour. Legacy has a text output that `--input` mode
+/// lacks, which is the asymmetry that made one shared set unable to describe both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LegacyOutputFormat {
+    Text,
+    Json,
+    Markdown,
+}
+
+impl LegacyOutputFormat {
+    /// `Err` carries the message for the one spelling legacy mode does not honour. It used to fall
+    /// through a `_` arm and print text, which is the defect this narrowing removes.
+    pub(crate) fn narrow(format: CoverageFormat) -> std::result::Result<Self, &'static str> {
+        match format {
+            CoverageFormat::Text => Ok(Self::Text),
+            CoverageFormat::Json => Ok(Self::Json),
+            CoverageFormat::Markdown => Ok(Self::Markdown),
+            CoverageFormat::Md => {
+                Err("--format md is only supported with --input mode; use --format markdown")
+            }
+        }
+    }
 }
 
 const DEFAULT_ROUTES_TOP: usize = 10;
@@ -63,5 +101,15 @@ pub async fn cmd_coverage(args: CoverageArgs) -> Result<i32> {
         return generate::cmd_coverage_generate(&args).await;
     }
 
-    legacy::cmd_coverage_legacy(args).await
+    // Both mode rules sit here, and both refuse an argument this mode cannot honour instead of
+    // reinterpreting it.
+    let output = match LegacyOutputFormat::narrow(args.format) {
+        Ok(output) => output,
+        Err(message) => {
+            eprintln!("Measurement error: {message}");
+            return Ok(crate::exit_codes::EXIT_CONFIG_ERROR);
+        }
+    };
+
+    legacy::cmd_coverage_legacy(args, output).await
 }

--- a/crates/assay-cli/tests/coverage_format_modes.rs
+++ b/crates/assay-cli/tests/coverage_format_modes.rs
@@ -1,0 +1,155 @@
+//! `coverage --format` is read by two commands, and each honours a different set.
+//!
+//! `coverage/mod.rs` dispatches on `--input`, so the same spelling reaches two renderers. While
+//! the argument was a bare `String`, legacy mode matched `json`, `markdown` and `github` and let a
+//! `_` arm print text for everything else, which meant `--format md` asked for markdown and
+//! silently produced text with no message. These tests pin what each spelling means in each mode
+//! so the two can no longer diverge without a test saying so.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const POLICY: &str = "version: 2\nname: format-modes\ntools:\n  allow:\n    - read_file\n";
+const TRACE: &str = "{\"tool\":\"read_file\",\"args\":{\"path\":\"/app/x.txt\"}}\n";
+
+struct Fixture {
+    _dir: TempDir,
+    policy: PathBuf,
+    trace: PathBuf,
+}
+
+fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let policy = dir.path().join("policy.yaml");
+    let trace = dir.path().join("trace.jsonl");
+    std::fs::write(&policy, POLICY).expect("write policy");
+    std::fs::write(&trace, TRACE).expect("write trace");
+    Fixture {
+        _dir: dir,
+        policy,
+        trace,
+    }
+}
+
+/// Legacy mode: no `--input`, so `coverage/mod.rs` routes to the legacy renderer.
+fn legacy(format: &str) -> Output {
+    let f = fixture();
+    Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(["coverage", "--policy"])
+        .arg(&f.policy)
+        .arg("--trace-file")
+        .arg(&f.trace)
+        .args(["--format", format])
+        .output()
+        .expect("failed to run assay")
+}
+
+/// The report's own first line names its shape, so the assertions do not depend on exit codes.
+/// Legacy exits 1 whenever it finds a high-risk gap, which is orthogonal to the format.
+fn shape(out: &Output) -> &'static str {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let first = stdout.lines().next().unwrap_or("").trim().to_string();
+    if first.starts_with("# Coverage Report") {
+        "markdown"
+    } else if first.starts_with('{') {
+        "json"
+    } else if first.starts_with("Coverage Report") {
+        "text"
+    } else if stdout.trim().is_empty() {
+        "none"
+    } else {
+        "unknown"
+    }
+}
+
+#[test]
+fn legacy_mode_honours_each_advertised_spelling() {
+    assert_eq!(shape(&legacy("text")), "text");
+    assert_eq!(shape(&legacy("json")), "json");
+    assert_eq!(shape(&legacy("markdown")), "markdown");
+}
+
+/// `github` was an explicit arm of its own before the type; it stays accepted as an alias of
+/// `markdown` and renders the same report.
+#[test]
+fn legacy_mode_still_accepts_the_github_alias() {
+    let out = legacy("github");
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("invalid value"),
+        "the `github` alias was dropped rather than hidden",
+    );
+    assert_eq!(shape(&out), "markdown");
+}
+
+/// The defect this file exists for. `md` asked for markdown and produced text, at exit 0 or 1 and
+/// with nothing on stderr, so a caller could not tell it had not been honoured.
+#[test]
+fn legacy_mode_rejects_md_by_name_instead_of_printing_text() {
+    let out = legacy("md");
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "`--format md` in legacy mode did not exit with the config-error code",
+    );
+    assert_eq!(
+        shape(&out),
+        "none",
+        "a rejected run still wrote a report, which is where the wrong shape used to go",
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--format md is only supported with --input mode"),
+        "the error does not say which mode honours `md`: {stderr}",
+    );
+    assert!(
+        stderr.contains("--format markdown"),
+        "the error does not name the spelling to use instead: {stderr}",
+    );
+}
+
+/// The property the two modes have to keep: a spelling either means the same thing in both, or the
+/// mode that cannot honour it says so. It must never mean two things silently.
+///
+/// `md` is the case that used to fail this. It means markdown with `--input`, and legacy mode now
+/// refuses it rather than answering with a third shape.
+#[test]
+fn no_spelling_means_two_things_without_saying_so() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out_path = dir.path().join("coverage.md");
+    let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/ci/fixtures/coverage")
+        .join("input_basic.jsonl");
+
+    let generated = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(["coverage", "--input"])
+        .arg(&input)
+        .arg("--out")
+        .arg(&out_path)
+        .args(["--declared-tool", "read_document", "--format", "md"])
+        .output()
+        .expect("failed to run assay");
+    assert!(
+        generated.status.success(),
+        "`--format md` with --input failed: {}",
+        String::from_utf8_lossy(&generated.stderr),
+    );
+    let written = std::fs::read_to_string(&out_path).expect("markdown should be written");
+    assert!(
+        written.contains("# Coverage Report"),
+        "`--format md` with --input no longer writes markdown",
+    );
+
+    let refused = legacy("md");
+    assert_ne!(
+        refused.status.code(),
+        Some(0),
+        "legacy mode accepted `md`, so the spelling means two things again",
+    );
+    assert!(
+        !String::from_utf8_lossy(&refused.stderr).is_empty(),
+        "legacy mode refused `md` without saying anything",
+    );
+}

--- a/crates/assay-cli/tests/format_value_parser.rs
+++ b/crates/assay-cli/tests/format_value_parser.rs
@@ -69,11 +69,20 @@ const FORMAT_ARGS: &[(&[&str], &str, &[&str])] = &[
     ),
     (&["mcp", "discover"], "--format", &["table", "json", "yaml"]),
     (&["sandbox"], "--profile-format", &["yaml", "json"]),
+    // `github` is accepted as an alias of `markdown` and deliberately not advertised. `md` stays
+    // advertised because it is the documented `--input` spelling, and legacy mode rejects it by
+    // name rather than reinterpreting it, so it is not interchangeable with `markdown`.
     (
         &["coverage"],
         "--format",
-        &["text", "json", "md", "markdown", "github"],
+        &["text", "json", "md", "markdown"],
     ),
+];
+
+/// Aliases that parse without appearing in the value list, as `(command, flag, alias)`.
+const HIDDEN_ALIASES: &[(&[&str], &str, &str)] = &[
+    (&["explain"], "--format", "md"),
+    (&["coverage"], "--format", "github"),
 ];
 
 #[test]
@@ -144,13 +153,24 @@ fn an_unrecognized_format_is_rejected_rather_than_reinterpreted() {
 /// breaks callers who relied on the old behaviour.
 #[test]
 fn an_alias_is_accepted_without_being_advertised() {
-    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
-        .args(["explain", "--format", "md"])
-        .output()
-        .expect("failed to run assay");
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !stderr.contains("invalid value"),
-        "the `md` alias was dropped rather than hidden: {stderr}"
-    );
+    for (cmd, flag, alias) in HIDDEN_ALIASES {
+        let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+            .args(*cmd)
+            .args([*flag, *alias])
+            .output()
+            .expect("failed to run assay");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !stderr.contains("invalid value"),
+            "`assay {} {flag} {alias}`: the alias was dropped rather than hidden: {stderr}",
+            cmd.join(" "),
+        );
+
+        let line = option_block(&help_for(cmd), flag);
+        assert!(
+            !line.contains(&format!("{alias},")) && !line.contains(&format!("{alias}]")),
+            "`assay {} {flag}` advertises `{alias}`, so it is a value and not a hidden alias: {line}",
+            cmd.join(" "),
+        );
+    }
 }


### PR DESCRIPTION
Closes #2048. Last of the seven boundary arguments in #2039, and the only one whose fix cannot preserve behaviour.

## ⚠️ Behaviour change

`assay coverage --format md` **without** `--input` now exits 2 with

```
Measurement error: --format md is only supported with --input mode; use --format markdown
```

It used to print the text report. Nothing else changes: `md` with `--input` still writes markdown, and `github` still renders markdown in both modes.

Measured before and after, with a policy and trace supplied so legacy mode actually runs:

| `--format` | legacy before | legacy after | `--input`, unchanged |
|---|---|---|---|
| `text` | text | text | JSON |
| `json` | JSON | JSON | JSON |
| `md` | **text, silently** | rejected, exit 2 | markdown |
| `markdown` | markdown | markdown | markdown |
| `github` | markdown | markdown | markdown |

## Why an enum over the union was not enough

`coverage/mod.rs` dispatches on `--input`, so one `--format` string reaches two renderers that honour different sets. A single enum over the union would move the ambiguity into the type instead of removing it, since `Md` would still mean markdown on one path and text on the other.

So the spelling and the output kind are separate types. `CoverageFormat` is the argument's surface. Each mode narrows it to its own output kind at the boundary, which is where `--out-md` is already refused for the same reason. Legacy mode gets `LegacyOutputFormat`, which has no `Md` to answer for; input mode keeps `CoverageOutputFormat`.

The asymmetry that forced this: legacy has a text output and `--input` mode does not, so no single set describes both.

## Three parts that change nothing

- `github` becomes `#[value(alias = "github")]` on `Markdown`. Both modes already rendered it identically. It drops out of `--help`, so `FORMAT_ARGS` loses it and `an_alias_is_accepted_without_being_advertised` gains a case.
- The `other =>` arm in `generate.rs` goes with the string. It was already unreachable: `parse_generate_output_format` was only called with `args.format`, clap had narrowed that to five spellings, and all five matched an earlier arm, so its message could never print.
- `text` still names the canonical JSON report in `--input` mode.

## Why `md` is not simply an alias of `markdown`

That is the tidier type, three variants for three output kinds and no per-mode logic, and it was the recommendation in a comment on #2048 until that comment was retracted. Two reasons against it:

- Rejection needs the spelling to survive parsing. Once `md` is an alias, nothing downstream can tell which spelling arrived, so legacy mode can no longer refuse it by name.
- Anyone with `--format md` in a legacy invocation today gets text and would start getting markdown with no message. That is the same defect class this issue is about, moved from the CLI boundary into a caller's pipeline.

`explain` is not a precedent for mapping: its old code already read `"markdown" | "md" => explanation.to_markdown()`, so typing it preserved behaviour. The precedent there is keeping an alias that was already an alias.

## Tests

New `tests/coverage_format_modes.rs`, four tests: each advertised spelling in legacy mode, the `github` alias, the rejection with its message, and the cross-mode property that a spelling either means the same thing in both modes or the mode that cannot honour it says so.

Both were checked by mutation rather than trusted for being green:

- Reverting the narrowing to `CoverageFormat::Md => Ok(Self::Text)` fails exactly the two tests that should catch it, and leaves the other two green.
- Turning `github` back into an advertised variant does not compile, because both narrowing matches are exhaustive. A new spelling cannot be added without both modes deciding what it means. Adding the arms by hand to get past that then fails the new half of the alias test.

`cargo clippy -p assay-cli --all-targets -- -D warnings` clean, `cargo test -p assay-cli` all green.

## No doc comment on a variant

clap renders per-value help as a bulleted list and drops the inline `[possible values: ...]` and `[default: ...]`, which would leave this the one format argument in the CLI whose help is laid out differently, and breaks both gate tests in `format_value_parser.rs`. The reasoning sits on the enum instead.

## Not fixed here

`--format` carries one `default_value = "text"` for both modes while `--input` mode has no text output, so that mode has to accept `text` and mean JSON by it. That shared default is what generates the divergence, and it survives this change: `md` was the symptom. Untangling it needs `Option<CoverageFormat>` with a default per mode, which also changes `every_default_is_an_accepted_value`, since that test currently requires a default to be present. Worth its own issue rather than folding in here.
