### PR TITLE
feat(plugin): package Claude golden-path marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "assay",
+  "owner": {
+    "name": "Assay"
+  },
+  "plugins": [
+    {
+      "name": "assay",
+      "description": "Connect Claude Code to Assay's MCP policy and evidence tools and golden-path skill.",
+      "source": "./packaging/claude-plugin"
+    }
+  ]
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@ examples/mcp-jsonrpc-id-conformance/** text eol=lf
 .claude-plugin/marketplace.json text eol=lf
 packaging/claude-plugin/.claude-plugin/plugin.json text eol=lf
 packaging/claude-plugin/.mcp.json text eol=lf
+packaging/claude-plugin/skills/assay-golden-path/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@ crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/** text eol=lf
 examples/mcp-jsonrpc-id-conformance/** text eol=lf
 .agents/skills/assay-golden-path/SKILL.md text eol=lf
 .claude/skills/assay-golden-path/SKILL.md text eol=lf
+.claude-plugin/marketplace.json text eol=lf
+packaging/claude-plugin/.claude-plugin/plugin.json text eol=lf
+packaging/claude-plugin/.mcp.json text eol=lf

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -19,6 +19,8 @@ on:
       - "scripts/**"
       - ".agents/**"
       - ".claude/**"
+      - ".claude-plugin/**"
+      - "packaging/claude-plugin/**"
       - ".gitignore"
       - ".gitattributes"
       - ".pre-commit-config.yaml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,7 @@ repos:
         # Both properties this pins have failed here before: `check-aee-seal-fixture-drift.sh`
         # documents an earlier version that ran its emitter in place and destroyed the fixtures it
         # audited, and `check-linux.sh` returned 0 on every failure (#2076).
-        files: ^(scripts/ci/(check-docs-generated-drift|test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot)\.sh|scripts/docs/generate-agent-golden-path\.py|\.(agents|claude)/skills/assay-golden-path/SKILL\.md)$
+        files: ^(scripts/ci/(check-docs-generated-drift|test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot)\.sh|scripts/docs/generate-agent-golden-path\.py|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*)$
 
       - id: docs-generated-drift
         name: Generated docs match their generators
@@ -124,14 +124,14 @@ repos:
         # Caught here instead, the diagram edge lands in the pull request that added the dependency,
         # where a reviewer can see why it moved. It also makes the bot's `has_changes` false by
         # construction, so the un-mergeable PR is never created.
-        files: ^(Cargo\.toml|crates/.*/Cargo\.toml|scripts/docs/.*\.(sh|py)|docs/generated/.*|docs/AIcontext/architecture-diagrams\.md|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|scripts/ci/check-docs-generated-drift\.sh|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|crates/.*/Cargo\.toml|scripts/docs/.*\.(sh|py)|docs/generated/.*|docs/AIcontext/architecture-diagrams\.md|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|scripts/ci/check-docs-generated-drift\.sh|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: agent-golden-path-skill-contract
         name: Agent golden-path skill contract
         entry: bash -c 'python3 scripts/ci/test-agent-golden-path-skill.py && bash scripts/ci/test-agent-golden-path-skill-optimization.sh && bash scripts/ci/test-agent-golden-path-skill-hardening.sh'
         language: system
         pass_filenames: false
-        files: ^(scripts/docs/generate-agent-golden-path\.py|scripts/ci/test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(scripts/docs/generate-agent-golden-path\.py|scripts/ci/test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: docs-auto-update-reconcile-self-test
         name: Docs auto-update reconciliation self-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,6 +133,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/docs/generate-agent-golden-path\.py|scripts/ci/test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
+      - id: claude-plugin-install-workflow-self-test
+        name: Claude plugin install workflow self-test
+        entry: bash scripts/ci/test-claude-plugin-install.sh --self-test
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/(test-claude-plugin-install\.sh|claude_plugin_install_workflow\.py)|docs/guides/editor-mcp-recipe\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.pre-commit-config\.yaml)$
+
       - id: docs-auto-update-reconcile-self-test
         name: Docs auto-update reconciliation self-test
         entry: bash scripts/ci/test-reconcile-docs-auto-pr.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,16 +128,30 @@ repos:
 
       - id: agent-golden-path-skill-contract
         name: Agent golden-path skill contract
-        entry: bash -c 'python3 scripts/ci/test-agent-golden-path-skill.py && bash scripts/ci/test-agent-golden-path-skill-optimization.sh && bash scripts/ci/test-agent-golden-path-skill-hardening.sh'
+        entry: bash -c 'python3 scripts/ci/test-agent-golden-path-skill.py && python3 scripts/ci/test-golden-path-mock-bounds.py'
         language: system
         pass_filenames: false
-        files: ^(scripts/docs/generate-agent-golden-path\.py|scripts/ci/test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(scripts/docs/generate-agent-golden-path\.py|scripts/ci/(test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py)|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+
+      - id: agent-golden-path-skill-mutations
+        name: Agent golden-path skill mutations
+        entry: bash -c 'bash scripts/ci/test-agent-golden-path-skill-optimization.sh && bash scripts/ci/test-agent-golden-path-skill-hardening.sh'
+        language: system
+        pass_filenames: false
+        # The 86 mutation cases prove the validator has teeth, but their cost belongs
+        # at the publish boundary rather than in every intermediate commit.
+        stages: [pre-push]
+        files: ^(scripts/docs/generate-agent-golden-path\.py|scripts/ci/(test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py)|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test
         entry: bash scripts/ci/test-claude-plugin-install.sh --self-test
         language: system
         pass_filenames: false
+        # The full mutation suite drives install/update/cache/MCP/session behavior and
+        # costs several seconds warm. Keep commit-time feedback fast; the same hook is
+        # installed and enforced before push, where end-to-end workflow proof belongs.
+        stages: [pre-push]
         files: ^(scripts/ci/(test-claude-plugin-install\.sh|claude_plugin_install_workflow\.py)|docs/guides/editor-mcp-recipe\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.pre-commit-config\.yaml)$
 
       - id: docs-auto-update-reconcile-self-test

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -81,6 +81,11 @@ fn clean_server_command() -> Command {
 }
 
 fn assert_release_server_surface(cwd: &Path, args: &[String], context: &str) {
+    std::fs::write(
+        cwd.join("install-surface-policy.yaml"),
+        "blocklist:\n  - install_surface_probe\n",
+    )
+    .expect("write consumer-project policy probe");
     let child = clean_server_command()
         .args(args)
         .current_dir(cwd)
@@ -118,6 +123,19 @@ fn assert_release_server_surface(cwd: &Path, args: &[String], context: &str) {
         "method": "tools/list"
     }));
     let response = conn.read_response_for_id(1);
+    conn.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "assay_policy_decide",
+            "arguments": {
+                "tool": "install_surface_probe",
+                "policy": "install-surface-policy.yaml"
+            }
+        }
+    }));
+    let policy_response = conn.read_response_for_id(3);
     let status = conn.shutdown();
     assert!(
         status.success(),
@@ -152,6 +170,15 @@ fn assert_release_server_surface(cwd: &Path, args: &[String], context: &str) {
         "assay_policy_decide",
     ];
     assert_eq!(actual, expected, "release tool surface changed");
+
+    let policy_text = policy_response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("policy decision text");
+    let policy_result: Value = serde_json::from_str(policy_text).expect("policy decision JSON");
+    assert_eq!(
+        policy_result["allowed"], false,
+        "{context} did not resolve policy from its consuming-project cwd"
+    );
 }
 
 #[test]
@@ -181,39 +208,31 @@ args = ["--policy-root", "."]"#;
         .iter()
         .map(|arg| arg.as_str().expect("manifest string arg").to_string())
         .collect();
-    assert_release_server_surface(&workspace_root(), &args, "project manifest");
+    let project = tempfile::tempdir().expect("temporary project-manifest consumer");
+    assert_release_server_surface(project.path(), &args, "project manifest");
 }
 
 #[test]
 fn plugin_manifest_drives_the_release_server_surface() {
     let plugin = manifest_entry(InstallFile::PluginManifest);
-    assert_eq!(plugin["command"], "assay-mcp-server");
+    let project_manifest = manifest_entry(InstallFile::ClaudeManifest);
     assert_eq!(
-        plugin["args"],
-        serde_json::json!(["--policy-root", "${CLAUDE_PROJECT_DIR}"])
+        plugin, project_manifest,
+        "project and plugin manifests must intentionally share cwd-relative policy-root semantics"
     );
+    assert_eq!(plugin["command"], "assay-mcp-server");
+    assert_eq!(plugin["args"], serde_json::json!(["--policy-root", "."]));
 
     let project = tempfile::tempdir().expect("temporary Claude project");
-    let project_root = project
-        .path()
-        .to_str()
-        .expect("temporary Claude project path must be UTF-8");
     let args: Vec<String> = plugin["args"]
         .as_array()
         .expect("plugin manifest args array")
         .iter()
-        .map(
-            |arg| match arg.as_str().expect("plugin manifest string arg") {
-                "${CLAUDE_PROJECT_DIR}" => project_root.to_string(),
-                value => {
-                    assert!(
-                        !value.contains("${"),
-                        "plugin manifest contains unsupported placeholder: {value}"
-                    );
-                    value.to_string()
-                }
-            },
-        )
+        .map(|arg| {
+            arg.as_str()
+                .expect("plugin manifest string arg")
+                .to_string()
+        })
         .collect();
     assert_release_server_surface(project.path(), &args, "plugin manifest");
 }

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -1,7 +1,7 @@
-//! Project install surfaces must launch the release MCP server they describe.
+//! Install surfaces must launch the release MCP server they describe.
 //!
-//! The JSON locations differ by client, while Codex uses TOML. This test keeps
-//! those three representations on one invocation and drives the built server so
+//! The JSON locations differ by surface, while Codex uses TOML. This test keeps
+//! those representations on one invocation and drives the built server so
 //! a syntactically correct manifest cannot advertise the wrong binary or tools.
 
 use serde_json::Value;
@@ -15,17 +15,19 @@ use jsonrpc_conn::Conn;
 const MAX_PROJECT_FILE_BYTES: u64 = 1024 * 1024;
 
 #[derive(Clone, Copy)]
-enum ProjectFile {
+enum InstallFile {
     ClaudeManifest,
     CursorManifest,
+    PluginManifest,
     EditorGuide,
 }
 
-impl ProjectFile {
+impl InstallFile {
     fn relative_path(self) -> &'static Path {
         Path::new(match self {
             Self::ClaudeManifest => ".mcp.json",
             Self::CursorManifest => ".cursor/mcp.json",
+            Self::PluginManifest => "packaging/claude-plugin/.mcp.json",
             Self::EditorGuide => "docs/guides/editor-mcp-recipe.md",
         })
     }
@@ -38,7 +40,7 @@ fn workspace_root() -> PathBuf {
         .expect("workspace root")
 }
 
-fn read_project_file(file: ProjectFile) -> String {
+fn read_install_file(file: InstallFile) -> String {
     let path = workspace_root().join(file.relative_path());
     let mut source = std::fs::File::open(&path)
         .unwrap_or_else(|error| panic!("open checked project file {}: {error}", path.display()));
@@ -58,9 +60,9 @@ fn read_project_file(file: ProjectFile) -> String {
     contents
 }
 
-fn manifest_entry(file: ProjectFile) -> Value {
+fn manifest_entry(file: InstallFile) -> Value {
     let manifest: Value =
-        serde_json::from_str(&read_project_file(file)).expect("valid project MCP manifest JSON");
+        serde_json::from_str(&read_install_file(file)).expect("valid MCP manifest JSON");
     manifest["mcpServers"]["assay"].clone()
 }
 
@@ -78,41 +80,15 @@ fn clean_server_command() -> Command {
     command
 }
 
-#[test]
-fn project_surfaces_launch_the_five_production_tools() {
-    let claude = manifest_entry(ProjectFile::ClaudeManifest);
-    let cursor = manifest_entry(ProjectFile::CursorManifest);
-    assert_eq!(claude, cursor, "Claude and Cursor entries drifted");
-    assert_eq!(claude["command"], "assay-mcp-server");
-    assert_eq!(claude["args"], serde_json::json!(["--policy-root", "."]));
-
-    let codex_entry = r#"[mcp_servers.assay]
-command = "assay-mcp-server"
-args = ["--policy-root", "."]"#;
-    let guide = read_project_file(ProjectFile::EditorGuide).replace("\r\n", "\n");
-    assert!(
-        guide.contains("cargo install --path crates/assay-mcp-server --locked"),
-        "editor guide install must use the reviewed checkout"
-    );
-    assert!(
-        guide.contains(codex_entry),
-        "Codex guide does not carry the manifest invocation"
-    );
-
-    let args: Vec<&str> = claude["args"]
-        .as_array()
-        .expect("manifest args array")
-        .iter()
-        .map(|arg| arg.as_str().expect("manifest string arg"))
-        .collect();
+fn assert_release_server_surface(cwd: &Path, args: &[String], context: &str) {
     let child = clean_server_command()
         .args(args)
-        .current_dir(workspace_root())
+        .current_dir(cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()
-        .expect("spawn assay-mcp-server from project manifest");
+        .unwrap_or_else(|error| panic!("spawn assay-mcp-server from {context}: {error}"));
 
     let mut conn = Conn::attach(child);
     conn.send(serde_json::json!({
@@ -122,7 +98,7 @@ args = ["--policy-root", "."]"#;
         "params": {
             "protocolVersion": "2024-11-05",
             "capabilities": {},
-            "clientInfo": {"name": "project-install-contract", "version": "1.0"}
+            "clientInfo": {"name": "install-surface-contract", "version": "1.0"}
         }
     }));
     let initialize = conn.read_response_for_id(0);
@@ -145,7 +121,7 @@ args = ["--policy-root", "."]"#;
     let status = conn.shutdown();
     assert!(
         status.success(),
-        "manifest invocation failed with status {status}"
+        "{context} invocation failed with status {status}"
     );
     let mut actual: Vec<&str> = response["result"]["tools"]
         .as_array()
@@ -176,4 +152,68 @@ args = ["--policy-root", "."]"#;
         "assay_policy_decide",
     ];
     assert_eq!(actual, expected, "release tool surface changed");
+}
+
+#[test]
+fn project_surfaces_launch_the_five_production_tools() {
+    let claude = manifest_entry(InstallFile::ClaudeManifest);
+    let cursor = manifest_entry(InstallFile::CursorManifest);
+    assert_eq!(claude, cursor, "Claude and Cursor entries drifted");
+    assert_eq!(claude["command"], "assay-mcp-server");
+    assert_eq!(claude["args"], serde_json::json!(["--policy-root", "."]));
+
+    let codex_entry = r#"[mcp_servers.assay]
+command = "assay-mcp-server"
+args = ["--policy-root", "."]"#;
+    let guide = read_install_file(InstallFile::EditorGuide).replace("\r\n", "\n");
+    assert!(
+        guide.contains("cargo install --path crates/assay-mcp-server --locked"),
+        "editor guide install must use the reviewed checkout"
+    );
+    assert!(
+        guide.contains(codex_entry),
+        "Codex guide does not carry the manifest invocation"
+    );
+
+    let args: Vec<String> = claude["args"]
+        .as_array()
+        .expect("manifest args array")
+        .iter()
+        .map(|arg| arg.as_str().expect("manifest string arg").to_string())
+        .collect();
+    assert_release_server_surface(&workspace_root(), &args, "project manifest");
+}
+
+#[test]
+fn plugin_manifest_drives_the_release_server_surface() {
+    let plugin = manifest_entry(InstallFile::PluginManifest);
+    assert_eq!(plugin["command"], "assay-mcp-server");
+    assert_eq!(
+        plugin["args"],
+        serde_json::json!(["--policy-root", "${CLAUDE_PROJECT_DIR}"])
+    );
+
+    let project = tempfile::tempdir().expect("temporary Claude project");
+    let project_root = project
+        .path()
+        .to_str()
+        .expect("temporary Claude project path must be UTF-8");
+    let args: Vec<String> = plugin["args"]
+        .as_array()
+        .expect("plugin manifest args array")
+        .iter()
+        .map(
+            |arg| match arg.as_str().expect("plugin manifest string arg") {
+                "${CLAUDE_PROJECT_DIR}" => project_root.to_string(),
+                value => {
+                    assert!(
+                        !value.contains("${"),
+                        "plugin manifest contains unsupported placeholder: {value}"
+                    );
+                    value.to_string()
+                }
+            },
+        )
+        .collect();
+    assert_release_server_surface(project.path(), &args, "plugin manifest");
 }

--- a/crates/assay-mcp-server/tests/project_install_surfaces.rs
+++ b/crates/assay-mcp-server/tests/project_install_surfaces.rs
@@ -42,22 +42,66 @@ fn workspace_root() -> PathBuf {
 
 fn read_install_file(file: InstallFile) -> String {
     let path = workspace_root().join(file.relative_path());
-    let mut source = std::fs::File::open(&path)
-        .unwrap_or_else(|error| panic!("open checked project file {}: {error}", path.display()));
-    let bytes = source
-        .metadata()
-        .unwrap_or_else(|error| panic!("stat checked project file {}: {error}", path.display()))
-        .len();
+    read_bounded_install_path(&path)
+}
+
+fn read_bounded_install_path(path: &Path) -> String {
+    let metadata = std::fs::symlink_metadata(path)
+        .unwrap_or_else(|error| panic!("stat checked project file {}: {error}", path.display()));
+    assert!(
+        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+        "checked project path must be a regular non-symlink file: {}",
+        path.display()
+    );
+    let bytes = metadata.len();
     assert!(
         bytes <= MAX_PROJECT_FILE_BYTES,
         "checked project file exceeds {MAX_PROJECT_FILE_BYTES} bytes: {} ({bytes} bytes)",
         path.display()
     );
-    let mut contents = String::with_capacity(bytes as usize);
-    source
-        .read_to_string(&mut contents)
+    let source = std::fs::File::open(path)
+        .unwrap_or_else(|error| panic!("open checked project file {}: {error}", path.display()));
+    let mut bounded = source.take(MAX_PROJECT_FILE_BYTES + 1);
+    let mut contents = Vec::with_capacity(bytes as usize);
+    bounded
+        .read_to_end(&mut contents)
         .unwrap_or_else(|error| panic!("read checked project file {}: {error}", path.display()));
-    contents
+    assert!(
+        contents.len() as u64 <= MAX_PROJECT_FILE_BYTES,
+        "checked project file grew beyond {MAX_PROJECT_FILE_BYTES} bytes while reading: {}",
+        path.display()
+    );
+    String::from_utf8(contents).unwrap_or_else(|error| {
+        panic!(
+            "checked project file is not UTF-8 {}: {error}",
+            path.display()
+        )
+    })
+}
+
+#[test]
+fn install_file_reader_rejects_oversized_regular_file() {
+    let directory = tempfile::tempdir().expect("temporary install-file probe");
+    let path = directory.path().join("oversized.json");
+    let file = std::fs::File::create(&path).expect("create sparse oversized probe");
+    file.set_len(MAX_PROJECT_FILE_BYTES + 1)
+        .expect("size oversized probe");
+    let result = std::panic::catch_unwind(|| read_bounded_install_path(&path));
+    assert!(result.is_err(), "oversized install file was accepted");
+}
+
+#[cfg(unix)]
+#[test]
+fn install_file_reader_rejects_symlink_to_regular_file() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().expect("temporary install-file probe");
+    let target = directory.path().join("manifest.json");
+    let link = directory.path().join("manifest-link.json");
+    std::fs::write(&target, "{}\n").expect("write symlink target");
+    symlink(&target, &link).expect("create install-file symlink probe");
+    let result = std::panic::catch_unwind(|| read_bounded_install_path(&link));
+    assert!(result.is_err(), "symlinked install file was accepted");
 }
 
 fn manifest_entry(file: InstallFile) -> Value {
@@ -174,6 +218,11 @@ fn assert_release_server_surface(cwd: &Path, args: &[String], context: &str) {
     let policy_text = policy_response["result"]["content"][0]["text"]
         .as_str()
         .expect("policy decision text");
+    assert_eq!(
+        policy_response["result"]["isError"].as_bool(),
+        Some(true),
+        "{context} did not preserve the server contract that a denied tool result sets isError"
+    );
     let policy_result: Value = serde_json::from_str(policy_text).expect("policy decision JSON");
     assert_eq!(
         policy_result["allowed"], false,

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -5,6 +5,70 @@ servers it uses by wrapping each server with `assay mcp wrap`, so every tool cal
 checked against your policy inline. No bespoke plugin is needed; you only change the
 server command in the agent's standard MCP config.
 
+## Install the Claude Code plugin
+
+The marketplace plugin packages Assay's five MCP review tools and the
+`assay-golden-path` skill. It does **not** package the server binary, invoke a target
+tool, or enforce another MCP server by itself.
+
+From the project where Claude Code should use Assay:
+
+```bash
+# 1. Install the local stdio server prerequisite.
+cargo install assay-mcp-server --locked
+
+# 2. Add Assay's marketplace and install the plugin for this project.
+claude plugin marketplace add Rul1an/assay
+claude plugin install assay@assay --scope local
+
+# 3. Verify that the installed plugin can start the server.
+claude mcp list
+```
+
+Restart Claude Code after installation, then ask it to use
+`assay:assay-golden-path`. The skill carries its contract and the three fixtures it
+needs from the isolated plugin cache. Python is optional for steps 1-5; only the
+protected-action simulation in step 6 runs the bundled Python fixture.
+
+The plugin starts `assay-mcp-server --policy-root .`. Claude Code `2.1.32` local
+scope was measured to start it from the consuming project, so `.` resolves policy
+files from that project. Other clients or scopes may choose another working
+directory. If that happens, override the Assay entry in project MCP configuration
+with an explicit absolute `--policy-root`; do not edit the installed plugin cache.
+
+### Update and inspect stale state
+
+Plugin updates require a restart to take effect:
+
+```bash
+claude plugin marketplace update assay
+claude plugin update assay@assay --scope local
+claude plugin list --json
+```
+
+The JSON listing exposes the installed cache version and path. If an update still
+shows old bytes, remove and reinstall `assay@assay` rather than modifying the cache.
+
+### Diagnose the layer that failed
+
+| Observation | Layer | Next step |
+|---|---|---|
+| `assay@assay` is absent from `claude plugin list --json` | Plugin installation | Add/update the `assay` marketplace, then install the local-scope plugin. |
+| `claude mcp list` reports a spawn or command failure | Binary prerequisite | Run `command -v assay-mcp-server`, install it on `PATH`, then restart Claude Code. |
+| The server connects but reports a missing policy | Project policy root | Start Claude Code from the project or configure an explicit absolute `--policy-root`. |
+| `assay_policy_decide` returns `allowed=false` | Assay policy verdict | Inspect the matched rule and change the proposed action or the reviewed policy. This is not an installation failure. |
+
+A missing plugin, failed process spawn, or unavailable policy is never a clean Assay
+verdict. The server is local stdio and needs no network or transport authentication,
+but installing it does not prove provider execution or external side effects.
+
+Maintainers can exercise the bounded, disposable installation contract without
+touching their normal Claude configuration:
+
+```bash
+bash scripts/ci/test-claude-plugin-install.sh --self-test
+```
+
 ## Install Assay's review tools
 
 The repository ships project configuration for the five tools exposed by the

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -205,27 +205,44 @@ Commit as `feat(plugin): generate cache-safe golden-path resources`.
 **Files:**
 - Modify: `docs/guides/editor-mcp-recipe.md`
 - Create: `scripts/ci/test-claude-plugin-install.sh`
+- Create: `scripts/ci/claude_plugin_install_workflow.py`
 - Modify: `.pre-commit-config.yaml`
 
 **Interfaces:**
 - Consumes: marketplace root, `assay@assay`, server on `PATH`, Claude CLI.
 - Produces: bounded disposable-client proof recording client version, source SHA, cache version, health-subcommand connection, actual-session connection, consumer-project policy-root proof, and each phase.
 
-- [ ] **Step 1: Write a failing workflow self-test**
+- [x] **Step 1: Write a failing workflow self-test**
 
 Use a fake Claude executable and require validate, add/install/update, cache inspection, `mcp list`, complete JSON-RPC exchange, actual-session MCP connection, consumer-only policy-root proof, and skill discovery. It must reject a source-directory-only success.
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
 Run `bash scripts/ci/test-claude-plugin-install.sh --self-test`; expect the named missing update/cache/protocol phase.
 
-- [ ] **Step 3: Add honest installation documentation**
+- [x] **Step 3: Add honest installation documentation**
 
 State that the plugin bundles no server, installation alone enforces nothing, policy resolves from the Claude project, Python is optional except for step 6, spawn failure is not an Assay verdict, and update plus cache inspection exposes stale state.
 
-- [ ] **Step 4: Implement the bounded disposable workflow**
+- [x] **Step 4: Implement the bounded disposable workflow**
 
 Use fresh `CLAUDE_CONFIG_DIR`, temporary marketplace and consuming project, trap cleanup, 1 MiB output ceilings, and process-tree deadlines equivalent to #2189. Do not inject `CLAUDE_PROJECT_DIR`. Prove both health-subcommand and actual-session MCP connection, then prove policy-root resolution with a policy available only inside the consuming project. Never mutate normal Claude config or pass credentials. Fail if installed cache resolves inside the source checkout.
+
+The implementation uses a thin shell entrypoint and a standard-library Python
+driver because the existing Rust helper is integration-test-only and cannot
+bound vendor CLI commands without compiling a test harness. The scoped driver
+starts a POSIX session, kills the process group, keeps one absolute deadline
+while draining inherited pipes, and caps stdout/stderr separately. Its self-test
+includes hangs, a direct child that exits while a descendant retains the pipe,
+and output overflow. This is a macOS/Linux workflow proof, not a Windows-native
+process-supervision claim.
+
+The consumer probe has no `policies/` directory and pins the installed argv to
+`--policy-root .` before writing a unique root-level policy. That prevents the
+server's default `policies` value from making the policy denial false-green. A
+fake update that exits zero but retains stale cache bytes must fail on cache
+parity. Failures use stable `phase`, `status`, `reason`, and `next_step` lines;
+success evidence uses one scan-friendly `key=pass` line per proven boundary.
 
 - [ ] **Step 5: Run the real-client proof**
 
@@ -238,13 +255,19 @@ installed_cache_version=<exact value>
 plugin_validate=pass
 mcp_list_connected=pass
 actual_session_mcp_connected=pass
-consumer_project_policy_root=pass
+policy_root_resolved_to_consumer=pass
 initialize=pass
 tools_list=pass
 skill_discovery=pass
+model_mediated_tool_call=unavailable
+verification=pass
 ```
 
-Unavailable vendor behavior is unavailable/failed proof, never pass.
+The last line means the scoped installation/protocol proof passed. It does not
+promote `model_mediated_tool_call=unavailable` to a model/tool-use pass. If the
+fresh client unexpectedly has working authentication, the status is
+`not_exercised` unless a separate test actually observes a model-mediated tool
+call. Unavailable vendor behavior is unavailable/failed proof, never pass.
 
 - [ ] **Step 6: Commit**
 

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -13,7 +13,7 @@
 - Work only in the dedicated worktree on `codex/2152-plugin-packaging`; use a private `CARGO_TARGET_DIR`.
 - Implement against approved design commit `ed6accbb0fe5c44a810cf6414d7afdbefffff8e8`.
 - Plugin identity is `assay@assay`; neither marketplace nor plugin manifest has a `version`.
-- MCP is `assay-mcp-server --policy-root ${CLAUDE_PROJECT_DIR}`; no binary is bundled.
+- MCP is `assay-mcp-server --policy-root .`; no binary is bundled.
 - Default server exposes exactly five named production tools; `assay_test_outbound` is feature-only.
 - Package exactly three canonical fixtures, including executable Python; Python is optional except for journey step 6.
 - Bound hostile manifest/resource reads to 1 MiB and reject symlinks or invalid types.
@@ -56,9 +56,12 @@ list` reported `Connected`. The cached manifest independently completed
 `initialize` and `tools/list` and returned the five exact production names.
 Without the explicit variable, the standalone health subcommand failed before
 spawn and its debug log reported `Missing environment variables in plugin MCP
-config: CLAUDE_PROJECT_DIR`; Task 3 therefore owns separate actual-session
-injection proof. All temporary config, marketplace, cache, and project paths
-were deleted after each probe.
+config: CLAUDE_PROJECT_DIR`. Task 3 then falsified session-time injection too:
+Claude Code `2.1.32` passed the literal placeholder to the server. A disposable
+`--policy-root .` control connected from the consuming project and discovered
+the packaged skill, so the implementation now pins `.` and separately proves
+the root with a consumer-only policy. All temporary config, marketplace, cache,
+and project paths were deleted after each completed probe.
 
 ### Task 1: Pin Marketplace, Plugin, and Driven MCP Contracts
 
@@ -76,7 +79,7 @@ were deleted after each probe.
 - Produces: exact parsed manifest contracts, `InstallFile::PluginManifest`, and one shared
   manifest-to-release-surface driver for project and plugin installs.
 
-- [ ] **Step 1: Write failing parsed-manifest assertions**
+- [x] **Step 1: Write failing parsed-manifest assertions**
 
 Add bounded paths and compare parsed objects, not text:
 
@@ -98,9 +101,9 @@ if marketplace != {
     fail("Claude marketplace identity or local source drifted")
 ```
 
-Assert exact plugin fields (`name`, `description`, `author`), absence of `version`, and one `mcpServers.assay` entry with string command plus exact string args.
+Assert exact plugin fields (`name`, `description`, `author`), absence of `version`, and one `mcpServers.assay` entry with string command plus exact `--policy-root .` args. Assert that the project and plugin entries intentionally match.
 
-- [ ] **Step 2: Write the failing manifest-driven Rust test**
+- [x] **Step 2: Write the failing manifest-driven Rust test**
 
 ```rust
 #[test]
@@ -118,7 +121,7 @@ fn plugin_manifest_drives_the_release_server_surface() {
 
 Pin the five names, not only the count, and retain bidirectional `test-outbound` coverage.
 
-- [ ] **Step 3: Verify RED**
+- [x] **Step 3: Verify RED**
 
 ```bash
 python3 scripts/ci/test-agent-golden-path-skill.py
@@ -127,15 +130,15 @@ CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --test pr
 
 Both must fail on the named missing manifest, not on compilation or setup.
 
-- [ ] **Step 4: Create only the minimal typed manifests**
+- [x] **Step 4: Create only the minimal typed manifests**
 
 Create the exact approved JSON. Add LF attributes. Do not add versions, commands, agents, auth, network, or a `note` extension.
 
-- [ ] **Step 5: Verify GREEN**
+- [x] **Step 5: Verify GREEN**
 
 Run both Step 3 commands, the full focused test target, and its `--features test-outbound` variant. Default must return the five exact production names; all-features may add only `assay_test_outbound`.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add -A -- scripts/ci/test-agent-golden-path-skill.py crates/assay-mcp-server/tests/project_install_surfaces.rs .claude-plugin/marketplace.json packaging/claude-plugin/.claude-plugin/plugin.json packaging/claude-plugin/.mcp.json .gitattributes
@@ -159,7 +162,7 @@ git commit -m "feat(plugin): pin Claude marketplace and MCP contracts"
 - Consumes: `CONTRACT`, project skill renderer, canonical step-6 fixtures.
 - Produces: `render_plugin_skill() -> str` and `PLUGIN_RESOURCE_COPIES: tuple[tuple[Path, Path], ...]`.
 
-- [ ] **Step 1: Write failing profile/resource checks**
+- [x] **Step 1: Write failing profile/resource checks**
 
 Require plugin-root contract guidance, the exact source-to-bundle mapping, no executable/read instruction through source-only `docs/`, `scripts/`, or `examples/`, and byte parity:
 
@@ -171,19 +174,19 @@ for source, packaged in PLUGIN_RESOURCE_COPIES:
         fail(f"packaged resource drifted: {packaged.relative_to(ROOT)}")
 ```
 
-- [ ] **Step 2: Extend drift/hardening selectors and verify RED**
+- [x] **Step 2: Extend drift/hardening selectors and verify RED**
 
 Add all generated package files to `GENERATED` and wholly recreated outputs to `FRESH_GENERATED`. Seed them in hardening scratch repos. Add named failures for missing mapping, source-only instructions, and fixture-byte drift. Run validator, drift, and hardening scripts; failures must name absent generated outputs.
 
-- [ ] **Step 3: Implement one shared renderer with a plugin profile**
+- [x] **Step 3: Implement one shared renderer with a plugin profile**
 
 Extract only the shared journey rendering. Keep project skills byte-identical. The plugin profile uses `${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/references/agent-golden-path.json`, omits source-generator editing instructions, and adds exactly one approved fixture mapping sentence.
 
-- [ ] **Step 4: Copy canonical resources in the generator**
+- [x] **Step 4: Copy canonical resources in the generator**
 
 Use `shutil.copyfile` after creating parents. Copy generated contract bytes after writing them and only the three approved fixtures: `mock_github_mcp.py`, `baseline-approved.json`, and `policies/no-allowance.yaml`.
 
-- [ ] **Step 5: Generate and verify GREEN**
+- [x] **Step 5: Generate and verify GREEN**
 
 ```bash
 python3 scripts/docs/generate-agent-golden-path.py
@@ -193,7 +196,7 @@ bash scripts/ci/test-agent-golden-path-skill-hardening.sh
 cmp .agents/skills/assay-golden-path/SKILL.md .claude/skills/assay-golden-path/SKILL.md
 ```
 
-- [ ] **Step 6: Commit exact generator/gate/output paths**
+- [x] **Step 6: Commit exact generator/gate/output paths**
 
 Commit as `feat(plugin): generate cache-safe golden-path resources`.
 
@@ -206,11 +209,11 @@ Commit as `feat(plugin): generate cache-safe golden-path resources`.
 
 **Interfaces:**
 - Consumes: marketplace root, `assay@assay`, server on `PATH`, Claude CLI.
-- Produces: bounded disposable-client proof recording client version, source SHA, cache version, health-subcommand connection, actual-session connection, and each phase.
+- Produces: bounded disposable-client proof recording client version, source SHA, cache version, health-subcommand connection, actual-session connection, consumer-project policy-root proof, and each phase.
 
 - [ ] **Step 1: Write a failing workflow self-test**
 
-Use a fake Claude executable and require validate, add/install/update, cache inspection, explicit-project-dir `mcp list`, complete JSON-RPC exchange, actual-session MCP connection without manual project-dir injection, and skill discovery. It must reject a source-directory-only success.
+Use a fake Claude executable and require validate, add/install/update, cache inspection, `mcp list`, complete JSON-RPC exchange, actual-session MCP connection, consumer-only policy-root proof, and skill discovery. It must reject a source-directory-only success.
 
 - [ ] **Step 2: Verify RED**
 
@@ -222,7 +225,7 @@ State that the plugin bundles no server, installation alone enforces nothing, po
 
 - [ ] **Step 4: Implement the bounded disposable workflow**
 
-Use fresh `CLAUDE_CONFIG_DIR`, temporary marketplace and consuming project, trap cleanup, 1 MiB output ceilings, and process-tree deadlines equivalent to #2189. Set `CLAUDE_PROJECT_DIR` explicitly only for the standalone `mcp list` health check. Invoke the actual Claude session without that manual injection and prove its MCP connection separately. Never mutate normal Claude config or pass credentials. Fail if installed cache resolves inside the source checkout.
+Use fresh `CLAUDE_CONFIG_DIR`, temporary marketplace and consuming project, trap cleanup, 1 MiB output ceilings, and process-tree deadlines equivalent to #2189. Do not inject `CLAUDE_PROJECT_DIR`. Prove both health-subcommand and actual-session MCP connection, then prove policy-root resolution with a policy available only inside the consuming project. Never mutate normal Claude config or pass credentials. Fail if installed cache resolves inside the source checkout.
 
 - [ ] **Step 5: Run the real-client proof**
 
@@ -235,6 +238,7 @@ installed_cache_version=<exact value>
 plugin_validate=pass
 mcp_list_connected=pass
 actual_session_mcp_connected=pass
+consumer_project_policy_root=pass
 initialize=pass
 tools_list=pass
 skill_discovery=pass
@@ -281,17 +285,14 @@ Include exact SHA/worktree, diffstat, hot files, contract changes, RED/GREEN evi
 
 - [ ] **Step 5: Obtain exact-head quorum and merge only when green**
 
-Follow the repository `AGENTS.md` quorum: one non-building agent plus CodeRabbit
-or Copilot, or two non-building agents when the bot-unavailability conditions
-are met and recorded on the final head. Claude Code Desktop may supply one
-non-building review, but the plan does not depend on a local chat identity. Fix
-or technically disposition every actionable finding. Any push restarts review
-and proof.
+Follow the repository `AGENTS.md` quorum: one non-building agent review on the
+final head. Automated reviews can add evidence but neither satisfy nor block
+quorum. Fix or technically disposition every actionable finding. Any push
+restarts review and proof.
 
 ## Self-Review
 
 - Spec coverage: pre-commit shape selection, identity, manifests, generated package, canonical resources, installed client, drift, mutation, security/failure policy, and non-claims each map to a task.
 - Placeholder scan: no deferred implementation or unnamed error-handling instruction remains.
-- Type consistency: `render_plugin_skill` and `PLUGIN_RESOURCE_COPIES` are introduced once and
-  consumed consistently; the existing install-surface driver owns the MCP invocation rule.
-- Residual: exact Claude marketplace flags must be read from the installed client during Task 3 and recorded with its version; the plan does not hardcode unverified vendor syntax.
+- Type consistency: one profiled `render_skill` function and `PLUGIN_RESOURCE_COPIES` are consumed consistently; the existing install-surface driver owns the MCP invocation and consumer-policy-root rules.
+- Residual: actual-session proof can establish MCP and skill startup without an authenticated API call; model-mediated tool use remains unavailable in a fresh unauthenticated `CLAUDE_CONFIG_DIR` and must not be reported as pass.

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -64,15 +64,17 @@ were deleted after each probe.
 
 **Files:**
 - Modify: `scripts/ci/test-agent-golden-path-skill.py`
-- Modify: `crates/assay-mcp-server/tests/agent_golden_path_contract.rs`
+- Modify: `crates/assay-mcp-server/tests/project_install_surfaces.rs`
 - Create after RED: `.claude-plugin/marketplace.json`
 - Create after RED: `packaging/claude-plugin/.claude-plugin/plugin.json`
 - Create after RED: `packaging/claude-plugin/.mcp.json`
 - Modify after RED: `.gitattributes`
 
 **Interfaces:**
-- Consumes: `read_bounded_evidence`, `CARGO_BIN_EXE_assay-mcp-server`, JSON-RPC `Conn`.
-- Produces: exact parsed manifest contracts and `plugin_mcp_entry() -> serde_json::Value`.
+- Consumes: `read_bounded_evidence`, the existing bounded install-surface reader,
+  `CARGO_BIN_EXE_assay-mcp-server`, and JSON-RPC `Conn`.
+- Produces: exact parsed manifest contracts, `InstallFile::PluginManifest`, and one shared
+  manifest-to-release-surface driver for project and plugin installs.
 
 - [ ] **Step 1: Write failing parsed-manifest assertions**
 
@@ -103,7 +105,7 @@ Assert exact plugin fields (`name`, `description`, `author`), absence of `versio
 ```rust
 #[test]
 fn plugin_manifest_drives_the_release_server_surface() {
-    let entry = plugin_mcp_entry();
+    let entry = manifest_entry(InstallFile::PluginManifest);
     assert_eq!(entry["command"], "assay-mcp-server");
     let project = tempfile::tempdir().expect("temporary Claude project");
     let args = plugin_args(&entry, project.path());
@@ -120,7 +122,7 @@ Pin the five names, not only the count, and retain bidirectional `test-outbound`
 
 ```bash
 python3 scripts/ci/test-agent-golden-path-skill.py
-CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --test agent_golden_path_contract plugin_manifest_drives_the_release_server_surface -- --exact --nocapture
+CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --test project_install_surfaces plugin_manifest_drives_the_release_server_surface -- --exact --nocapture
 ```
 
 Both must fail on the named missing manifest, not on compilation or setup.
@@ -136,7 +138,7 @@ Run both Step 3 commands, the full focused test target, and its `--features test
 - [ ] **Step 6: Commit**
 
 ```bash
-git add -A -- scripts/ci/test-agent-golden-path-skill.py crates/assay-mcp-server/tests/agent_golden_path_contract.rs .claude-plugin/marketplace.json packaging/claude-plugin/.claude-plugin/plugin.json packaging/claude-plugin/.mcp.json .gitattributes
+git add -A -- scripts/ci/test-agent-golden-path-skill.py crates/assay-mcp-server/tests/project_install_surfaces.rs .claude-plugin/marketplace.json packaging/claude-plugin/.claude-plugin/plugin.json packaging/claude-plugin/.mcp.json .gitattributes
 git commit -m "feat(plugin): pin Claude marketplace and MCP contracts"
 ```
 
@@ -262,8 +264,8 @@ python3 scripts/ci/test-agent-golden-path-skill.py
 bash scripts/ci/test-agent-golden-path-skill-optimization.sh
 bash scripts/ci/test-agent-golden-path-skill-hardening.sh
 bash scripts/ci/check-docs-generated-drift.sh
-CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --test agent_golden_path_contract -- --nocapture
-CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --features test-outbound --test agent_golden_path_contract -- --nocapture
+CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --test project_install_surfaces -- --nocapture
+CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --features test-outbound --test project_install_surfaces -- --nocapture
 cargo fmt --all -- --check
 CARGO_TARGET_DIR=/tmp/assay-2152-target cargo clippy -p assay-mcp-server --all-targets --all-features -- -D warnings
 git diff --check
@@ -290,5 +292,6 @@ and proof.
 
 - Spec coverage: pre-commit shape selection, identity, manifests, generated package, canonical resources, installed client, drift, mutation, security/failure policy, and non-claims each map to a task.
 - Placeholder scan: no deferred implementation or unnamed error-handling instruction remains.
-- Type consistency: `render_plugin_skill`, `PLUGIN_RESOURCE_COPIES`, and `plugin_mcp_entry` are introduced once and consumed consistently.
+- Type consistency: `render_plugin_skill` and `PLUGIN_RESOURCE_COPIES` are introduced once and
+  consumed consistently; the existing install-surface driver owns the MCP invocation rule.
 - Residual: exact Claude marketplace flags must be read from the installed client during Task 3 and recorded with its version; the plan does not hardcode unverified vendor syntax.

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -244,7 +244,7 @@ fake update that exits zero but retains stale cache bytes must fail on cache
 parity. Failures use stable `phase`, `status`, `reason`, and `next_step` lines;
 success evidence uses one scan-friendly `key=pass` line per proven boundary.
 
-- [ ] **Step 5: Run the real-client proof**
+- [x] **Step 5: Run the real-client proof**
 
 Build/install the exact-SHA server into an isolated bin directory and record:
 
@@ -269,9 +269,20 @@ fresh client unexpectedly has working authentication, the status is
 `not_exercised` unless a separate test actually observes a model-mediated tool
 call. Unavailable vendor behavior is unavailable/failed proof, never pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Stage the exact guide, workflow script, and hook paths. Commit as `docs(plugin): add measured Claude install workflow`.
+
+**Task 3 evidence:** Commit
+`c61b43959b67c62037c3403c871d627bea517375` built
+`assay-mcp-server 5.0.0` with rustc/cargo `1.96.0` and drove Claude Code
+`2.1.32` from a fresh config and consumer project. Marketplace validation,
+add/install/update, cache parity, MCP health, `initialize`, the five exact tools,
+consumer-root policy denial, actual-session MCP startup, and packaged-skill
+discovery passed. Installed cache version was `c61b43959b67`.
+`model_mediated_tool_call=unavailable` because the disposable client had no
+credentials; no model/tool-use or provider-execution claim is made. The final
+head re-runs this proof after this evidence note is committed.
 
 ### Task 4: Mutation, Full Verification, and PR
 

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -22,6 +22,31 @@
 
 ---
 
+### Task 0: Falsify the Selected Manifest Shape Before Committing It
+
+**Files:**
+- No repository files; use only a disposable directory and fresh `CLAUDE_CONFIG_DIR`.
+
+**Interfaces:**
+- Consumes: installed Claude CLI, the approved wrapper-shaped MCP entry, and `assay-mcp-server` on an isolated `PATH`.
+- Produces: exact client-version/argv/output evidence selecting wrapper or bare server-map shape for Task 1.
+
+- [ ] **Step 1: Build an ephemeral minimal marketplace and plugin**
+
+Create the approved marketplace/plugin metadata and wrapper-shaped `.mcp.json` under `mktemp -d`; do not copy these files into the worktree. Use the installed client's help output to derive marketplace add/install/list syntax.
+
+- [ ] **Step 2: Drive the installed client from a disposable project**
+
+With a fresh `CLAUDE_CONFIG_DIR`, add the temporary marketplace, install `assay@assay` at local scope, inspect the installed cache rather than the source directory, and run `claude mcp list`. Then drive the cached manifest against the built server through full `initialize` and `tools/list`.
+
+- [ ] **Step 3: Branch explicitly on the result**
+
+If the wrapper connects and returns the five exact tools, record it and continue. If the wrapper is rejected, repeat once with a bare server map. Update the approved design and obtain a new design review before Task 1 if and only if the bare shape succeeds. If neither works, stop as a client/plugin compatibility blocker; do not commit either shape.
+
+- [ ] **Step 4: Record provenance**
+
+Record exact source SHA, `claude --version`, generated temporary paths, executed argv, installed cache version/path, `mcp list`, `initialize`, and `tools/list` outcomes. This preflight selects a shape; Task 3 later proves the complete shipped package and update workflow.
+
 ### Task 1: Pin Marketplace, Plugin, and Driven MCP Contracts
 
 **Files:**
@@ -110,7 +135,9 @@ git commit -m "feat(plugin): pin Claude marketplace and MCP contracts"
 - Modify: `scripts/ci/check-docs-generated-drift.sh`
 - Modify: `scripts/ci/test-agent-golden-path-skill-hardening.sh`
 - Modify: `.pre-commit-config.yaml`
-- Modify: `.github/workflows/kernel-matrix.yml`
+- Modify: `.github/workflows/kernel-matrix.yml` so `packaging/claude-plugin/**`
+  and `.claude-plugin/**` changes trigger the head-side contract gates instead
+  of bypassing them through the workflow path filter.
 - Generate: `packaging/claude-plugin/skills/assay-golden-path/{SKILL.md,references/agent-golden-path.json,assets/privileged-action-gate/**}`
 
 **Interfaces:**
@@ -238,11 +265,16 @@ Include exact SHA/worktree, diffstat, hot files, contract changes, RED/GREEN evi
 
 - [ ] **Step 5: Obtain exact-head quorum and merge only when green**
 
-Use Claude Code Desktop's existing `Issue prioritering en overzicht` chat plus CodeRabbit/Copilot. Fix or technically disposition every actionable finding. Any push restarts review and proof.
+Follow the repository `AGENTS.md` quorum: one non-building agent plus CodeRabbit
+or Copilot, or two non-building agents when the bot-unavailability conditions
+are met and recorded on the final head. Claude Code Desktop may supply one
+non-building review, but the plan does not depend on a local chat identity. Fix
+or technically disposition every actionable finding. Any push restarts review
+and proof.
 
 ## Self-Review
 
-- Spec coverage: identity, manifests, generated package, canonical resources, installed client, drift, mutation, security/failure policy, and non-claims each map to a task.
+- Spec coverage: pre-commit shape selection, identity, manifests, generated package, canonical resources, installed client, drift, mutation, security/failure policy, and non-claims each map to a task.
 - Placeholder scan: no deferred implementation or unnamed error-handling instruction remains.
 - Type consistency: `render_plugin_skill`, `PLUGIN_RESOURCE_COPIES`, and `plugin_mcp_entry` are introduced once and consumed consistently.
 - Residual: exact Claude marketplace flags must be read from the installed client during Task 3 and recorded with its version; the plan does not hardcode unverified vendor syntax.

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -1,0 +1,248 @@
+# Claude Plugin Marketplace Packaging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the existing `assay-mcp-server` and generated `assay-golden-path` journey as an installable, cache-safe Claude Code marketplace plugin.
+
+**Architecture:** Keep the golden-path Python generator as the single owner of the contract, all three skill renderings, and packaged fixtures. Add parsed static contracts for marketplace/plugin identity and a Rust integration test that drives the manifest arguments against the workspace server binary. Treat vendor validation and an isolated installed-client probe as additional evidence, never as a substitute for repository assertions.
+
+**Tech Stack:** Python 3 standard library, Bash, JSON manifests, Rust integration tests, Claude Code CLI with its exact measured version recorded during proof.
+
+## Global Constraints
+
+- Work only in the dedicated worktree on `codex/2152-plugin-packaging`; use a private `CARGO_TARGET_DIR`.
+- Implement against approved design commit `ed6accbb0fe5c44a810cf6414d7afdbefffff8e8`.
+- Plugin identity is `assay@assay`; neither marketplace nor plugin manifest has a `version`.
+- MCP is `assay-mcp-server --policy-root ${CLAUDE_PROJECT_DIR}`; no binary is bundled.
+- Default server exposes exactly five named production tools; `assay_test_outbound` is feature-only.
+- Package exactly three canonical fixtures, including executable Python; Python is optional except for journey step 6.
+- Bound hostile manifest/resource reads to 1 MiB and reject symlinks or invalid types.
+- Do not claim token, per-turn, per-session, host-cache, provider execution, external side effects, compliance, certification, or Cursor plugin-runtime behavior.
+- Use exact pathspec staging. A new push invalidates prior reviews and runtime proof.
+
+---
+
+### Task 1: Pin Marketplace, Plugin, and Driven MCP Contracts
+
+**Files:**
+- Modify: `scripts/ci/test-agent-golden-path-skill.py`
+- Modify: `crates/assay-mcp-server/tests/agent_golden_path_contract.rs`
+- Create after RED: `.claude-plugin/marketplace.json`
+- Create after RED: `packaging/claude-plugin/.claude-plugin/plugin.json`
+- Create after RED: `packaging/claude-plugin/.mcp.json`
+- Modify after RED: `.gitattributes`
+
+**Interfaces:**
+- Consumes: `read_bounded_evidence`, `CARGO_BIN_EXE_assay-mcp-server`, JSON-RPC `Conn`.
+- Produces: exact parsed manifest contracts and `plugin_mcp_entry() -> serde_json::Value`.
+
+- [ ] **Step 1: Write failing parsed-manifest assertions**
+
+Add bounded paths and compare parsed objects, not text:
+
+```python
+MARKETPLACE_PATH = ROOT / ".claude-plugin/marketplace.json"
+PLUGIN_MANIFEST_PATH = ROOT / "packaging/claude-plugin/.claude-plugin/plugin.json"
+PLUGIN_MCP_PATH = ROOT / "packaging/claude-plugin/.mcp.json"
+
+marketplace = json.loads(read_bounded_evidence(MARKETPLACE_PATH, "marketplace manifest"))
+if marketplace != {
+    "name": "assay",
+    "owner": {"name": "Assay"},
+    "plugins": [{
+        "name": "assay",
+        "description": EXPECTED_PLUGIN_DESCRIPTION,
+        "source": "./packaging/claude-plugin",
+    }],
+}:
+    fail("Claude marketplace identity or local source drifted")
+```
+
+Assert exact plugin fields (`name`, `description`, `author`), absence of `version`, and one `mcpServers.assay` entry with string command plus exact string args.
+
+- [ ] **Step 2: Write the failing manifest-driven Rust test**
+
+```rust
+#[test]
+fn plugin_manifest_drives_the_release_server_surface() {
+    let entry = plugin_mcp_entry();
+    assert_eq!(entry["command"], "assay-mcp-server");
+    let project = tempfile::tempdir().expect("temporary Claude project");
+    let args = plugin_args(&entry, project.path());
+    let mut connection = Conn::attach(spawn_server(project.path(), &args));
+    assert!(connection.request("initialize", initialize_params(), 1)["result"].is_object());
+    let tools = connection.request("tools/list", serde_json::json!({}), 2);
+    assert_eq!(release_tool_names(&tools), EXPECTED_RELEASE_TOOLS);
+}
+```
+
+Pin the five names, not only the count, and retain bidirectional `test-outbound` coverage.
+
+- [ ] **Step 3: Verify RED**
+
+```bash
+python3 scripts/ci/test-agent-golden-path-skill.py
+CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --test agent_golden_path_contract plugin_manifest_drives_the_release_server_surface -- --exact --nocapture
+```
+
+Both must fail on the named missing manifest, not on compilation or setup.
+
+- [ ] **Step 4: Create only the minimal typed manifests**
+
+Create the exact approved JSON. Add LF attributes. Do not add versions, commands, agents, auth, network, or a `note` extension.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run both Step 3 commands, the full focused test target, and its `--features test-outbound` variant. Default must return the five exact production names; all-features may add only `assay_test_outbound`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A -- scripts/ci/test-agent-golden-path-skill.py crates/assay-mcp-server/tests/agent_golden_path_contract.rs .claude-plugin/marketplace.json packaging/claude-plugin/.claude-plugin/plugin.json packaging/claude-plugin/.mcp.json .gitattributes
+git commit -m "feat(plugin): pin Claude marketplace and MCP contracts"
+```
+
+### Task 2: Generate the Cache-Safe Skill and Canonical Resources
+
+**Files:**
+- Modify: `scripts/docs/generate-agent-golden-path.py`
+- Modify: `scripts/ci/test-agent-golden-path-skill.py`
+- Modify: `scripts/ci/check-docs-generated-drift.sh`
+- Modify: `scripts/ci/test-agent-golden-path-skill-hardening.sh`
+- Modify: `.pre-commit-config.yaml`
+- Modify: `.github/workflows/kernel-matrix.yml`
+- Generate: `packaging/claude-plugin/skills/assay-golden-path/{SKILL.md,references/agent-golden-path.json,assets/privileged-action-gate/**}`
+
+**Interfaces:**
+- Consumes: `CONTRACT`, project skill renderer, canonical step-6 fixtures.
+- Produces: `render_plugin_skill() -> str` and `PLUGIN_RESOURCE_COPIES: tuple[tuple[Path, Path], ...]`.
+
+- [ ] **Step 1: Write failing profile/resource checks**
+
+Require plugin-root contract guidance, the exact source-to-bundle mapping, no executable/read instruction through source-only `docs/`, `scripts/`, or `examples/`, and byte parity:
+
+```python
+for source, packaged in PLUGIN_RESOURCE_COPIES:
+    if read_bounded_evidence(source, "canonical resource") != read_bounded_evidence(
+        packaged, "packaged resource"
+    ):
+        fail(f"packaged resource drifted: {packaged.relative_to(ROOT)}")
+```
+
+- [ ] **Step 2: Extend drift/hardening selectors and verify RED**
+
+Add all generated package files to `GENERATED` and wholly recreated outputs to `FRESH_GENERATED`. Seed them in hardening scratch repos. Add named failures for missing mapping, source-only instructions, and fixture-byte drift. Run validator, drift, and hardening scripts; failures must name absent generated outputs.
+
+- [ ] **Step 3: Implement one shared renderer with a plugin profile**
+
+Extract only the shared journey rendering. Keep project skills byte-identical. The plugin profile uses `${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/references/agent-golden-path.json`, omits source-generator editing instructions, and adds exactly one approved fixture mapping sentence.
+
+- [ ] **Step 4: Copy canonical resources in the generator**
+
+Use `shutil.copyfile` after creating parents. Copy generated contract bytes after writing them and only the three approved fixtures: `mock_github_mcp.py`, `baseline-approved.json`, and `policies/no-allowance.yaml`.
+
+- [ ] **Step 5: Generate and verify GREEN**
+
+```bash
+python3 scripts/docs/generate-agent-golden-path.py
+python3 scripts/ci/test-agent-golden-path-skill.py
+bash scripts/ci/check-docs-generated-drift.sh
+bash scripts/ci/test-agent-golden-path-skill-hardening.sh
+cmp .agents/skills/assay-golden-path/SKILL.md .claude/skills/assay-golden-path/SKILL.md
+```
+
+- [ ] **Step 6: Commit exact generator/gate/output paths**
+
+Commit as `feat(plugin): generate cache-safe golden-path resources`.
+
+### Task 3: Document and Drive the Installed Claude Workflow
+
+**Files:**
+- Modify: `docs/guides/editor-mcp-recipe.md`
+- Create: `scripts/ci/test-claude-plugin-install.sh`
+- Modify: `.pre-commit-config.yaml`
+
+**Interfaces:**
+- Consumes: marketplace root, `assay@assay`, server on `PATH`, Claude CLI.
+- Produces: bounded disposable-client proof recording client version, source SHA, cache version, and each phase.
+
+- [ ] **Step 1: Write a failing workflow self-test**
+
+Use a fake Claude executable and require validate, add/install/update, cache inspection, `mcp list`, complete JSON-RPC exchange, and skill discovery. It must reject a source-directory-only success.
+
+- [ ] **Step 2: Verify RED**
+
+Run `bash scripts/ci/test-claude-plugin-install.sh --self-test`; expect the named missing update/cache/protocol phase.
+
+- [ ] **Step 3: Add honest installation documentation**
+
+State that the plugin bundles no server, installation alone enforces nothing, policy resolves from the Claude project, Python is optional except for step 6, spawn failure is not an Assay verdict, and update plus cache inspection exposes stale state.
+
+- [ ] **Step 4: Implement the bounded disposable workflow**
+
+Use fresh `CLAUDE_CONFIG_DIR`, temporary marketplace and consuming project, trap cleanup, 1 MiB output ceilings, and process-tree deadlines equivalent to #2189. Never mutate normal Claude config or pass credentials. Fail if installed cache resolves inside the source checkout.
+
+- [ ] **Step 5: Run the real-client proof**
+
+Build/install the exact-SHA server into an isolated bin directory and record:
+
+```text
+source_sha=<40 hex>
+claude_version=<exact output>
+installed_cache_version=<exact value>
+plugin_validate=pass
+mcp_list_connected=pass
+initialize=pass
+tools_list=pass
+skill_discovery=pass
+```
+
+Unavailable vendor behavior is unavailable/failed proof, never pass.
+
+- [ ] **Step 6: Commit**
+
+Stage the exact guide, workflow script, and hook paths. Commit as `docs(plugin): add measured Claude install workflow`.
+
+### Task 4: Mutation, Full Verification, and PR
+
+**Files:**
+- Modify if needed: `scripts/ci/test-agent-golden-path-skill-hardening.sh`
+- Modify if needed: `scripts/ci/test-claude-plugin-install.sh`
+- Update: this plan's checkboxes and evidence notes.
+
+- [ ] **Step 1: Run six required mutations individually**
+
+Each temporary mutation must reach its own guard, then be restored: command becomes number; fixture byte changes; instruction points to source-only path; production tool is renamed; manifest version is added; mapping sentence is removed.
+
+- [ ] **Step 2: Run final verification**
+
+```bash
+python3 scripts/ci/test-agent-golden-path-skill.py
+bash scripts/ci/test-agent-golden-path-skill-optimization.sh
+bash scripts/ci/test-agent-golden-path-skill-hardening.sh
+bash scripts/ci/check-docs-generated-drift.sh
+CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --test agent_golden_path_contract -- --nocapture
+CARGO_TARGET_DIR=/tmp/assay-2152-target cargo test -p assay-mcp-server --features test-outbound --test agent_golden_path_contract -- --nocapture
+cargo fmt --all -- --check
+CARGO_TARGET_DIR=/tmp/assay-2152-target cargo clippy -p assay-mcp-server --all-targets --all-features -- -D warnings
+git diff --check
+```
+
+- [ ] **Step 3: Run user/workflow/AI simulations**
+
+Exercise missing binary, missing optional Python, missing policy, stale cache before update, successful update/cache inspection, connected five-tool surface, skill discovery, and protected-action denial. Verify host/prerequisite/policy failures remain distinct and absence never becomes clean.
+
+- [ ] **Step 4: Push and open an audit-grade PR**
+
+Include exact SHA/worktree, diffstat, hot files, contract changes, RED/GREEN evidence, six mutation failures, real-client outputs, threat-model delta, fail-open/closed table, compatibility, and non-claims.
+
+- [ ] **Step 5: Obtain exact-head quorum and merge only when green**
+
+Use Claude Code Desktop's existing `Issue prioritering en overzicht` chat plus CodeRabbit/Copilot. Fix or technically disposition every actionable finding. Any push restarts review and proof.
+
+## Self-Review
+
+- Spec coverage: identity, manifests, generated package, canonical resources, installed client, drift, mutation, security/failure policy, and non-claims each map to a task.
+- Placeholder scan: no deferred implementation or unnamed error-handling instruction remains.
+- Type consistency: `render_plugin_skill`, `PLUGIN_RESOURCE_COPIES`, and `plugin_mcp_entry` are introduced once and consumed consistently.
+- Residual: exact Claude marketplace flags must be read from the installed client during Task 3 and recorded with its version; the plan does not hardcode unverified vendor syntax.

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -31,21 +31,34 @@
 - Consumes: installed Claude CLI, the approved wrapper-shaped MCP entry, and `assay-mcp-server` on an isolated `PATH`.
 - Produces: exact client-version/argv/output evidence selecting wrapper or bare server-map shape for Task 1.
 
-- [ ] **Step 1: Build an ephemeral minimal marketplace and plugin**
+- [x] **Step 1: Build an ephemeral minimal marketplace and plugin**
 
 Create the approved marketplace/plugin metadata and wrapper-shaped `.mcp.json` under `mktemp -d`; do not copy these files into the worktree. Use the installed client's help output to derive marketplace add/install/list syntax.
 
-- [ ] **Step 2: Drive the installed client from a disposable project**
+- [x] **Step 2: Drive the installed client from a disposable project**
 
-With a fresh `CLAUDE_CONFIG_DIR`, add the temporary marketplace, install `assay@assay` at local scope, inspect the installed cache rather than the source directory, and run `claude mcp list`. Then drive the cached manifest against the built server through full `initialize` and `tools/list`.
+With a fresh `CLAUDE_CONFIG_DIR`, add the temporary marketplace, install `assay@assay` at local scope, and inspect the installed cache rather than the source directory. Run `CLAUDE_PROJECT_DIR="$PWD" claude mcp list`: the standalone health subcommand does not synthesize this session variable, so this proves cached-wrapper parsing and connection but not session-time injection. Then drive the cached manifest against the built server through full `initialize` and `tools/list`.
 
-- [ ] **Step 3: Branch explicitly on the result**
+- [x] **Step 3: Branch explicitly on the result**
 
 If the wrapper connects and returns the five exact tools, record it and continue. If the wrapper is rejected, repeat once with a bare server map. Update the approved design and obtain a new design review before Task 1 if and only if the bare shape succeeds. If neither works, stop as a client/plugin compatibility blocker; do not commit either shape.
 
-- [ ] **Step 4: Record provenance**
+- [x] **Step 4: Record provenance**
 
 Record exact source SHA, `claude --version`, generated temporary paths, executed argv, installed cache version/path, `mcp list`, `initialize`, and `tools/list` outcomes. This preflight selects a shape; Task 3 later proves the complete shipped package and update workflow.
+
+**Task 0 evidence:** At source SHA
+`932ea9507560e47b0dbd3a3840218b8da601e2a8`, Claude Code `2.1.32`
+accepted the wrapper, installed `assay@assay` at local scope into its isolated
+cache, and exposed the entry through `plugin list --json`. With
+`CLAUDE_PROJECT_DIR` explicitly set to the disposable project, `claude mcp
+list` reported `Connected`. The cached manifest independently completed
+`initialize` and `tools/list` and returned the five exact production names.
+Without the explicit variable, the standalone health subcommand failed before
+spawn and its debug log reported `Missing environment variables in plugin MCP
+config: CLAUDE_PROJECT_DIR`; Task 3 therefore owns separate actual-session
+injection proof. All temporary config, marketplace, cache, and project paths
+were deleted after each probe.
 
 ### Task 1: Pin Marketplace, Plugin, and Driven MCP Contracts
 
@@ -191,11 +204,11 @@ Commit as `feat(plugin): generate cache-safe golden-path resources`.
 
 **Interfaces:**
 - Consumes: marketplace root, `assay@assay`, server on `PATH`, Claude CLI.
-- Produces: bounded disposable-client proof recording client version, source SHA, cache version, and each phase.
+- Produces: bounded disposable-client proof recording client version, source SHA, cache version, health-subcommand connection, actual-session connection, and each phase.
 
 - [ ] **Step 1: Write a failing workflow self-test**
 
-Use a fake Claude executable and require validate, add/install/update, cache inspection, `mcp list`, complete JSON-RPC exchange, and skill discovery. It must reject a source-directory-only success.
+Use a fake Claude executable and require validate, add/install/update, cache inspection, explicit-project-dir `mcp list`, complete JSON-RPC exchange, actual-session MCP connection without manual project-dir injection, and skill discovery. It must reject a source-directory-only success.
 
 - [ ] **Step 2: Verify RED**
 
@@ -207,7 +220,7 @@ State that the plugin bundles no server, installation alone enforces nothing, po
 
 - [ ] **Step 4: Implement the bounded disposable workflow**
 
-Use fresh `CLAUDE_CONFIG_DIR`, temporary marketplace and consuming project, trap cleanup, 1 MiB output ceilings, and process-tree deadlines equivalent to #2189. Never mutate normal Claude config or pass credentials. Fail if installed cache resolves inside the source checkout.
+Use fresh `CLAUDE_CONFIG_DIR`, temporary marketplace and consuming project, trap cleanup, 1 MiB output ceilings, and process-tree deadlines equivalent to #2189. Set `CLAUDE_PROJECT_DIR` explicitly only for the standalone `mcp list` health check. Invoke the actual Claude session without that manual injection and prove its MCP connection separately. Never mutate normal Claude config or pass credentials. Fail if installed cache resolves inside the source checkout.
 
 - [ ] **Step 5: Run the real-client proof**
 
@@ -219,6 +232,7 @@ claude_version=<exact output>
 installed_cache_version=<exact value>
 plugin_validate=pass
 mcp_list_connected=pass
+actual_session_mcp_connected=pass
 initialize=pass
 tools_list=pass
 skill_discovery=pass

--- a/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
+++ b/docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md
@@ -256,6 +256,7 @@ plugin_validate=pass
 mcp_list_connected=pass
 actual_session_mcp_connected=pass
 policy_root_resolved_to_consumer=pass
+missing_policy_refused=pass
 initialize=pass
 tools_list=pass
 skill_discovery=pass
@@ -291,11 +292,11 @@ head re-runs this proof after this evidence note is committed.
 - Modify if needed: `scripts/ci/test-claude-plugin-install.sh`
 - Update: this plan's checkboxes and evidence notes.
 
-- [ ] **Step 1: Run six required mutations individually**
+- [x] **Step 1: Run six required mutations individually**
 
 Each temporary mutation must reach its own guard, then be restored: command becomes number; fixture byte changes; instruction points to source-only path; production tool is renamed; manifest version is added; mapping sentence is removed.
 
-- [ ] **Step 2: Run final verification**
+- [x] **Step 2: Run final verification**
 
 ```bash
 python3 scripts/ci/test-agent-golden-path-skill.py
@@ -309,9 +310,31 @@ CARGO_TARGET_DIR=/tmp/assay-2152-target cargo clippy -p assay-mcp-server --all-t
 git diff --check
 ```
 
-- [ ] **Step 3: Run user/workflow/AI simulations**
+- [x] **Step 3: Run user/workflow/AI simulations**
 
 Exercise missing binary, missing optional Python, missing policy, stale cache before update, successful update/cache inspection, connected five-tool surface, skill discovery, and protected-action denial. Verify host/prerequisite/policy failures remain distinct and absence never becomes clean.
+
+**Task 4 evidence before PR:** All six required mutations bit their named
+guards: typed MCP command, fixture parity, source-only instruction, exact server
+tool names, unversioned plugin identity, and fixture mapping. The generated-skill
+hardening suite observed 84 cases plus 22 structural probes. The disposable
+workflow additionally rejected a missing server at `phase=prerequisite`, a
+source-checkout cache, a successful no-op update retaining stale bytes, tool
+drift, output overflow, a hung process tree, and an exited parent whose
+descendant retained the output pipe. The exact built server denied the
+consumer-only marker and returned `E_POLICY_NOT_FOUND` for a missing policy;
+neither absence became clean. The generated contract contains `<python>` only
+in protected-action step 6; installation and steps 1-5 do not claim Python is
+needed. A fresh unauthenticated Claude session connected the MCP server and
+discovered the skill while leaving model-mediated tool use unavailable.
+
+On head `a43edcb7e927894c1973635d71be0ce56b73ced8`, the full
+`assay-mcp-server` crate suite, the `test-outbound` install surface, all-targets
+and all-features clippy with `-D warnings`, fmt, and diff checks passed. The
+first post-mutation client run correctly caught that the debug binary still
+contained the temporary renamed tool even though source was restored. Rebuilding
+from the committed head restored artifact provenance, after which all installed
+workflow phases, including `missing_policy_refused=pass`, passed.
 
 - [ ] **Step 4: Push and open an audit-grade PR**
 

--- a/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
+++ b/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
@@ -21,8 +21,10 @@ built from the base SHA above:
 
 - Claude Code copies installed plugins into an isolated cache. Paths outside
   the plugin root are unavailable after installation.
-- `${CLAUDE_PLUGIN_ROOT}` resolves in skill content. `${CLAUDE_PROJECT_DIR}`
-  resolves in stdio MCP arguments.
+- `${CLAUDE_PLUGIN_ROOT}` resolves in skill content. `${CLAUDE_PROJECT_DIR}` is
+  accepted in stdio MCP arguments and substituted when the variable is present
+  in the environment. The standalone health subcommand does not synthesize it;
+  session-time synthesis remains unproven until the Task 3 session check.
 - Sixteen inspected plugin artifacts are mixed: six use an `mcpServers` wrapper
   and ten use a bare server map. The installed cache artifact uses the wrapper;
   the bare examples are predominantly marketplace-source artifacts. Neither

--- a/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
+++ b/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
@@ -1,0 +1,250 @@
+# Claude Plugin Marketplace Packaging Design
+
+Date: 2026-08-09
+Issue: [#2152](https://github.com/Rul1an/assay/issues/2152), step 4
+Base: `48beb09d1ba581f275da7775228262c778914a28`
+
+## Goal
+
+Publish the already shipped `assay-mcp-server` and generated
+`assay-golden-path` journey as one installable Claude Code marketplace plugin.
+The installed plugin must work from Claude Code's isolated plugin cache without
+reading the Assay source checkout, while its MCP server evaluates policy from
+the consuming project.
+
+This is packaging, not a new enforcement or evidence capability.
+
+## Measured Constraints
+
+The design is based on direct probes with Claude Code `2.1.32` and the server
+built from the base SHA above:
+
+- Claude Code copies installed plugins into an isolated cache. Paths outside
+  the plugin root are unavailable after installation.
+- `${CLAUDE_PLUGIN_ROOT}` resolves in skill content. `${CLAUDE_PROJECT_DIR}`
+  resolves in stdio MCP arguments.
+- Plugin `.mcp.json` files use the `mcpServers` wrapper.
+- A plugin with no explicit version installs under a SHA-derived version and
+  advances after a marketplace update.
+- `claude plugin validate` accepts a referenced `.mcp.json` whose `command` is
+  a number, so successful vendor validation is insufficient by itself.
+- A default-feature `initialize` plus `tools/list` exchange returns exactly the
+  five production tools and no `assay_test_outbound`.
+- The compact `tools/list` JSON-RPC response is 8,120 UTF-8 bytes. This is a
+  wire-byte measurement, not a token, per-turn, per-session, or cache claim.
+
+The current project skill is not directly packageable. It instructs callers to
+read `docs/generated/agent-golden-path.json`, edit
+`scripts/docs/generate-agent-golden-path.py`, and run step 6 from
+`examples/privileged-action-gate`. Those paths do not exist in an installed
+plugin cache.
+
+## Package Layout
+
+The repository publishes one marketplace containing one config-only plugin:
+
+```text
+.claude-plugin/
+  marketplace.json
+packaging/claude-plugin/
+  .claude-plugin/
+    plugin.json
+  .mcp.json
+  skills/
+    assay-golden-path/
+      SKILL.md
+      references/
+        agent-golden-path.json
+      assets/
+        privileged-action-gate/
+          mock_github_mcp.py
+          baseline-approved.json
+          policies/
+            no-allowance.yaml
+```
+
+The marketplace and plugin are both named `assay`, giving install identity
+`assay@assay`. Claude Code auto-discovers
+`skills/assay-golden-path/SKILL.md`; `plugin.json` does not invent an unsupported
+`skills` field. The package has no commands or agents.
+
+The plugin omits `version`. Config-only changes must not be coupled to the Rust
+crate release cadence, and the measured Claude client already provides a
+commit-derived version for an unversioned git marketplace. The absence is a
+tested decision rather than an omitted field by accident.
+
+## MCP Configuration
+
+The plugin's `.mcp.json` contains one stdio server under `mcpServers.assay`:
+
+```json
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay-mcp-server",
+      "args": ["--policy-root", "${CLAUDE_PROJECT_DIR}"]
+    }
+  }
+}
+```
+
+The plugin is config-only: `assay-mcp-server` must already be on `PATH`. The
+server reads policies from the consuming project, not the marketplace checkout
+or plugin cache. The manifest has no unverified `note` extension field; limits
+belong in the generated skill and install guide.
+
+## Generated Skill Profile
+
+`scripts/docs/generate-agent-golden-path.py` remains the single owner of the
+golden-path contract and all three skill renderings:
+
+1. `.agents/skills/assay-golden-path/SKILL.md` for project discovery;
+2. `.claude/skills/assay-golden-path/SKILL.md` for project discovery;
+3. `packaging/claude-plugin/skills/assay-golden-path/SKILL.md` for an installed
+   plugin.
+
+The two project skills remain byte-identical. The plugin profile intentionally
+differs only where location semantics differ:
+
+- its authoritative contract is
+  `${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/references/agent-golden-path.json`;
+- it does not tell a user to edit a generator absent from the plugin;
+- step 6 assets resolve under
+  `${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/assets/privileged-action-gate`.
+
+The bundled JSON remains byte-identical to
+`docs/generated/agent-golden-path.json`. Its schema-v1 `working_directory`
+continues to mean a path relative to the source repository. The plugin profile
+does not rewrite that field and does not add `working_directory_base`.
+Instead, it includes one generated declarative mapping sentence:
+
+> Fixtures named by the contract under `examples/privileged-action-gate` are
+> bundled at
+> `${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/assets/privileged-action-gate`.
+
+That sentence translates packaging location without creating a second Assay
+contract vocabulary. Static checks reject executable or read instructions that
+resolve through repository-only paths, while allowing this one named mapping.
+
+## Bundled Resources
+
+Only the files required by the step-6 command are bundled:
+
+- `mock_github_mcp.py`;
+- `baseline-approved.json`;
+- `policies/no-allowance.yaml`.
+
+The Python fixture imports only the standard library and opens no additional
+local files. The JSON and YAML fixtures do not reference other files. The
+remaining files in `examples/privileged-action-gate` serve other demos and are
+excluded.
+
+The generator copies these three resources byte-for-byte. The generated-docs
+drift gate covers their package destinations, so source changes cannot leave a
+stale plugin copy. The package does not fetch mutable GitHub URLs and does not
+require an Assay checkout.
+
+## Installation Documentation
+
+`docs/guides/editor-mcp-recipe.md` adds the measured Claude Code path:
+
+1. install `assay-mcp-server` from a reviewed release or checkout;
+2. add the repository marketplace;
+3. install `assay@assay`;
+4. verify the plugin and its MCP server from the consuming project.
+
+The guide says plainly that the plugin does not bundle the binary, does not
+enforce anything merely by being installed, and consumes policy from the
+current Claude project.
+
+## Verification Design
+
+### Static and generation gates
+
+Extend the existing golden-path validator so it proves:
+
+- the generator owns all three skill destinations;
+- the two project skills remain byte-identical;
+- the plugin profile contains only `${CLAUDE_PLUGIN_ROOT}` resource
+  instructions plus the one explicit source-to-bundle mapping;
+- the bundled contract and three fixtures are byte-identical to their canonical
+  sources;
+- generated drift catches edits to every packaged generated resource;
+- private planning vocabulary and unsupported claims remain absent.
+
+Parse, do not search, the marketplace and plugin JSON. Assert the install
+identity, local source path, auto-discovered skill location, `mcpServers`
+wrapper, string command, exact argument vector, and absence of `version`.
+
+### Driven server contract
+
+A workspace-only `assay-mcp-server` integration test reads the plugin MCP entry,
+uses its argument vector with `${CLAUDE_PROJECT_DIR}` replaced by the temporary
+consuming-project directory, and launches
+`CARGO_BIN_EXE_assay-mcp-server`. An `initialize` plus `tools/list` exchange must
+return these names exactly:
+
+- `assay_check_args`;
+- `assay_check_coverage`;
+- `assay_check_sequence`;
+- `assay_explain_trace`;
+- `assay_policy_decide`.
+
+The default build must omit `assay_test_outbound`; an all-features run retains
+the existing bidirectional feature assertion.
+
+### Real-client proof
+
+Before push, run both layers with the installed Claude client:
+
+- `claude plugin validate` on the marketplace and plugin;
+- isolated marketplace add/install/update using a fresh
+  `CLAUDE_CONFIG_DIR`;
+- inspect the cached plugin rather than the source directory;
+- drive the cached `.mcp.json` against the built server;
+- invoke Claude Code from a disposable project and verify discovery of the
+  packaged `assay-golden-path` skill.
+
+Record the exact client version, source SHA, installed cache version, commands,
+and outcomes in the PR review packet. Vendor validation supplements rather than
+replaces repository assertions.
+
+### TDD and mutation proof
+
+Write static and runtime tests before package files exist and confirm they fail
+on the named missing artifact, not merely on compile setup. After green, each
+of these temporary mutations must fail its named assertion:
+
+| mutation | required failure |
+|---|---|
+| set plugin MCP `command` to `42` | typed MCP command assertion |
+| alter one bundled fixture byte | canonical resource parity assertion |
+| point a packaged read/run instruction at `docs/`, `scripts/`, or source `examples/` | cache-safe instruction assertion |
+| rename one production tool | exact release tool-surface assertion |
+| add plugin or marketplace `version` | unversioned git-marketplace decision assertion |
+| remove the source-to-bundle mapping sentence | packaged contract-location assertion |
+
+Every mutation is restored before final verification.
+
+## Security and Failure Policy
+
+- Treat marketplace, manifest, skill, and bundled fixture inputs as hostile in
+  tests; bound reads before materialization.
+- Manifest/schema/type errors fail closed.
+- Missing `assay-mcp-server` is reported as a host spawn failure; the plugin
+  must not imply that a server ran.
+- Missing project policy never becomes a clean enforcement result.
+- The bundled mock is a local stdio fixture. It performs no network or provider
+  action.
+- No credentials, OAuth, network endpoint, or persistent access are introduced.
+
+## Non-Goals
+
+- No self-contained cross-platform binary distribution.
+- No new MCP tool, result envelope, cache field, or protocol-version claim;
+  [#2157](https://github.com/Rul1an/assay/issues/2157) owns those changes.
+- No `tools/list` token, per-turn, per-session, or host-cache claim;
+  [#2185](https://github.com/Rul1an/assay/issues/2185) owns wire measurement.
+- No Cursor plugin-runtime claim.
+- No proof of provider execution or external side effects.
+- No trust score, whole-action verdict, compliance claim, or certification.

--- a/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
+++ b/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
@@ -21,10 +21,16 @@ built from the base SHA above:
 
 - Claude Code copies installed plugins into an isolated cache. Paths outside
   the plugin root are unavailable after installation.
-- `${CLAUDE_PLUGIN_ROOT}` resolves in skill content. `${CLAUDE_PROJECT_DIR}` is
-  accepted in stdio MCP arguments and substituted when the variable is present
-  in the environment. The standalone health subcommand does not synthesize it;
-  session-time synthesis remains unproven until the Task 3 session check.
+- `${CLAUDE_PLUGIN_ROOT}` resolves in skill content. Claude Code `2.1.32` does
+  not synthesize `${CLAUDE_PROJECT_DIR}` for either the standalone health
+  subcommand or an actual non-interactive session: the client reports the
+  variable missing and passes the literal string to the server. The server then
+  fails closed while canonicalizing that nonexistent policy root.
+- A disposable installed-plugin control using `--policy-root .` connected from
+  the consuming project without manual environment injection and discovered the
+  packaged skill. This proves the measured local-scope host cwd; other scopes
+  and hosts remain unproven. Acceptance additionally drives a policy found only
+  in that consuming project, because connection alone does not prove the root.
 - Sixteen inspected plugin artifacts are mixed: six use an `mcpServers` wrapper
   and ten use a bare server map. The installed cache artifact uses the wrapper;
   the bare examples are predominantly marketplace-source artifacts. Neither
@@ -99,16 +105,19 @@ The plugin's `.mcp.json` contains one stdio server under `mcpServers.assay`:
   "mcpServers": {
     "assay": {
       "command": "assay-mcp-server",
-      "args": ["--policy-root", "${CLAUDE_PROJECT_DIR}"]
+      "args": ["--policy-root", "."]
     }
   }
 }
 ```
 
 The plugin does not bundle `assay-mcp-server`; that binary must already be on
-`PATH`. The server reads policies from the consuming project, not the
-marketplace checkout or plugin cache. The manifest has no unverified `note`
-extension field; limits belong in the generated skill and install guide.
+`PATH`. For the measured Claude Code `2.1.32` local-scope flow, the server starts
+with the consuming project as cwd, so `.` resolves there. This host-cwd behavior
+is an explicit assumption outside that measured flow. If a host starts the
+server elsewhere, the user must override `--policy-root` in a project-specific
+MCP entry. The manifest has no unverified `note` extension field; limits and
+recovery belong in the generated skill and install guide.
 
 ## Generated Skill Profile
 
@@ -204,10 +213,10 @@ argument vector, and absence of `version`.
 ### Driven server contract
 
 A workspace-only `assay-mcp-server` integration test reads the plugin MCP entry,
-uses its argument vector with `${CLAUDE_PROJECT_DIR}` replaced by the temporary
-consuming-project directory, and launches
-`CARGO_BIN_EXE_assay-mcp-server`. An `initialize` plus `tools/list` exchange must
-return these names exactly:
+uses its argument vector unchanged from a temporary consuming-project cwd, and
+launches `CARGO_BIN_EXE_assay-mcp-server`. The project and plugin MCP entries are
+intentionally identical. An `initialize` plus `tools/list` exchange must return
+these names exactly:
 
 - `assay_check_args`;
 - `assay_check_coverage`;
@@ -218,6 +227,11 @@ return these names exactly:
 The default build must omit `assay_test_outbound`; an all-features run retains
 the existing bidirectional feature assertion.
 
+The same driven connection writes a unique blocklist policy only inside the
+temporary consuming project and calls `assay_policy_decide`. The marker tool
+must be denied. This proves that `.` resolves to the consuming project rather
+than merely proving that the server can connect from some existing directory.
+
 ### Real-client proof
 
 Before push, run both layers with the installed Claude client:
@@ -226,16 +240,15 @@ Before push, run both layers with the installed Claude client:
 - isolated marketplace add/install/update using a fresh
   `CLAUDE_CONFIG_DIR`;
 - inspect the cached plugin rather than the source directory;
-- from a disposable consuming project, run
-  `CLAUDE_PROJECT_DIR="$PWD" claude mcp list`; the standalone health subcommand
-  does not synthesize this session variable, so the explicit value proves that
-  the cached wrapper-shaped configuration is accepted and the stdio server
-  connects, but does not prove session-time variable injection;
+- from a disposable consuming project, run `claude mcp list` without injecting
+  a project-root variable and require the cached wrapper-shaped configuration to
+  connect;
 - drive the cached `.mcp.json` against the built server through a complete
   `initialize` plus `tools/list` exchange, not merely a config-listing command;
-- invoke an actual Claude Code session from a disposable project without
-  manually setting `CLAUDE_PROJECT_DIR`, and verify both session-time MCP
-  connection and discovery of the packaged `assay-golden-path` skill.
+- invoke an actual Claude Code session from a disposable project, verify both
+  session-time MCP connection and discovery of the packaged
+  `assay-golden-path` skill, and drive the consumer-only policy marker through
+  the installed MCP connection.
 
 Record the exact client version, source SHA, installed cache version, commands,
 and outcomes in the PR review packet. Vendor validation supplements rather than

--- a/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
+++ b/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
@@ -23,7 +23,12 @@ built from the base SHA above:
   the plugin root are unavailable after installation.
 - `${CLAUDE_PLUGIN_ROOT}` resolves in skill content. `${CLAUDE_PROJECT_DIR}`
   resolves in stdio MCP arguments.
-- Plugin `.mcp.json` files use the `mcpServers` wrapper.
+- Shipped plugin artifacts are mixed: the installed Vercel partner plugin uses
+  an `mcpServers` wrapper, while Anthropic's marketplace `example-plugin` uses
+  a bare server map. Neither artifact alone proves what the installed client
+  executes. This design selects the wrapper used by the shipped partner
+  plugin, but acceptance requires a real-client connection probe plus the full
+  manifest-driven `initialize` and `tools/list` exchange below.
 - A plugin with no explicit version installs under a SHA-derived version and
   advances after a marketplace update.
 - `claude plugin validate` accepts a referenced `.mcp.json` whose `command` is
@@ -41,7 +46,8 @@ plugin cache.
 
 ## Package Layout
 
-The repository publishes one marketplace containing one config-only plugin:
+The repository publishes one marketplace containing one plugin made of MCP
+configuration and three fixtures, one of which is executable Python:
 
 ```text
 .claude-plugin/
@@ -68,7 +74,15 @@ The marketplace and plugin are both named `assay`, giving install identity
 `skills/assay-golden-path/SKILL.md`; `plugin.json` does not invent an unsupported
 `skills` field. The package has no commands or agents.
 
-The plugin omits `version`. Config-only changes must not be coupled to the Rust
+The marketplace manifest has the explicit minimal field set `name`, `owner`,
+and `plugins`; `owner` is `{ "name": "Assay" }`. Its sole plugin entry has
+`name`, `description`, and local `source: "./packaging/claude-plugin"`. The
+plugin manifest has `name`, `description`, and
+`author: { "name": "Assay" }`; neither manifest has a `version`. These fields
+follow inspected local-source marketplace artifacts rather than relying on
+directory discovery for the marketplace entry itself.
+
+The plugin omits `version`. Packaging-only changes must not be coupled to the Rust
 crate release cadence, and the measured Claude client already provides a
 commit-derived version for an unversioned git marketplace. The absence is a
 tested decision rather than an omitted field by accident.
@@ -88,10 +102,10 @@ The plugin's `.mcp.json` contains one stdio server under `mcpServers.assay`:
 }
 ```
 
-The plugin is config-only: `assay-mcp-server` must already be on `PATH`. The
-server reads policies from the consuming project, not the marketplace checkout
-or plugin cache. The manifest has no unverified `note` extension field; limits
-belong in the generated skill and install guide.
+The plugin does not bundle `assay-mcp-server`; that binary must already be on
+`PATH`. The server reads policies from the consuming project, not the
+marketplace checkout or plugin cache. The manifest has no unverified `note`
+extension field; limits belong in the generated skill and install guide.
 
 ## Generated Skill Profile
 
@@ -139,6 +153,11 @@ local files. The JSON and YAML fixtures do not reference other files. The
 remaining files in `examples/privileged-action-gate` serve other demos and are
 excluded.
 
+This is not a config-only package: `mock_github_mcp.py` is executable fixture
+code that step 6 starts through the user's Python interpreter. The install
+guide therefore requires `python3` or `python` on `PATH` for that optional
+step, separately from the mandatory `assay-mcp-server` prerequisite.
+
 The generator copies these three resources byte-for-byte. The generated-docs
 drift gate covers their package destinations, so source changes cannot leave a
 stale plugin copy. The package does not fetch mutable GitHub URLs and does not
@@ -151,7 +170,9 @@ require an Assay checkout.
 1. install `assay-mcp-server` from a reviewed release or checkout;
 2. add the repository marketplace;
 3. install `assay@assay`;
-4. verify the plugin and its MCP server from the consuming project.
+4. verify the plugin and its MCP server from the consuming project;
+5. after a marketplace update, run the plugin update and inspect the installed
+   cache version so stale cache state is visible rather than inferred away.
 
 The guide says plainly that the plugin does not bundle the binary, does not
 enforce anything merely by being installed, and consumes policy from the
@@ -173,8 +194,9 @@ Extend the existing golden-path validator so it proves:
 - private planning vocabulary and unsupported claims remain absent.
 
 Parse, do not search, the marketplace and plugin JSON. Assert the install
-identity, local source path, auto-discovered skill location, `mcpServers`
-wrapper, string command, exact argument vector, and absence of `version`.
+identity, exact owner and author field shapes, local source path,
+auto-discovered skill location, `mcpServers` wrapper, string command, exact
+argument vector, and absence of `version`.
 
 ### Driven server contract
 
@@ -201,13 +223,23 @@ Before push, run both layers with the installed Claude client:
 - isolated marketplace add/install/update using a fresh
   `CLAUDE_CONFIG_DIR`;
 - inspect the cached plugin rather than the source directory;
-- drive the cached `.mcp.json` against the built server;
+- from a disposable consuming project, run `claude mcp list` to
+  prove that the cached wrapper-shaped configuration is accepted and the
+  stdio server connects;
+- drive the cached `.mcp.json` against the built server through a complete
+  `initialize` plus `tools/list` exchange, not merely a config-listing command;
 - invoke Claude Code from a disposable project and verify discovery of the
   packaged `assay-golden-path` skill.
 
 Record the exact client version, source SHA, installed cache version, commands,
 and outcomes in the PR review packet. Vendor validation supplements rather than
 replaces repository assertions.
+
+These real-client steps remain a manual pre-push procedure. If they are later
+automated through `tests/support/bounded_process.rs`, that automation must use
+the process-tree and early-EPIPE semantics accepted by #2189; marketplace
+operations may spawn `git`, so direct-child-only timeout handling is not an
+equivalent proof.
 
 ### TDD and mutation proof
 
@@ -233,6 +265,8 @@ Every mutation is restored before final verification.
 - Manifest/schema/type errors fail closed.
 - Missing `assay-mcp-server` is reported as a host spawn failure; the plugin
   must not imply that a server ran.
+- Missing Python blocks only the optional step-6 fixture workflow and is named
+  as a prerequisite failure; it is not reported as an Assay policy verdict.
 - Missing project policy never becomes a clean enforcement result.
 - The bundled mock is a local stdio fixture. It performs no network or provider
   action.

--- a/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
+++ b/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
@@ -23,12 +23,13 @@ built from the base SHA above:
   the plugin root are unavailable after installation.
 - `${CLAUDE_PLUGIN_ROOT}` resolves in skill content. `${CLAUDE_PROJECT_DIR}`
   resolves in stdio MCP arguments.
-- Shipped plugin artifacts are mixed: the installed Vercel partner plugin uses
-  an `mcpServers` wrapper, while Anthropic's marketplace `example-plugin` uses
-  a bare server map. Neither artifact alone proves what the installed client
-  executes. This design selects the wrapper used by the shipped partner
-  plugin, but acceptance requires a real-client connection probe plus the full
-  manifest-driven `initialize` and `tools/list` exchange below.
+- Sixteen inspected plugin artifacts are mixed: six use an `mcpServers` wrapper
+  and ten use a bare server map. The installed cache artifact uses the wrapper;
+  the bare examples are predominantly marketplace-source artifacts. Neither
+  shape alone proves what the installed client executes. This design selects
+  the installed partner plugin's wrapper, but acceptance requires a real-client
+  connection probe plus the full manifest-driven `initialize` and `tools/list`
+  exchange below.
 - A plugin with no explicit version installs under a SHA-derived version and
   advances after a marketplace update.
 - `claude plugin validate` accepts a referenced `.mcp.json` whose `command` is

--- a/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
+++ b/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
@@ -224,13 +224,16 @@ Before push, run both layers with the installed Claude client:
 - isolated marketplace add/install/update using a fresh
   `CLAUDE_CONFIG_DIR`;
 - inspect the cached plugin rather than the source directory;
-- from a disposable consuming project, run `claude mcp list` to
-  prove that the cached wrapper-shaped configuration is accepted and the
-  stdio server connects;
+- from a disposable consuming project, run
+  `CLAUDE_PROJECT_DIR="$PWD" claude mcp list`; the standalone health subcommand
+  does not synthesize this session variable, so the explicit value proves that
+  the cached wrapper-shaped configuration is accepted and the stdio server
+  connects, but does not prove session-time variable injection;
 - drive the cached `.mcp.json` against the built server through a complete
   `initialize` plus `tools/list` exchange, not merely a config-listing command;
-- invoke Claude Code from a disposable project and verify discovery of the
-  packaged `assay-golden-path` skill.
+- invoke an actual Claude Code session from a disposable project without
+  manually setting `CLAUDE_PROJECT_DIR`, and verify both session-time MCP
+  connection and discovery of the packaged `assay-golden-path` skill.
 
 Record the exact client version, source SHA, installed cache version, commands,
 and outcomes in the PR review packet. Vendor validation supplements rather than

--- a/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
+++ b/docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md
@@ -231,6 +231,9 @@ The same driven connection writes a unique blocklist policy only inside the
 temporary consuming project and calls `assay_policy_decide`. The marker tool
 must be denied. This proves that `.` resolves to the consuming project rather
 than merely proving that the server can connect from some existing directory.
+The temporary project must not contain a `policies/` directory, and the cached
+manifest must still carry exact args `--policy-root .`; otherwise the server's
+default `policies` value could make a policy lookup look like proof of `.`.
 
 ### Real-client proof
 
@@ -254,11 +257,16 @@ Record the exact client version, source SHA, installed cache version, commands,
 and outcomes in the PR review packet. Vendor validation supplements rather than
 replaces repository assertions.
 
-These real-client steps remain a manual pre-push procedure. If they are later
-automated through `tests/support/bounded_process.rs`, that automation must use
-the process-tree and early-EPIPE semantics accepted by #2189; marketplace
-operations may spawn `git`, so direct-child-only timeout handling is not an
-equivalent proof.
+These real-client steps run through `scripts/ci/test-claude-plugin-install.sh`.
+The shell entrypoint delegates to a normal Python module so each language keeps
+its own linting boundary. The driver uses a fresh POSIX session/process group,
+one absolute deadline while draining inherited pipes, separate 1 MiB
+stdout/stderr ceilings, and bounded reaping. Its self-test covers a hung tree, a
+direct child that exits while a descendant retains an output handle, overflow,
+source-checkout cache substitution, stale cache after a successful no-op update,
+and tool-name drift. This is a separately proven macOS/Linux strategy for the
+vendor workflow; it does not replace the shared Rust test helper or claim native
+Windows support.
 
 ### TDD and mutation proof
 

--- a/examples/privileged-action-gate/mock_github_mcp.py
+++ b/examples/privileged-action-gate/mock_github_mcp.py
@@ -17,6 +17,7 @@ import os
 import sys
 
 MODE = os.environ.get("MOCK_MODE", "approved")
+MAX_REQUEST_BYTES = 1_048_576
 
 
 def _send(obj):
@@ -47,10 +48,24 @@ def _tools():
     return [_SEARCH, _DEPLOY_KEY_READONLY if MODE == "drifted" else _DEPLOY_KEY]
 
 
+def _read_request():
+    raw = sys.stdin.buffer.readline(MAX_REQUEST_BYTES + 1)
+    if not raw:
+        return None
+    if len(raw) <= MAX_REQUEST_BYTES:
+        return raw
+
+    while not raw.endswith(b"\n"):
+        raw = sys.stdin.buffer.readline(MAX_REQUEST_BYTES + 1)
+        if not raw:
+            break
+    return b""
+
+
 def main():
     while True:
-        raw = sys.stdin.readline()
-        if not raw:
+        raw = _read_request()
+        if raw is None:
             break
         line = raw.strip()
         if not line:

--- a/packaging/claude-plugin/.claude-plugin/plugin.json
+++ b/packaging/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "assay",
+  "description": "Connect Claude Code to Assay's MCP policy and evidence tools and golden-path skill.",
+  "author": {
+    "name": "Assay"
+  }
+}

--- a/packaging/claude-plugin/.mcp.json
+++ b/packaging/claude-plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "assay-mcp-server",
       "args": [
         "--policy-root",
-        "${CLAUDE_PROJECT_DIR}"
+        "."
       ]
     }
   }

--- a/packaging/claude-plugin/.mcp.json
+++ b/packaging/claude-plugin/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay-mcp-server",
+      "args": [
+        "--policy-root",
+        "${CLAUDE_PROJECT_DIR}"
+      ]
+    }
+  }
+}

--- a/packaging/claude-plugin/skills/assay-golden-path/SKILL.md
+++ b/packaging/claude-plugin/skills/assay-golden-path/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: assay-golden-path
+description: Drive Assay's install-to-evidence golden path and interpret its stdout and exit codes. Use when an agent must operate or diagnose Assay; do not use it to infer provider execution, external side effects, or a clean result from missing output.
+---
+
+# Assay Golden Path
+
+Drive the nine steps below in order. Read stdout and the process exit code
+separately; a policy denial can be a successful JSON-RPC exchange rather than
+a process failure.
+
+`${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/references/agent-golden-path.json` is the authoritative machine contract.
+Read it when exact argv, fields, or per-outcome metadata are needed.
+
+When a step has no `working_directory`, run it from the invocation cwd.
+Fixtures named by the contract under `examples/privileged-action-gate` are bundled at `${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/assets/privileged-action-gate`.
+A present `working_directory` in the contract resolves through that mapping.
+Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.
+
+Empty stdout in a gap row is an observed limitation, not permission for a caller to infer success from missing evidence.
+Do not replace a linked gap with an inferred clean result.
+
+Claude Code loads this skill from the installed Assay plugin.
+
+## Journey
+
+### 1. Install check
+
+Run: `assay version`
+
+Exit: Success `0`.
+
+Stdout: One `MAJOR.MINOR.PATCH` line.
+
+On failure: A missing or unstartable binary is a host spawn failure: no Assay process runs, so Assay produces no stdout or exit code.
+
+### 2. Preflight
+
+Run: `assay doctor --format json`
+
+Exit: Success `0`; invalid explicit config `1`.
+
+Stdout: Parses as `assay.doctor_report.v0`. A config failure remains JSON and carries `config_error.code: E_CFG_PARSE`.
+
+On failure: `reason_code` and `next_step` are absent, and the exit is outside the frozen config/usage class: [gap #2160](https://github.com/Rul1an/assay/issues/2160).
+
+### 3. Starter files
+
+Run: `assay init --preset dev --hello-trace`
+
+Exit: Success `0`; unknown preset `2`.
+
+Stdout: Human progress text; success ends with `Next: assay validate --config eval.yaml --trace-file traces/hello.jsonl`. A failing run writes partial progress text, not the fatal diagnosis.
+
+On failure: No machine report, `reason_code`, or `next_step` on stdout: [gap #2161](https://github.com/Rul1an/assay/issues/2161).
+
+### 4. Policy validation
+
+Run: `assay policy validate --input <policy>`
+
+Exit: Valid `0`; malformed `2`.
+
+Stdout: Empty on both paths.
+
+On failure: The diagnosis, registered reason, and next step are absent from stdout: [gap #2162](https://github.com/Rul1an/assay/issues/2162).
+
+### 5. Evaluation result
+
+Run: `assay run --config eval.yaml --trace-file traces/hello.jsonl --format json`
+
+Exit: All tests pass `0`; completed run with failed tests `1`.
+
+Stdout: Both completed outcomes parse as `assay.run_report.v1`; failed results carry `status: fail` inside `results`.
+
+On failure: Exit `1` is a completed results report, not an early-failure diagnosis; `reason_code` and `next_step` are absent by design.
+
+### 6. Protected action
+
+Working directory: `${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/assets/privileged-action-gate`
+
+Run: `assay-mcp-server proxy-enforce --upstream-command <python> --upstream-arg -u --upstream-arg mock_github_mcp.py --enforce-policy policies/no-allowance.yaml --declared-mcp-manifest baseline-approved.json`
+
+Exit: Policy-denied call after stdin closes `0`; startup input failure `1`.
+
+Stdout: The denied `tools/call` response pins `error.code: -32042`, `error.data.origin: assay-proxy`, and `error.data.reason: no_declared_allowance`.
+
+On failure: Policy denial is not a process failure. A missing enforcement policy fails startup with empty stdout and no stable reason/next-step object: [gap #2163](https://github.com/Rul1an/assay/issues/2163).
+
+### 7. Evidence inspection
+
+Run: `assay evidence show <bundle> --format json`
+
+Exit: Valid `0`; integrity failure `2`.
+
+Stdout: Success parses as an object containing `manifest` and `events`. Integrity failure produces no stdout.
+
+On failure: No JSON failure report, `reason_code`, or `next_step`: [gap #2164](https://github.com/Rul1an/assay/issues/2164).
+
+### 8. Offline profile verification
+
+Run: `assay evidence verify-privileged-mcp-action <bundle> --format json`
+
+Exit: Valid `0`; integrity or profile failure `2`.
+
+Stdout: Both paths parse as `assay.privileged_mcp_action.verify.report.v0`. Success has `bundle_integrity: pass` and `verdict: valid`; tamper has `bundle_integrity: fail`, a bounded finding, and no verdict.
+
+On failure: The failure report has no registered `reason_code` or actionable `next_step`: [gap #2165](https://github.com/Rul1an/assay/issues/2165).
+
+### 9. SARIF projection
+
+Run: `assay-mcp-server enforcement-sarif --input - --output -`
+
+Exit: Valid input `0`; malformed non-empty NDJSON `0`.
+
+Stdout: Valid input produces SARIF `2.1.0`. Malformed lines are currently discarded and can produce a clean report with zero results.
+
+On failure: This is fail-open, not a successful empty projection: [gap #2166](https://github.com/Rul1an/assay/issues/2166). No reason or next step is emitted.
+
+## Non-claims
+
+- The contract records current behavior; gap rows are not clean results.
+- Schema identity conventions outside this narrow contract remain owned by issue #2167.
+- A passing evidence integrity check does not prove an external side effect.

--- a/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json
+++ b/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json
@@ -1,0 +1,37 @@
+{
+  "note": "operator-pinned per-tool baseline; manifest_digest recomputes from tools via the guard test and equals the committed P60a manifest_digest (same canonical tools)",
+  "schema": "assay.declared_mcp_manifest.v0",
+  "server": {
+    "id": "github"
+  },
+  "canonicalization": "assay.mcp_manifest_projection.v0",
+  "manifest_digest": "sha256:f8a95098345d600f7a2d742c4e941ace5e9594918b2aa82a9a8f48f72f701ffa",
+  "tools": [
+    {
+      "name": "search",
+      "tool_digest": "sha256:2318d9fd63878b81e992300635172e75053e086db757e31b7ebc917a7c721697",
+      "privileged": false,
+      "privilege_classification": "unclassified",
+      "action_class": null,
+      "field_digests": {
+        "description": "sha256:44c1a1350496d95897e53865330ee56cbf07b02ee54450c191d7d72b2d7005ea",
+        "input_schema": "sha256:e0522e896196457208cca527b92ed8155a72673ccb7723ade56ef69f57230290",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
+    },
+    {
+      "name": "github.add_deploy_key",
+      "tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6",
+      "privileged": true,
+      "privilege_classification": "classified",
+      "action_class": "github_deploy_key",
+      "field_digests": {
+        "description": "sha256:7e326787191c47250d1541c8dd2e5c8e9e8c5345ef3da8b66694e32788a29d99",
+        "input_schema": "sha256:52e5c928edb4433b517b5410a20c6a8a2ed87ff90b7931c000ba2a43fca3644c",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
+    }
+  ]
+}

--- a/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
+++ b/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Self-contained mock GitHub MCP server (stdio) for the privileged-action-gate example.
+
+Newline-delimited JSON-RPC over stdin/stdout. It exposes two tools: a read-only `search` and the
+privileged `github.add_deploy_key`. No network, no auth, no real GitHub call. The tool definitions
+are byte-for-byte the ones the shipped approved baselines were computed from, so the proxy's drift
+gate allows the matching mode and denies the drifted one.
+
+  MOCK_MODE=approved  github.add_deploy_key as approved (per-tool digest matches baseline-approved.json)
+  MOCK_MODE=drifted   github.add_deploy_key now DECLARES readOnlyHint:true (a post-approval change):
+                      its digest differs from baseline-approved.json (-> drift) and matches
+                      baseline-approved-readonly.json (-> allowed, with a separate conformance signal,
+                      because the call is still a create/mutating action).
+"""
+import json
+import os
+import sys
+
+MODE = os.environ.get("MOCK_MODE", "approved")
+
+
+def _send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def _tool(name, description, input_schema, annotations=None):
+    tool = {"name": name, "description": description, "inputSchema": input_schema}
+    if annotations is not None:
+        tool["annotations"] = annotations
+    return tool
+
+
+_SEARCH = _tool("search", "does a thing", {"type": "object"})
+_DEPLOY_KEY = _tool(
+    "github.add_deploy_key", "Add a deploy key", {"type": "object", "required": ["owner", "repo"]}
+)
+_DEPLOY_KEY_READONLY = _tool(
+    "github.add_deploy_key",
+    "Add a deploy key",
+    {"type": "object", "required": ["owner", "repo"]},
+    annotations={"readOnlyHint": True},
+)
+
+
+def _tools():
+    return [_SEARCH, _DEPLOY_KEY_READONLY if MODE == "drifted" else _DEPLOY_KEY]
+
+
+def main():
+    while True:
+        raw = sys.stdin.readline()
+        if not raw:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        method = msg.get("method")
+        mid = msg.get("id")
+        if method == "initialize":
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-github", "version": "0.0.0"},
+                },
+            })
+        elif method == "ping":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        elif method == "tools/list":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {"tools": _tools()}})
+        elif method == "tools/call":
+            # Only the proxy's allow path forwards a tools/call to us. Canned success; no real call.
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "content": [{"type": "text", "text": "forwarded-ok (mock; no real GitHub call)"}],
+                    "isError": False,
+                },
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
+++ b/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
@@ -17,6 +17,7 @@ import os
 import sys
 
 MODE = os.environ.get("MOCK_MODE", "approved")
+MAX_REQUEST_BYTES = 1_048_576
 
 
 def _send(obj):
@@ -47,10 +48,24 @@ def _tools():
     return [_SEARCH, _DEPLOY_KEY_READONLY if MODE == "drifted" else _DEPLOY_KEY]
 
 
+def _read_request():
+    raw = sys.stdin.buffer.readline(MAX_REQUEST_BYTES + 1)
+    if not raw:
+        return None
+    if len(raw) <= MAX_REQUEST_BYTES:
+        return raw
+
+    while not raw.endswith(b"\n"):
+        raw = sys.stdin.buffer.readline(MAX_REQUEST_BYTES + 1)
+        if not raw:
+            break
+    return b""
+
+
 def main():
     while True:
-        raw = sys.stdin.readline()
-        if not raw:
+        raw = _read_request()
+        if raw is None:
             break
         line = raw.strip()
         if not line:

--- a/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml
+++ b/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml
@@ -1,0 +1,8 @@
+# No allowance declares github_deploy_key, so the caller-allowance gate denies: the action was never
+# declared for this caller, even though a credential is present.
+caller:
+  id: "ci-agent"
+upstream_credential:
+  alias: "gh-deploy"
+  scopes: ["repo:deploy_key:write"]
+allowances: []

--- a/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
+++ b/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
@@ -1,0 +1,441 @@
+{
+  "schema": "assay.agent_golden_path.v1",
+  "schema_version": 1,
+  "generated_by": "scripts/docs/generate-agent-golden-path.py",
+  "source_issue": 2154,
+  "journey_issue": 1975,
+  "non_claims": [
+    "The contract records current behavior; gap rows are not clean results.",
+    "Schema identity conventions outside this narrow contract remain owned by issue #2167.",
+    "A passing evidence integrity check does not prove an external side effect."
+  ],
+  "steps": [
+    {
+      "step": 1,
+      "id": "install-check",
+      "label": "Install check",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "Success",
+          "exit_code": 0,
+          "argv": [
+            "version"
+          ],
+          "stdout": {
+            "kind": "text",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        }
+      ],
+      "stdout_summary": "One `MAJOR.MINOR.PATCH` line.",
+      "failure_summary": "A missing or unstartable binary is a host spawn failure: no Assay process runs, so Assay produces no stdout or exit code.",
+      "command": "assay version"
+    },
+    {
+      "step": 2,
+      "id": "preflight",
+      "label": "Preflight",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "Success",
+          "exit_code": 0,
+          "argv": [
+            "doctor",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.doctor_report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "invalid-config",
+          "label": "invalid explicit config",
+          "exit_code": 1,
+          "argv": [
+            "doctor",
+            "--format",
+            "json",
+            "--config",
+            "<config>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.doctor_report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2160,
+          "config_error_code": "E_CFG_PARSE"
+        }
+      ],
+      "stdout_summary": "Parses as `assay.doctor_report.v0`. A config failure remains JSON and carries `config_error.code: E_CFG_PARSE`.",
+      "failure_summary": "`reason_code` and `next_step` are absent, and the exit is outside the frozen config/usage class: [gap #2160](https://github.com/Rul1an/assay/issues/2160).",
+      "command": "assay doctor --format json"
+    },
+    {
+      "step": 3,
+      "id": "starter-files",
+      "label": "Starter files",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "Success",
+          "exit_code": 0,
+          "argv": [
+            "init",
+            "--preset",
+            "dev",
+            "--hello-trace"
+          ],
+          "stdout": {
+            "kind": "text",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "unknown-preset",
+          "label": "unknown preset",
+          "exit_code": 2,
+          "argv": [
+            "init",
+            "--preset",
+            "not-a-preset"
+          ],
+          "stdout": {
+            "kind": "text",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2161
+        }
+      ],
+      "stdout_summary": "Human progress text; success ends with `Next: assay validate --config eval.yaml --trace-file traces/hello.jsonl`. A failing run writes partial progress text, not the fatal diagnosis.",
+      "failure_summary": "No machine report, `reason_code`, or `next_step` on stdout: [gap #2161](https://github.com/Rul1an/assay/issues/2161).",
+      "command": "assay init --preset dev --hello-trace"
+    },
+    {
+      "step": 4,
+      "id": "policy-validation",
+      "label": "Policy validation",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid",
+          "exit_code": 0,
+          "argv": [
+            "policy",
+            "validate",
+            "--input",
+            "<policy>"
+          ],
+          "stdout": {
+            "kind": "empty",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "malformed",
+          "label": "malformed",
+          "exit_code": 2,
+          "argv": [
+            "policy",
+            "validate",
+            "--input",
+            "<policy>"
+          ],
+          "stdout": {
+            "kind": "empty",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2162
+        }
+      ],
+      "stdout_summary": "Empty on both paths.",
+      "failure_summary": "The diagnosis, registered reason, and next step are absent from stdout: [gap #2162](https://github.com/Rul1an/assay/issues/2162).",
+      "command": "assay policy validate --input <policy>"
+    },
+    {
+      "step": 5,
+      "id": "evaluation-result",
+      "label": "Evaluation result",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "All tests pass",
+          "exit_code": 0,
+          "argv": [
+            "run",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            "traces/hello.jsonl",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_report.v1"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "completed-test-failure",
+          "label": "completed run with failed tests",
+          "exit_code": 1,
+          "argv": [
+            "run",
+            "--config",
+            "<config>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_report.v1"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null,
+          "classification": "completed_test_failure"
+        }
+      ],
+      "stdout_summary": "Both completed outcomes parse as `assay.run_report.v1`; failed results carry `status: fail` inside `results`.",
+      "failure_summary": "Exit `1` is a completed results report, not an early-failure diagnosis; `reason_code` and `next_step` are absent by design.",
+      "command": "assay run --config eval.yaml --trace-file traces/hello.jsonl --format json"
+    },
+    {
+      "step": 6,
+      "id": "protected-action",
+      "label": "Protected action",
+      "binary": "assay-mcp-server",
+      "working_directory": "examples/privileged-action-gate",
+      "outcomes": [
+        {
+          "name": "policy-denied",
+          "label": "Policy-denied call after stdin closes",
+          "exit_code": 0,
+          "argv": [
+            "proxy-enforce",
+            "--upstream-command",
+            "<python>",
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            "mock_github_mcp.py",
+            "--enforce-policy",
+            "policies/no-allowance.yaml",
+            "--declared-mcp-manifest",
+            "baseline-approved.json"
+          ],
+          "stdout": {
+            "kind": "json_lines",
+            "document": "jsonrpc-2.0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null,
+          "jsonrpc_error_code": -32042,
+          "origin": "assay-proxy",
+          "reason": "no_declared_allowance"
+        },
+        {
+          "name": "startup-failure",
+          "label": "startup input failure",
+          "exit_code": 1,
+          "argv": [
+            "proxy-enforce",
+            "--upstream-command",
+            "<python>",
+            "--enforce-policy",
+            "missing.yaml",
+            "--declared-mcp-manifest",
+            "missing.json"
+          ],
+          "stdout": {
+            "kind": "empty",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2163
+        }
+      ],
+      "stdout_summary": "The denied `tools/call` response pins `error.code: -32042`, `error.data.origin: assay-proxy`, and `error.data.reason: no_declared_allowance`.",
+      "failure_summary": "Policy denial is not a process failure. A missing enforcement policy fails startup with empty stdout and no stable reason/next-step object: [gap #2163](https://github.com/Rul1an/assay/issues/2163).",
+      "command": "assay-mcp-server proxy-enforce --upstream-command <python> --upstream-arg -u --upstream-arg mock_github_mcp.py --enforce-policy policies/no-allowance.yaml --declared-mcp-manifest baseline-approved.json"
+    },
+    {
+      "step": 7,
+      "id": "evidence-inspection",
+      "label": "Evidence inspection",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid",
+          "exit_code": 0,
+          "argv": [
+            "evidence",
+            "show",
+            "<bundle>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "tampered",
+          "label": "integrity failure",
+          "exit_code": 2,
+          "argv": [
+            "evidence",
+            "show",
+            "<bundle>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "empty",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2164
+        }
+      ],
+      "stdout_summary": "Success parses as an object containing `manifest` and `events`. Integrity failure produces no stdout.",
+      "failure_summary": "No JSON failure report, `reason_code`, or `next_step`: [gap #2164](https://github.com/Rul1an/assay/issues/2164).",
+      "command": "assay evidence show <bundle> --format json"
+    },
+    {
+      "step": 8,
+      "id": "offline-profile-verification",
+      "label": "Offline profile verification",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid",
+          "exit_code": 0,
+          "argv": [
+            "evidence",
+            "verify-privileged-mcp-action",
+            "<bundle>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.privileged_mcp_action.verify.report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "tampered",
+          "label": "integrity or profile failure",
+          "exit_code": 2,
+          "argv": [
+            "evidence",
+            "verify-privileged-mcp-action",
+            "<bundle>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.privileged_mcp_action.verify.report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2165
+        }
+      ],
+      "stdout_summary": "Both paths parse as `assay.privileged_mcp_action.verify.report.v0`. Success has `bundle_integrity: pass` and `verdict: valid`; tamper has `bundle_integrity: fail`, a bounded finding, and no verdict.",
+      "failure_summary": "The failure report has no registered `reason_code` or actionable `next_step`: [gap #2165](https://github.com/Rul1an/assay/issues/2165).",
+      "command": "assay evidence verify-privileged-mcp-action <bundle> --format json"
+    },
+    {
+      "step": 9,
+      "id": "sarif-projection",
+      "label": "SARIF projection",
+      "binary": "assay-mcp-server",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid input",
+          "exit_code": 0,
+          "argv": [
+            "enforcement-sarif",
+            "--input",
+            "-",
+            "--output",
+            "-"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "sarif-2.1.0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "malformed",
+          "label": "malformed non-empty NDJSON",
+          "exit_code": 0,
+          "argv": [
+            "enforcement-sarif",
+            "--input",
+            "-",
+            "--output",
+            "-"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "sarif-2.1.0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2166
+        }
+      ],
+      "stdout_summary": "Valid input produces SARIF `2.1.0`. Malformed lines are currently discarded and can produce a clean report with zero results.",
+      "failure_summary": "This is fail-open, not a successful empty projection: [gap #2166](https://github.com/Rul1an/assay/issues/2166). No reason or next step is emitted.",
+      "command": "assay-mcp-server enforcement-sarif --input - --output -"
+    }
+  ]
+}

--- a/scripts/ci/check-docs-generated-drift.sh
+++ b/scripts/ci/check-docs-generated-drift.sh
@@ -45,6 +45,11 @@ GENERATORS=(
 GENERATED=(
   .agents/skills/assay-golden-path/SKILL.md
   .claude/skills/assay-golden-path/SKILL.md
+  packaging/claude-plugin/skills/assay-golden-path/SKILL.md
+  packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
+  packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
+  packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json
+  packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml
   docs/generated/agent-golden-path.json
   docs/generated/crate-deps.mermaid
   docs/generated/module-map.mermaid
@@ -58,6 +63,11 @@ GENERATED=(
 FRESH_GENERATED=(
   .agents/skills/assay-golden-path/SKILL.md
   .claude/skills/assay-golden-path/SKILL.md
+  packaging/claude-plugin/skills/assay-golden-path/SKILL.md
+  packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
+  packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
+  packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json
+  packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml
   docs/generated/agent-golden-path.json
 )
 

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -295,6 +295,18 @@ def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], 
                 },
             },
         },
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "assay_policy_decide",
+                "arguments": {
+                    "tool": "install_surface_probe",
+                    "policy": "missing-install-surface-policy.yaml",
+                },
+            },
+        },
     ]
     stdin = b"".join(json.dumps(request, separators=(",", ":")).encode() + b"\n" for request in requests)
     result = run_bounded("initialize", [resolved, *args], cwd=consumer, env=env, stdin=stdin)
@@ -322,6 +334,19 @@ def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], 
             "override the project MCP entry with an absolute --policy-root for hosts that use another cwd",
         )
     print("policy_root_resolved_to_consumer=pass")
+
+    missing_content = responses.get(4, {}).get("result", {}).get("content", [])
+    try:
+        missing = json.loads(missing_content[0]["text"])
+    except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
+        fail("missing_policy_refused", f"missing-policy response is invalid: {error}", "inspect assay_policy_decide error output")
+    if missing.get("error", {}).get("code") != "E_POLICY_NOT_FOUND":
+        fail(
+            "missing_policy_refused",
+            f"missing policy did not return E_POLICY_NOT_FOUND: {missing}",
+            "keep missing policy distinct from a clean allow or deny verdict",
+        )
+    print("missing_policy_refused=pass")
 
 
 def verify_workflow() -> None:
@@ -522,8 +547,6 @@ import json, os, pathlib, sys
 tool_names = {EXPECTED_TOOLS!r}
 if os.environ.get("FAKE_TOOL_DRIFT"):
     tool_names[-1] = "assay_policy_changed"
-policy = pathlib.Path.cwd() / "install-surface-policy.yaml"
-blocked = "install_surface_probe" in policy.read_text() if policy.is_file() else False
 for line in sys.stdin:
     request = json.loads(line)
     if "id" not in request: continue
@@ -533,7 +556,14 @@ for line in sys.stdin:
     elif method == "tools/list":
         result = {{"tools":[{{"name":name,"description":"test","inputSchema":{{"type":"object"}}}} for name in tool_names]}}
     elif method == "tools/call":
-        result = {{"content":[{{"type":"text","text":json.dumps({{"allowed": not blocked}})}}],"isError":False}}
+        policy_name = request["params"]["arguments"]["policy"]
+        policy = pathlib.Path.cwd() / policy_name
+        if not policy.is_file():
+            payload = {{"error":{{"code":"E_POLICY_NOT_FOUND","message":f"Policy not found: {{policy_name}}"}}}}
+        else:
+            blocked = "install_surface_probe" in policy.read_text()
+            payload = {{"allowed": not blocked}}
+        result = {{"content":[{{"type":"text","text":json.dumps(payload)}}],"isError":False}}
     else:
         result = {{}}
     print(json.dumps({{"jsonrpc":"2.0","id":request["id"],"result":result}}), flush=True)
@@ -571,6 +601,7 @@ def self_test() -> None:
             "initialize=pass",
             "tools_list=pass",
             "policy_root_resolved_to_consumer=pass",
+            "missing_policy_refused=pass",
             "actual_session_mcp_connected=pass",
             "skill_discovery=pass",
             "model_mediated_tool_call=unavailable",

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -25,6 +25,9 @@ EXPECTED_TOOLS = [
     "assay_policy_decide",
 ]
 AUTH_ENV_PREFIXES = ("ANTHROPIC_", "CLAUDE_CODE_OAUTH_", "ASSAY_AUTH_")
+DRIVER = Path(__file__).resolve()
+SOURCE_ROOT = DRIVER.parents[2]
+WORKFLOW_SCRIPT = DRIVER.with_name("test-claude-plugin-install.sh")
 
 
 class WorkflowError(RuntimeError):
@@ -204,13 +207,6 @@ def plugin_record(payload: object) -> dict[str, object]:
     fail("installed_cache", "plugin list omitted assay@assay", "run `claude plugin list --json` and reinstall assay@assay")
 
 
-def assert_under(path: Path, parent: Path, phase: str, message: str) -> None:
-    try:
-        path.relative_to(parent)
-    except ValueError:
-        fail(phase, message, "remove the stale install and reinstall with a fresh CLAUDE_CONFIG_DIR")
-
-
 def compare_installed_package(source_package: Path, installed: Path) -> None:
     source_files = descendants_are_regular(source_package, "installed_cache")
     descendants_are_regular(installed, "installed_cache")
@@ -250,6 +246,8 @@ def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], 
         fail("initialize", f"installed MCP manifest is invalid: {error}", "reinstall the plugin from the reviewed marketplace")
     if not isinstance(command, str) or not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
         fail("initialize", "installed MCP command/args are not strings", "restore the typed plugin manifest")
+    if command != "assay-mcp-server":
+        fail("binary_spawn", f"installed MCP command drifted: {command!r}", "restore the release binary name in the plugin manifest")
     if args != ["--policy-root", "."]:
         fail(
             "policy_root_resolved_to_consumer",
@@ -309,7 +307,13 @@ def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], 
         },
     ]
     stdin = b"".join(json.dumps(request, separators=(",", ":")).encode() + b"\n" for request in requests)
-    result = run_bounded("initialize", [resolved, *args], cwd=consumer, env=env, stdin=stdin)
+    result = run_bounded(
+        "initialize",
+        [str(expected_server), "--policy-root", "."],
+        cwd=consumer,
+        env=env,
+        stdin=stdin,
+    )
     responses = parse_protocol(result.stdout)
     initialize = responses.get(1, {})
     if initialize.get("result", {}).get("protocolVersion") != "2024-11-05":
@@ -350,22 +354,25 @@ def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], 
 
 
 def verify_workflow() -> None:
-    script = Path(os.environ["ASSAY_CLAUDE_WORKFLOW_SCRIPT"]).resolve()
-    source_root = Path(os.environ.get("ASSAY_SOURCE_ROOT", script.parents[2])).resolve()
+    script = WORKFLOW_SCRIPT
+    source_root = SOURCE_ROOT
     source_package = source_root / "packaging/claude-plugin"
     marketplace = source_root / ".claude-plugin/marketplace.json"
-    claude = Path(os.environ.get("ASSAY_CLAUDE_BIN", shutil.which("claude") or ""))
-    server = Path(os.environ.get("ASSAY_MCP_SERVER_BIN", shutil.which("assay-mcp-server") or ""))
-    if not claude.is_file():
-        fail("prerequisite", "Claude Code executable not found", "install Claude Code and set ASSAY_CLAUDE_BIN if needed")
-    if not server.is_file():
-        fail("prerequisite", "assay-mcp-server executable not found", "install the exact-SHA server and set ASSAY_MCP_SERVER_BIN")
+    claude_lookup = shutil.which("claude")
+    server_lookup = shutil.which("assay-mcp-server")
+    if claude_lookup is None:
+        fail("prerequisite", "Claude Code executable not found", "install Claude Code and put `claude` on PATH")
+    if server_lookup is None:
+        fail("prerequisite", "assay-mcp-server executable not found", "install the exact-SHA `assay-mcp-server` on PATH")
+    claude = Path(claude_lookup).resolve()
+    server = Path(server_lookup).resolve()
     read_bounded(marketplace, "plugin_validate")
 
     git = run_bounded("source_sha", ["git", "rev-parse", "HEAD"], cwd=source_root, env=clean_env())
     source_sha = git.stdout.decode().strip()
     if len(source_sha) != 40 or any(char not in "0123456789abcdef" for char in source_sha):
         fail("source_sha", f"invalid git SHA: {source_sha!r}", "run from a committed git worktree")
+    expected_cache_version = source_sha[:12]
 
     with tempfile.TemporaryDirectory(prefix="assay-claude-plugin-") as temporary:
         temp = Path(temporary).resolve()
@@ -400,17 +407,23 @@ def verify_workflow() -> None:
         listing = run_bounded("installed_cache", [str(claude), "plugin", "list", "--json"], cwd=consumer, env=env)
         try:
             record = plugin_record(json.loads(listing.stdout))
-            installed = Path(str(record["installPath"])).resolve()
             cache_version = str(record["version"])
+            reported_install_path = str(record["installPath"])
         except (KeyError, TypeError, json.JSONDecodeError) as error:
             fail("installed_cache", f"plugin list JSON is invalid: {error}", "run `claude plugin list --json` and inspect assay@assay")
-        assert_under(installed, config, "installed_cache", "installed cache escaped the fresh Claude config")
-        try:
-            installed.relative_to(source_root)
-        except ValueError:
-            pass
-        else:
-            fail("installed_cache", "installed plugin resolves inside the source checkout", "install through the marketplace instead of reading source files directly")
+        installed = config / "plugins/cache/assay/assay" / expected_cache_version
+        if cache_version != expected_cache_version:
+            fail(
+                "installed_cache",
+                f"installed cache version {cache_version!r} does not match source {expected_cache_version!r}",
+                "run marketplace update and plugin update from the committed source head",
+            )
+        if reported_install_path != str(installed):
+            fail(
+                "installed_cache",
+                f"plugin list reported an unexpected install path: {reported_install_path}",
+                "remove the stale install and reinstall with a fresh CLAUDE_CONFIG_DIR",
+            )
         compare_installed_package(source_package, installed)
         print("installed_cache=pass")
 
@@ -458,7 +471,7 @@ def verify_workflow() -> None:
         print("verification=pass")
 
 
-def write_fake_tools(root: Path) -> tuple[Path, Path]:
+def write_fake_tools(root: Path, cache_version: str) -> tuple[Path, Path]:
     fake_bin = root / "fake-bin"
     fake_bin.mkdir()
     claude = fake_bin / "claude"
@@ -512,7 +525,7 @@ elif args[:3] == ["plugin", "marketplace", "add"]:
     print("added")
 elif args[:2] == ["plugin", "install"]:
     source = pathlib.Path(source_file.read_text())
-    cache = config / "plugins/cache/assay/assay/fake-v1"
+    cache = config / "plugins/cache/assay/assay/{cache_version}"
     cache.parent.mkdir(parents=True, exist_ok=True)
     if cache.exists(): shutil.rmtree(cache)
     shutil.copytree(source / "packaging/claude-plugin", cache)
@@ -522,15 +535,16 @@ elif args[:3] == ["plugin", "marketplace", "update"]:
     print("marketplace updated")
 elif args[:2] == ["plugin", "update"]:
     source = pathlib.Path(source_file.read_text())
-    cache = config / "plugins/cache/assay/assay/fake-v1"
+    cache = config / "plugins/cache/assay/assay/{cache_version}"
     if not os.environ.get("FAKE_NO_UPDATE"):
         if cache.exists(): shutil.rmtree(cache)
         shutil.copytree(source / "packaging/claude-plugin", cache)
     print("plugin updated")
 elif args[:3] == ["plugin", "list", "--json"]:
     source = pathlib.Path(source_file.read_text())
-    cache = source / "packaging/claude-plugin" if os.environ.get("FAKE_SOURCE_ONLY") else config / "plugins/cache/assay/assay/fake-v1"
-    print(json.dumps([{{"id":"assay@assay","version":"fake-v1","installPath":str(cache)}}]))
+    cache = source / "packaging/claude-plugin" if os.environ.get("FAKE_SOURCE_ONLY") else config / "plugins/cache/assay/assay/{cache_version}"
+    version = "forged-v2" if os.environ.get("FAKE_CACHE_VERSION_DRIFT") else "{cache_version}"
+    print(json.dumps([{{"id":"assay@assay","version":version,"installPath":str(cache)}}]))
 elif args[:2] == ["mcp", "list"]:
     print("assay: Connected")
 else:
@@ -576,16 +590,17 @@ for line in sys.stdin:
 
 
 def self_test() -> None:
-    script = Path(os.environ["ASSAY_CLAUDE_WORKFLOW_SCRIPT"]).resolve()
-    source_root = script.parents[2]
+    script = WORKFLOW_SCRIPT
+    source_root = SOURCE_ROOT
+    git = run_bounded("self_test", ["git", "rev-parse", "HEAD"], cwd=source_root, env=clean_env())
+    source_sha = git.stdout.decode().strip()
+    if len(source_sha) != 40 or any(char not in "0123456789abcdef" for char in source_sha):
+        fail("self_test", f"invalid git SHA: {source_sha!r}", "run the self-test from a committed git worktree")
     with tempfile.TemporaryDirectory(prefix="assay-claude-plugin-selftest-") as temporary:
         temp = Path(temporary)
-        claude, server = write_fake_tools(temp)
+        claude, _server = write_fake_tools(temp, source_sha[:12])
         base_env = clean_env(
             {
-                "ASSAY_CLAUDE_BIN": str(claude),
-                "ASSAY_MCP_SERVER_BIN": str(server),
-                "ASSAY_SOURCE_ROOT": str(source_root),
                 "ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": "2",
                 "PATH": os.pathsep.join([str(claude.parent), os.environ.get("PATH", "")]),
             }
@@ -614,6 +629,7 @@ def self_test() -> None:
         mutations = [
             ("FAKE_FAIL_PHASE", "marketplace_update", "phase=marketplace_update"),
             ("FAKE_SOURCE_ONLY", "1", "phase=installed_cache"),
+            ("FAKE_CACHE_VERSION_DRIFT", "1", "phase=installed_cache"),
             ("FAKE_TOOL_DRIFT", "1", "phase=tools_list"),
             ("FAKE_NO_UPDATE", "1", "phase=installed_cache"),
             ("FAKE_OVERSIZE_PHASE", "plugin_validate", "stdout exceeded 1048576-byte ceiling"),

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -1,0 +1,625 @@
+"""Drive and self-test the disposable Claude plugin installation contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import selectors
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+MAX_BYTES = 1_048_576
+DEFAULT_TIMEOUT_SECONDS = 30.0
+EXPECTED_TOOLS = [
+    "assay_check_args",
+    "assay_check_coverage",
+    "assay_check_sequence",
+    "assay_explain_trace",
+    "assay_policy_decide",
+]
+AUTH_ENV_PREFIXES = ("ANTHROPIC_", "CLAUDE_CODE_OAUTH_", "ASSAY_AUTH_")
+
+
+class WorkflowError(RuntimeError):
+    def __init__(self, phase: str, reason: str, next_step: str) -> None:
+        super().__init__(reason)
+        self.phase = phase
+        self.reason = reason
+        self.next_step = next_step
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+def fail(phase: str, reason: str, next_step: str) -> "None":
+    raise WorkflowError(phase, reason, next_step)
+
+
+def clean_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.upper().startswith(AUTH_ENV_PREFIXES)
+    }
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    if extra:
+        env.update(extra)
+    return env
+
+
+def terminate_tree(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=1.0)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def run_bounded(
+    phase: str,
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    stdin: bytes = b"",
+    allowed_codes: Iterable[int] = (0,),
+) -> CommandResult:
+    timeout = float(os.environ.get("ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+    process = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    if stdin:
+        try:
+            process.stdin.write(stdin)
+            process.stdin.flush()
+        except BrokenPipeError:
+            pass
+    process.stdin.close()
+
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    deadline = time.monotonic() + timeout
+
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                terminate_tree(process)
+                fail(
+                    phase,
+                    f"process tree exceeded {timeout:g}s deadline",
+                    "retry after checking the client/server command for a prompt, hang, or inherited pipe",
+                )
+            events = selector.select(min(remaining, 0.1))
+            for key, _ in events:
+                chunk = os.read(key.fd, 65_536)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                target = buffers[key.data]
+                target.extend(chunk)
+                if len(target) > MAX_BYTES:
+                    terminate_tree(process)
+                    fail(
+                        phase,
+                        f"{key.data} exceeded {MAX_BYTES}-byte ceiling",
+                        "inspect the command directly; the bounded workflow will not retain unbounded diagnostics",
+                    )
+
+            if process.poll() is not None and not events:
+                # Descendants can inherit a pipe after the direct child exits. The
+                # same absolute deadline continues to govern that drain.
+                continue
+    finally:
+        selector.close()
+
+    remaining = max(0.0, deadline - time.monotonic())
+    try:
+        returncode = process.wait(timeout=remaining)
+    except subprocess.TimeoutExpired:
+        terminate_tree(process)
+        process.wait()
+        fail(
+            phase,
+            f"process tree did not reap within {timeout:g}s deadline",
+            "inspect descendant processes spawned by the client command",
+        )
+
+    result = CommandResult(returncode, bytes(buffers["stdout"]), bytes(buffers["stderr"]))
+    if returncode not in set(allowed_codes):
+        diagnostic = (result.stderr or result.stdout).decode("utf-8", "replace").strip()
+        diagnostic = diagnostic[-600:] if diagnostic else "no diagnostic output"
+        fail(
+            phase,
+            f"command exited {returncode}: {diagnostic}",
+            "run the named phase directly with the same fresh config and consumer directory",
+        )
+    return result
+
+
+def read_bounded(path: Path, phase: str) -> bytes:
+    try:
+        stat = path.lstat()
+    except FileNotFoundError:
+        fail(phase, f"missing file: {path}", "reinstall or update the plugin, then inspect its cache path")
+    if path.is_symlink() or not path.is_file():
+        fail(phase, f"expected regular non-symlink file: {path}", "replace the cache entry from the marketplace source")
+    if stat.st_size > MAX_BYTES:
+        fail(phase, f"file exceeds {MAX_BYTES}-byte ceiling: {path}", "inspect the package before installing it")
+    return path.read_bytes()
+
+
+def descendants_are_regular(root: Path, phase: str) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            fail(phase, f"symlink is not allowed in plugin package: {path}", "replace it with a generated regular file")
+        if path.is_file():
+            read_bounded(path, phase)
+            files.append(path)
+        elif not path.is_dir():
+            fail(phase, f"unsupported plugin package entry: {path}", "retain only regular files and directories")
+    return files
+
+
+def plugin_record(payload: object) -> dict[str, object]:
+    records: list[object]
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict):
+        candidate = payload.get("plugins", payload.get("installedPlugins", []))
+        records = candidate if isinstance(candidate, list) else []
+    else:
+        records = []
+    for record in records:
+        if isinstance(record, dict) and record.get("id") == "assay@assay":
+            return record
+    fail("installed_cache", "plugin list omitted assay@assay", "run `claude plugin list --json` and reinstall assay@assay")
+
+
+def assert_under(path: Path, parent: Path, phase: str, message: str) -> None:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        fail(phase, message, "remove the stale install and reinstall with a fresh CLAUDE_CONFIG_DIR")
+
+
+def compare_installed_package(source_package: Path, installed: Path) -> None:
+    source_files = descendants_are_regular(source_package, "installed_cache")
+    descendants_are_regular(installed, "installed_cache")
+    for source in source_files:
+        relative = source.relative_to(source_package)
+        cached = installed / relative
+        if read_bounded(source, "installed_cache") != read_bounded(cached, "installed_cache"):
+            fail(
+                "installed_cache",
+                f"installed bytes drifted for {relative}",
+                "run marketplace update and plugin update, then restart Claude Code",
+            )
+
+
+def parse_protocol(stdout: bytes) -> dict[int, dict[str, object]]:
+    responses: dict[int, dict[str, object]] = {}
+    for raw_line in stdout.splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            value = json.loads(raw_line)
+        except json.JSONDecodeError as error:
+            fail("initialize", f"server emitted non-JSON stdout: {error}", "run assay-mcp-server directly and keep logs on stderr")
+        if isinstance(value, dict) and isinstance(value.get("id"), int):
+            responses[value["id"]] = value
+    return responses
+
+
+def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], expected_server: Path) -> None:
+    manifest_path = installed / ".mcp.json"
+    try:
+        manifest = json.loads(read_bounded(manifest_path, "initialize"))
+        entry = manifest["mcpServers"]["assay"]
+        command = entry["command"]
+        args = entry["args"]
+    except (KeyError, TypeError, json.JSONDecodeError) as error:
+        fail("initialize", f"installed MCP manifest is invalid: {error}", "reinstall the plugin from the reviewed marketplace")
+    if not isinstance(command, str) or not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+        fail("initialize", "installed MCP command/args are not strings", "restore the typed plugin manifest")
+    if args != ["--policy-root", "."]:
+        fail(
+            "policy_root_resolved_to_consumer",
+            f"installed MCP args do not pin the consumer cwd: {args}",
+            "restore `--policy-root .` or use an explicit absolute project override",
+        )
+    resolved = shutil.which(command, path=env.get("PATH"))
+    if resolved is None:
+        fail("binary_spawn", f"{command} is not on PATH", "install assay-mcp-server and restart the client")
+    if Path(resolved).resolve() != expected_server.resolve():
+        fail("binary_spawn", f"PATH resolved an unexpected server: {resolved}", "put the exact-SHA assay-mcp-server first on the isolated PATH")
+
+    policy = consumer / "install-surface-policy.yaml"
+    if (consumer / "policies").exists():
+        fail(
+            "policy_root_resolved_to_consumer",
+            "consumer probe unexpectedly contains the server's default policies directory",
+            "remove the default-path fixture so the probe discriminates `.` from `policies`",
+        )
+    policy.write_text("blocklist:\n  - install_surface_probe\n", encoding="utf-8")
+    requests = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "claude-plugin-workflow", "version": "1.0"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "assay_policy_decide",
+                "arguments": {
+                    "tool": "install_surface_probe",
+                    "policy": policy.name,
+                },
+            },
+        },
+    ]
+    stdin = b"".join(json.dumps(request, separators=(",", ":")).encode() + b"\n" for request in requests)
+    result = run_bounded("initialize", [resolved, *args], cwd=consumer, env=env, stdin=stdin)
+    responses = parse_protocol(result.stdout)
+    initialize = responses.get(1, {})
+    if initialize.get("result", {}).get("protocolVersion") != "2024-11-05":
+        fail("initialize", "server did not negotiate protocol 2024-11-05", "inspect the installed server version and manifest argv")
+    print("initialize=pass")
+
+    tools = responses.get(2, {}).get("result", {}).get("tools", [])
+    names = sorted(tool.get("name") for tool in tools if isinstance(tool, dict))
+    if names != EXPECTED_TOOLS:
+        fail("tools_list", f"release tool names drifted: {names}", "install the release server built from the same source SHA")
+    print("tools_list=pass")
+
+    content = responses.get(3, {}).get("result", {}).get("content", [])
+    try:
+        decision = json.loads(content[0]["text"])
+    except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
+        fail("policy_root_resolved_to_consumer", f"policy response is invalid: {error}", "inspect assay_policy_decide output")
+    if decision.get("allowed") is not False:
+        fail(
+            "policy_root_resolved_to_consumer",
+            "consumer-only policy did not deny install_surface_probe",
+            "override the project MCP entry with an absolute --policy-root for hosts that use another cwd",
+        )
+    print("policy_root_resolved_to_consumer=pass")
+
+
+def verify_workflow() -> None:
+    script = Path(os.environ["ASSAY_CLAUDE_WORKFLOW_SCRIPT"]).resolve()
+    source_root = Path(os.environ.get("ASSAY_SOURCE_ROOT", script.parents[2])).resolve()
+    source_package = source_root / "packaging/claude-plugin"
+    marketplace = source_root / ".claude-plugin/marketplace.json"
+    claude = Path(os.environ.get("ASSAY_CLAUDE_BIN", shutil.which("claude") or ""))
+    server = Path(os.environ.get("ASSAY_MCP_SERVER_BIN", shutil.which("assay-mcp-server") or ""))
+    if not claude.is_file():
+        fail("prerequisite", "Claude Code executable not found", "install Claude Code and set ASSAY_CLAUDE_BIN if needed")
+    if not server.is_file():
+        fail("prerequisite", "assay-mcp-server executable not found", "install the exact-SHA server and set ASSAY_MCP_SERVER_BIN")
+    read_bounded(marketplace, "plugin_validate")
+
+    git = run_bounded("source_sha", ["git", "rev-parse", "HEAD"], cwd=source_root, env=clean_env())
+    source_sha = git.stdout.decode().strip()
+    if len(source_sha) != 40 or any(char not in "0123456789abcdef" for char in source_sha):
+        fail("source_sha", f"invalid git SHA: {source_sha!r}", "run from a committed git worktree")
+
+    with tempfile.TemporaryDirectory(prefix="assay-claude-plugin-") as temporary:
+        temp = Path(temporary).resolve()
+        config = temp / "config"
+        consumer = temp / "consumer"
+        isolated_bin = temp / "bin"
+        config.mkdir()
+        consumer.mkdir()
+        isolated_bin.mkdir()
+        server_link = isolated_bin / "assay-mcp-server"
+        server_link.symlink_to(server.resolve())
+        env = clean_env(
+            {
+                "CLAUDE_CONFIG_DIR": str(config),
+                "PATH": os.pathsep.join([str(isolated_bin), str(claude.parent), os.environ.get("PATH", "")]),
+            }
+        )
+
+        version = run_bounded("claude_version", [str(claude), "--version"], cwd=consumer, env=env)
+        claude_version = version.stdout.decode("utf-8", "replace").strip()
+        run_bounded("plugin_validate", [str(claude), "plugin", "validate", str(marketplace)], cwd=consumer, env=env)
+        print("plugin_validate=pass")
+        run_bounded("marketplace_add", [str(claude), "plugin", "marketplace", "add", str(source_root)], cwd=consumer, env=env)
+        print("marketplace_add=pass")
+        run_bounded("plugin_install", [str(claude), "plugin", "install", "assay@assay", "--scope", "local"], cwd=consumer, env=env)
+        print("plugin_install=pass")
+        run_bounded("marketplace_update", [str(claude), "plugin", "marketplace", "update", "assay"], cwd=consumer, env=env)
+        print("marketplace_update=pass")
+        run_bounded("plugin_update", [str(claude), "plugin", "update", "assay@assay", "--scope", "local"], cwd=consumer, env=env)
+        print("plugin_update=pass")
+
+        listing = run_bounded("installed_cache", [str(claude), "plugin", "list", "--json"], cwd=consumer, env=env)
+        try:
+            record = plugin_record(json.loads(listing.stdout))
+            installed = Path(str(record["installPath"])).resolve()
+            cache_version = str(record["version"])
+        except (KeyError, TypeError, json.JSONDecodeError) as error:
+            fail("installed_cache", f"plugin list JSON is invalid: {error}", "run `claude plugin list --json` and inspect assay@assay")
+        assert_under(installed, config, "installed_cache", "installed cache escaped the fresh Claude config")
+        try:
+            installed.relative_to(source_root)
+        except ValueError:
+            pass
+        else:
+            fail("installed_cache", "installed plugin resolves inside the source checkout", "install through the marketplace instead of reading source files directly")
+        compare_installed_package(source_package, installed)
+        print("installed_cache=pass")
+
+        mcp_list = run_bounded("mcp_list_connected", [str(claude), "mcp", "list"], cwd=consumer, env=env)
+        mcp_text = (mcp_list.stdout + mcp_list.stderr).decode("utf-8", "replace")
+        if "assay" not in mcp_text or "Connected" not in mcp_text:
+            fail("mcp_list_connected", "Claude MCP health output did not report assay connected", "check binary PATH, project cwd, and plugin cache")
+        print("mcp_list_connected=pass")
+
+        drive_cached_manifest(installed, consumer, env, server_link)
+
+        debug = temp / "session-debug.log"
+        session = run_bounded(
+            "actual_session",
+            [
+                str(claude),
+                "-p",
+                "Use the assay golden-path skill and report only its first contract step.",
+                "--debug-file",
+                str(debug),
+                "--output-format",
+                "json",
+            ],
+            cwd=consumer,
+            env=env,
+            allowed_codes=range(0, 256),
+        )
+        debug_text = read_bounded(debug, "actual_session").decode("utf-8", "replace")
+        if "Successfully connected" not in debug_text or "assay" not in debug_text:
+            fail("actual_session_mcp_connected", "actual session did not connect the assay MCP server", "inspect the session debug log for plugin or spawn errors")
+        print("actual_session_mcp_connected=pass")
+        if "assay:assay-golden-path" not in debug_text:
+            fail("skill_discovery", "actual session did not discover assay:assay-golden-path", "inspect the installed skill and restart Claude Code")
+        print("skill_discovery=pass")
+
+        combined = ((session.stdout + session.stderr).decode("utf-8", "replace") + debug_text).lower()
+        model_status = "not_exercised" if session.returncode == 0 else "unavailable"
+        if model_status == "unavailable" and not any(token in combined for token in ("api key", "auth", "login", "credential")):
+            fail("model_mediated_tool_call", "session failed for a reason other than unavailable authentication", "inspect the bounded session diagnostic")
+
+        print(f"source_sha={source_sha}")
+        print(f"claude_version={claude_version}")
+        print(f"installed_cache_version={cache_version}")
+        print(f"model_mediated_tool_call={model_status}")
+        print("verification=pass")
+
+
+def write_fake_tools(root: Path) -> tuple[Path, Path]:
+    fake_bin = root / "fake-bin"
+    fake_bin.mkdir()
+    claude = fake_bin / "claude"
+    server = fake_bin / "assay-mcp-server"
+    python = sys.executable
+    claude.write_text(
+        f"""#!{python}
+import json, os, pathlib, shutil, subprocess, sys, time
+args = sys.argv[1:]
+config = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"])
+source_file = config / "marketplace-source"
+fail_phase = os.environ.get("FAKE_FAIL_PHASE")
+
+def phase_name(values):
+    mapping = {{
+        ("plugin", "validate"): "plugin_validate",
+        ("plugin", "marketplace", "add"): "marketplace_add",
+        ("plugin", "install"): "plugin_install",
+        ("plugin", "marketplace", "update"): "marketplace_update",
+        ("plugin", "update"): "plugin_update",
+        ("plugin", "list"): "installed_cache",
+        ("mcp", "list"): "mcp_list_connected",
+    }}
+    for prefix, name in mapping.items():
+        if tuple(values[:len(prefix)]) == prefix:
+            return name
+    return "actual_session"
+
+phase = phase_name(args)
+if fail_phase == phase:
+    print(f"synthetic failure in {{phase}}", file=sys.stderr)
+    raise SystemExit(9)
+if os.environ.get("FAKE_OVERSIZE_PHASE") == phase:
+    print("x" * 1_048_577)
+    raise SystemExit(0)
+if os.environ.get("FAKE_HANG_PHASE") == phase:
+    subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    time.sleep(60)
+if os.environ.get("FAKE_ORPHAN_PIPE_PHASE") == phase:
+    subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    raise SystemExit(0)
+
+if args == ["--version"]:
+    print("2.1.32 (Claude Code)")
+elif args[:2] == ["plugin", "validate"]:
+    assert pathlib.Path(args[2]).is_file()
+    print("valid")
+elif args[:3] == ["plugin", "marketplace", "add"]:
+    config.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(str(pathlib.Path(args[3]).resolve()))
+    print("added")
+elif args[:2] == ["plugin", "install"]:
+    source = pathlib.Path(source_file.read_text())
+    cache = config / "plugins/cache/assay/assay/fake-v1"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    if cache.exists(): shutil.rmtree(cache)
+    shutil.copytree(source / "packaging/claude-plugin", cache)
+    (cache / ".mcp.json").write_text('{{"stale":true}}')
+    print("installed")
+elif args[:3] == ["plugin", "marketplace", "update"]:
+    print("marketplace updated")
+elif args[:2] == ["plugin", "update"]:
+    source = pathlib.Path(source_file.read_text())
+    cache = config / "plugins/cache/assay/assay/fake-v1"
+    if not os.environ.get("FAKE_NO_UPDATE"):
+        if cache.exists(): shutil.rmtree(cache)
+        shutil.copytree(source / "packaging/claude-plugin", cache)
+    print("plugin updated")
+elif args[:3] == ["plugin", "list", "--json"]:
+    source = pathlib.Path(source_file.read_text())
+    cache = source / "packaging/claude-plugin" if os.environ.get("FAKE_SOURCE_ONLY") else config / "plugins/cache/assay/assay/fake-v1"
+    print(json.dumps([{{"id":"assay@assay","version":"fake-v1","installPath":str(cache)}}]))
+elif args[:2] == ["mcp", "list"]:
+    print("assay: Connected")
+else:
+    debug = pathlib.Path(args[args.index("--debug-file") + 1])
+    debug.write_text('Successfully connected to assay\\nSkill prompt: showing "assay:assay-golden-path"\\n')
+    print("Invalid API key", file=sys.stderr)
+    raise SystemExit(1)
+""",
+        encoding="utf-8",
+    )
+    server.write_text(
+        f"""#!{python}
+import json, os, pathlib, sys
+tool_names = {EXPECTED_TOOLS!r}
+if os.environ.get("FAKE_TOOL_DRIFT"):
+    tool_names[-1] = "assay_policy_changed"
+policy = pathlib.Path.cwd() / "install-surface-policy.yaml"
+blocked = "install_surface_probe" in policy.read_text() if policy.is_file() else False
+for line in sys.stdin:
+    request = json.loads(line)
+    if "id" not in request: continue
+    method = request.get("method")
+    if method == "initialize":
+        result = {{"protocolVersion":"2024-11-05","capabilities":{{}},"serverInfo":{{"name":"fake","version":"1"}}}}
+    elif method == "tools/list":
+        result = {{"tools":[{{"name":name,"description":"test","inputSchema":{{"type":"object"}}}} for name in tool_names]}}
+    elif method == "tools/call":
+        result = {{"content":[{{"type":"text","text":json.dumps({{"allowed": not blocked}})}}],"isError":False}}
+    else:
+        result = {{}}
+    print(json.dumps({{"jsonrpc":"2.0","id":request["id"],"result":result}}), flush=True)
+""",
+        encoding="utf-8",
+    )
+    claude.chmod(0o755)
+    server.chmod(0o755)
+    return claude, server
+
+
+def self_test() -> None:
+    script = Path(os.environ["ASSAY_CLAUDE_WORKFLOW_SCRIPT"]).resolve()
+    source_root = script.parents[2]
+    with tempfile.TemporaryDirectory(prefix="assay-claude-plugin-selftest-") as temporary:
+        temp = Path(temporary)
+        claude, server = write_fake_tools(temp)
+        base_env = clean_env(
+            {
+                "ASSAY_CLAUDE_BIN": str(claude),
+                "ASSAY_MCP_SERVER_BIN": str(server),
+                "ASSAY_SOURCE_ROOT": str(source_root),
+                "ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS": "2",
+                "PATH": os.pathsep.join([str(claude.parent), os.environ.get("PATH", "")]),
+            }
+        )
+
+        passing = run_bounded("self_test", [str(script), "--verify"], cwd=source_root, env=base_env)
+        text = passing.stdout.decode("utf-8", "replace")
+        required = [
+            "marketplace_update=pass",
+            "plugin_update=pass",
+            "installed_cache=pass",
+            "mcp_list_connected=pass",
+            "initialize=pass",
+            "tools_list=pass",
+            "policy_root_resolved_to_consumer=pass",
+            "actual_session_mcp_connected=pass",
+            "skill_discovery=pass",
+            "model_mediated_tool_call=unavailable",
+            "verification=pass",
+        ]
+        missing = [line for line in required if line not in text]
+        if missing:
+            fail("self_test", f"passing workflow omitted phases: {missing}", "restore the explicit phase output contract")
+
+        mutations = [
+            ("FAKE_FAIL_PHASE", "marketplace_update", "phase=marketplace_update"),
+            ("FAKE_SOURCE_ONLY", "1", "phase=installed_cache"),
+            ("FAKE_TOOL_DRIFT", "1", "phase=tools_list"),
+            ("FAKE_NO_UPDATE", "1", "phase=installed_cache"),
+            ("FAKE_OVERSIZE_PHASE", "plugin_validate", "stdout exceeded 1048576-byte ceiling"),
+            ("FAKE_HANG_PHASE", "plugin_validate", "process tree exceeded 2s deadline"),
+            ("FAKE_ORPHAN_PIPE_PHASE", "plugin_validate", "process tree exceeded 2s deadline"),
+        ]
+        for key, value, expected in mutations:
+            mutated_env = dict(base_env)
+            mutated_env[key] = value
+            result = run_bounded(
+                "self_test_mutation",
+                [str(script), "--verify"],
+                cwd=source_root,
+                env=mutated_env,
+                allowed_codes=range(0, 256),
+            )
+            output = (result.stdout + result.stderr).decode("utf-8", "replace")
+            if result.returncode == 0 or expected not in output:
+                fail("self_test", f"mutation {key} did not bite its named guard: {output[-600:]}", "repair the workflow discriminator")
+
+    print("claude_plugin_install_self_test=pass")
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "--verify"
+    try:
+        if mode == "--self-test":
+            self_test()
+        elif mode == "--verify":
+            verify_workflow()
+        else:
+            fail("arguments", f"unknown argument: {mode}", "use --verify or --self-test")
+    except WorkflowError as error:
+        print(f"phase={error.phase} status=fail reason={error.reason}", file=sys.stderr)
+        print(f"next_step={error.next_step}", file=sys.stderr)
+        return 1
+    return 0
+
+
+raise SystemExit(main())

--- a/scripts/ci/claude_plugin_install_workflow.py
+++ b/scripts/ci/claude_plugin_install_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import selectors
 import shutil
@@ -13,7 +14,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, NoReturn
 
 MAX_BYTES = 1_048_576
 DEFAULT_TIMEOUT_SECONDS = 30.0
@@ -45,8 +46,29 @@ class CommandResult:
     stderr: bytes
 
 
-def fail(phase: str, reason: str, next_step: str) -> "None":
+def fail(phase: str, reason: str, next_step: str) -> NoReturn:
     raise WorkflowError(phase, reason, next_step)
+
+
+def workflow_timeout_seconds() -> float:
+    raw = os.environ.get(
+        "ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT_SECONDS)
+    )
+    try:
+        timeout = float(raw)
+    except ValueError:
+        fail(
+            "arguments",
+            f"ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS must be a positive number, got {raw!r}",
+            "set ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS to a finite value greater than zero",
+        )
+    if not math.isfinite(timeout) or timeout <= 0:
+        fail(
+            "arguments",
+            f"ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS must be positive and finite, got {raw!r}",
+            "set ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS to a finite value greater than zero",
+        )
+    return timeout
 
 
 def clean_env(extra: dict[str, str] | None = None) -> dict[str, str]:
@@ -82,7 +104,7 @@ def run_bounded(
     stdin: bytes = b"",
     allowed_codes: Iterable[int] = (0,),
 ) -> CommandResult:
-    timeout = float(os.environ.get("ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+    timeout = workflow_timeout_seconds()
     process = subprocess.Popen(
         argv,
         cwd=cwd,
@@ -136,10 +158,8 @@ def run_bounded(
                         "inspect the command directly; the bounded workflow will not retain unbounded diagnostics",
                     )
 
-            if process.poll() is not None and not events:
-                # Descendants can inherit a pipe after the direct child exits. The
-                # same absolute deadline continues to govern that drain.
-                continue
+            # Descendants can inherit a pipe after the direct child exits. The
+            # same absolute deadline continues to govern that drain.
     finally:
         selector.close()
 
@@ -176,7 +196,11 @@ def read_bounded(path: Path, phase: str) -> bytes:
         fail(phase, f"expected regular non-symlink file: {path}", "replace the cache entry from the marketplace source")
     if stat.st_size > MAX_BYTES:
         fail(phase, f"file exceeds {MAX_BYTES}-byte ceiling: {path}", "inspect the package before installing it")
-    return path.read_bytes()
+    with path.open("rb") as source:
+        payload = source.read(MAX_BYTES + 1)
+    if len(payload) > MAX_BYTES:
+        fail(phase, f"file grew beyond {MAX_BYTES}-byte ceiling: {path}", "inspect the package before installing it")
+    return payload
 
 
 def descendants_are_regular(root: Path, phase: str) -> list[Path]:
@@ -209,7 +233,17 @@ def plugin_record(payload: object) -> dict[str, object]:
 
 def compare_installed_package(source_package: Path, installed: Path) -> None:
     source_files = descendants_are_regular(source_package, "installed_cache")
-    descendants_are_regular(installed, "installed_cache")
+    installed_files = descendants_are_regular(installed, "installed_cache")
+    source_relatives = {path.relative_to(source_package) for path in source_files}
+    installed_relatives = {path.relative_to(installed) for path in installed_files}
+    if source_relatives != installed_relatives:
+        missing = sorted(str(path) for path in source_relatives - installed_relatives)
+        extra = sorted(str(path) for path in installed_relatives - source_relatives)
+        fail(
+            "installed_cache",
+            f"installed file set drifted: missing={missing}, extra={extra}",
+            "remove the stale install, update the marketplace, and reinstall the plugin",
+        )
     for source in source_files:
         relative = source.relative_to(source_package)
         cached = installed / relative
@@ -233,6 +267,18 @@ def parse_protocol(stdout: bytes) -> dict[int, dict[str, object]]:
         if isinstance(value, dict) and isinstance(value.get("id"), int):
             responses[value["id"]] = value
     return responses
+
+
+def response_result(
+    responses: dict[int, dict[str, object]], response_id: int, phase: str
+) -> dict[str, object]:
+    response = responses.get(response_id)
+    if not isinstance(response, dict):
+        fail(phase, f"missing JSON-RPC response id {response_id}", "inspect the server stdout protocol stream")
+    result = response.get("result")
+    if not isinstance(result, dict):
+        fail(phase, f"JSON-RPC response id {response_id} has no object result", "inspect the server response shape")
+    return result
 
 
 def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], expected_server: Path) -> None:
@@ -315,18 +361,30 @@ def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], 
         stdin=stdin,
     )
     responses = parse_protocol(result.stdout)
-    initialize = responses.get(1, {})
-    if initialize.get("result", {}).get("protocolVersion") != "2024-11-05":
+    initialize = response_result(responses, 1, "initialize")
+    if initialize.get("protocolVersion") != "2024-11-05":
         fail("initialize", "server did not negotiate protocol 2024-11-05", "inspect the installed server version and manifest argv")
     print("initialize=pass")
 
-    tools = responses.get(2, {}).get("result", {}).get("tools", [])
-    names = sorted(tool.get("name") for tool in tools if isinstance(tool, dict))
+    tools = response_result(responses, 2, "tools_list").get("tools")
+    if not isinstance(tools, list) or any(
+        not isinstance(tool, dict) or not isinstance(tool.get("name"), str)
+        for tool in tools
+    ):
+        fail("tools_list", "tools/list returned an untyped tool entry", "inspect the release server tool schema")
+    names = sorted(tool["name"] for tool in tools)
     if names != EXPECTED_TOOLS:
         fail("tools_list", f"release tool names drifted: {names}", "install the release server built from the same source SHA")
     print("tools_list=pass")
 
-    content = responses.get(3, {}).get("result", {}).get("content", [])
+    policy_result = response_result(responses, 3, "policy_root_resolved_to_consumer")
+    if policy_result.get("isError") is not True:
+        fail(
+            "policy_root_resolved_to_consumer",
+            "consumer policy denial did not set MCP isError",
+            "preserve the release server's denied-result contract before interpreting its payload",
+        )
+    content = policy_result.get("content", [])
     try:
         decision = json.loads(content[0]["text"])
     except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
@@ -339,7 +397,7 @@ def drive_cached_manifest(installed: Path, consumer: Path, env: dict[str, str], 
         )
     print("policy_root_resolved_to_consumer=pass")
 
-    missing_content = responses.get(4, {}).get("result", {}).get("content", [])
+    missing_content = response_result(responses, 4, "missing_policy_refused").get("content", [])
     try:
         missing = json.loads(missing_content[0]["text"])
     except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
@@ -539,6 +597,8 @@ elif args[:2] == ["plugin", "update"]:
     if not os.environ.get("FAKE_NO_UPDATE"):
         if cache.exists(): shutil.rmtree(cache)
         shutil.copytree(source / "packaging/claude-plugin", cache)
+        if os.environ.get("FAKE_EXTRA_CACHE_FILE"):
+            (cache / "unexpected.txt").write_text("unexpected")
     print("plugin updated")
 elif args[:3] == ["plugin", "list", "--json"]:
     source = pathlib.Path(source_file.read_text())
@@ -569,6 +629,8 @@ for line in sys.stdin:
         result = {{"protocolVersion":"2024-11-05","capabilities":{{}},"serverInfo":{{"name":"fake","version":"1"}}}}
     elif method == "tools/list":
         result = {{"tools":[{{"name":name,"description":"test","inputSchema":{{"type":"object"}}}} for name in tool_names]}}
+        if os.environ.get("FAKE_NAMELESS_TOOL"):
+            result["tools"].append({{"description":"nameless"}})
     elif method == "tools/call":
         policy_name = request["params"]["arguments"]["policy"]
         policy = pathlib.Path.cwd() / policy_name
@@ -577,9 +639,13 @@ for line in sys.stdin:
         else:
             blocked = "install_surface_probe" in policy.read_text()
             payload = {{"allowed": not blocked}}
-        result = {{"content":[{{"type":"text","text":json.dumps(payload)}}],"isError":False}}
+        result = {{"content":[{{"type":"text","text":json.dumps(payload)}}],"isError":True}}
     else:
         result = {{}}
+    if os.environ.get("FAKE_NULL_RESULT_METHOD") == method:
+        result = None
+    if os.environ.get("FAKE_POLICY_IS_NOT_ERROR") and method == "tools/call" and policy_name == "install-surface-policy.yaml":
+        result["isError"] = False
     print(json.dumps({{"jsonrpc":"2.0","id":request["id"],"result":result}}), flush=True)
 """,
         encoding="utf-8",
@@ -630,11 +696,16 @@ def self_test() -> None:
             ("FAKE_FAIL_PHASE", "marketplace_update", "phase=marketplace_update"),
             ("FAKE_SOURCE_ONLY", "1", "phase=installed_cache"),
             ("FAKE_CACHE_VERSION_DRIFT", "1", "phase=installed_cache"),
+            ("FAKE_EXTRA_CACHE_FILE", "1", "phase=installed_cache"),
             ("FAKE_TOOL_DRIFT", "1", "phase=tools_list"),
+            ("FAKE_NAMELESS_TOOL", "1", "phase=tools_list"),
+            ("FAKE_NULL_RESULT_METHOD", "initialize", "phase=initialize"),
+            ("FAKE_POLICY_IS_NOT_ERROR", "1", "phase=policy_root_resolved_to_consumer"),
             ("FAKE_NO_UPDATE", "1", "phase=installed_cache"),
             ("FAKE_OVERSIZE_PHASE", "plugin_validate", "stdout exceeded 1048576-byte ceiling"),
             ("FAKE_HANG_PHASE", "plugin_validate", "process tree exceeded 2s deadline"),
             ("FAKE_ORPHAN_PIPE_PHASE", "plugin_validate", "process tree exceeded 2s deadline"),
+            ("ASSAY_CLAUDE_WORKFLOW_TIMEOUT_SECONDS", "invalid", "phase=arguments"),
         ]
         for key, value, expected in mutations:
             mutated_env = dict(base_env)

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -107,6 +107,7 @@ seed_case() {
   cp "$ROOT/scripts/docs/generate-agent-golden-path.py" "$case_root/scripts/docs/"
   cp "$ROOT/.gitignore" "$case_root/"
   cp "$ROOT/.gitattributes" "$case_root/"
+  cp "$ROOT/.mcp.json" "$case_root/"
   cp "$ROOT/.pre-commit-config.yaml" "$case_root/"
   cp "$ROOT/docs/generated/agent-golden-path.json" "$case_root/docs/generated/"
   cp "$ROOT/docs/guides/agent-golden-path.md" "$case_root/docs/guides/"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 
 # PR B adds discoverability, cwd wording, and issue-reference hardening cases to
 # the 58-case durability boundary established by PR B0.
-EXPECTED_CASES=75
+EXPECTED_CASES=84
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -95,10 +95,13 @@ seed_case() {
     "$case_root/scripts/docs" \
     "$case_root/docs/generated" \
     "$case_root/docs/guides" \
+    "$case_root/examples/privileged-action-gate/policies" \
     "$case_root/.agents/skills/assay-golden-path" \
     "$case_root/.claude/skills/assay-golden-path" \
     "$case_root/.claude-plugin" \
     "$case_root/packaging/claude-plugin/.claude-plugin" \
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/references" \
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies" \
     "$case_root/.github/workflows"
   cp "$ROOT/scripts/ci/test-agent-golden-path-skill.py" "$case_root/scripts/ci/"
   cp "$ROOT/scripts/docs/generate-agent-golden-path.py" "$case_root/scripts/docs/"
@@ -107,6 +110,12 @@ seed_case() {
   cp "$ROOT/.pre-commit-config.yaml" "$case_root/"
   cp "$ROOT/docs/generated/agent-golden-path.json" "$case_root/docs/generated/"
   cp "$ROOT/docs/guides/agent-golden-path.md" "$case_root/docs/guides/"
+  cp "$ROOT/examples/privileged-action-gate/mock_github_mcp.py" \
+    "$case_root/examples/privileged-action-gate/"
+  cp "$ROOT/examples/privileged-action-gate/baseline-approved.json" \
+    "$case_root/examples/privileged-action-gate/"
+  cp "$ROOT/examples/privileged-action-gate/policies/no-allowance.yaml" \
+    "$case_root/examples/privileged-action-gate/policies/"
   cp "$ROOT/.agents/skills/assay-golden-path/SKILL.md" \
     "$case_root/.agents/skills/assay-golden-path/"
   cp "$ROOT/.claude/skills/assay-golden-path/SKILL.md" \
@@ -115,6 +124,16 @@ seed_case() {
   cp "$ROOT/packaging/claude-plugin/.claude-plugin/plugin.json" \
     "$case_root/packaging/claude-plugin/.claude-plugin/"
   cp "$ROOT/packaging/claude-plugin/.mcp.json" "$case_root/packaging/claude-plugin/"
+  cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/SKILL.md" \
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/"
+  cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json" \
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/references/"
+  cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py" \
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/"
+  cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json" \
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/"
+  cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml" \
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/"
   cp "$ROOT/.github/workflows/kernel-matrix.yml" "$case_root/.github/workflows/"
   case_git "$case_root" -c init.defaultBranch=main init -q
   case_git "$case_root" -c core.excludesFile= -c core.attributesFile= \
@@ -137,6 +156,7 @@ append_contract_evidence_issue() {
 import json
 import re
 import os
+import shutil
 from pathlib import Path
 
 root = Path(os.environ["CASE_ROOT"])
@@ -163,6 +183,11 @@ claim = (
 )
 contract["non_claims"].append(claim)
 contract_path.write_text(json.dumps(contract, indent=2) + "\n", encoding="utf-8")
+shutil.copyfile(
+    contract_path,
+    root
+    / "packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json",
+)
 
 for skill_path in (
     root / ".agents/skills/assay-golden-path/SKILL.md",
@@ -342,7 +367,7 @@ hook_files = (
     "        files: ^(scripts/ci/(check-docs-generated-drift|"
     "test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot)\\.sh|scripts/docs/"
     "generate-agent-golden-path\\.py|\\.(agents|claude)/skills/"
-    "assay-golden-path/SKILL\\.md)$\n"
+    "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*)$\n"
 )
 root_anchor = "default_install_hook_types: [pre-commit, pre-push]\n"
 
@@ -462,6 +487,34 @@ expect_named_failure \
   "human guide without protected-action cwd" \
   "$case_root" \
   "guide omits working directory for protected-action"
+
+case_root="$SCRATCH/plugin-missing-fixture-mapping"
+seed_case "$case_root"
+sed -i.bak '/Fixtures named by the contract under `examples\/privileged-action-gate` are bundled at/d' \
+  "$case_root/packaging/claude-plugin/skills/assay-golden-path/SKILL.md"
+rm "$case_root/packaging/claude-plugin/skills/assay-golden-path/SKILL.md.bak"
+expect_named_failure \
+  "plugin skill missing fixture mapping" \
+  "$case_root" \
+  "Claude plugin skill must contain exactly one source-to-bundle fixture mapping"
+
+case_root="$SCRATCH/plugin-source-path-leak"
+seed_case "$case_root"
+printf '\nRead docs/generated/agent-golden-path.json directly.\n' \
+  >> "$case_root/packaging/claude-plugin/skills/assay-golden-path/SKILL.md"
+expect_named_failure \
+  "plugin skill source-only path leak" \
+  "$case_root" \
+  "Claude plugin skill contains source-only path outside mapping: docs/generated/agent-golden-path.json"
+
+case_root="$SCRATCH/plugin-fixture-byte-drift"
+seed_case "$case_root"
+printf '\n' \
+  >> "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json"
+expect_named_failure \
+  "plugin fixture byte drift" \
+  "$case_root" \
+  "packaged plugin resource drifted: packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json"
 
 vocabulary_mutations=(
   'next-slice|The NEXT---SLICE owns this public wording.|skill introduces private planning vocabulary: next slice'
@@ -688,7 +741,12 @@ seed_case "$case_root"
 append_contract_evidence_issue "$case_root"
 expect_named_success "public vocabulary novel contract evidence allow case" "$case_root"
 
-for workflow_path in 'scripts/**' '.github/workflows/kernel-matrix.yml'; do
+for workflow_path in \
+  'scripts/**' \
+  '.github/workflows/kernel-matrix.yml' \
+  '.claude-plugin/**' \
+  'packaging/claude-plugin/**'
+do
   for mutation in remove comment; do
     case_root="$SCRATCH/workflow-$mutation-$(printf '%s' "$workflow_path" | tr '/.*' '---')"
     seed_case "$case_root"
@@ -709,6 +767,34 @@ PY
       "$case_root" \
       "kernel-matrix workflow does not cover skill contract path: $workflow_path"
   done
+done
+
+for hook_id in docs-generated-drift agent-golden-path-skill-contract; do
+  case_root="$SCRATCH/hook-plugin-surface-$hook_id"
+  seed_case "$case_root"
+  CASE_ROOT="$case_root" HOOK_ID="$hook_id" python3 - <<'PY'
+import os
+from pathlib import Path
+
+path = Path(os.environ["CASE_ROOT"]) / ".pre-commit-config.yaml"
+hook_id = os.environ["HOOK_ID"]
+text = path.read_text(encoding="utf-8")
+start = text.find(f"      - id: {hook_id}\n")
+if start < 0:
+    raise SystemExit(f"hook is not declared: {hook_id}")
+end = text.find("      - id: ", start + 1)
+if end < 0:
+    end = len(text)
+block = text[start:end]
+source = "|\\.claude-plugin/.*|packaging/claude-plugin/.*"
+if block.count(source) != 1:
+    raise SystemExit(f"hook plugin surface is not unique: {hook_id}")
+path.write_text(text[:start] + block.replace(source, "", 1) + text[end:], encoding="utf-8")
+PY
+  expect_named_failure \
+    "hook omits plugin surface $hook_id" \
+    "$case_root" \
+    "${hook_id} does not cover .claude-plugin/marketplace.json"
 done
 
 for skill_path in \
@@ -963,7 +1049,7 @@ source = (
     "        files: ^(scripts/ci/(check-docs-generated-drift|"
     "test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot)\\.sh|scripts/docs/"
     "generate-agent-golden-path\\.py|\\.(agents|claude)/skills/"
-    "assay-golden-path/SKILL\\.md)$\n"
+    "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*)$\n"
 )
 replacement = "        stages: [pre-push]\n" + source
 text = path.read_text(encoding="utf-8")

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -97,6 +97,8 @@ seed_case() {
     "$case_root/docs/guides" \
     "$case_root/.agents/skills/assay-golden-path" \
     "$case_root/.claude/skills/assay-golden-path" \
+    "$case_root/.claude-plugin" \
+    "$case_root/packaging/claude-plugin/.claude-plugin" \
     "$case_root/.github/workflows"
   cp "$ROOT/scripts/ci/test-agent-golden-path-skill.py" "$case_root/scripts/ci/"
   cp "$ROOT/scripts/docs/generate-agent-golden-path.py" "$case_root/scripts/docs/"
@@ -109,6 +111,10 @@ seed_case() {
     "$case_root/.agents/skills/assay-golden-path/"
   cp "$ROOT/.claude/skills/assay-golden-path/SKILL.md" \
     "$case_root/.claude/skills/assay-golden-path/"
+  cp "$ROOT/.claude-plugin/marketplace.json" "$case_root/.claude-plugin/"
+  cp "$ROOT/packaging/claude-plugin/.claude-plugin/plugin.json" \
+    "$case_root/packaging/claude-plugin/.claude-plugin/"
+  cp "$ROOT/packaging/claude-plugin/.mcp.json" "$case_root/packaging/claude-plugin/"
   cp "$ROOT/.github/workflows/kernel-matrix.yml" "$case_root/.github/workflows/"
   case_git "$case_root" -c init.defaultBranch=main init -q
   case_git "$case_root" -c core.excludesFile= -c core.attributesFile= \

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 
 # PR B adds discoverability, cwd wording, and issue-reference hardening cases to
 # the 58-case durability boundary established by PR B0.
-EXPECTED_CASES=84
+EXPECTED_CASES=86
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -228,6 +228,23 @@ expect_named_success() {
   if ! python3 "$case_root/scripts/ci/test-agent-golden-path-skill.py" >"$output" 2>&1; then
     cat "$output" >&2
     echo "FAIL: $name was rejected" >&2
+    return 1
+  fi
+  record_case_pass "$name"
+}
+
+expect_generator_failure() {
+  local name="$1" case_root="$2" expected="$3"
+  local output="$case_root/generator.log"
+  if (cd "$case_root" && python3 scripts/docs/generate-agent-golden-path.py) \
+    >"$output" 2>&1
+  then
+    echo "FAIL: $name was accepted by the generator" >&2
+    return 1
+  fi
+  if ! grep -Fq "$expected" "$output"; then
+    cat "$output" >&2
+    echo "FAIL: $name did not reach named generator guard: $expected" >&2
     return 1
   fi
   record_case_pass "$name"
@@ -516,6 +533,35 @@ expect_named_failure \
   "plugin fixture byte drift" \
   "$case_root" \
   "packaged plugin resource drifted: packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json"
+
+case_root="$SCRATCH/plugin-resource-source-symlink"
+seed_case "$case_root"
+mv "$case_root/examples/privileged-action-gate/mock_github_mcp.py" \
+  "$case_root/examples/privileged-action-gate/mock_github_mcp-copy.py"
+if create_required_symlink \
+  "plugin resource source symlink" \
+  "mock_github_mcp-copy.py" \
+  "$case_root/examples/privileged-action-gate/mock_github_mcp.py"
+then
+  expect_generator_failure \
+    "plugin resource source symlink" \
+    "$case_root" \
+    "plugin resource source must not be a symlink"
+fi
+
+case_root="$SCRATCH/plugin-resource-source-oversized"
+seed_case "$case_root"
+python3 - "$case_root/examples/privileged-action-gate/baseline-approved.json" <<'PY'
+from pathlib import Path
+import sys
+
+with Path(sys.argv[1]).open("wb") as handle:
+    handle.truncate(1048577)
+PY
+expect_generator_failure \
+  "plugin resource source oversized" \
+  "$case_root" \
+  "plugin resource source exceeds 1048576 bytes"
 
 vocabulary_mutations=(
   'next-slice|The NEXT---SLICE owns this public wording.|skill introduces private planning vocabulary: next slice'

--- a/scripts/ci/test-agent-golden-path-skill-optimization.sh
+++ b/scripts/ci/test-agent-golden-path-skill-optimization.sh
@@ -21,16 +21,25 @@ mkdir -p \
   "$SCRATCH/scripts/ci" \
   "$SCRATCH/scripts/docs" \
   "$SCRATCH/docs/generated" \
+  "$SCRATCH/examples/privileged-action-gate/policies" \
   "$SCRATCH/.agents/skills/assay-golden-path" \
   "$SCRATCH/.claude/skills/assay-golden-path" \
   "$SCRATCH/.claude-plugin" \
-  "$SCRATCH/packaging/claude-plugin/.claude-plugin"
+  "$SCRATCH/packaging/claude-plugin/.claude-plugin" \
+  "$SCRATCH/packaging/claude-plugin/skills/assay-golden-path/references" \
+  "$SCRATCH/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies"
 
 cp "$ROOT/scripts/ci/test-agent-golden-path-skill.py" "$SCRATCH/scripts/ci/"
 cp "$ROOT/scripts/docs/generate-agent-golden-path.py" "$SCRATCH/scripts/docs/"
 cp "$ROOT/.gitignore" "$SCRATCH/"
 cp "$ROOT/.gitattributes" "$SCRATCH/"
 cp "$ROOT/docs/generated/agent-golden-path.json" "$SCRATCH/docs/generated/"
+cp "$ROOT/examples/privileged-action-gate/mock_github_mcp.py" \
+  "$SCRATCH/examples/privileged-action-gate/"
+cp "$ROOT/examples/privileged-action-gate/baseline-approved.json" \
+  "$SCRATCH/examples/privileged-action-gate/"
+cp "$ROOT/examples/privileged-action-gate/policies/no-allowance.yaml" \
+  "$SCRATCH/examples/privileged-action-gate/policies/"
 cp "$ROOT/.agents/skills/assay-golden-path/SKILL.md" \
   "$SCRATCH/.agents/skills/assay-golden-path/"
 cp "$ROOT/.claude/skills/assay-golden-path/SKILL.md" \
@@ -39,6 +48,16 @@ cp "$ROOT/.claude-plugin/marketplace.json" "$SCRATCH/.claude-plugin/"
 cp "$ROOT/packaging/claude-plugin/.claude-plugin/plugin.json" \
   "$SCRATCH/packaging/claude-plugin/.claude-plugin/"
 cp "$ROOT/packaging/claude-plugin/.mcp.json" "$SCRATCH/packaging/claude-plugin/"
+cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/SKILL.md" \
+  "$SCRATCH/packaging/claude-plugin/skills/assay-golden-path/"
+cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json" \
+  "$SCRATCH/packaging/claude-plugin/skills/assay-golden-path/references/"
+cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py" \
+  "$SCRATCH/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/"
+cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json" \
+  "$SCRATCH/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/"
+cp "$ROOT/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml" \
+  "$SCRATCH/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/"
 scratch_git -c init.defaultBranch=main init -q
 scratch_git -c core.excludesFile= -c core.attributesFile= \
   add -f -- .

--- a/scripts/ci/test-agent-golden-path-skill-optimization.sh
+++ b/scripts/ci/test-agent-golden-path-skill-optimization.sh
@@ -22,7 +22,9 @@ mkdir -p \
   "$SCRATCH/scripts/docs" \
   "$SCRATCH/docs/generated" \
   "$SCRATCH/.agents/skills/assay-golden-path" \
-  "$SCRATCH/.claude/skills/assay-golden-path"
+  "$SCRATCH/.claude/skills/assay-golden-path" \
+  "$SCRATCH/.claude-plugin" \
+  "$SCRATCH/packaging/claude-plugin/.claude-plugin"
 
 cp "$ROOT/scripts/ci/test-agent-golden-path-skill.py" "$SCRATCH/scripts/ci/"
 cp "$ROOT/scripts/docs/generate-agent-golden-path.py" "$SCRATCH/scripts/docs/"
@@ -33,6 +35,10 @@ cp "$ROOT/.agents/skills/assay-golden-path/SKILL.md" \
   "$SCRATCH/.agents/skills/assay-golden-path/"
 cp "$ROOT/.claude/skills/assay-golden-path/SKILL.md" \
   "$SCRATCH/.claude/skills/assay-golden-path/"
+cp "$ROOT/.claude-plugin/marketplace.json" "$SCRATCH/.claude-plugin/"
+cp "$ROOT/packaging/claude-plugin/.claude-plugin/plugin.json" \
+  "$SCRATCH/packaging/claude-plugin/.claude-plugin/"
+cp "$ROOT/packaging/claude-plugin/.mcp.json" "$SCRATCH/packaging/claude-plugin/"
 scratch_git -c init.defaultBranch=main init -q
 scratch_git -c core.excludesFile= -c core.attributesFile= \
   add -f -- .

--- a/scripts/ci/test-agent-golden-path-skill-optimization.sh
+++ b/scripts/ci/test-agent-golden-path-skill-optimization.sh
@@ -33,6 +33,7 @@ cp "$ROOT/scripts/ci/test-agent-golden-path-skill.py" "$SCRATCH/scripts/ci/"
 cp "$ROOT/scripts/docs/generate-agent-golden-path.py" "$SCRATCH/scripts/docs/"
 cp "$ROOT/.gitignore" "$SCRATCH/"
 cp "$ROOT/.gitattributes" "$SCRATCH/"
+cp "$ROOT/.mcp.json" "$SCRATCH/"
 cp "$ROOT/docs/generated/agent-golden-path.json" "$SCRATCH/docs/generated/"
 cp "$ROOT/examples/privileged-action-gate/mock_github_mcp.py" \
   "$SCRATCH/examples/privileged-action-gate/"

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -17,6 +17,9 @@ CONTRACT_PATH = ROOT / "docs/generated/agent-golden-path.json"
 GUIDE_PATH = ROOT / "docs/guides/agent-golden-path.md"
 WORKFLOW_PATH = ROOT / ".github/workflows/kernel-matrix.yml"
 PRECOMMIT_PATH = ROOT / ".pre-commit-config.yaml"
+MARKETPLACE_PATH = ROOT / ".claude-plugin/marketplace.json"
+PLUGIN_MANIFEST_PATH = ROOT / "packaging/claude-plugin/.claude-plugin/plugin.json"
+PLUGIN_MCP_PATH = ROOT / "packaging/claude-plugin/.mcp.json"
 SKILL_PATHS = (
     ROOT / ".agents/skills/assay-golden-path/SKILL.md",
     ROOT / ".claude/skills/assay-golden-path/SKILL.md",
@@ -41,6 +44,9 @@ EXPECTED_DESCRIPTION = (
     "Drive Assay's install-to-evidence golden path and interpret its stdout and exit "
     "codes. Use when an agent must operate or diagnose Assay; do not use it to infer "
     "provider execution, external side effects, or a clean result from missing output."
+)
+EXPECTED_PLUGIN_DESCRIPTION = (
+    "Connect Claude Code to Assay's MCP policy and evidence tools and golden-path skill."
 )
 EMPTY_STDOUT_RULE = (
     "Empty stdout in a gap row is an observed limitation, not permission for a caller "
@@ -317,6 +323,48 @@ def read_bounded_evidence(path: Path, label: str) -> bytes:
     if len(payload) > MAX_EVIDENCE_BYTES:
         fail(f"{label} exceeds {MAX_EVIDENCE_BYTES}-byte limit")
     return payload
+
+
+def validate_plugin_manifests() -> None:
+    marketplace = json.loads(
+        read_bounded_evidence(MARKETPLACE_PATH, "Claude marketplace manifest")
+    )
+    expected_marketplace = {
+        "name": "assay",
+        "owner": {"name": "Assay"},
+        "plugins": [
+            {
+                "name": "assay",
+                "description": EXPECTED_PLUGIN_DESCRIPTION,
+                "source": "./packaging/claude-plugin",
+            }
+        ],
+    }
+    if marketplace != expected_marketplace:
+        fail("Claude marketplace identity or local source drifted")
+
+    plugin = json.loads(
+        read_bounded_evidence(PLUGIN_MANIFEST_PATH, "Claude plugin manifest")
+    )
+    expected_plugin = {
+        "name": "assay",
+        "description": EXPECTED_PLUGIN_DESCRIPTION,
+        "author": {"name": "Assay"},
+    }
+    if plugin != expected_plugin:
+        fail("Claude plugin identity, fields, or unversioned contract drifted")
+
+    mcp = json.loads(read_bounded_evidence(PLUGIN_MCP_PATH, "Claude plugin MCP manifest"))
+    expected_mcp = {
+        "mcpServers": {
+            "assay": {
+                "command": "assay-mcp-server",
+                "args": ["--policy-root", "${CLAUDE_PROJECT_DIR}"],
+            }
+        }
+    }
+    if mcp != expected_mcp:
+        fail("Claude plugin MCP command or project-root arguments drifted")
 
 
 def indentation(line: str) -> int:
@@ -942,6 +990,7 @@ def exit_summary(step: dict[str, object]) -> str:
 
 def main() -> None:
     validate_skill_repository_state()
+    validate_plugin_manifests()
     contract = json.loads(read_bounded_evidence(CONTRACT_PATH, "contract evidence"))
     if not isinstance(contract, dict):
         fail("golden-path contract root must be an object")

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -410,8 +410,8 @@ def validate_plugin_skill(contract: dict[str, object]) -> None:
     payload = read_bounded_evidence(PLUGIN_SKILL_PATH, "Claude plugin skill")
     try:
         text = payload.decode("ascii")
-    except UnicodeDecodeError as error:
-        raise AssertionError("Claude plugin skill must be ASCII") from error
+    except UnicodeDecodeError:
+        fail("Claude plugin skill must be ASCII")
     fields, body = parse_frontmatter(text)
     expected_fields = {
         "name": "assay-golden-path",
@@ -1217,8 +1217,15 @@ def main() -> None:
     precommit_text = read_bounded_evidence(
         PRECOMMIT_PATH, "pre-commit config evidence"
     ).decode("utf-8")
-    hook = parse_precommit_self_test(precommit_text)
-    validate_precommit_self_test(hook)
+    self_test_hook = parse_precommit_self_test(precommit_text)
+    validate_precommit_self_test(self_test_hook)
+    mutation_hook = parse_precommit_hook(
+        precommit_text,
+        "agent-golden-path-skill-mutations",
+        "agent golden-path skill mutations",
+    )
+    if mutation_hook.stages != ("pre-push",):
+        fail("agent golden-path skill mutations must run only at pre-push")
 
     required_hook_paths = (
         ".gitattributes",
@@ -1227,10 +1234,10 @@ def main() -> None:
         "packaging/claude-plugin/skills/assay-golden-path/SKILL.md",
     )
     for hook_id in ("docs-generated-drift", "agent-golden-path-skill-contract"):
-        hook = parse_precommit_hook(precommit_text, hook_id, hook_id)
+        contract_hook = parse_precommit_hook(precommit_text, hook_id, hook_id)
         for required_path in required_hook_paths:
             if not precommit_pattern_matches(
-                hook.files_pattern, required_path, f"{hook_id} files selector"
+                contract_hook.files_pattern, required_path, f"{hook_id} files selector"
             ):
                 fail(f"{hook_id} does not cover {required_path}")
 

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -20,6 +20,7 @@ PRECOMMIT_PATH = ROOT / ".pre-commit-config.yaml"
 MARKETPLACE_PATH = ROOT / ".claude-plugin/marketplace.json"
 PLUGIN_MANIFEST_PATH = ROOT / "packaging/claude-plugin/.claude-plugin/plugin.json"
 PLUGIN_MCP_PATH = ROOT / "packaging/claude-plugin/.mcp.json"
+PROJECT_MCP_PATH = ROOT / ".mcp.json"
 PLUGIN_SKILL_PATH = ROOT / "packaging/claude-plugin/skills/assay-golden-path/SKILL.md"
 PLUGIN_CONTRACT_PATH = (
     ROOT
@@ -392,12 +393,17 @@ def validate_plugin_manifests() -> None:
         "mcpServers": {
             "assay": {
                 "command": "assay-mcp-server",
-                "args": ["--policy-root", "${CLAUDE_PROJECT_DIR}"],
+                "args": ["--policy-root", "."],
             }
         }
     }
     if mcp != expected_mcp:
         fail("Claude plugin MCP command or project-root arguments drifted")
+    project_mcp = json.loads(
+        read_bounded_evidence(PROJECT_MCP_PATH, "project MCP manifest")
+    )
+    if project_mcp != mcp:
+        fail("project and plugin MCP manifests no longer share the cwd-relative invocation")
 
 
 def validate_plugin_skill(contract: dict[str, object]) -> None:

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -20,6 +20,11 @@ PRECOMMIT_PATH = ROOT / ".pre-commit-config.yaml"
 MARKETPLACE_PATH = ROOT / ".claude-plugin/marketplace.json"
 PLUGIN_MANIFEST_PATH = ROOT / "packaging/claude-plugin/.claude-plugin/plugin.json"
 PLUGIN_MCP_PATH = ROOT / "packaging/claude-plugin/.mcp.json"
+PLUGIN_SKILL_PATH = ROOT / "packaging/claude-plugin/skills/assay-golden-path/SKILL.md"
+PLUGIN_CONTRACT_PATH = (
+    ROOT
+    / "packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json"
+)
 SKILL_PATHS = (
     ROOT / ".agents/skills/assay-golden-path/SKILL.md",
     ROOT / ".claude/skills/assay-golden-path/SKILL.md",
@@ -47,6 +52,34 @@ EXPECTED_DESCRIPTION = (
 )
 EXPECTED_PLUGIN_DESCRIPTION = (
     "Connect Claude Code to Assay's MCP policy and evidence tools and golden-path skill."
+)
+PLUGIN_CONTRACT_REFERENCE = (
+    "${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/references/agent-golden-path.json"
+)
+PLUGIN_ASSET_ROOT = (
+    "${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/assets/privileged-action-gate"
+)
+PLUGIN_FIXTURE_MAPPING = (
+    "Fixtures named by the contract under `examples/privileged-action-gate` are bundled at "
+    f"`{PLUGIN_ASSET_ROOT}`."
+)
+PLUGIN_RESOURCE_COPIES = (
+    (CONTRACT_PATH, PLUGIN_CONTRACT_PATH),
+    (
+        ROOT / "examples/privileged-action-gate/mock_github_mcp.py",
+        ROOT
+        / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py",
+    ),
+    (
+        ROOT / "examples/privileged-action-gate/baseline-approved.json",
+        ROOT
+        / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json",
+    ),
+    (
+        ROOT / "examples/privileged-action-gate/policies/no-allowance.yaml",
+        ROOT
+        / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml",
+    ),
 )
 EMPTY_STDOUT_RULE = (
     "Empty stdout in a gap row is an observed limitation, not permission for a caller "
@@ -365,6 +398,42 @@ def validate_plugin_manifests() -> None:
     }
     if mcp != expected_mcp:
         fail("Claude plugin MCP command or project-root arguments drifted")
+
+
+def validate_plugin_skill(contract: dict[str, object]) -> None:
+    payload = read_bounded_evidence(PLUGIN_SKILL_PATH, "Claude plugin skill")
+    try:
+        text = payload.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise AssertionError("Claude plugin skill must be ASCII") from error
+    fields, body = parse_frontmatter(text)
+    expected_fields = {
+        "name": "assay-golden-path",
+        "description": EXPECTED_DESCRIPTION,
+    }
+    if fields != expected_fields:
+        fail("Claude plugin skill frontmatter or trigger boundaries drifted")
+    if f"`{PLUGIN_CONTRACT_REFERENCE}` is the authoritative machine contract." not in body:
+        fail("Claude plugin skill omits its bundled authoritative contract")
+    if body.count(PLUGIN_FIXTURE_MAPPING) != 1:
+        fail("Claude plugin skill must contain exactly one source-to-bundle fixture mapping")
+    without_mapping = body.replace(PLUGIN_FIXTURE_MAPPING, "", 1)
+    for source_only in (
+        "docs/generated/agent-golden-path.json",
+        "scripts/docs/generate-agent-golden-path.py",
+        "examples/privileged-action-gate",
+    ):
+        if source_only in without_mapping:
+            fail(f"Claude plugin skill contains source-only path outside mapping: {source_only}")
+    if f"Working directory: `{PLUGIN_ASSET_ROOT}`" not in body:
+        fail("Claude plugin skill does not resolve protected-action assets through plugin root")
+    validate_public_vocabulary(text, contract)
+
+    for source, packaged in PLUGIN_RESOURCE_COPIES:
+        if read_bounded_evidence(source, "canonical plugin resource") != read_bounded_evidence(
+            packaged, "packaged plugin resource"
+        ):
+            fail(f"packaged plugin resource drifted: {packaged.relative_to(ROOT)}")
 
 
 def indentation(line: str) -> int:
@@ -998,6 +1067,7 @@ def main() -> None:
         fail("unexpected golden-path contract schema")
     if contract.get("schema_version") != 1:
         fail("unexpected golden-path contract schema version")
+    validate_plugin_skill(contract)
 
     payloads: list[bytes] = []
     for path in SKILL_PATHS:
@@ -1125,6 +1195,8 @@ def main() -> None:
         'scripts/**',
         '.agents/**',
         '.claude/**',
+        '.claude-plugin/**',
+        'packaging/claude-plugin/**',
         '.gitignore',
         '.gitattributes',
         '.pre-commit-config.yaml',
@@ -1142,12 +1214,19 @@ def main() -> None:
     hook = parse_precommit_self_test(precommit_text)
     validate_precommit_self_test(hook)
 
+    required_hook_paths = (
+        ".gitattributes",
+        ".claude-plugin/marketplace.json",
+        "packaging/claude-plugin/.mcp.json",
+        "packaging/claude-plugin/skills/assay-golden-path/SKILL.md",
+    )
     for hook_id in ("docs-generated-drift", "agent-golden-path-skill-contract"):
         hook = parse_precommit_hook(precommit_text, hook_id, hook_id)
-        if not precommit_pattern_matches(
-            hook.files_pattern, ".gitattributes", f"{hook_id} files selector"
-        ):
-            fail(f"{hook_id} does not cover .gitattributes")
+        for required_path in required_hook_paths:
+            if not precommit_pattern_matches(
+                hook.files_pattern, required_path, f"{hook_id} files selector"
+            ):
+                fail(f"{hook_id} does not cover {required_path}")
 
     print("agent golden-path skill: portable, byte-identical, and contract-complete")
 

--- a/scripts/ci/test-check-docs-generated-drift-safety.sh
+++ b/scripts/ci/test-check-docs-generated-drift-safety.sh
@@ -189,7 +189,7 @@ if [[ "$COUNT_STATUS" -ne 1 ]]; then
   echo "FAIL: deleted drift-battery row exited $COUNT_STATUS, wanted 1" >&2
   exit 1
 fi
-if ! grep -Fq 'FAIL: full drift self-test executed 9 cases, wanted 10' "$COUNT_OUTPUT"; then
+if ! grep -Fq 'FAIL: full drift self-test executed 11 cases, wanted 12' "$COUNT_OUTPUT"; then
   cat "$COUNT_OUTPUT" >&2
   echo "FAIL: deleted drift-battery row did not reach the exact count guard" >&2
   exit 1

--- a/scripts/ci/test-check-docs-generated-drift.sh
+++ b/scripts/ci/test-check-docs-generated-drift.sh
@@ -13,7 +13,7 @@ SELECTED_CASE="${ASSAY_DOCS_DRIFT_SELF_TEST_CASE:-}"
 INTERRUPT_CASE="${ASSAY_DOCS_DRIFT_INTERRUPT_AFTER_MUTATION:-}"
 GATE_OUTPUT=""
 # Full mode is a fixed mutation battery; selected mode deliberately executes one row.
-EXPECTED_CASES=10
+EXPECTED_CASES=12
 
 seed_repo() {
   local destination="$1"
@@ -136,6 +136,14 @@ case_hand_edited_codex_skill() {
   expect_gate_status "$name" "$case_root" 1
 }
 
+case_hand_edited_plugin_skill() {
+  local case_root="$1" name="$2"
+  printf '\n%%%% drift planted by the drift-check self-test\n' \
+    >> "$case_root/packaging/claude-plugin/skills/assay-golden-path/SKILL.md"
+  maybe_interrupt_after_mutation "$name"
+  expect_gate_status "$name" "$case_root" 1
+}
+
 case_missing_codex_destination() {
   local case_root="$1" name="$2"
   local destination=".agents/skills/assay-golden-path/SKILL.md"
@@ -148,6 +156,15 @@ case_missing_codex_destination() {
 case_missing_claude_destination() {
   local case_root="$1" name="$2"
   local destination=".claude/skills/assay-golden-path/SKILL.md"
+  remove_generator_destination "$case_root" "$destination"
+  maybe_interrupt_after_mutation "$name"
+  expect_gate_status "$name" "$case_root" 1
+  expect_gate_output "$name" "error: the generators did not produce $destination."
+}
+
+case_missing_plugin_destination() {
+  local case_root="$1" name="$2"
+  local destination="packaging/claude-plugin/skills/assay-golden-path/SKILL.md"
   remove_generator_destination "$case_root" "$destination"
   maybe_interrupt_after_mutation "$name"
   expect_gate_status "$name" "$case_root" 1
@@ -196,8 +213,10 @@ CASES=(
   "hand-edited-machine-contract|case_hand_edited_machine_contract"
   "hand-edited-rendered-guide-table|case_hand_edited_rendered_guide_table"
   "hand-edited-codex-skill|case_hand_edited_codex_skill"
+  "hand-edited-plugin-skill|case_hand_edited_plugin_skill"
   "missing-codex-skill-destination|case_missing_codex_destination"
   "missing-claude-skill-destination|case_missing_claude_destination"
+  "missing-plugin-skill-destination|case_missing_plugin_destination"
   "generator-unable-to-run|case_generator_unable_to_run"
   "gate-reads-working-tree|case_gate_reads_working_tree"
   "gate-leaves-worktree-untouched|case_gate_leaves_worktree_untouched"

--- a/scripts/ci/test-claude-plugin-install.sh
+++ b/scripts/ci/test-claude-plugin-install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ASSAY_CLAUDE_WORKFLOW_SCRIPT="$SCRIPT_DIR/$(basename -- "${BASH_SOURCE[0]}")"
+export ASSAY_CLAUDE_WORKFLOW_SCRIPT
+
+exec python3 "$SCRIPT_DIR/claude_plugin_install_workflow.py" "$@"

--- a/scripts/ci/test-claude-plugin-install.sh
+++ b/scripts/ci/test-claude-plugin-install.sh
@@ -2,7 +2,4 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-ASSAY_CLAUDE_WORKFLOW_SCRIPT="$SCRIPT_DIR/$(basename -- "${BASH_SOURCE[0]}")"
-export ASSAY_CLAUDE_WORKFLOW_SCRIPT
-
 exec python3 "$SCRIPT_DIR/claude_plugin_install_workflow.py" "$@"

--- a/scripts/ci/test-golden-path-mock-bounds.py
+++ b/scripts/ci/test-golden-path-mock-bounds.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Prove the bundled mock discards oversized records without losing the stream."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MOCK = ROOT / "examples/privileged-action-gate/mock_github_mcp.py"
+MAX_REQUEST_BYTES = 1_048_576
+
+
+def main() -> None:
+    oversized = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"padding": "x" * MAX_REQUEST_BYTES},
+    }
+    ping = {"jsonrpc": "2.0", "id": 2, "method": "ping"}
+    stdin = (
+        json.dumps(oversized, separators=(",", ":"))
+        + "\n"
+        + json.dumps(ping, separators=(",", ":"))
+        + "\n"
+    ).encode("utf-8")
+    try:
+        result = subprocess.run(
+            [sys.executable, str(MOCK)],
+            input=stdin,
+            cwd=MOCK.parent,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise SystemExit(f"mock server did not bound oversized request handling: {error}")
+    if result.returncode != 0:
+        raise SystemExit(
+            f"mock server rejected the bounded follow-up probe: {result.stderr[-300:]!r}"
+        )
+    response_ids = [json.loads(raw).get("id") for raw in result.stdout.splitlines()]
+    if response_ids != [2]:
+        raise SystemExit(
+            "mock server must discard an oversized request and continue at the next "
+            f"newline-delimited request; got response ids {response_ids}"
+        )
+    print("golden-path mock request bound: pass")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 
@@ -13,6 +14,34 @@ MARKDOWN_OUTPUT = ROOT / "docs/guides/agent-golden-path.md"
 SKILL_OUTPUTS = (
     ROOT / ".agents/skills/assay-golden-path/SKILL.md",
     ROOT / ".claude/skills/assay-golden-path/SKILL.md",
+)
+PLUGIN_SKILL_OUTPUTS = (
+    ROOT / "packaging/claude-plugin/skills/assay-golden-path/SKILL.md",
+)
+PLUGIN_CONTRACT_OUTPUT = (
+    ROOT
+    / "packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json"
+)
+PLUGIN_ASSET_ROOT = (
+    "${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/assets/privileged-action-gate"
+)
+PLUGIN_RESOURCE_COPIES = (
+    (JSON_OUTPUT, PLUGIN_CONTRACT_OUTPUT),
+    (
+        ROOT / "examples/privileged-action-gate/mock_github_mcp.py",
+        ROOT
+        / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py",
+    ),
+    (
+        ROOT / "examples/privileged-action-gate/baseline-approved.json",
+        ROOT
+        / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json",
+    ),
+    (
+        ROOT / "examples/privileged-action-gate/policies/no-allowance.yaml",
+        ROOT
+        / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml",
+    ),
 )
 TABLE_START = "<!-- agent-golden-path-table:start -->"
 TABLE_END = "<!-- agent-golden-path-table:end -->"
@@ -488,7 +517,7 @@ def render_markdown(current: str) -> str:
     )
 
 
-def render_skill() -> str:
+def render_skill(*, plugin: bool = False) -> str:
     lines = [
         "---",
         "name: assay-golden-path",
@@ -501,31 +530,55 @@ def render_skill() -> str:
         "separately; a policy denial can be a successful JSON-RPC exchange rather than",
         "a process failure.",
         "",
-        "`docs/generated/agent-golden-path.json` is the authoritative machine contract.",
-        "Read it when exact argv, fields, or per-outcome metadata are needed. Edit and",
-        "run `scripts/docs/generate-agent-golden-path.py` instead of editing this file.",
-        "",
-        INVOCATION_CWD_RULE,
-        SOURCE_REPO_CWD_RULE,
-        PYTHON_PLACEHOLDER_RULE,
-        "",
-        f"{EMPTY_STDOUT_RULE}",
-        "Do not replace a linked gap with an inferred clean result.",
-        "",
-        "Codex and Claude Code are the project-skill hosts exercised here.",
-        f"Cursor's skill documentation ({CURSOR_DOCS_URL}), accessed on "
-        f"{CURSOR_DOCS_ACCESSED}, describes .agents/skills as a project-level location "
-        "and .claude/skills as a compatibility location. This repository does not "
-        "exercise Cursor runtime discovery.",
-        "",
-        "## Journey",
-        "",
     ]
+    if plugin:
+        lines.extend(
+            [
+                "`${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/references/agent-golden-path.json` is the authoritative machine contract.",
+                "Read it when exact argv, fields, or per-outcome metadata are needed.",
+                "",
+                INVOCATION_CWD_RULE,
+                "Fixtures named by the contract under `examples/privileged-action-gate` are bundled at "
+                f"`{PLUGIN_ASSET_ROOT}`.",
+                "A present `working_directory` in the contract resolves through that mapping.",
+                PYTHON_PLACEHOLDER_RULE,
+                "",
+                f"{EMPTY_STDOUT_RULE}",
+                "Do not replace a linked gap with an inferred clean result.",
+                "",
+                "Claude Code loads this skill from the installed Assay plugin.",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "`docs/generated/agent-golden-path.json` is the authoritative machine contract.",
+                "Read it when exact argv, fields, or per-outcome metadata are needed. Edit and",
+                "run `scripts/docs/generate-agent-golden-path.py` instead of editing this file.",
+                "",
+                INVOCATION_CWD_RULE,
+                SOURCE_REPO_CWD_RULE,
+                PYTHON_PLACEHOLDER_RULE,
+                "",
+                f"{EMPTY_STDOUT_RULE}",
+                "Do not replace a linked gap with an inferred clean result.",
+                "",
+                "Codex and Claude Code are the project-skill hosts exercised here.",
+                f"Cursor's skill documentation ({CURSOR_DOCS_URL}), accessed on "
+                f"{CURSOR_DOCS_ACCESSED}, describes .agents/skills as a project-level location "
+                "and .claude/skills as a compatibility location. This repository does not "
+                "exercise Cursor runtime discovery.",
+                "",
+            ]
+        )
+    lines.extend(["## Journey", ""])
     for step in STEPS:
         lines.extend([f"### {step['step']}. {step['label']}", ""])
         working_directory = step.get("working_directory")
         if working_directory is not None:
-            lines.extend([f"Working directory: `{working_directory}`", ""])
+            rendered_working_directory = PLUGIN_ASSET_ROOT if plugin else working_directory
+            lines.extend([f"Working directory: `{rendered_working_directory}`", ""])
         lines.extend(
             [
                 f"Run: `{step['command']}`",
@@ -550,6 +603,7 @@ def main() -> None:
     current = MARKDOWN_OUTPUT.read_text(encoding="utf-8")
     rendered_markdown = render_markdown(current)
     rendered_skill = render_skill()
+    rendered_plugin_skill = render_skill(plugin=True)
     JSON_OUTPUT.write_text(
         json.dumps(CONTRACT, indent=2, ensure_ascii=True) + "\n",
         encoding="utf-8",
@@ -558,6 +612,12 @@ def main() -> None:
     for output in SKILL_OUTPUTS:
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(rendered_skill, encoding="ascii")
+    for output in PLUGIN_SKILL_OUTPUTS:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered_plugin_skill, encoding="ascii")
+    for source, output in PLUGIN_RESOURCE_COPIES:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, output)
 
 
 if __name__ == "__main__":

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-import shutil
+import stat
 from pathlib import Path
 
 
@@ -43,6 +43,7 @@ PLUGIN_RESOURCE_COPIES = (
         / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml",
     ),
 )
+MAX_PLUGIN_RESOURCE_BYTES = 1024 * 1024
 TABLE_START = "<!-- agent-golden-path-table:start -->"
 TABLE_END = "<!-- agent-golden-path-table:end -->"
 DISCOVERY_START = "<!-- agent-golden-path-discovery:start -->"
@@ -599,15 +600,42 @@ def render_skill(*, plugin: bool = False) -> str:
     return "\n".join(lines)
 
 
+def read_plugin_resource(source: Path) -> bytes:
+    if source.is_symlink():
+        raise RuntimeError(f"plugin resource source must not be a symlink: {source}")
+    try:
+        metadata = source.stat()
+    except FileNotFoundError as error:
+        raise RuntimeError(f"plugin resource source is missing: {source}") from error
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"plugin resource source must be a regular file: {source}")
+    if metadata.st_size > MAX_PLUGIN_RESOURCE_BYTES:
+        raise RuntimeError(
+            f"plugin resource source exceeds {MAX_PLUGIN_RESOURCE_BYTES} bytes: {source}"
+        )
+    with source.open("rb") as resource:
+        payload = resource.read(MAX_PLUGIN_RESOURCE_BYTES + 1)
+    if len(payload) > MAX_PLUGIN_RESOURCE_BYTES:
+        raise RuntimeError(
+            f"plugin resource source grew beyond {MAX_PLUGIN_RESOURCE_BYTES} bytes: {source}"
+        )
+    return payload
+
+
 def main() -> None:
     current = MARKDOWN_OUTPUT.read_text(encoding="utf-8")
     rendered_markdown = render_markdown(current)
     rendered_skill = render_skill()
     rendered_plugin_skill = render_skill(plugin=True)
-    JSON_OUTPUT.write_text(
-        json.dumps(CONTRACT, indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
+    rendered_contract = (json.dumps(CONTRACT, indent=2, ensure_ascii=True) + "\n").encode(
+        "ascii"
     )
+    plugin_resources = [
+        (rendered_contract if source == JSON_OUTPUT else read_plugin_resource(source), output)
+        for source, output in PLUGIN_RESOURCE_COPIES
+    ]
+
+    JSON_OUTPUT.write_bytes(rendered_contract)
     MARKDOWN_OUTPUT.write_text(rendered_markdown, encoding="utf-8")
     for output in SKILL_OUTPUTS:
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -615,9 +643,9 @@ def main() -> None:
     for output in PLUGIN_SKILL_OUTPUTS:
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(rendered_plugin_skill, encoding="ascii")
-    for source, output in PLUGIN_RESOURCE_COPIES:
+    for payload, output in plugin_resources:
         output.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(source, output)
+        output.write_bytes(payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Package Assay's existing five MCP review tools and generated golden path as an installable Claude Code marketplace plugin.

- publish marketplace identity `assay@assay`;
- install a cache-safe generated skill with its canonical contract and three required fixtures;
- start the separately installed `assay-mcp-server --policy-root .`;
- prove add/install/update/cache/startup/tool-list/policy behavior with Claude Code 2.1.32;
- document the shortest install route and a four-layer recovery ladder.

Part of #2152. This PR completes packaging step 4; it does not claim #1840's independent external reproduction.

## Scope / DoD

- [x] Plugin installs through a fresh Claude marketplace/config, not from source-only paths.
- [x] Installed cache bytes match the reviewed package and resolve outside the checkout.
- [x] Default server exposes exactly five named production tools; feature-only test tool stays excluded.
- [x] Consumer cwd is proven with exact `--policy-root .`, no default `policies/`, and a root-only marker denial.
- [x] Missing policy is `E_POLICY_NOT_FOUND`, never a clean allow/deny.
- [x] Actual Claude session connects MCP and discovers `assay:assay-golden-path`.
- [x] User docs distinguish plugin install, binary spawn, policy root, and Assay verdict.
- [x] Generated resources, workflow selectors, and update/cache behavior are drift-gated.

Out of scope: MCP 2026-07-28 envelope remediation (#2157), bundled server binaries, Cursor plugin runtime, model-mediated tool use, provider execution, and external-side-effect proof.

## Review provenance

- exact head: `1b62bf219b34d1f27b931f3e8059c6027e165cc8`
- worktree: `/Users/roelschuurkes/.config/superpowers/worktrees/assay-2152-plugin-packaging/worktree`
- toolchain: rustc/cargo 1.96.0, Python 3.14.3, Claude Code 2.1.32
- diff: 26 files, +2947/-94

Hot files:

- `scripts/ci/claude_plugin_install_workflow.py`: bounded disposable-client and adversarial self-test
- `scripts/ci/test-agent-golden-path-skill.py`: typed manifests and cache-safe package contract
- `crates/assay-mcp-server/tests/project_install_surfaces.rs`: manifest-driven five-tool/policy-root proof
- `scripts/docs/generate-agent-golden-path.py`: single owner of all skill renderings/resources
- `.claude-plugin/marketplace.json` and `packaging/claude-plugin/.mcp.json`: public install contract

## Contract changes

New:

- Claude marketplace/plugin identity: `assay@assay`
- MCP invocation: `assay-mcp-server --policy-root .`
- packaged skill identity: `assay:assay-golden-path`
- maintainer evidence output: stable `key=pass` lines; failures use `phase`, `status`, `reason`, `next_step`

Unchanged:

- no new MCP tools;
- no run/summary/evidence JSON schema change;
- root Claude/Cursor manifests and Codex invocation retain the same argv;
- project Codex/Claude skills remain byte-identical to their pre-plugin generated form.

No migration is needed. Users install the server prerequisite once and the plugin at local project scope.

## Real-client proof

```text
plugin_validate=pass
marketplace_add=pass
plugin_install=pass
marketplace_update=pass
plugin_update=pass
installed_cache=pass
mcp_list_connected=pass
initialize=pass
tools_list=pass
policy_root_resolved_to_consumer=pass
missing_policy_refused=pass
actual_session_mcp_connected=pass
skill_discovery=pass
source_sha=1b62bf219b34d1f27b931f3e8059c6027e165cc8
claude_version=2.1.32 (Claude Code)
installed_cache_version=1b62bf219b34
model_mediated_tool_call=unavailable
verification=pass
```

`verification=pass` covers the scoped installation/protocol proof only. It does not promote the explicitly unavailable model-mediated call to pass.

## TDD and mutation evidence

RED:

```text
missing required workflow phase: marketplace_update
```

Later RED for the failure contract:

```text
phase=self_test status=fail reason=passing workflow omitted phases: ['missing_policy_refused=pass']
```

CodeQL blocker RED for cache-path provenance:

```text
phase=self_test status=fail reason=mutation FAKE_CACHE_VERSION_DRIFT did not bite its named guard
installed_cache_version=forged-v2
```

The fix removes externally supplied executable/source/script paths, derives repository files from
`__file__`, rebuilds the installed cache path from the fresh config root plus `source_sha[:12]`,
and compares Claude's reported version/path as data before opening that fixed path.

Six required mutations each bit their named guard:

| Mutation | Guard |
|---|---|
| MCP command becomes number | typed command/argv contract |
| packaged fixture byte changes | canonical resource parity |
| skill reads source-only path | cache-safe instruction boundary |
| production tool is renamed | exact five release names |
| plugin version is added | unversioned marketplace identity |
| fixture mapping is removed | generated mapping contract |

Additional workflow controls reject source-checkout cache substitution, forged cache-version provenance, a successful no-op update retaining stale bytes, oversized output, a hung tree, and an exited parent whose descendant retains an output pipe.

## Local verification

```bash
python3 scripts/ci/test-agent-golden-path-skill.py
bash scripts/ci/test-agent-golden-path-skill-optimization.sh
bash scripts/ci/test-agent-golden-path-skill-hardening.sh
bash scripts/ci/check-docs-generated-drift.sh
bash scripts/ci/test-claude-plugin-install.sh --self-test
cargo test -p assay-mcp-server
cargo test -p assay-mcp-server --features test-outbound --test project_install_surfaces -- --nocapture
cargo clippy -p assay-mcp-server --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
git diff --check
git push origin codex/2152-plugin-packaging
```

Results: full crate suite passed; 86 hardening cases plus 22 structural probes passed; all pre-commit and pre-push gates passed.

Reproduce the installed path after building the server:

```bash
cargo build -p assay-mcp-server --bin assay-mcp-server
PATH="$PWD/target/debug:$PATH" scripts/ci/test-claude-plugin-install.sh --verify
```

Failure path:

```bash
tmp_bin="$(mktemp -d)"
ln -s "$(command -v claude)" "$tmp_bin/claude"
PATH="$tmp_bin:/usr/bin:/bin" scripts/ci/test-claude-plugin-install.sh --verify
```

Expected: `phase=prerequisite status=fail` plus an install `next_step`.

## Threat-model delta

Now blocked/detected:

- plugin cache silently resolving inside the source checkout;
- stale installed bytes after an update command exits zero;
- symlink, invalid-type, or over-1-MiB package resources;
- malformed/untypeable MCP command and argv;
- release tool-name drift or accidental test-tool publication;
- wrong policy-root semantics masked by a successful MCP handshake;
- absent policy becoming a clean outcome;
- child/descendant hangs and bounded-output exhaustion in the verification workflow;
- executable/source-root overrides reaching command or path sinks;
- cache paths reported by the client being opened before SHA/path provenance is checked.

Still not blocked/claimed:

- installation does not enforce a target MCP call;
- no bundled binary or cross-platform binary lifecycle;
- no native Windows process-runner proof;
- no provider outcome, external side effect, compliance, or certification claim;
- no model-mediated tool-use claim from an unauthenticated session.

## Failure policy

| Boundary | Behavior |
|---|---|
| Missing Claude/server prerequisite | Fail closed with phase + next step |
| Invalid or source-only cache | Fail closed |
| Update exits zero but bytes remain stale | Fail closed on parity |
| MCP connects from wrong/default policy root | Fail closed before policy credit |
| Missing policy | Structured `E_POLICY_NOT_FOUND` |
| Policy blocks marker | Successful protocol exchange with `allowed=false` |
| Claude auth unavailable | MCP/skill startup may pass; model-mediated call remains `unavailable` |
| Missing Python | Installation and steps 1-5 remain usable; only protected-action step 6 needs it |

## Docs / UX

Normative design and execution evidence:

- `docs/superpowers/specs/2026-08-09-claude-plugin-marketplace-packaging-design.md`
- `docs/superpowers/plans/2026-08-09-claude-plugin-marketplace-packaging.md`

User-facing install/recovery path:

- `docs/guides/editor-mcp-recipe.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an installable Assay Claude Code marketplace plugin.
  * Added MCP configuration and a packaged Golden Path skill covering installation, policy checks, protected actions, evidence inspection, and SARIF output.
  * Added bundled fixtures and privileged-action examples for offline demonstrations.

* **Documentation**
  * Added installation, troubleshooting, design, and implementation guidance.

* **Tests**
  * Added comprehensive validation for packaging, installation, MCP connectivity, policy resolution, generated artifacts, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

