### PR TITLE
feat(cli): name validate and run JSON schema contracts

### DIFF
--- a/crates/assay-cli/src/cli/commands/reporting.rs
+++ b/crates/assay-cli/src/cli/commands/reporting.rs
@@ -39,7 +39,7 @@ pub(crate) fn write_error_artifacts(
         eprintln!("WARNING: failed to write summary.json: {}", e);
     }
     if json_stdout {
-        match serde_json::to_string_pretty(&summary) {
+        match assay_core::report::summary::render_summary_json(&summary) {
             Ok(rendered) => println!("{rendered}"),
             // A failure to render is reported and does not change the exit code: the code is the
             // classification of the run, not of our ability to describe it.

--- a/crates/assay-cli/src/cli/commands/validate.rs
+++ b/crates/assay-cli/src/cli/commands/validate.rs
@@ -7,6 +7,8 @@ use crate::cli::args::{ValidateArgs, ValidateOutputFormat};
 use crate::cli::util::{decide_exit, infer_policy_path, normalize_severity};
 use crate::exit_codes;
 
+const VALIDATE_REPORT_SCHEMA: &str = "assay.validate_report.v1";
+
 pub async fn run(args: ValidateArgs, legacy_mode: bool) -> anyhow::Result<i32> {
     if args.deny_deprecations {
         std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
@@ -206,6 +208,7 @@ fn build_validate_json(
     );
 
     json!({
+        "schema": VALIDATE_REPORT_SCHEMA,
         "schema_version": 1,
         "ok": error_count == 0,
         "exit_code": exit_code,

--- a/crates/assay-cli/tests/named_json_envelopes.rs
+++ b/crates/assay-cli/tests/named_json_envelopes.rs
@@ -1,6 +1,7 @@
 //! Named identities for the JSON documents a non-interactive validate/run caller receives.
 
 use serde_json::Value;
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::process::{Command, Output};
 
@@ -150,12 +151,8 @@ fn validate_and_run_json_documents_name_the_contract_they_follow() {
         run_failure["schema"].as_str(),
     ];
     assert_eq!(
-        identities,
-        [
-            Some(VALIDATE_REPORT_SCHEMA),
-            Some(RUN_REPORT_SCHEMA),
-            Some(RUN_SUMMARY_SCHEMA),
-        ],
-        "the three documents must remain distinguishable"
+        identities.into_iter().collect::<BTreeSet<_>>().len(),
+        3,
+        "the three observed documents must remain distinguishable"
     );
 }

--- a/crates/assay-cli/tests/named_json_envelopes.rs
+++ b/crates/assay-cli/tests/named_json_envelopes.rs
@@ -137,6 +137,13 @@ fn validate_and_run_json_documents_name_the_contract_they_follow() {
     );
     assert_schema(&run_failure, RUN_SUMMARY_SCHEMA, "run failure");
 
+    let failure_summary: Value = serde_json::from_slice(
+        &std::fs::read(failure_project.path().join("summary.json"))
+            .expect("read failure summary.json"),
+    )
+    .expect("failure summary.json parses");
+    assert_schema(&failure_summary, RUN_SUMMARY_SCHEMA, "failure summary.json");
+
     let identities = [
         validate_success["schema"].as_str(),
         run_success["schema"].as_str(),

--- a/crates/assay-cli/tests/named_json_envelopes.rs
+++ b/crates/assay-cli/tests/named_json_envelopes.rs
@@ -1,0 +1,154 @@
+//! Named identities for the JSON documents a non-interactive validate/run caller receives.
+
+use serde_json::Value;
+use std::path::Path;
+use std::process::{Command, Output};
+
+const VALIDATE_REPORT_SCHEMA: &str = "assay.validate_report.v1";
+const RUN_REPORT_SCHEMA: &str = "assay.run_report.v1";
+const RUN_SUMMARY_SCHEMA: &str = "assay.run_summary.v1";
+
+fn assay(cwd: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+        .current_dir(cwd)
+        .env("NO_COLOR", "1")
+        .args(args)
+        .output()
+        .expect("run assay binary")
+}
+
+fn stdout_json(output: &Output, expected_exit: i32, context: &str) -> Value {
+    assert_eq!(
+        output.status.code(),
+        Some(expected_exit),
+        "{context} exit differed; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{context} stdout is not JSON: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn assert_schema(document: &Value, expected: &str, context: &str) {
+    assert_eq!(document["schema"], expected, "{context} schema identity");
+    assert_eq!(
+        document["schema_version"], 1,
+        "{context} schema version must be an integer scoped by schema"
+    );
+}
+
+#[test]
+fn validate_and_run_json_documents_name_the_contract_they_follow() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let init = assay(
+        project.path(),
+        &["init", "--preset", "dev", "--hello-trace"],
+    );
+    assert_eq!(
+        init.status.code(),
+        Some(0),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let validate_success = stdout_json(
+        &assay(
+            project.path(),
+            &[
+                "validate",
+                "--config",
+                "eval.yaml",
+                "--trace-file",
+                "traces/hello.jsonl",
+                "--format",
+                "json",
+            ],
+        ),
+        0,
+        "validate success",
+    );
+    assert_schema(
+        &validate_success,
+        VALIDATE_REPORT_SCHEMA,
+        "validate success",
+    );
+
+    let validate_failure = stdout_json(
+        &assay(
+            project.path(),
+            &["validate", "--config", "missing.yaml", "--format", "json"],
+        ),
+        2,
+        "validate failure",
+    );
+    assert_schema(
+        &validate_failure,
+        VALIDATE_REPORT_SCHEMA,
+        "validate failure",
+    );
+
+    let run_success = stdout_json(
+        &assay(
+            project.path(),
+            &[
+                "run",
+                "--config",
+                "eval.yaml",
+                "--trace-file",
+                "traces/hello.jsonl",
+                "--format",
+                "json",
+            ],
+        ),
+        0,
+        "run success",
+    );
+    assert_schema(&run_success, RUN_REPORT_SCHEMA, "run success");
+
+    let summary: Value = serde_json::from_slice(
+        &std::fs::read(project.path().join("summary.json")).expect("read summary.json"),
+    )
+    .expect("summary.json parses");
+    assert_schema(&summary, RUN_SUMMARY_SCHEMA, "summary.json");
+
+    let failure_project = tempfile::tempdir().expect("failure project tempdir");
+    let run_failure = stdout_json(
+        &assay(
+            failure_project.path(),
+            &["run", "--config", "missing.yaml", "--format", "json"],
+        ),
+        2,
+        "run failure",
+    );
+    assert_schema(&run_failure, RUN_SUMMARY_SCHEMA, "run failure");
+
+    let identities = [
+        validate_success["schema"].as_str(),
+        run_success["schema"].as_str(),
+        run_failure["schema"].as_str(),
+    ];
+    assert_eq!(
+        identities,
+        [
+            Some(VALIDATE_REPORT_SCHEMA),
+            Some(RUN_REPORT_SCHEMA),
+            Some(RUN_SUMMARY_SCHEMA),
+        ],
+        "the three documents must remain distinguishable"
+    );
+}

--- a/crates/assay-core/src/report/json.rs
+++ b/crates/assay-core/src/report/json.rs
@@ -2,6 +2,9 @@ use crate::render_safety::{render_details_safe, Sink};
 use crate::report::RunArtifacts;
 use std::path::Path;
 
+pub const RUN_REPORT_SCHEMA: &str = "assay.run_report.v1";
+pub const RUN_REPORT_SCHEMA_VERSION: u32 = 1;
+
 /// Render the run results report as a pretty-printed JSON string.
 ///
 /// Single source of truth for the JSON report shape: both the file writer
@@ -15,6 +18,8 @@ use std::path::Path;
 /// content. Assay-owned keys (ids, status, score, fingerprint, skip.*) stay byte-stable.
 pub fn render_json(artifacts: &RunArtifacts) -> anyhow::Result<String> {
     let v = serde_json::json!({
+        "schema": RUN_REPORT_SCHEMA,
+        "schema_version": RUN_REPORT_SCHEMA_VERSION,
         "run_id": artifacts.run_id,
         "suite": artifacts.suite,
         "results": artifacts.results,
@@ -26,4 +31,30 @@ pub fn render_json(artifacts: &RunArtifacts) -> anyhow::Result<String> {
 pub fn write_json(artifacts: &RunArtifacts, out: &Path) -> anyhow::Result<()> {
     std::fs::write(out, render_json(artifacts)?)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::RunArtifacts;
+
+    #[test]
+    fn rendered_run_report_has_named_integer_versioned_schema() {
+        let artifacts = RunArtifacts {
+            run_id: 1,
+            suite: "schema-contract".to_string(),
+            results: Vec::new(),
+            order_seed: None,
+            runner_clone_ms: None,
+        };
+
+        let rendered: serde_json::Value =
+            serde_json::from_str(&render_json(&artifacts).expect("render run report"))
+                .expect("parse run report");
+
+        assert_eq!(RUN_REPORT_SCHEMA, "assay.run_report.v1");
+        assert_eq!(RUN_REPORT_SCHEMA_VERSION, 1);
+        assert_eq!(rendered["schema"], RUN_REPORT_SCHEMA);
+        assert_eq!(rendered["schema_version"], RUN_REPORT_SCHEMA_VERSION);
+    }
 }

--- a/crates/assay-core/src/report/json.rs
+++ b/crates/assay-core/src/report/json.rs
@@ -7,15 +7,15 @@ pub const RUN_REPORT_SCHEMA_VERSION: u32 = 1;
 
 /// Render the run results report as a pretty-printed JSON string.
 ///
-/// Single source of truth for the JSON report shape: both the file writer
-/// ([`write_json`]) and stdout emission (`assay run --format json`) use it,
-/// so the on-disk and piped representations never diverge.
+/// Single source of truth for the detailed run-results report emitted by
+/// `assay run --format json` and by the [`write_json`] helper. The CLI's
+/// extended `run.json` artifact is a separate envelope and writer.
 ///
 /// Render-safety (MCP01a): the untrusted model / agent / tool content carried in result `message`
 /// and `details.*` is rendered through the render-safety pipeline before serialization, so a raw
-/// credential / PII / terminal-control value never reaches `run.json`. As a record sink it redacts
-/// and control-strips but does NOT truncate (`usize::MAX`): the eval record keeps full, redacted
-/// content. Assay-owned keys (ids, status, score, fingerprint, skip.*) stay byte-stable.
+/// credential / PII / terminal-control value never reaches this rendered report. As a record sink
+/// it redacts and control-strips but does NOT truncate (`usize::MAX`): the eval record keeps full,
+/// redacted content. Assay-owned keys (ids, status, score, fingerprint, skip.*) stay byte-stable.
 pub fn render_json(artifacts: &RunArtifacts) -> anyhow::Result<String> {
     let v = serde_json::json!({
         "schema": RUN_REPORT_SCHEMA,

--- a/crates/assay-core/src/report/summary.rs
+++ b/crates/assay-core/src/report/summary.rs
@@ -9,4 +9,4 @@ mod writer;
 
 pub use metrics::judge_metrics_from_results;
 pub use types::*;
-pub use writer::write_summary;
+pub use writer::{render_summary_json, write_summary, SUMMARY_SCHEMA};

--- a/crates/assay-core/src/report/summary/writer.rs
+++ b/crates/assay-core/src/report/summary/writer.rs
@@ -43,7 +43,11 @@ mod tests {
         assert_eq!(SUMMARY_SCHEMA, "assay.run_summary.v1");
         assert_eq!(value["schema"], SUMMARY_SCHEMA);
         assert_eq!(value["schema_version"], 1);
-        assert_eq!(rendered.lines().nth(1), Some("  \"schema_version\": 1,"));
+        assert_eq!(
+            rendered.lines().nth(1),
+            Some("  \"schema_version\": 1,"),
+            "serde_json preserve_order must retain the historical first summary key"
+        );
     }
 
     #[test]

--- a/crates/assay-core/src/report/summary/writer.rs
+++ b/crates/assay-core/src/report/summary/writer.rs
@@ -2,9 +2,58 @@ use std::path::Path;
 
 use super::types::Summary;
 
+pub const SUMMARY_SCHEMA: &str = "assay.run_summary.v1";
+
+/// Render the public summary artifact without expanding the public `Summary` Rust type.
+///
+/// The schema identity is added at the document boundary. Existing summary fields retain their
+/// order and byte representation; render-safety for this artifact is tracked separately in #2168.
+pub fn render_summary_json(summary: &Summary) -> anyhow::Result<String> {
+    let mut value = serde_json::to_value(summary)?;
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("summary must serialize as a JSON object"))?;
+    object.insert(
+        "schema".to_string(),
+        serde_json::Value::String(SUMMARY_SCHEMA.to_string()),
+    );
+    Ok(serde_json::to_string_pretty(&value)?)
+}
+
 /// Write summary.json to file.
 pub fn write_summary(summary: &Summary, out: &Path) -> anyhow::Result<()> {
-    let json = serde_json::to_string_pretty(summary)?;
+    let json = render_summary_json(summary)?;
     std::fs::write(out, json)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary() -> Summary {
+        Summary::success("5.0.0", true)
+    }
+
+    #[test]
+    fn renderer_adds_named_schema_without_changing_public_summary_type() {
+        let rendered = render_summary_json(&summary()).expect("render summary");
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("parse summary");
+
+        assert_eq!(SUMMARY_SCHEMA, "assay.run_summary.v1");
+        assert_eq!(value["schema"], SUMMARY_SCHEMA);
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(rendered.lines().nth(1), Some("  \"schema_version\": 1,"));
+    }
+
+    #[test]
+    fn legacy_and_named_documents_deserialize_and_rerender_idempotently() {
+        let legacy = serde_json::to_string(&summary()).expect("serialize legacy summary");
+        let legacy_summary: Summary = serde_json::from_str(&legacy).expect("read legacy summary");
+        let named = render_summary_json(&legacy_summary).expect("render named summary");
+        let named_summary: Summary = serde_json::from_str(&named).expect("read named summary");
+        let rerendered = render_summary_json(&named_summary).expect("rerender named summary");
+
+        assert_eq!(named, rerendered);
+    }
 }

--- a/docs/AIcontext/run-output.md
+++ b/docs/AIcontext/run-output.md
@@ -10,7 +10,7 @@
 After a run, Assay writes:
 
 1. **run.json** — Exit outcome, reason code, seeds, and judge metrics (extended or minimal on early-exit).
-2. **summary.json** — Full `Summary` with schema_version, reason_code_version, seeds, judge_metrics, results, performance.
+2. **summary.json** — Full `Summary` with `schema: "assay.run_summary.v1"`, schema_version, reason_code_version, seeds, judge_metrics, results, performance.
 3. **Console footer** (stderr) — One line: `Seeds: seed_version=1 order_seed=… judge_seed=…`; then a judge metrics line when present.
 
 Consumers should branch on **`(reason_code_version, reason_code)`** for semantics; exit code is coarse transport only.
@@ -36,6 +36,7 @@ Contains all run.json outcome fields plus:
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `schema` | string | Stable document identity; `assay.run_summary.v1` |
 | `schema_version` | integer | Summary schema version |
 | `reason_code_version` | integer | Reason code registry version |
 | `seeds` | object | Required; `{ "seed_version": 1, "order_seed": string|null, "judge_seed": string|null }` |
@@ -89,7 +90,8 @@ When **SARIF was truncated** (e.g. more than 25k eligible results), both run.jso
 On config error, missing trace, or similar early-exit:
 
 - **run.json** (minimal): exit_code, reason_code, reason_code_version, seed_version present; **order_seed** and **judge_seed** may be **null**.
-- **summary.json**: Same; seeds object present with seed_version; order_seed/judge_seed null when unknown.
+- **summary.json**: Uses `schema: "assay.run_summary.v1"`; seeds object present with seed_version; order_seed/judge_seed null when unknown.
+- **`assay run --format json` stdout**: uses `assay.run_report.v1` after a completed run, but emits the same `assay.run_summary.v1` diagnosis as `summary.json` when the run fails before results exist.
 
 Replay-specific note (E9d hardening): for replay early-exit paths (missing dependency, verify fail, parse/open fail), seeds are intentionally written as `null` to indicate that no new deterministic replay execution occurred.
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -41,6 +41,7 @@ When `assay ci` (or the equivalent run invoked by the blessed workflow) complete
 
 | Field                 | Type    | Required | Description |
 |-----------------------|---------|----------|-------------|
+| `schema`             | string  | **Yes**  | Stable document identity. MUST be `assay.run_summary.v1` for `summary.json`. |
 | `schema_version`     | integer | **Yes**  | Version of this summary schema. MUST be `1` for this spec. Increment when adding or changing fields in a backward-incompatible way. |
 | `reason_code_version`| integer | **Yes**  | Version of the reason code registry. MUST be present. MUST equal `1` in Outputs-v1. Future changes to the reason code set use this version. Consumers MUST branch on `(reason_code_version, reason_code)` for semantics; exit code is coarse transport only. Consumers MUST treat unknown versions as "compat required" (fail closed or fallback parsing). |
 | `exit_code`           | integer | **Yes**  | Process exit code: 0 = pass, 1 = test failure, 2 = config/user error, 3 = infra/judge unavailable. See §4. |
@@ -115,6 +116,7 @@ When the run had judge evaluations, a top-level **`judge_metrics`** object MAY b
 
 ```json
 {
+  "schema": "assay.run_summary.v1",
   "schema_version": 1,
   "reason_code_version": 1,
   "exit_code": 0,
@@ -138,6 +140,7 @@ When the run had judge evaluations, a top-level **`judge_metrics`** object MAY b
 
 ```json
 {
+  "schema": "assay.run_summary.v1",
   "schema_version": 1,
   "reason_code_version": 1,
   "exit_code": 2,
@@ -316,6 +319,7 @@ For every non-zero exit, the implementation MUST provide **at least one suggeste
 | 1              | 2026-02  | E2.3: SARIF truncation metadata (§6.3): properties.assay (truncated, omitted_count) in SARIF run; sarif.omitted in summary.json and run.json when truncated. Deterministic truncation order. |
 | 1              | 2026-02  | E9c alignment draft: replay provenance keys in `provenance` (`replay`, `bundle_digest`, `replay_mode`, `source_run_id`) and `E_REPLAY_MISSING_DEPENDENCY` reason code. |
 | 1              | 2026-07  | Added `E_REPLAY_LIMIT_EXCEEDED` (§5.1). Backward compatible: a new registry string under the existing `reason_code_version` 1, so consumers branching on `(reason_code_version, reason_code)` treat it as an unknown code under a known version and fall back as they already must. No version bump. |
+| 1              | 2026-08  | Added the stable `assay.run_summary.v1` document identity. This is additive; the existing integer `schema_version` remains `1`. |
 
 ---
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -114,6 +114,8 @@ When the run had judge evaluations, a top-level **`judge_metrics`** object MAY b
 
 ### 3.4 Example (Minimal)
 
+JSON object key order in these examples is illustrative, not normative.
+
 ```json
 {
   "schema": "assay.run_summary.v1",
@@ -305,8 +307,8 @@ For every non-zero exit, the implementation MUST provide **at least one suggeste
 ## 8. Conformance
 
 - **Producers:** `assay ci` and any code path that writes `summary.json`, `junit.xml`, or `sarif.json` for the PR gate MUST follow §2–§7.
-- **Consumers:** CI workflows and the GitHub Action MAY rely on schema_version, exit_code, reason_code, and next_step as defined above. Unknown summary fields MUST be ignored.
-- **Contract tests:** Implementations MUST include tests that (1) validate summary.json schema_version and required fields, (2) validate that every SARIF result has at least one location, (3) optionally validate SARIF against the official 2.1.0 schema and/or a minimal upload-smoke test.
+- **Consumers:** CI workflows and the GitHub Action MAY rely on `schema` when present, plus `schema_version`, `exit_code`, `reason_code`, and `next_step` as defined above. Consumers MUST apply the pre-identity compatibility rule in §3.1. Unknown summary fields MUST be ignored.
+- **Contract tests:** Implementations MUST include tests that (1) validate `schema`, `schema_version`, and required fields on newly produced `summary.json`, while accepting a pre-identity version-1 summary without `schema`, (2) validate that every SARIF result has at least one location, (3) optionally validate SARIF against the official 2.1.0 schema and/or a minimal upload-smoke test.
 
 ---
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -41,7 +41,7 @@ When `assay ci` (or the equivalent run invoked by the blessed workflow) complete
 
 | Field                 | Type    | Required | Description |
 |-----------------------|---------|----------|-------------|
-| `schema`             | string  | **Yes**  | Stable document identity. MUST be `assay.run_summary.v1` for `summary.json`. |
+| `schema`             | string  | **Yes (2026-08 and later)** | Stable document identity. MUST be `assay.run_summary.v1` for newly produced `summary.json`. Consumers MUST treat an absent `schema` on a `schema_version: 1` document as a pre-identity summary and MUST NOT reject it for that absence. |
 | `schema_version`     | integer | **Yes**  | Version of this summary schema. MUST be `1` for this spec. Increment when adding or changing fields in a backward-incompatible way. |
 | `reason_code_version`| integer | **Yes**  | Version of the reason code registry. MUST be present. MUST equal `1` in Outputs-v1. Future changes to the reason code set use this version. Consumers MUST branch on `(reason_code_version, reason_code)` for semantics; exit code is coarse transport only. Consumers MUST treat unknown versions as "compat required" (fail closed or fallback parsing). |
 | `exit_code`           | integer | **Yes**  | Process exit code: 0 = pass, 1 = test failure, 2 = config/user error, 3 = infra/judge unavailable. See §4. |
@@ -319,7 +319,7 @@ For every non-zero exit, the implementation MUST provide **at least one suggeste
 | 1              | 2026-02  | E2.3: SARIF truncation metadata (§6.3): properties.assay (truncated, omitted_count) in SARIF run; sarif.omitted in summary.json and run.json when truncated. Deterministic truncation order. |
 | 1              | 2026-02  | E9c alignment draft: replay provenance keys in `provenance` (`replay`, `bundle_digest`, `replay_mode`, `source_run_id`) and `E_REPLAY_MISSING_DEPENDENCY` reason code. |
 | 1              | 2026-07  | Added `E_REPLAY_LIMIT_EXCEEDED` (§5.1). Backward compatible: a new registry string under the existing `reason_code_version` 1, so consumers branching on `(reason_code_version, reason_code)` treat it as an unknown code under a known version and fall back as they already must. No version bump. |
-| 1              | 2026-08  | Added the stable `assay.run_summary.v1` document identity. This is additive; the existing integer `schema_version` remains `1`. |
+| 1              | 2026-08  | Added the stable `assay.run_summary.v1` document identity for newly produced summaries. This is additive; consumers MUST continue accepting pre-identity version-1 summaries without `schema`, and the existing integer `schema_version` remains `1`. |
 
 ---
 

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -66,8 +66,19 @@ assay ci \
 
 `assay run` writes:
 - `run.json` (exit/status/reason metadata)
-- `summary.json` (machine-readable summary including seeds and optional judge metrics)
+- `summary.json` (`assay.run_summary.v1`; machine-readable summary including seeds and optional judge metrics)
 - Console summary + footer
+
+### JSON document identities
+
+`--format json` has two documented stdout shapes:
+
+| Path | `schema` | `schema_version` | Meaning |
+|------|----------|------------------|---------|
+| Completed run | `assay.run_report.v1` | `1` | Results report containing `run_id`, `suite`, and `results`. |
+| Early failure before a run report exists | `assay.run_summary.v1` | `1` | The same diagnosis shape written to `summary.json`, including `exit_code`, `reason_code`, and `next_step`. |
+
+The `summary.json` artifact always uses `assay.run_summary.v1`. These identities are intentionally distinct even though both documents currently carry integer version `1`.
 
 ---
 

--- a/docs/reference/cli/validate.md
+++ b/docs/reference/cli/validate.md
@@ -46,8 +46,12 @@ Designed for CI pipelines:
 
 Use `--format json` to get a structured, machine-parsable report that follows the **Assay Agentic Contract**. This allows AI agents to read the report and self-correct their policies.
 
+Both successful and failing JSON reports use `schema: "assay.validate_report.v1"` with integer `schema_version: 1`. Consumers should branch on both fields rather than treating every version `1` document as the same shape.
+
 ```json
 {
+  "schema": "assay.validate_report.v1",
+  "schema_version": 1,
   "ok": false,
   "exit_code": 1,
   "diagnostics": [

--- a/docs/superpowers/plans/2026-08-08-named-cli-json-schemas.md
+++ b/docs/superpowers/plans/2026-08-08-named-cli-json-schemas.md
@@ -29,7 +29,7 @@
 - Consumes: `CARGO_BIN_EXE_assay`, `init --preset dev --hello-trace`, validate/run JSON output, and `summary.json`.
 - Produces: one failing integration contract over the three schema identities.
 
-- [ ] **Step 1: Write the failing binary test**
+- [x] **Step 1: Write the failing binary test**
 
 Create a temporary initialized project, drive validate success/failure and run
 success/failure, parse stdout, and assert:
@@ -45,7 +45,7 @@ assert_eq!(summary_file["schema"], "assay.run_summary.v1");
 Require integer `schema_version == 1` on all paths and require the three ids to
 be distinct.
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 ```bash
 CARGO_TARGET_DIR=/tmp/assay-target-2159 \
@@ -70,7 +70,7 @@ Expected: FAIL because every `schema` key is absent and run-success also lacks
 - Produces: `VALIDATE_REPORT_SCHEMA`, `RUN_REPORT_SCHEMA`, `RUN_REPORT_SCHEMA_VERSION`, `SUMMARY_SCHEMA`, and `render_summary_json(&Summary) -> anyhow::Result<String>`.
 - Consumes: unchanged `Summary`, existing `render_json(&RunArtifacts)`, and existing validate JSON builder.
 
-- [ ] **Step 1: Add focused core tests and verify RED**
+- [x] **Step 1: Add focused core tests and verify RED**
 
 Pin the run-report id/version, summary id, first summary key, legacy/new
 deserialization, and render-read-render idempotence. Run:
@@ -83,7 +83,7 @@ CARGO_TARGET_DIR=/tmp/assay-target-2159 \
 Expected: compile/test failure because the constants and summary renderer do
 not exist.
 
-- [ ] **Step 2: Implement the minimal rendering changes**
+- [x] **Step 2: Implement the minimal rendering changes**
 
 Add schema constants beside each renderer. Add `schema` and integer
 `schema_version` to the run-results JSON object. Add `schema` to validate's
@@ -91,7 +91,7 @@ JSON object. Implement the summary renderer by serializing the unchanged
 struct, inserting `schema`, and pretty-printing; call it from `write_summary`
 and `reporting.rs`.
 
-- [ ] **Step 3: Run focused tests and verify GREEN**
+- [x] **Step 3: Run focused tests and verify GREEN**
 
 ```bash
 CARGO_TARGET_DIR=/tmp/assay-target-2159 \
@@ -114,13 +114,13 @@ Expected: all focused tests pass.
 - Consumes: the three exact schema ids from Task 2.
 - Produces: public documentation that distinguishes run success, run early failure, and summary artifacts.
 
-- [ ] **Step 1: Update documentation**
+- [x] **Step 1: Update documentation**
 
 Add `assay.run_summary.v1` to the normative summary table/examples/history;
 add validate and run identity sections; name success/failure behavior exactly;
 record #2167 and #2168 only as bounded follow-ups where needed.
 
-- [ ] **Step 2: Verify literals and public claims**
+- [x] **Step 2: Verify literals and public claims**
 
 ```bash
 rg -n 'assay\.(validate_report|run_report|run_summary)\.v1' \
@@ -142,7 +142,7 @@ Expected: each id appears only in its constant/tests/docs; no expanded claim.
 - Consumes: completed code, tests, and docs.
 - Produces: a verified exact-head PR that closes #2159 and unblocks #2154.
 
-- [ ] **Step 1: Run affected verification**
+- [x] **Step 1: Run affected verification**
 
 ```bash
 CARGO_TARGET_DIR=/tmp/assay-target-2159 cargo test -p assay-core
@@ -153,7 +153,7 @@ cargo fmt --all -- --check
 git diff --check
 ```
 
-- [ ] **Step 2: Kill the three schema mutations**
+- [x] **Step 2: Kill the three schema mutations**
 
 On reversible copies, change each schema id in its production renderer and
 require the focused owning test to fail for that exact mismatch. Restore the

--- a/docs/superpowers/plans/2026-08-08-named-cli-json-schemas.md
+++ b/docs/superpowers/plans/2026-08-08-named-cli-json-schemas.md
@@ -1,0 +1,177 @@
+# Named CLI JSON Schemas Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each JSON document observed on the validate/run golden path a stable, named schema identity without breaking the public `Summary` Rust type.
+
+**Architecture:** Existing validate, run-results, and summary builders remain responsible for their own documents. The summary writer gains one renderer shared by file output and early-failure stdout; the public `Summary` data type remains unchanged.
+
+**Tech Stack:** Rust, serde_json, assertive binary integration tests, Markdown contracts.
+
+## Global Constraints
+
+- Preserve `schema_version: 1`; add identities without wrapping or renaming existing fields.
+- Do not add a field to public `assay_core::report::summary::Summary`.
+- Define each schema id once and make every output path call its owning renderer.
+- Preserve existing summary key order and existing render-safety behavior.
+- Use `CARGO_TARGET_DIR=/tmp/assay-target-2159` for all Rust commands.
+- Stage only exact paths touched by this issue.
+- Obtain Claude Code Desktop read-only review on every final head.
+
+---
+
+### Task 1: Freeze the Three Binary Surfaces
+
+**Files:**
+- Create: `crates/assay-cli/tests/named_json_envelopes.rs`
+
+**Interfaces:**
+- Consumes: `CARGO_BIN_EXE_assay`, `init --preset dev --hello-trace`, validate/run JSON output, and `summary.json`.
+- Produces: one failing integration contract over the three schema identities.
+
+- [ ] **Step 1: Write the failing binary test**
+
+Create a temporary initialized project, drive validate success/failure and run
+success/failure, parse stdout, and assert:
+
+```rust
+assert_eq!(validate_success["schema"], "assay.validate_report.v1");
+assert_eq!(validate_failure["schema"], "assay.validate_report.v1");
+assert_eq!(run_success["schema"], "assay.run_report.v1");
+assert_eq!(run_failure["schema"], "assay.run_summary.v1");
+assert_eq!(summary_file["schema"], "assay.run_summary.v1");
+```
+
+Require integer `schema_version == 1` on all paths and require the three ids to
+be distinct.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-target-2159 \
+  cargo test -p assay-cli --test named_json_envelopes -- --nocapture
+```
+
+Expected: FAIL because every `schema` key is absent and run-success also lacks
+`schema_version`.
+
+### Task 2: Add the Three Named Renderers
+
+**Files:**
+- Modify: `crates/assay-cli/src/cli/commands/validate.rs`
+- Modify: `crates/assay-core/src/report/json.rs`
+- Modify: `crates/assay-core/src/report/summary/writer.rs`
+- Modify: `crates/assay-core/src/report/summary.rs`
+- Modify: `crates/assay-cli/src/cli/commands/reporting.rs`
+- Test: `crates/assay-core/src/report/json.rs`
+- Test: `crates/assay-core/src/report/summary/writer.rs`
+
+**Interfaces:**
+- Produces: `VALIDATE_REPORT_SCHEMA`, `RUN_REPORT_SCHEMA`, `RUN_REPORT_SCHEMA_VERSION`, `SUMMARY_SCHEMA`, and `render_summary_json(&Summary) -> anyhow::Result<String>`.
+- Consumes: unchanged `Summary`, existing `render_json(&RunArtifacts)`, and existing validate JSON builder.
+
+- [ ] **Step 1: Add focused core tests and verify RED**
+
+Pin the run-report id/version, summary id, first summary key, legacy/new
+deserialization, and render-read-render idempotence. Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-target-2159 \
+  cargo test -p assay-core report::json::tests report::summary::writer::tests
+```
+
+Expected: compile/test failure because the constants and summary renderer do
+not exist.
+
+- [ ] **Step 2: Implement the minimal rendering changes**
+
+Add schema constants beside each renderer. Add `schema` and integer
+`schema_version` to the run-results JSON object. Add `schema` to validate's
+JSON object. Implement the summary renderer by serializing the unchanged
+struct, inserting `schema`, and pretty-printing; call it from `write_summary`
+and `reporting.rs`.
+
+- [ ] **Step 3: Run focused tests and verify GREEN**
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-target-2159 \
+  cargo test -p assay-core report::json::tests report::summary::writer::tests
+CARGO_TARGET_DIR=/tmp/assay-target-2159 \
+  cargo test -p assay-cli --test named_json_envelopes -- --nocapture
+```
+
+Expected: all focused tests pass.
+
+### Task 3: Update the Normative and CLI Contracts
+
+**Files:**
+- Modify: `docs/architecture/SPEC-PR-Gate-Outputs-v1.md`
+- Modify: `docs/reference/cli/validate.md`
+- Modify: `docs/reference/cli/run.md`
+- Modify: `docs/AIcontext/run-output.md`
+
+**Interfaces:**
+- Consumes: the three exact schema ids from Task 2.
+- Produces: public documentation that distinguishes run success, run early failure, and summary artifacts.
+
+- [ ] **Step 1: Update documentation**
+
+Add `assay.run_summary.v1` to the normative summary table/examples/history;
+add validate and run identity sections; name success/failure behavior exactly;
+record #2167 and #2168 only as bounded follow-ups where needed.
+
+- [ ] **Step 2: Verify literals and public claims**
+
+```bash
+rg -n 'assay\.(validate_report|run_report|run_summary)\.v1' \
+  crates/assay-cli/src crates/assay-core/src docs/architecture/SPEC-PR-Gate-Outputs-v1.md \
+  docs/reference/cli/validate.md docs/reference/cli/run.md docs/AIcontext/run-output.md
+rg -n 'trust score|safe agent|certif|compliance claim' \
+  docs/architecture/SPEC-PR-Gate-Outputs-v1.md docs/reference/cli/validate.md \
+  docs/reference/cli/run.md docs/AIcontext/run-output.md || true
+```
+
+Expected: each id appears only in its constant/tests/docs; no expanded claim.
+
+### Task 4: Verify, Mutate, Review, and Deliver
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-08-named-cli-json-schemas.md`
+
+**Interfaces:**
+- Consumes: completed code, tests, and docs.
+- Produces: a verified exact-head PR that closes #2159 and unblocks #2154.
+
+- [ ] **Step 1: Run affected verification**
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-target-2159 cargo test -p assay-core
+CARGO_TARGET_DIR=/tmp/assay-target-2159 cargo test -p assay-cli
+CARGO_TARGET_DIR=/tmp/assay-target-2159 \
+  cargo clippy -p assay-core -p assay-cli --all-targets -- -D warnings
+cargo fmt --all -- --check
+git diff --check
+```
+
+- [ ] **Step 2: Kill the three schema mutations**
+
+On reversible copies, change each schema id in its production renderer and
+require the focused owning test to fail for that exact mismatch. Restore the
+tree and rerun all focused tests.
+
+- [ ] **Step 3: Commit with exact pathspecs**
+
+Stage only the two plan/spec files and the implementation/test/documentation
+paths listed above. Do not use a whole-tree staging command.
+
+- [ ] **Step 4: Obtain exact-head Claude Code Desktop review**
+
+Give Claude Desktop the full commit SHA and `origin/main...<sha>` diff in
+read-only mode. Fix every actionable finding and repeat on any new head.
+
+- [ ] **Step 5: Push, open a ready PR, and satisfy quorum**
+
+Push `codex/2159-named-json-schemas`, open a ready PR linked to #2159, request
+Copilot, and record the exact head, verification, Claude review, non-goals,
+and follow-ups #2167/#2168. Merge only after required checks and exact-head
+review quorum are satisfied.

--- a/docs/superpowers/plans/2026-08-08-named-cli-json-schemas.md
+++ b/docs/superpowers/plans/2026-08-08-named-cli-json-schemas.md
@@ -76,8 +76,8 @@ Pin the run-report id/version, summary id, first summary key, legacy/new
 deserialization, and render-read-render idempotence. Run:
 
 ```bash
-CARGO_TARGET_DIR=/tmp/assay-target-2159 \
-  cargo test -p assay-core report::json::tests report::summary::writer::tests
+CARGO_TARGET_DIR=/tmp/assay-target-2159 cargo test -p assay-core report::json::tests
+CARGO_TARGET_DIR=/tmp/assay-target-2159 cargo test -p assay-core report::summary::writer::tests
 ```
 
 Expected: compile/test failure because the constants and summary renderer do
@@ -94,8 +94,8 @@ and `reporting.rs`.
 - [x] **Step 3: Run focused tests and verify GREEN**
 
 ```bash
-CARGO_TARGET_DIR=/tmp/assay-target-2159 \
-  cargo test -p assay-core report::json::tests report::summary::writer::tests
+CARGO_TARGET_DIR=/tmp/assay-target-2159 cargo test -p assay-core report::json::tests
+CARGO_TARGET_DIR=/tmp/assay-target-2159 cargo test -p assay-core report::summary::writer::tests
 CARGO_TARGET_DIR=/tmp/assay-target-2159 \
   cargo test -p assay-cli --test named_json_envelopes -- --nocapture
 ```

--- a/docs/superpowers/specs/2026-08-08-named-cli-json-schemas-design.md
+++ b/docs/superpowers/specs/2026-08-08-named-cli-json-schemas-design.md
@@ -66,7 +66,8 @@ silently reorder every summary artifact.
 
 - `validate.rs` defines the validate schema id beside its sole JSON builder.
 - `report/json.rs` defines the run-results schema id and version beside the
-  one renderer used by stdout and its file writer.
+  renderer used by stdout and the public `write_json` helper. The CLI's
+  extended `run.json` artifact remains a separate writer and envelope.
 - `summary/writer.rs` defines the summary schema id beside the one renderer
   used by summary files and early-failure stdout.
 
@@ -98,10 +99,10 @@ Core tests pin:
 
 - the run-results renderer's schema id and integer version;
 - the summary renderer's schema id;
-- the existing summary key order before the appended field;
+- the historical first summary key before the appended field;
 - old direct-serialized summaries and new rendered summaries both
   deserializing into `Summary`;
-- a render-read-render round trip retaining exactly one schema field.
+- render-read-render idempotence through the shared summary renderer.
 
 Targeted mutations must prove that changing each of the three schema ids makes
 its owning test fail.

--- a/docs/superpowers/specs/2026-08-08-named-cli-json-schemas-design.md
+++ b/docs/superpowers/specs/2026-08-08-named-cli-json-schemas-design.md
@@ -1,0 +1,124 @@
+# Named CLI JSON Schemas Design
+
+Date: 2026-08-08
+Issue: [#2159](https://github.com/Rul1an/assay/issues/2159)
+
+## Problem
+
+The golden-path measurements found three different JSON documents behind two
+commands:
+
+| command path | current top-level keys |
+|---|---|
+| `assay validate --format json` | `command`, `diagnostics`, `exit_code`, `ok`, `schema_version`, `suggested_actions`, `suggested_patches`, `summary`, `tool` |
+| successful `assay run --format json` | `results`, `run_id`, `suite` |
+| early-failure `assay run --format json` | `exit_code`, `message`, `next_step`, `provenance`, `reason_code`, `reason_code_version`, `schema_version`, `seeds` |
+
+The two run paths have no top-level key in common. An integer
+`schema_version: 1` does not identify which document a caller holds, and the
+successful run document has no schema identity at all.
+
+## Decision
+
+Add a top-level string `schema` discriminator and retain an integer
+`schema_version` for these three documents:
+
+- `assay.validate_report.v1` for validate JSON;
+- `assay.run_report.v1` for the detailed successful run-results report;
+- `assay.run_summary.v1` for `summary.json` and early-failure run stdout.
+
+The identifiers name documents, not commands. A caller branches on `schema`
+before interpreting document-specific fields. `schema_version` remains `1`
+and is scoped by that name.
+
+The broader repository convention is intentionally separate. Coverage and
+session-state-window currently put string identities in `schema_version`;
+[#2167](https://github.com/Rul1an/assay/issues/2167) owns inventory and
+migration of that cross-command convention. It does not block naming the
+three documents required by #2154.
+
+## Compatibility
+
+Do not add a field to public `assay_core::report::summary::Summary`. That
+struct is constructible downstream, so adding a field would be a semver-major
+Rust API change.
+
+Instead, add one public summary renderer in the existing writer module:
+
+1. serialize `Summary` to a `serde_json::Value`;
+2. insert `schema: assay.run_summary.v1` into the top-level object;
+3. pretty-print the value;
+4. call that renderer from both `write_summary` and early-failure stdout.
+
+Old summaries remain deserializable because `Summary` continues to accept
+unknown fields and does not require the discriminator. Replaying an old
+summary reads the old shape, then the shared writer adds the current identity.
+Replaying a new summary drops the unknown field during deserialization and
+adds the same value again, so the round trip is idempotent.
+
+The renderer preserves existing key order before appending `schema` because
+the active serde_json graph enables `preserve_order`. A unit test pins the
+first key as `schema_version`, so removal of that transitive feature cannot
+silently reorder every summary artifact.
+
+## Single Sources
+
+- `validate.rs` defines the validate schema id beside its sole JSON builder.
+- `report/json.rs` defines the run-results schema id and version beside the
+  one renderer used by stdout and its file writer.
+- `summary/writer.rs` defines the summary schema id beside the one renderer
+  used by summary files and early-failure stdout.
+
+No caller restates these string literals.
+
+## Render Safety
+
+This change preserves current `Summary` bytes except for the additive schema
+field. It does not silently add or remove sanitization. The current asymmetry
+between summary rendering and the render-safety walk used by run results is
+tracked in [#2168](https://github.com/Rul1an/assay/issues/2168), which must
+first establish whether untrusted bytes can reach `Summary.message` or
+`next_step`.
+
+The new run-report keys pass through the existing JSON safety walk. They are
+Assay-owned constants and are not part of its untrusted-field vocabulary.
+
+## Tests
+
+A binary-level CLI contract test drives:
+
+1. validate success and failure, both named `assay.validate_report.v1`;
+2. run success, named `assay.run_report.v1`;
+3. run early failure, named `assay.run_summary.v1`;
+4. the success-path `summary.json`, also named `assay.run_summary.v1`;
+5. distinct identities across all three document contracts.
+
+Core tests pin:
+
+- the run-results renderer's schema id and integer version;
+- the summary renderer's schema id;
+- the existing summary key order before the appended field;
+- old direct-serialized summaries and new rendered summaries both
+  deserializing into `Summary`;
+- a render-read-render round trip retaining exactly one schema field.
+
+Targeted mutations must prove that changing each of the three schema ids makes
+its owning test fail.
+
+## Documentation
+
+- Add `schema` to the normative `summary.json` table and examples in
+  `SPEC-PR-Gate-Outputs-v1.md` as an additive v1 field.
+- Document validate's schema identity in its CLI reference.
+- Document the run-success, run-failure, and summary-artifact identities in
+  the run reference.
+- Add the summary identity to the run-output AI context.
+
+## Non-Goals
+
+- No shared envelope or payload wrapper.
+- No removal or repurposing of `schema_version`.
+- No migration of coverage or session-state-window; #2167 owns that.
+- No provenance expansion.
+- No summary render-safety behavior change; #2168 owns that decision.
+- No change to exit codes, reason codes, result semantics, or output channels.

--- a/docs/superpowers/specs/2026-08-08-named-cli-json-schemas-design.md
+++ b/docs/superpowers/specs/2026-08-08-named-cli-json-schemas-design.md
@@ -31,8 +31,9 @@ The identifiers name documents, not commands. A caller branches on `schema`
 before interpreting document-specific fields. `schema_version` remains `1`
 and is scoped by that name.
 
-The broader repository convention is intentionally separate. Coverage and
-session-state-window currently put string identities in `schema_version`;
+The broader repository convention is intentionally separate. Coverage,
+session-state-window, and soak reports currently put string identities in
+`schema_version`;
 [#2167](https://github.com/Rul1an/assay/issues/2167) owns inventory and
 migration of that cross-command convention. It does not block naming the
 three documents required by #2154.
@@ -118,7 +119,9 @@ its owning test fail.
 
 - No shared envelope or payload wrapper.
 - No removal or repurposing of `schema_version`.
-- No migration of coverage or session-state-window; #2167 owns that.
+- No identity for the separately written `run.json` artifact; #2167 owns that.
+- No migration of coverage, session-state-window, or soak reports; #2167 owns
+  that.
 - No provenance expansion.
 - No summary render-safety behavior change; #2168 owns that decision.
 - No change to exit codes, reason codes, result semantics, or output channels.


### PR DESCRIPTION
## Summary

- add stable names to the three JSON documents observed by the validate/run golden path
- keep integer `schema_version: 1` and preserve every existing field
- route `summary.json` and early-failure JSON stdout through one renderer without changing the public `Summary` Rust type
- document the success/failure distinction and the bounded follow-ups

## Contract changes

| Surface | Schema identity | Version |
|---|---|---:|
| `assay validate --format json` success/failure | `assay.validate_report.v1` | `1` |
| completed `assay run --format json` stdout | `assay.run_report.v1` | `1` |
| `summary.json` and early-failure run stdout | `assay.run_summary.v1` | `1` |

No field is removed, wrapped, or renamed. `assay_core::report::summary::Summary` remains unchanged; the public additions are renderer/constants only.

## Why

`validate` and early-failure `run` both exposed `schema_version: 1` for disjoint documents, while completed `run` stdout had no version or identity at all. A consumer could not identify which contract it held from the document.

Closes #2159.

## Verification

Measured on exact head `6cb340b871e481e36619eea94f22a149a9d75f05` in worktree `/Users/roelschuurkes/.config/superpowers/worktrees/assay/2159-named-json-schemas`, with Rust `1.96.0` and `CARGO_TARGET_DIR=/tmp/assay-target-2159`.

- `cargo test -p assay-core`: pass, 903 unit tests plus integrations/doc-tests; existing VCR generators ignored
- `cargo test -p assay-cli`: pass, 538 unit tests plus all integrations; existing generator ignored
- `cargo clippy -p assay-core -p assay-cli --all-targets -- -D warnings`: pass
- focused renderer tests and `cargo test -p assay-cli --test named_json_envelopes`: pass on final head
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass
- pre-commit and pre-push hooks: pass, including workspace clippy and Linux cross-target gate

Additional scenario evidence on the same head:

- `cargo test -p assay-sim`: pass, 37 unit tests plus 16 invariant/mutation tests; 3 result-dump helpers remain intentionally ignored
- agent/AI behavior: `assertions_smoke`, `assertion_companion_cover`, and `assertions_vacuity`: pass, 34 tests
- user/workflow behavior: `named_json_envelopes` and `contract_run_ci_parity`: pass, 7 tests

## TDD and mutation proof

RED before production changes:

```text
validate success schema identity
left: Null
right: "assay.validate_report.v1"
```

Each production identity was then mutated independently. The real binary contract failed on the exact changed value for:

- `assay.validate_report.MUTATED`
- `assay.run_report.MUTATED`
- `assay.run_summary.MUTATED`

All mutations were restored and focused tests rerun green.

## Review fixes

CodeRabbit identified two valid gaps on a prior head. Final head `6cb340b87`:

- splits the invalid two-filter Cargo examples into separate valid invocations;
- asserts the early-failure `summary.json` artifact in addition to stdout.

The delta contains no production-code change.

## Review

The independent review cycle through `64870f777a6f44ff17e74c7cc5053daf3aae275e` found one normative compatibility defect plus documentation and test-diagnostic gaps. Final head `6cb340b871e481e36619eea94f22a149a9d75f05` fixes them:

- legacy `schema_version: 1` summaries without `schema` remain accepted;
- distinctness is checked over observed document identities;
- #2167's deferral inventory includes soak reports and the unnamed `run.json` artifact.
- renderer documentation distinguishes the stdout/`write_json` report from the separately written extended `run.json`;
- §8 names `schema` and the pre-identity compatibility rule, example key order is explicitly non-normative, and test descriptions match what is actually asserted.

`schema` intentionally remains last in rendered summaries so every historical key keeps its byte position; this is a documented disposition, not an accidental order.

Claude Code Desktop, a second independent Claude review agent, Copilot, and CodeRabbit have been re-requested on exact final head `6cb340b871e481e36619eea94f22a149a9d75f05`. Merge remains disabled until the final-head review quorum and CI are complete.

Non-blocking findings were dispositioned:

- the separately written, currently unnamed `run.json` artifact is recorded on #2167
- repo-wide string-vs-integer schema convention remains #2167
- summary render-safety policy remains #2168
- exit-1 completed runs use the same `render_json` branch as exit 0; the binary test pins the branch rather than duplicating that case

## Non-claims

- no shared cross-command envelope
- no identity yet for the separate `run.json` artifact
- no render-safety policy change for `Summary`
- no provenance expansion or public `Summary` field
