### PR TITLE
There is no 0.8 to wait for

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -26,15 +26,17 @@ use crate::enforcement_health_v1::{EnforcementHealthV1, Mechanism, Probe, Status
 pub const COLLECTION_PATH_LANDLOCK_TCP_CONNECT: &str = "landlock-tcp-connect";
 /// AEE draft version this payload is shape-compatible with. Not a conformance claim.
 ///
-/// **Stays at 0.7, decided in #2093.** in-toto/attestation#570 is still open at v0.7, and the
-/// predicate author has proposed shipping 0.7 as it stands and repairing the referencedness defect
-/// — which she rates Major — in 0.8. Pointing this at 0.8 would name a version that does not exist
-/// upstream, which is a conformance claim about an unpublished document.
+/// **Stays at 0.7, and there is no 0.8 to wait for.** Decided in #2093; the reason was corrected
+/// after the predicate author answered on in-toto/attestation#570 (2026-08-07).
 ///
-/// The migration trigger, stated so it is not rediscovered: **0.8 is adopted when it exists
-/// upstream, not when it is proposed.** Moving the constant is a one-line change today and a
-/// migration once runs emit sealed records, which is why #2093 resolved it before the producer
-/// lands rather than after.
+/// This first read her earlier sentence as an offer to ship 0.7 and repair the referencedness
+/// defect in 0.8, and recorded a migration trigger accordingly. She has since said to pin 0.7 and
+/// not plan for 0.8: the repair already landed on that branch as `c0c4da6` on 4 August, inside the
+/// 0.7 changelog rather than behind a bump, so that nobody has to pin a version whose reject family
+/// one edit empties.
+///
+/// So this constant tracks whatever version #570 carries. The thing to watch is that branch, not a
+/// successor version. See ADR-045 for the full correction.
 ///
 /// `tests/aee_version_parity.rs` pins this against the fixture checker's own copy. Two literals
 /// for one version drift silently, and a bump that reaches only one side would leave a producer

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -266,14 +266,24 @@ The counts that follow from it: `REQUIRED_SEAL_FIELDS` names **six** of the ten 
 the checker's known-optional set names the other four. The positive payload carried **eight** when
 this was written; it carries all ten as of the decision below.
 
-**`aeeVersion` stays 0.7, decided 2026-08-08 (#2093).** in-toto/attestation#570 is still open at
-v0.7, and the predicate author proposed shipping 0.7 as it stands and repairing the referencedness
-defect — which she rates Major — in 0.8. Pointing the constant at a version that does not exist
-upstream would be a conformance claim about an unpublished document.
+**`aeeVersion` stays 0.7, decided 2026-08-08 (#2093), and there is no 0.8 to wait for.**
 
-The migration trigger, recorded so it is not rediscovered: **0.8 is adopted when it exists upstream,
-not when it is proposed.** The constant lives in two places, `aee_seal.rs` and the fixture checker,
-pinned against each other by `crates/assay-cli/tests/aee_version_parity.rs`.
+The outcome stands; the reason it was first recorded on does not, and the correction is worth
+keeping rather than overwriting. This ADR said the predicate author had proposed shipping 0.7 and
+repairing the referencedness defect in 0.8, so the migration trigger read "0.8 is adopted when it
+exists upstream, not when it is proposed."
+
+She has since answered that plainly (in-toto/attestation#570, 2026-08-07): **pin 0.7, and do not
+plan for 0.8.** The repair had already landed on that branch as `c0c4da6` on 4 August — verified,
+"docs(aee): constrain every carried record, not only the referenced ones" — placed inside the 0.7
+changelog rather than behind a version bump, on the reasoning that a reject family a single edit
+empties is not something anyone should have to pin a version against. She names the ambiguity in
+her earlier sentence as hers, and our reading as the one her words invited.
+
+So the trigger above is void, and planning a 0.8 migration is the thing the placement was designed
+to avoid. What replaces it: the constant tracks whatever version #570 carries, and the pin to watch
+is the branch, not a successor version. The constant lives in two places, `aee_seal.rs` and the
+fixture checker, pinned against each other by `crates/assay-cli/tests/aee_version_parity.rs`.
 
 This is recorded here rather than only on the constant because the other half of the same
 acceptance item is, and a decision recorded one notch weaker than its sibling is the asymmetry an


### PR DESCRIPTION
Documentation only. Corrects the reasoning under a decision that merged yesterday; the decision itself is unchanged.

## What was recorded

#2125 and #2128 recorded that `aeeVersion` stays 0.7 because the predicate author had proposed shipping 0.7 as it stands and repairing the referencedness defect in 0.8, with a migration trigger:

> **0.8 is adopted when it exists upstream, not when it is proposed.**

## What he actually said

On [in-toto/attestation#570](https://github.com/in-toto/attestation/pull/570), 2026-08-07: **pin 0.7, and do not plan for 0.8.**

The repair had already landed on that branch as `c0c4da6` on 4 August — verified against the API, *"docs(aee): constrain every carried record, not only the referenced ones"*, two days before we asked. He put it inside the 0.7 changelog rather than behind a version bump, on the reasoning that nobody should have to pin a version whose reject family a single edit empties.

He names the ambiguity in his earlier sentence as his, and our reading as the one his words invited. Worth repeating here rather than quietly benefiting from it.

## Why this matters beyond a stale note

The trigger was void two days before we wrote it, and it pointed at exactly the behaviour the placement was designed to prevent. A record that tells a future reader to watch for 0.8 would have them watching for something deliberately not coming.

**Corrected in both places rather than overwritten.** The outcome is unchanged, so the useful artifact is the one that shows what it was corrected from — the same reason ADR-045 keeps its earlier drop-proof decision beside the one that amends it.

What replaces the trigger: the constant tracks whatever version #570 carries; the pin to watch is that branch, not a successor version.

## Verification

`adr045_citations` 3/3, `aee_version_parity` 2/2, fmt clean. No behaviour change.

*Corrected 2026-08-08: referred to the AEE predicate author as "she". He is a man. Same fix as Rul1an/assay#2137 and #2138, which scoped the working tree and missed text stored on GitHub.*