### PR TITLE
docs(agent): make Cargo.toml the version source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,7 @@ See `docs/PERFORMANCE-ASSESSMENT.md` for full documentation, including measureme
 
 ## Conventions
 
-- Workspace version in root `Cargo.toml` (`version = "3.31.1"`)
+- Workspace version lives in root `Cargo.toml`
 - Internal crate deps use `workspace = true` with path + version
 - `#[deny(unsafe_code)]` on all crates except assay-ebpf
 - Error handling: `anyhow` for applications, `thiserror` for libraries


### PR DESCRIPTION
## Summary

- remove the stale workspace version literal from `CLAUDE.md` conventions
- keep root `Cargo.toml` as the named version source
- avoid making the next workspace bump synchronize a second conventions literal

Closes #2179

## Scope

This changes one documentation line only. It does not bump the workspace version or alter runtime, schema, policy, evidence, MCP, or release behavior.

## Verification

Measured on exact head `8af9e1a646b2c735eefa3a15db7fec8c5218604c` in `/Users/roelschuurkes/.config/superpowers/worktrees/assay-2179-version-source`:

```text
rg check: no hardcoded Conventions semver remains
pre-commit run --files CLAUDE.md: passed
git diff --check: passed
```

## Risk

Low. The header still reports the current workspace version; the binding convention now points to the canonical `Cargo.toml` value instead of restating a stale literal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the workspace version guidance to clarify that the version is defined in the root project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->