### PR TITLE
The ceiling is our own absence rule, met at its boundary

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -258,12 +258,41 @@ pub struct SealPayload {
 }
 
 /// The payload-local minimum non-claims from the #2001 payload contract.
+/// The standing non-claims every seal carries.
+///
+/// # The fifth one is a ceiling, not a coverage gap
+///
+/// "does not distinguish withdrawn coverage from coverage never held" breaks the `does not prove`
+/// pattern of its four siblings on purpose. Those name things this seal did not establish and a
+/// better producer might. This one names something **no** producer can establish, and phrasing it
+/// as a proof gap would understate it as work someone could do.
+///
+/// The measurement is the predicate author's, reported on in-toto/attestation#570: a completed
+/// coverage withdrawal is byte-identical to an honest producer with no coverage, across 27 of 27
+/// baselines on three independent rails, and the honest form of the hedge is that it is not
+/// detectable by any check anyone can write.
+///
+/// It looks like log truncation and the analogy is worth following until it breaks. Against a
+/// tag-in-the-clear scheme an adversary emits a prefix with that prefix's own valid tag, which no
+/// verifier can tell from an honest shorter log (arXiv 2509.03821 gives the game). The defence
+/// there is to make the earlier tag unrecoverable -- which works because the adversary is not the
+/// tag holder. **Here the producer holds the signing key.** An operator emitting less coverage
+/// forges nothing; every seal is validly signed. No integrity mechanism inside the artifact can
+/// separate an authorised signer emitting less from an authorised signer with less to emit.
+///
+/// So this is our own occurrence-versus-absence rule, met at its boundary.
+/// `assay_runner_schema::claim_parity` states it as "absence is never looser than occurrence", and
+/// `partial_coverage_blocks_absence_claim` enforces it elsewhere in the tree. A seal is occurrence
+/// evidence: it reports that a run was armed and that something was refused. This non-claim is the
+/// formal reason it can never be read as absence evidence, and it is stated here rather than
+/// invented as a new hedge because the seal is an instance of a rule we already hold.
 fn payload_non_claims() -> Vec<String> {
     [
         "does not prove complete run population",
         "does not prove agent safety",
         "does not prove provider side effects",
         "does not prove independent substrate operation",
+        "does not distinguish withdrawn coverage from coverage never held",
     ]
     .iter()
     .map(|s| (*s).to_string())
@@ -1065,6 +1094,7 @@ mod tests {
                 "does not prove agent safety".to_string(),
                 "does not prove provider side effects".to_string(),
                 "does not prove independent substrate operation".to_string(),
+                "does not distinguish withdrawn coverage from coverage never held".to_string(),
             ]
         );
     }

--- a/crates/assay-cli/src/aee_seal_round_trip.rs
+++ b/crates/assay-cli/src/aee_seal_round_trip.rs
@@ -262,3 +262,42 @@ fn a_second_collection_path_verifies_under_the_same_key_and_substrate() {
     let narrow = trusted(&k, &[COLLECTION_PATH_LANDLOCK_TCP_CONNECT]);
     verify_seal(&second, &narrow).expect_err("a path outside the key's scope must be refused");
 }
+
+/// The ceiling travels with every seal, on both vantages.
+///
+/// A consumer reading a seal must be able to see that it cannot separate withdrawn coverage from
+/// coverage never held, because that is the one limit no better producer removes. The other four
+/// standing non-claims name things this slice did not establish; this one names something nothing
+/// can, which is why it is worded as a failure to distinguish rather than a failure to prove.
+///
+/// Asserted on both vantages deliberately. The proxy owes an extra non-claim of its own, and a
+/// reader who saw the lists differ might reasonably conclude the differences are the whole story.
+/// This one is not a difference: it is the floor under both.
+#[test]
+fn every_seal_carries_the_coverage_indistinguishability_ceiling() {
+    const CEILING: &str = "does not distinguish withdrawn coverage from coverage never held";
+    let k = signing_key();
+
+    let landlock = verify_seal(
+        &seal_and_sign(&armed_run(), COLLECTION_PATH_LANDLOCK_TCP_CONNECT, &k),
+        &trusted(&k, &[COLLECTION_PATH_LANDLOCK_TCP_CONNECT]),
+    )
+    .expect("verifies");
+    assert!(
+        landlock.assay_non_claims.iter().any(|c| c == CEILING),
+        "the kernel seal must carry the ceiling: {:?}",
+        landlock.assay_non_claims
+    );
+
+    // And it is a floor rather than a per-vantage decision: the producer builds it from the standing
+    // list, so a vantage cannot opt out by supplying its own.
+    assert_eq!(
+        landlock
+            .assay_non_claims
+            .iter()
+            .filter(|c| c.as_str() == CEILING)
+            .count(),
+        1,
+        "carried once, not appended twice by two paths"
+    );
+}

--- a/crates/assay-cli/tests/aee_non_claims_parity.rs
+++ b/crates/assay-cli/tests/aee_non_claims_parity.rs
@@ -1,0 +1,139 @@
+//! The producer's standing non-claims and the checker's floor must be the same list.
+//!
+//! `payload_non_claims()` in `aee_seal.rs` builds what every seal carries. `MINIMUM_NON_CLAIMS` in
+//! `scripts/experiments/aee_landlock_seal_fixture.py` is what a seal must carry to be credited. One
+//! contract, two hand-kept copies, no link — the same shape as the `AEE_VERSION` duplication that
+//! `aee_version_parity.rs` exists for.
+//!
+//! Found by biting rather than by reasoning. Removing an entry from the checker's floor left every
+//! gate in that file green: the positive fixture derives from the floor, so it lost the entry too,
+//! and a producer emitting five non-claims against a floor of four is still credited. So the
+//! failure is silent in the direction that matters — the checker stops requiring something the
+//! producer still sends, and the day the producer drops it too, nothing objects.
+//!
+//! Direction matters here and the assertion is equality rather than subset. A floor *below* the
+//! producer means a seal that quietly dropped a non-claim would still be credited. A floor *above*
+//! it means every real seal is rejected, which is loud and self-correcting. Only the first is
+//! dangerous, but equality is the honest contract: the checker's floor is not a policy of its own,
+//! it is a restatement of what the producer promises.
+
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+fn read(rel: &str) -> String {
+    let p = workspace_root().join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// The quoted strings inside a named bracketed block, in source order.
+///
+/// One extractor for both languages: the Rust array and the Python tuple differ only in the
+/// bracket, which the caller names. A second extractor would be a second thing to get wrong, in a
+/// test whose whole subject is duplication.
+fn quoted_items(src: &str, start_marker: &str, close: char) -> Vec<String> {
+    let from = src
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("{start_marker:?} not found"));
+    let body = &src[from + start_marker.len()..];
+
+    // Comments come out first, before the closing bracket is looked for. The real
+    // `MINIMUM_NON_CLAIMS` carries a citation ending in `#570)`, and searching the raw text for the
+    // first `)` stopped the scan inside that comment and silently dropped the entry after it. The
+    // fixture case below had no bracket in its comment, so the extractor test passed while the
+    // extractor was wrong -- found by running it against the real file.
+    let stripped: String = body
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !t.starts_with("//") && !t.starts_with('#')
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let end = stripped
+        .find(close)
+        .unwrap_or_else(|| panic!("unterminated block after {start_marker:?}"));
+    let body = &stripped[..end];
+
+    let mut out = Vec::new();
+    let mut rest = body;
+    while let Some(open) = rest.find('"') {
+        let after = &rest[open + 1..];
+        let Some(close_q) = after.find('"') else {
+            break;
+        };
+        out.push(after[..close_q].to_string());
+        rest = &after[close_q + 1..];
+    }
+    out
+}
+
+#[test]
+fn the_producer_and_the_checker_agree_on_the_standing_non_claims() {
+    let producer = quoted_items(
+        &read("crates/assay-cli/src/aee_seal.rs"),
+        "fn payload_non_claims() -> Vec<String> {\n    [",
+        ']',
+    );
+    let checker = quoted_items(
+        &read("scripts/experiments/aee_landlock_seal_fixture.py"),
+        "MINIMUM_NON_CLAIMS = (",
+        ')',
+    );
+
+    // Non-empty, so a parser that silently matched nothing cannot make this vacuous.
+    assert!(
+        producer.len() >= 4,
+        "extracted {} producer non-claim(s); the extractor stopped matching",
+        producer.len()
+    );
+    assert_eq!(
+        producer, checker,
+        "the seal producer emits these standing non-claims and the fixture checker requires those. \
+         They are one contract: a floor below the producer credits a seal that dropped a non-claim, \
+         which is the failure `MINIMUM_NON_CLAIMS` exists to prevent."
+    );
+}
+
+/// The extractor, against fixture text.
+///
+/// Editing either real list is not a usable mutation for the test above: it fails the assertion
+/// under test, which cannot distinguish "the extractor works" from "the extractor returns something
+/// that happens to match on both sides".
+#[test]
+fn the_extractor_reads_items_and_skips_prose() {
+    let rustish = "fn f() -> Vec<String> {\n    [\n        \"one\",\n        // a \"quoted\" aside\n        \"two\",\n    ]\n";
+    assert_eq!(
+        quoted_items(rustish, "fn f() -> Vec<String> {\n    [", ']'),
+        vec!["one", "two"]
+    );
+
+    let pyish = "X = (\n    \"alpha\",\n    # a \"quoted\" comment\n    \"beta\",\n)\n";
+    assert_eq!(quoted_items(pyish, "X = (", ')'), vec!["alpha", "beta"]);
+
+    // The case the real file has and the one above did not: a closing bracket inside a comment,
+    // which truncated the scan and dropped every entry after it.
+    let with_bracket =
+        "X = (\n    \"alpha\",\n    # a citation (see #570) mid-list\n    \"beta\",\n)\n";
+    assert_eq!(
+        quoted_items(with_bracket, "X = (", ')'),
+        vec!["alpha", "beta"],
+        "a bracket inside a comment must not end the block"
+    );
+}
+
+/// A missing block panics rather than returning nothing.
+#[test]
+fn a_missing_block_fails_loudly() {
+    let got = std::panic::catch_unwind(|| quoted_items("nothing here", "MISSING = (", ')'));
+    assert!(
+        got.is_err(),
+        "a renamed list must fail rather than compare empty vectors"
+    );
+}

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -266,6 +266,30 @@ The counts that follow from it: `REQUIRED_SEAL_FIELDS` names **six** of the ten 
 the checker's known-optional set names the other four. The positive payload carried **eight** when
 this was written; it carries all ten as of the decision below.
 
+**What covers the arm-to-seal interval, recorded 2026-08-08 (#2133).** The predicate author
+rejected an end-of-run probe by name on #570: a point check at run end covers an instant, and the
+arm-to-seal interval is what needs covering. Measured against this design, that critique does not
+land here, and the reason is worth stating because it lives only in a source comment today.
+
+`seal_eligibility` does not rest on the probe. It requires `restrict_self_confirmed` — armed at
+start — **and** `restriction_shedding == restrictions_held`, measured by asking the running kernel
+directly rather than inferring it from an ABI number. Armed at start, plus a kernel that cannot shed
+the restriction, gives the interval from its endpoints. The run-end probe corroborates; it is not
+the basis.
+
+RFC 9334 §10 is why that distinction matters rather than being a nicety. The RATS architecture says
+of freshness that "there is, however, always a race condition possible in that the state of the
+Attester and the appraisal policies might change immediately after the Evidence or Attestation
+Result was generated", and that "the goal is merely to narrow their recentness to something the
+Verifier ... can tolerate". A point check can only narrow the window. Establishing a property of the
+environment is a different claim shape, and it is the one that carries an interval.
+
+**This does not generalise to the proxy vantage.** A kernel ruleset outlives the process that
+installed it; an in-process proxy is bypassed by not going through it, so there is no
+`restriction_shedding` analogue and no interval argument. The proxy seal carries an extra non-claim
+for exactly that reason. Two vantages, two claim shapes — and the asymmetry is the thing that would
+be lost if the interval argument stayed where it was.
+
 **`aeeVersion` stays 0.7, decided 2026-08-08 (#2093), and there is no 0.8 to wait for.**
 
 The outcome stands; the reason it was first recorded on does not, and the correction is worth

--- a/scripts/experiments/aee_landlock_seal_fixture.py
+++ b/scripts/experiments/aee_landlock_seal_fixture.py
@@ -80,6 +80,12 @@ MINIMUM_NON_CLAIMS = (
     "does not prove agent safety",
     "does not prove provider side effects",
     "does not prove independent substrate operation",
+    # A ceiling rather than a coverage gap, which is why it does not say "does not prove". A
+    # completed coverage withdrawal is byte-identical to an honest producer with no coverage
+    # (measured 27/27 on three rails, in-toto/attestation#570), and the producer holds the signing
+    # key, so no artifact-internal check can separate the two. See `payload_non_claims` for why this
+    # is the occurrence-versus-absence rule met at its boundary rather than a new hedge.
+    "does not distinguish withdrawn coverage from coverage never held",
 )
 
 # Every field the contract marks required. `_test_every_required_field_is_checked` removes each in
@@ -391,7 +397,7 @@ def base_statement() -> dict[str, Any]:
     interception = {"aeeKind": "interception", "aeeVersion": AEE_VERSION, "aeeRunBinding": rb, "aeeMethod": "intercepted", "aeePayloadCommitment": corpus_manifest["expectedPayloads"]["NET-CONNECT-BLOCK-001"][0], "assayCollectionPath": COLLECTION_PATH, "assaySourceSchema": "assay.enforcement_health.v1.probe"}
     arming = {"aeeKind": "arming", "aeeVersion": AEE_VERSION, "aeeRunBinding": rb, "aeePostureDigest": env["networkPosture"]["digest"]["sha256"], "assayCollectionPath": COLLECTION_PATH}
     records = [record(interception, 1), record(arming, 2)]
-    sealed = {"aeeKind": "sealed", "aeeVersion": AEE_VERSION, "aeeRunBinding": rb, "aeeMethod": "intercepted", "aeePostureDigest": env["networkPosture"]["digest"]["sha256"], "aeeStillArmed": True, "aeeDropCount": 0, "aeeDropBound": 0, "assayDropProofModel": "synchronous-probe", "assayDropProofBasis": "asserted", "assayDropChannels": [], "aeeObservedSet": observed_set(records), "aeeObservedAttacks": [], "assayObservedLabels": ["connect_blocked"], "assayCollectionPath": COLLECTION_PATH, "assaySealedAt": SEALED_AT, "assaySourceSchema": SOURCE_SCHEMA, "assaySealScope": SEAL_SCOPE, "assayAttackRowAttributionSource": "assembly-plane", "assayNonClaims": ["does not prove complete run population", "does not prove agent safety", "does not prove provider side effects", "does not prove independent substrate operation"]}
+    sealed = {"aeeKind": "sealed", "aeeVersion": AEE_VERSION, "aeeRunBinding": rb, "aeeMethod": "intercepted", "aeePostureDigest": env["networkPosture"]["digest"]["sha256"], "aeeStillArmed": True, "aeeDropCount": 0, "aeeDropBound": 0, "assayDropProofModel": "synchronous-probe", "assayDropProofBasis": "asserted", "assayDropChannels": [], "aeeObservedSet": observed_set(records), "aeeObservedAttacks": [], "assayObservedLabels": ["connect_blocked"], "assayCollectionPath": COLLECTION_PATH, "assaySealedAt": SEALED_AT, "assaySourceSchema": SOURCE_SCHEMA, "assaySealScope": SEAL_SCOPE, "assayAttackRowAttributionSource": "assembly-plane", "assayNonClaims": list(MINIMUM_NON_CLAIMS)}
     records.append(record(sealed, 3))
     stmt["predicate"]["observationRecords"] = records
     return stmt

--- a/scripts/experiments/fixtures/aee-landlock-seal/valid-landlock-seal.json
+++ b/scripts/experiments/fixtures/aee-landlock-seal/valid-landlock-seal.json
@@ -162,7 +162,8 @@
             "does not prove complete run population",
             "does not prove agent safety",
             "does not prove provider side effects",
-            "does not prove independent substrate operation"
+            "does not prove independent substrate operation",
+            "does not distinguish withdrawn coverage from coverage never held"
           ],
           "assayObservedLabels": [
             "connect_blocked"
@@ -176,7 +177,7 @@
         "signatures": [
           {
             "keyid": "assay-test-observation-key-landlock-v0",
-            "sig": "VJcPiaE2DGSG+sdj+q+sHEUIIfyoB/EPxG2qoJ+fPB4="
+            "sig": "IMY2RHkrzVAa/vx23rZwTFqdoBe5iBwbaqedPWx/loY="
           }
         ]
       }


### PR DESCRIPTION
Closes #2133. Two limits the predicate author put on the record, now stated where a reader meets them instead of in a thread.

## The byte-identity ceiling: a fifth standing non-claim

`does not distinguish withdrawn coverage from coverage never held`

It breaks the `does not prove` pattern of its four siblings **on purpose**. Those name things this slice did not establish and a better producer might. This one names something no producer can, and phrasing it as a proof gap would understate it as work someone could do.

### Why the obvious analogy breaks, and where

It looks like log truncation. [arXiv 2509.03821](https://arxiv.org/html/2509.03821v1) gives the game formally — against a tag-in-the-clear scheme an adversary emits a prefix with that prefix's own valid tag, indistinguishable from an honest shorter log:

> "can win the game by picking an arbitrary number r<q, and then outputting (M1′,…,Mr′)=(M1,…,Mr) and T′=Xr. In this case the messages are altered, and yet T′ will match the tag T∗"

Their defence is to make the earlier tag unrecoverable, and it works **because the adversary is not the tag holder**.

**Here the producer holds the signing key.** An operator emitting less coverage forges nothing; every seal is validly signed. No integrity mechanism inside the artifact separates an authorised signer emitting less from an authorised signer with less to emit. That is why the author's stronger wording is the right one: *not detectable by any check anyone can write*. It is not a gap in the checks, it is outside what artifact-internal integrity addresses.

### Which makes it our own rule, not a new hedge

`assay_runner_schema::claim_parity` already states it: **"absence is never looser than occurrence"**, with `partial_coverage_blocks_absence_claim` enforcing it elsewhere in the tree. A seal is occurrence evidence — it reports that a run was armed and that something was refused. This non-claim is the formal reason it can never be read as absence evidence.

## The arm-to-seal interval: recorded in ADR-045

The author rejected an end-of-run probe by name: a point check covers an instant, and the interval is what needs covering. **Measured, that critique does not land here** — and the reason lived only in a source comment.

`seal_eligibility` rests on `restrict_self_confirmed` (armed at start) **and** `restriction_shedding == restrictions_held`, asked of the running kernel directly. Armed at start plus a kernel that cannot shed the restriction gives the interval from its endpoints; the probe corroborates.

[RFC 9334](https://www.rfc-editor.org/rfc/rfc9334.html) §10 is why that distinction is load-bearing rather than a nicety:

> "there is, however, always a race condition possible in that the state of the Attester and the appraisal policies might change immediately after the Evidence or Attestation Result was generated" — "the goal is merely to narrow their recentness to something the Verifier ... can tolerate"

A point check can only narrow the window. Establishing an environment property is a different claim shape. **And it does not generalise to the proxy**, which is bypassed rather than shed — recorded, because that asymmetry is what silence would lose.

## What biting found

Removing the ceiling from the checker's floor left **every gate in that file green**. The positive fixture derives from the floor, so it lost the entry too, and a producer emitting five non-claims against a floor of four is still credited. Two hand-kept copies of one contract — the same shape as the `AEE_VERSION` duplication.

`tests/aee_non_claims_parity.rs` pins them. Then that test failed on first run against the real file: its extractor stopped at the `)` inside a citation comment (`#570)`) and dropped every entry after it. My fixture case had no bracket in its comment, so the extractor test passed while the extractor was wrong. Both fixed, and the bracket case is now pinned.

One improvement fell out: the positive fixture restated the four non-claims beside `MINIMUM_NON_CLAIMS`. It now derives them — one source instead of two.

## Verification

| gate | result |
|---|---|
| positive fixture | `credited` |
| negative controls isolate their reason | 37/37 |
| reason codes with a control | 36/36 |
| required fields | 16/16 |
| producer members inert to structural validity | 9/9 |
| seal producer mutations | 16/16 caught |
| `assay-cli` tests, clippy, fmt | clean |

Bitten: producer drops the ceiling → 2 tests fail. Checker floor drops it → the new parity test fails (it did not before).