### PR TITLE
A seal signed while the enforcement is still in force

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -33,6 +33,12 @@ const BLOCKING_ERRNO: &str = "EACCES";
 /// that cannot express a TCP-connect restriction at all.
 const LANDLOCK_ABI_NET_CONNECT_TCP: u32 = 4;
 
+/// The one `restriction_shedding` value that lets a seal claim `aeeStillArmed`.
+///
+/// Same spelling as `backend::SheddingProbeOutcome::label`, and only that value: `inconclusive`
+/// means the probe found nothing, which is not the same as finding that restrictions hold.
+const RESTRICTIONS_HELD: &str = "restrictions_held";
+
 /// The operator-facing label for what this probe observed.
 fn observed_label(probe: &Probe) -> String {
     if probe.listener_reached {
@@ -74,6 +80,14 @@ pub enum NotSealEligible {
     UnprovenContextValue { field: &'static str },
     /// A digest the seal must derive could not be computed from the inputs given.
     DerivationFailed { what: &'static str },
+    /// The run did not establish that Landlock restrictions cannot be shed on this kernel, so
+    /// `aeeStillArmed` would rest on an invariant this run has no evidence for.
+    ///
+    /// ADR-045 lets still-armed rest on "a documented kernel-level invariant showing the applied
+    /// Landlock restrictions cannot be relaxed". CVE-2024-42318 is that invariant's exception --
+    /// `keyctl(KEYCTL_SESSION_TO_PARENT)` shed every restriction from 5.13 until v6.11-rc1 -- and
+    /// `abi >= 4` does not exclude it, because ABI 4 arrives four releases earlier at 6.7.
+    RestrictionSheddingNotEstablished { found: String },
     /// A counted-queue channel reported lost observations, so zero cannot be carried.
     ObservationsLost { channel: String, lost: u64 },
     /// A counted-queue model was declared with no channels, which proves nothing.
@@ -95,6 +109,9 @@ impl NotSealEligible {
             Self::RecordSelfContradictory { .. } => "record-self-contradictory",
             Self::UnprovenContextValue { .. } => "unproven-context-value",
             Self::DerivationFailed { .. } => "derivation-failed",
+            Self::RestrictionSheddingNotEstablished { .. } => {
+                "restriction-shedding-not-established"
+            }
             Self::ObservationsLost { .. } => "observations-lost",
             Self::DropAccountingUnnamed => "drop-accounting-unnamed",
         }
@@ -114,6 +131,10 @@ impl std::fmt::Display for NotSealEligible {
             Self::RecordSelfContradictory { detail } => write!(f, "health record contradicts itself: {detail}"),
             Self::UnprovenContextValue { field } => write!(f, "run-context field {field} is not a value this run proved"),
             Self::DerivationFailed { what } => write!(f, "could not derive a required digest: {what}"),
+            Self::RestrictionSheddingNotEstablished { found } => write!(
+                f,
+                "restriction-shedding was not established for this kernel ({found}); aeeStillArmed would rest on an invariant CVE-2024-42318 shows has an exception, and the Landlock ABI does not exclude it"
+            ),
             Self::ObservationsLost { channel, lost } => write!(f, "channel {channel} lost {lost} observations, so zero drop accounting cannot be carried"),
             Self::DropAccountingUnnamed => write!(f, "a counted-queue model with no channels names no proof at all"),
         }
@@ -262,6 +283,28 @@ fn sha256_hex(bytes: &[u8]) -> String {
 }
 
 /// RFC 8785 canonical bytes, then SHA-256. The one canonicalizer, from `assay-canonical`.
+/// The declared digest of a carried object, for a producer building a posture.
+///
+/// Public because the producer lives in `sandbox/child.rs` and must compute the posture's *declared*
+/// digest with the same canonicalization the seal derives its own digests with. A second
+/// implementation there would be a second answer to "what is this object's digest", which is the
+/// one question a run binding cannot have two answers to.
+///
+/// Falls back to the empty-object digest only if canonicalization fails, which cannot happen for a
+/// posture built from literals; `build_sealed_run` rejects a posture whose declared digest is not
+/// 64 hex characters, so a degenerate value is refused rather than sealed.
+pub fn digest_json_public(value: &serde_json::Value) -> String {
+    digest_json(value).unwrap_or_default()
+}
+
+/// The current instant in the shape `is_rfc3339_utc` accepts.
+///
+/// Seconds precision, `Z`, no fractional part: the ADR-045 checker's validity-window check parses
+/// exactly `YYYY-MM-DDTHH:MM:SSZ`, and an instant it cannot parse is refused rather than compared.
+pub fn now_rfc3339_utc() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
 fn digest_json(value: &serde_json::Value) -> Result<String, NotSealEligible> {
     let bytes =
         assay_canonical::jcs::to_vec(value).map_err(|_| NotSealEligible::DerivationFailed {
@@ -388,6 +431,19 @@ pub fn seal_eligibility(health: &EnforcementHealthV1) -> Result<&Probe, NotSealE
         return Err(NotSealEligible::RecordSelfContradictory {
             detail: "status is active but the ruleset was never confirmed applied".into(),
         });
+    }
+    // Measured, not inferred. `restrict_self_confirmed` above says the child was armed at start;
+    // still-armed at end follows only if this kernel cannot shed restrictions, and that is a
+    // property of the running kernel rather than of the ABI number.
+    // `backend::landlock_shedding_probe` asks it directly, so no per-distribution backport table
+    // has to be kept correct here -- and a table of backport facts is a thing that rots silently.
+    match health.landlock.restriction_shedding.as_deref() {
+        Some(RESTRICTIONS_HELD) => {}
+        other => {
+            return Err(NotSealEligible::RestrictionSheddingNotEstablished {
+                found: other.unwrap_or("not measured").to_string(),
+            })
+        }
     }
     let probe = health
         .probe
@@ -600,7 +656,12 @@ mod tests {
     }
 
     fn healthy() -> EnforcementHealthV1 {
-        EnforcementHealthV1::landlock_active(4, vec![443], Some(probe(false, "EACCES")))
+        EnforcementHealthV1::landlock_active(
+            4,
+            vec![443],
+            Some(probe(false, "EACCES")),
+            Some("restrictions_held".to_string()),
+        )
     }
 
     fn parity() -> serde_json::Value {
@@ -1063,7 +1124,12 @@ mod tests {
 
     #[test]
     fn a_run_without_a_run_end_probe_is_refused() {
-        let h = EnforcementHealthV1::landlock_active(4, vec![443], None);
+        let h = EnforcementHealthV1::landlock_active(
+            4,
+            vec![443],
+            None,
+            Some("restrictions_held".to_string()),
+        );
         assert!(
             h.landlock.restrict_self_confirmed,
             "the start-time fact is present"
@@ -1074,8 +1140,12 @@ mod tests {
     #[test]
     fn an_abi_that_cannot_express_the_restriction_is_refused() {
         for abi in [1, 2, 3] {
-            let h =
-                EnforcementHealthV1::landlock_active(abi, vec![443], Some(probe(false, "EACCES")));
+            let h = EnforcementHealthV1::landlock_active(
+                abi,
+                vec![443],
+                Some(probe(false, "EACCES")),
+                Some("restrictions_held".to_string()),
+            );
             assert_eq!(refusal(&h), "abi-cannot-express-restriction", "abi {abi}");
         }
     }
@@ -1083,10 +1153,20 @@ mod tests {
     #[test]
     fn weak_and_absent_block_signals_are_refused() {
         for errno in ["ECONNREFUSED", "ETIMEDOUT", "", "eacces", "EACCES "] {
-            let h = EnforcementHealthV1::landlock_active(4, vec![443], Some(probe(false, errno)));
+            let h = EnforcementHealthV1::landlock_active(
+                4,
+                vec![443],
+                Some(probe(false, errno)),
+                Some("restrictions_held".to_string()),
+            );
             assert_eq!(refusal(&h), "probe-signal-too-weak", "errno {errno:?}");
         }
-        let h = EnforcementHealthV1::landlock_active(4, vec![443], Some(probe(true, "EACCES")));
+        let h = EnforcementHealthV1::landlock_active(
+            4,
+            vec![443],
+            Some(probe(true, "EACCES")),
+            Some("restrictions_held".to_string()),
+        );
         assert_eq!(refusal(&h), "probe-reached-listener");
     }
 
@@ -1152,6 +1232,51 @@ mod tests {
             run.seal.assay_seal_scope, h.scope,
             "the seal scope is the record's, not a constant"
         );
+    }
+
+    /// A record from before the shedding measurement existed does not seal.
+    ///
+    /// This is the whole point of the gate and it is deliberately a *fixture*, not a hand-built
+    /// struct: every enforcement-health record written before this field existed looks exactly like
+    /// this, and each one would otherwise have sealed with `aeeStillArmed: true` resting on an
+    /// invariant CVE-2024-42318 shows has an exception.
+    #[test]
+    fn a_record_that_never_measured_shedding_does_not_seal() {
+        let raw = include_str!(
+            "../tests/fixtures/enforcement_health/v1/active_probe_shedding_unmeasured.json"
+        );
+        let h: EnforcementHealthV1 = serde_json::from_str(raw).expect("fixture parses");
+        let err = build_sealed_run(
+            &h,
+            &env_from_parity(),
+            &[],
+            "2026-08-05T00:00:00Z",
+            &DropAccounting::SynchronousProbe,
+        )
+        .expect_err("a record with no measurement must not seal");
+        assert_eq!(err.code(), "restriction-shedding-not-established");
+        assert!(err.to_string().contains("not measured"), "{err}");
+    }
+
+    /// The two non-held outcomes are refused for their own reasons, and `inconclusive` is the one
+    /// that matters: a probe that could not run has found nothing, which is not a finding that
+    /// restrictions hold. Treating it as one is the fail-open the three-valued outcome exists for.
+    #[test]
+    fn a_shed_or_inconclusive_measurement_does_not_seal() {
+        for value in ["restrictions_shed", "inconclusive"] {
+            let mut h = healthy();
+            h.landlock.restriction_shedding = Some(value.to_string());
+            let err = build_sealed_run(
+                &h,
+                &env_from_parity(),
+                &[],
+                "2026-08-05T00:00:00Z",
+                &DropAccounting::SynchronousProbe,
+            )
+            .expect_err("must not seal");
+            assert_eq!(err.code(), "restriction-shedding-not-established");
+            assert!(err.to_string().contains(value), "{err}");
+        }
     }
 
     /// The committed June carrier fixture is an applied-ruleset shape, and it seals. That is the

--- a/crates/assay-cli/src/aee_seal_envelope.rs
+++ b/crates/assay-cli/src/aee_seal_envelope.rs
@@ -167,6 +167,22 @@ pub enum SealSignError {
     WrongKeyRole,
 }
 
+impl std::fmt::Display for SealSignError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotCanonicalizable(detail) => {
+                write!(f, "seal payload does not canonicalize: {detail}")
+            }
+            Self::WrongKeyRole => write!(
+                f,
+                "the signing key is not a substrate observation key; ADR-045 forbids a policy-decision key from signing a substrate observation"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SealSignError {}
+
 /// The exact bytes a seal signature covers: RFC 8785 canonical JSON, UTF-8.
 ///
 /// One function, called by both [`sign_seal`] and [`verify_seal`], so the producer and the verifier
@@ -323,6 +339,7 @@ mod tests {
                 blocked_errno: "EACCES".into(),
                 listener_reached: false,
             }),
+            Some("restrictions_held".to_string()),
         );
         build_sealed_run(
             &health,

--- a/crates/assay-cli/src/backend.rs
+++ b/crates/assay-cli/src/backend.rs
@@ -456,6 +456,177 @@ pub fn self_probe_denied_connect(
     Ok(SelfProbeOutcome::ProbeInfraError("not linux"))
 }
 
+/// Whether this kernel lets a restricted process shed its own Landlock restrictions.
+///
+/// # Why this is measured rather than inferred from a version
+///
+/// ADR-045 lets `aeeStillArmed` rest on "a documented kernel-level invariant showing the applied
+/// Landlock restrictions cannot be relaxed". That invariant is real -- restrictions are irrevocable
+/// for the process lifetime, preserved across `execve`, inherited by children -- and it has a
+/// documented exception.
+///
+/// CVE-2024-42318 ("Landlock Houdini", Jann Horn, 2024-07-24): Landlock implemented the
+/// `cred_prepare` LSM hook but not `cred_transfer`, and `keyctl(KEYCTL_SESSION_TO_PARENT)` uses the
+/// latter. A process with `fork()` and `keyctl()` could therefore drop every Landlock restriction on
+/// itself. Present from 5.13; fixed in v6.11-rc1, commit `39705a6c29f8`, and backported.
+///
+/// The version route is a dead end. `LANDLOCK_ACCESS_NET_CONNECT_TCP` arrives at ABI 4 (kernel 6.7)
+/// and the fix lands in 6.11, so every kernel in 6.7..6.11 passes an ABI-4 gate while the workload
+/// child -- which by definition runs the code under test -- could shed its sandbox with two
+/// syscalls. Closing that by kernel version needs a per-distribution backport table, and a table of
+/// backport facts is a thing that rots silently: Ubuntu Noble carries the fix at `6.8.0-50.51`,
+/// which no version comparison against 6.11 would ever discover.
+///
+/// So this asks the kernel. It is the same shape as [`self_probe_denied_connect`]: a throwaway
+/// process, a capability question, an outcome that is never assumed.
+///
+/// # Structure, and why it needs two forks
+///
+/// `KEYCTL_SESSION_TO_PARENT` replaces the *parent's* credentials, so the process under test has to
+/// be the parent of the caller:
+///
+/// ```text
+/// this process        forks ->  restricted child   applies Landlock, confirms EACCES
+///                                     forks ->     grandchild   calls KEYCTL_SESSION_TO_PARENT
+///                               restricted child   re-tests: still EACCES?
+/// ```
+///
+/// The calling process is never a target, so running the exploit deliberately does not weaken it.
+#[cfg(target_os = "linux")]
+pub fn landlock_shedding_probe() -> anyhow::Result<SheddingProbeOutcome> {
+    use std::os::fd::AsRawFd;
+
+    const PR_SET_NO_NEW_PRIVS: libc::c_int = 38;
+    const KEYCTL_SESSION_TO_PARENT: libc::c_int = 18;
+    // Deliberately outside errno range so an infrastructure failure can never be read as a verdict.
+    const EXIT_HELD: i32 = 0;
+    const EXIT_SHED: i32 = 42;
+    const EXIT_NNP_FAILED: i32 = 200;
+    const EXIT_RESTRICT_FAILED: i32 = 201;
+    const EXIT_NOT_BLOCKED_BEFORE: i32 = 202;
+
+    // An empty allowlist: every TCP connect is denied, so the probe needs no free port and cannot
+    // race one.
+    let created = landlock_impl::build_net_ruleset(&[])?;
+    let owned: Option<std::os::fd::OwnedFd> = created.into();
+    let Some(fd) = owned.as_ref() else {
+        return Ok(SheddingProbeOutcome::Inconclusive("no_net_ruleset"));
+    };
+    let raw_fd = fd.as_raw_fd();
+
+    // SAFETY: between fork and `_exit` the children run only async-signal-safe syscalls (prctl,
+    // landlock_restrict_self, socket, connect, keyctl, fork, waitpid, _exit). No allocation, no
+    // destructors. The parent only waitpid.
+    let code = unsafe {
+        let child = libc::fork();
+        if child == 0 {
+            if libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+                libc::_exit(EXIT_NNP_FAILED);
+            }
+            if libc::syscall(libc::SYS_landlock_restrict_self, raw_fd, 0) != 0 {
+                libc::_exit(EXIT_RESTRICT_FAILED);
+            }
+            // The restriction must be in force before the attempt, or "still blocked after" proves
+            // nothing about shedding.
+            if connect_errno_raw() != libc::EACCES {
+                libc::_exit(EXIT_NOT_BLOCKED_BEFORE);
+            }
+            let grandchild = libc::fork();
+            if grandchild == 0 {
+                libc::syscall(
+                    libc::SYS_keyctl,
+                    KEYCTL_SESSION_TO_PARENT as libc::c_long,
+                    0,
+                    0,
+                    0,
+                    0,
+                );
+                libc::_exit(0);
+            }
+            let mut st: libc::c_int = 0;
+            libc::waitpid(grandchild, &mut st, 0);
+            if connect_errno_raw() == libc::EACCES {
+                libc::_exit(EXIT_HELD);
+            }
+            libc::_exit(EXIT_SHED);
+        }
+        let mut st: libc::c_int = 0;
+        libc::waitpid(child, &mut st, 0);
+        if libc::WIFEXITED(st) {
+            libc::WEXITSTATUS(st)
+        } else {
+            -1
+        }
+    };
+
+    Ok(match code {
+        EXIT_HELD => SheddingProbeOutcome::RestrictionsHeld,
+        EXIT_SHED => SheddingProbeOutcome::RestrictionsShed,
+        EXIT_NNP_FAILED => SheddingProbeOutcome::Inconclusive("no_new_privs_failed"),
+        EXIT_RESTRICT_FAILED => SheddingProbeOutcome::Inconclusive("restrict_self_failed"),
+        EXIT_NOT_BLOCKED_BEFORE => SheddingProbeOutcome::Inconclusive("not_blocked_before_attempt"),
+        _ => SheddingProbeOutcome::Inconclusive("probe_child_did_not_exit_normally"),
+    })
+}
+
+/// A loopback TCP connect to a port nothing is listening on, returning the raw errno.
+///
+/// Async-signal-safe: raw syscalls only. Port 9 (discard) is used because the allowlist is empty, so
+/// the ruleset denies the connect before anything about the port matters.
+#[cfg(target_os = "linux")]
+unsafe fn connect_errno_raw() -> libc::c_int {
+    let fd = libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0);
+    if fd < 0 {
+        return -1;
+    }
+    let mut addr: libc::sockaddr_in = std::mem::zeroed();
+    addr.sin_family = libc::AF_INET as libc::sa_family_t;
+    addr.sin_port = 9u16.to_be();
+    addr.sin_addr.s_addr = u32::from(std::net::Ipv4Addr::LOCALHOST).to_be();
+    let rc = libc::connect(
+        fd,
+        &addr as *const libc::sockaddr_in as *const libc::sockaddr,
+        std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+    );
+    let e = if rc == 0 {
+        0
+    } else {
+        *libc::__errno_location()
+    };
+    libc::close(fd);
+    e
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn landlock_shedding_probe() -> anyhow::Result<SheddingProbeOutcome> {
+    Ok(SheddingProbeOutcome::Inconclusive("not linux"))
+}
+
+/// What the shedding probe found.
+///
+/// Three outcomes, not two. `Inconclusive` is the one that matters: a probe that could not run has
+/// found nothing, and reporting that as "held" is the fail-open this whole feature exists to avoid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SheddingProbeOutcome {
+    /// The restriction survived `KEYCTL_SESSION_TO_PARENT`. The irrevocability invariant holds here.
+    RestrictionsHeld,
+    /// The restriction was shed. This kernel is vulnerable to CVE-2024-42318.
+    RestrictionsShed,
+    /// The probe could not reach a verdict, and says why.
+    Inconclusive(&'static str),
+}
+
+impl SheddingProbeOutcome {
+    /// The stable string for the enforcement-health record.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::RestrictionsHeld => "restrictions_held",
+            Self::RestrictionsShed => "restrictions_shed",
+            Self::Inconclusive(_) => "inconclusive",
+        }
+    }
+}
+
 // =============================================================================
 // Non-Linux stubs (no-op)
 // =============================================================================

--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -208,6 +208,30 @@ pub struct SandboxArgs {
     #[arg(long = "enforcement-health")]
     pub enforcement_health: Option<PathBuf>,
 
+    // Six digests -- subject, substrate, corpus, catch policy, observation vocabulary, run entropy
+    // -- supplied by whoever owns the AEE run. The sandbox is one enforcement episode inside a run,
+    // not the run, and it cannot derive them; the seventh input, the network posture, is the one it
+    // genuinely observes and is built here rather than carried (#2093).
+    //
+    // `//`, not `///`. A long doc comment here flips clap into multi-line help for the whole
+    // command, which moves `[possible values]` onto its own line and breaks `--profile-format`'s
+    // advertisement. That is the same mistake this repo made on `doctor --format` earlier the same
+    // day: why a flag exists belongs next to the code, not in `--help`.
+    /// AEE run context for the seal
+    #[arg(long, requires = "aee_seal_key", requires = "aee_seal")]
+    pub aee_run_context: Option<PathBuf>,
+
+    // The key signs the run-end seal inside this process, at the moment enforcement is still in
+    // force. A later command signing a health artifact off disk would claim a past moment.
+    /// Substrate observation key descriptor
+    #[arg(long, requires = "aee_run_context")]
+    pub aee_seal_key: Option<PathBuf>,
+
+    // Absent, no seal is emitted and the run is unchanged.
+    /// Where to write the signed seal envelope
+    #[arg(long, requires = "aee_run_context")]
+    pub aee_seal: Option<PathBuf>,
+
     /// Strict env mode: only safe base vars + explicit allows
     #[arg(long = "env-strict")]
     pub env_strict: bool,

--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -300,6 +300,9 @@ mod tests {
 
     fn sandbox_args() -> SandboxArgs {
         SandboxArgs {
+            aee_run_context: None,
+            aee_seal_key: None,
+            aee_seal: None,
             command: vec!["true".into()],
             policy: None,
             workdir: None,

--- a/crates/assay-cli/src/cli/commands/sandbox/child.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox/child.rs
@@ -133,10 +133,47 @@ pub(super) async fn run_child(
                 } else {
                     None
                 };
+                // Measured only when a seal is being asked for. The probe forks twice and runs the
+                // CVE-2024-42318 sequence against a throwaway pair; there is no reason to pay for
+                // it on a run that will not carry the answer, and a field nobody reads is a field
+                // that drifts.
+                let shedding = if args.aee_seal.is_some() {
+                    match crate::backend::landlock_shedding_probe() {
+                        Ok(outcome) => {
+                            if !args.quiet
+                                && outcome != crate::backend::SheddingProbeOutcome::RestrictionsHeld
+                            {
+                                eprintln!(
+                                    "WARN: aee-seal: restriction-shedding probe returned {:?}; this run cannot claim still-armed",
+                                    outcome
+                                );
+                            }
+                            Some(outcome.label().to_string())
+                        }
+                        Err(e) => {
+                            if !args.quiet {
+                                eprintln!(
+                                    "WARN: aee-seal: restriction-shedding probe could not run: {e}"
+                                );
+                            }
+                            Some(
+                                crate::backend::SheddingProbeOutcome::Inconclusive("probe_error")
+                                    .label()
+                                    .to_string(),
+                            )
+                        }
+                    }
+                } else {
+                    None
+                };
                 let health = crate::enforcement_health_v1::EnforcementHealthV1::landlock_active(
-                    abi, ports, probe,
+                    abi,
+                    ports.clone(),
+                    probe,
+                    shedding,
                 );
                 write_enforcement_health_v1(args, &health)?;
+                maybe_emit_aee_seal(args, &health, &ports);
             }
             Err(_) => {
                 let health = crate::enforcement_health_v1::EnforcementHealthV1::landlock_failed(
@@ -225,6 +262,120 @@ pub(super) async fn run_child(
 /// Write the `assay.enforcement_health.v1` artifact when `--enforcement-health` is set. Fail-closed:
 /// a requested artifact that cannot be written is an error so the caller does not exit successfully
 /// in a state where the evidence is absent on disk (the same rule v0 enforces).
+/// Build the network-posture object the seal binds to, with its declared digest.
+///
+/// The order is the trap ADR-045 names under *Field interpretation*: `aeePostureDigest` must equal
+/// the digest the posture object *declares*, which is computed over the object **before** the
+/// `digest` member is inserted. `run_binding` then hashes the whole object *including* that member.
+/// Two different digests over the same object, and building them in the wrong order yields a seal
+/// that is refused for a reason bearing no resemblance to its cause.
+#[cfg(target_os = "linux")]
+fn build_network_posture(allowed_ports: &[u16]) -> serde_json::Value {
+    let mut posture = serde_json::json!({
+        "mode": "deny-default",
+        "mechanism": "landlock",
+        "scope": crate::enforcement_health_v1::SCOPE_TCP_CONNECT_LANDLOCK_PORT,
+        "allowedConnectTcpPorts": allowed_ports,
+    });
+    let declared = crate::aee_seal::digest_json_public(&posture);
+    posture["digest"] = serde_json::json!({ "sha256": declared });
+    posture
+}
+
+/// Emit the substrate-signed run-end seal, if the caller asked for one.
+///
+/// Called from the enforcing process at the moment the health record is written, which is the only
+/// place `aeeStillArmed` can mean anything: a later command signing a health artifact off disk would
+/// be claiming a property of a moment that has passed.
+///
+/// Every failure here is loud and non-fatal to the workload. A run that could not seal is a run
+/// without a seal, never a run with a weaker one.
+#[cfg(target_os = "linux")]
+fn maybe_emit_aee_seal(
+    args: &SandboxArgs,
+    health: &crate::enforcement_health_v1::EnforcementHealthV1,
+    allowed_ports: &[u16],
+) {
+    let (Some(ctx_path), Some(key_path), Some(out_path)) = (
+        args.aee_run_context.as_ref(),
+        args.aee_seal_key.as_ref(),
+        args.aee_seal.as_ref(),
+    ) else {
+        return;
+    };
+
+    let warn = |what: &str| {
+        if !args.quiet {
+            eprintln!("WARN: aee-seal: {what}; no seal was written");
+        }
+    };
+
+    let ctx_raw = match std::fs::read_to_string(ctx_path) {
+        Ok(r) => r,
+        Err(e) => return warn(&format!("run context unreadable: {e}")),
+    };
+    let context = match crate::aee_run_context::AeeRunContext::parse(&ctx_raw) {
+        Ok(c) => c,
+        Err(e) => return warn(&e.to_string()),
+    };
+
+    let key_raw = match std::fs::read_to_string(key_path) {
+        Ok(r) => r,
+        Err(e) => return warn(&format!("key descriptor unreadable: {e}")),
+    };
+    let key = match crate::aee_seal_key::load(key_path, &key_raw) {
+        Ok(k) => k,
+        Err(e) => return warn(&e.to_string()),
+    };
+
+    let env = context.into_environment(build_network_posture(allowed_ports));
+    let sealed_at = crate::aee_seal::now_rfc3339_utc();
+
+    // `SynchronousProbe`: the only sealed observation is the run-end probe itself, obtained with no
+    // queue between capture and the seal builder. Its basis is `declared`, not `checked`, and the
+    // payload says so -- the zero is this producer asserting its topology has no lossy channel.
+    let run = match crate::aee_seal::build_sealed_run(
+        health,
+        &env,
+        &[],
+        &sealed_at,
+        &crate::aee_seal::DropAccounting::SynchronousProbe,
+    ) {
+        Ok(r) => r,
+        Err(e) => return warn(&format!("not seal-eligible: {e}")),
+    };
+
+    let envelope = match crate::aee_seal_envelope::sign_seal(
+        &run.seal,
+        key.signing_key(),
+        key.keyid(),
+        key.role(),
+    ) {
+        Ok(e) => e,
+        Err(e) => return warn(&format!("signing failed: {e}")),
+    };
+
+    let doc = match serde_json::to_string_pretty(&envelope) {
+        Ok(d) => d,
+        Err(e) => return warn(&format!("envelope not serializable: {e}")),
+    };
+    if let Some(parent) = out_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::write(out_path, doc + "\n") {
+        Ok(()) => {
+            if !args.quiet {
+                eprintln!(
+                    "aee-seal: wrote {} (keyid {})",
+                    out_path.display(),
+                    key.keyid()
+                );
+            }
+        }
+        Err(e) => warn(&format!("could not write {}: {e}", out_path.display())),
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn write_enforcement_health_v1(
     args: &SandboxArgs,

--- a/crates/assay-cli/src/enforcement_health_v1.rs
+++ b/crates/assay-cli/src/enforcement_health_v1.rs
@@ -98,6 +98,18 @@ pub struct LandlockBlock {
     pub no_new_privs_confirmed: bool,
     /// Whether `landlock_restrict_self` was confirmed (by the enforcing child, not assumed by parent).
     pub restrict_self_confirmed: bool,
+    /// Whether this kernel lets a restricted process shed its own Landlock restrictions, measured.
+    ///
+    /// `restrictions_held` | `restrictions_shed` | `inconclusive`, absent when the probe was not run.
+    ///
+    /// This exists because ADR-045 permits `aeeStillArmed` to rest on Landlock's irrevocability, and
+    /// that invariant has a documented exception: CVE-2024-42318 let a process with `fork()` and
+    /// `keyctl()` drop every Landlock restriction on itself, from 5.13 until the fix in v6.11-rc1.
+    /// `abi` cannot stand in for it -- ABI 4 arrives at kernel 6.7, four releases before the fix --
+    /// and a kernel-version comparison cannot see a distribution backport, so the property is
+    /// measured on the running kernel instead of inferred. See `backend::landlock_shedding_probe`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub restriction_shedding: Option<String>,
 }
 
 /// The optional real-block probe. Its presence upgrades the claim from "ruleset applied" to "a denied
@@ -156,7 +168,12 @@ impl EnforcementHealthV1 {
     /// `restrict_self` confirmed). `probe` is `Some` only when a real-block probe was actually run;
     /// `None` records "ruleset applied, no real-block claim".
     #[must_use]
-    pub fn landlock_active(abi: u32, allowed_ports: Vec<u16>, probe: Option<Probe>) -> Self {
+    pub fn landlock_active(
+        abi: u32,
+        allowed_ports: Vec<u16>,
+        probe: Option<Probe>,
+        restriction_shedding: Option<String>,
+    ) -> Self {
         Self {
             schema: SCHEMA_V1.to_string(),
             status: Status::Active,
@@ -171,6 +188,7 @@ impl EnforcementHealthV1 {
                 allowed_connect_tcp_ports: Some(allowed_ports),
                 no_new_privs_confirmed: true,
                 restrict_self_confirmed: true,
+                restriction_shedding,
             },
             probe,
             non_claims: landlock_non_claims(),
@@ -204,6 +222,10 @@ impl EnforcementHealthV1 {
                 allowed_connect_tcp_ports: None,
                 no_new_privs_confirmed,
                 restrict_self_confirmed: false,
+                // Nothing was armed, so there is nothing to shed. Absent rather than
+                // "inconclusive": the probe was not attempted, and a record that says
+                // "could not tell" implies it tried.
+                restriction_shedding: None,
             },
             probe: None,
             non_claims: landlock_non_claims(),
@@ -253,6 +275,7 @@ mod fixture_values {
                 allowed_connect_tcp_ports: Some(vec![443]),
                 no_new_privs_confirmed: true,
                 restrict_self_confirmed: true,
+                restriction_shedding: Some("restrictions_held".to_string()),
             },
             probe: Some(Probe {
                 kind: "real_block".to_string(),
@@ -291,6 +314,7 @@ mod fixture_values {
                 allowed_connect_tcp_ports: None,
                 no_new_privs_confirmed: false,
                 restrict_self_confirmed: false,
+                restriction_shedding: None,
             },
             probe: None,
             non_claims: base_non_claims(),

--- a/crates/assay-cli/tests/fixtures/enforcement_health/v1/active_probe_shedding_unmeasured.json
+++ b/crates/assay-cli/tests/fixtures/enforcement_health/v1/active_probe_shedding_unmeasured.json
@@ -13,8 +13,7 @@
       443
     ],
     "no_new_privs_confirmed": true,
-    "restrict_self_confirmed": true,
-    "restriction_shedding": "restrictions_held"
+    "restrict_self_confirmed": true
   },
   "probe": {
     "kind": "real_block",

--- a/crates/assay-cli/tests/fixtures/enforcement_health/v1/active_probe_shedding_unmeasured.json
+++ b/crates/assay-cli/tests/fixtures/enforcement_health/v1/active_probe_shedding_unmeasured.json
@@ -4,6 +4,7 @@
   "mechanism": "landlock",
   "scope": "tcp_connect_landlock_port",
   "policy_semantics": "allowlist",
+  "enforcement_class": "strong",
   "landlock": {
     "abi": 4,
     "handled_access_net": [


### PR DESCRIPTION
## Description

#2093, slice C. **Stacked on #2096 (A) and #2097 (B)** — it calls both, so it cannot build until they land, and its diff shrinks to slice C alone once they do. #2093 stays open after this: the second collection path and the `aeeVersion` 0.7/0.8 decision remain.

The seal is emitted from `sandbox/child.rs`, in the enforcing process, at the moment the health record is written. A later command signing a health artifact off disk would be claiming a property of a moment that has passed — the gap ADR-045's run-end requirement exists to close.

## The research changed what this slice had to be

ADR-045 permits `aeeStillArmed` to rest on Landlock's irrevocability. That invariant is real and documented — and it has an exception.

**[CVE-2024-42318](https://ubuntu.com/security/CVE-2024-42318)** ("Landlock Houdini", Jann Horn, 2024-07-24): Landlock implemented the `cred_prepare` LSM hook but not `cred_transfer`, so `keyctl(KEYCTL_SESSION_TO_PARENT)` dropped **every** Landlock restriction. Present from 5.13; fixed in v6.11-rc1, commit `39705a6c29f8`.

**`abi >= 4` does not exclude it.** ABI 4 arrives at kernel 6.7, four releases before the fix:

| | |
|---|---|
| `LANDLOCK_ACCESS_NET_CONNECT_TCP` (ABI 4) | 6.7 |
| CVE-2024-42318 fixed | 6.11 |
| what the record carried | `abi`, and no kernel version |

So every kernel in 6.7–6.11 passed every check `seal_eligibility` made, while the workload child — which by definition runs the code under test — could shed its sandbox with two syscalls.

## Why it is measured rather than gated on a version

Closing this by kernel version needs a per-distribution backport table, and a table of backport facts rots silently. Ubuntu Noble carries the fix at **`6.8.0-50.51`**, which no comparison against 6.11 would ever discover — our own runner would have been refused while patched.

`backend::landlock_shedding_probe` runs the CVE sequence against a throwaway process pair and reports **held / shed / inconclusive**. `seal_eligibility` requires `restrictions_held`; `inconclusive` is a probe that found nothing, which is not a finding that restrictions hold.

It needs **two** forks: `KEYCTL_SESSION_TO_PARENT` replaces the *parent's* credentials, so the process under test must be the caller's parent. The real process is never a target, which is why running the exploit deliberately does not weaken it.

Every enforcement-health record written before this field existed is now refused — by *fixture*, not a hand-built struct, because each one would otherwise have sealed with `aeeStillArmed: true` resting on an invariant nothing checked.

## Verified on the runner, not inferred

`6.8.0-136-generic`, patched at `50.51`. A real Landlock run, our own Ed25519 key:

```
restriction_shedding: restrictions_held
aeeStillArmed: true          assayDropProofBasis: declared
aeeObservedAttacks: []       assayCollectionPath: landlock-tcp-connect
aeeRunBinding: 50b143da...   945 payload bytes, 64 signature bytes
keyid sha256:af5dc9d8...
```

And without a run-end probe it refuses, loudly, writing nothing:

```
WARN: aee-seal: not seal-eligible: no run-end probe: a start-time restrict_self
confirmation proves the ruleset was applied, not that it was still applied at
run end; no seal was written
```

`assayDropProofBasis: declared` is deliberate and not dressed up: the synchronous-probe model's zero is this producer asserting its topology has no lossy channel, not a counter read.

## The posture-digest trap

Built declared-digest-first, the order ADR-045 names under *Field interpretation*: `aeePostureDigest` is the digest computed **before** the `digest` member is inserted, while `run_binding` hashes the object **including** it. `digest_json_public` shares the seal's own canonicalization rather than adding a second answer to "what is this object's digest".

## Two things this cost

**`SealSignError` had no `Display`** — invisible until the Linux path compiled for the first time on the runner.

**The three new args first carried long `///` comments**, which flip clap into multi-line help for the whole command and broke `sandbox --profile-format`'s `[possible values]` advertisement. Caught by #2086's own test, one day old. Same mistake as `doctor --format` that morning: why a flag exists belongs next to the code, not in `--help`.

## Boundary

The Linux **unit** tests did not run on the runner: `/opt/rust/registry` is root-owned there, so a test-only dev-dependency could not be fetched. The Linux path is verified by the end-to-end run above, which exercises more than a unit test would. The platform-independent suite (51 suites) passes on the dev box.

## Scope

`gates=all` — touches the sandbox enforcement path. Needs a delegated proof bound to its head.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
