### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,77 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-08-06
+
+The first major since the 3.x line, for one field. Everything else here is
+gate-hardening and defect repair.
+
+### Breaking
+- `MetricResult` carries a fifth public field, `exercised`, so a struct-literal
+  construction that compiled against 3.38.0 no longer does
+  (`error[E0063]: missing field 'exercised'`). Every constructor —
+  `pass`, `fail`, `unstable`, `not_applicable`, `not_exercised` — is unchanged,
+  so callers using those are unaffected. The field is what lets a consumer tell
+  a metric that ran and passed from one that returned 1.0 without evaluating
+  anything, which was previously indistinguishable (#2068).
+
+  This break reached `main` unnoticed because the `cargo-semver-checks` job is
+  in a `workflow_dispatch`-only workflow and has never run on a pull request.
+  Tracked as #2088.
+
+### Added
+- Metrics and assertions now report whether they were actually exercised, not
+  only whether they passed. Assertion-based verification calls this a companion
+  cover: an assert with zero attempts is a coverage hole, not a pass.
+  - `Exercised { NotApplicable, NotExercised, Exercised }` on `MetricResult`,
+    with 22 sites across `assay-metrics` reclassified from a vacuous `pass(1.0)`
+    (#2068).
+  - A test whose named metric evaluated nothing is reported in the console
+    summary, in `run.json`'s `warnings`, and in the `ci` job summary, under
+    `W_METRIC_NOT_EXERCISED`. It never changes a status, a count or an exit
+    code (#2083).
+  - The same for the `assertions:` surface, under
+    `W_ASSERTION_NOT_EXERCISED`. A `trace_must_not_call_tool` naming a tool the
+    agent was never offered held on every trace and could not have failed;
+    availability is now the antecedent, and an unrecorded tool list reports
+    nothing rather than guessing (#2085).
+  - The baseline treats an `Exercised → NotExercised` drop between runs as a
+    coverage regression. Without it a metric that stopped running made the
+    baseline look *better*, because its score rises to 1.0 (#2082).
+
+### Fixed
+- A test's score is no longer whichever metric ran last. `final_score` was
+  assigned unconditionally per metric, and `semantic` is fifth of thirteen, so a
+  semantic test scoring 0.87 reported 1.0 in `run.json` and SARIF — a number
+  from a metric that was never asked to run (#2068).
+- Five `--format` arguments accepted any string and fell through to a default.
+  `assay doctor --format totally-invalid` printed the text report at exit 0;
+  `policy generate --format jsom` wrote a YAML policy into whatever path was
+  named. The check that should have caught them compared against a hand-kept
+  table that never listed them, and now derives the set from the command tree
+  (#2086).
+- The Linux compile gate returned 0 on failure, so it could not catch the
+  `cfg(target_os = "linux")` errors it exists for (#2076).
+- The docs bot opened pull requests whose required checks could never run,
+  because `create-pull-request` signs them with the default `GITHUB_TOKEN` and
+  GitHub does not trigger workflows for that token. The drift is now checked on
+  the change that causes it (#2080).
+- `normalize_severity` downgraded an unrecognized severity to `note`, which
+  could turn a failing run into exit 0; `assay-core` carried a second copy, and
+  that was the one reaching GitHub Code Scanning (#2025, #2033).
+- `decide_exit` classified by string prefix, so one missing trace produced two
+  different exit codes. The exit class is now a table the registry owns (#2024).
+
+### Changed
+- ADR-046 records that the two reason-code registries stay separate, after
+  measuring that the collision #2010 was filed on does not exist: the two SARIF
+  producers write different `tool.driver.name`, so GitHub keys them in separate
+  namespaces (#2028).
+- `docs/architecture/REASON-CODE-VOCABULARIES.md` inventories every
+  reason-code-shaped vocabulary by the artifact field it writes to, with four
+  machine-checked blocks (#2026, #2027).
+
+
 ## [3.38.0] - 2026-08-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "aya",
  "chrono",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.38.0"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -76,19 +76,19 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.38.0" }
-assay-common = { path = "crates/assay-common", version = "3.38.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.38.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.38.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.38.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.38.0" }
-assay-canonical = { path = "crates/assay-canonical", version = "3.38.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.38.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.38.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.38.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.38.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.38.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.38.0" }
+assay-core = { path = "crates/assay-core", version = "4.0.0" }
+assay-common = { path = "crates/assay-common", version = "4.0.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "4.0.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "4.0.0" }
+assay-policy = { path = "crates/assay-policy", version = "4.0.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "4.0.0" }
+assay-canonical = { path = "crates/assay-canonical", version = "4.0.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "4.0.0" }
+assay-sim = { path = "crates/assay-sim", version = "4.0.0" }
+assay-registry = { path = "crates/assay-registry", version = "4.0.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "4.0.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "4.0.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "4.0.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/crates/assay-adapter-a2a/Cargo.toml
+++ b/crates/assay-adapter-a2a/Cargo.toml
@@ -10,8 +10,8 @@ readme.workspace = true
 publish = false
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
-assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-adapter-acp/Cargo.toml
+++ b/crates/assay-adapter-acp/Cargo.toml
@@ -10,8 +10,8 @@ readme.workspace = true
 publish = false
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
-assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-adapter-api/Cargo.toml
+++ b/crates/assay-adapter-api/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 publish = false
 
 [dependencies]
-assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }

--- a/crates/assay-adapter-ucp/Cargo.toml
+++ b/crates/assay-adapter-ucp/Cargo.toml
@@ -10,8 +10,8 @@ readme.workspace = true
 publish = false
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
-assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -21,7 +21,7 @@ kill-switch-capture = ["kill-switch", "dep:procfs"]
 runtime-monitor = []
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
 assay-common = { workspace = true, features = ["std"] }
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/assay-sim/Cargo.toml
+++ b/crates/assay-sim/Cargo.toml
@@ -23,6 +23,6 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 tempfile = { workspace = true }
 
-assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
 assay-core = { workspace = true }
 assay-evidence = { workspace = true }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -52,7 +52,7 @@ assay --version
 
 Expected output:
 ```
-assay 3.38.0
+assay 4.0.0
 ```
 
 ---

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "hex",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "libc",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.38.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assay-canonical",

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -26,6 +26,11 @@
 #   2. The `assay --version` sample output in the installation guide, compared against what the
 #      binary actually prints, so the expectation comes from the program rather than from a
 #      hard-coded string.
+#   3. Every tracked `Cargo.lock` that pins a workspace crate. The root lock is the obvious one and
+#      `fuzz/Cargo.lock` is the one that was missed: it is a separate workspace, so a release bump
+#      that touched only the root lock left it pinning the previous version, and the fuzz job failed
+#      on `--locked` after the release PR was already open. The set is discovered with `git ls-files`
+#      rather than listed, so a third lockfile is covered the day it appears.
 #
 # Nothing is excluded by pattern. Lines that must stay historical are out of scope because they are
 # not derived from the current version in the first place.
@@ -110,6 +115,53 @@ fi
 # Derived from the binary rather than compared to a literal, so this cannot drift into asserting a
 # version the program does not print.
 # ---------------------------------------------------------------------------
+note ""
+note "workspace lockfiles:"
+
+# A lockfile that pins a workspace crate at the previous version is not cosmetic: any job running
+# with `--locked` refuses outright. `fuzz/Cargo.lock` is a separate workspace, so the root bump does
+# not reach it, and nothing else in this script would have looked.
+#
+# Discovered, not listed. Only locks that actually pin one of our crates are considered, so the
+# vendored upstream reference lock under scripts/ci/fixtures is out of scope by construction rather
+# than by an exclusion someone has to maintain.
+# The crates this workspace publishes, read from their own manifests. `assay-fuzz` is deliberately
+# excluded by this derivation rather than by name: it lives outside `crates/`, pins itself at 0.0.0
+# and is never published, so a name-prefix match would have flagged it forever.
+WORKSPACE_MEMBERS="$(
+  for manifest in crates/*/Cargo.toml assay-python-sdk/Cargo.toml; do
+    [ -f "$manifest" ] || continue
+    grep -q '^version\.workspace = true' "$manifest" || continue
+    awk -F' *= *' '/^name *=/ { gsub(/"/, "", $2); print $2; exit }' "$manifest"
+  done | tr '\n' ' '
+)"
+[ -n "$WORKSPACE_MEMBERS" ] || fail "could not derive the workspace member set; the manifest shape moved"
+
+locks_checked=0
+while IFS= read -r lock; do
+  [ -f "$lock" ] || continue
+  pinned="$(awk -v members="$WORKSPACE_MEMBERS" '
+    BEGIN { split(members, m, " "); for (i in m) is_member[m[i]] = 1 }
+    /^\[\[package\]\]/ { name = ""; next }
+    /^name = / { n = $3; gsub(/"/, "", n); if (n in is_member) name = n; next }
+    name != "" && /^version = / {
+      v = $3; gsub(/"/, "", v)
+      printf "%s\t%s\n", name, v
+      name = ""
+    }
+  ' "$lock")"
+  [ -n "$pinned" ] || continue
+  locks_checked=$((locks_checked + 1))
+  while IFS=$'\t' read -r name version; do
+    [ -n "$name" ] || continue
+    if [ "$version" != "$WORKSPACE_VERSION" ]; then
+      fail "$lock: $name pinned at \"$version\", workspace is \"$WORKSPACE_VERSION\""
+    fi
+  done <<< "$pinned"
+done < <(git ls-files '*Cargo.lock')
+
+note "  checked ${locks_checked} lockfile(s) pinning workspace crates"
+
 note ""
 note "documented CLI version output:"
 


### PR DESCRIPTION
## Description

Version bump only. `3.38.0` → `4.0.0`, plus the changelog section.

## Why a major

`MetricResult` gained a fifth public member in #2068, and it is a plain `pub struct` with no `#[non_exhaustive]`:

```
error[E0063]: missing field `exercised` in initializer of `MetricResult`
```

Established by compiling the old struct-literal form against `main`, not read off the diff. `assay-core` is published, so 3.39.0 would have handed cargo consumers a compile error on a minor bump.

Every constructor (`pass`, `fail`, `unstable`, `not_applicable`, `not_exercised`) is unchanged, so callers using those are unaffected. The break is narrow; the number is honest.

**Nothing in CI raised it.** The `cargo-semver-checks` job is in a `workflow_dispatch`-only workflow and has never run on a pull request. Filed as #2088 and deliberately not fixed here — a release prep is the wrong place to change what gates a merge.

## What the major surfaced that a minor would not

**Nine internal dependency requirements** were pinned at `version = "3.0.0"` rather than tracking the workspace. `cargo check --locked --offline` refused until they moved. Third-party `ed25519-dalek = "3.0"` is untouched — only `assay-*` path deps changed.

**`docs/getting-started/installation.md`** still showed `assay 3.38.0` as the expected `--version` output. `check-release-surface.sh` caught it, which is the check #1996 added after three files sat a release behind since v3.37.0.

## Method

`Cargo.lock` edited with `sed` rather than `cargo update -w`. On v3.34.0 the latter let an unrelated dependency re-resolve into a release diff. Verified the diff is version lines and nothing else.

## #1949

Moved to v4.1.0 before this, with the reasoning recorded on the issue. Its v3.39.0 scope was complete — the opt-in gate is built and fail-closed at `config.rs:124` — and its remaining item is gated on an announced window that has not run. It was blocking a release for work it had scheduled elsewhere.

## Verification

`cargo check --workspace --locked --offline` clean, `assay --version` prints `assay 4.0.0`, `check-release-surface.sh` consistent at 4.0.0, full `assay-core` and `assay-cli` suites pass.

## Scope

`Gate.ALL` — this touches the workspace dependency surface, so it needs a delegated proof bound to head `6a2026a45daa3b583b085e6f2fecff68bf38023c`.

## Checklist

- [x] My code follows the code style of this project.
- [ ] Tests — version bump only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exercised-state reporting and warnings for metrics and assertions.
  * Added coverage-regression detection and reason-code documentation.
* **Bug Fixes**
  * Improved score and format validation.
  * Corrected severity and exit-code classification.
  * Fixed Linux compile-gate and workflow issues.
* **Breaking Changes**
  * The `MetricResult.exercised` field has changed in version 4.0.0.
* **Documentation**
  * Updated the installation guide and changelog for the 4.0.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->