### PR TITLE
Put the diagnosis on stdout when the run fails and json was asked for

### DIFF
--- a/crates/assay-cli/src/cli/commands/ci.rs
+++ b/crates/assay-cli/src/cli/commands/ci.rs
@@ -15,7 +15,7 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
     let input = PipelineInput::from_ci(&args);
     let execution = match execute_pipeline(&input, legacy_mode).await {
         Ok(ok) => ok,
-        Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path),
+        Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path, false),
     };
 
     if execution.cfg.version > 0 {

--- a/crates/assay-cli/src/cli/commands/pipeline_error.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline_error.rs
@@ -174,6 +174,7 @@ impl PipelineError {
         version: ExitCodeVersion,
         verify_enabled: bool,
         run_json_path: &Path,
+        json_stdout: bool,
     ) -> anyhow::Result<i32> {
         match self {
             Self::Classified {
@@ -199,6 +200,7 @@ impl PipelineError {
                     version,
                     verify_enabled,
                     run_json_path,
+                    json_stdout,
                 )
             }
             Self::Fatal(err) => Err(err),

--- a/crates/assay-cli/src/cli/commands/reporting.rs
+++ b/crates/assay-cli/src/cli/commands/reporting.rs
@@ -3,6 +3,18 @@ use super::run_output::{export_baseline, summary_from_outcome, write_run_json_mi
 use crate::exit_codes::{ExitCodeVersion, ReasonCode, RunOutcome};
 use std::path::{Path, PathBuf};
 
+/// Write the early-exit artifacts, and put the diagnosis on stdout when the caller asked for
+/// machine-readable output.
+///
+/// `json_stdout` exists because `--format json` documents "machine-readable report on stdout" and
+/// the failure path wrote nothing there: the diagnosis went to `summary.json` and to a
+/// human-formatted block on stderr. A caller that captures stdout, which is what a non-interactive
+/// consumer has along with the exit code, saw an empty stream from a run that had in fact produced
+/// a complete answer including a `next_step` (#2150).
+///
+/// The object emitted is the same `Summary` that goes to disk rather than a second shape built for
+/// the occasion. Two renderings of one diagnosis is the drift this repository keeps paying for
+/// elsewhere, and the artifact is the one consumers already depend on.
 pub(crate) fn write_error_artifacts(
     reason: ReasonCode,
     message: String,
@@ -10,6 +22,7 @@ pub(crate) fn write_error_artifacts(
     version: ExitCodeVersion,
     verify_enabled: bool,
     run_json_path: &Path,
+    json_stdout: bool,
 ) -> anyhow::Result<i32> {
     let mut o = RunOutcome::from_reason(reason, Some(message), context);
     o.exit_code = reason.exit_code_for(version);
@@ -24,6 +37,14 @@ pub(crate) fn write_error_artifacts(
     let summary = summary_from_outcome(&o, verify_enabled).with_seeds(None, None);
     if let Err(e) = assay_core::report::summary::write_summary(&summary, &summary_path) {
         eprintln!("WARNING: failed to write summary.json: {}", e);
+    }
+    if json_stdout {
+        match serde_json::to_string_pretty(&summary) {
+            Ok(rendered) => println!("{rendered}"),
+            // A failure to render is reported and does not change the exit code: the code is the
+            // classification of the run, not of our ability to describe it.
+            Err(e) => eprintln!("WARNING: failed to render summary for stdout: {e}"),
+        }
     }
     Ok(o.exit_code)
 }

--- a/crates/assay-cli/src/cli/commands/run.rs
+++ b/crates/assay-cli/src/cli/commands/run.rs
@@ -15,7 +15,14 @@ pub(crate) async fn run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32>
     let input = PipelineInput::from_run(&args);
     let execution = match execute_pipeline(&input, legacy_mode).await {
         Ok(ok) => ok,
-        Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path),
+        Err(e) => {
+            return e.into_exit_code(
+                version,
+                !args.no_verify,
+                &run_json_path,
+                matches!(args.format, super::super::args::OutputFormat::Json),
+            )
+        }
     };
 
     let cfg = execution.cfg;

--- a/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
+++ b/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
@@ -1,0 +1,123 @@
+//! `--format json` puts the diagnosis on stdout when the run fails, not only when it succeeds.
+//!
+//! The flag documents "machine-readable report on stdout". On the failure path it wrote nothing
+//! there: the diagnosis went to `summary.json` and to a human-formatted block on stderr, so a caller
+//! that captures stdout and reads the exit code, which is what a non-interactive consumer has, saw
+//! an empty stream from a run that had produced a complete answer including a suggested next step
+//! (#2150).
+//!
+//! Driven rather than asserted, for the reason the gap existed at all: every constant involved was
+//! already correct. `summary.json` carried `reason_code` and `next_step`, the exit code was right,
+//! and the only wrong thing was which stream the bytes reached. A test over constants cannot see
+//! that, which is why this one runs the binary and reads its actual stdout.
+
+use std::io::Write;
+use std::process::Command;
+
+/// A suite that fails at load: one assertion that no trace could fail (#1949).
+fn vacuous_suite(dir: &std::path::Path) -> std::path::PathBuf {
+    let path = dir.join("suite.yaml");
+    let mut f = std::fs::File::create(&path).expect("create suite");
+    write!(
+        f,
+        r#"configVersion: 1
+suite: stdout_contract_probe
+model: dummy
+tests:
+  - id: t1
+    input: hello
+    assertions:
+      - type: trace_must_call_tool
+        tool: search
+        min_calls: 0
+"#
+    )
+    .expect("write suite");
+    path
+}
+
+#[test]
+fn a_failing_run_writes_the_diagnosis_to_stdout_under_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let suite = vacuous_suite(dir.path());
+
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .current_dir(dir.path())
+        .args(["run", "--format", "json", "--config"])
+        .arg(&suite)
+        .output()
+        .expect("the binary runs");
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a config that cannot load is exit 2; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+    assert!(
+        !stdout.trim().is_empty(),
+        "--format json documents a machine-readable report on stdout, and the failure path wrote \
+         nothing there. stderr was: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout must parse as JSON: {e}\n{stdout}"));
+
+    // The three fields a caller needs to act without reading a file or the human channel. Asserted
+    // by name rather than by shape, because a consumer branches on `reason_code` and follows
+    // `next_step`, and an object that merely parses gives it neither.
+    assert_eq!(parsed["exit_code"], 2, "stdout must carry the exit code");
+    assert_eq!(
+        parsed["reason_code"], "E_CFG_PARSE",
+        "stdout must carry the machine-readable reason"
+    );
+    assert!(
+        parsed["next_step"]
+            .as_str()
+            .is_some_and(|s| s.contains("assay")),
+        "a non-zero exit must suggest a concrete next command, got {:?}",
+        parsed["next_step"]
+    );
+
+    // `summary.json` is unchanged and still the artifact. Consumers depend on it, and this fix adds
+    // a stream rather than moving one.
+    let summary = dir.path().join("summary.json");
+    assert!(summary.is_file(), "summary.json must still be written");
+    let from_disk: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&summary).expect("read summary"))
+            .expect("summary.json parses");
+    assert_eq!(
+        from_disk["reason_code"], parsed["reason_code"],
+        "the artifact and stdout must be one diagnosis, not two renderings"
+    );
+}
+
+#[test]
+fn the_text_format_keeps_stdout_clear() {
+    // The other half of the contract: `--format text` says the human report goes to stderr, so a
+    // caller redirecting stdout under the default gets nothing to misparse. Without this, "put it
+    // on stdout" could be satisfied by putting it there always, which would break every existing
+    // pipeline that treats stdout as the machine channel only when asked.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let suite = vacuous_suite(dir.path());
+
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .current_dir(dir.path())
+        .args(["run", "--config"])
+        .arg(&suite)
+        .output()
+        .expect("the binary runs");
+
+    assert_eq!(out.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+        "under the default format the diagnosis belongs on stderr"
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "and stderr must still carry the human report"
+    );
+}


### PR DESCRIPTION
Closes #2150. Found while measuring the CLI against agent-ergonomic CLI guidance for #1975.

## Measured, before and after

Same suite, same command, one changed line of routing:

| | stdout | stderr | exit |
|---|---|---|---|
| before | **0 B** | 477 B | 2 |
| after | **714 B valid JSON** | 477 B | 2 |

The JSON carries `exit_code`, `reason_code: "E_CFG_PARSE"`, `reason_code_version: 1` and `next_step: "Run: assay doctor --config s.yaml"`.

## Why it mattered

`--format json` documents "machine-readable report on stdout". On the failure path it wrote nothing there. A caller that captures stdout and reads the exit code — which is all a non-interactive consumer reliably has — saw an empty stream from a run that had produced a complete diagnosis, including a suggested next command.

The data was never missing. It was in `summary.json` and in a human-formatted block on stderr, both places the flag says the caller does not have to look.

## Design

The object emitted is the **same `Summary` that goes to disk**, not a second shape for the occasion, and the test asserts the two agree on `reason_code`. Two renderings of one diagnosis is drift this repository has paid for elsewhere.

A rendering failure warns and leaves the exit code untouched: the code classifies the run, not our ability to describe it.

## Tests

Both drive the binary, because every constant involved was already correct. The reason code, the next step and the exit code were right and reaching the wrong stream — which a test over constants cannot see, and is exactly how this survived.

- `a_failing_run_writes_the_diagnosis_to_stdout_under_json` — stdout is non-empty, parses, and carries the three fields a caller acts on; and matches `summary.json`.
- `the_text_format_keeps_stdout_clear` — the other half, so "put it on stdout" cannot be satisfied by putting it there unconditionally and breaking pipelines that treat stdout as the machine channel only when asked.

Bitten: reverting the routing fails the first test with a message that states the defect.

## Scope

`ci.rs` takes `false` because that command has no `--format` argument. Exit codes are unaffected and remain as frozen in #2148.