### PR TITLE
Two things our SARIF promised that were not true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,22 @@ gate-hardening and defect repair.
     baseline look *better*, because its score rises to 1.0 (#2082).
 
 ### Fixed
+- Every SARIF report pointed its help links at a domain that is not ours.
+  `docs.assay.dev` does not resolve, and `assay.dev` belongs to an unrelated
+  third party; six rule `helpUri`s and the driver `informationUri` shipped in
+  every report, and a seventh reference printed to the terminal. They now point
+  at a lint rules reference under `docs/lint/`, with anchors pinned explicitly
+  rather than derived, and a test asserts every emitted fragment resolves
+  against the committed page. The repo's link checker could not have caught
+  this: it triggers only on `docs/**`, so a change to Rust source never fires
+  it, it skips anything starting with `http`, and it reads only files changed
+  in the pull request (#2091).
+- The lint truncation disclosure named the cap only once the cap had fired.
+  Since `max_results` defaults to 5000 there is always a ceiling, so a clean
+  report was indistinguishable from an unbounded one. `appliedCap` is now
+  declared on every run and `droppedCount` only when a drop occurred, which is
+  the split ratified across four emitters in the SARIF envelope RFC and which
+  this producer's own defect report is cited in (#2091).
 - A test's score is no longer whichever metric ran last. `final_score` was
   assigned unconditionally per metric, and `semantic` is fifth of thirteen, so a
   semantic test scoring 0.87 reported 1.0 in `run.json` and SARIF — a number

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -19,7 +19,7 @@ metadata:
     - url: https://github.com/Rul1an/assay
       title: Repository
       icon: github
-    - url: https://docs.assay.dev
+    - url: https://docs.getassay.dev
       title: Documentation Site
     - url: https://github.com/Rul1an/assay/tree/main/docs/architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md
       title: ADR-032

--- a/crates/assay-core/src/mcp/policy/legacy.rs
+++ b/crates/assay-core/src/mcp/policy/legacy.rs
@@ -82,7 +82,7 @@ fn emit_deprecation_warning() {
              \x1b[33m   The 'constraints:' syntax is deprecated and will be removed in Assay v2.0.0.\x1b[0m\n\
              \x1b[33m   Migrate now:\x1b[0m\n\
              \x1b[33m     assay policy migrate --input <file>\x1b[0m\n\
-             \x1b[33m   See: https://docs.assay.dev/migration/v1-to-v2\x1b[0m\n"
+             \x1b[33m   See: https://docs.getassay.dev/migration/v1-to-v2\x1b[0m\n"
         );
     });
 }

--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -79,7 +79,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-W001",
         default_severity: Severity::Warn,
         description: "Subject may contain a secret (API key, token, password pattern)",
-        help_uri: Some("https://docs.assay.dev/lint/ASSAY-W001"),
+        help_uri: Some("https://docs.getassay.dev/lint/#assay-w001"),
         tags: &["security", "secrets"],
         security_severity: Some("7.0"),
         check: check_secret_in_subject,
@@ -88,7 +88,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-W002",
         default_severity: Severity::Warn,
         description: "Event flagged as containing PII but subject is non-empty",
-        help_uri: Some("https://docs.assay.dev/lint/ASSAY-W002"),
+        help_uri: Some("https://docs.getassay.dev/lint/#assay-w002"),
         tags: &["privacy", "pii"],
         security_severity: Some("4.0"),
         check: check_pii_flag_consistency,
@@ -97,7 +97,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-I001",
         default_severity: Severity::Info,
         description: "Source format does not follow URN convention",
-        help_uri: Some("https://docs.assay.dev/lint/ASSAY-I001"),
+        help_uri: Some("https://docs.getassay.dev/lint/#assay-i001"),
         tags: &["convention", "format"],
         security_severity: None,
         check: check_source_format,
@@ -106,7 +106,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-W003",
         default_severity: Severity::Warn,
         description: "Event flagged as containing secrets but secrets flag is false",
-        help_uri: Some("https://docs.assay.dev/lint/ASSAY-W003"),
+        help_uri: Some("https://docs.getassay.dev/lint/#assay-w003"),
         tags: &["security", "secrets"],
         security_severity: Some("6.5"),
         check: check_secrets_flag_consistency,
@@ -116,7 +116,7 @@ pub static RULES: &[RuleDefinition] = &[
         default_severity: Severity::Warn,
         description:
             "Observed enforcement marker is not supported by a bound enforcement decision record",
-        help_uri: Some("https://docs.assay.dev/lint/ASSAY-W004"),
+        help_uri: Some("https://docs.getassay.dev/lint/#assay-w004"),
         tags: &["security", "enforcement", "attribution"],
         security_severity: Some("4.0"),
         check: check_enforcement_attribution_binding,
@@ -127,7 +127,7 @@ pub static RULES: &[RuleDefinition] = &[
         description:
             "Approval basis declares an opaque or unknown retained view — content-review claims \
              over it cap at incomplete",
-        help_uri: Some("https://docs.assay.dev/lint/ASSAY-W005"),
+        help_uri: Some("https://docs.getassay.dev/lint/#assay-w005"),
         tags: &["retention", "review", "sufficiency"],
         security_severity: None,
         check: check_retained_view_readability,
@@ -172,7 +172,7 @@ fn check_secret_in_subject(event: &EvidenceEvent, ctx: &LintContext<'_>) -> Opti
                     }),
                     vec!["security".into(), "secrets".into()],
                 )
-                .with_help_uri("https://docs.assay.dev/lint/ASSAY-W001"),
+                .with_help_uri("https://docs.getassay.dev/lint/#assay-w001"),
             );
         }
     }
@@ -193,7 +193,7 @@ fn check_pii_flag_consistency(event: &EvidenceEvent, ctx: &LintContext<'_>) -> O
                 }),
                 vec!["privacy".into(), "pii".into()],
             )
-            .with_help_uri("https://docs.assay.dev/lint/ASSAY-W002"),
+            .with_help_uri("https://docs.getassay.dev/lint/#assay-w002"),
         );
     }
     None
@@ -217,7 +217,7 @@ fn check_source_format(event: &EvidenceEvent, ctx: &LintContext<'_>) -> Option<L
                 }),
                 vec!["convention".into(), "format".into()],
             )
-            .with_help_uri("https://docs.assay.dev/lint/ASSAY-I001"),
+            .with_help_uri("https://docs.getassay.dev/lint/#assay-i001"),
         );
     }
     None
@@ -247,7 +247,7 @@ fn check_secrets_flag_consistency(
                     }),
                     vec!["security".into(), "secrets".into()],
                 )
-                .with_help_uri("https://docs.assay.dev/lint/ASSAY-W003"),
+                .with_help_uri("https://docs.getassay.dev/lint/#assay-w003"),
             );
         }
     }
@@ -293,7 +293,7 @@ fn check_enforcement_attribution_binding(
                 "attribution".into(),
             ],
         )
-        .with_help_uri("https://docs.assay.dev/lint/ASSAY-W004"),
+        .with_help_uri("https://docs.getassay.dev/lint/#assay-w004"),
     )
 }
 
@@ -374,7 +374,7 @@ fn check_retained_view_readability(
             }),
             vec!["retention".into(), "review".into(), "sufficiency".into()],
         )
-        .with_help_uri("https://docs.assay.dev/lint/ASSAY-W005"),
+        .with_help_uri("https://docs.getassay.dev/lint/#assay-w005"),
     )
 }
 

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -322,12 +322,20 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     // Truncation is read off the report rather than the pack metadata. Both carry it and both are
     // set from the same values, but pack metadata is absent whenever no packs are configured, so
     // keying on it meant a default-path run disclosed nothing here at all.
+    //
+    // `appliedCap` is declared on every run, including runs where nothing was dropped. The cap is
+    // configuration: `engine.rs` resolves `max_results.unwrap_or(5000)`, so a ceiling is always in
+    // force and a run that stayed under it was still bounded. Gating this on `report.truncated`
+    // (which is what this code did until 2026-08-06) left a clean report unable to distinguish
+    // "no bound exists" from "a bound exists and did not fire" — and since the default path always
+    // has a bound, the honest reading of that silence was always the second one.
     let mut run_props = serde_json::Map::new();
     if let Some(ref meta) = options.pack_meta {
         if let Some(ref disclaimer) = meta.disclaimer {
             run_props.insert("disclaimer".into(), json!(disclaimer));
         }
     }
+    run_props.append(&mut cap_declaration(report));
     if report.truncated {
         run_props.append(&mut truncation_properties(report));
     }
@@ -356,12 +364,22 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     // comment claimed SARIF had no home for a reporting cap; that was wrong, and the correction is
     // that SARIF has a position instead of a gap.
     //
-    // Until the cap goes, disclose it in both available places and claim neither as a blessing.
-    // `run.properties` is the machine-readable carrier. The notification is a human-readable aid at
-    // `warning`, which 3.58.6 defines as covering the case where "the analysis might be incomplete
-    // but the results that were generated are probably valid". It stays below Appendix I's `error`
-    // gate deliberately: 3.20.21 makes an error-level notification mean the run failed, and a cap
-    // is not a failed run.
+    // Until the cap goes, disclose it, and claim the disclosure as no kind of blessing.
+    //
+    // The two facts are split by kind rather than duplicated, which is the shape ratified in
+    // `aliksir/claude-code-skill-security-check#24` across four emitters. The cap is configuration:
+    // true of the whole run whether or not it ever bit, so it belongs in `run.properties`. The drop
+    // is an event: it happened, it is specific to this run, and it is what a consumer following the
+    // OWASP agentic-skills rule already reads, so it belongs in the notification. An earlier version
+    // of this code put `appliedCap` in both, on the reasoning that a count without its ceiling is
+    // not actionable. That concern is real and the split answers it better: the ceiling is now on
+    // every run, so a consumer holding any notification can always resolve the cap it was measured
+    // against, including on the runs that carry no notification at all.
+    //
+    // The notification stays at `warning`, which 3.58.6 defines as covering the case where "the
+    // analysis might be incomplete but the results that were generated are probably valid". It
+    // stays below Appendix I's `error` gate deliberately: 3.20.21 makes an error-level notification
+    // mean the run failed, and a cap is not a failed run.
     let mut invocation = json!({
         "executionSuccessful": true
     });
@@ -380,8 +398,8 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
                         report.truncated_count, report.applied_cap
                     )
                 },
-                // The same keys the run properties carry, from the same builder — see
-                // The cross-emitter names, not this tool's; see `truncation_properties`.
+                // The drop only. The ceiling it was measured against is on the run — see
+                // `cap_declaration`.
                 "properties": truncation_notification_properties(report)
             }]),
         );
@@ -392,7 +410,7 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
         "name": "assay-evidence-lint",
         "version": report.tool_version,
         "semanticVersion": report.tool_version,
-        "informationUri": "https://docs.assay.dev/lint",
+        "informationUri": "https://docs.getassay.dev/lint/",
         "rules": rules
     });
     if !driver_props.is_empty() {
@@ -429,54 +447,64 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
     })
 }
 
-/// The truncation disclosure, built from one pair of values for two carriers that name them
-/// differently on purpose.
+/// The truncation disclosure: what was dropped, in this tool's own vocabulary.
 ///
-/// The names used to disagree by accident, which is a real defect and is what a consumer reading
-/// two names for one number cannot resolve. The fix is not to pick one, because the two bags
-/// address different readers.
+/// One number used to live in two carriers under two names, which is a real defect and is what a
+/// consumer reading two spellings of one fact cannot resolve. The resolution is the split in
+/// [`cap_declaration`] rather than a rename: the two carriers were not saying the same thing
+/// twice, they were conflating a configured bound with an event.
 ///
-/// `run.properties` is this tool's own carrier. `truncated` and `truncatedCount` are the names the
-/// pack-engine spec and the changelog publish, so renaming them would break consumers to settle an
-/// internal inconsistency.
+/// `truncated` and `truncatedCount` stay here because they are the names the pack-engine spec and
+/// the changelog publish. Renaming them would break consumers to settle an inconsistency that the
+/// split already settles.
 ///
-/// The notification is where a consumer following the OWASP agentic-skills rule reads, and
-/// `appliedCap` / `droppedCount` is the pair a second emitter already carries and that
-/// `aliksir/claude-code-skill-security-check#24` is settling as the cross-emitter shape, citing
-/// this emitter for those keys. Renaming away from a vocabulary while it is being standardised,
-/// and while this producer is named in it, buys internal tidiness and pays for it in interop.
+/// Worth knowing for whoever revisits this, and corrected here on 2026-08-06 after the earlier
+/// version of this paragraph asserted the opposite: **SARIF property-bag names are not flat.**
+/// 2.1.0 §3.8.1 says "the property names are hierarchical strings (§3.5.4)", and §3.5.4.1 defines
+/// a hierarchical string as forward-slash-separated components. `oasis-tcs/sarif-spec#181`
+/// proposed exactly that in 2018 with `semmle/query-path` as the example, and it was closed
+/// `resolved-fixed` under the `CSD.1` label. It landed. The 2.2 draft carries the same sentence.
 ///
-/// So the invariant is on the values rather than on the strings: both bags are derived from
-/// `applied_cap` and `truncated_count`, and the test asserts the carriers agree on what they
-/// disclose rather than on how they spell it. If the RFC pins a different pair, one function
-/// changes.
+/// What 2.1.0 does not do is *require* a producer to use the mechanism: the grammar admits a
+/// single component, so a bare `appliedCap` is conformant. So the shared namespace this code has
+/// to live with is a choice made here rather than a limitation of the format, and the honest
+/// reading is that the spec has offered a namespace since 2.1.0 and this producer has not taken
+/// it. That is the condition that let one fact acquire two names.
 ///
-/// Worth knowing for whoever revisits this: SARIF property-bag names are flat. Making them
-/// hierarchical was proposed as `oasis-tcs/sarif-spec#181` in 2018, with `semmle/query-path` as
-/// the example, and closed without discussion, so 2.1.0 requires nothing. Every bare key shares
-/// one namespace with every other producer's, which is the condition that lets one fact acquire
-/// two names.
+/// Do not repeat the flat claim. Zero comments on a closed OASIS TC issue is not evidence of no
+/// discussion, because TC deliberation lives in meeting minutes rather than the tracker; the
+/// labels are the state that travels.
 ///
-/// `appliedCap` travels with the count rather than only near it: without the ceiling a consumer
-/// sees how many findings fell past a bound but not what the bound was (OWASP agentic-skills #49
-/// review point).
-///
-/// Callers gate on `report.truncated`; these return the disclosure for a run already known to be
+/// Callers gate on `report.truncated`; this returns the disclosure for a run already known to be
 /// truncated.
 fn truncation_properties(report: &LintReport) -> serde_json::Map<String, serde_json::Value> {
     let mut props = serde_json::Map::new();
     props.insert("truncated".into(), json!(true));
     props.insert("truncatedCount".into(), json!(report.truncated_count));
+    props
+}
+
+/// The ceiling in force, declared on **every** run.
+///
+/// Not gated on whether it fired. `engine.rs` resolves `max_results.unwrap_or(5000)`, so there is
+/// always a bound, and an emitter that only mentions it after it bites leaves a clean report
+/// ambiguous between "unbounded" and "bounded, did not fire". Declaring it unconditionally is what
+/// makes the silence of a notification-free run mean something.
+///
+/// `appliedCap` is the cross-emitter spelling settled in
+/// `aliksir/claude-code-skill-security-check#24`, where this producer is cited by name for it.
+fn cap_declaration(report: &LintReport) -> serde_json::Map<String, serde_json::Value> {
+    let mut props = serde_json::Map::new();
     props.insert("appliedCap".into(), json!(report.applied_cap));
     props
 }
 
-/// The same two values in the cross-emitter vocabulary. See [`truncation_properties`].
+/// The drop, in the cross-emitter vocabulary. The ceiling lives on the run — see
+/// [`cap_declaration`].
 fn truncation_notification_properties(
     report: &LintReport,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut props = serde_json::Map::new();
-    props.insert("appliedCap".into(), json!(report.applied_cap));
     props.insert("droppedCount".into(), json!(report.truncated_count));
     props
 }

--- a/crates/assay-evidence/tests/lint_help_uri_targets.rs
+++ b/crates/assay-evidence/tests/lint_help_uri_targets.rs
@@ -1,0 +1,158 @@
+//! Every `helpUri` this producer emits must land on a section that exists.
+//!
+//! This test exists because the emitter shipped a dead pointer for a long time and nothing caught
+//! it. The rule `helpUri`s and the driver `informationUri` pointed at `docs.assay.dev`, a host that
+//! does not resolve — and `assay.dev` is not even ours, so the pointers named a third party's
+//! domain. The repo does run a link checker (`.github/workflows/docs-link-check.yml`), and it could
+//! not have caught this three times over: it triggers only on `paths: [docs/**]` so a change to
+//! Rust source never fires it, it explicitly skips anything starting with `http`, and it only reads
+//! files changed in the PR.
+//!
+//! The general shape is that the link checker verifies the *docs* while the URIs a consumer
+//! actually receives live in Rust string literals, checked by nothing. A pointer is a promise made
+//! to someone reading the artifact, so it belongs to the artifact's tests.
+//!
+//! Scope, stated so nobody reads more into a pass than is here. This asserts the anchor exists in
+//! the committed markdown. It does not assert the page is deployed, and it emphatically does not
+//! assert the prose is true: if a rule's behaviour changes and its section does not, the anchor
+//! keeps resolving and starts lying. That failure is quieter than a dead link, and this test does
+//! not reach it.
+//!
+//! Anchors are pinned explicitly with `attr_list` (`{#assay-w001}`) rather than left to mkdocs'
+//! slugify, so the emitted fragment is a literal that appears in the source rather than something
+//! derived by two implementations that could disagree.
+
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions};
+use assay_evidence::lint::sarif::to_sarif;
+use assay_evidence::types::EvidenceEvent;
+use assay_evidence::VerifyLimits;
+use chrono::{TimeZone, Utc};
+use std::collections::BTreeSet;
+use std::io::Cursor;
+
+const DOCS_PAGE: &str = "../../docs/lint/index.md";
+const EXPECTED_PREFIX: &str = "https://docs.getassay.dev/lint/#";
+
+/// A bundle with one clean event. The rule registry is emitted in full regardless of what fired,
+/// so this is enough to see every `helpUri` the producer can ship.
+fn minimal_sarif() -> serde_json::Value {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    let mut event = EvidenceEvent::new(
+        "assay.net.connect",
+        "urn:assay:test",
+        "run_help_uri",
+        0,
+        serde_json::json!({"url": "https://api.example.com"}),
+    );
+    event.time = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    writer.add_event(event);
+    writer.finish().unwrap();
+
+    let report = lint_bundle_with_options(
+        Cursor::new(&buffer),
+        VerifyLimits::default(),
+        LintOptions {
+            packs: Vec::new(),
+            max_results: None,
+            bundle_path: None,
+        },
+    )
+    .expect("lint should succeed")
+    .report;
+
+    to_sarif(&report)
+}
+
+/// Explicit `{#anchor}` targets declared by headings in the committed page.
+fn declared_anchors() -> BTreeSet<String> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(DOCS_PAGE);
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("the help target page must exist at {}: {e}", path.display()));
+
+    text.lines()
+        .filter(|line| line.starts_with('#'))
+        .filter_map(|line| {
+            let start = line.find("{#")? + 2;
+            let end = line[start..].find('}')? + start;
+            Some(line[start..end].to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn every_rule_help_uri_resolves_to_a_declared_anchor() {
+    let sarif = minimal_sarif();
+    let anchors = declared_anchors();
+    assert!(
+        !anchors.is_empty(),
+        "no {{#anchor}} declarations found — the extraction is broken, not the page"
+    );
+
+    let rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("the driver must declare its rules");
+    assert!(!rules.is_empty(), "the registry must not be empty");
+
+    let mut checked = 0;
+    for rule in rules {
+        let id = rule["id"].as_str().expect("rule id");
+        let uri = rule["helpUri"]
+            .as_str()
+            .unwrap_or_else(|| panic!("rule {id} ships no helpUri"));
+
+        let fragment = uri
+            .strip_prefix(EXPECTED_PREFIX)
+            .unwrap_or_else(|| panic!("rule {id} points outside the help page: {uri}"));
+        assert!(
+            anchors.contains(fragment),
+            "rule {id} points at #{fragment}, which no heading declares. \
+             Declared: {anchors:?}"
+        );
+        checked += 1;
+    }
+    assert_eq!(
+        checked,
+        rules.len(),
+        "every registry rule must be covered, not merely the ones that fired"
+    );
+}
+
+/// The negative control. A test that only ever passes on correct input proves nothing about its
+/// own sensitivity, and this whole class of defect is one that silently passed for months.
+#[test]
+fn a_fragment_with_no_heading_is_rejected() {
+    let anchors = declared_anchors();
+    assert!(
+        !anchors.contains("assay-w999-does-not-exist"),
+        "the anchor check must be able to fail; it accepted a fabricated target"
+    );
+}
+
+/// The driver-level pointer is the one a consumer follows when no rule fired, which is exactly the
+/// report most likely to be read as an all-clear.
+#[test]
+fn the_driver_information_uri_points_at_the_help_page() {
+    let sarif = minimal_sarif();
+    let uri = sarif["runs"][0]["tool"]["driver"]["informationUri"]
+        .as_str()
+        .expect("the driver must carry an informationUri");
+
+    assert_eq!(uri, "https://docs.getassay.dev/lint/", "got {uri}");
+    assert!(
+        !uri.contains("docs.assay.dev"),
+        "docs.assay.dev is NXDOMAIN and assay.dev belongs to a third party: {uri}"
+    );
+}
+
+/// No pointer anywhere in the emitted document may name the dead host again.
+#[test]
+fn nothing_emitted_names_the_dead_host() {
+    let sarif = minimal_sarif();
+    let serialised = serde_json::to_string(&sarif).expect("serialise");
+    assert!(
+        !serialised.contains("docs.assay.dev"),
+        "the emitted SARIF still names the dead host"
+    );
+}

--- a/crates/assay-evidence/tests/lint_truncation_disclosure.rs
+++ b/crates/assay-evidence/tests/lint_truncation_disclosure.rs
@@ -122,33 +122,35 @@ fn truncation_is_announced_in_a_tool_execution_notification() {
         "the notice must carry how many were dropped: {text}"
     );
     // OWASP agentic-skills #49 review point: a disclosed truncation is only actionable if the
-    // consumer can see the ceiling, not just the overflow. The cap travels as a machine-readable
-    // field and in the message, so a consumer reconstructs both without parsing prose.
+    // consumer can see the ceiling, not just the overflow. The prose still names it, for a human
+    // reading the notice alone.
     assert!(
         text.contains(&report.applied_cap.to_string()),
         "the notice must name the cap the count was measured against: {text}"
     );
-    assert_eq!(notifications[0]["properties"]["appliedCap"], 3);
-    // The notification speaks the cross-emitter vocabulary; `run.properties` keeps this tool's
-    // published names. See `both_carriers_disclose_the_same_two_values`.
+    // The machine-readable ceiling is NOT here. It is on the run, unconditionally, so it is
+    // resolvable from every report including the ones with no notification at all. See
+    // `the_cap_is_declared_once_at_run_level`.
+    assert!(
+        notifications[0]["properties"].get("appliedCap").is_none(),
+        "the cap is configuration and belongs on the run, not duplicated per event: {}",
+        notifications[0]["properties"]
+    );
     assert_eq!(
         notifications[0]["properties"]["droppedCount"],
         report.truncated_count
     );
 }
 
-/// One cap firing, said the same way in both places it is said. The notification used to call the
-/// suppressed count `droppedCount` where `run.properties` called it `truncatedCount`, so a consumer
-/// reading both saw two names for one number. Pinned as equality rather than key-by-key, because
-/// the point is that neither carrier can grow a truncation key the other lacks. Equality is exact
-/// The two carriers name the cap differently on purpose, so the invariant is that they disclose
-/// the same two values rather than the same two strings. `run.properties` keeps this tool's
-/// published names; the notification carries the cross-emitter pair that
-/// aliksir/claude-code-skill-security-check#24 is settling. Asserting string equality here would
-/// pin the wrong thing and would break the moment either vocabulary moved, which is exactly what
-/// is expected to happen to one of them.
+/// Each fact in exactly one carrier, split by what kind of fact it is.
+///
+/// This used to assert that both carriers disclosed the same two values, which was the best
+/// available answer while the cap lived in both places: the names differed, so the invariant had to
+/// be on the numbers. The split makes the question go away. The cap is configuration and is stated
+/// once, on the run; the drop is an event and is stated once, in the notification. Nothing is
+/// duplicated, so nothing can disagree.
 #[test]
-fn both_carriers_disclose_the_same_two_values() {
+fn each_fact_travels_in_exactly_one_carrier() {
     let bundle = bundle_with_many_findings(10);
     let report = lint_capped(&bundle, Some(3));
     let sarif = to_sarif(&report);
@@ -156,17 +158,18 @@ fn both_carriers_disclose_the_same_two_values() {
     let note = &sarif["runs"][0]["invocations"][0]["toolExecutionNotifications"][0]["properties"];
     let run = &sarif["runs"][0]["properties"];
 
+    assert_eq!(run["appliedCap"], 3, "the ceiling is on the run: {run}");
     assert_eq!(
-        note["appliedCap"], run["appliedCap"],
-        "the cap must be one number: notification {note}, run {run}"
+        note["droppedCount"], report.truncated_count,
+        "the drop is on the event: {note}"
     );
-    assert_eq!(
-        note["droppedCount"], run["truncatedCount"],
-        "the suppressed count must be one number under either name: \
-         notification {note}, run {run}"
+
+    // Neither carrier may grow the other's fact back. A future edit that "helpfully" restores the
+    // cap to the notification fails here rather than on someone else's consumer.
+    assert!(
+        note.get("appliedCap").is_none(),
+        "the cap is not duplicated per event: {note}"
     );
-    // And each carrier must actually use its own vocabulary, so a future edit that quietly
-    // unifies them fails here rather than surfacing on someone else's consumer.
     assert!(
         note.get("truncatedCount").is_none(),
         "the notification carries the cross-emitter name only: {note}"
@@ -174,6 +177,31 @@ fn both_carriers_disclose_the_same_two_values() {
     assert!(
         run.get("droppedCount").is_none(),
         "run.properties carries this tool's published names only: {run}"
+    );
+}
+
+/// The reason the split is worth the churn: silence has to mean something.
+///
+/// `engine.rs` resolves `max_results.unwrap_or(5000)`, so every run is bounded. While the cap was
+/// gated on truncation, a clean report said nothing about it, and a consumer could not tell an
+/// unbounded run from a bounded one that did not fire. Since the default path is always bounded,
+/// that silence was always misleading in the same direction.
+#[test]
+fn the_cap_is_declared_once_at_run_level() {
+    let bundle = bundle_with_many_findings(3);
+    let report = lint_capped(&bundle, Some(5000));
+    let sarif = to_sarif(&report);
+
+    assert!(!report.truncated, "precondition: nothing was dropped");
+
+    let run = &sarif["runs"][0]["properties"];
+    assert_eq!(
+        run["appliedCap"], 5000,
+        "a run that stayed under its ceiling still had one: {run}"
+    );
+    assert!(
+        run.get("truncated").is_none() && run.get("truncatedCount").is_none(),
+        "declaring the cap must not imply a drop that did not happen: {run}"
     );
 }
 

--- a/docs/architecture/SPEC-Pack-Engine-v1.md
+++ b/docs/architecture/SPEC-Pack-Engine-v1.md
@@ -498,7 +498,7 @@ owes a consumer; it is not a construct the format provides for capping.
         "name": "assay-evidence-lint",
         "version": "2.9.0",
         "semanticVersion": "2.9.0",
-        "informationUri": "https://docs.assay.dev/lint",
+        "informationUri": "https://docs.getassay.dev/lint/",
         "properties": {
           "assayPacks": [
             {
@@ -906,7 +906,7 @@ Error: Pack './my-pack.yaml' validation failed:
   - Line 12: Rule 'MY-001' missing required field 'check'
   - Line 18: Unknown check type 'custom_check'
 
-See: https://docs.assay.dev/packs/schema
+See: https://docs.getassay.dev/architecture/SPEC-Pack-Engine-v1/
 ```
 
 ### Disclaimer Missing

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -371,7 +371,7 @@ When validation fails, Assay provides actionable feedback:
 
    Suggestion: Use percent <= 30
 
-   Docs: https://docs.assay.dev/config/policies
+   Docs: https://docs.getassay.dev/concepts/policies/
 ```
 
 ---

--- a/docs/lint/index.md
+++ b/docs/lint/index.md
@@ -1,0 +1,171 @@
+# Lint Rules Reference
+
+`assay evidence lint` verifies an evidence bundle and then applies a fixed registry of rules to
+every event in it. This page is the target of the `helpUri` that each finding carries in SARIF
+output, so every rule below has a stable anchor and the emitter is tested against this file.
+
+```bash
+assay evidence lint bundle.tar.gz --format sarif
+```
+
+**Verification runs first.** Lint never reads an unverified bundle. If verification fails the
+command exits 2 and no rules run, so a lint finding always describes a bundle whose integrity
+already held.
+
+**Exit codes.** `0` no findings above the threshold, `1` findings, `2` verification failure.
+
+## Reading a clean run
+
+A run with no findings means no rule in the registry matched. It is not a statement that the
+bundle is free of the problems these rules look for. Three of the six rules key on structural
+fields that an event may simply not carry — `ASSAY-W004` needs a refusal marker, `ASSAY-W005`
+needs an `approval_retained_view` field, `ASSAY-W002` needs the PII flag set — and an event that
+omits the field is silent rather than clean. The secret-pattern rules match a fixed list of
+literal prefixes and will not find a credential shaped differently.
+
+A passing lint is a lower bound on what was checked, not a coverage claim.
+
+## Severity and `security-severity`
+
+Rules carry a default severity (`error`, `warning`, `note`) and security-relevant rules also carry
+a CVSS-like `security-severity` used by GitHub Code Scanning to bucket alerts. The two are
+independent: `ASSAY-W005` is a warning with no `security-severity`, because an unreadable approval
+basis caps what a review can claim rather than describing an exploitable weakness.
+
+---
+
+## ASSAY-W001 — Subject may contain a secret {#assay-w001}
+
+**Severity** warning · **security-severity** 7.0 · **Tags** `security`, `secrets`
+
+Fires when `event.subject` contains any of a fixed list of literal credential prefixes, compared
+case-insensitively: `sk-`, `sk_live_`, `sk_test_`, `api_key=`, `apikey=`, `token=`, `password=`,
+`secret=`, `Bearer `, `AKIA` (AWS access key), `ghp_`, `gho_`, `github_pat_` (GitHub tokens). The
+message names the pattern that matched.
+
+**Why it matters.** A subject travels in the manifest and in every projection of the bundle. A
+credential there is disclosed to everyone who can read the evidence, including anyone the bundle
+is shared with for audit.
+
+**How to fix.** Redact the value at the producer before the event is written. Rewriting the bundle
+afterwards changes its content hashes and invalidates the Merkle root.
+
+**Note.** The match is a literal substring test, not a validator. It has both false positives
+(`token=` in prose) and false negatives (a credential with no recognised prefix).
+
+## ASSAY-W002 — PII flag set with a non-empty subject {#assay-w002}
+
+**Severity** warning · **security-severity** 4.0 · **Tags** `privacy`, `pii`
+
+Fires when `contains_pii` is true and `subject` is present and non-empty.
+
+**Why it matters.** The flag is the producer stating that this event carries personal data. A
+non-empty subject on such an event is the most likely place for that data to be sitting in the
+clear, and the subject is the field most widely reproduced downstream.
+
+**How to fix.** Redact or omit the subject on PII-bearing events. If the subject is genuinely free
+of personal data, the flag is describing the payload only — that is a legitimate shape, and the
+finding is advisory.
+
+## ASSAY-W003 — Secret pattern present but `contains_secrets` is false {#assay-w003}
+
+**Severity** warning · **security-severity** 6.5 · **Tags** `security`, `secrets`
+
+Fires when `subject` matches any pattern from the `ASSAY-W001` list and `contains_secrets` is
+false.
+
+**Why it matters.** This is a disagreement between what the producer declared and what the record
+contains. A consumer filtering on `contains_secrets` to decide what may be shared will treat the
+event as safe, so the flag being wrong is worse than the secret being present and declared.
+
+**How to fix.** Correct the producer so the flag reflects the content, then redact.
+
+**Note.** `ASSAY-W001` and `ASSAY-W003` share one pattern list, so an undeclared secret raises
+both: one for the disclosure, one for the mislabelling. They are not duplicates.
+
+## ASSAY-W004 — Refusal observation not backed by a decision record {#assay-w004}
+
+**Severity** warning · **security-severity** 4.0 · **Tags** `security`, `enforcement`,
+`attribution`
+
+Fires when an event carries a proxy refusal marker and the bundle contains no
+`assay.enforcement_decision.v0` record with a `deny` decision bound to the same
+`(tool_name, target_digest)` pair. Two distinct messages:
+
+- **unbacked** — no decision record for that key at all.
+- **contradicted** — a decision record exists for that key and says `allow`.
+
+**Why it matters.** "The call was denied" is an attribution claim: it says an enforcement point
+acted. Without a digest-bound decision record, the observation asserts an actor that left no
+trace. The contradicted case is stronger — an audit record and the enforcement record disagree
+about the same digest, and that conflict is itself the finding.
+
+**How to fix.** Ensure the enforcing component emits `assay.enforcement_decision.v0` bound to the
+same target digest the refusal marker uses. A refusal recorded by one component and a decision
+recorded by another must agree on the digest, or they cannot be joined.
+
+## ASSAY-W005 — Approval basis declares an unreadable retained view {#assay-w005}
+
+**Severity** warning · **Tags** `retention`, `review`, `sufficiency`
+
+Applies only to `assay.enforcement_decision.v0` events that carry an `approval_retained_view`
+field. An absent field is not a finding — the record makes no retained-view claim, so the rule is
+out of scope.
+
+Silent for the one readable value, `structured_meta_jcs`, which is a digest-recomputable
+structured basis. Every other value is treated as not readable, fail-closed, in three cases:
+
+| declared view | reading | recovery |
+|---|---|---|
+| `encrypted` **with** `approval_plaintext_commitment` | `opaque_bindable` | a later disclosure is checkable against the commitment |
+| `encrypted` **without** the commitment | `opaque_unbindable` | key disclosure only |
+| unknown value, empty string, or non-string | fail-closed | correct the producer |
+
+**Why it matters.** A content-review claim over an approval nobody can read is not a review. The
+rule caps such claims at *incomplete* rather than rejecting the bundle, because integrity is a
+floor and never a lift: a bundle can verify perfectly and still not support the claim being made
+over it.
+
+**How to fix.** Emit `structured_meta_jcs` where the approval basis is structured. Where the body
+genuinely must be encrypted, emit `approval_plaintext_commitment` alongside it so a later
+disclosure can be bound to what was approved at the time.
+
+## ASSAY-I001 — Source does not follow the URN convention {#assay-i001}
+
+**Severity** note · **Tags** `convention`, `format`
+
+Fires when `event.source` starts with neither `urn:` nor `https://`.
+
+**Why it matters.** Convention only. A source that is neither a URN nor an absolute URL is not
+resolvable or globally unique, which makes correlation across bundles from different producers
+unreliable.
+
+**How to fix.** Use `urn:` for logical producers and `https://` where the source is a real
+resolvable endpoint.
+
+---
+
+## Truncation disclosure
+
+When a run produces more findings than the configured cap, the report discloses it in two places:
+
+- `run.properties.appliedCap` — the ceiling in force, declared on every run whether or not it was
+  reached, so silence is never ambiguous between "no bound" and "a bound that did not fire".
+- a `toolExecutionNotifications` entry at `warning` carrying `droppedCount` — emitted only when a
+  drop actually occurred.
+
+`executionSuccessful` stays `true` on a truncated run. Per SARIF §3.20.21 an `error`-level
+notification asserts the run failed; a bounded report over a complete analysis is not a failed
+run, and reporting it as one would make a deliberate policy indistinguishable from an
+environmental fault.
+
+This shape follows the cross-emitter envelope agreed in
+[`aliksir/claude-code-skill-security-check#24`](https://github.com/aliksir/claude-code-skill-security-check/issues/24),
+where the split between run-level configuration and run-specific event was settled.
+
+## Known gap
+
+The `helpUri` values point at this page as published from the default branch, not at the release
+that emitted the report. A consumer reading an old SARIF file gets the current text, which may
+describe a rule that has since changed. Release-tagged pointers would fix it and are not
+implemented.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,6 +222,8 @@ nav:
     - tool_blocklist: metrics/tool-blocklist.md
     - Custom Metrics: metrics/custom.md
 
+  - Lint Rules: lint/index.md
+
   - Use Cases:
     - use-cases/index.md
     - Promptfoo JSONL Receipts: use-cases/evidence-receipts-from-promptfoo-jsonl.md


### PR DESCRIPTION
Both found by reading [`aliksir/claude-code-skill-security-check#24`](https://github.com/aliksir/claude-code-skill-security-check/issues/24), the four-emitter SARIF envelope RFC, rather than by anything in our own CI.

## 1. Every `helpUri` pointed at a domain that is not ours

`docs.assay.dev` is NXDOMAIN. `assay.dev` resolves, but to an unrelated third party — "Science and Technology of Assay Development". Ours is `getassay.dev`, per `docs/CNAME`.

Eighteen references. **Thirteen ship inside every SARIF report** — six rule `helpUri`s and the driver `informationUri`. One more prints to the terminal as a migration hint.

Fixing the host alone would have been worse than leaving it: the live site has 559 pages and **no lint pages at all**, so a rename converts thirteen obviously-dead links into thirteen live-host 404s. So this adds `docs/lint/index.md` as the real target, with anchors pinned explicitly via `attr_list` rather than derived from heading text, and a test asserting every emitted fragment resolves against the committed page.

Mutation-tested in both directions:

| bite | result |
|---|---|
| typo in an emitted `helpUri` | fails — `points at #assay-w001-typo, which no heading declares` |
| a heading's `{#anchor}` removed | fails — `rule ASSAY-W004 points at #assay-w004, which no heading declares` |

**Why CI never caught it.** `docs-link-check.yml` triggers only on `paths: [docs/**]` so a change to Rust source never fires it, explicitly `continue`s on anything starting with `http`, and reads only files changed in the PR. It verifies the docs. The URIs a consumer actually receives live in Rust string literals and were verified by nothing.

## 2. The cap and the drop were conflated

`appliedCap` travelled in both `run.properties` and the notification, and both were gated on truncation having fired. Since `engine.rs` resolves `max_results.unwrap_or(5000)`, **every run is bounded** — so a clean report stayed silent about a ceiling that was always in force, leaving a consumer unable to distinguish "unbounded" from "bounded, did not fire".

Split by kind, which is the shape #24 ratified across four emitters after our own report of this defect:

| fact | kind | carrier |
|---|---|---|
| `appliedCap` | configuration — true of the run whether or not it bit | `run.properties`, **every run** |
| `droppedCount` | event — happened, specific to this run | `toolExecutionNotifications` at `warning` |

Nothing is duplicated, so nothing can disagree. The earlier justification for carrying the cap in both places (OWASP agentic-skills #49: a count without its ceiling is not actionable) is better served by the split — the ceiling is now on every report, including those carrying no notification at all.

Bite: restoring `appliedCap` to the notification fails `each_fact_travels_in_exactly_one_carrier`.

## Also

Corrects a comment claiming SARIF property-bag names are flat. SARIF 2.1.0 §3.8.1 defines them as hierarchical strings (§3.5.4.1), and `oasis-tcs/sarif-spec#181` landed as `resolved-fixed` in 2018 — the claim had it exactly backwards.

## Verification

- `cargo test -p assay-evidence` — all green, 13 tests across the two affected files
- `cargo test -p assay-core --lib` — 876 passed
- `cargo clippy -p assay-evidence -p assay-core --all-targets` — clean
- every new URL checked live: all 200 except `/lint/`, which 404s until this merges and Pages rebuilds

## Known gap, stated rather than left to be found

The `helpUri`s point at the page as published from the default branch, not at the release that emitted the report. A consumer reading an old SARIF gets current text. Release-tagged pointers would fix it and are not implemented; it is recorded in the page itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SARIF help links to point to the appropriate lint-rule documentation anchors.
  * Improved lint report metadata so applied limits are consistently disclosed, while dropped-result counts appear only when applicable.
  * Updated migration and documentation links to the current documentation site.

* **Documentation**
  * Added a comprehensive lint rules reference covering rules, severity, remediation, exit codes, and truncation behavior.
  * Added the lint rules reference to the documentation navigation.

* **Tests**
  * Added coverage for SARIF link resolution and truncation metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->