### PR TITLE
A gate whose only test was cutting a release

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Verify software and conformance release channels stay separate
         run: bash scripts/ci/test-release-channel-separation.sh
 
+      # The release-blocking gate's only test used to be cutting a release. This is where it stops
+      # being that.
+      - name: Exercise the release-blocking gate
+        run: bash scripts/ci/test-release-blocking-gate.sh
+
       - name: Build CLI once
         run: cargo build --release --workspace --exclude assay-ebpf
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,78 +67,19 @@ jobs:
 
       # A release gate that lives only in an issue's prose is not a gate. v3.37.0 shipped with a
       # blocker open because the only place the gate existed was one sentence, and nothing could
-      # read it. This step is what makes `release-blocking` mean something.
+      # read it.
       #
-      # Deliberately no override input. If a release must go out with a blocker open, the way to
-      # do it is to remove the label or move the issue out of the milestone — both are recorded
-      # decisions on the issue itself, which is better provenance than a workflow input nobody
-      # will find later.
-      #
-      # A release with no matching milestone is not blocked. Milestones are optional here, and
-      # failing on their absence would push people to stop using them, which costs the gate its
-      # only input.
+      # The decision lives in a script so it can be tested without cutting a release. As ~25 inline
+      # lines here it acquired three fail-open defects in one day, each of which logged like
+      # success, because production was its only test. `test-release-blocking-gate.sh` replays all
+      # three and runs on every PR.
       - name: Refuse to release over an open blocker
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          set -euo pipefail
-
-          # `resolve-release-version.sh` returns the tag form, WITH the leading v (verified by
-          # running it: refs/tags/v3.38.0 -> "v3.38.0"). Blindly prefixing another one produced
-          # "vv3.38.0", which matches no milestone and takes the nothing-to-gate-on path -- a
-          # fail-open that logs like success, in the gate whose entire point is to fail closed.
-          # Normalise both known shapes and refuse anything else rather than guessing.
-          case "$VERSION" in
-            v[0-9]*)  milestone="$VERSION" ;;
-            [0-9]*)   milestone="v$VERSION" ;;
-            *)
-              echo "::error::unrecognised release version '${VERSION}'; refusing to release rather than guessing which milestone to check."
-              exit 1
-              ;;
-          esac
-
-          # Capture before testing, and paginate. Both matter, and both are fail-closed fixes:
-          #
-          #   - `if ! gh api ... | grep -q` would treat an API failure as "milestone not found",
-          #     because `set -e` is suspended inside an `if` condition and `!` inverts the pipe's
-          #     non-zero status. A rate limit or a network blip would have released over an open
-          #     blocker. Assigning first means a failure is distinguishable from a miss.
-          #   - `--paginate` because this gate is meant to outlive the milestones it reads. A repo
-          #     with more than one page of them would find nothing on page 1 and disable the gate
-          #     precisely when the project is old enough to have forgotten it exists.
-          if ! titles="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/milestones?state=all" --jq '.[].title')"; then
-            echo "::error::could not list milestones; refusing to release rather than guessing."
-            exit 1
-          fi
-
-          if ! grep -Fxq "$milestone" <<<"$titles"; then
-            echo "No milestone named ${milestone}; nothing to gate on."
-            exit 0
-          fi
-
-          # Deliberately NOT inside an `if`. Under `set -e` a failed query aborts the step, which
-          # is the fail-closed behaviour a gate needs. Wrapping this in a condition would swallow
-          # the failure and release, which is the same shape as the milestone bug above.
-          blockers="$(gh issue list \
-            --repo "${GITHUB_REPOSITORY}" \
-            --label release-blocking \
-            --milestone "$milestone" \
-            --state open \
-            --limit 100 \
-            --json number,title \
-            --jq '.[] | "  #\(.number) \(.title)"')"
-
-          if [ -n "$blockers" ]; then
-            echo "::error::${milestone} has open release-blocking issues; refusing to release."
-            echo "$blockers"
-            echo
-            echo "Close them, drop the release-blocking label, or move them to a later milestone."
-            exit 1
-          fi
-
-          echo "No open release-blocking issues in ${milestone}."
+          bash scripts/ci/release_blocking_gate.sh \
+            "${{ steps.version.outputs.version }}" "${GITHUB_REPOSITORY}"
 
   # ============================================================
   # Build matrix for all platforms

--- a/scripts/ci/release_blocking_gate.sh
+++ b/scripts/ci/release_blocking_gate.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Refuse to release over an open `release-blocking` issue in the release's milestone.
+#
+# Extracted from ~25 inline lines in `release.yml` (#1993). In one day that step acquired three
+# fail-open defects, all the same shape -- the gate deciding it had nothing to check and exiting 0:
+# a milestone lookup that read an API failure as "no such milestone", a lookup that read only the
+# first page, and a version prefixed twice so it searched for `vv3.38.0`. Every one of them logged
+# like success.
+#
+# It could not be exercised without cutting a release, so its only test was production and its
+# failure mode was silence. That is the shape this repository refuses everywhere else. The two API
+# calls go through `$GH_BIN` for the same reason `release_proof_kit_build.sh` does: the seam is what
+# lets `test-release-blocking-gate.sh` drive the paths that have no other way to be reached.
+#
+# Usage: release_blocking_gate.sh <version> <owner/repo>
+#
+# Exit 0 = release may proceed. Exit 1 = refuse. There is no third outcome, and no override input:
+# if a release must go out over a blocker, the way is to drop the label or move the issue to a later
+# milestone, both of which are recorded on the issue itself.
+
+set -euo pipefail
+
+GH_BIN="${GH_BIN:-gh}"
+
+version="${1:-}"
+repo="${2:-}"
+
+if [ -z "$version" ] || [ -z "$repo" ]; then
+  echo "usage: $(basename "$0") <version> <owner/repo>" >&2
+  exit 1
+fi
+
+# `::error::` only where something reads it. The decision above this line is the same either way,
+# which is what makes the decision testable outside a job.
+fail() {
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::error::$1"
+  else
+    echo "error: $1" >&2
+  fi
+}
+
+# `resolve-release-version.sh` returns the tag form, WITH the leading v. Blindly prefixing another
+# one produced `vv3.38.0`, which matches no milestone and takes the nothing-to-gate-on path -- a
+# fail-open that logs like success, in the gate whose entire point is to fail closed. Normalise both
+# known shapes and refuse anything else rather than guessing.
+case "$version" in
+  v[0-9]*) milestone="$version" ;;
+  [0-9]*)  milestone="v$version" ;;
+  *)
+    fail "unrecognised release version '${version}'; refusing to release rather than guessing which milestone to check."
+    exit 1
+    ;;
+esac
+
+# Capture before testing, and paginate. Both matter, and both are fail-closed fixes:
+#
+#   - `if ! gh api ... | grep -q` would treat an API failure as "milestone not found", because
+#     `set -e` is suspended inside an `if` condition and `!` inverts the pipeline's non-zero status.
+#     A rate limit or a network blip would have released over an open blocker. Assigning first makes
+#     a failure distinguishable from a miss.
+#   - `--paginate` because this gate is meant to outlive the milestones it reads. A repo with more
+#     than one page of them would find nothing on page 1 and disable the gate precisely when the
+#     project is old enough to have forgotten it exists.
+if ! titles="$("$GH_BIN" api --paginate "repos/${repo}/milestones?state=all" --jq '.[].title')"; then
+  fail "could not list milestones; refusing to release rather than guessing."
+  exit 1
+fi
+
+# A release with no matching milestone is not blocked. Milestones are optional here, and failing on
+# their absence would push people to stop using them, which costs the gate its only input.
+#
+# This is the one deliberate open path in the gate. It is here, once, and
+# `test-release-blocking-gate.sh` pins it so it stays deliberate rather than becoming the fourth
+# accident.
+if ! grep -Fxq "$milestone" <<<"$titles"; then
+  echo "No milestone named ${milestone}; nothing to gate on."
+  exit 0
+fi
+
+# Deliberately NOT inside an `if`. Under `set -e` a failed query aborts the script, which is the
+# fail-closed behaviour a gate needs. Wrapping this in a condition would swallow the failure and
+# release, which is the same shape as the milestone bug above.
+blockers="$("$GH_BIN" issue list \
+  --repo "$repo" \
+  --label release-blocking \
+  --milestone "$milestone" \
+  --state open \
+  --limit 100 \
+  --json number,title \
+  --jq '.[] | "  #\(.number) \(.title)"')"
+
+if [ -n "$blockers" ]; then
+  fail "${milestone} has open release-blocking issues; refusing to release."
+  echo "$blockers"
+  echo
+  echo "Close them, drop the release-blocking label, or move them to a later milestone."
+  exit 1
+fi
+
+echo "${milestone} has no open release-blocking issues."

--- a/scripts/ci/test-release-blocking-gate.sh
+++ b/scripts/ci/test-release-blocking-gate.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Every case here is a defect that has already happened, or one that would pass silently today.
+#
+# The gate this tests decides whether a release may proceed. Before the extraction in #1993 it was
+# inline bash in `release.yml`, so its only test was cutting a release, and it failed open three
+# times in one day -- each time logging like success. The `$GH_BIN` seam exists so the two cases
+# that had no other way to be reached (a milestone listing that fails, and a milestone past the
+# first page) can be driven here.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/ci/release_blocking_gate.sh"
+REPO="Rul1an/assay"
+TEST_TEMP_DIR=""
+FAILURES=0
+
+cleanup() { [ -n "$TEST_TEMP_DIR" ] && rm -rf "$TEST_TEMP_DIR"; }
+trap cleanup EXIT
+
+# A `gh` that answers from files, and honours `--paginate` the way the real one does.
+#
+# The pagination behaviour is the point: without `--paginate` it returns only the first page, so a
+# gate that drops the flag finds nothing and opens. That is defect 2 from #1993, and it is
+# reachable here and nowhere else.
+make_fake_gh() {
+  cat > "$1" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+
+case "$1" in
+  api)
+    [ "${FAKE_MILESTONES_FAIL:-}" = "1" ] && { echo "API rate limit exceeded" >&2; exit 1; }
+    if printf '%s\n' "$@" | grep -qx -- '--paginate'; then
+      cat "$FAKE_MILESTONES_ALL"
+    else
+      head -n "${FAKE_PAGE_SIZE:-100}" "$FAKE_MILESTONES_ALL"
+    fi
+    ;;
+  issue)
+    [ "${FAKE_ISSUES_FAIL:-}" = "1" ] && { echo "API rate limit exceeded" >&2; exit 1; }
+    cat "$FAKE_BLOCKERS"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$1"
+}
+
+# Runs the gate and reports the exit code plus combined output.
+run_gate() {
+  local version="$1"
+  set +e
+  GATE_OUT="$(GH_BIN="$TEST_TEMP_DIR/gh" \
+    FAKE_GH_LOG="$TEST_TEMP_DIR/gh.log" \
+    FAKE_MILESTONES_ALL="$TEST_TEMP_DIR/milestones.txt" \
+    FAKE_BLOCKERS="$TEST_TEMP_DIR/blockers.txt" \
+    FAKE_MILESTONES_FAIL="${FAKE_MILESTONES_FAIL:-}" \
+    FAKE_ISSUES_FAIL="${FAKE_ISSUES_FAIL:-}" \
+    FAKE_PAGE_SIZE="${FAKE_PAGE_SIZE:-100}" \
+    GITHUB_ACTIONS="${GITHUB_ACTIONS_OVERRIDE:-}" \
+    bash "$SCRIPT" "$version" "$REPO" 2>&1)"
+  GATE_STATUS=$?
+  set -e
+}
+
+check() {
+  local name="$1" want_status="$2" want_text="${3:-}"
+  if [ "$GATE_STATUS" != "$want_status" ]; then
+    echo "FAIL  $name: exit $GATE_STATUS, wanted $want_status"
+    echo "      output: $GATE_OUT"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  if [ -n "$want_text" ] && ! grep -qF -- "$want_text" <<<"$GATE_OUT"; then
+    echo "FAIL  $name: output does not contain '$want_text'"
+    echo "      output: $GATE_OUT"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  echo "ok    $name"
+}
+
+TEST_TEMP_DIR="$(mktemp -d)"
+make_fake_gh "$TEST_TEMP_DIR/gh"
+printf 'v3.37.0\nv3.38.0\n' > "$TEST_TEMP_DIR/milestones.txt"
+: > "$TEST_TEMP_DIR/blockers.txt"
+
+# --- Both version shapes resolve to one milestone -------------------------------------------
+#
+# Defect 3: `resolve-release-version.sh` returns the tag form, the gate prefixed another `v`, and
+# `vv3.38.0` matched nothing -- so the gate opened. The query logic had been verified twice against
+# live state; what was never checked was what the variable held.
+run_gate "v3.38.0"
+check "tag form v3.38.0 finds its milestone" 0 "no open release-blocking issues"
+run_gate "3.38.0"
+check "bare form 3.38.0 finds the same milestone" 0 "no open release-blocking issues"
+
+# --- An unrecognised version refuses rather than guessing -----------------------------------
+run_gate "release-candidate"
+check "unrecognised version refuses" 1 "refusing to release rather than guessing"
+run_gate ""
+check "empty version refuses" 1 "usage:"
+
+# --- A milestone with an open blocker fails, and names it ------------------------------------
+printf '  #1949 Reject nonempty but behaviorally vacuous assertions\n' > "$TEST_TEMP_DIR/blockers.txt"
+run_gate "v3.38.0"
+check "open blocker refuses" 1 "refusing to release"
+check "open blocker is named" 1 "#1949"
+: > "$TEST_TEMP_DIR/blockers.txt"
+
+# --- The deliberate open path, pinned so it stays deliberate ---------------------------------
+#
+# A release with no matching milestone is not blocked. This is the ONE path where the gate passes
+# without having checked anything, and all three shipped defects were accidental arrivals at it.
+# Pinned by name so a fourth arrival is a test change someone has to justify.
+run_gate "v9.99.0"
+check "no milestone at all passes, deliberately" 0 "nothing to gate on"
+
+# --- A failed milestone listing refuses, rather than reading as absence ----------------------
+#
+# Defect 1. `if ! gh api ... | grep -q` treated a rate limit as "no such milestone": `set -e` is
+# suspended inside an `if` condition and `!` inverts the pipeline's status. Unreachable before the
+# seam existed.
+FAKE_MILESTONES_FAIL=1 run_gate "v3.38.0"
+check "milestone listing failure refuses" 1 "could not list milestones"
+unset FAKE_MILESTONES_FAIL
+
+# --- A failed blocker query refuses too ------------------------------------------------------
+#
+# The mirror of the above, on the second call. It is fail-closed only because the assignment is not
+# wrapped in an `if`; nothing else enforces that, so it is pinned.
+FAKE_ISSUES_FAIL=1 run_gate "v3.38.0"
+check "blocker query failure refuses" 1 ""
+unset FAKE_ISSUES_FAIL
+
+# --- A milestone past the first page is still found ------------------------------------------
+#
+# Defect 2. The fake honours `--paginate` exactly as the real `gh` does, so dropping the flag makes
+# this case go red: page 1 would hold 100 older milestones and the release's own would be invisible.
+{ for i in $(seq 1 129); do printf 'v0.%d.0\n' "$i"; done; printf 'v3.38.0\n'; } \
+  > "$TEST_TEMP_DIR/milestones.txt"
+run_gate "v3.38.0"
+check "milestone beyond page 1 is found" 0 "no open release-blocking issues"
+
+if ! grep -q -- '--paginate' "$TEST_TEMP_DIR/gh.log"; then
+  echo "FAIL  the gate never passed --paginate"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "ok    the gate passes --paginate"
+fi
+printf 'v3.37.0\nv3.38.0\n' > "$TEST_TEMP_DIR/milestones.txt"
+
+# --- The annotation is the only thing the job context changes --------------------------------
+#
+# The decision must not depend on running inside Actions. Same inputs, same exit code, different
+# rendering.
+GITHUB_ACTIONS_OVERRIDE=true run_gate "release-candidate"
+check "inside Actions the refusal is annotated" 1 "::error::"
+GITHUB_ACTIONS_OVERRIDE="" run_gate "release-candidate"
+check "outside Actions the refusal is plain" 1 "error: unrecognised"
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo
+  echo "$FAILURES release-blocking gate case(s) failed"
+  exit 1
+fi
+echo
+echo "release-blocking gate: all cases pass"


### PR DESCRIPTION
## Description

Closes #1993.

The release-blocking gate was ~25 lines of inline bash in `release.yml`. In one day it acquired **three fail-open defects**, all the same shape — the gate deciding it had nothing to check and exiting 0:

| # | Defect | Why it opened |
|---|---|---|
| 1 | `if ! gh api … \| grep -q` | `set -e` is suspended inside an `if` condition and `!` inverts the pipeline's status, so a rate limit read as "no such milestone" |
| 2 | `per_page=100` without `--paginate` | a repo with more milestones than one page disables its own gate |
| 3 | the version prefixed twice | looked for `vv3.38.0`, found nothing, exited 0 |

Every one of them logged like success.

The third is the instructive one. The query logic had been verified against live repository state **twice**. What had never been checked was what the *variable* contained.

## The extraction

The decision lives in `scripts/ci/release_blocking_gate.sh`, taking the version and repository as arguments and reaching GitHub through `$GH_BIN` — the same seam `release_proof_kit_build.sh` already uses.

**The seam is the point of the extraction, not a side effect.** Two of the cases below have no other way to be reached.

`release.yml` now contains the invocation and nothing else (73 lines out, 7 in).

## Verification

Thirteen cases, run on every PR via `action-tests.yml`. Five mutants, the first three being the defects that actually shipped:

| Mutation | Result |
|---|---|
| API failure reads as absence | **red** |
| `--paginate` dropped | **red** (2 cases) |
| version prefixed twice | **red** (5 cases) |
| blocker query failure swallowed | **red** |
| an open blocker no longer refuses | **red** (2 cases) |

The fake `gh` **honours `--paginate` exactly as the real one does** — 130 milestones with the release's own last — so dropping the flag makes the test go red rather than merely failing to assert the flag is present.

## The deliberate open path is pinned

A release with no matching milestone is not blocked; milestones are optional here and failing on their absence would push people to stop using them. That is the one path where the gate passes without checking anything, and **all three shipped defects were accidental arrivals at it**. It is now asserted by name, so a fourth arrival is a test change someone has to justify.

## Two details

- `::error::` is emitted only when `GITHUB_ACTIONS=true`, and **both renderings are asserted**. The decision is identical either way, which is what lets it be exercised outside a job at all.
- The version shapes were **measured, not assumed** — the lesson defect 3 taught. Running `resolve-release-version.sh`: a tag ref gives `v3.38.0`, a dispatch input gives `3.38.0`, and both map to milestone `v3.38.0`. That pair is what the first two cases pin.

## Scope

`Gate.NONE`. `shellcheck` clean; `actionlint` passes on both workflows.

## Non-goals, as stated in the issue

Not changing what the gate decides. No override input — dropping the label or moving the milestone stay the recorded ways out, for the provenance reason in #1985.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
