### PR TITLE
docs(agent): harden golden-path cwd and discovery

### DIFF
--- a/.agents/skills/assay-golden-path/SKILL.md
+++ b/.agents/skills/assay-golden-path/SKILL.md
@@ -13,6 +13,9 @@ a process failure.
 Read it when exact argv, fields, or per-outcome metadata are needed. Edit and
 run `scripts/docs/generate-agent-golden-path.py` instead of editing this file.
 
+When a step has no `working_directory`, run it from the invocation cwd.
+A present `working_directory` is a POSIX path relative to the source repository.
+
 Empty stdout in a gap row is an observed limitation, not permission for a caller to infer success from missing evidence.
 Do not replace a linked gap with an inferred clean result.
 

--- a/.agents/skills/assay-golden-path/SKILL.md
+++ b/.agents/skills/assay-golden-path/SKILL.md
@@ -17,7 +17,7 @@ Empty stdout in a gap row is an observed limitation, not permission for a caller
 Do not replace a linked gap with an inferred clean result.
 
 Codex and Claude Code are the project-skill hosts exercised here.
-Cursor documents compatibility loading for these project roots, but this repository does not exercise Cursor runtime discovery.
+Cursor's skill documentation (https://cursor.com/docs/skills), accessed on 2026-08-09, describes .agents/skills as a project-level location and .claude/skills as a compatibility location. This repository does not exercise Cursor runtime discovery.
 
 ## Journey
 

--- a/.agents/skills/assay-golden-path/SKILL.md
+++ b/.agents/skills/assay-golden-path/SKILL.md
@@ -15,6 +15,7 @@ run `scripts/docs/generate-agent-golden-path.py` instead of editing this file.
 
 When a step has no `working_directory`, run it from the invocation cwd.
 A present `working_directory` is a POSIX path relative to the source repository.
+Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.
 
 Empty stdout in a gap row is an observed limitation, not permission for a caller to infer success from missing evidence.
 Do not replace a linked gap with an inferred clean result.

--- a/.claude/skills/assay-golden-path/SKILL.md
+++ b/.claude/skills/assay-golden-path/SKILL.md
@@ -13,6 +13,9 @@ a process failure.
 Read it when exact argv, fields, or per-outcome metadata are needed. Edit and
 run `scripts/docs/generate-agent-golden-path.py` instead of editing this file.
 
+When a step has no `working_directory`, run it from the invocation cwd.
+A present `working_directory` is a POSIX path relative to the source repository.
+
 Empty stdout in a gap row is an observed limitation, not permission for a caller to infer success from missing evidence.
 Do not replace a linked gap with an inferred clean result.
 

--- a/.claude/skills/assay-golden-path/SKILL.md
+++ b/.claude/skills/assay-golden-path/SKILL.md
@@ -17,7 +17,7 @@ Empty stdout in a gap row is an observed limitation, not permission for a caller
 Do not replace a linked gap with an inferred clean result.
 
 Codex and Claude Code are the project-skill hosts exercised here.
-Cursor documents compatibility loading for these project roots, but this repository does not exercise Cursor runtime discovery.
+Cursor's skill documentation (https://cursor.com/docs/skills), accessed on 2026-08-09, describes .agents/skills as a project-level location and .claude/skills as a compatibility location. This repository does not exercise Cursor runtime discovery.
 
 ## Journey
 

--- a/.claude/skills/assay-golden-path/SKILL.md
+++ b/.claude/skills/assay-golden-path/SKILL.md
@@ -15,6 +15,7 @@ run `scripts/docs/generate-agent-golden-path.py` instead of editing this file.
 
 When a step has no `working_directory`, run it from the invocation cwd.
 A present `working_directory` is a POSIX path relative to the source repository.
+Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.
 
 Empty stdout in a gap row is an observed limitation, not permission for a caller to infer success from missing evidence.
 Do not replace a linked gap with an inferred clean result.

--- a/crates/assay-cli/tests/agent_golden_path_contract.rs
+++ b/crates/assay-cli/tests/agent_golden_path_contract.rs
@@ -56,6 +56,23 @@ fn expected_outcome(step_id: &str, outcome_name: &str) -> Value {
     outcome
 }
 
+#[test]
+fn cli_contract_steps_default_to_invocation_cwd() {
+    for step in contract()["steps"]
+        .as_array()
+        .expect("contract steps array")
+        .iter()
+        .filter(|step| step["binary"] == "assay")
+    {
+        assert_eq!(
+            runtime_coverage::classify_working_directory(step),
+            Ok(runtime_coverage::WorkingDirectory::Invocation),
+            "CLI step {} unexpectedly depends on a source-repo cwd",
+            step["id"]
+        );
+    }
+}
+
 fn assert_exit(output: &Output, expected: &Value, context: &str) {
     let expected_exit = expected["exit_code"]
         .as_i64()

--- a/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
+++ b/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
@@ -241,14 +241,33 @@ fn required_python() -> &'static str {
 }
 
 fn contract_working_directory(expected: &Value) -> PathBuf {
-    match expected["working_directory"]
-        .as_str()
-        .expect("protected-action contract must pin its working directory")
+    match runtime_coverage::classify_working_directory(expected)
+        .expect("protected-action contract working directory must be safe")
     {
-        "examples/privileged-action-gate" => workspace_root()
-            .join("examples")
-            .join("privileged-action-gate"),
-        other => panic!("unsupported protected-action working directory: {other}"),
+        runtime_coverage::WorkingDirectory::Invocation => {
+            panic!("protected-action contract must pin its working directory")
+        }
+        runtime_coverage::WorkingDirectory::SourceRepoRelative(components) => components
+            .iter()
+            .fold(workspace_root().to_path_buf(), |path, component| {
+                path.join(component)
+            }),
+    }
+}
+
+#[test]
+fn protected_action_contract_cwd_is_source_repo_relative_and_materialized() {
+    let expected = expected_outcome("protected-action", "policy-denied");
+    let cwd = contract_working_directory(&expected);
+    for fixture in [
+        "mock_github_mcp.py",
+        "policies/no-allowance.yaml",
+        "baseline-approved.json",
+    ] {
+        assert!(
+            cwd.join(fixture).is_file(),
+            "contract cwd does not contain argv fixture {fixture}"
+        );
     }
 }
 

--- a/docs/guides/agent-golden-path.md
+++ b/docs/guides/agent-golden-path.md
@@ -24,6 +24,7 @@ The generated `assay-golden-path` project skill is available at both:
 
 When a step has no `working_directory`, run it from the invocation cwd.
 A present `working_directory` is a POSIX path relative to the source repository.
+Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.
 
 Source: [Cursor's skill documentation](https://cursor.com/docs/skills), accessed on `2026-08-09`.
 The documentation describes `.agents/skills/` as a project-level location and `.claude/skills/` as a compatibility location. This repository does not exercise Cursor runtime discovery.

--- a/docs/guides/agent-golden-path.md
+++ b/docs/guides/agent-golden-path.md
@@ -14,18 +14,33 @@ the table. Binary-level tests in `assay-cli` and `assay-mcp-server` load the
 JSON and drive every recorded outcome through `CARGO_BIN_EXE_*`. Paths in
 angle brackets are replaced with temporary files or committed fixtures.
 
+<!-- agent-golden-path-discovery:start -->
+## Project Skill Discovery
+
+The generated `assay-golden-path` project skill is available at both:
+
+- `.agents/skills/assay-golden-path/SKILL.md`
+- `.claude/skills/assay-golden-path/SKILL.md`
+
+When a step has no `working_directory`, run it from the invocation cwd.
+A present `working_directory` is a POSIX path relative to the source repository.
+
+Source: [Cursor's skill documentation](https://cursor.com/docs/skills), accessed on `2026-08-09`.
+The documentation describes `.agents/skills/` as a project-level location and `.claude/skills/` as a compatibility location. This repository does not exercise Cursor runtime discovery.
+<!-- agent-golden-path-discovery:end -->
+
 <!-- agent-golden-path-table:start -->
 | step | working directory | command | exit code | stdout | on failure |
 |---|---|---|---|---|---|
-| 1. Install check | `.` | `assay version` | Success `0`. | One `MAJOR.MINOR.PATCH` line. | A missing or unstartable binary is a host spawn failure: no Assay process runs, so Assay produces no stdout or exit code. |
-| 2. Preflight | `.` | `assay doctor --format json` | Success `0`; invalid explicit config `1`. | Parses as `assay.doctor_report.v0`. A config failure remains JSON and carries `config_error.code: E_CFG_PARSE`. | `reason_code` and `next_step` are absent, and the exit is outside the frozen config/usage class: [gap #2160](https://github.com/Rul1an/assay/issues/2160). |
-| 3. Starter files | `.` | `assay init --preset dev --hello-trace` | Success `0`; unknown preset `2`. | Human progress text; success ends with `Next: assay validate --config eval.yaml --trace-file traces/hello.jsonl`. A failing run writes partial progress text, not the fatal diagnosis. | No machine report, `reason_code`, or `next_step` on stdout: [gap #2161](https://github.com/Rul1an/assay/issues/2161). |
-| 4. Policy validation | `.` | `assay policy validate --input <policy>` | Valid `0`; malformed `2`. | Empty on both paths. | The diagnosis, registered reason, and next step are absent from stdout: [gap #2162](https://github.com/Rul1an/assay/issues/2162). |
-| 5. Evaluation result | `.` | `assay run --config eval.yaml --trace-file traces/hello.jsonl --format json` | All tests pass `0`; completed run with failed tests `1`. | Both completed outcomes parse as `assay.run_report.v1`; failed results carry `status: fail` inside `results`. | Exit `1` is a completed results report, not an early-failure diagnosis; `reason_code` and `next_step` are absent by design. |
+| 1. Install check | `invocation cwd` | `assay version` | Success `0`. | One `MAJOR.MINOR.PATCH` line. | A missing or unstartable binary is a host spawn failure: no Assay process runs, so Assay produces no stdout or exit code. |
+| 2. Preflight | `invocation cwd` | `assay doctor --format json` | Success `0`; invalid explicit config `1`. | Parses as `assay.doctor_report.v0`. A config failure remains JSON and carries `config_error.code: E_CFG_PARSE`. | `reason_code` and `next_step` are absent, and the exit is outside the frozen config/usage class: [gap #2160](https://github.com/Rul1an/assay/issues/2160). |
+| 3. Starter files | `invocation cwd` | `assay init --preset dev --hello-trace` | Success `0`; unknown preset `2`. | Human progress text; success ends with `Next: assay validate --config eval.yaml --trace-file traces/hello.jsonl`. A failing run writes partial progress text, not the fatal diagnosis. | No machine report, `reason_code`, or `next_step` on stdout: [gap #2161](https://github.com/Rul1an/assay/issues/2161). |
+| 4. Policy validation | `invocation cwd` | `assay policy validate --input <policy>` | Valid `0`; malformed `2`. | Empty on both paths. | The diagnosis, registered reason, and next step are absent from stdout: [gap #2162](https://github.com/Rul1an/assay/issues/2162). |
+| 5. Evaluation result | `invocation cwd` | `assay run --config eval.yaml --trace-file traces/hello.jsonl --format json` | All tests pass `0`; completed run with failed tests `1`. | Both completed outcomes parse as `assay.run_report.v1`; failed results carry `status: fail` inside `results`. | Exit `1` is a completed results report, not an early-failure diagnosis; `reason_code` and `next_step` are absent by design. |
 | 6. Protected action | `examples/privileged-action-gate` | `assay-mcp-server proxy-enforce --upstream-command <python> --upstream-arg -u --upstream-arg mock_github_mcp.py --enforce-policy policies/no-allowance.yaml --declared-mcp-manifest baseline-approved.json` | Policy-denied call after stdin closes `0`; startup input failure `1`. | The denied `tools/call` response pins `error.code: -32042`, `error.data.origin: assay-proxy`, and `error.data.reason: no_declared_allowance`. | Policy denial is not a process failure. A missing enforcement policy fails startup with empty stdout and no stable reason/next-step object: [gap #2163](https://github.com/Rul1an/assay/issues/2163). |
-| 7. Evidence inspection | `.` | `assay evidence show <bundle> --format json` | Valid `0`; integrity failure `2`. | Success parses as an object containing `manifest` and `events`. Integrity failure produces no stdout. | No JSON failure report, `reason_code`, or `next_step`: [gap #2164](https://github.com/Rul1an/assay/issues/2164). |
-| 8. Offline profile verification | `.` | `assay evidence verify-privileged-mcp-action <bundle> --format json` | Valid `0`; integrity or profile failure `2`. | Both paths parse as `assay.privileged_mcp_action.verify.report.v0`. Success has `bundle_integrity: pass` and `verdict: valid`; tamper has `bundle_integrity: fail`, a bounded finding, and no verdict. | The failure report has no registered `reason_code` or actionable `next_step`: [gap #2165](https://github.com/Rul1an/assay/issues/2165). |
-| 9. SARIF projection | `.` | `assay-mcp-server enforcement-sarif --input - --output -` | Valid input `0`; malformed non-empty NDJSON `0`. | Valid input produces SARIF `2.1.0`. Malformed lines are currently discarded and can produce a clean report with zero results. | This is fail-open, not a successful empty projection: [gap #2166](https://github.com/Rul1an/assay/issues/2166). No reason or next step is emitted. |
+| 7. Evidence inspection | `invocation cwd` | `assay evidence show <bundle> --format json` | Valid `0`; integrity failure `2`. | Success parses as an object containing `manifest` and `events`. Integrity failure produces no stdout. | No JSON failure report, `reason_code`, or `next_step`: [gap #2164](https://github.com/Rul1an/assay/issues/2164). |
+| 8. Offline profile verification | `invocation cwd` | `assay evidence verify-privileged-mcp-action <bundle> --format json` | Valid `0`; integrity or profile failure `2`. | Both paths parse as `assay.privileged_mcp_action.verify.report.v0`. Success has `bundle_integrity: pass` and `verdict: valid`; tamper has `bundle_integrity: fail`, a bounded finding, and no verdict. | The failure report has no registered `reason_code` or actionable `next_step`: [gap #2165](https://github.com/Rul1an/assay/issues/2165). |
+| 9. SARIF projection | `invocation cwd` | `assay-mcp-server enforcement-sarif --input - --output -` | Valid input `0`; malformed non-empty NDJSON `0`. | Valid input produces SARIF `2.1.0`. Malformed lines are currently discarded and can produce a clean report with zero results. | This is fail-open, not a successful empty projection: [gap #2166](https://github.com/Rul1an/assay/issues/2166). No reason or next step is emitted. |
 <!-- agent-golden-path-table:end -->
 
 ## Reading the Contract

--- a/docs/superpowers/specs/2026-08-09-golden-path-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-09-golden-path-hardening-design.md
@@ -320,13 +320,14 @@ exercise Cursor runtime discovery. It must not claim runtime support.
 Keep `working_directory` optional and define both states explicitly:
 
 - absence means the command runs in the caller-selected invocation directory;
-- presence requires `working_directory_base`, which names the path referent.
+- in schema v1, presence means a POSIX path relative to the source repository.
 
-The protected-action step retains
-`working_directory: examples/privileged-action-gate` and adds
-`working_directory_base: source_repo`. It is a checked-in reference scenario,
-not a path promised to exist in every caller project. No other step gains a
-working-directory field.
+The design review rejected a separate `working_directory_base` field: v1 has
+only one supported referent, so a second field would add contradictory states
+and require a schema change without adding information. The protected-action
+step retains `working_directory: examples/privileged-action-gate`. It is a
+checked-in reference scenario, not a path promised to exist in every caller
+project. No other step gains a working-directory field.
 
 The guide table renders `invocation cwd` for an absent field rather than
 silently substituting `.`. The generated skill defines the default once and
@@ -336,10 +337,10 @@ temporary invocation directory, the MCP SARIF scenario keeps its temporary
 directory, and the protected-action scenario resolves its declared path from
 the Assay workspace root.
 
-Tests independently add an unsupported base to a default-cwd step, remove or
-change the protected step's base, and alter its relative path. The binary driver
-and both human views must fail on the same contract rule. Renderer-only equality
-is not accepted as execution proof.
+Tests reject absolute, drive-prefixed, empty, dot, dot-dot, and backslash path
+components, and alter the protected step's relative path. The binary driver and
+both human views must fail on the same contract rule. Renderer-only equality is
+not accepted as execution proof.
 
 ### 4. Semantic Public-Vocabulary Gate
 

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 
 # PR B adds discoverability, cwd wording, and issue-reference hardening cases to
 # the 58-case durability boundary established by PR B0.
-EXPECTED_CASES=72
+EXPECTED_CASES=74
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -559,6 +559,38 @@ expect_named_failure \
   "guide invocation cwd rendered as dot" \
   "$case_root" \
   "guide omits working directory for install-check"
+
+for rule in source-repo python-placeholder; do
+  case_root="$SCRATCH/guide-runtime-rule-$rule"
+  seed_case "$case_root"
+  CASE_ROOT="$case_root" RULE="$rule" python3 - <<'PY'
+import os
+from pathlib import Path
+
+rules = {
+    "source-repo": (
+        "A present `working_directory` is a POSIX path relative to the source repository.\n"
+    ),
+    "python-placeholder": (
+        "Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.\n"
+    ),
+}
+rule = rules[os.environ["RULE"]]
+path = Path(os.environ["CASE_ROOT"]) / "docs/guides/agent-golden-path.md"
+text = path.read_text(encoding="utf-8")
+if text.count(rule) != 1:
+    raise SystemExit(f"guide runtime rule is not unique: {rule!r}")
+path.write_text(text.replace(rule, "", 1), encoding="utf-8")
+PY
+  expected='A present `working_directory` is a POSIX path relative to the source repository.'
+  if [[ "$rule" == "python-placeholder" ]]; then
+    expected='Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.'
+  fi
+  expect_named_failure \
+    "guide runtime rule $rule" \
+    "$case_root" \
+    "guide discovery block omits required wording: '$expected'"
+done
 
 for rule in invocation source-repo; do
   case_root="$SCRATCH/skill-cwd-rule-$rule"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 
 # PR B adds discoverability, cwd wording, and issue-reference hardening cases to
 # the 58-case durability boundary established by PR B0.
-EXPECTED_CASES=71
+EXPECTED_CASES=72
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -594,6 +594,29 @@ PY
     "$case_root" \
     "skill omits required guidance: '$expected'"
 done
+
+case_root="$SCRATCH/skill-python-placeholder-rule"
+seed_case "$case_root"
+CASE_ROOT="$case_root" python3 - <<'PY'
+import os
+from pathlib import Path
+
+rule = "Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.\n"
+root = Path(os.environ["CASE_ROOT"])
+for relative in (
+    ".agents/skills/assay-golden-path/SKILL.md",
+    ".claude/skills/assay-golden-path/SKILL.md",
+):
+    path = root / relative
+    text = path.read_text(encoding="ascii")
+    if text.count(rule) != 1:
+        raise SystemExit(f"skill Python placeholder rule is not unique: {rule!r}")
+    path.write_text(text.replace(rule, "", 1), encoding="ascii")
+PY
+expect_named_failure \
+  "skill Python placeholder rule" \
+  "$case_root" \
+  "skill omits required guidance: 'Replace \`<python>\` with \`python3\` on Unix-like hosts or \`python\` on Windows.'"
 
 case_root="$SCRATCH/public-vocabulary-allow-contract-evidence"
 seed_case "$case_root"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 
 # PR B adds discoverability, cwd wording, and issue-reference hardening cases to
 # the 58-case durability boundary established by PR B0.
-EXPECTED_CASES=74
+EXPECTED_CASES=75
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -500,7 +500,7 @@ PY
     "golden-path gap_issue must be a positive integer for preflight"
 done
 
-for mutation in missing duplicate hand-edited; do
+for mutation in missing duplicate reversed hand-edited; do
   case_root="$SCRATCH/guide-discovery-$mutation"
   seed_case "$case_root"
   CASE_ROOT="$case_root" MUTATION="$mutation" python3 - <<'PY'
@@ -516,6 +516,9 @@ if mutation == "missing":
     text = text.replace(start, "", 1).replace(end, "", 1)
 elif mutation == "duplicate":
     text = text.replace(end, f"{end}\n{start}\ncopy\n{end}", 1)
+elif mutation == "reversed":
+    sentinel = "<!-- agent-golden-path-discovery:sentinel -->"
+    text = text.replace(start, sentinel, 1).replace(end, start, 1).replace(sentinel, end, 1)
 else:
     text = text.replace(
         ".agents/skills/assay-golden-path/SKILL.md",
@@ -525,10 +528,27 @@ else:
 path.write_text(text, encoding="utf-8")
 PY
   expected="agent golden-path guide must contain exactly one discovery marker pair"
+  if [[ "$mutation" == "reversed" ]]; then
+    expected="agent golden-path guide discovery markers are out of order"
+  fi
   if [[ "$mutation" == "hand-edited" ]]; then
     expected="guide discovery block omits project skill root: .agents/skills/assay-golden-path/SKILL.md"
   fi
   expect_named_failure "guide discovery $mutation" "$case_root" "$expected"
+  if [[ "$mutation" == "reversed" ]]; then
+    output="$case_root/generator.log"
+    if (cd "$case_root" && python3 scripts/docs/generate-agent-golden-path.py --check) \
+      >"$output" 2>&1
+    then
+      echo "FAIL: guide discovery reversed was accepted by generator" >&2
+      exit 1
+    fi
+    if ! grep -Fq "$expected" "$output"; then
+      cat "$output" >&2
+      echo "FAIL: guide discovery reversed missed generator guard: $expected" >&2
+      exit 1
+    fi
+  fi
 done
 
 case_root="$SCRATCH/guide-discovery-private-vocabulary"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -5,9 +5,9 @@ ROOT="$(git rev-parse --show-toplevel)"
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-# PR B0 adds seven public-vocabulary mutations and two structural allow cases to
-# the 49-case durability boundary.
-EXPECTED_CASES=58
+# PR B adds discoverability, cwd wording, and issue-reference hardening cases to
+# the 58-case durability boundary established by PR B0.
+EXPECTED_CASES=69
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -462,6 +462,8 @@ vocabulary_mutations=(
   'future-marketplace|Future, MARKETPLACE packaging belongs here.|skill introduces private planning vocabulary: future marketplace'
   'future-market-place|Future market-place packaging belongs here.|skill introduces private planning vocabulary: future marketplace'
   'future-plug-in|Future plug-in packaging belongs here.|skill introduces private planning vocabulary: future marketplace'
+  'future-marketplaces|Future marketplaces belong here.|skill introduces private planning vocabulary: future marketplace'
+  'future-plugins|Future plugins belong here.|skill introduces private planning vocabulary: future marketplace'
   'roadmap-ownership|Road-map ownership belongs in this skill.|skill introduces private planning vocabulary: roadmap ownership'
   'number-word-step|Implementation step THREE owns this release.|skill introduces private planning vocabulary: implementation step 3 ownership'
   'unknown-issue|This is tracked by [gap #9999](https://github.com/Rul1an/assay/issues/9999).|skill references issue outside contract evidence: #9999'
@@ -473,6 +475,90 @@ for row in "${vocabulary_mutations[@]}"; do
   append_skill_text "$case_root" "$mutation"
   expect_named_failure "public vocabulary $name" "$case_root" "$expected"
 done
+
+case_root="$SCRATCH/public-vocabulary-markdown-anchor"
+seed_case "$case_root"
+append_skill_text "$case_root" 'See [starter files](#3-starter-files).'
+expect_named_success "public vocabulary ignores Markdown numeric anchor" "$case_root"
+
+for gap_issue in 0 -1; do
+  case_root="$SCRATCH/nonpositive-gap-issue-$gap_issue"
+  seed_case "$case_root"
+  CASE_ROOT="$case_root" GAP_ISSUE="$gap_issue" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["CASE_ROOT"]) / "docs/generated/agent-golden-path.json"
+contract = json.loads(path.read_text(encoding="utf-8"))
+contract["steps"][1]["outcomes"][1]["gap_issue"] = int(os.environ["GAP_ISSUE"])
+path.write_text(json.dumps(contract, indent=2) + "\n", encoding="utf-8")
+PY
+  expect_named_failure \
+    "nonpositive gap_issue $gap_issue" \
+    "$case_root" \
+    "golden-path gap_issue must be a positive integer for preflight"
+done
+
+for mutation in missing duplicate hand-edited; do
+  case_root="$SCRATCH/guide-discovery-$mutation"
+  seed_case "$case_root"
+  CASE_ROOT="$case_root" MUTATION="$mutation" python3 - <<'PY'
+import os
+from pathlib import Path
+
+path = Path(os.environ["CASE_ROOT"]) / "docs/guides/agent-golden-path.md"
+text = path.read_text(encoding="utf-8")
+start = "<!-- agent-golden-path-discovery:start -->"
+end = "<!-- agent-golden-path-discovery:end -->"
+mutation = os.environ["MUTATION"]
+if mutation == "missing":
+    text = text.replace(start, "", 1).replace(end, "", 1)
+elif mutation == "duplicate":
+    text = text.replace(end, f"{end}\n{start}\ncopy\n{end}", 1)
+else:
+    text = text.replace(
+        ".agents/skills/assay-golden-path/SKILL.md",
+        ".agents/skills/renamed/SKILL.md",
+        1,
+    )
+path.write_text(text, encoding="utf-8")
+PY
+  expected="agent golden-path guide must contain exactly one discovery marker pair"
+  if [[ "$mutation" == "hand-edited" ]]; then
+    expected="guide discovery block omits project skill root: .agents/skills/assay-golden-path/SKILL.md"
+  fi
+  expect_named_failure "guide discovery $mutation" "$case_root" "$expected"
+done
+
+case_root="$SCRATCH/guide-discovery-private-vocabulary"
+seed_case "$case_root"
+sed -i.bak \
+  's/The generated `assay-golden-path` project skill/Future marketplace packaging for the generated `assay-golden-path` project skill/' \
+  "$case_root/docs/guides/agent-golden-path.md"
+rm "$case_root/docs/guides/agent-golden-path.md.bak"
+expect_named_failure \
+  "guide discovery private vocabulary" \
+  "$case_root" \
+  "skill introduces private planning vocabulary: future marketplace"
+
+case_root="$SCRATCH/guide-discovery-cursor-provenance"
+seed_case "$case_root"
+sed -i.bak 's/`2026-08-09`/`unknown`/' "$case_root/docs/guides/agent-golden-path.md"
+rm "$case_root/docs/guides/agent-golden-path.md.bak"
+expect_named_failure \
+  "guide discovery Cursor provenance" \
+  "$case_root" \
+  "guide discovery block omits required wording: '2026-08-09'"
+
+case_root="$SCRATCH/guide-invocation-cwd"
+seed_case "$case_root"
+sed -i.bak 's/`invocation cwd`/`.`/' "$case_root/docs/guides/agent-golden-path.md"
+rm "$case_root/docs/guides/agent-golden-path.md.bak"
+expect_named_failure \
+  "guide invocation cwd rendered as dot" \
+  "$case_root" \
+  "guide omits working directory for install-check"
 
 case_root="$SCRATCH/public-vocabulary-allow-contract-evidence"
 seed_case "$case_root"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 
 # PR B adds discoverability, cwd wording, and issue-reference hardening cases to
 # the 58-case durability boundary established by PR B0.
-EXPECTED_CASES=69
+EXPECTED_CASES=71
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -559,6 +559,41 @@ expect_named_failure \
   "guide invocation cwd rendered as dot" \
   "$case_root" \
   "guide omits working directory for install-check"
+
+for rule in invocation source-repo; do
+  case_root="$SCRATCH/skill-cwd-rule-$rule"
+  seed_case "$case_root"
+  CASE_ROOT="$case_root" RULE="$rule" python3 - <<'PY'
+import os
+from pathlib import Path
+
+rules = {
+    "invocation": "When a step has no `working_directory`, run it from the invocation cwd.\n",
+    "source-repo": (
+        "A present `working_directory` is a POSIX path relative to the source repository.\n"
+    ),
+}
+rule = rules[os.environ["RULE"]]
+root = Path(os.environ["CASE_ROOT"])
+for relative in (
+    ".agents/skills/assay-golden-path/SKILL.md",
+    ".claude/skills/assay-golden-path/SKILL.md",
+):
+    path = root / relative
+    text = path.read_text(encoding="ascii")
+    if text.count(rule) != 1:
+        raise SystemExit(f"skill cwd rule is not unique: {rule!r}")
+    path.write_text(text.replace(rule, "", 1), encoding="ascii")
+PY
+  expected='When a step has no `working_directory`, run it from the invocation cwd.'
+  if [[ "$rule" == "source-repo" ]]; then
+    expected='A present `working_directory` is a POSIX path relative to the source repository.'
+  fi
+  expect_named_failure \
+    "skill cwd rule $rule" \
+    "$case_root" \
+    "skill omits required guidance: '$expected'"
+done
 
 case_root="$SCRATCH/public-vocabulary-allow-contract-evidence"
 seed_case "$case_root"

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -47,9 +47,19 @@ EMPTY_STDOUT_RULE = (
     "to infer success from missing evidence."
 )
 CURSOR_SCOPE = (
-    "Cursor documents compatibility loading for these project roots, but this "
-    "repository does not exercise Cursor runtime discovery."
+    "Cursor's skill documentation (https://cursor.com/docs/skills), accessed on "
+    "2026-08-09, describes .agents/skills as a project-level location and "
+    ".claude/skills as a compatibility location. This repository does not exercise "
+    "Cursor runtime discovery."
 )
+DISCOVERY_START = "<!-- agent-golden-path-discovery:start -->"
+DISCOVERY_END = "<!-- agent-golden-path-discovery:end -->"
+DISCOVERY_SKILL_ROOTS = (
+    ".agents/skills/assay-golden-path/SKILL.md",
+    ".claude/skills/assay-golden-path/SKILL.md",
+)
+CURSOR_DOCS_URL = "https://cursor.com/docs/skills"
+CURSOR_DOCS_ACCESSED = "2026-08-09"
 PROTECTED_ACTION_CWD = "examples/privileged-action-gate"
 MAX_EVIDENCE_BYTES = 1024 * 1024
 CANONICAL_PRECOMMIT = "pre-commit run --all-files --show-diff-on-failure"
@@ -58,7 +68,10 @@ SELF_TEST_TRIGGER_PATH = "scripts/docs/generate-agent-golden-path.py"
 SELF_TEST_TRIGGER_MODE = "100644"
 SELF_TEST_TRIGGER_TYPES = frozenset({"file", "non-executable", "python", "text"})
 MAPPING_ENTRY_PATTERN = re.compile(r"^(?P<key>[A-Za-z0-9_-]+) *:(?P<value>.*)$")
-ISSUE_REFERENCE_PATTERN = re.compile(r"(?:#|/issues/)([0-9]+)")
+ISSUE_REFERENCE_PATTERN = re.compile(
+    r"(?<!\]\()#(?P<short>[0-9]+)(?![A-Za-z0-9_-])"
+    r"|/issues/(?P<url>[0-9]+)(?![A-Za-z0-9_-])"
+)
 PUBLIC_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 PRIVATE_PHRASE_FAMILIES = (
     (
@@ -78,12 +91,16 @@ PRIVATE_PHRASE_FAMILIES = (
         "future marketplace",
         (
             ("future", "marketplace"),
+            ("future", "marketplaces"),
             ("future", "market", "place"),
             ("marketplace", "packaging"),
+            ("marketplaces", "packaging"),
             ("market", "place", "packaging"),
             ("future", "plugin"),
+            ("future", "plugins"),
             ("future", "plug", "in"),
             ("plugin", "packaging"),
+            ("plugins", "packaging"),
             ("plug", "in", "packaging"),
         ),
     ),
@@ -100,6 +117,8 @@ NUMBER_WORDS = {
     "nine": "9",
 }
 STEP_NUMBERS = frozenset(NUMBER_WORDS.values())
+# This closed vocabulary intentionally covers only the nine implementation-step
+# labels in the generated golden path. It is not a general number normalizer.
 
 # Both bounded YAML readers intentionally model the repository's two-space
 # layout rather than arbitrary YAML indentation or scalar forms.
@@ -159,6 +178,23 @@ def contains_token_sequence(tokens: tuple[str, ...], sequence: tuple[str, ...]) 
     )
 
 
+def issue_references(text: str) -> set[int]:
+    return {
+        int(match.group("short") or match.group("url"))
+        for match in ISSUE_REFERENCE_PATTERN.finditer(text)
+    }
+
+
+def generated_discovery_block(guide: str) -> str:
+    if guide.count(DISCOVERY_START) != 1 or guide.count(DISCOVERY_END) != 1:
+        fail("agent golden-path guide must contain exactly one discovery marker pair")
+    before, remainder = guide.split(DISCOVERY_START, 1)
+    block, after = remainder.split(DISCOVERY_END, 1)
+    if DISCOVERY_START in before or DISCOVERY_END in before + after:
+        fail("agent golden-path guide discovery markers are out of order")
+    return block
+
+
 def contract_issue_numbers(contract: dict[str, object]) -> set[int]:
     allowed: set[int] = set()
     steps = contract.get("steps")
@@ -176,8 +212,15 @@ def contract_issue_numbers(contract: dict[str, object]) -> set[int]:
             issue = outcome.get("gap_issue")
             if issue is None:
                 continue
-            if not isinstance(issue, int) or isinstance(issue, bool):
-                fail(f"golden-path gap_issue must be an integer for {step.get('id')}")
+            if (
+                not isinstance(issue, int)
+                or isinstance(issue, bool)
+                or issue <= 0
+            ):
+                fail(
+                    "golden-path gap_issue must be a positive integer for "
+                    f"{step.get('id')}"
+                )
             allowed.add(issue)
 
     non_claims = contract.get("non_claims")
@@ -186,13 +229,13 @@ def contract_issue_numbers(contract: dict[str, object]) -> set[int]:
     for claim in non_claims:
         if not isinstance(claim, str):
             fail("golden-path non-claims must be strings")
-        allowed.update(int(raw) for raw in ISSUE_REFERENCE_PATTERN.findall(claim))
+        allowed.update(issue_references(claim))
     return allowed
 
 
 def validate_public_vocabulary(text: str, contract: dict[str, object]) -> None:
     allowed_issues = contract_issue_numbers(contract)
-    observed_issues = {int(raw) for raw in ISSUE_REFERENCE_PATTERN.findall(text)}
+    observed_issues = issue_references(text)
     unexpected = sorted(observed_issues - allowed_issues)
     if unexpected:
         fail(f"skill references issue outside contract evidence: #{unexpected[0]}")
@@ -905,6 +948,22 @@ def main() -> None:
 
     text = payloads[0].decode("ascii")
     guide = read_bounded_evidence(GUIDE_PATH, "guide evidence").decode("utf-8")
+    discovery = generated_discovery_block(guide)
+    for root in DISCOVERY_SKILL_ROOTS:
+        if root not in discovery:
+            fail(f"guide discovery block omits project skill root: {root}")
+    for required in (
+        "assay-golden-path",
+        "invocation cwd",
+        CURSOR_DOCS_URL,
+        CURSOR_DOCS_ACCESSED,
+        "does not exercise Cursor runtime discovery",
+    ):
+        if required not in discovery:
+            fail(f"guide discovery block omits required wording: {required!r}")
+    # Only the generator-owned block is semantic-gated. The surrounding guide
+    # remains human-reviewed prose and is still protected by the drift gate.
+    validate_public_vocabulary(discovery, contract)
     fields, body = parse_frontmatter(text)
     expected_fields = {
         "name": "assay-golden-path",
@@ -958,7 +1017,7 @@ def main() -> None:
             cwd_line = f"Working directory: `{working_directory}`"
             if cwd_line not in body:
                 fail(f"skill omits working directory for {step['id']}")
-        guide_working_directory = working_directory or "."
+        guide_working_directory = working_directory or "invocation cwd"
         guide_row = (
             f"| {step['step']}. {step['label']} | `{guide_working_directory}` | "
             f"`{step['command']}` |"

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -963,7 +963,9 @@ def main() -> None:
             fail(f"guide discovery block omits project skill root: {root}")
     for required in (
         "assay-golden-path",
-        "invocation cwd",
+        INVOCATION_CWD_RULE,
+        SOURCE_REPO_CWD_RULE,
+        PYTHON_PLACEHOLDER_RULE,
         CURSOR_DOCS_URL,
         CURSOR_DOCS_ACCESSED,
         "does not exercise Cursor runtime discovery",

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -52,6 +52,9 @@ INVOCATION_CWD_RULE = (
 SOURCE_REPO_CWD_RULE = (
     "A present `working_directory` is a POSIX path relative to the source repository."
 )
+PYTHON_PLACEHOLDER_RULE = (
+    "Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows."
+)
 CURSOR_SCOPE = (
     "Cursor's skill documentation (https://cursor.com/docs/skills), accessed on "
     "2026-08-09, describes .agents/skills as a project-level location and "
@@ -983,6 +986,7 @@ def main() -> None:
         EMPTY_STDOUT_RULE,
         INVOCATION_CWD_RULE,
         SOURCE_REPO_CWD_RULE,
+        PYTHON_PLACEHOLDER_RULE,
         CURSOR_SCOPE,
     )
     for fragment in required_body:

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -46,6 +46,12 @@ EMPTY_STDOUT_RULE = (
     "Empty stdout in a gap row is an observed limitation, not permission for a caller "
     "to infer success from missing evidence."
 )
+INVOCATION_CWD_RULE = (
+    "When a step has no `working_directory`, run it from the invocation cwd."
+)
+SOURCE_REPO_CWD_RULE = (
+    "A present `working_directory` is a POSIX path relative to the source repository."
+)
 CURSOR_SCOPE = (
     "Cursor's skill documentation (https://cursor.com/docs/skills), accessed on "
     "2026-08-09, describes .agents/skills as a project-level location and "
@@ -975,6 +981,8 @@ def main() -> None:
     required_body = (
         "docs/generated/agent-golden-path.json",
         EMPTY_STDOUT_RULE,
+        INVOCATION_CWD_RULE,
+        SOURCE_REPO_CWD_RULE,
         CURSOR_SCOPE,
     )
     for fragment in required_body:

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -197,6 +197,8 @@ def issue_references(text: str) -> set[int]:
 def generated_discovery_block(guide: str) -> str:
     if guide.count(DISCOVERY_START) != 1 or guide.count(DISCOVERY_END) != 1:
         fail("agent golden-path guide must contain exactly one discovery marker pair")
+    if guide.index(DISCOVERY_START) > guide.index(DISCOVERY_END):
+        fail("agent golden-path guide discovery markers are out of order")
     before, remainder = guide.split(DISCOVERY_START, 1)
     block, after = remainder.split(DISCOVERY_END, 1)
     if DISCOVERY_START in before or DISCOVERY_END in before + after:

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -16,6 +16,10 @@ SKILL_OUTPUTS = (
 )
 TABLE_START = "<!-- agent-golden-path-table:start -->"
 TABLE_END = "<!-- agent-golden-path-table:end -->"
+DISCOVERY_START = "<!-- agent-golden-path-discovery:start -->"
+DISCOVERY_END = "<!-- agent-golden-path-discovery:end -->"
+CURSOR_DOCS_URL = "https://cursor.com/docs/skills"
+CURSOR_DOCS_ACCESSED = "2026-08-09"
 SKILL_DESCRIPTION = (
     "Drive Assay's install-to-evidence golden path and interpret its stdout and exit "
     "codes. Use when an agent must operate or diagnose Assay; do not use it to infer "
@@ -409,7 +413,7 @@ def render_table() -> str:
         "|---|---|---|---|---|---|",
     ]
     for step in STEPS:
-        working_directory = step.get("working_directory") or "."
+        working_directory = step.get("working_directory") or "invocation cwd"
         rows.append(
             "| {step}. {label} | `{working_directory}` | `{command}` | {exit_codes} | "
             "{stdout_summary} | {failure_summary} |".format(
@@ -425,12 +429,51 @@ def render_table() -> str:
     return "\n".join(rows)
 
 
+def render_discovery() -> str:
+    return "\n".join(
+        (
+            "## Project Skill Discovery",
+            "",
+            "The generated `assay-golden-path` project skill is available at both:",
+            "",
+            "- `.agents/skills/assay-golden-path/SKILL.md`",
+            "- `.claude/skills/assay-golden-path/SKILL.md`",
+            "",
+            "When a step has no `working_directory`, run it from the invocation cwd.",
+            "A present `working_directory` is a POSIX path relative to the source repository.",
+            "",
+            f"Source: [Cursor's skill documentation]({CURSOR_DOCS_URL}), accessed on "
+            f"`{CURSOR_DOCS_ACCESSED}`.",
+            "The documentation describes `.agents/skills/` as a project-level location "
+            "and `.claude/skills/` as a compatibility location. This repository does not "
+            "exercise Cursor runtime discovery.",
+        )
+    )
+
+
+def replace_generated_block(
+    current: str, start: str, end: str, rendered: str, label: str
+) -> str:
+    if current.count(start) != 1 or current.count(end) != 1:
+        raise SystemExit(
+            f"agent golden-path guide must contain exactly one {label} marker pair"
+        )
+    before, remainder = current.split(start, 1)
+    _, after = remainder.split(end, 1)
+    return f"{before}{start}\n{rendered}\n{end}{after}"
+
+
 def render_markdown(current: str) -> str:
-    if current.count(TABLE_START) != 1 or current.count(TABLE_END) != 1:
-        raise SystemExit("agent golden-path guide must contain exactly one table marker pair")
-    before, remainder = current.split(TABLE_START, 1)
-    _, after = remainder.split(TABLE_END, 1)
-    return f"{before}{TABLE_START}\n{render_table()}\n{TABLE_END}{after}"
+    with_discovery = replace_generated_block(
+        current,
+        DISCOVERY_START,
+        DISCOVERY_END,
+        render_discovery(),
+        "discovery",
+    )
+    return replace_generated_block(
+        with_discovery, TABLE_START, TABLE_END, render_table(), "table"
+    )
 
 
 def render_skill() -> str:
@@ -454,8 +497,10 @@ def render_skill() -> str:
         "Do not replace a linked gap with an inferred clean result.",
         "",
         "Codex and Claude Code are the project-skill hosts exercised here.",
-        "Cursor documents compatibility loading for these project roots, but this "
-        "repository does not exercise Cursor runtime discovery.",
+        f"Cursor's skill documentation ({CURSOR_DOCS_URL}), accessed on "
+        f"{CURSOR_DOCS_ACCESSED}, describes .agents/skills as a project-level location "
+        "and .claude/skills as a compatibility location. This repository does not "
+        "exercise Cursor runtime discovery.",
         "",
         "## Journey",
         "",

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -468,6 +468,8 @@ def replace_generated_block(
         raise SystemExit(
             f"agent golden-path guide must contain exactly one {label} marker pair"
         )
+    if current.index(start) > current.index(end):
+        raise SystemExit(f"agent golden-path guide {label} markers are out of order")
     before, remainder = current.split(start, 1)
     _, after = remainder.split(end, 1)
     return f"{before}{start}\n{rendered}\n{end}{after}"

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -29,6 +29,12 @@ EMPTY_STDOUT_RULE = (
     "Empty stdout in a gap row is an observed limitation, not permission for a caller "
     "to infer success from missing evidence."
 )
+INVOCATION_CWD_RULE = (
+    "When a step has no `working_directory`, run it from the invocation cwd."
+)
+SOURCE_REPO_CWD_RULE = (
+    "A present `working_directory` is a POSIX path relative to the source repository."
+)
 
 
 def stdout(kind: str, document: str | None = None) -> dict[str, object]:
@@ -492,6 +498,9 @@ def render_skill() -> str:
         "`docs/generated/agent-golden-path.json` is the authoritative machine contract.",
         "Read it when exact argv, fields, or per-outcome metadata are needed. Edit and",
         "run `scripts/docs/generate-agent-golden-path.py` instead of editing this file.",
+        "",
+        INVOCATION_CWD_RULE,
+        SOURCE_REPO_CWD_RULE,
         "",
         f"{EMPTY_STDOUT_RULE}",
         "Do not replace a linked gap with an inferred clean result.",

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -448,8 +448,9 @@ def render_discovery() -> str:
             "- `.agents/skills/assay-golden-path/SKILL.md`",
             "- `.claude/skills/assay-golden-path/SKILL.md`",
             "",
-            "When a step has no `working_directory`, run it from the invocation cwd.",
-            "A present `working_directory` is a POSIX path relative to the source repository.",
+            INVOCATION_CWD_RULE,
+            SOURCE_REPO_CWD_RULE,
+            PYTHON_PLACEHOLDER_RULE,
             "",
             f"Source: [Cursor's skill documentation]({CURSOR_DOCS_URL}), accessed on "
             f"`{CURSOR_DOCS_ACCESSED}`.",

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -35,6 +35,9 @@ INVOCATION_CWD_RULE = (
 SOURCE_REPO_CWD_RULE = (
     "A present `working_directory` is a POSIX path relative to the source repository."
 )
+PYTHON_PLACEHOLDER_RULE = (
+    "Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows."
+)
 
 
 def stdout(kind: str, document: str | None = None) -> dict[str, object]:
@@ -501,6 +504,7 @@ def render_skill() -> str:
         "",
         INVOCATION_CWD_RULE,
         SOURCE_REPO_CWD_RULE,
+        PYTHON_PLACEHOLDER_RULE,
         "",
         f"{EMPTY_STDOUT_RULE}",
         "Do not replace a linked gap with an inferred clean result.",

--- a/tests/support/agent_golden_path.rs
+++ b/tests/support/agent_golden_path.rs
@@ -18,7 +18,7 @@ pub fn classify_working_directory(step: &Value) -> Result<WorkingDirectory, Stri
     let path = value
         .as_str()
         .ok_or_else(|| "working_directory must be a POSIX-relative string".to_owned())?;
-    if path.is_empty() || path.starts_with('/') || path.contains('\\') || has_drive_prefix(path) {
+    if path.is_empty() || path.starts_with('/') || path.contains('\\') {
         return Err(format!(
             "working_directory must be a non-empty POSIX path relative to the source repo: {path:?}"
         ));
@@ -26,7 +26,10 @@ pub fn classify_working_directory(step: &Value) -> Result<WorkingDirectory, Stri
     let components = path
         .split('/')
         .map(|component| {
-            if component.is_empty() || matches!(component, "." | "..") {
+            if component.is_empty()
+                || matches!(component, "." | "..")
+                || has_drive_prefix(component)
+            {
                 Err(format!(
                     "working_directory contains an unsafe path component: {path:?}"
                 ))
@@ -128,6 +131,8 @@ mod working_directory_tests {
             "/tmp/assay",
             "C:/assay",
             "C:\\assay",
+            "examples/C:/escape",
+            "examples/D:escape",
             "examples//privileged-action-gate",
             "./examples",
             "examples/.",

--- a/tests/support/agent_golden_path.rs
+++ b/tests/support/agent_golden_path.rs
@@ -2,6 +2,47 @@ use serde_json::Value;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum WorkingDirectory {
+    Invocation,
+    SourceRepoRelative(Vec<String>),
+}
+
+pub fn classify_working_directory(step: &Value) -> Result<WorkingDirectory, String> {
+    let Some(value) = step.get("working_directory") else {
+        return Ok(WorkingDirectory::Invocation);
+    };
+    if value.is_null() {
+        return Ok(WorkingDirectory::Invocation);
+    }
+    let path = value
+        .as_str()
+        .ok_or_else(|| "working_directory must be a POSIX-relative string".to_owned())?;
+    if path.is_empty() || path.starts_with('/') || path.contains('\\') || has_drive_prefix(path) {
+        return Err(format!(
+            "working_directory must be a non-empty POSIX path relative to the source repo: {path:?}"
+        ));
+    }
+    let components = path
+        .split('/')
+        .map(|component| {
+            if component.is_empty() || matches!(component, "." | "..") {
+                Err(format!(
+                    "working_directory contains an unsafe path component: {path:?}"
+                ))
+            } else {
+                Ok(component.to_owned())
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(WorkingDirectory::SourceRepoRelative(components))
+}
+
+fn has_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
 thread_local! {
     static DRIVEN_OUTCOMES: RefCell<BTreeMap<(String, String), usize>> =
         const { RefCell::new(BTreeMap::new()) };
@@ -51,4 +92,68 @@ fn expected_contract_outcomes(contract: &Value, binary: &str) -> BTreeMap<(Strin
         }
     }
     expected
+}
+
+#[cfg(test)]
+mod working_directory_tests {
+    use super::{classify_working_directory, WorkingDirectory};
+    use serde_json::json;
+
+    #[test]
+    fn absent_working_directory_means_invocation_cwd() {
+        assert_eq!(
+            classify_working_directory(&json!({"id": "doctor"})),
+            Ok(WorkingDirectory::Invocation)
+        );
+    }
+
+    #[test]
+    fn source_repo_relative_working_directory_is_split_into_safe_components() {
+        assert_eq!(
+            classify_working_directory(&json!({
+                "id": "protected-action",
+                "working_directory": "examples/privileged-action-gate"
+            })),
+            Ok(WorkingDirectory::SourceRepoRelative(vec![
+                "examples".to_owned(),
+                "privileged-action-gate".to_owned(),
+            ]))
+        );
+    }
+
+    #[test]
+    fn hostile_or_ambiguous_working_directories_are_rejected() {
+        for path in [
+            "",
+            "/tmp/assay",
+            "C:/assay",
+            "C:\\assay",
+            "examples//privileged-action-gate",
+            "./examples",
+            "examples/.",
+            "../examples",
+            "examples/..",
+            "examples\\privileged-action-gate",
+        ] {
+            let error = classify_working_directory(&json!({
+                "id": "protected-action",
+                "working_directory": path,
+            }))
+            .expect_err("unsafe working directory must be rejected");
+            assert!(
+                error.contains("working_directory"),
+                "diagnostic for {path:?} did not name working_directory: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_string_working_directory_is_rejected() {
+        let error = classify_working_directory(&json!({
+            "id": "protected-action",
+            "working_directory": ["examples", "privileged-action-gate"],
+        }))
+        .expect_err("non-string working directory must be rejected");
+        assert!(error.contains("working_directory"));
+    }
 }


### PR DESCRIPTION
## Summary

- define `working_directory` cwd semantics once and exercise them from CLI/MCP golden-path contracts
- make the generated skill self-contained for invocation cwd, source-repository-relative cwd, and the `<python>` placeholder on Unix/Windows
- document Cursor discovery evidence with an explicit runtime non-claim
- extend validator and mutation coverage so guide/skill drift, unsafe paths, and false-green case accounting fail loudly

Part of #2176.

## Scope / DoD

- [x] missing or `null` `working_directory` means invocation cwd
- [x] present `working_directory` is a safe POSIX path relative to the Assay source repository
- [x] absolute paths, backslashes, dot components, empty components, traversal, and drive-prefixed components at any position are rejected
- [x] protected-action step resolves to the fixture directory and executes contract-derived argv there
- [x] both generated skill roots are byte-identical and independently runnable on Unix/Windows
- [x] guide and skill share generator-owned wording for all three runtime rules
- [x] Cursor documentation provenance and runtime non-claim are preserved
- [x] hardening bookkeeping detects missing cases instead of silently reducing coverage

## Design decision

Schema v1 does **not** add `working_directory_base`. A present `working_directory` has one referent: the source repository. A second field adds contradictory states without adding information. The checked-in design records this decision and the shared classifier is the single implementation of the rule.

## TDD / mutation proof

RED was observed before each behavior change:

- a protected step pointed at the existing but wrong `examples/` cwd and failed because required fixtures were absent
- removing cwd guidance from the generated skill failed validation
- removing the `<python>` replacement rule failed validation
- `examples/C:/escape` and `examples/D:escape` initially passed classification, then failed after the tests were added
- removing source-repository or Python wording from the guide now fails named mutations

GREEN on exact head `d3c66b11c2ce55e1a9e3656803a14b17f8dc007b` in worktree `/Users/roelschuurkes/.config/superpowers/worktrees/assay-2176-b-isolated/worktree`:

```text
python3 scripts/ci/test-agent-golden-path-skill.py
PASS

python3 -OO scripts/ci/test-agent-golden-path-skill.py
PASS

bash scripts/ci/test-agent-golden-path-skill-hardening.sh
75 case(s) + 22 structural probe(s), PASS

python3 scripts/docs/generate-agent-golden-path.py --check
7 generated files, no drift

cargo test -p assay-cli --test agent_golden_path_contract
13 passed

cargo test -p assay-mcp-server --test agent_golden_path_contract
8 passed

cargo fmt --all -- --check
PASS

cargo clippy -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
PASS

git diff --check
PASS
```

Tooling: isolated `CARGO_TARGET_DIR=/tmp/assay-target-2176-b-compact`, `CARGO_PROFILE_DEV_DEBUG=0`, `CARGO_INCREMENTAL=0`, `CARGO_BUILD_JOBS=2`.

Local full pre-commit remains unable to evaluate `cargo deny` because the current RustSec database contains duplicate `RUSTSEC-2026-0244`; this was reproduced independently in PR B0. No hook or CI gate was weakened or bypassed. GitHub dependency-security CI remains the integration authority.

## Review / workflow simulation

Both reviews are bound to exact head `d3c66b11c2ce55e1a9e3656803a14b17f8dc007b`:

- Claude Code Desktop, chat `Issue prioritering en overzicht`: `READY - no blockers`; cold-start discovery and runnable guidance pass on Unix and Windows
- independent non-building Codex reviewer: `PASS`; no blocking findings across the full ten-file base...head diff

Non-blocking advice retained for follow-up/disposition:

- report skipped hardening cases separately from passed cases on non-Linux hosts
- record the theoretical post-validation symlink-containment boundary explicitly
- consider deriving fixture assertions from contract argv rather than maintaining a parallel hardcoded list

## Risk / non-claims

- no production runtime code changed
- no public JSON schema, exit-code, policy, evidence, MCP protocol, or security behavior changed
- no Cursor runtime-discovery support is claimed; only the cited documentation behavior is reported
- no plugin or marketplace packaging is included
- public generated strings were checked for private strategy or unsupported claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified working-directory behavior, path conventions, and Python executable selection.
  * Added guidance for discovering generated project skills and documented platform compatibility details.

* **Bug Fixes**
  * Commands now default to the caller’s working directory when no directory is specified.
  * Improved validation and handling of supported relative paths while rejecting unsafe or ambiguous paths.

* **Tests**
  * Expanded coverage for working-directory resolution, documentation guidance, path validation, and contract rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review finding disposition on current head

- CodeRabbit reversed discovery markers: fixed TDD-first; validator and generator now emit the same controlled out-of-order diagnostic, pinned by a named mutation.
- CodeRabbit Python version pin: not applicable. The hardening script does not install Python and therefore has no independent install/invocation version literals that can drift; it consistently invokes the host-provided `python3` selected by CI.
