### PR TITLE
The test passed and the check it named never ran

### DIFF
--- a/crates/assay-cli/src/cli/commands/run_output.rs
+++ b/crates/assay-cli/src/cli/commands/run_output.rs
@@ -59,7 +59,31 @@ pub(crate) fn reason_code_from_error_message(message: &str) -> Option<ReasonCode
     reason_code_from_run_error(&classified)
 }
 
+/// Decide the run's outcome, then attach the observations that do not decide it.
+///
+/// A wrapper rather than a line at the end of the body below, because that body has six early
+/// returns. An observation appended on one of them would be missing from the other five, and the
+/// path it would be missing from most often is the one that matters here: success. A metric that
+/// evaluated nothing shows up on a green run by definition.
+///
+/// Both `assay run` and `assay ci` reach this through `execute_pipeline`, so the two commands
+/// cannot report different coverage.
 pub(crate) fn decide_run_outcome(
+    results: &[assay_core::model::TestResultRow],
+    strict: bool,
+    version: crate::exit_codes::ExitCodeVersion,
+) -> crate::exit_codes::RunOutcome {
+    let mut outcome = decide_run_outcome_impl(results, strict, version);
+    // Appended, never assigned: `warnings` already carries report-writing failures, and this must
+    // not displace them. It does not participate in `exit_code` — that is what makes it a review
+    // signal instead of a gate (#1949 layer 2, slice 4).
+    outcome
+        .warnings
+        .extend(assay_core::report::exercised::warnings(results));
+    outcome
+}
+
+fn decide_run_outcome_impl(
     results: &[assay_core::model::TestResultRow],
     strict: bool,
     version: crate::exit_codes::ExitCodeVersion,

--- a/crates/assay-cli/src/cli/commands/run_output/tests.rs
+++ b/crates/assay-cli/src/cli/commands/run_output/tests.rs
@@ -236,3 +236,121 @@ fn test_decide_outcome_uses_typed_details_before_legacy_message_fallback() {
         ReasonCode::EInvalidArgs.exit_code_for(ExitCodeVersion::V2)
     );
 }
+
+/// A passing row whose named metric evaluated nothing, shaped as `single.rs` writes it.
+fn not_exercised_row(test_id: &str, metric: &str, reason: &str) -> TestResultRow {
+    TestResultRow {
+        test_id: test_id.into(),
+        status: TestStatus::Pass,
+        score: None,
+        cached: false,
+        message: "ok".into(),
+        details: serde_json::json!({
+            "metrics": {
+                metric: {
+                    "score": 1.0,
+                    "passed": true,
+                    "unstable": false,
+                    "exercised": "not_exercised",
+                    "details": { "reason": reason }
+                }
+            }
+        }),
+        duration_ms: Some(1),
+        fingerprint: None,
+        skip_reason: None,
+        attempts: None,
+        error_policy_applied: None,
+    }
+}
+
+/// The success path is the one that matters, and it is the one an early `return` would have missed.
+///
+/// `decide_run_outcome` has six early returns; a not-exercised metric appears on a *green* run by
+/// definition, so the warning must survive the path that returns first and reports nothing else.
+#[test]
+fn a_not_exercised_metric_warns_on_a_passing_run_without_changing_the_exit_code() {
+    let rows = vec![not_exercised_row(
+        "t1",
+        "sequence_valid",
+        "no tool calls in the trace",
+    )];
+    let outcome = decide_run_outcome(&rows, false, ExitCodeVersion::default());
+
+    assert_eq!(outcome.exit_code, 0, "a coverage observation is not a gate");
+    assert_eq!(outcome.reason_code, ReasonCode::Success.as_str());
+    assert!(
+        outcome
+            .warnings
+            .iter()
+            .any(|w| w.contains("W_METRIC_NOT_EXERCISED") && w.contains("sequence_valid")),
+        "warnings: {:?}",
+        outcome.warnings
+    );
+}
+
+/// And on a failing run too — the early return at priority 1/2 must not swallow it.
+#[test]
+fn a_failing_run_still_reports_what_was_never_exercised() {
+    let mut fail = not_exercised_row("t2", "tool_output_valid", "no output schemas configured");
+    fail.status = TestStatus::Fail;
+    fail.message = "failed: must_contain".into();
+    let rows = vec![
+        not_exercised_row("t1", "tool_output_valid", "no output schemas configured"),
+        fail,
+    ];
+    let outcome = decide_run_outcome(&rows, false, ExitCodeVersion::default());
+
+    assert_ne!(outcome.exit_code, 0, "the failure still decides the exit");
+    assert!(
+        outcome.warnings.iter().any(|w| w.contains("2 test(s)")),
+        "the failing run lost its coverage warning: {:?}",
+        outcome.warnings
+    );
+}
+
+/// `--strict` promotes Warn/Flaky/Unstable *statuses* to a violation. A not-exercised metric is not
+/// a status, so strict mode must not turn a coverage observation into a failing build — that is
+/// precisely the over-eager detection that earns a suppression.
+#[test]
+fn strict_mode_does_not_promote_a_coverage_observation_to_a_violation() {
+    let rows = vec![not_exercised_row("t1", "seq", "no tool calls")];
+    let outcome = decide_run_outcome(&rows, true, ExitCodeVersion::default());
+    assert_eq!(outcome.exit_code, 0, "strict mode failed a green suite");
+    assert!(!outcome.warnings.is_empty());
+}
+
+/// The warning reaches the artifact, not just the struct.
+#[test]
+fn the_warning_lands_in_run_json() {
+    let artifacts = RunArtifacts {
+        run_id: 1,
+        suite: "s".into(),
+        results: vec![not_exercised_row("t1", "seq", "no tool calls in the trace")],
+        order_seed: None,
+        runner_clone_ms: None,
+    };
+    let outcome = decide_run_outcome(&artifacts.results, false, ExitCodeVersion::default());
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("run.json");
+    write_extended_run_json(&artifacts, &outcome, &path, None).unwrap();
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    let warnings = parsed["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings.iter().any(|w| w
+            .as_str()
+            .is_some_and(|s| s.contains("W_METRIC_NOT_EXERCISED"))),
+        "run.json: {parsed}"
+    );
+}
+
+/// A run with nothing to say adds no `warnings` key at all.
+#[test]
+fn a_fully_exercised_run_adds_no_warnings() {
+    let mut row = not_exercised_row("t1", "semantic", "n/a");
+    row.details["metrics"]["semantic"]["exercised"] = serde_json::json!("exercised");
+    let outcome = decide_run_outcome(&[row], false, ExitCodeVersion::default());
+    assert!(outcome.warnings.is_empty(), "{:?}", outcome.warnings);
+}

--- a/crates/assay-cli/tests/reason_code_vocabularies.rs
+++ b/crates/assay-cli/tests/reason_code_vocabularies.rs
@@ -139,6 +139,39 @@ fn string_literal(s: &str) -> Option<String> {
     Some(s[start..end].to_owned())
 }
 
+/// Every `pub const` string in `assay_core::report::exercised`.
+///
+/// These reach the `warnings` array of `run.json` / `summary.json`, which is a different field from
+/// `reason_code` and a different surface from a SARIF `ruleId`. Parsed the same way as `codes::` and
+/// for the same reason: a second `pub const` added beside the first would otherwise reach a
+/// published artifact with nothing recording it.
+fn run_json_warning_codes() -> BTreeSet<String> {
+    let src = read("crates/assay-core/src/report/exercised.rs");
+    let mut found = BTreeSet::new();
+    for line in src.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("pub const ") else {
+            continue;
+        };
+        let Some((_, value)) = rest.split_once('=') else {
+            continue;
+        };
+        // Only string-valued constants are codes. A numeric bound is not a vocabulary member, and
+        // treating one as a missing entry would make this check noise.
+        if let Some(value) = string_literal(value) {
+            assert!(
+                found.insert(value.clone()),
+                "duplicate warning code value {value:?}"
+            );
+        }
+    }
+    assert!(
+        !found.is_empty(),
+        "parsed no run.json warning codes; the module shape moved"
+    );
+    found
+}
+
 fn lint_rule_ids() -> BTreeSet<String> {
     assay_evidence::lint::rules::RULES
         .iter()
@@ -174,6 +207,38 @@ fn inventory_records_every_lint_rule_id() {
         lint_rule_ids(),
         recorded("lint-rule-ids"),
         "`assay_evidence::lint::rules::RULES` and the inventory disagree."
+    );
+}
+
+#[test]
+fn inventory_records_every_run_json_warning_code() {
+    assert_eq!(
+        run_json_warning_codes(),
+        recorded("run-json-warning-codes"),
+        "`assay_core::report::exercised` and the inventory disagree. A code reaching the \
+         `warnings` array of run.json is a published id and belongs in \
+         docs/architecture/REASON-CODE-VOCABULARIES.md."
+    );
+}
+
+/// The `warnings` codes are deliberately not in `codes::`, and that must stay a decision.
+///
+/// `codes::` is inventoried as the SARIF `ruleId` vocabulary under `tool.driver.name = "assay"`.
+/// The `run` path does build `Diagnostic`s — the trace client, the assertion matchers, the pipeline
+/// error classifier — but none of them reaches `build_sarif_diagnostics`, whose only non-test caller
+/// is `assay validate --format sarif`. So a code moved into that registry to tidy it up would be
+/// recorded on a surface it never reaches: the inventory would state something false, and this file
+/// is the reason the inventory is trusted. If a run-path diagnostic ever gains a route to
+/// `build_sarif_diagnostics`, move the constant and delete this test in the same change.
+#[test]
+fn the_run_json_warning_codes_are_not_in_the_sarif_registry() {
+    let warnings = run_json_warning_codes();
+    let sarif = diagnostic_codes();
+    let overlap: Vec<&String> = warnings.intersection(&sarif).collect();
+    assert!(
+        overlap.is_empty(),
+        "these codes are in both `report::exercised` and `codes::`, so the inventory records them \
+         on a SARIF surface they do not reach: {overlap:?}"
     );
 }
 

--- a/crates/assay-core/src/engine/runner_next/single.rs
+++ b/crates/assay-core/src/engine/runner_next/single.rs
@@ -225,13 +225,11 @@ fn score_after(current: Option<f64>, r: &crate::metrics_api::MetricResult) -> Op
 
 /// The stable string for an `Exercised` value in `details["metrics"][…]`.
 ///
-/// A vocabulary, not a `Debug` rendering: this reaches `run.json`, so it is an interface.
+/// Delegates to [`crate::metrics_api::Exercised::label`], which is where the vocabulary moved once
+/// it acquired a reader (`report::exercised`). Kept as a named function because the tests below
+/// pin the mapping at the point the runner uses it.
 fn exercised_label(e: crate::metrics_api::Exercised) -> &'static str {
-    match e {
-        crate::metrics_api::Exercised::Exercised => "exercised",
-        crate::metrics_api::Exercised::NotApplicable => "not_applicable",
-        crate::metrics_api::Exercised::NotExercised => "not_exercised",
-    }
+    e.label()
 }
 
 #[cfg(test)]

--- a/crates/assay-core/src/metrics_api.rs
+++ b/crates/assay-core/src/metrics_api.rs
@@ -28,6 +28,22 @@ pub enum Exercised {
     Exercised,
 }
 
+impl Exercised {
+    /// The stable string for this value in `details["metrics"][…]["exercised"]`.
+    ///
+    /// A vocabulary, not a `Debug` rendering: it reaches `run.json`, so it is an interface. It
+    /// lives on the enum rather than beside the writer because there is now a reader —
+    /// [`crate::report::exercised`] — and a reader with its own copy of `"not_exercised"` would
+    /// match nothing the day the spelling moved, reporting a clean run instead of a broken one.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Exercised => "exercised",
+            Self::NotApplicable => "not_applicable",
+            Self::NotExercised => "not_exercised",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MetricResult {
     pub score: f64,

--- a/crates/assay-core/src/report/console.rs
+++ b/crates/assay-core/src/report/console.rs
@@ -268,6 +268,33 @@ pub fn print_summary(results: &[TestResultRow], explain_skip: bool) {
         "Summary: {} passed, {} failed, {} skipped{}, {} flaky, {} unstable, {} warn, {} error",
         pass, fail, skipped, skip_hint, flaky, unstable, warn, error
     );
+
+    print_not_exercised(results);
+}
+
+/// The companion cover, printed under the summary (#1949 layer 2, slice 4).
+///
+/// Below the counts rather than beside a test, because it is a property of the suite's coverage
+/// and not of any one result. Nothing here touches a status or a count: a suite whose metrics all
+/// passed still says "passed", and this says what was never checked to get there.
+///
+/// Derived from the same [`crate::report::exercised::collect`] the `warnings` array uses, so the
+/// console and `run.json` cannot report different holes.
+fn print_not_exercised(results: &[TestResultRow]) {
+    let findings = crate::report::exercised::collect(results);
+    if findings.is_empty() {
+        return;
+    }
+    eprintln!(
+        "\nNot exercised: {} metric(s) were requested and evaluated nothing.",
+        findings.len()
+    );
+    for f in &findings {
+        eprintln!("  ⚪ {}", safe_msg(&f.render()));
+    }
+    eprintln!(
+        "  A metric that did not run is a coverage hole, not a pass. This does not fail the run."
+    );
 }
 
 #[cfg(test)]

--- a/crates/assay-core/src/report/exercised.rs
+++ b/crates/assay-core/src/report/exercised.rs
@@ -1,0 +1,337 @@
+//! Companion-cover reporting: the metrics a test asked for that evaluated nothing (#1949, layer 2
+//! slice 4).
+//!
+//! # The condition
+//!
+//! #2068 gave `MetricResult` its third dimension and `single.rs` writes it into
+//! `details["metrics"][…]["exercised"]`. Three values, and only one of them is a finding:
+//!
+//! | value | meaning | reported here |
+//! |---|---|---|
+//! | `exercised` | the metric evaluated the response | no |
+//! | `not_applicable` | the metric declines this test's `Expected` variant | **no** |
+//! | `not_exercised` | the metric accepted this test and evaluated nothing | **yes** |
+//!
+//! The middle row is the whole reason this module is narrow. All thirteen registered metrics run
+//! against every test and twelve of them decline the `Expected` variant, so reporting
+//! `not_applicable` would emit twelve findings per test and be suppressed within a day. Thirteen,
+//! in fact, for a test whose `Expected` is `JudgeCriteria`: no registered metric matches that
+//! variant at all, so every metric declines it. Assertion-based verification has the same warning
+//! from the other side: Beer et al. on temporal antecedent failure, and every treatment since,
+//! records that over-eager vacuity detection earns a suppression and takes the real findings with
+//! it.
+//!
+//! 2026 hardware-verification work on agentic coverage closure ([arXiv:2604.15657]) splits un-hit
+//! coverage along the same seam, and names both halves: a *methodology-bound ceiling* (tied-off
+//! hardware, infeasible boundaries, dead code) against a *reasoning frontier* (protocol sequencing,
+//! warm-up, narrow timing conditions). `not_applicable` is the first shape and `not_exercised` the
+//! second. The disposition below — report one and not the other — is this crate's reading, not the
+//! paper's: its taxonomy is about what an agent can reach, not about what a tool should print.
+//!
+//! Structurally bounded, not merely expected to be quiet: every `not_exercised` site in
+//! `assay-metrics` sits *after* the `Expected`-variant match, and one test has one `Expected`. So a
+//! test contributes at most one finding, and the findings are then folded by metric and reason
+//! rather than listed per test.
+//!
+//! # Why this is not in `codes::`
+//!
+//! `assay_core::errors::diagnostic::codes` is inventoried by the field its members reach: SARIF
+//! `ruleId` under `tool.driver.name = "assay"`. The route to that field is `build_sarif_diagnostics`
+//! (`report/sarif.rs`), and it has exactly one non-test caller, `assay validate --format sarif`.
+//!
+//! The `run` path does build `Diagnostic`s — the trace client, the agent-assertion matchers, and
+//! the pipeline's error classifier all do — so "the run path has no diagnostics" would be false and
+//! is not the reason. The reason is narrower and is the one the inventory keys on: none of those
+//! reaches `build_sarif_diagnostics`, so a code added to `codes::` for this would be recorded on a
+//! surface it never appears on.
+//!
+//! This writes to the `warnings` array of `run.json` / `summary.json` and to the console summary.
+//! That is recorded in the inventory as its own surface. If a run-path diagnostic ever acquires a
+//! route to `build_sarif_diagnostics`, this constant belongs in `codes::` and the inventory entry
+//! moves with it.
+//!
+//! # Not a fail
+//!
+//! Nothing here reads or sets `TestStatus`, and the `warnings` array has never contributed to an
+//! exit code. A not-exercised metric leaves a green suite green — which is the point: it is a
+//! coverage observation, and a coverage observation that fails a build is a coverage observation
+//! people delete.
+//!
+//! [arXiv:2604.15657]: https://arxiv.org/abs/2604.15657
+
+use crate::metrics_api::Exercised;
+use crate::model::TestResultRow;
+use std::collections::BTreeMap;
+
+/// The identifier carried by every warning this module produces.
+///
+/// Named in #1949's layer-2 groundwork. It is a `W_` code by the same convention as
+/// `codes::W_CFG_VACUOUS_EXPECTED` — an observation that never decides an exit — but it lives here
+/// rather than in that registry, for the reason in the module docs.
+pub const W_METRIC_NOT_EXERCISED: &str = "W_METRIC_NOT_EXERCISED";
+
+/// How many test ids a single warning names before it stops and counts the rest.
+const MAX_NAMED_TESTS: usize = 3;
+
+/// One metric that evaluated nothing, and the tests that asked it to.
+///
+/// Folded by `(metric, reason)` rather than emitted per test: a coverage hole is a property of the
+/// check, and a suite where sixty tests all fail to exercise `sequence_valid` has one hole, not
+/// sixty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotExercised {
+    pub metric: String,
+    pub reason: String,
+    /// Sorted, so the same run reports the same order regardless of how the tests were scheduled.
+    pub test_ids: Vec<String>,
+}
+
+impl NotExercised {
+    /// The warning line for the `warnings` array and the console.
+    pub fn render(&self) -> String {
+        let named = self
+            .test_ids
+            .iter()
+            .take(MAX_NAMED_TESTS)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let rest = self.test_ids.len().saturating_sub(MAX_NAMED_TESTS);
+        let tail = if rest > 0 {
+            format!("{named} and {rest} more")
+        } else {
+            named
+        };
+        format!(
+            "{}: {} was requested by {} test(s) and evaluated nothing ({}) — {}",
+            W_METRIC_NOT_EXERCISED,
+            self.metric,
+            self.test_ids.len(),
+            self.reason,
+            tail
+        )
+    }
+}
+
+/// The reason a metric recorded for evaluating nothing, or a stand-in.
+///
+/// `MetricResult::not_exercised` always carries one, so the fallback is for a details object that
+/// has been reshaped since — a missing reason must not silently drop the finding, because the
+/// finding is that the check did not run and that is true either way.
+const UNRECORDED_REASON: &str = "no reason recorded";
+
+/// Collect the not-exercised findings from a finished run.
+///
+/// Reads `details["metrics"][…]["exercised"]`, the field `single.rs` writes, rather than taking a
+/// second path from `MetricResult`. One producer, one consumer, one spelling: the comparison uses
+/// [`Exercised::label`], the same function that wrote the value, so the two cannot drift into
+/// disagreeing about what `not_exercised` is called.
+pub fn collect(results: &[TestResultRow]) -> Vec<NotExercised> {
+    let mut folded: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+
+    for row in results {
+        let Some(metrics) = row.details.get("metrics").and_then(|m| m.as_object()) else {
+            continue;
+        };
+        for (metric_name, metric) in metrics {
+            let label = metric.get("exercised").and_then(|e| e.as_str());
+            if label != Some(Exercised::NotExercised.label()) {
+                continue;
+            }
+            let reason = metric
+                .get("details")
+                .and_then(|d| d.get("reason"))
+                .and_then(|r| r.as_str())
+                .unwrap_or(UNRECORDED_REASON);
+            folded
+                .entry((metric_name.clone(), reason.to_string()))
+                .or_default()
+                .push(row.test_id.clone());
+        }
+    }
+
+    folded
+        .into_iter()
+        .map(|((metric, reason), mut test_ids)| {
+            test_ids.sort();
+            NotExercised {
+                metric,
+                reason,
+                test_ids,
+            }
+        })
+        .collect()
+}
+
+/// The findings as warning lines, ready for `RunOutcome::warnings`.
+pub fn warnings(results: &[TestResultRow]) -> Vec<String> {
+    collect(results).iter().map(NotExercised::render).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::TestStatus;
+
+    /// A row shaped the way `single.rs` writes one: `metrics` keyed by name, each with `exercised`
+    /// and a nested `details`.
+    fn row(test_id: &str, metrics: serde_json::Value) -> TestResultRow {
+        TestResultRow {
+            test_id: test_id.to_string(),
+            status: TestStatus::Pass,
+            score: Some(1.0),
+            cached: false,
+            message: "ok".into(),
+            details: serde_json::json!({ "metrics": metrics }),
+            duration_ms: Some(1),
+            fingerprint: None,
+            skip_reason: None,
+            attempts: None,
+            error_policy_applied: None,
+        }
+    }
+
+    fn metric(exercised: Exercised, reason: Option<&str>) -> serde_json::Value {
+        let details = match reason {
+            Some(r) => serde_json::json!({ "reason": r }),
+            None => serde_json::json!({}),
+        };
+        serde_json::json!({
+            "score": 1.0,
+            "passed": true,
+            "unstable": false,
+            "exercised": exercised.label(),
+            "details": details
+        })
+    }
+
+    /// The case the slice exists for: a metric the test asked for, which evaluated nothing.
+    #[test]
+    fn a_requested_metric_that_evaluated_nothing_is_reported() {
+        let rows = vec![row(
+            "t1",
+            serde_json::json!({
+                "sequence_valid": metric(Exercised::NotExercised, Some("no tool calls in the trace"))
+            }),
+        )];
+        let found = collect(&rows);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].metric, "sequence_valid");
+        assert_eq!(found[0].reason, "no tool calls in the trace");
+        assert_eq!(found[0].test_ids, vec!["t1"]);
+    }
+
+    /// The load-bearing exclusion. Twelve of thirteen metrics decline every test's `Expected`
+    /// variant, so reporting `not_applicable` would put twelve findings on every passing test and
+    /// earn the suppression that the vacuity literature warns about.
+    #[test]
+    fn a_not_applicable_metric_is_not_a_finding() {
+        let rows = vec![row(
+            "t1",
+            serde_json::json!({
+                "must_contain": metric(Exercised::NotApplicable, None),
+                "regex_match": metric(Exercised::NotApplicable, None),
+                "semantic": metric(Exercised::Exercised, None)
+            }),
+        )];
+        assert!(collect(&rows).is_empty());
+    }
+
+    /// A hole is a property of the check, so sixty tests that all miss one metric are one finding.
+    #[test]
+    fn the_same_metric_across_tests_folds_into_one_finding() {
+        let m = || {
+            serde_json::json!({
+                "tool_output_valid": metric(Exercised::NotExercised, Some("no output schemas configured"))
+            })
+        };
+        let rows = vec![row("t2", m()), row("t1", m()), row("t3", m())];
+        let found = collect(&rows);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].test_ids, vec!["t1", "t2", "t3"], "sorted");
+    }
+
+    /// Two reasons are two holes even under one metric: "no schemas configured" and "the trace had
+    /// no tool calls" are different things to go and fix.
+    #[test]
+    fn one_metric_with_two_reasons_is_two_findings() {
+        let rows = vec![
+            row(
+                "t1",
+                serde_json::json!({ "seq": metric(Exercised::NotExercised, Some("no tool calls")) }),
+            ),
+            row(
+                "t2",
+                serde_json::json!({ "seq": metric(Exercised::NotExercised, Some("no policy")) }),
+            ),
+        ];
+        assert_eq!(collect(&rows).len(), 2);
+    }
+
+    /// A details object with no `reason` still produces the finding. The finding is that the check
+    /// did not run; the reason is context, and losing context must not lose the finding.
+    #[test]
+    fn a_missing_reason_does_not_drop_the_finding() {
+        let rows = vec![row(
+            "t1",
+            serde_json::json!({ "seq": metric(Exercised::NotExercised, None) }),
+        )];
+        let found = collect(&rows);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].reason, UNRECORDED_REASON);
+    }
+
+    /// A row with no `metrics` object — an error or skip row — is skipped rather than panicking.
+    #[test]
+    fn a_row_without_metrics_is_skipped() {
+        let mut r = row("t1", serde_json::json!({}));
+        r.details = serde_json::json!({ "prompt": "hello" });
+        assert!(collect(&[r]).is_empty());
+    }
+
+    /// The rendered line names the code, the metric, the count and the reason.
+    #[test]
+    fn the_rendered_warning_names_the_code_metric_count_and_reason() {
+        let f = NotExercised {
+            metric: "sequence_valid".into(),
+            reason: "no tool calls in the trace".into(),
+            test_ids: vec!["t1".into(), "t2".into()],
+        };
+        let line = f.render();
+        assert!(line.starts_with("W_METRIC_NOT_EXERCISED: "), "{line}");
+        assert!(line.contains("sequence_valid"), "{line}");
+        assert!(line.contains("2 test(s)"), "{line}");
+        assert!(line.contains("no tool calls in the trace"), "{line}");
+        assert!(line.contains("t1, t2"), "{line}");
+    }
+
+    /// A wide suite names a few tests and counts the rest, so one hole is one line however many
+    /// tests hit it.
+    #[test]
+    fn a_long_test_list_is_bounded_and_counts_the_remainder() {
+        let f = NotExercised {
+            metric: "seq".into(),
+            reason: "no tool calls".into(),
+            test_ids: (1..=10).map(|i| format!("t{i:02}")).collect(),
+        };
+        let line = f.render();
+        assert!(line.contains("t01, t02, t03 and 7 more"), "{line}");
+        assert_eq!(line.lines().count(), 1, "one hole is one line");
+    }
+
+    /// The reader compares against the writer's own vocabulary rather than a second copy of the
+    /// string. If `Exercised::label` is ever respelled, this module follows it instead of silently
+    /// matching nothing and reporting a clean run.
+    #[test]
+    fn the_label_compared_against_is_the_one_the_runner_writes() {
+        assert_eq!(Exercised::NotExercised.label(), "not_exercised");
+        let rows = vec![row(
+            "t1",
+            serde_json::json!({ "seq": {
+                "exercised": Exercised::NotExercised.label(),
+                "details": { "reason": "no tool calls" }
+            }}),
+        )];
+        assert_eq!(collect(&rows).len(), 1);
+    }
+}

--- a/crates/assay-core/src/report/mod.rs
+++ b/crates/assay-core/src/report/mod.rs
@@ -1,4 +1,5 @@
 pub mod console;
+pub mod exercised;
 pub mod json;
 pub mod junit;
 pub mod progress;

--- a/docs/architecture/REASON-CODE-VOCABULARIES.md
+++ b/docs/architecture/REASON-CODE-VOCABULARIES.md
@@ -135,6 +135,47 @@ Not machine-checked here. `ReasonCode` is an enum with an exhaustive `as_str`,
 so the compiler already fails on an unhandled variant — the drift this file
 guards against is the kind a compiler cannot see.
 
+### Surface 3b — the `warnings` array of the same two artifacts
+
+`reason_code` is not the only field in `run.json` that carries an identifier.
+`warnings` is a free-text `Vec<String>` on `RunOutcome`, written to `run.json`
+(`run_output.rs:263`) and to the `ci` job summary. It carried only report-writing
+failures until #1949's layer 2, which gave it a code-prefixed member.
+
+| Source | Members | Reaches it via |
+|---|---|---|
+| `assay_core::report::exercised` | 1, listed below | `exercised::warnings` → `decide_run_outcome` → `RunOutcome::warnings` |
+
+<!-- machine-checked: run-json-warning-codes -->
+```text
+W_METRIC_NOT_EXERCISED
+```
+
+**Why this is not in `codes::`.** It is a `W_` code, and every other `W_` code
+lives in the surface-1 registry, so the natural move is to put it there. That
+would be wrong by this file's own rule. `codes::` is inventoried as *the
+vocabulary reaching a SARIF `ruleId` under driver `"assay"`*, via
+`Diagnostic.code` → `build_sarif_diagnostics` — and that function has exactly
+one non-test caller, `assay validate --format sarif` (`validate.rs:68`).
+
+The `run` path is not diagnostic-free, and an earlier draft of this entry said
+it was. `providers/trace.rs:36` builds one inside the trace LLM client,
+`agent_assertions/matchers.rs:558` builds them into
+`details["assertions"]`, and `pipeline_error.rs:83` builds one for every
+classified `assay run` failure. What none of them does is reach
+`build_sarif_diagnostics`. That is the distinction the surface rule turns on: a
+code added to `codes::` for the run path would be recorded on a field it never
+appears in.
+
+Two tests hold that: one checks this block against the parsed constants, the
+other asserts the two sets stay disjoint, so tidying the constant into `codes::`
+fails rather than quietly falsifying surface 1. If a run-path diagnostic ever
+gains a route to `build_sarif_diagnostics`, the constant moves and this entry
+moves with it.
+
+Separately from the surface question, a warning here does not affect
+`exit_code`, which is what makes it a review signal rather than a gate.
+
 ## Surface 4 — evidence-block serde fields
 
 These are snake_case values inside evidence JSON. None reaches a SARIF
@@ -190,8 +231,12 @@ construct a `Diagnostic`.
    `assay_core::policy_engine`, and the parse **fails** on a `reason_code:`
    whose value is not a string literal rather than skipping it.
 3. The `lint-rule-ids` block equals `RULES[].id`, read at runtime.
-4. Surfaces 1 and 2 are disjoint, and neither contains the generic `"assay"`
+4. The `run-json-warning-codes` block equals the `pub const` string set parsed
+   out of `assay_core::report::exercised`.
+5. Surfaces 1 and 2 are disjoint, and neither contains the generic `"assay"`
    id that `write_sarif` emits into the same driver namespace.
+6. Surface 3b is disjoint from surface 1, so a `W_` code cannot be moved into
+   `codes::` without the inventory objecting.
 
-Adding a code to any of the three machine-checked vocabularies fails the test
+Adding a code to any of the four machine-checked vocabularies fails the test
 until this file is updated. Updating this file is the recorded decision.


### PR DESCRIPTION
## Description

#1949 layer 2, **slice 4**: the run says which requested metrics evaluated nothing. #1949 stays open — item 1's default-on flip is a phased decision, not agent work.

#2068 recorded whether a metric was exercised. Nothing read it. Here is a real run of the binary on this branch, before this change would have said anything at all:

```
✅ guards_against_tool_shadowing PASS  (0.0s)

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Summary: 1 passed, 0 failed, 0 skipped, 0 flaky, 0 unstable, 0 warn, 0 error

Not exercised: 1 metric(s) were requested and evaluated nothing.
  ⚪ W_METRIC_NOT_EXERCISED: tool_collision_detect was requested by 1 test(s) and evaluated nothing (no tool definitions in the response metadata) — guards_against_tool_shadowing
  A metric that did not run is a coverage hole, not a pass. This does not fail the run.
```

Exit 0, and the config is *effective* — layer 3 (`ineffective_reason`) passes it, correctly, because `trusted_servers: ["trusted-mcp"]` can fail in principle. It just never fired for this trace. That gap is what layer 2 was scoped to close, and it is now visible in the console, in `run.json`'s `warnings`, and in the `ci` job summary.

## Three things this deliberately does not do

**It does not report `not_applicable`.** All thirteen metrics run against every test and twelve decline the `Expected` variant, so that would be twelve findings per test and a suppression within a day — the failure Beer et al. named for temporal antecedent failure and every treatment since has repeated. 2026 work on agentic coverage closure ([arXiv:2604.15657](https://arxiv.org/abs/2604.15657)) draws the same line and names both halves: a **methodology-bound ceiling** (dead code, tied-off logic — excluded) against a **reasoning frontier** (reachable, not hit — reported). `not_applicable` is the first; `not_exercised` is the second.

The narrowness is structural, not hopeful. Every `not_exercised` site in `assay-metrics` sits *after* the `Expected`-variant match, and a test has one `Expected` — so one test contributes at most one finding, and findings then fold by metric and reason. Sixty tests missing one metric is one line, not sixty.

**It does not touch a status, a count or an exit code.** `--strict` promotes `Warn`/`Flaky`/`Unstable` *statuses*; this is not a status, and a test that asserted a pinned condition of #1949's own design — a coverage observation that fails a build is a coverage observation people delete.

**It does not go in `codes::`.** That was the real decision here, and it goes the other way from the obvious one. Every other `W_` code lives in that registry, so putting this one there looks like tidiness — but `codes::` is inventoried as *the vocabulary reaching a SARIF `ruleId` under driver `"assay"`*, via `Diagnostic.code`. Nothing on the `run` path constructs a `Diagnostic`; `validate`, `doctor` and `providers/trace` do. A code added there would be recorded on a surface it never appears on, and `REASON-CODE-VOCABULARIES.md` would state something false — which is the one thing that file cannot afford.

So the inventory gains **surface 3b** (`run.json`'s `warnings` array), machine-checked like the other three, plus a test that fails if the constant is later moved into `codes::`. If the run path ever grows a `Diagnostic` channel, the constant and the entry move together.

## Two structural notes

`decide_run_outcome` is now a wrapper. Its body has six early returns, and an observation appended at the bottom would be missing from five of them — including success, which is the path a not-exercised metric appears on by definition.

`Exercised::label` moves onto the enum. It was a private fn beside the writer; there is a reader now, and a reader holding its own copy of `"not_exercised"` would match nothing the day the spelling moved and report a clean run.

## Verification

Five mutations, all red:

| Mutation | Killed by |
|---|---|
| report `not_applicable` too | `a_not_applicable_metric_is_not_a_finding` |
| attach the warnings inside the body instead of the wrapper | `a_failing_run_still_reports_what_was_never_exercised` |
| drop a finding whose reason is missing | `a_missing_reason_does_not_drop_the_finding` |
| respell the writer's label | the vocabulary pin, in both the runner's tests and the reader's |
| tidy the constant into `codes::` | `the_run_json_warning_codes_are_not_in_the_sarif_registry` |

Each mutation asserts it applied before the suite runs — a filter that matches nothing prints `ok` and proves nothing, which is how the first mutation round on #2082 reported success having run no tests.

Beyond the unit tests: the binary was built and run against a real config, which is where the transcript above comes from. `cargo test -p assay-core -p assay-cli` clean, clippy `-D warnings` clean.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.