### PR TITLE
ci(proof): measure a Windows flake rate instead of asserting one

### DIFF
--- a/.github/workflows/windows-flake-rate-proof.yml
+++ b/.github/workflows/windows-flake-rate-proof.yml
@@ -42,6 +42,11 @@ on:
         required: true
         default: "20"
         type: string
+      iteration_ceiling_s:
+        description: "Per-iteration ceiling in seconds; a breach is recorded as data"
+        required: true
+        default: "300"
+        type: string
       load:
         description: "Concurrent load arm(s) to measure"
         required: true
@@ -54,8 +59,12 @@ on:
   # Bootstrap lane. `workflow_dispatch` resolves the workflow from the default
   # branch, so an unmerged instrument cannot be dispatched — and measuring an
   # unmerged fix is the whole purpose. Pushing to this reserved namespace runs
-  # the definition from that branch. The namespace carries no pull request, so
-  # this can never attach a check to one, and it never matches `main`.
+  # the definition from that branch, and it never matches `main`.
+  #
+  # By convention no pull request is opened from this namespace, which is why a
+  # push here does not put a check on one. That is a convention and not a
+  # guarantee: open a PR from such a branch and its push-triggered checks would
+  # appear on it like any other.
   push:
     branches:
       - "proof/windows-flake-rate/**"
@@ -84,6 +93,14 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      # Run the instrument's own behavioural self-test on the host that will
+      # take the measurement, before it takes it. A broken classifier reports a
+      # confident rate for something else.
+      - name: Self-test the instrument
+        shell: bash
+        working-directory: scripts/ci
+        run: python3 windows_flake_rate_proof_selftest.py
+
       - name: Measure
         shell: bash
         env:
@@ -93,6 +110,7 @@ jobs:
           PROOF_TEST_TARGET: ${{ inputs.test_target || 'agent_golden_path_contract' }}
           PROOF_FILTER: ${{ inputs.filter || 'bounded_process' }}
           PROOF_ITERATIONS: ${{ inputs.iterations || '20' }}
+          PROOF_ITERATION_CEILING_S: ${{ inputs.iteration_ceiling_s || '300' }}
           PROOF_REF_INPUT: ${{ inputs.ref || github.ref }}
         run: |
           set -euo pipefail
@@ -104,6 +122,7 @@ jobs:
             --test-target "$PROOF_TEST_TARGET" \
             --filter "$PROOF_FILTER" \
             --iterations "$PROOF_ITERATIONS" \
+            --iteration-ceiling-s "$PROOF_ITERATION_CEILING_S" \
             --load "${{ matrix.load }}" \
             --out "proof-out/windows-flake-rate-${{ matrix.load }}.json"
 
@@ -129,9 +148,14 @@ jobs:
           print(f"- runner image: {runner['image_os']} {runner['image_version']}")
           print(f"- toolchain: {proof['toolchain']['rustc']}")
           print(f"- failed runs: {summary['failed_runs']} / {summary['measured']} measured"
-                f" (rate {summary['failure_rate']})")
+                f" (observed rate {summary['observed_failure_rate']}, not a causal claim)")
+          print(f"- reuse rule: {manifest['reuse_rule']}")
+          if summary["timed_out"]:
+              print(f"- iterations that breached the ceiling: {summary['timed_out']}")
           if summary["could_not_measure"]:
               print(f"- iterations that measured nothing: {summary['could_not_measure']}")
+          if summary["load_gaps"]:
+              print(f"- iterations that lost their load: {summary['load_gaps']}")
           for name, count in sorted(summary["failures_by_test"].items()):
               print(f"  - {name}: {count}")
           EOF

--- a/.github/workflows/windows-flake-rate-proof.yml
+++ b/.github/workflows/windows-flake-rate-proof.yml
@@ -1,0 +1,146 @@
+# Windows flake-rate proof producer.
+#
+# Contract: docs/reference/ci/windows-flake-rate-proof.md. An instrument, not a
+# gate. It mirrors host-capability-proof.yml: dispatch-only, produces a measurement
+# on a host the developer cannot reach, and uploads an artifact that *is* the proof.
+#
+# It makes no pass/fail claim about any change. A red required check is never
+# discharged by a green proof here, and this workflow is deliberately absent from
+# the `CI` rollup and from every required context.
+#
+# Why a rate and not an outcome: one green run cannot separate "fixed" from "won
+# the race this time", so every iteration is recorded and the artifact reports the
+# rate behind them. The `load` arms make the load hypothesis directly testable —
+# the same SHA measured alone and under the concurrency a full `cargo test`
+# produces — rather than inferred from which branches happen to be red.
+name: windows-flake-rate-proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Ref or SHA whose tree is measured"
+        required: true
+        type: string
+      package:
+        description: "cargo package (-p)"
+        required: true
+        default: assay-mcp-server
+        type: string
+      test_target:
+        description: "Integration test target (--test)"
+        required: true
+        default: agent_golden_path_contract
+        type: string
+      filter:
+        description: "libtest name filter"
+        required: false
+        default: bounded_process
+        type: string
+      iterations:
+        description: "How many times to run the selection"
+        required: true
+        default: "20"
+        type: string
+      load:
+        description: "Concurrent load arm(s) to measure"
+        required: true
+        default: both
+        type: choice
+        options:
+          - none
+          - workspace-tests
+          - both
+  # Bootstrap lane. `workflow_dispatch` resolves the workflow from the default
+  # branch, so an unmerged instrument cannot be dispatched — and measuring an
+  # unmerged fix is the whole purpose. Pushing to this reserved namespace runs
+  # the definition from that branch. The namespace carries no pull request, so
+  # this can never attach a check to one, and it never matches `main`.
+  push:
+    branches:
+      - "proof/windows-flake-rate/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize arms so a load arm never becomes another arm's ambient load.
+  group: windows-flake-rate-proof
+  cancel-in-progress: false
+
+jobs:
+  arms:
+    name: "Measure (load=${{ matrix.load }})"
+    runs-on: windows-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        load: ${{ (github.event_name == 'push' || inputs.load == 'both') && fromJSON('["none","workspace-tests"]') || fromJSON(format('["{0}"]', inputs.load)) }}
+    steps:
+      - name: Checkout the tree under measurement
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Measure
+        shell: bash
+        env:
+          # A push-triggered bootstrap run has no inputs, so the defaults live
+          # here once and both triggers read them from this one place.
+          PROOF_PACKAGE: ${{ inputs.package || 'assay-mcp-server' }}
+          PROOF_TEST_TARGET: ${{ inputs.test_target || 'agent_golden_path_contract' }}
+          PROOF_FILTER: ${{ inputs.filter || 'bounded_process' }}
+          PROOF_ITERATIONS: ${{ inputs.iterations || '20' }}
+          PROOF_REF_INPUT: ${{ inputs.ref || github.ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p proof-out
+          python3 scripts/ci/windows_flake_rate_proof.py \
+            --ref-input "$PROOF_REF_INPUT" \
+            --workflow-path ".github/workflows/windows-flake-rate-proof.yml" \
+            --package "$PROOF_PACKAGE" \
+            --test-target "$PROOF_TEST_TARGET" \
+            --filter "$PROOF_FILTER" \
+            --iterations "$PROOF_ITERATIONS" \
+            --load "${{ matrix.load }}" \
+            --out "proof-out/windows-flake-rate-${{ matrix.load }}.json"
+
+      - name: Summarize
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          file="proof-out/windows-flake-rate-${{ matrix.load }}.json"
+          if [ ! -f "$file" ]; then
+            echo "- no proof produced for load=${{ matrix.load }}" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 - "$file" >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          import json, sys
+          proof = json.load(open(sys.argv[1], encoding="utf-8"))
+          manifest, runner, summary = proof["manifest"], proof["runner"], proof["summary"]
+          print(f"### load={proof['load']['mode']}")
+          print(f"- claim ceiling: `{manifest['claim_ceiling']}`")
+          print(f"- head_sha: `{manifest['head_sha']}`")
+          for path, digest in manifest["subject_digests"].items():
+              print(f"- `{path}` blob: `{digest.get('blob_oid','')}`")
+          print(f"- runner image: {runner['image_os']} {runner['image_version']}")
+          print(f"- toolchain: {proof['toolchain']['rustc']}")
+          print(f"- failed runs: {summary['failed_runs']} / {summary['measured']} measured"
+                f" (rate {summary['failure_rate']})")
+          if summary["could_not_measure"]:
+              print(f"- iterations that measured nothing: {summary['could_not_measure']}")
+          for name, count in sorted(summary["failures_by_test"].items()):
+              print(f"  - {name}: {count}")
+          EOF
+
+      - name: Upload proof artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-flake-rate-proof-${{ github.run_id }}-${{ matrix.load }}
+          path: proof-out/
+          if-no-files-found: error
+          retention-days: 90

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,17 @@ repos:
         # workflow checks out the PR base on purpose, so a PR never runs this
         # against its own tree.
 
+      - id: windows-flake-rate-proof-self-test
+        name: Windows flake-rate instrument self-test
+        entry: bash -c 'cd scripts/ci && python3 windows_flake_rate_proof_selftest.py'
+        language: system
+        pass_filenames: false
+        # The instrument decides which output is a pass, a failure, a timeout or
+        # no measurement at all, and fails closed on the last two. A silent
+        # inversion there reports a confident rate for something else, so the
+        # classifications are pinned rather than reviewed.
+        files: ^scripts/ci/windows_flake_rate_proof(_selftest)?\.py$
+
       - id: docs-generated-drift-self-test
         name: Generated-docs drift check self-test
         entry: bash -c 'bash scripts/ci/test-check-docs-generated-drift-safety.sh && bash scripts/ci/test-check-docs-generated-drift.sh'

--- a/docs/reference/ci/windows-flake-rate-proof.md
+++ b/docs/reference/ci/windows-flake-rate-proof.md
@@ -1,0 +1,107 @@
+# Windows Flake-Rate Proof Contract
+
+> Instrument, not a gate. It measures; it never decides.
+
+`.github/workflows/windows-flake-rate-proof.yml` runs one `cargo test` selection
+repeatedly on `windows-latest` and uploads a JSON artifact that records **every
+iteration**. It exists because a developer without a Windows host cannot answer a
+question about a *rate*, and because a single green run cannot separate a fixed
+test from one that won the race that time.
+
+It mirrors the delegated proof lane's shape — a manually started producer of a
+measurement the author cannot take locally, a manifest binding the numbers to an
+exact commit, digests over the subjects, content-addressed reuse, and a claim
+ceiling stated in the artifact — while making none of that lane's claims.
+
+## Claim ceiling
+
+The artifact states its own ceiling:
+
+```text
+hosted_windows_flake_rate_measurement_only_not_a_verdict
+```
+
+The delegated lane runs on a dedicated privileged host because eBPF load, cgroup
+placement and kernel-to-policy correspondence are unprovable anywhere else, and
+its pack is attested over OIDC. **This instrument has no such story and must not
+borrow its language.** It runs on the GitHub-hosted `windows-latest` image: there
+is no dedicated machine, no privileged-host claim, and no attestation. Its
+`non_claims` list says so in the artifact rather than leaving it to the reader.
+
+## Boundaries
+
+- Not in any required context, not in the `CI` rollup, and never a substitute for
+  a red required check. A proof that quietly discharges a required check is the
+  defect `AGENTS.md` forbids, wearing a better name.
+- A failing iteration is the datum, so the job exits 0. Two things are failures.
+  A subject that will not build exits 2. **An iteration that executed no test
+  exits 40** — a filter matching nothing, or a binary that never ran. This copies
+  the delegated lane's stance that an environment skip is a failure and not a
+  neutral outcome: a run that could not measure is not a run that measured zero
+  failures, which is the most likely way a failure-rate instrument lies quietly.
+- It proves nothing about macOS, Linux, or any host other than the
+  GitHub-hosted image version named in the artifact.
+
+## What the artifact carries
+
+`schema: assay.windows-flake-rate-proof/v1`:
+
+- `manifest` — `claim_ceiling` and `non_claims`; `head_sha`, `repository`, `ref`,
+  `workflow_sha`, `workflow_path`, `run_id`, `run_attempt`, `run_url`; and
+  `worktree_clean`. The binding set is the delegated manifest's, minus its
+  attestation, so a number is addressable rather than asserted.
+- `manifest.subject_digests` — blob OID and SHA-256 for each file the rate is a
+  measurement *of*, and `manifest.instrument_digests` for the files that define
+  the measurement itself. A rate taken with a different instrument is a different
+  rate.
+- `runner.image_os` / `runner.image_version` — stated explicitly, because if a
+  failure turns out to be an image rollout, that field is what proves it.
+- `toolchain.rustc` / `toolchain.cargo`.
+- `load.mode` — `none` or `workspace-tests`. The second keeps a full
+  `cargo test --workspace` (the Windows CI selection) running alongside the
+  measured iterations, so the load hypothesis is testable by comparing two arms
+  at one SHA on one image instead of inferred from which branches were red.
+- `iterations[]` — per iteration: exit code, duration, pass/fail/ignore counts,
+  `could_not_measure`, the names of failing tests, and each panic's site and
+  first message line.
+- `summary.failure_rate` — failed runs over *measured* runs, with the indices of
+  any iteration that measured nothing listed beside it.
+
+## Content-addressed reuse
+
+A rate carries to a later head only when `manifest.subject_digests` blob OIDs,
+`manifest.instrument_digests`, `toolchain` and `runner.image_version` are
+identical; otherwise the number describes different content and a fresh run is
+required. Unlike the delegated lane, nothing enforces this — no verifier consumes
+this artifact — so it is a reading rule for whoever quotes the rate.
+
+## Running it
+
+Diagnostic discipline follows the delegated lane's: start as narrow as possible —
+one arm, few iterations, a tight filter — and run the full form (both arms, the
+full iteration count) on the definitive candidate commit.
+
+```bash
+gh workflow run windows-flake-rate-proof.yml \
+  -f ref=<sha> -f iterations=20 -f load=both \
+  -f package=assay-mcp-server -f test_target=agent_golden_path_contract \
+  -f filter=bounded_process
+```
+
+`workflow_dispatch` resolves the workflow from the default branch, so an
+instrument that has not landed cannot be dispatched — and measuring an unlanded
+fix is the point. Pushing to `proof/windows-flake-rate/**` runs the definition
+from that branch with the defaults. That namespace carries no pull request, so it
+can never attach a check to one, and it never matches `main`.
+
+Reading a proof back:
+
+```bash
+gh run download <run-id> --name windows-flake-rate-proof-<run-id>-none
+```
+
+## Reporting a rate
+
+Quote the rate with its iteration count, its `head_sha`, its subject blob OIDs,
+and its runner image version. A rate without those is not a measurement of
+anything addressable.

--- a/docs/reference/ci/windows-flake-rate-proof.md
+++ b/docs/reference/ci/windows-flake-rate-proof.md
@@ -10,8 +10,8 @@ test from one that won the race that time.
 
 It mirrors the delegated proof lane's shape — a manually started producer of a
 measurement the author cannot take locally, a manifest binding the numbers to an
-exact commit, digests over the subjects, content-addressed reuse, and a claim
-ceiling stated in the artifact — while making none of that lane's claims.
+exact commit, digests over the subjects, and a claim ceiling stated in the
+artifact — while making none of that lane's claims.
 
 ## Claim ceiling
 
@@ -28,52 +28,82 @@ borrow its language.** It runs on the GitHub-hosted `windows-latest` image: ther
 is no dedicated machine, no privileged-host claim, and no attestation. Its
 `non_claims` list says so in the artifact rather than leaving it to the reader.
 
+## Correlation is not causation
+
+Two arms at one commit produce two *observed* rates. That is evidence about a
+hypothesis, and it is not a causal measurement of load:
+
+- the samples are small, so the intervals around each rate overlap widely;
+- the arms run on two separate hosted machines, so machine and image scheduling
+  differences are confounded with the load difference;
+- the arms are not interleaved or randomised, so drift over the run is not
+  separated from the arm.
+
+Report both rates with their provenance and describe load as a hypothesis. To
+claim causation the design has to change: both arms on one runner, interleaved in
+randomised order, with a pre-registered iteration count and effect size, and at
+least one further manipulation of the suspected mechanism (parallelism, spawn
+concurrency) that moves the rate the way the hypothesis predicts.
+
 ## Boundaries
 
 - Not in any required context, not in the `CI` rollup, and never a substitute for
   a red required check. A proof that quietly discharges a required check is the
   defect `AGENTS.md` forbids, wearing a better name.
-- A failing iteration is the datum, so the job exits 0. Two things are failures.
-  A subject that will not build exits 2. **An iteration that executed no test
-  exits 40** — a filter matching nothing, or a binary that never ran. This copies
-  the delegated lane's stance that an environment skip is a failure and not a
-  neutral outcome: a run that could not measure is not a run that measured zero
-  failures, which is the most likely way a failure-rate instrument lies quietly.
+- A failing iteration is the datum, so the job exits 0. Three things are failures,
+  because each produces a number describing something other than what it claims:
+
+  | exit | meaning |
+  |---|---|
+  | `2` | the subject would not build |
+  | `40` | an iteration executed no test at all |
+  | `41` | a load arm lost its load, so an iteration labelled loaded was not |
+
+  `40` and `41` copy the delegated lane's stance that an environment skip is a
+  failure and not a neutral skip. A run that could not measure is not a run that
+  measured zero failures, and a green load arm that had no load reads as "no
+  defect" when it means "no load" — the quietest way a rate lies.
+- Each iteration has an explicit ceiling (`iteration_ceiling_s`, default 300s).
+  A breach is recorded as data, the process tree is killed, and the measurement
+  continues, so one hung iteration cannot consume the job and take the artifact
+  with it. One iteration has been observed at 462 seconds.
 - It proves nothing about macOS, Linux, or any host other than the
   GitHub-hosted image version named in the artifact.
 
 ## What the artifact carries
 
-`schema: assay.windows-flake-rate-proof/v1`:
+`schema: assay.windows-flake-rate-proof/v2`:
 
-- `manifest` — `claim_ceiling` and `non_claims`; `head_sha`, `repository`, `ref`,
-  `workflow_sha`, `workflow_path`, `run_id`, `run_attempt`, `run_url`; and
-  `worktree_clean`. The binding set is the delegated manifest's, minus its
-  attestation, so a number is addressable rather than asserted.
-- `manifest.subject_digests` — blob OID and SHA-256 for each file the rate is a
-  measurement *of*, and `manifest.instrument_digests` for the files that define
-  the measurement itself. A rate taken with a different instrument is a different
-  rate.
+- `manifest` — `claim_ceiling`, `non_claims` and `reuse_rule`; `head_sha`,
+  `repository`, `ref`, `workflow_sha`, `workflow_path`, `run_id`, `run_attempt`,
+  `run_url`; and `worktree_clean`. The binding set is the delegated manifest's,
+  minus its attestation, so a number is addressable rather than asserted.
+- `manifest.subject_digests` and `manifest.instrument_digests` — blob OID and
+  SHA-256, as provenance for the reader.
 - `runner.image_os` / `runner.image_version` — stated explicitly, because if a
   failure turns out to be an image rollout, that field is what proves it.
 - `toolchain.rustc` / `toolchain.cargo`.
 - `load.mode` — `none` or `workspace-tests`. The second keeps a full
   `cargo test --workspace` (the Windows CI selection) running alongside the
-  measured iterations, so the load hypothesis is testable by comparing two arms
-  at one SHA on one image instead of inferred from which branches were red.
+  measured iterations, supervised continuously and restarted as often as needed.
 - `iterations[]` — per iteration: exit code, duration, pass/fail/ignore counts,
-  `could_not_measure`, the names of failing tests, and each panic's site and
-  first message line.
-- `summary.failure_rate` — failed runs over *measured* runs, with the indices of
-  any iteration that measured nothing listed beside it.
+  `timed_out`, `could_not_measure`, `load.alive_fraction` and `load.gap`, the
+  names of failing tests, and each panic's site and first message line.
+- `summary.observed_failure_rate` — failed runs over *measured* runs, beside the
+  indices of any iteration that timed out, measured nothing, or lost its load.
 
-## Content-addressed reuse
+## Reuse
 
-A rate carries to a later head only when `manifest.subject_digests` blob OIDs,
-`manifest.instrument_digests`, `toolchain` and `runner.image_version` are
-identical; otherwise the number describes different content and a fresh run is
-required. Unlike the delegated lane, nothing enforces this — no verifier consumes
-this artifact — so it is a reading rule for whoever quotes the rate.
+A rate carries only to an **identical `head_sha`**, with identical
+`instrument_digests`, `toolchain` and `runner.image_version`.
+
+An earlier version of this document allowed carry when one test file's blob OID
+matched. That was wrong: the number also depends on the test target, the package
+and workspace manifests, the lockfile, and what cargo does with them, so a
+file-level rule could carry a rate across changed test code or a changed
+dependency. The subject closure is not something this instrument can honestly
+enumerate, so reuse is pinned to the commit instead. Nothing enforces it — no
+verifier consumes this artifact — so it binds whoever quotes the rate.
 
 ## Running it
 
@@ -83,7 +113,7 @@ full iteration count) on the definitive candidate commit.
 
 ```bash
 gh workflow run windows-flake-rate-proof.yml \
-  -f ref=<sha> -f iterations=20 -f load=both \
+  -f ref=<sha> -f iterations=20 -f load=both -f iteration_ceiling_s=300 \
   -f package=assay-mcp-server -f test_target=agent_golden_path_contract \
   -f filter=bounded_process
 ```
@@ -91,8 +121,9 @@ gh workflow run windows-flake-rate-proof.yml \
 `workflow_dispatch` resolves the workflow from the default branch, so an
 instrument that has not landed cannot be dispatched — and measuring an unlanded
 fix is the point. Pushing to `proof/windows-flake-rate/**` runs the definition
-from that branch with the defaults. That namespace carries no pull request, so it
-can never attach a check to one, and it never matches `main`.
+from that branch with the defaults, and never matches `main`. By convention no
+pull request is opened from that namespace, which is why a push there does not put
+a check on one; that is a convention, not a guarantee.
 
 Reading a proof back:
 
@@ -100,8 +131,16 @@ Reading a proof back:
 gh run download <run-id> --name windows-flake-rate-proof-<run-id>-none
 ```
 
+## Self-test
+
+`scripts/ci/windows_flake_rate_proof_selftest.py` pins the classifications a rate
+depends on — pass, failure, timeout, executed-nothing, the rate arithmetic, load
+absence, and the fail-closed verdict for each. A pre-commit hook runs it, and so
+does the workflow, on the host that is about to measure.
+
 ## Reporting a rate
 
-Quote the rate with its iteration count, its `head_sha`, its subject blob OIDs,
-and its runner image version. A rate without those is not a measurement of
-anything addressable.
+Quote the rate with its iteration count, its `head_sha`, its runner image version
+and its toolchain, and call it observed. A rate without those is not a
+measurement of anything addressable; a rate presented as a cause is not a
+measurement of anything the design supports.

--- a/docs/reference/ci/windows-flake-rate-proof.md
+++ b/docs/reference/ci/windows-flake-rate-proof.md
@@ -86,6 +86,10 @@ concurrency) that moves the rate the way the hypothesis predicts.
 - `load.mode` — `none` or `workspace-tests`. The second keeps a full
   `cargo test --workspace` (the Windows CI selection) running alongside the
   measured iterations, supervised continuously and restarted as often as needed.
+  Its selection is built before the first iteration (`load.prebuilt`), so the arm
+  reproduces test concurrency rather than a compile storm: run 31417348260
+  breached a 300s ceiling on iteration 2 and spent 243s on iteration 3 in both
+  trees it compared, which was the load arm's build and not either tree.
 - `iterations[]` — per iteration: exit code, duration, pass/fail/ignore counts,
   `timed_out`, `could_not_measure`, `load.alive_fraction` and `load.gap`, the
   names of failing tests, and each panic's site and first message line.

--- a/scripts/ci/windows_flake_rate_proof.py
+++ b/scripts/ci/windows_flake_rate_proof.py
@@ -374,6 +374,19 @@ def main(argv: list[str] | None = None) -> int:
         print("ERROR: the instrument could not build its subject", file=sys.stderr)
         return EXIT_INSTRUMENT_BROKEN
 
+    # Build the load arm's own selection before measuring, or the first minutes
+    # of the arm are a compile storm rather than the test concurrency the arm is
+    # supposed to reproduce. Measured on run 31417348260: iteration 2 breached a
+    # 300s ceiling and iteration 3 took 243s, in both the baseline and the
+    # candidate, which is the build starving the box and not either tree.
+    if load_command is not None:
+        prebuild = run([*load_command, "--no-run"])
+        if prebuild.returncode != 0:
+            sys.stderr.write(prebuild.stdout)
+            sys.stderr.write(prebuild.stderr)
+            print("ERROR: the instrument could not build its load arm", file=sys.stderr)
+            return EXIT_INSTRUMENT_BROKEN
+
     load = LoadSupervisor(load_command)
     load.start()
     iterations: list[dict] = []
@@ -412,7 +425,12 @@ def main(argv: list[str] | None = None) -> int:
             "command": measured,
             "iteration_ceiling_s": args.iteration_ceiling_s,
         },
-        "load": {"mode": args.load, "command": load_command, "starts": load.starts},
+        "load": {
+            "mode": args.load,
+            "command": load_command,
+            "starts": load.starts,
+            "prebuilt": load_command is not None,
+        },
         "iterations": iterations,
         "summary": summary,
     }

--- a/scripts/ci/windows_flake_rate_proof.py
+++ b/scripts/ci/windows_flake_rate_proof.py
@@ -2,20 +2,25 @@
 """Repeat one cargo test selection N times and record every iteration.
 
 A single pass cannot separate "fixed" from "won the race once", so this
-instrument reports a rate and the per-iteration record behind it.
+instrument reports two observed rates and the per-iteration record behind them.
+It supports or weakens a hypothesis; it does not establish causation, and its
+own wording must not pretend otherwise.
 
 It measures and never judges: a failing iteration is the datum, so the process
-still exits 0. Two things are failures instead. A subject that will not build
-exits 2. An iteration that executed no test -- a filter that matched nothing, a
-binary that never ran -- exits 40, mirroring the delegated lane where an
-environment skip is a failure rather than a neutral outcome. A run that could
-not measure is not a run that measured zero failures, and for a failure-rate
-instrument that is the most likely way to lie quietly.
+still exits 0. Three things are failures instead, because each one produces a
+number that describes something other than what it claims:
+
+- exit 2, the subject would not build;
+- exit 40, an iteration executed no test at all;
+- exit 41, a load arm lost its load, so an iteration labelled loaded was not.
+
+That last one matters most. If load can vanish without the run failing, a clean
+result means "no load" as readily as "no defect", and the instrument reports a
+confident measurement of nothing.
 
 The manifest binds the numbers to the head SHA, workflow SHA, repository, ref,
-run and attempt, and digests the files that define both subject and measurement,
-so a rate is addressable rather than asserted. It also states its own claim
-ceiling: see CLAIM_CEILING below.
+run and attempt, and digests the subject and the instrument. A rate carries only
+to the identical `head_sha`: see REUSE_RULE.
 """
 
 from __future__ import annotations
@@ -28,10 +33,11 @@ import platform
 import re
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
-SCHEMA = "assay.windows-flake-rate-proof/v1"
+SCHEMA = "assay.windows-flake-rate-proof/v2"
 
 # Deliberately narrow, in the shape of the delegated lane's ceiling but making
 # none of its claims. This instrument runs on a GitHub-hosted `windows-latest`
@@ -41,10 +47,17 @@ CLAIM_CEILING = "hosted_windows_flake_rate_measurement_only_not_a_verdict"
 NON_CLAIMS = [
     "not a gate: no required context consumes this artifact and no check is discharged by it",
     "no privileged, dedicated or attested host: GitHub-hosted windows-latest only",
-    "no claim that a measured selection is fixed, only the rate the recorded iterations produced",
-    "no claim about any image version, toolchain or SHA other than the ones recorded here",
+    "no causal claim: arms run on separate hosted machines and these sample sizes do not"
+    " separate a load effect from machine or scheduling variation",
+    "no claim that a measured selection is fixed, only the rates the recorded iterations produced",
+    "no claim about any head SHA, toolchain or image version other than the ones recorded here",
     "no claim about macOS or Linux behaviour",
 ]
+# The subject closure is larger than any file list the instrument can honestly
+# assert: the test target, the manifests, the lockfile and cargo's own behaviour
+# all move the number. So reuse is pinned to the commit rather than to a
+# curated set of paths that would silently carry a rate across changed content.
+REUSE_RULE = "identical head_sha, instrument digests, toolchain and runner image version"
 
 FAILED_TEST = re.compile(r"^test (\S+) \.\.\. FAILED\s*$", re.MULTILINE)
 SUMMARY = re.compile(
@@ -58,20 +71,22 @@ PANIC = re.compile(
 )
 MAX_MESSAGE_CHARS = 600
 
-# The files whose content the rate is a measurement of. Recording their blob
-# OIDs is what lets a rate carry to a later head: it carries only when these are
-# identical, which is the delegated lane's content-addressed rule applied to a
-# measurement instead of a gate.
+# Recorded as provenance for the reader, not as a reuse key: see REUSE_RULE.
 SUBJECT_PATHS = ("tests/support/bounded_process.rs",)
-# The files that define the measurement itself. A rate taken with a different
-# instrument is a different rate.
 INSTRUMENT_PATHS = (
     "scripts/ci/windows_flake_rate_proof.py",
+    "scripts/ci/windows_flake_rate_proof_selftest.py",
     ".github/workflows/windows-flake-rate-proof.yml",
 )
 
+# How often load liveness is sampled, and how much of an iteration must be
+# covered before the iteration counts as loaded at all.
+LOAD_SAMPLE_INTERVAL_S = 0.25
+MIN_LOAD_ALIVE_FRACTION = 0.95
+
 EXIT_INSTRUMENT_BROKEN = 2
 EXIT_COULD_NOT_MEASURE = 40
+EXIT_LOAD_ABSENT = 41
 
 
 def run(command: list[str], **kwargs) -> subprocess.CompletedProcess:
@@ -91,6 +106,141 @@ def digest_of(path: str) -> dict:
     return entry
 
 
+def kill_tree(pid: int) -> None:
+    """Kill a timed-out iteration's whole tree, bounded.
+
+    `cargo test` is the parent of the test binary, which is the parent of
+    whatever the test spawned, so killing the invocation alone would leave the
+    measurement's load behind and poison every later iteration.
+    """
+    if sys.platform == "win32":
+        run(["taskkill", "/T", "/F", "/PID", str(pid)], timeout=60)
+    else:
+        run(["pkill", "-KILL", "-P", str(pid)], timeout=60)
+        run(["kill", "-KILL", str(pid)], timeout=60)
+
+
+def run_with_ceiling(command: list[str], ceiling_s: float) -> tuple[int | None, str, bool]:
+    """Return (exit code or None when timed out, combined output, timed_out)."""
+    process = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+    try:
+        out, err = process.communicate(timeout=ceiling_s)
+        return process.returncode, out + err, False
+    except subprocess.TimeoutExpired:
+        kill_tree(process.pid)
+        try:
+            out, err = process.communicate(timeout=60)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            out, err = "", ""
+        return None, (out or "") + (err or ""), True
+
+
+def parse_iteration(output: str, timed_out: bool) -> dict:
+    passed = failed = ignored = 0
+    verdicts = []
+    for match in SUMMARY.finditer(output):
+        passed += int(match.group("passed"))
+        failed += int(match.group("failed"))
+        ignored += int(match.group("ignored"))
+        verdicts.append(match.group("verdict"))
+    panics = [
+        {
+            "test": match.group("test"),
+            "site": match.group("site").strip(),
+            "message": match.group("message").strip()[:MAX_MESSAGE_CHARS],
+        }
+        for match in PANIC.finditer(output)
+    ]
+    return {
+        "passed": passed,
+        "failed": failed,
+        "ignored": ignored,
+        "verdicts": verdicts,
+        "timed_out": timed_out,
+        # A timeout measured something: the selection did not finish inside its
+        # ceiling. Executing no test at all measured nothing, and that must not
+        # be counted as a clean run.
+        "could_not_measure": not timed_out and (not verdicts or passed + failed == 0),
+        "failed_tests": sorted(set(FAILED_TEST.findall(output))),
+        "panics": panics,
+    }
+
+
+class LoadSupervisor:
+    """Keeps the concurrent load alive and records how much of each iteration it covered.
+
+    Checking liveness only between iterations would let the load exit during a
+    measured test and leave the rest of it unloaded while still labelled loaded.
+    So a thread samples continuously, restarts as often as needed -- no hidden
+    cap -- and reports per-iteration coverage that the caller fails closed on.
+    """
+
+    def __init__(self, command: list[str] | None, interval_s: float = LOAD_SAMPLE_INTERVAL_S) -> None:
+        self.command = command
+        self.interval_s = interval_s
+        self.starts = 0
+        self._process: subprocess.Popen | None = None
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._samples = 0
+        self._alive = 0
+
+    def _spawn(self) -> None:
+        self._process = subprocess.Popen(
+            self.command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        self.starts += 1
+
+    def _supervise(self) -> None:
+        while not self._stop.is_set():
+            alive = self._process is not None and self._process.poll() is None
+            with self._lock:
+                self._samples += 1
+                self._alive += 1 if alive else 0
+            # Sample before restarting, so a gap is visible rather than papered
+            # over by the restart that closes it.
+            if not alive:
+                self._spawn()
+            self._stop.wait(self.interval_s)
+
+    def start(self) -> None:
+        if self.command is None:
+            return
+        self._spawn()
+        self._thread = threading.Thread(target=self._supervise, daemon=True)
+        self._thread.start()
+
+    def begin_iteration(self) -> None:
+        with self._lock:
+            self._samples = 0
+            self._alive = 0
+
+    def iteration_coverage(self) -> dict:
+        if self.command is None:
+            return {"expected": False, "samples": 0, "alive_fraction": None, "gap": False}
+        with self._lock:
+            samples, alive = self._samples, self._alive
+        fraction = round(alive / samples, 4) if samples else 0.0
+        return {
+            "expected": True,
+            "samples": samples,
+            "alive_fraction": fraction,
+            # No sample at all is not "fully covered": it is no evidence of load.
+            "gap": samples == 0 or fraction < MIN_LOAD_ALIVE_FRACTION,
+        }
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=30)
+        if self._process is not None and self._process.poll() is None:
+            kill_tree(self._process.pid)
+
+
 def manifest(ref_input: str, workflow_path: str) -> dict:
     server = os.environ.get("GITHUB_SERVER_URL", "")
     repository = os.environ.get("GITHUB_REPOSITORY", "")
@@ -98,6 +248,7 @@ def manifest(ref_input: str, workflow_path: str) -> dict:
     return {
         "claim_ceiling": CLAIM_CEILING,
         "non_claims": NON_CLAIMS,
+        "reuse_rule": REUSE_RULE,
         "ref_input": ref_input,
         "head_sha": git_output(["rev-parse", "HEAD"]),
         "worktree_clean": git_output(["status", "--porcelain"]) == "",
@@ -133,65 +284,54 @@ def toolchain_facts() -> dict:
     }
 
 
-def parse_iteration(output: str) -> dict:
-    passed = failed = ignored = 0
-    verdicts = []
-    for match in SUMMARY.finditer(output):
-        passed += int(match.group("passed"))
-        failed += int(match.group("failed"))
-        ignored += int(match.group("ignored"))
-        verdicts.append(match.group("verdict"))
-    panics = [
-        {
-            "test": match.group("test"),
-            "site": match.group("site").strip(),
-            "message": match.group("message").strip()[:MAX_MESSAGE_CHARS],
-        }
-        for match in PANIC.finditer(output)
+def summarize(iterations: list[dict], requested: int) -> dict:
+    measured = [record for record in iterations if not record["could_not_measure"]]
+    failed = [
+        record
+        for record in measured
+        if record["timed_out"] or record["exit_code"] not in (0, None)
     ]
+    per_test: dict[str, int] = {}
+    for record in failed:
+        for name in record["failed_tests"]:
+            per_test[name] = per_test.get(name, 0) + 1
     return {
-        "passed": passed,
-        "failed": failed,
-        "ignored": ignored,
-        "verdicts": verdicts,
-        # No summary line, or a summary reporting nothing executed, means this
-        # iteration measured nothing. It must not be counted as a clean run.
-        "could_not_measure": not verdicts or passed + failed == 0,
-        "failed_tests": sorted(set(FAILED_TEST.findall(output))),
-        "panics": panics,
+        "requested": requested,
+        "measured": len(measured),
+        "could_not_measure": [r["index"] for r in iterations if r["could_not_measure"]],
+        "timed_out": [r["index"] for r in iterations if r["timed_out"]],
+        "load_gaps": [r["index"] for r in iterations if r["load"]["gap"]],
+        "failed_runs": len(failed),
+        "observed_failure_rate": (
+            round(len(failed) / len(measured), 4) if measured else None
+        ),
+        "failures_by_test": per_test,
     }
 
 
-class BackgroundLoad:
-    """Keeps a concurrent workspace test run alive for the whole measurement.
+def instrument_verdict(summary: dict, completed: int) -> tuple[int, str]:
+    """Decide whether the measurement describes what it claims to.
 
-    The load arm exists so the load hypothesis can be tested directly rather
-    than inferred: same SHA, same image, once alone and once under the
-    concurrency an ordinary `cargo test` produces.
+    Kept separate from the loop that produces it so the fail-closed rule has one
+    home and can be pinned by the self-test without running cargo.
     """
-
-    def __init__(self, command: list[str] | None, max_starts: int = 20) -> None:
-        self.command = command
-        self.max_starts = max_starts
-        self.starts = 0
-        self.process: subprocess.Popen | None = None
-
-    def keep_alive(self) -> None:
-        if self.command is None or self.starts >= self.max_starts:
-            return
-        if self.process is None or self.process.poll() is not None:
-            self.starts += 1
-            self.process = subprocess.Popen(
-                self.command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-            )
-
-    def stop(self) -> None:
-        if self.process is not None and self.process.poll() is None:
-            self.process.kill()
-            self.process.wait(timeout=60)
+    if summary["could_not_measure"] or completed != summary["requested"]:
+        return (
+            EXIT_COULD_NOT_MEASURE,
+            "ERROR: iterations that executed no test: "
+            f"{summary['could_not_measure']}; a run that could not measure is not a run that "
+            "measured zero failures",
+        )
+    if summary["load_gaps"]:
+        return (
+            EXIT_LOAD_ABSENT,
+            f"ERROR: iterations labelled loaded ran without it: {summary['load_gaps']}; "
+            "an unloaded iteration cannot answer a question about load",
+        )
+    return 0, ""
 
 
-def main() -> int:
+def build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--ref-input", default="")
     parser.add_argument("--workflow-path", default=".github/workflows/windows-flake-rate-proof.yml")
@@ -199,12 +339,17 @@ def main() -> int:
     parser.add_argument("--test-target", required=True)
     parser.add_argument("--filter", default="")
     parser.add_argument("--iterations", type=int, required=True)
+    parser.add_argument("--iteration-ceiling-s", type=float, default=300.0)
     parser.add_argument("--load", choices=["none", "workspace-tests"], default="none")
     parser.add_argument("--out", required=True)
-    args = parser.parse_args()
+    return parser
 
-    if args.iterations < 1:
-        print("ERROR: iterations must be at least 1", file=sys.stderr)
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_argument_parser().parse_args(argv)
+
+    if args.iterations < 1 or args.iteration_ceiling_s <= 0:
+        print("ERROR: iterations and the per-iteration ceiling must be positive", file=sys.stderr)
         return EXIT_INSTRUMENT_BROKEN
 
     measured = ["cargo", "test", "--locked", "-p", args.package, "--test", args.test_target]
@@ -229,41 +374,32 @@ def main() -> int:
         print("ERROR: the instrument could not build its subject", file=sys.stderr)
         return EXIT_INSTRUMENT_BROKEN
 
-    load = BackgroundLoad(load_command)
-    iterations = []
+    load = LoadSupervisor(load_command)
+    load.start()
+    iterations: list[dict] = []
     try:
         for index in range(1, args.iterations + 1):
-            load.keep_alive()
+            load.begin_iteration()
             started = time.monotonic()
-            result = run(measured)
-            elapsed = round(time.monotonic() - started, 3)
+            code, output, timed_out = run_with_ceiling(measured, args.iteration_ceiling_s)
             record = {
                 "index": index,
-                "exit_code": result.returncode,
-                "duration_s": elapsed,
-                **parse_iteration(result.stdout + result.stderr),
+                "exit_code": code,
+                "duration_s": round(time.monotonic() - started, 3),
+                "load": load.iteration_coverage(),
+                **parse_iteration(output, timed_out),
             }
             iterations.append(record)
             print(
-                f"iteration {index}/{args.iterations}: exit={record['exit_code']} "
-                f"failed={record['failed']} in {elapsed}s {record['failed_tests']}",
+                f"iteration {index}/{args.iterations}: exit={code} timed_out={timed_out} "
+                f"failed={record['failed']} load={record['load']['alive_fraction']} "
+                f"in {record['duration_s']}s {record['failed_tests']}",
                 flush=True,
             )
     finally:
         load.stop()
 
-    unmeasured = [record["index"] for record in iterations if record["could_not_measure"]]
-    failed_runs = [
-        record
-        for record in iterations
-        if record["exit_code"] != 0 and not record["could_not_measure"]
-    ]
-    measured_runs = [record for record in iterations if not record["could_not_measure"]]
-    per_test: dict[str, int] = {}
-    for record in failed_runs:
-        for name in record["failed_tests"]:
-            per_test[name] = per_test.get(name, 0) + 1
-
+    summary = summarize(iterations, args.iterations)
     proof = {
         "schema": SCHEMA,
         "manifest": manifest(args.ref_input, args.workflow_path),
@@ -274,31 +410,19 @@ def main() -> int:
             "test_target": args.test_target,
             "filter": args.filter,
             "command": measured,
+            "iteration_ceiling_s": args.iteration_ceiling_s,
         },
         "load": {"mode": args.load, "command": load_command, "starts": load.starts},
         "iterations": iterations,
-        "summary": {
-            "requested": args.iterations,
-            "measured": len(measured_runs),
-            "could_not_measure": unmeasured,
-            "failed_runs": len(failed_runs),
-            "failure_rate": (
-                round(len(failed_runs) / len(measured_runs), 4) if measured_runs else None
-            ),
-            "failures_by_test": per_test,
-        },
+        "summary": summary,
     }
     Path(args.out).write_text(json.dumps(proof, indent=2) + "\n", encoding="utf-8")
-    print(json.dumps(proof["summary"], indent=2))
+    print(json.dumps(summary, indent=2))
 
-    if unmeasured or len(iterations) != args.iterations:
-        print(
-            f"ERROR: {len(unmeasured) or args.iterations - len(iterations)} iteration(s) measured "
-            "nothing; a run that could not measure is not a run that measured zero failures",
-            file=sys.stderr,
-        )
-        return EXIT_COULD_NOT_MEASURE
-    return 0
+    code, message = instrument_verdict(summary, len(iterations))
+    if code != 0:
+        print(message, file=sys.stderr)
+    return code
 
 
 if __name__ == "__main__":

--- a/scripts/ci/windows_flake_rate_proof.py
+++ b/scripts/ci/windows_flake_rate_proof.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Repeat one cargo test selection N times and record every iteration.
+
+A single pass cannot separate "fixed" from "won the race once", so this
+instrument reports a rate and the per-iteration record behind it.
+
+It measures and never judges: a failing iteration is the datum, so the process
+still exits 0. Two things are failures instead. A subject that will not build
+exits 2. An iteration that executed no test -- a filter that matched nothing, a
+binary that never ran -- exits 40, mirroring the delegated lane where an
+environment skip is a failure rather than a neutral outcome. A run that could
+not measure is not a run that measured zero failures, and for a failure-rate
+instrument that is the most likely way to lie quietly.
+
+The manifest binds the numbers to the head SHA, workflow SHA, repository, ref,
+run and attempt, and digests the files that define both subject and measurement,
+so a rate is addressable rather than asserted. It also states its own claim
+ceiling: see CLAIM_CEILING below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCHEMA = "assay.windows-flake-rate-proof/v1"
+
+# Deliberately narrow, in the shape of the delegated lane's ceiling but making
+# none of its claims. This instrument runs on a GitHub-hosted `windows-latest`
+# image: there is no privileged or dedicated host, no OIDC attestation of the
+# machine, and no verifier consuming this artifact.
+CLAIM_CEILING = "hosted_windows_flake_rate_measurement_only_not_a_verdict"
+NON_CLAIMS = [
+    "not a gate: no required context consumes this artifact and no check is discharged by it",
+    "no privileged, dedicated or attested host: GitHub-hosted windows-latest only",
+    "no claim that a measured selection is fixed, only the rate the recorded iterations produced",
+    "no claim about any image version, toolchain or SHA other than the ones recorded here",
+    "no claim about macOS or Linux behaviour",
+]
+
+FAILED_TEST = re.compile(r"^test (\S+) \.\.\. FAILED\s*$", re.MULTILINE)
+SUMMARY = re.compile(
+    r"^test result: (?P<verdict>\w+)\. (?P<passed>\d+) passed; (?P<failed>\d+) failed;"
+    r" (?P<ignored>\d+) ignored",
+    re.MULTILINE,
+)
+PANIC = re.compile(
+    r"^thread '(?P<test>[^']+)'.*panicked at (?P<site>[^\n]*)\n(?P<message>[^\n]*)",
+    re.MULTILINE,
+)
+MAX_MESSAGE_CHARS = 600
+
+# The files whose content the rate is a measurement of. Recording their blob
+# OIDs is what lets a rate carry to a later head: it carries only when these are
+# identical, which is the delegated lane's content-addressed rule applied to a
+# measurement instead of a gate.
+SUBJECT_PATHS = ("tests/support/bounded_process.rs",)
+# The files that define the measurement itself. A rate taken with a different
+# instrument is a different rate.
+INSTRUMENT_PATHS = (
+    "scripts/ci/windows_flake_rate_proof.py",
+    ".github/workflows/windows-flake-rate-proof.yml",
+)
+
+EXIT_INSTRUMENT_BROKEN = 2
+EXIT_COULD_NOT_MEASURE = 40
+
+
+def run(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True, check=False, **kwargs)
+
+
+def git_output(args: list[str]) -> str:
+    result = run(["git", *args])
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def digest_of(path: str) -> dict:
+    entry = {"blob_oid": git_output(["rev-parse", f"HEAD:{path}"])}
+    file = Path(path)
+    if file.is_file():
+        entry["sha256"] = hashlib.sha256(file.read_bytes()).hexdigest()
+    return entry
+
+
+def manifest(ref_input: str, workflow_path: str) -> dict:
+    server = os.environ.get("GITHUB_SERVER_URL", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    return {
+        "claim_ceiling": CLAIM_CEILING,
+        "non_claims": NON_CLAIMS,
+        "ref_input": ref_input,
+        "head_sha": git_output(["rev-parse", "HEAD"]),
+        "worktree_clean": git_output(["status", "--porcelain"]) == "",
+        "repository": repository,
+        "ref": os.environ.get("GITHUB_REF", ""),
+        "workflow_name": os.environ.get("GITHUB_WORKFLOW", ""),
+        "workflow_path": workflow_path,
+        "workflow_sha": os.environ.get("GITHUB_WORKFLOW_SHA", ""),
+        "run_id": run_id,
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+        "run_url": f"{server}/{repository}/actions/runs/{run_id}" if server and repository else "",
+        "subject_digests": {path: digest_of(path) for path in SUBJECT_PATHS},
+        "instrument_digests": {path: digest_of(path) for path in INSTRUMENT_PATHS},
+    }
+
+
+def runner_facts() -> dict:
+    return {
+        # Set by GitHub-hosted runners. If a failure turns out to be an image
+        # rollout, this field is what proves it.
+        "image_os": os.environ.get("ImageOS", ""),
+        "image_version": os.environ.get("ImageVersion", ""),
+        "runner_name": os.environ.get("RUNNER_NAME", ""),
+        "platform": platform.platform(),
+        "processor_count": os.cpu_count(),
+    }
+
+
+def toolchain_facts() -> dict:
+    return {
+        "rustc": run(["rustc", "--version"]).stdout.strip(),
+        "cargo": run(["cargo", "--version"]).stdout.strip(),
+    }
+
+
+def parse_iteration(output: str) -> dict:
+    passed = failed = ignored = 0
+    verdicts = []
+    for match in SUMMARY.finditer(output):
+        passed += int(match.group("passed"))
+        failed += int(match.group("failed"))
+        ignored += int(match.group("ignored"))
+        verdicts.append(match.group("verdict"))
+    panics = [
+        {
+            "test": match.group("test"),
+            "site": match.group("site").strip(),
+            "message": match.group("message").strip()[:MAX_MESSAGE_CHARS],
+        }
+        for match in PANIC.finditer(output)
+    ]
+    return {
+        "passed": passed,
+        "failed": failed,
+        "ignored": ignored,
+        "verdicts": verdicts,
+        # No summary line, or a summary reporting nothing executed, means this
+        # iteration measured nothing. It must not be counted as a clean run.
+        "could_not_measure": not verdicts or passed + failed == 0,
+        "failed_tests": sorted(set(FAILED_TEST.findall(output))),
+        "panics": panics,
+    }
+
+
+class BackgroundLoad:
+    """Keeps a concurrent workspace test run alive for the whole measurement.
+
+    The load arm exists so the load hypothesis can be tested directly rather
+    than inferred: same SHA, same image, once alone and once under the
+    concurrency an ordinary `cargo test` produces.
+    """
+
+    def __init__(self, command: list[str] | None, max_starts: int = 20) -> None:
+        self.command = command
+        self.max_starts = max_starts
+        self.starts = 0
+        self.process: subprocess.Popen | None = None
+
+    def keep_alive(self) -> None:
+        if self.command is None or self.starts >= self.max_starts:
+            return
+        if self.process is None or self.process.poll() is not None:
+            self.starts += 1
+            self.process = subprocess.Popen(
+                self.command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+
+    def stop(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            self.process.kill()
+            self.process.wait(timeout=60)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ref-input", default="")
+    parser.add_argument("--workflow-path", default=".github/workflows/windows-flake-rate-proof.yml")
+    parser.add_argument("--package", required=True)
+    parser.add_argument("--test-target", required=True)
+    parser.add_argument("--filter", default="")
+    parser.add_argument("--iterations", type=int, required=True)
+    parser.add_argument("--load", choices=["none", "workspace-tests"], default="none")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    if args.iterations < 1:
+        print("ERROR: iterations must be at least 1", file=sys.stderr)
+        return EXIT_INSTRUMENT_BROKEN
+
+    measured = ["cargo", "test", "--locked", "-p", args.package, "--test", args.test_target]
+    if args.filter:
+        measured.append(args.filter)
+    # The Windows leg of CI runs this selection, so the load arm reproduces the
+    # concurrency the measured tests actually meet there.
+    load_command = (
+        [
+            "cargo", "test", "--locked", "--workspace",
+            "--exclude", "assay-ebpf", "--exclude", "assay-it",
+            "--exclude", "assay-monitor", "--exclude", "assay-cli",
+        ]
+        if args.load == "workspace-tests"
+        else None
+    )
+
+    build = run([*measured, "--no-run"])
+    if build.returncode != 0:
+        sys.stderr.write(build.stdout)
+        sys.stderr.write(build.stderr)
+        print("ERROR: the instrument could not build its subject", file=sys.stderr)
+        return EXIT_INSTRUMENT_BROKEN
+
+    load = BackgroundLoad(load_command)
+    iterations = []
+    try:
+        for index in range(1, args.iterations + 1):
+            load.keep_alive()
+            started = time.monotonic()
+            result = run(measured)
+            elapsed = round(time.monotonic() - started, 3)
+            record = {
+                "index": index,
+                "exit_code": result.returncode,
+                "duration_s": elapsed,
+                **parse_iteration(result.stdout + result.stderr),
+            }
+            iterations.append(record)
+            print(
+                f"iteration {index}/{args.iterations}: exit={record['exit_code']} "
+                f"failed={record['failed']} in {elapsed}s {record['failed_tests']}",
+                flush=True,
+            )
+    finally:
+        load.stop()
+
+    unmeasured = [record["index"] for record in iterations if record["could_not_measure"]]
+    failed_runs = [
+        record
+        for record in iterations
+        if record["exit_code"] != 0 and not record["could_not_measure"]
+    ]
+    measured_runs = [record for record in iterations if not record["could_not_measure"]]
+    per_test: dict[str, int] = {}
+    for record in failed_runs:
+        for name in record["failed_tests"]:
+            per_test[name] = per_test.get(name, 0) + 1
+
+    proof = {
+        "schema": SCHEMA,
+        "manifest": manifest(args.ref_input, args.workflow_path),
+        "runner": runner_facts(),
+        "toolchain": toolchain_facts(),
+        "subject": {
+            "package": args.package,
+            "test_target": args.test_target,
+            "filter": args.filter,
+            "command": measured,
+        },
+        "load": {"mode": args.load, "command": load_command, "starts": load.starts},
+        "iterations": iterations,
+        "summary": {
+            "requested": args.iterations,
+            "measured": len(measured_runs),
+            "could_not_measure": unmeasured,
+            "failed_runs": len(failed_runs),
+            "failure_rate": (
+                round(len(failed_runs) / len(measured_runs), 4) if measured_runs else None
+            ),
+            "failures_by_test": per_test,
+        },
+    }
+    Path(args.out).write_text(json.dumps(proof, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(proof["summary"], indent=2))
+
+    if unmeasured or len(iterations) != args.iterations:
+        print(
+            f"ERROR: {len(unmeasured) or args.iterations - len(iterations)} iteration(s) measured "
+            "nothing; a run that could not measure is not a run that measured zero failures",
+            file=sys.stderr,
+        )
+        return EXIT_COULD_NOT_MEASURE
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/windows_flake_rate_proof_selftest.py
+++ b/scripts/ci/windows_flake_rate_proof_selftest.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Behavioural self-test for the Windows flake-rate instrument.
+
+Pins the classifications a rate depends on: which output counts as a pass, a
+failure, a timeout or no measurement at all; how the observed rate is computed;
+whether missing load is detected; and that each of those makes the run fail
+closed rather than read clean. Every assertion here fails if the corresponding
+branch in the instrument is inverted or dropped.
+
+Run: `python3 scripts/ci/windows_flake_rate_proof_selftest.py`
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import windows_flake_rate_proof as proof
+
+PASS_OUTPUT = """
+running 3 tests
+test bounded_process::tests::kills_stdout_flood ... ok
+test result: ok. 3 passed; 0 failed; 1 ignored; 0 measured; 10 filtered out; finished in 0.29s
+"""
+
+FAIL_OUTPUT = """
+running 3 tests
+test bounded_process::tests::kills_quiet_descendant_after_normal_parent_exit ... FAILED
+
+---- bounded_process::tests::kills_quiet_descendant_after_normal_parent_exit stdout ----
+thread 'bounded_process::tests::kills_quiet_descendant_after_normal_parent_exit' (6824) panicked at tests/support/bounded_process.rs:893:14:
+normal parent completion must retain its outcome: deadline of 5s expired
+test result: FAILED. 2 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 10.40s
+"""
+
+NO_TEST_OUTPUT = """
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.00s
+"""
+
+EMPTY_OUTPUT = ""
+
+failures: list[str] = []
+
+
+def check(label: str, actual, expected) -> None:
+    if actual != expected:
+        failures.append(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def iteration(index: int, **overrides) -> dict:
+    """A measured, passing, fully loaded iteration, before any override."""
+    record = {
+        "index": index,
+        "exit_code": 0,
+        "duration_s": 6.0,
+        "load": {"expected": True, "samples": 24, "alive_fraction": 1.0, "gap": False},
+        **proof.parse_iteration(PASS_OUTPUT, timed_out=False),
+    }
+    record.update(overrides)
+    return record
+
+
+def check_parsing() -> None:
+    passed = proof.parse_iteration(PASS_OUTPUT, timed_out=False)
+    check("pass counts", (passed["passed"], passed["failed"], passed["ignored"]), (3, 0, 1))
+    check("pass is measured", passed["could_not_measure"], False)
+    check("pass has no failing tests", passed["failed_tests"], [])
+    check("pass records no timeout", passed["timed_out"], False)
+
+    failed = proof.parse_iteration(FAIL_OUTPUT, timed_out=False)
+    check("fail counts", (failed["passed"], failed["failed"]), (2, 1))
+    check(
+        "fail names the test",
+        failed["failed_tests"],
+        ["bounded_process::tests::kills_quiet_descendant_after_normal_parent_exit"],
+    )
+    check("fail is measured", failed["could_not_measure"], False)
+    check("fail captures one panic", len(failed["panics"]), 1)
+    check(
+        "panic message is captured",
+        failed["panics"][0]["message"].startswith("normal parent completion must retain"),
+        True,
+    )
+
+    # A filter that matched nothing exits 0 and looks perfect. It measured
+    # nothing, and treating it as a clean run is how this instrument would lie.
+    nothing = proof.parse_iteration(NO_TEST_OUTPUT, timed_out=False)
+    check("zero executed tests measured nothing", nothing["could_not_measure"], True)
+    check("no summary at all measured nothing", proof.parse_iteration(EMPTY_OUTPUT, False)["could_not_measure"], True)
+
+    # A timeout did measure something: the selection did not finish in its
+    # ceiling. It must stay data rather than become an instrument failure.
+    hung = proof.parse_iteration(EMPTY_OUTPUT, timed_out=True)
+    check("timeout is measured", hung["could_not_measure"], False)
+    check("timeout is recorded", hung["timed_out"], True)
+
+
+def check_rate() -> None:
+    clean = [iteration(i) for i in (1, 2, 3, 4)]
+    check("all-pass rate", proof.summarize(clean, 4)["observed_failure_rate"], 0.0)
+
+    mixed = [
+        iteration(1),
+        iteration(2, exit_code=101, **proof.parse_iteration(FAIL_OUTPUT, timed_out=False)),
+        iteration(3),
+        iteration(4),
+    ]
+    summary = proof.summarize(mixed, 4)
+    check("one failure in four", summary["observed_failure_rate"], 0.25)
+    check("failed runs counted", summary["failed_runs"], 1)
+    check(
+        "failure attributed to the test",
+        summary["failures_by_test"],
+        {"bounded_process::tests::kills_quiet_descendant_after_normal_parent_exit": 1},
+    )
+
+    # A timed-out iteration is a failed run: the selection did not pass.
+    timed_out = [iteration(1), iteration(2, exit_code=None, **proof.parse_iteration(EMPTY_OUTPUT, True))]
+    summary = proof.summarize(timed_out, 2)
+    check("timeout counts as a failure", summary["failed_runs"], 1)
+    check("timeout is listed", summary["timed_out"], [2])
+    check("timeout rate", summary["observed_failure_rate"], 0.5)
+
+    # An iteration that measured nothing is excluded from the denominator
+    # instead of diluting the rate.
+    unmeasured = [iteration(1), iteration(2, **proof.parse_iteration(NO_TEST_OUTPUT, False))]
+    summary = proof.summarize(unmeasured, 2)
+    check("unmeasured excluded from denominator", summary["measured"], 1)
+    check("unmeasured listed", summary["could_not_measure"], [2])
+
+
+def check_fail_closed() -> None:
+    clean = proof.summarize([iteration(i) for i in (1, 2)], 2)
+    check("a clean measurement passes", proof.instrument_verdict(clean, 2), (0, ""))
+
+    # Fewer iterations than requested is not a smaller measurement, it is an
+    # incomplete one.
+    check("short run fails", proof.instrument_verdict(clean, 1)[0], proof.EXIT_COULD_NOT_MEASURE)
+
+    unmeasured = proof.summarize(
+        [iteration(1), iteration(2, **proof.parse_iteration(NO_TEST_OUTPUT, False))], 2
+    )
+    check(
+        "no-test iteration fails the run",
+        proof.instrument_verdict(unmeasured, 2)[0],
+        proof.EXIT_COULD_NOT_MEASURE,
+    )
+
+    # The load arm's own failure mode: a green result that means "no load"
+    # rather than "no defect".
+    gapped = proof.summarize(
+        [
+            iteration(1),
+            iteration(2, load={"expected": True, "samples": 20, "alive_fraction": 0.4, "gap": True}),
+        ],
+        2,
+    )
+    check("absent load fails the run", proof.instrument_verdict(gapped, 2)[0], proof.EXIT_LOAD_ABSENT)
+    check("absent load names the iteration", gapped["load_gaps"], [2])
+
+
+def check_load_supervision() -> None:
+    quiet = proof.LoadSupervisor(None)
+    quiet.start()
+    quiet.begin_iteration()
+    coverage = quiet.iteration_coverage()
+    check("no load arm expects none", coverage["expected"], False)
+    check("no load arm reports no gap", coverage["gap"], False)
+    quiet.stop()
+
+    # A load command that exits at once cannot cover an iteration, however
+    # eagerly it is restarted. Without this the arm silently measures no load.
+    dying = proof.LoadSupervisor(
+        [sys.executable, "-c", "pass"], interval_s=0.05
+    )
+    dying.start()
+    dying.begin_iteration()
+    time.sleep(1.0)
+    coverage = dying.iteration_coverage()
+    dying.stop()
+    check("a load that keeps dying is a gap", coverage["gap"], True)
+    check("restarts are visible", dying.starts > 1, True)
+
+    alive = proof.LoadSupervisor(
+        [sys.executable, "-c", "import time; time.sleep(30)"], interval_s=0.05
+    )
+    alive.start()
+    alive.begin_iteration()
+    time.sleep(1.0)
+    coverage = alive.iteration_coverage()
+    alive.stop()
+    check("a live load is no gap", coverage["gap"], False)
+    check("a live load is fully covered", coverage["alive_fraction"], 1.0)
+    check("a live load starts once", alive.starts, 1)
+
+
+def check_claim_surface() -> None:
+    # The manifest states its ceiling and its reuse rule; a proof that carries
+    # further than its author intended does so through this text.
+    check("reuse is pinned to the commit", "head_sha" in proof.REUSE_RULE, True)
+    check(
+        "the ceiling claims no verdict",
+        proof.CLAIM_CEILING,
+        "hosted_windows_flake_rate_measurement_only_not_a_verdict",
+    )
+    check(
+        "causation is disclaimed in the pack",
+        any("no causal claim" in claim for claim in proof.NON_CLAIMS),
+        True,
+    )
+
+
+def main() -> int:
+    check_parsing()
+    check_rate()
+    check_fail_closed()
+    check_load_supervision()
+    check_claim_surface()
+    for failure in failures:
+        print(f"FAIL {failure}", file=sys.stderr)
+    if failures:
+        print(f"{len(failures)} self-test assertion(s) failed", file=sys.stderr)
+        return 1
+    print("windows flake-rate instrument self-test: all assertions hold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Bound to head **`919f1b1f04d0`** (branch `cursor/windows-flake-rate-proof`, base `main` at `bc07ffb0e`).

## Why

#2249 and #2246 both turn on a question about a **rate**, not an outcome, and an author without a Windows host cannot take that measurement locally. This adds the instrument that can, modelled on the repository's delegated-proof pattern. Contract: `docs/reference/ci/windows-flake-rate-proof.md`.

`.github/workflows/windows-flake-rate-proof.yml` runs one `cargo test` selection N times on `windows-latest` and uploads a JSON artifact recording every iteration. The manifest binds the numbers to head SHA, workflow SHA, repository, ref, run and attempt, and digests the subject and the instrument.

## The six blockers from the review of `33a374f74`

Every one of them was a way the instrument could report a clean measurement of nothing, so each is now a way it fails instead.

| # | Blocker | Change |
|---|---|---|
| 1 | No per-iteration ceiling; one iteration was observed at 462s and could have consumed the job and taken the artifact with it | `--iteration-ceiling-s` (default 300, an input), a bounded `taskkill /T /F` process-tree kill on breach, and the breach recorded as data — a failed run, not a lost one |
| 2 | Reuse key incomplete: one test file's blob OID could carry a rate across changed test code or dependencies | Reuse is pinned to an **identical `head_sha`** plus instrument digests, toolchain and image version. The subject closure is not something this instrument can honestly enumerate, so it does not pretend to |
| 3 | `max_starts=20` silently stopped restarting the load while `iterations` is unbounded | The cap is gone; the supervisor restarts as often as needed and records `load.starts` |
| 4 | Load was checked only between iterations, so it could vanish mid-test while the iteration stayed labelled loaded | A supervisor thread samples liveness every 250ms **during** each iteration, samples before restarting so a gap is visible rather than papered over, and records `load.alive_fraction` per iteration. Coverage below 0.95 — or no sample at all — is a gap |
| 5 | "Can never attach a check to a PR" was inaccurate | Stated as a repository convention, in the workflow and the contract: no PR is opened from `proof/windows-flake-rate/**`, and if one were, its push checks would appear on it |
| 6 | No tests for the 305-line parser | `scripts/ci/windows_flake_rate_proof_selftest.py` pins pass, failure, timeout, executed-nothing, the rate arithmetic, load absence, and the fail-closed verdict each produces. A pre-commit hook runs it, and so does the workflow on the host about to measure |

Exit codes now carry the stance: `2` the subject would not build, `40` an iteration executed no test, **`41` a load arm lost its load**. The last one is the delegated lane's exit-40 rule applied where it matters most here — if load can vanish without the run failing, a clean load arm reads as "no defect" when it means "no load".

The self-test was verified to fail, not just to pass: inverting the executed-nothing rule breaks four assertions, and neutralising the load-gap rule breaks the one that exists for it.

## Correlation, not causation

`0/20` versus `2/20` supports the hypothesis that load affects #2249. It does not establish it, and that is now said in the artifact's `non_claims`, in the contract, and in the step summary: the samples are small and their intervals overlap, the arms ran on two separate hosted machines, and they were neither interleaved nor randomised. Claiming causation needs both arms on one runner, interleaved in randomised order, a pre-registered iteration count and effect size, and a further manipulation of the suspected mechanism that moves the rate as predicted.

Per the review, no rate is offered here as transferable evidence. Fresh measurements with this hardened version are running; they will be reported with their exact heads and read as observed rates only.

## Boundaries

Instrument, not a gate: not in the `CI` rollup, not in any required context, discharges no check. Claim ceiling stated in the artifact — `hosted_windows_flake_rate_measurement_only_not_a_verdict` — with no privileged-host or attestation language borrowed from the delegated lane, because this runs on a GitHub-hosted image.

## Verification

At `919f1b1f0`: self-test passes; `cargo fmt --all -- --check`, `actionlint`, `typos`, yaml checks and pre-push clippy pass. The workflow's own dispatch path is exercised by the two runs in flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-demand Windows test flake-rate measurement workflow with configurable iterations, timeouts, and load conditions.
  * Produces detailed JSON results, job summaries, provenance metadata, and downloadable artifacts.
  * Detects incomplete or unmeasurable runs and reports test failures without treating measurements as pass/fail gates.

* **Documentation**
  * Added guidance covering measurement claims, reuse rules, diagnostics, artifacts, failure semantics, and reporting requirements.

* **Tests**
  * Added behavioral self-tests and a pre-commit check to validate classifications, timeouts, load coverage, and failure-rate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->