### PR TITLE
The wildcard reference was right, and two matchers disagree about a dot

### DIFF
--- a/crates/assay-core/src/mcp/policy/matcher.rs
+++ b/crates/assay-core/src/mcp/policy/matcher.rs
@@ -27,3 +27,143 @@ pub(in crate::mcp::policy) fn matches_tool_pattern(tool_name: &str, pattern: &st
         (false, false) => tool_name == pattern,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::matches_tool_pattern;
+    use crate::runtime::authorizer::authorizer_internal::policy::glob_matches_impl;
+
+    /// The five behaviours `docs/reference/config/policies.md` promises, pinned so the doc and the
+    /// matcher cannot drift apart silently. The reference has been accurate since it was written;
+    /// nothing was checking that it stayed so.
+    #[test]
+    fn the_documented_wildcard_forms_behave_as_documented() {
+        assert!(
+            matches_tool_pattern("anything_at_all", "*"),
+            "`*` matches all tools"
+        );
+        assert!(matches_tool_pattern("read_file", "read_*"), "prefix");
+        // Anchored, and the negative case has to contain the prefix somewhere other than the
+        // start or it proves nothing: `write_file` does not contain `read_` at all, so asserting
+        // on it holds even if prefix matching degraded to substring. Found by biting this test.
+        assert!(
+            !matches_tool_pattern("my_read_file", "read_*"),
+            "prefix is anchored at the start, not merely present"
+        );
+        assert!(matches_tool_pattern("read_file", "*_file"), "suffix");
+        assert!(
+            !matches_tool_pattern("_file_reader", "*_file"),
+            "suffix is anchored at the end, not merely present"
+        );
+        assert!(
+            matches_tool_pattern("web_search_api", "*search*"),
+            "substring"
+        );
+        assert!(
+            !matches_tool_pattern("web_fetch", "*search*"),
+            "substring is real"
+        );
+        assert!(matches_tool_pattern("exec", "exec"), "no star is exact");
+        assert!(
+            !matches_tool_pattern("exec_shell", "exec"),
+            "no star is not a prefix"
+        );
+    }
+
+    /// A `*` anywhere but the first or last position is a literal character, and the doc did not
+    /// say so. `read_*_file` does not match `read_config_file`; it matches only a tool literally
+    /// named `read_*_file`, because the pattern falls through to the exact-match arm with the
+    /// asterisk still in it.
+    ///
+    /// The consequence runs the dangerous way. In `allow`, such a pattern matches nothing and the
+    /// tool is refused -- fail-closed, visible. In `deny`, it matches nothing and the tool is
+    /// **permitted**, silently, by a line whose author believed it was blocking something.
+    #[test]
+    fn a_star_in_the_middle_is_a_literal_not_a_wildcard() {
+        assert!(
+            !matches_tool_pattern("read_config_file", "read_*_file"),
+            "a middle star does not expand"
+        );
+        assert!(
+            matches_tool_pattern("read_*_file", "read_*_file"),
+            "it is matched literally, asterisk included"
+        );
+        assert!(
+            !matches_tool_pattern("abc", "a*b*c"),
+            "multiple interior stars are literal too"
+        );
+    }
+
+    /// Only-stars and the empty pattern, so the corners are stated rather than discovered.
+    #[test]
+    fn degenerate_patterns_have_stated_answers() {
+        assert!(
+            matches_tool_pattern("anything", "**"),
+            "leading+trailing star is the substring form with an empty inner"
+        );
+        assert!(
+            matches_tool_pattern("anything", "***"),
+            "same, whatever the count"
+        );
+        assert!(
+            !matches_tool_pattern("anything", ""),
+            "an empty pattern matches nothing"
+        );
+        assert!(
+            matches_tool_pattern("", "*"),
+            "`*` matches the empty tool name too"
+        );
+    }
+
+    /// Two matchers, one character, two meanings — and the difference is deliberate.
+    ///
+    /// `matches_tool_pattern` serves the MCP policy's `tools.allow` / `tools.deny`, where a name is
+    /// flat and `*` is unbounded. `glob_matches_impl` serves mandate `tool_patterns`, where names
+    /// are hierarchical and `*` stops at a `.` while `**` crosses it, the way a filesystem glob
+    /// treats `/`.
+    ///
+    /// Pinned because an undocumented segment rule is the defect itself, whichever way it goes:
+    /// AWS documented that a wildcard could not span ARN segments while the implementation spanned
+    /// them, it was reported as a security concern, and the issue was archived unresolved
+    /// (`awsdocs/iam-user-guide#175`). Two matchers that differ by accident converge by accident.
+    /// This test makes the difference a decision.
+    #[test]
+    fn the_two_tool_pattern_languages_differ_deliberately_at_a_dot() {
+        // Flat name: the two agree.
+        assert!(matches_tool_pattern("read_file", "read_*"));
+        assert!(glob_matches_impl("read_*", "read_file"));
+
+        // Hierarchical name: they do not, and this is the whole difference.
+        assert!(
+            matches_tool_pattern("fs.read_file", "*"),
+            "the policy matcher's `*` is unbounded"
+        );
+        assert!(
+            !glob_matches_impl("*", "fs.read_file"),
+            "the mandate matcher's `*` stops at a dot; `**` is the crossing form"
+        );
+        assert!(
+            glob_matches_impl("**", "fs.read_file"),
+            "`**` crosses, which is why it exists"
+        );
+
+        // `**` means nothing special to the policy matcher: leading and trailing star is the
+        // substring form, so it matches for a different reason than a reader might assume.
+        assert!(matches_tool_pattern("fs.read_file", "**"));
+    }
+
+    /// An unbounded `*` over-blocks in `deny` and over-permits in `allow`. Only the second is
+    /// dangerous, and the asymmetry is invisible in a policy file, which is why the reference
+    /// states it. Azure RBAC measured the cost of the permissive direction: roughly 39% of actions
+    /// reach across Resource Providers under non-obvious wildcards (arXiv 2506.10755), and its
+    /// recommendation is explicit enumeration rather than a cleverer pattern language.
+    #[test]
+    fn a_star_in_allow_admits_every_tool_including_ones_not_yet_written() {
+        for tool in ["read_file", "exec", "shell", "a.tool.added.next.week"] {
+            assert!(
+                matches_tool_pattern(tool, "*"),
+                "`allow: ['*']` admits {tool}"
+            );
+        }
+    }
+}

--- a/crates/assay-core/src/mcp/policy/matcher.rs
+++ b/crates/assay-core/src/mcp/policy/matcher.rs
@@ -1,7 +1,4 @@
 pub(in crate::mcp::policy) fn matches_tool_pattern(tool_name: &str, pattern: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
     if !pattern.contains('*') {
         return tool_name == pattern;
     }
@@ -31,11 +28,10 @@ pub(in crate::mcp::policy) fn matches_tool_pattern(tool_name: &str, pattern: &st
 #[cfg(test)]
 mod tests {
     use super::matches_tool_pattern;
-    use crate::runtime::authorizer::authorizer_internal::policy::glob_matches_impl;
+    use crate::runtime::glob_matches_impl;
 
     /// The five behaviours `docs/reference/config/policies.md` promises, pinned so the doc and the
-    /// matcher cannot drift apart silently. The reference has been accurate since it was written;
-    /// nothing was checking that it stayed so.
+    /// matcher cannot drift apart silently. Nothing was checking that they agreed.
     #[test]
     fn the_documented_wildcard_forms_behave_as_documented() {
         assert!(
@@ -70,7 +66,7 @@ mod tests {
         );
     }
 
-    /// A `*` anywhere but the first or last position is a literal character, and the doc did not
+    /// A `*` that is neither the first nor the last character is a literal, and the doc did not
     /// say so. `read_*_file` does not match `read_config_file`; it matches only a tool literally
     /// named `read_*_file`, because the pattern falls through to the exact-match arm with the
     /// asterisk still in it.
@@ -78,6 +74,10 @@ mod tests {
     /// The consequence runs the dangerous way. In `allow`, such a pattern matches nothing and the
     /// tool is refused -- fail-closed, visible. In `deny`, it matches nothing and the tool is
     /// **permitted**, silently, by a line whose author believed it was blocking something.
+    ///
+    /// It is not only the exact-match arm. A pattern that is a wildcard at both ends carries its
+    /// interior stars into the substring it searches for, so `*a*b*` looks for the three
+    /// characters `a*b` and finds them only in a tool name that really contains an asterisk.
     #[test]
     fn a_star_in_the_middle_is_a_literal_not_a_wildcard() {
         assert!(
@@ -92,9 +92,23 @@ mod tests {
             !matches_tool_pattern("abc", "a*b*c"),
             "multiple interior stars are literal too"
         );
+        assert!(
+            !matches_tool_pattern("axbc", "*a*b*"),
+            "an interior star inside the substring form is literal as well"
+        );
+        assert!(
+            matches_tool_pattern("a*b", "*a*b*"),
+            "which is to say the substring searched for is `a*b`, asterisk and all"
+        );
     }
 
     /// Only-stars and the empty pattern, so the corners are stated rather than discovered.
+    ///
+    /// The first version of this test asserted `!matches_tool_pattern("anything", "")` under the
+    /// message "an empty pattern matches nothing". The assertion held and the message was false:
+    /// an empty pattern has no star, so it takes the exact-match arm and matches the empty tool
+    /// name. A corner stated wrongly is worse than a corner left undocumented, and this test
+    /// exists to state corners.
     #[test]
     fn degenerate_patterns_have_stated_answers() {
         assert!(
@@ -107,7 +121,11 @@ mod tests {
         );
         assert!(
             !matches_tool_pattern("anything", ""),
-            "an empty pattern matches nothing"
+            "an empty pattern is an exact match against the empty name, so it matches no real tool"
+        );
+        assert!(
+            matches_tool_pattern("", ""),
+            "and it does match the empty name, which is what makes it exact rather than inert"
         );
         assert!(
             matches_tool_pattern("", "*"),
@@ -115,25 +133,34 @@ mod tests {
         );
     }
 
-    /// Two matchers, one character, two meanings — and the difference is deliberate.
+    /// Two matchers, one character, several meanings — and the differences are deliberate.
     ///
     /// `matches_tool_pattern` serves the MCP policy's `tools.allow` / `tools.deny`, where a name is
     /// flat and `*` is unbounded. `glob_matches_impl` serves mandate `tool_patterns`, where names
     /// are hierarchical and `*` stops at a `.` while `**` crosses it, the way a filesystem glob
     /// treats `/`.
     ///
-    /// Pinned because an undocumented segment rule is the defect itself, whichever way it goes:
-    /// AWS documented that a wildcard could not span ARN segments while the implementation spanned
-    /// them, it was reported as a security concern, and the issue was archived unresolved
-    /// (`awsdocs/iam-user-guide#175`). Two matchers that differ by accident converge by accident.
-    /// This test makes the difference a decision.
+    /// Neither is uniformly stricter, which is the part worth pinning. At a dot the mandate
+    /// matcher refuses what the policy matcher admits; at an interior star or a backslash escape
+    /// it admits what the policy matcher refuses, because the policy matcher has no such syntax.
+    ///
+    /// Pinned because an unstated segment rule is the defect itself, whichever way it goes. AWS's
+    /// resource-ARN reference says a wildcard "cannot span segments", meaning the colon-delimited
+    /// parts of an ARN. A reader took `segment` in its other common sense — the slash-delimited
+    /// parts of a path — checked `arn:aws:s3:::my-bucket/foo/*/bar` in the policy simulator, found
+    /// it spanning slashes, and filed it as a security concern with a worked misconfiguration
+    /// (`awsdocs/iam-user-guide#175`, 2020). The documentation was correct; he withdrew the same
+    /// day. What survives the correction is the hazard: the rule was stated in a vocabulary the
+    /// reader did not share, so he inferred one and reasoned about the breadth of real policies
+    /// from it. Two matchers that differ by accident converge by accident. This test makes the
+    /// difference a decision.
     #[test]
-    fn the_two_tool_pattern_languages_differ_deliberately_at_a_dot() {
-        // Flat name: the two agree.
+    fn the_two_tool_pattern_languages_differ_deliberately() {
+        // Flat name, no interior syntax: the two agree.
         assert!(matches_tool_pattern("read_file", "read_*"));
         assert!(glob_matches_impl("read_*", "read_file"));
 
-        // Hierarchical name: they do not, and this is the whole difference.
+        // A dot: the mandate matcher is the stricter one.
         assert!(
             matches_tool_pattern("fs.read_file", "*"),
             "the policy matcher's `*` is unbounded"
@@ -147,6 +174,29 @@ mod tests {
             "`**` crosses, which is why it exists"
         );
 
+        // An interior star: the mandate matcher is the more permissive one. Stated in this
+        // direction because "they disagree about `.`" was the whole claim before, and it is only
+        // half of the disagreement -- the half where the policy matcher is safe by accident.
+        assert!(
+            glob_matches_impl("read_*_file", "read_config_file"),
+            "the mandate matcher expands an interior star"
+        );
+        assert!(
+            !matches_tool_pattern("read_config_file", "read_*_file"),
+            "the policy matcher reads it as a literal asterisk"
+        );
+
+        // An escape: the mandate matcher has one and the policy matcher has no notion of it, so
+        // `\` is just a character to match.
+        assert!(
+            glob_matches_impl(r"file\*name", "file*name"),
+            r"`\*` is a literal asterisk to the mandate matcher"
+        );
+        assert!(
+            !matches_tool_pattern("file*name", r"file\*name"),
+            "to the policy matcher the backslash is part of the name it is looking for"
+        );
+
         // `**` means nothing special to the policy matcher: leading and trailing star is the
         // substring form, so it matches for a different reason than a reader might assume.
         assert!(matches_tool_pattern("fs.read_file", "**"));
@@ -154,9 +204,15 @@ mod tests {
 
     /// An unbounded `*` over-blocks in `deny` and over-permits in `allow`. Only the second is
     /// dangerous, and the asymmetry is invisible in a policy file, which is why the reference
-    /// states it. Azure RBAC measured the cost of the permissive direction: roughly 39% of actions
-    /// reach across Resource Providers under non-obvious wildcards (arXiv 2506.10755), and its
-    /// recommendation is explicit enumeration rather than a cleverer pattern language.
+    /// states it. Azure RBAC measured the cost of the permissive direction: about half of the
+    /// 15,481 catalogued actions reach across Resource Providers under non-obvious wildcards
+    /// (arXiv 2506.10755v3), and the recommendation is explicit enumeration rather than a
+    /// cleverer pattern language.
+    ///
+    /// Note what this test cannot show. `*` reaches the same answer through the empty-inner
+    /// substring arm, so no branch is uniquely its own -- an earlier version of this file carried
+    /// a `pattern == "*"` guard clause above the match, and deleting it changed nothing. A test
+    /// named for a pattern is not a test of a branch.
     #[test]
     fn a_star_in_allow_admits_every_tool_including_ones_not_yet_written() {
         for tool in ["read_file", "exec", "shell", "a.tool.added.next.week"] {

--- a/crates/assay-core/src/runtime/authorizer.rs
+++ b/crates/assay-core/src/runtime/authorizer.rs
@@ -14,7 +14,11 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 
 #[path = "authorizer_internal/mod.rs"]
-pub(crate) mod authorizer_internal;
+mod authorizer_internal;
+
+/// See `runtime::glob_matches_impl` for why this is a re-export and not a wider `mod`.
+#[cfg(test)]
+pub(crate) use authorizer_internal::policy::glob_matches_impl;
 
 /// Default clock skew tolerance in seconds.
 pub const DEFAULT_CLOCK_SKEW_SECONDS: i64 = 30;

--- a/crates/assay-core/src/runtime/authorizer.rs
+++ b/crates/assay-core/src/runtime/authorizer.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 
 #[path = "authorizer_internal/mod.rs"]
-mod authorizer_internal;
+pub(crate) mod authorizer_internal;
 
 /// Default clock skew tolerance in seconds.
 pub const DEFAULT_CLOCK_SKEW_SECONDS: i64 = 30;

--- a/crates/assay-core/src/runtime/mod.rs
+++ b/crates/assay-core/src/runtime/mod.rs
@@ -20,7 +20,10 @@
 //! └─────────────────────────────────────────────────────────────────┘
 //! ```
 
-mod authorizer;
+// `pub(crate)` so the tool-pattern matcher below it is reachable from the divergence test in
+// `mcp::policy::matcher`. Its `authorizer_internal::policy::glob_matches_impl` was already marked
+// `pub(crate)`, which meant nothing behind a private parent; this makes that marker true.
+pub(crate) mod authorizer;
 mod mandate_store;
 mod schema;
 

--- a/crates/assay-core/src/runtime/mod.rs
+++ b/crates/assay-core/src/runtime/mod.rs
@@ -20,12 +20,18 @@
 //! └─────────────────────────────────────────────────────────────────┘
 //! ```
 
-// `pub(crate)` so the tool-pattern matcher below it is reachable from the divergence test in
-// `mcp::policy::matcher`. Its `authorizer_internal::policy::glob_matches_impl` was already marked
-// `pub(crate)`, which meant nothing behind a private parent; this makes that marker true.
-pub(crate) mod authorizer;
+mod authorizer;
 mod mandate_store;
 mod schema;
+
+/// One item, under `cfg(test)` only, for the divergence test in `mcp::policy::matcher`.
+///
+/// The first version of this made `mod authorizer` and `mod authorizer_internal` both
+/// `pub(crate)`, which reached the matcher by exposing the authorizer's entire internal surface
+/// — the mandate store, the consume path, the policy evaluator — in release builds, to get one
+/// function into one test. A re-export costs the crate exactly what the test needs.
+#[cfg(test)]
+pub(crate) use authorizer::glob_matches_impl;
 
 pub use authorizer::{
     AuthorizeError, Authorizer, AuthzConfig, MandateData, MandateKind, OperationClass, PolicyError,

--- a/docs/reference/config/policies.md
+++ b/docs/reference/config/policies.md
@@ -101,6 +101,32 @@ Assay uses simple `*` wildcards:
 - `"*search*"` matches by substring
 - patterns without `*` are exact matches
 
+**A `*` anywhere but the first or last position is a literal character.** `read_*_file` does not
+match `read_config_file`; it matches only a tool literally named `read_*_file`. So is a pattern
+with several interior stars, such as `a*b*c`. The four forms above are the whole language.
+
+This one fails in the dangerous direction. In `allow`, an interior-star pattern matches nothing
+and the tool is refused, which is visible. In `deny`, it matches nothing and the tool is
+**permitted** -- by a line whose author believed it was blocking something. If a `deny` entry ever
+looks like a glob and is not one of the four forms above, it is not blocking what it names.
+
+These are unbounded: a `*` crosses any character, including the `.` or `__` a server may use to
+namespace its tools. `"*"` therefore admits tools that do not exist yet, including ones a future
+upstream adds.
+
+**The risk is one-sided, and a policy file does not show it.** A wildcard in `deny` over-blocks,
+which fails visibly and safely. The same wildcard in `allow` over-permits, which fails silently.
+Azure RBAC measured this direction: roughly 39% of actions reach across Resource Providers under
+non-obvious wildcards, and the recommendation there was explicit enumeration rather than a more
+careful pattern language ([arXiv 2506.10755](https://arxiv.org/html/2506.10755v1)). Prefer naming
+the tools you mean in `allow`, and keep `"*"` for the cases where admitting the unknown is the
+intent rather than the default.
+
+> A different pattern language applies to mandate `tool_patterns`, where `*` stops at a `.` and
+> `**` crosses it, the way a filesystem glob treats `/`. The two are deliberately different and
+> pinned against each other by a test; do not carry a pattern from one surface to the other
+> without re-reading it.
+
 ## JSON Schema in `schemas:`
 
 Each tool can have a full JSON Schema for its argument object:

--- a/docs/reference/config/policies.md
+++ b/docs/reference/config/policies.md
@@ -93,7 +93,7 @@ The `tools` section handles both filtering and extra controls.
 
 ### Wildcards
 
-Assay uses simple `*` wildcards:
+Assay uses simple `*` wildcards, and the language has exactly five forms:
 
 - `"*"` matches all tools
 - `"read_*"` matches by prefix
@@ -101,26 +101,33 @@ Assay uses simple `*` wildcards:
 - `"*search*"` matches by substring
 - patterns without `*` are exact matches
 
-**A `*` anywhere but the first or last position is a literal character.** `read_*_file` does not
-match `read_config_file`; it matches only a tool literally named `read_*_file`. So is a pattern
-with several interior stars, such as `a*b*c`. The four forms above are the whole language.
+In the four wildcard forms a `*` is unbounded: it crosses any character, including the `.` or
+`__` a server may use to namespace its tools. `"*"` therefore admits tools that do not exist yet,
+including ones a future upstream adds.
 
-This one fails in the dangerous direction. In `allow`, an interior-star pattern matches nothing
-and the tool is refused, which is visible. In `deny`, it matches nothing and the tool is
-**permitted** -- by a line whose author believed it was blocking something. If a `deny` entry ever
-looks like a glob and is not one of the four forms above, it is not blocking what it names.
+**A `*` that is neither the first nor the last character is a literal asterisk.** There is no
+fifth wildcard form. `read_*_file` does not match `read_config_file`; it matches only a tool
+literally named `read_*_file`. The same goes for several interior stars, such as `a*b*c`, and for
+interior stars inside the substring form: `*a*b*` searches for the three characters `a*b`.
 
-These are unbounded: a `*` crosses any character, including the `.` or `__` a server may use to
-namespace its tools. `"*"` therefore admits tools that do not exist yet, including ones a future
-upstream adds.
+**That one fails in the dangerous direction.** In `allow`, an interior-star pattern matches
+nothing and the tool is refused, which is visible. In `deny`, it matches nothing and the tool is
+**permitted** -- by a line whose author believed it was blocking something. If a `deny` entry
+looks like a glob and is not one of the five forms above, it is not blocking what it names.
 
-**The risk is one-sided, and a policy file does not show it.** A wildcard in `deny` over-blocks,
-which fails visibly and safely. The same wildcard in `allow` over-permits, which fails silently.
-Azure RBAC measured this direction: roughly 39% of actions reach across Resource Providers under
-non-obvious wildcards, and the recommendation there was explicit enumeration rather than a more
-careful pattern language ([arXiv 2506.10755](https://arxiv.org/html/2506.10755v1)). Prefer naming
-the tools you mean in `allow`, and keep `"*"` for the cases where admitting the unknown is the
-intent rather than the default.
+For the four forms that do expand, **the risk is one-sided and a policy file does not show it.**
+A wildcard in `deny` over-blocks, which fails visibly and safely. The same wildcard in `allow`
+over-permits, which fails silently. Azure RBAC measured this direction: about half of the 15,481
+catalogued actions reach across Resource Providers under non-obvious wildcards, and the
+recommendation there was explicit enumeration rather than a more careful pattern language
+([arXiv 2506.10755v3](https://arxiv.org/abs/2506.10755)). Prefer naming the tools you mean in
+`allow`, and keep `"*"` for the cases where admitting the unknown is the intent rather than the
+default.
+
+Two corners, so they are stated rather than discovered. `"**"` (and any longer run of stars) is
+the substring form with an empty substring, so it matches everything, exactly as `"*"` does — it
+is not the mandate surface's crossing operator. An empty pattern `""` has no star, so it is an
+exact match against the empty name and matches no real tool.
 
 > A different pattern language applies to mandate `tool_patterns`, where `*` stops at a `.` and
 > `**` crosses it, the way a filesystem glob treats `/`. The two are deliberately different and


### PR DESCRIPTION
The wildcard section of `docs/reference/config/policies.md` describes five forms. Nothing was checking that `matches_tool_pattern` still implemented them, and it turned out the reference was right about four and silent about the fifth.

## What the reference did not say

A `*` that is neither the first nor the last character is a **literal asterisk**. `read_*_file` does not match `read_config_file`; it matches only a tool literally named `read_*_file`, because the pattern falls through to the exact-match arm with the asterisk still in it. The same holds inside the substring form: `*a*b*` searches for the three characters `a*b`.

The consequence is asymmetric and runs the dangerous way:

- in `allow`, such a pattern matches nothing and the tool is **refused** — fail-closed, visible;
- in `deny`, it matches nothing and the tool is **permitted**, silently, by a line whose author believed it was blocking something.

Found by reading the branch structure rather than by testing the reference's own claims. Checking a doc against what it asserts can only find claims that are wrong, never claims that are missing — and `(false, false) => tool_name == pattern` catches both "no star at all" and "stars in the middle", of which only the first was documented.

## What is pinned

- **Doc parity.** Each of the five documented forms, with anchored negatives. The first version's negatives were decorative: `write_file` does not contain `read_` at all, so `!matches("write_file", "read_*")` holds even if prefix matching degrades to substring. Replaced with `my_read_file` and `_file_reader`, and bitten.
- **The interior-star rule**, in both the exact-match and substring arms.
- **The degenerate corners** — `**`, `***`, and the empty pattern — stated rather than discovered.
- **Divergence from the mandate matcher.** `tools.allow`/`tools.deny` and mandate `tool_patterns` are two languages over the same character, and neither is uniformly stricter. At a `.` the mandate matcher refuses what the policy matcher admits; at an interior star or a `\*` escape it admits what the policy matcher refuses, because the policy matcher has no such syntax. Both directions are asserted, so a future change that quietly converges them fails.

## Corrections after adversarial review

The review is at `08c224876`; every finding below was reproduced here before acting.

- **The AWS precedent said the opposite of what I cited it for.** `awsdocs/iam-user-guide#175` was written up in the rustdoc as a documented/implemented mismatch that was archived unresolved. It was neither. The reference was correct — "segment" means the colon-delimited parts of an ARN — the reporter had read it as path segments, withdrew the same day, and the issue was closed as completed two days after it opened. A fabricated precedent inside a PR about documentation accuracy is the defect this PR exists to fix. What actually happened is the better story and is what the rustdoc now tells: the rule was stated in a vocabulary the reader did not share, so he inferred one and reasoned about the breadth of real policies from it.
- **The doc contradicted itself twice.** "These are unbounded: a `*` crosses any character" sat seven lines below the new interior-star rule, and "a wildcard in `deny` over-blocks, which fails visibly and safely" sat directly under a paragraph saying the opposite. Both are now scoped to the four forms that expand.
- **Four versus five** was unsettled across the doc, the rustdoc and this body. Five forms, four of them wildcards.
- **"An empty pattern matches nothing" was false as written** — `matches_tool_pattern("", "")` is `true`. In a test whose stated purpose is to state corners, a corner stated wrongly is worse than one left out.
- **`if pattern == "*" { return true }` was dead code.** `"*"` reaches the same answer through the empty-inner substring arm, so the test named for `*` could not discriminate the branch it appeared to be about — mutating that arm left it green. Deleted, and the mutation now kills four tests.
- **arXiv 2506.10755 is at v3** and says about 50 percent; the doc pinned v1's 39 percent.
- **The visibility change was two `mod`s, not one**, and exposed the authorizer's entire internal surface — mandate store, consume path, policy evaluator — in release builds to reach one function from one test. Replaced with a `#[cfg(test)] pub(crate) use` of exactly that function.

## Verification

901 lib tests, clippy `-D warnings` clean, `cargo fmt --check` clean.

Bitten, each restored after:

| mutation | result |
|---|---|
| prefix `starts_with` → `contains` | killed |
| suffix `ends_with` → `contains` | killed |
| substring `contains` → `==` | killed |
| empty-inner arm → `false` | killed (4 tests) |
| interior-star arm → a real wildcard | killed (2 tests) |
| mandate `*` crosses a dot | killed |
| mandate `**` stops at a dot | killed |

## Not fixed here

`crates/assay-metrics/src/args_valid_next/matcher.rs` carries a byte-identical copy of this function, untested, serving both `allow` and `deny` — so the interior-star fail-open lives there too, unpinned. Filed separately rather than widened into this PR: unifying it needs a cross-crate export and choosing between that and a parity test is its own decision.
