### PR TITLE
The ceiling has to be before the decode, which is why it cannot live in PAE

### DIFF
--- a/crates/assay-registry/src/dsse.rs
+++ b/crates/assay-registry/src/dsse.rs
@@ -124,12 +124,21 @@ pub fn verify_dsse_envelope_offline(
         );
     }
 
-    let payload = match BASE64.decode(payload_b64.as_bytes()) {
-        Ok(b) => b,
-        Err(_) => {
+    // Bounded before the allocation, not after: see `dsse_limits`. An oversized payload is a
+    // refusal in its own right, distinct from malformed base64, because the two are different
+    // things for an operator to act on.
+    let payload = match crate::dsse_limits::decode_bounded(payload_b64.as_bytes()) {
+        Ok(Some(b)) => b,
+        Ok(None) => {
             return DsseOutcome::new(
                 CheckStatus::UnsupportedFormat,
                 "DSSE payload is not valid base64",
+            )
+        }
+        Err(_) => {
+            return DsseOutcome::new(
+                CheckStatus::UnsupportedFormat,
+                crate::dsse_limits::OVERSIZED_REASON,
             )
         }
     };
@@ -259,6 +268,32 @@ mod tests {
         let env = envelope(IN_TOTO_PAYLOAD_TYPE, &tampered, &sig);
         let out = verify_dsse_envelope_offline(&leaf, &env, ARTIFACT_SHA256);
         assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+    }
+
+    /// The ceiling is reached through the real entry point, not through `decode_bounded`.
+    ///
+    /// A unit test on the helper proves the helper works. It says nothing about whether this flow
+    /// calls it, which is the only question that matters -- the defect in #1969 was three flows
+    /// that each decoded first, and a helper nobody reached would leave all three exactly as they
+    /// were.
+    #[test]
+    fn an_oversized_payload_is_refused_by_the_offline_verifier() {
+        let (leaf, key) = leaf_with_key();
+        let payload = statement(ARTIFACT_SHA256);
+        let sig = sign(&key, &dsse_pae(IN_TOTO_PAYLOAD_TYPE, &payload));
+        let oversized = "A".repeat(crate::dsse_limits::MAX_DSSE_PAYLOAD_BYTES * 2);
+        let env = format!(
+            r#"{{"payloadType":"{IN_TOTO_PAYLOAD_TYPE}","payload":"{oversized}","signatures":[{{"sig":"{}"}}]}}"#,
+            BASE64.encode(&sig)
+        );
+        let out = verify_dsse_envelope_offline(&leaf, env.as_bytes(), ARTIFACT_SHA256);
+        assert_eq!(out.status, CheckStatus::UnsupportedFormat, "{}", out.reason);
+        assert_eq!(
+            out.reason,
+            crate::dsse_limits::OVERSIZED_REASON,
+            "an oversized payload must be refused as oversized, not as malformed base64 -- they \
+             are different things for an operator to act on"
+        );
     }
 
     #[test]

--- a/crates/assay-registry/src/dsse_limits.rs
+++ b/crates/assay-registry/src/dsse_limits.rs
@@ -1,0 +1,182 @@
+//! One ceiling for DSSE payloads, applied where the allocation happens.
+//!
+//! `assay-registry` base64-decodes and JSON-parses DSSE payloads in three flows -- pack signature
+//! verification, sign-off, and SLSA provenance. Every one of them allocated the decoded payload
+//! before anything looked at its size.
+//!
+//! PAE is the wrong place to fix that, and #1969 exists to say so before someone puts it there.
+//! `build_pae` runs *after* the decode: by the time it is reached the memory is already committed,
+//! so a ceiling in PAE would refuse a payload the process had finished allocating. The check has to
+//! precede the decode, and the only quantity available then is the encoded length.
+//!
+//! The ceiling is domain-local on purpose. `assay-common` holds the DSSE Pre-Authentication
+//! Encoding because two constructions of PAE are two definitions of what a signature covers; a size
+//! budget is not that. It is this crate's answer about this crate's inputs, in the same class as
+//! `VerifyLimits` describing an evidence bundle, and it does not travel.
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+
+/// The largest DSSE payload this crate will decode, in decoded bytes.
+///
+/// These payloads are in-toto Statements: a subject digest and a predicate. The largest thing that
+/// legitimately appears is an SLSA provenance predicate listing resolved dependencies, which runs to
+/// tens of kilobytes. 1 MiB is roughly two orders of magnitude above that -- generous enough that no
+/// honest producer meets it, small enough that a hostile one cannot make the process allocate on
+/// demand.
+pub(crate) const MAX_DSSE_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+/// The refusal message for a surface whose reason is `&'static str` and cannot carry the numbers.
+///
+/// The compile-time assertion below is what keeps the wording and the constant from drifting: a
+/// message naming a ceiling the code does not enforce is worse than one naming no ceiling at all.
+pub(crate) const OVERSIZED_REASON: &str = "DSSE payload exceeds the 1 MiB ceiling";
+
+const _: () = assert!(
+    MAX_DSSE_PAYLOAD_BYTES == 1024 * 1024,
+    "OVERSIZED_REASON says 1 MiB; change both or neither"
+);
+
+/// A payload refused for its size, carrying both numbers so the caller can say which ceiling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PayloadTooLarge {
+    pub(crate) limit: usize,
+    /// Decoded bytes when known, otherwise the bound implied by the encoded length. `exact` says
+    /// which, so a diagnostic never presents an upper bound as a measurement.
+    pub(crate) size: usize,
+    pub(crate) exact: bool,
+}
+
+impl PayloadTooLarge {
+    pub(crate) fn reason(&self) -> String {
+        if self.exact {
+            format!(
+                "DSSE payload is {} bytes, over the {}-byte ceiling",
+                self.size, self.limit
+            )
+        } else {
+            format!(
+                "DSSE payload encodes to more than {} bytes, over the {}-byte ceiling",
+                self.size, self.limit
+            )
+        }
+    }
+}
+
+/// The largest base64 input that can decode within `MAX_DSSE_PAYLOAD_BYTES`.
+///
+/// Standard base64 emits four characters per three input bytes, padded up. Anything longer than
+/// this decodes to more than the ceiling, so it can be refused without being decoded.
+const fn max_encoded_len() -> usize {
+    MAX_DSSE_PAYLOAD_BYTES.div_ceil(3) * 4
+}
+
+/// Base64-decode a DSSE payload, refusing an oversized one before it is allocated.
+///
+/// Two checks, and both are load-bearing. The first is on the encoded length and is what actually
+/// bounds the allocation. The second is on the decoded length and is what makes the ceiling exact:
+/// the encoded bound is conservative by up to three bytes of padding, and a limit that is
+/// "1 MiB, give or take" is not a limit anyone can test.
+///
+/// `Ok(None)` means the input is not valid base64. The caller decides what that is, because the
+/// three flows call it three things.
+pub(crate) fn decode_bounded(payload_b64: &[u8]) -> Result<Option<Vec<u8>>, PayloadTooLarge> {
+    if payload_b64.len() > max_encoded_len() {
+        return Err(PayloadTooLarge {
+            limit: MAX_DSSE_PAYLOAD_BYTES,
+            size: MAX_DSSE_PAYLOAD_BYTES,
+            exact: false,
+        });
+    }
+    let decoded = match BASE64.decode(payload_b64) {
+        Ok(bytes) => bytes,
+        Err(_) => return Ok(None),
+    };
+    if decoded.len() > MAX_DSSE_PAYLOAD_BYTES {
+        return Err(PayloadTooLarge {
+            limit: MAX_DSSE_PAYLOAD_BYTES,
+            size: decoded.len(),
+            exact: true,
+        });
+    }
+    Ok(Some(decoded))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded_of(decoded_len: usize) -> String {
+        BASE64.encode(vec![b'a'; decoded_len])
+    }
+
+    #[test]
+    fn a_payload_at_the_ceiling_is_accepted() {
+        let b64 = encoded_of(MAX_DSSE_PAYLOAD_BYTES);
+        let decoded = decode_bounded(b64.as_bytes())
+            .expect("exactly at the ceiling must not be refused")
+            .expect("valid base64");
+        assert_eq!(decoded.len(), MAX_DSSE_PAYLOAD_BYTES);
+    }
+
+    #[test]
+    fn one_byte_over_the_ceiling_is_refused() {
+        let b64 = encoded_of(MAX_DSSE_PAYLOAD_BYTES + 1);
+        let err = decode_bounded(b64.as_bytes()).expect_err("one byte over must be refused");
+        assert_eq!(err.limit, MAX_DSSE_PAYLOAD_BYTES);
+    }
+
+    /// The check that matters: refusal happens on the encoded length, before any decode.
+    ///
+    /// Without this the guard would still reject, but only after allocating the very thing the
+    /// ceiling exists to prevent — which is the defect #1969 describes, moved rather than fixed.
+    #[test]
+    fn a_grossly_oversized_payload_is_refused_before_it_is_decoded() {
+        let encoded_len = max_encoded_len() + 1;
+        let b64 = vec![b'A'; encoded_len];
+        let err = decode_bounded(&b64).expect_err("must be refused");
+        assert!(
+            !err.exact,
+            "an inexact size means the refusal came from the encoded length, before the decode; \
+             an exact one means the payload was allocated first"
+        );
+        assert_eq!(err.size, MAX_DSSE_PAYLOAD_BYTES);
+    }
+
+    #[test]
+    fn the_encoded_bound_admits_everything_under_the_ceiling() {
+        // The conservative direction has to be the safe one: the encoded bound must never refuse a
+        // payload that would have decoded within the ceiling, or the exact check below it is dead.
+        assert!(encoded_of(MAX_DSSE_PAYLOAD_BYTES).len() <= max_encoded_len());
+        assert!(encoded_of(MAX_DSSE_PAYLOAD_BYTES - 1).len() <= max_encoded_len());
+        assert!(encoded_of(MAX_DSSE_PAYLOAD_BYTES - 2).len() <= max_encoded_len());
+    }
+
+    #[test]
+    fn invalid_base64_is_not_a_size_refusal() {
+        assert_eq!(decode_bounded(b"!!!not base64!!!"), Ok(None));
+    }
+
+    #[test]
+    fn an_ordinary_payload_round_trips() {
+        let b64 = BASE64.encode(br#"{"_type":"https://in-toto.io/Statement/v1"}"#);
+        let decoded = decode_bounded(b64.as_bytes()).unwrap().unwrap();
+        assert_eq!(&decoded[..7], br#"{"_type"#);
+    }
+
+    #[test]
+    fn a_refusal_never_presents_a_bound_as_a_measurement() {
+        let inexact = PayloadTooLarge {
+            limit: 10,
+            size: 10,
+            exact: false,
+        };
+        assert!(inexact.reason().contains("encodes to more than"));
+        let exact = PayloadTooLarge {
+            limit: 10,
+            size: 11,
+            exact: true,
+        };
+        assert!(exact.reason().contains("is 11 bytes"));
+    }
+}

--- a/crates/assay-registry/src/lib.rs
+++ b/crates/assay-registry/src/lib.rs
@@ -51,6 +51,7 @@ pub mod canonicalize;
 pub mod client;
 mod digest;
 pub mod dsse;
+mod dsse_limits;
 pub mod error;
 pub mod lockfile;
 pub mod reference;

--- a/crates/assay-registry/src/supply_chain/provenance.rs
+++ b/crates/assay-registry/src/supply_chain/provenance.rs
@@ -41,9 +41,18 @@ fn verify_dsse_signature(envelope: &DsseEnvelope, trust_store: &TrustStore) -> C
     if envelope.payload_type != DSSE_PAYLOAD_TYPE {
         return CheckStatus::UnsupportedFormat;
     }
-    let payload_bytes = match BASE64.decode(&envelope.payload) {
-        Ok(b) => b,
-        Err(_) => return CheckStatus::Failed,
+    // Bounded before the allocation; see `dsse_limits`.
+    //
+    // Oversize is `UnsupportedFormat`, not `Failed`, and the distinction is load-bearing in two
+    // ways. It is more honest -- `Failed` says the signature did not verify, and here nothing was
+    // verified at all, which is the "we did not check this" outcome this codebase refuses to report
+    // as anything else. It is also the only thing that makes the ceiling testable on this path: an
+    // oversized payload of valid base64 fails signature verification whether or not the bound
+    // exists, so a test asserting `Failed` would pass with the bound removed.
+    let payload_bytes = match crate::dsse_limits::decode_bounded(envelope.payload.as_bytes()) {
+        Ok(Some(b)) => b,
+        Ok(None) => return CheckStatus::Failed,
+        Err(_) => return CheckStatus::UnsupportedFormat,
     };
     if envelope.signatures.is_empty() {
         return CheckStatus::NotPresent;
@@ -76,7 +85,7 @@ fn verify_dsse_signature(envelope: &DsseEnvelope, trust_store: &TrustStore) -> C
 }
 
 fn decode_statement(envelope: &DsseEnvelope) -> Option<InTotoStatement> {
-    let payload = BASE64.decode(&envelope.payload).ok()?;
+    let payload = crate::dsse_limits::decode_bounded(envelope.payload.as_bytes()).ok()??;
     serde_json::from_slice::<InTotoStatement>(&payload).ok()
 }
 

--- a/crates/assay-registry/src/supply_chain/tests.rs
+++ b/crates/assay-registry/src/supply_chain/tests.rs
@@ -132,6 +132,42 @@ fn valid_pinned_key_slsa_provenance_is_verified_and_clean() {
     assert!(is_clean(&report));
 }
 
+/// The ceiling is reached through `verify_supply_chain`, not through `decode_bounded`.
+///
+/// #1969's defect was three flows that each decoded before checking anything. A helper that no
+/// flow calls leaves all three exactly as they were, so each flow is driven with an oversized
+/// payload through its own real entry point.
+#[test]
+fn an_oversized_provenance_payload_is_refused_before_it_is_decoded() {
+    let sk = SigningKey::from_bytes(&[7u8; 32]);
+    let (store, key_id) = trust_with(&sk.verifying_key());
+    let mut env = signed_dsse(
+        &sk,
+        &key_id,
+        &statement_json(hex_of(ARTIFACT_DIGEST), SLSA_PROVENANCE_PREDICATE, BUILDER),
+    );
+    // Two megabytes of base64, over the one-megabyte ceiling. The signature is left intact so the
+    // only thing that changed is the size.
+    env.payload = "A".repeat(2 * 1024 * 1024);
+    let report = verify_supply_chain(VerifyInput {
+        subject: subject(),
+        expected_artifact_digest: Some(ARTIFACT_DIGEST.to_string()),
+        provenance: ProvenanceInput::Dsse(env),
+        pinning: clean_pinning(),
+        policy: policy(2),
+        trust_store: &store,
+    });
+    assert_eq!(
+        report.checks.provenance.dsse_signature,
+        CheckStatus::UnsupportedFormat,
+        "an oversized payload must be refused as unsupported, not reported as a failed signature. \
+         `Failed` would be true with the bound removed too -- 2 MiB of 'A' is valid base64 and its \
+         signature does not verify -- so asserting it would prove nothing about the ceiling"
+    );
+    assert_ne!(report.policy_result, PolicyResult::Pass);
+    assert!(!is_clean(&report));
+}
+
 #[test]
 fn missing_provenance_is_not_present_never_clean() {
     let store = crate::trust::TrustStore::new();

--- a/crates/assay-registry/src/verify_internal/dsse.rs
+++ b/crates/assay-registry/src/verify_internal/dsse.rs
@@ -33,12 +33,20 @@ pub(crate) fn verify_dsse_signature_bytes_impl(
         });
     }
 
-    let payload_bytes =
-        BASE64
-            .decode(&envelope.payload)
-            .map_err(|e| RegistryError::SignatureInvalid {
-                reason: format!("invalid base64 payload: {}", e),
-            })?;
+    // Bounded before the allocation; see `dsse_limits`.
+    let payload_bytes = match crate::dsse_limits::decode_bounded(envelope.payload.as_bytes()) {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => {
+            return Err(RegistryError::SignatureInvalid {
+                reason: "invalid base64 payload".to_string(),
+            })
+        }
+        Err(too_large) => {
+            return Err(RegistryError::SignatureInvalid {
+                reason: too_large.reason(),
+            })
+        }
+    };
 
     if payload_bytes != canonical_bytes {
         return Err(RegistryError::DigestMismatch {

--- a/crates/assay-registry/src/verify_internal/tests/dsse.rs
+++ b/crates/assay-registry/src/verify_internal/tests/dsse.rs
@@ -218,3 +218,51 @@ fn test_dsse_invalid_signature_rejected() {
         result
     );
 }
+
+/// The ceiling is reached through the sign-off verifier, not through `decode_bounded`.
+///
+/// #1969's defect was three flows that each decoded before checking anything. A helper no flow
+/// calls leaves all three exactly as they were, so each flow is driven with an oversized payload
+/// through its own real entry point. This is the third.
+#[test]
+fn an_oversized_payload_is_refused_by_the_signoff_verifier() {
+    let signing_key = keypair_from_seed([0x11; 32]);
+    let content = "name: test-pack\nversion: \"1.0.0\"\nrules: []";
+    let (mut envelope, key_id) = create_signed_envelope(&signing_key, content);
+
+    use ed25519_dalek::pkcs8::EncodePublicKey;
+    let spki_der = signing_key.verifying_key().to_public_key_der().unwrap();
+    let trusted_key = crate::types::TrustedKey {
+        key_id,
+        algorithm: "Ed25519".to_string(),
+        public_key: BASE64.encode(spki_der.as_bytes()),
+        description: Some("Test key".to_string()),
+        added_at: None,
+        expires_at: None,
+        revoked: false,
+    };
+    let trust_store = TrustStore::new();
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(trust_store.add_pinned_key(&trusted_key))
+        .unwrap();
+
+    let canonical = crate::canonicalize::to_canonical_jcs_bytes(
+        &crate::canonicalize::parse_yaml_strict(content).unwrap(),
+    )
+    .unwrap();
+    let content_str = String::from_utf8(canonical).unwrap();
+
+    // Two megabytes of base64, over the one-megabyte ceiling. Everything else is a valid envelope,
+    // so size is the only difference from the passing case above.
+    envelope.payload = "A".repeat(2 * 1024 * 1024);
+
+    let err = verify_dsse_signature_legacy_for_tests(&content_str, &envelope, &trust_store)
+        .expect_err("an oversized payload must be refused");
+    let reason = format!("{err:?}");
+    assert!(
+        reason.contains("ceiling"),
+        "the refusal must name the size ceiling rather than reading as a generic decode failure: \
+         {reason}"
+    );
+}


### PR DESCRIPTION
## Description

Closes #1969.

`assay-registry` base64-decodes DSSE payloads in three flows — pack signature verification, sign-off, and SLSA provenance — and **every one allocated the decoded payload before anything looked at its size**.

## Why PAE is the wrong place, which is what the issue exists to say

`build_pae` runs *after* the decode. By the time it is reached the memory is already committed, so a ceiling there would refuse a payload the process had finished allocating.

The check has to precede the decode, and the only quantity available then is the encoded length.

## The shape

`dsse_limits::decode_bounded` does two checks, and both are load-bearing:

- the **encoded** pre-check is what bounds the allocation
- the **decoded** post-check is what makes the ceiling exact — the encoded bound is conservative by up to three bytes of padding, and "1 MiB, give or take" is not a limit anyone can test

The ceiling is **domain-local**. `assay-common` holds PAE because two constructions of it are two definitions of what a signature covers; a size budget is not that. It is this crate's answer about this crate's inputs, in the class of `VerifyLimits`, and it does not travel. `assay-common/src/dsse.rs` is untouched.

## Verification

Each flow is driven with an oversized payload **through its own real entry point**, not through the helper. A unit test on `decode_bounded` proves the helper works and says nothing about whether any flow calls it — and a helper nobody reaches leaves all three flows exactly as they were.

| Mutation | Result |
|---|---|
| dsse flow decodes unbounded again | **red** |
| provenance flow decodes unbounded again | **red** |
| sign-off flow decodes unbounded again | **red** |
| the pre-decode check removed (bound applied only after allocating) | **red** |

## One behaviour change, and why

**The provenance mutant was green on the first attempt.** 2 MiB of `A` is valid base64 whose signature does not verify, so `CheckStatus::Failed` was the outcome with *or* without the bound — the test proved nothing about the ceiling.

Oversize on that path is now `CheckStatus::UnsupportedFormat`. That is both the honest answer — nothing was verified, and "we did not check this" is not reported as a failed signature anywhere else in this codebase — and the only thing that makes the ceiling observable there.

## One detail

`DsseOutcome.reason` is `&'static str`, so that surface gets a fixed message rather than a widened public type. A `const` assertion ties the wording to the constant, because a message naming a ceiling the code does not enforce is worse than one naming no ceiling at all.

## Scope

`Gate.NONE`. Full `assay-registry` suite passes (354 tests); `cargo clippy --all-targets` clean.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
