### PR TITLE
Cut 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-08-08
+
+A major spent deliberately rather than paid by accident. Two of these breaks were
+waiting for a major to exist: the ineffective-assertion default was phased to one
+in #1949, and the `Payload` variant was deferred out of #2122 for the same reason.
+The other three rode it rather than motivating one of their own. Grouping them is
+the point: after this, a new event kind, a new failure mode and a new rule step
+are all minors.
+
 ### Breaking
 - **An assertion that cannot fail is now refused at load.** `assay run` and `assay ci` stop before
   execution when a config carries an assertion no trace could fail, such as
@@ -31,6 +40,25 @@ All notable changes to this project will be documented in this file.
 - `assay_evidence::types::Payload` is `#[non_exhaustive]` and carries `SessionFinding`, so admitting
   a future event kind is a minor rather than a major (#2126).
 - The 27 public error enums are `#[non_exhaustive]`, so a new failure mode is a minor (#2140).
+- Sequence rules read calls rather than names. `SequenceRule`'s tool fields are `CallSelector`,
+  which deserialises from a bare string exactly as before, so **every existing YAML parses
+  unchanged**; the object form is new capability. A step may now constrain the call's arguments:
+
+  ```yaml
+  - type: never_after
+    trigger:   { tool: bash, args_match: { command: "\\.aws/credentials" } }
+    forbidden: { tool: bash, args_match: { command: "^curl\\b.*-d" } }
+  ```
+
+  This is what makes "credential read followed by egress" writable at all: in the recorded
+  demonstration that motivated it, all three calls are `bash` and only the arguments separate them.
+  `evaluate_rules` takes `&[SequenceCall]` instead of `&[String]`, and `assay-metrics` no longer
+  discards `args` before evaluation (#2124).
+
+### Added
+- `PayloadSessionFinding::new` and `EVENT_TYPE` are added so a producer does not restate the field
+  order or respell the tag. No command emits a session finding yet; the kind is admitted to the
+  format and wiring a producer is separate work (ADR-047, #2105).
 
 ## [4.0.0] - 2026-08-06
 


### PR DESCRIPTION
Names the changelog section so the release notes say what shipped rather than `[Unreleased]`. The version has been `5.0.0` in `Cargo.toml` since #2139, which is what the semver gate required of the branch that opened the major.

## What 5.0.0 carries

Five breaks, and the grouping is the point:

| | |
|---|---|
| ineffective assertions refused at load | #1949 |
| `Payload::Unknown` removed | #2123 |
| `Payload` `#[non_exhaustive]` + `SessionFinding` | #2126 |
| 27 public error enums `#[non_exhaustive]` | #2140 |
| `SequenceRule` fields are `CallSelector` | #2124 |

**Two of them were waiting for a major to exist.** The ineffective-assertion default was phased to one in #1949 ("warning → opt-in → default at a major"), and the `Payload` variant was deferred out of #2122 for the same reason. The other three rode the open major rather than motivating one of their own.

After this, a new event kind, a new failure mode and a new rule step are each a **minor**. That was the argument in #2140 and it is why these landed together rather than one per release.

## Note on the one non-break

`PayloadSessionFinding::new` and `EVENT_TYPE` are listed under `### Added`, not `### Breaking`. They are additive, and filing them as a break would have overstated the upgrade cost by a sixth — a small error of exactly the kind a changelog section exists to prevent.

## Order

This must land **before** the tag. `release.yml` triggers on `v*` and builds from the tag, so tagging first would publish a 5.0.0 whose release notes read `[Unreleased]`, and a crates.io version can be yanked but not withdrawn.

The release-surface check deliberately does not gate `CHANGELOG.md` — entries there are supposed to be stale, since they record what happened rather than what is current. So this step is one a person has to get right rather than one a gate catches.