### PR TITLE
Remove the fallback member rather than rename it

### DIFF
--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -301,6 +301,21 @@ impl EvidenceEvent {
 /// type would either break them or push them into the crate as unit tests, where they would stop
 /// exercising the public surface a reader of a bundle actually meets. Removing the gate by
 /// removing the only place the gate is tried is not a simplification.
+///
+/// **There is no fallback member, and an unregistered `type` is a deserialisation error.** That is
+/// the contract, stated here because the previous shape stated the opposite by accident: an
+/// `Unknown(Value)` variant read like a catch-all while being adjacently tagged with no
+/// `#[serde(other)]`, so it matched the literal tag `"Unknown"`, which no producer emits, and
+/// every other unregistered kind still failed to parse. It promised forward compatibility the type
+/// did not provide, so it was removed rather than renamed (#2123).
+///
+/// Forward compatibility lives one layer down, where it already works. `EvidenceEvent::payload` is
+/// a raw `serde_json::Value`, so a consumer meeting a newer producer keeps the bytes and can skip
+/// what it does not recognise. That is the same split protocol buffers makes, where unknown data is
+/// preserved on the wire rather than given a named member, and `UNSPECIFIED` answers a different
+/// question: the default of a scalar field, not the identity of a message. Naming a member for
+/// "everything else" also implies the set is otherwise closed, which `#[non_exhaustive]` above
+/// already says structurally and more accurately.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "payload")]
 #[non_exhaustive]
@@ -327,7 +342,6 @@ pub enum Payload {
     /// version; it lands here with `#[non_exhaustive]` so that the next one does not.
     #[serde(rename = "assay.session.finding")]
     SessionFinding(PayloadSessionFinding),
-    Unknown(serde_json::Value),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/assay-evidence/src/types/tests.rs
+++ b/crates/assay-evidence/src/types/tests.rs
@@ -242,13 +242,13 @@ fn sandbox_degraded_payload_serde_shape_is_stable() {
 /// deferred to the next major together with `#[non_exhaustive]`, so the break is paid once for
 /// every kind that follows rather than once per kind.
 ///
-/// The control is what makes this worth pinning. `Unknown(serde_json::Value)` reads like a
-/// catch-all and is not one: adjacently tagged with no `#[serde(other)]`, it matches the literal
-/// tag `"Unknown"` and nothing else, so an unregistered kind is a hard deserialisation error rather
-/// than an untyped landing. That is why the wire stays raw `Value` and why the deferral above costs
-/// consumers nothing today.
+/// The control is what makes this worth pinning: **there is no fallback member at all**, so an
+/// unregistered kind is a deserialisation error and not an untyped landing. `Unknown(Value)` used
+/// to sit here reading like a catch-all while matching only the literal tag `"Unknown"`, which no
+/// producer emits; #2123 removed it rather than renaming it, because the thing the name described
+/// should not exist. Forward compatibility is `EvidenceEvent::payload` staying a raw `Value`.
 #[test]
-fn a_session_finding_parses_as_a_typed_record_and_unknown_is_not_a_fallback() {
+fn a_session_finding_parses_as_a_typed_record_and_there_is_no_fallback_member() {
     let payload = serde_json::json!({
         "rule_id": "after:read_credentials->http_post",
         "kind": "after",
@@ -275,12 +275,21 @@ fn a_session_finding_parses_as_a_typed_record_and_unknown_is_not_a_fallback() {
         "expected a variant error, got: {err}"
     );
 
+    // The old shape's own tag is now just another unregistered kind. This is the assertion that
+    // fails if a fallback member is ever reintroduced under any name: nothing may absorb a tag the
+    // enum does not list.
     let literal = serde_json::json!({"type": "Unknown", "payload": {"anything": 1}});
+    let err = serde_json::from_value::<Payload>(literal)
+        .expect_err("no member absorbs an unlisted tag, including the one this used to have");
     assert!(
-        matches!(
-            serde_json::from_value::<Payload>(literal).expect("the literal tag parses"),
-            Payload::Unknown(_)
-        ),
-        "Unknown matches its own name and nothing else"
+        err.to_string().contains("unknown variant"),
+        "expected a variant error, got: {err}"
     );
+
+    // And the layer that does carry forward compatibility still does: the raw wire keeps the bytes
+    // of a kind this build has never heard of, which is why removing the member costs nothing.
+    let raw: serde_json::Value =
+        serde_json::from_str(r#"{"type":"assay.from.the.future","payload":{"kept":[1,2]}}"#)
+            .expect("the wire is untyped and parses regardless");
+    assert_eq!(raw["payload"]["kept"], serde_json::json!([1, 2]));
 }


### PR DESCRIPTION
Closes #2123.

`Payload::Unknown(Value)` read like a catch-all and was not one. Adjacently tagged with no `#[serde(other)]`, it matched the literal tag `"Unknown"` — which no producer emits — while every other unregistered kind still failed to parse.

## Why removal rather than the rename #2123 proposed

Option 2 in the issue is "keep the strictness and rename, because if failing closed is the intent then `Unknown` is the wrong name". Taken literally that leads here: renaming keeps a member that still matches only its own tag, so it stays dead code with a better label. If the name is wrong because the thing should not exist, the fix is to delete it.

## Forward compatibility was never in this type

It lives one layer down and works there. `EvidenceEvent::payload` is a raw `serde_json::Value`, so a consumer meeting a newer producer keeps the bytes and skips what it does not recognise.

That is the same split [protocol buffers](https://protobuf.dev/programming-guides/field_presence/) makes: unknown data is preserved on the wire rather than given a named member, and `UNSPECIFIED` answers a different question — the default of a scalar field, not the identity of a message. And naming a member for "everything else" [implies the set is otherwise closed](https://devblogs.microsoft.com/oldnewthing/20250217-00/?p=110873), which `#[non_exhaustive]` now says structurally and more accurately.

## Cost

Breaking, and free right now: 5.0.0 is declared and unreleased, so this rides the major #2139 opened rather than motivating another one. `cargo check --workspace --all-targets`: 0 errors.

## The test now pins the contract, not the artefact

It used to assert that `Unknown` matched its own name. It now asserts that **no member absorbs an unlisted tag**, so reintroducing a fallback under any name fails it — bitten to confirm. A second assertion holds the raw wire still carrying a kind this build has never heard of, so the removal cannot be read as removing the property.