### PR TITLE
Two doc lines still said `declared` after the value was renamed

### DIFF
--- a/crates/assay-cli/src/aee_seal.rs
+++ b/crates/assay-cli/src/aee_seal.rs
@@ -251,10 +251,10 @@ pub struct SealPayload {
     pub assay_seal_scope: String,
     #[serde(rename = "assayDropProofModel")]
     pub assay_drop_proof_model: String,
-    /// `checked` or `declared` -- whether anything was verified about the model above.
+    /// `checked` or `asserted` -- whether anything was verified about the model above.
     #[serde(rename = "assayDropProofBasis")]
     pub assay_drop_proof_basis: String,
-    /// `name=lost` per channel, empty when the basis is `declared`. The readings the claim rests on.
+    /// `name=lost` per channel, empty when the basis is `asserted`. The readings the claim rests on.
     #[serde(rename = "assayDropChannels")]
     pub assay_drop_channels: Vec<String>,
     #[serde(rename = "assayAttackRowAttributionSource")]


### PR DESCRIPTION
`DROP_BASIS_ASSERTED` was renamed from `declared` on the predicate author's report that the word collided with his evidence tier (in-toto/attestation#570). The rename rationale lives in this same file. The two doc comments on `SealPayload` that describe the *emitted members* were not updated with it, so the struct a reader meets first still documented a value the code no longer produces.

Found while drafting a reply upstream that cites this pair as a worked case. Reporting a rename to a spec author while our own field docs still carry the old name is the kind of gap that costs more than the edit.

The four remaining occurrences of the old word are in the rename rationale, where it is the subject rather than a description.