### PR TITLE
The last --format that answered a typo with a file

### DIFF
--- a/crates/assay-cli/src/cli/args/baseline.rs
+++ b/crates/assay-cli/src/cli/args/baseline.rs
@@ -86,7 +86,20 @@ pub struct BaselineReportArgs {
     #[arg(long, default_value = "hygiene.json")]
     pub out: PathBuf,
 
-    /// Output format: json | md
+    /// Output format.
     #[arg(long, default_value = "json")]
-    pub format: String,
+    pub format: BaselineReportFormat,
+}
+
+/// The shapes `baseline report` can write.
+///
+/// It was a bare `String` matched with `==`, and the final `else` wrote JSON with a
+/// `// Default to JSON` comment -- so `--format mdd` produced a JSON file at `hygiene.md`, at
+/// exit 0, with no note that the spelling was not honoured. That is the class #2039 exists to
+/// close: a fixed set of meanings carried as a string and enumerated at the point of use.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BaselineReportFormat {
+    #[default]
+    Json,
+    Md,
 }

--- a/crates/assay-cli/src/cli/commands/baseline.rs
+++ b/crates/assay-cli/src/cli/commands/baseline.rs
@@ -1,4 +1,5 @@
 use crate::cli::args::BaselineReportArgs;
+use crate::cli::args::BaselineReportFormat;
 use anyhow::Context;
 use assay_core::baseline::report::report_from_db;
 use assay_core::storage::Store;
@@ -9,20 +10,20 @@ pub fn cmd_baseline_report(args: BaselineReportArgs) -> anyhow::Result<()> {
     store.init_schema()?;
     let report = report_from_db(&store, &args.suite, args.last)?;
 
-    if args.format == "json" && args.out.extension().is_none_or(|ext| ext == "json") {
-        let json = serde_json::to_string_pretty(&report)?;
-        std::fs::write(&args.out, json)?;
-        eprintln!("wrote {}", args.out.display());
-    } else if args.format == "md" || args.out.extension().is_some_and(|ext| ext == "md") {
-        let md = generate_markdown(&report);
-        fs::write(&args.out, md)?;
-        eprintln!("wrote {}", args.out.display());
+    // The extension still wins over the flag, which is the behaviour that shipped: `--out x.md`
+    // writes markdown whatever `--format` says. What is gone is the third branch -- an unrecognized
+    // spelling used to fall past both tests into a `// Default to JSON` else, so `--format mdd`
+    // wrote JSON to `hygiene.md` at exit 0. Clap now rejects the spelling at the boundary, and the
+    // match below is exhaustive over the two shapes that remain.
+    let markdown = args.out.extension().is_some_and(|ext| ext == "md")
+        || matches!(args.format, BaselineReportFormat::Md);
+
+    if markdown {
+        fs::write(&args.out, generate_markdown(&report))?;
     } else {
-        // Default to JSON
-        let json = serde_json::to_string_pretty(&report)?;
-        std::fs::write(&args.out, json)?;
-        eprintln!("wrote {}", args.out.display());
+        std::fs::write(&args.out, serde_json::to_string_pretty(&report)?)?;
     }
+    eprintln!("wrote {}", args.out.display());
 
     Ok(())
 }

--- a/crates/assay-cli/tests/format_value_parser.rs
+++ b/crates/assay-cli/tests/format_value_parser.rs
@@ -77,6 +77,10 @@ const FORMAT_ARGS: &[(&[&str], &str, &[&str])] = &[
         "--format",
         &["text", "json", "md", "markdown"],
     ),
+    // Typed last (#2039). It was a bare `String` compared with `==`, and the final `else` wrote
+    // JSON with a `// Default to JSON` comment, so a typo'd spelling produced a JSON file at the
+    // markdown path at exit 0.
+    (&["baseline", "report"], "--format", &["json", "md"]),
 ];
 
 /// Aliases that parse without appearing in the value list, as `(command, flag, alias)`.


### PR DESCRIPTION
## Description

#2039 — the remaining live instance of the class it was filed to close. #2039 stays open; see below.

`baseline report --format` was a bare `String` compared with `==`:

```rust
if args.format == "json" && ... { json }
else if args.format == "md" || ... { markdown }
else { /* Default to JSON */ json }
```

So `--format mdd --out hygiene.md` wrote **JSON, at exit 0, to a file named `.md`**. A typo produced an artifact of the wrong shape and said nothing — the same defect as #2032 and #2034, still shipping.

## The change

`BaselineReportFormat` is a `ValueEnum`, so clap refuses the spelling at the boundary and names the set:

```
error: invalid value 'mdd' for '--format <FORMAT>'
  [possible values: json, md]
```

The extension still wins over the flag, which is the behaviour that shipped: `--out x.md` writes markdown whatever `--format` says. What is gone is the **third branch**. Two shapes, one exhaustive decision, no arm answering for a spelling nobody recognised.

Added to `FORMAT_ARGS`, so it is held by the same three assertions as the other seven: it advertises its values, its default is inside its own set, and a typo is rejected rather than reinterpreted.

## Why #2039 stays open

Re-measured on `main` — **all four of its numbers have moved**:

| | issue says | measured |
|---|---|---|
| bare `String` args under `cli/` | 46 | **20** |
| of those with `value_parser` | 7 | **0** — the stopgap became types |
| `match … .as_str()` in `commands/` | 24 | **10** |
| `ValueEnum` files | 14 | **20** |

Step 3 (one definition of `fail_on`) landed in #2054. Most of the remaining 20 bare `String`s are paths, ids and free-form names that are legitimately strings.

What remains is **the acceptance criterion itself**: it demands `clippy::wildcard_enum_match_arm` be enabled workspace-wide, which #2055 measured and rejected (1-in-9 precision at the boundary; `KeyCode` alone needs ~25 do-nothing arms). #2069 ships the alternative — per-site `#[expect]` plus a narrow check that fails only on a stale suppression. #2039's acceptance should be rewritten to that, or the two issues will keep pulling in opposite directions.

## Verification

Full `assay-cli` suite passes; `cargo clippy --all-targets` clean.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.