### PR TITLE
feat(mcp): publish project install manifests

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay-mcp-server",
+      "args": ["--policy-root", "."]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ docs/DISTRIBUTION-CHANNELS.md
 !.cursor/
 .cursor/*
 !.cursor/BUGBOT.md
+!.cursor/mcp.json
 .mcpregistry_*
 _v.txt
 ai-agent-eval-plugin/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay-mcp-server",
+      "args": ["--policy-root", "."]
+    }
+  }
+}

--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -183,7 +183,7 @@ impl Conn {
         let deadline = Instant::now() + self.take_budget();
         loop {
             let v = self.read_json_by(deadline);
-            if v.get("method").is_none() {
+            if is_response(&v) {
                 return v;
             }
         }
@@ -194,8 +194,7 @@ impl Conn {
         let deadline = Instant::now() + self.take_budget();
         loop {
             let v = self.read_json_by(deadline);
-            if v.get("method").is_none() && v.get("id").and_then(Value::as_u64) == Some(expected_id)
-            {
+            if is_response(&v) && v.get("id").and_then(Value::as_u64) == Some(expected_id) {
                 return v;
             }
         }
@@ -370,4 +369,8 @@ fn describe(v: &Value) -> String {
         Some(id) => format!("id={id} method={method}"),
         None => format!("notification method={method}"),
     }
+}
+
+fn is_response(value: &Value) -> bool {
+    value.get("method").is_none()
 }

--- a/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
+++ b/crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs
@@ -189,6 +189,18 @@ impl Conn {
         }
     }
 
+    /// [`Conn::read_response`], but also skips responses for other numeric request IDs.
+    pub fn read_response_for_id(&mut self, expected_id: u64) -> Value {
+        let deadline = Instant::now() + self.take_budget();
+        loop {
+            let v = self.read_json_by(deadline);
+            if v.get("method").is_none() && v.get("id").and_then(Value::as_u64) == Some(expected_id)
+            {
+                return v;
+            }
+        }
+    }
+
     /// Every remaining stdout line up to EOF, used to prove nothing further reached the client.
     ///
     /// Named for its precondition because it has one: the returned lines are accumulated in memory,

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -96,6 +96,22 @@ args = ["--policy-root", "."]"#;
     let mut conn = Conn::attach(child);
     conn.send(serde_json::json!({
         "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "project-install-contract", "version": "1.0"}
+        }
+    }));
+    let initialize = conn.read_response_for_id(0);
+    assert_eq!(initialize["result"]["protocolVersion"], "2024-11-05");
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    }));
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
         "id": 2,
         "method": "tools/list"
     }));

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -1,0 +1,149 @@
+//! Project install surfaces must launch the release MCP server they describe.
+//!
+//! The JSON locations differ by client, while Codex uses TOML. This test keeps
+//! those three representations on one invocation and drives the built server so
+//! a syntactically correct manifest cannot advertise the wrong binary or tools.
+
+use serde_json::Value;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+#[derive(Clone, Copy)]
+enum ProjectFile {
+    ClaudeManifest,
+    CursorManifest,
+    EditorGuide,
+}
+
+impl ProjectFile {
+    fn relative_path(self) -> &'static Path {
+        Path::new(match self {
+            Self::ClaudeManifest => ".mcp.json",
+            Self::CursorManifest => ".cursor/mcp.json",
+            Self::EditorGuide => "docs/guides/editor-mcp-recipe.md",
+        })
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+fn read_project_file(file: ProjectFile) -> String {
+    let path = workspace_root().join(file.relative_path());
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read checked project file {}: {error}", path.display()))
+}
+
+fn manifest_entry(file: ProjectFile) -> Value {
+    let manifest: Value =
+        serde_json::from_str(&read_project_file(file)).expect("valid project MCP manifest JSON");
+    manifest["mcpServers"]["assay"].clone()
+}
+
+fn clean_server_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_AUTH_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+}
+
+#[test]
+fn project_surfaces_launch_the_five_production_tools() {
+    let claude = manifest_entry(ProjectFile::ClaudeManifest);
+    let cursor = manifest_entry(ProjectFile::CursorManifest);
+    assert_eq!(claude, cursor, "Claude and Cursor entries drifted");
+    assert_eq!(claude["command"], "assay-mcp-server");
+    assert_eq!(claude["args"], serde_json::json!(["--policy-root", "."]));
+
+    let codex_entry = r#"[mcp_servers.assay]
+command = "assay-mcp-server"
+args = ["--policy-root", "."]"#;
+    let guide = read_project_file(ProjectFile::EditorGuide);
+    assert!(
+        guide.contains(codex_entry),
+        "Codex guide does not carry the manifest invocation"
+    );
+
+    let args: Vec<&str> = claude["args"]
+        .as_array()
+        .expect("manifest args array")
+        .iter()
+        .map(|arg| arg.as_str().expect("manifest string arg"))
+        .collect();
+    let mut child = clean_server_command()
+        .args(args)
+        .current_dir(workspace_root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn assay-mcp-server from project manifest");
+
+    {
+        let mut stdin = child.stdin.take().expect("server stdin");
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list"
+            })
+        )
+        .expect("write tools/list request");
+    }
+
+    let output = child.wait_with_output().expect("wait for server");
+    assert!(
+        output.status.success(),
+        "manifest invocation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "parse tools/list response: {error}; stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    let mut actual: Vec<&str> = response["result"]["tools"]
+        .as_array()
+        .expect("tools/list result array")
+        .iter()
+        .map(|tool| tool["name"].as_str().expect("tool name"))
+        .collect();
+    #[cfg(feature = "test-outbound")]
+    {
+        assert!(
+            actual.contains(&"assay_test_outbound"),
+            "test-outbound feature did not expose its test-only tool"
+        );
+        actual.retain(|name| *name != "assay_test_outbound");
+    }
+    #[cfg(not(feature = "test-outbound"))]
+    assert!(
+        !actual.contains(&"assay_test_outbound"),
+        "default build advertised the test-only outbound tool"
+    );
+    actual.sort_unstable();
+
+    let expected = [
+        "assay_check_args",
+        "assay_check_coverage",
+        "assay_check_sequence",
+        "assay_explain_trace",
+        "assay_policy_decide",
+    ];
+    assert_eq!(actual, expected, "release tool surface changed");
+}

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -5,11 +5,14 @@
 //! a syntactically correct manifest cannot advertise the wrong binary or tools.
 
 use serde_json::Value;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 mod jsonrpc_conn;
 use jsonrpc_conn::Conn;
+
+const MAX_PROJECT_FILE_BYTES: u64 = 1024 * 1024;
 
 #[derive(Clone, Copy)]
 enum ProjectFile {
@@ -37,8 +40,22 @@ fn workspace_root() -> PathBuf {
 
 fn read_project_file(file: ProjectFile) -> String {
     let path = workspace_root().join(file.relative_path());
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|error| panic!("read checked project file {}: {error}", path.display()))
+    let mut source = std::fs::File::open(&path)
+        .unwrap_or_else(|error| panic!("open checked project file {}: {error}", path.display()));
+    let bytes = source
+        .metadata()
+        .unwrap_or_else(|error| panic!("stat checked project file {}: {error}", path.display()))
+        .len();
+    assert!(
+        bytes <= MAX_PROJECT_FILE_BYTES,
+        "checked project file exceeds {MAX_PROJECT_FILE_BYTES} bytes: {} ({bytes} bytes)",
+        path.display()
+    );
+    let mut contents = String::with_capacity(bytes as usize);
+    source
+        .read_to_string(&mut contents)
+        .unwrap_or_else(|error| panic!("read checked project file {}: {error}", path.display()));
+    contents
 }
 
 fn manifest_entry(file: ProjectFile) -> Value {

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -91,6 +91,10 @@ command = "assay-mcp-server"
 args = ["--policy-root", "."]"#;
     let guide = read_project_file(ProjectFile::EditorGuide).replace("\r\n", "\n");
     assert!(
+        guide.contains("cargo install --path crates/assay-mcp-server --locked"),
+        "editor guide install must use the reviewed checkout"
+    );
+    assert!(
         guide.contains(codex_entry),
         "Codex guide does not carry the manifest invocation"
     );

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -5,9 +5,11 @@
 //! a syntactically correct manifest cannot advertise the wrong binary or tools.
 
 use serde_json::Value;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
 
 #[derive(Clone, Copy)]
 enum ProjectFile {
@@ -70,7 +72,7 @@ fn project_surfaces_launch_the_five_production_tools() {
     let codex_entry = r#"[mcp_servers.assay]
 command = "assay-mcp-server"
 args = ["--policy-root", "."]"#;
-    let guide = read_project_file(ProjectFile::EditorGuide);
+    let guide = read_project_file(ProjectFile::EditorGuide).replace("\r\n", "\n");
     assert!(
         guide.contains(codex_entry),
         "Codex guide does not carry the manifest invocation"
@@ -82,41 +84,32 @@ args = ["--policy-root", "."]"#;
         .iter()
         .map(|arg| arg.as_str().expect("manifest string arg"))
         .collect();
-    let mut child = clean_server_command()
+    let child = clean_server_command()
         .args(args)
         .current_dir(workspace_root())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::inherit())
         .spawn()
         .expect("spawn assay-mcp-server from project manifest");
 
-    {
-        let mut stdin = child.stdin.take().expect("server stdin");
-        writeln!(
-            stdin,
-            "{}",
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/list"
-            })
-        )
-        .expect("write tools/list request");
-    }
-
-    let output = child.wait_with_output().expect("wait for server");
+    let mut conn = Conn::attach(child);
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list"
+    }));
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list"
+    }));
+    let response = conn.read_response_for_id(1);
+    let status = conn.shutdown();
     assert!(
-        output.status.success(),
-        "manifest invocation failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        status.success(),
+        "manifest invocation failed with status {status}"
     );
-    let response: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
-        panic!(
-            "parse tools/list response: {error}; stdout={}",
-            String::from_utf8_lossy(&output.stdout)
-        )
-    });
     let mut actual: Vec<&str> = response["result"]["tools"]
         .as_array()
         .expect("tools/list result array")

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -5,6 +5,37 @@ servers it uses by wrapping each server with `assay mcp wrap`, so every tool cal
 checked against your policy inline. No bespoke plugin is needed; you only change the
 server command in the agent's standard MCP config.
 
+## Install Assay's review tools
+
+The repository ships project configuration for the five tools exposed by the
+standalone `assay-mcp-server` binary. Install that binary on `PATH`, then open the
+repository in your client:
+
+```bash
+cargo install assay-mcp-server --locked
+```
+
+- Claude Code reads `.mcp.json` from the repository root.
+- Cursor reads `.cursor/mcp.json`.
+- Codex users can add the equivalent entry to project `.codex/config.toml` or
+  user `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.assay]
+command = "assay-mcp-server"
+args = ["--policy-root", "."]
+```
+
+The server is local stdio and needs no network or transport authentication. It
+evaluates policy and trace inputs supplied to its tools; it does not invoke or
+enforce the target MCP tool call. `--policy-root .` resolves policy paths against
+the server process's working directory. Project-scoped clients normally use the
+project root; if a host uses another directory, set an explicit local policy root
+in that client's uncommitted user or project configuration.
+
+The rest of this guide covers a different surface: wrapping a real MCP server so
+Assay can enforce its tool calls at the protocol boundary.
+
 ## The wrap command
 
 ```bash

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -12,7 +12,7 @@ standalone `assay-mcp-server` binary. Install that binary on `PATH`, then open t
 repository in your client:
 
 ```bash
-cargo install assay-mcp-server --locked
+cargo install --path crates/assay-mcp-server --locked
 ```
 
 - Claude Code reads `.mcp.json` from the repository root.

--- a/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
@@ -1,0 +1,119 @@
+# MCP Project Install Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish the existing five-tool `assay-mcp-server` stdio surface to Claude Code, Cursor, and Codex with one tested invocation.
+
+**Architecture:** Two client-specific JSON locations carry an identical `mcpServers.assay` entry. The Codex guide carries the same command and arguments. One Rust integration test reads only an enum allowlist of repository files, drives the built binary over stdio, and pins the five server-emitted production tool names.
+
+**Tech Stack:** JSON project manifests, Markdown/TOML documentation, Rust integration tests, `serde_json`, `std::process`.
+
+## Global Constraints
+
+- Canonical invocation: `assay-mcp-server --policy-root .` with no mode subcommand.
+- Production names: `assay_check_args`, `assay_check_coverage`, `assay_check_sequence`, `assay_explain_trace`, `assay_policy_decide`.
+- `assay_test_outbound` is test-only and must not be advertised.
+- Do not add proxy, `SKILL.md`, plugin, authentication, network, or MCP 2026-07-28 remediation work.
+- Do not accept arbitrary relative paths in the test helper; map enum variants to fixed repository paths before joining the workspace root.
+
+---
+
+### Task 1: Contract Test and Install Surfaces
+
+**Files:**
+- Create: `crates/assay-mcp-server/tests/project_install_surfaces.rs`
+- Create: `.mcp.json`
+- Create: `.cursor/mcp.json`
+- Modify: `.gitignore`
+- Modify: `docs/guides/editor-mcp-recipe.md`
+- Modify: `docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md`
+
+**Interfaces:**
+- Consumes: `CARGO_BIN_EXE_assay-mcp-server` and the existing stdio `tools/list` method.
+- Produces: two identical `mcpServers.assay` entries and one equivalent Codex TOML example.
+
+- [x] **Step 1: Write the failing integration test**
+
+Create an enum whose variants map internally to exactly `.mcp.json`,
+`.cursor/mcp.json`, and `docs/guides/editor-mcp-recipe.md`. Parse both JSON
+entries, assert the exact Codex snippet, then spawn the built server with the
+manifest arguments and send:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+```
+
+Sort the returned names and compare them with this literal set:
+
+```rust
+[
+    "assay_check_args",
+    "assay_check_coverage",
+    "assay_check_sequence",
+    "assay_explain_trace",
+    "assay_policy_decide",
+]
+```
+
+- [x] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-target-2152 cargo test -p assay-mcp-server --test project_install_surfaces -- --nocapture
+```
+
+Expected: FAIL while reading the absent repository-root `.mcp.json`; compilation and binary startup setup must otherwise be valid.
+
+- [x] **Step 3: Add the minimal manifests and guide section**
+
+Both JSON files contain:
+
+```json
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay-mcp-server",
+      "args": ["--policy-root", "."]
+    }
+  }
+}
+```
+
+The guide adds this exact Codex block:
+
+```toml
+[mcp_servers.assay]
+command = "assay-mcp-server"
+args = ["--policy-root", "."]
+```
+
+It includes `cargo install assay-mcp-server --locked`, distinguishes the
+standalone five-tool evaluator from `assay mcp wrap`, and says the server does
+not invoke or enforce the target MCP tool call. `.gitignore` unignores only
+`.cursor/mcp.json` inside the otherwise local `.cursor/` directory.
+
+- [x] **Step 4: Run the focused test and verify GREEN**
+
+Run the command from Step 2. Expected: PASS with the exact five names and exit
+0 after stdin closes.
+
+- [x] **Step 5: Run affected verification**
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-target-2152 cargo test -p assay-mcp-server
+CARGO_TARGET_DIR=/tmp/assay-target-2152 cargo clippy -p assay-mcp-server --all-targets -- -D warnings
+cargo fmt --all -- --check
+git diff --check
+```
+
+Expected: all pass with no warnings.
+
+- [ ] **Step 6: Commit the implementation**
+
+Stage only the six touched implementation/test/document paths plus this plan
+and the reviewed design correction, then commit with:
+
+```bash
+git commit -m "feat(mcp): publish project install manifests"
+```

--- a/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
@@ -91,8 +91,8 @@ args = ["--policy-root", "."]
 
 It includes `cargo install assay-mcp-server --locked`, distinguishes the
 standalone five-tool evaluator from `assay mcp wrap`, and says the server does
-not invoke or enforce the target MCP tool call. `.gitignore` unignores only
-`.cursor/mcp.json` inside the otherwise local `.cursor/` directory.
+not invoke or enforce the target MCP tool call. `.gitignore` adds `mcp.json` to
+the existing `.cursor/` allowlist while preserving its Bugbot exception.
 
 - [x] **Step 4: Run the focused test and verify GREEN**
 

--- a/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
@@ -22,6 +22,7 @@
 
 **Files:**
 - Create: `crates/assay-mcp-server/tests/project_install_surfaces.rs`
+- Modify: `crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs`
 - Create: `.mcp.json`
 - Create: `.cursor/mcp.json`
 - Modify: `.gitignore`
@@ -125,7 +126,7 @@ After restoring all three mutations, rerun the focused test and require green.
 
 - [x] **Step 7: Commit the implementation**
 
-Stage only the seven paths named under **Files** above, including this plan and
+Stage only the eight paths named under **Files** above, including this plan and
 the reviewed design correction, then commit with:
 
 ```bash

--- a/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
@@ -26,6 +26,7 @@
 - Create: `.cursor/mcp.json`
 - Modify: `.gitignore`
 - Modify: `docs/guides/editor-mcp-recipe.md`
+- Modify: `docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md`
 - Modify: `docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md`
 
 **Interfaces:**

--- a/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
@@ -90,7 +90,7 @@ command = "assay-mcp-server"
 args = ["--policy-root", "."]
 ```
 
-It includes `cargo install assay-mcp-server --locked`, distinguishes the
+It includes `cargo install --path crates/assay-mcp-server --locked`, distinguishes the
 standalone five-tool evaluator from `assay mcp wrap`, and says the server does
 not invoke or enforce the target MCP tool call. `.gitignore` adds `mcp.json` to
 the existing `.cursor/` allowlist while preserving its Bugbot exception.

--- a/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-project-install-surfaces.md
@@ -109,10 +109,23 @@ git diff --check
 
 Expected: all pass with no warnings.
 
-- [ ] **Step 6: Commit the implementation**
+- [x] **Step 6: Kill the three targeted mutations**
 
-Stage only the six touched implementation/test/document paths plus this plan
-and the reviewed design correction, then commit with:
+Against committed baseline `fdcf2c878aa0c115772064591f2faf233787c3a2`,
+temporarily make each change below, run the focused test, verify the named
+failure, and restore the original content before continuing:
+
+1. Change one manifest's `args`: `Claude and Cursor entries drifted`.
+2. Rename one `list_tools()` tool: `release tool surface changed`.
+3. Remove `--policy-root` from the Codex block:
+   `Codex guide does not carry the manifest invocation`.
+
+After restoring all three mutations, rerun the focused test and require green.
+
+- [x] **Step 7: Commit the implementation**
+
+Stage only the seven paths named under **Files** above, including this plan and
+the reviewed design correction, then commit with:
 
 ```bash
 git commit -m "feat(mcp): publish project install manifests"

--- a/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
@@ -1,0 +1,126 @@
+# MCP Project Install Surfaces Design
+
+Date: 2026-08-08
+Issue: [#2152](https://github.com/Rul1an/assay/issues/2152)
+Scope: steps 1 and 2 only
+
+## Goal
+
+Make the five production tools exposed by `assay-mcp-server` discoverable from
+Claude Code, Cursor, and Codex in a cloned project. This publishes an existing
+local stdio capability; it does not add tools or change their behavior.
+
+## Surfaces
+
+The repository will carry two project manifests because the clients use
+different locations:
+
+- Claude Code reads `.mcp.json` at the repository root.
+- Cursor reads `.cursor/mcp.json`.
+- Codex users get an equivalent `[mcp_servers.assay]` block in
+  `docs/guides/editor-mcp-recipe.md`; Codex does not read either JSON manifest.
+
+Both JSON files use the `mcpServers` wrapper and contain the same `assay`
+server entry.
+
+## Canonical Invocation
+
+All three surfaces express the same process:
+
+```text
+assay-mcp-server --policy-root .
+```
+
+`assay-mcp-server` is a separate binary. `assay mcp` is a different CLI
+command family and is not a substitute.
+
+No server mode subcommand is supplied, so the process runs the standalone
+stdio server. The `proxy`, `proxy-enforce`, and `enforcement-sarif` modes are
+outside this slice.
+
+The explicit policy root is required. The binary default is `policies/`, which
+does not exist in this repository and is not a safe assumption for downstream
+projects. `.` exists when the client starts the project-scoped server and makes
+tool-supplied policy paths relative to the project root.
+
+## Manifest Shape
+
+Each JSON manifest contains only the portable, documented stdio fields:
+
+```json
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay-mcp-server",
+      "args": ["--policy-root", "."]
+    }
+  }
+}
+```
+
+An additional `note` field is deliberately omitted. A shipped Claude plugin
+demonstrates that field, but Cursor's project-manifest documentation does not.
+The server's limits belong in the adjacent guide and existing tool
+descriptions rather than in an unverified cross-client extension field.
+
+The guide will state that this standalone server:
+
+- uses local stdio and needs no network or transport authentication;
+- evaluates supplied policy and trace inputs;
+- does not invoke or enforce the target MCP tool call;
+- requires `assay-mcp-server` to be installed on `PATH`.
+
+## Production Tool Contract
+
+The normal release build must advertise these server-emitted names:
+
+- `assay_check_args`
+- `assay_check_coverage`
+- `assay_check_sequence`
+- `assay_explain_trace`
+- `assay_policy_decide`
+
+The test-only `assay_test_outbound` tool is behind the non-default
+`test-outbound` feature and is not part of the install contract. Tests pin the
+five names, not only their count, and do not pin host-specific renamespacing.
+
+## Verification Design
+
+A new `assay-mcp-server` integration test will fail before the manifests and
+documentation exist, then prove the completed behavior:
+
+1. Parse both JSON manifests and assert their `assay` entries are identical.
+2. Assert the command and argument vector match the canonical invocation.
+3. Assert the Codex TOML example carries the same command and arguments.
+4. Start the built `assay-mcp-server` using the manifest arguments from the
+   repository root.
+5. Send a real `tools/list` request over stdio and assert the exact five
+   production tool names.
+6. Assert the process exits successfully after stdin closes.
+
+The test uses `CARGO_BIN_EXE_assay-mcp-server`, so it exercises the binary built
+for the same test run rather than an unrelated executable on the developer's
+`PATH`.
+
+This test does not claim full MCP 2026-07-28 conformance. Issue
+[#2157](https://github.com/Rul1an/assay/issues/2157) separately tracks missing
+`resultType`, `ttlMs`, and `cacheScope` fields plus deterministic tool ordering.
+Those protocol gaps do not prevent a client from starting the server and
+discovering its current production tools, which is the bounded contract here.
+
+## Failure Behavior
+
+The manifests do not fall back to another binary or server mode. If
+`assay-mcp-server` is absent, the host reports a spawn/configuration failure. If
+the policy root cannot be opened, server startup remains non-zero. Neither case
+is presented as a working tool surface.
+
+## Non-Goals
+
+- No new MCP tools or tool behavior.
+- No `assay mcp wrap` configuration for an upstream server.
+- No `SKILL.md`; that remains blocked on #2154.
+- No Claude plugin or marketplace packaging.
+- No proxy, enforcement proxy, HTTP, OAuth, or authentication configuration.
+- No MCP 2026-07-28 result, caching, ordering, or error-code remediation.
+- No trust score, whole-action verdict, detector catalogue, or expanded claim.

--- a/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
@@ -100,6 +100,23 @@ documentation exist, then prove the completed behavior:
    production tool names.
 6. Assert the process exits successfully after stdin closes.
 
+After the green run, three temporary mutations must each make the contract test
+fail for the named assertion before the original content is restored:
+
+| Mutation | Required failure |
+|---|---|
+| Change `args` in one JSON manifest only | `Claude and Cursor entries drifted` |
+| Rename one tool emitted by `list_tools()` | `release tool surface changed` |
+| Remove `--policy-root` from the Codex TOML block | `Codex guide does not carry the manifest invocation` |
+
+This mutation check was run against committed baseline
+`fdcf2c878aa0c115772064591f2faf233787c3a2` in worktree
+`/Users/roelschuurkes/.config/superpowers/worktrees/assay/2152-mcp-manifest`,
+using the test binary built by Cargo with
+`CARGO_TARGET_DIR=/tmp/assay-target-2152`. All three mutations were killed by
+their required assertion, then the original tree was restored and the focused
+test passed again.
+
 The test uses `CARGO_BIN_EXE_assay-mcp-server`, so it exercises the binary built
 for the same test run rather than an unrelated executable on the developer's
 `PATH`.

--- a/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
@@ -40,8 +40,10 @@ outside this slice.
 
 The explicit policy root is required. The binary default is `policies/`, which
 does not exist in this repository and is not a safe assumption for downstream
-projects. `.` exists when the client starts the project-scoped server and makes
-tool-supplied policy paths relative to the project root.
+projects. `.` always names the server process's current directory. Treating it
+as the project root assumes the host starts a project-scoped server there; if a
+host chooses another working directory, tool-supplied policy paths resolve
+against that directory instead.
 
 ## Manifest Shape
 

--- a/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-project-install-surfaces-design.md
@@ -110,9 +110,8 @@ fail for the named assertion before the original content is restored:
 | Remove `--policy-root` from the Codex TOML block | `Codex guide does not carry the manifest invocation` |
 
 This mutation check was run against committed baseline
-`fdcf2c878aa0c115772064591f2faf233787c3a2` in worktree
-`/Users/roelschuurkes/.config/superpowers/worktrees/assay/2152-mcp-manifest`,
-using the test binary built by Cargo with
+`fdcf2c878aa0c115772064591f2faf233787c3a2` in an isolated mutation-check
+worktree, using the test binary built by Cargo with
 `CARGO_TARGET_DIR=/tmp/assay-target-2152`. All three mutations were killed by
 their required assertion, then the original tree was restored and the focused
 test passed again.


### PR DESCRIPTION
## Summary

- add project MCP manifests for Claude Code and Cursor using the same local stdio invocation
- document the equivalent Codex `config.toml` entry and the boundary between review tools and `assay mcp wrap`
- add a driven integration contract that starts the built server and pins the five production tool names
- record three targeted mutation checks proving the contract assertions discriminate

Refs #2152. This PR implements steps 1 and 2 only; it intentionally does not close the issue.

## Why

`assay-mcp-server` already exposes agent-facing review tools, but cloned projects had no checked-in install surface for Claude Code or Cursor and no reproducible Codex configuration. The canonical invocation is:

```text
assay-mcp-server --policy-root .
```

The binary is `assay-mcp-server`, not an `assay mcp-server` subcommand. `--policy-root .` avoids the binary's `policies/` default, while still depending on the host's working directory; the guide states that assumption explicitly.

## Contract Changes

- new root `.mcp.json` for Claude Code
- new `.cursor/mcp.json` for Cursor
- documented `[mcp_servers.assay]` Codex entry
- exact production surface pinned by name:
  - `assay_check_args`
  - `assay_check_coverage`
  - `assay_check_sequence`
  - `assay_explain_trace`
  - `assay_policy_decide`

`assay_test_outbound` remains test-only and is excluded from the production contract. No Rust public API, output schema, proxy behavior, or enforcement behavior changes.

## TDD And Mutation Evidence

Final head: `14e0895859af22332c442c8c5cdbc494cc3c878e`

Implementation baseline: `fdcf2c878aa0c115772064591f2faf233787c3a2`

RED:

```text
cargo test -p assay-mcp-server --test project_install_surfaces -- --nocapture
FAIL: read checked project file .../.mcp.json: No such file or directory
```

GREEN:

```text
cargo test -p assay-mcp-server --test project_install_surfaces -- --nocapture
1 passed; 0 failed
```

After green, three temporary mutations were applied independently to the committed implementation baseline. Each failed for its required assertion, was restored, and the focused test passed again:

| Mutation | Observed failure |
|---|---|
| change one manifest's `args` | `Claude and Cursor entries drifted` |
| rename one tool emitted by `list_tools()` | `release tool surface changed` |
| remove `--policy-root` from the Codex block | `Codex guide does not carry the manifest invocation` |

The all-features probe initially exposed the sixth feature-gated test tool. The final test verifies that tool only under `test-outbound`, removes it from the comparison, and still pins the five production names.

## Verification

Mutation measurements target baseline `fdcf2c878aa0c115772064591f2faf233787c3a2`. Final focused validation and push gates target head `14e0895859af22332c442c8c5cdbc494cc3c878e`. Validation ran in an isolated worktree with `CARGO_TARGET_DIR=/tmp/assay-target-2152-final` where applicable.

Implementation baseline:

- `cargo test -p assay-mcp-server`
- `cargo test -p assay-mcp-server --all-features --test project_install_surfaces -- --nocapture`
- `cargo clippy -p assay-mcp-server --all-targets --all-features -- -D warnings`

Final head:

- focused project-install contract test after restoring mutations
- CRLF checkout simulation for the Codex documentation contract
- bounded, line-oriented JSON-RPC exchange with exact response-id selection
- complete MCP initialize/initialized handshake before tool discovery
- 1 MiB pre-materialization ceiling for allowlisted project files
- checkout-bound install command guarded by a RED-to-GREEN contract assertion
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-commit hooks
- pre-push hooks, including workspace clippy and cross-target Linux compile gate

## Risk And Non-Claims

- The manifests assume project-scoped hosts launch the stdio server with the intended project working directory; the guide documents how to override the policy root when they do not.
- The server is local stdio and this surface adds no HTTP, network, OAuth, or transport authentication.
- The standalone review tools evaluate supplied policy and trace inputs; they do not invoke or enforce a target MCP tool call.
- No `SKILL.md`, Claude plugin, marketplace package, proxy mode, or new MCP tool is included.
- This PR does not claim full MCP 2026-07-28 conformance. #2157 tracks `resultType`, `ttlMs`, `cacheScope`, and deterministic ordering separately.

## Type Of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Checklist

- [x] Code style and formatting checks pass.
- [x] Documentation reflects the bounded install behavior.
- [x] Behavioral contract coverage was added with a verified red/green cycle.
- [x] Three targeted mutations were killed by their intended assertions.
- [x] Public strings were checked against the ADR-042 stop list.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-level MCP configurations for Claude Code, Cursor, and Codex.
  * Enabled the standalone `assay-mcp-server` to use the current project as its policy root.

* **Documentation**
  * Added setup guidance covering installation, client configuration, local usage, and limitations.

* **Tests**
  * Added integration coverage verifying configuration paths, server startup, responses, shutdown, and available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





