### PR TITLE
fix(cli): encode config recovery as JSON argv

### DIFF
--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -21,8 +21,9 @@ exclude = [
     "tests/e2e_mcp_wrap_assert_cmd.rs",
     # Workspace-only contract: reads generated docs and shared test support outside this package.
     "tests/agent_golden_path_contract.rs",
-    # Workspace-only contract: uses the shared bounded-process helper outside this package.
+    # Workspace-only contracts: use the shared bounded-process helper outside this package.
     "tests/policy_validate_machine_contract.rs",
+    "tests/config_recovery_argv_contract.rs",
 ]
 
 [lints]

--- a/crates/assay-cli/src/cli/commands/pipeline_error.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline_error.rs
@@ -235,6 +235,14 @@ mod tests {
         )
     }
 
+    fn recovery_argv(step: &str) -> Vec<String> {
+        serde_json::from_str(
+            step.strip_prefix("Run argv: ")
+                .expect("command recovery must publish JSON argv"),
+        )
+        .expect("command recovery argv must parse")
+    }
+
     /// The property this issue exists to establish: an operator grepping stderr and
     /// a CI job parsing run.json see the same code for the same failure.
     #[test]
@@ -275,8 +283,8 @@ mod tests {
         let config = RunError::config_parse(Some("suites/prod.yaml".to_string()), "bad indent");
         let diagnostic = diagnostic_for(&config, ReasonCode::ECfgParse);
         assert_eq!(
-            diagnostic.fix_steps[0],
-            "Run: assay doctor --config suites/prod.yaml"
+            recovery_argv(&diagnostic.fix_steps[0]),
+            ["assay", "doctor", "--config", "suites/prod.yaml"]
         );
         assert_eq!(
             outcome_as_written(&config, ReasonCode::ECfgParse).next_step,
@@ -302,8 +310,8 @@ mod tests {
         let run_error = RunError::config_parse(None, "could not locate a config");
         let diagnostic = diagnostic_for(&run_error, ReasonCode::ECfgParse);
         assert_eq!(
-            diagnostic.fix_steps[0],
-            "Run: assay doctor --config <config.yaml>"
+            recovery_argv(&diagnostic.fix_steps[0]),
+            ["assay", "doctor", "--config", "<config.yaml>"]
         );
         assert_eq!(
             outcome_as_written(&run_error, ReasonCode::ECfgParse).next_step,
@@ -440,10 +448,19 @@ mod tests {
             .fix_steps
             .iter()
             .any(|s| s.contains("Regenerate baseline")));
-        assert!(
-            folded.fix_steps.iter().any(|s| s.contains("assay doctor")),
-            "the reason's own next step survives too: {:?}",
-            folded.fix_steps
+        let own_recovery = folded
+            .fix_steps
+            .iter()
+            .find(|step| step.starts_with("Run argv: "))
+            .unwrap_or_else(|| {
+                panic!(
+                    "the reason's own next step survives too: {:?}",
+                    folded.fix_steps
+                )
+            });
+        assert_eq!(
+            recovery_argv(own_recovery),
+            ["assay", "doctor", "--config", "assay.yaml"]
         );
 
         let rendered = folded.format_plain();

--- a/crates/assay-cli/src/exit_codes.rs
+++ b/crates/assay-cli/src/exit_codes.rs
@@ -521,6 +521,31 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_recovery_argv_round_trips_json_significant_paths() {
+        let path = "cfg \"quoted\"\\nested\nline\ttab\u{0007}.yaml";
+        let cases = [
+            (
+                ReasonCode::ECfgParse,
+                vec!["assay", "doctor", "--config", path],
+            ),
+            (
+                ReasonCode::EPolicyParse,
+                vec!["assay", "policy", "validate", "--input", path],
+            ),
+        ];
+
+        for (reason, expected) in cases {
+            let next_step = reason.next_step(Some(path));
+            let encoded = next_step
+                .strip_prefix("Run argv: ")
+                .expect("dynamic recovery must publish JSON argv");
+            let argv: Vec<String> =
+                serde_json::from_str(encoded).expect("recovery argv must remain valid JSON");
+            assert_eq!(argv, expected, "{reason:?} must preserve one path argument");
+        }
+    }
+
+    #[test]
     fn test_reason_code_display() {
         assert_eq!(
             format!("{}", ReasonCode::ETraceNotFound),

--- a/crates/assay-cli/src/exit_codes.rs
+++ b/crates/assay-cli/src/exit_codes.rs
@@ -106,6 +106,10 @@ pub enum ReasonCode {
     EArgSchema,
 }
 
+fn format_recovery_argv(args: &[&str]) -> String {
+    format!("Run argv: {}", serde_json::json!(args))
+}
+
 impl ReasonCode {
     /// Get the corresponding exit code for this reason, respecting version
     pub fn exit_code_for(&self, version: ExitCodeVersion) -> i32 {
@@ -200,16 +204,20 @@ impl ReasonCode {
         }
     }
 
-    /// Suggested next step for this error
+    /// Suggested next step for this error.
+    ///
+    /// Executable recovery with caller-controlled values is JSON argv. Dynamic trace-path
+    /// guidance is prose rather than a command; remaining command-like steps are static strings
+    /// and therefore carry no caller-controlled argument boundary.
     pub fn next_step(&self, context: Option<&str>) -> String {
         match self {
             ReasonCode::Success => String::new(),
-            ReasonCode::ECfgParse => {
-                format!(
-                    "Run: assay doctor --config {}",
-                    context.unwrap_or("<config.yaml>")
-                )
-            }
+            ReasonCode::ECfgParse => format_recovery_argv(&[
+                "assay",
+                "doctor",
+                "--config",
+                context.unwrap_or("<config.yaml>"),
+            ]),
             ReasonCode::ETraceNotFound => {
                 format!(
                     "Check trace file exists: {}",
@@ -224,16 +232,13 @@ impl ReasonCode {
             ReasonCode::EBaselineInvalid => {
                 "Run: assay baseline record to create a new baseline".to_string()
             }
-            ReasonCode::EPolicyParse => {
-                let argv = serde_json::json!([
-                    "assay",
-                    "policy",
-                    "validate",
-                    "--input",
-                    context.unwrap_or("<policy.yaml>")
-                ]);
-                format!("Run argv: {argv}")
-            }
+            ReasonCode::EPolicyParse => format_recovery_argv(&[
+                "assay",
+                "policy",
+                "validate",
+                "--input",
+                context.unwrap_or("<policy.yaml>"),
+            ]),
             ReasonCode::EReplayMissingDependency => {
                 "Replay bundle missing required offline dependency; rerun with --live or create a complete bundle".to_string()
             }
@@ -445,10 +450,21 @@ mod tests {
         // Success returns empty string
         assert!(ReasonCode::Success.next_step(None).is_empty());
 
-        // Config errors provide actionable next steps
-        assert!(ReasonCode::ECfgParse
-            .next_step(Some("test.yaml"))
-            .contains("test.yaml"));
+        // Dynamic command recovery preserves hostile paths as one argv element.
+        let config_path = "cfg file;$(touch should-not-exist).yaml";
+        let config_next_step = ReasonCode::ECfgParse.next_step(Some(config_path));
+        assert_eq!(
+            config_next_step,
+            r#"Run argv: ["assay","doctor","--config","cfg file;$(touch should-not-exist).yaml"]"#,
+            "the shared recovery formatter must preserve the published compact representation"
+        );
+        let config_argv: Vec<String> = serde_json::from_str(
+            config_next_step
+                .strip_prefix("Run argv: ")
+                .expect("config recovery must publish JSON argv"),
+        )
+        .expect("config recovery argv must parse");
+        assert_eq!(config_argv, ["assay", "doctor", "--config", config_path]);
         assert!(ReasonCode::ETraceNotFound
             .next_step(Some("traces/ci.jsonl"))
             .contains("traces/ci.jsonl"));

--- a/crates/assay-cli/tests/config_recovery_argv_contract.rs
+++ b/crates/assay-cli/tests/config_recovery_argv_contract.rs
@@ -1,0 +1,81 @@
+//! Binary contract for argument-safe recovery from `E_CFG_PARSE` (#2200).
+
+#[path = "../../../tests/support/bounded_process.rs"]
+#[allow(dead_code)]
+mod bounded_process;
+
+use bounded_process::{run_bounded, ProcessLimits};
+use std::path::Path;
+use std::process::{Command, Output};
+use std::time::Duration;
+
+const LIMITS: ProcessLimits = ProcessLimits::new(Duration::from_secs(5), 64 * 1024, 64 * 1024);
+
+fn assay(cwd: &Path, args: &[&str], context: &str) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command.current_dir(cwd).env("NO_COLOR", "1").args(args);
+    run_bounded(command, b"", LIMITS, context).unwrap_or_else(|error| panic!("{error}"))
+}
+
+#[test]
+fn config_parse_recovery_argv_executes_without_a_shell() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config_name = "cfg file;$(touch should-not-exist).yaml";
+    std::fs::write(dir.path().join(config_name), "version: [\n").expect("write malformed config");
+
+    let failed = assay(
+        dir.path(),
+        &["run", "--format", "json", "--config", config_name],
+        "produce config recovery",
+    );
+    assert_eq!(
+        failed.status.code(),
+        Some(2),
+        "malformed config must be a config error: {}",
+        String::from_utf8_lossy(&failed.stderr)
+    );
+    let summary: serde_json::Value =
+        serde_json::from_slice(&failed.stdout).expect("failure stdout must be JSON");
+    assert_eq!(summary["reason_code"], "E_CFG_PARSE");
+
+    let encoded = summary["next_step"]
+        .as_str()
+        .expect("config failure next_step")
+        .strip_prefix("Run argv: ")
+        .expect("config recovery must publish JSON argv");
+    let recovery: Vec<String> =
+        serde_json::from_str(encoded).expect("config recovery argv must parse");
+    assert_eq!(
+        recovery,
+        ["assay", "doctor", "--config", config_name],
+        "the hostile path must remain one argv element"
+    );
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    command
+        .current_dir(dir.path())
+        .env("NO_COLOR", "1")
+        .args(&recovery[1..]);
+    let recovered = run_bounded(command, b"", LIMITS, "execute config recovery")
+        .unwrap_or_else(|error| panic!("{error}"));
+    assert_eq!(recovered.status.code(), Some(1));
+    let recovered_stdout = String::from_utf8_lossy(&recovered.stdout);
+    assert!(
+        recovered_stdout.contains("Config Status: FAILED"),
+        "published argv must reach doctor: {recovered_stdout}"
+    );
+    assert!(!recovered_stdout.contains("Usage:"));
+    assert!(
+        !dir.path().join("should-not-exist").exists(),
+        "recovery must not execute shell metacharacters"
+    );
+}

--- a/crates/assay-cli/tests/config_recovery_argv_contract.rs
+++ b/crates/assay-cli/tests/config_recovery_argv_contract.rs
@@ -5,15 +5,19 @@
 mod bounded_process;
 
 use bounded_process::{run_bounded, ProcessLimits};
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use std::process::{Command, Output};
 use std::time::Duration;
 
 const LIMITS: ProcessLimits = ProcessLimits::new(Duration::from_secs(5), 64 * 1024, 64 * 1024);
 
-fn assay(cwd: &Path, args: &[&str], context: &str) -> Output {
+fn assay_command_with_environment(
+    cwd: &Path,
+    environment_names: impl IntoIterator<Item = OsString>,
+) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
-    for (name, _) in std::env::vars_os() {
+    for name in environment_names {
         if name
             .to_string_lossy()
             .to_ascii_uppercase()
@@ -22,7 +26,40 @@ fn assay(cwd: &Path, args: &[&str], context: &str) -> Output {
             command.env_remove(name);
         }
     }
-    command.current_dir(cwd).env("NO_COLOR", "1").args(args);
+    command.current_dir(cwd).env("NO_COLOR", "1");
+    command
+}
+
+fn assay_command(cwd: &Path) -> Command {
+    assay_command_with_environment(cwd, std::env::vars_os().map(|(name, _)| name))
+}
+
+#[test]
+fn assay_command_scrubs_assay_environment_case_insensitively() {
+    let command = assay_command_with_environment(
+        Path::new("."),
+        [
+            OsString::from("ASSAY_EXIT_CODES"),
+            OsString::from("assay_vcr_dir"),
+            OsString::from("NO_COLOR"),
+        ],
+    );
+    let env = command.get_envs().collect::<Vec<_>>();
+
+    assert!(env
+        .iter()
+        .any(|(name, value)| *name == "ASSAY_EXIT_CODES" && value.is_none()));
+    assert!(env
+        .iter()
+        .any(|(name, value)| *name == "assay_vcr_dir" && value.is_none()));
+    assert!(env
+        .iter()
+        .any(|(name, value)| *name == "NO_COLOR" && *value == Some("1".as_ref())));
+}
+
+fn assay<T: AsRef<OsStr>>(cwd: &Path, args: &[T], context: &str) -> Output {
+    let mut command = assay_command(cwd);
+    command.args(args);
     run_bounded(command, b"", LIMITS, context).unwrap_or_else(|error| panic!("{error}"))
 }
 
@@ -60,13 +97,7 @@ fn config_parse_recovery_argv_executes_without_a_shell() {
         "the hostile path must remain one argv element"
     );
 
-    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
-    command
-        .current_dir(dir.path())
-        .env("NO_COLOR", "1")
-        .args(&recovery[1..]);
-    let recovered = run_bounded(command, b"", LIMITS, "execute config recovery")
-        .unwrap_or_else(|error| panic!("{error}"));
+    let recovered = assay(dir.path(), &recovery[1..], "execute config recovery");
     assert_eq!(recovered.status.code(), Some(1));
     let recovered_stdout = String::from_utf8_lossy(&recovered.stdout);
     assert!(

--- a/docs/AIcontext/decision-trees.md
+++ b/docs/AIcontext/decision-trees.md
@@ -201,7 +201,7 @@ flowchart TD
 | Error | Reason Code | Recovery Action |
 |-------|-------------|-----------------|
 | Trace file not found | `E_TRACE_NOT_FOUND` | Check path, use `assay import` |
-| Config parse error | `E_CFG_PARSE` | Run `assay doctor --config <file>` |
+| Config parse error | `E_CFG_PARSE` | Parse `Run argv: ["assay","doctor","--config","<file>"]` and execute the argv directly (no shell) |
 | Judge unavailable | `E_JUDGE_UNAVAILABLE` | Check API key, retry later |
 | Rate limited | `E_RATE_LIMIT` | Wait, reduce parallelism |
 | Test failed | `E_TEST_FAILED` | Run `assay explain` |

--- a/docs/AIcontext/entry-points.md
+++ b/docs/AIcontext/entry-points.md
@@ -592,12 +592,15 @@ Reason codes provide precise error identification for automation and debugging.
 #### Config/User Errors (Exit 2)
 | Code | Description | Next Step |
 |------|-------------|-----------|
-| `E_CFG_PARSE` | Config file parse error | `assay doctor --config <file>` |
+| `E_CFG_PARSE` | Config file parse error | argv `["assay","doctor","--config","<file>"]` |
 | `E_TRACE_NOT_FOUND` | Trace file not found | Check path exists |
 | `E_MISSING_CONFIG` | Required config missing | `assay init` |
 | `E_BASELINE_INVALID` | Baseline file invalid | `assay baseline record` |
 | `E_POLICY_PARSE` | Policy YAML syntax error | argv `["assay","policy","validate","--input","<file>"]` |
 | `E_INVALID_ARGS` | Invalid CLI arguments | `assay --help` |
+
+For `Run argv:` recovery steps, parse the JSON array and pass its elements directly to a process
+API. Do not join the elements into a shell command.
 
 #### Infrastructure Errors (Exit 3)
 | Code | Description | Next Step |

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -54,11 +54,14 @@ assay explain --trace traces.jsonl --policy policy.yaml  # Explain violations
 ### Config Errors (exit 2)
 | Code | Meaning | Next Step |
 |------|---------|-----------|
-| `E_CFG_PARSE` | YAML/JSON parse error | `assay doctor --config <file>` |
+| `E_CFG_PARSE` | YAML/JSON parse error | argv `["assay","doctor","--config","<file>"]` |
 | `E_TRACE_NOT_FOUND` | Trace file missing | Check path exists |
 | `E_MISSING_CONFIG` | Config file missing | `assay init` |
 | `E_BASELINE_INVALID` | Baseline file invalid | `assay baseline record` |
 | `E_POLICY_PARSE` | Policy YAML syntax error | argv `["assay","policy","validate","--input","<file>"]` |
+
+Parse a `Run argv:` JSON array and pass its elements directly to a process API. Never join
+caller-controlled path elements into a shell command.
 
 ### Infra Errors (exit 3)
 | Code | Meaning | Next Step |

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -297,7 +297,7 @@ SARIF produced for GitHub Code Scanning MUST satisfy the following so that `uplo
 
 For every non-zero exit, the implementation MUST provide **at least one suggested next step** so that users and CI logs know what to do next.
 
-- **Console:** When exiting with exit_code ≠ 0, the process MUST print at least one line that is a concrete command or hint (e.g. "Run: assay doctor ...", "See: assay explain ...", "Fix baseline: assay baseline record ...").
+- **Console:** When exiting with exit_code ≠ 0, the process MUST print at least one line that is a concrete command or hint. Executable recovery containing caller-controlled values MUST use the argument-safe form from §3.1 (for example, `Run argv: ["assay","doctor","--config","path with spaces.yaml"]`). Fully static commands MAY use `Run: assay explain ...`; non-command guidance MAY use `See: ...` or `Fix baseline: ...` prose.
 - **summary.json:** The `next_step` field SHOULD be set when exit_code ≠ 0 (see §3.1). It MAY be the same as or a shortened form of the console message.
 
 **Normative:** Contract tests MAY verify that for a set of known error conditions (missing config, missing trace, failing test), the output contains a non-empty next_step (in summary.json) and a console line with a suggested command.
@@ -322,6 +322,7 @@ For every non-zero exit, the implementation MUST provide **at least one suggeste
 | 1              | 2026-02  | E9c alignment draft: replay provenance keys in `provenance` (`replay`, `bundle_digest`, `replay_mode`, `source_run_id`) and `E_REPLAY_MISSING_DEPENDENCY` reason code. |
 | 1              | 2026-07  | Added `E_REPLAY_LIMIT_EXCEEDED` (§5.1). Backward compatible: a new registry string under the existing `reason_code_version` 1, so consumers branching on `(reason_code_version, reason_code)` treat it as an unknown code under a known version and fall back as they already must. No version bump. |
 | 1              | 2026-08  | Added the stable `assay.run_summary.v1` document identity for newly produced summaries. This is additive; consumers MUST continue accepting pre-identity version-1 summaries without `schema`, and the existing integer `schema_version` remains `1`. |
+| 1              | 2026-08  | Required executable recovery containing caller-controlled values to use `Run argv: <JSON array>` in both structured and console output. Static commands and non-command guidance remain valid prose; no schema change. |
 
 ---
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -47,7 +47,7 @@ When `assay ci` (or the equivalent run invoked by the blessed workflow) complete
 | `exit_code`           | integer | **Yes**  | Process exit code: 0 = pass, 1 = test failure, 2 = config/user error, 3 = infra/judge unavailable. See §4. |
 | `reason_code`         | string  | **Yes**  | Stable machine-readable code when exit_code ≠ 0; e.g. `E_TRACE_NOT_FOUND`, `E_JUDGE_UNAVAILABLE`. See §5. When exit_code is 0, MAY be empty string or a designated success code (e.g. OK); empty is allowed and common. |
 | `message`             | string  | No       | Human-readable one-line description of outcome. |
-| `next_step`           | string  | No       | Single suggested command or hint when exit_code ≠ 0; e.g. "Run: assay doctor --config ...", "See: assay explain ...". See §7. |
+| `next_step`           | string  | No       | Single suggested command or hint when exit_code ≠ 0. Executable recovery containing caller-controlled values uses `Run argv: <JSON array>` so consumers can invoke it without a shell; non-command guidance remains prose. See §7. |
 
 ### 3.2 Provenance (Artifact Auditability)
 
@@ -148,7 +148,7 @@ JSON object key order in these examples is illustrative, not normative.
   "exit_code": 2,
   "reason_code": "E_TRACE_NOT_FOUND",
   "message": "Trace file not found: traces/ci.jsonl",
-  "next_step": "Run: assay doctor --config ci-eval.yaml --trace-file traces/ci.jsonl",
+  "next_step": "Check trace file exists: traces/ci.jsonl",
   "provenance": {
     "assay_version": "2.12.0",
     "verify_mode": "enabled"

--- a/docs/superpowers/plans/2026-08-10-cfg-parse-json-argv.md
+++ b/docs/superpowers/plans/2026-08-10-cfg-parse-json-argv.md
@@ -1,0 +1,165 @@
+# E_CFG_PARSE JSON Argv Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish `E_CFG_PARSE` recovery as argument-safe JSON argv and prove that a hostile config path remains one process argument.
+
+**Architecture:** Keep `RunOutcome.next_step` and its schema unchanged. Extract one private formatter in `exit_codes.rs` so the two dynamic executable recoveries, `E_CFG_PARSE` and `E_POLICY_PARSE`, cannot drift in representation; leave dynamic non-command prose as prose and static commands unchanged because they contain no caller-controlled value.
+
+**Tech Stack:** Rust, serde_json, std::process::Command, shared bounded-process test support, Markdown contract documentation.
+
+## Global Constraints
+
+- Implement on `codex/2200-cfg-argv` in the isolated worktree with its own `CARGO_TARGET_DIR`.
+- Confirm RED before production edits and implement the smallest passing change.
+- Preserve the existing summary schema and `next_step` field; add no envelope field.
+- Execute parsed recovery argv directly with `Command::args`; never route it through a shell.
+- Treat paths containing whitespace and shell metacharacters as one exact argv element.
+- Do not change generated golden-path outputs: their doctor row intentionally records the #2160 typed-output gap.
+- Stage only explicit paths touched by this slice.
+
+---
+
+### Task 1: Pin and implement the recovery representation
+
+**Files:**
+- Modify: `crates/assay-cli/src/exit_codes.rs`
+- Modify: `crates/assay-cli/src/cli/commands/pipeline_error.rs`
+- Create: `crates/assay-cli/tests/config_recovery_argv_contract.rs`
+- Modify: `crates/assay-cli/Cargo.toml`
+
+**Interfaces:**
+- Consumes: `ReasonCode::next_step(context: Option<&str>) -> String` and the existing `Run argv: <JSON array>` contract.
+- Produces: private `format_recovery_argv(args: &[&str]) -> String`; `E_CFG_PARSE` argv `['assay', 'doctor', '--config', path]` and unchanged `E_POLICY_PARSE` argv semantics.
+
+- [x] **Step 1: Write the failing unit and binary contract assertions**
+
+In `exit_codes.rs`, replace the weak config-path containment assertion with parsing and exact argument comparison:
+
+```rust
+let config_path = "cfg file;$(touch should-not-exist).yaml";
+let config_next_step = ReasonCode::ECfgParse.next_step(Some(config_path));
+assert_eq!(
+    config_next_step,
+    r#"Run argv: ["assay","doctor","--config","cfg file;$(touch should-not-exist).yaml"]"#,
+);
+let config_argv: Vec<String> = serde_json::from_str(
+    config_next_step
+        .strip_prefix("Run argv: ")
+        .expect("config recovery must publish JSON argv"),
+)
+.expect("config recovery argv must parse");
+assert_eq!(config_argv, ["assay", "doctor", "--config", config_path]);
+```
+
+In `config_recovery_argv_contract.rs`, use the shared bounded-process helper, create malformed YAML at the same hostile filename, parse the emitted `next_step`, assert exact argv, replace only argv element zero with `CARGO_BIN_EXE_assay`, pass `argv[1..]` directly to `Command::args`, and assert the doctor path is reached without Clap usage or creation of the shell sentinel.
+
+- [x] **Step 2: Run the focused tests to verify RED**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$PWD/target" cargo test -p assay-cli --bin assay exit_codes::tests::test_reason_code_next_step
+CARGO_TARGET_DIR="$PWD/target" cargo test -p assay-cli --test config_recovery_argv_contract
+```
+
+Expected: the unit test fails because the current string begins `Run:`, and the binary contract fails while parsing the same legacy shell prose.
+
+- [x] **Step 3: Implement one formatter and use it in both dynamic command arms**
+
+Add the private helper:
+
+```rust
+fn format_recovery_argv(args: &[&str]) -> String {
+    format!("Run argv: {}", serde_json::json!(args))
+}
+```
+
+Call it from `E_CFG_PARSE` and `E_POLICY_PARSE`. Add a doc comment to `next_step` recording the completed audit:
+
+```rust
+/// Executable recovery with caller-controlled values is JSON argv. Dynamic
+/// trace-path guidance is prose rather than a command; remaining commands are
+/// static strings and therefore carry no caller-controlled argument boundary.
+```
+
+Update pipeline parity expectations to parse and compare the JSON argv instead of pinning the retired shell string.
+
+- [x] **Step 4: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$PWD/target" cargo test -p assay-cli --bin assay exit_codes::tests::test_reason_code_next_step
+CARGO_TARGET_DIR="$PWD/target" cargo test -p assay-cli --bin assay pipeline_error::tests
+CARGO_TARGET_DIR="$PWD/target" cargo test -p assay-cli --test config_recovery_argv_contract
+```
+
+Expected: PASS. The end-to-end recovery process reaches `doctor`, emits no Clap usage, and creates no shell sentinel.
+
+### Task 2: Align public recovery references
+
+**Files:**
+- Modify: `docs/AIcontext/entry-points.md`
+- Modify: `docs/AIcontext/quick-reference.md`
+- Modify: `docs/AIcontext/decision-trees.md`
+- Modify: `docs/architecture/SPEC-PR-Gate-Outputs-v1.md`
+- Review without editing: `scripts/docs/generate-agent-golden-path.py`
+
+**Interfaces:**
+- Consumes: the exact `Run argv: ["assay","doctor","--config","<file>"]` runtime representation.
+- Produces: public AI-context examples that teach callers to parse JSON and invoke argv directly.
+
+- [x] **Step 1: Replace E_CFG_PARSE shell examples in hand-written references**
+
+Use the exact example:
+
+```text
+Run argv: ["assay","doctor","--config","<file>"]
+```
+
+Add one concise note that consumers parse the array and pass elements directly to a process API, not a shell.
+
+- [x] **Step 2: Record generated/spec non-changes**
+
+Confirm the golden-path generator only names `E_CFG_PARSE` because #2160 still owns doctor machine output. Align the hand-written PR-gate spec with the existing dynamic-command rule and replace its stale `E_TRACE_NOT_FOUND` shell-command example with the actual prose recovery; do not hand-edit generated outputs or widen this slice.
+
+- [x] **Step 3: Verify public strings and docs drift**
+
+Run:
+
+```bash
+rg -n 'E_CFG_PARSE|assay doctor --config|Run argv' docs/AIcontext scripts/docs/generate-agent-golden-path.py docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+bash scripts/ci/check-docs-generated-drift.sh
+git diff --check
+```
+
+Expected: no hand-written E_CFG_PARSE reference advertises a shell-interpolated path; generated outputs are unchanged and the drift check passes.
+
+### Task 3: Verify, mutate, and publish the slice
+
+**Files:**
+- Verify all files changed by Tasks 1-2.
+
+**Interfaces:**
+- Consumes: final working tree for #2200.
+- Produces: exact-SHA verification and review packet for PR review.
+
+- [x] **Step 1: Run affected and repository gates**
+
+```bash
+CARGO_TARGET_DIR="$PWD/target" cargo test -p assay-cli
+CARGO_TARGET_DIR="$PWD/target" cargo clippy -p assay-cli --all-targets -- -D warnings
+CARGO_TARGET_DIR="$PWD/target" cargo package -p assay-cli --allow-dirty --no-verify
+cargo fmt --all -- --check
+git diff --check
+bash scripts/ci/check-docs-generated-drift.sh
+```
+
+- [x] **Step 2: Run workflow and mutation probes**
+
+Run the real binary contract with the hostile path. Then temporarily restore the old `E_CFG_PARSE` arm and confirm both the unit and end-to-end tests fail; restore the implementation and rerun both tests green. This proves the tests are not decorative.
+
+- [ ] **Step 3: Commit with explicit pathspec, push, and open the PR**
+
+Stage only the plan, source, test, package metadata, three AI-context files, and the PR-gate spec. Record the exact committed SHA with verification provenance. Request one independent reviewer plus CodeRabbit or Copilot; use two independent agents only if the bot is unavailable under `AGENTS.md`.


### PR DESCRIPTION
## Summary

- encode `E_CFG_PARSE` recovery as compact JSON argv instead of shell-interpolated prose
- use one private formatter for the dynamic `E_CFG_PARSE` and `E_POLICY_PARSE` command recoveries
- prove a path containing whitespace and shell metacharacters remains one argument and executes through `Command::args` without a shell
- align stderr/run-output parity and the hand-written AI/public contract references

Closes #2200
Parent: #2177

## Scope / DoD

- [x] `E_CFG_PARSE` publishes `Run argv: ["assay","doctor","--config",path]`
- [x] binary contract parses the JSON and passes `argv[1..]` directly to `Command::args`
- [x] hostile path remains exactly one argument and creates no shell sentinel
- [x] all `ReasonCode::next_step` arms audited: dynamic executable caller data uses JSON argv; dynamic trace guidance is prose; remaining command-like strings contain no caller data
- [x] generated golden-path output remains generator-owned and unchanged because #2160 still owns doctor typed output
- [x] no envelope field or schema identity changes

## Compatibility

This intentionally changes the `next_step` bytes for `E_CFG_PARSE` from `Run: ...` to `Run argv: <JSON array>`. A consumer matching the old shell string will stop rather than execute an injection-prone command; the schema and field type remain unchanged. Parse the JSON array and invoke it directly without a shell.

The existing `unwrap_or(E_CFG_PARSE)` fallback can still overstate config remediation for an unclassified error. That pre-existing classification issue is not hidden in this slice and is recorded on #2177: https://github.com/Rul1an/assay/issues/2177#issuecomment-5237917917

## Smoking Gun

```text
Run argv: ["assay","doctor","--config","cfg file;$(touch should-not-exist).yaml"]
```

The bounded test executes those parsed elements directly, reaches `doctor` (`Config Status: FAILED`), emits no Clap `Usage:`, and verifies `should-not-exist` was not created.

## Threat Model Delta

- blocks shell interpretation of caller-controlled config paths in published recovery guidance
- preserves argument boundaries across whitespace and shell metacharacters
- does not claim the config is trustworthy or that `doctor` repairs it
- does not change classification, exit code, summary schema, or generated golden-path gaps
- malformed config remains fail-closed with exit 2; unavailable/unclassified behavior is not converted to success

## TDD / Mutation Proof

RED on the pre-change tree:

- unit test failed at `config recovery must publish JSON argv`
- bounded binary contract failed at the same missing prefix

Mutation after implementation: temporarily restoring the old `Run:` arm made both tests fail independently (`exit 101`); restoring the JSON argv arm made both green.

## Verification

Exact committed head: `11f9ad035d526b143032cd89bc35235e8d1d7fc7`
Toolchain: `rustc/cargo 1.96.0`

The verification below was first recorded on `4b993474e8a0`. Three commits followed; the re-run on the final head is in the [final-head verification comment](https://github.com/Rul1an/assay/pull/2204#issuecomment-5238794463).
Worktree: `/Users/roelschuurkes/.config/superpowers/worktrees/assay-2200-cfg-argv/worktree`
Toolchain: workspace Rust toolchain, `assay-cli 5.0.0`

```bash
CARGO_TARGET_DIR="$PWD/target" cargo test -p assay-cli
CARGO_TARGET_DIR="$PWD/target" cargo clippy -p assay-cli --all-targets -- -D warnings
CARGO_TARGET_DIR="$PWD/target" cargo package -p assay-cli --allow-dirty --no-verify
cargo fmt --all -- --check
bash scripts/ci/check-docs-generated-drift.sh
git diff --check
```

All pass on the exact head. Pre-commit and pre-push hooks also pass, including workspace clippy and the Linux cross-target gate.

## Workflow / AI Review

- real-binary user workflow: malformed config -> JSON failure -> parsed argv -> direct `doctor` invocation
- adversarial input: whitespace, semicolon, `$()`, and sentinel side-effect check
- agent workflow: JSON argv is deterministic and process-API ready; no shell reconstruction
- Claude Code Desktop, existing chat `Issue prioritering en overzicht`: advisory design review found no blockers, confirmed the generated non-change, requested the compact wire-format pin, and explicitly does not count toward formal quorum

## Review Focus

1. Does the shared formatter preserve the previously shipped compact `E_POLICY_PARSE` bytes?
2. Is the binary test genuinely shell-free and mutation-sensitive?
3. Are any remaining public E_CFG_PARSE shell examples still reachable?
4. Is the safe compatibility break described precisely enough for downstream agents?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery commands now use safely encoded JSON argument arrays, preserving paths—including those with special characters—as single arguments.
  * Configuration and policy recovery actions no longer require shell interpretation, preventing unintended execution of path content.

* **Documentation**
  * Updated recovery guidance and output contracts to describe the new `Run argv` JSON format and direct process execution.

* **Tests**
  * Added coverage for malformed configurations, hostile paths, argument preservation, and end-to-end recovery execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
