### PR TITLE
The test that guarded the rule could not see the rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,7 +163,7 @@ repos:
         # `--producer-vocabulary-test` says an Assay producer member withholds credit and never
         # voids the record. The other three are blind to it: a phase is one word passed to `add`,
         # so `assayDropProofModel` decided AEE structural validity for two slices while all three
-        # stayed green, and six sibling members did for four. It also reads `validate` back, so a
+        # stayed green, and six sibling members did for three. It also reads `validate` back, so a
         # producer member that acquires a rule cannot acquire a phase by default.
         #
         # pre-commit, not pre-push: all four run in well under a second, and they are the tests

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -361,7 +361,10 @@ wrong value straight through.
 Where this leaves the prefix rule: **seven** of the ten producer members are read by some rule in the
 checker, all seven are enforced inert by test, and the remaining three are inert by having no rule.
 Every rule that can still return `malformed` reads an `aee*` member, the envelope, or the predicate
-structure.
+structure, where reads means interprets. A producer member mutated inside an interception record
+still changes `aeeObservedSet`, which is a digest over payload bytes and commits to them opaquely.
+That is not a breach: a consumer ignoring Assay vocabulary recomputes the identical digest and
+reaches the identical verdict, so no two consumers disagree, which is the harm this rule names.
 
 Fields beginning with `assay` in the sealed payload are Assay producer vocabulary. AEE consumers may ignore them unless their own policy understands them. They MUST NOT alter AEE structural validity. Any future AEE statement exporter MUST also carry predicate-level `doesNotAssert` for statement-level non-claims; `assayNonClaims` inside the sealed payload is only producer vocabulary and does not weaken required AEE checks.
 

--- a/docs/experiments/aee-landlock-seal-fixtures-2026-08.md
+++ b/docs/experiments/aee-landlock-seal-fixtures-2026-08.md
@@ -155,6 +155,13 @@ Every rule that can still return `malformed` reads an `aee*` member, the envelop
 or the predicate structure. That is the property, not a coincidence of the current
 list.
 
+Read means interprets. Mutating a producer member inside an interception record
+does change `aeeObservedSet` and so can return `malformed`, because the observed
+set is a digest over payload bytes and commits to them opaquely. That is not a
+breach of the prefix rule: a consumer that ignores Assay vocabulary recomputes the
+identical digest and reaches the identical verdict, so there is no disagreement
+between consumers, which is the harm the rule names.
+
 Trust rejections (`structurally-valid-not-credited`):
 
 - the signing key is not in the consumer trust set;
@@ -175,7 +182,9 @@ Trust rejections (`structurally-valid-not-credited`):
 - `assaySealedAt` is not an RFC 3339 UTC instant.
 
 Everything from `assayDropProofModel` down is a policy verdict rather than a
-structural one, and all of it used to be filed above. ADR-045 states that
+structural one. Three of them used to be filed above; the rest were structural
+in the checker without this document ever saying so, and `assaySealScope` and
+`assayNonClaims` appear here for the first time. ADR-045 states that
 `assay`-prefixed members are producer vocabulary and must not alter AEE structural
 validity, and the checker was breaking its own rule: values only Assay defines
 decided whether an AEE record was well formed. This consumer's policy does read

--- a/scripts/experiments/aee_landlock_seal_fixture.py
+++ b/scripts/experiments/aee_landlock_seal_fixture.py
@@ -146,8 +146,15 @@ PRODUCER_CREDIT_FIELDS = (
 # attack IDs is required under `substrate-runner` and not under `assembly-plane` (ADR-045, attack
 # attribution rules 2 and 3). Flipping the positive fixture from one legal value to the other, with
 # no other edit, used to turn a credited record into a malformed one.
+#
+# `assaySealScope` is here for a duller reason and was the gap this table shipped with. Its rule is
+# an `elif`: the `if` above it catches absent, empty and ill-typed alike and raises
+# `seal-scope-missing`, so all three generic mutations stop one branch short and the mismatch arm
+# below it is never reached. Reverting that arm to `PHASE_MALFORMED` left all four modes green.
+# Any non-empty string other than `SEAL_SCOPE` reaches it; the value here is arbitrary and legal.
 PRODUCER_CREDIT_ALTERNATE_VALUES: dict[str, tuple[str, ...]] = {
     "assayAttackRowAttributionSource": ("substrate-runner",),
+    "assaySealScope": ("filesystem_write_all",),
 }
 
 # Removal, distinguishable from setting the member to any value including `None`. A member set to
@@ -1000,10 +1007,17 @@ def run_producer_vocabulary_test() -> int:
 
     # The mutations above only reach members already in the tuple, so a producer member that gets a
     # new rule and no decision about its phase is invisible to them -- which is how six members sat
-    # structural for four slices. `validate` is therefore read back: every `assay`-prefixed member it
+    # structural for three slices. `validate` is therefore read back: every `assay`-prefixed member it
     # consults must be one this file has decided.
+    #
+    # Both quote styles, and digits and underscores in the name. The first version matched
+    # double-quoted literals only, which reads as a checked property and is not one: no formatter
+    # runs on this file, so quote style is a matter of what the last author typed, and switching one
+    # reference to single quotes walked a re-malformed rule straight past this guard. What it still
+    # does not cover is a member reached through a variable, a constant, or a callee --
+    # `inspect.getsource` returns this function's own body and nothing it calls.
     body = inspect.getsource(validate)
-    consulted = {name for name in re.findall(r'"(assay[A-Z][A-Za-z]*)"', body)} - set(PRODUCER_CREDIT_FIELDS)
+    consulted = {name for name in re.findall(r"""["'](assay[A-Z][A-Za-z0-9_]*)["']""", body)} - set(PRODUCER_CREDIT_FIELDS)
     # Not a payload member: the `_ext` block is consumer trust configuration carried beside the
     # records, not producer vocabulary inside a signed payload, so the prefix rule does not reach it.
     consulted -= {"assayLandlockSeal"}


### PR DESCRIPTION
Closes #2109. Four gaps carried over from #2108, all in the assurance rather than in behaviour: no detection changes, and no path reaches `credited` that did not before.

## The blocker

`seal-scope-mismatch` was the one moved rule with no coverage. Its arm is an `elif`, and the `if` above it answers absent, empty and ill-typed alike with `seal-scope-missing`, so all three generic mutations stopped one branch short and never reached it. Reverting that arm to `PHASE_MALFORMED` — the exact regression `PRODUCER_CREDIT_ALTERNATE_VALUES` exists to catch — left all four modes green.

`assaySealScope` now carries a legal alternate value, which is the only mutation shape that reaches an `elif` at all.

## The guard that claimed more than it did

The read-back matched double-quoted literals only. No formatter runs on this file, so quote style is whatever the last author typed; switching one reference to single quotes walked a re-malformed rule straight past it. Widened to both quote styles and to digits and underscores in the member name.

What it still cannot see is a member reached through a variable, a constant or a callee, since `inspect.getsource` returns the function body and nothing it calls. The comment now says that rather than asserting the property outright.

One review reported that `validate` already contained such a single-quoted reference, making the gap live. It did not — grepping `'assay[A-Z]` returned zero. The gap was real but unexercised, which is why this widens the regex instead of repairing a live defect.

## Three prose corrections

- **three slices, not four.** `run_meta_test` arrived in #2008 (`1619cad9d`), `run_required_field_test` in #2067 (`2639d12a3`), `run_rule_coverage_test` in #2072 (`53b41efe5`), so all three coexist only from #2072, giving #2072, #2095, #2107.
- **"all of it used to be filed above"** was true of three of the seven. `assaySealScope` and `assayNonClaims` had never appeared in that document at all.
- **`malformed` precision.** Reads now means interprets. A producer member mutated inside an interception record does change `aeeObservedSet`, which is a digest over payload bytes and commits to them opaquely. Not a breach: a consumer ignoring Assay vocabulary recomputes the identical digest and reaches the identical verdict, so no two consumers disagree, which is the harm the prefix rule names. Without this, the next reader mutates an interception payload, gets `malformed`, and files a bug.

## Verification

Both fixes proved in both directions, on the committed tree rather than a dirty one:

| bite | result |
|---|---|
| revert `seal-scope-mismatch` to `PHASE_MALFORMED` | `FAIL assaySealScope legal value 'filesystem_write_all'` — caught |
| single-quoted reference + dropped from tuple + rule re-malformed | `FAIL assaySourceSchema` — caught |

Clean tree: `--meta-test` 33/33, `--required-field-test` 16/16, `--rule-coverage-test` 33/33, `--producer-vocabulary-test` all inert, positive fixture `credited`. `cargo test -p assay-cli --test adr045_citations --test adr045_prefix_table`: 5 passed.

No Rust production code changed.

## Review

Ledger: none active. Quorum unmet on this head; needs one non-building agent review plus a bot, or two agent reviews if the bots stay silent past thirty minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)