### PR TITLE
The bot opened a PR that nothing was allowed to check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,33 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/assay_runner_lane_check\.py|scripts/ci/assay_runner_gated_paths\.json|\.github/workflows/assay-runner-lane-check\.yml|\.pre-commit-config\.yaml)$
 
+      - id: docs-generated-drift-self-test
+        name: Generated-docs drift check self-test
+        entry: bash scripts/ci/test-check-docs-generated-drift.sh
+        language: system
+        pass_filenames: false
+        # Both properties this pins have failed here before: `check-aee-seal-fixture-drift.sh`
+        # documents an earlier version that ran its emitter in place and destroyed the fixtures it
+        # audited, and `check-linux.sh` returned 0 on every failure (#2076).
+        stages: [pre-push]
+        files: ^scripts/ci/(check-docs-generated-drift|test-check-docs-generated-drift)\.sh$
+
+      - id: docs-generated-drift
+        name: Generated docs match their generators
+        entry: bash scripts/ci/check-docs-generated-drift.sh
+        language: system
+        pass_filenames: false
+        # The drift used to be found *after* a merge, by `docs-auto-update.yml`, which then opened a
+        # PR from `docs/auto-update` that could never be checked: `create-pull-request` signs it with
+        # the default GITHUB_TOKEN, and GitHub does not run workflows for that token's events. #2021
+        # sat blocked for a day with fifteen `action_required` runs and nothing to approve them
+        # (#2080).
+        #
+        # Caught here instead, the diagram edge lands in the pull request that added the dependency,
+        # where a reviewer can see why it moved. It also makes the bot's `has_changes` false by
+        # construction, so the un-mergeable PR is never created.
+        files: ^(Cargo\.toml|crates/.*/Cargo\.toml|scripts/docs/.*\.sh|docs/generated/.*|docs/AIcontext/architecture-diagrams\.md|scripts/ci/check-docs-generated-drift\.sh|\.pre-commit-config\.yaml)$
+
       - id: docs-auto-update-reconcile-self-test
         name: Docs auto-update reconciliation self-test
         entry: bash scripts/ci/test-reconcile-docs-auto-pr.sh

--- a/docs/AIcontext/architecture-diagrams.md
+++ b/docs/AIcontext/architecture-diagrams.md
@@ -859,6 +859,7 @@ flowchart TB
     assay_adapter_api --> assay_evidence
     assay_adapter_ucp --> assay_adapter_api
     assay_adapter_ucp --> assay_evidence
+    assay_cli --> assay_canonical
     assay_cli --> assay_common
     assay_cli --> assay_core
     assay_cli --> assay_evidence

--- a/docs/generated/crate-deps.mermaid
+++ b/docs/generated/crate-deps.mermaid
@@ -31,6 +31,7 @@ flowchart TB
     assay_adapter_api --> assay_evidence
     assay_adapter_ucp --> assay_adapter_api
     assay_adapter_ucp --> assay_evidence
+    assay_cli --> assay_canonical
     assay_cli --> assay_common
     assay_cli --> assay_core
     assay_cli --> assay_evidence

--- a/scripts/ci/check-docs-generated-drift.sh
+++ b/scripts/ci/check-docs-generated-drift.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# The generated docs must match what the generators produce (#2080).
+#
+# `docs-auto-update.yml` used to detect this drift after a merge and open a PR from
+# `docs/auto-update`. Those PRs cannot be checked: `create-pull-request` signs them with the default
+# `GITHUB_TOKEN`, and GitHub does not run workflows for events raised by that token -- an
+# anti-recursion safeguard. Fifteen `pull_request` runs on #2021 sat at `action_required` and none
+# executed, so `CI` and `host-capability-check` never reported and the PR was blocked forever.
+#
+# Dispatching those workflows by hand looks like a fix and is not: every substantive job is
+# conditioned on pull-request context, so a `workflow_dispatch` run of CI skips its whole matrix and
+# reports success having examined nothing.
+#
+# GitHub's own remedy is a GitHub App installation token, which does trigger workflows. That keeps
+# the bot-PR flow and needs an App plus two secrets. This takes the other route, and it is the one
+# this repository already committed to: the drift is *checked* on the change that causes it rather
+# than auto-committed afterwards. Six sibling checks work this way -- the gating map, the ADR-045
+# seal fixtures, the release surface, the CI gate expectation, the MCP registry transaction, the
+# fuzz lane -- and each of them exists because a generated artifact and its generator drift apart
+# silently.
+#
+# The practical difference: the diagram edge lands in the pull request that added the dependency,
+# where a reviewer can see *why* it changed, instead of arriving hours later in a PR nobody can
+# merge.
+#
+# The generators write in place, so this copies the worktree to a scratch directory and runs them
+# there. `check-aee-seal-fixture-drift.sh` carries the same warning for the same reason: an earlier
+# version of that script ran its emitter in place and destroyed uncommitted edits in the very
+# fixtures it was auditing.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+GENERATORS=(
+  scripts/docs/generate-crate-deps.sh
+  scripts/docs/generate-module-map.sh
+  scripts/docs/update-architecture-docs.sh
+)
+
+# The files the generators own. Anything outside this list is not compared, so a hand-written doc
+# living beside a generated one is not held to the generator's output.
+GENERATED=(
+  docs/generated/crate-deps.mermaid
+  docs/generated/module-map.mermaid
+  docs/AIcontext/architecture-diagrams.md
+)
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# Tracked files as they are *now*, not as they are at HEAD.
+#
+# `git archive HEAD` was the first version and is wrong for the case that matters: at pre-commit
+# time HEAD is the previous commit, so the generators would run against source that predates the
+# change being committed and the check would pass on exactly the change it exists to catch.
+# `git ls-files` takes the working-tree contents of tracked files, which is the state under review.
+#
+# Tracked-only, so a stray `target/` or an untracked scratch file cannot change what the generators
+# see — and so the copy stays small.
+mkdir -p "$scratch/repo"
+git ls-files -z | tar -cf - --null -T - | (cd "$scratch/repo" && tar -xf -)
+
+for generator in "${GENERATORS[@]}"; do
+  if ! (cd "$scratch/repo" && bash "$generator" >/dev/null 2>&1); then
+    echo "error: $generator failed inside the scratch copy, so no comparison was made." >&2
+    echo "       This is a 'could not check', not a pass." >&2
+    exit 1
+  fi
+done
+
+drifted=()
+for path in "${GENERATED[@]}"; do
+  if [ ! -f "$scratch/repo/$path" ]; then
+    echo "error: the generators did not produce $path." >&2
+    exit 1
+  fi
+  if ! diff -q "$path" "$scratch/repo/$path" >/dev/null 2>&1; then
+    drifted+=("$path")
+  fi
+done
+
+if [ ${#drifted[@]} -gt 0 ]; then
+  echo "error: generated docs do not match their generators:" >&2
+  for path in "${drifted[@]}"; do
+    echo >&2
+    diff -u "$path" "$scratch/repo/$path" | sed -n '1,40p' >&2
+  done
+  echo >&2
+  echo "Regenerate and commit:" >&2
+  for generator in "${GENERATORS[@]}"; do
+    echo "  bash $generator" >&2
+  done
+  echo >&2
+  echo "The diagram belongs in the change that moved it. A dependency edge added in one PR and" >&2
+  echo "documented in another is a diagram nobody reviewed against the code it describes." >&2
+  exit 1
+fi
+
+echo "generated docs reproduce from their generators (${#GENERATED[@]} files)."

--- a/scripts/ci/test-check-docs-generated-drift.sh
+++ b/scripts/ci/test-check-docs-generated-drift.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# The generated-docs drift check must be able to fail, and must not destroy what it audits.
+#
+# Both properties have gone wrong in this repository before. `check-aee-seal-fixture-drift.sh`
+# carries a header about an earlier version that ran its emitter in place and destroyed uncommitted
+# edits in the fixtures it was checking. `check-linux.sh` returned 0 on every failure and could not
+# report anything at all (#2076). This pins both for the docs check.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$ROOT/scripts/ci/check-docs-generated-drift.sh"
+SUBJECT="$ROOT/docs/generated/crate-deps.mermaid"
+FAILURES=0
+BACKUP="$(mktemp)"
+
+cleanup() { [ -f "$BACKUP" ] && cp "$BACKUP" "$SUBJECT"; rm -f "$BACKUP"; }
+trap cleanup EXIT
+cp "$SUBJECT" "$BACKUP"
+
+check() {
+  local name="$1" want="$2"
+  (cd "$ROOT" && bash "$GATE" >/dev/null 2>&1)
+  local status=$?
+  if [ "$status" = "$want" ]; then echo "ok    $name"; else
+    echo "FAIL  $name: exit $status, wanted $want"; FAILURES=$((FAILURES + 1)); fi
+}
+
+check "a tree in sync passes" 0
+
+# --- drift is caught ---------------------------------------------------------------------------
+printf '\n%%%% drift planted by the drift-check self-test\n' >> "$SUBJECT"
+check "a hand-edited generated file fails" 1
+cp "$BACKUP" "$SUBJECT"
+
+# --- the check does not edit what it audits ----------------------------------------------------
+#
+# The generators write in place, so a check that ran them in the worktree would silently rewrite the
+# very files under review — and would then always pass, having made itself right.
+before="$(shasum -a 256 "$SUBJECT" | awk '{print $1}')"
+(cd "$ROOT" && bash "$GATE" >/dev/null 2>&1)
+after="$(shasum -a 256 "$SUBJECT" | awk '{print $1}')"
+if [ "$before" = "$after" ]; then
+  echo "ok    the check leaves the worktree untouched"
+else
+  echo "FAIL  the check rewrote the file it was auditing"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# --- an uncommitted change is what gets checked ------------------------------------------------
+#
+# The first version generated from `git archive HEAD`, so at pre-commit time it compared against the
+# previous commit and would have passed on the very change being committed. This pins the fix.
+if grep -q "git ls-files" "$GATE" && ! grep -q "git archive --format=tar HEAD" "$GATE"; then
+  echo "ok    the check reads the working tree, not HEAD"
+else
+  echo "FAIL  the check generates from HEAD; an uncommitted change would go unchecked"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# --- a generator that cannot run is not a pass -------------------------------------------------
+if grep -q "could not check" "$GATE"; then
+  echo "ok    a generator failure refuses rather than passing"
+else
+  echo "FAIL  a generator failure has no explicit refusal"
+  FAILURES=$((FAILURES + 1))
+fi
+
+if [ "$FAILURES" -ne 0 ]; then echo; echo "$FAILURES docs-drift case(s) failed"; exit 1; fi
+echo
+echo "generated-docs drift check: all cases pass"


### PR DESCRIPTION
## Description

Closes #2080. Supersedes #2021.

`docs-auto-update.yml` detected generated-doc drift after a merge and opened a PR from `docs/auto-update`. **Those PRs cannot be checked.** `create-pull-request` signs them with the default `GITHUB_TOKEN`, and [GitHub does not run workflows for events raised by that token](https://docs.github.com/en/actions/concepts/security/github_token) — an anti-recursion safeguard.

#2021 sat blocked for a day:

```
pull_request/action_required  x15
workflow_dispatch/success     x5
```

Fifteen runs created, **none executed**, so `CI` and `host-capability-check` never reported.

The manual dispatches look like a workaround and are not: every substantive job is conditioned on pull-request context, so a dispatched CI run **skips its whole matrix and reports success having examined nothing**. Same shape as #1993 and #2076 — twice in one day.

## Why a drift check rather than an App token

[GitHub's own remedy](https://docs.github.com/actions/using-workflows/triggering-a-workflow) is a GitHub App installation token — it triggers workflows and skips the approval prompt, and App tokens are finer-grained and better scoped than a PAT. That keeps the bot-PR flow and needs an App plus two secrets.

This takes the route **the repository already committed to**. Six sibling checks work this way — the gating map, the ADR-045 seal fixtures, the release surface, the CI gate expectation, the MCP registry transaction, the fuzz lane — each because a generated artifact and its generator drift apart silently. This is the seventh.

The practical difference: the diagram edge lands in the pull request that added the dependency, where a reviewer can see **why** it moved, instead of arriving hours later in a PR nobody can merge.

The bot's `has_changes` becomes **false by construction** — drift cannot reach `main`, so there is nothing to open a PR about. Nothing is deleted: `docs-auto-update.yml` and its 348-line reconciliation test are untouched, and the workflow stays available as a manual regenerator.

## The drift it found first was mine

`assay_cli --> assay_canonical` — the edge #2071 added when the seal envelope started calling `assay_canonical::jcs` and `parse_strict`. The diagram had been stale ever since. Regenerated here, which is also what #2021 was trying to land.

## Two defects in the check itself, found by testing it

| Defect | Effect |
|---|---|
| generated from `git archive HEAD` | at pre-commit time HEAD is the *previous* commit, so it ran the generators against source predating the change being committed — **passing on exactly the change it exists to catch**. Reads the working tree via `git ls-files` now. |
| generators write in place | running them in the worktree would rewrite the files under review and then always pass, having made itself right. Copies tracked files to a scratch dir, as the seal-fixture check does for the same reason. |

## Verification

Five cases in `test-check-docs-generated-drift.sh`:

- a tree in sync passes
- a hand-edited generated file **fails**
- the check **leaves the worktree untouched**
- the check reads the working tree, not HEAD
- a generator that cannot run **refuses** rather than passing

`shellcheck` clean. The hook runs under `pre-commit run --all-files`, which is what the `Lint (pre-commit)` CI job does — verified, not assumed.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.