### PR TITLE
The guard held because the agent never had the tool

### DIFF
--- a/crates/assay-cli/tests/reason_code_vocabularies.rs
+++ b/crates/assay-cli/tests/reason_code_vocabularies.rs
@@ -146,6 +146,17 @@ fn string_literal(s: &str) -> Option<String> {
 /// for the same reason: a second `pub const` added beside the first would otherwise reach a
 /// published artifact with nothing recording it.
 fn run_json_warning_codes() -> BTreeSet<String> {
+    // `pub const` strings in that module that are deliberately not codes.
+    //
+    // An allow-list rather than a pattern-only filter. A pattern alone ("looks like `W_…`") would
+    // let a code with an unforeseen prefix slip past unrecorded, which is the exact drift this file
+    // exists to catch. So every `pub const` string must be either a recorded code or named here.
+    const NOT_A_CODE: &[&str] = &[
+        // A `details` key, not a vocabulary member: it names the field the runner writes assertion
+        // covers to, and it never appears in the `warnings` array.
+        "assertions_not_exercised",
+    ];
+
     let src = read("crates/assay-core/src/report/exercised.rs");
     let mut found = BTreeSet::new();
     for line in src.lines() {
@@ -156,14 +167,18 @@ fn run_json_warning_codes() -> BTreeSet<String> {
         let Some((_, value)) = rest.split_once('=') else {
             continue;
         };
-        // Only string-valued constants are codes. A numeric bound is not a vocabulary member, and
-        // treating one as a missing entry would make this check noise.
-        if let Some(value) = string_literal(value) {
-            assert!(
-                found.insert(value.clone()),
-                "duplicate warning code value {value:?}"
-            );
+        // Only string-valued constants can be codes. A numeric bound is not a vocabulary member,
+        // and treating one as a missing entry would make this check noise.
+        let Some(value) = string_literal(value) else {
+            continue;
+        };
+        if NOT_A_CODE.contains(&value.as_str()) {
+            continue;
         }
+        assert!(
+            found.insert(value.clone()),
+            "duplicate warning code value {value:?}"
+        );
     }
     assert!(
         !found.is_empty(),

--- a/crates/assay-core/src/agent_assertions/cover.rs
+++ b/crates/assay-core/src/agent_assertions/cover.rs
@@ -1,0 +1,404 @@
+//! The companion cover for trace assertions (#1949, layer 2, the assertion half).
+//!
+//! # The case this exists for
+//!
+//! `matchers::check_one` returns `Option<Diagnostic>`: `Some` is a failure, `None` is a pass. A
+//! pass therefore says nothing about whether anything was checked, and for one variant that gap is
+//! the whole issue:
+//!
+//! ```yaml
+//! assertions:
+//!   - type: trace_must_not_call_tool
+//!     tool: delete_repository
+//! ```
+//!
+//! If the agent was never offered `delete_repository`, this holds on every trace forever. It is
+//! syntactically perfect, it is *config*-effective — layer 3's `ineffective_reason` passes it
+//! correctly, because a trace that called the tool would fail it — and it has never once
+//! constrained the agent. #1949's groundwork named it the headline case, and it is the one thing
+//! neither the static sweep nor the metric-side cover (#2083) could reach: assertions produce
+//! `Diagnostic`s, not `MetricResult`s, so they have no `exercised` dimension to carry.
+//!
+//! # The antecedent is availability, not absence
+//!
+//! The naive signal — "the tool was never called" — is the assertion's own passing condition, so
+//! reporting it would fire on every `trace_must_not_call_tool` that holds. That is the over-eager
+//! detection Beer et al. warn about, and it would be suppressed immediately and deservedly.
+//!
+//! The signal is whether the tool was ever **available** to the agent:
+//!
+//! | the agent | verdict |
+//! |---|---|
+//! | had the tool and did not call it | exercised. A real pass, and the assertion earned it. |
+//! | never had the tool | not exercised. No trace could have failed this. |
+//! | availability unrecorded | **nothing is reported.** |
+//!
+//! The third row is what makes this safe to turn on. Availability comes from
+//! `meta["tool_definitions"]`, which many traces do not carry; treating "no record" as "no tool"
+//! would put a finding on every `trace_must_not_call_tool` in every suite that replays a plain
+//! trace. Absence of evidence is not evidence of absence, and the asymmetry is the same one
+//! `coverage_regressed` uses for a baseline that predates its dimension (#2082).
+//!
+//! Tools that were *called* count as available even when no definition list was recorded: a call
+//! is proof of availability, and it is proof that does not depend on the producer having written
+//! the metadata.
+//!
+//! # What this deliberately does not claim
+//!
+//! Availability is a weaker fact than opportunity. An agent may hold a tool that no reachable state
+//! would ever prompt it to use, and this reports that as exercised. Trajectory evaluation has the
+//! general form of that limit: a single rollout "rules out only one realized path"
+//! ([DiagEval, arXiv:2605.17439]), so no per-run signal settles what the agent *could* have done.
+//! What this catches is the case that needs no counterfactual at all — the tool was not on the
+//! table.
+//!
+//! [DiagEval, arXiv:2605.17439]: https://arxiv.org/abs/2605.17439
+
+use super::model::TraceAssertion;
+use super::EpisodeGraph;
+
+/// The tools an agent could have called during an episode.
+///
+/// `declared` is `None` when nothing recorded a tool list. That is *unknown*, not *empty*, and
+/// every method here keeps the two apart — an empty declared list means "the agent was offered no
+/// tools", which is a real and reportable fact.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolAvailability {
+    declared: Option<Vec<String>>,
+    called: Vec<String>,
+}
+
+impl ToolAvailability {
+    /// Read what an episode and its response say about which tools existed.
+    ///
+    /// `meta["tool_definitions"]` is the same field `tool_collision_detect` and
+    /// `tool_description_integrity` read, spelled once here so the three cannot disagree about
+    /// where a tool list lives.
+    pub fn observe(meta: &serde_json::Value, graph: &EpisodeGraph) -> Self {
+        let declared = meta
+            .get("tool_definitions")
+            .and_then(|v| v.as_array())
+            .map(|defs| {
+                defs.iter()
+                    .filter_map(|d| d.get("name").and_then(|n| n.as_str()))
+                    .map(str::to_owned)
+                    .collect()
+            });
+        let called = graph
+            .tool_calls
+            .iter()
+            .filter_map(|t| t.tool_name.clone())
+            .collect();
+        Self { declared, called }
+    }
+
+    /// Whether `tool` was available: `None` when nothing recorded enough to say.
+    ///
+    /// A tri-state on purpose. Collapsing the unknown case into `false` is precisely the mistake
+    /// that would make this check noise.
+    fn was_available(&self, tool: &str) -> Option<bool> {
+        if self.called.iter().any(|c| c == tool) {
+            // It was called, so it existed. True regardless of what was declared, and true even
+            // when nothing was declared.
+            return Some(true);
+        }
+        let declared = self.declared.as_ref()?;
+        Some(declared.iter().any(|d| d == tool))
+    }
+}
+
+/// One assertion that could not have failed for this run, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssertionCover {
+    /// The assertion's `type:` tag, as written in the config.
+    pub assertion: String,
+    pub reason: String,
+}
+
+/// The `type:` tag for an assertion, matching the serde rename in [`TraceAssertion`].
+fn tag(a: &TraceAssertion) -> &'static str {
+    match a {
+        TraceAssertion::TraceMustCallTool { .. } => "trace_must_call_tool",
+        TraceAssertion::TraceMustNotCallTool { .. } => "trace_must_not_call_tool",
+        TraceAssertion::TraceToolSequence { .. } => "trace_tool_sequence",
+        TraceAssertion::TraceMaxSteps { .. } => "trace_max_steps",
+        TraceAssertion::ArgsValid { .. } => "args_valid",
+        TraceAssertion::SequenceValid { .. } => "sequence_valid",
+        TraceAssertion::ToolBlocklist { .. } => "tool_blocklist",
+    }
+}
+
+/// Why this assertion could not have failed for this run, or `None` if it was genuinely exercised.
+///
+/// Separate from `check_one` rather than folded into it, and that is not an accident of
+/// convenience. "Did this fail" and "was this exercised" are orthogonal questions — the reason
+/// `Exercised` is a dimension on `MetricResult` rather than a fourth status. Folding the cover into
+/// `check_one` would also disturb `ineffective_reason`, which runs `check_one` against an empty
+/// episode and keeps the config-decided codes; a cover that fired on that empty episode would be
+/// indistinguishable from a static verdict and the sweep would start rejecting working configs.
+///
+/// Only two variants can be vacuous at runtime, and the rest are listed here rather than caught by
+/// a `_` arm so that a new variant has to be considered:
+///
+/// - `trace_must_call_tool` compares a count against a minimum on every trace, and a trace with no
+///   calls **fails** it. Its antecedent always fires.
+/// - `trace_tool_sequence` likewise: an empty actual sequence fails both the subsequence and the
+///   exact form.
+/// - `args_valid`, `sequence_valid` and `tool_blocklist` evaluate `test_*` fixtures and never read
+///   the graph, so a run cannot leave them unexercised. Without those fixtures they check nothing
+///   at all, which layer 3 already refuses at config time.
+pub fn not_exercised(
+    graph: &EpisodeGraph,
+    tools: &ToolAvailability,
+    a: &TraceAssertion,
+) -> Option<AssertionCover> {
+    let reason = match a {
+        TraceAssertion::TraceMustNotCallTool { tool } => {
+            // `Some(false)` only. `None` is "nothing recorded a tool list", which is not evidence
+            // that the tool was missing.
+            if tools.was_available(tool) == Some(false) {
+                Some(format!(
+                    "the agent was never offered `{tool}`, so no trace could have called it"
+                ))
+            } else {
+                None
+            }
+        }
+        TraceAssertion::TraceMaxSteps { .. } => {
+            // A step ceiling against an episode with no steps compared a budget to nothing. The
+            // assertion is fine; the run had nothing to hold it against.
+            if graph.steps.is_empty() {
+                Some("the episode recorded no steps, so the ceiling was never approached".into())
+            } else {
+                None
+            }
+        }
+        TraceAssertion::TraceMustCallTool { .. }
+        | TraceAssertion::TraceToolSequence { .. }
+        | TraceAssertion::ArgsValid { .. }
+        | TraceAssertion::SequenceValid { .. }
+        | TraceAssertion::ToolBlocklist { .. } => None,
+    }?;
+
+    Some(AssertionCover {
+        assertion: tag(a).to_string(),
+        reason,
+    })
+}
+
+/// The covers for a whole assertion list.
+pub fn evaluate_cover(
+    graph: &EpisodeGraph,
+    tools: &ToolAvailability,
+    assertions: &[TraceAssertion],
+) -> Vec<AssertionCover> {
+    assertions
+        .iter()
+        .filter_map(|a| not_exercised(graph, tools, a))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::rows::{StepRow, ToolCallRow};
+
+    fn call(tool: &str) -> ToolCallRow {
+        ToolCallRow {
+            id: 1,
+            step_id: "s1".into(),
+            episode_id: "e1".into(),
+            tool_name: Some(tool.into()),
+            call_index: Some(0),
+            args: None,
+            result: None,
+        }
+    }
+
+    fn step() -> StepRow {
+        StepRow {
+            id: "s1".into(),
+            episode_id: "e1".into(),
+            idx: 0,
+            kind: Some("assistant".into()),
+            name: None,
+            content: None,
+        }
+    }
+
+    fn graph(steps: Vec<StepRow>, calls: Vec<ToolCallRow>) -> EpisodeGraph {
+        EpisodeGraph {
+            episode_id: "e1".into(),
+            steps,
+            tool_calls: calls,
+        }
+    }
+
+    fn defs(names: &[&str]) -> serde_json::Value {
+        serde_json::json!({
+            "tool_definitions": names.iter().map(|n| serde_json::json!({"name": n})).collect::<Vec<_>>()
+        })
+    }
+
+    fn must_not_call(tool: &str) -> TraceAssertion {
+        TraceAssertion::TraceMustNotCallTool { tool: tool.into() }
+    }
+
+    /// The headline case: the agent was never offered the tool, so the guard never guarded.
+    #[test]
+    fn a_guard_against_a_tool_the_agent_never_had_is_not_exercised() {
+        let g = graph(vec![step()], vec![call("read_file")]);
+        let tools = ToolAvailability::observe(&defs(&["read_file", "list_dir"]), &g);
+        let cover = not_exercised(&g, &tools, &must_not_call("delete_repository")).unwrap();
+        assert_eq!(cover.assertion, "trace_must_not_call_tool");
+        assert!(cover.reason.contains("never offered"), "{}", cover.reason);
+    }
+
+    /// The pass that was earned: the tool was on the table and the agent left it alone. Reporting
+    /// this would fire on every working guard, which is the whole failure mode to avoid.
+    #[test]
+    fn a_guard_against_an_available_tool_the_agent_declined_is_exercised() {
+        let g = graph(vec![step()], vec![call("read_file")]);
+        let tools = ToolAvailability::observe(&defs(&["read_file", "delete_repository"]), &g);
+        assert_eq!(
+            not_exercised(&g, &tools, &must_not_call("delete_repository")),
+            None
+        );
+    }
+
+    /// No tool list recorded is *unknown*, never *absent*. Without this, every suite replaying a
+    /// plain trace would get a finding on every guard it has.
+    #[test]
+    fn an_unrecorded_tool_list_reports_nothing() {
+        let g = graph(vec![step()], vec![call("read_file")]);
+        let tools = ToolAvailability::observe(&serde_json::json!({}), &g);
+        assert_eq!(
+            not_exercised(&g, &tools, &must_not_call("delete_repository")),
+            None
+        );
+        assert_eq!(
+            tools.was_available("delete_repository"),
+            None,
+            "unknown, not false"
+        );
+    }
+
+    /// A tool that was called is available even when nothing declared it: the call is the proof,
+    /// and it does not depend on the producer writing the metadata.
+    #[test]
+    fn a_called_tool_counts_as_available_without_a_declaration() {
+        let g = graph(vec![step()], vec![call("delete_repository")]);
+        let tools = ToolAvailability::observe(&serde_json::json!({}), &g);
+        assert_eq!(tools.was_available("delete_repository"), Some(true));
+        assert_eq!(
+            not_exercised(&g, &tools, &must_not_call("delete_repository")),
+            None
+        );
+    }
+
+    /// A recorded but empty tool list is a real fact — the agent was offered nothing — and is not
+    /// the unknown case.
+    #[test]
+    fn an_empty_declared_list_is_evidence_and_reports() {
+        let g = graph(vec![step()], vec![]);
+        let tools = ToolAvailability::observe(&defs(&[]), &g);
+        assert_eq!(tools.was_available("anything"), Some(false));
+        assert!(not_exercised(&g, &tools, &must_not_call("anything")).is_some());
+    }
+
+    #[test]
+    fn a_step_ceiling_against_an_empty_episode_is_not_exercised() {
+        let g = graph(vec![], vec![]);
+        let tools = ToolAvailability::observe(&serde_json::json!({}), &g);
+        let cover = not_exercised(&g, &tools, &TraceAssertion::TraceMaxSteps { max: 10 }).unwrap();
+        assert!(cover.reason.contains("no steps"), "{}", cover.reason);
+
+        let with_steps = graph(vec![step()], vec![]);
+        assert_eq!(
+            not_exercised(
+                &with_steps,
+                &tools,
+                &TraceAssertion::TraceMaxSteps { max: 10 }
+            ),
+            None
+        );
+    }
+
+    /// `trace_must_call_tool` FAILS on an empty trace, so it is never unexercised. Pinned because
+    /// the intuition "no tool calls means nothing was checked" is wrong here, and acting on it
+    /// would report a finding alongside a failure that already says more.
+    #[test]
+    fn a_must_call_assertion_is_never_reported_as_unexercised() {
+        let g = graph(vec![], vec![]);
+        let tools = ToolAvailability::observe(&serde_json::json!({}), &g);
+        assert_eq!(
+            not_exercised(
+                &g,
+                &tools,
+                &TraceAssertion::TraceMustCallTool {
+                    tool: "read_file".into(),
+                    min_calls: Some(1)
+                }
+            ),
+            None
+        );
+    }
+
+    /// The fixture-driven variants never read the graph, so a run cannot leave them unexercised.
+    #[test]
+    fn fixture_driven_variants_are_never_reported() {
+        let g = graph(vec![], vec![]);
+        let tools = ToolAvailability::observe(&serde_json::json!({}), &g);
+        let fixtures = [
+            TraceAssertion::ArgsValid {
+                tool: "t".into(),
+                test_args: Some(serde_json::json!({})),
+                policy: Some(serde_json::json!({})),
+                expect: None,
+            },
+            TraceAssertion::SequenceValid {
+                test_trace: None,
+                test_trace_raw: Some(vec![]),
+                policy: Some(serde_json::json!({})),
+                expect: None,
+            },
+            TraceAssertion::ToolBlocklist {
+                test_tool_calls: Some(vec![]),
+                policy: Some(serde_json::json!({})),
+                expect: None,
+            },
+        ];
+        for a in &fixtures {
+            assert_eq!(not_exercised(&g, &tools, a), None, "{}", tag(a));
+        }
+    }
+
+    /// The tags match the serde renames, so a config author reads back the word they wrote.
+    #[test]
+    fn the_tags_match_the_config_vocabulary() {
+        let yaml = "type: trace_must_not_call_tool\ntool: x\n";
+        let a: TraceAssertion = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(tag(&a), "trace_must_not_call_tool");
+    }
+
+    #[test]
+    fn evaluate_cover_collects_each_unexercised_assertion() {
+        let g = graph(vec![], vec![]);
+        let tools = ToolAvailability::observe(&defs(&["read_file"]), &g);
+        let covers = evaluate_cover(
+            &g,
+            &tools,
+            &[
+                must_not_call("delete_repository"),
+                TraceAssertion::TraceMaxSteps { max: 5 },
+                TraceAssertion::TraceMustCallTool {
+                    tool: "read_file".into(),
+                    min_calls: Some(1),
+                },
+            ],
+        );
+        assert_eq!(covers.len(), 2);
+        assert_eq!(covers[0].assertion, "trace_must_not_call_tool");
+        assert_eq!(covers[1].assertion, "trace_max_steps");
+    }
+}

--- a/crates/assay-core/src/agent_assertions/mod.rs
+++ b/crates/assay-core/src/agent_assertions/mod.rs
@@ -1,3 +1,4 @@
+pub mod cover;
 pub mod matchers;
 pub mod model;
 
@@ -10,15 +11,53 @@ pub struct EpisodeGraph {
     pub tool_calls: Vec<crate::storage::rows::ToolCallRow>,
 }
 
+/// The failures, and the assertions that could not have failed.
+///
+/// Two lists rather than one: a diagnostic says a check did not hold, a cover says a check was
+/// never put to the test. Folding the second into the first would make a coverage observation
+/// fail a build, which is the thing #1949's own design forbids.
+pub struct AssertionOutcome {
+    pub diagnostics: Vec<Diagnostic>,
+    pub not_exercised: Vec<cover::AssertionCover>,
+}
+
+/// The failures alone, for callers with no response to hand.
+///
+/// Delegates rather than duplicating: one evaluation, two entry points. `meta` is `Null`, so the
+/// companion cover sees no declared tool list and — by the asymmetry in [`cover`] — reports
+/// nothing. That is the correct answer for a caller that cannot supply the metadata, and it is
+/// why this shortcut is safe to keep for the assertion tests and the published API.
+///
+/// A production caller that has an `LlmResponse` should use [`verify_assertions_with_meta`]; this
+/// one silently has no coverage signal to give.
 pub fn verify_assertions(
     store: &Store,
     run_id: i64,
     test_id: &str,
     assertions: &[model::TraceAssertion],
 ) -> anyhow::Result<Vec<Diagnostic>> {
+    verify_assertions_with_meta(store, run_id, test_id, assertions, &serde_json::Value::Null)
+        .map(|o| o.diagnostics)
+}
+
+pub fn verify_assertions_with_meta(
+    store: &Store,
+    run_id: i64,
+    test_id: &str,
+    assertions: &[model::TraceAssertion],
+    meta: &serde_json::Value,
+) -> anyhow::Result<AssertionOutcome> {
+    let finish = |graph: &EpisodeGraph| -> anyhow::Result<AssertionOutcome> {
+        let tools = cover::ToolAvailability::observe(meta, graph);
+        Ok(AssertionOutcome {
+            diagnostics: matchers::evaluate(graph, assertions)?,
+            not_exercised: cover::evaluate_cover(graph, &tools, assertions),
+        })
+    };
+
     let graph_res = store.get_episode_graph(run_id, test_id);
     match graph_res {
-        Ok(graph) => matchers::evaluate(&graph, assertions),
+        Ok(graph) => finish(&graph),
         Err(e) => {
             // FALLBACK 1: Unit Test Mode (Policy Validation)
             // If assertions have explicit `test_args`, `test_trace`, etc., we don't need a real episode.
@@ -47,7 +86,7 @@ pub fn verify_assertions(
                     steps: vec![],
                     tool_calls: vec![],
                 };
-                return matchers::evaluate(&dummy, assertions);
+                return finish(&dummy);
             }
 
             // FALLBACK 2 (PR-406): If no episode found for this run_id,
@@ -55,7 +94,7 @@ pub fn verify_assertions(
             // This supports the "Demo Flow": Record -> Ingest (Run A) -> Verify (Run B)
             if e.to_string().contains("E_TRACE_EPISODE_MISSING") {
                 match store.get_latest_episode_graph_by_test_id(test_id) {
-                    Ok(latest_graph) => return matchers::evaluate(&latest_graph, assertions),
+                    Ok(latest_graph) => return finish(&latest_graph),
                     Err(fallback_err) => {
                         return Err(anyhow::anyhow!("E_TRACE_EPISODE_MISSING: Primary query failed ({}), Fallback failed: {}", e, fallback_err));
                     }

--- a/crates/assay-core/src/engine/runner.rs
+++ b/crates/assay-core/src/engine/runner.rs
@@ -59,9 +59,10 @@ impl Runner {
         &self,
         run_id: i64,
         tc: &TestCase,
+        resp: &crate::model::LlmResponse,
         final_row: &mut TestResultRow,
     ) -> anyhow::Result<()> {
-        runner_next::assertions::apply_agent_assertions_impl(self, run_id, tc, final_row)
+        runner_next::assertions::apply_agent_assertions_impl(self, run_id, tc, resp, final_row)
     }
 
     async fn run_test_once(

--- a/crates/assay-core/src/engine/runner_next/assertions.rs
+++ b/crates/assay-core/src/engine/runner_next/assertions.rs
@@ -1,21 +1,44 @@
 use super::super::Runner;
-use crate::model::{TestCase, TestResultRow, TestStatus};
+use crate::model::{LlmResponse, TestCase, TestResultRow, TestStatus};
+
+use crate::report::exercised::ASSERTIONS_NOT_EXERCISED;
 
 pub(crate) fn apply_agent_assertions_impl(
     runner: &Runner,
     run_id: i64,
     tc: &TestCase,
+    resp: &LlmResponse,
     final_row: &mut TestResultRow,
 ) -> anyhow::Result<()> {
     if let Some(assertions) = &tc.assertions {
         if !assertions.is_empty() {
-            match crate::agent_assertions::verify_assertions(
+            match crate::agent_assertions::verify_assertions_with_meta(
                 &runner.store,
                 run_id,
                 &tc.id,
                 assertions,
+                &resp.meta,
             ) {
-                Ok(diags) => {
+                Ok(outcome) => {
+                    // Recorded before the pass/fail branch below, so a test that both failed one
+                    // assertion and never exercised another reports both. The failure is the
+                    // louder finding; it is not the only one.
+                    if !outcome.not_exercised.is_empty() {
+                        final_row.details[ASSERTIONS_NOT_EXERCISED] = serde_json::Value::Array(
+                            outcome
+                                .not_exercised
+                                .iter()
+                                .map(|c| {
+                                    serde_json::json!({
+                                        "assertion": c.assertion,
+                                        "reason": c.reason,
+                                    })
+                                })
+                                .collect(),
+                        );
+                    }
+
+                    let diags = outcome.diagnostics;
                     if !diags.is_empty() {
                         final_row.status = TestStatus::Fail;
 

--- a/crates/assay-core/src/engine/runner_next/execute.rs
+++ b/crates/assay-core/src/engine/runner_next/execute.rs
@@ -161,7 +161,7 @@ pub(crate) async fn run_test_with_policy_impl(
     let output = last_output.unwrap_or_else(|| empty_output_for_model_impl(runner, cfg));
 
     final_row.attempts = Some(attempts.clone());
-    runner.apply_agent_assertions(run_id, tc, &mut final_row)?;
+    runner.apply_agent_assertions(run_id, tc, &output, &mut final_row)?;
 
     runner
         .store

--- a/crates/assay-core/src/report/console.rs
+++ b/crates/assay-core/src/report/console.rs
@@ -286,14 +286,14 @@ fn print_not_exercised(results: &[TestResultRow]) {
         return;
     }
     eprintln!(
-        "\nNot exercised: {} metric(s) were requested and evaluated nothing.",
+        "\nNot exercised: {} check(s) were requested and evaluated nothing.",
         findings.len()
     );
     for f in &findings {
         eprintln!("  ⚪ {}", safe_msg(&f.render()));
     }
     eprintln!(
-        "  A metric that did not run is a coverage hole, not a pass. This does not fail the run."
+        "  A check that did not run is a coverage hole, not a pass. This does not fail the run."
     );
 }
 

--- a/crates/assay-core/src/report/exercised.rs
+++ b/crates/assay-core/src/report/exercised.rs
@@ -1,5 +1,13 @@
-//! Companion-cover reporting: the metrics a test asked for that evaluated nothing (#1949, layer 2
-//! slice 4).
+//! Companion-cover reporting: the checks a test asked for that evaluated nothing (#1949, layer 2).
+//!
+//! Two config surfaces reach this, and they are found by different means:
+//!
+//! - **`expected:`** — a metric declares its own `Exercised` value and `single.rs` writes it into
+//!   `details["metrics"][…]["exercised"]`. Read here.
+//! - **`assertions:`** — an assertion has no such dimension to declare, because
+//!   `matchers::check_one` returns `Option<Diagnostic>` where `None` is a pass. A separate cover in
+//!   `agent_assertions::cover` judges it, and the runner writes the verdict to
+//!   [`ASSERTIONS_NOT_EXERCISED`]. Read here too, and folded into the same output.
 //!
 //! # The condition
 //!
@@ -70,17 +78,58 @@ use std::collections::BTreeMap;
 /// rather than in that registry, for the reason in the module docs.
 pub const W_METRIC_NOT_EXERCISED: &str = "W_METRIC_NOT_EXERCISED";
 
+/// The same observation for the `assertions:` surface.
+///
+/// A separate code rather than a broader spelling of the first. The two are found differently — a
+/// metric declares its own `exercised` value, an assertion is judged by a companion cover in
+/// `agent_assertions::cover` — and they name different things in a config. A reader filtering their
+/// CI log for one should not silently get the other.
+pub const W_ASSERTION_NOT_EXERCISED: &str = "W_ASSERTION_NOT_EXERCISED";
+
+/// The `details` key the runner writes assertion covers to, and this module reads back.
+///
+/// Beside `details["assertions"]` rather than inside it, because that field already holds two
+/// different shapes — an array of diagnostics when something failed, `{"passed": true}` when
+/// nothing did — and a reader that had to branch on which one it got would break the first time a
+/// third shape appeared.
+///
+/// Declared here, in the reader, and imported by the writer. The other way round is not reachable:
+/// `engine::runner_next` is private to its parent, and a second copy of the string in this module
+/// would be a reader that silently stops finding anything the day the writer's spelling changes.
+pub const ASSERTIONS_NOT_EXERCISED: &str = "assertions_not_exercised";
+
 /// How many test ids a single warning names before it stops and counts the rest.
 const MAX_NAMED_TESTS: usize = 3;
 
-/// One metric that evaluated nothing, and the tests that asked it to.
+/// Which config surface a finding came from.
 ///
-/// Folded by `(metric, reason)` rather than emitted per test: a coverage hole is a property of the
-/// check, and a suite where sixty tests all fail to exercise `sequence_valid` has one hole, not
-/// sixty.
+/// Carried rather than inferred from the name: `sequence_valid` is both a metric under `expected:`
+/// and an assertion under `assertions:`, so the string alone cannot say which was meant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Surface {
+    Metric,
+    Assertion,
+}
+
+impl Surface {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Metric => W_METRIC_NOT_EXERCISED,
+            Self::Assertion => W_ASSERTION_NOT_EXERCISED,
+        }
+    }
+}
+
+/// One check that evaluated nothing, and the tests that asked for it.
+///
+/// Folded by `(surface, check, reason)` rather than emitted per test: a coverage hole is a property
+/// of the check, and a suite where sixty tests all fail to exercise `sequence_valid` has one hole,
+/// not sixty.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NotExercised {
-    pub metric: String,
+    pub surface: Surface,
+    /// The metric's name, or the assertion's `type:` tag.
+    pub check: String,
     pub reason: String,
     /// Sorted, so the same run reports the same order regardless of how the tests were scheduled.
     pub test_ids: Vec<String>,
@@ -104,8 +153,8 @@ impl NotExercised {
         };
         format!(
             "{}: {} was requested by {} test(s) and evaluated nothing ({}) — {}",
-            W_METRIC_NOT_EXERCISED,
-            self.metric,
+            self.surface.code(),
+            self.check,
             self.test_ids.len(),
             self.reason,
             tail
@@ -120,31 +169,53 @@ impl NotExercised {
 /// finding is that the check did not run and that is true either way.
 const UNRECORDED_REASON: &str = "no reason recorded";
 
-/// Collect the not-exercised findings from a finished run.
+/// Collect the not-exercised findings from a finished run, across both config surfaces.
 ///
-/// Reads `details["metrics"][…]["exercised"]`, the field `single.rs` writes, rather than taking a
-/// second path from `MetricResult`. One producer, one consumer, one spelling: the comparison uses
-/// [`Exercised::label`], the same function that wrote the value, so the two cannot drift into
-/// disagreeing about what `not_exercised` is called.
+/// Reads the fields the runner writes — `details["metrics"][…]["exercised"]` from `single.rs` and
+/// `details["assertions_not_exercised"]` from `runner_next::assertions` — rather than taking a
+/// second path from `MetricResult` or re-running the cover. One producer, one consumer, one
+/// spelling: the metric comparison uses [`Exercised::label`], the same function that wrote the
+/// value, so the two cannot drift into disagreeing about what `not_exercised` is called.
 pub fn collect(results: &[TestResultRow]) -> Vec<NotExercised> {
-    let mut folded: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+    let mut folded: BTreeMap<(Surface, String, String), Vec<String>> = BTreeMap::new();
 
     for row in results {
-        let Some(metrics) = row.details.get("metrics").and_then(|m| m.as_object()) else {
-            continue;
-        };
-        for (metric_name, metric) in metrics {
-            let label = metric.get("exercised").and_then(|e| e.as_str());
-            if label != Some(Exercised::NotExercised.label()) {
-                continue;
+        if let Some(metrics) = row.details.get("metrics").and_then(|m| m.as_object()) {
+            for (metric_name, metric) in metrics {
+                let label = metric.get("exercised").and_then(|e| e.as_str());
+                if label != Some(Exercised::NotExercised.label()) {
+                    continue;
+                }
+                let reason = metric
+                    .get("details")
+                    .and_then(|d| d.get("reason"))
+                    .and_then(|r| r.as_str())
+                    .unwrap_or(UNRECORDED_REASON);
+                folded
+                    .entry((Surface::Metric, metric_name.clone(), reason.to_string()))
+                    .or_default()
+                    .push(row.test_id.clone());
             }
-            let reason = metric
-                .get("details")
-                .and_then(|d| d.get("reason"))
+        }
+
+        let covers = row
+            .details
+            .get(ASSERTIONS_NOT_EXERCISED)
+            .and_then(|c| c.as_array());
+        for cover in covers.into_iter().flatten() {
+            let Some(assertion) = cover.get("assertion").and_then(|a| a.as_str()) else {
+                continue;
+            };
+            let reason = cover
+                .get("reason")
                 .and_then(|r| r.as_str())
                 .unwrap_or(UNRECORDED_REASON);
             folded
-                .entry((metric_name.clone(), reason.to_string()))
+                .entry((
+                    Surface::Assertion,
+                    assertion.to_string(),
+                    reason.to_string(),
+                ))
                 .or_default()
                 .push(row.test_id.clone());
         }
@@ -152,10 +223,11 @@ pub fn collect(results: &[TestResultRow]) -> Vec<NotExercised> {
 
     folded
         .into_iter()
-        .map(|((metric, reason), mut test_ids)| {
+        .map(|((surface, check, reason), mut test_ids)| {
             test_ids.sort();
             NotExercised {
-                metric,
+                surface,
+                check,
                 reason,
                 test_ids,
             }
@@ -216,7 +288,8 @@ mod tests {
         )];
         let found = collect(&rows);
         assert_eq!(found.len(), 1);
-        assert_eq!(found[0].metric, "sequence_valid");
+        assert_eq!(found[0].surface, Surface::Metric);
+        assert_eq!(found[0].check, "sequence_valid");
         assert_eq!(found[0].reason, "no tool calls in the trace");
         assert_eq!(found[0].test_ids, vec!["t1"]);
     }
@@ -293,7 +366,8 @@ mod tests {
     #[test]
     fn the_rendered_warning_names_the_code_metric_count_and_reason() {
         let f = NotExercised {
-            metric: "sequence_valid".into(),
+            surface: Surface::Metric,
+            check: "sequence_valid".into(),
             reason: "no tool calls in the trace".into(),
             test_ids: vec!["t1".into(), "t2".into()],
         };
@@ -310,13 +384,68 @@ mod tests {
     #[test]
     fn a_long_test_list_is_bounded_and_counts_the_remainder() {
         let f = NotExercised {
-            metric: "seq".into(),
+            surface: Surface::Metric,
+            check: "seq".into(),
             reason: "no tool calls".into(),
             test_ids: (1..=10).map(|i| format!("t{i:02}")).collect(),
         };
         let line = f.render();
         assert!(line.contains("t01, t02, t03 and 7 more"), "{line}");
         assert_eq!(line.lines().count(), 1, "one hole is one line");
+    }
+
+    /// An assertion cover reaches the same output as a metric, under its own code.
+    #[test]
+    fn an_assertion_cover_is_collected_under_the_assertion_code() {
+        let mut r = row("t1", serde_json::json!({}));
+        r.details[ASSERTIONS_NOT_EXERCISED] = serde_json::json!([{
+            "assertion": "trace_must_not_call_tool",
+            "reason": "the agent was never offered `delete_repository`, so no trace could have called it"
+        }]);
+        let found = collect(&[r]);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].surface, Surface::Assertion);
+        assert_eq!(found[0].check, "trace_must_not_call_tool");
+        assert!(found[0].render().starts_with("W_ASSERTION_NOT_EXERCISED: "));
+    }
+
+    /// The two surfaces stay apart even when they share a name.
+    ///
+    /// `sequence_valid` is both a metric under `expected:` and an assertion type under
+    /// `assertions:`. Folding on the name alone would merge two different holes into one line and
+    /// report a test id under a check it never ran.
+    #[test]
+    fn a_name_shared_by_both_surfaces_does_not_fold_together() {
+        let mut r = row(
+            "t1",
+            serde_json::json!({
+                "sequence_valid": metric(Exercised::NotExercised, Some("no sequence configured"))
+            }),
+        );
+        r.details[ASSERTIONS_NOT_EXERCISED] = serde_json::json!([{
+            "assertion": "sequence_valid",
+            "reason": "no sequence configured"
+        }]);
+        let found = collect(&[r]);
+        assert_eq!(found.len(), 2, "{found:?}");
+        assert_eq!(found[0].surface, Surface::Metric);
+        assert_eq!(found[1].surface, Surface::Assertion);
+        assert_ne!(found[0].render(), found[1].render());
+    }
+
+    /// A cover with no `assertion` name is skipped rather than reported as an empty check.
+    #[test]
+    fn a_nameless_cover_is_skipped() {
+        let mut r = row("t1", serde_json::json!({}));
+        r.details[ASSERTIONS_NOT_EXERCISED] = serde_json::json!([{ "reason": "something" }]);
+        assert!(collect(&[r]).is_empty());
+    }
+
+    /// The key is absent on almost every row, and that is not a finding.
+    #[test]
+    fn a_row_without_assertion_covers_reports_nothing() {
+        let r = row("t1", serde_json::json!({}));
+        assert!(collect(&[r]).is_empty());
     }
 
     /// The reader compares against the writer's own vocabulary rather than a second copy of the

--- a/crates/assay-core/tests/assertion_companion_cover.rs
+++ b/crates/assay-core/tests/assertion_companion_cover.rs
@@ -1,0 +1,273 @@
+//! The headline case of #1949, end to end through the store (layer 2, assertion half).
+//!
+//! `trace_must_not_call_tool` naming a tool the agent never had is syntactically perfect,
+//! config-effective — `ineffective_reason` passes it, correctly, because a trace that called the
+//! tool would fail it — and permanently vacuous. Neither the static sweep nor the metric-side cover
+//! could reach it: assertions produce `Diagnostic`s, not `MetricResult`s.
+//!
+//! These go through a real `Store` and the real event ingest rather than a hand-built
+//! `EpisodeGraph`, so they exercise `verify_assertions_with_meta` on the shape the runner passes.
+
+use assay_core::agent_assertions::{model::TraceAssertion, verify_assertions_with_meta};
+use assay_core::storage::Store;
+use assay_core::trace::schema::{EpisodeStart, StepEntry, ToolCallEntry, TraceEvent};
+use serde_json::json;
+
+/// A store holding one episode: one step, and one call to each tool in `calls`.
+fn seeded_store(calls: &[&str]) -> anyhow::Result<(Store, i64, &'static str)> {
+    let store = Store::memory()?;
+    store.init_schema()?;
+    let run_id = store.insert_run("cover-suite")?;
+    let test_id = "agent-under-test";
+
+    store.insert_event(
+        &TraceEvent::EpisodeStart(EpisodeStart {
+            episode_id: "ep-1".into(),
+            timestamp: 1000,
+            input: json!({"prompt": "do the thing"}),
+            meta: json!({}),
+        }),
+        Some(run_id),
+        Some(test_id),
+    )?;
+    store.insert_event(
+        &TraceEvent::Step(StepEntry {
+            episode_id: "ep-1".into(),
+            step_id: "s-1".into(),
+            idx: 0,
+            timestamp: 1001,
+            kind: "tool".into(),
+            name: Some("model".into()),
+            content: None,
+            content_sha256: None,
+            truncations: vec![],
+            meta: json!({}),
+        }),
+        Some(run_id),
+        Some(test_id),
+    )?;
+    for (i, tool) in calls.iter().enumerate() {
+        store.insert_event(
+            &TraceEvent::ToolCall(ToolCallEntry {
+                episode_id: "ep-1".into(),
+                step_id: "s-1".into(),
+                timestamp: 1002 + i as u64,
+                tool_name: (*tool).into(),
+                call_index: Some(i as u32),
+                args: json!({}),
+                args_sha256: None,
+                result: None,
+                result_sha256: None,
+                error: None,
+                truncations: vec![],
+            }),
+            Some(run_id),
+            Some(test_id),
+        )?;
+    }
+    Ok((store, run_id, test_id))
+}
+
+fn tool_definitions(names: &[&str]) -> serde_json::Value {
+    json!({
+        "tool_definitions": names.iter().map(|n| json!({"name": n})).collect::<Vec<_>>()
+    })
+}
+
+fn guard(tool: &str) -> Vec<TraceAssertion> {
+    vec![TraceAssertion::TraceMustNotCallTool { tool: tool.into() }]
+}
+
+/// The case the whole layer exists for: the assertion passes, and it never could have failed.
+#[test]
+fn a_guard_on_a_tool_the_agent_never_had_passes_and_is_reported_as_unexercised(
+) -> anyhow::Result<()> {
+    let (store, run_id, test_id) = seeded_store(&["read_file"])?;
+    let outcome = verify_assertions_with_meta(
+        &store,
+        run_id,
+        test_id,
+        &guard("delete_repository"),
+        &tool_definitions(&["read_file", "list_dir"]),
+    )?;
+
+    assert!(
+        outcome.diagnostics.is_empty(),
+        "the assertion holds: nothing failed"
+    );
+    assert_eq!(outcome.not_exercised.len(), 1, "and it held vacuously");
+    assert_eq!(
+        outcome.not_exercised[0].assertion,
+        "trace_must_not_call_tool"
+    );
+    assert!(
+        outcome.not_exercised[0].reason.contains("never offered"),
+        "{}",
+        outcome.not_exercised[0].reason
+    );
+    Ok(())
+}
+
+/// The pass that was earned. Reporting this would fire on every working guard in every suite, which
+/// is how a vacuity check earns its suppression.
+#[test]
+fn a_guard_on_an_available_tool_the_agent_declined_is_silent() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = seeded_store(&["read_file"])?;
+    let outcome = verify_assertions_with_meta(
+        &store,
+        run_id,
+        test_id,
+        &guard("delete_repository"),
+        &tool_definitions(&["read_file", "delete_repository"]),
+    )?;
+
+    assert!(outcome.diagnostics.is_empty());
+    assert!(
+        outcome.not_exercised.is_empty(),
+        "the agent had the tool and left it alone; that is a real pass"
+    );
+    Ok(())
+}
+
+/// A trace with no tool list recorded says nothing about availability, and this must stay silent.
+///
+/// Most traces are this. Treating "unrecorded" as "absent" would put a finding on every
+/// `trace_must_not_call_tool` in every suite that replays a plain trace.
+#[test]
+fn a_trace_without_a_recorded_tool_list_is_silent() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = seeded_store(&["read_file"])?;
+    let outcome = verify_assertions_with_meta(
+        &store,
+        run_id,
+        test_id,
+        &guard("delete_repository"),
+        &json!({}),
+    )?;
+
+    assert!(outcome.diagnostics.is_empty());
+    assert!(outcome.not_exercised.is_empty());
+    Ok(())
+}
+
+/// A guard that actually caught something is a failure, and a failure is never also a coverage
+/// hole: the tool was called, so it plainly existed.
+#[test]
+fn a_guard_that_fires_is_a_failure_and_not_a_cover() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = seeded_store(&["delete_repository"])?;
+    let outcome = verify_assertions_with_meta(
+        &store,
+        run_id,
+        test_id,
+        &guard("delete_repository"),
+        // Deliberately *not* declared, to prove a call alone establishes availability.
+        &json!({}),
+    )?;
+
+    assert_eq!(outcome.diagnostics.len(), 1);
+    assert_eq!(outcome.diagnostics[0].code, "E_TRACE_ASSERT_FAIL");
+    assert!(outcome.not_exercised.is_empty());
+    Ok(())
+}
+
+/// A tool that was called but is missing from the declared list is still available.
+///
+/// The declared list can be incomplete — a proxy that recorded a partial `tools/list`, a tool
+/// injected later in the episode. Trusting it over the observed call would report the *opposite* of
+/// the truth: that the agent never had a tool it demonstrably used.
+#[test]
+fn a_called_tool_missing_from_the_declared_list_is_not_a_cover() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = seeded_store(&["delete_repository"])?;
+    let outcome = verify_assertions_with_meta(
+        &store,
+        run_id,
+        test_id,
+        // A guard on a *different* tool, so the guard itself passes and the only question is what
+        // the availability of `read_file` is judged to be.
+        &guard("read_file"),
+        // `read_file` is declared; `delete_repository` was called and is not. The call is what
+        // settles the second one.
+        &tool_definitions(&["read_file"]),
+    )?;
+    assert!(
+        outcome.not_exercised.is_empty(),
+        "{:?}",
+        outcome.not_exercised
+    );
+
+    // And the reverse: a guard on the called-but-undeclared tool must not read as unexercised.
+    let outcome = verify_assertions_with_meta(
+        &store,
+        run_id,
+        test_id,
+        &guard("delete_repository"),
+        &tool_definitions(&["read_file"]),
+    )?;
+    assert_eq!(
+        outcome.diagnostics.len(),
+        1,
+        "it was called, so the guard fires"
+    );
+    assert!(
+        outcome.not_exercised.is_empty(),
+        "a tool the agent demonstrably used was reported as never offered: {:?}",
+        outcome.not_exercised
+    );
+    Ok(())
+}
+
+/// One test can fail one assertion and never exercise another. Both are reported.
+#[test]
+fn a_failing_assertion_does_not_hide_an_unexercised_one() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = seeded_store(&["read_file"])?;
+    let outcome = verify_assertions_with_meta(
+        &store,
+        run_id,
+        test_id,
+        &[
+            TraceAssertion::TraceMustCallTool {
+                tool: "write_file".into(),
+                min_calls: Some(1),
+            },
+            TraceAssertion::TraceMustNotCallTool {
+                tool: "delete_repository".into(),
+            },
+        ],
+        &tool_definitions(&["read_file"]),
+    )?;
+
+    assert_eq!(outcome.diagnostics.len(), 1, "write_file was never called");
+    assert_eq!(
+        outcome.not_exercised.len(),
+        1,
+        "and the guard never guarded"
+    );
+    Ok(())
+}
+
+/// The four-argument entry point keeps working and reports no covers, which is the honest answer
+/// for a caller that has no response metadata to give.
+#[test]
+fn the_metadata_free_entry_point_still_returns_the_diagnostics() -> anyhow::Result<()> {
+    let (store, run_id, test_id) = seeded_store(&["delete_repository"])?;
+    let diags = assay_core::agent_assertions::verify_assertions(
+        &store,
+        run_id,
+        test_id,
+        &guard("delete_repository"),
+    )?;
+    assert_eq!(diags.len(), 1);
+    Ok(())
+}
+
+/// Layer 3 passes this config, and it must: a trace that called the tool would fail it. Pinned so
+/// nobody "fixes" the static sweep to catch it, which would reject working guards.
+#[test]
+fn the_static_sweep_correctly_declines_to_flag_this_config() {
+    let a = TraceAssertion::TraceMustNotCallTool {
+        tool: "delete_repository".into(),
+    };
+    assert!(
+        assay_core::agent_assertions::matchers::ineffective_reason(&a).is_none(),
+        "layer 3 flagged a config-effective guard; layer 2 is what covers this case"
+    );
+}

--- a/docs/architecture/REASON-CODE-VOCABULARIES.md
+++ b/docs/architecture/REASON-CODE-VOCABULARIES.md
@@ -144,12 +144,20 @@ failures until #1949's layer 2, which gave it a code-prefixed member.
 
 | Source | Members | Reaches it via |
 |---|---|---|
-| `assay_core::report::exercised` | 1, listed below | `exercised::warnings` → `decide_run_outcome` → `RunOutcome::warnings` |
+| `assay_core::report::exercised` | 2, listed below | `exercised::warnings` → `decide_run_outcome` → `RunOutcome::warnings` |
 
 <!-- machine-checked: run-json-warning-codes -->
 ```text
+W_ASSERTION_NOT_EXERCISED
 W_METRIC_NOT_EXERCISED
 ```
+
+Two codes for one condition on two config surfaces: `expected:` and
+`assertions:`. They are found by different means — a metric declares its own
+`Exercised` value, an assertion is judged by a companion cover in
+`agent_assertions::cover` — and a name can belong to both (`sequence_valid` is a
+metric *and* an assertion type), so a single code would make a CI-log filter
+ambiguous about which surface it matched.
 
 **Why this is not in `codes::`.** It is a `W_` code, and every other `W_` code
 lives in the surface-1 registry, so the natural move is to put it there. That


### PR DESCRIPTION
## Description

#1949 layer 2, **the assertion half**. #2083 made "did this check actually run" observable for `expected:`; this does the same for `assertions:` — which is the surface this issue's acceptance criterion is actually about. #1949 stays open; item 1's default-on flip is a phased decision.

## The case

```yaml
assertions:
  - type: trace_must_not_call_tool
    tool: delete_repository
```

If the agent was never offered `delete_repository`, this holds on every trace forever. The groundwork called it the headline case, and **neither existing layer could reach it**:

- **Layer 3** passes it, and is right to. A trace that called the tool *would* fail it, so `ineffective_reason` correctly stays quiet. There is a test pinning this, so nobody later "fixes" the static sweep into rejecting working guards.
- **Layer 2 (#2083)** could not see it either. `matchers::check_one` returns `Option<Diagnostic>` where `None` is a pass, so assertions have no `exercised` dimension to declare — the same shape defect #2068 fixed for metrics, on the other surface.

## The antecedent is availability, not absence

The naive signal — "the tool was never called" — *is* the assertion's passing condition, so reporting it would fire on every guard that works. What gets reported is narrower:

| the agent | verdict |
|---|---|
| had the tool and did not call it | exercised. The guard earned its pass. |
| never had the tool | **not exercised.** No trace could have failed this. |
| availability unrecorded | **nothing is reported.** |

The third row is what makes this safe to turn on by default. `meta["tool_definitions"]` is absent from most traces, and reading absence as evidence would put a finding on every `trace_must_not_call_tool` in every replay suite — the same asymmetry `coverage_regressed` uses for a baseline predating its dimension (#2082).

A tool that was **called** counts as available regardless of what was declared. A declared list can be incomplete, and trusting it over an observed call would report the opposite of the truth: that the agent never had a tool it demonstrably used.

### What it does not claim

Availability is weaker than opportunity — an agent may hold a tool no reachable state would prompt it to use, and that reads as exercised here. Trajectory evaluation has the general form of that limit: a single rollout ["rules out only one realized path"](https://arxiv.org/abs/2605.17439). What this catches is the case needing no counterfactual at all: the tool was not on the table.

## Two structural notes

**`cover::not_exercised` is separate from `check_one`, not folded into it.** "Did this fail" and "was this exercised" are orthogonal — the reason `Exercised` is a dimension rather than a fourth status. There is also a concrete hazard: `ineffective_reason` runs `check_one` against an *empty* episode and keeps the config-decided codes. A cover living inside `check_one` would fire on that empty episode and be indistinguishable from a static verdict, so the sweep would start rejecting working configs.

**`verify_assertions` keeps its four-argument shape** and delegates to `verify_assertions_with_meta`, so 32 test call sites and the published API are untouched. One evaluation, two entry points.

`W_ASSERTION_NOT_EXERCISED` is its own code beside `W_METRIC_NOT_EXERCISED`, and `NotExercised` now carries which `Surface` it came from: `sequence_valid` is both a metric under `expected:` and an assertion type under `assertions:`, so a single code would leave a CI-log filter unable to say which one it matched — and folding on the name alone would merge two different holes into one line.

## Verification

Six mutations, all red:

| Mutation | Killed by |
|---|---|
| unknown availability treated as absent | `a_trace_without_a_recorded_tool_list_is_silent` |
| report the naive "never called" signal | 2 tests, including the earned-pass case |
| a called tool no longer proves availability | `a_called_tool_missing_from_the_declared_list_is_not_a_cover` |
| the cover swallows the failures | 3 tests |
| layer 3 "fixed" to flag the guard statically | `the_static_sweep_correctly_declines_to_flag_this_config` |
| unknown collapsed to `false` in `was_available` | `an_unrecorded_tool_list_reports_nothing` |

The third one is worth flagging: it initially survived the integration suite and was caught only by a unit test of the internal function. That is a weaker kill than it looks, so I found the case where the mutation actually changes output — a tool called but missing from the declared list — and added it. The mutation is behaviourally dead now, not just structurally.

The integration tests go through a real `Store` and the real event ingest rather than a hand-built `EpisodeGraph`, so they exercise the shape the runner passes. Full `assay-core` and `assay-cli` suites pass; clippy `-D warnings` clean.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.


---

**Correction (post-merge):** the call-site count is **32**, not 33. I measured it after opening this PR and pushed the fix, but the squash landed first, so the merged commit message on `main` still reads 33. Recorded here and on #1949 rather than left standing.
