### PR TITLE
The semver gate shipped with the defect it was written to prevent

### DIFF
--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -413,7 +413,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch --tags --quiet origin || true
+          # No `|| true`. A failed fetch leaves whatever tags the checkout happens to have, and
+          # `git tag --list` would then pick a stale baseline and compare against the wrong release
+          # while reporting success. That is the exact failure this job exists to stop, so it must
+          # not be the way this job fails.
+          git fetch --tags --quiet origin
           tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)"
           if [ -z "${tag}" ]; then
             echo "::error::no v* release tag found, so there is nothing to compare against."

--- a/scripts/ci/test-semver-gate.sh
+++ b/scripts/ci/test-semver-gate.sh
@@ -101,7 +101,7 @@ if [ "${ASSAY_SEMVER_GATE_FULL:-0}" = "1" ]; then
       cp "$backup" "$subject"
       cp "$manifest_backup/root.toml" "$ROOT/Cargo.toml"
       (cd "$ROOT" && for m in crates/*/Cargo.toml; do cp "$manifest_backup/$m" "$m"; done)
-      rm -rf "$backup" "$manifest_backup"
+      rm -rf "$backup" "$manifest_backup" "${scratch_target:-}"
     }
     trap restore EXIT
 
@@ -126,7 +126,12 @@ assert anchor in t, "MetricResult moved; update the self-test"
 t = t.replace(anchor, anchor + "\n    pub deliberately_planted_for_the_gate_test: bool,", 1)
 open(p, "w").write(t)
 PY
-    out="$(cd "$ROOT" && cargo semver-checks check-release -p assay-core --baseline-rev "$resolved" 2>&1)"
+    # Its own target directory. This check downgrades the workspace version and plants a breaking
+    # change; artifacts built from that tree are keyed to a version and a source that do not exist,
+    # and writing them into the shared target dir would leave them there for the next build.
+    scratch_target="$(mktemp -d)"
+    out="$(cd "$ROOT" && CARGO_TARGET_DIR="$scratch_target" \
+      cargo semver-checks check-release -p assay-core --baseline-rev "$resolved" 2>&1)"
     status=$?
     restore
     trap - EXIT
@@ -147,6 +152,7 @@ PY
   fi
 else
   echo "skip  planted-break check (set ASSAY_SEMVER_GATE_FULL=1 to run it)"
+  PLANTED_BREAK_RAN=0
 fi
 
 if [ "$FAILURES" -ne 0 ]; then
@@ -155,4 +161,11 @@ if [ "$FAILURES" -ne 0 ]; then
   exit 1
 fi
 echo
-echo "semver gate: all cases pass"
+if [ "${PLANTED_BREAK_RAN:-1}" = "1" ]; then
+  echo "semver gate: all cases pass"
+else
+  # Not "all cases pass". The cheap cases check the gate's SHAPE; the planted break is the only one
+  # that shows it reaches a verdict, and it did not run. Saying "all cases pass" here would be a
+  # green line standing in for a check nobody performed, which is the defect this file exists for.
+  echo "semver gate: shape cases pass; the planted-break case was NOT run"
+fi


### PR DESCRIPTION
## Why this is a separate PR

#2094 merged at 05:20 — before I read its reviews. CodeRabbit raised four findings on it, three are valid, and **two of them are live on `main` right now**. This applies them.

## The two that matter, and why they sting

Both are this repository's own rule broken by the code enforcing it.

**`git fetch --tags --quiet origin || true`.** A failed fetch fell through to whatever tags the checkout happened to carry. The job would then resolve a stale baseline, compare against the wrong release, and **report success**. #2094 exists because "could not check" and "found nothing" were spelled the same way; it then failed that way itself. The suppression is gone, so a fetch failure fails the job.

**`semver gate: all cases pass`** printed when `ASSAY_SEMVER_GATE_FULL` was unset — that is, on every pre-push run, where the only case that proves the gate *reaches a verdict* is skipped. The cheap cases check the gate's shape; the planted break is the one that shows it can fail. A green line was standing in for a check nobody performed.

```
before:  semver gate: all cases pass
after:   semver gate: shape cases pass; the planted-break case was NOT run
```

**Third, taken:** the full self-test now builds into its own `CARGO_TARGET_DIR`. It downgrades the workspace version and plants a breaking change, so its artifacts are keyed to a version and a source that do not exist and have no business in the shared cache.

## Declined, with reasoning

**Pinning `cargo-semver-checks` to a fixed version.** The concern is real — an unpinned tool can change its verdict without a code change.

But the planted-break case asserts a non-zero exit *and* the lint name `constructible_struct_adds_field`. If that lint is renamed or removed, the self-test goes red on the next run. Tool drift surfaces as a failing check rather than as a quiet shift in what the gate accepts.

Pinning would suppress that signal and add a version constant somebody has to bump — the same shape as the hardcoded baseline SHA #2094 removed, one level over. If the self-test is ever weakened so it stops naming the lint, pinning becomes correct and this reasoning should be revisited.

## Verification

Both modes, on top of `main`:

```
cheap:  semver gate: shape cases pass; the planted-break case was NOT run
full:   ok  a planted breaking change fails the gate
        ok    and names the lint that caught it
        semver gate: all cases pass
```

## Note on the review itself

Copilot reviewed none of this batch — *"the user who requested the review has reached their quota limit"* — so CodeRabbit was the only automated reviewer, and it caught two real defects in a gate written specifically about this failure mode. Worth knowing when weighing the rest of the queue.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.