### PR TITLE
The publish order was a topological sort nobody compared to the graph

### DIFF
--- a/scripts/ci/publish_idempotent.sh
+++ b/scripts/ci/publish_idempotent.sh
@@ -19,18 +19,71 @@ CRATES=(
   "assay-common"
   "assay-registry"
   "assay-canonical"
+  # Before assay-evidence, not after it. `assay-evidence` dev-depends on this crate for
+  # `tests/claim_gate_parity.rs` (#2084), and `cargo publish` resolves dev-dependencies from the
+  # registry like any other. With this crate at position 10, v4.0.0 failed here with "failed to
+  # select a version for the requirement `assay-runner-schema = ^4.0.0`" -- and because this script
+  # is `set -e`, the nine crates after it never published at all.
+  "assay-runner-schema"
   "assay-evidence"
   "assay-core"
   "assay-metrics"
   "assay-policy"
   "assay-mcp-server"
   "assay-monitor"
-  "assay-runner-schema"
   "assay-runner-linux"
   "assay-runner-core"
   "assay-sim"
   "assay-cli"
 )
+
+# The list above is hand-kept, so it is checked against the manifests before anything is published.
+#
+# A publish order is a topological sort someone wrote by hand, and v4.0.0 is what happens when the
+# graph moves and the list does not: a dev-dependency added in #2084 put `assay-runner-schema` ahead
+# of `assay-evidence` in the graph while it stayed six places behind it here. CLAUDE.md documents
+# that edge. Nothing compared the two.
+#
+# Dev-dependencies count, and that is the point: the edge that broke this was dev-only, and
+# `cargo publish` does not care -- a versioned dev-dependency must resolve from the registry.
+#
+# Checked before the first upload, because publishing is not reversible. An order discovered to be
+# wrong at crate three has already put two crates on crates.io that cannot be taken back.
+validate_publish_order() {
+  python3 - "${CRATES[@]}" <<'ORDER_CHECK'
+import pathlib, re, sys
+
+order = sys.argv[1:]
+position = {name: i for i, name in enumerate(order)}
+problems = []
+
+for name in order:
+    manifest = pathlib.Path("crates") / name / "Cargo.toml"
+    if not manifest.is_file():
+        problems.append(f"{name}: no crates/{name}/Cargo.toml")
+        continue
+    text = manifest.read_text(encoding="utf-8")
+    # Every internal dependency this manifest names, in any dependency table. A mention in a comment
+    # cannot match: the name has to start a key.
+    for dep in sorted(set(re.findall(r"^(assay-[a-z0-9-]+)\s*=", text, re.M))):
+        if dep == name or dep not in position:
+            continue
+        if position[dep] > position[name]:
+            problems.append(
+                f"{name} (position {position[name]}) depends on {dep} "
+                f"(position {position[dep]}), which publishes later and will not resolve"
+            )
+
+if problems:
+    print("publish order does not respect the dependency graph:", file=sys.stderr)
+    for p in problems:
+        print(f"  - {p}", file=sys.stderr)
+    sys.exit(1)
+print(f"publish order respects the dependency graph ({len(order)} crates).")
+ORDER_CHECK
+}
+
+validate_publish_order
 
 CRATESIO_PUBLISH_WAIT_ATTEMPTS="${CRATESIO_PUBLISH_WAIT_ATTEMPTS:-36}"
 CRATESIO_PUBLISH_WAIT_DELAY_SECONDS="${CRATESIO_PUBLISH_WAIT_DELAY_SECONDS:-10}"


### PR DESCRIPTION
## What happened

v4.0.0 tagged cleanly. The GitHub release has its 23 assets, PyPI published, the MCP registry published. **crates.io got two of fourteen crates and stopped.**

```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `assay-runner-schema = "^4.0.0"`
❌ cargo publish failed for assay-evidence
```

| crate | on crates.io |
|---|---|
| `assay-common` | 4.0.0 |
| `assay-canonical` | 4.0.0 |
| `assay-evidence` | **3.38.0** ← stopped here |
| `assay-core`, `assay-metrics`, `assay-cli`, … | **3.38.0** |

So `cargo install assay-cli` still gets 3.38.0. Anyone using the release binaries is unaffected.

## Cause

`assay-runner-schema` was at position **10**; `assay-evidence` at position **4**. #2084 added a dev-dependency from the second to the first, for `tests/claim_gate_parity.rs` — the test that pins this crate's claim gate against `RunnerClaimGate` so the two cannot drift.

`cargo publish` resolves dev-dependencies from the registry like any other. It asked for `^4.0.0`, found `3.38.0`, refused. The script is `set -e`, so the nine crates after it never ran.

It had never been wrong before because the edge did not exist at v3.38.0.

## The part worth more than the reorder

CLAUDE.md's dependency graph **already documents this edge**, marked `DEV-ONLY`. The publish order is a topological sort someone wrote by hand, and nothing compared the two. That is the third time this week a rule was correct in prose and unenforced in fact — after `FORMAT_ARGS` that never listed `doctor` and the semver baseline pinned two majors back.

So the list is checked against the manifests, **before the first upload**. Publishing is not reversible: an order found wrong at crate three has already put two crates on crates.io that cannot be taken back.

Dev-dependencies are included on purpose. The edge that broke this was dev-only and `cargo publish` did not care.

## Verification

| | |
|---|---|
| corrected order | `publish order respects the dependency graph (14 crates).` |
| the order that shipped | `assay-evidence (position 3) depends on assay-runner-schema (position 9), which publishes later and will not resolve` |

The check names the exact dependency that failed, from the manifests, without being told what to look for.

## Recovery after this merges

`release.yml` accepts `workflow_dispatch` with a version input and its checkout takes the dispatched ref, so dispatching on `main` runs the corrected order at 4.0.0. Every job is idempotent: the publisher skips crates already at 4.0.0, PyPI is `skip-existing: true`, and the release step clobbers rather than re-creates (#1817).

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.