### PR TITLE
The attestation header described the shape the module refuses

### DIFF
--- a/crates/assay-evidence/src/attestation.rs
+++ b/crates/assay-evidence/src/attestation.rs
@@ -1,10 +1,16 @@
-//! In-toto / DSSE attestation over an evidence bundle manifest (ADR-039).
+//! In-toto / DSSE attestation over a finished evidence bundle (ADR-039, subject shape per ADR-044).
 //!
-//! Wraps a bundle [`Manifest`] as an in-toto v1 Statement and signs it as a DSSE
+//! Wraps the completed `.tar.gz` as an in-toto v1 Statement and signs it as a DSSE
 //! envelope, reusing the mandate DSSE primitives (PAE + Ed25519). The anchor
 //! (a transparency log or timestamp) stays pluggable and external.
 //!
-//! Honest boundary: an attestation binds who-said-it and the *semantic event chain*.
+//! These two paragraphs used to say the statement wrapped a [`Manifest`], which is the v0 shape
+//! this module now exists partly to refuse — while the paragraph four below described the ADR-044
+//! subject correctly. A reader who stopped at the header got the superseded answer, and at least
+//! one did: it was cited as the current shape in a design decision on #2105. The header is the
+//! part people read, so it is the part that has to be right.
+//!
+//! Honest boundary: an attestation binds who-said-it and the bytes of one archive.
 //! It does NOT upgrade observed support, and provides no trust root or transparency
 //! log on its own.
 //!


### PR DESCRIPTION
Docs-only, one file.

## The defect

`crates/assay-evidence/src/attestation.rs` opened with:

> In-toto / DSSE attestation over an evidence bundle manifest (ADR-039).
> Wraps a bundle `Manifest` as an in-toto v1 Statement …

Four paragraphs below, the same doc comment says:

> Before ADR-044 the subject digest was `manifest.run_root` … Such statements carry the `v0` predicate type and are refused rather than reinterpreted: nothing in them says which bytes they described.

So the header described the shape the module exists partly to refuse. It was written for ADR-039 and never revisited when ADR-044 moved the subject to the SHA-256 of the finished `.tar.gz` — which is what `statement_for_bundle(bundle_bytes)` actually does.

## Why it is worth a commit

A self-contradicting docstring reads as authoritative from whichever end you enter, and the header is the end people enter from. Entering from the top produced a wrong subject shape in a scope decision on #2105, which specified "an in-toto statement over the bundle **manifest digest** as subject" — precisely the v0 shape ADR-044 refused and ADR-045 restates as binding.

That error was caught by an adversarial review of the decision, not by anyone reading this file. The code was correct throughout; only its description was not, which is the failure mode a reader has no defence against.

## The change

Header now names the finished archive as the subject and cites both ADRs. The paragraph explaining the v0 refusal is unchanged — it was already right. The "honest boundary" note said an attestation binds "the *semantic event chain*"; post-ADR-044 it binds the bytes of one archive, with the semantic root travelling inside the predicate, so that line is corrected too.

I left a sentence recording that the header and body disagreed and what it cost. A doc comment that was wrong once tends to be re-broken by someone restoring the "simpler" phrasing.

## Verification

`cargo test -p assay-evidence attestation`: 24 passed. Clippy `-D warnings` clean, fmt clean. No code changed — `git diff --stat` is one file, comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)