### PR TITLE
Let the CLI decide fail_on, because the bash case decided nothing

### DIFF
--- a/assay-action/action.yml
+++ b/assay-action/action.yml
@@ -49,7 +49,7 @@ inputs:
     required: false
     default: ''
   fail_on:
-    description: 'Fail threshold: error, warn, info, none'
+    description: 'Fail threshold: error, warn (or warning), info, none. Validated by the CLI, so an unrecognized value fails the run instead of disabling the gate.'
     required: false
     default: 'error'
   sarif:
@@ -478,13 +478,40 @@ runs:
         # Lint all bundles (one at a time, aggregate results)
         TOTAL_ERRORS=0
         TOTAL_WARNS=0
+        GATE_HITS=0
         echo '{"findings":[]}' > "$REPORTS_DIR/lint.json"
 
         for bundle in $BUNDLES; do
           echo "Linting: $bundle"
 
-          # Lint to JSON for counting
-          LINT_JSON=$(assay evidence lint --format json "$bundle" 2>/dev/null || echo '{"findings":[]}')
+          # Lint to JSON for counting, and let the CLI decide the threshold.
+          #
+          # $FAIL_ON goes to the CLI unmodified so the vocabulary has one definition, the one clap
+          # validates. This replaces a bash `case` that had no default arm: any value it did not
+          # recognize gated nothing and exited 0, so `fail_on: warning` (which the cicd-starter
+          # README tells users to set) silently disabled the gate, as did any typo or casing.
+          #
+          # One invocation still serves both jobs. `assay evidence lint` writes its report first and
+          # decides the gate last, so the JSON below is produced whether or not the gate trips.
+          # `--fail-on none` is honoured by the CLI, so no case for it is needed here.
+          set +e
+          LINT_JSON=$(assay evidence lint --format json --fail-on "$FAIL_ON" "$bundle" 2>"$TEMP_DIR/lint.err")
+          LINT_CODE=$?
+          set -e
+
+          case "$LINT_CODE" in
+            0) ;;
+            1) GATE_HITS=$((GATE_HITS + 1)) ;;
+            *)
+              # 2 = verification failure, 3 = pack fault, 2 also = a fail_on the CLI does not accept.
+              # A threshold that could not be applied must not read as a threshold that passed.
+              echo "::error::Could not apply fail_on='$FAIL_ON' to $bundle (assay exited $LINT_CODE)"
+              cat "$TEMP_DIR/lint.err" >&2 || true
+              exit 2
+              ;;
+          esac
+
+          [ -n "$LINT_JSON" ] || LINT_JSON='{"findings":[]}'
 
           # Count findings in this bundle
           BUNDLE_ERRORS=$(echo "$LINT_JSON" | jq '[.findings // [] | .[] | select(.severity == "error")] | length' 2>/dev/null || echo "0")
@@ -523,32 +550,15 @@ runs:
         echo "findings_error=$ERRORS" >> $GITHUB_OUTPUT
         echo "findings_warn=$WARNS" >> $GITHUB_OUTPUT
 
-        # Apply fail_on threshold
-        case "$FAIL_ON" in
-          error)
-            if [ "$ERRORS" -gt 0 ]; then
-              echo "::error::$ERRORS error-level findings exceed threshold"
-              exit 1
-            fi
-            ;;
-          warn)
-            if [ "$ERRORS" -gt 0 ] || [ "$WARNS" -gt 0 ]; then
-              echo "::error::$ERRORS errors, $WARNS warnings exceed threshold"
-              exit 1
-            fi
-            ;;
-          info)
-            # Fail on any finding (info not yet implemented, treat as warn)
-            if [ "$ERRORS" -gt 0 ] || [ "$WARNS" -gt 0 ]; then
-              exit 1
-            fi
-            ;;
-          none)
-            # Never fail on findings
-            ;;
-        esac
-
+        # The counters above stay: they feed findings_error, findings_warn and diff_summary. Only the
+        # deciding moved, to the per-bundle `--fail-on` exit code collected in $GATE_HITS. The
+        # summary is written before the gate so a gated run still reports what it found.
         echo "diff_summary=Verified: $VERIFIED, Errors: $ERRORS, Warnings: $WARNS" >> $GITHUB_OUTPUT
+
+        if [ "$GATE_HITS" -gt 0 ]; then
+          echo "::error::$GATE_HITS bundle(s) have findings at or above '$FAIL_ON' ($ERRORS errors, $WARNS warnings)"
+          exit 1
+        fi
 
     # =========================================================================
     # E3: SARIF Upload
@@ -970,8 +980,8 @@ runs:
         # and pack_status readable by later steps, and exits 1 -- a policy failure, distinct from
         # the exit 3 this step uses for pack faults.
         #
-        # $FAIL_ON goes to the CLI unmodified. The CLI accepts "warning" as an alias of "warn";
-        # the bash case earlier in this file does not, which is tracked separately.
+        # $FAIL_ON goes to the CLI unmodified, as it now does on the non-pack path too. The CLI
+        # accepts "warning" as an alias of "warn", so both paths honour it.
         if [ "$FAIL_ON" != "none" ]; then
           PACK_GATE_HITS=0
           while IFS= read -r bundle || [ -n "$bundle" ]; do

--- a/crates/assay-cli/src/cli/commands/evidence/lint.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/lint.rs
@@ -254,8 +254,10 @@ pub fn cmd_lint(args: LintArgs) -> Result<i32> {
 /// `--fail-on none` at `action.yml:888`, and it was never implemented: the old match sent it to
 /// `_ => Severity::Error`, gating on exactly the findings the caller had asked to ignore.
 ///
-/// The action input also called `fail_on` is a different thing — it is implemented in bash at
-/// `action.yml:527-549` and never reaches this flag.
+/// The action input also called `fail_on` used to be a different thing, implemented in a bash
+/// `case` that never reached this flag and had no default arm, so any value it did not recognize
+/// gated nothing. It now forwards the input here unmodified, which makes this function the only
+/// definition of the threshold vocabulary on either side of that boundary.
 ///
 /// The value parser on `--fail-on` decides what reaches this function, so an unrecognized value is
 /// rejected before the command runs and never arrives here.

--- a/crates/assay-cli/tests/fail_on_gate.rs
+++ b/crates/assay-cli/tests/fail_on_gate.rs
@@ -166,3 +166,33 @@ fn every_advertised_spelling_is_accepted() {
         );
     }
 }
+
+/// The `warning` alias by effect rather than by acceptance.
+///
+/// `every_advertised_spelling_is_accepted` runs on a bundle with no findings, where every valid
+/// threshold exits 0, so it cannot tell `warning` from `error`. It only proves the spelling parses.
+///
+/// The distinction is load-bearing outside this crate. `packs/open/cicd-starter/README.md` tells
+/// users to set `fail_on: warning`, and the Action's own bash `case` had no arm for it and no
+/// default, so the value gated nothing at all (#2037). The Action now forwards the input here
+/// unmodified, which makes this the assertion standing behind that README.
+#[test]
+fn warning_gates_the_same_findings_as_warn() {
+    let warn = lint_pack(WARNING_PACK, "warn").status.code();
+    let warning = lint_pack(WARNING_PACK, "warning").status.code();
+    let error = lint_pack(WARNING_PACK, "error").status.code();
+
+    assert_eq!(
+        warn,
+        Some(1),
+        "fixture no longer yields a warning finding under {WARNING_PACK}, so the rest proves nothing"
+    );
+    assert_eq!(
+        warning, warn,
+        "`warning` is not the alias of `warn` its callers rely on"
+    );
+    assert_ne!(
+        warning, error,
+        "`warning` decides what `error` decides, so the alias distinguishes nothing"
+    );
+}


### PR DESCRIPTION
Closes #2037. Step 3 of #2039, on the non-pack path.

## ⚠️ Two behaviour changes, one of them not in the issue

`action.yml` applied the threshold in a bash `case` with arms for `error`, `warn`, `info` and `none`, and no default. `packs/open/cicd-starter/README.md:23,28` tells users to set `fail_on: warning`, which matched no arm, so the gate exited 0 and enforced nothing. Any other value the arms did not name did the same: a casing difference, a trailing space, a typo.

The threshold now goes to `assay evidence lint --fail-on` unmodified and its exit code is the decision, which is what the compliance-pack path in the same file already did. One definition of the vocabulary, the one clap validates. `warning` works because the CLI has always carried the alias (`lint.rs:28`), and an unusable value now fails the run instead of disabling the gate.

**The second defect was found by running the block, not by reading it.** The old JSON invocation was

```bash
LINT_JSON=$(assay evidence lint --format json "$bundle" 2>/dev/null || echo '{"findings":[]}')
```

`assay evidence lint` writes its report *before* deciding the gate (`lint.rs:244`, after the output at `:232-241`), so whenever the default threshold tripped the substitution captured the report **and** the fallback. jq then emitted one count per document and the next line became a bash syntax error, fatal under `set -euo pipefail`.

Confirmed against the real binary, not a stub:

```
$ assay evidence lint --format json --pack soc2-baseline tests/fixtures/evidence/test-bundle.tar.gz
exit=1, report on stdout

$ # the old expression over that
BUNDLE_ERRORS=[0
0]
bash: 0
0: syntax error in expression (error token is "0")
```

So on `main` today, a bundle whose default lint has a finding at or above `error` makes the step exit 1 having written **no** `findings_error`, no `findings_warn`, no `diff_summary` and no `::error::` annotation. It reads as a tripped gate. Capturing the exit code explicitly and keeping the fallback out of the substitution removes it.

## Measured, before and after

The real `run:` block was sliced out of `action.yml` and executed against a stub CLI that mirrors the documented exit contract (0 none at/above, 1 findings, 2 rejected value). Both revisions, same harness:

| `fail_on` | finding | before | after |
|---|---|---|---|
| `warning` | warning | **exit 0, no annotation** | exit 1, annotated |
| `warn` | warning | exit 1 | exit 1 |
| `bogus` | error | **exit 0** | exit 2, names the value |
| `ERROR` | error | **exit 0** | exit 2, names the value |
| `error` | error | exit 1, **zero outputs written** | exit 1, all outputs written |
| `error` | warning | exit 0 | exit 0 |
| `none` | error | exit 0 | exit 0 |
| `info` | warning | exit 1 | exit 1 |

One harness correction worth recording: the first run reported all-zero for the old block, which was the stub rejecting an empty `--fail-on` rather than the code being uniformly broken. The old path passes no `--fail-on`, so the stub had to default to `error` the way the CLI does. A harness that reports one number for every input is more likely wrong than the code is.

## What did not move

`ERRORS` and `WARNS` still feed `findings_error`, `findings_warn` and `diff_summary`. Only the deciding moved. `diff_summary` is now written *before* the gate so a gated run still reports what it found.

The exit-code `case` that replaces it has a `*)` arm, and it switches on a closed set of three documented exit codes rather than on an open vocabulary of user input.

## Tests

`warning_gates_the_same_findings_as_warn` in `tests/fail_on_gate.rs` covers the alias by **effect**: `warning` and `warn` must gate the same finding, and neither may behave like `error`. The existing `every_advertised_spelling_is_accepted` runs on a bundle with no findings, where every valid threshold exits 0, so it only proved the spelling parses.

`cargo clippy -p assay-cli --all-targets -- -D warnings` clean, `fail_on_gate` 8/8, `action.yml` parses as YAML and the extracted block is shellcheck-clean at `-S warning`.

## Also corrected

Three descriptions of the surface disagreed. The input description said `error, warn, info, none` while the pack README said `warning`; the doc comment on `gate_threshold` and the comment on the pack path both described the bash `case` that is now gone.

## Note on the pattern claim in #2037

The issue and #2048 were paired as two instances of a doc-presence CI check standing in for a correctness check. That pairing was retracted on #2048, where the behaviour did exist in the mode its ADR described. This one is a genuine instance: `review-adr023-starter-docs-followup.sh:45` greps the starter docs for the claim, and the behaviour behind it was absent.
