### PR TITLE
docs(build): name the worktree target as the review-build default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,13 @@ cargo xtask build-ebpf                      # Build eBPF (Linux)
 ```
 
 Build in the worktree's own `target/`, including for read-only reviews: `/target` is git-ignored,
-so an in-tree build leaves `git status --porcelain` empty and needs no scratch directory. Set
-`CARGO_TARGET_DIR` only when a build genuinely must not warm the branch's cache, and then to one
-stable path per repository — `scripts/ci/phase5-check.sh` and the pre-push hook are the idiom. Not
-one path per reviewed head: those are never reaped (`/tmp` has no expiry on macOS) and reached
-~40 GB across seven merged pull requests on 2026-08-10.
+so an in-tree build leaves `git status --porcelain` empty and needs no scratch directory. That
+already satisfies `AGENTS.md`'s rule against sharing a target between active worktrees, so a
+scratch path is not required to honour it. If you do set `CARGO_TARGET_DIR`, keep one path per
+worktree — never one per reviewed head. macOS does reap `/tmp` daily through
+`/usr/libexec/tmp_cleaner`, but only files untouched for three days and then only directories that
+have become empty, so a target still being built against never ages out while its pull request is
+open; per-head paths therefore accumulate one full target per review round.
 
 ## CLI Entry Points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,13 @@ cargo clippy --workspace --all-targets -- -D warnings  # Lint
 cargo xtask build-ebpf                      # Build eBPF (Linux)
 ```
 
+Build in the worktree's own `target/`, including for read-only reviews: `/target` is git-ignored,
+so an in-tree build leaves `git status --porcelain` empty and needs no scratch directory. Set
+`CARGO_TARGET_DIR` only when a build genuinely must not warm the branch's cache, and then to one
+stable path per repository — `scripts/ci/phase5-check.sh` and the pre-push hook are the idiom. Not
+one path per reviewed head: those are never reaped (`/tmp` has no expiry on macOS) and reached
+~40 GB across seven merged pull requests on 2026-08-10.
+
 ## CLI Entry Points
 
 All commands defined in `crates/assay-cli/src/cli/args/mod.rs`, dispatched in `crates/assay-cli/src/cli/commands/mod.rs`. The table below is a representative subset; the CLI has ~40 subcommands (see `commands/` for the full set, including `import`, `project-otel`, `inventory`, `discover`, and the `verify-*` evidence family).


### PR DESCRIPTION
Closes #2202.

## Summary

One paragraph in `CLAUDE.md`'s Key Commands section: review builds use the worktree's own `target/`, and `CARGO_TARGET_DIR` is set only when a build must not warm the branch's cache, to one stable path rather than one per reviewed head.

## Why

Review rounds in this programme improvised a scratch target per reviewed head — `/tmp/assay-review-<sha>-target`, `/tmp/assay-target-<issue>`. Two measurements, both on `4125d81b`:

- **The per-head form is inconsistent, not unsourced.** My original claim that it had no source was wrong: I grepped the wrong ref. Against `4125d81b`, `git grep -hoI "CARGO_TARGET_DIR=[^ "]*"` returns 13 distinct values across tracked files, a majority of them per-issue `/tmp` paths in plan documents. What the repository lacks is not a source but a stated default.
- **The scratch was not needed at all.** `.gitignore:29` is `/target`, so an in-tree build leaves `git status --porcelain` empty. Every read-only review in this programme asserted exactly that after building, so the property a scratch directory was protecting was never at risk.

The cost is real but the mechanism is narrower than I first wrote. macOS **does** reap `/tmp`, daily, through `/usr/libexec/tmp_cleaner` — files untouched for three days, then directories that have become empty. My original evidence was void: `/etc/periodic` does not exist on this machine, so an empty listing was an absent directory rather than an absence of jobs. A target still being built against keeps a fresh atime and never ages out while its pull request is open, which is why per-head paths accumulate across concurrent reviews.

This also folds an unmanaged class into a managed one. Worktree targets already have hygiene: clean them when the pull request merges. The `/tmp` scratch had none.

## Verification

Every factual claim in the added paragraph was checked against this tree rather than recalled:

- `grep -c "^/target$" .gitignore` → 1
- `grep -c 'CARGO_TARGET_DIR:-/tmp/assay-target' scripts/ci/phase5-check.sh` → 1
- `scripts/precommit/cargo-clippy.sh:57` sets `${common_dir}/prepush-target`, and `.pre-commit-config.yaml:317` declares `stages: [pre-push]`, so the hook attribution is accurate
- `pre-commit run --files CLAUDE.md` → all applicable hooks pass

## Non-goals

- No `.cargo/config.toml` change. A repository-level `target-dir` would apply to CI and to every contributor, which is a different decision with a different blast radius.
- No global `~/.cargo/config.toml` change; that would silently affect unrelated Rust work on the same machine.
- No enforcement check. A gate inspecting how someone sets an environment variable would cost more than it saves.
- No change to the pre-push hook, the worktree layout, or existing worktree hygiene.

## Non-claims

This does not reclaim space by itself and does not replace worktree cleanup at merge time. It states a default so the unmanaged class stops being created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring build output directories.
  * Clarified when to use an external build cache and recommended a stable repository path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->