### PR TITLE
fix(adr-045): the six siblings the prefix rule already covered

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,7 +163,8 @@ repos:
         # `--producer-vocabulary-test` says an Assay producer member withholds credit and never
         # voids the record. The other three are blind to it: a phase is one word passed to `add`,
         # so `assayDropProofModel` decided AEE structural validity for two slices while all three
-        # stayed green.
+        # stayed green, and six sibling members did for four. It also reads `validate` back, so a
+        # producer member that acquires a rule cannot acquire a phase by default.
         #
         # pre-commit, not pre-push: all four run in well under a second, and they are the tests
         # that tell you a rule you just wrote does not isolate.

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -267,16 +267,83 @@ the checker's known-optional set names the other four, and the checker's positiv
 carries **eight** — the drop-proof basis and channels are permitted rather than fixtured, since the
 Rust producer's key-set test is what pins their emission.
 
-Bounded deliberately, and the bound is the honest part. Six sibling producer members —
-`assayCollectionPath`, `assaySealedAt`, `assaySourceSchema`, `assaySealScope`,
-`assayAttackRowAttributionSource`, `assayNonClaims` — still raise structural findings in this same
-checker, so the prefix rule below is enforced for one member and stated for eleven. They carry
-identities, instants, and paths rather than a rankable axis, which is why the normative paragraph
-in in-toto/attestation#570 reaches `assayDropProofModel` and not them, and each has a reason for
-being structural that predates this decision (`assaySealScope` carries #2014's rule that a seal
-must not claim a boundary nothing observed). Moving them is six contract questions, not one edit.
-They are named here so the decision is not read as wider than it is, and so the next pass has a
-list rather than a rediscovery.
+**The six siblings, decided 2026-08-07.** The passage above bounded itself to `assayDropProofModel`
+and parked six sibling producer members — `assaySourceSchema`, `assaySealScope`,
+`assayCollectionPath`, `assayAttackRowAttributionSource`, `assayNonClaims`, `assaySealedAt` — as six
+contract questions rather than one edit. They are decided here, and all six move.
+
+The reason they were parked does not survive being written out. It was that the normative paragraph
+in in-toto/attestation#570 governs members whose values a reader might rank, and these carry
+identities, instants and paths instead. That is true of the upstream paragraph and beside the point
+for us: the prefix rule below is not scoped to rankable members. It says *fields beginning with
+`assay`*, all of them, and has said so since this ADR was written. So six local decisions were being
+held against an upstream sentence that could only ever be narrower than the rule we already had. The
+question left open at in-toto/attestation#570 — whether a producer member is inert whether or not
+its values rank — is still unanswered upstream as of this decision, and is not load-bearing here. An
+answer would confirm the local rule, not extend it.
+
+What was worth checking per member was never whether the rule reaches them. It was whether moving
+each one gives up something the structural phase was buying.
+
+- **`assaySourceSchema`** (`payload-source-schema-invalid`). A non-empty-string gate on a member the
+  table above marks non-normative, and no other rule reads the value. Nothing attached, nothing lost.
+- **`assaySealScope`** (`seal-scope-missing`, `seal-scope-mismatch`). #2014 is why this rule exists,
+  and reading it settles the question rather than blocking it. The harm #2014 names is that the
+  checker "credits it as attested substrate evidence", and the rule it holds up as the model to copy
+  is `key-scope-collection-path-mismatch`, which is a not-credited rule. Withholding credit is the
+  whole of what was asked for. A seal naming `filesystem_write_all` is still refused; it is refused
+  as one this consumer will not credit rather than as a record no consumer can parse.
+- **`assayCollectionPath`** (`payload-collection-path-mismatch`). This member was already being read
+  at both phases in one file. `key-scope-collection-path-mismatch` withholds credit and
+  `payload-collection-path-mismatch` voided the record, and the key-scope side is the one this ADR
+  specifies itself: a credited signature requires that "the key's trusted scope includes the
+  payload's `assayCollectionPath`", and a key outside scope "is structurally valid but not credited".
+  #2106 reached the same place from the producer side — a path types a vantage, and must not rank one
+  above another.
+- **`assayAttackRowAttributionSource`** (`payload-attribution-source-unknown`, and
+  `substrate-runner-observed-attacks-mismatch`). Two rules, and the second is why this member was the
+  worst of the six rather than one more of them. It is not only gated against a closed set; its value
+  *selects how strictly an AEE member is checked*. Under the attack-attribution rules below, equality
+  between `aeeObservedAttacks` and the caught row attack IDs is required when the value is
+  `substrate-runner` and not when it is `assembly-plane`. Changing the positive fixture from one of
+  its two legal values to the other, with no other edit, turned a credited record into a malformed
+  one. Both rules move. The baseline — every named attack must be supported by a caught row — reads
+  only AEE members and stays structural; only the tightening is Assay policy, and only the tightening
+  withholds credit.
+- **`assayNonClaims`** (`payload-non-claims-incomplete`). The prefix paragraph below already rules on
+  this member by name: it "is only producer vocabulary and does not weaken required AEE checks". A
+  rule that lets an incomplete list void the record does the converse, letting producer vocabulary
+  strengthen a required check into a rejection every consumer must honour. The checker's own comment
+  asks that a subset be "a rejection rather than a warning", and it still is — not-credited is a
+  rejection carrying a reason code, not a warning.
+- **`assaySealedAt`** (`seal-instant-invalid`). The one with a real entanglement, and so the one to
+  check rather than assume. The parsed instant is the input to `key-outside-validity-window`, and an
+  unparsable value makes that check skip its record — so the structural finding was load-bearing for
+  a bad instant not bypassing key expiry. It survives the move because the finding it raises is
+  itself a not-credited finding: a seal whose instant will not parse cannot reach `credited` by any
+  path, whether or not the window check ran. The window is not weakened. The record merely stops
+  being called unreadable *by every consumer* on the strength of an Assay member.
+
+Two things deliberately unchanged. The six stay in `REQUIRED_SEAL_FIELDS`, because that list states
+what the Assay producer contract obliges a seal to carry, and the test over it asserts that absence
+is not credited rather than that absence is malformed — so "required" reads as required-for-credit
+for a producer member, which is the strongest thing the prefix rule permits it to mean. And
+`assayObservedLabels`, `assayDropProofBasis` and `assayDropChannels` needed no decision at all: no
+rule reads them, and nothing can demote what nothing consults.
+
+Two checks were added with the move, because the existing ones could not see it.
+`--producer-vocabulary-test` now also mutates a member to a *legal* alternate value, which is the
+only mutation that reaches the selector case above — absent, ineligible and ill-typed are all
+values `substrate-runner` is not. And it reads `validate` back, requiring every `assay`-prefixed member the
+function consults to be one this file has decided, so the next producer member to acquire a rule
+cannot acquire a phase by default. The generic ineligible value is now `""` rather than a borrowed
+one, since `assaySourceSchema` accepts any non-empty string and would have passed a plausible
+wrong value straight through.
+
+Where this leaves the prefix rule: **seven** of the ten producer members are read by some rule in the
+checker, all seven are enforced inert by test, and the remaining three are inert by having no rule.
+Every rule that can still return `malformed` reads an `aee*` member, the envelope, or the predicate
+structure.
 
 Fields beginning with `assay` in the sealed payload are Assay producer vocabulary. AEE consumers may ignore them unless their own policy understands them. They MUST NOT alter AEE structural validity. Any future AEE statement exporter MUST also carry predicate-level `doesNotAssert` for statement-level non-claims; `assayNonClaims` inside the sealed payload is only producer vocabulary and does not weaken required AEE checks.
 

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -273,14 +273,32 @@ and parked six sibling producer members — `assaySourceSchema`, `assaySealScope
 contract questions rather than one edit. They are decided here, and all six move.
 
 The reason they were parked does not survive being written out. It was that the normative paragraph
-in in-toto/attestation#570 governs members whose values a reader might rank, and these carry
-identities, instants and paths instead. That is true of the upstream paragraph and beside the point
-for us: the prefix rule below is not scoped to rankable members. It says *fields beginning with
-`assay`*, all of them, and has said so since this ADR was written. So six local decisions were being
-held against an upstream sentence that could only ever be narrower than the rule we already had. The
-question left open at in-toto/attestation#570 — whether a producer member is inert whether or not
-its values rank — is still unanswered upstream as of this decision, and is not load-bearing here. An
-answer would confirm the local rule, not extend it.
+in in-toto/attestation#570 governed members whose values a reader might rank, and these carry
+identities, instants and paths instead. That was true of the upstream paragraph as it stood at
+`35ca6f899`, and beside the point either way: the prefix rule below is not scoped to rankable
+members. It says *fields beginning with `assay`*, all of them, and has said so since this ADR was
+written. So six local decisions were being held against an upstream sentence that could only ever be
+narrower than the rule we already had.
+
+That sentence is no longer narrower, and the tense above is load-bearing. The question we left open
+at in-toto/attestation#570 — whether a producer member is inert whether or not its values rank — was
+answered upstream at `237f83b9f`, sixteen minutes after we asked it, in a commit titled *make
+producer territory inert, not merely unrankable*. The paragraph now reads that a producer-defined
+member "MUST NOT affect structural validity, MUST NOT affect `result`, and MUST NOT affect the
+evidence tier, whether or not its values can be ordered". The upstream rule and the local prefix rule
+now say the same thing, and this decision is what the two of them jointly require rather than what
+one of them permitted. Nothing below changes as a result — the reasoning never rested on the upstream
+paragraph — but a decision recorded as unconfirmed when it is in fact confirmed reads as weaker
+evidence than it is.
+
+One boundary this does not settle, named so it is not read as settled. The new paragraph opens with a
+verifier reading *nothing* in producer territory, and the three obligations it then states are
+structural validity, `result`, and the evidence tier. The not-credited verdict this checker reaches
+is none of those three: it is a consumer trust decision of the same class as an untrusted signing
+key, which the key-scope section above already treats as a consumer's own to make, and AEE's `result`
+is a predicate field this checker does not emit. So this reading holds that withholding credit is
+outside the three obligations. It is a reading, not a quotation, and it is the one to re-check if the
+opening sentence acquires normative weight of its own.
 
 What was worth checking per member was never whether the rule reaches them. It was whether moving
 each one gives up something the structural phase was buying.

--- a/docs/experiments/aee-landlock-seal-fixtures-2026-08.md
+++ b/docs/experiments/aee-landlock-seal-fixtures-2026-08.md
@@ -113,6 +113,16 @@ given the wrong type, and every mutation must land on
 is one word passed to `add`, so a rule can move between outcomes without changing a
 reason code, a control, or a required field.
 
+Two mutations are not of that shape. A member listed in
+`PRODUCER_CREDIT_ALTERNATE_VALUES` is also set to one of its own *legal* values,
+and that mutation asserts only that the record is not voided — a legal value may
+well leave it credited. This is what catches a member whose permitted value
+decides how strictly some other rule runs, which absent, ineligible and ill-typed
+mutations cannot reach. The test then reads `validate` back and requires every
+`assay`-prefixed member the function consults to appear in
+`PRODUCER_CREDIT_FIELDS`, so a producer member that acquires a rule cannot acquire
+a phase by default.
+
 ## Three outcomes
 
 The checker distinguishes three outcomes, because ADR-043's rule that integrity
@@ -136,12 +146,14 @@ Structural rejections (`malformed`):
 - `aeeStillArmed` is not true;
 - `aeeObservedSet` does not recompute over emitted interception/examination record leaves;
 - `aeeObservedAttacks` names attacks unsupported by caught rows;
-- substrate-runner attribution requires equality and the lower-bound set does not match;
-- `assaySourceSchema` is absent or not a non-empty string;
 - `aeeObservedAttacks` is not an array of strings;
 - the envelope's payload type is one this checker does not implement — rejected
   as unsupported, never skipped, because a "we did not check this" path that
   returns success is how an unverified record comes to read as verified.
+
+Every rule that can still return `malformed` reads an `aee*` member, the envelope,
+or the predicate structure. That is the property, not a coincidence of the current
+list.
 
 Trust rejections (`structurally-valid-not-credited`):
 
@@ -152,16 +164,34 @@ Trust rejections (`structurally-valid-not-credited`):
 - the seal instant falls outside the key's validity window;
 - a fixture key is used in a production-like path;
 - `assayDropProofModel` names no eligible proof model for the zero drop accounting,
-  or is absent.
+  or is absent;
+- `assaySourceSchema` is absent or not a non-empty string;
+- `assaySealScope` is absent, or names a boundary other than the one this slice
+  observes;
+- the seal's `assayCollectionPath` is not the path this slice collects on;
+- `assayAttackRowAttributionSource` is outside its closed set, or is
+  `substrate-runner` while `aeeObservedAttacks` and the caught rows disagree;
+- `assayNonClaims` omits one of the payload-local minimum non-claims;
+- `assaySealedAt` is not an RFC 3339 UTC instant.
 
-That last one is a policy verdict, not a structural one, and it used to be filed
-above. ADR-045 states that `assay`-prefixed members are producer vocabulary and
-must not alter AEE structural validity, and the checker was breaking its own rule:
-a value only Assay defines decided whether an AEE record was well formed. This
-consumer's policy does read the member, so it may withhold credit; a consumer whose
-policy does not read it must still see a verifiable seal. The correction is
-recorded in ADR-045 and was committed to publicly in
-[in-toto/attestation#570](https://github.com/in-toto/attestation/pull/570#issuecomment-5216879286).
+Everything from `assayDropProofModel` down is a policy verdict rather than a
+structural one, and all of it used to be filed above. ADR-045 states that
+`assay`-prefixed members are producer vocabulary and must not alter AEE structural
+validity, and the checker was breaking its own rule: values only Assay defines
+decided whether an AEE record was well formed. This consumer's policy does read
+those members, so it may withhold credit; a consumer whose policy does not read
+them must still see a verifiable seal. `assayDropProofModel` was corrected first
+and committed to publicly in
+[in-toto/attestation#570](https://github.com/in-toto/attestation/pull/570#issuecomment-5216879286);
+the six siblings follow it, each decided on its own in ADR-045.
+
+The attribution entry is two rules, and the second is the one worth knowing about.
+`assayAttackRowAttributionSource` does not merely carry a gated value — its value
+*selects* whether `aeeObservedAttacks` must equal the caught rows or may be a
+lower bound. So flipping that one member between its two legal values used to move
+the record between `credited` and `malformed`, which is the prefix rule's failure
+mode in its purest form: two consumers disagreeing about whether a record is well
+formed, because one of them reads Assay vocabulary and the other does not.
 
 The validity window is not key management. This slice checks that a window handed
 to the checker is honoured; rotation, revocation, and distribution belong with the

--- a/scripts/experiments/aee_landlock_seal_fixture.py
+++ b/scripts/experiments/aee_landlock_seal_fixture.py
@@ -117,9 +117,11 @@ REQUIRED_SEAL_FIELDS = (
 # consumer that cannot read this vocabulary must still see a structurally valid seal.
 #
 # The six siblings this was once scoped away from are here now, decided one at a time in ADR-045.
-# The scoping argument was that the upstream paragraph reaches members whose values rank and these
-# carry identities, instants and paths -- true of the upstream paragraph, and beside the point, since
-# the local prefix rule is not scoped to rankable members. It says fields beginning with `assay`.
+# The scoping argument was that the upstream paragraph reached members whose values rank and these
+# carry identities, instants and paths -- true of that paragraph as it stood, and beside the point,
+# since the local prefix rule is not scoped to rankable members. It says fields beginning with
+# `assay`. Upstream has since said the same thing: a producer-defined member must not affect
+# structural validity whether or not its values can be ordered. Both rules now require this tuple.
 #
 # This tuple is now every producer member any rule in `validate` reads. The other three
 # (`assayObservedLabels`, `assayDropProofBasis`, `assayDropChannels`) are inert by having no rule at

--- a/scripts/experiments/aee_landlock_seal_fixture.py
+++ b/scripts/experiments/aee_landlock_seal_fixture.py
@@ -26,6 +26,7 @@ import base64
 import copy
 import hashlib
 import hmac
+import inspect
 import json
 import re
 from datetime import datetime
@@ -115,13 +116,41 @@ REQUIRED_SEAL_FIELDS = (
 # rule implies -- an ineligible model withholds credit rather than voiding the record, because a
 # consumer that cannot read this vocabulary must still see a structurally valid seal.
 #
-# Scoped to the members whose values rank, deliberately. Six sibling producer members
-# (`assayCollectionPath`, `assaySealedAt`, `assaySourceSchema`, `assaySealScope`,
-# `assayAttackRowAttributionSource`, `assayNonClaims`) still raise structural findings. They carry
-# identities and instants rather than an ordered axis, so the upstream paragraph does not reach
-# them; the local prefix rule does, and that gap is recorded in the ADR rather than closed by an
-# edit here. Adding one to this tuple is what `--producer-vocabulary-test` then enforces.
-PRODUCER_CREDIT_FIELDS = ("assayDropProofModel",)
+# The six siblings this was once scoped away from are here now, decided one at a time in ADR-045.
+# The scoping argument was that the upstream paragraph reaches members whose values rank and these
+# carry identities, instants and paths -- true of the upstream paragraph, and beside the point, since
+# the local prefix rule is not scoped to rankable members. It says fields beginning with `assay`.
+#
+# This tuple is now every producer member any rule in `validate` reads. The other three
+# (`assayObservedLabels`, `assayDropProofBasis`, `assayDropChannels`) are inert by having no rule at
+# all, which needs no entry here and no test: nothing can demote what nothing consults.
+PRODUCER_CREDIT_FIELDS = (
+    "assayDropProofModel",
+    "assaySourceSchema",
+    "assaySealScope",
+    "assayCollectionPath",
+    "assayAttackRowAttributionSource",
+    "assayNonClaims",
+    "assaySealedAt",
+)
+
+# Legal values of a producer member that change what this checker checks. The generic mutations in
+# `--producer-vocabulary-test` cannot reach these: they are neither absent, nor ill-typed, nor
+# outside the member's own value set, so a member that stays structural for one of its own permitted
+# values passes that test while the property is false.
+#
+# `assayAttackRowAttributionSource` is the case that made this necessary. Its value selects how
+# strictly an *AEE* member is checked -- equality between `aeeObservedAttacks` and the caught row
+# attack IDs is required under `substrate-runner` and not under `assembly-plane` (ADR-045, attack
+# attribution rules 2 and 3). Flipping the positive fixture from one legal value to the other, with
+# no other edit, used to turn a credited record into a malformed one.
+PRODUCER_CREDIT_ALTERNATE_VALUES: dict[str, tuple[str, ...]] = {
+    "assayAttackRowAttributionSource": ("substrate-runner",),
+}
+
+# Removal, distinguishable from setting the member to any value including `None`. A member set to
+# `None` and a member that is absent are different payloads and this test needs both to be sayable.
+_POP = object()
 
 # Values of `assayDropProofModel` that license the zero drop accounting this slice credits.
 DROP_PROOF_MODELS_ELIGIBLE = ("synchronous-probe", "counted-queue-zero")
@@ -678,7 +707,12 @@ def validate(statement: dict[str, Any], disabled: frozenset[str] = frozenset()) 
     # checker with no window silently keeps crediting a retired key.
     sealed_at = parse_instant(payloads[seals[0]].get("assaySealedAt")) if seals else None
     if seals and sealed_at is None:
-        add("seal-instant-invalid", PHASE_MALFORMED, f"sealed record {seals[0]} assaySealedAt is not an RFC 3339 UTC instant")
+        # Not-credited, and this is the one of the seven where the phase was load-bearing for
+        # something other than itself: an unparsable instant makes the window check below `continue`,
+        # so the structural finding was what stopped a bad instant from bypassing key expiry. It
+        # survives the move because *this* finding already withholds credit -- a seal whose instant
+        # will not parse cannot reach `credited` by any path, whether or not the window check ran.
+        add("seal-instant-invalid", PHASE_NOT_CREDITED, f"sealed record {seals[0]} assaySealedAt is not an RFC 3339 UTC instant")
     for idx in credit_eligible:
         scope = scopes[records[idx]["signatures"][0]["keyid"]]
         valid_from = parse_instant(scope.get("validFrom"))
@@ -695,9 +729,13 @@ def validate(statement: dict[str, Any], disabled: frozenset[str] = frozenset()) 
     for idx in seals:
         seal = payloads[idx]
         # Payload-only rules (#2006 item 4).
+        # Every `assay`-prefixed rule below is not-credited, per the prefix rule in ADR-045. The
+        # phase is the only thing separating a claim that no consumer can verify this record from a
+        # claim that this consumer's policy declines it, and a member only Assay defines cannot
+        # speak for the first.
         source_schema = seal.get("assaySourceSchema")
         if not isinstance(source_schema, str) or not source_schema:
-            add("payload-source-schema-invalid", PHASE_MALFORMED, f"sealed record {idx} assaySourceSchema must be a non-empty string")
+            add("payload-source-schema-invalid", PHASE_NOT_CREDITED, f"sealed record {idx} assaySourceSchema must be a non-empty string")
         observed_attacks = seal.get("aeeObservedAttacks")
         if not isinstance(observed_attacks, list) or not all(isinstance(item, str) for item in observed_attacks):
             add("payload-observed-attacks-invalid", PHASE_MALFORMED, f"sealed record {idx} aeeObservedAttacks must be an array of strings")
@@ -726,20 +764,31 @@ def validate(statement: dict[str, Any], disabled: frozenset[str] = frozenset()) 
             add("payload-method-unsupported", PHASE_MALFORMED, f"sealed record {idx} aeeMethod {method!r} is not {SEAL_METHOD!r}, the only method this slice observes")
         attribution = seal.get("assayAttackRowAttributionSource")
         if attribution not in ATTRIBUTION_SOURCES:
-            add("payload-attribution-source-unknown", PHASE_MALFORMED, f"sealed record {idx} assayAttackRowAttributionSource {attribution!r} is not one of {ATTRIBUTION_SOURCES}")
+            add("payload-attribution-source-unknown", PHASE_NOT_CREDITED, f"sealed record {idx} assayAttackRowAttributionSource {attribution!r} is not one of {ATTRIBUTION_SOURCES}")
+        # A subset is still a rejection rather than a warning, which is what `MINIMUM_NON_CLAIMS`
+        # exists to make true. Not-credited is a rejection with a reason code; the prefix rule below
+        # names this member and says it "does not weaken required AEE checks", and a rule that voids
+        # the record does the converse -- it lets producer vocabulary strengthen one.
         non_claims = seal.get("assayNonClaims")
         if not isinstance(non_claims, list) or not set(MINIMUM_NON_CLAIMS).issubset(non_claims):
             missing = [c for c in MINIMUM_NON_CLAIMS if not isinstance(non_claims, list) or c not in non_claims]
-            add("payload-non-claims-incomplete", PHASE_MALFORMED, f"sealed record {idx} assayNonClaims omits the payload-local minimum: {missing}")
+            add("payload-non-claims-incomplete", PHASE_NOT_CREDITED, f"sealed record {idx} assayNonClaims omits the payload-local minimum: {missing}")
+        # The sibling rule `key-scope-collection-path-mismatch` reads this same member and has always
+        # been not-credited, which is what ADR-045's key-scope section specifies: a signature outside
+        # the key's trusted collection path is "structurally valid but not credited". One member was
+        # being read at both phases in one file.
         collection_path = seal.get("assayCollectionPath")
         if collection_path != COLLECTION_PATH:
-            add("payload-collection-path-mismatch", PHASE_MALFORMED, f"sealed record {idx} assayCollectionPath {collection_path!r} is not {COLLECTION_PATH!r}, the path this slice collects on")
+            add("payload-collection-path-mismatch", PHASE_NOT_CREDITED, f"sealed record {idx} assayCollectionPath {collection_path!r} is not {COLLECTION_PATH!r}, the path this slice collects on")
 
+        # #2014 asked that a seal not claim a boundary nothing observed, and named the harm as the
+        # checker "credits it as attested substrate evidence". Withholding credit is the whole of
+        # what it asked for; the model it cites one field over is the not-credited rule above.
         seal_scope = seal.get("assaySealScope")
         if not isinstance(seal_scope, str) or not seal_scope:
-            add("seal-scope-missing", PHASE_MALFORMED, f"sealed record {idx} assaySealScope must be a non-empty string naming the sealed enforcement scope")
+            add("seal-scope-missing", PHASE_NOT_CREDITED, f"sealed record {idx} assaySealScope must be a non-empty string naming the sealed enforcement scope")
         elif seal_scope != SEAL_SCOPE:
-            add("seal-scope-mismatch", PHASE_MALFORMED, f"sealed record {idx} assaySealScope {seal_scope!r} is not the scope this checker implements ({SEAL_SCOPE!r})")
+            add("seal-scope-mismatch", PHASE_NOT_CREDITED, f"sealed record {idx} assaySealScope {seal_scope!r} is not the scope this checker implements ({SEAL_SCOPE!r})")
 
         if "aeePostureDigest" not in malformed_digests and seal.get("aeePostureDigest") != env.get("networkPosture", {}).get("digest", {}).get("sha256"):
             add("posture-digest-mismatch", PHASE_MALFORMED, f"sealed record {idx} aeePostureDigest mismatch")
@@ -758,8 +807,15 @@ def validate(statement: dict[str, Any], disabled: frozenset[str] = frozenset()) 
         for attack_id in observed_attacks:
             if attack_id not in caught_attacks:
                 add("observed-attack-unsupported", PHASE_MALFORMED, f"sealed record {idx} names attack not supported by caught rows: {attack_id}")
+        # The strictest case of the prefix rule, and the reason `PRODUCER_CREDIT_ALTERNATE_VALUES`
+        # exists. This rule is not gated on a producer member's validity; it is *selected* by one of
+        # its two legal values, and it tightens a rule about an AEE member. So a consumer that reads
+        # the vocabulary applies it and a consumer that ignores the member does not, and before this
+        # they would have disagreed about whether the record was well formed. The baseline rule above
+        # -- every named attack must be supported by a caught row -- is consumer-independent and stays
+        # structural. Only the tightening is Assay policy, so only the tightening withholds credit.
         if seal.get("assayAttackRowAttributionSource") == "substrate-runner" and sorted(observed_attacks) != caught_attacks:
-            add("substrate-runner-observed-attacks-mismatch", PHASE_MALFORMED, f"sealed record {idx} substrate-runner observed attacks mismatch")
+            add("substrate-runner-observed-attacks-mismatch", PHASE_NOT_CREDITED, f"sealed record {idx} substrate-runner observed attacks mismatch")
 
     for row_idx, row in enumerate(rows):
         refs = row.get("observationRefs", [])
@@ -889,6 +945,14 @@ def run_producer_vocabulary_test() -> int:
     A phase is a one-word argument to `add`, invisible to every other test here: `--meta-test` reads
     reason codes, `--rule-coverage-test` greps `add("...` out of the source, and neither would
     notice this moving back. So the property gets a test of its own.
+
+    Two kinds of mutation, and the second was added because the first kind cannot see a whole class
+    of violation. The three generic ones -- absent, ineligible, ill-typed -- must withhold credit,
+    since a member this checker's policy reads and cannot make sense of is a member it declines.
+    A value from `PRODUCER_CREDIT_ALTERNATE_VALUES` is *legal*, so it may well leave the record
+    credited; all that is asserted of it is that it does not void the record. That is the weaker
+    assertion and the one that catches the selector case, where a member's permitted value decides
+    how strictly some other rule runs.
     """
     base = load_case(POSITIVE_CASE)
     if outcome_of(validate(base)) != OUTCOME_CREDITED:
@@ -897,33 +961,59 @@ def run_producer_vocabulary_test() -> int:
 
     failures = 0
     for field in PRODUCER_CREDIT_FIELDS:
-        for label, mutate in (
-            ("absent", lambda seal, f: seal.pop(f)),
-            ("ineligible", lambda seal, f: seal.__setitem__(f, "uncounted-queue")),
-            ("wrong type", lambda seal, f: seal.__setitem__(f, 7)),
-        ):
+        # `""` rather than a plausible-looking wrong value, because the seven members do not share a
+        # shape: two gate a closed set, two require equality with a constant, one requires an RFC 3339
+        # instant, one a list, and `assaySourceSchema` accepts any non-empty string at all. A
+        # borrowed value from one member's vocabulary is legal for that last one, so the mutation
+        # would pass it through and the check would read as "credit was not withheld". The empty
+        # string is the one value none of the seven accepts.
+        mutations: list[tuple[str, Any, bool]] = [
+            ("absent", _POP, True),
+            ("ineligible", "", True),
+            ("wrong type", 7, True),
+        ]
+        mutations += [(f"legal value {value!r}", value, False) for value in PRODUCER_CREDIT_ALTERNATE_VALUES.get(field, ())]
+
+        for label, value, must_withhold_credit in mutations:
             stmt = json.loads(json.dumps(base))
             seal = stmt["predicate"]["observationRecords"][2]["payload"]
             if field not in seal:
                 print(f"FAIL {field}: not present in the positive fixture, so it cannot be mutated")
                 failures += 1
                 break
-            mutate(seal, field)
+            if value is _POP:
+                del seal[field]
+            else:
+                seal[field] = value
             replace_payload(stmt, 2, seal)
             outcome = outcome_of(validate(stmt))
             if outcome == OUTCOME_MALFORMED:
                 print(f"FAIL {field} {label}: a producer member voided the record")
                 failures += 1
-            elif outcome == OUTCOME_CREDITED:
+            elif must_withhold_credit and outcome == OUTCOME_CREDITED:
                 print(f"FAIL {field} {label}: credit was not withheld")
                 failures += 1
             else:
                 print(f"ok   {field} {label}: {outcome}")
 
+    # The mutations above only reach members already in the tuple, so a producer member that gets a
+    # new rule and no decision about its phase is invisible to them -- which is how six members sat
+    # structural for four slices. `validate` is therefore read back: every `assay`-prefixed member it
+    # consults must be one this file has decided.
+    body = inspect.getsource(validate)
+    consulted = {name for name in re.findall(r'"(assay[A-Z][A-Za-z]*)"', body)} - set(PRODUCER_CREDIT_FIELDS)
+    # Not a payload member: the `_ext` block is consumer trust configuration carried beside the
+    # records, not producer vocabulary inside a signed payload, so the prefix rule does not reach it.
+    consulted -= {"assayLandlockSeal"}
+    for name in sorted(consulted):
+        print(f"FAIL {name}: `validate` reads this producer member and it is not in PRODUCER_CREDIT_FIELDS")
+        failures += 1
+
     if failures:
         print(f"\n{failures} producer-vocabulary check(s) failed")
         return 1
-    print(f"\nall {len(PRODUCER_CREDIT_FIELDS)} producer credit field(s) are inert to structural validity")
+    print(f"\nall {len(PRODUCER_CREDIT_FIELDS)} producer credit field(s) are inert to structural validity,")
+    print("and `validate` reads no producer member outside that tuple")
     return 0
 
 


### PR DESCRIPTION
> **#2107 is merged**, so this now targets `main` directly. It introduced `PRODUCER_CREDIT_FIELDS` and `--producer-vocabulary-test`; this PR decides the six members it parked, and extends that test so it can see them.

## ADR Boundary Slice

- Canonical ledger: **none active.** AGENTS.md records that the previous programme ([#1866](https://github.com/Rul1an/assay/issues/1866)) closed on 2026-08-01 and no new one has opened. This is a standalone follow-up with no ledger to record to.
- Slice: ADR-045 producer-vocabulary prefix rule — the six sibling members #2107 parked
- Builder: Claude (Opus 5)
- Reviewers: <!-- pending -->
- Final head SHA: `e78c4f502e7dadbf9cdd59f58ff2df95a7949407`
- ADR invariants affected: ADR-045 prefix rule (`assay`-prefixed members MUST NOT alter AEE structural validity); ADR-043's requirement that the three outcomes stay distinguishable

## Behavior

#2107 made `assayDropProofModel` inert to AEE structural validity and parked six siblings as "six contract questions, not one edit". They are decided here, and all six move to `PHASE_NOT_CREDITED`.

**The reason they were parked does not survive being written out.** It was that the normative paragraph at in-toto/attestation#570 governed members whose values a reader might rank, and these carry identities, instants and paths. That was true of the upstream paragraph **as it stood at `35ca6f899`**, and beside the point either way. ADR-045's own prefix rule is not scoped to rankable members:

> Fields beginning with `assay` in the sealed payload are Assay producer vocabulary. […] They MUST NOT alter AEE structural validity.

All of them, and it has said so since the ADR was written. Six local decisions were being held against an upstream sentence that could only ever be **narrower** than the rule we already had.

**Upstream then answered, and the earlier draft of this PR got that wrong.** When this was written, the question at [#570 (comment)](https://github.com/in-toto/attestation/pull/570#issuecomment-5216879286) — whether a producer member is inert whether or not its values rank — was open, and the body said so. It was answered at `237f83b9f`, **sixteen minutes** after we asked, in a commit titled *make producer territory inert, not merely unrankable*. The paragraph now reads:

> a producer-defined member MUST NOT affect structural validity, MUST NOT affect `result`, and MUST NOT affect the evidence tier, whether or not its values can be ordered

So the upstream rule and the local prefix rule now say the same thing, and this slice is what the two **jointly require** rather than what one of them permitted. Nothing about the six decisions changes — the reasoning never rested on the upstream paragraph, which is why it survived the paragraph moving — but a decision recorded as unconfirmed when it is confirmed reads as weaker evidence than it is. Corrected in `e78c4f5`, along with the tense of the scoping argument.

The upstream commit message names the gap as ours, unprompted: an implementer who "also emit[s] an unordered producer member, per-channel loss counters" (`assayDropChannels`), and a checker that "gated AEE validity on a producer member's value, which their own design document forbade in as many words". Both halves of #2107 and this PR.

**One boundary this does not settle**, named in the ADR rather than assumed. The new paragraph opens with a verifier reading *nothing* in producer territory, while the three obligations it states are structural validity, `result`, and the evidence tier. The not-credited verdict here is none of those three — it is a consumer trust decision of the same class as an untrusted signing key, which ADR-045's key-scope section already treats as the consumer's own, and AEE's `result` is a field this checker does not emit. That is a reading, not a quotation, and it is recorded as one so it gets re-checked if the opening sentence acquires normative weight.

### What was actually worth checking

Not whether the rule reaches each member — it always did. Whether moving it gives up what the structural phase was buying.

| Member | Rule(s) moved | What the check found |
|---|---|---|
| `assaySourceSchema` | `payload-source-schema-invalid` | Non-empty-string gate on a member the ADR table marks non-normative; no other rule reads the value. Nothing attached. |
| `assaySealScope` | `seal-scope-missing`, `seal-scope-mismatch` | Reading #2014 **settles** this rather than blocking it. The harm it names is that the checker "credits it as attested substrate evidence", and the rule it holds up as the model to copy is `key-scope-collection-path-mismatch` — already not-credited. Withholding credit is the whole of what #2014 asked for. |
| `assayCollectionPath` | `payload-collection-path-mismatch` | This member was being read at **both phases in one file**. The ADR's own key-scope section specifies the not-credited one: a key outside scope "is structurally valid but not credited". #2106 reached the same place from the producer side — a path types a vantage, and must not rank one above another. |
| `assayAttackRowAttributionSource` | `payload-attribution-source-unknown`, **`substrate-runner-observed-attacks-mismatch`** | See below. |
| `assayNonClaims` | `payload-non-claims-incomplete` | The prefix paragraph rules on this member by name: it "is only producer vocabulary and does not weaken required AEE checks". A rule that voids the record does the converse. A subset is still "a rejection rather than a warning" — not-credited is a rejection carrying a reason code. |
| `assaySealedAt` | `seal-instant-invalid` | The one with a real entanglement, so the one to check rather than assume. The parsed instant feeds `key-outside-validity-window`, and an unparsable value makes that check `continue` — so the structural phase was load-bearing for a bad instant not bypassing key expiry. It survives because *this* finding already withholds credit: no path reaches `credited`. The window is not weakened. |

### The finding the parked list did not contain

`assayAttackRowAttributionSource` had a **second** rule, and it is a different kind of violation. It is not only gated against a closed set — its value *selects how strictly an AEE member is checked*. Per ADR-045's attack-attribution rules 2–3, equality between `aeeObservedAttacks` and the caught row attack IDs is required under `substrate-runner` and not under `assembly-plane`.

Measured on the positive fixture at `ede1ee7c1`:

```
assayAttackRowAttributionSource = "assembly-plane"   (as fixtured) -> credited
assayAttackRowAttributionSource = "substrate-runner" (no other edit) -> malformed  ['substrate-runner-observed-attacks-mismatch']
```

One member, between its **two legal values**, moving a record across the structural boundary. That is the prefix rule's failure mode in its purest form: two consumers disagreeing about whether a record is well formed, because one reads Assay vocabulary and the other does not.

Moving only the closed-set rule would have left the property **false with `--producer-vocabulary-test` green**, because `substrate-runner` is neither absent, ineligible, nor ill-typed. Both rules move, and the test gained the ability to see it.

The baseline rule — every named attack must be supported by a caught row — reads only AEE members and stays structural. Only the tightening is Assay policy, so only the tightening withholds credit.

### Two checks added, because the existing ones could not see the move

1. **`PRODUCER_CREDIT_ALTERNATE_VALUES`** — mutate a member to one of its own *legal* values, asserting only that the record is not voided (a legal value may rightly leave it credited). This is the only mutation that reaches the selector case.
2. **`validate` read back** — every `assay`-prefixed member the function consults must appear in `PRODUCER_CREDIT_FIELDS`, so the next producer member to acquire a rule cannot acquire a phase by default. This is what makes "every producer member any rule reads is decided" a checked property rather than a comment.

Also: the generic ineligible value is now `""` rather than a borrowed one. `assaySourceSchema` accepts any non-empty string, so a plausible-looking wrong value passed straight through and the check read as "credit was not withheld". `""` is the one value none of the seven members' own rules accept.

### One deliberate divergence from #2107

The six **stay in `REQUIRED_SEAL_FIELDS`** (#2107 removed `assayDropProofModel` from it). That list states what the *Assay producer contract* obliges a seal to carry, and `--required-field-test` asserts absence is `!= CREDITED` — which not-credited satisfies. So "required" reads as required-for-credit for a producer member, which is the strongest thing the prefix rule permits it to mean. Keeping them preserves the per-member coverage proof, and keeps the ADR's existing "`REQUIRED_SEAL_FIELDS` names **six** of the ten producer members" sentence true without an edit.

### Where this leaves the rule

Seven of the ten producer members are read by some rule in the checker, all seven are enforced inert by test, and the remaining three (`assayObservedLabels`, `assayDropProofBasis`, `assayDropChannels`) are inert by having no rule — nothing can demote what nothing consults. **Every rule that can still return `malformed` reads an `aee*` member, the envelope, or the predicate structure.**

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

This changes only which of three existing outcomes a checker returns for a fixture. It is not a production exporter, and ADR-045 still blocks one.

## Test Evidence

All measurements on `e78c4f502e7dadbf9cdd59f58ff2df95a7949407` (rebased onto `main` after #2107 squash-merged; content identical to the reviewed tree plus the `e78c4f5` doc correction), worktree `friendly-matsumoto-e291ed`, macOS 25.6.0 (darwin), stable toolchain.

### RED

The property is a phase — one word passed to `add` — so the failing state is demonstrated by mutation rather than by a test written first. Each mutation applied in-memory against the committed source:

```
bite 1  assaySealScope removed from PRODUCER_CREDIT_FIELDS        -> CAUGHT
        FAIL assaySealScope: `validate` reads this producer member and it is not in PRODUCER_CREDIT_FIELDS

bite 2  payload-attribution-source-unknown back to PHASE_MALFORMED -> CAUGHT
        FAIL assayAttackRowAttributionSource absent: a producer member voided the record
        FAIL assayAttackRowAttributionSource ineligible: a producer member voided the record
        FAIL assayAttackRowAttributionSource wrong type: a producer member voided the record

bite 3  substrate-runner-observed-attacks-mismatch back to PHASE_MALFORMED -> CAUGHT
        FAIL assayAttackRowAttributionSource legal value 'substrate-runner': a producer member voided the record
```

Bite 3 is the one that matters: it is caught **only** by the new alternate-value mutation. The three generic mutations stay green through it, which is the gap this PR closes.

### GREEN

```
--meta-test                  PASS   33/33 controls isolate their reason
--required-field-test        PASS   16/16 required fields rejected when absent
--rule-coverage-test         PASS   33/33 reason codes have a control
--producer-vocabulary-test   PASS   7 credit fields x 22 mutations, all structurally-valid-not-credited;
                                    `validate` reads no producer member outside the tuple

cargo test -p assay-cli      53 test binaries ok, 0 failures
cargo fmt --all -- --check   clean
cargo clippy -p assay-cli --all-targets -- -D warnings   clean
git diff --check             clean
pre-commit (4 changed files) all hooks pass
scripts/ci/check-aee-seal-fixture-drift.sh  "fixtures reproduce from the emitter, with no extra files"
```

Documented smoke loop in `docs/experiments/aee-landlock-seal-fixtures-2026-08.md` re-run verbatim: positive credited, all 33 negative controls reject with their own reason, exit 0.

Outcome shift across the negative controls: exactly the 8 changed rule sites moved from `malformed` to `structurally-valid-not-credited` (`empty-source-schema`, `seal-scope-absent`, `seal-scope-other-boundary`, `seal-collection-path-other`, `unknown-attribution-source`, `substrate-runner-observed-attacks-mismatch`, `incomplete-non-claims`, `seal-instant-not-rfc3339`). No control changed reason code; the positive fixture is still `credited`.

`adr045_citations.rs` caught two paraphrases I had written inside quotation marks near an ADR-045 mention. Fixed, and every remaining quotation was re-grepped against the source it is attributed to (ADR-045, the checker's own comment, and issue #2014) before this was pushed.

### Not covered

No Rust production code changed, so the Rust producer's behaviour is unchanged and untested by this PR — `crates/assay-cli/src/aee_seal.rs` still emits the same twenty members. This moves only what the checker says about them. The Linux-only paths are untouched.

## Review Quorum

- [ ] One non-building agent review
- [ ] CodeRabbit or Copilot review on this head SHA
- [ ] If bots were unavailable for 30 minutes, a second non-building agent review is linked
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

The builder's self-review does not count, so the boxes above are for reviewers to fill. Auto-merge is deliberately **not** enabled: the quorum above is unmet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
