### PR TITLE
The list of format arguments was itself hand-kept, so five were never on it

### DIFF
--- a/crates/assay-cli/src/cli/args/common.rs
+++ b/crates/assay-cli/src/cli/args/common.rs
@@ -74,3 +74,102 @@ impl Default for JudgeArgs {
         }
     }
 }
+
+/// The `--format` vocabulary for the two MCP transcript importers.
+///
+/// A CLI-side enum rather than `assay_core`'s `McpInputFormat` directly, because that type lives in
+/// a library that must not depend on clap, and because the accepted spellings include aliases
+/// (`mcp-inspector`, `sse-legacy`) that `ValueEnum` has to declare for `--help` to list them.
+///
+/// Two spellings of one vocabulary is exactly the drift this repo keeps paying for, so the mapping
+/// is total and `mcp_format_vocabularies_agree` holds it to `McpInputFormat::from_cli_label`. The
+/// enum is the boundary; the core function stays the definition.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum McpTranscriptFormat {
+    #[default]
+    #[value(alias = "mcp-inspector", alias = "mcp-inspector@v1")]
+    Inspector,
+    Jsonrpc,
+    #[value(name = "streamable-http")]
+    StreamableHttp,
+    #[value(name = "http-sse", alias = "sse-legacy")]
+    HttpSse,
+}
+
+impl McpTranscriptFormat {
+    /// The label `McpInputFormat::from_cli_label` understands.
+    pub fn as_core_label(self) -> &'static str {
+        match self {
+            Self::Inspector => "inspector",
+            Self::Jsonrpc => "jsonrpc",
+            Self::StreamableHttp => "streamable-http",
+            Self::HttpSse => "http-sse",
+        }
+    }
+
+    pub fn to_core(self) -> assay_core::mcp::McpInputFormat {
+        // `expect` rather than a fallback: `as_core_label` returns a literal this enum controls, so
+        // a `None` here means the two vocabularies have diverged, which the parity test catches
+        // first and which must not degrade into a silent default at runtime.
+        assay_core::mcp::McpInputFormat::from_cli_label(self.as_core_label())
+            .expect("McpTranscriptFormat label is not one McpInputFormat accepts")
+    }
+}
+
+/// Output format for `policy generate`.
+///
+/// `generate.rs:108` passed a bare `String` to `serialize`, whose `_` arm wrote YAML. `--format
+/// jsom` produced a YAML policy at exit 0, into a path the user may well have named `.json`.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PolicyOutputFormat {
+    #[default]
+    Yaml,
+    Json,
+}
+
+/// Output format for `evidence show`.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ShowFormat {
+    #[default]
+    Table,
+    Json,
+}
+
+#[cfg(test)]
+mod mcp_format_vocabulary_tests {
+    use super::McpTranscriptFormat;
+    use clap::ValueEnum;
+
+    /// Every CLI spelling — variant names and aliases — is one `from_cli_label` accepts, and every
+    /// variant maps to a distinct core format.
+    ///
+    /// Without this the two lists drift and the CLI advertises a value the core rejects, which is
+    /// the failure `--format sse-legacy` would have hit the moment the alias was dropped.
+    #[test]
+    fn mcp_format_vocabularies_agree() {
+        let mut seen = std::collections::BTreeSet::new();
+        for variant in McpTranscriptFormat::value_variants() {
+            let core = variant.to_core();
+            assert!(
+                seen.insert(format!("{core:?}")),
+                "{variant:?} maps to a core format another variant already claims"
+            );
+        }
+        assert_eq!(seen.len(), 4, "a core format lost its CLI spelling");
+
+        // The aliases the old `String` argument accepted must still parse.
+        for label in [
+            "inspector",
+            "mcp-inspector",
+            "jsonrpc",
+            "streamable-http",
+            "http-sse",
+            "sse-legacy",
+        ] {
+            assert!(
+                McpTranscriptFormat::from_str(label, true).is_ok(),
+                "`--format {label}` used to work and no longer parses"
+            );
+        }
+    }
+}

--- a/crates/assay-cli/src/cli/args/import.rs
+++ b/crates/assay-cli/src/cli/args/import.rs
@@ -1,3 +1,4 @@
+use super::common::McpTranscriptFormat;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -43,9 +44,9 @@ pub struct ImportArgs {
     /// Input file (MCP transcript or Inspector JSON)
     pub input: std::path::PathBuf,
 
-    /// Input format: inspector | jsonrpc | streamable-http | http-sse (alias: sse-legacy)
-    #[arg(long, default_value = "inspector")]
-    pub format: String,
+    /// Input format for the transcript.
+    #[arg(long, value_enum, default_value_t = McpTranscriptFormat::Inspector)]
+    pub format: McpTranscriptFormat,
 
     /// Generate initial eval config and policy
     #[arg(long)]

--- a/crates/assay-cli/src/cli/args/replay.rs
+++ b/crates/assay-cli/src/cli/args/replay.rs
@@ -136,9 +136,9 @@ pub enum TraceSub {
         #[arg(long)]
         out_trace: PathBuf,
 
-        /// Input format: inspector | jsonrpc | streamable-http | http-sse | sse-legacy (alias for http-sse)
-        #[arg(long, default_value = "inspector")]
-        format: String,
+        /// Input format for the transcript.
+        #[arg(long, value_enum, default_value_t = crate::cli::args::common::McpTranscriptFormat::Inspector)]
+        format: crate::cli::args::common::McpTranscriptFormat,
 
         #[arg(long)]
         episode_id: Option<String>,

--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -1,3 +1,4 @@
+use super::common::OutputFormat;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -44,8 +45,13 @@ pub struct DoctorArgs {
     #[arg(long, default_value = "false")]
     pub replay_strict: bool,
 
-    #[arg(long, default_value = "text")]
-    pub format: String, // text|json
+    // Typed rather than a `String` with a `== "json"` test downstream (#2039). The declaration
+    // here used to read `// text|json` while `--format totally-invalid` silently produced text and
+    // exited 0 — a documented set that nothing enforced. A `//` comment, not a doc comment: this
+    // is why the type is what it is, and `--help` is not where that belongs.
+    /// Output format for the report.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
 
     #[arg(long)]
     pub out: Option<std::path::PathBuf>,

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -193,3 +193,63 @@ fn sim_soak_parses_explicit_values() {
         _ => panic!("expected Command::Sim"),
     }
 }
+
+/// Every argument whose name ends in `format` advertises the values it accepts.
+///
+/// `tests/format_value_parser.rs` checks the same property against a hand-kept table, and that is
+/// exactly how `doctor --format` escaped: it was a bare `String` with `// text|json` beside it,
+/// `--format totally-invalid` printed the text report and exited 0, and every test there passed
+/// because the table never named it. A list beside the thing it describes drifts silently, and in
+/// the dangerous direction — the argument nobody listed is the one nobody checked.
+///
+/// So this derives the set from clap instead of listing it. It lives here rather than beside its
+/// sibling because `assay-cli` has no library target, so only an in-crate test can walk the real
+/// command tree. Adding a `--format` to a new command fails here until it carries a `value_enum`.
+#[test]
+fn every_format_argument_advertises_its_accepted_values() {
+    use clap::CommandFactory;
+
+    fn walk(cmd: &clap::Command, path: &[String], untyped: &mut Vec<String>) {
+        for arg in cmd.get_arguments() {
+            let Some(long) = arg.get_long() else { continue };
+            if !long.ends_with("format") {
+                continue;
+            }
+            if arg.get_possible_values().is_empty() {
+                untyped.push(format!("assay {} --{long}", path.join(" ")));
+            }
+        }
+        for sub in cmd.get_subcommands() {
+            let mut child = path.to_vec();
+            child.push(sub.get_name().to_string());
+            walk(sub, &child, untyped);
+        }
+    }
+
+    let cli = super::Cli::command();
+    let mut untyped = Vec::new();
+    walk(&cli, &[], &mut untyped);
+
+    // A walk that finds nothing would pass silently, so prove it reached the arguments first.
+    let mut total = 0usize;
+    fn count(cmd: &clap::Command, total: &mut usize) {
+        *total += cmd
+            .get_arguments()
+            .filter(|a| a.get_long().is_some_and(|l| l.ends_with("format")))
+            .count();
+        for sub in cmd.get_subcommands() {
+            count(sub, total);
+        }
+    }
+    count(&cli, &mut total);
+    assert!(
+        total > 5,
+        "the walk found only {total} format arguments; it is not reaching them"
+    );
+
+    assert!(
+        untyped.is_empty(),
+        "these format arguments accept any string, so a typo selects a fallback silently:\n  {}",
+        untyped.join("\n  ")
+    );
+}

--- a/crates/assay-cli/src/cli/commands/doctor/implementation.rs
+++ b/crates/assay-cli/src/cli/commands/doctor/implementation.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use assay_core::config::{load_config, path_resolver::PathResolver};
 
+use crate::cli::args::common::OutputFormat;
 use crate::cli::args::DoctorArgs;
 use crate::cli::helpers::normalize_severity;
 use crate::diagnostics;
@@ -11,7 +12,7 @@ use super::fixes::run_doctor_fix;
 use super::parse_error::try_fix_parse_error;
 
 pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
-    if args.fix && args.format == "json" {
+    if args.fix && args.format == OutputFormat::Json {
         eprintln!("doctor --fix currently supports text output only; use --format text");
         return Ok(1);
     }
@@ -38,7 +39,7 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         (None, None)
     };
 
-    if args.format == "json" {
+    if args.format == OutputFormat::Json {
         let timestamp = chrono::Utc::now().to_rfc3339();
         let mut json_out = serde_json::to_value(&report)?;
 

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -123,9 +123,9 @@ pub struct EvidenceShowArgs {
     #[arg(long)]
     pub no_verify: bool,
 
-    /// Output format: 'table' or 'json' (raw dump)
-    #[arg(long, default_value = "table")]
-    pub format: String,
+    /// Output format for the bundle listing.
+    #[arg(long, value_enum, default_value_t = crate::cli::args::common::ShowFormat::Table)]
+    pub format: crate::cli::args::common::ShowFormat,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -297,7 +297,7 @@ fn cmd_show(args: EvidenceShowArgs) -> Result<i32> {
     let verified = !args.no_verify; // If open() succeeded above, it IS verified.
     let manifest = br.manifest();
 
-    if args.format == "json" {
+    if args.format == crate::cli::args::common::ShowFormat::Json {
         // Output complete bundle as JSON: manifest + events
         let events = br.events().collect::<Result<Vec<_>>>()?;
         let bundle_json = serde_json::json!({

--- a/crates/assay-cli/src/cli/commands/generate.rs
+++ b/crates/assay-cli/src/cli/commands/generate.rs
@@ -105,7 +105,7 @@ pub fn run(args: GenerateArgs) -> Result<i32> {
         allow_count, review_count, deny_count
     );
 
-    let output = serialize(&policy, &args.format)?;
+    let output = serialize(&policy, args.format)?;
 
     if args.dry_run {
         println!("{}", output);

--- a/crates/assay-cli/src/cli/commands/generate/args.rs
+++ b/crates/assay-cli/src/cli/commands/generate/args.rs
@@ -19,8 +19,9 @@ pub struct GenerateArgs {
     #[arg(long, default_value = "Generated Policy")]
     pub name: String,
 
-    #[arg(long, default_value = "yaml")]
-    pub format: String,
+    /// Output format for the generated policy.
+    #[arg(long, value_enum, default_value_t = crate::cli::args::common::PolicyOutputFormat::Yaml)]
+    pub format: crate::cli::args::common::PolicyOutputFormat,
 
     #[arg(long)]
     pub dry_run: bool,
@@ -115,7 +116,7 @@ mod tests {
             profile: None,
             output: PathBuf::from("policy.yaml"),
             name: "Generated Policy".to_string(),
-            format: "yaml".to_string(),
+            format: crate::cli::args::common::PolicyOutputFormat::Yaml,
             dry_run: false,
             diff: false,
             heuristics: false,

--- a/crates/assay-cli/src/cli/commands/generate/model.rs
+++ b/crates/assay-cli/src/cli/commands/generate/model.rs
@@ -1,3 +1,4 @@
+use crate::cli::args::common::PolicyOutputFormat;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -61,9 +62,14 @@ pub enum Entry {
     },
 }
 
-pub fn serialize(policy: &Policy, format: &str) -> Result<String> {
+/// Render a policy in the requested format.
+///
+/// Takes the enum, not a `&str`. The `&str` version's `_` arm wrote YAML, so `--format jsom`
+/// produced a YAML policy at exit 0 — into whatever path the user named, `.json` included. With
+/// the enum there is no arm left for a value nobody chose.
+pub fn serialize(policy: &Policy, format: PolicyOutputFormat) -> Result<String> {
     Ok(match format {
-        "json" => serde_json::to_string_pretty(policy)?,
-        _ => serde_yaml::to_string(policy)?,
+        PolicyOutputFormat::Json => serde_json::to_string_pretty(policy)?,
+        PolicyOutputFormat::Yaml => serde_yaml::to_string(policy)?,
     })
 }

--- a/crates/assay-cli/src/cli/commands/generate/profile.rs
+++ b/crates/assay-cli/src/cli/commands/generate/profile.rs
@@ -227,7 +227,7 @@ mod tests {
             profile: None,
             output: PathBuf::from("policy.yaml"),
             name: "".into(),
-            format: "yaml".into(),
+            format: crate::cli::args::common::PolicyOutputFormat::Yaml,
             dry_run: false,
             diff: false,
             heuristics: false,

--- a/crates/assay-cli/src/cli/commands/import.rs
+++ b/crates/assay-cli/src/cli/commands/import.rs
@@ -1,7 +1,7 @@
 use crate::cli::args::ImportArgs;
 use crate::exit_codes;
 use anyhow::{Context, Result};
-use assay_core::mcp::{mcp_events_to_v2_trace, parse_mcp_transcript, McpInputFormat};
+use assay_core::mcp::{mcp_events_to_v2_trace, parse_mcp_transcript};
 use assay_core::trace::schema::TraceEvent;
 use std::collections::BTreeSet;
 use std::fs;
@@ -9,8 +9,8 @@ use std::path::Path;
 
 pub fn cmd_import(args: ImportArgs) -> Result<i32> {
     let input_path = args.input;
-    let format_enum = McpInputFormat::from_cli_label(&args.format)
-        .ok_or_else(|| anyhow::anyhow!("unknown format: {}", args.format))?;
+    // Clap rejects anything outside the vocabulary before this runs, so the conversion is total.
+    let format_enum = args.format.to_core();
 
     println!("Importing MCP transcript from: {:?}", input_path);
     let text = fs::read_to_string(&input_path)

--- a/crates/assay-cli/src/cli/commands/init.rs
+++ b/crates/assay-cli/src/cli/commands/init.rs
@@ -192,7 +192,8 @@ fn run_from_trace(args: &InitArgs, trace_path: &std::path::Path) -> anyhow::Resu
     // 2. Generate policy
     let heur_cfg = HeuristicsConfig::default();
     let policy = generate::generate_from_trace("generated", &agg, args.heuristics, &heur_cfg);
-    let policy_yaml = generate::serialize(&policy, "yaml")?;
+    let policy_yaml =
+        generate::serialize(&policy, crate::cli::args::common::PolicyOutputFormat::Yaml)?;
 
     // Count entries for summary
     let allow_count = policy.files.allow.len()

--- a/crates/assay-cli/src/cli/commands/record.rs
+++ b/crates/assay-cli/src/cli/commands/record.rs
@@ -125,7 +125,7 @@ pub async fn run(args: RecordArgs) -> Result<i32> {
         profile: None,
         output: args.output.clone(),
         name: args.name,
-        format: "yaml".to_string(),
+        format: crate::cli::args::common::PolicyOutputFormat::Yaml,
         dry_run: false,
         diff: false,
         heuristics: true, // Enable heuristics for record mode

--- a/crates/assay-cli/src/cli/commands/trace.rs
+++ b/crates/assay-cli/src/cli/commands/trace.rs
@@ -232,8 +232,9 @@ pub async fn cmd_trace(args: TraceArgs, legacy_mode: bool) -> anyhow::Result<i32
             test_id,
             prompt,
         } => {
-            let format_enum = assay_core::mcp::McpInputFormat::from_cli_label(&format)
-                .ok_or_else(|| anyhow::anyhow!("unknown format: {}", format))?;
+            // Clap rejected anything outside the vocabulary before this point, so the
+            // conversion is total; `to_core` panics rather than defaulting if the two ever drift.
+            let format_enum = format.to_core();
 
             import_mcp::run(import_mcp::ImportMcpArgs {
                 input,

--- a/crates/assay-cli/tests/format_value_parser.rs
+++ b/crates/assay-cli/tests/format_value_parser.rs
@@ -81,6 +81,7 @@ const FORMAT_ARGS: &[(&[&str], &str, &[&str])] = &[
     // JSON with a `// Default to JSON` comment, so a typo'd spelling produced a JSON file at the
     // markdown path at exit 0.
     (&["baseline", "report"], "--format", &["json", "md"]),
+    (&["doctor"], "--format", &["text", "json"]),
 ];
 
 /// Aliases that parse without appearing in the value list, as `(command, flag, alias)`.


### PR DESCRIPTION
## Description

`assay doctor --format totally-invalid` printed the text report and exited 0. Found while auditing the issues closed over the last few days for work that looks done and isn't.

```
$ assay doctor --config eval.yaml --format totally-invalid
Assay v3.38.0          ← text, exit 0
```

`args/runtime.rs:48` read `pub format: String, // text|json`, and `doctor/implementation.rs:41` did `if args.format == "json"` with everything else falling through. A documented set that nothing enforced — the class #2032 and #2034 closed on seven other commands.

## Why the existing tests were green

`tests/format_value_parser.rs` checks exactly this property, and passed the whole time. Its `FORMAT_ARGS` table is hand-kept and never named `doctor`. **A list beside the thing it describes drifts in the dangerous direction: the argument nobody listed is the argument nobody checked.**

So the set is now derived. `every_format_argument_advertises_its_accepted_values` walks the real clap command tree and fails on any `--*format` carrying no possible values. It lives in the bin crate because `assay-cli` has no library target, and it asserts it found more than five arguments before checking any of them — a walk that reached nothing would otherwise pass in silence, which is the same defect one level up.

## Run once, it found four more

| command | what was wrong |
|---|---|
| `policy generate` | `serialize`'s `_` arm wrote YAML, so `--format jsom` produced a YAML policy at exit 0, into whatever path the user named — `.json` included |
| `evidence show` | `== "json"`, everything else fell through to the table |
| `import` | validated downstream: right message, but only after the work had started |
| `trace import-mcp` | same |

I had looked at `policy generate` earlier in the audit and concluded `serialize` had no caller. That was wrong — my grep was scoped to `commands/generate/` and missed `commands/generate.rs`, the sibling file. The derived walk found in one run what I had mis-measured by hand.

## The importer vocabulary

`McpTranscriptFormat` carries it at the CLI boundary, with `mcp-inspector` and `sse-legacy` declared as clap aliases so the documented spellings still parse — and `--help` now lists them, which it never did.

`assay_core`'s `McpInputFormat` stays the definition; it can't be the clap type, since a library that parses arguments for someone else is a dependency nobody asked for. Two spellings of one vocabulary is the drift this repo keeps paying for, so `mcp_format_vocabularies_agree` holds them to each other, and `to_core` panics rather than defaulting if they ever diverge.

## One thing the first version got wrong

The rationale for doctor's new type went in a `///` doc comment, and `assay doctor --help` started explaining #2039 to users. It's a `//` comment now. Why a type is what it is belongs next to the code, not in the help text.

## Verification

Against the binary, not the source:

| | |
|---|---|
| all five reject `BOGUS` | with their own value list |
| `--format sse-legacy`, `--format mcp-inspector` | still parse |
| `doctor` with no `--format` | still text |
| `doctor --format json` | still JSON |

`cargo test -p assay-cli -p assay-core` clean, clippy `-D warnings` clean. Both new tests confirmed present in `--list` and passing — a suite that goes green without running the new test proves nothing, which cost a mutation round earlier this week.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.