### PR TITLE
A metric that stopped running made the baseline look better

### DIFF
--- a/crates/assay-cli/src/cli/commands/run_output.rs
+++ b/crates/assay-cli/src/cli/commands/run_output.rs
@@ -323,7 +323,13 @@ pub(crate) fn export_baseline(
                         test_id: r.test_id.clone(),
                         metric: metric_name.clone(),
                         score,
-                        meta: None,
+                        // Carried so a later run can tell "this metric scored worse" from "this
+                        // metric stopped being evaluated". Without it the two are the same row.
+                        // `meta` is an existing optional field, so an older baseline still loads
+                        // and simply reports no prior coverage.
+                        meta: m_val
+                            .get("exercised")
+                            .map(|e| serde_json::json!({ "exercised": e })),
                     });
                 }
             }

--- a/crates/assay-core/src/baseline/mod.rs
+++ b/crates/assay-core/src/baseline/mod.rs
@@ -137,6 +137,21 @@ impl Baseline {
             .map(|e| e.score)
     }
 
+    /// Whether the baseline run actually evaluated this metric.
+    ///
+    /// `None` means the baseline predates the `exercised` dimension (#1949 layer 2) and says
+    /// nothing either way — which is not the same as saying the metric was not exercised, and is
+    /// why the coverage check treats it as no evidence rather than as a drop.
+    pub fn was_exercised(&self, test_id: &str, metric: &str) -> Option<bool> {
+        self.entries
+            .iter()
+            .find(|e| e.test_id == test_id && e.metric == metric)
+            .and_then(|e| e.meta.as_ref())
+            .and_then(|m| m.get("exercised"))
+            .and_then(|v| v.as_str())
+            .map(|s| s == "exercised")
+    }
+
     pub fn diff(&self, candidate: &Baseline) -> BaselineDiff {
         let mut regressions = Vec::new();
         let mut improvements = Vec::new();
@@ -251,5 +266,58 @@ pub fn compute_config_fingerprint(config_path: &Path) -> String {
         format!("md5:{:x}", digest)
     } else {
         "md5:unknown".to_string()
+    }
+}
+
+#[cfg(test)]
+mod was_exercised_tests {
+    use super::*;
+
+    fn baseline_with(meta: Option<serde_json::Value>) -> Baseline {
+        Baseline {
+            schema_version: 1,
+            suite: "s".into(),
+            assay_version: "test".into(),
+            created_at: "2026-08-06T00:00:00Z".into(),
+            config_fingerprint: "fp".into(),
+            git_info: None,
+            entries: vec![BaselineEntry {
+                test_id: "t1".into(),
+                metric: "semantic".into(),
+                score: 0.87,
+                meta,
+            }],
+        }
+    }
+
+    #[test]
+    fn an_exercised_baseline_entry_reads_as_exercised() {
+        let b = baseline_with(Some(serde_json::json!({"exercised": "exercised"})));
+        assert_eq!(b.was_exercised("t1", "semantic"), Some(true));
+    }
+
+    #[test]
+    fn a_not_applicable_baseline_entry_reads_as_not_exercised() {
+        let b = baseline_with(Some(serde_json::json!({"exercised": "not_applicable"})));
+        assert_eq!(b.was_exercised("t1", "semantic"), Some(false));
+    }
+
+    /// A baseline written before the dimension existed says nothing either way.
+    ///
+    /// `None` rather than `Some(false)` is the whole point: treating silence as "was not exercised"
+    /// would make every pre-existing baseline look like it had no coverage, and the coverage check
+    /// would then never fire because there is nothing to have lost.
+    #[test]
+    fn a_baseline_predating_the_dimension_says_nothing() {
+        assert_eq!(baseline_with(None).was_exercised("t1", "semantic"), None);
+        let b = baseline_with(Some(serde_json::json!({"other": "field"})));
+        assert_eq!(b.was_exercised("t1", "semantic"), None);
+    }
+
+    #[test]
+    fn an_absent_entry_says_nothing() {
+        let b = baseline_with(Some(serde_json::json!({"exercised": "exercised"})));
+        assert_eq!(b.was_exercised("t1", "nosuch"), None);
+        assert_eq!(b.was_exercised("nosuch", "semantic"), None);
     }
 }

--- a/crates/assay-core/src/baseline/report.rs
+++ b/crates/assay-core/src/baseline/report.rs
@@ -116,7 +116,7 @@ pub fn report_from_db(store: &Store, suite: &str, last_runs: u32) -> anyhow::Res
                             attempt.details.get("metrics").and_then(|m| m.as_object())
                         {
                             for (metric_name, mv) in obj {
-                                if let Some(score) = mv.get("score").and_then(|s| s.as_f64()) {
+                                if let Some(score) = exercised_score(mv) {
                                     scores.entry(metric_name.clone()).or_default().push(score);
                                 }
                             }
@@ -128,7 +128,7 @@ pub fn report_from_db(store: &Store, suite: &str, last_runs: u32) -> anyhow::Res
                     // But for safety:
                     if let Some(obj) = r.details.get("metrics").and_then(|m| m.as_object()) {
                         for (metric_name, mv) in obj {
-                            if let Some(score) = mv.get("score").and_then(|s| s.as_f64()) {
+                            if let Some(score) = exercised_score(mv) {
                                 scores.entry(metric_name.clone()).or_default().push(score);
                             }
                         }
@@ -138,7 +138,7 @@ pub fn report_from_db(store: &Store, suite: &str, last_runs: u32) -> anyhow::Res
                 // Fallback for old records without attempts
                 if let Some(obj) = r.details.get("metrics").and_then(|m| m.as_object()) {
                     for (metric_name, mv) in obj {
-                        if let Some(score) = mv.get("score").and_then(|s| s.as_f64()) {
+                        if let Some(score) = exercised_score(mv) {
                             scores.entry(metric_name.clone()).or_default().push(score);
                         }
                     }
@@ -262,4 +262,62 @@ pub fn report_from_db(store: &Store, suite: &str, last_runs: u32) -> anyhow::Res
         tests,
         notes,
     })
+}
+
+/// A metric's score, but only when the metric actually evaluated something.
+///
+/// The three collection sites above (attempts, the attempts fallback, and pre-attempts records)
+/// each read the same object, so the rule lives here once. Three copies of one rule is how the
+/// baseline and the runner would come to disagree about what counts as a score.
+///
+/// A record without an `exercised` field predates #1949 layer 2 and is counted, because treating
+/// silence as "not exercised" would drop every historical score at once.
+fn exercised_score(metric: &serde_json::Value) -> Option<f64> {
+    let exercised = metric.get("exercised").and_then(|v| v.as_str());
+    if exercised.is_some_and(|e| e != "exercised") {
+        return None;
+    }
+    metric.get("score").and_then(|s| s.as_f64())
+}
+
+#[cfg(test)]
+mod exercised_score_tests {
+    use super::exercised_score;
+    use serde_json::json;
+
+    /// A metric that declined the test's `Expected` variant reports `passed` with score 1.0
+    /// (#1949 layer 2). That number is not evidence about quality and must not enter the statistics.
+    #[test]
+    fn a_not_applicable_metric_contributes_no_score() {
+        assert_eq!(
+            exercised_score(&json!({"score": 1.0, "exercised": "not_applicable"})),
+            None
+        );
+        assert_eq!(
+            exercised_score(&json!({"score": 1.0, "exercised": "not_exercised"})),
+            None
+        );
+    }
+
+    #[test]
+    fn an_exercised_metric_contributes_its_score() {
+        assert_eq!(
+            exercised_score(&json!({"score": 0.87, "exercised": "exercised"})),
+            Some(0.87)
+        );
+    }
+
+    /// A record written before the dimension existed says nothing either way, and is counted.
+    ///
+    /// Reading silence as "not exercised" would drop every historical score at once, which would
+    /// look like the baseline improving and is the direction that hides a change.
+    #[test]
+    fn a_record_predating_the_dimension_is_counted() {
+        assert_eq!(exercised_score(&json!({"score": 0.5})), Some(0.5));
+    }
+
+    #[test]
+    fn a_record_without_a_score_contributes_nothing() {
+        assert_eq!(exercised_score(&json!({"exercised": "exercised"})), None);
+    }
 }

--- a/crates/assay-core/src/engine/runner_next/baseline.rs
+++ b/crates/assay-core/src/engine/runner_next/baseline.rs
@@ -15,7 +15,40 @@ pub(crate) fn check_baseline_regressions_impl(
 
     for m in metrics {
         let metric_name = m.name();
-        let score = details["metrics"][metric_name]["score"].as_f64()?;
+
+        // `continue`, not `?`. `?` returns from the whole function, so one metric without a numeric
+        // score silently disabled regression checking for every metric after it in the list.
+        let Some(score) = details["metrics"][metric_name]["score"].as_f64() else {
+            continue;
+        };
+
+        // Did this run actually evaluate the metric? #1949 layer 2: a metric that declined the
+        // test's `Expected` variant, or found no antecedent, reports `passed` with score 1.0. That
+        // number is stable run to run, so it never trips a score regression — and if a metric that
+        // used to be exercised stops being so, its score *rises* to 1.0 and the baseline reads the
+        // coverage loss as an improvement.
+        let exercised = details["metrics"][metric_name]["exercised"].as_str();
+        let is_exercised = exercised.is_none_or(|e| e == "exercised");
+
+        // The coverage regression the score comparison cannot see. Warn rather than fail: this is
+        // an observation about what ran, and over-eager vacuity detection earns a suppression and
+        // takes real findings with it.
+        if coverage_regressed(exercised, baseline.was_exercised(&tc.id, metric_name)) {
+            return Some((
+                TestStatus::Warn,
+                format!(
+                    "coverage regression: {} was exercised in the baseline and is {} now",
+                    metric_name,
+                    exercised.unwrap_or("not exercised")
+                ),
+            ));
+        }
+
+        // A score from a metric that evaluated nothing is not evidence about quality, so it is not
+        // compared. Continue rather than return, so later metrics are still checked.
+        if !is_exercised {
+            continue;
+        }
 
         let (mode, max_drop) =
             resolve_threshold_config_impl(runner, tc, metric_name, suite_defaults);
@@ -68,4 +101,63 @@ pub(crate) fn resolve_threshold_config_impl(
     }
 
     (mode, max_drop)
+}
+
+/// Did this metric stop being evaluated since the baseline?
+///
+/// Extracted so the loop above and the tests below apply one rule. The asymmetry is the point:
+///
+/// - a baseline that predates the `exercised` dimension reports `None`, which is *no evidence*
+///   rather than evidence of no coverage. Treating it as a drop would fire on every historical
+///   baseline at once.
+/// - a current result with no `exercised` field is treated as exercised, for the same reason in
+///   the other direction: a run from an older binary must not read as a coverage loss.
+///
+/// So this fires only when the baseline positively recorded coverage and this run positively
+/// reports its absence.
+fn coverage_regressed(current: Option<&str>, baseline_exercised: Option<bool>) -> bool {
+    let now_exercised = current.is_none_or(|e| e == "exercised");
+    !now_exercised && baseline_exercised == Some(true)
+}
+
+#[cfg(test)]
+mod coverage_regression_tests {
+    use super::coverage_regressed;
+
+    /// The case the score comparison cannot see: a metric that used to run and now declines.
+    ///
+    /// Its score *rises* to 1.0 when that happens, so a score-only check reads the coverage loss as
+    /// an improvement.
+    #[test]
+    fn a_metric_that_stopped_being_evaluated_is_a_regression() {
+        assert!(coverage_regressed(Some("not_applicable"), Some(true)));
+        assert!(coverage_regressed(Some("not_exercised"), Some(true)));
+    }
+
+    #[test]
+    fn a_metric_that_still_runs_is_not_a_regression() {
+        assert!(!coverage_regressed(Some("exercised"), Some(true)));
+    }
+
+    /// It was already not exercised, so nothing was lost.
+    #[test]
+    fn a_metric_that_never_ran_is_not_a_regression() {
+        assert!(!coverage_regressed(Some("not_applicable"), Some(false)));
+    }
+
+    /// A baseline predating the dimension is no evidence, not evidence of absence.
+    ///
+    /// Without this the check would fire on every historical baseline the first time it ran, which
+    /// is the over-eager vacuity detection that earns a suppression and takes real findings with it.
+    #[test]
+    fn a_baseline_that_says_nothing_is_not_a_regression() {
+        assert!(!coverage_regressed(Some("not_applicable"), None));
+        assert!(!coverage_regressed(Some("not_exercised"), None));
+    }
+
+    /// A run from a binary older than the dimension must not read as a coverage loss either.
+    #[test]
+    fn a_current_result_that_says_nothing_is_not_a_regression() {
+        assert!(!coverage_regressed(None, Some(true)));
+    }
 }


### PR DESCRIPTION
## Description

#1949 layer 2, **slice 5**: the baseline distinguishes a score that got worse from a metric that stopped being evaluated. #1949 stays open — slice 4 and the default-on decision remain.

#2068 gave `MetricResult` the `exercised` dimension and one consumer. The baseline was not it: `check_baseline_regressions_impl` compared every metric's score, and `baseline/report.rs` fed every score into its statistics — including the `1.0` a metric reports when it declines the test's `Expected` variant.

## The case that matters

That `1.0` is stable run to run, so it never trips a regression. The sharper case is this:

> When a metric that **used to** be exercised stops being so, its score **rises** to 1.0 — and a score-only comparison reads the coverage loss as an **improvement**.

The [2026 eval literature](https://futureagi.com/glossary/llm-regression-testing/) is thorough on score regression between a candidate and the last passing baseline, and silent on a metric that is no longer evaluated at all. Assertion-based verification has the concept — an assert with zero attempts is a coverage hole, not a pass — which is where layer 2 took it from.

## The shape

| | |
|---|---|
| `export_baseline` | records `exercised` in the existing optional `meta` — no schema break |
| `Baseline::was_exercised` | reads it back |
| `coverage_regressed` | decides; the loop and the tests call the same function |
| `exercised_score` | one rule for the three collection sites in `report.rs` |

## The asymmetry is the design

- A baseline **predating** the dimension reports `None` — *no evidence*, not evidence of no coverage. Treating it as a drop would fire on every historical baseline at once: the over-eager vacuity detection that earns a suppression and takes real findings with it.
- A **current** result with no `exercised` field is treated as exercised, so a run from an older binary does not read as a coverage loss.

It fires only when the baseline positively recorded coverage **and** this run positively reports its absence. `Warn`, never `Fail` — this is an observation about what ran.

## One unrelated defect fixed in passing

```rust
let score = details["metrics"][metric_name]["score"].as_f64()?;
```

`?` returns from the whole function, so a single metric without a numeric score **silently disabled regression checking for every metric after it**. It is a `continue` now.

## Verification

| Mutation | Result |
|---|---|
| the coverage check fires when the baseline says nothing | **red** (3 tests) |
| an older run reads as a coverage loss | **red** |
| vacuous scores back in the baseline statistics | **red** |

**The first mutation run proved nothing and reported success.** The filter `"coverage_regression|exercised_score|was_exercised"` is a substring, not a regex, so cargo matched no test and printed `ok` for all four runs. Re-run per suite, with an assertion that each mutation actually applied.

Full `assay-core` and `assay-cli` suites pass; clippy clean.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.