### PR TITLE
test(agent): bound golden-path subprocesses

### DIFF
--- a/crates/assay-cli/tests/agent_golden_path_contract.rs
+++ b/crates/assay-cli/tests/agent_golden_path_contract.rs
@@ -1,5 +1,7 @@
 //! The #1975 journey as observed by a caller that reads only stdout and the exit status.
 
+#[path = "../../../tests/support/bounded_process.rs"]
+mod bounded_process;
 #[path = "../../../tests/support/agent_golden_path.rs"]
 mod runtime_coverage;
 
@@ -7,7 +9,9 @@ use serde_json::Value;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::process::{Command, Output};
+use std::time::Duration;
 
+use bounded_process::{run_bounded, ProcessLimits, GOLDEN_PATH_LIMITS};
 use runtime_coverage::ExpectedOutcome;
 
 fn workspace_root() -> &'static Path {
@@ -136,12 +140,14 @@ fn assay<S: AsRef<OsStr>>(cwd: &Path, args: &[S]) -> Output {
             command.env_remove(name);
         }
     }
-    command
-        .current_dir(cwd)
-        .env("NO_COLOR", "1")
-        .args(args)
-        .output()
-        .expect("run assay binary")
+    command.current_dir(cwd).env("NO_COLOR", "1").args(args);
+    run_bounded(
+        &mut command,
+        b"",
+        GOLDEN_PATH_LIMITS,
+        "agent golden-path CLI command",
+    )
+    .unwrap_or_else(|error| panic!("{error}"))
 }
 
 fn assay_contract(cwd: &Path, expected: &Value, replacements: &[(&str, &str)]) -> Output {
@@ -407,4 +413,57 @@ fn every_cli_contract_outcome_is_executed_once() {
             offline_profile_verifier_keeps_both_outcomes_on_stdout,
         ],
     );
+}
+
+#[cfg(unix)]
+fn hanging_command() -> Command {
+    let mut command = Command::new("sh");
+    command.args(["-c", "while :; do :; done"]);
+    command
+}
+
+#[cfg(windows)]
+fn hanging_command() -> Command {
+    let mut command = Command::new("cmd");
+    command.args([
+        "/V:ON",
+        "/C",
+        "@echo off & :loop & set /a x+=1 >NUL & goto loop",
+    ]);
+    command
+}
+
+#[cfg(unix)]
+fn stdout_flood_command() -> Command {
+    let mut command = Command::new("sh");
+    command.args(["-c", "while :; do printf '0123456789abcdef'; done"]);
+    command
+}
+
+#[cfg(windows)]
+fn stdout_flood_command() -> Command {
+    let mut command = Command::new("cmd");
+    command.args(["/C", "for /L %i in (1,1,1000000) do @echo 0123456789abcdef"]);
+    command
+}
+
+#[test]
+fn bounded_runner_kills_timeout_and_reports_context() {
+    let mut command = hanging_command();
+    let limits = ProcessLimits::new(Duration::from_millis(100), 1024, 1024);
+    let error = run_bounded(&mut command, b"", limits, "hanging mutation")
+        .expect_err("hanging child must time out");
+    assert!(error.contains("hanging mutation"));
+    assert!(error.contains("deadline"));
+}
+
+#[test]
+fn bounded_runner_kills_output_flood() {
+    let mut command = stdout_flood_command();
+    let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 1024);
+    let error = run_bounded(&mut command, b"", limits, "flood mutation")
+        .expect_err("output flood must exceed its ceiling");
+    assert!(error.contains("flood mutation"));
+    assert!(error.contains("stdout"));
+    assert!(error.contains("1024"));
 }

--- a/crates/assay-cli/tests/agent_golden_path_contract.rs
+++ b/crates/assay-cli/tests/agent_golden_path_contract.rs
@@ -9,9 +9,8 @@ use serde_json::Value;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::process::{Command, Output};
-use std::time::Duration;
 
-use bounded_process::{run_bounded, ProcessLimits, GOLDEN_PATH_LIMITS};
+use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
 use runtime_coverage::ExpectedOutcome;
 
 fn workspace_root() -> &'static Path {
@@ -413,57 +412,4 @@ fn every_cli_contract_outcome_is_executed_once() {
             offline_profile_verifier_keeps_both_outcomes_on_stdout,
         ],
     );
-}
-
-#[cfg(unix)]
-fn hanging_command() -> Command {
-    let mut command = Command::new("sh");
-    command.args(["-c", "while :; do :; done"]);
-    command
-}
-
-#[cfg(windows)]
-fn hanging_command() -> Command {
-    let mut command = Command::new("cmd");
-    command.args([
-        "/V:ON",
-        "/C",
-        "@echo off & :loop & set /a x+=1 >NUL & goto loop",
-    ]);
-    command
-}
-
-#[cfg(unix)]
-fn stdout_flood_command() -> Command {
-    let mut command = Command::new("sh");
-    command.args(["-c", "while :; do printf '0123456789abcdef'; done"]);
-    command
-}
-
-#[cfg(windows)]
-fn stdout_flood_command() -> Command {
-    let mut command = Command::new("cmd");
-    command.args(["/C", "for /L %i in (1,1,1000000) do @echo 0123456789abcdef"]);
-    command
-}
-
-#[test]
-fn bounded_runner_kills_timeout_and_reports_context() {
-    let mut command = hanging_command();
-    let limits = ProcessLimits::new(Duration::from_millis(100), 1024, 1024);
-    let error = run_bounded(&mut command, b"", limits, "hanging mutation")
-        .expect_err("hanging child must time out");
-    assert!(error.contains("hanging mutation"));
-    assert!(error.contains("deadline"));
-}
-
-#[test]
-fn bounded_runner_kills_output_flood() {
-    let mut command = stdout_flood_command();
-    let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 1024);
-    let error = run_bounded(&mut command, b"", limits, "flood mutation")
-        .expect_err("output flood must exceed its ceiling");
-    assert!(error.contains("flood mutation"));
-    assert!(error.contains("stdout"));
-    assert!(error.contains("1024"));
 }

--- a/crates/assay-cli/tests/agent_golden_path_contract.rs
+++ b/crates/assay-cli/tests/agent_golden_path_contract.rs
@@ -8,6 +8,8 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::process::{Command, Output};
 
+use runtime_coverage::ExpectedOutcome;
+
 fn workspace_root() -> &'static Path {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -35,25 +37,8 @@ fn contract() -> Value {
     contract
 }
 
-fn expected_outcome(step_id: &str, outcome_name: &str) -> Value {
-    let contract = contract();
-    let step = contract["steps"]
-        .as_array()
-        .expect("contract steps array")
-        .iter()
-        .find(|step| step["id"] == step_id)
-        .unwrap_or_else(|| panic!("contract step {step_id:?} is missing"));
-    let mut outcome = step["outcomes"]
-        .as_array()
-        .expect("step outcomes array")
-        .iter()
-        .find(|outcome| outcome["name"] == outcome_name)
-        .unwrap_or_else(|| panic!("contract outcome {step_id}/{outcome_name} is missing"))
-        .clone();
-    outcome["command"] = step["command"].clone();
-    outcome["binary"] = step["binary"].clone();
-    runtime_coverage::record_outcome(step_id, outcome_name);
-    outcome
+fn expected_outcome(step_id: &str, outcome_name: &str) -> ExpectedOutcome {
+    runtime_coverage::expected_outcome(&contract(), step_id, outcome_name)
 }
 
 #[test]
@@ -73,7 +58,7 @@ fn cli_contract_steps_default_to_invocation_cwd() {
     }
 }
 
-fn assert_exit(output: &Output, expected: &Value, context: &str) {
+fn assert_exit(output: &Output, expected: &ExpectedOutcome, context: &str) {
     let expected_exit = expected["exit_code"]
         .as_i64()
         .expect("contract exit_code must be an integer");
@@ -89,6 +74,12 @@ fn assert_exit(output: &Output, expected: &Value, context: &str) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    runtime_coverage::record_observation(expected);
+}
+
+#[test]
+fn golden_path_contract_uses_only_supported_binaries() {
+    runtime_coverage::assert_contract_binaries(&contract(), &["assay", "assay-mcp-server"]);
 }
 
 fn assert_gap(expected: &Value, issue: u64) {

--- a/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
+++ b/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
+use runtime_coverage::ExpectedOutcome;
+
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_STDOUT_BYTES: u64 = 1024 * 1024;
 
@@ -42,29 +44,11 @@ fn contract() -> Value {
     contract
 }
 
-fn expected_outcome(step_id: &str, outcome_name: &str) -> Value {
-    let contract = contract();
-    let step = contract["steps"]
-        .as_array()
-        .expect("contract steps array")
-        .iter()
-        .find(|step| step["id"] == step_id)
-        .unwrap_or_else(|| panic!("contract step {step_id:?} is missing"));
-    let mut outcome = step["outcomes"]
-        .as_array()
-        .expect("step outcomes array")
-        .iter()
-        .find(|outcome| outcome["name"] == outcome_name)
-        .unwrap_or_else(|| panic!("contract outcome {step_id}/{outcome_name} is missing"))
-        .clone();
-    outcome["command"] = step["command"].clone();
-    outcome["binary"] = step["binary"].clone();
-    outcome["working_directory"] = step["working_directory"].clone();
-    runtime_coverage::record_outcome(step_id, outcome_name);
-    outcome
+fn expected_outcome(step_id: &str, outcome_name: &str) -> ExpectedOutcome {
+    runtime_coverage::expected_outcome(&contract(), step_id, outcome_name)
 }
 
-fn assert_exit(output: &Output, expected: &Value, context: &str) {
+fn assert_exit(output: &Output, expected: &ExpectedOutcome, context: &str) {
     let expected_exit = expected["exit_code"]
         .as_i64()
         .expect("contract exit_code must be an integer");
@@ -80,6 +64,7 @@ fn assert_exit(output: &Output, expected: &Value, context: &str) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    runtime_coverage::record_observation(expected);
 }
 
 fn assert_gap(expected: &Value, issue: u64) {
@@ -327,6 +312,7 @@ fn enforcing_proxy_denial_is_structured_but_startup_failure_is_not() {
         status.code().map(i64::from),
         denied_expected["exit_code"].as_i64()
     );
+    runtime_coverage::record_observation(&denied_expected);
 
     let startup_expected = expected_outcome("protected-action", "startup-failure");
     let startup_argv = contract_argv(&startup_expected, &[("<python>", python)]);

--- a/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
+++ b/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
@@ -1,21 +1,19 @@
 //! MCP-owned rows of the #1975 stdout-and-exit-code journey contract.
 
+#[path = "../../../tests/support/bounded_process.rs"]
+mod bounded_process;
 mod jsonrpc_conn;
 #[path = "../../../tests/support/agent_golden_path.rs"]
 mod runtime_coverage;
 
+use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
 use jsonrpc_conn::Conn;
 use serde_json::Value;
 use std::ffi::OsStr;
-use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Output, Stdio};
-use std::time::{Duration, Instant};
+use std::process::{Command, Output, Stdio};
 
 use runtime_coverage::ExpectedOutcome;
-
-const PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
-const MAX_STDOUT_BYTES: u64 = 1024 * 1024;
 
 fn workspace_root() -> &'static Path {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -145,61 +143,14 @@ fn clean_server_command() -> Command {
 
 fn run_server<S: AsRef<OsStr>>(cwd: &Path, args: &[S], stdin: &[u8]) -> Output {
     let mut command = clean_server_command();
-    command
-        .current_dir(cwd)
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit());
-    let mut child = command.spawn().expect("spawn assay-mcp-server");
-    let mut child_stdin = child.stdin.take().expect("child stdin");
-    let stdin = stdin.to_vec();
-    let writer = std::thread::spawn(move || {
-        child_stdin.write_all(&stdin)?;
-        Ok::<(), std::io::Error>(())
-    });
-    let output = wait_bounded(child);
-    writer
-        .join()
-        .expect("join stdin writer")
-        .expect("write child stdin");
-    output
-}
-
-fn wait_bounded(mut child: Child) -> Output {
-    let stdout = child.stdout.take().expect("child stdout");
-    let reader = std::thread::spawn(move || {
-        let mut bytes = Vec::new();
-        stdout
-            .take(MAX_STDOUT_BYTES + 1)
-            .read_to_end(&mut bytes)
-            .expect("read bounded child stdout");
-        bytes
-    });
-    let deadline = Instant::now() + PROCESS_TIMEOUT;
-    let status = loop {
-        match child.try_wait().expect("poll assay-mcp-server") {
-            Some(status) => break status,
-            None if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let status = child.wait().expect("reap timed-out assay-mcp-server");
-                panic!(
-                    "assay-mcp-server did not exit within {PROCESS_TIMEOUT:?}; killed it ({status})"
-                );
-            }
-            None => std::thread::sleep(Duration::from_millis(10)),
-        }
-    };
-    let stdout = reader.join().expect("join stdout reader");
-    assert!(
-        stdout.len() <= MAX_STDOUT_BYTES as usize,
-        "assay-mcp-server stdout exceeded the {MAX_STDOUT_BYTES}-byte test ceiling"
-    );
-    Output {
-        status,
-        stdout,
-        stderr: Vec::new(),
-    }
+    command.current_dir(cwd).args(args);
+    run_bounded(
+        &mut command,
+        stdin,
+        GOLDEN_PATH_LIMITS,
+        "agent golden-path MCP command",
+    )
+    .unwrap_or_else(|error| panic!("{error}"))
 }
 
 fn python() -> &'static str {
@@ -212,12 +163,17 @@ fn python() -> &'static str {
 
 fn required_python() -> &'static str {
     let interpreter = python();
-    let output = Command::new(interpreter)
-        .arg("--version")
-        .output()
-        .unwrap_or_else(|error| {
-            panic!("the protected-action reference fixture requires {interpreter} on PATH: {error}")
-        });
+    let mut command = Command::new(interpreter);
+    command.arg("--version");
+    let output = run_bounded(
+        &mut command,
+        b"",
+        GOLDEN_PATH_LIMITS,
+        "protected-action Python preflight",
+    )
+    .unwrap_or_else(|error| {
+        panic!("the protected-action reference fixture requires {interpreter} on PATH: {error}")
+    });
     assert!(
         output.status.success(),
         "the protected-action reference fixture requires a working {interpreter}"

--- a/docs/superpowers/plans/2026-08-08-agent-golden-path-contract.md
+++ b/docs/superpowers/plans/2026-08-08-agent-golden-path-contract.md
@@ -121,7 +121,8 @@ scenarios and requires every MCP-owned contract outcome exactly once.
 cargo test -p assay-mcp-server --test agent_golden_path_contract -- --nocapture
 ```
 
-Expected: FAIL because the machine contract is absent.
+Expected: FAIL because the MCP-owned protected-action and SARIF outcomes are
+still missing or incomplete in the machine contract.
 
 - [x] **Step 3: Complete the machine outcomes and generated table**
 

--- a/docs/superpowers/plans/2026-08-09-golden-path-process-bounds.md
+++ b/docs/superpowers/plans/2026-08-09-golden-path-process-bounds.md
@@ -1,0 +1,350 @@
+# Golden Path Process Bounds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the golden-path execution gate prove post-execution observation, reject unknown binaries, and bound every CLI/Python subprocess it owns.
+
+**Architecture:** Consolidate contract lookup and observation accounting in the existing workspace-only support module, and add one standard-library bounded process helper under `tests/support/` for both crate-local integration tests. The helper pipes stdin/stdout/stderr, enforces a wall-clock deadline and independent byte ceilings, kills and reaps on timeout or overflow, and returns diagnostics containing the logical context plus the spawned command.
+
+**Tech Stack:** Rust standard library process/thread/channel APIs, `serde_json`, Cargo integration tests, Markdown plans.
+
+## Global Constraints
+
+- Base all work on `48beb09d1ba581f275da7775228262c778914a28` in `/Users/roelschuurkes/.config/superpowers/worktrees/assay-2173-process-bounds`.
+- Use `CARGO_TARGET_DIR=/tmp/assay-2173-process-bounds-target`; do not share another worktree's target directory.
+- No production CLI or MCP behavior changes.
+- Generated contract reads remain ordinary generator-owned repository reads; do not add a hostile-input ceiling to them.
+- Preserve standalone scenario tests and orchestrator execution.
+- Use one implementation for the process rule and one implementation for contract outcome lookup.
+- Bound stdout and stderr independently at 1 MiB and use a 10-second default deadline.
+- On timeout or overflow, kill and reap before returning an error.
+- Keep command context and bounded stdout/stderr excerpts in failure diagnostics.
+- Do not add a Python version pin.
+
+---
+
+### Task 1: Post-observation coverage and closed binary set
+
+**Files:**
+- Modify: `tests/support/agent_golden_path.rs`
+- Modify: `crates/assay-cli/tests/agent_golden_path_contract.rs`
+- Modify: `crates/assay-mcp-server/tests/agent_golden_path_contract.rs`
+
+**Interfaces:**
+- Produces: `ExpectedOutcome`, `expected_outcome(&Value, &str, &str)`, `record_observation(&ExpectedOutcome)`, and `assert_contract_binaries(&Value, &[&str])` in shared test support.
+- Consumes: the canonical generated contract and existing thread-local exact-coverage map.
+
+- [ ] **Step 1: Write failing support tests**
+
+Add a test proving lookup alone does not satisfy `assert_exact`:
+
+```rust
+fn lookup_only_scenario() {
+    let contract = fixture_contract();
+    let _ = expected_outcome(&contract, "doctor", "success");
+}
+
+#[test]
+fn lookup_without_observation_fails_exact_coverage() {
+    let panic = std::panic::catch_unwind(|| {
+        assert_exact(&fixture_contract(), "assay", &[lookup_only_scenario]);
+    });
+    assert!(panic.is_err(), "lookup alone unexpectedly counted as observation");
+}
+```
+
+Add a binary-set test whose third-binary mutation fails:
+
+```rust
+#[test]
+fn contract_binary_set_is_closed() {
+    assert_contract_binaries(
+        &fixture_contract(),
+        &["assay", "assay-mcp-server"],
+    );
+    let mut mutated = fixture_contract();
+    mutated["steps"].as_array_mut().unwrap().push(json!({
+        "id": "third", "binary": "other", "outcomes": []
+    }));
+    assert!(std::panic::catch_unwind(|| {
+        assert_contract_binaries(&mutated, &["assay", "assay-mcp-server"]);
+    }).is_err());
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-2173-process-bounds-target \
+  cargo test -p assay-cli --test agent_golden_path_contract --locked -- --nocapture
+```
+
+Expected: compile failure naming missing `ExpectedOutcome`, `expected_outcome`, or `assert_contract_binaries`.
+
+- [ ] **Step 3: Implement shared lookup and observation**
+
+Move duplicated lookup logic into `tests/support/agent_golden_path.rs`:
+
+```rust
+pub struct ExpectedOutcome {
+    step_id: String,
+    outcome_name: String,
+    value: Value,
+}
+
+impl std::ops::Deref for ExpectedOutcome {
+    type Target = Value;
+    fn deref(&self) -> &Self::Target { &self.value }
+}
+
+pub fn expected_outcome(
+    contract: &Value,
+    step_id: &str,
+    outcome_name: &str,
+) -> ExpectedOutcome {
+    // Locate the step/outcome once, clone it, and attach command, binary, and
+    // working_directory from the step. Do not record coverage here.
+}
+
+pub fn record_observation(outcome: &ExpectedOutcome) {
+    record_outcome(&outcome.step_id, &outcome.outcome_name);
+}
+```
+
+Implement `assert_contract_binaries` by collecting all step `binary` strings
+into a `BTreeSet` and comparing them with the expected set. Replace both local
+`expected_outcome` functions with calls to this shared implementation.
+
+- [ ] **Step 4: Move registration to observed-result sites**
+
+Change both `assert_exit` helpers to accept `&ExpectedOutcome` and call
+`record_observation(expected)` only after the child status has been read and
+matched. For the JSON-RPC policy-denial path, call `record_observation` only
+after `connection.shutdown()` returns and its status matches. Add one real
+contract test calling `assert_contract_binaries` against exactly `assay` and
+`assay-mcp-server`.
+
+- [ ] **Step 5: Run both focused suites and verify GREEN**
+
+```bash
+CARGO_TARGET_DIR=/tmp/assay-2173-process-bounds-target \
+  cargo test -p assay-cli --test agent_golden_path_contract --locked -- --nocapture
+CARGO_TARGET_DIR=/tmp/assay-2173-process-bounds-target \
+  cargo test -p assay-mcp-server --test agent_golden_path_contract --locked -- --nocapture
+```
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add -A tests/support/agent_golden_path.rs \
+  crates/assay-cli/tests/agent_golden_path_contract.rs \
+  crates/assay-mcp-server/tests/agent_golden_path_contract.rs
+git commit -m "test(agent): count observed golden-path outcomes"
+```
+
+### Task 2: Shared bounded process runner
+
+**Files:**
+- Create: `tests/support/bounded_process.rs`
+- Modify: `crates/assay-cli/tests/agent_golden_path_contract.rs`
+
+**Interfaces:**
+- Produces: `ProcessLimits`, `GOLDEN_PATH_LIMITS`, and `run_bounded(&mut Command, &[u8], ProcessLimits, &str) -> Result<Output, String>`.
+- Guarantees: independent stdout/stderr ceilings, deadline, kill/reap, bounded diagnostics, and no surviving child on error.
+
+- [ ] **Step 1: Write timeout and flood tests before implementation**
+
+Include the shared module from the CLI integration test and add Unix/Windows
+shell-command factories. Require a timeout and a stdout flood to return errors
+that name the supplied context and failure class:
+
+```rust
+#[test]
+fn bounded_runner_kills_timeout_and_reports_context() {
+    let mut command = hanging_command();
+    let limits = ProcessLimits::new(Duration::from_millis(100), 1024, 1024);
+    let error = run_bounded(&mut command, b"", limits, "hanging mutation")
+        .expect_err("hanging child must time out");
+    assert!(error.contains("hanging mutation"));
+    assert!(error.contains("deadline"));
+}
+
+#[test]
+fn bounded_runner_kills_output_flood() {
+    let mut command = stdout_flood_command();
+    let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 1024);
+    let error = run_bounded(&mut command, b"", limits, "flood mutation")
+        .expect_err("output flood must exceed its ceiling");
+    assert!(error.contains("stdout"));
+    assert!(error.contains("1024"));
+}
+```
+
+- [ ] **Step 2: Run the CLI suite and verify RED**
+
+Run the Task 1 CLI command. Expected: compile failure because
+`tests/support/bounded_process.rs` or its interfaces do not exist.
+
+- [ ] **Step 3: Implement `run_bounded`**
+
+Use only standard-library APIs:
+
+```rust
+#[derive(Clone, Copy)]
+pub struct ProcessLimits {
+    pub timeout: Duration,
+    pub max_stdout_bytes: usize,
+    pub max_stderr_bytes: usize,
+}
+
+pub const GOLDEN_PATH_LIMITS: ProcessLimits = ProcessLimits {
+    timeout: Duration::from_secs(10),
+    max_stdout_bytes: 1024 * 1024,
+    max_stderr_bytes: 1024 * 1024,
+};
+```
+
+`run_bounded` must:
+
+1. force piped stdin/stdout/stderr and retain `format!("{command:?}")`;
+2. spawn one stdin writer and one bounded reader per output stream;
+3. have readers signal overflow after `limit + 1` bytes;
+4. poll `try_wait()` until exit, overflow, or deadline;
+5. kill and `wait()` on overflow/deadline before joining threads;
+6. return `Output` only when both streams stay within their limits;
+7. include context, command, status/reap result, stream, ceiling, and bounded
+   stdout/stderr excerpts in errors.
+
+- [ ] **Step 4: Run bounded-runner tests and verify GREEN**
+
+Run the Task 1 CLI command and require both new negative controls to pass on
+the current platform.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add -A tests/support/bounded_process.rs \
+  crates/assay-cli/tests/agent_golden_path_contract.rs
+git commit -m "test(agent): add bounded process runner"
+```
+
+### Task 3: Apply the one process rule to all owned paths
+
+**Files:**
+- Modify: `crates/assay-cli/tests/agent_golden_path_contract.rs`
+- Modify: `crates/assay-mcp-server/tests/agent_golden_path_contract.rs`
+- Modify: `docs/superpowers/plans/2026-08-08-agent-golden-path-contract.md`
+
+**Interfaces:**
+- Consumes: `run_bounded` and `GOLDEN_PATH_LIMITS` from Task 2.
+- Removes: the MCP-local `wait_bounded`, `PROCESS_TIMEOUT`, and `MAX_STDOUT_BYTES` implementation.
+
+- [ ] **Step 1: Write integration assertions for bounded diagnostics**
+
+Require the CLI `assay()` helper and MCP `run_server()` helper to return
+`run_bounded(...).unwrap_or_else(|error| panic!("{error}"))`. Change the Python
+availability probe to use the same helper with context
+`"protected-action Python preflight"`.
+
+- [ ] **Step 2: Run both suites and verify RED**
+
+Temporarily make the local MCP `wait_bounded` unavailable. Run both focused
+suites and verify the MCP suite fails to compile until it imports the shared
+runner.
+
+- [ ] **Step 3: Replace all three owned subprocess paths**
+
+Add the same path import to both integration tests:
+
+```rust
+#[path = "../../../tests/support/bounded_process.rs"]
+mod bounded_process;
+```
+
+Route CLI commands, MCP stdin-driven commands, and `python --version` through
+`run_bounded`. Preserve `Conn` for interactive JSON-RPC; it already has its own
+bounded response/shutdown behavior. Delete the duplicate MCP wait function and
+its reader/time imports.
+
+- [ ] **Step 4: Correct the historical Task 2 RED statement**
+
+Replace the stale claim that the machine contract is absent with the actual
+checkpoint: MCP-owned protected-action and SARIF outcomes are missing or
+incomplete at that point. Do not rewrite historical commands or checked boxes.
+
+- [ ] **Step 5: Run both focused suites and verify GREEN**
+
+Run both Task 1 commands. Confirm standalone scenario tests and exact-coverage
+orchestrators still execute.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add -A tests/support/bounded_process.rs \
+  crates/assay-cli/tests/agent_golden_path_contract.rs \
+  crates/assay-mcp-server/tests/agent_golden_path_contract.rs \
+  docs/superpowers/plans/2026-08-08-agent-golden-path-contract.md
+git commit -m "test(agent): bound golden-path subprocesses"
+```
+
+### Task 4: Mutation proof and final verification
+
+**Files:**
+- Modify if required by review only: the four files from Tasks 1-3
+- Update: PR body and issue #2173 with exact-SHA evidence after commit
+
+**Interfaces:**
+- Produces: exact-head verification and mutation evidence for review.
+
+- [ ] **Step 1: Run the four required mutations one at a time**
+
+Each temporary mutation must fail for its own reason:
+
+1. replace a scenario body with `expected_outcome(...)` only: exact coverage
+   reports the missing outcome;
+2. append a third `binary` to a scratch contract: binary-set assertion reports
+   `other`;
+3. run the bounded helper against the hanging command: deadline diagnostic and
+   reaped child;
+4. run it against the flood command: named stream/ceiling diagnostic and reaped
+   child.
+
+Restore every mutation and verify `git diff` contains only intended changes.
+
+- [ ] **Step 2: Run affected verification**
+
+```bash
+export CARGO_TARGET_DIR=/tmp/assay-2173-process-bounds-target
+cargo test -p assay-cli --test agent_golden_path_contract --locked -- --nocapture
+cargo test -p assay-mcp-server --test agent_golden_path_contract --locked -- --nocapture
+cargo test -p assay-cli --locked
+cargo test -p assay-mcp-server --locked
+cargo fmt --all -- --check
+cargo clippy -p assay-cli -p assay-mcp-server --all-targets --all-features --locked -- -D warnings
+python3 scripts/ci/test-agent-golden-path-skill.py
+scripts/ci/check-docs-generated-drift.sh
+git diff --check
+```
+
+- [ ] **Step 3: Run the shared simulation/eval matrix**
+
+```bash
+cargo test -p assay-sim --locked
+cargo test -p assay-core agentic::tests --locked
+cargo test -p assay-core judge_internal::tests::contract --locked
+```
+
+Record executed/ignored counts as measurements, not coverage claims.
+
+- [ ] **Step 4: Commit any verification-only correction**
+
+Stage only named changed paths. Do not create an empty commit.
+
+- [ ] **Step 5: Push, open PR, and request exact-head reviews**
+
+Open a ready PR with `Closes #2173`, exact head/worktree/toolchain provenance,
+RED/GREEN evidence, mutation results, verification commands, and non-claims.
+Request Claude Code Desktop read-only review plus CodeRabbit or Copilot. A new
+push invalidates prior reviews.

--- a/tests/support/agent_golden_path.rs
+++ b/tests/support/agent_golden_path.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Deref;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum WorkingDirectory {
@@ -49,6 +50,66 @@ fn has_drive_prefix(path: &str) -> bool {
 thread_local! {
     static DRIVEN_OUTCOMES: RefCell<BTreeMap<(String, String), usize>> =
         const { RefCell::new(BTreeMap::new()) };
+}
+
+pub struct ExpectedOutcome {
+    step_id: String,
+    outcome_name: String,
+    value: Value,
+}
+
+impl Deref for ExpectedOutcome {
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+pub fn expected_outcome(contract: &Value, step_id: &str, outcome_name: &str) -> ExpectedOutcome {
+    let step = contract["steps"]
+        .as_array()
+        .expect("contract steps array")
+        .iter()
+        .find(|step| step["id"] == step_id)
+        .unwrap_or_else(|| panic!("contract step {step_id:?} is missing"));
+    let mut value = step["outcomes"]
+        .as_array()
+        .expect("step outcomes array")
+        .iter()
+        .find(|outcome| outcome["name"] == outcome_name)
+        .unwrap_or_else(|| panic!("contract outcome {step_id}/{outcome_name} is missing"))
+        .clone();
+    value["command"] = step["command"].clone();
+    value["binary"] = step["binary"].clone();
+    value["working_directory"] = step["working_directory"].clone();
+    ExpectedOutcome {
+        step_id: step_id.to_owned(),
+        outcome_name: outcome_name.to_owned(),
+        value,
+    }
+}
+
+pub fn record_observation(outcome: &ExpectedOutcome) {
+    record_outcome(&outcome.step_id, &outcome.outcome_name);
+}
+
+pub fn assert_contract_binaries(contract: &Value, expected: &[&str]) {
+    let actual = contract["steps"]
+        .as_array()
+        .expect("contract steps array")
+        .iter()
+        .map(|step| {
+            step["binary"]
+                .as_str()
+                .expect("contract step binary string")
+        })
+        .collect::<BTreeSet<_>>();
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(
+        actual, expected,
+        "agent golden-path contract binary set changed"
+    );
 }
 
 pub fn record_outcome(step_id: &str, outcome_name: &str) {
@@ -160,5 +221,58 @@ mod working_directory_tests {
         }))
         .expect_err("non-string working directory must be rejected");
         assert!(error.contains("working_directory"));
+    }
+}
+
+#[cfg(test)]
+mod execution_coverage_tests {
+    use super::{assert_contract_binaries, assert_exact, expected_outcome};
+    use serde_json::{json, Value};
+
+    fn fixture_contract() -> Value {
+        json!({
+            "steps": [{
+                "id": "doctor",
+                "binary": "assay",
+                "command": "assay doctor --format json",
+                "outcomes": [{"name": "success"}]
+            }]
+        })
+    }
+
+    fn lookup_only_scenario() {
+        let contract = fixture_contract();
+        let _ = expected_outcome(&contract, "doctor", "success");
+    }
+
+    #[test]
+    fn lookup_without_observation_fails_exact_coverage() {
+        let panic = std::panic::catch_unwind(|| {
+            assert_exact(&fixture_contract(), "assay", &[lookup_only_scenario]);
+        });
+        assert!(
+            panic.is_err(),
+            "looking up an outcome unexpectedly counted as observing a command"
+        );
+    }
+
+    #[test]
+    fn contract_binary_set_is_closed() {
+        assert_contract_binaries(&fixture_contract(), &["assay"]);
+
+        let mut mutated = fixture_contract();
+        mutated["steps"]
+            .as_array_mut()
+            .expect("fixture steps array")
+            .push(json!({
+                "id": "third",
+                "binary": "other",
+                "command": "other",
+                "outcomes": []
+            }));
+        let panic = std::panic::catch_unwind(|| {
+            assert_contract_binaries(&mutated, &["assay"]);
+        });
+        assert!(panic.is_err(), "a third contract binary was accepted");
     }
 }

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -275,3 +275,92 @@ fn excerpt(bytes: &[u8]) -> String {
     };
     format!("{:?}{suffix}", String::from_utf8_lossy(kept))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{run_bounded, ProcessLimits};
+    use std::process::Command;
+    use std::time::Duration;
+
+    #[cfg(unix)]
+    fn hanging_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "while :; do :; done"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn hanging_command() -> Command {
+        let mut command = Command::new("ping");
+        command.args(["-t", "127.0.0.1"]);
+        command
+    }
+
+    #[cfg(unix)]
+    fn stdout_flood_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "while :; do printf '0123456789abcdef'; done"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn stdout_flood_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "for /L %i in (1,1,1000000) do @echo 0123456789abcdef"]);
+        command
+    }
+
+    #[cfg(unix)]
+    fn stderr_flood_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "while :; do printf '0123456789abcdef' >&2; done"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn stderr_flood_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args([
+            "/C",
+            "for /L %i in (1,1,1000000) do @echo 0123456789abcdef 1>&2",
+        ]);
+        command
+    }
+
+    #[test]
+    fn kills_timeout_and_reports_context() {
+        let mut command = hanging_command();
+        let limits = ProcessLimits::new(Duration::from_millis(100), 1024, 1024);
+        let error = run_bounded(&mut command, b"", limits, "hanging mutation")
+            .expect_err("hanging child must time out");
+        assert!(error.contains("hanging mutation"));
+        assert!(error.contains("deadline"));
+    }
+
+    #[test]
+    fn kills_stdout_flood() {
+        let mut command = stdout_flood_command();
+        let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 2048);
+        let error = run_bounded(&mut command, b"", limits, "stdout flood mutation")
+            .expect_err("stdout flood must exceed its ceiling");
+        assert!(error.contains("stdout flood mutation"));
+        assert!(error.contains("stdout"));
+        assert!(error.contains("1024-byte ceiling"));
+    }
+
+    #[test]
+    fn stderr_flood_uses_its_own_ceiling_and_bounded_diagnostic() {
+        let mut command = stderr_flood_command();
+        let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 8192);
+        let error = run_bounded(&mut command, b"", limits, "stderr flood mutation")
+            .expect_err("stderr flood must exceed its ceiling");
+        assert!(error.contains("stderr flood mutation"));
+        assert!(error.contains("stderr exceeded its 8192-byte ceiling"));
+        assert!(error.contains("... (8193 bytes total)"));
+        assert!(
+            error.len() < 5000,
+            "diagnostic escaped its bounded excerpt: {} bytes",
+            error.len()
+        );
+    }
+}

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -1,0 +1,277 @@
+use std::ffi::OsStr;
+use std::io::{Read, Write};
+use std::process::{Command, ExitStatus, Output, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const MAX_DIAGNOSTIC_BYTES: usize = 4096;
+
+#[derive(Clone, Copy)]
+pub struct ProcessLimits {
+    pub timeout: Duration,
+    pub max_stdout_bytes: usize,
+    pub max_stderr_bytes: usize,
+}
+
+impl ProcessLimits {
+    pub const fn new(timeout: Duration, max_stdout_bytes: usize, max_stderr_bytes: usize) -> Self {
+        Self {
+            timeout,
+            max_stdout_bytes,
+            max_stderr_bytes,
+        }
+    }
+}
+
+pub const GOLDEN_PATH_LIMITS: ProcessLimits =
+    ProcessLimits::new(Duration::from_secs(10), 1024 * 1024, 1024 * 1024);
+
+#[derive(Clone, Copy)]
+enum CapturedStream {
+    Stdout,
+    Stderr,
+}
+
+impl CapturedStream {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+pub fn run_bounded(
+    command: &mut Command,
+    stdin: &[u8],
+    limits: ProcessLimits,
+    context: &str,
+) -> Result<Output, String> {
+    assert!(
+        limits.max_stdout_bytes > 0,
+        "stdout ceiling must be positive"
+    );
+    assert!(
+        limits.max_stderr_bytes > 0,
+        "stderr ceiling must be positive"
+    );
+    let command_display = display_command(command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("{context}: spawn {command_display}: {error}"))?;
+
+    let mut child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| format!("{context}: {command_display}: child stdin was not piped"))?;
+    let child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| format!("{context}: {command_display}: child stdout was not piped"))?;
+    let child_stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| format!("{context}: {command_display}: child stderr was not piped"))?;
+
+    let stdin = stdin.to_vec();
+    let stdin_writer = thread::spawn(move || {
+        let result = child_stdin.write_all(&stdin);
+        drop(child_stdin);
+        result
+    });
+
+    let (overflow_tx, overflow_rx) = mpsc::channel();
+    let stdout_reader = spawn_reader(
+        child_stdout,
+        limits.max_stdout_bytes,
+        CapturedStream::Stdout,
+        overflow_tx.clone(),
+    );
+    let stderr_reader = spawn_reader(
+        child_stderr,
+        limits.max_stderr_bytes,
+        CapturedStream::Stderr,
+        overflow_tx,
+    );
+
+    let deadline = Instant::now() + limits.timeout;
+    let mut early_failure = None;
+    let status = loop {
+        if let Ok(stream) = overflow_rx.try_recv() {
+            early_failure = Some(format!(
+                "{} exceeded its {}-byte ceiling",
+                stream.name(),
+                stream_limit(limits, stream)
+            ));
+            break kill_and_reap(&mut child, context, &command_display)?;
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
+                break kill_and_reap(&mut child, context, &command_display)?;
+            }
+            Ok(None) => thread::sleep(POLL_INTERVAL),
+            Err(error) => {
+                let reap = kill_and_reap(&mut child, context, &command_display);
+                return Err(format!(
+                    "{context}: poll {command_display}: {error}; kill/reap: {reap:?}"
+                ));
+            }
+        }
+    };
+
+    let stdin_result = stdin_writer
+        .join()
+        .map_err(|_| format!("{context}: {command_display}: stdin writer panicked"))?;
+    let stdout = join_reader(stdout_reader, context, &command_display, "stdout")?;
+    let stderr = join_reader(stderr_reader, context, &command_display, "stderr")?;
+
+    if let Some(failure) = early_failure {
+        return Err(failure_diagnostic(
+            context,
+            &command_display,
+            &failure,
+            &status,
+            &stdout,
+            &stderr,
+        ));
+    }
+    if stdout.len() > limits.max_stdout_bytes {
+        return Err(failure_diagnostic(
+            context,
+            &command_display,
+            &format!(
+                "stdout exceeded its {}-byte ceiling",
+                limits.max_stdout_bytes
+            ),
+            &status,
+            &stdout,
+            &stderr,
+        ));
+    }
+    if stderr.len() > limits.max_stderr_bytes {
+        return Err(failure_diagnostic(
+            context,
+            &command_display,
+            &format!(
+                "stderr exceeded its {}-byte ceiling",
+                limits.max_stderr_bytes
+            ),
+            &status,
+            &stdout,
+            &stderr,
+        ));
+    }
+    stdin_result.map_err(|error| {
+        failure_diagnostic(
+            context,
+            &command_display,
+            &format!("write stdin: {error}"),
+            &status,
+            &stdout,
+            &stderr,
+        )
+    })?;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn spawn_reader<R: Read + Send + 'static>(
+    reader: R,
+    limit: usize,
+    stream: CapturedStream,
+    overflow: mpsc::Sender<CapturedStream>,
+) -> thread::JoinHandle<std::io::Result<Vec<u8>>> {
+    thread::spawn(move || {
+        let mut bytes = Vec::with_capacity(limit.saturating_add(1));
+        reader
+            .take(limit.saturating_add(1) as u64)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() > limit {
+            let _ = overflow.send(stream);
+        }
+        Ok(bytes)
+    })
+}
+
+fn join_reader(
+    reader: thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    context: &str,
+    command: &str,
+    stream: &str,
+) -> Result<Vec<u8>, String> {
+    reader
+        .join()
+        .map_err(|_| format!("{context}: {command}: {stream} reader panicked"))?
+        .map_err(|error| format!("{context}: read {stream} from {command}: {error}"))
+}
+
+fn kill_and_reap(
+    child: &mut std::process::Child,
+    context: &str,
+    command: &str,
+) -> Result<ExitStatus, String> {
+    let kill_error = child.kill().err();
+    child.wait().map_err(|wait_error| {
+        format!(
+            "{context}: failed to reap {command} after kill; kill={kill_error:?}; wait={wait_error}"
+        )
+    })
+}
+
+fn stream_limit(limits: ProcessLimits, stream: CapturedStream) -> usize {
+    match stream {
+        CapturedStream::Stdout => limits.max_stdout_bytes,
+        CapturedStream::Stderr => limits.max_stderr_bytes,
+    }
+}
+
+fn display_command(command: &Command) -> String {
+    let mut parts = vec![display_os(command.get_program())];
+    parts.extend(command.get_args().map(display_os));
+    let rendered = parts.join(" ");
+    match command.get_current_dir() {
+        Some(cwd) => format!("{rendered} (cwd {})", cwd.display()),
+        None => rendered,
+    }
+}
+
+fn display_os(value: &OsStr) -> String {
+    format!("{:?}", value.to_string_lossy())
+}
+
+fn failure_diagnostic(
+    context: &str,
+    command: &str,
+    failure: &str,
+    status: &ExitStatus,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> String {
+    format!(
+        "{context}: {command}: {failure}; status={status}; stdout={}; stderr={}",
+        excerpt(stdout),
+        excerpt(stderr)
+    )
+}
+
+fn excerpt(bytes: &[u8]) -> String {
+    let kept = &bytes[..bytes.len().min(MAX_DIAGNOSTIC_BYTES)];
+    let suffix = if kept.len() < bytes.len() {
+        format!("... ({} bytes total)", bytes.len())
+    } else {
+        format!(" ({} bytes)", bytes.len())
+    };
+    format!("{:?}{suffix}", String::from_utf8_lossy(kept))
+}


### PR DESCRIPTION
## Summary

- add one shared bounded subprocess runner for golden-path CLI, MCP, and Python preflight tests
- register contract outcomes only after observed process output/status
- pin the production contract binary set to exactly `assay` and `assay-mcp-server`
- run the timeout/flood self-tests from shared support so the MCP crate executes them on Windows too
- correct the historical Task 2 RED description

Closes #2173.

## Scope and risk

- Test infrastructure and implementation-plan text only.
- No production CLI or MCP behavior changes.
- No public API, CLI flag, JSON schema, policy, or evidence-contract changes.
- The runner bounds direct child wall time plus captured stdout/stderr; it does not claim process-tree containment.

## Review packet

**Base:** `origin/main` at `f2ea96166ddb0ea760d6b31aac598286b53cc9c3`  
**Head:** `a45a51ed3ffe684937dcc4190c333e6cac5386c7`  
**Worktree:** `/Users/roelschuurkes/.config/superpowers/worktrees/assay-2173-process-bounds`  
**Toolchain:** `rustc 1.96.0`, `cargo 1.96.0`

### Contract changes

- `tests/support/agent_golden_path.rs` owns the single expected-outcome lookup and post-observation registration rule.
- `tests/support/bounded_process.rs` provides the shared deadline/output-bounded child runner and cross-platform self-tests.
- The real contract binary set is asserted as exactly `{assay, assay-mcp-server}`.
- Golden-path subprocess limits are 10 seconds and 1 MiB per output stream; diagnostic excerpts are bounded to 4096 bytes.

### TDD and mutation evidence

- RED: shared process API absent before implementation.
- Lookup-only mutation fails exact coverage with missing `("install-check", "success")`.
- Third-binary mutation fails with actual `{assay, assay-mcp-server, other}` versus the exact allowed set.
- Hanging-child test terminates and reaps the child with command context in the diagnostic.
- Stdout and asymmetric stderr flood tests terminate/reap the child and pin their independent ceilings.
- Mutating stderr to use the stdout ceiling fails the new stderr assertion.
- Raising the diagnostic excerpt ceiling fails the truncation assertion.
- Windows timeout uses the native indefinite `ping -t 127.0.0.1` form and is included through the non-excluded MCP integration crate.

### Verification

```text
cargo test -p assay-cli --test agent_golden_path_contract --locked
# 19 passed

cargo test -p assay-mcp-server --test agent_golden_path_contract --locked
# 13 passed

cargo test -p assay-cli --locked
cargo test -p assay-mcp-server --locked
cargo fmt --all -- --check
cargo clippy -p assay-cli -p assay-mcp-server --all-targets --all-features --locked -- -D warnings
python3 scripts/ci/test-agent-golden-path-skill.py
sh scripts/ci/check-docs-generated-drift.sh
cargo test -p assay-sim --locked
cargo test -p assay-core agentic::tests --locked
cargo test -p assay-core judge_internal::tests::contract --locked
git diff --check
pre-commit run --all-files
pre-commit run --hook-stage pre-push --all-files
# all passed for the changed tree; push hooks passed on final head
```

The simulation and AI-oriented checks include the full `assay-sim` suite, the core agentic tests, and judge contract tests.

### Failure policy

- Timeout or output overflow is fail-closed for the test: kill, reap, and return a bounded diagnostic.
- A scenario is not credited merely for looking up its expected outcome; it must record an observed result.
- Unknown binaries fail exact contract coverage instead of being ignored by per-binary filters.

### Review disposition

The first exact-head review found that the prior inline Windows `cmd` label was not a reliable hang and that stderr/truncation mutation coverage was incomplete. Both are fixed on this head. The broader process-tree/inherited-pipe and early-EPIPE semantics remain outside the safe current callsites and are tracked in #2189 before plugin commands may reuse this runner.

### Non-claims

- No Python version pin.
- No process-tree kill guarantee.
- No new ceiling on generated, tracked contract artifacts.
