### PR TITLE
Include otel-mcp fixture lockfile in scheduled OSV targets

### DIFF
--- a/.github/osv/non-rust-manifests.txt
+++ b/.github/osv/non-rust-manifests.txt
@@ -2,6 +2,7 @@
 #
 # Keep this list limited to tracked non-Rust dependency inputs. Rust advisory
 # policy is owned by cargo-deny/cargo-audit in PR CI.
+crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/generator/package-lock.json
 docs/requirements-ci.txt
 examples/agentevals-trajectory-strict-match-evidence/requirements.txt
 examples/autoevals-exactmatch-evidence/requirements.txt


### PR DESCRIPTION
## Summary
- Scheduled OSV discovery found one tracked non-Rust lockfile missing from `.github/osv/non-rust-manifests.txt`: `crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/generator/package-lock.json`.
- Added that path (sorted) so discovery-vs-allowlist coverage is green again.
- One-line allowlist fix only; no exclusion mechanism.

## Non-claim
Coverage-green means every discovered `package-lock.json` / `requirements*.txt` is listed for scheduled scan. It does **not** mean the repository or the fixture is vulnerability-free.

## Base / head
- Base (exact): `161b968fb723d5ea794a9bda40913055567b9391`
- Head: `64d21b4d4a914e9757fdbfa963466075a2827be9`
- Branch: `cursor/fix-osv-fixture-target`
- Worktree: `/tmp/assay-wt-osv-fixture-target`

## RED evidence
Command (at base `161b968fb723d5ea794a9bda40913055567b9391` before the allowlist edit):

```bash
listed=$(grep -Ev '^[[:space:]]*(#|$)' .github/osv/non-rust-manifests.txt | LC_ALL=C sort -u)
discovered=$(git ls-files | grep -E '(^|/)(package-lock\.json|requirements[^/]*\.txt)$' | LC_ALL=C sort -u)
comm -13 <(printf '%s\n' \"$listed\") <(printf '%s\n' \"$discovered\")
```

Output:

```
crates/assay-core/tests/fixtures/otel-mcp-ingest-v0/generator/package-lock.json
```

## GREEN evidence
Same `comm -13` after the edit: empty (coverage green).

Also verified:
- every listed path is git-tracked and exists on disk
- no `Cargo.lock` in the allowlist
- list remains `LC_ALL=C` sorted
- `.github/workflows/osv-scanner-scheduled.yml` parses as YAML (Ruby `YAML.load_file`)
- `git diff --check` clean
- allowlist comments contain no vulnerability-free / safe-agent claim language

Local OSV scanner (v2.3.8 binary `osv-scanner_darwin_arm64`, lockfile-only — no `npm install`, no package scripts):

```
osv-scanner version: 2.3.8
Scanned .../generator/package-lock.json file and found 14 packages
No issues found
osv-scanner_exit=0
```

Docker daemon was unavailable locally (`docker.sock` missing); binary scan substituted. Exit 0 here means the scanner ingested the lockfile and reported no matching advisories for that snapshot — not a product claim that Assay or the fixture is vulnerability-free.

## Test plan
- [x] RED: discovery-vs-allowlist shows the one missing fixture path
- [x] GREEN: `comm -13` empty; listed paths tracked+exist; no Cargo.lock
- [x] Workflow YAML still valid
- [x] osv-scanner v2.3.8 lockfile scan against the fixture (no package scripts)
- [ ] CI `Scheduled OSV Advisory` / related checks on the PR head

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the OTEL MCP ingest fixture’s dependency lockfile to scheduled security advisory scans.
  * Improved coverage for detecting vulnerabilities in tracked non-Rust dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->