### PR TITLE
The wall a reproducer hits first was not in the pack

### DIFF
--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -7,15 +7,19 @@ verifier logic, interpret the profile, or establish that an implementation is in
 ## Authorship order
 
 1. Obtain the clean-room pack.
-2. Read `spec.md` and `descriptor.json`.
-3. Implement a command that consumes one bundle path and emits the profile report.
-4. Freeze the implementation commit and record all materials consulted.
-5. Run the scorer. It snapshots the canonical oracle into scorer-private memory for tamper resistance,
+2. Run `canonicalization/rfc8785-vectors.json` against your canonicalizer before anything else. It
+   is a prerequisite check, not profile work: passing it is not progress and agreement with it is
+   not conformance. It is here because a wrong canonicalizer makes every later result
+   uninterpretable, and because that is what broke the one completed cross-language attempt.
+3. Read `spec.md` and `descriptor.json`.
+4. Implement a command that consumes one bundle path and emits the profile report.
+5. Freeze the implementation commit and record all materials consulted.
+6. Run the scorer. It snapshots the canonical oracle into scorer-private memory for tamper resistance,
    executes every opaque case without passing that oracle to the candidate, and only then compares.
-6. Publish the implementation source, run record, and completed implementation report.
+7. Publish the implementation source, run record, and completed implementation report.
 
 Reading Assay's verifier, `gen_vectors.py`, the canonical `MANIFEST.json`, or a prior scored report
-before step 4 changes the methodological classification. Disclose that access rather than describing
+before step 5 changes the methodological classification. Disclose that access rather than describing
 the run as blind.
 
 ## Candidate command
@@ -102,7 +106,7 @@ steps:
     env:
       GH_TOKEN: ${{ github.token }}
     run: |
-      tag=privileged-mcp-action-v0-candidate.3
+      tag=privileged-mcp-action-v0-candidate.4
       source_digest="$(gh api "repos/Rul1an/assay/commits/$tag" --jq .sha)"
       gh release download "$tag" \
         --repo Rul1an/assay \
@@ -133,7 +137,7 @@ The release controller runs only from `main`, validates `candidate-release.json`
 checked-out corpus, and creates the annotated tag after the pack, transformation check, and
 attestation succeed. Pack verification resolves that tag to the attested source commit. The
 composite action is pinned separately to the full commit carrying the action implementation; the
-`candidate.3` release-preparation change does not alter the invoked scoring path. Keep full-commit
+`candidate.4` release-preparation change does not alter the invoked scoring path. Keep full-commit
 pinning when updating the action used by a long-lived workflow.
 
 ## Claim ceiling

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -27,15 +27,35 @@ repinned to verified release bytes.
 
 ### Clean-room path
 
-The active release target is `privileged-mcp-action-v0-candidate.3`. Once its GitHub
+The active release target is `privileged-mcp-action-v0-candidate.4`. Once its GitHub
 [Releases](https://github.com/Rul1an/assay/releases) entry is published, it contains a
-deterministic, attested clean-room pack with `spec.md`, `descriptor.json`, and fourteen opaque
-cases. It omits expected outcomes, semantic case names, the vector generator, and Assay's
-implementation. `candidate.2` remains unchanged historical input for the superseded 13-case
-digest; do not use it for a new attempt against the current corpus.
+deterministic, attested clean-room pack with `spec.md`, `descriptor.json`, fourteen opaque
+cases, and the RFC 8785 canonicalization vectors. It omits expected outcomes, semantic case names,
+the vector generator, and Assay's implementation. `candidate.2` remains unchanged historical input
+for the superseded 13-case digest; do not use it for a new attempt against the current corpus.
+
+`candidate.4` re-releases the **same corpus** as `candidate.3` — identical digest, identical
+fourteen cases — and adds only onboarding. A reproduction against `candidate.3` remains valid and
+in scope; there is nothing to redo.
+
+#### Start with the canonicalization vectors
+
+The pack's `canonicalization/` directory carries the 31 RFC 8785 vectors this workspace tests its
+own canonicalizer against, byte-identical, plus a note. Run them before implementing any stage.
+
+The reason is empirical rather than tidy: the one completed cross-language reproduction in this
+ecosystem failed on its first attempt because native insertion-order serialization produced a
+different digest. Content ids, mandate ids and the bundle run root are all sha256 over canonical
+bytes, so a canonicalizer that is wrong makes every later result uninterpretable, and you find out
+fourteen bundles later.
+
+**Passing them is not progress on the profile and agreement with them is not conformance.** They
+describe byte formation under a published RFC that `descriptor.json` already requires
+(`canon: jcs-rfc8785`); they say nothing about what any bundle verifies to. Every profile outcome is
+still yours to derive.
 
 ```bash
-tag=privileged-mcp-action-v0-candidate.3
+tag=privileged-mcp-action-v0-candidate.4
 source_digest="$(gh api "repos/Rul1an/assay/commits/$tag" --jq .sha)"
 gh release download "$tag" --repo Rul1an/assay \
   --pattern privileged-mcp-action-v0-clean-room.tar.gz \

--- a/conformance/privileged-mcp-action-v0/candidate-release.json
+++ b/conformance/privileged-mcp-action-v0/candidate-release.json
@@ -1,6 +1,6 @@
 {
   "schema": "assay.privileged_mcp_action.candidate_release.v0",
-  "tag": "privileged-mcp-action-v0-candidate.3",
+  "tag": "privileged-mcp-action-v0-candidate.4",
   "case_count": 14,
   "corpus_digest": "sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342"
 }

--- a/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
+++ b/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
@@ -28,6 +28,11 @@ CORPUS_PATH = "conformance/privileged-mcp-action-v0"
 SPEC_PATH = "docs/profiles/privileged-mcp-action/v0.md"
 DESCRIPTOR_PATH = f"{CORPUS_PATH}/descriptor.json"
 MANIFEST_PATH = f"{CORPUS_PATH}/MANIFEST.json"
+# RFC 8785 conformance vectors (#1982), shipped in the pack since candidate.4 (#1990).
+#
+# Read from the same pinned commit as the spec and descriptor, so the pack stays reproducible from
+# a commit rather than from whatever happens to be in the working tree.
+JCS_VECTORS_PATH = "crates/assay-canonical/tests/vectors/rfc8785.json"
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 MAX_GIT_BLOB_BYTES = 32 * 1024 * 1024
 MAX_GIT_ERROR_BYTES = 64 * 1024
@@ -48,6 +53,52 @@ inputs.
 `cases.json` binds each opaque case to its bytes and records the declared source
 commit, source-corpus digest, and rendered-set digest. It does not contain expected
 results. Verify the release attestation separately before relying on pack provenance.
+
+Start with `canonicalization/`. A canonicalizer that is wrong makes every later
+result uninterpretable, and it is the first thing a cross-language attempt has
+been observed to fail on. Read `canonicalization/README.md` before the spec.
+"""
+
+
+JCS_README = """\
+# RFC 8785 conformance vectors
+
+## What these are
+
+Thirty-one vectors pinning byte formation under RFC 8785 (JCS): number
+reformatting, both ES6 exponent boundaries, UTF-16 code-unit key ordering, and
+the absence of Unicode normalization. Each carries the exact expected bytes and
+names the property it pins.
+
+The profile's `descriptor.json` already requires `canon: jcs-rfc8785`. These let
+you check that requirement before you have anything else to check it with.
+
+## What they are not
+
+**Passing them is not progress on the profile.** They say nothing about what any
+bundle should verify to, which stages exist, or what any case's outcome is. You
+still have to derive every profile result yourself from `spec.md` and
+`descriptor.json`, and this pack still omits the expected outcomes, the semantic
+case names, the vector generator, and Assay's implementation.
+
+**Agreement with them is not conformance.** It is the absence of one specific
+way to be wrong.
+
+## Why they are in a clean-room pack at all
+
+Because the expectations are derived from a published RFC rather than from this
+implementation, and because the one cross-language reproduction anyone in this
+ecosystem has completed failed on its first attempt for exactly this reason:
+native insertion-order serialization produced a different digest.
+
+Shipping them removes a wall that has nothing to do with the profile. It does
+not lower the independence bar, because a canonicalizer is not an answer.
+
+## Running them
+
+Each entry maps an input JSON value to the exact bytes RFC 8785 requires. Feed
+the input to your canonicalizer and compare bytes, not parsed values. The
+`_about` key is metadata and is not a vector.
 """
 
 
@@ -79,6 +130,10 @@ def build_pack(repo_root: Path, source_commit: str) -> bytes:
     descriptor = clean_room_descriptor(
         git_bytes(repo_root, source_commit, DESCRIPTOR_PATH)
     )
+    # Unchanged bytes, deliberately: the vectors are shipped as they are tested here, so a
+    # reproducer and this workspace are checking their canonicalizers against the same file.
+    jcs_vectors = git_bytes(repo_root, source_commit, JCS_VECTORS_PATH)
+
     manifest_bytes = git_bytes(repo_root, source_commit, MANIFEST_PATH)
     manifest = json.loads(manifest_bytes)
 
@@ -127,6 +182,8 @@ def build_pack(repo_root: Path, source_commit: str) -> bytes:
     }
     files = {
         "README.md": README.encode(),
+        "canonicalization/README.md": JCS_README.encode(),
+        "canonicalization/rfc8785-vectors.json": jcs_vectors,
         "cases.json": (
             json.dumps(case_index, indent=2, sort_keys=True) + "\n"
         ).encode(),

--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -47,7 +47,10 @@ EXPECTED_CASE_COUNT = 14
 # spec.md, descriptor.json, cases.json, README.md. Derived rather than written out again:
 # the pack member count and the case count are one fact, and holding them as two numbers is
 # how the corpus grew to fourteen while a constant still said thirteen.
-EXPECTED_PACK_MEMBERS = EXPECTED_CASE_COUNT + 4
+# README, cases.json, descriptor.json, spec.md, plus the two canonicalization members added in
+# candidate.4 (#1990). Counted rather than derived so a pack that grew a member fails here instead
+# of being accepted because the scorer was taught to expect whatever it was handed.
+EXPECTED_PACK_MEMBERS = EXPECTED_CASE_COUNT + 6
 MAX_PACK_ARCHIVE_BYTES = 32 * 1024 * 1024
 MAX_MEMBER_NAME_BYTES = 512
 MAX_OUTPUT_BYTES = 1024 * 1024
@@ -142,6 +145,8 @@ def load_pack(pack: Path, destination: Path) -> dict[str, Any]:
         f"{PACK_ROOT}/cases.json",
         f"{PACK_ROOT}/descriptor.json",
         f"{PACK_ROOT}/spec.md",
+        f"{PACK_ROOT}/canonicalization/README.md",
+        f"{PACK_ROOT}/canonicalization/rfc8785-vectors.json",
     }
     seen_ids: set[str] = set()
     seen_hashes: set[str] = set()

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -7,6 +7,7 @@ import gzip
 import hashlib
 import io
 import json
+import re
 import os
 import shlex
 import subprocess
@@ -21,6 +22,14 @@ from unittest import mock
 
 CORPUS_DIR = Path(__file__).resolve().parents[1]
 REPO_ROOT = CORPUS_DIR.parents[1]
+
+# A synthetic string carrying one instance of each thing the canonicalization vectors must never
+# contain. Used only to prove the leak patterns in `test_pack_ships_the_canonicalization_vectors...`
+# actually match; it is never packed and never read by anything else.
+LEAKY_FIXTURE = (
+    'see case-07 for the shape; ok-privileged-call is an accept and '
+    'bad-arg-drift is a reject; expected_outcome=accept; verdict: pass'
+)
 BUILD_SCRIPT = CORPUS_DIR / "scripts" / "build_clean_room_pack.py"
 SCORE_SCRIPT = CORPUS_DIR / "scripts" / "score_candidate.py"
 VALIDATE_SCRIPT = CORPUS_DIR / "scripts" / "validate_run_record.py"
@@ -213,6 +222,78 @@ class CleanRoomPackTests(unittest.TestCase):
                 b"bad-108",
             ):
                 self.assertNotIn(forbidden, public_inputs)
+
+    def test_pack_ships_the_canonicalization_vectors_without_leaking_answers(self) -> None:
+        """The RFC 8785 vectors ship, and shipping them does not make the pack less clean-room.
+
+        A reproducer hits canonicalization before anything else -- the one completed cross-language
+        attempt failed there first -- and a wrong canonicalizer makes every later result
+        uninterpretable. The vectors are derived from a published RFC, not from this implementation,
+        so they remove that wall without answering anything about the profile (#1990).
+
+        What this asserts is the second half of that claim, because the first half is easy to
+        believe and the second is the one that could quietly stop being true.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "pack.tar.gz"
+            self.build(pack)
+            files = read_archive(pack)
+
+            vectors_name = "privileged-mcp-action-v0/canonicalization/rfc8785-vectors.json"
+            note_name = "privileged-mcp-action-v0/canonicalization/README.md"
+            self.assertIn(vectors_name, files)
+            self.assertIn(note_name, files)
+
+            # Byte-identical to the file this workspace tests against. If the pack carried a
+            # re-serialized copy, a reproducer and this repo would be checking their canonicalizers
+            # against two different files, which is the failure the vectors exist to prevent.
+            in_repo = (
+                REPO_ROOT / "crates/assay-canonical/tests/vectors/rfc8785.json"
+            ).read_bytes()
+            self.assertEqual(files[vectors_name], in_repo)
+
+            vectors = json.loads(files[vectors_name])
+            self.assertGreater(len(vectors), 20, "the vector set shrank")
+
+            # The clean-room property. The vectors describe byte formation and must not name a
+            # profile case, an outcome, or a stage.
+            #
+            # Anchored patterns, not substrings. A bare "case-" matches "case-insensitive" in a
+            # vector's own description of code-unit ordering, which is a false positive that would
+            # either be suppressed or would make someone edit a correct vector to appease a test.
+            blob = json.dumps(vectors)
+            leak_patterns = (
+                (r"\bcase-\d", "a profile case id"),
+                (r"\b(ok|bad)-[a-z0-9-]{3,}", "a corpus vector name"),
+                (r"expected_outcome|\bverdict\b", "an outcome field"),
+            )
+
+            # The patterns are self-tested, because a leak check that has never been shown to fire
+            # is indistinguishable from one that matches nothing. Planting a leak in the working
+            # tree does not exercise them: the pack reads the file from the pinned commit, so the
+            # byte-identity assertion above catches that first and these never run.
+            for pattern, _ in leak_patterns:
+                self.assertIsNotNone(
+                    re.search(pattern, LEAKY_FIXTURE),
+                    f"leak pattern {pattern!r} matches nothing, so it protects nothing",
+                )
+            # And it does not fire on the vectors' own prose. "case-insensitive" appears in a
+            # description of code-unit ordering and is not a profile case id.
+            self.assertIsNotNone(re.search(r"case-insensitive", blob))
+
+            for pattern, what in leak_patterns:
+                self.assertIsNone(
+                    re.search(pattern, blob),
+                    f"vectors leak {what} (matched {pattern!r})",
+                )
+
+            note = files[note_name].decode()
+            for required in (
+                "not progress on the profile",
+                "not conformance",
+                "derive every profile result yourself",
+            ):
+                self.assertIn(required, note)
 
     def test_candidate_release_is_bound_to_the_current_corpus(self) -> None:
         candidate = json.loads(CANDIDATE_RELEASE.read_text())

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -253,7 +253,20 @@ class CleanRoomPackTests(unittest.TestCase):
             self.assertEqual(files[vectors_name], in_repo)
 
             vectors = json.loads(files[vectors_name])
-            self.assertGreater(len(vectors), 20, "the vector set shrank")
+            # Exactly the 31 vectors #1982 landed, with `_about` excluded because it is metadata and
+            # not a vector -- that key is also what made the count ambiguous when this was first
+            # measured, since the file has 32 keys and 31 vectors.
+            #
+            # `> 20` was the first version and is too loose. The byte-identity assertion above
+            # already catches the pack drifting from the repo, so the case this one owns is the
+            # other one: both shrinking together. Ten vectors deleted from the source file would
+            # keep the pack byte-identical to it and pass every other check here.
+            cases = {k: v for k, v in vectors.items() if k != "_about"}
+            self.assertEqual(
+                len(cases),
+                31,
+                f"expected the 31 RFC 8785 vectors, packed {len(cases)}",
+            )
 
             # The clean-room property. The vectors describe byte formation and must not name a
             # profile case, an outcome, or a stage.


### PR DESCRIPTION
## Description

#1990. The clean-room pack shipped `spec.md`, `descriptor.json` and fourteen opaque cases, and left an implementer to derive RFC 8785 canonicalization from prose with nothing to check it against.

That is not a hypothetical friction. The one completed cross-language reproduction in this ecosystem **failed on its first attempt** because native insertion-order serialization produced a different digest. Content ids, mandate ids and the bundle run root are all sha256 over canonical bytes, so a wrong canonicalizer makes every later result uninterpretable — and you find out fourteen bundles later.

`candidate.4` carries the 31 vectors from #1982, **byte-identical** to the file this workspace tests its own canonicalizer against, plus a note.

## Same corpus

| | |
|---|---|
| `corpus_digest` | unchanged, `sha256:cb58ce91…` |
| cases | the same fourteen |
| a `candidate.3` reproduction | **remains valid, nothing to redo** |

`candidate.4` re-releases the same corpus with better onboarding. That is stated in the corpus README so nobody mid-attempt thinks they lost work.

## It does not weaken the clean-room property

The easy half of that claim is that the expectations come from a published RFC which `descriptor.json` already requires (`canon: jcs-rfc8785`), not from our implementation. The hard half is that the vectors stay free of profile answers — and that is the half that could quietly stop being true, so it is asserted rather than argued:

```
a profile case id      \bcase-\d
a corpus vector name   \b(ok|bad)-[a-z0-9-]{3,}
an outcome field       expected_outcome|\bverdict\b
```

The note says twice, in the pack itself, that passing them is not progress on the profile and that agreement with them is not conformance.

## Two things the work surfaced

**The scorer's pack contract is a fixed member count plus an explicit name set**, so adding two files failed it. Both moved deliberately rather than being derived from whatever the builder emits — a scorer taught to expect what it is handed cannot detect a pack that grew a member.

**My first leak check was a substring sweep and it was wrong.** It flagged `case-` inside *"case-insensitive"*, in a vector's own description of code-unit ordering. Anchored now.

Then the planted-leak mutation was caught by the **byte-identity** assertion rather than by the patterns, because the pack reads the file from the pinned commit and never saw my working-tree edit. So the patterns were still unproven — a check whose firing has never been demonstrated. They now self-test against a fixture carrying one instance of each, and the test also asserts they do *not* fire on the vectors' own prose.

## Verification

- 25 activation-kit tests pass
- pack built from a pinned commit, **byte-identical across two builds**
- packed vectors sha256 `64a71a5e…` == the file at `HEAD`
- 20 members: 14 cases + 4 original + 2 new

## Acceptance

- [x] pack contains the RFC 8785 vectors and the note
- [x] `candidate-release.json` names `candidate.4`, corpus digest unchanged
- [x] the note makes explicit that the vectors are not answers and agreement is not conformance
- [ ] `candidate.4` published from `main` — release controller, after merge
- [ ] #1840 repinned to `candidate.4` — after the release exists

Does not close #1990: the last two need the release to be cut.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated clean-room reproduction instructions for candidate release `.4`.
  - Added guidance to run 31 RFC 8785 canonicalization vectors before profile work.
  - Clarified release contents, attested pack details, and disclosure timing.

- **Conformance**
  - Added canonicalization vectors and supporting documentation to clean-room packs.
  - Strengthened validation to confirm required materials are complete and answer-free.
  - Updated release references and download instructions to candidate `.4`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->