### PR TITLE
Cite the sentence, not its position

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -406,8 +406,9 @@ pub fn seal_eligibility(health: &EnforcementHealthV1) -> Result<&Probe, NotSealE
 
 /// How the caller proves the drop accounting the seal will carry.
 ///
-/// ADR-045 line 232 permits `aeeDropCount = 0` and `aeeDropBound = 0` only under a named collection
-/// model, and forbids "an AEE-looking seal with guessed zero drop accounting". This module cannot
+/// Under ADR-045 "Drop accounting decision for first slice", zero counts "may be emitted only under
+/// one of these explicitly named collection models", and the ADR forbids emitting
+/// "an AEE-looking seal with guessed zero drop accounting". This module cannot
 /// observe the collection path, so the model is the caller's to declare -- but it is a required
 /// argument rather than a default, because a value that can be omitted is a value that gets guessed.
 ///
@@ -526,11 +527,14 @@ pub fn build_sealed_run(
         return Err(NotSealEligible::UnprovenContextValue { field: "sealed_at" });
     }
     let rb = run_binding(env)?;
-    // ADR-045 line 192, and its line 476 negative fixture: `aeePostureDigest` is the digest the
-    // posture object *declares*, not the digest *of* that object. They differ by construction --
-    // the declared value is computed before the `digest` member is inserted, so hashing the carried
-    // object hashes a strictly larger thing. Two plausible readings, and the ADR names the wrong one
-    // by name because it is the one an implementer reaches for.
+    // ADR-045 "Field interpretation" pins `aeePostureDigest` to the carried posture digest and says
+    // "It is distinct from the AEE v0.7 run-binding" input taken over the whole object. So this is
+    // the digest the posture object *declares*, not the digest *of* that object. They differ by
+    // construction -- the declared value is computed before the `digest` member is inserted, so
+    // hashing the carried object hashes a strictly larger thing. Two plausible readings, and the ADR
+    // requires a negative fixture for the wrong one by name,
+    // "`aeePostureDigest` confused with the run-binding digest of the full `networkPosture` object",
+    // because it is the one an implementer reaches for.
     let posture_digest = env
         .network_posture
         .get("digest")
@@ -646,8 +650,9 @@ mod tests {
     }
 
     /// The seal must carry the digest the posture object *declares*, not the digest *of* that
-    /// object. ADR-045 line 476 names this confusion as a required negative fixture, and the two
-    /// values differ by construction because the declared one is computed before the `digest`
+    /// object. ADR-045 requires a negative fixture for
+    /// "`aeePostureDigest` confused with the run-binding digest of the full `networkPosture` object",
+    /// and the two values differ by construction because the declared one is computed before the `digest`
     /// member is inserted. Asserted on the payload rather than on a helper: a test that checks the
     /// function and not where its result lands is how the wrong quantity reached the wire.
     #[test]
@@ -778,7 +783,7 @@ mod tests {
 
     /// A run carrying attack evidence must still be sealable. The previous gate counted committed
     /// observations and refused anything but a lone probe, which forbade exactly the statements
-    /// ADR-045 line 425 allows ("zero or more interception records per run") and the checker
+    /// ADR-045 allows -- "zero or more interception records per run" -- and the checker
     /// requires for a caught substrate row.
     #[test]
     fn a_run_carrying_an_interception_can_still_seal() {

--- a/crates/assay-cli/src/aee_seal_envelope.rs
+++ b/crates/assay-cli/src/aee_seal_envelope.rs
@@ -33,8 +33,8 @@
 //!
 //! **Ed25519.** Asymmetric, as the ADR requires, and already a workspace dependency. The fixture
 //! harness signs with HMAC over the same PAE; that key shape cannot verify here, which is the
-//! ADR's "fixture-only signing cannot be mistaken for production observation signing" made
-//! structural rather than documentary.
+//! ADR's "fixture keys are rejected by construction in production paths" made structural rather
+//! than documentary.
 //!
 //! # The ordering that matters
 //!
@@ -419,7 +419,8 @@ mod tests {
         assert_eq!(err.code(), "seal-envelope-payload-not-strict-json");
     }
 
-    /// The ADR's "fixture-only signing cannot be mistaken for production" gate, made structural.
+    /// The ADR's "fixture keys are rejected by construction in production paths" gate, made
+    /// structural.
     ///
     /// The PAE binds the payload type, so a fixture envelope signs different bytes than a
     /// production one even for an identical payload -- and this verifier refuses the type outright,

--- a/crates/assay-cli/tests/adr045_citations.rs
+++ b/crates/assay-cli/tests/adr045_citations.rs
@@ -1,0 +1,211 @@
+//! Anything this code quotes from ADR-045 must still be in ADR-045.
+//!
+//! Six citations pointed at line numbers, and all six had gone stale: line 232 had become a table
+//! row, 192 a JSON key inside an example, 425 a blank line, and 476 a bullet about issue #1998,
+//! cited three times across two languages. Every underlying claim was correct. Only the pointers
+//! had rotted, each one landing 16 to 42 lines short of its target, which is what insertion above
+//! does to a document that keeps growing.
+//!
+//! So the fix was not better line numbers. A position into a living document is a reference that
+//! decays on someone else's edit and fails silently, because nothing reads it. A quotation does
+//! not: it carries its own referent, and this test turns "the sentence I relied on still exists"
+//! into something the build checks.
+//!
+//! The rule is therefore: inside a comment block that mentions ADR-045, every double-quoted span
+//! must appear verbatim in the ADR. If you want to quote something else in such a block, put it in
+//! a different block.
+//!
+//! What this does not do, stated so a pass is not read as more than it is: it proves the sentence
+//! survives, not that the code obeys it. A quote can stay accurate while the code drifts away from
+//! what it says. That is a real gap and this test does not reach it.
+
+use std::path::PathBuf;
+
+const ADR: &str = "docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md";
+
+/// Files that cite the ADR. Extend when a new one starts quoting it.
+const CITING_SOURCES: &[&str] = &[
+    "crates/assay-cli/src/aee_seal.rs",
+    "crates/assay-cli/src/aee_seal_envelope.rs",
+    "scripts/experiments/aee_landlock_seal_fixture.py",
+];
+
+/// A floor, not a target. It exists so a broken extractor fails loudly instead of passing with
+/// nothing to check, since the failure mode of an extractor is to find zero and report success.
+///
+/// Set below the 18 found when this was written, so ordinary deletion does not trip it. Six of
+/// those eighteen were the line-number citations this replaced; the rest were already quotations
+/// and had never been checked against anything.
+const KNOWN_CITATIONS: usize = 12;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Whitespace-insensitive, so a quotation may wrap across comment lines.
+fn flatten(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Terminal punctuation is not part of what was said.
+///
+/// Most of the ADR's normative statements are list items ending in `;`. Quoting one inside a
+/// sentence and writing `.` or `,` instead is ordinary editing, not a misquotation, and failing on
+/// it would push people back towards paraphrase — which is the thing that actually goes wrong.
+/// Every word still has to match.
+fn trim_terminal(s: &str) -> &str {
+    s.trim_end_matches([',', '.', ';', ':'])
+}
+
+/// Strip a comment marker, or return `None` for a line that is not a comment.
+fn comment_body(line: &str) -> Option<&str> {
+    let t = line.trim_start();
+    for marker in ["///", "//!", "//", "#"] {
+        if let Some(rest) = t.strip_prefix(marker) {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// Contiguous comment lines, joined. Blocks are what let a quotation wrap.
+fn comment_blocks(src: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current: Vec<&str> = Vec::new();
+    for line in src.lines() {
+        match comment_body(line) {
+            Some(body) => current.push(body),
+            None => {
+                if !current.is_empty() {
+                    blocks.push(flatten(&current.join(" ")));
+                    current.clear();
+                }
+            }
+        }
+    }
+    if !current.is_empty() {
+        blocks.push(flatten(&current.join(" ")));
+    }
+    blocks
+}
+
+/// Double-quoted spans in a block. Unpaired trailing quotes are ignored rather than panicked on,
+/// since prose legitimately contains a lone quote character.
+fn quoted_spans(block: &str) -> Vec<String> {
+    let mut spans = Vec::new();
+    let mut rest = block;
+    while let Some(open) = rest.find('"') {
+        rest = &rest[open + 1..];
+        let Some(close) = rest.find('"') else { break };
+        let span = rest[..close].trim().to_string();
+        if !span.is_empty() {
+            spans.push(span);
+        }
+        rest = &rest[close + 1..];
+    }
+    spans
+}
+
+/// Every (file, quotation) pair in a comment block that mentions the ADR.
+fn citations() -> Vec<(&'static str, String)> {
+    let mut found = Vec::new();
+    for src in CITING_SOURCES {
+        for block in comment_blocks(&read(src)) {
+            if !block.contains("ADR-045") {
+                continue;
+            }
+            for span in quoted_spans(&block) {
+                found.push((*src, span));
+            }
+        }
+    }
+    found
+}
+
+#[test]
+fn every_quotation_from_the_adr_is_still_in_the_adr() {
+    let adr = flatten(&read(ADR));
+    let citations = citations();
+
+    assert!(
+        citations.len() >= KNOWN_CITATIONS,
+        "found {} citations, expected at least {KNOWN_CITATIONS}. Either they were deleted or the \
+         extractor stopped seeing them; both are worth looking at before lowering this number.",
+        citations.len()
+    );
+
+    let missing: Vec<String> = citations
+        .iter()
+        .filter(|(_, q)| !adr.contains(trim_terminal(&flatten(q))))
+        .map(|(f, q)| format!("{f}: \"{q}\""))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "these are quoted as ADR-045 and are not in it. Either the ADR moved and the comment needs \
+         updating, or the quotation was never exact:\n  {}",
+        missing.join("\n  ")
+    );
+}
+
+/// The negative control. A checker that only ever runs against correct input proves nothing about
+/// whether it can fail, and this whole class of defect is one that passed silently for months.
+#[test]
+fn a_quotation_absent_from_the_adr_is_rejected() {
+    let adr = flatten(&read(ADR));
+    let fabricated = "the ADR does not contain this sentence anywhere at all";
+    assert!(
+        !adr.contains(fabricated),
+        "the containment check accepted a fabricated quotation, so it cannot fail"
+    );
+}
+
+/// Line-number citations are what this replaced. Reintroducing one puts a decaying pointer back
+/// into a file the test can see, and the test would not notice: no quotation, nothing to check.
+#[test]
+fn no_citation_points_at_a_line_number() {
+    let pattern = regex_lite_line_citation();
+    let mut offenders = Vec::new();
+    for src in CITING_SOURCES {
+        for (n, line) in read(src).lines().enumerate() {
+            let Some(body) = comment_body(line) else {
+                continue;
+            };
+            if pattern(body) {
+                offenders.push(format!("{src}:{}: {}", n + 1, body.trim()));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "cite the sentence, not its position -- a line number decays on someone else's edit and \
+         nothing reads it:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// `ADR-045 line <n>` / `ADR-045 lines <n>`, without pulling in a regex dependency for one pattern.
+fn regex_lite_line_citation() -> impl Fn(&str) -> bool {
+    |body: &str| {
+        let flat = flatten(body);
+        for marker in [" line ", " lines "] {
+            let mut rest = flat.as_str();
+            while let Some(i) = rest.find(marker) {
+                let after = &rest[i + marker.len()..];
+                if after.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                    // Only a defect when it is the ADR being cited by position.
+                    if flat.contains("ADR-045") {
+                        return true;
+                    }
+                }
+                rest = &rest[i + marker.len()..];
+            }
+        }
+        false
+    }
+}

--- a/scripts/experiments/aee_landlock_seal_fixture.py
+++ b/scripts/experiments/aee_landlock_seal_fixture.py
@@ -370,7 +370,9 @@ def case_statement(name: str) -> dict[str, Any]:
     elif name == "key-outside-validity-window":
         set_scopes(stmt, [trusted_scope(STRUCTURAL_KEY, validUntil=KEY_EXPIRED_UNTIL)])
     elif name == "posture-digest-is-run-binding-input":
-        # ADR-045 line 476 requires this control by name. `aeePostureDigest` must equal the carried
+        # ADR-045 requires this control by name:
+        # "`aeePostureDigest` confused with the run-binding digest of the full `networkPosture` object".
+        # `aeePostureDigest` must equal the carried
         # `networkPosture.digest.sha256`; the run-binding input is the digest of the whole carried
         # object, which -- because the digest member is inserted after that member is computed -- is
         # a strictly larger object and a different value. Two plausible readings, one correct, and


### PR DESCRIPTION
Closes the citation defect reported on #2093, at the scope the check turned out to need.

## What was wrong

All six line-number citations into ADR-045 had gone stale, across two languages:

| where | cites | that line actually is | true line |
|---|---|---|---|
| `aee_seal.rs:409` | line 232 | a table row for `assayNonClaims` | 274 |
| `aee_seal.rs:529` | line 192 | `"assayNonClaims": [`, inside a JSON example | 208 |
| `aee_seal.rs:529` | line 476 | a bullet about issue #1998 | 514 |
| `aee_seal.rs:649` | line 476 | same bullet | 514 |
| `aee_seal.rs:781` | line 425 | a blank line | 463 |
| `aee_landlock_seal_fixture.py:373` | line 476 | same bullet | 514 |

**Every underlying claim was correct.** Line 208 does state the `aeePostureDigest` rule; line 514 does name the control verbatim. Only the pointers had rotted, each landing 16 to 42 lines short, which is what insertion above does to a document that keeps growing. Two shared an offset of exactly 38, so they were written against one revision and drifted together.

## Why not just better line numbers

They would decay the same way, silently, because nothing reads a line number. A quotation carries its own referent. `crates/assay-cli/tests/adr045_citations.rs` turns "the sentence I relied on still exists" into something the build checks: inside a comment block mentioning ADR-045, every double-quoted span must appear in the ADR.

Terminal punctuation is tolerated. Most of the ADR's normative statements are `;`-terminated list items, and quoting one inside a sentence as `.` or `,` is editing rather than misquotation. Failing on that would push people back to paraphrase, which is the thing that actually goes wrong.

## Writing the test found more than it was built for

It sees **18** citations, not the 6 that named line numbers, and four of the other twelve did not survive it.

Three differed only in terminal punctuation. The fourth was a quotation the ADR does not contain, used twice:

> "fixture-only signing cannot be mistaken for production observation signing"

That is a fair summary of what the ADR requires and is not a sentence it has. Replaced with the real one, `"fixture keys are rejected by construction in production paths"` (ADR line 114). **A fabricated quote is worse than a stale line number**, because re-reading the document at a different line cannot find it, and the quotation marks assert it is verbatim.

## Mutation-tested

| bite | result |
|---|---|
| a line-number citation is reintroduced | fails: `cite the sentence, not its position` |
| a quotation is altered to something the ADR lacks | fails, naming the span |
| **the ADR sentence is edited, code untouched** | fails, naming the span |

The third is the real scenario and the one nothing previously caught.

## Verification

- `cargo test -p assay-cli --test adr045_citations --test adr045_prefix_table` green
- `cargo clippy -p assay-cli --all-targets` clean
- fixture checker self-tests unaffected: `--meta-test` (33 controls isolate their reason), `--required-field-test` (17 fields), `--rule-coverage-test` (33 reason codes)
- both ADR-045 pre-commit hooks pass
- no changed file is in the lane gating map, so this needs no delegated proof

## Scope

A pass proves the sentence survives, not that the code obeys it. A quotation can stay accurate while the code drifts from what it says. That gap is stated in the test rather than left implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)