### PR TITLE
docs(agents): resolve the worktree target rule against its own tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,9 @@ including its explicit non-claims, or amend the decision through a new ADR.
   isolation this rule asks for needs no configuration, and `/target` is git-ignored so an in-tree
   build leaves a read-only review's tree clean. Set `CARGO_TARGET_DIR` only to keep a build out of
   the branch's cache, and scope it to one worktree — never one path per reviewed head. A tool may
-  share one target across worktrees when its script records why: the pre-push hook does, for one
-  build cache instead of one per worktree, and `scripts/ci/phase5-check.sh` does, to avoid VM
-  mount filesystem issues. Sharing costs cargo's lock, and under the pre-push hook's timeout that
-  can abort a push rather than only delay it.
+  share one target across worktrees only where it must, and its script records the reason: the
+  pre-push hook does, trading cargo's lock for one build cache instead of one per worktree, and
+  under that hook's timeout the lock can abort a push rather than only delay it.
 - Remove merged branches and their worktrees only after recording the merge in the programme ledger.
 
 ## Development Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,13 @@ including its explicit non-claims, or amend the decision through a new ADR.
 - At most two ADR-042/043 implementation branches may be active at once.
 - Use `codex/`, `claude/`, or `cursor/` branch prefixes matching the writer.
 - Do not implement on `main`.
-- Do not share `target/` directories between active worktrees. Use `CARGO_TARGET_DIR`.
+- Build in the worktree's own `target/`. Each worktree already has one, so the isolation this rule
+  asks for needs no configuration, and `/target` is git-ignored so an in-tree build leaves a
+  read-only review's tree clean. Set `CARGO_TARGET_DIR` only when a build must not warm the
+  branch's cache, and then scope it to one worktree — never one path per reviewed head. The
+  pre-push hook is the single deliberate exception: it shares one target under the common git
+  directory across every worktree, trading cargo's lock on concurrent pushes for one build cache
+  instead of one per worktree.
 - Remove merged branches and their worktrees only after recording the merge in the programme ledger.
 
 ## Development Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,12 +46,10 @@ including its explicit non-claims, or amend the decision through a new ADR.
 - At most two ADR-042/043 implementation branches may be active at once.
 - Use `codex/`, `claude/`, or `cursor/` branch prefixes matching the writer.
 - Do not implement on `main`.
-- Build in the worktree's own `target/`. Cargo creates one per worktree on first build, so the
-  isolation this rule asks for needs no configuration, and `/target` is git-ignored so an in-tree
-  build leaves a read-only review's tree clean. Setting `CARGO_TARGET_DIR` is allowed; whoever sets
-  it owns bounding it, by reusing one directory or by removing it when the run ends. The pre-push
-  hook reuses one; `scripts/ci/test-semver-gate.sh` removes its own on `trap`. An unbounded target
-  per run is what fills the disk — the name is not the problem.
+- Build in the worktree's own `target/`. Cargo creates one per worktree on first build, so
+  worktrees do not share one unless told to, and `/target` is git-ignored so an in-tree build
+  leaves a read-only review's tree clean. A `CARGO_TARGET_DIR` you export by hand, you remove when
+  the work ends. Paths set by checked-in scripts are those scripts' business.
 - Remove merged branches and their worktrees only after recording the merge in the programme ledger.
 
 ## Development Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ including its explicit non-claims, or amend the decision through a new ADR.
 - Build in the worktree's own `target/`. Cargo creates one per worktree on first build, so
   worktrees do not share one unless told to, and `/target` is git-ignored so an in-tree build
   leaves a read-only review's tree clean. A `CARGO_TARGET_DIR` you export by hand, you remove when
-  the work ends. Paths set by checked-in scripts are those scripts' business.
+  the work ends.
 - Remove merged branches and their worktrees only after recording the merge in the programme ledger.
 
 ## Development Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,10 @@ including its explicit non-claims, or amend the decision through a new ADR.
 - Do not implement on `main`.
 - Build in the worktree's own `target/`. Cargo creates one per worktree on first build, so the
   isolation this rule asks for needs no configuration, and `/target` is git-ignored so an in-tree
-  build leaves a read-only review's tree clean. Set `CARGO_TARGET_DIR` only to keep a build out of
-  the branch's cache, and scope it to one worktree — never one path per reviewed head. A tool may
-  share one target across worktrees only where it must, and its script records the reason: the
-  pre-push hook does, trading cargo's lock for one build cache instead of one per worktree, and
-  under that hook's timeout the lock can abort a push rather than only delay it.
+  build leaves a read-only review's tree clean. Setting `CARGO_TARGET_DIR` is allowed; whoever sets
+  it owns bounding it, by reusing one directory or by removing it when the run ends. The pre-push
+  hook reuses one; `scripts/ci/test-semver-gate.sh` removes its own on `trap`. An unbounded target
+  per run is what fills the disk — the name is not the problem.
 - Remove merged branches and their worktrees only after recording the merge in the programme ledger.
 
 ## Development Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,13 +46,14 @@ including its explicit non-claims, or amend the decision through a new ADR.
 - At most two ADR-042/043 implementation branches may be active at once.
 - Use `codex/`, `claude/`, or `cursor/` branch prefixes matching the writer.
 - Do not implement on `main`.
-- Build in the worktree's own `target/`. Each worktree already has one, so the isolation this rule
-  asks for needs no configuration, and `/target` is git-ignored so an in-tree build leaves a
-  read-only review's tree clean. Set `CARGO_TARGET_DIR` only when a build must not warm the
-  branch's cache, and then scope it to one worktree — never one path per reviewed head. The
-  pre-push hook is the single deliberate exception: it shares one target under the common git
-  directory across every worktree, trading cargo's lock on concurrent pushes for one build cache
-  instead of one per worktree.
+- Build in the worktree's own `target/`. Cargo creates one per worktree on first build, so the
+  isolation this rule asks for needs no configuration, and `/target` is git-ignored so an in-tree
+  build leaves a read-only review's tree clean. Set `CARGO_TARGET_DIR` only to keep a build out of
+  the branch's cache, and scope it to one worktree — never one path per reviewed head. A tool may
+  share one target across worktrees when its script records why: the pre-push hook does, for one
+  build cache instead of one per worktree, and `scripts/ci/phase5-check.sh` does, to avoid VM
+  mount filesystem issues. Sharing costs cargo's lock, and under the pre-push hook's timeout that
+  can abort a push rather than only delay it.
 - Remove merged branches and their worktrees only after recording the merge in the programme ledger.
 
 ## Development Discipline

--- a/docs/guides/agent-golden-path.md
+++ b/docs/guides/agent-golden-path.md
@@ -61,7 +61,6 @@ The documentation describes `.agents/skills/` as a project-level location and `.
 From the repository root:
 
 ```bash
-export CARGO_TARGET_DIR="$(mktemp -d "${TMPDIR:-/tmp}/assay-target-2154.XXXXXX")"
 cargo test -p assay-cli --test agent_golden_path_contract
 cargo test -p assay-mcp-server --test agent_golden_path_contract
 ```


### PR DESCRIPTION
Step 1 of the revised order on #2202. Governance: one rule in `AGENTS.md`, plus one guide line that would otherwise contradict it. No code, no `CLAUDE.md`.

## The old rule contradicted its own tooling under either reading

`AGENTS.md` read: "Do not share `target/` directories between active worktrees. Use `CARGO_TARGET_DIR`."

- **If the second sentence prescribes always setting the variable**, an in-tree build violates the rule — even though cargo gives each worktree its own `target/` on first build.
- **If it is advice on how to avoid sharing**, the pre-push hook violates the first sentence: `scripts/precommit/cargo-clippy.sh` resolves `--git-common-dir`, the single shared `.git`, so one `prepush-target` serves every worktree.

Two further readings were attacked and died: "active" as *concurrently building* is refuted by `AGENTS.md:46`, which permits two active branches; `target/` as a literal path would license the exact harm the rule prevents.

## Five passes, and the axis moved twice

Every adversarial pass found a defect in the same clause, and each time the diagnosis was the clause's organising axis rather than its wording:

- **naming** — "never one path per reviewed head" condemned `scripts/ci/test-semver-gate.sh:132`, which takes a per-invocation `mktemp` target for the sanctioned reason and removes it on `trap`;
- **lifetime** — "reuse one directory or remove it" blessed `/tmp/assay-target-2189`: one directory, reused for that work, never removed, 18 GB, about 45% of the accumulation #2202 measured. Reuse also bounds nothing in bytes: a reused directory grows monotonically with no removal obligation;
- **who chose the path** — a checked-in script owns its target; a target exported by hand for a piece of work is the one that outlives the work.

The rule now states only the third, as a bare obligation: a target you export by hand, you remove. No exception clause and no grant for script-set paths — the rule is silent about those rather than permissive about them. Checked against every known case: it condemns the scratch that filled the disk and the guide's `mktemp` export, and condemns none of `cargo-clippy.sh`, `test-semver-gate.sh`, or `phase5-check.sh`.

Dropping the clause also retires two things that kept regressing — a cost sentence the rule no longer needs, and an enumeration of exemplars that made deleting dead code falsify a governance sentence.

## The guide line

`docs/guides/agent-golden-path.md` exported a fresh `mktemp` target per invocation with nothing to remove it, in a hand-written block outside the generator markers. It is hand-exported and unremoved, so the rule condemns it.

## Verification

- `grep -n "^/target$" .gitignore` → line 37
- `scripts/precommit/cargo-clippy.sh` resolves `--git-common-dir` and reuses one directory
- `scripts/ci/test-semver-gate.sh` removes `scratch_target` through its `trap`; review verified that by signal, not by reading
- the removed guide line sat outside both generator marker pairs (17–31, 33–45)
- `bash scripts/ci/check-docs-generated-drift.sh` → "generated artifacts reproduce from their generators (12 files)"
- `pre-commit run --files AGENTS.md docs/guides/agent-golden-path.md` → applicable hooks pass. Hooks staged `pre-push` do not run there and are not claimed.

Worktree counts are deliberately not cited here. An earlier body quoted "86 worktrees, 7 with a target"; review re-ran it and got 41 and 2. Volatile machine state does not belong in a durable claim.

## Non-goals

- No `CLAUDE.md` change — step 3 of #2202.
- No change to `cargo-clippy.sh`, `test-semver-gate.sh`, or `phase5-check.sh`. Whether the last should be deleted, being invoked nowhere but `CHANGELOG.md`, is a separate question.
- No edits to completed plan records.
- No enforcement check.

## Two items now genuinely recorded on #2202

An earlier body claimed `tests/integration/phase6-check.sh:8` and the plan-checkbox readability were "tracked on #2202". They were not — the claim named an artifact that did not exist. Both are now posted there, and the axis progression above with them.

## Non-claims

This reclaims no disk space and changes no build behaviour. It makes a rule true that its own tooling contradicted, on the axis that sorts every case we have.

## Review note

I am the author and cannot fill the quorum. **Seven adversarial passes** are recorded — two on #2203, which stays a draft pending this decision, and five here. Pass six returned *"do not merge as written; delete one sentence, then merge"*; that sentence is deleted and pass seven reviewed the merging head.
