### PR TITLE
Name the adversary the drop accounting exists for

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -514,6 +514,37 @@ pub enum DropAccounting {
     ///
     /// Completeness is the caller's obligation and is not checkable here: a list that omits the
     /// lossy channel passes. Naming it rather than implying it.
+    ///
+    /// # The adversary this exists for
+    ///
+    /// Dropped events are not only an overload symptom, they are an attack. The super producer
+    /// threat is a systematic study of exactly this: attackers "may try to compromise the system
+    /// auditing frameworks to conceal their malicious activities", and the threat "enables attackers
+    /// to either corrupt the auditing framework or paralyze the entire system", with the root cause
+    /// identified as "the lack of data isolation in the centralized architecture of existing
+    /// solutions" (arXiv 2307.15895, USENIX Security). Follow-on work restates it as provenance
+    /// generation being used "to overload a system to force the system to drop security-relevant
+    /// events and allow an attacker to hide their actions" (arXiv 2510.08479).
+    ///
+    /// That sharpens what the omission above costs. A zero count over a **complete** channel list
+    /// is evidence that nothing was hidden this way. A zero count over an **incomplete** one is the
+    /// attacker's preferred outcome: the seal reports no loss while the unenumerated channel is
+    /// where the evidence went. The gap is not a documentation nicety, it is the surface the threat
+    /// aims at, so a caller adding a collection path owes an argument for why its list is closed.
+    ///
+    /// # Why this is recorded rather than solved
+    ///
+    /// Neither of those papers claims completeness is achievable. 2510.08479 notes that resource
+    /// isolation — NODROP's answer — "does not fully solve the problems resulting from hardware
+    /// dependencies and performance limitations", and offers a scheduler that "significantly
+    /// improves" completeness rather than guaranteeing it. If the state of the art cannot promise a
+    /// complete audit trail, an evidence format that *claimed* one would be asserting more than the
+    /// field can support.
+    ///
+    /// So the seal records whether the claim was checked instead of asserting that it holds, which
+    /// is what [`DROP_BASIS_CHECKED`] and [`DROP_BASIS_DECLARED`] carry. A consumer can then price
+    /// the difference. That is the honest shape for a property the literature says is approximated,
+    /// and it is why the basis travels with the count rather than the count travelling alone.
     CountedQueue { channels: Vec<(String, u64)> },
 }
 


### PR DESCRIPTION
Documentation only, no behaviour change. It closes a gap in *why* the drop accounting in #2125 is shaped the way it is, using the literature that names the adversary.

## What was missing

`DropAccounting::CountedQueue` already carried an honest caveat:

> Completeness is the caller's obligation and is not checkable here: a list that omits the lossy channel passes. Naming it rather than implying it.

True, and it reads as a documentation nicety. It is not. An attacker *wants* that omission.

## The adversary, named

The **super producer threat** is a systematic study of dropped audit events as an attack rather than an overload symptom. From [arXiv 2307.15895](https://arxiv.org/abs/2307.15895) (USENIX Security), verbatim:

> "attackers may try to compromise the system auditing frameworks to conceal their malicious activities"

> "the super producer threat in auditing frameworks, which enables attackers to either corrupt the auditing framework or paralyze the entire system"

> "the main cause of the super producer threat is the lack of data isolation in the centralized architecture of existing solutions"

Follow-on work restates the mechanism ([arXiv 2510.08479](https://arxiv.org/abs/2510.08479)):

> "provenance generation can overload a system to force the system to drop security-relevant events and allow an attacker to hide their actions"

## Why that reprices our caveat

A zero drop count over a **complete** channel list is evidence that nothing was hidden this way. A zero count over an **incomplete** list is the attacker's preferred outcome: the seal reports no loss while the unenumerated channel is exactly where the evidence went.

So the completeness gap is not a caveat, it is the surface the threat aims at — which makes it a live obligation for the second collection path in #2093 rather than a hypothetical. A caller adding a path owes an argument for why its channel list is closed.

## Why this is recorded rather than solved

Neither paper claims completeness is achievable. 2510.08479 notes that resource isolation — NODROP's answer in the first paper — *"does not fully solve the problems resulting from hardware dependencies and performance limitations"*, and offers a scheduler that *"significantly improves"* completeness rather than guaranteeing it.

If the state of the art cannot promise a complete audit trail, an evidence format that claimed one would assert more than the field supports. Recording **whether the claim was checked** — the `checked`/`declared` basis that #2125 made credit-affecting — is the shape that survives that, and it is why the basis travels with the count rather than the count travelling alone.

This is a case where the literature ratifies a decision already taken rather than changing it, which is worth writing down precisely because the alternative reading (claim completeness, drop the basis) looks tidier and is wrong.

## Verification

Both abstracts fetched from arXiv and quoted verbatim. `cargo clippy -D warnings` clean, `cargo fmt --check` clean, `assay-cli` tests green.

One detail the search summaries offered — that a super producer needs no root privilege — appears in **neither** abstract and I could not confirm it in the body, so it is not claimed here. It would have strengthened the applicability argument, which is exactly why it needed checking.
