### PR TITLE
test(process): bound subprocess trees and preserve early exits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "once_cell",
  "pkcs8 0.11.0",
  "predicates",
+ "process-wrap",
  "proptest",
  "rand 0.8.7",
  "ratatui",
@@ -421,7 +422,9 @@ dependencies = [
  "clap",
  "hex",
  "jsonwebtoken",
+ "libc",
  "moka",
+ "process-wrap",
  "rand 0.8.7",
  "reqwest 0.12.28",
  "rsa",
@@ -3833,6 +3836,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "indexmap",
+ "nix 0.31.3",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,7 +5150,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -5970,6 +5984,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5989,6 +6024,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6018,6 +6064,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -6119,6 +6175,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ clap = { version = "4", features = ["derive", "env"] }
 uuid = { version = "1.23", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"], default-features = false }
 tempfile = "3"
+process-wrap = { version = "9.1", default-features = false }
 regex = "1"
 async-trait = "0.1"
 sha2 = "0.11"

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -123,3 +123,9 @@ predicates = "3.1.4"
 proptest = "1.10"
 serial_test = "3.5.0"
 criterion = "0.8"
+
+[target.'cfg(unix)'.dev-dependencies]
+process-wrap = { workspace = true, features = ["process-group", "std"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+process-wrap = { workspace = true, features = ["job-object", "std"] }

--- a/crates/assay-cli/tests/agent_golden_path_contract.rs
+++ b/crates/assay-cli/tests/agent_golden_path_contract.rs
@@ -141,7 +141,7 @@ fn assay<S: AsRef<OsStr>>(cwd: &Path, args: &[S]) -> Output {
     }
     command.current_dir(cwd).env("NO_COLOR", "1").args(args);
     run_bounded(
-        &mut command,
+        command,
         b"",
         GOLDEN_PATH_LIMITS,
         "agent golden-path CLI command",

--- a/crates/assay-mcp-server/Cargo.toml
+++ b/crates/assay-mcp-server/Cargo.toml
@@ -51,3 +51,10 @@ base64 = "0.22"
 # uuid = { version = "1.0", features = ["v4"] } # Removed in favor of SystemTime
 rsa = "0.9"
 rand = "0.8"
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+process-wrap = { workspace = true, features = ["process-group", "std"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+process-wrap = { workspace = true, features = ["job-object", "std"] }

--- a/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
+++ b/crates/assay-mcp-server/tests/agent_golden_path_contract.rs
@@ -145,7 +145,7 @@ fn run_server<S: AsRef<OsStr>>(cwd: &Path, args: &[S], stdin: &[u8]) -> Output {
     let mut command = clean_server_command();
     command.current_dir(cwd).args(args);
     run_bounded(
-        &mut command,
+        command,
         stdin,
         GOLDEN_PATH_LIMITS,
         "agent golden-path MCP command",
@@ -166,7 +166,7 @@ fn required_python() -> &'static str {
     let mut command = Command::new(interpreter);
     command.arg("--version");
     let output = run_bounded(
-        &mut command,
+        command,
         b"",
         GOLDEN_PATH_LIMITS,
         "protected-action Python preflight",

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -82,7 +82,6 @@ pub fn run_bounded(
     let mut child = command
         .spawn()
         .map_err(|error| format!("{context}: spawn {command_display}: {error}"))?;
-
     let mut child_stdin = child
         .stdin()
         .take()
@@ -121,19 +120,18 @@ pub fn run_bounded(
     let mut early_failure = None;
     let mut observed_status = None;
     let status = loop {
-        if let Ok(stream) = overflow_rx.try_recv() {
-            early_failure = Some(format!(
-                "{} exceeded its {}-byte ceiling",
-                stream.name(),
-                stream_limit(limits, stream)
-            ));
-            break terminate_and_reap(
-                child.as_mut(),
-                observed_status.take(),
-                context,
-                &command_display,
-            )?;
+        if early_failure.is_none() {
+            if let Ok(stream) = overflow_rx.try_recv() {
+                // The reader closes its pipe after limit + 1 bytes. Keep the
+                // child under this same deadline while it observes the close.
+                early_failure = Some(format!(
+                    "{} exceeded its {}-byte ceiling",
+                    stream.name(),
+                    stream_limit(limits, stream)
+                ));
+            }
         }
+
         if observed_status.is_none() {
             match child.try_wait() {
                 Ok(Some(status)) => observed_status = Some(status),
@@ -159,7 +157,9 @@ pub fn run_bounded(
         }
 
         if Instant::now() >= deadline {
-            early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
+            if early_failure.is_none() {
+                early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
+            }
             break terminate_and_reap(
                 child.as_mut(),
                 observed_status.take(),
@@ -212,6 +212,8 @@ pub fn run_bounded(
             &stderr,
         ));
     }
+    // Status and both output streams are already collected, so BrokenPipe here
+    // records an early stdin close without replacing the child's outcome.
     stdin_result.or_else(|error| {
         if error.kind() == std::io::ErrorKind::BrokenPipe {
             return Ok(());
@@ -300,7 +302,7 @@ fn finish_process_tree(
 ) -> Result<(), String> {
     match child.start_kill() {
         Ok(()) => Ok(()),
-        Err(error) if process_tree_absent(&error) => Ok(()),
+        Err(error) if process_tree_quiescent_after_io(&error) => Ok(()),
         Err(error) => Err(format!(
             "{context}: terminate remaining process tree for {command}: {error}"
         )),
@@ -309,13 +311,25 @@ fn finish_process_tree(
 
 #[cfg(unix)]
 fn process_tree_absent(error: &std::io::Error) -> bool {
-    // macOS may report EPERM when the owned group has only an already-reaped leader.
-    matches!(error.raw_os_error(), Some(libc::ESRCH) | Some(libc::EPERM))
+    error.raw_os_error() == Some(libc::ESRCH)
 }
 
 #[cfg(windows)]
 fn process_tree_absent(_error: &std::io::Error) -> bool {
     false
+}
+
+#[cfg(unix)]
+fn process_tree_quiescent_after_io(error: &std::io::Error) -> bool {
+    // macOS may report EPERM for an already-empty group. This is accepted only
+    // after child status, stdin, stdout, and stderr are all complete, so it can
+    // never lead into a blocking join on a live inherited pipe.
+    matches!(error.raw_os_error(), Some(libc::ESRCH) | Some(libc::EPERM))
+}
+
+#[cfg(windows)]
+fn process_tree_quiescent_after_io(error: &std::io::Error) -> bool {
+    process_tree_absent(error)
 }
 
 fn stream_limit(limits: ProcessLimits, stream: CapturedStream) -> usize {
@@ -366,6 +380,8 @@ fn excerpt(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use super::{process_tree_absent, process_tree_quiescent_after_io};
     use super::{run_bounded, ProcessLimits};
     use std::path::Path;
     use std::process::{Command, Stdio};
@@ -424,14 +440,14 @@ mod tests {
     #[cfg(windows)]
     fn inherited_output_descendant_command(pid_file: &Path) -> Command {
         let mut command = Command::new("powershell.exe");
+        command.env("ASSAY_DESCENDANT_PID_FILE", pid_file);
         command.args([
             "-NoLogo",
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            "$p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -NoNewWindow -PassThru; [IO.File]::WriteAllText($args[0], [string]$p.Id); [Console]::Out.Write('parent-ready')",
+            "$path = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID_FILE'); $p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -NoNewWindow -PassThru; [IO.File]::WriteAllText($path, [string]$p.Id); [Console]::Out.Write('parent-ready')",
         ]);
-        command.arg(pid_file);
         command
     }
 
@@ -474,15 +490,17 @@ mod tests {
 
     #[cfg(windows)]
     fn descendant_is_alive(pid: u32) -> bool {
-        Command::new("powershell.exe")
+        let mut command = Command::new("powershell.exe");
+        command
+            .env("ASSAY_DESCENDANT_PID", pid.to_string())
             .args([
                 "-NoLogo",
                 "-NoProfile",
                 "-NonInteractive",
                 "-Command",
-                "if (Get-Process -Id $args[0] -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
-                &pid.to_string(),
-            ])
+                "$pid = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID'); if (Get-Process -Id $pid -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
+            ]);
+        command
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
@@ -625,5 +643,14 @@ mod tests {
         assert_eq!(output.status.code(), Some(23));
         assert!(output.stdout.is_empty());
         assert!(output.stderr.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn eperm_is_quiescent_only_after_all_io_is_complete() {
+        let error = std::io::Error::from_raw_os_error(libc::EPERM);
+
+        assert!(!process_tree_absent(&error));
+        assert!(process_tree_quiescent_after_io(&error));
     }
 }

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -539,6 +539,14 @@ mod tests {
         !descendant_is_alive(pid)
     }
 
+    #[test]
+    fn liveness_probe_recognizes_the_current_test_process() {
+        assert!(
+            descendant_is_alive(std::process::id()),
+            "liveness probe must distinguish a live process from an exited descendant"
+        );
+    }
+
     #[cfg(windows)]
     fn stderr_flood_command() -> Command {
         let mut command = Command::new("cmd");

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -5,6 +5,12 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(windows)]
+use process_wrap::std::JobObject;
+#[cfg(unix)]
+use process_wrap::std::ProcessGroup;
+use process_wrap::std::{ChildWrapper, CommandWrap};
+
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const MAX_DIAGNOSTIC_BYTES: usize = 4096;
 
@@ -43,8 +49,14 @@ impl CapturedStream {
     }
 }
 
+/// Runs one non-interactive command and owns its subprocess tree for the call.
+///
+/// A hard termination is sent to descendants that remain in the Unix process
+/// group or Windows Job Object before this function returns. Processes that
+/// deliberately escape those OS containers are outside this test helper's
+/// supported process shape.
 pub fn run_bounded(
-    command: &mut Command,
+    mut command: Command,
     stdin: &[u8],
     limits: ProcessLimits,
     context: &str,
@@ -57,25 +69,30 @@ pub fn run_bounded(
         limits.max_stderr_bytes > 0,
         "stderr ceiling must be positive"
     );
-    let command_display = display_command(command);
+    let command_display = display_command(&command);
     command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    let mut command = CommandWrap::from(command);
+    #[cfg(unix)]
+    command.wrap(ProcessGroup::leader());
+    #[cfg(windows)]
+    command.wrap(JobObject);
     let mut child = command
         .spawn()
         .map_err(|error| format!("{context}: spawn {command_display}: {error}"))?;
 
     let mut child_stdin = child
-        .stdin
+        .stdin()
         .take()
         .ok_or_else(|| format!("{context}: {command_display}: child stdin was not piped"))?;
     let child_stdout = child
-        .stdout
+        .stdout()
         .take()
         .ok_or_else(|| format!("{context}: {command_display}: child stdout was not piped"))?;
     let child_stderr = child
-        .stderr
+        .stderr()
         .take()
         .ok_or_else(|| format!("{context}: {command_display}: child stderr was not piped"))?;
 
@@ -102,6 +119,7 @@ pub fn run_bounded(
 
     let deadline = Instant::now() + limits.timeout;
     let mut early_failure = None;
+    let mut observed_status = None;
     let status = loop {
         if let Ok(stream) = overflow_rx.try_recv() {
             early_failure = Some(format!(
@@ -109,22 +127,47 @@ pub fn run_bounded(
                 stream.name(),
                 stream_limit(limits, stream)
             ));
-            break kill_and_reap(&mut child, context, &command_display)?;
+            break terminate_and_reap(
+                child.as_mut(),
+                observed_status.take(),
+                context,
+                &command_display,
+            )?;
         }
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) if Instant::now() >= deadline => {
-                early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
-                break kill_and_reap(&mut child, context, &command_display)?;
-            }
-            Ok(None) => thread::sleep(POLL_INTERVAL),
-            Err(error) => {
-                let reap = kill_and_reap(&mut child, context, &command_display);
-                return Err(format!(
-                    "{context}: poll {command_display}: {error}; kill/reap: {reap:?}"
-                ));
+        if observed_status.is_none() {
+            match child.try_wait() {
+                Ok(Some(status)) => observed_status = Some(status),
+                Ok(None) => {}
+                Err(error) => {
+                    let reap = terminate_and_reap(child.as_mut(), None, context, &command_display);
+                    return Err(format!(
+                        "{context}: poll {command_display}: {error}; terminate/reap: {reap:?}"
+                    ));
+                }
             }
         }
+
+        if observed_status.is_some()
+            && stdin_writer.is_finished()
+            && stdout_reader.is_finished()
+            && stderr_reader.is_finished()
+        {
+            finish_process_tree(child.as_mut(), context, &command_display)?;
+            break observed_status
+                .take()
+                .expect("status was checked immediately above");
+        }
+
+        if Instant::now() >= deadline {
+            early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
+            break terminate_and_reap(
+                child.as_mut(),
+                observed_status.take(),
+                context,
+                &command_display,
+            )?;
+        }
+        thread::sleep(POLL_INTERVAL);
     };
 
     let stdin_result = stdin_writer
@@ -169,15 +212,18 @@ pub fn run_bounded(
             &stderr,
         ));
     }
-    stdin_result.map_err(|error| {
-        failure_diagnostic(
+    stdin_result.or_else(|error| {
+        if error.kind() == std::io::ErrorKind::BrokenPipe {
+            return Ok(());
+        }
+        Err(failure_diagnostic(
             context,
             &command_display,
             &format!("write stdin: {error}"),
             &status,
             &stdout,
             &stderr,
-        )
+        ))
     })?;
 
     Ok(Output {
@@ -217,17 +263,59 @@ fn join_reader(
         .map_err(|error| format!("{context}: read {stream} from {command}: {error}"))
 }
 
-fn kill_and_reap(
-    child: &mut std::process::Child,
+fn terminate_and_reap(
+    child: &mut dyn ChildWrapper,
+    observed_status: Option<ExitStatus>,
     context: &str,
     command: &str,
 ) -> Result<ExitStatus, String> {
-    let kill_error = child.kill().err();
-    child.wait().map_err(|wait_error| {
+    let tree_error = child
+        .start_kill()
+        .err()
+        .filter(|error| !process_tree_absent(error));
+    let direct_kill_error = tree_error
+        .as_ref()
+        .and_then(|_| child.inner_mut().start_kill().err());
+    let status = match observed_status {
+        Some(status) => Ok(status),
+        None => child.wait(),
+    }
+    .map_err(|wait_error| {
         format!(
-            "{context}: failed to reap {command} after kill; kill={kill_error:?}; wait={wait_error}"
+            "{context}: failed to reap {command} after tree termination; tree={tree_error:?}; direct_kill={direct_kill_error:?}; wait={wait_error}"
         )
-    })
+    })?;
+    if let Some(tree_error) = tree_error {
+        return Err(format!(
+            "{context}: failed to terminate process tree for {command}: {tree_error}; direct_kill={direct_kill_error:?}; status={status}"
+        ));
+    }
+    Ok(status)
+}
+
+fn finish_process_tree(
+    child: &mut dyn ChildWrapper,
+    context: &str,
+    command: &str,
+) -> Result<(), String> {
+    match child.start_kill() {
+        Ok(()) => Ok(()),
+        Err(error) if process_tree_absent(&error) => Ok(()),
+        Err(error) => Err(format!(
+            "{context}: terminate remaining process tree for {command}: {error}"
+        )),
+    }
+}
+
+#[cfg(unix)]
+fn process_tree_absent(error: &std::io::Error) -> bool {
+    // macOS may report EPERM when the owned group has only an already-reaped leader.
+    matches!(error.raw_os_error(), Some(libc::ESRCH) | Some(libc::EPERM))
+}
+
+#[cfg(windows)]
+fn process_tree_absent(_error: &std::io::Error) -> bool {
+    false
 }
 
 fn stream_limit(limits: ProcessLimits, stream: CapturedStream) -> usize {
@@ -279,8 +367,11 @@ fn excerpt(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::{run_bounded, ProcessLimits};
-    use std::process::Command;
-    use std::time::Duration;
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     #[cfg(unix)]
     fn hanging_command() -> Command {
@@ -317,6 +408,120 @@ mod tests {
         command
     }
 
+    #[cfg(unix)]
+    fn inherited_output_descendant_command(pid_file: &Path) -> Command {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(
+                "sh -c 'echo \"$$\" > \"$1\"; while :; do :; done' descendant \"$1\" & printf parent-ready",
+            )
+            .arg("runner")
+            .arg(pid_file);
+        command
+    }
+
+    #[cfg(windows)]
+    fn inherited_output_descendant_command(pid_file: &Path) -> Command {
+        let mut command = Command::new("powershell.exe");
+        command.args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -NoNewWindow -PassThru; [IO.File]::WriteAllText($args[0], [string]$p.Id); [Console]::Out.Write('parent-ready')",
+        ]);
+        command.arg(pid_file);
+        command
+    }
+
+    #[cfg(unix)]
+    fn early_exit_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 23"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn early_exit_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "exit", "/B", "23"]);
+        command
+    }
+
+    fn read_descendant_pid(pid_file: &Path) -> Option<u32> {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            if let Ok(raw) = std::fs::read_to_string(pid_file) {
+                if let Ok(pid) = raw.trim().parse() {
+                    return Some(pid);
+                }
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        None
+    }
+
+    #[cfg(unix)]
+    fn descendant_is_alive(pid: u32) -> bool {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    #[cfg(windows)]
+    fn descendant_is_alive(pid: u32) -> bool {
+        Command::new("powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "if (Get-Process -Id $args[0] -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
+                &pid.to_string(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    fn wait_for_descendant_exit(pid: u32) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            if !descendant_is_alive(pid) {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        !descendant_is_alive(pid)
+    }
+
+    #[cfg(unix)]
+    fn cleanup_descendant(pid_file: &Path) {
+        if let Some(pid) = read_descendant_pid(pid_file) {
+            let _ = Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+    }
+
+    #[cfg(windows)]
+    fn cleanup_descendant(pid_file: &Path) {
+        if let Some(pid) = read_descendant_pid(pid_file) {
+            let _ = Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+    }
+
     #[cfg(windows)]
     fn stderr_flood_command() -> Command {
         let mut command = Command::new("cmd");
@@ -329,9 +534,9 @@ mod tests {
 
     #[test]
     fn kills_timeout_and_reports_context() {
-        let mut command = hanging_command();
+        let command = hanging_command();
         let limits = ProcessLimits::new(Duration::from_millis(100), 1024, 1024);
-        let error = run_bounded(&mut command, b"", limits, "hanging mutation")
+        let error = run_bounded(command, b"", limits, "hanging mutation")
             .expect_err("hanging child must time out");
         assert!(error.contains("hanging mutation"));
         assert!(error.contains("deadline"));
@@ -339,28 +544,86 @@ mod tests {
 
     #[test]
     fn kills_stdout_flood() {
-        let mut command = stdout_flood_command();
+        let command = stdout_flood_command();
         let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 2048);
-        let error = run_bounded(&mut command, b"", limits, "stdout flood mutation")
+        let error = run_bounded(command, b"", limits, "stdout flood mutation")
             .expect_err("stdout flood must exceed its ceiling");
         assert!(error.contains("stdout flood mutation"));
         assert!(error.contains("stdout"));
-        assert!(error.contains("1024-byte ceiling"));
+        assert!(error.contains("1024-byte ceiling"), "{error}");
     }
 
     #[test]
     fn stderr_flood_uses_its_own_ceiling_and_bounded_diagnostic() {
-        let mut command = stderr_flood_command();
+        let command = stderr_flood_command();
         let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 8192);
-        let error = run_bounded(&mut command, b"", limits, "stderr flood mutation")
+        let error = run_bounded(command, b"", limits, "stderr flood mutation")
             .expect_err("stderr flood must exceed its ceiling");
         assert!(error.contains("stderr flood mutation"));
-        assert!(error.contains("stderr exceeded its 8192-byte ceiling"));
+        assert!(
+            error.contains("stderr exceeded its 8192-byte ceiling"),
+            "{error}"
+        );
         assert!(error.contains("... (8193 bytes total)"));
         assert!(
             error.len() < 5000,
             "diagnostic escaped its bounded excerpt: {} bytes",
             error.len()
         );
+    }
+
+    #[test]
+    fn kills_descendant_that_holds_inherited_output_open() {
+        let temp = tempfile::tempdir().expect("temporary pid directory");
+        let pid_file = temp.path().join("descendant.pid");
+        let cleanup_path = pid_file.clone();
+        let (result_tx, result_rx) = mpsc::channel();
+        let started = Instant::now();
+
+        let worker = thread::spawn(move || {
+            let command = inherited_output_descendant_command(&pid_file);
+            let limits = ProcessLimits::new(Duration::from_millis(250), 1024, 1024);
+            let result = run_bounded(command, b"", limits, "inherited output mutation");
+            let _ = result_tx.send(result);
+        });
+
+        let result = match result_rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(error) => {
+                cleanup_descendant(&cleanup_path);
+                let _ = result_rx.recv_timeout(Duration::from_secs(2));
+                let _ = worker.join();
+                panic!("runner escaped its wall-clock bound: {error}");
+            }
+        };
+        worker.join().expect("bounded runner worker");
+
+        let error = result.expect_err("inherited output holder must force tree termination");
+        assert!(error.contains("inherited output mutation"));
+        assert!(error.contains("deadline"));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "process-tree cleanup exceeded the test bound"
+        );
+        let descendant_pid = read_descendant_pid(&cleanup_path)
+            .expect("descendant must publish its pid before inheriting output");
+        if !wait_for_descendant_exit(descendant_pid) {
+            cleanup_descendant(&cleanup_path);
+            panic!("descendant {descendant_pid} survived process-tree termination");
+        }
+    }
+
+    #[test]
+    fn preserves_child_outcome_when_stdin_closes_early() {
+        let command = early_exit_command();
+        let stdin = vec![b'x'; 8 * 1024 * 1024];
+        let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 1024);
+
+        let output = run_bounded(command, &stdin, limits, "early stdin close mutation")
+            .expect("BrokenPipe must not hide an observed child outcome");
+
+        assert_eq!(output.status.code(), Some(23));
+        assert!(output.stdout.is_empty());
+        assert!(output.stderr.is_empty());
     }
 }

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -519,7 +519,7 @@ mod tests {
                 "-NoProfile",
                 "-NonInteractive",
                 "-Command",
-                "$pid = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID'); if (Get-Process -Id $pid -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
+                "$targetPid = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID'); if (Get-Process -Id $targetPid -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
             ]);
         command
             .stdout(Stdio::null())

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -12,6 +12,7 @@ use process_wrap::std::ProcessGroup;
 use process_wrap::std::{ChildWrapper, CommandWrap};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const REAP_GRACE: Duration = Duration::from_secs(1);
 const MAX_DIAGNOSTIC_BYTES: usize = 4096;
 
 #[derive(Clone, Copy)]
@@ -278,13 +279,9 @@ fn terminate_and_reap(
     let direct_kill_error = tree_error
         .as_ref()
         .and_then(|_| child.inner_mut().start_kill().err());
-    let status = match observed_status {
-        Some(status) => Ok(status),
-        None => child.wait(),
-    }
-    .map_err(|wait_error| {
+    let status = reap_after_tree_kill(child, observed_status).map_err(|reap_error| {
         format!(
-            "{context}: failed to reap {command} after tree termination; tree={tree_error:?}; direct_kill={direct_kill_error:?}; wait={wait_error}"
+            "{context}: failed to reap {command} after tree termination; tree={tree_error:?}; direct_kill={direct_kill_error:?}; reap={reap_error}"
         )
     })?;
     if let Some(tree_error) = tree_error {
@@ -293,6 +290,25 @@ fn terminate_and_reap(
         ));
     }
     Ok(status)
+}
+
+fn reap_after_tree_kill(
+    child: &mut dyn ChildWrapper,
+    observed_status: Option<ExitStatus>,
+) -> Result<ExitStatus, String> {
+    if let Some(status) = observed_status {
+        return Ok(status);
+    }
+
+    let deadline = Instant::now() + REAP_GRACE;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if Instant::now() < deadline => thread::sleep(POLL_INTERVAL),
+            Ok(None) => return Err(format!("reap grace of {REAP_GRACE:?} expired")),
+            Err(error) => return Err(format!("poll after termination: {error}")),
+        }
+    }
 }
 
 fn finish_process_tree(
@@ -319,12 +335,17 @@ fn process_tree_absent(_error: &std::io::Error) -> bool {
     false
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "macos")]
 fn process_tree_quiescent_after_io(error: &std::io::Error) -> bool {
     // macOS may report EPERM for an already-empty group. This is accepted only
     // after child status, stdin, stdout, and stderr are all complete, so it can
     // never lead into a blocking join on a live inherited pipe.
     matches!(error.raw_os_error(), Some(libc::ESRCH) | Some(libc::EPERM))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn process_tree_quiescent_after_io(error: &std::io::Error) -> bool {
+    process_tree_absent(error)
 }
 
 #[cfg(windows)]
@@ -518,34 +539,59 @@ mod tests {
         !descendant_is_alive(pid)
     }
 
-    #[cfg(unix)]
-    fn cleanup_descendant(pid_file: &Path) {
-        if let Some(pid) = read_descendant_pid(pid_file) {
-            let _ = Command::new("kill")
-                .args(["-9", &pid.to_string()])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status();
-        }
-    }
-
-    #[cfg(windows)]
-    fn cleanup_descendant(pid_file: &Path) {
-        if let Some(pid) = read_descendant_pid(pid_file) {
-            let _ = Command::new("taskkill")
-                .args(["/PID", &pid.to_string(), "/T", "/F"])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status();
-        }
-    }
-
     #[cfg(windows)]
     fn stderr_flood_command() -> Command {
         let mut command = Command::new("cmd");
         command.args([
             "/C",
             "for /L %i in (1,1,1000000) do @echo 0123456789abcdef 1>&2",
+        ]);
+        command
+    }
+
+    #[cfg(unix)]
+    fn descendant_run_timeout() -> Duration {
+        Duration::from_millis(250)
+    }
+
+    #[cfg(windows)]
+    fn descendant_run_timeout() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    #[cfg(unix)]
+    fn descendant_test_guard() -> Duration {
+        Duration::from_secs(2)
+    }
+
+    #[cfg(windows)]
+    fn descendant_test_guard() -> Duration {
+        Duration::from_secs(10)
+    }
+
+    #[cfg(unix)]
+    fn quiet_descendant_command(pid_file: &Path) -> Command {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(
+                "sh -c 'echo \"$$\" > \"$1\"; exec </dev/null >/dev/null 2>&1; while :; do :; done' descendant \"$1\" & while [ ! -s \"$1\" ]; do :; done; printf parent-ready",
+            )
+            .arg("runner")
+            .arg(pid_file);
+        command
+    }
+
+    #[cfg(windows)]
+    fn quiet_descendant_command(pid_file: &Path) -> Command {
+        let mut command = Command::new("powershell.exe");
+        command.env("ASSAY_DESCENDANT_PID_FILE", pid_file);
+        command.args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$path = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID_FILE'); $p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -WindowStyle Hidden -PassThru; [IO.File]::WriteAllText($path, [string]$p.Id); [Console]::Out.Write('parent-ready')",
         ]);
         command
     }
@@ -600,19 +646,14 @@ mod tests {
 
         let worker = thread::spawn(move || {
             let command = inherited_output_descendant_command(&pid_file);
-            let limits = ProcessLimits::new(Duration::from_millis(250), 1024, 1024);
+            let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
             let result = run_bounded(command, b"", limits, "inherited output mutation");
             let _ = result_tx.send(result);
         });
 
-        let result = match result_rx.recv_timeout(Duration::from_secs(2)) {
+        let result = match result_rx.recv_timeout(descendant_test_guard()) {
             Ok(result) => result,
-            Err(error) => {
-                cleanup_descendant(&cleanup_path);
-                let _ = result_rx.recv_timeout(Duration::from_secs(2));
-                let _ = worker.join();
-                panic!("runner escaped its wall-clock bound: {error}");
-            }
+            Err(error) => panic!("runner escaped its wall-clock bound: {error}"),
         };
         worker.join().expect("bounded runner worker");
 
@@ -620,15 +661,34 @@ mod tests {
         assert!(error.contains("inherited output mutation"));
         assert!(error.contains("deadline"));
         assert!(
-            started.elapsed() < Duration::from_secs(2),
+            started.elapsed() < descendant_test_guard(),
             "process-tree cleanup exceeded the test bound"
         );
         let descendant_pid = read_descendant_pid(&cleanup_path)
             .expect("descendant must publish its pid before inheriting output");
         if !wait_for_descendant_exit(descendant_pid) {
-            cleanup_descendant(&cleanup_path);
             panic!("descendant {descendant_pid} survived process-tree termination");
         }
+    }
+
+    #[test]
+    fn kills_quiet_descendant_after_normal_parent_exit() {
+        let temp = tempfile::tempdir().expect("temporary pid directory");
+        let pid_file = temp.path().join("quiet-descendant.pid");
+        let command = quiet_descendant_command(&pid_file);
+        let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
+
+        let output = run_bounded(command, b"", limits, "normal completion mutation")
+            .expect("normal parent completion must retain its outcome");
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"parent-ready");
+        let descendant_pid =
+            read_descendant_pid(&pid_file).expect("quiet descendant must publish its pid");
+        assert!(
+            wait_for_descendant_exit(descendant_pid),
+            "quiet descendant {descendant_pid} survived normal completion cleanup"
+        );
     }
 
     #[test]
@@ -647,10 +707,13 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn eperm_is_quiescent_only_after_all_io_is_complete() {
+    fn eperm_is_quiescent_only_on_macos_after_all_io_is_complete() {
         let error = std::io::Error::from_raw_os_error(libc::EPERM);
 
         assert!(!process_tree_absent(&error));
+        #[cfg(target_os = "macos")]
         assert!(process_tree_quiescent_after_io(&error));
+        #[cfg(not(target_os = "macos"))]
+        assert!(!process_tree_quiescent_after_io(&error));
     }
 }


### PR DESCRIPTION
## Summary

- own each bounded one-shot test command through a Unix process group or Windows Job Object
- terminate descendants on timeout, output overflow, and normal direct-child completion
- preserve an observed child status when the stdin writer receives `BrokenPipe`
- add bounded cross-platform regressions for inherited-output descendants, quiet descendants, early stdin close, and platform-specific `EPERM`

Closes #2189.

## Scope / non-scope

Changed behavior is confined to the shared integration-test helper used by the CLI and MCP golden-path contracts. No production process supervisor, CLI schema, MCP protocol, or interactive JSON-RPC path changes.

Processes that deliberately escape the owned process group or Job Object remain outside the supported shape.

## Design

`process-wrap 9.1` is pinned once in workspace dependencies and enabled per target:

- Unix: `ProcessGroup::leader()`
- Windows: `JobObject`, which starts suspended and assigns the process before resume
- both dependencies are dev-only

The helper waits for child status, stdin completion, and bounded stdout/stderr readers under one deadline. Output overflow closes the reader pipe at `limit + 1` and remains under that deadline. Tree termination is followed by a separate one-second polling grace; no `Child::wait()` remains. `BrokenPipe` is ignored only at the final ordering point, after status and both output streams have been collected, so it cannot replace the child outcome.

## Review packet

**Base:** `main`

**Head measured:** `207da8ce958621c2f10d81c281387d51054f6772`

**Worktree:** `/Users/roelschuurkes/.config/superpowers/worktrees/assay-2189-process-tree`

**Hot file:** `tests/support/bounded_process.rs`

**Risk flags:**

- production behavior: no
- public output/schema: no
- test process isolation: yes
- cross-platform behavior: yes
- new dependency: dev-only, `cargo deny` accepted

## TDD and mutation proof

RED before implementation:

- inherited-output descendant: runner escaped its wall-clock bound after 2.01 seconds
- 8 MiB stdin with child exit 23: runner returned `Broken pipe (os error 32)` instead of status 23

Mutations killed by the final tests:

- removing `ProcessGroup::leader()` reproduces the bounded outer timeout
- rejecting `BrokenPipe` reproduces the status-23 masking failure
- replacing normal-completion tree cleanup with a no-op leaves the quiet descendant alive and fails its PID assertion
- accepting `EPERM` in the strict tree-absence classifier fails the platform boundary assertion
- the inherited-output test pins the spawned PID and fails if it survives tree termination

## Review dispositions

Review on the prior head found four blockers; all are addressed on the measured head:

1. Windows fixture values use environment variables rather than trailing PowerShell `$args`; the liveness probe also avoids the read-only, case-insensitive `$PID` automatic variable by using `$targetPid`. The Windows inner deadline is 5 seconds with a separate 10-second test guard.
2. The guard failure path performs no unbounded join or cleanup command. It fails immediately; the normal result path joins only after the worker has sent its terminal result.
3. A quiet descendant closes inherited stdio while its parent exits normally; the test preserves the parent outcome and proves the descendant is killed. The no-op mutation fails.
4. `EPERM` is never process-tree absence. It is accepted only on macOS, only in the post-status/post-I/O normal-completion path; Linux and forced termination accept only `ESRCH`.

CodeRabbit's poll-error finding is also fixed: post-kill reaping is a bounded `try_wait()` loop, not `wait()`. Its PID-reuse nit is dispositioned by removing cleanup signals entirely; the short liveness poll can now only produce a conservative test failure, never signal a reused unrelated PID. A positive calibration test pins that the platform liveness probe recognizes the current test process, so an always-dead probe cannot make descendant assertions pass.

## Verification

On the measured tree committed as the head above:

- `cargo test -p assay-cli` - pass
- `cargo test -p assay-mcp-server` - pass
- CLI bounded runner module - 8/8 pass
- MCP bounded runner module - 8/8 pass
- `cargo clippy -p assay-cli -p assay-mcp-server --all-targets --all-features -- -D warnings` - pass
- `cargo fmt --all -- --check` - pass
- `cargo deny check` - pass; existing duplicate/yanked/unmatched-license warnings only
- exact-file pre-commit - pass
- pre-push workspace clippy, RustSec audit, and Linux cross-target gate - pass
- `git diff --check` - pass

Dedicated feature proof in an isolated target from the first implementation commit remains applicable because later commits touch only the shared helper:

- `cargo test -p assay-mcp-server --features test-outbound --locked no_passthrough` - 1/1 pass

Delegated exact-head proof in progress:

- gate: `all`
- run: https://github.com/Rul1an/assay/actions/runs/31334297252
- sha: `207da8ce958621c2f10d81c281387d51054f6772`

## Known test-harness interaction

A synthetic combined command over `assay-cli` and `assay-mcp-server` with `--all-features` can fail `no_passthrough_e2e`: the existing CLI `e2e_mcp_wrap_assert_cmd` performs a nested featureless server build into the same Cargo uplift path. The test file already documents this Cargo behavior. The canonical package suites and isolated feature gate pass; this PR does not weaken or alter that gate.

## Platform non-claim

The local host proved macOS behavior and the pre-push gate proved Linux compilation. No Windows Rust target is installed locally, so Job Object runtime behavior is delegated to the final-head Windows GitHub Actions job and is not claimed before that job passes.

## Fail policy

- timeout/output overflow: fail closed after process-tree termination and bounded diagnostics
- process-tree termination/reap error: fail closed within a bounded grace; direct-child kill is cleanup and the tree error remains primary
- observed child status plus stdin `BrokenPipe`: preserve the child outcome after all observable output is collected
- other stdin failures: fail with bounded diagnostic context
