### PR TITLE
An empty docs PR is a finished one, not a broken one

### DIFF
--- a/scripts/ci/reconcile-docs-auto-pr.sh
+++ b/scripts/ci/reconcile-docs-auto-pr.sh
@@ -136,14 +136,33 @@ files_json="$(
     --slurp \
     "repos/${REPO}/pulls/${pr_number}/files?per_page=100"
 )"
-if ! jq -e '
-  type == "array" and
-  length > 0 and
-  all(.[]; type == "array") and
-  ([.[][]] | length > 0)
-' >/dev/null <<<"$files_json"; then
-  echo "docs PR #${pr_number} returned an invalid or empty files response" >&2
+# Malformed and empty are different answers and need different handling.
+#
+# This used to require `length > 0` and reject anything else as "an invalid or empty files
+# response" -- naming both conditions in one breath, which is the tell. A malformed response means
+# the reconciler cannot see what it is reconciling and must refuse. An EMPTY one means the docs PR
+# changes nothing, which is not a fault: it is what a docs PR looks like once the drift it existed
+# for has been fixed at the source.
+#
+# #2081 moved the drift check onto the pull request that causes the drift, so #2021's diff became
+# empty. `Auto-Update Docs` then failed on every merge to `main` -- eight consecutive runs -- for a
+# condition that meant the system had done its job. Nobody noticed, because it runs post-merge where
+# a red tick has nobody waiting on it.
+if ! jq -e 'type == "array" and all(.[]; type == "array")' >/dev/null <<<"$files_json"; then
+  echo "docs PR #${pr_number} returned a malformed files response" >&2
   exit 2
+fi
+
+if [[ "$(jq '[.[][]] | length' <<<"$files_json")" -eq 0 ]]; then
+  echo "docs PR #${pr_number} changes no files, so there is no drift left to reconcile."
+  echo "Closing it: an empty docs PR is a finished one, not a broken one."
+  gh pr close "$pr_number" \
+    --repo "$REPO" \
+    --comment "Closed by the reconciler: this PR changes no files, so the drift it was opened for is already resolved on the base branch." >&2 || {
+    echo "could not close docs PR #${pr_number}" >&2
+    exit 2
+  }
+  exit 0
 fi
 
 non_docs="$(jq -c '[.[][] | .filename | select(startswith("docs/") | not)]' <<<"$files_json")"

--- a/scripts/ci/test-reconcile-docs-auto-pr.sh
+++ b/scripts/ci/test-reconcile-docs-auto-pr.sh
@@ -56,6 +56,9 @@ case "$1 $2" in
   "pr list")
     printf '%s\n' "$FAKE_LIST_JSON"
     ;;
+  "pr close")
+    # Recorded in FAKE_GH_LOG by the printf above, so a case can assert it happened.
+    ;;
   "pr view")
     count="$(cat "$FAKE_VIEW_COUNT")"
     count=$((count + 1))
@@ -349,6 +352,35 @@ DOCS_WORKFLOW="${ROOT}/.github/workflows/docs-auto-update.yml"
 CI_WORKFLOW="${ROOT}/.github/workflows/ci.yml"
 LANE_WORKFLOW="${ROOT}/.github/workflows/assay-runner-lane-check.yml"
 HOST_WORKFLOW="${ROOT}/.github/workflows/host-capability-check.yml"
+
+# --- an empty docs PR is finished, not broken ------------------------------------------------
+#
+# The reconciler used to reject this as "an invalid or empty files response" and exit 2, so
+# `Auto-Update Docs` failed on every merge to main for eight consecutive runs while the system was
+# working correctly: #2081 moved the drift check onto the PR that causes the drift, which is exactly
+# what makes the bot's PR empty.
+run_case "empty docs PR closes and succeeds" \
+  '[{"number":42}]' \
+  "$(valid_view 42 head-current CLEAN)" \
+  '[[]]' \
+  true
+
+if grep -q "pr close 42" "${CASE_DIR}/gh.log"; then
+  echo "ok    an empty docs PR is closed"
+else
+  echo "FAIL  an empty docs PR was not closed"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# --- a malformed response still refuses --------------------------------------------------------
+#
+# The distinction the old check collapsed: this one means the reconciler cannot see what it is
+# reconciling, and refusing is correct.
+run_case "malformed files response refuses" \
+  '[{"number":42}]' \
+  "$(valid_view 42 head-current CLEAN)" \
+  '{"message":"Not Found"}' \
+  false
 
 check_workflow_contract \
   "$DOCS_WORKFLOW" \


### PR DESCRIPTION
## What was happening

`Auto-Update Docs` failed on **every merge to `main` today** — eight consecutive runs:

```
docs PR #2021 returned an invalid or empty files response
```

The system was working correctly. #2081 moved the generated-docs drift check onto the pull request that *causes* the drift, so what the bot wanted to write was already on `main` and its diff went empty. `reconcile-docs-auto-pr.sh` required `length > 0` and treated that as a fault.

## The distinction the check collapsed

The error message named both conditions in one breath, which is the tell:

| response | means | correct answer |
|---|---|---|
| malformed | the reconciler cannot see what it is reconciling | refuse, exit 2 |
| **empty** | there is no drift left to reconcile | **close the PR, exit 0** |

Fail-closed is right for the first and wrong for the second. An empty docs PR is what a docs PR looks like once the thing it existed for has been fixed at the source.

**Nobody noticed for a day** because this runs post-merge on `main`, where a red tick has nobody waiting on it. I found it by looking at what failed, not by anything failing in front of me.

## #2021 is closed

Its diff was empty, and it could never have merged regardless — that was #2081's finding: bot PRs signed with the default `GITHUB_TOKEN` raise no workflow events, so fifteen `pull_request` runs on it sat at `action_required` and none ever executed.

## Verification

Two cases added, and the fake `gh` taught to close a PR so the first can assert it happened rather than infer it:

```
ok    an empty docs PR is closed
      malformed files response refuses
```

Mutation: restoring the conflated `length > 0` check fails `empty docs PR closes and succeeds` — the same shape as the production failure, reproduced in the self-test.

## Scope

`Gate.NONE`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.