### PR TITLE
A metric that never ran reported the same thing as one that passed

### DIFF
--- a/crates/assay-core/src/engine/runner_next/single.rs
+++ b/crates/assay-core/src/engine/runner_next/single.rs
@@ -149,9 +149,19 @@ pub(crate) async fn run_test_once_impl(
         };
 
         details["metrics"][metric_name] = serde_json::json!({
-            "score": r.score, "passed": r.passed, "unstable": r.unstable, "details": r.details
+            "score": r.score,
+            "passed": r.passed,
+            "unstable": r.unstable,
+            "exercised": exercised_label(r.exercised),
+            "details": r.details
         });
-        final_score = Some(r.score);
+        // Only a metric that actually evaluated something may set the test's score.
+        //
+        // This used to be unconditional, so the score belonged to whichever metric ran last. All
+        // thirteen registered metrics run against every test and eleven of them return a
+        // not-applicable 1.0, so a semantic test that scored 0.87 reported 1.0 -- the number came
+        // from a metric that was never asked to run. `pass_rate_masking_is_reported` pins it.
+        final_score = score_after(final_score, &r);
 
         if r.unstable {
             final_status = TestStatus::Warn;
@@ -198,4 +208,101 @@ pub(crate) async fn run_test_once_impl(
     row.details["prompt"] = serde_json::Value::String(tc.input.prompt.clone());
 
     Ok((row, resp))
+}
+
+/// The test's score after folding in one metric result.
+///
+/// A metric that evaluated nothing does not get to set the score. Extracted rather than written
+/// inline so the loop above and the tests below apply the same rule -- two implementations of one
+/// rule drift, and this one decides a number that reaches `run.json` and SARIF.
+fn score_after(current: Option<f64>, r: &crate::metrics_api::MetricResult) -> Option<f64> {
+    if r.is_exercised() {
+        Some(r.score)
+    } else {
+        current
+    }
+}
+
+/// The stable string for an `Exercised` value in `details["metrics"][…]`.
+///
+/// A vocabulary, not a `Debug` rendering: this reaches `run.json`, so it is an interface.
+fn exercised_label(e: crate::metrics_api::Exercised) -> &'static str {
+    match e {
+        crate::metrics_api::Exercised::Exercised => "exercised",
+        crate::metrics_api::Exercised::NotApplicable => "not_applicable",
+        crate::metrics_api::Exercised::NotExercised => "not_exercised",
+    }
+}
+
+#[cfg(test)]
+mod exercised_tests {
+    use super::*;
+    use crate::metrics_api::{Exercised, MetricResult};
+
+    /// Folds with `score_after`, the same function the runner's loop calls. A test that reimplemented
+    /// the rule would assert its own copy and stay green while the loop drifted away from it.
+    fn fold_score(results: &[MetricResult]) -> Option<f64> {
+        results.iter().fold(None, score_after)
+    }
+
+    #[test]
+    fn a_not_applicable_metric_does_not_set_the_score() {
+        // The shape that made this issue: one metric evaluates and scores 0.87, then eight metrics
+        // that do not handle the variant return a not-applicable 1.0 after it.
+        let mut results = vec![MetricResult::pass(0.87)];
+        results.extend((0..8).map(|_| MetricResult::not_applicable()));
+        assert_eq!(
+            fold_score(&results),
+            Some(0.87),
+            "the score came from a metric that was never asked to run"
+        );
+    }
+
+    #[test]
+    fn a_not_exercised_metric_does_not_set_the_score() {
+        let results = vec![
+            MetricResult::pass(0.62),
+            MetricResult::not_exercised("no tool definitions in the trace"),
+        ];
+        assert_eq!(fold_score(&results), Some(0.62));
+    }
+
+    #[test]
+    fn a_test_with_no_exercised_metric_has_no_score() {
+        // Not 1.0. A test nothing evaluated has no score, and saying so is the point of the
+        // dimension -- a 1.0 here is the vacuous pass the issue is about.
+        let results = vec![
+            MetricResult::not_applicable(),
+            MetricResult::not_exercised("no output schemas configured"),
+        ];
+        assert_eq!(fold_score(&results), None);
+    }
+
+    #[test]
+    fn a_real_evaluation_still_sets_the_score() {
+        assert_eq!(fold_score(&[MetricResult::pass(0.5)]), Some(0.5));
+        assert_eq!(fold_score(&[MetricResult::fail(0.1, "nope")]), Some(0.1));
+    }
+
+    #[test]
+    fn the_label_vocabulary_is_stable() {
+        // These strings land in run.json, so they are an interface rather than a rendering.
+        assert_eq!(exercised_label(Exercised::Exercised), "exercised");
+        assert_eq!(exercised_label(Exercised::NotApplicable), "not_applicable");
+        assert_eq!(exercised_label(Exercised::NotExercised), "not_exercised");
+    }
+
+    #[test]
+    fn not_applicable_and_not_exercised_never_fail_a_test() {
+        // Over-eager vacuity detection earns a suppression and takes real findings with it, so
+        // these report and never decide.
+        for r in [
+            MetricResult::not_applicable(),
+            MetricResult::not_exercised("nothing to check"),
+        ] {
+            assert!(r.passed, "a non-exercised metric must not fail the test");
+            assert!(!r.unstable);
+            assert!(!r.is_exercised());
+        }
+    }
 }

--- a/crates/assay-core/src/metrics_api.rs
+++ b/crates/assay-core/src/metrics_api.rs
@@ -1,11 +1,41 @@
 use crate::model::{Expected, LlmResponse, TestCase};
 use async_trait::async_trait;
 
+/// Whether a metric actually evaluated anything for this test.
+///
+/// Orthogonal to `passed`, and deliberately not folded into it. Assertion-based verification
+/// settled this decades ago: an assertion with zero attempts is a coverage hole with no
+/// verification value, so every assert is paired with a *companion cover* confirming it was
+/// genuinely exercised rather than vacuously passed. `passed` answers "did the check hold";
+/// this answers "was there a check to hold".
+///
+/// The distinction is load-bearing here because the runner evaluates all thirteen registered
+/// metrics against every test, and a metric that does not handle a test's `Expected` variant used
+/// to return `pass(1.0)` — indistinguishable from a metric that ran and was satisfied.
+///
+/// `NotExercised` is a status and never a failure. Over-eager vacuity detection earns a
+/// suppression and takes real findings with it (Beer et al. on temporal antecedent failure), so
+/// this reports rather than decides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Exercised {
+    /// The metric does not handle this test's `Expected` variant. Nothing was checked.
+    NotApplicable,
+    /// The metric applies, but the data it needs never appeared in this run, so its antecedent
+    /// never fired. A `trace_must_not_call_tool` naming a tool the agent never had is the shape:
+    /// syntactically perfect, permanently vacuous for this trace.
+    NotExercised,
+    /// Genuinely evaluated against the response.
+    Exercised,
+}
+
 #[derive(Debug, Clone)]
 pub struct MetricResult {
     pub score: f64,
     pub passed: bool,
     pub unstable: bool,
+    /// Additive on purpose. Existing `passed` readers keep working, and callers that want to know
+    /// whether the number means anything now have somewhere to look.
+    pub exercised: Exercised,
     pub details: serde_json::Value,
 }
 
@@ -15,6 +45,7 @@ impl MetricResult {
             score,
             passed: true,
             unstable: false,
+            exercised: Exercised::Exercised,
             details: serde_json::json!({}),
         }
     }
@@ -23,6 +54,7 @@ impl MetricResult {
             score,
             passed: false,
             unstable: false,
+            exercised: Exercised::Exercised,
             details: serde_json::json!({"message": msg}),
         }
     }
@@ -31,8 +63,43 @@ impl MetricResult {
             score,
             passed: false,
             unstable: true,
+            exercised: Exercised::Exercised,
             details: serde_json::json!({"message": msg}),
         }
+    }
+
+    /// This metric does not handle the test's `Expected` variant.
+    ///
+    /// `passed` stays true and the score stays 1.0 so that no existing reader starts failing tests
+    /// over a metric that was never asked to run. What changes is that the result now says so, and
+    /// the runner no longer lets it set the test's score.
+    pub fn not_applicable() -> Self {
+        Self {
+            score: 1.0,
+            passed: true,
+            unstable: false,
+            exercised: Exercised::NotApplicable,
+            details: serde_json::json!({"exercised": "not_applicable"}),
+        }
+    }
+
+    /// This metric applies, but the run produced nothing for it to check.
+    ///
+    /// `reason` names the missing antecedent, because "not exercised" without it is the same
+    /// unactionable silence the dimension exists to remove.
+    pub fn not_exercised(reason: &str) -> Self {
+        Self {
+            score: 1.0,
+            passed: true,
+            unstable: false,
+            exercised: Exercised::NotExercised,
+            details: serde_json::json!({"exercised": "not_exercised", "reason": reason}),
+        }
+    }
+
+    /// Whether this result's `score` and `passed` describe an actual evaluation.
+    pub fn is_exercised(&self) -> bool {
+        matches!(self.exercised, Exercised::Exercised)
     }
 }
 

--- a/crates/assay-metrics/src/args_valid_next/evaluator.rs
+++ b/crates/assay-metrics/src/args_valid_next/evaluator.rs
@@ -26,7 +26,7 @@ impl Metric for ArgsValidMetric {
     ) -> anyhow::Result<MetricResult> {
         let (policy_path, inline_schema) = match expected {
             Expected::ArgsValid { policy, schema } => (policy, schema),
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
         if policy_path.is_none() && inline_schema.is_none() {
             anyhow::bail!("config error: args_valid requires `policy` or `schema`");
@@ -47,7 +47,7 @@ impl Metric for ArgsValidMetric {
 
             load_policy_source(Path::new(path))?
         } else {
-            return Ok(MetricResult::pass(1.0));
+            return Ok(MetricResult::not_exercised("no args policy configured"));
         };
 
         // No calls -> valid args (vacuously true)
@@ -179,6 +179,7 @@ impl Metric for ArgsValidMetric {
             details.insert("violations".to_string(), serde_json::Value::Array(errors));
 
             Ok(MetricResult {
+                exercised: assay_core::metrics_api::Exercised::Exercised,
                 passed: false,
                 score: 0.0,
                 details: serde_json::Value::Object(details),

--- a/crates/assay-metrics/src/json_schema.rs
+++ b/crates/assay-metrics/src/json_schema.rs
@@ -22,7 +22,7 @@ impl Metric for JsonSchemaMetric {
             schema_file,
         } = expected
         else {
-            return Ok(MetricResult::pass(1.0));
+            return Ok(MetricResult::not_applicable());
         };
 
         let schema_str = if let Some(path) = schema_file {
@@ -78,6 +78,7 @@ impl Metric for JsonSchemaMetric {
                 .map(|e| e.to_string())
                 .collect();
             Ok(MetricResult {
+                exercised: assay_core::metrics_api::Exercised::Exercised,
                 score: 0.0,
                 passed: false,
                 unstable: false,

--- a/crates/assay-metrics/src/judge.rs
+++ b/crates/assay-metrics/src/judge.rs
@@ -24,7 +24,7 @@ impl Metric for FaithfulnessMetric {
                 rubric_version,
                 ..
             } => (*min_score, rubric_version),
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
 
         evaluate_judge_result("faithfulness", min_score, rubric_version.as_deref(), output)
@@ -51,7 +51,7 @@ impl Metric for RelevanceMetric {
                 rubric_version,
                 ..
             } => (*min_score, rubric_version),
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
 
         evaluate_judge_result("relevance", min_score, rubric_version.as_deref(), output)
@@ -69,6 +69,7 @@ fn evaluate_judge_result(
     let Some(data) = judge_data else {
         // Judge result missing
         return Ok(MetricResult {
+            exercised: assay_core::metrics_api::Exercised::Exercised,
             passed: false,
             score: 0.0,
             details: serde_json::json!({
@@ -108,6 +109,7 @@ fn evaluate_judge_result(
     }
 
     Ok(MetricResult {
+        exercised: assay_core::metrics_api::Exercised::Exercised,
         passed,
         score,
         details,

--- a/crates/assay-metrics/src/must_contain.rs
+++ b/crates/assay-metrics/src/must_contain.rs
@@ -17,7 +17,7 @@ impl Metric for MustContainMetric {
         resp: &LlmResponse,
     ) -> anyhow::Result<MetricResult> {
         let Expected::MustContain { must_contain } = expected else {
-            return Ok(MetricResult::pass(1.0));
+            return Ok(MetricResult::not_applicable());
         };
         for s in must_contain {
             if !resp.text.contains(s) {

--- a/crates/assay-metrics/src/must_not_contain.rs
+++ b/crates/assay-metrics/src/must_not_contain.rs
@@ -17,7 +17,7 @@ impl Metric for MustNotContainMetric {
         resp: &LlmResponse,
     ) -> anyhow::Result<MetricResult> {
         let Expected::MustNotContain { must_not_contain } = expected else {
-            return Ok(MetricResult::pass(1.0));
+            return Ok(MetricResult::not_applicable());
         };
         for s in must_not_contain {
             if resp.text.contains(s) {

--- a/crates/assay-metrics/src/regex_match.rs
+++ b/crates/assay-metrics/src/regex_match.rs
@@ -23,7 +23,7 @@ impl Metric for RegexMatchMetric {
             Expected::RegexNotMatch { pattern, flags } => {
                 (pattern.as_str(), flags.as_slice(), true)
             }
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
 
         let mut b = RegexBuilder::new(pattern);

--- a/crates/assay-metrics/src/semantic.rs
+++ b/crates/assay-metrics/src/semantic.rs
@@ -18,7 +18,7 @@ impl Metric for SemanticSimilarityMetric {
         resp: &LlmResponse,
     ) -> anyhow::Result<MetricResult> {
         let Expected::SemanticSimilarityTo { min_score, .. } = expected else {
-            return Ok(MetricResult::pass(1.0));
+            return Ok(MetricResult::not_applicable());
         };
 
         let a = resp
@@ -63,6 +63,7 @@ impl Metric for SemanticSimilarityMetric {
         let passed = score + SEMANTIC_SIMILARITY_EPSILON >= *min_score;
 
         Ok(MetricResult {
+            exercised: assay_core::metrics_api::Exercised::Exercised,
             score,
             passed,
             unstable: false,

--- a/crates/assay-metrics/src/sequence_valid.rs
+++ b/crates/assay-metrics/src/sequence_valid.rs
@@ -25,7 +25,7 @@ impl Metric for SequenceValidMetric {
                 sequence,
                 rules,
             } => (policy, sequence, rules),
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
 
         // 1. Resolve Rules & Sequence from Policy File (if any)
@@ -67,7 +67,9 @@ impl Metric for SequenceValidMetric {
         let effective_rules = inline_rules.as_ref().or(file_rules.as_ref());
 
         if effective_sequence.is_none() && effective_rules.is_none() {
-            return Ok(MetricResult::pass(1.0));
+            return Ok(MetricResult::not_exercised(
+                "no sequence and no rules configured",
+            ));
         }
 
         // Parse Tool Calls

--- a/crates/assay-metrics/src/tool_blocklist.rs
+++ b/crates/assay-metrics/src/tool_blocklist.rs
@@ -20,7 +20,7 @@ impl Metric for ToolBlocklistMetric {
     ) -> anyhow::Result<MetricResult> {
         let blocked = match expected {
             Expected::ToolBlocklist { blocked } => blocked,
-            _ => return Ok(MetricResult::pass(1.0)), // N/A
+            _ => return Ok(MetricResult::not_applicable()), // N/A
         };
 
         let tool_calls: Vec<ToolCallRecord> = match extract_tool_calls_canonical(resp) {

--- a/crates/assay-metrics/src/tool_collision_detect.rs
+++ b/crates/assay-metrics/src/tool_collision_detect.rs
@@ -29,12 +29,14 @@ impl Metric for ToolCollisionDetectMetric {
     ) -> anyhow::Result<MetricResult> {
         let trusted_servers = match expected {
             Expected::ToolCollisionDetect { trusted_servers } => trusted_servers,
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
 
         let defs = tool_defs(resp);
         if defs.is_empty() {
-            return Ok(MetricResult::pass(1.0)); // N/A — no tool definitions in meta.
+            return Ok(MetricResult::not_exercised(
+                "no tool definitions in the response metadata",
+            )); // N/A — no tool definitions in meta.
         }
 
         // Build: tool_name → list of server_ids that registered it.
@@ -107,6 +109,7 @@ impl Metric for ToolCollisionDetectMetric {
             Ok(MetricResult::pass(1.0))
         } else {
             Ok(MetricResult {
+                exercised: assay_core::metrics_api::Exercised::Exercised,
                 passed: false,
                 score: 0.0,
                 unstable: false,

--- a/crates/assay-metrics/src/tool_description_integrity.rs
+++ b/crates/assay-metrics/src/tool_description_integrity.rs
@@ -63,7 +63,7 @@ impl Metric for ToolDescriptionIntegrityMetric {
     ) -> anyhow::Result<MetricResult> {
         let pinned_tools = match expected {
             Expected::ToolDescriptionIntegrity { pinned_tools } => pinned_tools,
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
 
         let mut violations: Vec<serde_json::Value> = Vec::new();
@@ -72,7 +72,9 @@ impl Metric for ToolDescriptionIntegrityMetric {
             // Snapshot mode: compare multiple tools/list responses for mutations.
             let snaps = snapshots(resp);
             if snaps.len() < 2 {
-                return Ok(MetricResult::pass(1.0)); // Single snapshot — nothing to compare.
+                return Ok(MetricResult::not_exercised(
+                    "single tool-definition snapshot: nothing to compare against",
+                )); // Single snapshot — nothing to compare.
             }
 
             // Baseline: snapshot 0.
@@ -116,7 +118,9 @@ impl Metric for ToolDescriptionIntegrityMetric {
             // Pinned mode: verify tool definitions in meta match operator-supplied pins.
             let defs = tool_defs(resp);
             if defs.is_empty() {
-                return Ok(MetricResult::pass(1.0)); // No definitions in trace — N/A.
+                return Ok(MetricResult::not_exercised(
+                    "no tool definitions in the trace",
+                )); // No definitions in trace — N/A.
             }
 
             let by_name: HashMap<String, &serde_json::Value> = defs
@@ -174,6 +178,7 @@ impl Metric for ToolDescriptionIntegrityMetric {
             Ok(MetricResult::pass(1.0))
         } else {
             Ok(MetricResult {
+                exercised: assay_core::metrics_api::Exercised::Exercised,
                 passed: false,
                 score: 0.0,
                 unstable: false,

--- a/crates/assay-metrics/src/tool_output_valid.rs
+++ b/crates/assay-metrics/src/tool_output_valid.rs
@@ -21,11 +21,12 @@ impl Metric for ToolOutputValidMetric {
     ) -> anyhow::Result<MetricResult> {
         let schemas = match expected {
             Expected::ToolOutputValid { schemas } => schemas,
-            _ => return Ok(MetricResult::pass(1.0)),
+            _ => return Ok(MetricResult::not_applicable()),
         };
 
         let Some(schemas_value) = schemas else {
-            return Ok(MetricResult::pass(1.0)); // N/A — no schemas configured.
+            return Ok(MetricResult::not_exercised("no output schemas configured"));
+            // N/A — no schemas configured.
         };
 
         // Validate that schemas is a JSON object; return a config error otherwise
@@ -106,6 +107,7 @@ impl Metric for ToolOutputValidMetric {
             Ok(MetricResult::pass(1.0))
         } else {
             Ok(MetricResult {
+                exercised: assay_core::metrics_api::Exercised::Exercised,
                 passed: false,
                 score: 0.0,
                 unstable: false,


### PR DESCRIPTION
## Description

#1949 layer 2 — the exercised/not-exercised companion cover. Does **not** close #1949; layer 2's remaining consumers are named at the bottom.

The runner evaluates all thirteen registered metrics against every test, and a metric that does not handle a test's `Expected` variant returned `MetricResult::pass(1.0)`. Nothing distinguished that from a metric that ran and was satisfied — **"this does not apply" and "this passed" were the same value.**

## It was not only a reporting nicety

`single.rs` set `final_score = Some(r.score)` **unconditionally, once per metric**, so the test's score belonged to whichever metric ran last.

`semantic` is 5th of 13 and returns the real cosine similarity. So a semantic test that scored **0.87 reported 1.0** in `run.json` and in SARIF — a number produced by a metric that was never asked to run.

## Why this shape, from SOTA

Assertion-based verification settled it decades ago: an assertion with **zero attempts is a coverage hole with no verification value**, which is why every assert is paired with a *companion cover* confirming it was genuinely exercised rather than vacuously passed. Vacuity is measured at **evaluation time**, not read off the text of the property — precisely the layer 3 / layer 2 split this issue already draws.

The 2026 agent-eval literature says the same thing from the other end: [pass rate without a visible denominator is a story, not a metric](https://www.digitalapplied.com/blog/agent-quality-metrics-pass-rate-revision-rate-2026), and [false success in LLM agents](https://arxiv.org/html/2606.09863) is characterised by confident completion signals that the environment state does not support. A vacuous `1.0` is both at once.

## The dimension

```rust
pub enum Exercised { NotApplicable, NotExercised, Exercised }
```

**Additive on purpose.** `passed` stays true and the score stays 1.0 for both non-exercised kinds, so no existing reader starts failing tests over a metric nobody asked to run. What changes is that the result *says so*, and `score_after` lets only an exercised result set the test's score.

`NotExercised` is a **status and never a failure**. Over-eager vacuity detection earns a suppression and takes real findings with it (Beer et al., temporal antecedent failure), so this reports rather than decides.

## Classification

19 of the 31 `pass(1.0)` sites reclassified — **13** variant mismatches, **6** no-data branches. The remaining **12 are genuine passes** and are untouched.

**One was reclassified against the groundwork.** `sequence_valid.rs:152` is listed there as a no-data branch; the line above it is `actual_names == *expected_sequence`, so the check ran and held. It stays a pass.

## Verification

`score_after` is **one function called by both the loop and the tests**. A test that reimplemented the rule would assert its own copy and stay green while the loop drifted — and this rule decides a number reaching two published artifacts.

| Mutation | Result |
|---|---|
| the score set unconditionally again | **red** (3 tests) |
| `not_applicable` claims to be exercised | **red** (3 tests) |
| `not_exercised` fails the test | **red** |
| the `run.json` label vocabulary drifts | **red** |

Full workspace suite passes (**214** binaries); `cargo clippy --workspace --all-targets` clean. The compiler forced completeness at all 9 struct-literal construction sites.

## Deliberately not here

- `W_METRIC_NOT_EXERCISED` in reporting
- baseline excluding non-exercised results from regression, and treating `Exercised → NotExercised` as a coverage drop

This slice is the dimension plus the one consumer that makes it load-bearing. A dimension nothing reads is decoration.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Metrics no longer report passing results when they are incompatible with the configured expectation.
  - Metrics without sufficient configuration or evaluation data are now clearly identified as not applicable or not exercised.
  - Score aggregation now ignores metrics that were not actually evaluated, preserving valid scores.
  - Metric results consistently indicate whether evaluation occurred.
  - Added clearer status details for unsupported, unevaluated, and evaluated metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->