### PR TITLE
A new failure mode should not be a major: 27 error enums

### DIFF
--- a/crates/assay-canonical/src/set_paths.rs
+++ b/crates/assay-canonical/src/set_paths.rs
@@ -17,6 +17,7 @@ pub type SetPath = Vec<String>;
 
 /// Why a record could not be set-normalized.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum SetPathError {
     /// A registry entry had no keys; a set-path must name at least one field.
     #[error("empty set-path in registry")]

--- a/crates/assay-cli/tests/error_enums_non_exhaustive.rs
+++ b/crates/assay-cli/tests/error_enums_non_exhaustive.rs
@@ -34,20 +34,36 @@ fn workspace_root() -> PathBuf {
         .expect("workspace root")
 }
 
-/// A directory entry resolved and proven to sit inside `root`, or `None`.
+/// One path component, admitted only if it is an ordinary name.
 ///
-/// Every path below is built from a `read_dir` entry, which is untrusted input to a static
-/// analyser and is a symlink away from being untrusted in fact: a link under `crates/` pointing
-/// outside the workspace would have this test read, and report on, a file that is not ours.
-/// Canonicalising first and then requiring containment resolves `..` and follows the link before
-/// the decision is made, so the check is on the real target rather than on the spelling.
+/// Paths here start at a `read_dir` entry, which is untrusted input to a static analyser and is a
+/// symlink away from being untrusted in fact: a link under `crates/` pointing outside the workspace
+/// would have this test read, and report on, a file that is not ours.
 ///
-/// This mirrors the path-containment rule the bundle reader and `validate_baseline_key()` already
-/// apply to archive members. It is the same class of input and gets the same treatment, rather
-/// than an exemption because this one happens to be a test.
-fn contained(root: &Path, candidate: &Path) -> Option<PathBuf> {
-    let resolved = candidate.canonicalize().ok()?;
-    resolved.starts_with(root).then_some(resolved)
+/// The first fix canonicalised and then required containment under the root. That is a correct
+/// check and CodeQL still flagged the read, which is fair: it is a check applied *after* an
+/// arbitrary path exists. This admits the component instead, so a traversal cannot be spelled in
+/// the first place. `.`, `..`, separators, and anything not in the allowed set are refused, and
+/// every path below is then built from `root` plus fixed segments plus admitted names.
+///
+/// Same rule the bundle reader and `validate_baseline_key()` apply to archive members. Being a
+/// test is not a reason for an exemption.
+fn safe_component(name: &std::ffi::OsStr) -> Option<String> {
+    let s = name.to_str()?;
+    let ordinary = !s.is_empty()
+        && s != "."
+        && s != ".."
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    ordinary.then(|| s.to_string())
+}
+
+/// True when `p` resolves to something inside `root`, so a symlink cannot lead the walk out.
+///
+/// Kept alongside the component rule rather than instead of it: the allowlist stops a traversal
+/// being written, and this stops one being followed.
+fn resolves_inside(root: &Path, p: &Path) -> bool {
+    p.canonicalize().is_ok_and(|r| r.starts_with(root))
 }
 
 /// Crates that can break a downstream consumer: published, and carrying a library target.
@@ -59,15 +75,15 @@ fn crates_with_public_api(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let dir = root.join("crates");
     for entry in fs::read_dir(&dir).expect("crates/ is readable") {
-        let Some(path) = contained(root, &entry.expect("dir entry").path()) else {
+        let Some(name) = safe_component(&entry.expect("dir entry").file_name()) else {
             continue;
         };
-        let (Some(manifest), Some(_lib)) = (
-            contained(root, &path.join("Cargo.toml")),
-            contained(root, &path.join("src/lib.rs")),
-        ) else {
+        // Rebuilt from the root and an admitted name, so this path cannot express a traversal.
+        let path = dir.join(&name);
+        let manifest = path.join("Cargo.toml");
+        if !resolves_inside(root, &manifest) || !resolves_inside(root, &path.join("src/lib.rs")) {
             continue;
-        };
+        }
         let text = fs::read_to_string(&manifest).expect("manifest is readable");
         if text
             .lines()
@@ -91,9 +107,13 @@ fn rust_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
         return;
     };
     for entry in entries.flatten() {
-        let Some(p) = contained(root, &entry.path()) else {
+        let Some(name) = safe_component(&entry.file_name()) else {
             continue;
         };
+        let p = dir.join(&name);
+        if !resolves_inside(root, &p) {
+            continue;
+        }
         if p.is_dir() {
             rust_files(root, &p, out);
         } else if p.extension().is_some_and(|e| e == "rs") {
@@ -185,6 +205,26 @@ fn every_public_error_enum_is_non_exhaustive() {
          `#[non_exhaustive]` at the declaration, per the decision in #2140:\n  {}",
         offenders.join("\n  ")
     );
+}
+
+/// The component allowlist, which is now the load-bearing half of the path handling.
+#[test]
+fn the_component_rule_refuses_anything_that_could_leave_the_directory() {
+    use std::ffi::OsStr;
+    for ok in ["assay-core", "assay_evidence", "mod.rs", "a.b-c_1"] {
+        assert_eq!(
+            safe_component(OsStr::new(ok)).as_deref(),
+            Some(ok),
+            "{ok} is an ordinary name"
+        );
+    }
+    for bad in ["", ".", "..", "../etc", "a/b", "a\\b", "a b", "naïve"] {
+        assert_eq!(
+            safe_component(OsStr::new(bad)),
+            None,
+            "{bad:?} must not be admitted as a component"
+        );
+    }
 }
 
 /// The detector, against fixture text.

--- a/crates/assay-cli/tests/error_enums_non_exhaustive.rs
+++ b/crates/assay-cli/tests/error_enums_non_exhaustive.rs
@@ -34,6 +34,22 @@ fn workspace_root() -> PathBuf {
         .expect("workspace root")
 }
 
+/// A directory entry resolved and proven to sit inside `root`, or `None`.
+///
+/// Every path below is built from a `read_dir` entry, which is untrusted input to a static
+/// analyser and is a symlink away from being untrusted in fact: a link under `crates/` pointing
+/// outside the workspace would have this test read, and report on, a file that is not ours.
+/// Canonicalising first and then requiring containment resolves `..` and follows the link before
+/// the decision is made, so the check is on the real target rather than on the spelling.
+///
+/// This mirrors the path-containment rule the bundle reader and `validate_baseline_key()` already
+/// apply to archive members. It is the same class of input and gets the same treatment, rather
+/// than an exemption because this one happens to be a test.
+fn contained(root: &Path, candidate: &Path) -> Option<PathBuf> {
+    let resolved = candidate.canonicalize().ok()?;
+    resolved.starts_with(root).then_some(resolved)
+}
+
 /// Crates that can break a downstream consumer: published, and carrying a library target.
 ///
 /// `publish = false` crates have no downstream. `assay-cli` is published but is a binary with no
@@ -43,11 +59,15 @@ fn crates_with_public_api(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let dir = root.join("crates");
     for entry in fs::read_dir(&dir).expect("crates/ is readable") {
-        let path = entry.expect("dir entry").path();
-        let manifest = path.join("Cargo.toml");
-        if !manifest.is_file() || !path.join("src/lib.rs").is_file() {
+        let Some(path) = contained(root, &entry.expect("dir entry").path()) else {
             continue;
-        }
+        };
+        let (Some(manifest), Some(_lib)) = (
+            contained(root, &path.join("Cargo.toml")),
+            contained(root, &path.join("src/lib.rs")),
+        ) else {
+            continue;
+        };
         let text = fs::read_to_string(&manifest).expect("manifest is readable");
         if text
             .lines()
@@ -66,14 +86,16 @@ fn crates_with_public_api(root: &Path) -> Vec<PathBuf> {
     out
 }
 
-fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+fn rust_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
-        let p = entry.path();
+        let Some(p) = contained(root, &entry.path()) else {
+            continue;
+        };
         if p.is_dir() {
-            rust_files(&p, out);
+            rust_files(root, &p, out);
         } else if p.extension().is_some_and(|e| e == "rs") {
             out.push(p);
         }
@@ -130,7 +152,7 @@ fn every_public_error_enum_is_non_exhaustive() {
 
     for krate in crates_with_public_api(&root) {
         let mut files = Vec::new();
-        rust_files(&krate.join("src"), &mut files);
+        rust_files(&root, &krate.join("src"), &mut files);
         for f in files {
             let text = fs::read_to_string(&f).expect("source is readable");
             checked += text

--- a/crates/assay-cli/tests/error_enums_non_exhaustive.rs
+++ b/crates/assay-cli/tests/error_enums_non_exhaustive.rs
@@ -1,0 +1,208 @@
+//! Every public error enum carries `#[non_exhaustive]`, so a new failure mode is not a major.
+//!
+//! #2140 measured the whole public surface: 697 types, 9 marked, 609 that could not grow without a
+//! major version paid by every published crate. The decision recorded there is deliberately narrow.
+//! Error enums get the attribute and almost nothing else does, for two reasons that pull the same
+//! way.
+//!
+//! The first is that a new failure mode is the most ordinary change a library makes, and every
+//! source agrees this is the canonical case. The second is measured rather than argued: marking all
+//! 27 public error enums produced **zero** compile errors across the workspace, because error types
+//! are consumed through `?` and `Display` rather than matched exhaustively. Marking every at-risk
+//! enum instead produced 19, and the twelve `E0004`s named `ClaimSupport` and
+//! `NetworkProtocolCoverageStatus` -- the claim and coverage vocabularies, where an exhaustive match
+//! is the enforcement and a wildcard arm would remove the thing the parity tests exist to hold.
+//!
+//! So this test guards the boundary the decision drew. It is not a general "mark everything" rule
+//! and must not become one.
+//!
+//! **Why the rule is `pub enum *Error` and not "public error enums":** deciding what is truly public
+//! needs module-visibility resolution through `pub mod` chains and `pub use` re-exports, and #2140
+//! got that wrong twice before rustdoc JSON settled it -- a `pub` type in a private module is still
+//! public API when re-exported, and a grep for the attribute counted fifteen doc-comment mentions as
+//! code. A check that needs a fragile analysis is a check that reports clean when it breaks. The
+//! name-shaped rule over-includes instead: an error enum in a private module gets an attribute that
+//! is a no-op there, which costs nothing and cannot silently under-report.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+/// Crates that can break a downstream consumer: published, and carrying a library target.
+///
+/// `publish = false` crates have no downstream. `assay-cli` is published but is a binary with no
+/// `lib.rs`, so it has no public API surface at all, which is why its own error enums are outside
+/// this rule rather than exceptions to it.
+fn crates_with_public_api(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let dir = root.join("crates");
+    for entry in fs::read_dir(&dir).expect("crates/ is readable") {
+        let path = entry.expect("dir entry").path();
+        let manifest = path.join("Cargo.toml");
+        if !manifest.is_file() || !path.join("src/lib.rs").is_file() {
+            continue;
+        }
+        let text = fs::read_to_string(&manifest).expect("manifest is readable");
+        if text
+            .lines()
+            .any(|l| l.trim_start().starts_with("publish") && l.contains("false"))
+        {
+            continue;
+        }
+        out.push(path);
+    }
+    out.sort();
+    assert!(
+        out.len() >= 10,
+        "found only {} crates with a public API; the walk is broken, not the workspace",
+        out.len()
+    );
+    out
+}
+
+fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            rust_files(&p, out);
+        } else if p.extension().is_some_and(|e| e == "rs") {
+            out.push(p);
+        }
+    }
+}
+
+/// `pub enum <Name>Error` declarations in `text` that lack `#[non_exhaustive]`, by line number.
+///
+/// The attribute block is read by walking *up* from the declaration over contiguous attribute and
+/// doc-comment lines, stopping at the first line that is neither. A fixed-distance lookback was
+/// tried first and produced a false positive by catching the attribute of the item above, which is
+/// why this walks lines rather than characters.
+fn unmarked_error_enums(text: &str) -> Vec<(usize, String)> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut out = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        let t = line.trim_start();
+        let Some(rest) = t.strip_prefix("pub enum ") else {
+            continue;
+        };
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if !name.ends_with("Error") {
+            continue;
+        }
+        let mut marked = false;
+        let mut j = i;
+        while j > 0 {
+            j -= 1;
+            let a = lines[j].trim_start();
+            if a.starts_with("#[") {
+                if a.contains("non_exhaustive") {
+                    marked = true;
+                    break;
+                }
+            } else if !(a.starts_with("///") || a.starts_with("//!") || a.starts_with("//")) {
+                break;
+            }
+        }
+        if !marked {
+            out.push((i + 1, name));
+        }
+    }
+    out
+}
+
+#[test]
+fn every_public_error_enum_is_non_exhaustive() {
+    let root = workspace_root();
+    let mut offenders = Vec::new();
+    let mut checked = 0usize;
+
+    for krate in crates_with_public_api(&root) {
+        let mut files = Vec::new();
+        rust_files(&krate.join("src"), &mut files);
+        for f in files {
+            let text = fs::read_to_string(&f).expect("source is readable");
+            checked += text
+                .lines()
+                .filter(|l| {
+                    l.trim_start().strip_prefix("pub enum ").is_some_and(|r| {
+                        r.split(|c: char| !(c.is_alphanumeric() || c == '_'))
+                            .next()
+                            .is_some_and(|n| n.ends_with("Error"))
+                    })
+                })
+                .count();
+            for (line, name) in unmarked_error_enums(&text) {
+                offenders.push(format!(
+                    "{}:{line} {name}",
+                    f.strip_prefix(&root).unwrap_or(&f).display()
+                ));
+            }
+        }
+    }
+
+    // Non-vacuous: if the walk stops finding declarations, this test would pass by finding nothing.
+    assert!(
+        checked >= 20,
+        "only {checked} error enum declaration(s) seen; the walk is broken, so a pass here means nothing"
+    );
+    assert!(
+        offenders.is_empty(),
+        "these public error enums can only grow a variant at a major version. Add \
+         `#[non_exhaustive]` at the declaration, per the decision in #2140:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// The detector, against fixture text.
+///
+/// Editing a real enum is not a usable mutation for the test above: it fails the assertion under
+/// test, which cannot tell "the detector works" from "the detector found nothing".
+#[test]
+fn the_detector_reads_the_attribute_block_and_not_the_neighbourhood() {
+    assert_eq!(
+        unmarked_error_enums("#[non_exhaustive]\npub enum FooError {\n}\n").len(),
+        0,
+        "an attribute directly above must count"
+    );
+    assert_eq!(
+        unmarked_error_enums(
+            "#[non_exhaustive]\n#[derive(Debug)]\n/// doc\npub enum FooError {\n}\n"
+        )
+        .len(),
+        0,
+        "the attribute must still count through derives and docs"
+    );
+    assert_eq!(
+        unmarked_error_enums("pub enum FooError {\n}\n").len(),
+        1,
+        "a bare declaration must be reported"
+    );
+
+    // The false positive that a fixed-distance lookback produced: the attribute belongs to the item
+    // above, and a character-window search attributes it to the enum below.
+    let neighbour = "#[non_exhaustive]\npub enum Other {\n    A,\n}\n\npub enum FooError {\n}\n";
+    assert_eq!(
+        unmarked_error_enums(neighbour),
+        vec![(6, "FooError".to_string())],
+        "an attribute on a preceding item must not be read as this one's"
+    );
+
+    // Names that merely contain `Error` are out of scope; the rule is on the suffix.
+    assert_eq!(
+        unmarked_error_enums("pub enum ErrorKind {\n}\n").len(),
+        0,
+        "the rule keys on the Error suffix, not on the substring"
+    );
+}

--- a/crates/assay-core/src/mcp/signing.rs
+++ b/crates/assay-core/src/mcp/signing.rs
@@ -56,6 +56,7 @@ pub struct VerifyResult {
 
 /// Verification errors with exit codes.
 #[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
 pub enum VerifyError {
     #[error("tool is not signed")]
     NoSignature,

--- a/crates/assay-core/src/replay/bundle/limits.rs
+++ b/crates/assay-core/src/replay/bundle/limits.rs
@@ -66,6 +66,7 @@ impl Default for ReplayLimits {
 /// Refusal raised by the bounded replay reader. Callers match the variant; the rendered
 /// message is a diagnostic, never a contract.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ReplayIngestError {
     #[error("replay bundle exceeded {kind} limit of {limit}")]
     SourceCeiling { kind: LimitKind, limit: u64 },
@@ -103,6 +104,7 @@ pub enum ReplayIngestError {
 /// it hands an attacker a channel into the operator's terminal and into every log that ingests
 /// the message, while telling the reader nothing they can act on.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ReplayContractError {
     /// Two entries normalize to the same path. Last-wins is undefined, and silently keeping one
     /// lets an archive present different bytes to a verifier than to a consumer.

--- a/crates/assay-core/src/runtime/authorizer.rs
+++ b/crates/assay-core/src/runtime/authorizer.rs
@@ -117,6 +117,7 @@ pub struct ToolCallData {
 
 /// Policy-level authorization errors (before DB).
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PolicyError {
     #[error("Mandate expired: expires_at={expires_at}, now={now}")]
     Expired {
@@ -151,6 +152,7 @@ pub enum PolicyError {
 
 /// Combined authorization error.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum AuthorizeError {
     #[error("Policy error: {0}")]
     Policy(#[from] PolicyError),

--- a/crates/assay-core/src/runtime/mandate_store.rs
+++ b/crates/assay-core/src/runtime/mandate_store.rs
@@ -29,6 +29,7 @@ pub struct AuthzReceipt {
 
 /// Authorization errors.
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AuthzError {
     #[error("Mandate not found: {mandate_id}")]
     MandateNotFound { mandate_id: String },

--- a/crates/assay-evidence/src/json_strict/errors.rs
+++ b/crates/assay-evidence/src/json_strict/errors.rs
@@ -9,6 +9,7 @@ pub const MAX_STRING_LENGTH: usize = 1_048_576; // 1MB
 
 /// Error returned when strict JSON parsing fails.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StrictJsonError {
     #[error("Duplicate key '{key}' at path '{path}'")]
     DuplicateKey { key: String, path: String },

--- a/crates/assay-evidence/src/lint/packs/loader.rs
+++ b/crates/assay-evidence/src/lint/packs/loader.rs
@@ -54,6 +54,7 @@ impl LoadedPack {
 
 /// Pack loading error.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PackError {
     #[error("Pack '{reference}' not found. {suggestion}")]
     NotFound {

--- a/crates/assay-evidence/src/lint/packs/schema_next/errors.rs
+++ b/crates/assay-evidence/src/lint/packs/schema_next/errors.rs
@@ -1,5 +1,6 @@
 /// Pack validation error.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PackValidationError {
     #[error("Pack '{pack}' is kind 'compliance' but missing 'disclaimer'")]
     MissingDisclaimer { pack: String },

--- a/crates/assay-evidence/src/mandate/policy.rs
+++ b/crates/assay-evidence/src/mandate/policy.rs
@@ -258,6 +258,7 @@ impl PolicyValidationResult {
 
 /// Policy validation error.
 #[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
 pub enum PolicyValidationError {
     #[error("mandate is not signed but require_signed is true")]
     NotSigned,

--- a/crates/assay-evidence/src/mandate/signing.rs
+++ b/crates/assay-evidence/src/mandate/signing.rs
@@ -27,6 +27,7 @@ use sha2::{Digest, Sha256};
 
 /// Verification errors with exit codes per SPEC-Mandate-v1 §5.5.
 #[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
 pub enum VerifyError {
     #[error("mandate is not signed")]
     Unsigned,

--- a/crates/assay-evidence/src/store/error.rs
+++ b/crates/assay-evidence/src/store/error.rs
@@ -7,6 +7,7 @@ pub type StoreResult<T> = Result<T, StoreError>;
 
 /// Errors that can occur during bundle storage operations.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StoreError {
     /// Bundle already exists (conditional write failed).
     /// This is not necessarily an error—it means the bundle was already uploaded.

--- a/crates/assay-monitor/src/error.rs
+++ b/crates/assay-monitor/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MonitorError {
     #[error("failed to load BPF object: {0}")]
     LoadError(String),

--- a/crates/assay-monitor/src/tree/tracker.rs
+++ b/crates/assay-monitor/src/tree/tracker.rs
@@ -27,6 +27,7 @@ impl Default for TrackerConfig {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum TrackerError {
     #[error("PID {0} already tracked")]
     AlreadyTracked(u32),

--- a/crates/assay-registry/src/canonicalize/errors.rs
+++ b/crates/assay-registry/src/canonicalize/errors.rs
@@ -22,6 +22,7 @@ pub const MIN_SAFE_INTEGER: i64 = -9_007_199_254_740_992; // -2^53
 
 /// Errors specific to canonicalization.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CanonicalizeError {
     /// YAML contains anchors (forbidden).
     AnchorFound { position: String },

--- a/crates/assay-registry/src/error.rs
+++ b/crates/assay-registry/src/error.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 /// Registry errors.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RegistryError {
     /// Pack not found in registry.
     #[error("pack not found: {name}@{version}")]

--- a/crates/assay-runner-core/src/archive.rs
+++ b/crates/assay-runner-core/src/archive.rs
@@ -27,6 +27,7 @@ pub struct RunnerSpikeArchive {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum RunnerSpikeArchiveError {
     #[error("run_id must not be empty")]
     EmptyRunId,

--- a/crates/assay-runner-core/src/kernel.rs
+++ b/crates/assay-runner-core/src/kernel.rs
@@ -134,6 +134,7 @@ pub struct DropLayers {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum KernelLayerError {
     #[error("kernel layer run_id must not be empty")]
     EmptyRunId,

--- a/crates/assay-runner-core/src/policy.rs
+++ b/crates/assay-runner-core/src/policy.rs
@@ -29,6 +29,7 @@ pub struct PolicyLayerCapture {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PolicyLayerError {
     #[error("policy layer run_id must not be empty")]
     EmptyRunId,

--- a/crates/assay-runner-core/src/run.rs
+++ b/crates/assay-runner-core/src/run.rs
@@ -20,6 +20,7 @@ pub struct RunSpec {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum RunSpecError {
     #[error("command must not be empty")]
     EmptyCommand,
@@ -36,6 +37,7 @@ pub enum RunSpecError {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum RunExecutionError {
     #[error(transparent)]
     Spec(#[from] RunSpecError),

--- a/crates/assay-runner-core/src/sdk.rs
+++ b/crates/assay-runner-core/src/sdk.rs
@@ -12,6 +12,7 @@ pub struct SdkLayerCapture {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SdkLayerError {
     #[error("sdk layer run_id must not be empty")]
     EmptyRunId,

--- a/crates/assay-runner-schema/src/correlation.rs
+++ b/crates/assay-runner-schema/src/correlation.rs
@@ -37,6 +37,7 @@ pub struct CorrelationReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum CorrelationReportError {
     #[error("correlation report schema must be {CORRELATION_REPORT_SCHEMA}")]
     InvalidSchema,

--- a/crates/assay-runner-schema/src/health.rs
+++ b/crates/assay-runner-schema/src/health.rs
@@ -139,6 +139,7 @@ pub struct ObservationHealth {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum ObservationHealthError {
     #[error("observation health schema must be {OBSERVATION_HEALTH_SCHEMA}")]
     InvalidSchema,

--- a/crates/assay-runner-schema/src/surface.rs
+++ b/crates/assay-runner-schema/src/surface.rs
@@ -20,6 +20,7 @@ pub struct CapabilitySurface {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum CapabilitySurfaceError {
     #[error("capability surface schema must be {CAPABILITY_SURFACE_SCHEMA}")]
     InvalidSchema,

--- a/crates/assay-sim/src/attacks/integrity.rs
+++ b/crates/assay-sim/src/attacks/integrity.rs
@@ -151,6 +151,7 @@ fn create_event(seq: u64) -> EvidenceEvent {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum IntegrityError {
     BudgetExceeded,
     Other(anyhow::Error),


### PR DESCRIPTION
Implements the decision recorded on #2140. Adds `#[non_exhaustive]` to the 27 public error enums across 12 crates, plus a test that holds the rule.

## The scope was priced, not argued

Both options were applied to the tree and measured with `cargo check --workspace --all-targets`:

| applied to | result |
|---|---|
| the 27 public error enums | **0 errors** |
| all 176 at-risk enums | 19 errors, 12 of them `E0004` |

Error types come back at zero because they are consumed through `?` and `Display` rather than matched exhaustively. That is the whole reason this scope is cheap and the wider one is not.

## The twelve are why the rest stays closed

They land on exactly two places, and both are load-bearing:

- **`ClaimSupport`**, matched exhaustively in `assay-runner-schema/tests/claim_support_parity.rs`. That test exists to fail when the claim vocabulary grows on one side and not the other. A wildcard arm is not a cost there, it removes the guarantee the test was written for.
- **`NetworkProtocolCoverageStatus`**, matched in `assay-runner-core/src/kernel/health.rs` to map coverage status onto `NetworkEndpointClaimScope`. Take the wildcard and a real coverage gap maps to a claim scope nobody chose.

Buying release ergonomics with those two would trade the property this repository is about for the packaging it ships in.

## Two scope decisions worth stating

**Not applied where it is a no-op.** The first pass marked 33 enums. Six were in `assay-cli` (published, but a binary with no `lib.rs`, so no public API) and `gateway-evidence-replay` (`publish = false`). `#[non_exhaustive]` only acts across a crate boundary, so those have no downstream to protect. Reverted, which lands the change on exactly the decided 27. Published and *has a public API* are not the same predicate.

**The test keys on `pub enum *Error`, not on true visibility.** Deciding what is genuinely public needs resolution through `pub mod` chains and `pub use` re-exports, and #2140 got that wrong twice before rustdoc JSON settled it: a `pub` type in a private module is still public API when re-exported, and a grep for the attribute counted 15 doc-comment mentions as code. A check that needs a fragile analysis is a check that reports clean when it breaks. The name rule over-includes instead, which costs a no-op attribute in a private module and cannot silently under-report.

## Verification

- `cargo check --workspace --all-targets`: 0 errors, matching the measurement.
- Tests green for `assay-evidence`, `assay-runner-schema`, `assay-runner-core`, `assay-registry`, including `claim_support_parity`.
- The enforcement test is bitten: removing the attribute from `StoreError` fails it with file and line. The detector has its own fixture test for the false positive a fixed-distance lookback produced.

## Note on the semver gate

It will pass, but it is not evidence here. `main` declares 5.0.0 against release tag v4.0.0, so a declared major licenses every break and the gate reports `0 checks, all skip`. The real checks on this PR are the compile and the tests.