### PR TITLE
docs(governance): require one independent review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/adr-boundary.md
+++ b/.github/PULL_REQUEST_TEMPLATE/adr-boundary.md
@@ -30,7 +30,7 @@
 ## Review Quorum
 
 - [ ] One non-building agent review
-- [ ] CodeRabbit or Copilot review on this head SHA
-- [ ] If bots were unavailable for 30 minutes, a second non-building agent review is linked
 - [ ] Every actionable finding is fixed or has a technical disposition
 - [ ] Any delegated proof targets this exact head SHA
+
+Optional automated reviews can add evidence, but do not count toward or block quorum.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ including its explicit non-claims, or amend the decision through a new ADR.
 The builder's self-review does not count. On the final head SHA, require one non-building agent
 review that actually reviews the change and records its verdict and findings. Automated reviewers
 may add evidence, but they are not part of the quorum and their absence never needs a substitute.
+A non-building reviewer authored or edited neither the PR's change nor the normative specification
+or implementation plan it claims to satisfy. Prior read-only review of that specification or plan
+does not itself make the reviewer a builder.
 
 A new push invalidates the review on the prior head, and the head a review was measured on is the
 head it counts for — a merge commit that brings `main` into the branch is a new head like any other.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,9 @@ including its explicit non-claims, or amend the decision through a new ADR.
 The builder's self-review does not count. On the final head SHA, require one non-building agent
 review that actually reviews the change and records its verdict and findings. Automated reviewers
 may add evidence, but they are not part of the quorum and their absence never needs a substitute.
-A non-building reviewer authored or edited neither the PR's change nor the normative specification
-or implementation plan it claims to satisfy. Prior read-only review of that specification or plan
-does not itself make the reviewer a builder.
+A non-building reviewer authored or edited neither the PR's change nor any normative specification
+or implementation plan governing that change, whether or not the PR cites the artifact. Prior
+read-only review of that specification or plan does not itself make the reviewer a builder.
 
 A new push invalidates the review on the prior head, and the head a review was measured on is the
 head it counts for — a merge commit that brings `main` into the branch is a new head like any other.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,37 +71,29 @@ including its explicit non-claims, or amend the decision through a new ADR.
 
 ## Review Quorum
 
-The builder's self-review does not count. On the final head SHA, require:
+The builder's self-review does not count. On the final head SHA, require one non-building agent
+review that actually reviews the change and records its verdict and findings. Automated reviewers
+may add evidence, but they are not part of the quorum and their absence never needs a substitute.
 
-1. one non-building agent review plus CodeRabbit or Copilot; or
-2. two non-building agent reviews, when each bot is skipped, silent for 30 minutes after the last
-   push, or declares a limit in its own record on the current head — a declared limit opens that
-   bot's slot immediately, while a merely silent bot still gets its 30 minutes.
-
-`skipped` is not `pass`. A new push invalidates reviews on the prior head, and the head a review was
-measured on is the head it counts for — a merge commit that brings `main` into the branch is a new
-head like any other. A review is revalidated for a new head only by a recorded equivalence check
-with two conditions: the new head introduces no change, to any file, that is not already on `main`
-— its tree is what merging `main` into the reviewed head produces without conflicts — and the
-advance from the reviewed head to the new head touched no file the review covered, meaning the
-PR's changed files as of the reviewed head. The first covers the whole tree, never a file list, so
-content outside the reviewed files cannot ride the carry; the second exists because an upstream
-change to a reviewed file changes what lands even though it smuggles nothing, and "the branch added
-nothing" is a neighbouring property of "what was reviewed is what merges", not the same one. Put
-both checks in the review record; without them, the review does not carry. Rewritten history
-(rebase, squash) does not carry a review even when the tree is identical: revalidation is for
-upstream advances only.
+A new push invalidates the review on the prior head, and the head a review was measured on is the
+head it counts for — a merge commit that brings `main` into the branch is a new head like any other.
+A review is revalidated for a new head only by a recorded equivalence check with two conditions: the
+new head introduces no change, to any file, that is not already on `main` — its tree is what merging
+`main` into the reviewed head produces without conflicts — and the advance from the reviewed head to
+the new head touched no file the review covered, meaning the PR's changed files as of the reviewed
+head. The first covers the whole tree, never a file list, so content outside the reviewed files cannot
+ride the carry; the second exists because an upstream change to a reviewed file changes what lands
+even though it smuggles nothing, and "the branch added nothing" is a neighbouring property of "what
+was reviewed is what merges", not the same one. Put both checks in the review record; without them,
+the review does not carry. Rewritten history (rebase, squash) does not carry a review even when the
+tree is identical: revalidation is for upstream advances only.
 
 A review record that says it did not review is not a review. A bot that returns `COMMENTED` with
 "unable to review — quota limit", or a check that reports `pass` alongside "review rate limited",
 leaves no findings and no reviewer; it is unavailable infrastructure wearing the shape of a verdict,
-and it satisfies neither route. Read what a record says, not that it exists. A limit-shaped record
-is, however, itself the observation that the reviewer is unavailable, and that bot's slot in route
-2 opens immediately — provided the record declaring the limit is on the head the substitution
-covers (quotas reset; an earlier head's limit record does not carry forward), and the review record
-documents which reviewer was limited, which agent reviewed instead, and on which head. Reviews
-count as artifacts bound to an exact head, not as entries in GitHub's review list; a reviewer whose
-tooling cannot submit a review record counts through a comment bound to the SHA it reviewed.
+not a pass. Read what a record says, not that it exists. Reviews count as artifacts bound to an exact
+head, not as entries in GitHub's review list; a reviewer whose tooling cannot submit a review record
+counts through a comment bound to the SHA it reviewed.
 
 Auto-merge may be enabled only when:
 
@@ -167,6 +159,6 @@ so that display and round-trip "can never drift apart".
   plan/read-only mode.
 - Cursor may implement locally in its own worktree. Cursor Background Agents must not mutate auth
   or evidence-boundary code.
-- Bugbot, CodeRabbit, and Copilot are reviewers, not authorities. Their findings require technical
-  verification; their absence is handled by the review fallback above.
+- Bugbot, CodeRabbit, and Copilot are optional reviewers, not authorities. Their findings require
+  technical verification; their absence does not block the non-building-agent quorum above.
 - Heartbeats may monitor status only. They must not generate, edit, commit, push, or merge code.


### PR DESCRIPTION
## Summary

- require one non-building review on the final head SHA
- define non-building so PR/spec/plan authors cannot satisfy their own quorum
- keep stale-review invalidation and exact-head equivalence rules
- make CodeRabbit, Copilot, and Bugbot optional evidence rather than quorum dependencies
- retain required CI and actionable-finding disposition before auto-merge

## Why

This deliberately removes the second independent reader that both previous routes required. That reduces defence in depth, but also removes bot availability and duplicate-review latency from the MVP critical path. The retained control is one reviewer who is independent from both the PR delta and its normative spec/plan, bound to the final SHA; required CI and disposition of every actionable finding remain mandatory.

A reviewer who only reviewed a prior spec/plan remains eligible because read-only review supplied context without authoring the requirement or implementation.

## Compatibility

- no code, schema, workflow, or branch-protection change
- GitHub branch protection currently requires zero platform approvals; review artifacts may continue to be exact-SHA PR comments when the reviewer cannot submit an approval
- this transition PR follows the previous quorum; subsequent PRs use the merged contract

## Verification

- `pre-commit run --files AGENTS.md --show-diff-on-failure`
- `git diff --check`

## Review disposition

Claude's first-head review returned READY with three non-blocking findings. The material finding was the undefined `non-building` boundary; this head defines it. The PR body now states the loss of the second reader explicitly. The remaining placement observation about rate-limit records is retained as useful evidence semantics and does not alter quorum.
