### PR TITLE
Record the aeeVersion decision where its sibling is recorded

### DIFF
--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -266,6 +266,20 @@ The counts that follow from it: `REQUIRED_SEAL_FIELDS` names **six** of the ten 
 the checker's known-optional set names the other four. The positive payload carried **eight** when
 this was written; it carries all ten as of the decision below.
 
+**`aeeVersion` stays 0.7, decided 2026-08-08 (#2093).** in-toto/attestation#570 is still open at
+v0.7, and the predicate author proposed shipping 0.7 as it stands and repairing the referencedness
+defect — which she rates Major — in 0.8. Pointing the constant at a version that does not exist
+upstream would be a conformance claim about an unpublished document.
+
+The migration trigger, recorded so it is not rediscovered: **0.8 is adopted when it exists upstream,
+not when it is proposed.** The constant lives in two places, `aee_seal.rs` and the fixture checker,
+pinned against each other by `crates/assay-cli/tests/aee_version_parity.rs`.
+
+This is recorded here rather than only on the constant because the other half of the same
+acceptance item is, and a decision recorded one notch weaker than its sibling is the asymmetry an
+adversarial review flagged on #2125 for the drop-proof half. The doc comment survives a reader who
+opens the file; an ADR survives the constant being moved.
+
 **The drop-proof pair, decided 2026-08-08 (#2093).** The paragraph above left `assayDropProofBasis`
 and `assayDropChannels` permitted rather than fixtured, and #2093 recorded the open question as a
 binary: the checker requires the pair, or the producer stops emitting it.


### PR DESCRIPTION
Documentation only. Completes acceptance item 5 of #2093 to one standard instead of two.

## The asymmetry

Item 5 is that the `aeeVersion` and drop-proof questions are *"decided, either way, and the decision is recorded."* Both were decided in #2125. Only one was recorded to the standard the review held the other to.

- **Drop-proof pair** → ADR-045, under a dated heading, beside the decision it amends. It went there because an adversarial review pointed out that recording it only in a Python comment left the ADR still telling readers the pair was "permitted rather than fixtured".
- **`aeeVersion`** → a Rust doc comment on the constant, and nowhere else. `git grep` against `main` finds no decision record for it in ADR-045; the file mentions `0.7` only descriptively, in context paragraphs, field lists and payload examples.

Same acceptance item, same PR, one notch apart. I applied the review's finding to one half and not the other.

## Why the doc comment is the weaker place, specifically

Not a general preference for ADRs. The thing being recorded is a **migration trigger** — *"0.8 is adopted when it exists upstream, not when it is proposed"* — and its whole job is to survive the moment someone edits the constant. A comment attached to that constant is exactly what a rename, a move or a refactor takes with it. The ADR is where a decision outlives its subject.

## What changed

ADR-045 now carries both decisions under 2026-08-08, adjacent, with the trigger and the two-literal parity pin named. The doc comment stays where it is — a reader who opens `aee_seal.rs` should still find it.

No behaviour change, no test change.