### PR TITLE
Pay the major once, so the next event kind is free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "aya",
  "chrono",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-evidence-replay"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "4.0.0"
+version = "5.0.0"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -76,19 +76,19 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "4.0.0" }
-assay-common = { path = "crates/assay-common", version = "4.0.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "4.0.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "4.0.0" }
-assay-policy = { path = "crates/assay-policy", version = "4.0.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "4.0.0" }
-assay-canonical = { path = "crates/assay-canonical", version = "4.0.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "4.0.0" }
-assay-sim = { path = "crates/assay-sim", version = "4.0.0" }
-assay-registry = { path = "crates/assay-registry", version = "4.0.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "4.0.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "4.0.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "4.0.0" }
+assay-core = { path = "crates/assay-core", version = "5.0.0" }
+assay-common = { path = "crates/assay-common", version = "5.0.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "5.0.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "5.0.0" }
+assay-policy = { path = "crates/assay-policy", version = "5.0.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "5.0.0" }
+assay-canonical = { path = "crates/assay-canonical", version = "5.0.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "5.0.0" }
+assay-sim = { path = "crates/assay-sim", version = "5.0.0" }
+assay-registry = { path = "crates/assay-registry", version = "5.0.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "5.0.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "5.0.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "5.0.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/crates/assay-adapter-a2a/Cargo.toml
+++ b/crates/assay-adapter-a2a/Cargo.toml
@@ -10,8 +10,8 @@ readme.workspace = true
 publish = false
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
-assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "5.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "5.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-adapter-acp/Cargo.toml
+++ b/crates/assay-adapter-acp/Cargo.toml
@@ -10,8 +10,8 @@ readme.workspace = true
 publish = false
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
-assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "5.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "5.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-adapter-api/Cargo.toml
+++ b/crates/assay-adapter-api/Cargo.toml
@@ -24,7 +24,7 @@ readme.workspace = true
 publish = true
 
 [dependencies]
-assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "5.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }

--- a/crates/assay-adapter-ucp/Cargo.toml
+++ b/crates/assay-adapter-ucp/Cargo.toml
@@ -10,8 +10,8 @@ readme.workspace = true
 publish = false
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
-assay-evidence = { path = "../assay-evidence", version = "4.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "5.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "5.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -21,7 +21,7 @@ kill-switch-capture = ["kill-switch", "dep:procfs"]
 runtime-monitor = []
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "5.0.0" }
 assay-common = { workspace = true, features = ["std"] }
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -282,8 +282,28 @@ impl EvidenceEvent {
 // -- Strongly Typed Payload Helpers --
 
 /// Typed payload variants (for convenience, not enforced by contract)
+///
+/// `#[non_exhaustive]` so that admitting an event kind is a minor release rather than a major one.
+/// Without it `cargo semver-checks` reports `enum_variant_added` against the published baseline,
+/// and because the workspace shares one version in the root `Cargo.toml`, that major is paid by
+/// every published crate. This is the enum of an evidence format designed to grow: ADR-047 admits
+/// one kind and #2124 motivates more, so the shape that charges a major per kind is the wrong one
+/// to keep. Marking it costs one major, once (#2126).
+///
+/// **Visibility decision, recorded because #2126 asks for it either way: this type stays `pub`.**
+/// The tempting alternative is `pub(crate)`, which would remove this class of gate outright rather
+/// than widen it, and it looked cheap because there are no production consumers: the raw wire is
+/// `serde_json::Value` on `EvidenceEvent::payload`, and `lint/`, `diff/` and
+/// `trust_basis/classifiers.rs` all read that value rather than this view. What that argument
+/// misses is where the consumers actually are. `tests/session_finding_bundle_roundtrip.rs` and
+/// `tests/coding_agent_evidence_pack.rs` live in `tests/`, so they link against this crate from
+/// outside and are external consumers in exactly the sense `pub(crate)` excludes. Narrowing the
+/// type would either break them or push them into the crate as unit tests, where they would stop
+/// exercising the public surface a reader of a bundle actually meets. Removing the gate by
+/// removing the only place the gate is tried is not a simplification.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "payload")]
+#[non_exhaustive]
 pub enum Payload {
     #[serde(rename = "assay.coding_agent.evidence_pack.v0")]
     CodingAgentEvidencePack(crate::coding_agent::CodingAgentEvidencePayload),
@@ -301,6 +321,12 @@ pub enum Payload {
     ProfileFinished(PayloadProfileFinished),
     #[serde(rename = "assay.policy.suggested")]
     PolicySuggested(PayloadPolicySuggested),
+    /// A finding about the session rather than about one call (ADR-047).
+    ///
+    /// Deferred out of #2122 because on an exhaustive enum this single variant cost a major
+    /// version; it lands here with `#[non_exhaustive]` so that the next one does not.
+    #[serde(rename = "assay.session.finding")]
+    SessionFinding(PayloadSessionFinding),
     Unknown(serde_json::Value),
 }
 

--- a/crates/assay-evidence/tests/session_finding_bundle_roundtrip.rs
+++ b/crates/assay-evidence/tests/session_finding_bundle_roundtrip.rs
@@ -16,7 +16,7 @@
 //! writer, a payload filter in the reader — fails this test rather than being invisible to it.
 
 use assay_evidence::bundle::{verify_bundle_with_limits, BundleWriter, ErrorClass, VerifyLimits};
-use assay_evidence::types::{EvidenceEvent, PayloadSessionFinding};
+use assay_evidence::types::{EvidenceEvent, Payload, PayloadSessionFinding};
 use serde_json::json;
 use std::io::Cursor;
 
@@ -66,14 +66,27 @@ fn a_session_finding_round_trips_through_the_writer_and_the_verifier() {
     assert_eq!(result.event_count, 2, "both events survived the round trip");
 
     // The payload is readable as a typed record rather than as loose JSON, which is what
-    // `PayloadSessionFinding` adds. It is parsed directly rather than through `Payload`: wiring the
-    // variant into that enum is a semver major (see ADR-047), so the struct ships first and the
-    // convenience view follows. A consumer reading `EvidenceEvent::payload` -- a raw `Value` --
+    // `PayloadSessionFinding` adds. A consumer reading `EvidenceEvent::payload` -- a raw `Value` --
     // does exactly this.
     let f: PayloadSessionFinding = serde_json::from_value(finding_payload("violated"))
         .expect("the written payload parses as the typed record");
     assert_eq!(f.spanned, vec![1, 2]);
     assert_eq!(f.outcome, "violated");
+
+    // And through the convenience view, which #2122 had to defer: on an exhaustive enum the
+    // variant alone was a semver major, so the struct shipped first and this followed once
+    // `#[non_exhaustive]` made the next kind cheap (#2126). This asserts the tag maps to the
+    // variant, which is the half a direct `from_value` on the struct cannot see: the struct
+    // parses the same bytes whether or not `Payload` knows the kind exists.
+    let tagged = serde_json::json!({
+        "type": "assay.session.finding",
+        "payload": finding_payload("violated"),
+    });
+    let view: Payload = serde_json::from_value(tagged).expect("the tag resolves to a variant");
+    match view {
+        Payload::SessionFinding(f) => assert_eq!(f.outcome, "violated"),
+        other => panic!("expected the session-finding variant, got {other:?}"),
+    }
 }
 
 /// Change the finding after the fact and verification refuses the bundle.

--- a/crates/assay-sim/Cargo.toml
+++ b/crates/assay-sim/Cargo.toml
@@ -23,6 +23,6 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 tempfile = { workspace = true }
 
-assay-adapter-api = { path = "../assay-adapter-api", version = "4.0.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "5.0.0" }
 assay-core = { workspace = true }
 assay-evidence = { workspace = true }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -52,7 +52,7 @@ assay --version
 
 Expected output:
 ```
-assay 4.0.0
+assay 5.0.0
 ```
 
 ---

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "assay-adapter-api"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "hex",
  "serde",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "chrono",
  "libc",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assay-canonical",


### PR DESCRIPTION
Closes #2126. Lands `#[non_exhaustive]` on `Payload` together with the `SessionFinding` variant #2122 deferred.

## Both acceptance criteria, measured

**One major covers both changes.** Against the 4.0.0 baseline, with `#[non_exhaustive]` applied, the added variant no longer trips `enum_variant_added` at all:

```
Checked  223 checks: 222 pass, 1 fail, 0 warn, 31 skip
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---
Summary  semver requires new major version: 1 major and 0 minor checks failed
```

**The next kind is free.** A further variant added on top of this commit, with no version bump at all, against `--baseline-rev HEAD`:

```
Checking assay-evidence v5.0.0 -> v5.0.0 (no change; assume patch)
Checked  223 checks: 223 pass, 31 skip
Summary  no semver update required
```

That probe was reverted; it exists in this description, not in the diff.

## Visibility, decided rather than left open

`Payload` stays `pub`. `pub(crate)` looked cheap because there are no production consumers: the wire is `serde_json::Value` on `EvidenceEvent::payload`, and `lint/`, `diff/` and `trust_basis/classifiers.rs` read that value. But the two consumers that exist are `tests/session_finding_bundle_roundtrip.rs` and `tests/coding_agent_evidence_pack.rs`, which live in `tests/` and therefore link from **outside** the crate. They are external in exactly the sense `pub(crate)` excludes. Narrowing the type would break them or push them inside as unit tests, where they stop exercising the surface a bundle reader meets.

## Two things worth knowing before merging

**This PR is the 5.0.0.** The semver gate is built so that "a break with no bump fails; a release PR that bumps to cover it passes", so the bump cannot wait for a separate release PR. It reached four hand-kept surfaces: `[workspace.package]`, nine pins in crate manifests that do not use `[workspace.dependencies]`, `fuzz/Cargo.lock`, and the version string in the installation docs. The build found the second; the release-surface hook found the last two.

**While this branch declares 5.0.0 against release tag v4.0.0, the CI semver gate is vacuous on it:**

```
Checking assay-evidence v4.0.0 -> v5.0.0 (major change)
Checked  0 checks: 0 pass, 254 skip
Summary  no semver update required
```

A declared major licenses every break, which is the same condition the workflow's own comment records for the whole 3.x line ("structurally unable to fail"). So this gate says nothing about any other API change that lands on this branch, and that is an argument for keeping the branch narrow or for deciding deliberately what else rides the major.

Related: #2123 is the same enum and the same design question, and is the obvious candidate to ride this major rather than motivate a later one.