### PR TITLE
A gate that returned 0 on failure could not catch what it existed for

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -247,6 +247,19 @@ repos:
         stages: [pre-push]
         pass_filenames: false
 
+      - id: linux-gate-self-test
+        name: Linux compile gate self-test
+        entry: bash scripts/ci/test-check-linux.sh
+        language: system
+        pass_filenames: false
+        # The gate could not fail (#2076): every branch ended in `return 0`, so a timeout, a
+        # third-party build script and a real Linux compile error were one outcome. #2074 pushed
+        # four E0425s through it and the delegated host found them.
+        #
+        # This plants a deliberate `cfg(target_os = "linux")` error and requires a non-zero exit --
+        # the property the gate exists for and could not previously demonstrate.
+        stages: [pre-push]
+        files: ^scripts/ci/(check-linux|test-check-linux)\.sh$
       - id: linux-check
         name: linux compile gate (target/multipass)
         entry: bash scripts/ci/check-linux.sh

--- a/scripts/ci/check-linux.sh
+++ b/scripts/ci/check-linux.sh
@@ -1,93 +1,127 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Linux-only compile guard for macOS dev: catches `cfg(target_os = "linux")` compile errors.
+#
+# This gate previously could not fail. Both branches ended:
+#
+#     cargo check --workspace ... || { echo "WARN: ... Relying on CI."; return 0; }
+#
+# so a timeout, a missing toolchain, a third-party build script, and *your code not compiling on
+# Linux* were one outcome: WARN, and pre-push reported Passed. #2074 pushed four `E0425`s through
+# it and found out on the delegated host (#2076).
+#
+# Worse, on a stock macOS box the workspace check fails every time -- `ring` and `aws-lc-sys` build
+# scripts need a C cross-compiler -- so it took the return-0 path every time and had never been able
+# to report anything.
+#
+# The distinction this restores is the one the 2026 supply-chain literature keeps naming: a step
+# that logs "could not verify" and leaves the pipeline green is a silent pass. "Could not check" and
+# "your code is broken" must not be spelled the same way.
+#
+#   FAIL   a compiler error in our source, on the Linux target
+#   WARN   a cause that is not our code (build script, toolchain, timeout) -- and the crates it
+#          left unchecked are named, because a gate that cannot check everything must say what it
+#          did not check
+#
+# ASSAY_LINUX_CHECK_REQUIRE_FULL=1 promotes incomplete coverage to a failure, for a host that can
+# cross-compile everything and wants the stronger guarantee.
 
-# Linux-only compile guard for macOS dev: catches cfg(target_os="linux") compile errors.
-# Default: target (cross-compile only, no VM) so pre-push does not hang on multipass.
-# Set ASSAY_LINUX_CHECK_MODE=multipass for full in-VM clippy; auto tries multipass then target.
+set -uo pipefail
 
-VM_NAME="${ASSAY_LINUX_VM:-assay-bpf-runner}"   # override via env
-WORKDIR="${ASSAY_LINUX_WORKDIR:-/home/ubuntu/assay}" # path inside VM (if you mount/sync)
-MODE="${ASSAY_LINUX_CHECK_MODE:-target}"        # target (default) | multipass | auto
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root" || exit 1
 
-run_target_check() {
-  echo "==> Linux cross-target: cargo check (no Docker/VM)"
-  rustup target add x86_64-unknown-linux-gnu >/dev/null 2>&1 || true
-  # Timeout so pre-push does not hang; full workspace cross-check can take 5–10+ min. CI runs this too.
-  # ASSAY_LINUX_TARGET_TIMEOUT=0 to disable. On macOS use gtimeout (brew install coreutils).
-  local t=${ASSAY_LINUX_TARGET_TIMEOUT:-300}
-  local timeout_bin=""
-  if [ "$t" -gt 0 ] 2>/dev/null; then
-    command -v timeout >/dev/null 2>&1 && timeout_bin=timeout
-    [ -z "$timeout_bin" ] && command -v gtimeout >/dev/null 2>&1 && timeout_bin=gtimeout
-  fi
+TARGET="x86_64-unknown-linux-gnu"
+TIMEOUT_SECS="${ASSAY_LINUX_TARGET_TIMEOUT:-300}"
+REQUIRE_FULL="${ASSAY_LINUX_CHECK_REQUIRE_FULL:-0}"
+
+# A compiler diagnostic against our source is path-prefixed by `--message-format=short`:
+#
+#   crates/assay-monitor/src/loader.rs:440:19: error[E0425]: cannot find value ...
+#
+# A cause that is not our code is not:
+#
+#   error: failed to run custom build command for `ring v0.17.14`
+#
+# That prefix is the whole classifier. Deliberately anchored, so an error mentioning a path in its
+# message body is not mistaken for one located there.
+OURS='^(crates|assay-python-sdk)/[^:]+:[0-9]+:[0-9]+: error'
+
+# The crates that actually carry Linux-gated code, derived from the source rather than listed.
+#
+# A hand-kept list is one more thing to drift, and the drift is silent in the dangerous direction: a
+# new crate with `cfg(target_os = "linux")` code would simply not be checked, and nothing would say
+# so. `assay-runner-linux` is included by name because the whole crate is Linux-only and may carry
+# no `cfg` attribute at all.
+linux_crates() {
+  {
+    grep -rl 'cfg(target_os = "linux")' --include='*.rs' crates assay-python-sdk 2>/dev/null \
+      | cut -d/ -f2
+    echo "assay-runner-linux"
+  } | sort -u
+}
+
+if ! rustup target list --installed 2>/dev/null | grep -qx "$TARGET"; then
+  rustup target add "$TARGET" >/dev/null 2>&1 || true
+fi
+if ! rustup target list --installed 2>/dev/null | grep -qx "$TARGET"; then
+  echo "WARN: the $TARGET std component is not installed and could not be added."
+  echo "      Nothing was checked. This is a 'could not check', not a pass."
+  [ "$REQUIRE_FULL" = "1" ] && exit 1
+  exit 0
+fi
+
+timeout_bin=""
+if [ "$TIMEOUT_SECS" -gt 0 ] 2>/dev/null; then
+  command -v timeout >/dev/null 2>&1 && timeout_bin=timeout
+  [ -z "$timeout_bin" ] && command -v gtimeout >/dev/null 2>&1 && timeout_bin=gtimeout
+fi
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+checked=(); broken=(); unchecked=()
+
+for crate in $(linux_crates); do
   if [ -n "$timeout_bin" ]; then
-    "$timeout_bin" "$t" cargo check --workspace --all-targets --target x86_64-unknown-linux-gnu || {
-      echo "WARN: Linux cross-target check timed out or failed. Relying on CI."
-      return 0
-    }
+    "$timeout_bin" "$TIMEOUT_SECS" cargo check -p "$crate" --all-targets --target "$TARGET" \
+      --message-format=short > "$log" 2>&1
   else
-    cargo check --workspace --all-targets --target x86_64-unknown-linux-gnu || {
-      echo "WARN: Linux cross-target check failed. Relying on CI."
-      return 0
-    }
+    cargo check -p "$crate" --all-targets --target "$TARGET" --message-format=short > "$log" 2>&1
   fi
-}
+  status=$?
 
-run_multipass_check() {
-  echo "==> Multipass Linux check in VM: ${VM_NAME}"
-  if ! command -v multipass >/dev/null 2>&1; then
-    echo "WARN: multipass not found"
-    return 1
+  if grep -qE "$OURS" "$log"; then
+    broken+=("$crate")
+    echo "FAIL $crate"
+    grep -E "$OURS" "$log" | sed 's/^/     /'
+  elif [ "$status" -ne 0 ]; then
+    # Non-zero with no diagnostic against our source. The cause is a build script, the toolchain,
+    # or the timeout -- none of which is evidence about our code, and none of which may be reported
+    # as if it were.
+    reason="$(grep -m1 -E '^error' "$log" || echo 'no diagnostic captured')"
+    unchecked+=("$crate")
+    echo "SKIP $crate -- could not be checked: ${reason}"
+  else
+    checked+=("$crate")
+    echo "ok   $crate"
   fi
+done
 
-  # VM must exist + be running
-  if ! multipass info "$VM_NAME" >/dev/null 2>&1; then
-    echo "WARN: multipass VM '$VM_NAME' not found"
-    return 1
+total=$(( ${#checked[@]} + ${#broken[@]} + ${#unchecked[@]} ))
+echo
+echo "Linux cross-target: ${#checked[@]} ok, ${#broken[@]} broken, ${#unchecked[@]} unchecked, of ${total} crate(s) carrying Linux-gated code."
+
+if [ ${#broken[@]} -gt 0 ]; then
+  echo "error: ${broken[*]} do not compile for ${TARGET}." >&2
+  exit 1
+fi
+
+if [ ${#unchecked[@]} -gt 0 ]; then
+  echo "WARN: not checked, so this run says nothing about them: ${unchecked[*]}"
+  if [ "$REQUIRE_FULL" = "1" ]; then
+    echo "error: ASSAY_LINUX_CHECK_REQUIRE_FULL=1 and coverage is incomplete." >&2
+    exit 1
   fi
+fi
 
-  # Execute in VM. Assumes repo available at $WORKDIR in VM.
-  # (Mount or git clone inside VM; see notes below.)
-  # NOTE: Full clippy in VM can take 2–5 min on cold/heavy build; script times out at 180s.
-  # Default is ASSAY_LINUX_CHECK_MODE=target (no VM) to avoid pre-push hangs.
-  timeout 180 multipass exec "$VM_NAME" -- bash -lc "
-    export PATH=\"\$HOME/.cargo/bin:\$PATH\"
-    if [ -f \"\$HOME/.cargo/env\" ]; then . \"\$HOME/.cargo/env\"; fi
-    export CARGO_TARGET_DIR=\"/tmp/assay-target\"
-    set -euo pipefail
-    cd '$WORKDIR'
-    rustup component add clippy >/dev/null 2>&1 || true
-    cargo clippy --locked --workspace --all-targets -- -D warnings
-  " || {
-    echo "WARN: Linux check timed out or failed. Relying on CI."
-    return 0  # Don't block push; CI will catch issues
-  }
-}
-
-case "$MODE" in
-  target)
-    if run_target_check; then
-      exit 0
-    fi
-    echo "WARN: Linux cross-target check failed (e.g. no x86_64-linux-gnu-gcc). Relying on CI."
-    exit 0
-    ;;
-  multipass)
-    run_multipass_check
-    ;;
-  auto)
-    if run_multipass_check; then
-      exit 0
-    fi
-    # Always try target-check as good fallback
-    if run_target_check; then
-      exit 0
-    fi
-    echo "WARN: Skipping Linux check (no Multipass + target check failed). Relying on CI."
-    exit 0
-    ;;
-  *)
-    echo "Unknown ASSAY_LINUX_CHECK_MODE='$MODE' (use auto|target|multipass)"
-    exit 2
-    ;;
-esac
+exit 0

--- a/scripts/ci/test-check-linux.sh
+++ b/scripts/ci/test-check-linux.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# The Linux compile gate must be able to fail.
+#
+# It could not (#2076). Both branches of the old `run_target_check` ended in `return 0`, so a
+# timeout, a missing toolchain, a third-party build script and a real compile error were one
+# outcome. #2074 pushed four `E0425`s through it; the delegated host found them.
+#
+# Every case here is that defect or a way of re-introducing it. The first is the one that matters:
+# a deliberate `cfg(target_os = "linux")` error must make the script exit non-zero.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$ROOT/scripts/ci/check-linux.sh"
+FAILURES=0
+
+# A crate that cross-checks cleanly on a stock macOS box, so the error under test is the only cause.
+# `assay-cli` and `assay-core` cannot be used: `ring`'s build script aborts before cargo reaches
+# them, which is the "unchecked" case rather than the "broken" one.
+SUBJECT="$ROOT/crates/assay-monitor/src/lib.rs"
+BACKUP="$(mktemp)"
+
+cleanup() {
+  [ -f "$BACKUP" ] && cp "$BACKUP" "$SUBJECT"
+  rm -f "$BACKUP"
+}
+trap cleanup EXIT
+cp "$SUBJECT" "$BACKUP"
+
+check() {
+  local name="$1" want="$2" out status
+  out="$(cd "$ROOT" && bash "$GATE" 2>&1)"
+  status=$?
+  if [ "$status" != "$want" ]; then
+    echo "FAIL  $name: exit $status, wanted $want"
+    printf '%s\n' "$out" | sed 's/^/      /'
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  echo "ok    $name"
+  LAST_OUT="$out"
+}
+
+contains() {
+  local name="$1" needle="$2"
+  if grep -qF -- "$needle" <<<"$LAST_OUT"; then
+    echo "ok    $name"
+  else
+    echo "FAIL  $name: output does not contain '$needle'"
+    printf '%s\n' "$LAST_OUT" | sed 's/^/      /'
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# --- a clean tree passes, and says what it could not check -----------------------------------
+check "a clean tree passes" 0
+contains "  and names the crates it could not check" "unchecked"
+
+# --- a Linux-gated compile error fails ---------------------------------------------------------
+#
+# The defect, exactly: this code is invisible to `cargo build` on macOS, which is why the gate
+# exists and why its inability to fail mattered.
+cat >> "$SUBJECT" <<'RS'
+
+#[cfg(target_os = "linux")]
+fn deliberately_broken_for_the_gate_test() {
+    let _ = A_VALUE_THAT_DOES_NOT_EXIST;
+}
+RS
+check "a cfg(linux) compile error fails the gate" 1
+contains "  and names the crate" "assay-monitor"
+cp "$BACKUP" "$SUBJECT"
+
+# --- the same error outside the cfg would also fail, and must not be how we prove it ----------
+#
+# A test that planted an unconditional error would pass against a gate that only ever ran a host
+# build. The `#[cfg(target_os = "linux")]` above is what makes the case load-bearing, so it is
+# asserted rather than assumed.
+if cargo check -p assay-monitor --quiet 2>/dev/null; then
+  echo "ok    the host build is clean, so the planted error was Linux-only"
+else
+  echo "FAIL  the host build is dirty; the planted error was not Linux-only"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# --- incomplete coverage can be promoted to a failure ------------------------------------------
+#
+# On this host two crates cannot be cross-checked, so the strict mode has something to refuse.
+if (cd "$ROOT" && ASSAY_LINUX_CHECK_REQUIRE_FULL=1 bash "$GATE" >/dev/null 2>&1); then
+  echo "FAIL  REQUIRE_FULL=1 passed despite incomplete coverage"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "ok    REQUIRE_FULL=1 refuses incomplete coverage"
+fi
+
+# --- the crate list is derived, not hand-kept --------------------------------------------------
+#
+# A list beside the code drifts silently in the dangerous direction: a new crate with Linux-gated
+# code would simply not be checked, and nothing would say so.
+if grep -qE '^\s*linux_crates\(\)' "$GATE" && grep -q 'grep -rl' "$GATE"; then
+  echo "ok    the crate set is derived from the source"
+else
+  echo "FAIL  the crate set is no longer derived from the source"
+  FAILURES=$((FAILURES + 1))
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo
+  echo "$FAILURES linux-gate case(s) failed"
+  exit 1
+fi
+echo
+echo "linux compile gate: all cases pass"


### PR DESCRIPTION
## Description

Closes #2076.

`check-linux.sh` catches `cfg(target_os = "linux")` compile errors from macOS. Both branches ended:

```bash
cargo check --workspace ... || { echo "WARN: ..."; return 0; }
```

so a timeout, a missing toolchain, a third-party build script and **your code not compiling on Linux** were one outcome: `WARN`, and pre-push reported **Passed**.

## Observed, not reasoned about

#2074 added four `MONITOR_STAT_SEND*` reads without their imports, inside a `cfg(target_os = "linux")` block.

| | |
|---|---|
| `cargo build` on macOS | clean |
| pre-push linux gate | **Passed** |
| delegated run [31090057720](https://github.com/Rul1an/assay/actions/runs/31090057720) | four `error[E0425]` |

And it had **never** been able to report anything. The workspace cross-check fails on every stock macOS box — `ring` and `aws-lc-sys` build scripts need a C cross-compiler — so it took the `return 0` path every time.

## The distinction restored

A step that logs *"could not verify"* and leaves the pipeline green is a [silent pass](https://securityboulevard.com/2025/10/secret-drift-the-silent-ci-cd-breaker/) — the shape [GitLab is fixing in policy checks](https://gitlab.com/gitlab-org/gitlab/-/issues/389905) and that [`soft_fail`](https://www.appknox.com/blog/ci-cd-security-checklist-engineering-managers) makes an explicit dial rather than an accident. This repo draws the same line in `ErrorClass`, in #1993's release gate, and in the AEE checker's refusal to *skip* an envelope shape it does not implement.

```
FAIL   a compiler diagnostic against our source, on the Linux target
WARN   a cause that is not our code, with the crates it left unchecked named
```

The classifier is the path prefix `--message-format=short` puts on a diagnostic: `crates/…/loader.rs:440:19: error[E0425]` is ours; `error: failed to run custom build command for ring` is not. Anchored, so an error *mentioning* a path is not mistaken for one *located* there.

The crate set is **derived** (`grep -rl 'cfg(target_os = "linux")'`), not listed — a hand-kept list drifts silently in the dangerous direction: a new crate with Linux-gated code would simply not be checked, and nothing would say so.

## Coverage is stated, not implied

```
Linux cross-target: 4 ok, 0 broken, 2 unchecked, of 6 crate(s) …
WARN: not checked, so this run says nothing about them: assay-cli assay-core
```

Those two still cannot be cross-checked here. That is now a **visible denominator** instead of a silent pass. `ASSAY_LINUX_CHECK_REQUIRE_FULL=1` promotes incomplete coverage to a failure for a host that can check everything.

## Verification

`test-check-linux.sh` plants a deliberate `cfg(linux)` error and requires a non-zero exit — the property the gate exists for and could not demonstrate. It also asserts the **host build stays clean**, so the planted error is genuinely Linux-only rather than something any build would have caught.

Replaying #2074's actual missing import:

| | |
|---|---|
| new gate | `FAIL assay-monitor`, `1 broken`, **exit 1** |
| `cargo check` on the host | **0 errors** |

Seven cases, all passing; `shellcheck` clean; wired as a pre-push hook.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.