### PR TITLE
Three more pronoun sites, and why the first count was wrong

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -36,7 +36,7 @@ pub const PROXY_SEAL_SCOPE: &str = "tool_call:mcp_proxy_policy";
 /// after the predicate author answered on in-toto/attestation#570 (2026-08-07).
 ///
 /// This first read his earlier sentence as an offer to ship 0.7 and repair the referencedness
-/// defect in 0.8, and recorded a migration trigger accordingly. She has since said to pin 0.7 and
+/// defect in 0.8, and recorded a migration trigger accordingly. He has since said to pin 0.7 and
 /// not plan for 0.8: the repair already landed on that branch as `c0c4da6` on 4 August, inside the
 /// 0.7 changelog rather than behind a bump, so that nobody has to pin a version whose reject family
 /// one edit empties.

--- a/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
+++ b/docs/architecture/ADR-045-aee-substrate-signed-run-end-seal.md
@@ -297,11 +297,11 @@ keeping rather than overwriting. This ADR said the predicate author had proposed
 repairing the referencedness defect in 0.8, so the migration trigger read "0.8 is adopted when it
 exists upstream, not when it is proposed."
 
-She has since answered that plainly (in-toto/attestation#570, 2026-08-07): **pin 0.7, and do not
+He has since answered that plainly (in-toto/attestation#570, 2026-08-07): **pin 0.7, and do not
 plan for 0.8.** The repair had already landed on that branch as `c0c4da6` on 4 August — verified,
 "docs(aee): constrain every carried record, not only the referenced ones" — placed inside the 0.7
 changelog rather than behind a version bump, on the reasoning that a reject family a single edit
-empties is not something anyone should have to pin a version against. She names the ambiguity in
+empties is not something anyone should have to pin a version against. He names the ambiguity in
 his earlier sentence as his, and our reading as the one his words invited.
 
 So the trigger above is void, and planning a 0.8 migration is the thing the placement was designed


### PR DESCRIPTION
Follow-up to #2137, which said four sites and fixed four. Three sentence-initial `She` survived it: `aee_seal.rs:39`, `ADR-045:300`, `ADR-045:304`.

## Why the count was wrong

The audit used `git grep -E '\bshe\b'`. **git grep's POSIX ERE has no `\b`**, so the pattern matched nothing, and that zero was read as a clean tree. The same broken pattern was then used to verify the fix after #2137 merged, and reported clean for the same reason.

The step that would have caught it immediately is a positive control. Grepping the same file for `his`, a word the #2137 diff proves is present, also returned nothing. A matcher that cannot find a word known to be there is not reporting on the tree, and a grep returning nothing has two indistinguishable meanings until a must-match case separates them.

## The check, stated with its control

```
git grep -ciw -e his -- crates/assay-cli/src/aee_seal.rs        # 2  <- control passes
git grep -niw -e she -e her -e hers -- . ':!*.png' ':!*.jpg'    # 0  <- real result
```

Binaries are excluded because three PNGs under `demo/output/` match `her` as a byte sequence.