### PR TITLE
Check the release surface against the workspace version, and bring it current

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,6 +142,16 @@ repos:
         # file that used to trigger this hook.
         files: ^(scripts/ci/test-fuzz-lane-contract\.sh|\.github/workflows/fuzz-smoke\.yml|fuzz/Cargo\.(toml|lock)|\.pre-commit-config\.yaml)$
 
+      - id: release-surface
+        name: Release surface names the current version
+        entry: bash scripts/ci/check-release-surface.sh
+        language: system
+        pass_filenames: false
+        # Triggers on the files it can be wrong about, plus itself. It does not need a binary: with
+        # no `target/` build it falls back to the manifest version, so a release-prep commit is
+        # checked without waiting on a compile.
+        files: ^(scripts/ci/check-release-surface\.sh|Cargo\.toml|docs/getting-started/installation\.md|\.pre-commit-config\.yaml)$
+
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract
         entry: bash scripts/ci/test-ci-gate-expectations.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,19 +76,19 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.36.0" }
-assay-common = { path = "crates/assay-common", version = "3.36.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.36.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.19.1" }
-assay-policy = { path = "crates/assay-policy", version = "3.19.1" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.19.1" }
-assay-canonical = { path = "crates/assay-canonical", version = "3.19.1" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.36.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.19.1" }
-assay-registry = { path = "crates/assay-registry", version = "3.19.1" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.19.1" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.19.1" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.19.1" }
+assay-core = { path = "crates/assay-core", version = "3.38.0" }
+assay-common = { path = "crates/assay-common", version = "3.38.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.38.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.38.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.38.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.38.0" }
+assay-canonical = { path = "crates/assay-canonical", version = "3.38.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.38.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.38.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.38.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.38.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.38.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.38.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -52,7 +52,7 @@ assay --version
 
 Expected output:
 ```
-assay 3.36.0
+assay 3.38.0
 ```
 
 ---

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Every place that must name the current version names it. #1996.
+#
+# A release prep touches a fixed set of files and nothing checked that it did: three of them sat a
+# release behind from v3.37.0 onward, and the internal dependency declarations had drifted as far
+# back as 3.19.1 while the workspace was at 3.38.0.
+#
+# WHY THIS IS NOT A GREP FOR OLD VERSION STRINGS
+#
+# Most version strings in this repo are supposed to be stale, because they record what happened
+# rather than what is current:
+#
+#   - CHANGELOG.md entries.
+#   - "Releases starting with 3.36.0 declare Rust 1.89 as their MSRV" in
+#     docs/getting-started/installation.md and docs/reference/rust-support.md. That sentence is
+#     permanently true and bumping the number would make it false.
+#   - Dated status syncs in docs/ROADMAP.md, which narrate a specific release line.
+#   - Recorded measurement provenance, e.g. docs/interop/sep2828-decision-pairing-v0.md.
+#
+# A repo-wide "no old versions" check flags exactly those, gets suppressed, and then catches
+# nothing. So this script checks only facts it can DERIVE, and never scans for version-shaped text:
+#
+#   1. Internal dependency declarations. Enumerated from the root Cargo.toml itself, not from a
+#      list kept here, so a new workspace crate is covered the day it is added.
+#   2. The `assay --version` sample output in the installation guide, compared against what the
+#      binary actually prints, so the expectation comes from the program rather than from a
+#      hard-coded string.
+#
+# Nothing is excluded by pattern. Lines that must stay historical are out of scope because they are
+# not derived from the current version in the first place.
+#
+# Usage: scripts/ci/check-release-surface.sh
+#        ASSAY_BIN=path/to/assay scripts/ci/check-release-surface.sh   (skips cargo build)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+failures=0
+fail() {
+  failures=$((failures + 1))
+  printf 'FAIL: %s\n' "$*"
+}
+note() { printf '%s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# The one source of truth.
+# ---------------------------------------------------------------------------
+WORKSPACE_VERSION="$(
+  awk '
+    /^\[workspace\.package\]/ { in_section = 1; next }
+    /^\[/                     { in_section = 0 }
+    in_section && /^version *=/ {
+      gsub(/^version *= *"|".*$/, "")
+      print
+      exit
+    }
+  ' Cargo.toml
+)"
+
+if [ -z "$WORKSPACE_VERSION" ]; then
+  echo "could not read [workspace.package] version from Cargo.toml" >&2
+  exit 2
+fi
+note "workspace version: $WORKSPACE_VERSION"
+
+# ---------------------------------------------------------------------------
+# 1. Internal dependency declarations, enumerated from the manifest.
+#
+# Every crate in this workspace sets `version.workspace = true`, so each one is published at
+# WORKSPACE_VERSION. A declaration naming an older version still resolves, because ^3.19.1 is
+# satisfied by 3.38.0, which is why this drifted silently for so long. What it costs is a published
+# requirement looser than the truth: a consumer that pins the declared minimum gets a version this
+# workspace has not compiled against since.
+# ---------------------------------------------------------------------------
+note ""
+note "internal dependency declarations:"
+
+checked=0
+while IFS=$'\t' read -r name declared; do
+  checked=$((checked + 1))
+  if [ "$declared" != "$WORKSPACE_VERSION" ]; then
+    fail "Cargo.toml: $name declares version \"$declared\", workspace is \"$WORKSPACE_VERSION\""
+  fi
+done < <(
+  awk '
+    /^\[workspace\.dependencies\]/ { in_section = 1; next }
+    /^\[/                          { in_section = 0 }
+    in_section && /path *= *"(crates|assay-python-sdk)/ {
+      name = $1
+      if (match($0, /version *= *"[^"]+"/)) {
+        v = substr($0, RSTART, RLENGTH)
+        gsub(/version *= *"|"/, "", v)
+        printf "%s\t%s\n", name, v
+      }
+    }
+  ' Cargo.toml
+)
+
+if [ "$checked" -eq 0 ]; then
+  fail "no internal path dependencies found in [workspace.dependencies]; the enumeration is broken"
+else
+  note "  checked $checked declaration(s)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The documented `assay --version` output.
+#
+# Derived from the binary rather than compared to a literal, so this cannot drift into asserting a
+# version the program does not print.
+# ---------------------------------------------------------------------------
+note ""
+note "documented CLI version output:"
+
+INSTALL_DOC="docs/getting-started/installation.md"
+ASSAY_BIN="${ASSAY_BIN:-}"
+
+if [ -z "$ASSAY_BIN" ]; then
+  if [ -x "target/debug/assay" ]; then
+    ASSAY_BIN="target/debug/assay"
+  elif [ -x "target/release/assay" ]; then
+    ASSAY_BIN="target/release/assay"
+  fi
+fi
+
+if [ -n "$ASSAY_BIN" ]; then
+  ACTUAL="$("$ASSAY_BIN" --version | head -1 | tr -d '\r')"
+  note "  binary prints: $ACTUAL"
+  if ! grep -qxF "$ACTUAL" "$INSTALL_DOC"; then
+    fail "$INSTALL_DOC does not show \"$ACTUAL\" as the expected \`assay --version\` output"
+  fi
+else
+  # No binary to ask, so fall back to the manifest. Still derived, one step further removed.
+  note "  no assay binary available; comparing against the manifest version instead"
+  if ! grep -qxF "assay $WORKSPACE_VERSION" "$INSTALL_DOC"; then
+    fail "$INSTALL_DOC does not show \"assay $WORKSPACE_VERSION\" as the expected \`assay --version\` output"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+note ""
+if [ "$failures" -gt 0 ]; then
+  note "release surface: $failures disagreement(s) with [workspace.package] version"
+  note ""
+  note "If this fired on a release prep, bump the files it names. If it fired on a line that is"
+  note "supposed to record history, that line should not be derived from the current version and"
+  note "this script should not be looking at it: fix the check, do not suppress it."
+  exit 1
+fi
+
+note "release surface: consistent at $WORKSPACE_VERSION"


### PR DESCRIPTION
Closes #1996.

## What had drifted

Thirteen internal dependency declarations in `[workspace.dependencies]` named a version the workspace had left behind: four at 3.36.0 and **nine at 3.19.1**, against a workspace at 3.38.0.

Every crate sets `version.workspace = true`, verified across all 21, so all thirteen are published at 3.38.0 and every declaration was looser than the truth. Nothing broke, because `^3.19.1` is satisfied by 3.38.0. That is exactly why it drifted nineteen minor versions unnoticed, and it is what the issue means by "fails quietly and benignly": the published requirement lets a consumer pin a version this workspace has not compiled against since.

`docs/getting-started/installation.md` showed `assay 3.36.0` as the expected `assay --version` output.

`fuzz/Cargo.lock` is current at 3.38.0, so #1991's fix held.

## ⚠️ Two files the issue lists that must not change

The issue's table lists three docs as "reads 3.36.0, should read current". Two of those references are permanently correct, and bumping them would introduce a falsehood:

- `docs/getting-started/installation.md:24` and `docs/reference/rust-support.md:10-11` say that releases **starting with** 3.36.0 declare Rust 1.89 as their MSRV, and that releases through 3.35.0 did not. That is a fact about when the guarantee began, not a statement about the current release.
- `docs/ROADMAP.md:3` is a dated status sync ("2026-07-29, `v3.36.0` release line") narrating what that line shipped. Changing the number while keeping the description makes it wrong. What is missing there is a *newer* sync, which is editorial content rather than a version bump, so this PR does not invent one.

So of the three files, one line in one file was genuinely stale. `docs/reference/rust-support.md` needs no change at all.

The issue warned that a naive check "produces false positives on exactly the lines that are correct, gets suppressed, and then catches nothing". Its own acceptance table had walked into that, which is worth recording because it is the same declared-versus-actual shape the check exists to catch.

## The check

`scripts/ci/check-release-surface.sh` never scans for version-shaped text. It compares only facts it derives:

1. **Internal dependency declarations**, enumerated from the root `Cargo.toml` itself rather than from a list kept in the script, so a crate added tomorrow is covered without editing the check.
2. **The documented `assay --version` output**, compared against what the binary actually prints. With no build available it falls back to the manifest version, so a release-prep commit is checked without waiting on a compile.

Nothing is excluded by pattern. CHANGELOG entries, MSRV anchors, dated status syncs and recorded measurement provenance are out of scope because they are not derived from the current version, not because a suppression hides them. That is the acceptance criterion "excluded by construction, not by suppression", and it is why the check has no allowlist to rot.

Wired as a pre-commit hook, which also runs as `Lint (pre-commit)` in CI, triggered by `Cargo.toml` so a release prep cannot miss it.

## Verified by mutation, not by being green

| tree | exit | reports |
|---|---|---|
| this branch | 0 | consistent at 3.38.0 |
| `main`'s `Cargo.toml` restored | 1 | all 13 declarations, each by name and version |
| `main`'s `installation.md` restored | 1 | the sample output line |

The MSRV anchors at `installation.md:24` and `rust-support.md:10-11` are not flagged in any of those runs, which is the false-positive case the issue named. The check reaches the sample output by exact whole-line match, so it cannot couple to prose that happens to contain a version.

`cargo check --workspace --locked --offline` passes with `Cargo.lock` untouched: the declarations widened to the truth and resolution was already local. `shellcheck` clean.

## Lane

This touches the root `Cargo.toml`, which `scripts/ci/assay_runner_gated_paths.json` lists in `all_gate_paths`, so the PR needs `gates=all` with a delegated proof bound to this head. Dispatching it separately.
