### PR TITLE
Two facts in the file every agent reads first were wrong

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Assay is a **Policy-as-Code** engine for Model Context Protocol (MCP) that valid
 
 ## Workspace Structure
 
-Rust monorepo with workspace version `3.31.1` (21 crates). Curated view, grouped by role:
+Rust monorepo, workspace version `5.0.0`, 22 workspace packages (21 under `crates/` plus
+`assay-python-sdk`; 9 are `publish = false`). Curated view, grouped by role:
 
 ```
 crates/
@@ -72,7 +73,7 @@ All commands defined in `crates/assay-cli/src/cli/args/mod.rs`, dispatched in `c
 | `assay evidence diff` | Verified-only bundle comparison | `commands/evidence/diff.rs` |
 | `assay evidence explore` | Read-only TUI explorer | `commands/evidence/explore.rs` |
 | `assay evidence export` | Export evidence bundles | `commands/evidence.rs` |
-| `assay mcp-server` | MCP proxy with policy enforcement | `assay-mcp-server/src/main.rs` |
+| `assay-mcp-server` | MCP proxy with policy enforcement. A **separate binary**, not an `assay` subcommand: `assay mcp` exists and is a different thing (wrap, discover, inventory, kill, tool) | `assay-mcp-server/src/main.rs` |
 | `assay monitor` | eBPF runtime monitoring (Linux) | `commands/monitor.rs` |
 | `assay sandbox` | Landlock sandbox execution | `commands/sandbox.rs` |
 | `assay doctor` | Diagnostic tool | `commands/doctor.rs` |


### PR DESCRIPTION
`CLAUDE.md` is the first thing an agent loads, so a stale fact there propagates into work before anything checks it. Three corrections, all measured.

## The version said `3.31.1`

The workspace is at `5.0.0`. Four majors and a release line out of date.

## The crate count said 21, and the externally meaningful number is 22

```
ls -d crates/*/                     → 21
cargo metadata --no-deps            → 22
[workspace] members in Cargo.toml   → 22
```

`assay-python-sdk` is a member that does not live under `crates/`. The line now gives both numbers and says which is which, since the directory count is the one a reader will reproduce and be confused by. Nine are `publish = false`, which is the number that matters for anything semver-shaped.

## The command table said `assay mcp-server`, which does not exist

```
$ assay mcp-server --help
error: unrecognized subcommand 'mcp-server'
  tip: a similar subcommand exists: 'mcp'
```

`assay mcp` is real and is a different thing: `wrap`, `config-path`, `discover`, `inventory`, `kill`, `tool`. The MCP server is **`assay-mcp-server`**, its own binary.

Found while writing the `.mcp.json` manifest for #2152, where a wrong `command` value would have shipped to Claude Code, Cursor and Codex and failed for every user who installed it. That is the concrete cost of a stale line in this particular file, and it is why this is a PR rather than a note.

Corrected by running the binary rather than by reading the table, which is the only reason the third one surfaced at all.