### PR TITLE
docs(runner): state the host-capability proof gate as implemented, not planned

### DIFF
--- a/docs/reference/runner/host-capability-proof.md
+++ b/docs/reference/runner/host-capability-proof.md
@@ -1,7 +1,15 @@
-# Host-Capability Proof Gate (RFC, v0)
+# Host-Capability Proof Gate (v0)
 
-Status: accepted design, not yet implemented. This document is the contract; the checker and
-workflows land in a follow-up PR and must match what is written here.
+Status: implemented and active. This document remains the contract, and the implementation must
+match what is written here:
+
+- checker: `scripts/ci/assay_host_capability_check.py`
+- gate workflow: `.github/workflows/host-capability-check.yml`
+- proof producer: `.github/workflows/host-capability-proof.yml`
+
+`host-capability-check` is one of the contexts branch protection on `main` requires, alongside
+`CI` and `lane-check/proof`. A change that trips the trigger paths below cannot merge without a
+host proof bound to the exact PR head.
 
 ## Problem
 
@@ -53,11 +61,19 @@ suspicion as a change to the lane-check classifier.
 
 ```yaml
 on: workflow_dispatch
-runs-on: [self-hosted, assay-bpf-runner]
+runs-on: [self-hosted, linux, assay-bpf-runner]
 permissions:
   contents: read
   actions: read
+concurrency:
+  group: assay-bpf-runner-host
+  cancel-in-progress: false
+  queue: max
 ```
+
+The concurrency group is shared with `Runner Spike Delegated`: the host is a singleton, so
+dispatches queue rather than run in parallel. A run is usable as proof only for a PR whose head is
+exactly the dispatched SHA, so dispatch against the PR head, never against `main`.
 
 The run builds `assay-cli` from the dispatched ref and uploads an artifact containing:
 
@@ -77,12 +93,18 @@ operated infrastructure, not a safe arbitrary-fork runner.
 ## Check workflow (`host-capability-check.yml`)
 
 ```yaml
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs: [pr_number, expected_head_sha]
 permissions:
   contents: read
   actions: read
   pull-requests: read
 ```
+
+There is no path filter. A required check that does not run blocks merges as pending, so the
+checker runs on every PR and passes immediately when no trigger path changed.
 
 The job runs the checker and passes or fails; it posts no comment (a fork PR's `GITHUB_TOKEN` is
 read-only and must stay that way). No `pull_request_target` in v0: a write-token checker is exactly


### PR DESCRIPTION
## What

`docs/reference/runner/host-capability-proof.md` opened with:

> Status: accepted design, not yet implemented. This document is the contract; the checker and workflows land in a follow-up PR and must match what is written here.

That is false, and it is the kind of false that costs review attention: it tells a reader the gate is aspirational, so evidence the gate actually requires looks optional. The checker, both workflows, and the required branch-protection context are all live.

Documentation only. No code, no workflow, no behaviour change.

## Corrections, each checked against the thing it describes

Measured on head `0296b9c63a765ea0f31d78abe1aee980256f55c8`.

| Statement now in the doc | Verified against |
|---|---|
| Status implemented and active; names checker + both workflows | `scripts/ci/assay_host_capability_check.py`, `.github/workflows/host-capability-check.yml`, `.github/workflows/host-capability-proof.yml` all present |
| `host-capability-check` is required on `main` alongside `CI` and `lane-check/proof` | branch protection reports contexts `CI`, `host-capability-check`, `lane-check/proof` |
| `runs-on: [self-hosted, linux, assay-bpf-runner]` | `host-capability-proof.yml` L36 — the doc previously omitted `linux` |
| `concurrency: group assay-bpf-runner-host`, `cancel-in-progress: false`, `queue: max` | `host-capability-proof.yml` L25-31 |
| group is shared with `Runner Spike Delegated`; host is a singleton | `runner-spike-delegated.yml` L29 uses the same group |
| a run is proof only for the exact dispatched head, so never dispatch on `main` | checker returns `head_sha_mismatch` (L284) and `meta_sha_mismatch` (L343) |
| check workflow triggers are `pull_request` + `workflow_dispatch` with `pr_number` / `expected_head_sha` | `host-capability-check.yml` L11-22 — the doc previously said `on: pull_request` only |
| there is no path filter, because a required check that does not run blocks as pending | `host-capability-check.yml` has no `paths:` under `pull_request` |

The "never dispatch on `main`" line is not a style note. A proof run was dispatched on `main` today and could not have counted for any PR regardless of whether it finished.

## Verification

- `git diff --check` clean
- `python3 scripts/ci/assay_host_capability_check.py --self-test` → `self-test: all cases passed`
- pre-commit hooks passed on commit (fmt, typos, lane-check self-test, gating-map drift)
- This file is on the gate's own exemption list (`docs/**`, and the doc names itself as `not required`), so this PR does not itself need host proof

## Non-claims

- Does not claim the gate is correctly *configured*, only that it exists and is required.
- Does not claim the gate is currently *satisfiable*. It is not, at present, for PRs that trigger it; that is a separate finding filed against the timeout, not fixed here.
- Does not change any trigger path, field list, or failure reason.
- Reviewer note: I am this PR's builder, so my own reading is not the quorum review.

Made with [Cursor](https://cursor.com)