### PR TITLE
test(agent): gate private golden-path vocabulary

### DIFF
--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -5,11 +5,12 @@ ROOT="$(git rev-parse --show-toplevel)"
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-# Task 5 adds three tracked-symlink mutations to Task 4's 46-case boundary.
-EXPECTED_CASES=49
+# PR B0 adds five public-vocabulary mutations and one structural allow case to
+# the 49-case durability boundary.
+EXPECTED_CASES=55
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
-# 2 inline-parser checks; pin them so deletion cannot leave the 49-case total green.
+# 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
 EXPECTED_STRUCTURAL_PROBES=22
 case_count=0
 structural_probe_count=0
@@ -112,6 +113,16 @@ seed_case() {
   case_git "$case_root" -c init.defaultBranch=main init -q
   case_git "$case_root" -c core.excludesFile= -c core.attributesFile= \
     add -f -- .
+}
+
+append_skill_text() {
+  local case_root="$1" text="$2" skill_path
+  for skill_path in \
+    '.agents/skills/assay-golden-path/SKILL.md' \
+    '.claude/skills/assay-golden-path/SKILL.md'
+  do
+    printf '\n%s\n' "$text" >> "$case_root/$skill_path"
+  done
 }
 
 expect_failure_with_recorder() {
@@ -403,6 +414,28 @@ expect_named_failure \
   "human guide without protected-action cwd" \
   "$case_root" \
   "guide omits working directory for protected-action"
+
+vocabulary_mutations=(
+  'next-slice|The NEXT---SLICE owns this public wording.|skill introduces private planning vocabulary: next slice'
+  'future-marketplace|Future, MARKETPLACE packaging belongs here.|skill introduces private planning vocabulary: future marketplace'
+  'roadmap-ownership|Road-map ownership belongs in this skill.|skill introduces private planning vocabulary: roadmap ownership'
+  'number-word-step|Implementation step THREE owns this release.|skill introduces private planning vocabulary: implementation step 3 ownership'
+  'unknown-issue|This is tracked by [gap #9999](https://github.com/Rul1an/assay/issues/9999).|skill references issue outside contract evidence: #9999'
+)
+for row in "${vocabulary_mutations[@]}"; do
+  IFS='|' read -r name mutation expected <<<"$row"
+  case_root="$SCRATCH/public-vocabulary-$name"
+  seed_case "$case_root"
+  append_skill_text "$case_root" "$mutation"
+  expect_named_failure "public vocabulary $name" "$case_root" "$expected"
+done
+
+case_root="$SCRATCH/public-vocabulary-allow-contract-evidence"
+seed_case "$case_root"
+append_skill_text \
+  "$case_root" \
+  'The nine steps retain the existing [gap #2160](https://github.com/Rul1an/assay/issues/2160) evidence link.'
+expect_named_success "public vocabulary contract evidence allow case" "$case_root"
 
 for workflow_path in 'scripts/**' '.github/workflows/kernel-matrix.yml'; do
   for mutation in remove comment; do

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -5,9 +5,9 @@ ROOT="$(git rev-parse --show-toplevel)"
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-# PR B0 adds five public-vocabulary mutations and one structural allow case to
+# PR B0 adds seven public-vocabulary mutations and two structural allow cases to
 # the 49-case durability boundary.
-EXPECTED_CASES=55
+EXPECTED_CASES=58
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -123,6 +123,48 @@ append_skill_text() {
   do
     printf '\n%s\n' "$text" >> "$case_root/$skill_path"
   done
+}
+
+append_contract_evidence_issue() {
+  local case_root="$1"
+  CASE_ROOT="$case_root" python3 - <<'PY'
+import json
+import re
+import os
+from pathlib import Path
+
+root = Path(os.environ["CASE_ROOT"])
+contract_path = root / "docs/generated/agent-golden-path.json"
+contract = json.loads(contract_path.read_text(encoding="utf-8"))
+
+issue_numbers = {
+    int(match)
+    for claim in contract["non_claims"]
+    for match in re.findall(r"(?:#|/issues/)([0-9]+)", claim)
+}
+for step in contract["steps"]:
+    issue_numbers.update(
+        outcome["gap_issue"]
+        for outcome in step["outcomes"]
+        if isinstance(outcome.get("gap_issue"), int)
+        and not isinstance(outcome["gap_issue"], bool)
+    )
+
+novel_issue = max(issue_numbers) + 1000
+claim = (
+    "Mutation-only contract evidence is tracked by "
+    f"[#{novel_issue}](https://github.com/Rul1an/assay/issues/{novel_issue})."
+)
+contract["non_claims"].append(claim)
+contract_path.write_text(json.dumps(contract, indent=2) + "\n", encoding="utf-8")
+
+for skill_path in (
+    root / ".agents/skills/assay-golden-path/SKILL.md",
+    root / ".claude/skills/assay-golden-path/SKILL.md",
+):
+    with skill_path.open("a", encoding="ascii") as skill:
+        skill.write(f"\n{claim}\n")
+PY
 }
 
 expect_failure_with_recorder() {
@@ -418,6 +460,8 @@ expect_named_failure \
 vocabulary_mutations=(
   'next-slice|The NEXT---SLICE owns this public wording.|skill introduces private planning vocabulary: next slice'
   'future-marketplace|Future, MARKETPLACE packaging belongs here.|skill introduces private planning vocabulary: future marketplace'
+  'future-market-place|Future market-place packaging belongs here.|skill introduces private planning vocabulary: future marketplace'
+  'future-plug-in|Future plug-in packaging belongs here.|skill introduces private planning vocabulary: future marketplace'
   'roadmap-ownership|Road-map ownership belongs in this skill.|skill introduces private planning vocabulary: roadmap ownership'
   'number-word-step|Implementation step THREE owns this release.|skill introduces private planning vocabulary: implementation step 3 ownership'
   'unknown-issue|This is tracked by [gap #9999](https://github.com/Rul1an/assay/issues/9999).|skill references issue outside contract evidence: #9999'
@@ -436,6 +480,11 @@ append_skill_text \
   "$case_root" \
   'The nine steps retain the existing [gap #2160](https://github.com/Rul1an/assay/issues/2160) evidence link.'
 expect_named_success "public vocabulary contract evidence allow case" "$case_root"
+
+case_root="$SCRATCH/public-vocabulary-allow-novel-contract-evidence"
+seed_case "$case_root"
+append_contract_evidence_issue "$case_root"
+expect_named_success "public vocabulary novel contract evidence allow case" "$case_root"
 
 for workflow_path in 'scripts/**' '.github/workflows/kernel-matrix.yml'; do
   for mutation in remove comment; do

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -58,6 +58,44 @@ SELF_TEST_TRIGGER_PATH = "scripts/docs/generate-agent-golden-path.py"
 SELF_TEST_TRIGGER_MODE = "100644"
 SELF_TEST_TRIGGER_TYPES = frozenset({"file", "non-executable", "python", "text"})
 MAPPING_ENTRY_PATTERN = re.compile(r"^(?P<key>[A-Za-z0-9_-]+) *:(?P<value>.*)$")
+ISSUE_REFERENCE_PATTERN = re.compile(r"(?:#|/issues/)([0-9]+)")
+PUBLIC_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+PRIVATE_PHRASE_FAMILIES = (
+    (
+        "roadmap ownership",
+        (("roadmap", "ownership"), ("road", "map", "ownership")),
+    ),
+    (
+        "next slice",
+        (
+            ("next", "slice"),
+            ("future", "slice"),
+            ("next", "pr"),
+            ("future", "pr"),
+        ),
+    ),
+    (
+        "future marketplace",
+        (
+            ("future", "marketplace"),
+            ("marketplace", "packaging"),
+            ("future", "plugin"),
+            ("plugin", "packaging"),
+        ),
+    ),
+)
+NUMBER_WORDS = {
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7",
+    "eight": "8",
+    "nine": "9",
+}
+STEP_NUMBERS = frozenset(NUMBER_WORDS.values())
 
 # Both bounded YAML readers intentionally model the repository's two-space
 # layout rather than arbitrary YAML indentation or scalar forms.
@@ -107,6 +145,71 @@ class WorkflowContract:
 
 def fail(message: str) -> None:
     raise AssertionError(message)
+
+
+def contains_token_sequence(tokens: tuple[str, ...], sequence: tuple[str, ...]) -> bool:
+    width = len(sequence)
+    return any(
+        tokens[index : index + width] == sequence
+        for index in range(len(tokens) - width + 1)
+    )
+
+
+def contract_issue_numbers(contract: dict[str, object]) -> set[int]:
+    allowed: set[int] = set()
+    steps = contract.get("steps")
+    if not isinstance(steps, list):
+        fail("golden-path contract steps must be a list")
+    for step in steps:
+        if not isinstance(step, dict):
+            fail("golden-path steps must be objects")
+        outcomes = step.get("outcomes")
+        if not isinstance(outcomes, list):
+            fail(f"golden-path outcomes must be a list for {step.get('id')}")
+        for outcome in outcomes:
+            if not isinstance(outcome, dict):
+                fail(f"golden-path outcomes must be objects for {step.get('id')}")
+            issue = outcome.get("gap_issue")
+            if issue is None:
+                continue
+            if not isinstance(issue, int) or isinstance(issue, bool):
+                fail(f"golden-path gap_issue must be an integer for {step.get('id')}")
+            allowed.add(issue)
+
+    non_claims = contract.get("non_claims")
+    if not isinstance(non_claims, list):
+        fail("golden-path contract non_claims must be a list")
+    for claim in non_claims:
+        if not isinstance(claim, str):
+            fail("golden-path non-claims must be strings")
+        allowed.update(int(raw) for raw in ISSUE_REFERENCE_PATTERN.findall(claim))
+    return allowed
+
+
+def validate_public_vocabulary(text: str, contract: dict[str, object]) -> None:
+    allowed_issues = contract_issue_numbers(contract)
+    observed_issues = {int(raw) for raw in ISSUE_REFERENCE_PATTERN.findall(text)}
+    unexpected = sorted(observed_issues - allowed_issues)
+    if unexpected:
+        fail(f"skill references issue outside contract evidence: #{unexpected[0]}")
+
+    tokens = tuple(PUBLIC_TOKEN_PATTERN.findall(text.lower()))
+    for label, sequences in PRIVATE_PHRASE_FAMILIES:
+        if any(contains_token_sequence(tokens, sequence) for sequence in sequences):
+            fail(f"skill introduces private planning vocabulary: {label}")
+
+    ownership_tokens = frozenset({"belongs", "owned", "ownership", "owns"})
+    for index in range(len(tokens) - 2):
+        if tokens[index : index + 2] != ("implementation", "step"):
+            continue
+        step_number = NUMBER_WORDS.get(tokens[index + 2], tokens[index + 2])
+        if step_number not in STEP_NUMBERS:
+            continue
+        if any(token in ownership_tokens for token in tokens[index + 3 : index + 7]):
+            fail(
+                "skill introduces private planning vocabulary: "
+                f"implementation step {step_number} ownership"
+            )
 
 
 def run_git(*args: str) -> subprocess.CompletedProcess[str]:
@@ -868,17 +971,17 @@ def main() -> None:
         if non_claim not in body:
             fail(f"skill omits non-claim: {non_claim}")
 
-    forbidden = (
+    validate_public_vocabulary(text, contract)
+
+    forbidden_claims = (
         "assay mcp-server",
         "assay_test_outbound",
         "six production tools",
         "safe agent",
         "compliance claim",
-        "issue #2152 step 3",
-        "Plugin and marketplace packaging belongs",
         "Cursor does not discover this project skill",
     )
-    for phrase in forbidden:
+    for phrase in forbidden_claims:
         if phrase in text:
             fail(f"skill introduces forbidden or stale claim: {phrase!r}")
 

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -78,9 +78,13 @@ PRIVATE_PHRASE_FAMILIES = (
         "future marketplace",
         (
             ("future", "marketplace"),
+            ("future", "market", "place"),
             ("marketplace", "packaging"),
+            ("market", "place", "packaging"),
             ("future", "plugin"),
+            ("future", "plug", "in"),
             ("plugin", "packaging"),
+            ("plug", "in", "packaging"),
         ),
     ),
 )


### PR DESCRIPTION
## Summary

Add a bounded semantic gate that rejects private planning vocabulary and out-of-contract issue references in the generated agent golden-path skill, before any public wording changes land.

## Why

Issue #2176 requires the vocabulary gate to be independently falsifiable against unchanged generated bytes. This PR is the PR B0 prerequisite for the later cwd/discoverability slice.

## Scope

- normalize public skill text to lowercase ASCII tokens for case/punctuation-stable matching
- reject a closed set of private planning phrase families
- fold `one` through `nine` only inside `implementation step N` ownership matching
- derive permitted issue references from `steps[*].outcomes[*].gap_issue` and issue links in `non_claims`
- add seven named rejection mutations and two contract-evidence allow cases
- keep generated contract, guide, and both skills byte-unchanged

## TDD Evidence

Exact head: `dfeb6dd3445eda880301f7967ea7c3366cfc0644`

- RED before implementation: `FAIL: public vocabulary next-slice was accepted`
- GREEN: `agent golden-path hardening: 58 case(s) observed; 22 structural probe(s) observed`
- optimized Python validation: pass
- `python3 -OO` validation: pass
- seven generated artifacts reproduce from generators
- generated public artifacts: no diff from parent

## Verification

```text
python3 scripts/ci/test-agent-golden-path-skill.py
bash scripts/ci/test-agent-golden-path-skill-hardening.sh
bash scripts/ci/test-agent-golden-path-skill-optimization.sh
python3 -OO scripts/ci/test-agent-golden-path-skill.py
bash scripts/ci/check-docs-generated-drift.sh
bash scripts/ci/test-check-docs-generated-drift-safety.sh
bash scripts/ci/test-check-docs-generated-drift.sh
git diff --check
```

All commands above passed. Full pre-commit passed except `cargo-deny`: cargo-deny 0.19.0 reproduced the same parse failure with a fresh isolated `CARGO_HOME` because the current RustSec advisory database contains duplicate ID `RUSTSEC-2026-0244` for `gettext-rs` and `gettext-sys`. No hook or workflow was weakened; GitHub Actions remains the final security proof.

## Risk And Non-Claims

- no generated public wording or bytes change
- no runtime, schema, exit-code, policy, evidence, MCP, or security behavior change
- no cwd/discoverability implementation; a follow-up PR owns that
- no Cursor runtime-discovery or plugin/marketplace claim

## Review Focus

- false positives/negatives in bounded phrase matching
- scoping of number-word normalization
- structural issue allowlist derivation
- mutation bite, punctuation-equivalent compounds, and dynamic contract-evidence coverage

Related: #2176



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added validation to ensure skill text uses only approved issue references from contract evidence.
- Added checks to reject private planning language and ownership-related phrasing.
- Improved recognition of implementation-step counts, including number words.

## Tests
- Expanded golden-path coverage from 49 to 58 standard cases.
- Added rejection cases for unapproved public vocabulary and approval cases for valid contract evidence references.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->