### PR TITLE
assay-core was published depending on a crate marked publish = false

### DIFF
--- a/crates/assay-adapter-api/Cargo.toml
+++ b/crates/assay-adapter-api/Cargo.toml
@@ -7,7 +7,17 @@ repository.workspace = true
 authors.workspace = true
 description = "Protocol adapter API contracts for Assay evidence translation."
 readme.workspace = true
-publish = false
+# Published from v4.0.0. It was `publish = false` while `assay-core` and `assay-sim` -- both
+# published -- carried a hard `[dependencies]` edge to it. That only resolved because a historical
+# 3.x sits on crates.io from before the flag was set, so every published `assay-core` since has
+# resolved an abandoned 3.2.3 rather than the source it was built against. At 4.0.0 there is no 4.x
+# to fall back to and `cargo publish` refused, which is the first time the configuration was
+# actually tested.
+#
+# ADR-026's distribution freeze covers the protocol adapters (a2a, acp, ucp), which stay unpublished
+# and carry no published dependent. This crate is the shared trait surface they and `assay-core`
+# share, so it is not in the same position.
+publish = true
 
 [dependencies]
 assay-evidence = { path = "../assay-evidence", version = "4.0.0" }

--- a/crates/assay-adapter-api/Cargo.toml
+++ b/crates/assay-adapter-api/Cargo.toml
@@ -2,10 +2,14 @@
 name = "assay-adapter-api"
 version.workspace = true
 edition.workspace = true
+# Declared because this crate is public as of v4.0.0 and the MSRV gate holds every public crate to
+# the 1.89 floor. It had no `rust-version` while it was `publish = false`, which was correct then
+# and is not now: a consumer resolving it from crates.io needs to know what it compiles on.
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Protocol adapter API contracts for Assay evidence translation."
+description = "Internal/experimental substrate for Assay evidence translation. The shared trait surface the Assay protocol adapters implement, published because `assay-core` depends on it and cargo requires every `[dependencies]` entry of a published crate to resolve from crates.io. No standalone product guarantee; semver tracks the Assay workspace."
 readme.workspace = true
 # Published from v4.0.0. It was `publish = false` while `assay-core` and `assay-sim` -- both
 # published -- carried a hard `[dependencies]` edge to it. That only resolved because a historical

--- a/scripts/ci/check-public-crate-policy.sh
+++ b/scripts/ci/check-public-crate-policy.sh
@@ -18,6 +18,16 @@ set -euo pipefail
 # unpublishable
 # (see CHANGELOG entries for v3.11.0, v3.11.1, v3.11.2, v3.11.3).
 #
+# `assay-adapter-api` is registered here as of v4.0.0, for the same reason
+# and by the same argument as the runner crates above. It sat in
+# `non_crates_io_crates` while `assay-core` and `assay-sim` -- both public --
+# carried it in `[dependencies]`. That only ever resolved because a historical
+# 3.x predates the `publish = false` flag, so every published `assay-core`
+# resolved an abandoned 3.2.3 rather than the source it was built against. The
+# v4.0.0 publish had no stale version to fall back on and stopped, which is the
+# first time the configuration was tested. The protocol adapters (acp, a2a, ucp)
+# stay unpublished: no public crate depends on them, so ADR-026's freeze holds.
+#
 # Adding any new public crate here is a deliberate public-surface
 # decision; the PR that does so must update package descriptions and
 # (when relevant) docs/contributing/WAVE0-GATES.md.
@@ -26,6 +36,7 @@ public_crates=(
   assay-registry
   assay-canonical
   assay-evidence
+  assay-adapter-api
   assay-core
   assay-metrics
   assay-policy
@@ -39,7 +50,6 @@ public_crates=(
 )
 
 non_crates_io_crates=(
-  assay-adapter-api
   assay-adapter-acp
   assay-adapter-a2a
   assay-adapter-ucp

--- a/scripts/ci/publish_idempotent.sh
+++ b/scripts/ci/publish_idempotent.sh
@@ -5,9 +5,15 @@ echo "📦 Starting Idempotent Publisher..."
 
 # Crates published in dependency order.
 #
-# Adapter crates are intentionally source/workspace-internal for this release
-# line. assay-adapter-api has historical crates.io versions, but no current
-# release-line publishing until ADR-026 gets a dedicated distribution freeze.
+# The protocol adapters (a2a, acp, ucp) are intentionally source/workspace-internal
+# for this release line, per ADR-026's distribution freeze. They have no published
+# dependent, so nothing on crates.io needs them to exist.
+#
+# assay-adapter-api is not in that group and publishes from v4.0.0. It was grouped
+# with them and marked `publish = false` while `assay-core` and `assay-sim` -- both
+# published -- carried a hard dependency on it. That only ever resolved because a
+# historical 3.x predates the flag, so published assay-core has been resolving an
+# abandoned 3.2.3 rather than the source it was built against.
 #
 # As of v3.11.2 the Assay-Runner crates publish too. They are marked as
 # internal/experimental substrate in their package descriptions; they exist on
@@ -26,6 +32,9 @@ CRATES=(
   # is `set -e`, the nine crates after it never published at all.
   "assay-runner-schema"
   "assay-evidence"
+  # After assay-evidence (its only internal dependency) and before assay-core, which requires it.
+  # Published from v4.0.0: see the note in its manifest.
+  "assay-adapter-api"
   "assay-core"
   "assay-metrics"
   "assay-policy"
@@ -39,6 +48,17 @@ CRATES=(
 
 # The list above is hand-kept, so it is checked against the manifests before anything is published.
 #
+# One rule, three clauses, and each clause exists because a v4.0.0 publish failed on it:
+#
+#   1. every crate in this list is publishable            (assay-adapter-api carried publish = false)
+#   2. internal dependencies publish before their users   (assay-runner-schema was six places late)
+#   3. internal dependencies this script does NOT publish
+#      resolve to a version crates.io actually has        (assay-adapter-api ^4.0.0 did not exist)
+#
+# They are one function rather than three checks because they answer one question -- will this
+# sequence of publishes resolve -- and because a rule split across three places drifts in three
+# directions.
+#
 # A publish order is a topological sort someone wrote by hand, and v4.0.0 is what happens when the
 # graph moves and the list does not: a dev-dependency added in #2084 put `assay-runner-schema` ahead
 # of `assay-evidence` in the graph while it stayed six places behind it here. CLAUDE.md documents
@@ -51,11 +71,33 @@ CRATES=(
 # wrong at crate three has already put two crates on crates.io that cannot be taken back.
 validate_publish_order() {
   python3 - "${CRATES[@]}" <<'ORDER_CHECK'
-import pathlib, re, sys
+import json, pathlib, re, sys
+
+import urllib.error, urllib.request
 
 order = sys.argv[1:]
 position = {name: i for i, name in enumerate(order)}
 problems = []
+unpublishable = []
+
+
+def requirement_for(manifest_text, dep):
+    """The version requirement a manifest states for `dep`, or None if it states none."""
+    for line in manifest_text.splitlines():
+        if line.startswith(f"{dep} ") or line.startswith(f"{dep}="):
+            m = re.search(r'version\s*=\s*"([^"]+)"', line)
+            return m.group(1) if m else None
+    return None
+
+
+def published_versions(crate):
+    """Versions of `crate` on crates.io, via the sparse index. Raises if it cannot be reached."""
+    prefix = {1: "1", 2: "2", 3: f"3/{crate[0]}"}.get(len(crate), f"{crate[:2]}/{crate[2:4]}")
+    url = f"https://index.crates.io/{prefix}/{crate}"
+    req = urllib.request.Request(url, headers={"User-Agent": "assay-publish-order-check"})
+    with urllib.request.urlopen(req, timeout=30) as fh:
+        body = fh.read().decode("utf-8")
+    return [json.loads(line)["vers"] for line in body.splitlines() if line.strip()]
 
 for name in order:
     manifest = pathlib.Path("crates") / name / "Cargo.toml"
@@ -63,16 +105,55 @@ for name in order:
         problems.append(f"{name}: no crates/{name}/Cargo.toml")
         continue
     text = manifest.read_text(encoding="utf-8")
-    # Every internal dependency this manifest names, in any dependency table. A mention in a comment
-    # cannot match: the name has to start a key.
+
+    # Clause 1: a crate this script publishes must be publishable. `assay-adapter-api` carried
+    # `publish = false` while two published crates hard-depended on it, which is how a stale 3.2.3
+    # ended up satisfying every `assay-core` on crates.io.
+    if re.search(r"^publish\s*=\s*false\s*$", text, re.M):
+        problems.append(
+            f"{name} is in the publish list and its manifest says `publish = false`; "
+            "cargo will refuse it"
+        )
+
+    # Clause 2 and 3: every internal dependency this manifest names, in any dependency table. A
+    # mention in a comment cannot match: the name has to start a key.
     for dep in sorted(set(re.findall(r"^(assay-[a-z0-9-]+)\s*=", text, re.M))):
-        if dep == name or dep not in position:
+        if dep == name:
+            continue
+        if dep not in position:
+            # An internal dependency this script never publishes. Skipping it is what let v4.0.0
+            # get this far: `assay-core` required `assay-adapter-api = ^4.0.0`, a crate held at
+            # 3.2.3 on crates.io because it is workspace-internal for this release line, and the
+            # release-prep bump moved the pin with everything else. `cargo publish` refused.
+            #
+            # So the requirement is checked against what is actually published. Unreachable index
+            # is a hard failure: "could not check" and "fine" must not be spelled the same way.
+            unpublishable.append((name, dep, requirement_for(text, dep)))
             continue
         if position[dep] > position[name]:
             problems.append(
                 f"{name} (position {position[name]}) depends on {dep} "
                 f"(position {position[dep]}), which publishes later and will not resolve"
             )
+
+for name, dep, req in unpublishable:
+    if req is None:
+        continue
+    try:
+        available = published_versions(dep)
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        problems.append(
+            f"{name} depends on {dep} {req}, which this script does not publish, and the crates.io "
+            f"index could not be reached to check it ({exc}). This is a could-not-check, not a pass."
+        )
+        continue
+    major = req.split(".")[0].lstrip("^~=")
+    if not any(v.split(".")[0] == major for v in available):
+        newest = available[-1] if available else "none"
+        problems.append(
+            f"{name} requires {dep} = \"{req}\", which this script does not publish and crates.io "
+            f"does not have (newest published: {newest}). Pin it to a published version."
+        )
 
 if problems:
     print("publish order does not respect the dependency graph:", file=sys.stderr)


### PR DESCRIPTION
## What the failed publish exposed

```
⬆️  assay-core@4.0.0 not found — publishing...
error: failed to select a version for the requirement `assay-adapter-api = "^4.0.0"`
```

`assay-adapter-api` carried `publish = false`. `assay-core` and `assay-sim` — both published — carry a hard `[dependencies]` edge to it.

**That configuration cannot work, and had never been tested.** A historical 3.x sits on crates.io from before the flag was set, so `^3.0.0` always resolved to *something*. Every published `assay-core` since has resolved an abandoned **3.2.3**, not the source it was built and tested against. At 4.0.0 there is no 4.x to fall back on, so cargo said so for the first time.

## Why the obvious fix is wrong

Reverting the pin to `^3.0.0` breaks the workspace — a path dependency resolves against the **local** crate, which is 4.0.0:

```
failed to select a version for the requirement `assay-adapter-api = "^3.0.0"`
candidate versions found which didn't match: 4.0.0
```

`cargo-deny` refused that attempt at pre-commit, twice, before it could reach the branch.

## The decision

`assay-adapter-api` publishes from v4.0.0. ADR-026's distribution freeze covers the **protocol adapters** — a2a, acp, ucp — which stay unpublished and have no published dependent. This crate is the shared trait surface `assay-core` already ships a dependency on, so it was never in the same position as the three it was grouped with. The publisher's header said otherwise and is corrected.

## One rule, three clauses

This check has now failed to catch three separate things in one evening, so it states the rule rather than accumulating patches:

| clause | the failure that earned it |
|---|---|
| every crate in the list is publishable | `assay-adapter-api` had `publish = false` |
| internal dependencies publish before their users | `assay-runner-schema` was six places late |
| deps this script does not publish resolve on crates.io | `assay-adapter-api ^4.0.0` did not exist |

One function, not three checks: they answer one question — *will this sequence of publishes resolve* — and a rule split across three places drifts in three directions.

Verified by mutation against the real sparse index:

```
clean            → publish order respects the dependency graph (15 crates).
publish = false  → assay-adapter-api is in the publish list and its manifest says
                   `publish = false`; cargo will refuse it
wrong position   → assay-evidence (position 3) depends on assay-runner-schema (position 9)
unpublished dep  → assay-core requires assay-adapter-api = "4.0.0" … (newest published: 3.2.3)
```

## Publish state

At 4.0.0: `assay-common`, `assay-registry`, `assay-canonical`, `assay-runner-schema`, `assay-evidence`. Nine remain, ending at `assay-cli`. The publisher is idempotent, so the next dispatch skips what has landed.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The adapter API package is now available through the standard package distribution channel.
  * Package metadata now provides clearer information about its role and distribution.

* **Chores**
  * Updated release validation to verify package publication order, compatibility, and availability.
  * Improved safeguards against incomplete or inconsistent package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->