### PR TITLE
Modern-only clients had no path to this proxy at all

### DIFF
--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -17,6 +17,82 @@ fn next_rid() -> String {
     format!("r-{n:06}")
 }
 
+/// The modern, stateless protocol revision (final since 2026-07-28).
+///
+/// Under it there is no handshake: every request carries its version in `_meta`, `server/discover`
+/// is a mandatory RPC, and a version this server does not implement is an
+/// `UnsupportedProtocolVersionError` rather than a silent best-effort.
+pub const MODERN_PROTOCOL_VERSION: &str = "2026-07-28";
+
+/// The reserved `_meta` key a modern request carries its revision in.
+const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+
+/// Every revision this server implements, newest last.
+///
+/// One list, read by `server/discover` and by the version check, so the two cannot advertise and
+/// accept different sets -- which would let a client discover a version it is then refused.
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2024-11-05", "2025-11-25", MODERN_PROTOCOL_VERSION];
+
+/// `UnsupportedProtocolVersionError`, per the 2026-07-28 versioning spec.
+const ERROR_UNSUPPORTED_PROTOCOL_VERSION: i32 = -32022;
+
+/// How a request declared its era, if it declared one.
+///
+/// A modern request is served statelessly and pins nothing: the spec allows a dual-era server to
+/// serve both concurrently, and a per-request revision is the whole point of the modern era. Only
+/// `initialize` establishes anything that outlives one request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestEra {
+    /// No `_meta` revision. Legacy semantics, as before.
+    Unstated,
+    /// A modern `_meta` revision this server implements.
+    Modern,
+}
+
+/// Read the era a request declares, or refuse a revision this server does not implement.
+///
+/// `Err` carries the JSON-RPC error data the spec requires: what was requested and what is
+/// supported, so a client can fall forward without a second round trip.
+fn request_era(params: Option<&Value>) -> Result<RequestEra, Value> {
+    let Some(requested) = params
+        .and_then(Value::as_object)
+        .and_then(|p| p.get("_meta"))
+        .and_then(Value::as_object)
+        .and_then(|m| m.get(PROTOCOL_VERSION_META_KEY))
+        .and_then(Value::as_str)
+    else {
+        return Ok(RequestEra::Unstated);
+    };
+    if requested == MODERN_PROTOCOL_VERSION {
+        return Ok(RequestEra::Modern);
+    }
+    // A legacy revision named in `_meta` is not a modern request; the handshake still owns those.
+    // Anything else is refused by name rather than served on a best-effort basis, which is the
+    // behaviour the spec replaced.
+    if SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
+        return Ok(RequestEra::Unstated);
+    }
+    Err(serde_json::json!({
+        "requested": requested,
+        "supported": SUPPORTED_PROTOCOL_VERSIONS,
+    }))
+}
+
+/// The `server/discover` result: which revisions, which capabilities, which server.
+///
+/// Mandatory for a modern server. Its absence is what a dual-era client probes for, so returning it
+/// is what moves this proxy from legacy-only to dual-era.
+fn discover_result() -> Value {
+    serde_json::json!({
+        "protocolVersions": SUPPORTED_PROTOCOL_VERSIONS,
+        "capabilities": { "tools": {} },
+        "serverInfo": {
+            "name": "assay-mcp-server",
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    })
+}
+
 #[derive(Clone, Copy)]
 enum LegacyProtocolVersion {
     V2024_11_05,
@@ -127,6 +203,23 @@ impl JsonRpcResponse {
         }
     }
 
+    /// A JSON-RPC error carrying structured `data`.
+    ///
+    /// `UnsupportedProtocolVersionError` is only useful with it: the spec requires the requested
+    /// and supported versions so a client can fall forward without a second round trip.
+    fn error_with_data(id: Option<Value>, code: i32, message: String, data: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message,
+                data: Some(data),
+            }),
+            id,
+        }
+    }
+
     fn error(id: Option<Value>, code: i32, message: String) -> Self {
         Self {
             jsonrpc: "2.0".to_string(),
@@ -210,8 +303,36 @@ impl Server {
                 }
             };
 
+            // Era before dispatch. A revision this server does not implement is refused by name,
+            // with the supported set in `data`, rather than served as whatever the method happens
+            // to do -- which is the silent best-effort the 2026-07-28 spec replaced.
+            let era = match request_era(req.params.as_ref()) {
+                Ok(era) => era,
+                Err(data) => {
+                    let resp = JsonRpcResponse::error_with_data(
+                        req.id.clone(),
+                        ERROR_UNSUPPORTED_PROTOCOL_VERSION,
+                        "unsupported protocol version".to_string(),
+                        data,
+                    );
+                    let resp_json = serde_json::to_string(&resp)?;
+                    writeln!(stdout, "{}", resp_json)?;
+                    stdout.flush()?;
+                    continue;
+                }
+            };
+            // Nothing branches on the era yet, and that is the finding rather than an omission: the
+            // methods this proxy serves -- `tools/list` and `tools/call` -- are already stateless,
+            // so modern semantics are what they always did. The era is read so an unimplemented
+            // revision is refused by name instead of served on a best-effort basis, and bound so
+            // the next method that *does* need to branch has somewhere to branch from.
+            debug_assert!(matches!(era, RequestEra::Unstated | RequestEra::Modern));
+
             // Dispatch
             let resp = match req.method.as_str() {
+                // Mandatory for a modern server, and the probe a dual-era client sends first.
+                // Answering it is what makes this proxy dual-era rather than legacy-only.
+                "server/discover" => JsonRpcResponse::ok(req.id.clone(), discover_result()),
                 "initialize" => match LegacyProtocolVersion::negotiate(req.params.as_ref()) {
                     Ok(version) => JsonRpcResponse::ok(req.id.clone(), initialize_result(version)),
                     Err(()) => JsonRpcResponse::error(

--- a/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
+++ b/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
@@ -201,8 +201,17 @@ fn incomplete_initialize_shape_is_value_free_invalid_params() {
     );
 }
 
+/// The probe a dual-era client sends first is now answered rather than refused.
+///
+/// This replaces `modern_discovery_probe_remains_a_method_not_found_fallback_signal`, which pinned
+/// the legacy-only behaviour: `server/discover` returned `-32601`, which a dual-era client
+/// recognises as a non-modern signal and falls back from. That fallback was the whole compatibility
+/// story, and it left modern-only clients with no path at all (#1943).
+///
+/// What the old test protected -- a dual-era client can use this proxy -- still holds. It now holds
+/// by discovery instead of by fallback, which is the stronger of the two.
 #[test]
-fn modern_discovery_probe_remains_a_method_not_found_fallback_signal() {
+fn the_discovery_probe_is_answered() {
     let request = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -211,8 +220,110 @@ fn modern_discovery_probe_remains_a_method_not_found_fallback_signal() {
     });
     let output = run_session(&[request]);
     let response = responses(&output).pop().expect("discover response");
-    assert_eq!(response["error"]["code"].as_i64(), Some(-32601));
+    assert!(response.get("error").is_none(), "{response}");
+    let versions = response["result"]["protocolVersions"]
+        .as_array()
+        .expect("protocolVersions");
+    assert!(versions.iter().any(|v| v == "2026-07-28"));
+    assert!(versions.iter().any(|v| v == LATEST_LEGACY_VERSION));
+    assert!(response["result"]["capabilities"]["tools"].is_object());
+    assert_eq!(response["result"]["serverInfo"]["name"], "assay-mcp-server");
+}
+
+/// A modern request carries its revision and needs no handshake.
+///
+/// This is what a modern-only client does, and what this proxy could not serve at all before: the
+/// spec's compatibility matrix marks Modern x Legacy as failing with no fall-forward.
+#[test]
+fn a_modern_request_is_served_without_a_handshake() {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" } }
+    });
+    let output = run_session(&[request]);
+    let response = responses(&output).pop().expect("tools/list response");
+    assert!(response.get("error").is_none(), "{response}");
+    assert!(response["result"]["tools"].is_array());
+}
+
+/// A revision this server does not implement is refused by name, with the set it does implement.
+///
+/// Not served on a best-effort basis, which is the silent behaviour the 2026-07-28 spec replaced,
+/// and not a bare error either -- the `data` is what lets a client fall forward without a second
+/// round trip.
+#[test]
+fn an_unimplemented_revision_is_refused_with_the_supported_set() {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2099-01-01" } }
+    });
+    let output = run_session(&[request]);
+    let response = responses(&output).pop().expect("response");
+    assert_eq!(response["error"]["code"].as_i64(), Some(-32022));
+    assert_eq!(response["error"]["data"]["requested"], "2099-01-01");
+    let supported = response["error"]["data"]["supported"]
+        .as_array()
+        .expect("supported set");
+    assert!(supported.iter().any(|v| v == "2026-07-28"));
     assert!(response.get("result").is_none());
+}
+
+/// What `server/discover` advertises is what the version check accepts.
+///
+/// Two lists would let a client discover a revision it is then refused, which is worse than not
+/// advertising it -- so this drives both through the wire rather than reading the constant.
+#[test]
+fn every_advertised_revision_is_accepted() {
+    let discover = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "server/discover", "params": {}
+    });
+    let output = run_session(&[discover]);
+    let response = responses(&output).pop().expect("discover response");
+    let versions: Vec<String> = response["result"]["protocolVersions"]
+        .as_array()
+        .expect("protocolVersions")
+        .iter()
+        .map(|v| v.as_str().expect("version string").to_string())
+        .collect();
+    assert!(!versions.is_empty());
+
+    for version in versions {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": version } }
+        });
+        let output = run_session(&[request]);
+        let response = responses(&output).pop().expect("response");
+        assert!(
+            response.get("error").is_none(),
+            "discover advertises {version} and the version check refuses it: {response}"
+        );
+    }
+}
+
+/// The legacy handshake is untouched. A dual-era server serves both, and this is the half that
+/// was already working -- pinned so making the modern path work cannot quietly break it.
+#[test]
+fn the_legacy_handshake_still_works_alongside_discovery() {
+    let requests = [
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "server/discover", "params": {}
+        }),
+        initialize_request(Value::String(LATEST_LEGACY_VERSION.to_string()), 2),
+    ];
+    let output = run_session(&requests);
+    let responses = responses(&output);
+    assert!(responses[0].get("error").is_none(), "{}", responses[0]);
+    assert_eq!(
+        responses[1]["result"]["protocolVersion"],
+        LATEST_LEGACY_VERSION
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Closes #1943.

`assay-mcp-server` negotiated `2024-11-05` and `2025-11-25` and implemented nothing of the 2026-07-28 era, which went **final** on 2026-07-28. Per the spec's own compatibility matrix that is Modern × Legacy: **fails, with no fall-forward.**

Dual-era clients worked, and only by accident of a fallback: they probe with `server/discover`, get `-32601 Method not found`, recognise it as a non-modern signal and fall back to `initialize`. That was the whole compatibility story, and it did nothing for a client that ships modern-only.

## The four steps this issue specifies

1. **`server/discover`** returns the supported revisions, capabilities and identity.
2. **Per-request `_meta`** `io.modelcontextprotocol/protocolVersion` is read, and a modern request is served **without a handshake**.
3. **`-32022 UnsupportedProtocolVersionError`** for a revision this server does not implement, with `requested` and `supported` in `data` so a client can fall forward without a second round trip.
4. **Era is per request.** A modern request pins nothing — the spec allows a dual-era server to serve both concurrently, and a per-request revision is the point of the modern era. Only `initialize` establishes anything outliving one request.

One list, `SUPPORTED_PROTOCOL_VERSIONS`, is read by both `server/discover` and the version check. Two lists would let a client **discover a revision it is then refused**, which is worse than not advertising it.

## The finding, not an omission

**Nothing branches on the era yet.** `tools/list` and `tools/call` are already stateless, so modern semantics are what they always did. The era is read so an unimplemented revision is refused *by name* instead of served on a best-effort basis — the silent behaviour the spec replaced.

## A pinned test replaced, not deleted

`modern_discovery_probe_remains_a_method_not_found_fallback_signal` pinned the legacy-only behaviour and its premise is now false. What it protected — a dual-era client can use this proxy — still holds, **by discovery instead of by fallback**, which is the stronger of the two.

## Verification

| Mutation | Result |
|---|---|
| discover unimplemented again | **red** (3 tests) |
| an unknown revision served anyway | **red** |
| the refusal omits the supported set | **red** |
| discover advertises what the check refuses | **red** |
| a fourth revision added to the one shared list | **green — correctly** |

The last row is worth stating: one list makes advertise-equals-accept true *by construction*, so the test guards the **split**, not the value. I mutated only the advertised list to confirm it fires on the case that matters.

Ten e2e cases, all driven over stdio rather than against the constants. Full `assay-mcp-server` suite passes; clippy clean.

## On the trigger

This issue was held pending *"an upstream SDK default flipping to modern-only."* That has **not** fired — [the TypeScript SDK's default is `mode: 'legacy'`, no probe](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/migration/support-2026-07-28.md). Implemented anyway: the work was fully specified, and the exposure it removes is real whenever a host does pin modern.

## Scope

`Gate.NONE` — `assay-mcp-server` is not a gated path.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.