### PR TITLE
Read the command set from the commit GitHub attested

### DIFF
--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -70,7 +70,13 @@ cleanup and checkout.
    the GitHub artifact attestation, the proof-pack subjects, the selected gate,
    and the gated-path tree OIDs. During the transition, recording the workflow
    run URL, commit SHA, selected gate, and result in the PR body or a PR comment
-   remains a compatibility fallback.
+   remains a compatibility fallback -- but only where GitHub's artifact listing
+   shows no live proof pack. Once the listing names one, every later failure is
+   a verdict about that evidence and the fallback does not apply, so failing
+   verification is not equivalent to never having been verified. A Sigstore or
+   attestation-API outage therefore fails closed rather than falling back; that
+   is deliberate, and matches `ErrorClass`, which has no "could not check"
+   class.
 4. Do not treat a delegated skip as success. In the delegated lane, exit `40`
    means the runner contract has drifted.
 5. Do not bypass required repository checks for runner-impacting changes.

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1288,6 +1288,144 @@ def validate_gh_attestation_claims(
     return tuple(diagnostics)
 
 
+def attested_gate_diagnostics(
+    statement: dict[str, object], manifest: dict[str, object], label: str
+) -> tuple[str, ...]:
+    """The pack must record exactly the gates the attested workflow runs, all passed.
+
+    Set equality is possible here where it was not before. An earlier attempt
+    compared the recorded gates against this process's copy of the selection and
+    deadlocked: the verifier runs the base's code, the pack is built at the head,
+    and any change to the gate set produced a pack its own verifier rejected in
+    both directions. Reading the expected set out of the attestation compares the
+    pack against the workflow that actually produced it, so a change to the gate
+    set is simply reflected in both.
+
+    That closes the size hole `gates=all` carried: a pack labelled `all` with
+    fewer entries than the attested branch runs is now rejected.
+    """
+    expected, diagnostics = attested_command_set(statement, label)
+    if expected is None:
+        return diagnostics
+
+    raw = manifest.get("gates")
+    if not isinstance(raw, list) or not raw:
+        return ("proof manifest has no gates array",)
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, dict):
+            out.append("proof manifest gates entry is not an object")
+            continue
+        name = str(entry.get("gate") or "")
+        if not name:
+            out.append("proof manifest gates entry has no gate name")
+            continue
+        if name in seen:
+            out.append(f"proof manifest records gate {name!r} more than once")
+            continue
+        seen.add(name)
+        if name not in expected:
+            out.append(
+                f"proof manifest records gate {name!r}, which the attested "
+                f"workflow does not run for {label!r}"
+            )
+            continue
+        status = str(entry.get("status") or "")
+        if status != "passed":
+            out.append(f"proof manifest gate {name!r} is {status!r}, expected 'passed'")
+
+    for name in expected:
+        if name not in seen:
+            out.append(
+                f"proof manifest records no result for gate {name!r}, which the "
+                f"attested workflow runs for {label!r}"
+            )
+    return tuple(out)
+
+
+def _fixture_statement() -> dict[str, object]:
+    """The attestation the self-test fixtures describe, naming this HEAD."""
+    return {
+        "predicate": {
+            "buildDefinition": {
+                "externalParameters": {"workflow": {"path": DELEGATED_WORKFLOW_PATH}},
+                "resolvedDependencies": [{"digest": {"gitCommit": _fixture_head()}}],
+            }
+        }
+    }
+
+
+def _fixture_head() -> str:
+    """The commit self-test fixtures describe: this checkout's HEAD."""
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+
+def attested_command_set(statement: dict[str, object], label: str) -> tuple[dict[str, str] | None, tuple[str, ...]]:
+    """Which gates the label runs, read from the commit GitHub attested.
+
+    The gate-to-script mapping lives in the delegated workflow's `case` branch.
+    Nothing on the delegated host can be trusted to describe it: the gate runs
+    as root and is handed its own proof directory, so a record written there
+    would be self-attested. An earlier attempt did exactly that and a gate could
+    forge its own entry with a digest that matched the forgery (#2041).
+
+    The attestation is signed by GitHub and names both the workflow file and the
+    commit -- `externalParameters.workflow.path` and the `gitCommit` in
+    `resolvedDependencies`. Reading the mapping there is anchored outside
+    anything the pull request can write.
+
+    It also removes the deadlock a pinned copy caused. The verifier runs the
+    base's code by design, so a pin in this file could never agree with a pack
+    built at a head that renamed a script. Reading the attested commit compares
+    the pack against the workflow that produced it.
+    """
+    predicate = statement.get("predicate")
+    if not isinstance(predicate, dict):
+        return None, ("attestation statement has no predicate",)
+    build = predicate.get("buildDefinition")
+    if not isinstance(build, dict):
+        return None, ("attestation predicate has no buildDefinition",)
+
+    external = build.get("externalParameters")
+    workflow = external.get("workflow") if isinstance(external, dict) else None
+    path = str(workflow.get("path") or "") if isinstance(workflow, dict) else ""
+    if path != DELEGATED_WORKFLOW_PATH:
+        return None, (f"attested workflow path is {path!r}, expected {DELEGATED_WORKFLOW_PATH!r}",)
+
+    commit = ""
+    resolved = build.get("resolvedDependencies")
+    if isinstance(resolved, list):
+        for dependency in resolved:
+            digest = dependency.get("digest") if isinstance(dependency, dict) else None
+            if isinstance(digest, dict) and digest.get("gitCommit"):
+                commit = str(digest["gitCommit"])
+                break
+    if not commit:
+        return None, ("attestation predicate names no source commit",)
+
+    try:
+        workflow_text = subprocess.check_output(
+            ["git", "show", f"{commit}:{path}"], text=True, stderr=subprocess.DEVNULL
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None, (f"could not read {path} at attested commit {commit[:12]}",)
+
+    marker = f"\n            {label})\n"
+    start = workflow_text.find(marker)
+    if start == -1:
+        return None, (f"attested workflow has no case branch for {label!r}",)
+    branch = workflow_text[start : workflow_text.find(";;", start)]
+    live = "\n".join(
+        line for line in branch.splitlines() if not line.lstrip().startswith("#")
+    )
+    pairs = re.findall(r'run_gate "([^"]+)"[^\n]*\n\s*"([^"]+)"', live)
+    if not pairs:
+        return None, (f"attested workflow branch for {label!r} runs no gates",)
+    return {key: script.rsplit("/", 1)[-1] for key, script in pairs}, ()
+
+
 def validate_attestation_predicate(
     statement: dict[str, object],
     manifest: dict[str, object],
@@ -1491,6 +1629,13 @@ def find_valid_attested_proof(
         )
         if semantic_diagnostics:
             diagnostics.extend(f"run {run_id}: {line}" for line in semantic_diagnostics)
+            continue
+
+        gate_diagnostics = attested_gate_diagnostics(
+            statement, pack.manifest, str((pack.manifest.get("inputs") or {}).get("gates") or "")
+        )
+        if gate_diagnostics:
+            diagnostics.extend(f"run {run_id}: {line}" for line in gate_diagnostics)
             continue
 
         predicate_diagnostics = validate_attestation_predicate(statement, pack.manifest, run, api)
@@ -1886,6 +2031,7 @@ def self_test() -> None:
     _test_gating_map_is_current()
     _test_prefix_gated_surfaces_keep_their_coverage()
     _test_declared_gate_surfaces_exist()
+    _test_gates_match_the_attested_workflow()
     _test_fallback_keyed_on_the_substrate_not_the_pack()
     _test_content_tree_comparison()
 
@@ -2053,6 +2199,46 @@ def _test_declared_gate_surfaces_exist() -> None:
     assert not dead, f"declared gate surfaces matching no tracked file: {dead}"
 
 
+def _test_gates_match_the_attested_workflow() -> None:
+    """The pack must record exactly the gates the attested commit runs.
+
+    Reads the expectation out of the attestation rather than out of a pin in
+    this file. That is what makes set equality possible at all: an earlier
+    attempt compared against the verifier's own copy and deadlocked, because the
+    verifier runs the base's code while the pack is built at the head.
+    """
+    statement = _fixture_statement()
+    expected, diagnostics = attested_command_set(statement, "all")
+    assert expected, diagnostics
+    full = list(expected)
+
+    def diagnose(gates: object) -> tuple[str, ...]:
+        return attested_gate_diagnostics(statement, {"gates": gates}, "all")
+
+    assert diagnose([{"gate": g, "status": "passed"} for g in full]) == ()
+
+    # The size hole: a label claiming five gates with one recorded.
+    assert "records no result" in diagnose([{"gate": full[0], "status": "passed"}])[0]
+
+    missing = [{"gate": g, "status": "passed"} for g in full]
+    missing[-1]["status"] = "missing"
+    assert "is 'missing'" in diagnose(missing)[0]
+
+    assert any(
+        "more than once" in d
+        for d in diagnose(
+            [{"gate": full[0], "status": "missing"}, {"gate": full[0], "status": "passed"}]
+            + [{"gate": g, "status": "passed"} for g in full[1:]]
+        )
+    )
+    assert "does not run" in diagnose(
+        [{"gate": g, "status": "passed"} for g in full] + [{"gate": "invented", "status": "passed"}]
+    )[0]
+
+    # A statement that names no commit cannot be checked, and fails closed.
+    assert attested_command_set({"predicate": {"buildDefinition": {}}}, "all")[0] is None
+
+
 def _test_fallback_keyed_on_the_substrate_not_the_pack() -> None:
     """The fallback turns on GitHub's artifact listing, and on nothing else.
 
@@ -2175,7 +2361,7 @@ def _test_attested_proof_pack_helpers() -> None:
         "kind": PROOF_PACK_KIND,
         "claim_ceiling": PROOF_PACK_CLAIM_CEILING,
         "source": {
-            "head_sha": "abc123",
+            "head_sha": _fixture_head(),
             "ref": "refs/heads/test",
             "repository": "Rul1an/assay",
             "run_attempt": "1",
@@ -2183,9 +2369,15 @@ def _test_attested_proof_pack_helpers() -> None:
             "run_url": "https://github.com/Rul1an/assay/actions/runs/12345",
             "workflow_name": DELEGATED_WORKFLOW_NAME,
             "workflow_path": DELEGATED_WORKFLOW_PATH,
-            "workflow_sha": "abc123",
+            "workflow_sha": _fixture_head(),
         },
         "inputs": {"gates": "all", "build_ebpf": "true"},
+        # Exactly the gates the attested workflow runs for this label; the
+        # fixture has to describe a pack that would be accepted.
+        "gates": [
+            {"gate": name, "status": "passed"}
+            for name in (attested_command_set(_fixture_statement(), "all")[0] or {})
+        ],
         "content_provenance": {"path_trees": {}},
         "proof_pack": {
             "subjects": [
@@ -2219,7 +2411,10 @@ def _test_attested_proof_pack_helpers() -> None:
                         "runner_environment": "self-hosted",
                     }
                 },
-                "resolvedDependencies": [{"digest": {"gitCommit": "abc123"}}],
+                # A resolvable commit: attested_gate_diagnostics reads the
+                # workflow there, so a synthetic sha would make the fixture
+                # pass by failing to find anything.
+                "resolvedDependencies": [{"digest": {"gitCommit": _fixture_head()}}],
             },
             "runDetails": {
                 "metadata": {
@@ -2254,7 +2449,7 @@ def _test_attested_proof_pack_helpers() -> None:
         "conclusion": "success",
         "id": 12345,
         "html_url": "https://github.com/Rul1an/assay/actions/runs/12345",
-        "head_sha": "abc123",
+        "head_sha": _fixture_head(),
     }
     assert validate_attestation_predicate(verified_statement, pack.manifest, run, GitHubApi("Rul1an/assay", "t")) == ()
     assert validate_gh_attestation_claims(
@@ -2265,8 +2460,8 @@ def _test_attested_proof_pack_helpers() -> None:
                     "githubWorkflowName": DELEGATED_WORKFLOW_NAME,
                     "githubWorkflowTrigger": "workflow_dispatch",
                     "githubWorkflowRepository": "Rul1an/assay",
-                    "sourceRepositoryDigest": "abc123",
-                    "githubWorkflowSHA": "abc123",
+                    "sourceRepositoryDigest": _fixture_head(),
+                    "githubWorkflowSHA": _fixture_head(),
                     "sourceRepositoryRef": "refs/heads/test",
                     "runnerEnvironment": "self-hosted",
                 }
@@ -2276,7 +2471,7 @@ def _test_attested_proof_pack_helpers() -> None:
         GitHubApi("Rul1an/assay", "t"),
     ) == ()
     assert "attestation claim githubWorkflowName missing" in validate_gh_attestation_claims(
-        [{"verificationResult": {"sourceRepositoryDigest": "abc123"}}],
+        [{"verificationResult": {"sourceRepositoryDigest": _fixture_head()}}],
         pack.manifest,
         GitHubApi("Rul1an/assay", "t"),
     )
@@ -2396,8 +2591,8 @@ def _test_attested_proof_pack_helpers() -> None:
                         "githubWorkflowName": DELEGATED_WORKFLOW_NAME,
                         "githubWorkflowTrigger": "workflow_dispatch",
                         "githubWorkflowRepository": "Rul1an/assay",
-                        "sourceRepositoryDigest": "abc123",
-                        "githubWorkflowSHA": "abc123",
+                        "sourceRepositoryDigest": _fixture_head(),
+                        "githubWorkflowSHA": _fixture_head(),
                         "sourceRepositoryRef": "refs/heads/test",
                         "runnerEnvironment": "self-hosted",
                     }
@@ -2419,7 +2614,7 @@ def _test_attested_proof_pack_helpers() -> None:
                 title="synthetic accept path",
                 body="",
                 author_login="Rul1an",
-                head_sha="abc123",
+                head_sha=_fixture_head(),
                 files=(".github/workflows/runner-spike-delegated.yml",),
             ),
             Gate.ALL,

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -118,6 +118,11 @@ class AttestedProofCheck:
     accepted: bool
     run: dict[str, object] | None
     diagnostics: tuple[str, ...]
+    # True when GitHub's artifact listing showed a live proof pack for one of
+    # the runs considered. The legacy fallback exists for evidence that is not
+    # there; once the substrate says it is there, every later failure is a
+    # verdict about evidence rather than a report of its absence.
+    evidence_existed: bool = False
 
 
 @dataclass(frozen=True)
@@ -331,7 +336,7 @@ def read_zip_member(
     return bytes(body), None
 
 
-def load_proof_pack_zip(data: bytes) -> tuple[ProofPackArtifact | None, tuple[str, ...]]:
+def load_proof_pack_zip(data: bytes) -> tuple[ProofPackArtifact | None, tuple[str, ...], bool]:
     if len(data) > PROOF_PACK_ARCHIVE_MAX_BYTES:
         return None, (
             f"proof artifact archive size {len(data)} exceeds limit "
@@ -406,12 +411,12 @@ def download_proof_pack_artifact(
     try:
         response = api.request("GET", f"/actions/runs/{run_id}/artifacts")
     except TRANSIENT_REQUEST_ERRORS as exc:
-        return None, (f"run {run_id}: could not list artifacts ({exc})",)
+        return None, (f"run {run_id}: could not list artifacts ({exc})",), False
     if not isinstance(response, dict):
-        return None, (f"run {run_id}: artifacts response is not an object",)
+        return None, (f"run {run_id}: artifacts response is not an object",), False
     raw_artifacts = response.get("artifacts")
     if not isinstance(raw_artifacts, list):
-        return None, (f"run {run_id}: artifacts response missing artifacts list",)
+        return None, (f"run {run_id}: artifacts response missing artifacts list",), False
 
     expected_name = proof_pack_artifact_name(run_id)
     candidates = [
@@ -422,20 +427,23 @@ def download_proof_pack_artifact(
         and artifact.get("expired") is not True
     ]
     if not candidates:
-        return None, (f"run {run_id}: proof artifact {expected_name!r} not found or expired",)
+        return None, (f"run {run_id}: proof artifact {expected_name!r} not found or expired",), False
 
     artifact = dict(candidates[0])
     download_url = artifact.get("archive_download_url")
     if not isinstance(download_url, str) or not download_url:
-        return None, (f"run {run_id}: proof artifact missing archive_download_url",)
+        return None, (f"run {run_id}: proof artifact missing archive_download_url",), True
     try:
         data = api.download(download_url, max_bytes=PROOF_PACK_ARCHIVE_MAX_BYTES)
     except DownloadLimitExceeded as exc:
-        return None, (f"run {run_id}: proof artifact exceeds size limit ({exc})",)
+        return None, (f"run {run_id}: proof artifact exceeds size limit ({exc})",), True
     except TRANSIENT_REQUEST_ERRORS as exc:
-        return None, (f"run {run_id}: could not download proof artifact ({exc})",)
+        return None, (f"run {run_id}: could not download proof artifact ({exc})",), True
+    # GitHub's listing named a live artifact, so evidence existed for this run
+    # whatever happens to it from here. That answer comes from the substrate,
+    # not from parsing bytes the pull request author supplied.
     pack, diagnostics = load_proof_pack_zip(data)
-    return pack, tuple(f"run {run_id}: {line}" for line in diagnostics)
+    return pack, tuple(f"run {run_id}: {line}" for line in diagnostics), True
 
 
 def decode_dsse_statement(bundle: dict[str, object]) -> tuple[dict[str, object] | None, tuple[str, ...]]:
@@ -1451,6 +1459,7 @@ def find_valid_attested_proof(
     expected: Gate,
 ) -> AttestedProofCheck:
     diagnostics: list[str] = []
+    evidence_existed = False
     for run_id in run_ids:
         try:
             run = dict(api.request("GET", f"/actions/runs/{run_id}"))
@@ -1462,7 +1471,8 @@ def find_valid_attested_proof(
             diagnostics.append(basic)
             continue
 
-        pack, pack_diagnostics = download_proof_pack_artifact(api, run_id)
+        pack, pack_diagnostics, artifact_existed = download_proof_pack_artifact(api, run_id)
+        evidence_existed = evidence_existed or artifact_existed
         if pack is None:
             diagnostics.extend(pack_diagnostics)
             continue
@@ -1497,8 +1507,8 @@ def find_valid_attested_proof(
             diagnostics.extend(f"run {run_id}: {line}" for line in claim_diagnostics)
             continue
 
-        return AttestedProofCheck(True, run, tuple(diagnostics))
-    return AttestedProofCheck(False, None, tuple(diagnostics))
+        return AttestedProofCheck(True, run, tuple(diagnostics), evidence_existed)
+    return AttestedProofCheck(False, None, tuple(diagnostics), evidence_existed)
 
 
 def recorded_gate_ok(text: str, expected: Gate) -> bool:
@@ -1659,6 +1669,32 @@ def maybe_status(
             )
             return
         raise
+
+
+def fallback_applies(attested: AttestedProofCheck, eligible: bool) -> bool:
+    """Whether the legacy fallback may credit this PR.
+
+    The fallback exists for evidence that is not there: retention expired, a run
+    predating the attested lane, the artifacts API unreachable. It must not
+    cover evidence that is there and did not hold up, or failing verification
+    becomes no worse than never being verified (#2040).
+
+    The line is GitHub's artifact listing, and it is drawn once. An earlier
+    attempt set a flag at six separate failure sites and classified two of them
+    by matching words in `gh`'s stderr -- which echoes the malformed value out
+    of the pack, so a pull request author could put a marker string in their own
+    bundle and buy the fallback. Anything the interested party writes is the
+    wrong input for this decision. The listing is not: it comes from the
+    substrate, it carries `expired`, and it answers the only question that
+    matters here -- was there evidence at all.
+
+    Consequence, stated because it is a real cost: once the listing names a live
+    artifact, a Sigstore outage fails closed rather than falling back. That is
+    the current guidance for an unreachable verifier, and it matches this
+    repository's own `ErrorClass`, which has no "could not check" class -- in
+    the evidence path every failure is a verdict.
+    """
+    return eligible and not attested.evidence_existed
 
 
 def run_check(api: GitHubApi, pr_number: int, *, comment: bool, status: bool) -> int:
@@ -1850,6 +1886,7 @@ def self_test() -> None:
     _test_gating_map_is_current()
     _test_prefix_gated_surfaces_keep_their_coverage()
     _test_declared_gate_surfaces_exist()
+    _test_fallback_keyed_on_the_substrate_not_the_pack()
     _test_content_tree_comparison()
 
     valid_run = {
@@ -2014,6 +2051,72 @@ def _test_declared_gate_surfaces_exist() -> None:
         ]
     )
     assert not dead, f"declared gate surfaces matching no tracked file: {dead}"
+
+
+def _test_fallback_keyed_on_the_substrate_not_the_pack() -> None:
+    """The fallback turns on GitHub's artifact listing, and on nothing else.
+
+    Drives the real `find_valid_attested_proof`, so the construction of
+    `evidence_existed` is covered and not only the decision that reads it. Two
+    earlier attempts pinned the decision alone; every site that produced the
+    input stayed deletable with the suite green.
+    """
+    pr = PullRequest(
+        number=1, title="", body="", author_login="x", head_sha="abc123", files=()
+    )
+    run = {
+        "name": DELEGATED_WORKFLOW_NAME,
+        "event": "workflow_dispatch",
+        "head_sha": "abc123",
+        "conclusion": "success",
+        "id": 1,
+        "html_url": "u",
+    }
+    listed = {
+        "artifacts": [
+            {
+                "name": "assay-runner-delegated-proof-pack-1",
+                "archive_download_url": "x",
+                "size_in_bytes": 10,
+                "expired": False,
+            }
+        ]
+    }
+
+    class _Api:
+        repo = "Rul1an/assay"
+
+        def __init__(self, artifacts: object, blob: bytes = b"", exc: Exception | None = None):
+            self._artifacts = artifacts
+            self._blob = blob
+            self._exc = exc
+
+        def request(self, method: str, path: str, payload: object = None) -> object:
+            return self._artifacts if "/artifacts" in path else run
+
+        def download(self, url: str, max_bytes: int | None = None) -> bytes:
+            if self._exc is not None:
+                raise self._exc
+            return self._blob
+
+    def fallback_for(api: object) -> bool:
+        return fallback_applies(find_valid_attested_proof(api, ["1"], pr, Gate.ALL), True)
+
+    # Substrate says no evidence: the fallback keeps its purpose.
+    assert fallback_for(_Api({"artifacts": []})) is True
+    assert (
+        fallback_for(
+            _Api({"artifacts": [{"name": "assay-runner-delegated-proof-pack-1", "expired": True}]})
+        )
+        is True
+    )
+
+    # Substrate says evidence exists: every later failure is a verdict.
+    assert fallback_for(_Api(listed, b"not a zip")) is False
+    assert fallback_for(_Api(listed, b"")) is False
+    # Oversize was the bypass the previous attempt left open: bytes arrived and
+    # were refused on their size, which is a property of the evidence.
+    assert fallback_for(_Api(listed, exc=DownloadLimitExceeded("too large"))) is False
 
 
 def _test_content_tree_comparison() -> None:


### PR DESCRIPTION
## Description

Closes #2041. **Stacked on #2049** (#2040) — merge that first.

The first attempt at this was closed. It recorded the script on the delegated
host, where the gate runs as root and is handed its own proof directory, so the
record was self-attested: a gate could overwrite its own entry, and because the
digest was computed from the *recorded path* rather than what ran, the forgery
was internally consistent and every check returned clean.

## Where the trust comes from instead

The attestation is the one artifact here a pull request cannot write. GitHub
signs it, and it names both the workflow file and the commit:
`buildDefinition.externalParameters.workflow.path` and the `gitCommit` in
`resolvedDependencies`.

The gate-to-script mapping lives in that workflow's `case` branch. Reading it at
that commit is anchored entirely outside the host.

Verified against a real bundle — the attestation for run `31042268173` names
`.github/workflows/runner-spike-delegated.yml` at `f94f3011`, whose `all` branch
runs five gates, and the pack records exactly those five.

## This is what makes set equality possible

An earlier revision compared the recorded gates against *this process's* copy of
the selection, and had to drop the check: `assay-runner-lane-check.yml` checks
out the PR base by design, so that a PR can never run its own gatekeeper, while
the pack is built at the head. Any change to the gate set produced a pack its
own verifier rejected — in both directions, with no ordering that worked.

Reading the expectation out of the attestation compares the pack against the
workflow that produced it. A change to the gate set moves both sides at once, so
there is nothing to deadlock.

**So the `gates=all` size hole closes**, which the previous design documented as
deliberately open:

| Case | Result |
|---|---|
| full set, all passed | accept |
| one gate recorded under label `all` | **reject** — was accepted |
| a gate recorded `missing` | **reject** |
| duplicate key | **reject** |
| a gate the attested branch never runs | **reject** |
| statement naming no commit | **reject**, fails closed |

## What this retires

`GATE_SCRIPTS` and `_test_gate_selections_match_the_workflow` are no longer the
binding. Both were parity between two files a PR can edit, checked by a third
that had to move in step — and the parity assertion read the base, so it was
blind to the rewire it named.

## Verification

`_test_gates_match_the_attested_workflow` drives both halves. **Verified to
bite:** neutralising either `attested_command_set` or `attested_gate_diagnostics`
fails the suite. Two earlier revisions in this arc pinned only the decision and
left every producing site deletable with the suite green; that is the property
being checked for here.

## Fixture note

The self-test fixtures now name a resolvable commit. That cascade was five edits
— manifest source, predicate `resolvedDependencies`, certificate claims,
`workflow_sha`, and the gates array — because the validators genuinely
cross-check the commit against each other. Legitimate coupling, but worth
flagging for review: the fixture is now HEAD-dependent, which means it exercises
the real workflow file rather than a synthetic one.

## Scope

`Gate.NONE` — consumer only. No delegated dispatch required or claimed.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
