### PR TITLE
Emit the records the seal commits to

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -323,9 +323,18 @@ pub struct ObservationEnvironment {
 }
 
 /// One emitted observation record, as it appears in `observationRecords`.
-#[derive(Debug, Clone)]
+///
+/// Serializable because the seal commits to these and a consumer cannot check that commitment
+/// without them (#2135). `aeeObservedSet` is a digest over the interception and examination leaves;
+/// emitting the digest while withholding the leaves leaves a member only its own producer can
+/// re-derive, which is the party it exists to constrain.
+///
+/// Field names are the wire names, not the Rust ones: `payloadType` is what DSSE calls it and what
+/// an `observationRecords` entry carries.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ObservationRecord {
     pub payload: serde_json::Value,
+    #[serde(rename = "payloadType")]
     pub payload_type: String,
 }
 
@@ -385,6 +394,27 @@ fn leaf_hash(rec: &ObservationRecord) -> Result<String, NotSealEligible> {
     buf.push(0x00);
     buf.extend_from_slice(&pae);
     Ok(sha256_hex(&buf))
+}
+
+/// The records, as `--aee-records` writes them: one JSON object per line.
+///
+/// A function rather than a loop at the call site, because the call site is in `sandbox/child.rs`
+/// behind `cfg(target_os = "linux")` and nothing on a non-Linux host compiles it, let alone runs
+/// it. Biting the write path there changed nothing and no test noticed. The serialisation is the
+/// part with a property worth holding -- a consumer must be able to parse back what was written --
+/// so it lives where a test can reach it and the call site keeps only the file write.
+///
+/// The shape is **two members**, `payload` and `payloadType`. An `observationRecords` entry in a
+/// statement carries `seq` and `signatures` as well, so this file is the digest's inputs and not a
+/// statement fragment: enough for a consumer to recompute `aeeObservedSet`, not enough to feed the
+/// fixture checker, which requires exactly one signature per record.
+pub fn records_ndjson(records: &[ObservationRecord]) -> Result<String, serde_json::Error> {
+    let mut out = String::new();
+    for rec in records {
+        out.push_str(&serde_json::to_string(rec)?);
+        out.push('\n');
+    }
+    Ok(out)
 }
 
 /// AEE v0.7 `aeeObservedSet`: a digest over the sorted lowercase leaf hashes of every emitted

--- a/crates/assay-cli/src/aee_seal_round_trip.rs
+++ b/crates/assay-cli/src/aee_seal_round_trip.rs
@@ -496,3 +496,78 @@ fn every_seal_carries_the_coverage_indistinguishability_ceiling() {
         "carried once, not appended twice by two paths"
     );
 }
+
+/// A third party can recompute `aeeObservedSet` from what the run wrote down.
+///
+/// This is the property #2135 was filed for. The seal carries a digest over the interception and
+/// examination records; before `--aee-records` existed the run emitted the digest and not the
+/// records, so the one commitment the payload makes about anything outside itself could only ever
+/// be re-derived by its own producer.
+///
+/// The test is deliberately written the way a consumer would work: serialise the records to the
+/// NDJSON the flag writes, parse them back from that text, and recompute from the parsed values.
+/// Recomputing from the in-memory `run.records` would pass while the wire format lost a field, and
+/// that is the failure this exists to catch.
+#[test]
+fn the_observed_set_recomputes_from_the_emitted_records() {
+    use crate::aee_seal::{
+        build_sealed_run, observed_set, records_ndjson, ObservationRecord, OBSERVATION_PAYLOAD_TYPE,
+    };
+
+    // Two prior records, not zero. With `&[]` the run carries exactly one record -- the probe
+    // examination `build_sealed_run` appends -- so `records_ndjson`'s loop never runs more than
+    // once, and a `take(1)` mutation of it passed the whole suite and the standing mutation
+    // harness. A serialiser tested on one element is a serialiser whose loop is untested.
+    let prior = vec![
+        ObservationRecord {
+            payload: serde_json::json!({"aeeKind": "interception", "aeeVersion": "0.7", "n": 1}),
+            payload_type: OBSERVATION_PAYLOAD_TYPE.to_string(),
+        },
+        ObservationRecord {
+            payload: serde_json::json!({"aeeKind": "examination", "aeeVersion": "0.7", "n": 2}),
+            payload_type: OBSERVATION_PAYLOAD_TYPE.to_string(),
+        },
+    ];
+
+    let run = build_sealed_run(
+        Vantage::Landlock(&armed_run()),
+        &environment(),
+        &prior,
+        SEALED_AT,
+        &DropAccounting::SynchronousProbe,
+        COLLECTION_PATH_LANDLOCK_TCP_CONNECT,
+    )
+    .expect("seal-eligible");
+    assert!(
+        run.records.len() >= 3,
+        "the fixture must carry more than one record or the loop is untested: {}",
+        run.records.len()
+    );
+
+    // The function `--aee-records` calls, not a re-implementation of it. Reconstructing the
+    // serialisation here would test this test's idea of the wire format rather than the producer's.
+    let ndjson = records_ndjson(&run.records).expect("records serialise");
+    assert!(
+        !ndjson.is_empty(),
+        "a run with a run-end probe emits at least the examination record"
+    );
+
+    // Exactly what a consumer holding that file would do.
+    let parsed: Vec<ObservationRecord> = ndjson
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("emitted record parses back"))
+        .collect();
+    assert_eq!(
+        parsed.len(),
+        run.records.len(),
+        "no record lost on the wire"
+    );
+
+    assert_eq!(
+        observed_set(&parsed).expect("recomputes"),
+        run.seal.aee_observed_set,
+        "the seal's commitment must be checkable from the records the run wrote, not only from \
+         the values it held in memory"
+    );
+}

--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -232,6 +232,15 @@ pub struct SandboxArgs {
     #[arg(long, requires = "aee_run_context")]
     pub aee_seal: Option<PathBuf>,
 
+    // The seal's `aeeObservedSet` is a digest over the interception and examination records the run
+    // built. Emitting the digest without them leaves a member only this producer can re-derive,
+    // which is the party it exists to constrain (#2135). Optional rather than implied by
+    // `--aee-seal`, because a caller who wants only the signed payload should not silently get a
+    // second file; asking for the commitment's inputs is a separate decision.
+    /// Where to write the observation records the seal commits to (NDJSON)
+    #[arg(long, requires = "aee_seal")]
+    pub aee_records: Option<PathBuf>,
+
     /// Strict env mode: only safe base vars + explicit allows
     #[arg(long = "env-strict")]
     pub env_strict: bool,

--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -303,6 +303,7 @@ mod tests {
             aee_run_context: None,
             aee_seal_key: None,
             aee_seal: None,
+            aee_records: None,
             command: vec!["true".into()],
             policy: None,
             workdir: None,

--- a/crates/assay-cli/src/cli/commands/sandbox/child.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox/child.rs
@@ -359,6 +359,21 @@ fn maybe_emit_aee_seal(
         Err(e) => return warn(&format!("signing failed: {e}")),
     };
 
+    // Written before the seal, so a reader that finds a seal always finds its inputs beside it. The
+    // other order leaves a window where the commitment exists and the committed-to material does not.
+    if let Some(records_path) = args.aee_records.as_ref() {
+        let lines = match crate::aee_seal::records_ndjson(&run.records) {
+            Ok(l) => l,
+            Err(e) => return warn(&format!("observation record not serializable: {e}")),
+        };
+        if let Some(parent) = records_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(records_path, lines) {
+            return warn(&format!("could not write {}: {e}", records_path.display()));
+        }
+    }
+
     let doc = match serde_json::to_string_pretty(&envelope) {
         Ok(d) => d,
         Err(e) => return warn(&format!("envelope not serializable: {e}")),


### PR DESCRIPTION
Closes #2135.

## The gap

The seal carries `aeeObservedSet`, a digest over the interception and examination records the run built. `build_sealed_run` returns `SealedRun { seal, records }` and the call site used **only `.seal`** — 0 uses of `.records`. `verify_seal` never recomputes the set either.

So a run wrote a commitment and withheld the material it commits to. A consumer holding the emitted file could check the signature and **not the one claim the payload makes about anything outside itself** — leaving a member only its own producer can re-derive, which is the party it exists to constrain.

Found by a delivery-readiness check, not by a failure. Nothing was broken: the round trip passes because it holds both halves in memory, and the fixture checker recomputes because its fixtures carry the records. The gap was between what the tests exercise and what a run puts on disk.

## What this adds

`--aee-records <path>`, NDJSON, one record per line.

**Optional rather than implied by `--aee-seal`**: a caller who asked for a signed payload should not silently get a second file, and asking for the commitment's inputs is its own decision. **Written before the seal**, so a reader that finds a seal finds its inputs beside it rather than in a window where the commitment exists and the material does not.

`ObservationRecord` gains serde with the wire names — `payloadType`, not `payload_type` — since that is what an `observationRecords` entry carries.

## The test, and what biting changed about it

Written the way a consumer works rather than the way the producer does: serialise, parse back from that text, recompute from the parsed values. Recomputing from in-memory `run.records` would pass while the wire format silently lost a field.

Two bites, and the second changed the design:

| mutation | result |
|---|---|
| `payloadType` dropped from the wire | killed |
| the write path disabled in `child.rs` | **survived** |

The second survived because `child.rs` is `cfg(target_os = "linux")` — nothing on this host compiles it, let alone runs it, so a loop written there is untestable by construction. The serialisation is now `aee_seal::records_ndjson`, where a test can reach it, and the call site keeps only the file write. Re-bitten: breaking `records_ndjson` now fails the test.

The test also calls that function rather than re-implementing the format, so it tests the producer's wire format instead of its own idea of it.

## Verification

| gate | result |
|---|---|
| `assay-cli` tests | all suites green |
| clippy `-D warnings`, fmt | clean |
| **seal producer mutations** | **18/18 caught** |

## Not closed by this

The run still emits no `arming` record and no `attackResults` rows — the producer builds `examination` and `sealed` payloads only, and `attackResults` appears nowhere in `crates/`. So a run does not emit a complete AEE statement, and steps 2 through 4 of the plan committed on in-toto/attestation#570 remain unbuilt. Recorded in #2135 rather than implied by what this adds.