### PR TITLE
fix(adr-045): producer vocabulary no longer voids AEE structural validity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,10 +143,10 @@ repos:
         files: ^(crates/assay-cli/src/aee_seal\.rs|scripts/ci/test_aee_seal_producer_mutations\.py|\.pre-commit-config\.yaml)$
       - id: aee-seal-checker-coverage
         name: ADR-045 seal checker coverage
-        entry: bash -c 'f=scripts/experiments/aee_landlock_seal_fixture.py; python3 $f --meta-test && python3 $f --required-field-test && python3 $f --rule-coverage-test'
+        entry: bash -c 'f=scripts/experiments/aee_landlock_seal_fixture.py; python3 $f --meta-test && python3 $f --required-field-test && python3 $f --rule-coverage-test && python3 $f --producer-vocabulary-test'
         language: system
         pass_filenames: false
-        # Three properties the checker claims and nothing was checking.
+        # Four properties the checker claims and nothing was checking.
         #
         # `--meta-test` says every negative control rejects for its own reason and no other; without
         # it a rule that fires on every control would read as broad coverage instead of one
@@ -160,7 +160,12 @@ repos:
         # nine -- including the one #1998 requires by name. A rule can exist, be believed, and never
         # be shown to fire.
         #
-        # pre-commit, not pre-push: all three run in well under a second, and they are the tests
+        # `--producer-vocabulary-test` says an Assay producer member withholds credit and never
+        # voids the record. The other three are blind to it: a phase is one word passed to `add`,
+        # so `assayDropProofModel` decided AEE structural validity for two slices while all three
+        # stayed green.
+        #
+        # pre-commit, not pre-push: all four run in well under a second, and they are the tests
         # that tell you a rule you just wrote does not isolate.
         files: ^(scripts/experiments/aee_landlock_seal_fixture\.py|scripts/experiments/fixtures/aee-landlock-seal/.*|\.pre-commit-config\.yaml)$
       - id: aee-seal-fixture-drift

--- a/crates/assay-cli/tests/adr045_prefix_table.rs
+++ b/crates/assay-cli/tests/adr045_prefix_table.rs
@@ -103,10 +103,13 @@ fn the_adr_table_names_every_producer_member_the_payload_carries() {
 
 /// The checker's required set is a subset of what the payload declares.
 ///
-/// Not equality: `assayObservedLabels` is a debugging aid and the drop-proof pair postdates the
-/// checker, so three members are legitimately unrequired. What must never happen is the checker
-/// requiring a field the producer does not emit, because then every real seal fails for a reason
-/// that is the checker's fault.
+/// Not equality, and four members are legitimately unrequired: `assayObservedLabels` is a debugging
+/// aid, `assayDropProofBasis` and `assayDropChannels` postdate the checker, and
+/// `assayDropProofModel` was deliberately removed — requiring a producer member is what made one
+/// load-bearing for structural validity, which ADR-045's prefix rule forbids.
+///
+/// What must never happen is the checker requiring a field the producer does not emit, because then
+/// every real seal fails for a reason that is the checker's fault.
 #[test]
 fn the_checker_requires_nothing_the_payload_does_not_carry() {
     let src = read("scripts/experiments/aee_landlock_seal_fixture.py");

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -236,16 +236,47 @@ existed. It was written against the design and never re-read against the code, w
 hand-kept table beside a type always develops. Two of the missing six are the drop-proof pair, so
 the omission hid the one member that says whether the drop count was verified or asserted.
 
-Two counts still differ from this one, deliberately and not:
+**Decided 2026-08-07.** This passage previously recorded two count mismatches and parked them as a
+contract question: does the fixture checker require the drop-proof members, or does the producer
+stop emitting them? Neither. Both readings take for granted that an Assay producer member may be
+load-bearing for whether an AEE record is well formed, and the prefix rule below says it may not.
 
-- `REQUIRED_SEAL_FIELDS` in the fixture checker names **seven** of the ten. `assayObservedLabels`
-  is a debugging aid, and the drop-proof pair is not required because the checker predates it.
-- The fixture checker's own positive payload carries **eight**, omitting `assayDropProofBasis` and
-  `assayDropChannels` entirely. The Rust producer emits them unconditionally. So a real run would
-  carry two members the checker has never seen, one of which is `checked`-versus-`declared`.
+The checker did not obey that rule. `assayDropProofModel` sat in `REQUIRED_SEAL_FIELDS`, was gated
+against a closed value set, and the finding it raised was a structural one — so a value only Assay
+defines decided AEE structural validity, in the one tool we point at fixtures to prove the
+opposite. The resolution now in force:
 
-Recorded rather than repaired here, because closing it means deciding whether the checker requires
-the pair or the producer stops emitting it, and that is a contract question rather than an edit.
+- **Producer vocabulary never contributes to structural validity.** `assayDropProofModel` is out of
+  `REQUIRED_SEAL_FIELDS`, and an absent, ineligible, or wrongly typed value now yields
+  `structurally-valid-not-credited` instead of `malformed`. Withholding credit is a verdict this
+  consumer's own policy is entitled to reach, because it does read the member; the record stays
+  verifiable for a consumer that does not read it at all. That split is the whole point of keeping
+  the three outcomes distinguishable.
+- **The producer's full payload is now describable.** `assayDropProofBasis` and `assayDropChannels`
+  are known-optional to the checker rather than unlisted, so the twenty members a real run emits no
+  longer read as two members the contract has never heard of. The producer keeps emitting them
+  unconditionally, and `assayDropProofBasis` — the `checked`-versus-`declared` member — is the one
+  worth not losing.
+- **The rule has a test.** `aee_landlock_seal_fixture.py --producer-vocabulary-test` mutates the
+  positive fixture and asserts the outcome. A phase is one word passed to `add`, invisible to the
+  reason-code, rule-coverage, and required-field tests, all of which stayed green for two slices
+  while this was wrong.
+
+The counts that follow from it: `REQUIRED_SEAL_FIELDS` names **six** of the ten producer members,
+the checker's known-optional set names the other four, and the checker's positive payload still
+carries **eight** — the drop-proof basis and channels are permitted rather than fixtured, since the
+Rust producer's key-set test is what pins their emission.
+
+Bounded deliberately, and the bound is the honest part. Six sibling producer members —
+`assayCollectionPath`, `assaySealedAt`, `assaySourceSchema`, `assaySealScope`,
+`assayAttackRowAttributionSource`, `assayNonClaims` — still raise structural findings in this same
+checker, so the prefix rule below is enforced for one member and stated for eleven. They carry
+identities, instants, and paths rather than a rankable axis, which is why the normative paragraph
+in in-toto/attestation#570 reaches `assayDropProofModel` and not them, and each has a reason for
+being structural that predates this decision (`assaySealScope` carries #2014's rule that a seal
+must not claim a boundary nothing observed). Moving them is six contract questions, not one edit.
+They are named here so the decision is not read as wider than it is, and so the next pass has a
+list rather than a rediscovery.
 
 Fields beginning with `assay` in the sealed payload are Assay producer vocabulary. AEE consumers may ignore them unless their own policy understands them. They MUST NOT alter AEE structural validity. Any future AEE statement exporter MUST also carry predicate-level `doesNotAssert` for statement-level non-claims; `assayNonClaims` inside the sealed payload is only producer vocabulary and does not weaken required AEE checks.
 

--- a/docs/architecture/SKETCH-ADR-045-LANDLOCK-SEAL-PAYLOAD-2026-08.md
+++ b/docs/architecture/SKETCH-ADR-045-LANDLOCK-SEAL-PAYLOAD-2026-08.md
@@ -107,7 +107,7 @@ Illustrative JSON shape:
 | `aeeStillArmed` | yes | boolean | MUST be `true` for a successful Landlock seal. Unknown or failed state is invalid. | Claims run-end still-armed state only under ADR-045 proof rules. |
 | `aeeDropCount` | yes | integer | First slice MUST be `0`. | Counts observation drops/losses, not blocked policy events. |
 | `aeeDropBound` | yes | integer | First slice MUST be `0`. | Bounds unobserved/lost observations under the named proof model only. |
-| `assayDropProofModel` | yes | string | First slice MUST be `synchronous-probe` or `counted-queue-zero`. | Identifies the proof model that makes zero-drop accounting creditable. |
+| `assayDropProofModel` | yes | string | Producer MUST emit `synchronous-probe` or `counted-queue-zero` in the first slice. A consumer reading it MUST withhold credit for any other value and MUST NOT treat the record as structurally invalid, per ADR-045's producer-vocabulary resolution. | Identifies the proof model that makes zero-drop accounting creditable. |
 | `aeeObservedSet` | yes | string | Payload-only: MUST be lowercase SHA-256 hex. Post-assembly: MUST recompute over emitted interception/examination record leaves. | Digest commitment; not a label array. |
 | `aeeObservedAttacks` | yes | array of strings | Payload-only: MUST be an array whose every member is a string. Post-assembly: each named attack MUST be supported by a caught row unless validating standalone before statement assembly. | Lower-bound substrate attribution, not completeness. Empty is valid for pure Landlock assembly-plane attribution. |
 | `assayObservedLabels` | no | array of strings | If present, MUST NOT substitute for `aeeObservedSet`. | Operator/debug vocabulary only. |
@@ -152,7 +152,10 @@ field constraints:
 7. `aeeMethod` equals `intercepted` for the first slice.
 8. `aeeStillArmed` is true.
 9. `aeeDropCount` and `aeeDropBound` are both zero.
-10. `assayDropProofModel` is `synchronous-probe` or `counted-queue-zero`.
+10. `assayDropProofModel` is `synchronous-probe` or `counted-queue-zero`. This is
+    the one item on this list that withholds credit rather than voiding the
+    payload: it is Assay producer vocabulary, and ADR-045 records that such a
+    member never alters AEE structural validity.
 11. `assayCollectionPath` equals `landlock-tcp-connect` for the first slice.
 12. `assaySealScope` equals `tcp_connect_landlock_port` for the first slice.
 13. `assayAttackRowAttributionSource` is `assembly-plane` or

--- a/docs/experiments/aee-landlock-seal-fixtures-2026-08.md
+++ b/docs/experiments/aee-landlock-seal-fixtures-2026-08.md
@@ -50,31 +50,38 @@ had never been run.
 ```sh
 python3 scripts/experiments/aee_landlock_seal_fixture.py --emit
 python3 scripts/experiments/aee_landlock_seal_fixture.py valid-landlock-seal
-for name in \
-  missing-seal \
-  bad-run-binding \
-  not-still-armed \
-  bad-drop-accounting \
-  uncounted-channel-without-eligible-seal \
-  bad-observed-set \
-  unsupported-observed-attack \
-  substrate-runner-observed-attacks-mismatch \
-  fixture-key-production-scope \
-  untrusted-signing-key \
-  wrong-key-role \
-  key-scope-collection-path-mismatch \
-  key-scope-substrate-mismatch \
-  key-outside-validity-window \
-  unsupported-envelope-shape
- do
+while read -r name reason; do
   python3 scripts/experiments/aee_landlock_seal_fixture.py "$name" \
-    --expect-invalid --expect-reason "$name"
- done
+    --expect-invalid --expect-reason "$reason"
+done <<'PAIRS'
+missing-seal substrate-row-missing-sealed-coverage
+bad-run-binding run-binding-mismatch
+not-still-armed seal-not-still-armed
+bad-drop-accounting drop-accounting-nonzero
+uncounted-channel-without-eligible-seal drop-proof-model-ineligible
+bad-observed-set observed-set-mismatch
+unsupported-observed-attack observed-attack-unsupported
+substrate-runner-observed-attacks-mismatch substrate-runner-observed-attacks-mismatch
+fixture-key-production-scope fixture-key-in-production-path
+untrusted-signing-key untrusted-signing-key
+wrong-key-role wrong-key-role
+key-scope-collection-path-mismatch key-scope-collection-path-mismatch
+key-scope-substrate-mismatch key-scope-substrate-mismatch
+key-outside-validity-window key-outside-validity-window
+unsupported-envelope-shape unsupported-envelope-shape
+PAIRS
 ```
 
 `--expect-reason` is the part that matters. A control asserted only on a non-zero
 exit reports coverage it does not have, because it cannot distinguish "rejected
 for the reason I built" from "rejected because I broke the JSON".
+
+Case name and reason code are separate columns because they are separate things,
+and this block used to pass the case name as the reason. Eight of the fifteen
+cases then asserted a code no rule emits, so eight lines of a snippet published as
+the way to check this slice had never been run. `--meta-test` is the maintained
+form of the same property and is what a gate should call; this block is here to be
+read.
 
 Fixture drift:
 
@@ -94,6 +101,18 @@ case to become credited. If it still fails, the control was failing for some
 other reason and its coverage was imaginary. `--disable-check` exists for that
 test and for nothing else.
 
+Producer vocabulary never voids a record:
+
+```sh
+python3 scripts/experiments/aee_landlock_seal_fixture.py --producer-vocabulary-test
+```
+
+Each member in `PRODUCER_CREDIT_FIELDS` is removed, given an ineligible value, and
+given the wrong type, and every mutation must land on
+`structurally-valid-not-credited`. The three tests above are blind to this: a phase
+is one word passed to `add`, so a rule can move between outcomes without changing a
+reason code, a control, or a required field.
+
 ## Three outcomes
 
 The checker distinguishes three outcomes, because ADR-043's rule that integrity
@@ -102,7 +121,7 @@ never upgrades meaning only exists if a consumer can tell them apart:
 | Outcome | Meaning |
 |---|---|
 | `malformed` | Not structurally valid. |
-| `structurally-valid-not-credited` | The signature verifies, but the key is untrusted, out of scope, wrong role, or outside its validity window. |
+| `structurally-valid-not-credited` | The record is well formed, and this consumer's policy withholds credit — an untrusted key, one out of scope, in the wrong role, outside its validity window, or an Assay producer member whose value this policy reads and does not accept. |
 | `credited` | Structurally valid, and the key is trusted for this scope. |
 
 If the middle outcome rendered identically to the first, the distinction would
@@ -115,7 +134,6 @@ Structural rejections (`malformed`):
 - a substrate row has no sealed, arming, or interception coverage;
 - a seal carries a bad run binding;
 - `aeeStillArmed` is not true;
-- zero drop accounting is asserted without an eligible proof model;
 - `aeeObservedSet` does not recompute over emitted interception/examination record leaves;
 - `aeeObservedAttacks` names attacks unsupported by caught rows;
 - substrate-runner attribution requires equality and the lower-bound set does not match;
@@ -132,7 +150,18 @@ Trust rejections (`structurally-valid-not-credited`):
 - the key's trusted scope excludes the payload's `assayCollectionPath`;
 - the key's trusted scope names a different substrate than the statement;
 - the seal instant falls outside the key's validity window;
-- a fixture key is used in a production-like path.
+- a fixture key is used in a production-like path;
+- `assayDropProofModel` names no eligible proof model for the zero drop accounting,
+  or is absent.
+
+That last one is a policy verdict, not a structural one, and it used to be filed
+above. ADR-045 states that `assay`-prefixed members are producer vocabulary and
+must not alter AEE structural validity, and the checker was breaking its own rule:
+a value only Assay defines decided whether an AEE record was well formed. This
+consumer's policy does read the member, so it may withhold credit; a consumer whose
+policy does not read it must still see a verifiable seal. The correction is
+recorded in ADR-045 and was committed to publicly in
+[in-toto/attestation#570](https://github.com/in-toto/attestation/pull/570#issuecomment-5216879286).
 
 The validity window is not key management. This slice checks that a window handed
 to the checker is honoured; rotation, revocation, and distribution belong with the

--- a/scripts/experiments/aee_landlock_seal_fixture.py
+++ b/scripts/experiments/aee_landlock_seal_fixture.py
@@ -94,7 +94,6 @@ REQUIRED_SEAL_FIELDS = (
     "aeeStillArmed",
     "aeeDropCount",
     "aeeDropBound",
-    "assayDropProofModel",
     "aeeObservedSet",
     "aeeObservedAttacks",
     "assayCollectionPath",
@@ -104,6 +103,28 @@ REQUIRED_SEAL_FIELDS = (
     "assayAttackRowAttributionSource",
     "assayNonClaims",
 )
+
+# Producer members this checker's own policy reads, and which therefore may withhold credit and
+# nothing else. ADR-045 says of the `assay` prefix: "They MUST NOT alter AEE structural validity."
+# `assayDropProofModel` was in the required list above and gated on a closed value set, and the
+# finding it raised was structural -- so an Assay producer member decided whether an AEE record was
+# well formed at all, which is the thing that sentence forbids.
+#
+# It is a member whose values rank: an eligible proof model is worth more than an ineligible one.
+# That is the shape in-toto/attestation#570 now rules on, and the resolution here is the one that
+# rule implies -- an ineligible model withholds credit rather than voiding the record, because a
+# consumer that cannot read this vocabulary must still see a structurally valid seal.
+#
+# Scoped to the members whose values rank, deliberately. Six sibling producer members
+# (`assayCollectionPath`, `assaySealedAt`, `assaySourceSchema`, `assaySealScope`,
+# `assayAttackRowAttributionSource`, `assayNonClaims`) still raise structural findings. They carry
+# identities and instants rather than an ordered axis, so the upstream paragraph does not reach
+# them; the local prefix rule does, and that gap is recorded in the ADR rather than closed by an
+# edit here. Adding one to this tuple is what `--producer-vocabulary-test` then enforces.
+PRODUCER_CREDIT_FIELDS = ("assayDropProofModel",)
+
+# Values of `assayDropProofModel` that license the zero drop accounting this slice credits.
+DROP_PROOF_MODELS_ELIGIBLE = ("synchronous-probe", "counted-queue-zero")
 
 # Fixed instants. A validity window needs something to be checked against, and a
 # wall clock would make the drift check flaky, which is how a gate gets disabled.
@@ -726,8 +747,12 @@ def validate(statement: dict[str, Any], disabled: frozenset[str] = frozenset()) 
             add("seal-not-still-armed", PHASE_MALFORMED, f"sealed record {idx} is not still armed")
         if seal.get("aeeDropCount") != 0 or seal.get("aeeDropBound") != 0:
             add("drop-accounting-nonzero", PHASE_MALFORMED, f"sealed record {idx} has non-zero or inconsistent drop accounting")
-        if seal.get("assayDropProofModel") not in {"synchronous-probe", "counted-queue-zero"}:
-            add("drop-proof-model-ineligible", PHASE_MALFORMED, f"sealed record {idx} has no eligible drop-accounting proof model")
+        # Not-credited, not malformed. This is producer vocabulary, and this checker's own policy is
+        # what reads it -- so an ineligible model withholds credit, which is a policy verdict, and
+        # leaves the record structurally valid, which is a fact about the envelope every consumer
+        # shares. See `PRODUCER_CREDIT_FIELDS` for the rule and its bounds.
+        if seal.get("assayDropProofModel") not in DROP_PROOF_MODELS_ELIGIBLE:
+            add("drop-proof-model-ineligible", PHASE_NOT_CREDITED, f"sealed record {idx} has no eligible drop-accounting proof model")
         if "aeeObservedSet" not in malformed_digests and seal.get("aeeObservedSet") != observed_set(records):
             add("observed-set-mismatch", PHASE_MALFORMED, f"sealed record {idx} aeeObservedSet mismatch")
         for attack_id in observed_attacks:
@@ -828,7 +853,19 @@ def run_required_field_test() -> int:
     # The other half: the fixture must not carry a field the contract does not require, or the list
     # above stops being a statement about the contract and becomes a description of the fixture.
     seal = base["predicate"]["observationRecords"][2]["payload"]
-    optional = {"assayObservedLabels"}
+    # `assayObservedLabels` is a debugging aid. The drop-proof trio is producer vocabulary the
+    # producer in `crates/assay-cli/src/aee_seal.rs` emits unconditionally: `assayDropProofBasis`
+    # and `assayDropChannels` were never listed here at all, so a real producer payload -- as
+    # opposed to this fixture, which omits them -- would be reported as carrying unlisted members
+    # by a check meant to catch the opposite mistake. `assayDropProofModel` is listed here rather
+    # than as required because requiring it is what made a producer member load-bearing for
+    # structural validity; see `PRODUCER_CREDIT_FIELDS`.
+    optional = {
+        "assayObservedLabels",
+        "assayDropProofModel",
+        "assayDropProofBasis",
+        "assayDropChannels",
+    }
     unlisted = sorted(set(seal) - set(REQUIRED_SEAL_FIELDS) - optional)
     if unlisted:
         print(f"FAIL fixture carries fields that are neither required nor known-optional: {unlisted}")
@@ -838,6 +875,55 @@ def run_required_field_test() -> int:
         print(f"\n{failures} required-field check(s) failed")
         return 1
     print(f"\nall {len(REQUIRED_SEAL_FIELDS)} required fields are rejected when absent")
+    return 0
+
+
+def run_producer_vocabulary_test() -> int:
+    """No producer member in `PRODUCER_CREDIT_FIELDS` can make a record structurally invalid.
+
+    Absent, ineligible, wrong type: each must land on `structurally-valid-not-credited`, never on
+    `malformed`. Credit is withheld, because this checker's own policy does read the member; the
+    record stays well formed, because a consumer whose policy does not read it must still be able to
+    verify the seal.
+
+    A phase is a one-word argument to `add`, invisible to every other test here: `--meta-test` reads
+    reason codes, `--rule-coverage-test` greps `add("...` out of the source, and neither would
+    notice this moving back. So the property gets a test of its own.
+    """
+    base = load_case(POSITIVE_CASE)
+    if outcome_of(validate(base)) != OUTCOME_CREDITED:
+        print(f"FAIL {POSITIVE_CASE}: not credited before mutation, so nothing below isolates")
+        return 1
+
+    failures = 0
+    for field in PRODUCER_CREDIT_FIELDS:
+        for label, mutate in (
+            ("absent", lambda seal, f: seal.pop(f)),
+            ("ineligible", lambda seal, f: seal.__setitem__(f, "uncounted-queue")),
+            ("wrong type", lambda seal, f: seal.__setitem__(f, 7)),
+        ):
+            stmt = json.loads(json.dumps(base))
+            seal = stmt["predicate"]["observationRecords"][2]["payload"]
+            if field not in seal:
+                print(f"FAIL {field}: not present in the positive fixture, so it cannot be mutated")
+                failures += 1
+                break
+            mutate(seal, field)
+            replace_payload(stmt, 2, seal)
+            outcome = outcome_of(validate(stmt))
+            if outcome == OUTCOME_MALFORMED:
+                print(f"FAIL {field} {label}: a producer member voided the record")
+                failures += 1
+            elif outcome == OUTCOME_CREDITED:
+                print(f"FAIL {field} {label}: credit was not withheld")
+                failures += 1
+            else:
+                print(f"ok   {field} {label}: {outcome}")
+
+    if failures:
+        print(f"\n{failures} producer-vocabulary check(s) failed")
+        return 1
+    print(f"\nall {len(PRODUCER_CREDIT_FIELDS)} producer credit field(s) are inert to structural validity")
     return 0
 
 
@@ -879,6 +965,7 @@ def main() -> int:
     parser.add_argument("--meta-test", action="store_true", help="Assert each negative control fails for its own reason and no other")
     parser.add_argument("--required-field-test", action="store_true", help="Assert every required payload field is rejected when absent")
     parser.add_argument("--rule-coverage-test", action="store_true", help="Assert every reason code the checker can produce has a negative control")
+    parser.add_argument("--producer-vocabulary-test", action="store_true", help="Assert Assay producer members withhold credit and never void structural validity")
     args = parser.parse_args()
 
     if args.emit:
@@ -891,6 +978,8 @@ def main() -> int:
         return run_required_field_test()
     if args.rule_coverage_test:
         return run_rule_coverage_test()
+    if args.producer_vocabulary_test:
+        return run_producer_vocabulary_test()
     if not args.case:
         parser.error("case is required unless --emit or one of the --*-test flags is used")
 


### PR DESCRIPTION
Fixes the conformance defect we committed to publicly in [in-toto/attestation#570](https://github.com/in-toto/attestation/pull/570#issuecomment-5216879286).

## The defect

`scripts/experiments/aee_landlock_seal_fixture.py` required `assayDropProofModel` in `REQUIRED_SEAL_FIELDS` and gated its value against a closed set, raising the finding at `PHASE_MALFORMED`. `outcome_of()` turns any malformed finding into `OUTCOME_MALFORMED`, so an Assay producer member decided whether an AEE record was structurally valid at all.

Two rules forbid that:

- ADR-045, on the `assay` prefix: "They MUST NOT alter AEE structural validity."
- The normative paragraph at #570 head (`35ca6f89`): a verifier MUST NOT read a producer-defined ordered axis into `result` or the evidence tier. `assayDropProofModel` is such an axis — an eligible model outranks an ineligible one.

## The fix

| # | Change |
|---|---|
| 1 | `drop-proof-model-ineligible` moves to `PHASE_NOT_CREDITED`. An ineligible proof model withholds credit — a verdict this consumer's policy may reach, because it reads the member — and leaves the record verifiable for a consumer that does not. |
| 2 | `assayDropProofModel` leaves `REQUIRED_SEAL_FIELDS` and joins the known-optional set. Requiring a producer member is the same category error as gating on its value. |
| 3 | `assayDropProofBasis` and `assayDropChannels` join the known-optional set, so the twenty members the Rust producer emits no longer read as two the contract has never heard of. |
| 4 | ADR-045's parked "contract question" is rewritten as the recorded resolution. |
| 5 | New `--producer-vocabulary-test`, wired into the pre-commit gate. |

### Why the new test

A phase is one word passed to `add`. `--meta-test` reads reason codes, `--rule-coverage-test` greps `add("…` out of the source, and `--required-field-test` only asks whether credit was withheld. All three stayed green while this rule sat in the wrong phase for two slices, and all three would stay green if someone moved it back. `--producer-vocabulary-test` mutates the positive fixture — member absent, ineligible value, wrong type — and asserts the outcome is `structurally-valid-not-credited` every time.

### What this deliberately does not do

Six sibling producer members — `assayCollectionPath`, `assaySealedAt`, `assaySourceSchema`, `assaySealScope`, `assayAttackRowAttributionSource`, `assayNonClaims` — still raise structural findings in the same checker. They carry identities, instants, and paths rather than a rankable axis, so the upstream paragraph does not reach them while the local prefix rule does. Each has a reason for being structural that predates this decision (`assaySealScope` carries #2014's rule that a seal must not claim a boundary nothing observed), so moving them is six contract questions rather than one edit. They are named in the ADR and in `PRODUCER_CREDIT_FIELDS` so the next pass has a list rather than a rediscovery — and so this PR is not read as closing more than it closes.

### Unrelated defect fixed in passing

The experiment doc's smoke loop passed the case name as `--expect-reason`. Eight of its fifteen lines asserted a reason code no rule emits, so the snippet published as the way to check this slice had never been run. Corrected to case/reason pairs and run verbatim.

## Verification

Run on `ede1ee7c1`:

- `--meta-test` — 33/33 controls isolate their reason
- `--required-field-test` — 16/16 required fields rejected when absent
- `--rule-coverage-test` — 33/33 reason codes have a control
- `--producer-vocabulary-test` — 3/3 mutations land on `structurally-valid-not-credited` (fails on the pre-fix tree with all three reporting "a producer member voided the record")
- `scripts/ci/check-aee-seal-fixture-drift.sh` — fixtures reproduce, no extra files
- corrected smoke loop — 15/15
- `cargo test -p assay-cli` — 53 suites green, including `the_payload_member_names_are_the_ones_the_checker_reads` (the 20-key assertion), `the_adr_table_names_every_producer_member_the_payload_carries`, and `every_quotation_from_the_adr_is_still_in_the_adr`
- `cargo clippy -p assay-cli --all-targets` — clean
- `pre-commit run --files <changed>` — all applicable hooks pass

## Non-claims

- No production behaviour changes. The Rust producer emits the same twenty members; only the checker's reading of one of them moved.
- The prefix rule is now enforced for one of eleven producer members and stated for all of them. The gap is recorded, not closed.
- The upstream question in the #570 comment — whether any `assay`-prefixed member is inert whether or not its values rank — is still open, and its answer is what would decide the other six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)