### PR TITLE
The semver gate skipped 254 checks and called it success

### DIFF
--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -17,7 +17,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  WAVE0_SEMVER_BASELINE_SHA: "9cc23b4c684be7cfd81f170c4f66d59903dd76eb"
 
 jobs:
   detect-changes:
@@ -396,29 +395,51 @@ jobs:
       - name: Install cargo-semver-checks
         run: cargo install --locked cargo-semver-checks
 
-      - name: Ensure semver baseline commit is available
+
+      # The baseline is the last release, resolved now, not a SHA pinned in this file.
+      #
+      # It used to be `9cc23b4c`, which is `chore: release v2.18.0` from 2026-02-11. `check-release`
+      # does not ask "is there a breaking change"; it asks whether the declared version increment
+      # covers the changes it finds. Against a 2.x baseline the manifest already declared 3.x, a
+      # major, which licenses any break -- so the job had been structurally unable to fail for the
+      # whole 3.x line. #2068 added a public field to `MetricResult` and this job reported success
+      # (#2088).
+      #
+      # Against the last release tag the question becomes the one that matters: does THIS branch's
+      # version cover what THIS branch changed. A break with no bump fails; a release PR that bumps
+      # to cover it passes.
+      - name: Resolve semver baseline from the last release tag
+        id: baseline
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if git cat-file -e "${WAVE0_SEMVER_BASELINE_SHA}^{commit}" 2>/dev/null; then
-            echo "Baseline commit present: ${WAVE0_SEMVER_BASELINE_SHA}"
-          else
-            echo "Baseline commit missing locally, fetching explicitly..."
-            AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
-              fetch --no-tags origin "${WAVE0_SEMVER_BASELINE_SHA}" || \
-              git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
-                fetch --no-tags origin "${WAVE0_SEMVER_BASELINE_SHA}:refs/temp/wave0-baseline"
-            git cat-file -e "${WAVE0_SEMVER_BASELINE_SHA}^{commit}"
+          git fetch --tags --quiet origin || true
+          tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)"
+          if [ -z "${tag}" ]; then
+            echo "::error::no v* release tag found, so there is nothing to compare against."
+            echo "A missing baseline is a 'could not check', and this job must not report success"
+            echo "for a comparison it did not make."
+            exit 1
           fi
-          # Cleanup fallback ref if created by the alternate fetch path.
-          git update-ref -d refs/temp/wave0-baseline || true
+          git cat-file -e "${tag}^{commit}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Semver baseline: ${tag} ($(git rev-parse --short "${tag}^{commit}"))"
+
+      # Prove the gate can fail before trusting what it says about this branch.
+      #
+      # It could not, for the whole 3.x line, and nothing noticed because a gate that skips every
+      # check is indistinguishable from a gate that finds nothing. This plants a public field on a
+      # public struct -- the same shape as the break that got through -- and requires both a
+      # non-zero exit and the right lint name.
+      - name: Self-test the semver gate
+        env:
+          ASSAY_SEMVER_GATE_FULL: "1"
+        run: bash scripts/ci/test-semver-gate.sh
 
       - name: Run semver checks (allowlist)
         shell: bash
         env:
+          BASELINE_TAG: ${{ steps.baseline.outputs.tag }}
           RUN_ALL: ${{ needs.detect-changes.outputs.run_all }}
           GLOBAL_CHANGED: ${{ needs.detect-changes.outputs.global_changed }}
           CORE_CHANGED: ${{ needs.detect-changes.outputs.assay_core_changed }}
@@ -433,12 +454,12 @@ jobs:
           run_semver_for() {
             local crate="$1"
             echo "- ${crate}" >> "$GITHUB_STEP_SUMMARY"
-            cargo semver-checks check-release -p "${crate}" --baseline-rev "${WAVE0_SEMVER_BASELINE_SHA}"
+            cargo semver-checks check-release -p "${crate}" --baseline-rev "${BASELINE_TAG}"
           }
 
           {
             echo "## Semver checks"
-            echo "- Baseline SHA: ${WAVE0_SEMVER_BASELINE_SHA}"
+            echo "- Baseline: ${BASELINE_TAG} (last release tag)"
             echo "- Crates checked:"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -282,6 +282,20 @@ repos:
         stages: [pre-push]
         pass_filenames: false
 
+      - id: semver-gate-self-test
+        name: Semver gate self-test
+        entry: bash scripts/ci/test-semver-gate.sh
+        language: system
+        pass_filenames: false
+        # The gate could not fail (#2088). Its baseline was pinned to `chore: release v2.18.0`, so
+        # `check-release` saw a declared major and skipped all 254 checks -- reporting success while
+        # #2068's `MetricResult` break went through and was found by hand at release prep.
+        #
+        # The cheap cases run here: no pinned SHA, the baseline comes from the newest release tag,
+        # and a missing tag fails rather than skips. The planted-break case costs a rustdoc build per
+        # crate, so it runs under ASSAY_SEMVER_GATE_FULL=1 and in the workflow's own CI job.
+        stages: [pre-push]
+        files: ^(scripts/ci/test-semver-gate\.sh|\.github/workflows/split-wave0-gates\.yml)$
       - id: linux-gate-self-test
         name: Linux compile gate self-test
         entry: bash scripts/ci/test-check-linux.sh

--- a/scripts/ci/test-semver-gate.sh
+++ b/scripts/ci/test-semver-gate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# The semver gate must be able to fail.
+#
+# It could not (#2088). `WAVE0_SEMVER_BASELINE_SHA` was pinned to `9cc23b4c`, which is
+# `chore: release v2.18.0` from 2026-02-11. `cargo semver-checks check-release` does not ask "is
+# there a breaking change"; it asks whether the declared version increment covers the changes it
+# finds. Against a 2.x baseline the manifest already declared 3.x -- a major -- so the tool skipped
+# every check:
+#
+#     Checking assay-core v2.18.0 -> v3.38.0 (major change)
+#     Checked [0.000s] 0 checks: 0 pass, 254 skip
+#     Summary no semver update required
+#
+# Zero checks run, reported as success. #2068 added a public field to `MetricResult` and this job
+# said nothing; the break was found by hand during a release prep, after it had merged.
+#
+# Measured against the last release tag instead, the same tree gives:
+#
+#     Checked [0.115s] 223 checks: 222 pass, 1 fail, 0 warn, 31 skip
+#     --- failure constructible_struct_adds_field ---
+#       field MetricResult.exercised in crates/assay-core/src/metrics_api.rs:38
+#
+# This script holds the properties that make that difference real. The cheap ones always run. The
+# expensive one -- actually planting a break and requiring a non-zero exit -- runs when
+# ASSAY_SEMVER_GATE_FULL=1, because it costs a rustdoc build per crate and the workflow it guards
+# changes rarely.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/split-wave0-gates.yml"
+FAILURES=0
+
+ok()   { echo "ok    $1"; }
+bad()  { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
+
+# --- the baseline is resolved, not pinned ---------------------------------------------------
+#
+# The whole defect was a constant. A SHA in this file cannot know that the project released twice
+# since it was written, and a stale baseline looks exactly like a clean one.
+if grep -q 'WAVE0_SEMVER_BASELINE_SHA' "$WORKFLOW"; then
+  bad "the workflow still carries a pinned baseline SHA"
+else
+  ok "no pinned baseline SHA"
+fi
+
+if grep -q "git tag --list 'v\[0-9\]\*' --sort=-v:refname" "$WORKFLOW"; then
+  ok "the baseline is resolved from the newest release tag"
+else
+  bad "the baseline is no longer resolved from a release tag"
+fi
+
+# --- a missing baseline is a failure, not a skip ---------------------------------------------
+#
+# "Could not check" and "nothing to report" must not be spelled the same way. This is the rule the
+# Linux gate (#2076) and the release gate (#1993) were both fixed to follow.
+if grep -q 'no v\* release tag found' "$WORKFLOW" && \
+   awk '/no v\* release tag found/,/exit 1/' "$WORKFLOW" | grep -q 'exit 1'; then
+  ok "a missing release tag fails the job"
+else
+  bad "a missing release tag no longer fails the job"
+fi
+
+# --- the tag the workflow would pick is the one we expect ------------------------------------
+resolved="$(cd "$ROOT" && git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)"
+if [ -z "$resolved" ]; then
+  bad "no v* tag in this clone, so the workflow would fail closed here (fetch tags to test)"
+else
+  ok "baseline resolves to ${resolved}"
+fi
+
+# --- the expensive one: a planted break must fail --------------------------------------------
+#
+# Everything above checks the shape of the gate. This checks that the gate reaches a verdict, which
+# is the property that was actually missing: the job ran, on the right crates, with the right tool,
+# and could not fail.
+if [ "${ASSAY_SEMVER_GATE_FULL:-0}" = "1" ]; then
+  if ! command -v cargo-semver-checks >/dev/null 2>&1; then
+    bad "ASSAY_SEMVER_GATE_FULL=1 but cargo-semver-checks is not installed"
+  else
+    subject="$ROOT/crates/assay-core/src/metrics_api.rs"
+    backup="$(mktemp)"
+    cp "$subject" "$backup"
+
+    # The manifest version is set to the baseline's first, and that is not incidental.
+    #
+    # The first version of this check planted a break and expected a failure, and got a pass: main
+    # was at 4.0.0 with the newest tag at v3.38.0, so `check-release` saw a declared major and
+    # skipped all 254 checks. That is the gate being CORRECT -- a break merged before 4.0.0 ships is
+    # genuinely licensed by the major that has not shipped yet -- and the test being wrong.
+    #
+    # But a self-test whose result depends on whether a release happens to be pending is not a
+    # self-test. Equalising the versions asks the question that is always meaningful: with no bump
+    # to hide behind, does this gate reach a verdict?
+    baseline_version="$(cd "$ROOT" && git show "${resolved}:Cargo.toml" | awk -F'"' '/^version = /{print $2; exit}')"
+    current_version="$(awk -F'"' '/^version = /{print $2; exit}' "$ROOT/Cargo.toml")"
+    manifest_backup="$(mktemp -d)"
+    (cd "$ROOT" && cp Cargo.toml "$manifest_backup/root.toml" && \
+      for m in crates/*/Cargo.toml; do mkdir -p "$manifest_backup/$(dirname "$m")"; cp "$m" "$manifest_backup/$m"; done)
+    restore() {
+      cp "$backup" "$subject"
+      cp "$manifest_backup/root.toml" "$ROOT/Cargo.toml"
+      (cd "$ROOT" && for m in crates/*/Cargo.toml; do cp "$manifest_backup/$m" "$m"; done)
+      rm -rf "$backup" "$manifest_backup"
+    }
+    trap restore EXIT
+
+    # Every manifest, not only the root. The first version of this moved the workspace version alone
+    # and `cargo metadata` refused: nine internal dependencies still declared `version = "4.0.0"`,
+    # which the downgraded workspace no longer satisfied. The gate failed, but on a resolver error
+    # rather than on the lint -- which is why the check below asserts WHY it failed and not merely
+    # that it did.
+    (cd "$ROOT" && \
+      sed -i.bak "s/^version = \"${current_version}\"$/version = \"${baseline_version}\"/" Cargo.toml && \
+      sed -i.bak "s/version = \"${current_version}\"/version = \"${baseline_version}\"/g" Cargo.toml crates/*/Cargo.toml && \
+      rm -f Cargo.toml.bak crates/*/Cargo.toml.bak)
+
+    # A new pub field on a pub struct with no `#[non_exhaustive]`: the same shape as the break that
+    # got through, so this tests the lint that actually missed it rather than any breaking change.
+    python3 - "$subject" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+anchor = "pub struct MetricResult {"
+assert anchor in t, "MetricResult moved; update the self-test"
+t = t.replace(anchor, anchor + "\n    pub deliberately_planted_for_the_gate_test: bool,", 1)
+open(p, "w").write(t)
+PY
+    out="$(cd "$ROOT" && cargo semver-checks check-release -p assay-core --baseline-rev "$resolved" 2>&1)"
+    status=$?
+    restore
+    trap - EXIT
+
+    if [ "$status" -eq 0 ]; then
+      bad "a planted breaking change did not fail the gate"
+      printf '%s\n' "$out" | tail -5 | sed 's/^/      /'
+    else
+      ok "a planted breaking change fails the gate"
+    fi
+
+    # And it failed for the right reason. A gate that fails because the tool crashed is not a gate.
+    if printf '%s\n' "$out" | grep -q 'constructible_struct_adds_field'; then
+      ok "  and names the lint that caught it"
+    else
+      bad "  but not via constructible_struct_adds_field; it may have failed for an unrelated reason"
+    fi
+  fi
+else
+  echo "skip  planted-break check (set ASSAY_SEMVER_GATE_FULL=1 to run it)"
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo
+  echo "$FAILURES semver-gate case(s) failed"
+  exit 1
+fi
+echo
+echo "semver gate: all cases pass"


### PR DESCRIPTION
## Description

Closes #2088.

`WAVE0_SEMVER_BASELINE_SHA` was pinned to `9cc23b4c` — `chore: release v2.18.0`, dated 2026-02-11.

`cargo semver-checks check-release` does not ask whether there is a breaking change. It asks whether the **declared version increment covers the changes it finds**. Against a 2.x baseline the manifest already declared 3.x, so:

```
Checking assay-core v2.18.0 -> v3.38.0 (major change)
Checked [0.000s] 0 checks: 0 pass, 254 skip
Summary no semver update required
```

Zero checks run, reported green. The job had been structurally unable to fail for the entire 3.x line — and a gate that skips every check looks exactly like a gate that finds nothing.

## Measured, not argued

Same tree (#2068's merge commit), baseline moved to the last release tag:

```
Checked [0.115s] 223 checks: 222 pass, 1 fail, 0 warn, 31 skip

--- failure constructible_struct_adds_field ---
  field MetricResult.exercised in crates/assay-core/src/metrics_api.rs:38

Summary semver requires new major version: 1 major and 0 minor checks failed
```

223 checks instead of 0, naming the exact field that reached `main` unnoticed and was found by hand during a release prep.

The other direction was run too: **4.0.0 against `v3.38.0` passes**, because the bump covers the break. A release PR stays green. Both cases were executed against the real tool before this was written.

## The fix

The baseline is `git tag --list 'v[0-9]*' --sort=-v:refname | head -n1`. **No tag is a hard failure**, not a skip — "could not check" and "found nothing" must not be spelled the same way, which is the rule #2076 and #1993 were both fixed to follow.

`scripts/ci/test-semver-gate.sh` holds it: cheap cases pre-push, planted-break case in the workflow's own job under `ASSAY_SEMVER_GATE_FULL=1`. It plants a public field on a public struct — the same shape as the break that got through — and requires a non-zero exit **and** the right lint name.

## Three things caught by the checks that seemed pedantic

**The self-test first expected a failure and got a pass.** `main` is at 4.0.0 with the newest tag at `v3.38.0`, so `check-release` sees a declared major and skips everything again. That is the gate being *right* — a break merged before 4.0.0 ships is licensed by the major that hasn't shipped — and my test being wrong. But a self-test whose verdict depends on whether a release happens to be pending tests nothing, so it equalises the versions first.

**Equalising the root version alone failed on `cargo metadata`**, because nine internal dependencies still declared 4.0.0. The gate failed on a resolver error rather than on the lint. That is exactly why the check asserts *why* it failed and not merely that it did.

**`BASELINE_TAG` went into the wrong job.** A first-match replace put it in `feature-matrix`, which has no `baseline` step. actionlint named it before it could ship.

## One property worth knowing

Between a release merge and its tag, the manifest declares a major the baseline doesn't have, so checks skip. That is semantically correct — those breaks are covered by the unshipped major — but it means the gate is quiet in that window. It closes when the tag lands, which is an argument for tagging promptly after a release merges.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release compatibility checks by automatically using the latest available release as the comparison baseline.
  * Added failure handling when no release is available, preventing misleading validation results.

* **Tests**
  * Added automated validation to confirm semver checks detect breaking public API changes.
  * Added lightweight pre-push validation and an optional comprehensive verification mode for CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->