### PR TITLE
The config reference named two rule types that never existed

### DIFF
--- a/crates/assay-core/tests/config_reference_examples_parse.rs
+++ b/crates/assay-core/tests/config_reference_examples_parse.rs
@@ -18,12 +18,38 @@
 use assay_core::model::SequenceRule;
 use std::path::{Path, PathBuf};
 
-/// Documents that show sequence rules a reader is expected to copy.
-const DOCS: &[&str] = &[
-    "docs/reference/config/sequences.md",
-    "docs/metrics/sequence-valid.md",
-    "docs/concepts/metrics.md",
-];
+/// Every markdown file under `docs/` that shows a sequence rule.
+///
+/// Derived, not listed. A hand-kept list was a second place to forget in exactly the way the
+/// deleted type allowlist was: it omitted `docs/use-cases/ci-gate.md`, a page whose whole purpose
+/// is to be copied, which carried a `before` rule passing a list to a field that takes a string.
+fn docs_showing_rules(root: &Path) -> Vec<String> {
+    fn walk(dir: &Path, out: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|x| x == "md")
+                // `docs/archive/` is kept deliberately as a record of superseded reference text.
+                // Holding it to the current schema would be asking history to be current.
+                && !p.to_string_lossy().contains("/archive/")
+            {
+                if let Ok(text) = std::fs::read_to_string(&p) {
+                    if text.contains("- type:") {
+                        out.push(p.to_string_lossy().into_owned());
+                    }
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(&root.join("docs"), &mut out);
+    out.sort();
+    out
+}
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -59,23 +85,26 @@ fn yaml_blocks(md: &str) -> Vec<(usize, String)> {
 /// them carrying a `blocklist` rule written with `tools:` — the exact defect this test was added
 /// to catch, sitting in the half it could not see. Depth is not a property of a rule, so it must
 /// not be a property of the search.
-fn rules_in(block: &str) -> Vec<serde_yaml::Value> {
-    let Ok(v) = serde_yaml::from_str::<serde_yaml::Value>(block) else {
-        return Vec::new();
-    };
+fn rules_in(block: &str) -> Result<Vec<serde_yaml::Value>, String> {
+    // Not a skip. A block that is not valid YAML was silently dropped, so a typo, a tab or an
+    // undefined alias made every rule inside it invisible -- and one such block was already in
+    // the corpus (`concepts/metrics.md`, an undefined `*_dangerous` anchor). A reader copies
+    // these; if it does not parse as YAML it does not work for them either.
+    let v = serde_yaml::from_str::<serde_yaml::Value>(block)
+        .map_err(|e| format!("the yaml block itself does not parse: {e}"))?;
     let mut found = Vec::new();
     collect_rules(&v, &mut found);
-    found
+    Ok(found
         .into_iter()
         // A rule is a mapping carrying `type`. Other list entries in these docs are not rules.
         .filter(|e| {
             e.as_mapping()
                 .is_some_and(|m| m.contains_key(serde_yaml::Value::String("type".into())))
         })
-        .collect()
+        .collect())
 }
 
-/// Every `rules:` sequence anywhere in the value, plus a bare top-level sequence.
+/// Every `rules:` sequence anywhere in the value.
 fn collect_rules(v: &serde_yaml::Value, out: &mut Vec<serde_yaml::Value>) {
     match v {
         serde_yaml::Value::Mapping(m) => {
@@ -104,13 +133,31 @@ fn every_documented_sequence_rule_parses() {
     let mut failures = Vec::new();
     let mut checked = 0usize;
 
-    for doc in DOCS {
-        let path = root.join(doc);
+    let docs = docs_showing_rules(&root);
+    for doc in &docs {
+        let path = std::path::PathBuf::from(doc);
+        let rel = doc
+            .strip_prefix(&format!("{}/", root.display()))
+            .unwrap_or(doc)
+            .to_string();
         let md = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
 
         for (line, block) in yaml_blocks(&md) {
-            for rule in rules_in(&block) {
+            // Only blocks that purport to show rules. A block without a `- type:` entry is some
+            // other schema, and several docs legitimately show two alternative forms in one
+            // fence, which is not valid YAML as a single document and is not meant to be.
+            if !block.contains("- type:") {
+                continue;
+            }
+            let rules = match rules_in(&block) {
+                Ok(r) => r,
+                Err(e) => {
+                    failures.push(format!("{rel}:{line} — {e}"));
+                    continue;
+                }
+            };
+            for rule in rules {
                 // Only rules the loader would see: a `type` this crate owns. A block describing a
                 // different schema that happens to use `type` is not this test's business.
                 let printed = serde_yaml::to_string(&rule).unwrap_or_default();
@@ -121,7 +168,7 @@ fn every_documented_sequence_rule_parses() {
                 checked += 1;
                 if let Err(e) = serde_yaml::from_value::<SequenceRule>(rule) {
                     failures.push(format!(
-                        "{doc}:{line} — {e}\n  the example reads:\n{}",
+                        "{rel}:{line} — {e}\n  the example reads:\n{}",
                         printed
                             .lines()
                             .map(|l| format!("    {l}"))
@@ -134,9 +181,16 @@ fn every_documented_sequence_rule_parses() {
     }
 
     assert!(
+        docs.len() >= 4,
+        "found only {} documents showing rules; the walk stopped matching",
+        docs.len()
+    );
+    assert!(
         checked >= 40,
-        "found only {checked} documented rules to check. The four documents carry far more than \
-         that, so this means the extractor stopped matching rather than that the docs are clean."
+        "found only {checked} documented rules across {} document(s). The corpus carries well \
+         over that, so this means the extractor stopped matching rather than that the docs are \
+         clean.",
+        docs.len()
     );
     assert!(
         failures.is_empty(),
@@ -144,4 +198,35 @@ fn every_documented_sequence_rule_parses() {
         failures.len(),
         failures.join("\n\n")
     );
+}
+
+#[cfg(test)]
+mod extractor {
+    /// A block that is not valid YAML is a failure, not a skip.
+    ///
+    /// The corpus is clean, so nothing in the documents exercises this: reverting the guard
+    /// leaves every test green. It is pinned here instead, because the case it exists for --
+    /// an undefined anchor hiding every rule in its block -- was live in the corpus until this
+    /// PR and will be live again the next time someone writes a tab.
+    #[test]
+    fn an_unparsable_block_is_reported_not_skipped() {
+        let block = "rules:\n  - type: blocklist\n    pattern: *undefined_anchor\n";
+        let err = super::rules_in(block).expect_err("invalid yaml must not be silently dropped");
+        assert!(err.contains("does not parse"), "got {err}");
+    }
+
+    /// Rules are found at any depth, because depth is not a property of a rule.
+    #[test]
+    fn rules_are_found_under_a_nested_key() {
+        let block = "tests:\n  - id: x\n    metric: sequence_valid\n    rules:\n      - type: require\n        tool: A\n";
+        let found = super::rules_in(block).expect("parses");
+        assert_eq!(found.len(), 1, "nested rules were not collected: {found:?}");
+    }
+
+    /// A block carrying no rules yields none rather than erroring.
+    #[test]
+    fn a_block_without_rules_yields_nothing() {
+        let block = "suite: x\nversion: \"1\"\n";
+        assert!(super::rules_in(block).expect("parses").is_empty());
+    }
 }

--- a/crates/assay-core/tests/config_reference_examples_parse.rs
+++ b/crates/assay-core/tests/config_reference_examples_parse.rs
@@ -1,0 +1,151 @@
+//! Every sequence rule written in the documentation must parse.
+//!
+//! The parity test beside this one compares headings against variant names, and that is a weaker
+//! property than it looks. It passed on a `sequences.md` whose "Real-World Patterns" section still
+//! told a reader to write `type: immediately_before`, and on a `sequence-valid.md` whose
+//! `blocklist` example named a field the variant does not have — `tools:` where the type takes
+//! `pattern:`, which serde rejects with "missing field `pattern`". Neither is a heading, so
+//! neither was visible.
+//!
+//! The stronger property is simply that the examples run. A reader does not copy a heading; they
+//! copy the block underneath it. So this deserialises every rule the docs show, through the same
+//! type the loader uses, and reports the file and the snippet when one fails.
+//!
+//! Scope, stated because it bounds the guarantee: this proves a rule is *well-formed*, not that
+//! the surrounding prose describes its behaviour correctly. A `before` example that parses but is
+//! documented with the wrong pass/fail table is beyond what any parser can catch.
+
+use assay_core::model::SequenceRule;
+use std::path::{Path, PathBuf};
+
+/// Documents that show sequence rules a reader is expected to copy.
+const DOCS: &[&str] = &[
+    "docs/reference/config/sequences.md",
+    "docs/metrics/sequence-valid.md",
+    "docs/concepts/metrics.md",
+];
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+/// Every fenced yaml block in the document.
+fn yaml_blocks(md: &str) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    let mut lines = md.lines().enumerate();
+    while let Some((i, l)) = lines.next() {
+        if l.trim_start().starts_with("```yaml") {
+            let mut body = String::new();
+            for (_, b) in lines.by_ref() {
+                if b.trim_start().starts_with("```") {
+                    break;
+                }
+                body.push_str(b);
+                body.push('\n');
+            }
+            out.push((i + 1, body));
+        }
+    }
+    out
+}
+
+/// The rule mappings inside one block, as YAML values.
+///
+/// Blocks appear in two shapes: a bare `rules:` list, or a fragment that is already a list of
+/// rules. Anything that is neither is not a rule example and is skipped rather than failed —
+/// these documents also contain suite-level and policy-level yaml.
+fn rules_in(block: &str) -> Vec<serde_yaml::Value> {
+    let Ok(v) = serde_yaml::from_str::<serde_yaml::Value>(block) else {
+        return Vec::new();
+    };
+    let seq = match &v {
+        serde_yaml::Value::Mapping(m) => m
+            .get(serde_yaml::Value::String("rules".into()))
+            .and_then(|r| r.as_sequence())
+            .cloned(),
+        serde_yaml::Value::Sequence(s) => Some(s.clone()),
+        _ => None,
+    };
+    seq.unwrap_or_default()
+        .into_iter()
+        // A rule is a mapping carrying `type`. Other list entries in these docs are not rules.
+        .filter(|e| {
+            e.as_mapping()
+                .is_some_and(|m| m.contains_key(serde_yaml::Value::String("type".into())))
+        })
+        .collect()
+}
+
+#[test]
+fn every_documented_sequence_rule_parses() {
+    let root = workspace_root();
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+
+    for doc in DOCS {
+        let path = root.join(doc);
+        let md = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+        for (line, block) in yaml_blocks(&md) {
+            for rule in rules_in(&block) {
+                // Only rules the loader would see: a `type` this crate owns. A block describing a
+                // different schema that happens to use `type` is not this test's business.
+                let printed = serde_yaml::to_string(&rule).unwrap_or_default();
+                let ty = rule
+                    .as_mapping()
+                    .and_then(|m| m.get(serde_yaml::Value::String("type".into())))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if !SEQUENCE_RULE_TYPES.contains(&ty.as_str()) && !ty.is_empty() {
+                    continue;
+                }
+                checked += 1;
+                if let Err(e) = serde_yaml::from_value::<SequenceRule>(rule) {
+                    failures.push(format!(
+                        "{doc}:{line} — {e}\n  the example reads:\n{}",
+                        printed
+                            .lines()
+                            .map(|l| format!("    {l}"))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        checked >= 10,
+        "found only {checked} documented rules to check, which means the extractor stopped \
+         matching rather than that the docs are clean"
+    );
+    assert!(
+        failures.is_empty(),
+        "{} documented sequence rule(s) do not parse:\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}
+
+/// The types this crate owns, so a yaml block describing some other `type:` is skipped rather
+/// than reported. Kept deliberately loose: an unknown `type` that *looks* like a sequence rule
+/// still reaches the parser and fails there, which is the case worth catching.
+const SEQUENCE_RULE_TYPES: &[&str] = &[
+    "require",
+    "eventually",
+    "max_calls",
+    "before",
+    "after",
+    "never_after",
+    "sequence",
+    "blocklist",
+    // Historical spellings the documentation used to carry. Listed so that a reappearance is
+    // reported by the parser rather than silently skipped as "some other schema".
+    "immediately_before",
+    "allowlist",
+];

--- a/crates/assay-core/tests/config_reference_examples_parse.rs
+++ b/crates/assay-core/tests/config_reference_examples_parse.rs
@@ -35,7 +35,14 @@ fn docs_showing_rules(root: &Path) -> Vec<String> {
             } else if p.extension().is_some_and(|x| x == "md")
                 // `docs/archive/` is kept deliberately as a record of superseded reference text.
                 // Holding it to the current schema would be asking history to be current.
-                && !p.to_string_lossy().contains("/archive/")
+                //
+                // Compared by path component, not by substring. `contains("/archive/")` is a
+                // separator assumption: on Windows the path reads `docs\archive\...`, the
+                // exclusion missed, and the legacy reference was held to the current schema.
+                // Only the Windows leg of the matrix caught it.
+                && !p
+                    .components()
+                    .any(|c| c.as_os_str() == std::ffi::OsStr::new("archive"))
             {
                 if let Ok(text) = std::fs::read_to_string(&p) {
                     if text.contains("- type:") {
@@ -136,10 +143,12 @@ fn every_documented_sequence_rule_parses() {
     let docs = docs_showing_rules(&root);
     for doc in &docs {
         let path = std::path::PathBuf::from(doc);
-        let rel = doc
-            .strip_prefix(&format!("{}/", root.display()))
-            .unwrap_or(doc)
-            .to_string();
+        // Relative for the message, via `Path` so the separator is not assumed, then normalised
+        // to `/` so a failure reads the same on every platform.
+        let rel = path
+            .strip_prefix(&root)
+            .map(|r| r.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| doc.clone());
         let md = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
 

--- a/crates/assay-core/tests/config_reference_examples_parse.rs
+++ b/crates/assay-core/tests/config_reference_examples_parse.rs
@@ -52,24 +52,20 @@ fn yaml_blocks(md: &str) -> Vec<(usize, String)> {
     out
 }
 
-/// The rule mappings inside one block, as YAML values.
+/// The rule mappings inside one block, as YAML values, at any depth.
 ///
-/// Blocks appear in two shapes: a bare `rules:` list, or a fragment that is already a list of
-/// rules. Anything that is neither is not a rule example and is skipped rather than failed —
-/// these documents also contain suite-level and policy-level yaml.
+/// An earlier version looked only for a top-level `rules:` key or a top-level sequence, and the
+/// documents nest: `metric:` → `rules:`, `tests:` → `rules:`. Eight blocks were invisible, two of
+/// them carrying a `blocklist` rule written with `tools:` — the exact defect this test was added
+/// to catch, sitting in the half it could not see. Depth is not a property of a rule, so it must
+/// not be a property of the search.
 fn rules_in(block: &str) -> Vec<serde_yaml::Value> {
     let Ok(v) = serde_yaml::from_str::<serde_yaml::Value>(block) else {
         return Vec::new();
     };
-    let seq = match &v {
-        serde_yaml::Value::Mapping(m) => m
-            .get(serde_yaml::Value::String("rules".into()))
-            .and_then(|r| r.as_sequence())
-            .cloned(),
-        serde_yaml::Value::Sequence(s) => Some(s.clone()),
-        _ => None,
-    };
-    seq.unwrap_or_default()
+    let mut found = Vec::new();
+    collect_rules(&v, &mut found);
+    found
         .into_iter()
         // A rule is a mapping carrying `type`. Other list entries in these docs are not rules.
         .filter(|e| {
@@ -77,6 +73,29 @@ fn rules_in(block: &str) -> Vec<serde_yaml::Value> {
                 .is_some_and(|m| m.contains_key(serde_yaml::Value::String("type".into())))
         })
         .collect()
+}
+
+/// Every `rules:` sequence anywhere in the value, plus a bare top-level sequence.
+fn collect_rules(v: &serde_yaml::Value, out: &mut Vec<serde_yaml::Value>) {
+    match v {
+        serde_yaml::Value::Mapping(m) => {
+            for (k, val) in m {
+                if k.as_str() == Some("rules") {
+                    if let Some(seq) = val.as_sequence() {
+                        out.extend(seq.iter().cloned());
+                        continue;
+                    }
+                }
+                collect_rules(val, out);
+            }
+        }
+        serde_yaml::Value::Sequence(s) => {
+            for e in s {
+                collect_rules(e, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[test]
@@ -95,15 +114,10 @@ fn every_documented_sequence_rule_parses() {
                 // Only rules the loader would see: a `type` this crate owns. A block describing a
                 // different schema that happens to use `type` is not this test's business.
                 let printed = serde_yaml::to_string(&rule).unwrap_or_default();
-                let ty = rule
-                    .as_mapping()
-                    .and_then(|m| m.get(serde_yaml::Value::String("type".into())))
-                    .and_then(|t| t.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                if !SEQUENCE_RULE_TYPES.contains(&ty.as_str()) && !ty.is_empty() {
-                    continue;
-                }
+                // No type allowlist. Everything under a `rules:` key is a sequence rule by
+                // construction, and a hand-kept list of "types this crate owns" was a second
+                // place to forget: it omitted `count`, so every broken `count` example was
+                // skipped as though it belonged to some other schema.
                 checked += 1;
                 if let Err(e) = serde_yaml::from_value::<SequenceRule>(rule) {
                     failures.push(format!(
@@ -120,9 +134,9 @@ fn every_documented_sequence_rule_parses() {
     }
 
     assert!(
-        checked >= 10,
-        "found only {checked} documented rules to check, which means the extractor stopped \
-         matching rather than that the docs are clean"
+        checked >= 40,
+        "found only {checked} documented rules to check. The four documents carry far more than \
+         that, so this means the extractor stopped matching rather than that the docs are clean."
     );
     assert!(
         failures.is_empty(),
@@ -131,21 +145,3 @@ fn every_documented_sequence_rule_parses() {
         failures.join("\n\n")
     );
 }
-
-/// The types this crate owns, so a yaml block describing some other `type:` is skipped rather
-/// than reported. Kept deliberately loose: an unknown `type` that *looks* like a sequence rule
-/// still reaches the parser and fails there, which is the case worth catching.
-const SEQUENCE_RULE_TYPES: &[&str] = &[
-    "require",
-    "eventually",
-    "max_calls",
-    "before",
-    "after",
-    "never_after",
-    "sequence",
-    "blocklist",
-    // Historical spellings the documentation used to carry. Listed so that a reappearance is
-    // reported by the parser rather than silently skipped as "some other schema".
-    "immediately_before",
-    "allowlist",
-];

--- a/crates/assay-core/tests/config_reference_parity.rs
+++ b/crates/assay-core/tests/config_reference_parity.rs
@@ -41,15 +41,28 @@ fn read(rel: &str) -> String {
 /// makes every parity assertion below vacuously true, which is the shape this whole file exists
 /// to refuse.
 fn serde_renames(source_rel: &str, enum_name: &str) -> BTreeSet<String> {
-    let src = read(source_rel);
+    serde_renames_in(&read(source_rel), enum_name)
+}
+
+/// The parsing half, separated so it can be tested against fixture text.
+///
+/// Adding a variant to a real enum is not a usable mutation: it breaks every exhaustive match in
+/// the crate, so nothing compiles and nothing runs. The shapes below are therefore checked here,
+/// where a variant can exist without the rest of the world having to handle it.
+fn serde_renames_in(src: &str, enum_name: &str) -> BTreeSet<String> {
     let start = src
         .find(&format!("pub enum {enum_name}"))
-        .unwrap_or_else(|| panic!("{enum_name} not found in {source_rel}"));
+        .unwrap_or_else(|| panic!("{enum_name} not found in the source read for it"));
     // The enum body ends at the first line that closes it at column 0.
     let body = &src[start..];
     let end = body.find("\n}").expect("enum body is unterminated");
     let body = &body[..end];
 
+    // The union of both spellings, never one or the other. An earlier version returned the
+    // explicit set whenever it was non-empty, which made a new variant invisible on exactly the
+    // enum most likely to grow one: `TraceAssertion` carries `rename_all` *and* redundant
+    // per-variant renames, so a contributor who adds a variant and omits the redundant attribute
+    // drops out of the check silently. Confirmed by mutation, not reasoning.
     let explicit: BTreeSet<String> = body
         .match_indices("#[serde(rename = \"")
         .map(|(i, m)| {
@@ -57,26 +70,32 @@ fn serde_renames(source_rel: &str, enum_name: &str) -> BTreeSet<String> {
             rest[..rest.find('"').expect("unterminated serde rename")].to_string()
         })
         .collect();
-    if !explicit.is_empty() {
-        return explicit;
-    }
 
-    // No per-variant renames: derive from the variant identifiers under `rename_all`.
-    body.lines()
+    let derived: BTreeSet<String> = body
+        .lines()
         .filter_map(|l| {
             let t = l.trim();
             let ident: String = t
                 .chars()
                 .take_while(|c| c.is_ascii_alphanumeric())
                 .collect();
-            let looks_like_variant = !ident.is_empty()
-                && ident.starts_with(|c: char| c.is_ascii_uppercase())
-                && (t == ident
-                    || t.starts_with(&format!("{ident} {{"))
-                    || t == format!("{ident},"));
+            if ident.is_empty() || !ident.starts_with(|c: char| c.is_ascii_uppercase()) {
+                return None;
+            }
+            // Struct (`Foo {`), unit (`Foo` / `Foo,`), tuple (`Foo(`) and discriminant (`Foo =`).
+            // Tuple variants were missed by an earlier version: a `Teleport(String)` added to
+            // `SequenceRule` survived the entire suite.
+            let rest = t[ident.len()..].trim_start();
+            let looks_like_variant = rest.is_empty()
+                || rest.starts_with('{')
+                || rest.starts_with('(')
+                || rest.starts_with(',')
+                || rest.starts_with('=');
             looks_like_variant.then(|| snake_case(&ident))
         })
-        .collect()
+        .collect();
+
+    explicit.union(&derived).cloned().collect()
 }
 
 fn snake_case(ident: &str) -> String {
@@ -96,17 +115,25 @@ fn snake_case(ident: &str) -> String {
 
 /// The types a reference documents, taken from its headings at the given level.
 fn documented_types(doc_rel: &str, heading: &str) -> BTreeSet<String> {
-    read(doc_rel)
-        .lines()
+    documented_types_in(&read(doc_rel), heading)
+}
+
+/// The parsing half, separated so it can be tested against fixture text.
+fn documented_types_in(md: &str, heading: &str) -> BTreeSet<String> {
+    md.lines()
         .filter_map(|l| l.strip_prefix(heading))
         .filter_map(|rest| {
             let rest = rest.trim_start();
             let inner = rest.strip_prefix('`')?;
             let name = &inner[..inner.find('`')?];
             // Headings are `name` or `name` — Human Title; both carry the type in backticks.
-            name.chars()
-                .all(|c| c.is_ascii_lowercase() || c == '_')
-                .then(|| name.to_string())
+            // Digits allowed. Restricting to `[a-z_]` silently skipped any heading whose type
+            // carried one, making the phantom direction vacuous for it.
+            (!name.is_empty()
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'))
+            .then(|| name.to_string())
         })
         .collect()
 }
@@ -117,7 +144,10 @@ fn assert_parity(
     documented: &BTreeSet<String>,
     real: &BTreeSet<String>,
 ) {
+    // Both halves are computed before either is asserted, so a document broken in both
+    // directions still reports the undocumented one after the phantom assertion is fixed.
     let phantom: Vec<_> = documented.difference(real).cloned().collect();
+    let undocumented: Vec<_> = real.difference(documented).cloned().collect();
     assert!(
         phantom.is_empty(),
         "{doc_rel} documents {what} the parser rejects: {phantom:?}\n\
@@ -126,7 +156,6 @@ fn assert_parity(
          the variant."
     );
 
-    let undocumented: Vec<_> = real.difference(documented).cloned().collect();
     assert!(
         undocumented.is_empty(),
         "{doc_rel} has no section for {what} a user can write: {undocumented:?}\n\
@@ -137,9 +166,12 @@ fn assert_parity(
 #[test]
 fn sequence_rule_types_and_their_reference_agree() {
     let real = serde_renames("crates/assay-core/src/model/types.rs", "SequenceRule");
+    // Non-empty, not a pinned count. A pinned count fails on a legitimate variant removal with a
+    // message blaming the extractor, and aborts before reporting the stale section that removal
+    // actually leaves behind.
     assert!(
-        real.len() >= 8,
-        "expected the rename set to be populated, got {real:?}"
+        !real.is_empty(),
+        "extracted no variant names from SequenceRule, so every assertion below would be vacuous"
     );
     let documented = documented_types("docs/reference/config/sequences.md", "### ");
     assert_parity(
@@ -157,8 +189,8 @@ fn trace_assertion_types_and_their_reference_agree() {
         "TraceAssertion",
     );
     assert!(
-        real.len() >= 7,
-        "expected the rename set to be populated, got {real:?}"
+        !real.is_empty(),
+        "extracted no variant names from TraceAssertion, so every assertion below would be vacuous"
     );
     let documented = documented_types("docs/reference/config/eval-yaml.md", "#### ");
     assert_parity(
@@ -167,4 +199,91 @@ fn trace_assertion_types_and_their_reference_agree() {
         &documented,
         &real,
     );
+}
+
+#[cfg(test)]
+mod extractor {
+    use super::serde_renames_in;
+
+    /// A variant with no explicit rename, on an enum that has them elsewhere. This is the shape
+    /// that survived before: the extractor returned the explicit set whenever it was non-empty,
+    /// and `TraceAssertion` carries `rename_all` plus redundant per-variant renames, so the next
+    /// variant someone adds without the redundant attribute would have gone unchecked.
+    #[test]
+    fn a_variant_without_an_explicit_rename_is_still_found() {
+        let src = r#"
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Thing {
+    #[serde(rename = "already_named")]
+    AlreadyNamed { a: String },
+    NewCheck { thing: String },
+}
+"#;
+        let got = serde_renames_in(src, "Thing");
+        assert!(got.contains("already_named"), "got {got:?}");
+        assert!(
+            got.contains("new_check"),
+            "the unrenamed variant was dropped: {got:?}"
+        );
+    }
+
+    /// Tuple, unit and discriminant variants, none of which the first version recognised.
+    #[test]
+    fn every_variant_shape_is_found() {
+        let src = r#"
+#[serde(rename_all = "snake_case")]
+pub enum Thing {
+    Structy { a: String },
+    Tuply(String),
+    Unity,
+    Trailing,
+    Discriminated = 1,
+}
+"#;
+        let got = serde_renames_in(src, "Thing");
+        for want in ["structy", "tuply", "unity", "trailing", "discriminated"] {
+            assert!(got.contains(want), "{want} missing from {got:?}");
+        }
+    }
+
+    /// A heading whose type carries a digit. Filtering names to `[a-z_]` skipped these, which
+    /// made the phantom direction vacuous for any such name -- a `teleport2` section sat in the
+    /// document and no assertion saw it.
+    #[test]
+    fn a_documented_type_with_a_digit_is_read() {
+        let md = "### `sequence_v2` — Something\n### `plain` — Other\n";
+        let got = super::documented_types_in(md, "### ");
+        assert!(
+            got.contains("sequence_v2"),
+            "digit-bearing name dropped: {got:?}"
+        );
+        assert!(got.contains("plain"), "got {got:?}");
+    }
+
+    /// Headings that are prose, not types, must not be read as types.
+    #[test]
+    fn prose_headings_are_not_types() {
+        let md = "### 1. Start Simple\n### E-commerce: Payment Flow\n### `real_one`\n";
+        let got = super::documented_types_in(md, "### ");
+        assert_eq!(got.len(), 1, "got {got:?}");
+        assert!(got.contains("real_one"));
+    }
+
+    /// Doc comments, attributes and struct fields are not variants.
+    #[test]
+    fn non_variants_are_not_mistaken_for_variants() {
+        let src = r#"
+pub enum Thing {
+    /// Doc comment mentioning Something.
+    #[serde(default)]
+    Real { field_name: String, Another: u8 },
+}
+"#;
+        let got = serde_renames_in(src, "Thing");
+        assert!(got.contains("real"), "got {got:?}");
+        assert!(
+            !got.contains("doc"),
+            "doc comment read as a variant: {got:?}"
+        );
+    }
 }

--- a/crates/assay-core/tests/config_reference_parity.rs
+++ b/crates/assay-core/tests/config_reference_parity.rs
@@ -1,0 +1,170 @@
+//! The config reference and the enums it describes must name the same types.
+//!
+//! Both directions, and they are not one property. "Every variant has a section" is the assertion
+//! one naturally writes, and it passed on `sequences.md` for as long as that file existed while
+//! two sections described rule types the parser rejects — `immediately_before` and `allowlist`,
+//! neither ever present in the model, both introduced with `1822a7de4`. A phantom section is not
+//! a missing one, so only the converse catches it.
+//!
+//! The two failures also differ in cost. An undocumented variant is a discoverability gap: the
+//! code still tells the truth. A documented phantom is a falsehood in the one place a reader
+//! consults to resolve the confusion it causes.
+//!
+//! Ground truth is the serde rename, not a hand-kept list here, so a new variant is covered the
+//! moment it is added. `schemars` is already a dependency and deriving `JsonSchema` on these enums
+//! would let the check read a generated schema instead of parsing headings; that is a larger
+//! change and this file does not need it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+fn read(rel: &str) -> String {
+    let p = workspace_root().join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// The `type:` names the enum accepts.
+///
+/// Two spellings, because the two enums use different ones: `TraceAssertion` writes an explicit
+/// `#[serde(rename = "...")]` on each variant, `SequenceRule` relies on the container's
+/// `rename_all = "snake_case"`. Both are read out of the source rather than from a list here,
+/// because a list here would be a second place to forget, which is the defect under test.
+///
+/// An empty result is treated as a failure by the callers. A parser that silently matches nothing
+/// makes every parity assertion below vacuously true, which is the shape this whole file exists
+/// to refuse.
+fn serde_renames(source_rel: &str, enum_name: &str) -> BTreeSet<String> {
+    let src = read(source_rel);
+    let start = src
+        .find(&format!("pub enum {enum_name}"))
+        .unwrap_or_else(|| panic!("{enum_name} not found in {source_rel}"));
+    // The enum body ends at the first line that closes it at column 0.
+    let body = &src[start..];
+    let end = body.find("\n}").expect("enum body is unterminated");
+    let body = &body[..end];
+
+    let explicit: BTreeSet<String> = body
+        .match_indices("#[serde(rename = \"")
+        .map(|(i, m)| {
+            let rest = &body[i + m.len()..];
+            rest[..rest.find('"').expect("unterminated serde rename")].to_string()
+        })
+        .collect();
+    if !explicit.is_empty() {
+        return explicit;
+    }
+
+    // No per-variant renames: derive from the variant identifiers under `rename_all`.
+    body.lines()
+        .filter_map(|l| {
+            let t = l.trim();
+            let ident: String = t
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric())
+                .collect();
+            let looks_like_variant = !ident.is_empty()
+                && ident.starts_with(|c: char| c.is_ascii_uppercase())
+                && (t == ident
+                    || t.starts_with(&format!("{ident} {{"))
+                    || t == format!("{ident},"));
+            looks_like_variant.then(|| snake_case(&ident))
+        })
+        .collect()
+}
+
+fn snake_case(ident: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in ident.chars().enumerate() {
+        if c.is_ascii_uppercase() {
+            if i != 0 {
+                out.push('_');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// The types a reference documents, taken from its headings at the given level.
+fn documented_types(doc_rel: &str, heading: &str) -> BTreeSet<String> {
+    read(doc_rel)
+        .lines()
+        .filter_map(|l| l.strip_prefix(heading))
+        .filter_map(|rest| {
+            let rest = rest.trim_start();
+            let inner = rest.strip_prefix('`')?;
+            let name = &inner[..inner.find('`')?];
+            // Headings are `name` or `name` — Human Title; both carry the type in backticks.
+            name.chars()
+                .all(|c| c.is_ascii_lowercase() || c == '_')
+                .then(|| name.to_string())
+        })
+        .collect()
+}
+
+fn assert_parity(
+    what: &str,
+    doc_rel: &str,
+    documented: &BTreeSet<String>,
+    real: &BTreeSet<String>,
+) {
+    let phantom: Vec<_> = documented.difference(real).cloned().collect();
+    assert!(
+        phantom.is_empty(),
+        "{doc_rel} documents {what} the parser rejects: {phantom:?}\n\
+         A reader who follows the reference writes one of these and gets a parse error, with the \
+         reference being the thing they would consult to find out why. Remove the section, or add \
+         the variant."
+    );
+
+    let undocumented: Vec<_> = real.difference(documented).cloned().collect();
+    assert!(
+        undocumented.is_empty(),
+        "{doc_rel} has no section for {what} a user can write: {undocumented:?}\n\
+         Each of these carries a serde rename on a tagged enum, so it parses today."
+    );
+}
+
+#[test]
+fn sequence_rule_types_and_their_reference_agree() {
+    let real = serde_renames("crates/assay-core/src/model/types.rs", "SequenceRule");
+    assert!(
+        real.len() >= 8,
+        "expected the rename set to be populated, got {real:?}"
+    );
+    let documented = documented_types("docs/reference/config/sequences.md", "### ");
+    assert_parity(
+        "sequence rule types",
+        "docs/reference/config/sequences.md",
+        &documented,
+        &real,
+    );
+}
+
+#[test]
+fn trace_assertion_types_and_their_reference_agree() {
+    let real = serde_renames(
+        "crates/assay-core/src/agent_assertions/model.rs",
+        "TraceAssertion",
+    );
+    assert!(
+        real.len() >= 7,
+        "expected the rename set to be populated, got {real:?}"
+    );
+    let documented = documented_types("docs/reference/config/eval-yaml.md", "#### ");
+    assert_parity(
+        "assertion types",
+        "docs/reference/config/eval-yaml.md",
+        &documented,
+        &real,
+    );
+}

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -254,18 +254,19 @@ tests:
       - admin_override
 ```
 
-### Glob Patterns
+### Exact Names
 
-Use wildcards to match multiple tools:
+`tool_blocklist` compares each call against the list by exact name. Wildcards are not
+interpreted -- `admin_*` matches only a tool literally called `admin_*`.
 
 ```yaml
 tests:
   - id: no_admin_tools
     metric: tool_blocklist
     blocklist:
-      - admin_*        # Matches admin_delete, admin_create, etc.
-      - *_dangerous    # Matches delete_dangerous, run_dangerous
-      - debug_*        # Matches debug_mode, debug_dump
+      - admin_delete
+      - admin_create
+      - run_dangerous
 ```
 
 ### Example

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -184,8 +184,6 @@ tests:
 | `require` | Tool must be called at least once |
 | `before` | Tool A must precede Tool B |
 | `blocklist` | These tools must never be called |
-| `allowlist` | Only these tools are allowed |
-| `count` | Limit how many times a tool can be called |
 
 ### Example
 
@@ -233,7 +231,7 @@ tests:
         then: [read_data, write_data, delete_data]
       - type: blocklist
         tools: [admin_*, debug_*]
-      - type: count
+      - type: max_calls
         tool: api_call
         max: 10
 ```

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -228,9 +228,9 @@ tests:
         tool: authenticate
       - type: before
         first: authenticate
-        then: [read_data, write_data, delete_data]
+        then: read_data
       - type: blocklist
-        tools: [admin_*, debug_*]
+        pattern: admin_
       - type: max_calls
         tool: api_call
         max: 10
@@ -317,7 +317,7 @@ tests:
         tool: authenticate_user
       - type: before
         first: authenticate_user
-        then: [get_customer, update_customer]
+        then: get_customer
 
   # Block dangerous operations
   - id: no_destructive

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -183,7 +183,6 @@ tests:
 |------|-------------|
 | `require` | Tool must be called at least once |
 | `before` | Tool A must precede Tool B |
-| `immediately_before` | Tool A must directly precede Tool B |
 | `blocklist` | These tools must never be called |
 | `allowlist` | Only these tools are allowed |
 | `count` | Limit how many times a tool can be called |

--- a/docs/metrics/sequence-valid.md
+++ b/docs/metrics/sequence-valid.md
@@ -35,7 +35,6 @@ The `sequence_valid` metric checks that tools are called in the correct order. I
 |------|-------------|
 | `require` | Tool must be called at least once |
 | `before` | Tool A must precede Tool B |
-| `immediately_before` | Tool A must directly precede Tool B |
 | `blocklist` | These tools must never be called |
 | `allowlist` | Only these tools are allowed |
 | `count` | Limit call frequency |
@@ -61,34 +60,12 @@ rules:
     then: update_customer
 ```
 
-### Immediately Before
-
-```yaml
-rules:
-  - type: immediately_before
-    first: validate_input
-    then: execute_action
-```
-
 ### Blocklist
 
 ```yaml
 rules:
   - type: blocklist
-    tools:
-      - admin_delete
-      - system_reset
-```
-
-### Allowlist
-
-```yaml
-rules:
-  - type: allowlist
-    tools:
-      - get_customer
-      - update_customer
-      - send_email
+    pattern: admin_
 ```
 
 ### Count

--- a/docs/metrics/sequence-valid.md
+++ b/docs/metrics/sequence-valid.md
@@ -36,8 +36,6 @@ The `sequence_valid` metric checks that tools are called in the correct order. I
 | `require` | Tool must be called at least once |
 | `before` | Tool A must precede Tool B |
 | `blocklist` | These tools must never be called |
-| `allowlist` | Only these tools are allowed |
-| `count` | Limit call frequency |
 
 ---
 
@@ -72,7 +70,7 @@ rules:
 
 ```yaml
 rules:
-  - type: count
+  - type: max_calls
     tool: send_email
     max: 3
 ```
@@ -102,7 +100,7 @@ tests:
         tools: [admin_*, system_*]
 
       # Max 5 API calls
-      - type: count
+      - type: max_calls
         tool: external_api
         max: 5
 ```

--- a/docs/metrics/sequence-valid.md
+++ b/docs/metrics/sequence-valid.md
@@ -66,7 +66,7 @@ rules:
     pattern: admin_
 ```
 
-### Count
+### Max Calls
 
 ```yaml
 rules:
@@ -162,14 +162,15 @@ tests:
 
 ---
 
-## Glob Patterns
+## Substring Matching
 
-Blocklist and allowlist support globs:
+`blocklist` matches by plain substring, not by glob. A `*` is matched literally and will
+usually match nothing:
 
 ```yaml
 rules:
   - type: blocklist
-    pattern: debug_*       # debug_mode, debug_dump
+    pattern: debug_        # matches debug_mode, debug_dump
 ```
 
 ---

--- a/docs/metrics/sequence-valid.md
+++ b/docs/metrics/sequence-valid.md
@@ -93,11 +93,11 @@ tests:
       # Auth before data access
       - type: before
         first: authenticate
-        then: [get_data, update_data, delete_data]
+        then: get_data
 
       # No admin tools
       - type: blocklist
-        tools: [admin_*, system_*]
+        pattern: admin_
 
       # Max 5 API calls
       - type: max_calls
@@ -169,10 +169,7 @@ Blocklist and allowlist support globs:
 ```yaml
 rules:
   - type: blocklist
-    tools:
-      - admin_*       # admin_delete, admin_create, etc.
-      - *_dangerous   # delete_dangerous, run_dangerous
-      - debug_*       # debug_mode, debug_dump
+    pattern: debug_*       # debug_mode, debug_dump
 ```
 
 ---

--- a/docs/reference/cli/migrate.md
+++ b/docs/reference/cli/migrate.md
@@ -95,16 +95,20 @@ suite: my-agent
 
 ### Sequence Rules
 
+Before (v0):
+
 ```yaml
-# Before (v0)
 tests:
   - id: order_check
     metric: sequence_valid
     sequences:
       - [get_customer, update_customer]
       - [verify_identity, delete_customer]
+```
 
-# After (v1)
+After (v1):
+
+```yaml
 tests:
   - id: order_check
     metric: sequence_valid

--- a/docs/reference/config/eval-yaml.md
+++ b/docs/reference/config/eval-yaml.md
@@ -139,8 +139,9 @@ Limits the number of steps in the trace.
 ```
 
 #### `args_valid`
-Checks a tool's arguments against a policy. Distinct from the `args_valid` **metric** under
-`expected:` — this one asserts over the trace, that one over the response.
+Checks arguments against a policy. Note what this does **not** do: it evaluates the `test_args`
+you supply here, not the recorded trace. The evaluator calls this unit-test mode and hands it an
+empty episode. To assert over a real trace, use the `args_valid` metric under `expected:`.
 ```yaml
 - type: args_valid
   tool: "transfer_funds"
@@ -150,8 +151,10 @@ Checks a tool's arguments against a policy. Distinct from the `args_valid` **met
 ```
 
 #### `sequence_valid`
-Checks a tool-call ordering against a sequence policy. Distinct from the `sequence_valid`
-**metric** under `expected:`, which is documented above.
+Checks a supplied tool-call ordering against a sequence policy. Like `args_valid` above it reads
+`test_trace_raw`, not the recorded trace. `policy` must carry a non-empty `regex`, or the
+assertion cannot fail and is refused. A `test_trace` field also exists and is **not** evaluated;
+use `test_trace_raw`.
 ```yaml
 - type: sequence_valid
   test_trace_raw:              # optional
@@ -162,7 +165,8 @@ Checks a tool-call ordering against a sequence policy. Distinct from the `sequen
 ```
 
 #### `tool_blocklist`
-Checks tool calls against a blocklist policy.
+Checks the supplied `test_tool_calls` against a blocklist policy, not the recorded trace.
+`policy` must carry a `blocked` array of strings, or the assertion cannot fail and is refused.
 ```yaml
 - type: tool_blocklist
   test_tool_calls: ["delete_all"]   # optional

--- a/docs/reference/config/eval-yaml.md
+++ b/docs/reference/config/eval-yaml.md
@@ -137,3 +137,39 @@ Limits the number of steps in the trace.
 - type: trace_max_steps
   max: 8
 ```
+
+#### `args_valid`
+Checks a tool's arguments against a policy. Distinct from the `args_valid` **metric** under
+`expected:` — this one asserts over the trace, that one over the response.
+```yaml
+- type: args_valid
+  tool: "transfer_funds"
+  test_args: { amount: 100 }   # optional
+  policy: { ... }              # optional
+  expect: "pass"               # optional
+```
+
+#### `sequence_valid`
+Checks a tool-call ordering against a sequence policy. Distinct from the `sequence_valid`
+**metric** under `expected:`, which is documented above.
+```yaml
+- type: sequence_valid
+  test_trace_raw:              # optional
+    - tool: "Authenticate"
+      args: {}
+  policy: { ... }              # optional
+  expect: "pass"               # optional
+```
+
+#### `tool_blocklist`
+Checks tool calls against a blocklist policy.
+```yaml
+- type: tool_blocklist
+  test_tool_calls: ["delete_all"]   # optional
+  policy: { ... }                   # optional
+  expect: "pass"                    # optional
+```
+
+> Every field above marked optional is optional to the parser, not to the check. An assertion
+> whose fields leave it unable to fail is refused by `assay validate`, and by `assay run
+> --deny-ineffective-assertions` at load. See #1949.

--- a/docs/reference/config/sequences.md
+++ b/docs/reference/config/sequences.md
@@ -73,23 +73,6 @@ rules:
 
 ---
 
-### `immediately_before` — Strict Adjacency
-
-Tool A must be called *immediately* before Tool B (no other calls in between).
-
-```yaml
-rules:
-  - type: immediately_before
-    first: ValidateInput
-    then: ExecuteAction
-```
-
-| Trace | Result |
-|-------|--------|
-| `[ValidateInput, ExecuteAction]` | ✅ Pass |
-| `[ValidateInput, LogEvent, ExecuteAction]` | ❌ Fail |
-
----
 
 ### `blocklist` — Forbidden Tools
 
@@ -122,25 +105,6 @@ rules:
 
 ---
 
-### `allowlist` — Only These Tools
-
-Only the specified tools are allowed. Everything else fails.
-
-```yaml
-rules:
-  - type: allowlist
-    tools:
-      - GetCustomer
-      - UpdateCustomer
-      - SendEmail
-```
-
-| Trace | Result |
-|-------|--------|
-| `[GetCustomer, UpdateCustomer]` | ✅ Pass |
-| `[GetCustomer, DeleteCustomer]` | ❌ Fail (DeleteCustomer not in allowlist) |
-
----
 
 ### `max_calls` — Call Frequency Limit
 
@@ -212,6 +176,32 @@ rules:
 |-------|--------|
 | `[OpenFile, Read, CloseFile]` | ✅ Pass |
 | `[OpenFile, ..., (10 steps), ...]` | ❌ Fail |
+
+---
+
+### `sequence` — Exact Ordering
+
+The named tools must appear in the given order. With `strict: false` (the default) other
+tools may appear between them; with `strict: true` they must be consecutive.
+
+```yaml
+rules:
+  - type: sequence
+    tools:
+      - Authenticate
+      - LoadRecord
+      - WriteRecord
+    strict: false   # optional
+```
+
+| Trace | `strict: false` | `strict: true` |
+|-------|-----------------|----------------|
+| `[Authenticate, LoadRecord, WriteRecord]` | ✅ Pass | ✅ Pass |
+| `[Authenticate, Audit, LoadRecord, WriteRecord]` | ✅ Pass | ❌ Fail |
+| `[LoadRecord, Authenticate, WriteRecord]` | ❌ Fail | ❌ Fail |
+
+A trace that never calls any named tool does not exercise this rule; a trace that starts the
+sequence and ends part-way through fails it, because the ordering it asserts was not completed.
 
 ---
 

--- a/docs/reference/config/sequences.md
+++ b/docs/reference/config/sequences.md
@@ -89,7 +89,8 @@ rules:
 | `[GetCustomer, UpdateCustomer]` | ✅ Pass |
 | `[GetCustomer, admin_delete]` | ❌ Fail |
 
-**Glob patterns** are supported:
+Matching is by plain substring, so a prefix blocks every tool that starts with it. A `*` is
+matched literally, not as a wildcard:
 
 ```yaml
 rules:

--- a/docs/reference/config/sequences.md
+++ b/docs/reference/config/sequences.md
@@ -219,7 +219,7 @@ tests:
 
       # Never call admin tools
       - type: blocklist
-        tools: [admin_*]
+        pattern: admin_
 
       # Max 5 API calls
       - type: max_calls

--- a/docs/reference/config/sequences.md
+++ b/docs/reference/config/sequences.md
@@ -222,7 +222,7 @@ tests:
         tools: [admin_*]
 
       # Max 5 API calls
-      - type: count
+      - type: max_calls
         tool: ExternalAPI
         max: 5
 ```
@@ -267,7 +267,7 @@ rules:
     then: ProcessPayment
 
   # Never refund more than once
-  - type: count
+  - type: max_calls
     tool: ProcessRefund
     max: 1
 ```
@@ -306,10 +306,10 @@ rules:
     then: SpecialistA
 
   # Only one specialist per request
-  - type: count
+  - type: max_calls
     tool: SpecialistA
     max: 1
-  - type: count
+  - type: max_calls
     tool: SpecialistB
     max: 1
 ```

--- a/docs/reference/config/sequences.md
+++ b/docs/reference/config/sequences.md
@@ -81,10 +81,7 @@ These tools must never be called.
 ```yaml
 rules:
   - type: blocklist
-    tools:
-      - admin_delete
-      - system_reset
-      - drop_database
+    pattern: admin_delete
 ```
 
 | Trace | Result |
@@ -97,10 +94,7 @@ rules:
 ```yaml
 rules:
   - type: blocklist
-    tools:
-      - admin_*
-      - system_*
-      - *_dangerous
+    pattern: admin_
 ```
 
 ---
@@ -292,13 +286,14 @@ rules:
     then: GetPatientRecord
 
   # Log all access
-  - type: immediately_before
-    first: GetPatientRecord
+  - type: after
+    trigger: GetPatientRecord
     then: LogAccess
+    within: 1
 
   # No admin tools
   - type: blocklist
-    tools: [admin_*, system_override]
+    pattern: admin_
 ```
 
 ### Agent Handoffs: Multi-Agent
@@ -308,7 +303,7 @@ rules:
   # Router must run first
   - type: before
     first: RouterAgent
-    then: [SpecialistA, SpecialistB, SpecialistC]
+    then: SpecialistA
 
   # Only one specialist per request
   - type: count
@@ -373,7 +368,7 @@ Begin with `blocklist` and `require`, then add `before` rules.
 ```yaml
 rules:
   - type: blocklist
-    tools: [admin_*, dangerous_*]
+    pattern: admin_
   - type: require
     tool: Authenticate
 ```
@@ -402,9 +397,7 @@ Create traces that *should* fail to verify your rules catch violations.
 |-----------|-----------------|-----------------|
 | `require` | `tool` | — |
 | `before` | `first`, `then` | — |
-| `immediately_before` | `first`, `then` | — |
 | `blocklist` | `pattern` | — |
-| `allowlist` | `tools` | — |
 | `max_calls` | `tool`, `max` | — |
 | `eventually` | `tool`, `within` | — |
 | `never_after` | `trigger`, `forbidden` | — |

--- a/docs/use-cases/ci-gate.md
+++ b/docs/use-cases/ci-gate.md
@@ -100,7 +100,7 @@ tests:
         tool: authenticate
       - type: before
         first: authenticate
-        then: [get_data, update_data]
+        then: get_data
 
   # Block dangerous tools
   - id: safety


### PR DESCRIPTION
Closes #2115. Also closes the last open item of #1949.

## What was wrong

`docs/reference/config/sequences.md` carried full `###` sections — YAML examples, pass/fail tables — for two rule types the parser rejects:

| documented | parser |
|---|---|
| `immediately_before` (`:76`) | **REJECTED** |
| `allowlist` (`:125`) | **REJECTED** |
| `sequence` (real variant, no section, one table row) | parses |

`git log -S ImmediatelyBefore` and `-S Allowlist` against `crates/assay-core/src/model/types.rs` return **nothing at any commit**. These arrived with `1822a7de4` and have described features that were never built. Not documentation that went stale — documentation that was never true.

`eval-yaml.md` had the one-directional version: four of seven `TraceAssertion` variants documented. `args_valid`, `sequence_valid` and `tool_blocklist` each carry a serde rename on a `#[serde(tag = "type")]` enum, so they were writable and undocumented.

## Why the two directions are not one property

An undocumented variant is a discoverability gap — the code still tells the truth. A documented phantom is a falsehood in the one place a reader consults to resolve the confusion it caused.

This matters for the test as much as the fix. **"Every variant has a section" is the assertion one naturally writes, and it would have passed on `sequences.md` the entire time both phantoms sat in it**, because a phantom section is not a missing one. Only the converse catches it, and that's the direction that feels redundant until it fires.

## The change

- Removed both phantom sections.
- Documented `sequence`, including that a part-completed sequence fails rather than holds — the case the rule is usually written for.
- Documented the three assertion variants, each noting where it differs from the same-named *metric* under `expected:` (a distinction #1949 already records for `ArgsValid`).
- Added `crates/assay-core/tests/config_reference_parity.rs`, asserting both directions over both documents.

Ground truth is the serde spelling read out of the source, not a list in the test — a list there would be a second place to forget, which is the defect under test. The two enums spell it differently (`TraceAssertion` uses explicit per-variant renames, `SequenceRule` relies on the container's `rename_all`), so the extractor handles both and **treats an empty result as a failure**. That guard earned itself immediately: my first version returned `{}` for `SequenceRule` and every assertion would have been vacuously true.

## Verification

| bite | result |
|---|---|
| rename a section to a type that doesn't exist | `documents sequence rule types the parser rejects: ["teleport"]` |
| delete a section for a real variant | `no section for assertion types a user can write: ["tool_blocklist"]` |

Both directions proven separately, because a single bite that does both would not show which assertion fired. Clippy `-D warnings` clean, fmt clean.

## Not in scope

`schemars = "1.2.1"` is already a dependency of `assay-core` and deriving `JsonSchema` on these enums would let the check read a generated schema instead of parsing headings. That is a larger change and this doesn't need it. Whether `immediately_before` and `allowlist` *should* exist as rules is a separate question — nothing in the model or its history suggests they were ever intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)