### PR TITLE
The table said four and the struct declared ten

### DIFF
--- a/crates/assay-cli/tests/adr045_prefix_table.rs
+++ b/crates/assay-cli/tests/adr045_prefix_table.rs
@@ -1,0 +1,136 @@
+//! ADR-045's producer-vocabulary table must name every `assay*` member the seal payload carries.
+//!
+//! It named four while `SealPayload` declared ten, for as long as the struct had existed. The table
+//! was written against the design and never re-read against the code, which is what a hand-kept list
+//! beside a type does. The omission was not uniform either: two of the six missing were
+//! `assayDropProofModel` and `assayDropProofBasis`, so the table hid the member that says whether a
+//! drop count was verified or merely asserted — the most consequential thing in the payload for a
+//! consumer deciding what the seal is worth.
+//!
+//! Both sides are parsed here. A test that compared the table against a second hand-kept list would
+//! reproduce the defect one level up.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Every `assay*` wire name in `SealPayload`, from its serde renames.
+///
+/// Bounded to the struct rather than the whole file: the tests below it construct payloads with the
+/// same names in string literals, and counting those would make the check pass by accident.
+fn payload_members() -> BTreeSet<String> {
+    let src = read("crates/assay-cli/src/aee_seal.rs");
+    let start = src
+        .find("pub struct SealPayload {")
+        .expect("aee_seal.rs has no `pub struct SealPayload`");
+    let body = &src[start..];
+    let end = body.find("\n}\n").expect("SealPayload is unterminated");
+    let body = &body[..end];
+
+    let mut found = BTreeSet::new();
+    for line in body.lines() {
+        let Some(rest) = line.trim().strip_prefix("#[serde(rename = \"") else {
+            continue;
+        };
+        let Some(name) = rest.split('"').next() else {
+            continue;
+        };
+        if name.starts_with("assay") {
+            found.insert(name.to_owned());
+        }
+    }
+    assert!(
+        found.len() > 3,
+        "parsed only {} members from SealPayload; the struct shape moved and this check went blind",
+        found.len()
+    );
+    found
+}
+
+/// Every `assay*` member named in the ADR's producer-vocabulary table.
+fn table_members() -> BTreeSet<String> {
+    let doc = read("docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md");
+    let start = doc
+        .find("### AEE normative fields vs Assay producer vocabulary")
+        .expect("ADR-045 has no producer-vocabulary section");
+    let section = &doc[start..];
+    let end = section[1..]
+        .find("\n### ")
+        .map(|i| i + 1)
+        .unwrap_or(section.len());
+
+    let mut found = BTreeSet::new();
+    for line in section[..end].lines() {
+        let line = line.trim();
+        // Table rows only. Prose below the table mentions these names too, and counting those would
+        // let a member be "documented" by an aside rather than by a row.
+        if !line.starts_with("| `assay") {
+            continue;
+        }
+        if let Some(name) = line.trim_start_matches("| `").split('`').next() {
+            found.insert(name.to_owned());
+        }
+    }
+    found
+}
+
+#[test]
+fn the_adr_table_names_every_producer_member_the_payload_carries() {
+    let payload = payload_members();
+    let table = table_members();
+
+    let undocumented: Vec<&String> = payload.difference(&table).collect();
+    let phantom: Vec<&String> = table.difference(&payload).collect();
+
+    assert!(
+        undocumented.is_empty(),
+        "SealPayload carries these `assay*` members and ADR-045's table does not name them: {undocumented:?}\n\
+         A consumer reading the ADR to learn what the prefix covers would not know they exist."
+    );
+    assert!(
+        phantom.is_empty(),
+        "ADR-045's table names these members and SealPayload does not carry them: {phantom:?}"
+    );
+}
+
+/// The checker's required set is a subset of what the payload declares.
+///
+/// Not equality: `assayObservedLabels` is a debugging aid and the drop-proof pair postdates the
+/// checker, so three members are legitimately unrequired. What must never happen is the checker
+/// requiring a field the producer does not emit, because then every real seal fails for a reason
+/// that is the checker's fault.
+#[test]
+fn the_checker_requires_nothing_the_payload_does_not_carry() {
+    let src = read("scripts/experiments/aee_landlock_seal_fixture.py");
+    let start = src
+        .find("REQUIRED_SEAL_FIELDS = (")
+        .expect("the fixture checker has no REQUIRED_SEAL_FIELDS");
+    let body = &src[start..];
+    let end = body
+        .find(')')
+        .expect("REQUIRED_SEAL_FIELDS is unterminated");
+
+    let required: BTreeSet<String> = body[..end]
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix('"'))
+        .filter_map(|l| l.split('"').next())
+        .filter(|n| n.starts_with("assay"))
+        .map(str::to_owned)
+        .collect();
+    assert!(!required.is_empty(), "parsed no required assay* fields");
+
+    let payload = payload_members();
+    let missing: Vec<&String> = required.difference(&payload).collect();
+    assert!(
+        missing.is_empty(),
+        "the checker requires these and SealPayload does not emit them: {missing:?}"
+    );
+}

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -222,8 +222,30 @@ The empty `aeeObservedAttacks` in this example is deliberate. It is the safe def
 | `aeePostureDigest` | yes | Must equal `observationEnvironment.networkPosture.digest.sha256` |
 | `assayObservedLabels` | no | Assay-readable label summary for operators/debugging |
 | `assayCollectionPath` | no | Assay producer collection path |
+| `assaySealedAt` | no | RFC 3339 UTC instant the seal was signed |
+| `assaySourceSchema` | no | The Assay record schema the observation came from |
+| `assaySealScope` | no | The enforcement boundary this seal speaks for |
+| `assayDropProofModel` | no | Which named model licenses the drop accounting |
+| `assayDropProofBasis` | no | `checked` or `declared`, per the model above |
+| `assayDropChannels` | no | Per-channel loss counters, under the counted-queue model |
 | `assayAttackRowAttributionSource` | no | Assay explanation of row attribution source |
 | `assayNonClaims` | no | Assay payload-local non-claims |
+
+This table listed four members while `SealPayload` declared ten, for as long as the struct has
+existed. It was written against the design and never re-read against the code, which is the drift a
+hand-kept table beside a type always develops. Two of the missing six are the drop-proof pair, so
+the omission hid the one member that says whether the drop count was verified or asserted.
+
+Two counts still differ from this one, deliberately and not:
+
+- `REQUIRED_SEAL_FIELDS` in the fixture checker names **seven** of the ten. `assayObservedLabels`
+  is a debugging aid, and the drop-proof pair is not required because the checker predates it.
+- The fixture checker's own positive payload carries **eight**, omitting `assayDropProofBasis` and
+  `assayDropChannels` entirely. The Rust producer emits them unconditionally. So a real run would
+  carry two members the checker has never seen, one of which is `checked`-versus-`declared`.
+
+Recorded rather than repaired here, because closing it means deciding whether the checker requires
+the pair or the producer stops emitting it, and that is a contract question rather than an edit.
 
 Fields beginning with `assay` in the sealed payload are Assay producer vocabulary. AEE consumers may ignore them unless their own policy understands them. They MUST NOT alter AEE structural validity. Any future AEE statement exporter MUST also carry predicate-level `doesNotAssert` for statement-level non-claims; `assayNonClaims` inside the sealed payload is only producer vocabulary and does not weaken required AEE checks.
 


### PR DESCRIPTION
## Description

ADR-045's producer-vocabulary table has listed **four** `assay*` members since it was written. `SealPayload` declares **ten**, and has for as long as it has existed. The table was written against the design and never re-read against the code.

The omission is not uniform, which is what makes it worth a PR rather than a one-line edit. Two of the six missing are `assayDropProofModel` and `assayDropProofBasis` — so the table hid the member that says whether a drop count was **verified** or **asserted** (`checked` against `declared`), which is the most consequential thing in the payload for a consumer deciding what a seal is worth.

## How it was found

An adversarial pass over a draft written *from* this table. The draft inherited the number and would have gone out saying "four members" to a reader who can count them in the published payload in under a minute. A stale doc is not only wrong in the repo; it is wrong in everything downstream that trusted it.

## Both sides are parsed

`the_adr_table_names_every_producer_member_the_payload_carries` reads the serde renames out of the struct and the rows out of the ADR section, and fails in **either** direction — a member with no row, or a row with no member.

A test comparing the table against a second hand-kept list would have reproduced the defect one level up. That is not hypothetical: the same shape shipped this week in `tests/format_value_parser.rs`, whose hand-kept table is exactly why `doctor --format` went unchecked ([#2086](https://github.com/Rul1an/assay/pull/2086)).

## Two counts still differ, recorded rather than repaired

| source | count | why |
|---|---:|---|
| `SealPayload` | 10 | the producer |
| ADR table | 10 | now |
| `REQUIRED_SEAL_FIELDS` | 7 | three are legitimately unrequired |
| the checker's positive payload | 8 | omits the drop-proof pair entirely |

The last row is a real gap: **the Rust producer emits two members the fixture checker has never seen**, one of them `checked`-versus-`declared`. Closing it means deciding whether the checker requires the pair or the producer stops emitting it, which is a contract decision and not an edit — so it is written down in the ADR and left for that decision.

The second test asserts the weaker property that *is* true today: the checker requires nothing the producer does not emit. If that inverted, every real seal would fail for a reason that is the checker's fault.

## Verification

| Mutation | Result |
|---|---|
| drop a row from the table (the original defect) | **red** |
| add a row for a member nothing emits | **red** |

Both parsers assert they found something before comparing — a parser that silently matched nothing would pass and prove nothing, which is the failure this whole change is about.

## Scope

`Gate.NONE`. Documentation and one test.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.