### PR TITLE
We had the predicate author's pronouns wrong in our own tree

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -35,7 +35,7 @@ pub const PROXY_SEAL_SCOPE: &str = "tool_call:mcp_proxy_policy";
 /// **Stays at 0.7, and there is no 0.8 to wait for.** Decided in #2093; the reason was corrected
 /// after the predicate author answered on in-toto/attestation#570 (2026-08-07).
 ///
-/// This first read her earlier sentence as an offer to ship 0.7 and repair the referencedness
+/// This first read his earlier sentence as an offer to ship 0.7 and repair the referencedness
 /// defect in 0.8, and recorded a migration trigger accordingly. She has since said to pin 0.7 and
 /// not plan for 0.8: the repair already landed on that branch as `c0c4da6` on 4 August, inside the
 /// 0.7 changelog rather than behind a bump, so that nobody has to pin a version whose reject family
@@ -737,8 +737,8 @@ pub enum DropAccounting {
 /// # Why `asserted` and not `declared`
 ///
 /// This value was `declared` until the predicate author pointed out a collision on
-/// in-toto/attestation#570: her `declared` names the weakest **evidence tier**, ours named a
-/// **drop-proof basis**. One word doing two jobs in one thread, and she noted renaming costs less
+/// in-toto/attestation#570: his `declared` names the weakest **evidence tier**, ours named a
+/// **drop-proof basis**. One word doing two jobs in one thread, and he noted renaming costs less
 /// before producer code reads it than after. Measuring it found a third job -- our own
 /// `annotation_conformance` records use `declared` for the declared-versus-observed annotation
 /// split -- so the word was already overloaded inside this tree.

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -302,7 +302,7 @@ plan for 0.8.** The repair had already landed on that branch as `c0c4da6` on 4 A
 "docs(aee): constrain every carried record, not only the referenced ones" — placed inside the 0.7
 changelog rather than behind a version bump, on the reasoning that a reject family a single edit
 empties is not something anyone should have to pin a version against. She names the ambiguity in
-her earlier sentence as hers, and our reading as the one her words invited.
+his earlier sentence as his, and our reading as the one his words invited.
 
 So the trigger above is void, and planning a 0.8 migration is the thing the placement was designed
 to avoid. What replaces it: the constant tracks whatever version #570 carries, and the pin to watch


### PR DESCRIPTION
Four sites in `crates/assay-cli/src/aee_seal.rs` and `docs/architecture/ADR-045-…md` referred to the AEE predicate author as "she". He is a man. Corrected.

## How it surfaced

A draft comment for in-toto/attestation#570 opened by apologising to him *in that thread* for having used those pronouns there. Measured before posting: **we never did.** Zero occurrences of `she|her|hers` across all 19 of our comments on that PR, from either party.

The misgendering is real and it is entirely here, in our own repository, where it had been sitting uncorrected while the apology was being drafted for somewhere else.

So the apology comes out of the draft and the text gets fixed instead. **An inaccurate apology is not a smaller error than the thing it apologises for; it just fails in a direction that looks better.**

## What stays wrong

Commit messages (`35cddd7ff`, `9bbe08e1e`, `8cbbe6029`) and the merged bodies of #2130 and #2131 are on the record and immutable. Naming that here rather than implying the tree is clean.

No behaviour change.