### PR TITLE
fix(test-support): name the ending a bounded run reached, and stop timing PowerShell startup

### DIFF
--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -556,7 +556,8 @@ mod tests {
         /// Keeps stdout and stderr open after its parent exits, so the reader
         /// threads never reach EOF.
         Inherited,
-        /// Detached from both, so the readers finish when the parent exits.
+        /// Asks for neither handle. Whether asking is enough is a platform
+        /// question, answered where the two descendant tests are cfg-split.
         Detached,
     }
 
@@ -882,6 +883,24 @@ mod tests {
         }
     }
 
+    /// A descendant that asks for no output handles releases the bounded run's
+    /// on Unix, and cannot on Windows. `CreateProcess` is called with
+    /// `bInheritHandles = TRUE`, and a handle the bounded child inherited stays
+    /// inheritable inside it, so every process it spawns receives the run's
+    /// stdout and stderr write handles whatever its own stdio is set to.
+    ///
+    /// Job 93527135001 measured exactly that: the child exited 0, every byte it
+    /// wrote had been read, and the readers still had no EOF with only a
+    /// `Stdio::null()` descendant alive. The spawner this replaced escaped it
+    /// through `Start-Process`, which goes via `ShellExecuteEx` and inherits no
+    /// handles -- at the price of a `powershell.exe` start inside the bounded
+    /// window, which is the defect in #2249.
+    ///
+    /// So the success path with a live descendant is reachable on Unix and not
+    /// on Windows, and each platform asserts the ending it can actually reach.
+    /// The Windows test fails if that ever stops being true, which is the signal
+    /// to restore one cross-platform test here.
+    #[cfg(unix)]
     #[test]
     fn kills_quiet_descendant_after_normal_parent_exit() {
         let temp = tempfile::tempdir().expect("temporary pid directory");
@@ -912,11 +931,69 @@ mod tests {
         );
     }
 
-    /// The Windows descendant tests use this re-execution as their bounded
-    /// child. Running it on every platform keeps the mechanism exercised where
-    /// those tests use a shell instead, and separates "the helper is broken"
-    /// from "the bound was lost" when Windows goes red: this bound is the test
-    /// guard, not the deadline under test.
+    /// The Windows half of the split above: asking for detached output changes
+    /// nothing about who holds the run's handles, so the reachable ending is the
+    /// deadline, and the descendant must still not survive it.
+    ///
+    /// This is the tripwire. If Windows or `std::process` ever stops handing the
+    /// run's handles to every descendant, this test fails with a successful run
+    /// it did not expect, and the fix is to delete it and drop the `cfg(unix)`
+    /// from `kills_quiet_descendant_after_normal_parent_exit`.
+    #[cfg(windows)]
+    #[test]
+    fn a_descendant_that_asks_for_no_output_still_holds_the_run_open_and_is_killed() {
+        let temp = tempfile::tempdir().expect("temporary pid directory");
+        let pid_file = temp.path().join("quiet-descendant.pid");
+        let cleanup_path = pid_file.clone();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let worker = thread::spawn(move || {
+            let command = descendant_spawner_command(&pid_file, DescendantOutput::Detached);
+            let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
+            let _ = result_tx.send(run_bounded(
+                command,
+                b"",
+                limits,
+                "normal completion mutation",
+            ));
+        });
+
+        let result = match result_rx.recv_timeout(descendant_test_guard()) {
+            Ok(result) => result,
+            Err(error) => panic!("runner escaped its wall-clock bound: {error}"),
+        };
+        worker.join().expect("bounded runner worker");
+
+        let error = result.expect_err(
+            "a Windows descendant inherits the run's handles, so the deadline is the only \
+             reachable ending; a success here means the platform changed",
+        );
+        assert!(error.contains("normal completion mutation"));
+        // The spawner chose to exit; the deadline belongs to the handles its
+        // descendant holds. Reporting that as a child that timed out is the
+        // misdirection this diagnostic exists to prevent.
+        assert!(error.contains("(child exit)"), "{error}");
+        assert!(!error.contains("child still running"), "{error}");
+        assert!(error.contains("stdout handle still open"), "{error}");
+        assert!(error.contains("stderr handle still open"), "{error}");
+        // Readiness still has to be observable on the error path, or a child
+        // that never ran would read the same as one that ran and was outlived.
+        let marker = std::str::from_utf8(READY_MARKER).expect("marker is text");
+        assert!(error.contains(marker), "{error}");
+        let descendant_pid = read_descendant_pid(&cleanup_path)
+            .expect("quiet descendant must publish its pid before the deadline");
+        assert!(
+            wait_for_descendant_exit(descendant_pid),
+            "quiet descendant {descendant_pid} survived process-tree termination"
+        );
+    }
+
+    /// On Windows the descendant tests use this re-execution as their bounded
+    /// child, so it is covered there. Here it is the only exercise of it, since
+    /// the Unix spawner is a shell -- and it separates "the helper is broken"
+    /// from "the bound was lost": this bound is the test guard, not the deadline
+    /// under test.
+    #[cfg(unix)]
     #[test]
     fn the_re_executed_helper_publishes_a_pid_and_reports_readiness() {
         let temp = tempfile::tempdir().expect("temporary pid directory");

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -35,6 +35,83 @@ impl ProcessLimits {
 pub const GOLDEN_PATH_LIMITS: ProcessLimits =
     ProcessLimits::new(Duration::from_secs(10), 1024 * 1024, 1024 * 1024);
 
+/// Where a reported exit status came from.
+///
+/// A status the harness reaped after terminating the process tree is not an
+/// ending the child chose: on Windows `TerminateJobObject` supplies the exit
+/// code itself, and on Unix the group kill supplies the signal. Rendering that
+/// the same way as a child-chosen exit makes a timeout indistinguishable from a
+/// child that died instantly, which is what run 31404812176 reported.
+#[derive(Clone, Copy)]
+enum StatusOrigin {
+    ChildExit,
+    HarnessTermination,
+}
+
+/// A child's exit status together with the origin that explains it.
+#[derive(Clone, Copy)]
+struct Ending {
+    status: ExitStatus,
+    origin: StatusOrigin,
+}
+
+impl Ending {
+    fn child_exit(status: ExitStatus) -> Self {
+        Self {
+            status,
+            origin: StatusOrigin::ChildExit,
+        }
+    }
+
+    fn harness_termination(status: ExitStatus) -> Self {
+        Self {
+            status,
+            origin: StatusOrigin::HarnessTermination,
+        }
+    }
+
+    fn describe(&self) -> String {
+        match self.origin {
+            StatusOrigin::ChildExit => format!("{} (child exit)", self.status),
+            StatusOrigin::HarnessTermination => format!(
+                "{} (recorded after harness termination; may be the termination's own code)",
+                self.status
+            ),
+        }
+    }
+}
+
+/// Names what the deadline was still waiting for when it expired.
+///
+/// Without this, "deadline expired" covers two different endings — a child that
+/// never exited, and a child that exited while a descendant kept its output
+/// handles open — and the reader of a failure cannot tell them apart.
+fn deadline_expiry(
+    timeout: Duration,
+    child_exited: bool,
+    stdin_pending: bool,
+    stdout_pending: bool,
+    stderr_pending: bool,
+) -> String {
+    let mut outstanding = Vec::new();
+    if !child_exited {
+        outstanding.push("child still running");
+    }
+    if stdin_pending {
+        outstanding.push("stdin still being written");
+    }
+    if stdout_pending {
+        outstanding.push("stdout handle still open");
+    }
+    if stderr_pending {
+        outstanding.push("stderr handle still open");
+    }
+    format!(
+        "deadline of {timeout:?} expired; outstanding=[{}]",
+        outstanding.join(", ")
+    )
+}
+
 #[derive(Clone, Copy)]
 enum CapturedStream {
     Stdout,
@@ -120,7 +197,7 @@ pub fn run_bounded(
     let deadline = Instant::now() + limits.timeout;
     let mut early_failure = None;
     let mut observed_status = None;
-    let status = loop {
+    let ending = loop {
         if early_failure.is_none() {
             if let Ok(stream) = overflow_rx.try_recv() {
                 // The reader closes its pipe after limit + 1 bytes. Keep the
@@ -138,9 +215,13 @@ pub fn run_bounded(
                 Ok(Some(status)) => observed_status = Some(status),
                 Ok(None) => {}
                 Err(error) => {
-                    let reap = terminate_and_reap(child.as_mut(), None, context, &command_display);
+                    let reap =
+                        match terminate_and_reap(child.as_mut(), None, context, &command_display) {
+                            Ok(ending) => ending.describe(),
+                            Err(reap_error) => reap_error,
+                        };
                     return Err(format!(
-                        "{context}: poll {command_display}: {error}; terminate/reap: {reap:?}"
+                        "{context}: poll {command_display}: {error}; terminate/reap: {reap}"
                     ));
                 }
             }
@@ -152,14 +233,22 @@ pub fn run_bounded(
             && stderr_reader.is_finished()
         {
             finish_process_tree(child.as_mut(), context, &command_display)?;
-            break observed_status
-                .take()
-                .expect("status was checked immediately above");
+            break Ending::child_exit(
+                observed_status
+                    .take()
+                    .expect("status was checked immediately above"),
+            );
         }
 
         if Instant::now() >= deadline {
             if early_failure.is_none() {
-                early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
+                early_failure = Some(deadline_expiry(
+                    limits.timeout,
+                    observed_status.is_some(),
+                    !stdin_writer.is_finished(),
+                    !stdout_reader.is_finished(),
+                    !stderr_reader.is_finished(),
+                ));
             }
             break terminate_and_reap(
                 child.as_mut(),
@@ -182,7 +271,7 @@ pub fn run_bounded(
             context,
             &command_display,
             &failure,
-            &status,
+            &ending,
             &stdout,
             &stderr,
         ));
@@ -195,7 +284,7 @@ pub fn run_bounded(
                 "stdout exceeded its {}-byte ceiling",
                 limits.max_stdout_bytes
             ),
-            &status,
+            &ending,
             &stdout,
             &stderr,
         ));
@@ -208,7 +297,7 @@ pub fn run_bounded(
                 "stderr exceeded its {}-byte ceiling",
                 limits.max_stderr_bytes
             ),
-            &status,
+            &ending,
             &stdout,
             &stderr,
         ));
@@ -223,14 +312,14 @@ pub fn run_bounded(
             context,
             &command_display,
             &format!("write stdin: {error}"),
-            &status,
+            &ending,
             &stdout,
             &stderr,
         ))
     })?;
 
     Ok(Output {
-        status,
+        status: ending.status,
         stdout,
         stderr,
     })
@@ -271,7 +360,7 @@ fn terminate_and_reap(
     observed_status: Option<ExitStatus>,
     context: &str,
     command: &str,
-) -> Result<ExitStatus, String> {
+) -> Result<Ending, String> {
     let tree_error = child
         .start_kill()
         .err()
@@ -279,31 +368,32 @@ fn terminate_and_reap(
     let direct_kill_error = tree_error
         .as_ref()
         .and_then(|_| child.inner_mut().start_kill().err());
-    let status = reap_after_tree_kill(child, observed_status).map_err(|reap_error| {
+    let ending = reap_after_tree_kill(child, observed_status).map_err(|reap_error| {
         format!(
             "{context}: failed to reap {command} after tree termination; tree={tree_error:?}; direct_kill={direct_kill_error:?}; reap={reap_error}"
         )
     })?;
     if let Some(tree_error) = tree_error {
         return Err(format!(
-            "{context}: failed to terminate process tree for {command}: {tree_error}; direct_kill={direct_kill_error:?}; status={status}"
+            "{context}: failed to terminate process tree for {command}: {tree_error}; direct_kill={direct_kill_error:?}; status={}",
+            ending.describe()
         ));
     }
-    Ok(status)
+    Ok(ending)
 }
 
 fn reap_after_tree_kill(
     child: &mut dyn ChildWrapper,
     observed_status: Option<ExitStatus>,
-) -> Result<ExitStatus, String> {
+) -> Result<Ending, String> {
     if let Some(status) = observed_status {
-        return Ok(status);
+        return Ok(Ending::child_exit(status));
     }
 
     let deadline = Instant::now() + REAP_GRACE;
     loop {
         match child.try_wait() {
-            Ok(Some(status)) => return Ok(status),
+            Ok(Some(status)) => return Ok(Ending::harness_termination(status)),
             Ok(None) if Instant::now() < deadline => thread::sleep(POLL_INTERVAL),
             Ok(None) => return Err(format!("reap grace of {REAP_GRACE:?} expired")),
             Err(error) => return Err(format!("poll after termination: {error}")),
@@ -378,12 +468,13 @@ fn failure_diagnostic(
     context: &str,
     command: &str,
     failure: &str,
-    status: &ExitStatus,
+    ending: &Ending,
     stdout: &[u8],
     stderr: &[u8],
 ) -> String {
     format!(
-        "{context}: {command}: {failure}; status={status}; stdout={}; stderr={}",
+        "{context}: {command}: {failure}; status={}; stdout={}; stderr={}",
+        ending.describe(),
         excerpt(stdout),
         excerpt(stderr)
     )
@@ -401,10 +492,11 @@ fn excerpt(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::{deadline_expiry, run_bounded, ProcessLimits};
     #[cfg(unix)]
     use super::{process_tree_absent, process_tree_quiescent_after_io};
-    use super::{run_bounded, ProcessLimits};
-    use std::path::Path;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::sync::mpsc;
     use std::thread;
@@ -445,31 +537,156 @@ mod tests {
         command
     }
 
+    /// Selected on the bounded child so this test binary, re-executed, acts as
+    /// the descendant spawner instead of running the suite.
+    const HELPER_MODE_ENV: &str = "ASSAY_BOUNDED_PROCESS_HELPER_MODE";
+    const PID_FILE_ENV: &str = "ASSAY_DESCENDANT_PID_FILE";
+    /// libtest filter that selects the helper in every binary including this
+    /// module, whatever module path it is included under. A filter that matched
+    /// nothing would exit 0 silently, so
+    /// `the_re_executed_helper_is_selected_by_exactly_one_filter_match` pins it.
+    const HELPER_FILTER: &str = "descendant_spawner_helper_process";
+    /// Written to both channels by every spawner, so the bounded run can assert
+    /// one channel verbatim and find the marker on the other.
+    const READY_MARKER: &[u8] = b"parent-ready";
+
+    /// What the descendant does with the bounded run's output handles.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    enum DescendantOutput {
+        /// Keeps stdout and stderr open after its parent exits, so the reader
+        /// threads never reach EOF.
+        Inherited,
+        /// Detached from both, so the readers finish when the parent exits.
+        Detached,
+    }
+
+    impl DescendantOutput {
+        fn as_str(self) -> &'static str {
+            match self {
+                Self::Inherited => "inherited",
+                Self::Detached => "detached",
+            }
+        }
+
+        fn parse(value: &str) -> Option<Self> {
+            match value {
+                "inherited" => Some(Self::Inherited),
+                "detached" => Some(Self::Detached),
+                _ => None,
+            }
+        }
+    }
+
+    fn current_test_binary() -> PathBuf {
+        std::env::current_exe().expect("the running test binary must be addressable")
+    }
+
+    /// The bounded child that spawns a descendant and publishes its pid.
+    ///
+    /// On Windows this re-executes the test binary rather than scripting
+    /// `powershell.exe`. In run 31404812176 one `powershell.exe` start took
+    /// about 18 seconds on the runner, longer than the whole bounded window, so
+    /// interpreter startup rather than process-tree teardown decided the
+    /// result. Unix keeps its shell, whose startup is a fraction of that bound.
+    #[cfg(windows)]
+    fn descendant_spawner_command(pid_file: &Path, output: DescendantOutput) -> Command {
+        let mut command = Command::new(current_test_binary());
+        command
+            .args([
+                HELPER_FILTER,
+                "--ignored",
+                "--nocapture",
+                "--format",
+                "terse",
+            ])
+            .env(HELPER_MODE_ENV, output.as_str())
+            .env(PID_FILE_ENV, pid_file);
+        command
+    }
+
     #[cfg(unix)]
-    fn inherited_output_descendant_command(pid_file: &Path) -> Command {
+    fn descendant_spawner_command(pid_file: &Path, output: DescendantOutput) -> Command {
+        let detach = match output {
+            DescendantOutput::Inherited => "",
+            DescendantOutput::Detached => "exec </dev/null >/dev/null 2>&1;",
+        };
         let mut command = Command::new("sh");
         command
             .arg("-c")
-            .arg(
-                "sh -c 'echo \"$$\" > \"$1\"; while :; do :; done' descendant \"$1\" & printf parent-ready",
-            )
+            .arg(format!(
+                "sh -c 'echo \"$$\" > \"$1\"; {detach} while :; do :; done' descendant \"$1\" & \
+                 while [ ! -s \"$1\" ]; do :; done; printf parent-ready; printf parent-ready >&2",
+            ))
             .arg("runner")
             .arg(pid_file);
         command
     }
 
-    #[cfg(windows)]
-    fn inherited_output_descendant_command(pid_file: &Path) -> Command {
-        let mut command = Command::new("powershell.exe");
-        command.env("ASSAY_DESCENDANT_PID_FILE", pid_file);
-        command.args([
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "$path = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID_FILE'); $p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -NoNewWindow -PassThru; [IO.File]::WriteAllText($path, [string]$p.Id); [Console]::Out.Write('parent-ready')",
-        ]);
-        command
+    /// Runs as the bounded child of the Windows descendant tests, never as part
+    /// of the suite. `--ignored` keeps it out of a normal run.
+    #[test]
+    #[ignore = "re-executed as the bounded child of the descendant tests"]
+    fn descendant_spawner_helper_process() {
+        let mode = std::env::var(HELPER_MODE_ENV)
+            .unwrap_or_else(|error| panic!("{HELPER_MODE_ENV} must be set: {error}"));
+        let output = DescendantOutput::parse(&mode)
+            .unwrap_or_else(|| panic!("unknown descendant output mode {mode:?}"));
+        let pid_file = PathBuf::from(
+            std::env::var_os(PID_FILE_ENV).unwrap_or_else(|| panic!("{PID_FILE_ENV} must be set")),
+        );
+
+        let mut descendant = hanging_command();
+        descendant.stdin(Stdio::null());
+        if output == DescendantOutput::Detached {
+            descendant.stdout(Stdio::null()).stderr(Stdio::null());
+        }
+        let child = descendant
+            .spawn()
+            .unwrap_or_else(|error| panic!("spawn the descendant: {error}"));
+        std::fs::write(&pid_file, child.id().to_string())
+            .unwrap_or_else(|error| panic!("publish the descendant pid: {error}"));
+
+        // libtest prefixes this process's stdout with its own report, so the
+        // marker goes to both channels: stderr carries the child's bytes alone.
+        std::io::stdout()
+            .write_all(READY_MARKER)
+            .expect("report readiness on stdout");
+        std::io::stdout().flush().expect("flush readiness");
+        std::io::stderr()
+            .write_all(READY_MARKER)
+            .expect("report readiness on stderr");
+    }
+
+    #[test]
+    fn the_descendant_output_mode_survives_the_round_trip_to_the_helper() {
+        for mode in [DescendantOutput::Inherited, DescendantOutput::Detached] {
+            assert_eq!(DescendantOutput::parse(mode.as_str()), Some(mode));
+        }
+        assert_eq!(DescendantOutput::parse("hidden"), None);
+    }
+
+    #[test]
+    fn the_re_executed_helper_is_selected_by_exactly_one_filter_match() {
+        let listing = Command::new(current_test_binary())
+            .args([HELPER_FILTER, "--ignored", "--list", "--format", "terse"])
+            .output()
+            .expect("list the helper test");
+        assert!(
+            listing.status.success(),
+            "listing the helper test failed: {}",
+            listing.status
+        );
+        let listed = String::from_utf8_lossy(&listing.stdout);
+        let selected: Vec<&str> = listed
+            .lines()
+            .filter(|line| line.ends_with(": test"))
+            .collect();
+        assert_eq!(
+            selected.len(),
+            1,
+            "{HELPER_FILTER} must select exactly one test, listing was {listed:?}"
+        );
+        assert!(selected[0].contains(HELPER_FILTER), "{listed:?}");
     }
 
     #[cfg(unix)]
@@ -499,6 +716,8 @@ mod tests {
         None
     }
 
+    /// A probe that cannot run is not an answer, so a spawn failure panics
+    /// rather than reporting a descendant dead.
     #[cfg(unix)]
     fn descendant_is_alive(pid: u32) -> bool {
         Command::new("kill")
@@ -506,26 +725,25 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
-            .is_ok_and(|status| status.success())
+            .expect("the liveness probe must be runnable")
+            .success()
     }
 
+    /// `tasklist` is native. The interpreter this used to spawn cost as much as
+    /// 18 seconds on the runner in run 31404812176, inside a one-second wait.
     #[cfg(windows)]
     fn descendant_is_alive(pid: u32) -> bool {
-        let mut command = Command::new("powershell.exe");
-        command
-            .env("ASSAY_DESCENDANT_PID", pid.to_string())
-            .args([
-                "-NoLogo",
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                "$targetPid = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID'); if (Get-Process -Id $targetPid -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
-            ]);
-        command
-            .stdout(Stdio::null())
+        let listing = Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
             .stderr(Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
+            .output()
+            .expect("the liveness probe must be runnable");
+        // The filter admits only this pid, so a row naming it is the process
+        // being alive; a miss is an informational line with no such field.
+        let pid = pid.to_string();
+        String::from_utf8_lossy(&listing.stdout)
+            .split_whitespace()
+            .any(|field| field == pid)
     }
 
     fn wait_for_descendant_exit(pid: u32) -> bool {
@@ -539,6 +757,8 @@ mod tests {
         !descendant_is_alive(pid)
     }
 
+    /// Guards the probe against the failure that would make every descendant
+    /// assertion pass vacuously: reporting everything dead.
     #[test]
     fn liveness_probe_recognizes_the_current_test_process() {
         assert!(
@@ -575,33 +795,6 @@ mod tests {
     #[cfg(windows)]
     fn descendant_test_guard() -> Duration {
         Duration::from_secs(10)
-    }
-
-    #[cfg(unix)]
-    fn quiet_descendant_command(pid_file: &Path) -> Command {
-        let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg(
-                "sh -c 'echo \"$$\" > \"$1\"; exec </dev/null >/dev/null 2>&1; while :; do :; done' descendant \"$1\" & while [ ! -s \"$1\" ]; do :; done; printf parent-ready",
-            )
-            .arg("runner")
-            .arg(pid_file);
-        command
-    }
-
-    #[cfg(windows)]
-    fn quiet_descendant_command(pid_file: &Path) -> Command {
-        let mut command = Command::new("powershell.exe");
-        command.env("ASSAY_DESCENDANT_PID_FILE", pid_file);
-        command.args([
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "$path = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID_FILE'); $p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -WindowStyle Hidden -PassThru; [IO.File]::WriteAllText($path, [string]$p.Id); [Console]::Out.Write('parent-ready')",
-        ]);
-        command
     }
 
     #[test]
@@ -653,7 +846,7 @@ mod tests {
         let started = Instant::now();
 
         let worker = thread::spawn(move || {
-            let command = inherited_output_descendant_command(&pid_file);
+            let command = descendant_spawner_command(&pid_file, DescendantOutput::Inherited);
             let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
             let result = run_bounded(command, b"", limits, "inherited output mutation");
             let _ = result_tx.send(result);
@@ -667,7 +860,14 @@ mod tests {
 
         let error = result.expect_err("inherited output holder must force tree termination");
         assert!(error.contains("inherited output mutation"));
-        assert!(error.contains("deadline"));
+        assert!(error.contains("deadline"), "{error}");
+        // The spawner exits by itself here; the deadline is reached because the
+        // descendant still holds the handles. The diagnostic must say which
+        // ending this was, or it cannot be told from a child that never ran.
+        assert!(error.contains("stdout handle still open"), "{error}");
+        assert!(error.contains("stderr handle still open"), "{error}");
+        assert!(!error.contains("child still running"), "{error}");
+        assert!(error.contains("(child exit)"), "{error}");
         assert!(
             started.elapsed() < descendant_test_guard(),
             "process-tree cleanup exceeded the test bound"
@@ -683,20 +883,95 @@ mod tests {
     fn kills_quiet_descendant_after_normal_parent_exit() {
         let temp = tempfile::tempdir().expect("temporary pid directory");
         let pid_file = temp.path().join("quiet-descendant.pid");
-        let command = quiet_descendant_command(&pid_file);
+        let command = descendant_spawner_command(&pid_file, DescendantOutput::Detached);
         let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
 
         let output = run_bounded(command, b"", limits, "normal completion mutation")
             .expect("normal parent completion must retain its outcome");
 
         assert!(output.status.success());
-        assert_eq!(output.stdout, b"parent-ready");
+        // Both channels go through one reader, so stderr proves the bytes are
+        // returned verbatim while stdout may carry a test harness's own report.
+        assert_eq!(output.stderr, READY_MARKER);
+        assert!(
+            output
+                .stdout
+                .windows(READY_MARKER.len())
+                .any(|w| w == READY_MARKER),
+            "stdout must carry the child's readiness marker: {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        );
         let descendant_pid =
             read_descendant_pid(&pid_file).expect("quiet descendant must publish its pid");
         assert!(
             wait_for_descendant_exit(descendant_pid),
             "quiet descendant {descendant_pid} survived normal completion cleanup"
         );
+    }
+
+    /// The Windows descendant tests use this re-execution as their bounded
+    /// child. Running it on every platform keeps the mechanism exercised where
+    /// those tests use a shell instead, and separates "the helper is broken"
+    /// from "the bound was lost" when Windows goes red: this bound is the test
+    /// guard, not the deadline under test.
+    #[test]
+    fn the_re_executed_helper_publishes_a_pid_and_reports_readiness() {
+        let temp = tempfile::tempdir().expect("temporary pid directory");
+        let pid_file = temp.path().join("helper-descendant.pid");
+        let mut command = Command::new(current_test_binary());
+        command
+            .args([
+                HELPER_FILTER,
+                "--ignored",
+                "--nocapture",
+                "--format",
+                "terse",
+            ])
+            .env(HELPER_MODE_ENV, DescendantOutput::Detached.as_str())
+            .env(PID_FILE_ENV, &pid_file);
+        let limits = ProcessLimits::new(descendant_test_guard(), 1024, 1024);
+
+        let output = run_bounded(command, b"", limits, "helper re-execution")
+            .expect("the re-executed helper must complete within the test guard");
+
+        assert!(output.status.success(), "{:?}", output.status);
+        assert_eq!(output.stderr, READY_MARKER);
+        let descendant_pid = read_descendant_pid(&pid_file)
+            .expect("the re-executed helper must publish its descendant's pid");
+        assert!(
+            wait_for_descendant_exit(descendant_pid),
+            "descendant {descendant_pid} of the re-executed helper survived cleanup"
+        );
+    }
+
+    #[test]
+    fn a_deadline_reached_with_the_child_alive_reads_differently_from_one_reached_with_open_output()
+    {
+        let running = deadline_expiry(Duration::from_secs(5), false, false, true, true);
+        assert!(running.contains("child still running"), "{running}");
+
+        let exited = deadline_expiry(Duration::from_secs(5), true, false, true, true);
+        assert!(!exited.contains("child still running"), "{exited}");
+        assert!(exited.contains("stdout handle still open"), "{exited}");
+        assert!(exited.contains("stderr handle still open"), "{exited}");
+    }
+
+    #[test]
+    fn a_harness_terminated_status_is_not_reported_as_a_child_exit() {
+        let command = hanging_command();
+        let limits = ProcessLimits::new(Duration::from_millis(100), 1024, 1024);
+        let error = run_bounded(command, b"", limits, "harness termination mutation")
+            .expect_err("hanging child must time out");
+
+        assert!(
+            error.contains("outstanding=[child still running"),
+            "{error}"
+        );
+        assert!(
+            error.contains("recorded after harness termination"),
+            "{error}"
+        );
+        assert!(!error.contains("(child exit)"), "{error}");
     }
 
     #[test]

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -624,6 +624,9 @@ mod tests {
 
     /// Runs as the bounded child of the Windows descendant tests, never as part
     /// of the suite. `--ignored` keeps it out of a normal run.
+    // The descendant is deliberately never waited on: it has to outlive this
+    // process so that the process-tree termination under test is what reaps it.
+    #[allow(clippy::zombie_processes)]
     #[test]
     #[ignore = "re-executed as the bounded child of the descendant tests"]
     fn descendant_spawner_helper_process() {

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -556,6 +556,11 @@ mod tests {
     /// control channel with rules of its own: the pid now arrives through the
     /// same bounded capture the harness under test already governs.
     const READY_RECORD_PREFIX: &str = "READY pid=";
+    /// The control's record. It names no pid because the control spawns nothing,
+    /// and it deliberately does not carry the pid prefix, so a control run whose
+    /// output were mistaken for a descendant run would fail to parse rather than
+    /// report a pid nobody spawned.
+    const READY_SOLO_RECORD: &str = "READY solo";
     /// `u32::MAX` is ten digits, so anything longer is not a pid.
     const MAX_PID_DIGITS: usize = 10;
 
@@ -608,22 +613,32 @@ mod tests {
         seen.ok_or_else(|| format!("no readiness record: {record:?}"))
     }
 
-    /// What the descendant does with the bounded run's output handles.
+    /// What the bounded child does before it exits.
+    ///
+    /// The three variants are one manipulation with one variable: whether a
+    /// descendant exists and, if it does, what it asks for. Holding the rest of
+    /// the run fixed is what lets `Solo` act as the control for the
+    /// inherited-handle claim rather than as another sample.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-    enum DescendantOutput {
-        /// Keeps stdout and stderr open after its parent exits, so the reader
-        /// threads never reach EOF.
+    enum HelperPlan {
+        /// Spawns a descendant that keeps stdout and stderr open after its
+        /// parent exits, so the reader threads never reach EOF.
         Inherited,
-        /// Asks for neither handle. Whether asking is enough is a platform
-        /// question, answered where the two descendant tests are cfg-split.
+        /// Spawns a descendant that asks for neither handle. Whether asking is
+        /// enough is a platform question, answered where the descendant tests
+        /// are cfg-split.
         Detached,
+        /// Spawns nothing. The control: with no descendant to hold anything, the
+        /// readers must reach EOF when the child exits.
+        Solo,
     }
 
-    impl DescendantOutput {
+    impl HelperPlan {
         fn as_str(self) -> &'static str {
             match self {
                 Self::Inherited => "inherited",
                 Self::Detached => "detached",
+                Self::Solo => "solo",
             }
         }
 
@@ -631,6 +646,7 @@ mod tests {
             match value {
                 "inherited" => Some(Self::Inherited),
                 "detached" => Some(Self::Detached),
+                "solo" => Some(Self::Solo),
                 _ => None,
             }
         }
@@ -648,7 +664,7 @@ mod tests {
     /// interpreter startup rather than process-tree teardown decided the
     /// result. Unix keeps its shell, whose startup is a fraction of that bound.
     #[cfg(windows)]
-    fn descendant_spawner_command(output: DescendantOutput) -> Command {
+    fn descendant_spawner_command(plan: HelperPlan) -> Command {
         let mut command = Command::new(current_test_binary());
         command
             .args([
@@ -658,22 +674,30 @@ mod tests {
                 "--format",
                 "terse",
             ])
-            .env(HELPER_MODE_ENV, output.as_str());
+            .env(HELPER_MODE_ENV, plan.as_str());
         command
     }
 
     #[cfg(unix)]
-    fn descendant_spawner_command(output: DescendantOutput) -> Command {
-        let detach = match output {
-            DescendantOutput::Inherited => "",
-            DescendantOutput::Detached => "exec </dev/null >/dev/null 2>&1;",
+    fn descendant_spawner_command(plan: HelperPlan) -> Command {
+        let script = match plan {
+            HelperPlan::Solo => {
+                format!("printf '{READY_SOLO_RECORD}'; printf '{READY_SOLO_RECORD}' >&2",)
+            }
+            HelperPlan::Inherited | HelperPlan::Detached => {
+                let detach = match plan {
+                    HelperPlan::Detached => "exec </dev/null >/dev/null 2>&1;",
+                    _ => "",
+                };
+                format!(
+                    "sh -c '{detach} while :; do :; done' descendant & \
+                     printf '{READY_RECORD_PREFIX}%s' \"$!\"; \
+                     printf '{READY_RECORD_PREFIX}%s' \"$!\" >&2",
+                )
+            }
         };
         let mut command = Command::new("sh");
-        command.arg("-c").arg(format!(
-            "sh -c '{detach} while :; do :; done' descendant & \
-             printf '{READY_RECORD_PREFIX}%s' \"$!\"; \
-             printf '{READY_RECORD_PREFIX}%s' \"$!\" >&2",
-        ));
+        command.arg("-c").arg(script);
         command
     }
 
@@ -687,23 +711,28 @@ mod tests {
     fn descendant_spawner_helper_process() {
         let mode = std::env::var(HELPER_MODE_ENV)
             .unwrap_or_else(|error| panic!("{HELPER_MODE_ENV} must be set: {error}"));
-        let output = DescendantOutput::parse(&mode)
-            .unwrap_or_else(|| panic!("unknown descendant output mode {mode:?}"));
+        let plan =
+            HelperPlan::parse(&mode).unwrap_or_else(|| panic!("unknown helper plan {mode:?}"));
 
-        let mut descendant = hanging_command();
-        descendant.stdin(Stdio::null());
-        if output == DescendantOutput::Detached {
-            descendant.stdout(Stdio::null()).stderr(Stdio::null());
-        }
-        let child = descendant
-            .spawn()
-            .unwrap_or_else(|error| panic!("spawn the descendant: {error}"));
+        let record = match plan {
+            HelperPlan::Solo => READY_SOLO_RECORD.to_owned(),
+            HelperPlan::Inherited | HelperPlan::Detached => {
+                let mut descendant = hanging_command();
+                descendant.stdin(Stdio::null());
+                if plan == HelperPlan::Detached {
+                    descendant.stdout(Stdio::null()).stderr(Stdio::null());
+                }
+                let child = descendant
+                    .spawn()
+                    .unwrap_or_else(|error| panic!("spawn the descendant: {error}"));
+                ready_record(child.id())
+            }
+        };
 
         // The pid travels in the output the bounded run already captures, so
         // there is no second channel and no path to control. libtest prefixes
         // this process's stdout with its own report, so the record goes to both:
         // stderr carries this child's bytes alone.
-        let record = ready_record(child.id());
         std::io::stdout()
             .write_all(record.as_bytes())
             .expect("report readiness on stdout");
@@ -714,11 +743,18 @@ mod tests {
     }
 
     #[test]
-    fn the_descendant_output_mode_survives_the_round_trip_to_the_helper() {
-        for mode in [DescendantOutput::Inherited, DescendantOutput::Detached] {
-            assert_eq!(DescendantOutput::parse(mode.as_str()), Some(mode));
+    fn the_helper_plan_survives_the_round_trip_to_the_helper() {
+        for plan in [
+            HelperPlan::Inherited,
+            HelperPlan::Detached,
+            HelperPlan::Solo,
+        ] {
+            assert_eq!(HelperPlan::parse(plan.as_str()), Some(plan));
         }
-        assert_eq!(DescendantOutput::parse("hidden"), None);
+        assert_eq!(HelperPlan::parse("hidden"), None);
+        // The control's record must not read as a descendant's, or a run that
+        // spawned nothing could report a pid.
+        assert!(descendant_pid_from(READY_SOLO_RECORD).is_err());
     }
 
     #[test]
@@ -886,7 +922,7 @@ mod tests {
         let started = Instant::now();
 
         let worker = thread::spawn(move || {
-            let command = descendant_spawner_command(DescendantOutput::Inherited);
+            let command = descendant_spawner_command(HelperPlan::Inherited);
             let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
             let result = run_bounded(command, b"", limits, "inherited output mutation");
             let _ = result_tx.send(result);
@@ -941,7 +977,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn kills_quiet_descendant_after_normal_parent_exit() {
-        let command = descendant_spawner_command(DescendantOutput::Detached);
+        let command = descendant_spawner_command(HelperPlan::Detached);
         let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
 
         let output = run_bounded(command, b"", limits, "normal completion mutation")
@@ -980,7 +1016,7 @@ mod tests {
         let (result_tx, result_rx) = mpsc::channel();
 
         let worker = thread::spawn(move || {
-            let command = descendant_spawner_command(DescendantOutput::Detached);
+            let command = descendant_spawner_command(HelperPlan::Detached);
             let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
             let _ = result_tx.send(run_bounded(
                 command,
@@ -1019,6 +1055,66 @@ mod tests {
         );
     }
 
+    /// The control for the test above, and the reason the claim beside it is a
+    /// measurement rather than an inference.
+    ///
+    /// Everything is held fixed -- same binary, same re-execution, same limits,
+    /// same bound, same guard -- and one thing varies: the bounded child spawns
+    /// no descendant. The claim under test is that a descendant holds the run's
+    /// inherited stdout and stderr write handles, so the readers never see EOF.
+    /// That claim predicts the two arms disagree:
+    ///
+    /// - control succeeds and the descendant arm hits the deadline with both
+    ///   handles outstanding: the descendant is the holder, and nothing else in
+    ///   the run keeps the handles open;
+    /// - both arms hit the deadline: the holder is not the descendant, and the
+    ///   claim is refuted -- whatever retains the write end does so with no
+    ///   descendant in existence;
+    /// - both arms succeed: the descendant does release the handles, so the
+    ///   deadline seen in job 93527135001 was raced rather than structural. The
+    ///   descendant arm above fails first in that case, which is how it is the
+    ///   tripwire.
+    ///
+    /// The control is not cfg-split, because the prediction is the same on both
+    /// platforms and a control that only runs where it is expected to pass tests
+    /// nothing.
+    #[test]
+    fn the_same_child_reaches_eof_when_it_spawns_no_descendant() {
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let worker = thread::spawn(move || {
+            let command = descendant_spawner_command(HelperPlan::Solo);
+            let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
+            let _ = result_tx.send(run_bounded(command, b"", limits, "no descendant control"));
+        });
+
+        let result = match result_rx.recv_timeout(descendant_test_guard()) {
+            Ok(result) => result,
+            Err(error) => panic!("runner escaped its wall-clock bound: {error}"),
+        };
+        worker.join().expect("bounded runner worker");
+
+        let output = result.unwrap_or_else(|error| {
+            panic!(
+                "a child that spawned nothing must reach EOF; that it did not refutes the \
+                 inherited-handle account of #2249, since no descendant existed to hold the \
+                 run's handles: {error}"
+            )
+        });
+
+        assert!(output.status.success(), "{:?}", output.status);
+        let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is the child's text");
+        assert_eq!(
+            stderr, READY_SOLO_RECORD,
+            "the control must be the same child, reporting"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(READY_SOLO_RECORD),
+            "stdout must carry the same record: {stdout:?}"
+        );
+    }
+
     /// On Windows the descendant tests use this re-execution as their bounded
     /// child, so it is covered there. Here it is the only exercise of it, since
     /// the Unix spawner is a shell -- and it separates "the helper is broken"
@@ -1036,7 +1132,7 @@ mod tests {
                 "--format",
                 "terse",
             ])
-            .env(HELPER_MODE_ENV, DescendantOutput::Detached.as_str());
+            .env(HELPER_MODE_ENV, HelperPlan::Detached.as_str());
         let limits = ProcessLimits::new(descendant_test_guard(), 1024, 1024);
 
         let output = run_bounded(command, b"", limits, "helper re-execution")

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -496,7 +496,7 @@ mod tests {
     #[cfg(unix)]
     use super::{process_tree_absent, process_tree_quiescent_after_io};
     use std::io::Write;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::process::{Command, Stdio};
     use std::sync::mpsc;
     use std::thread;
@@ -540,15 +540,73 @@ mod tests {
     /// Selected on the bounded child so this test binary, re-executed, acts as
     /// the descendant spawner instead of running the suite.
     const HELPER_MODE_ENV: &str = "ASSAY_BOUNDED_PROCESS_HELPER_MODE";
-    const PID_FILE_ENV: &str = "ASSAY_DESCENDANT_PID_FILE";
     /// libtest filter that selects the helper in every binary including this
     /// module, whatever module path it is included under. A filter that matched
     /// nothing would exit 0 silently, so
     /// `the_re_executed_helper_is_selected_by_exactly_one_filter_match` pins it.
     const HELPER_FILTER: &str = "descendant_spawner_helper_process";
-    /// Written to both channels by every spawner, so the bounded run can assert
-    /// one channel verbatim and find the marker on the other.
-    const READY_MARKER: &[u8] = b"parent-ready";
+    /// Readiness and the descendant's pid travel as one record on both output
+    /// channels, so the bounded run can assert one verbatim and find it in the
+    /// other.
+    ///
+    /// This used to be a bare marker beside a pid file whose path came from the
+    /// environment, which put an environment-controlled path in front of a write
+    /// -- the sink CodeQL flagged on 870a02c9. Sanitising that path would narrow
+    /// the sink; carrying the pid in output removes it, and it removes a second
+    /// control channel with rules of its own: the pid now arrives through the
+    /// same bounded capture the harness under test already governs.
+    const READY_RECORD_PREFIX: &str = "READY pid=";
+    /// `u32::MAX` is ten digits, so anything longer is not a pid.
+    const MAX_PID_DIGITS: usize = 10;
+
+    fn ready_record(pid: u32) -> String {
+        format!("{READY_RECORD_PREFIX}{pid}")
+    }
+
+    /// Reads the descendant's pid out of a bounded run's captured record.
+    ///
+    /// The text is a child's output, or a diagnostic quoting it, so it is
+    /// untrusted and this rejects rather than scans. Only digits may follow the
+    /// prefix and they must be a non-zero `u32`; every record present must name
+    /// the same pid; and no record at all is an error.
+    /// A pid read out of noise would otherwise turn every descendant assertion
+    /// into a claim about a process nobody spawned.
+    ///
+    /// One record appears more than once by construction: the child writes it to
+    /// both channels and the diagnostic quotes both. Identical repetitions are
+    /// therefore admitted, while a disagreement is not, since two pids cannot say
+    /// which descendant the claim is about.
+    fn descendant_pid_from(record: &str) -> Result<u32, String> {
+        let mut seen: Option<u32> = None;
+        for (start, _) in record.match_indices(READY_RECORD_PREFIX) {
+            // Eleven digits is enough to decide: every eleven-digit run
+            // overflows `u32` and is rejected below, so bounding the scan here
+            // cannot truncate a longer run into a valid-looking pid.
+            let digits: String = record[start + READY_RECORD_PREFIX.len()..]
+                .chars()
+                .take(MAX_PID_DIGITS + 1)
+                .take_while(char::is_ascii_digit)
+                .collect();
+            if digits.is_empty() {
+                // The quoted command line carries the prefix with no pid behind
+                // it. That is not a record, and not a malformed one either.
+                continue;
+            }
+            let pid = match digits.parse::<u32>() {
+                Ok(0) | Err(_) => {
+                    return Err(format!("readiness record has no usable pid: {record:?}"));
+                }
+                Ok(pid) => pid,
+            };
+            match seen {
+                Some(first) if first != pid => {
+                    return Err(format!("readiness records disagree: {first} and {pid}"));
+                }
+                _ => seen = Some(pid),
+            }
+        }
+        seen.ok_or_else(|| format!("no readiness record: {record:?}"))
+    }
 
     /// What the descendant does with the bounded run's output handles.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -590,7 +648,7 @@ mod tests {
     /// interpreter startup rather than process-tree teardown decided the
     /// result. Unix keeps its shell, whose startup is a fraction of that bound.
     #[cfg(windows)]
-    fn descendant_spawner_command(pid_file: &Path, output: DescendantOutput) -> Command {
+    fn descendant_spawner_command(output: DescendantOutput) -> Command {
         let mut command = Command::new(current_test_binary());
         command
             .args([
@@ -600,26 +658,22 @@ mod tests {
                 "--format",
                 "terse",
             ])
-            .env(HELPER_MODE_ENV, output.as_str())
-            .env(PID_FILE_ENV, pid_file);
+            .env(HELPER_MODE_ENV, output.as_str());
         command
     }
 
     #[cfg(unix)]
-    fn descendant_spawner_command(pid_file: &Path, output: DescendantOutput) -> Command {
+    fn descendant_spawner_command(output: DescendantOutput) -> Command {
         let detach = match output {
             DescendantOutput::Inherited => "",
             DescendantOutput::Detached => "exec </dev/null >/dev/null 2>&1;",
         };
         let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg(format!(
-                "sh -c 'echo \"$$\" > \"$1\"; {detach} while :; do :; done' descendant \"$1\" & \
-                 while [ ! -s \"$1\" ]; do :; done; printf parent-ready; printf parent-ready >&2",
-            ))
-            .arg("runner")
-            .arg(pid_file);
+        command.arg("-c").arg(format!(
+            "sh -c '{detach} while :; do :; done' descendant & \
+             printf '{READY_RECORD_PREFIX}%s' \"$!\"; \
+             printf '{READY_RECORD_PREFIX}%s' \"$!\" >&2",
+        ));
         command
     }
 
@@ -635,9 +689,6 @@ mod tests {
             .unwrap_or_else(|error| panic!("{HELPER_MODE_ENV} must be set: {error}"));
         let output = DescendantOutput::parse(&mode)
             .unwrap_or_else(|| panic!("unknown descendant output mode {mode:?}"));
-        let pid_file = PathBuf::from(
-            std::env::var_os(PID_FILE_ENV).unwrap_or_else(|| panic!("{PID_FILE_ENV} must be set")),
-        );
 
         let mut descendant = hanging_command();
         descendant.stdin(Stdio::null());
@@ -647,17 +698,18 @@ mod tests {
         let child = descendant
             .spawn()
             .unwrap_or_else(|error| panic!("spawn the descendant: {error}"));
-        std::fs::write(&pid_file, child.id().to_string())
-            .unwrap_or_else(|error| panic!("publish the descendant pid: {error}"));
 
-        // libtest prefixes this process's stdout with its own report, so the
-        // marker goes to both channels: stderr carries the child's bytes alone.
+        // The pid travels in the output the bounded run already captures, so
+        // there is no second channel and no path to control. libtest prefixes
+        // this process's stdout with its own report, so the record goes to both:
+        // stderr carries this child's bytes alone.
+        let record = ready_record(child.id());
         std::io::stdout()
-            .write_all(READY_MARKER)
+            .write_all(record.as_bytes())
             .expect("report readiness on stdout");
         std::io::stdout().flush().expect("flush readiness");
         std::io::stderr()
-            .write_all(READY_MARKER)
+            .write_all(record.as_bytes())
             .expect("report readiness on stderr");
     }
 
@@ -705,19 +757,6 @@ mod tests {
         let mut command = Command::new("cmd");
         command.args(["/C", "exit", "/B", "23"]);
         command
-    }
-
-    fn read_descendant_pid(pid_file: &Path) -> Option<u32> {
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while Instant::now() < deadline {
-            if let Ok(raw) = std::fs::read_to_string(pid_file) {
-                if let Ok(pid) = raw.trim().parse() {
-                    return Some(pid);
-                }
-            }
-            thread::sleep(Duration::from_millis(10));
-        }
-        None
     }
 
     /// A probe that cannot run is not an answer, so a spawn failure panics
@@ -843,14 +882,11 @@ mod tests {
 
     #[test]
     fn kills_descendant_that_holds_inherited_output_open() {
-        let temp = tempfile::tempdir().expect("temporary pid directory");
-        let pid_file = temp.path().join("descendant.pid");
-        let cleanup_path = pid_file.clone();
         let (result_tx, result_rx) = mpsc::channel();
         let started = Instant::now();
 
         let worker = thread::spawn(move || {
-            let command = descendant_spawner_command(&pid_file, DescendantOutput::Inherited);
+            let command = descendant_spawner_command(DescendantOutput::Inherited);
             let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
             let result = run_bounded(command, b"", limits, "inherited output mutation");
             let _ = result_tx.send(result);
@@ -876,8 +912,10 @@ mod tests {
             started.elapsed() < descendant_test_guard(),
             "process-tree cleanup exceeded the test bound"
         );
-        let descendant_pid = read_descendant_pid(&cleanup_path)
-            .expect("descendant must publish its pid before inheriting output");
+        // The diagnostic quotes the bounded output, so the pid the child
+        // published arrives on the error path through the same capture.
+        let descendant_pid = descendant_pid_from(&error)
+            .unwrap_or_else(|reason| panic!("descendant pid unreadable: {reason}"));
         if !wait_for_descendant_exit(descendant_pid) {
             panic!("descendant {descendant_pid} survived process-tree termination");
         }
@@ -903,9 +941,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn kills_quiet_descendant_after_normal_parent_exit() {
-        let temp = tempfile::tempdir().expect("temporary pid directory");
-        let pid_file = temp.path().join("quiet-descendant.pid");
-        let command = descendant_spawner_command(&pid_file, DescendantOutput::Detached);
+        let command = descendant_spawner_command(DescendantOutput::Detached);
         let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
 
         let output = run_bounded(command, b"", limits, "normal completion mutation")
@@ -914,17 +950,16 @@ mod tests {
         assert!(output.status.success());
         // Both channels go through one reader, so stderr proves the bytes are
         // returned verbatim while stdout may carry a test harness's own report.
-        assert_eq!(output.stderr, READY_MARKER);
-        assert!(
-            output
-                .stdout
-                .windows(READY_MARKER.len())
-                .any(|w| w == READY_MARKER),
-            "stdout must carry the child's readiness marker: {:?}",
-            String::from_utf8_lossy(&output.stdout)
+        let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is the child's text");
+        let descendant_pid = descendant_pid_from(&stderr)
+            .unwrap_or_else(|reason| panic!("quiet descendant pid unreadable: {reason}"));
+        assert_eq!(stderr, ready_record(descendant_pid));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            descendant_pid_from(&stdout).ok(),
+            Some(descendant_pid),
+            "stdout must carry the same readiness record: {stdout:?}"
         );
-        let descendant_pid =
-            read_descendant_pid(&pid_file).expect("quiet descendant must publish its pid");
         assert!(
             wait_for_descendant_exit(descendant_pid),
             "quiet descendant {descendant_pid} survived normal completion cleanup"
@@ -942,13 +977,10 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn a_descendant_that_asks_for_no_output_still_holds_the_run_open_and_is_killed() {
-        let temp = tempfile::tempdir().expect("temporary pid directory");
-        let pid_file = temp.path().join("quiet-descendant.pid");
-        let cleanup_path = pid_file.clone();
         let (result_tx, result_rx) = mpsc::channel();
 
         let worker = thread::spawn(move || {
-            let command = descendant_spawner_command(&pid_file, DescendantOutput::Detached);
+            let command = descendant_spawner_command(DescendantOutput::Detached);
             let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
             let _ = result_tx.send(run_bounded(
                 command,
@@ -976,12 +1008,11 @@ mod tests {
         assert!(!error.contains("child still running"), "{error}");
         assert!(error.contains("stdout handle still open"), "{error}");
         assert!(error.contains("stderr handle still open"), "{error}");
-        // Readiness still has to be observable on the error path, or a child
-        // that never ran would read the same as one that ran and was outlived.
-        let marker = std::str::from_utf8(READY_MARKER).expect("marker is text");
-        assert!(error.contains(marker), "{error}");
-        let descendant_pid = read_descendant_pid(&cleanup_path)
-            .expect("quiet descendant must publish its pid before the deadline");
+        // Readiness has to be observable on the error path, or a child that
+        // never ran would read the same as one that ran and was outlived. The
+        // pid it published is what makes the teardown claim below checkable.
+        let descendant_pid = descendant_pid_from(&error)
+            .unwrap_or_else(|reason| panic!("quiet descendant pid unreadable: {reason}"));
         assert!(
             wait_for_descendant_exit(descendant_pid),
             "quiet descendant {descendant_pid} survived process-tree termination"
@@ -996,8 +1027,6 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn the_re_executed_helper_publishes_a_pid_and_reports_readiness() {
-        let temp = tempfile::tempdir().expect("temporary pid directory");
-        let pid_file = temp.path().join("helper-descendant.pid");
         let mut command = Command::new(current_test_binary());
         command
             .args([
@@ -1007,21 +1036,66 @@ mod tests {
                 "--format",
                 "terse",
             ])
-            .env(HELPER_MODE_ENV, DescendantOutput::Detached.as_str())
-            .env(PID_FILE_ENV, &pid_file);
+            .env(HELPER_MODE_ENV, DescendantOutput::Detached.as_str());
         let limits = ProcessLimits::new(descendant_test_guard(), 1024, 1024);
 
         let output = run_bounded(command, b"", limits, "helper re-execution")
             .expect("the re-executed helper must complete within the test guard");
 
         assert!(output.status.success(), "{:?}", output.status);
-        assert_eq!(output.stderr, READY_MARKER);
-        let descendant_pid = read_descendant_pid(&pid_file)
-            .expect("the re-executed helper must publish its descendant's pid");
+        let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is the child's text");
+        let descendant_pid = descendant_pid_from(&stderr)
+            .unwrap_or_else(|reason| panic!("helper pid unreadable: {reason}"));
+        assert_eq!(stderr, ready_record(descendant_pid));
         assert!(
             wait_for_descendant_exit(descendant_pid),
             "descendant {descendant_pid} of the re-executed helper survived cleanup"
         );
+    }
+
+    /// The pid arrives inside untrusted child output, and every descendant
+    /// assertion is only as good as this parse: a pid read from noise would make
+    /// those assertions pass against a process nobody spawned. So the shape is
+    /// exact and everything else is an error, never a skip.
+    #[test]
+    fn only_one_exactly_shaped_readiness_record_yields_a_pid() {
+        assert_eq!(descendant_pid_from("READY pid=4294967295"), Ok(u32::MAX));
+        assert_eq!(
+            descendant_pid_from("\nrunning 1 test\nREADY pid=1234.\ntest result: ok.\n"),
+            Ok(1234),
+            "libtest's own report surrounds the record and must not hide it"
+        );
+        // The shape a failing bounded run actually produces: the prefix appears
+        // in the quoted command line with no pid, and the record itself twice.
+        assert_eq!(
+            descendant_pid_from(
+                "sh -c printf 'READY pid=%s'\": deadline expired; \
+                 stdout=\"READY pid=77\" (12 bytes); stderr=\"READY pid=77\" (12 bytes)"
+            ),
+            Ok(77),
+            "one pid written to both channels and quoted back must still read"
+        );
+
+        for rejected in [
+            "",
+            "READY pid=",
+            "READY pid=x",
+            "READY pid=-1",
+            // Zero is not a process this test could wait on.
+            "READY pid=0",
+            // One past u32::MAX, and one digit too long to be a pid at all.
+            "READY pid=4294967296",
+            "READY pid=42949672960",
+            // Two different pids cannot say which descendant the claim is about.
+            "READY pid=1 READY pid=2",
+            "READY pid=1 READY pid=1 READY pid=3",
+            "parent-ready",
+        ] {
+            assert!(
+                descendant_pid_from(rejected).is_err(),
+                "{rejected:?} must not yield a pid"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Does not close #2249 yet.** The closing keyword is deliberately absent: this branch may not be shown to fix an intermittent defect until rate evidence at *this* head says so. See "What is still unproven".

Bound to head **`5ca462fc18e108035b6e61262f721e5dc60f5420`** (branch `cursor/fix-2249-bounded-process-windows`, base `main` at `bc07ffb0e`). Earlier evidence in this body referred to `870a02c9` and has been removed: that head's Windows contract and its control channel are both gone.

## What this branch now contains

**1. The harness says which ending it reached.** `deadline of 5s expired` and `status=exit code: 1` were both printed for one run and the pairing was meaningless: `process_wrap`'s Windows `start_kill` is `TerminateJobObject(job, 1)`, so `exit code: 1` was the harness's own kill code rendered exactly like a child's choice. The deadline text now names what it was still waiting for — `outstanding=[child still running]` versus `outstanding=[stdout handle still open, stderr handle still open]` — and a status reaped after termination is labelled as such instead of as `(child exit)`.

**2. PowerShell startup is out of the bounded window.** On Windows the bounded child is this test binary re-executed in a helper mode. One `powershell.exe` start was observed at ~18s inside a 5s bound (run 31404812176), so interpreter startup, not process-tree teardown, was deciding the result.

**3. The descendant pid no longer travels through a path from the environment.** CodeQL's high on `870a02c9` and `8b232621` was a real sink: the helper read `PID_FILE_ENV` into a `PathBuf` and wrote to it. Sanitising the path would narrow the sink; removing the channel removes it. The pid is now one `READY pid=<u32>` record on both captured channels, parsed strictly — digits only, non-zero `u32`, and every record present must agree. Identical repetition is admitted because the record goes to both channels and the diagnostic quotes both; a disagreement is an error, since two pids cannot say which descendant a teardown claim is about.

**4. Each platform asserts the ending it can reach.** Job 93527135001 showed a `Stdio::null()` descendant keeping the run's handles open after the child exited 0 with all of its bytes read. On Windows `CreateProcess` runs with `bInheritHandles = TRUE` and an inherited handle stays inheritable, so every process the bounded child spawns holds the run's stdout and stderr. A live descendant plus a successful bounded run is therefore reachable on Unix and not on Windows. Unix keeps `kills_quiet_descendant_after_normal_parent_exit`; Windows asserts the deadline ending with the descendant still killed, and **fails if the inheritance ever stops**, which is the signal to make the test cross-platform again.

## Evidence

GREEN, macOS `darwin 25.6.0`, cargo/clippy 1.96.0, head `5ca462fc1`, worktree `/tmp/assay-2249`:

- `cargo test -p assay-mcp-server --test agent_golden_path_contract bounded_process` — 14 passed, 1 ignored (the re-executed helper);
- `cargo clippy -p assay-mcp-server --tests -- -D warnings`, `cargo fmt --all -- --check`, pre-commit and pre-push hooks: pass.

The new assertions were checked against mutations rather than assumed to bite: dropping the diagnostic's `outstanding=` detail, and reverting the pid parser to a best-effort scan, each fail the tests that guard them. The parser's table caught the diagnostic's repeated record before Windows could, and showed an explicit digit-length check to be redundant with the overflow check.

## What is still unproven

- **Windows at this head.** No Windows evidence is bound to `5ca462fc1` yet. #2249 is intermittent, so one green run would not settle it; the rate instrument in #2253 is being used instead, and its numbers will be reported here with the exact head they were taken on.
- **Which process holds the open handles.** The claim that the *descendant* holds them is inferred from the child having exited with its output fully read and only that descendant alive. The decisive control — the same helper spawning no descendant at all, which should then reach EOF — has not been run on Windows.
- Review quorum: unsatisfied. No non-building review exists on this head.