### PR TITLE
ci: state the toolchain and the cargo-deny version instead of inferring them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Stated once for the whole job, because every cargo command below runs inside the repository,
+      # where rustup reads `rust-toolchain.toml` and selects 1.96.0 -- a toolchain this job never
+      # installs, so whether a step works depends on what the runner image happens to carry:
+      #
+      #   error: 'cargo' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'
+      #
+      # Both installs and both `cargo audit` invocations took that resolution, so stating it per
+      # step would write `stable` once per cargo command; the job is the smallest scope that covers
+      # them all with one statement. `install-cargo-deny.sh` honours an inherited value, so this is
+      # the selection there too rather than being shadowed by the script's own default.
+      #
+      # Scope, deliberately: no step in this job builds or tests the workspace -- checkout, two tool
+      # installs, a `sed`-only alignment check, `cargo-deny check` and two `cargo audit` runs. This
+      # selects the toolchain that runs the dependency tooling, never one that compiles a crate, and
+      # `rust-toolchain.toml` stays the source for every job that does compile.
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -159,16 +176,15 @@ jobs:
       - name: Install cargo-deny
         run: ./scripts/ci/install-cargo-deny.sh
       - name: Install cargo-audit
-        # Same toolchain selection as the cargo-deny install, and for the same reason: this job
-        # installs no toolchain, so without RUSTUP_TOOLCHAIN rustup reads rust-toolchain.toml and
-        # picks 1.96.0, which the runner image is not required to carry a cargo for.
-        run: RUSTUP_TOOLCHAIN=stable cargo install --locked cargo-audit
+        run: cargo install --locked cargo-audit
       - name: Check Aya/eBPF dependency alignment
         run: ./scripts/ci/check-aya-ebpf-alignment.sh
       - name: cargo deny (advisories, licenses, bans, sources)
-        # `cargo-deny` rather than `cargo deny`: invoking it through cargo re-enters the same
-        # toolchain resolution that broke the install, so the check would inherit the failure the
-        # install step was just fixed for. The binary is the one the pinned install asserted.
+        # `cargo-deny` rather than `cargo deny`: invoking it through cargo re-enters the toolchain
+        # resolution that broke the install. The job-level RUSTUP_TOOLCHAIN now states that
+        # resolution, so this form no longer carries the job on its own; it is kept because it does
+        # not depend on that variable surviving a later edit. The binary is the one the pinned
+        # install asserted.
         run: cargo-deny check advisories bans licenses sources
       - name: cargo audit (RustSec)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,13 +157,19 @@ jobs:
         with:
           persist-credentials: false
       - name: Install cargo-deny
-        run: cargo install --locked cargo-deny
+        run: ./scripts/ci/install-cargo-deny.sh
       - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
+        # Same toolchain selection as the cargo-deny install, and for the same reason: this job
+        # installs no toolchain, so without RUSTUP_TOOLCHAIN rustup reads rust-toolchain.toml and
+        # picks 1.96.0, which the runner image is not required to carry a cargo for.
+        run: RUSTUP_TOOLCHAIN=stable cargo install --locked cargo-audit
       - name: Check Aya/eBPF dependency alignment
         run: ./scripts/ci/check-aya-ebpf-alignment.sh
       - name: cargo deny (advisories, licenses, bans, sources)
-        run: cargo deny check advisories bans licenses sources
+        # `cargo-deny` rather than `cargo deny`: invoking it through cargo re-enters the same
+        # toolchain resolution that broke the install, so the check would inherit the failure the
+        # install step was just fixed for. The binary is the one the pinned install asserted.
+        run: cargo-deny check advisories bans licenses sources
       - name: cargo audit (RustSec)
         run: |
           rm -rf ~/.cargo/advisory-db

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -77,7 +77,7 @@ jobs:
           pip install pre-commit==4.4.0
 
       - name: Install cargo-deny (for pre-commit hook)
-        run: cargo install --locked cargo-deny
+        run: ./scripts/ci/install-cargo-deny.sh
 
       - name: Run pre-commit (all files)
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -293,7 +293,12 @@ repos:
       # --- Dependency security (shift-left) ---
       - id: cargo-deny
         name: cargo deny (advisories, licenses, bans, sources)
-        entry: bash -lc 'cargo deny check advisories bans licenses sources'
+        # `cargo-deny` rather than `cargo deny`: going through cargo resolves the toolchain from
+        # rust-toolchain.toml, which in CI selects a toolchain the lint job never installed. The
+        # binary runs the same checks without that resolution. No version assertion here -- the pin
+        # is enforced where CI installs it, and asserting it in a local hook would fail every
+        # developer whose cargo-deny predates the pin.
+        entry: bash -lc 'cargo-deny check advisories bans licenses sources'
         language: system
         pass_filenames: false
         # Only run when deps/policy change (avoids noise on unrelated commits)

--- a/scripts/ci/install-cargo-deny.sh
+++ b/scripts/ci/install-cargo-deny.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Install cargo-deny at the pinned version, from a toolchain this job actually has.
+#
+# The version lives here and nowhere else. Two workflows install cargo-deny -- the dependency
+# security job in ci.yml and the pre-commit lint job in kernel-matrix.yml -- and before this script
+# each ran its own `cargo install --locked cargo-deny`, resolving whatever was latest at run time.
+# Two jobs in one pull request could therefore enforce two different rule sets, and a new cargo-deny
+# release could redden a pull request that changed nothing related.
+#
+# `--locked` did not prevent that, and it is worth being explicit about why, because it reads like a
+# pin: it pins cargo-deny's *own dependency versions* from its published lockfile, not the version
+# of cargo-deny being installed. Anyone removing `--version` below because `--locked` looks
+# sufficient will reintroduce the drift.
+set -euo pipefail
+
+CARGO_DENY_VERSION="0.20.2"
+
+# Select the toolchain explicitly rather than letting rustup choose.
+#
+# Both jobs run inside the repository, where `rust-toolchain.toml` pins 1.96.0. rustup honours that
+# file, so `cargo install` selected 1.96.0 -- a toolchain neither job installs. The lint job installs
+# `stable` (observed as 1.97.1 in its own log) and the dependency job installs nothing at all, so
+# whether the step worked depended on what the runner image happened to carry:
+#
+#   error: 'cargo' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'
+#
+# The same branch passed at 11:43 and failed at 11:48 on 2026-08-10 with no code change. The log
+# named 1.97.1 while 1.96.0 ran, which is why reading the log gave the wrong answer about what was
+# selected. RUSTUP_TOOLCHAIN overrides the file, so the selection is now stated rather than inferred.
+export RUSTUP_TOOLCHAIN="${CARGO_DENY_TOOLCHAIN:-stable}"
+
+echo "installing cargo-deny ${CARGO_DENY_VERSION} using toolchain ${RUSTUP_TOOLCHAIN}"
+cargo install --locked --version "${CARGO_DENY_VERSION}" cargo-deny
+
+# Echo the resolved version and hold it against the pin, so the number in the log is one that was
+# checked rather than one that was printed. An install that silently produced a different version
+# would otherwise leave a log that looks like evidence of the pin.
+resolved="$(cargo-deny --version)"
+echo "cargo-deny resolved: ${resolved}"
+if [[ "${resolved}" != "cargo-deny ${CARGO_DENY_VERSION}" ]]; then
+  echo "cargo-deny reports '${resolved}', which is not the pinned ${CARGO_DENY_VERSION}" >&2
+  echo "the pin lives in scripts/ci/install-cargo-deny.sh and is the only place to change it" >&2
+  exit 1
+fi

--- a/scripts/ci/install-cargo-deny.sh
+++ b/scripts/ci/install-cargo-deny.sh
@@ -27,7 +27,13 @@ CARGO_DENY_VERSION="0.20.2"
 # The same branch passed at 11:43 and failed at 11:48 on 2026-08-10 with no code change. The log
 # named 1.97.1 while 1.96.0 ran, which is why reading the log gave the wrong answer about what was
 # selected. RUSTUP_TOOLCHAIN overrides the file, so the selection is now stated rather than inferred.
-export RUSTUP_TOOLCHAIN="${CARGO_DENY_TOOLCHAIN:-stable}"
+#
+# An inherited value wins. ci.yml's dependency job states the selection once for every cargo command
+# it runs; overriding that here would make the job's statement decorative for this step, and would
+# make `stable` a value written in two places that have to agree -- the defect this script exists to
+# remove. `stable` below is the fallback for a caller that states nothing, which is the lint job in
+# kernel-matrix.yml and anyone running the script by hand.
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-stable}"
 
 echo "installing cargo-deny ${CARGO_DENY_VERSION} using toolchain ${RUSTUP_TOOLCHAIN}"
 cargo install --locked --version "${CARGO_DENY_VERSION}" cargo-deny

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -1256,7 +1256,7 @@ import os
 from pathlib import Path
 
 path = Path(os.environ["CASE_ROOT"]) / ".github/workflows/kernel-matrix.yml"
-source = "run: cargo install --locked cargo-deny"
+source = "run: ./scripts/ci/install-cargo-deny.sh"
 replacement = "run: echo inline-parser-sentinel"
 text = path.read_text(encoding="utf-8")
 if text.count(source) != 1:


### PR DESCRIPTION
Closes #2214.

## Provenance

Branch `cursor/2214-pin-cargo-deny`, head `2be4026ee` on top of `aaf57f94c`, worktree `/Users/roelschuurkes/wt-2214`, based on `main` at `360c4963a8f978513948349204e12fc735595730`. Every observation below was made in that worktree.

## The defect

The `Lint (pre-commit)` job reddened pull requests at random. Same branch, no code change:

```text
2026-08-10T11:48  failure  pull_request  cursor/2199-evidence-integrity-reason
2026-08-10T11:43  success  pull_request  cursor/2199-evidence-integrity-reason
```

Failing step `Install cargo-deny`, job [93443840963](https://github.com/Rul1an/assay/actions/runs/31385161830/job/93443840963):

```text
error: 'cargo' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'
```

The job installs **stable** — its own log says `rustc 1.97.1` — but `cargo install` runs inside the repository, where rustup reads `rust-toolchain.toml` and selects **1.96.0**, which the job never installed. Whether the step worked therefore depended on what the runner image happened to carry.

Measured here rather than reasoned about:

```text
$ rustup show active-toolchain
1.96.0-aarch64-apple-darwin (overridden by '/Users/roelschuurkes/wt-2214/rust-toolchain.toml')

$ RUSTUP_TOOLCHAIN=stable rustup show active-toolchain
stable-aarch64-apple-darwin (overridden by environment variable RUSTUP_TOOLCHAIN)
```

This is the failure mode `AGENTS.md` names under version pinning — "an invocation can select a different toolchain through an alias while the log still names the pinned one." The log named 1.97.1 while 1.96.0 ran, so reading the log gave the wrong answer about what was selected. That is why it survived unnoticed until the image stopped covering for it.

## What changed

**The toolchain selection is now stated, not inferred.** `scripts/ci/install-cargo-deny.sh` exports `RUSTUP_TOOLCHAIN` (default `stable`, overridable) before installing, so the selection no longer depends on runner-image contents. The `cargo-audit` install in the same job gets the same treatment for the same reason — it had the identical latent failure, and fixing one would have left the other to fire later.

**The invocation had the same hole, and that is easy to miss.** `cargo deny check` re-enters the same toolchain resolution, so the check would have inherited exactly the failure the install step was fixed for. CI and the pre-commit hook now invoke the `cargo-deny` binary directly, which removes `cargo` from the path entirely.

**The version is pinned in one place.** Two workflows installed cargo-deny independently and unpinned, so two jobs in one pull request could enforce two different rule sets, and a new cargo-deny release could redden a PR that changed nothing related. `0.20.2` is what an unpinned install resolves today, so this freezes current behaviour rather than changing it.

**`--locked` is why the absence of a pin was invisible**, and the script says so in a comment, because this is the part a future reader will undo: `--locked` pins cargo-deny's *own dependency versions* from its published lockfile, not the version of cargo-deny being installed. It reads as a pin without being one. Anyone deleting `--version` because `--locked` looks sufficient reintroduces the drift.

**The run echoes the resolved version and fails if it differs from the pin**, so the number in the log is one that was checked rather than one that was printed.

## Verification

`RUSTUP_TOOLCHAIN` override: quoted above, both directions.

Version guard, both directions, using a stub `cargo` and `cargo-deny` first on `PATH` so no minutes-long install was needed:

```text
mismatch:  cargo-deny resolved: cargo-deny 0.19.0
           cargo-deny reports 'cargo-deny 0.19.0', which is not the pinned 0.20.2
           the pin lives in scripts/ci/install-cargo-deny.sh and is the only place to change it
           exit=1

match:     cargo-deny resolved: cargo-deny 0.20.2
           exit=0
```

The stub also confirms the argv is what it should be: `install --locked --version 0.20.2 cargo-deny`.

Other gates: `shellcheck` clean on the new script; `cargo-deny check --help` accepted, confirming the direct-invocation form is valid; the full pre-push hook set passed, including `shellcheck`, `cargo fmt --check`, workspace clippy with `-D warnings`, and the cross-target Linux compile gate.

## The second commit, and why it is separate

The first push was **refused by a gate**, which is worth showing rather than folding away:

```text
inline run anchor is not unique: 'run: cargo install --locked cargo-deny'
```

The hardening harness's inline-run parser probe anchors on that exact line in `kernel-matrix.yml` and requires exactly one occurrence. Replacing the install with a script made the count zero, so the probe's guard fired. The guard did its job — it refused to run a probe whose subject had disappeared, instead of passing vacuously — and only the anchor needed to move.

Recorded because the shape recurs: the probe needs *an* inline run step in the lint job, not this specific command, so pinning the literal text lets an unrelated workflow edit block a push. This is the second anchor in this harness to break on a legitimate change today. #2211 already covers the theme of the harness restating what it could derive; generalising this probe belongs there rather than here.

## What this does not prove

The negative control I could not run is the real one: a runner where the pinned toolchain has no `cargo`. The stub proves the version guard and `rustup show` proves the override, but the original failure was environmental, and the only complete proof is CI staying green across runs that would previously have flipped. Judge this change on the mechanism, and treat one green run as consistent with the fix rather than as evidence the flake is gone.

No change to `rust-toolchain.toml`, to what `cargo deny` checks, or to any hook's rule set. No required check weakened, relabelled, or removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized dependency checks on a pinned, verified cargo-deny version.
  * Improved CI consistency by using the stable Rust toolchain by default.
  * Updated pre-commit and workflow checks to use the standalone cargo-deny command.
  * Added validation to detect unexpected cargo-deny versions during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->