### PR TITLE
fix(test-support): kill remaining process tree before waiting on pipe EOF

### DIFF
--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -135,7 +135,19 @@ pub fn run_bounded(
 
         if observed_status.is_none() {
             match child.try_wait() {
-                Ok(Some(status)) => observed_status = Some(status),
+                Ok(Some(status)) => {
+                    observed_status = Some(status);
+                    // Descendants that still hold inherited pipes keep readers
+                    // from EOF. Terminate the remaining tree now — before
+                    // treating reader EOF as the success condition — then drain
+                    // buffered output within the same total deadline.
+                    let io_outstanding = !stdin_writer.is_finished()
+                        || !stdout_reader.is_finished()
+                        || !stderr_reader.is_finished();
+                    if io_outstanding {
+                        terminate_remaining_tree(child.as_mut(), context, &command_display)?;
+                    }
+                }
                 Ok(None) => {}
                 Err(error) => {
                     let reap = terminate_and_reap(child.as_mut(), None, context, &command_display);
@@ -151,6 +163,10 @@ pub fn run_bounded(
             && stdout_reader.is_finished()
             && stderr_reader.is_finished()
         {
+            // After I/O completion this may accept post-IO quiescence (including
+            // macOS EPERM on an empty group) that terminate_remaining_tree does
+            // not. When the early path already killed the tree, this is a
+            // no-op or that quiescent acceptance.
             finish_process_tree(child.as_mut(), context, &command_display)?;
             break observed_status
                 .take()
@@ -325,6 +341,27 @@ fn finish_process_tree(
     }
 }
 
+/// Terminates descendants that outlived the direct child so inherited pipes can
+/// reach EOF. Only demonstrably absent trees are accepted here
+/// (`process_tree_absent`); macOS EPERM is not, because I/O may still be
+/// outstanding and that error is reserved for the post-IO finish path.
+fn terminate_remaining_tree(
+    child: &mut dyn ChildWrapper,
+    context: &str,
+    command: &str,
+) -> Result<(), String> {
+    match child.start_kill() {
+        Ok(()) => Ok(()),
+        Err(error) if process_tree_absent(&error) => Ok(()),
+        Err(error) => {
+            let direct_kill_error = child.inner_mut().start_kill().err();
+            Err(format!(
+                "{context}: failed to terminate remaining process tree for {command}: {error}; direct_kill={direct_kill_error:?}"
+            ))
+        }
+    }
+}
+
 #[cfg(unix)]
 fn process_tree_absent(error: &std::io::Error) -> bool {
     error.raw_os_error() == Some(libc::ESRCH)
@@ -404,11 +441,263 @@ mod tests {
     #[cfg(unix)]
     use super::{process_tree_absent, process_tree_quiescent_after_io};
     use super::{run_bounded, ProcessLimits};
-    use std::path::Path;
+    use std::io::Write;
+    use std::path::PathBuf;
     use std::process::{Command, Stdio};
     use std::sync::mpsc;
     use std::thread;
     use std::time::{Duration, Instant};
+
+    /// Selected on the bounded child so this test binary, re-executed, acts as
+    /// the descendant spawner instead of running the suite.
+    const HELPER_MODE_ENV: &str = "ASSAY_BOUNDED_PROCESS_HELPER_MODE";
+    /// libtest filter that selects the helper in every binary including this
+    /// module, whatever module path it is included under. A filter that matched
+    /// nothing would exit 0 silently, so
+    /// `the_re_executed_helper_is_selected_by_exactly_one_filter_match` pins it.
+    const HELPER_FILTER: &str = "descendant_spawner_helper_process";
+    /// Readiness and the descendant's pid travel as one record on both output
+    /// channels, so the bounded run can assert one verbatim and find it in the
+    /// other. Carrying the pid in already-captured output removes the
+    /// environment-controlled pid-file write channel.
+    const READY_RECORD_PREFIX: &str = "READY pid=";
+    /// The control's record. It names no pid because the control spawns nothing,
+    /// and it deliberately does not carry the pid prefix.
+    const READY_SOLO_RECORD: &str = "READY solo";
+    /// `u32::MAX` is ten digits, so anything longer is not a pid.
+    const MAX_PID_DIGITS: usize = 10;
+
+    fn ready_record(pid: u32) -> String {
+        format!("{READY_RECORD_PREFIX}{pid}")
+    }
+
+    /// Reads the descendant's pid out of a bounded run's captured record.
+    ///
+    /// The text is a child's output, or a diagnostic quoting it, so it is
+    /// untrusted and this rejects rather than scans. Only digits may follow the
+    /// prefix and they must be a non-zero `u32`; every record present must name
+    /// the same pid; and no record at all is an error.
+    fn descendant_pid_from(record: &str) -> Result<u32, String> {
+        let mut seen: Option<u32> = None;
+        for (start, _) in record.match_indices(READY_RECORD_PREFIX) {
+            let digits: String = record[start + READY_RECORD_PREFIX.len()..]
+                .chars()
+                .take(MAX_PID_DIGITS + 1)
+                .take_while(char::is_ascii_digit)
+                .collect();
+            if digits.is_empty() {
+                // The quoted command line carries the prefix with no pid behind
+                // it. That is not a record, and not a malformed one either.
+                continue;
+            }
+            let pid = match digits.parse::<u32>() {
+                Ok(0) | Err(_) => {
+                    return Err(format!("readiness record has no usable pid: {record:?}"));
+                }
+                Ok(pid) => pid,
+            };
+            match seen {
+                Some(first) if first != pid => {
+                    return Err(format!("readiness records disagree: {first} and {pid}"));
+                }
+                _ => seen = Some(pid),
+            }
+        }
+        seen.ok_or_else(|| format!("no readiness record: {record:?}"))
+    }
+
+    /// What the bounded child does before it exits.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    enum HelperPlan {
+        /// Spawns a descendant that keeps stdout and stderr open after its
+        /// parent exits, so the reader threads never reach EOF until the tree
+        /// is terminated.
+        Inherited,
+        /// Spawns a descendant that asks for neither handle.
+        Detached,
+        /// Spawns nothing. The control: with no descendant to hold anything, the
+        /// readers must reach EOF when the child exits.
+        Solo,
+    }
+
+    impl HelperPlan {
+        fn as_str(self) -> &'static str {
+            match self {
+                Self::Inherited => "inherited",
+                Self::Detached => "detached",
+                Self::Solo => "solo",
+            }
+        }
+
+        fn parse(value: &str) -> Option<Self> {
+            match value {
+                "inherited" => Some(Self::Inherited),
+                "detached" => Some(Self::Detached),
+                "solo" => Some(Self::Solo),
+                _ => None,
+            }
+        }
+    }
+
+    fn current_test_binary() -> PathBuf {
+        std::env::current_exe().expect("the running test binary must be addressable")
+    }
+
+    /// The bounded child that spawns a descendant and publishes its pid.
+    ///
+    /// On Windows this re-executes the test binary rather than scripting
+    /// `powershell.exe`, whose startup has been observed longer than the
+    /// bounded window. Unix keeps a shell whose startup is a fraction of that
+    /// bound; both sides speak the same READY record protocol.
+    #[cfg(windows)]
+    fn descendant_spawner_command(plan: HelperPlan) -> Command {
+        let mut command = Command::new(current_test_binary());
+        command
+            .args([
+                HELPER_FILTER,
+                "--ignored",
+                "--nocapture",
+                "--format",
+                "terse",
+            ])
+            .env(HELPER_MODE_ENV, plan.as_str());
+        command
+    }
+
+    #[cfg(unix)]
+    fn descendant_spawner_command(plan: HelperPlan) -> Command {
+        let script = match plan {
+            HelperPlan::Solo => {
+                format!("printf '{READY_SOLO_RECORD}'; printf '{READY_SOLO_RECORD}' >&2",)
+            }
+            HelperPlan::Inherited | HelperPlan::Detached => {
+                let detach = match plan {
+                    HelperPlan::Detached => "exec </dev/null >/dev/null 2>&1;",
+                    _ => "",
+                };
+                format!(
+                    "sh -c '{detach} while :; do :; done' descendant & \
+                     printf '{READY_RECORD_PREFIX}%s' \"$!\"; \
+                     printf '{READY_RECORD_PREFIX}%s' \"$!\" >&2",
+                )
+            }
+        };
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(script);
+        command
+    }
+
+    /// Runs as the bounded child of the Windows descendant tests, never as part
+    /// of the suite. `--ignored` keeps it out of a normal run.
+    // The descendant is deliberately never waited on: it has to outlive this
+    // process so that the process-tree termination under test is what reaps it.
+    #[allow(clippy::zombie_processes)]
+    #[test]
+    #[ignore = "re-executed as the bounded child of the descendant tests"]
+    fn descendant_spawner_helper_process() {
+        let mode = std::env::var(HELPER_MODE_ENV)
+            .unwrap_or_else(|error| panic!("{HELPER_MODE_ENV} must be set: {error}"));
+        let plan =
+            HelperPlan::parse(&mode).unwrap_or_else(|| panic!("unknown helper plan {mode:?}"));
+
+        let record = match plan {
+            HelperPlan::Solo => READY_SOLO_RECORD.to_owned(),
+            HelperPlan::Inherited | HelperPlan::Detached => {
+                let mut descendant = hanging_command();
+                descendant.stdin(Stdio::null());
+                if plan == HelperPlan::Detached {
+                    descendant.stdout(Stdio::null()).stderr(Stdio::null());
+                }
+                let child = descendant
+                    .spawn()
+                    .unwrap_or_else(|error| panic!("spawn the descendant: {error}"));
+                ready_record(child.id())
+            }
+        };
+
+        // libtest prefixes this process's stdout with its own report, so the
+        // record goes to both: stderr carries this child's bytes alone.
+        std::io::stdout()
+            .write_all(record.as_bytes())
+            .expect("report readiness on stdout");
+        std::io::stdout().flush().expect("flush readiness");
+        std::io::stderr()
+            .write_all(record.as_bytes())
+            .expect("report readiness on stderr");
+    }
+
+    #[test]
+    fn the_helper_plan_survives_the_round_trip_to_the_helper() {
+        for plan in [
+            HelperPlan::Inherited,
+            HelperPlan::Detached,
+            HelperPlan::Solo,
+        ] {
+            assert_eq!(HelperPlan::parse(plan.as_str()), Some(plan));
+        }
+        assert_eq!(HelperPlan::parse("hidden"), None);
+        assert!(descendant_pid_from(READY_SOLO_RECORD).is_err());
+    }
+
+    #[test]
+    fn the_re_executed_helper_is_selected_by_exactly_one_filter_match() {
+        let listing = Command::new(current_test_binary())
+            .args([HELPER_FILTER, "--ignored", "--list", "--format", "terse"])
+            .output()
+            .expect("list the helper test");
+        assert!(
+            listing.status.success(),
+            "listing the helper test failed: {}",
+            listing.status
+        );
+        let listed = String::from_utf8_lossy(&listing.stdout);
+        let selected: Vec<&str> = listed
+            .lines()
+            .filter(|line| line.ends_with(": test"))
+            .collect();
+        assert_eq!(
+            selected.len(),
+            1,
+            "{HELPER_FILTER} must select exactly one test, listing was {listed:?}"
+        );
+        assert!(selected[0].contains(HELPER_FILTER), "{listed:?}");
+    }
+
+    #[test]
+    fn only_one_exactly_shaped_readiness_record_yields_a_pid() {
+        assert_eq!(descendant_pid_from("READY pid=4294967295"), Ok(u32::MAX));
+        assert_eq!(
+            descendant_pid_from("\nrunning 1 test\nREADY pid=1234.\ntest result: ok.\n"),
+            Ok(1234),
+            "libtest's own report surrounds the record and must not hide it"
+        );
+        assert_eq!(
+            descendant_pid_from(
+                "sh -c printf 'READY pid=%s'\": deadline expired; \
+                 stdout=\"READY pid=77\" (12 bytes); stderr=\"READY pid=77\" (12 bytes)"
+            ),
+            Ok(77),
+            "one pid written to both channels and quoted back must still read"
+        );
+
+        for rejected in [
+            "",
+            "READY pid=",
+            "READY pid=x",
+            "READY pid=-1",
+            "READY pid=0",
+            "READY pid=4294967296",
+            "READY pid=42949672960",
+            "READY pid=1 READY pid=2",
+            "READY pid=1 READY pid=1 READY pid=3",
+            "parent-ready",
+        ] {
+            assert!(
+                descendant_pid_from(rejected).is_err(),
+                "{rejected:?} must not yield a pid"
+            );
+        }
+    }
 
     #[cfg(unix)]
     fn hanging_command() -> Command {
@@ -445,29 +734,12 @@ mod tests {
         command
     }
 
-    #[cfg(unix)]
-    fn inherited_output_descendant_command(pid_file: &Path) -> Command {
-        let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg(
-                "sh -c 'echo \"$$\" > \"$1\"; while :; do :; done' descendant \"$1\" & printf parent-ready",
-            )
-            .arg("runner")
-            .arg(pid_file);
-        command
-    }
-
     #[cfg(windows)]
-    fn inherited_output_descendant_command(pid_file: &Path) -> Command {
-        let mut command = Command::new("powershell.exe");
-        command.env("ASSAY_DESCENDANT_PID_FILE", pid_file);
+    fn stderr_flood_command() -> Command {
+        let mut command = Command::new("cmd");
         command.args([
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "$path = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID_FILE'); $p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -NoNewWindow -PassThru; [IO.File]::WriteAllText($path, [string]$p.Id); [Console]::Out.Write('parent-ready')",
+            "/C",
+            "for /L %i in (1,1,1000000) do @echo 0123456789abcdef 1>&2",
         ]);
         command
     }
@@ -486,19 +758,8 @@ mod tests {
         command
     }
 
-    fn read_descendant_pid(pid_file: &Path) -> Option<u32> {
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while Instant::now() < deadline {
-            if let Ok(raw) = std::fs::read_to_string(pid_file) {
-                if let Ok(pid) = raw.trim().parse() {
-                    return Some(pid);
-                }
-            }
-            thread::sleep(Duration::from_millis(10));
-        }
-        None
-    }
-
+    /// A probe that cannot run is not an answer, so a spawn failure panics
+    /// rather than reporting a descendant dead.
     #[cfg(unix)]
     fn descendant_is_alive(pid: u32) -> bool {
         Command::new("kill")
@@ -506,26 +767,22 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
-            .is_ok_and(|status| status.success())
+            .expect("the liveness probe must be runnable")
+            .success()
     }
 
+    /// `tasklist` is native. PowerShell must stay out of the bounded window.
     #[cfg(windows)]
     fn descendant_is_alive(pid: u32) -> bool {
-        let mut command = Command::new("powershell.exe");
-        command
-            .env("ASSAY_DESCENDANT_PID", pid.to_string())
-            .args([
-                "-NoLogo",
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                "$targetPid = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID'); if (Get-Process -Id $targetPid -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
-            ]);
-        command
-            .stdout(Stdio::null())
+        let listing = Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
             .stderr(Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
+            .output()
+            .expect("the liveness probe must be runnable");
+        let pid = pid.to_string();
+        String::from_utf8_lossy(&listing.stdout)
+            .split_whitespace()
+            .any(|field| field == pid)
     }
 
     fn wait_for_descendant_exit(pid: u32) -> bool {
@@ -545,16 +802,6 @@ mod tests {
             descendant_is_alive(std::process::id()),
             "liveness probe must distinguish a live process from an exited descendant"
         );
-    }
-
-    #[cfg(windows)]
-    fn stderr_flood_command() -> Command {
-        let mut command = Command::new("cmd");
-        command.args([
-            "/C",
-            "for /L %i in (1,1,1000000) do @echo 0123456789abcdef 1>&2",
-        ]);
-        command
     }
 
     #[cfg(unix)]
@@ -577,31 +824,54 @@ mod tests {
         Duration::from_secs(10)
     }
 
-    #[cfg(unix)]
-    fn quiet_descendant_command(pid_file: &Path) -> Command {
-        let mut command = Command::new("sh");
-        command
-            .arg("-c")
-            .arg(
-                "sh -c 'echo \"$$\" > \"$1\"; exec </dev/null >/dev/null 2>&1; while :; do :; done' descendant \"$1\" & while [ ! -s \"$1\" ]; do :; done; printf parent-ready",
-            )
-            .arg("runner")
-            .arg(pid_file);
-        command
-    }
+    fn assert_parent_exit_preserves_ready_and_kills_descendant(plan: HelperPlan, context: &str) {
+        let (result_tx, result_rx) = mpsc::channel();
+        let started = Instant::now();
+        let context_for_worker = context.to_owned();
 
-    #[cfg(windows)]
-    fn quiet_descendant_command(pid_file: &Path) -> Command {
-        let mut command = Command::new("powershell.exe");
-        command.env("ASSAY_DESCENDANT_PID_FILE", pid_file);
-        command.args([
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "$path = [Environment]::GetEnvironmentVariable('ASSAY_DESCENDANT_PID_FILE'); $p = Start-Process -FilePath ping.exe -ArgumentList @('-t','127.0.0.1') -WindowStyle Hidden -PassThru; [IO.File]::WriteAllText($path, [string]$p.Id); [Console]::Out.Write('parent-ready')",
-        ]);
-        command
+        let worker = thread::spawn(move || {
+            let command = descendant_spawner_command(plan);
+            let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
+            let _ = result_tx.send(run_bounded(command, b"", limits, &context_for_worker));
+        });
+
+        let result = match result_rx.recv_timeout(descendant_test_guard()) {
+            Ok(result) => result,
+            Err(error) => panic!("runner escaped its wall-clock bound: {error}"),
+        };
+        worker.join().expect("bounded runner worker");
+
+        let output = result.unwrap_or_else(|error| {
+            panic!(
+                "{context}: direct child exit with a live descendant must return Ok before the \
+                 existing deadline, preserve parent status/READY bytes, and leave the descendant \
+                 dead; got Err: {error}"
+            )
+        });
+
+        assert!(
+            output.status.success(),
+            "{context}: preserved parent status must be success, got {:?}",
+            output.status
+        );
+        let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is the child's text");
+        let descendant_pid = descendant_pid_from(&stderr)
+            .unwrap_or_else(|reason| panic!("{context}: descendant pid unreadable: {reason}"));
+        assert_eq!(stderr, ready_record(descendant_pid));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            descendant_pid_from(&stdout).ok(),
+            Some(descendant_pid),
+            "{context}: stdout must carry the same readiness record: {stdout:?}"
+        );
+        assert!(
+            wait_for_descendant_exit(descendant_pid),
+            "{context}: descendant {descendant_pid} survived process-tree termination"
+        );
+        assert!(
+            started.elapsed() < descendant_test_guard(),
+            "{context}: process-tree cleanup exceeded the test bound"
+        );
     }
 
     #[test]
@@ -644,19 +914,42 @@ mod tests {
         );
     }
 
+    /// Contract: once the direct child exits, a descendant that still holds the
+    /// run's inherited stdout/stderr must not force a deadline. `run_bounded`
+    /// returns Ok with the parent's status and READY bytes, and the descendant
+    /// is dead — on every platform, with no Windows-expects-deadline split.
     #[test]
-    fn kills_descendant_that_holds_inherited_output_open() {
-        let temp = tempfile::tempdir().expect("temporary pid directory");
-        let pid_file = temp.path().join("descendant.pid");
-        let cleanup_path = pid_file.clone();
+    fn parent_exit_with_inherited_output_descendant_returns_ok_before_deadline() {
+        assert_parent_exit_preserves_ready_and_kills_descendant(
+            HelperPlan::Inherited,
+            "inherited output mutation",
+        );
+    }
+
+    /// Quiet-success contract: a descendant that asked for null stdio is still
+    /// terminated after a normal parent exit, and the run remains Ok with READY
+    /// bytes preserved. Same assertion on Windows and Unix — no platform split
+    /// that accepts the defect.
+    #[test]
+    fn parent_exit_with_quiet_descendant_returns_ok_before_deadline() {
+        assert_parent_exit_preserves_ready_and_kills_descendant(
+            HelperPlan::Detached,
+            "normal completion mutation",
+        );
+    }
+
+    /// Solo control for the inherited-handle claim: same binary/re-exec/shell
+    /// path, same limits and guard, but no descendant. Success here locates any
+    /// EOF failure in the descendant arm; a deadline here would refute that
+    /// account, because nothing exists to hold the handles.
+    #[test]
+    fn the_same_child_reaches_eof_when_it_spawns_no_descendant() {
         let (result_tx, result_rx) = mpsc::channel();
-        let started = Instant::now();
 
         let worker = thread::spawn(move || {
-            let command = inherited_output_descendant_command(&pid_file);
+            let command = descendant_spawner_command(HelperPlan::Solo);
             let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
-            let result = run_bounded(command, b"", limits, "inherited output mutation");
-            let _ = result_tx.send(result);
+            let _ = result_tx.send(run_bounded(command, b"", limits, "no descendant control"));
         });
 
         let result = match result_rx.recv_timeout(descendant_test_guard()) {
@@ -665,37 +958,56 @@ mod tests {
         };
         worker.join().expect("bounded runner worker");
 
-        let error = result.expect_err("inherited output holder must force tree termination");
-        assert!(error.contains("inherited output mutation"));
-        assert!(error.contains("deadline"));
-        assert!(
-            started.elapsed() < descendant_test_guard(),
-            "process-tree cleanup exceeded the test bound"
+        let output = result.unwrap_or_else(|error| {
+            panic!(
+                "a child that spawned nothing must reach EOF; that it did not refutes the \
+                 inherited-handle account of #2249, since no descendant existed to hold the \
+                 run's handles: {error}"
+            )
+        });
+
+        assert!(output.status.success(), "{:?}", output.status);
+        let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is the child's text");
+        assert_eq!(
+            stderr, READY_SOLO_RECORD,
+            "the control must be the same child, reporting"
         );
-        let descendant_pid = read_descendant_pid(&cleanup_path)
-            .expect("descendant must publish its pid before inheriting output");
-        if !wait_for_descendant_exit(descendant_pid) {
-            panic!("descendant {descendant_pid} survived process-tree termination");
-        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(READY_SOLO_RECORD),
+            "stdout must carry the same record: {stdout:?}"
+        );
     }
 
+    /// On Windows the descendant tests use this re-execution as their bounded
+    /// child. Here it separates "the helper is broken" from "the bound was
+    /// lost": this bound is the test guard, not the deadline under test.
+    #[cfg(unix)]
     #[test]
-    fn kills_quiet_descendant_after_normal_parent_exit() {
-        let temp = tempfile::tempdir().expect("temporary pid directory");
-        let pid_file = temp.path().join("quiet-descendant.pid");
-        let command = quiet_descendant_command(&pid_file);
-        let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
+    fn the_re_executed_helper_publishes_a_pid_and_reports_readiness() {
+        let mut command = Command::new(current_test_binary());
+        command
+            .args([
+                HELPER_FILTER,
+                "--ignored",
+                "--nocapture",
+                "--format",
+                "terse",
+            ])
+            .env(HELPER_MODE_ENV, HelperPlan::Detached.as_str());
+        let limits = ProcessLimits::new(descendant_test_guard(), 1024, 1024);
 
-        let output = run_bounded(command, b"", limits, "normal completion mutation")
-            .expect("normal parent completion must retain its outcome");
+        let output = run_bounded(command, b"", limits, "helper re-execution")
+            .expect("the re-executed helper must complete within the test guard");
 
-        assert!(output.status.success());
-        assert_eq!(output.stdout, b"parent-ready");
-        let descendant_pid =
-            read_descendant_pid(&pid_file).expect("quiet descendant must publish its pid");
+        assert!(output.status.success(), "{:?}", output.status);
+        let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is the child's text");
+        let descendant_pid = descendant_pid_from(&stderr)
+            .unwrap_or_else(|reason| panic!("helper pid unreadable: {reason}"));
+        assert_eq!(stderr, ready_record(descendant_pid));
         assert!(
             wait_for_descendant_exit(descendant_pid),
-            "quiet descendant {descendant_pid} survived normal completion cleanup"
+            "descendant {descendant_pid} of the re-executed helper survived cleanup"
         );
     }
 

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -1,10 +1,5 @@
-// Non-blocking pipe mode needs fcntl (Unix) / SetNamedPipeHandleState (Windows).
-// That FFI is what makes stdout/stderr capture cancelable when every tree-kill
-// attempt fails, so run_bounded can return without joining blocked readers.
-#![allow(unsafe_code)]
-
 use std::ffi::OsStr;
-use std::io::{ErrorKind, Read, Write};
+use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 use std::process::{Command, ExitStatus, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -44,33 +39,16 @@ static INJECTED_TREE_KILL_CHILD_PID: AtomicU32 = AtomicU32::new(0);
 #[cfg(test)]
 static INJECTED_TREE_KILL_HITS: AtomicUsize = AtomicUsize::new(0);
 
-// Test-only: when set on the `run_bounded` caller thread, spawned I/O workers
-// register in `LIVE_IO_WORKERS` for the duration of their closure.
+// Test-only: when set, stdout/stderr capture setup fails after spawn so the
+// post-spawn cleanup path can be exercised.
 #[cfg(test)]
 thread_local! {
-    static TRACK_IO_WORKERS: Cell<bool> = const { Cell::new(false) };
+    static INJECT_CAPTURE_SETUP_ERROR: Cell<Option<&'static str>> = const { Cell::new(None) };
 }
 
+// Test-only: last child pid observed at spawn, for cleanup-leak assertions.
 #[cfg(test)]
-static LIVE_IO_WORKERS: AtomicUsize = AtomicUsize::new(0);
-
-#[cfg(test)]
-struct IoWorkerGuard;
-
-#[cfg(test)]
-impl IoWorkerGuard {
-    fn enter() -> Self {
-        LIVE_IO_WORKERS.fetch_add(1, Ordering::SeqCst);
-        Self
-    }
-}
-
-#[cfg(test)]
-impl Drop for IoWorkerGuard {
-    fn drop(&mut self) {
-        LIVE_IO_WORKERS.fetch_sub(1, Ordering::SeqCst);
-    }
-}
+static LAST_SPAWNED_CHILD_PID: AtomicU32 = AtomicU32::new(0);
 
 #[derive(Clone, Copy)]
 pub struct ProcessLimits {
@@ -113,6 +91,10 @@ impl CapturedStream {
 /// group or Windows Job Object before this function returns. Processes that
 /// deliberately escape those OS containers are outside this test helper's
 /// supported process shape.
+///
+/// Stdin is file-backed before spawn (no writer thread). Stdout/stderr are
+/// polled by this owner with cancelable capture so return stays bounded even
+/// when every tree-kill attempt fails.
 pub fn run_bounded(
     mut command: Command,
     stdin: &[u8],
@@ -128,8 +110,9 @@ pub fn run_bounded(
         "stderr ceiling must be positive"
     );
     let command_display = display_command(&command);
+    let stdin_stdio = prepare_stdin_stdio(stdin, context, &command_display)?;
     command
-        .stdin(Stdio::piped())
+        .stdin(stdin_stdio)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     let mut command = CommandWrap::from(command);
@@ -140,10 +123,8 @@ pub fn run_bounded(
     let mut child = command
         .spawn()
         .map_err(|error| format!("{context}: spawn {command_display}: {error}"))?;
-    let mut child_stdin = child
-        .stdin()
-        .take()
-        .ok_or_else(|| format!("{context}: {command_display}: child stdin was not piped"))?;
+    #[cfg(test)]
+    LAST_SPAWNED_CHILD_PID.store(child.id(), Ordering::SeqCst);
     let child_stdout = child
         .stdout()
         .take()
@@ -153,32 +134,44 @@ pub fn run_bounded(
         .take()
         .ok_or_else(|| format!("{context}: {command_display}: child stderr was not piped"))?;
 
-    let stdin = stdin.to_vec();
-    #[cfg(test)]
-    let track_io_workers = TRACK_IO_WORKERS.get();
-    let stdin_writer = thread::spawn(move || {
-        #[cfg(test)]
-        let _worker_guard = track_io_workers.then(IoWorkerGuard::enter);
-        let result = child_stdin.write_all(&stdin);
-        drop(child_stdin);
-        result
-    });
-
-    // Non-blocking spoolers: capture is cancelable by dropping the pipe end, so
-    // return stays bounded even when every tree-kill attempt fails and EOF never
-    // arrives. Blocking read_to_end workers cannot offer that.
-    let mut stdout_capture = CapturedOutput::new(
+    // Capture setup is post-spawn (pipes exist only then). Failures must still
+    // terminate/reap — process-wrap does not kill on drop.
+    let mut stdout_capture = match open_capture(
         child_stdout,
         limits.max_stdout_bytes,
         CapturedStream::Stdout,
-    )
-    .map_err(|error| format!("{context}: {command_display}: stdout capture: {error}"))?;
-    let mut stderr_capture = CapturedOutput::new(
+        context,
+        &command_display,
+    ) {
+        Ok(capture) => capture,
+        Err(error) => {
+            drop(child_stderr);
+            return Err(fail_spawned_child(
+                child.as_mut(),
+                context,
+                &command_display,
+                error,
+            ));
+        }
+    };
+    let mut stderr_capture = match open_capture(
         child_stderr,
         limits.max_stderr_bytes,
         CapturedStream::Stderr,
-    )
-    .map_err(|error| format!("{context}: {command_display}: stderr capture: {error}"))?;
+        context,
+        &command_display,
+    ) {
+        Ok(capture) => capture,
+        Err(error) => {
+            stdout_capture.abandon();
+            return Err(fail_spawned_child(
+                child.as_mut(),
+                context,
+                &command_display,
+                error,
+            ));
+        }
+    };
 
     let deadline = Instant::now() + limits.timeout;
     let mut early_failure = None;
@@ -211,14 +204,9 @@ pub fn run_bounded(
                     // from EOF. Terminate the remaining tree now — before
                     // treating reader EOF as the success condition — then drain
                     // buffered output within the same total deadline.
-                    let io_outstanding = !stdin_writer.is_finished()
-                        || !stdout_capture.is_finished()
-                        || !stderr_capture.is_finished();
+                    let io_outstanding =
+                        !stdout_capture.is_finished() || !stderr_capture.is_finished();
                     if io_outstanding {
-                        // Preserve a tree-kill failure, but do not return while
-                        // the stdin worker or open captures may still be live.
-                        // Keep draining under the same deadline; terminate_and_reap
-                        // below retries termination before finalizing captures.
                         if let Err(error) =
                             terminate_remaining_tree(child.as_mut(), context, &command_display)
                         {
@@ -231,7 +219,6 @@ pub fn run_bounded(
                     let reap = terminate_and_reap(child.as_mut(), None, context, &command_display);
                     stdout_capture.abandon();
                     stderr_capture.abandon();
-                    let _ = stdin_writer.join();
                     return Err(format!(
                         "{context}: poll {command_display}: {error}; terminate/reap: {reap:?}"
                     ));
@@ -239,16 +226,17 @@ pub fn run_bounded(
             }
         }
 
-        if observed_status.is_some()
-            && stdin_writer.is_finished()
-            && stdout_capture.is_finished()
-            && stderr_capture.is_finished()
+        if observed_status.is_some() && stdout_capture.is_finished() && stderr_capture.is_finished()
         {
             // After I/O completion this may accept post-IO quiescence (including
             // macOS EPERM on an empty group) that terminate_remaining_tree does
             // not. When the early path already killed the tree, this is a
             // no-op or that quiescent acceptance.
-            finish_process_tree(child.as_mut(), context, &command_display)?;
+            if let Err(error) = finish_process_tree(child.as_mut(), context, &command_display) {
+                if tree_termination_error.is_none() {
+                    tree_termination_error = Some(error);
+                }
+            }
             break observed_status
                 .take()
                 .expect("status was checked immediately above");
@@ -307,9 +295,6 @@ pub fn run_bounded(
         thread::sleep(POLL_INTERVAL);
     };
 
-    let stdin_result = stdin_writer
-        .join()
-        .map_err(|_| format!("{context}: {command_display}: stdin writer panicked"))?;
     let stdout = stdout_capture
         .into_bytes()
         .map_err(|error| format!("{context}: read stdout from {command_display}: {error}"))?;
@@ -361,21 +346,6 @@ pub fn run_bounded(
             &stderr,
         ));
     }
-    // Status and both output streams are already collected, so BrokenPipe here
-    // records an early stdin close without replacing the child's outcome.
-    stdin_result.or_else(|error| {
-        if error.kind() == std::io::ErrorKind::BrokenPipe {
-            return Ok(());
-        }
-        Err(failure_diagnostic(
-            context,
-            &command_display,
-            &format!("write stdin: {error}"),
-            &status,
-            &stdout,
-            &stderr,
-        ))
-    })?;
 
     Ok(Output {
         status,
@@ -384,10 +354,36 @@ pub fn run_bounded(
     })
 }
 
+/// Prepare stdin before spawn so setup failures cannot leak a child. Empty
+/// stdin uses `/dev/null`; non-empty payloads are a bounded tempfile sized to
+/// the caller slice (not an output spool).
+fn prepare_stdin_stdio(stdin: &[u8], context: &str, command: &str) -> Result<Stdio, String> {
+    if stdin.is_empty() {
+        return Ok(Stdio::null());
+    }
+    let mut file = tempfile::tempfile()
+        .map_err(|error| format!("{context}: {command}: create stdin tempfile: {error}"))?;
+    file.write_all(stdin)
+        .map_err(|error| format!("{context}: {command}: write stdin tempfile: {error}"))?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| format!("{context}: {command}: rewind stdin tempfile: {error}"))?;
+    Ok(Stdio::from(file))
+}
+
+fn fail_spawned_child(
+    child: &mut dyn ChildWrapper,
+    context: &str,
+    command: &str,
+    setup_error: String,
+) -> String {
+    let reap = terminate_and_reap(child, None, context, command);
+    format!("{setup_error}; terminate/reap: {reap:?}")
+}
+
 /// Bounded stdout/stderr capture that never blocks the helper on EOF.
 ///
-/// Pipes are set non-blocking so `drain` returns when the kernel has no bytes
-/// ready. Dropping the reader (`abandon` / overflow / EOF) cancels capture
+/// Unix pipes use O_NONBLOCK. Windows uses PeekNamedPipe (no pipe-mode
+/// mutation). Dropping the reader (`abandon` / overflow / EOF) cancels capture
 /// without a joinable worker that can hang after a persistent tree-kill failure.
 struct CapturedOutput<R> {
     reader: Option<R>,
@@ -396,6 +392,44 @@ struct CapturedOutput<R> {
     stream: CapturedStream,
     overflowed: bool,
     read_error: Option<std::io::Error>,
+}
+
+#[cfg(unix)]
+fn open_capture<R: Read + AsRawFd>(
+    reader: R,
+    limit: usize,
+    stream: CapturedStream,
+    context: &str,
+    command: &str,
+) -> Result<CapturedOutput<R>, String> {
+    #[cfg(test)]
+    if let Some(injected) = INJECT_CAPTURE_SETUP_ERROR.get() {
+        return Err(format!(
+            "{context}: {command}: {} capture: {injected}",
+            stream.name()
+        ));
+    }
+    CapturedOutput::new(reader, limit, stream)
+        .map_err(|error| format!("{context}: {command}: {} capture: {error}", stream.name()))
+}
+
+#[cfg(windows)]
+fn open_capture<R: Read + AsRawHandle>(
+    reader: R,
+    limit: usize,
+    stream: CapturedStream,
+    context: &str,
+    command: &str,
+) -> Result<CapturedOutput<R>, String> {
+    #[cfg(test)]
+    if let Some(injected) = INJECT_CAPTURE_SETUP_ERROR.get() {
+        return Err(format!(
+            "{context}: {command}: {} capture: {injected}",
+            stream.name()
+        ));
+    }
+    CapturedOutput::new(reader, limit, stream)
+        .map_err(|error| format!("{context}: {command}: {} capture: {error}", stream.name()))
 }
 
 impl<R: Read> CapturedOutput<R> {
@@ -420,7 +454,8 @@ impl<R: Read> CapturedOutput<R> {
     where
         R: AsRawHandle,
     {
-        set_nonblocking(&reader)?;
+        // PeekNamedPipe path: do not mutate pipe mode (PIPE_NOWAIT needs
+        // FILE_WRITE_ATTRIBUTES that ChildStdout/ChildStderr lack).
         Ok(Self {
             reader: Some(reader),
             bytes: Vec::with_capacity(limit.saturating_add(1)),
@@ -431,13 +466,17 @@ impl<R: Read> CapturedOutput<R> {
         })
     }
 
+    #[cfg(unix)]
     fn drain(&mut self) {
-        let Some(reader) = self.reader.as_mut() else {
-            return;
-        };
         let mut chunk = [0u8; 8192];
         loop {
-            match reader.read(&mut chunk) {
+            let read_result = {
+                let Some(reader) = self.reader.as_mut() else {
+                    return;
+                };
+                reader.read(&mut chunk)
+            };
+            match read_result {
                 Ok(0) => {
                     self.reader = None;
                     return;
@@ -454,6 +493,86 @@ impl<R: Read> CapturedOutput<R> {
                         self.reader = None;
                         return;
                     }
+                }
+                Err(error)
+                    if error.kind() == ErrorKind::WouldBlock
+                        || error.kind() == ErrorKind::Interrupted =>
+                {
+                    return;
+                }
+                Err(error) => {
+                    self.read_error = Some(error);
+                    self.reader = None;
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Windows: PeekNamedPipe for availability; never mutate pipe mode.
+    /// Empty-open (`avail == 0`) is a poll; broken pipe is EOF.
+    #[cfg(windows)]
+    fn drain(&mut self)
+    where
+        R: AsRawHandle,
+    {
+        loop {
+            let available = {
+                let Some(reader) = self.reader.as_ref() else {
+                    return;
+                };
+                match peek_pipe_available(reader.as_raw_handle()) {
+                    Ok(0) => return,
+                    Ok(available) => available,
+                    Err(error) if is_broken_pipe(&error) => {
+                        self.reader = None;
+                        return;
+                    }
+                    Err(error) => {
+                        self.read_error = Some(error);
+                        self.reader = None;
+                        return;
+                    }
+                }
+            };
+            let room = self
+                .limit
+                .saturating_add(1)
+                .saturating_sub(self.bytes.len());
+            if room == 0 {
+                self.overflowed = true;
+                self.reader = None;
+                return;
+            }
+            let to_read = (available as usize).min(room).min(8192);
+            let mut chunk = vec![0u8; to_read];
+            let read_result = {
+                let Some(reader) = self.reader.as_mut() else {
+                    return;
+                };
+                reader.read(&mut chunk)
+            };
+            match read_result {
+                Ok(0) => {
+                    self.reader = None;
+                    return;
+                }
+                Ok(n) => {
+                    let room = self
+                        .limit
+                        .saturating_add(1)
+                        .saturating_sub(self.bytes.len());
+                    let take = room.min(n);
+                    self.bytes.extend_from_slice(&chunk[..take]);
+                    if self.bytes.len() > self.limit {
+                        self.overflowed = true;
+                        self.reader = None;
+                        return;
+                    }
+                }
+                Err(error) if is_broken_pipe(&error) => {
+                    self.reader = None;
+                    return;
                 }
                 Err(error)
                     if error.kind() == ErrorKind::WouldBlock
@@ -494,8 +613,8 @@ impl<R: Read> CapturedOutput<R> {
 /// After deadline termination, pull any already-readable bytes without waiting
 /// unboundedly for EOF that a failed tree kill will never deliver.
 fn drain_captures_briefly(
-    stdout: &mut CapturedOutput<impl Read>,
-    stderr: &mut CapturedOutput<impl Read>,
+    stdout: &mut CapturedOutput<impl CaptureDrain>,
+    stderr: &mut CapturedOutput<impl CaptureDrain>,
 ) {
     let drain_deadline = Instant::now() + REAP_GRACE;
     loop {
@@ -511,15 +630,28 @@ fn drain_captures_briefly(
     }
 }
 
+/// Platform read handle bounds required to drain a capture.
+#[cfg(unix)]
+trait CaptureDrain: Read {}
+#[cfg(unix)]
+impl<T: Read> CaptureDrain for T {}
+
+#[cfg(windows)]
+trait CaptureDrain: Read + AsRawHandle {}
+#[cfg(windows)]
+impl<T: Read + AsRawHandle> CaptureDrain for T {}
+
 #[cfg(unix)]
 fn set_nonblocking(pipe: &impl AsRawFd) -> std::io::Result<()> {
     let raw = pipe.as_raw_fd();
     // SAFETY: fcntl F_GETFL/F_SETFL on a live pipe fd owned by this helper.
+    #[allow(unsafe_code)]
     let flags = unsafe { libc::fcntl(raw, libc::F_GETFL) };
     if flags == -1 {
         return Err(std::io::Error::last_os_error());
     }
     // SAFETY: same fd; O_NONBLOCK is a valid flag for pipes.
+    #[allow(unsafe_code)]
     if unsafe { libc::fcntl(raw, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
         return Err(std::io::Error::last_os_error());
     }
@@ -527,33 +659,43 @@ fn set_nonblocking(pipe: &impl AsRawFd) -> std::io::Result<()> {
 }
 
 #[cfg(windows)]
-fn set_nonblocking(pipe: &impl AsRawHandle) -> std::io::Result<()> {
-    const PIPE_NOWAIT: u32 = 0x0000_0001;
+fn peek_pipe_available(handle: std::os::windows::io::RawHandle) -> std::io::Result<u32> {
     #[link(name = "kernel32")]
     extern "system" {
-        fn SetNamedPipeHandleState(
+        fn PeekNamedPipe(
             h_named_pipe: *mut core::ffi::c_void,
-            lp_mode: *const u32,
-            lp_max_collection_count: *const u32,
-            lp_collect_data_timeout: *const u32,
+            lp_buffer: *mut core::ffi::c_void,
+            n_buffer_size: u32,
+            lp_bytes_read: *mut u32,
+            lp_total_bytes_avail: *mut u32,
+            lp_bytes_left_this_message: *mut u32,
         ) -> i32;
     }
-    let mode = PIPE_NOWAIT;
-    // SAFETY: handle is the ChildStdout/ChildStderr pipe we own; PIPE_NOWAIT is
-    // a valid named-pipe mode for anonymous stdio pipes on Windows.
+    let mut available = 0u32;
+    // SAFETY: `handle` is the ChildStdout/ChildStderr pipe we own. PeekNamedPipe
+    // is the supported read-only availability probe for anonymous pipe reads
+    // (unlike SetNamedPipeHandleState, which needs FILE_WRITE_ATTRIBUTES).
+    #[allow(unsafe_code)]
     let ok = unsafe {
-        SetNamedPipeHandleState(
-            pipe.as_raw_handle(),
-            &mode,
-            std::ptr::null(),
-            std::ptr::null(),
+        PeekNamedPipe(
+            handle,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            &mut available,
+            std::ptr::null_mut(),
         )
     };
     if ok == 0 {
         Err(std::io::Error::last_os_error())
     } else {
-        Ok(())
+        Ok(available)
     }
+}
+
+#[cfg(windows)]
+fn is_broken_pipe(error: &std::io::Error) -> bool {
+    error.kind() == ErrorKind::BrokenPipe || error.raw_os_error() == Some(109) // ERROR_BROKEN_PIPE
 }
 
 fn terminate_and_reap(
@@ -798,6 +940,10 @@ mod tests {
         /// parent exits, so the reader threads never reach EOF until the tree
         /// is terminated.
         Inherited,
+        /// Like `Inherited`, but the descendant also keeps the inherited stdin
+        /// read end open without consuming it (re-exec only; shell async jobs
+        /// often redirect stdin from `/dev/null`).
+        StdinHold,
         /// Spawns a descendant that asks for neither handle.
         Detached,
         /// Spawns nothing. The control: with no descendant to hold anything, the
@@ -809,6 +955,7 @@ mod tests {
         fn as_str(self) -> &'static str {
             match self {
                 Self::Inherited => "inherited",
+                Self::StdinHold => "stdin_hold",
                 Self::Detached => "detached",
                 Self::Solo => "solo",
             }
@@ -817,6 +964,7 @@ mod tests {
         fn parse(value: &str) -> Option<Self> {
             match value {
                 "inherited" => Some(Self::Inherited),
+                "stdin_hold" => Some(Self::StdinHold),
                 "detached" => Some(Self::Detached),
                 "solo" => Some(Self::Solo),
                 _ => None,
@@ -834,8 +982,7 @@ mod tests {
     /// `powershell.exe`, whose startup has been observed longer than the
     /// bounded window. Unix keeps a shell whose startup is a fraction of that
     /// bound; both sides speak the same READY record protocol.
-    #[cfg(windows)]
-    fn descendant_spawner_command(plan: HelperPlan) -> Command {
+    fn reexec_helper_command(plan: HelperPlan) -> Command {
         let mut command = Command::new(current_test_binary());
         command
             .args([
@@ -849,8 +996,18 @@ mod tests {
         command
     }
 
+    #[cfg(windows)]
+    fn descendant_spawner_command(plan: HelperPlan) -> Command {
+        reexec_helper_command(plan)
+    }
+
     #[cfg(unix)]
     fn descendant_spawner_command(plan: HelperPlan) -> Command {
+        if plan == HelperPlan::StdinHold {
+            // Shell async lists often redirect stdin from /dev/null; re-exec so
+            // the descendant truly retains the pipe read end.
+            return reexec_helper_command(plan);
+        }
         let script = match plan {
             HelperPlan::Solo => {
                 format!("printf '{READY_SOLO_RECORD}'; printf '{READY_SOLO_RECORD}' >&2",)
@@ -866,6 +1023,7 @@ mod tests {
                      printf '{READY_RECORD_PREFIX}%s' \"$!\" >&2",
                 )
             }
+            HelperPlan::StdinHold => unreachable!("handled by re-exec above"),
         };
         let mut command = Command::new("sh");
         command.arg("-c").arg(script);
@@ -887,11 +1045,23 @@ mod tests {
 
         let record = match plan {
             HelperPlan::Solo => READY_SOLO_RECORD.to_owned(),
-            HelperPlan::Inherited | HelperPlan::Detached => {
+            HelperPlan::Inherited | HelperPlan::Detached | HelperPlan::StdinHold => {
                 let mut descendant = hanging_command();
-                descendant.stdin(Stdio::null());
-                if plan == HelperPlan::Detached {
-                    descendant.stdout(Stdio::null()).stderr(Stdio::null());
+                match plan {
+                    HelperPlan::Detached => {
+                        descendant
+                            .stdin(Stdio::null())
+                            .stdout(Stdio::null())
+                            .stderr(Stdio::null());
+                    }
+                    HelperPlan::Inherited => {
+                        // Hold stdout/stderr; do not retain the parent's stdin.
+                        descendant.stdin(Stdio::null());
+                    }
+                    HelperPlan::StdinHold => {
+                        // Inherit stdin/stdout/stderr and keep them open.
+                    }
+                    HelperPlan::Solo => unreachable!(),
                 }
                 let child = descendant
                     .spawn()
@@ -915,6 +1085,7 @@ mod tests {
     fn the_helper_plan_survives_the_round_trip_to_the_helper() {
         for plan in [
             HelperPlan::Inherited,
+            HelperPlan::StdinHold,
             HelperPlan::Detached,
             HelperPlan::Solo,
         ] {
@@ -995,6 +1166,22 @@ mod tests {
     fn hanging_command() -> Command {
         let mut command = Command::new("ping");
         command.args(["-t", "127.0.0.1"]);
+        command
+    }
+
+    /// Starts with an empty open stdout pipe, then delivers bytes after a short
+    /// delay so capture must poll empty-open rather than treating it as EOF.
+    #[cfg(unix)]
+    fn delayed_stdout_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 0.05; printf 'later'"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn delayed_stdout_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "ping -n 1 127.0.0.1 >NUL & echo|set /p=later"]);
         command
     }
 
@@ -1322,26 +1509,85 @@ mod tests {
         assert!(!process_tree_quiescent_after_io(&error));
     }
 
+    /// Contract: an empty-but-open stdout pipe must be polled, not treated as
+    /// EOF/error, so output that arrives after a delay is still captured. This
+    /// pins the Windows PeekNamedPipe empty-open model and the Unix O_NONBLOCK
+    /// WouldBlock poll model.
+    #[test]
+    fn delayed_stdout_after_empty_open_pipe_is_captured() {
+        let command = delayed_stdout_command();
+        let limits = ProcessLimits::new(Duration::from_secs(2), 1024, 1024);
+        let output = run_bounded(command, b"", limits, "delayed stdout mutation")
+            .expect("delayed stdout must be captured after empty-open polling");
+        assert!(output.status.success(), "{:?}", output.status);
+        assert_eq!(
+            output.stdout, b"later",
+            "empty-open polling must not drop later output"
+        );
+    }
+
+    /// Contract: capture setup failure after spawn must still terminate/reap the
+    /// child. Propagating with `?` before cleanup leaves a live process tree.
+    #[test]
+    fn capture_setup_failure_terminates_spawned_child() {
+        use super::{INJECT_CAPTURE_SETUP_ERROR, LAST_SPAWNED_CHILD_PID};
+        use std::sync::atomic::Ordering;
+
+        const INJECTED: &str = "injected capture setup failure";
+
+        struct InjectGuard;
+        impl Drop for InjectGuard {
+            fn drop(&mut self) {
+                INJECT_CAPTURE_SETUP_ERROR.set(None);
+                let pid = LAST_SPAWNED_CHILD_PID.swap(0, Ordering::SeqCst);
+                best_effort_kill_tree_for_test(pid);
+            }
+        }
+        let _guard = InjectGuard;
+        LAST_SPAWNED_CHILD_PID.store(0, Ordering::SeqCst);
+        INJECT_CAPTURE_SETUP_ERROR.set(Some(INJECTED));
+
+        let error = run_bounded(
+            hanging_command(),
+            b"",
+            ProcessLimits::new(Duration::from_secs(2), 1024, 1024),
+            "capture setup failure mutation",
+        )
+        .expect_err("capture setup failure must surface as Err");
+        assert!(
+            error.contains(INJECTED),
+            "setup failure must be preserved: {error}"
+        );
+
+        let child_pid = LAST_SPAWNED_CHILD_PID.load(Ordering::SeqCst);
+        assert_ne!(child_pid, 0, "spawn must have recorded a child pid");
+        assert!(
+            wait_for_descendant_exit(child_pid),
+            "capture setup failure leaked live child {child_pid}; error={error}"
+        );
+    }
+
     /// Contract: when every tree-kill attempt fails (early, deadline retry, and
-    /// fallback), `run_bounded` must still return inside the wall-clock guard
-    /// without leaving blocked I/O workers joined forever. The first termination
-    /// error is preserved and cleanup failure is reported. Descendant reaping
-    /// after a true persistent OS kill failure is outside this helper's power
-    /// and is left to the test guard.
+    /// fallback) while a descendant still holds inherited stdin and a large
+    /// stdin payload would otherwise block a writer thread, `run_bounded` must
+    /// still return inside the wall-clock guard. The first termination error is
+    /// preserved and cleanup failure is reported.
     #[test]
     fn early_tree_kill_failure_preserves_error_after_bounded_cleanup() {
         use super::{
             INJECTED_TREE_KILL_CHILD_PID, INJECTED_TREE_KILL_HITS,
-            INJECT_TERMINATE_REMAINING_TREE_ERROR, LIVE_IO_WORKERS, TRACK_IO_WORKERS,
+            INJECT_TERMINATE_REMAINING_TREE_ERROR,
         };
         use std::sync::atomic::Ordering;
 
         const INJECTED: &str = "injected tree-kill failure";
+        // Larger than a typical pipe buffer so a blocking stdin writer would hang
+        // if a descendant retained the read end without consuming it.
+        const BLOCKING_STDIN: &[u8] = &[b'x'; 256 * 1024];
 
         struct TrackingGuard;
         impl Drop for TrackingGuard {
             fn drop(&mut self) {
-                TRACK_IO_WORKERS.set(false);
                 INJECT_TERMINATE_REMAINING_TREE_ERROR.set(None);
                 INJECTED_TREE_KILL_HITS.store(0, Ordering::SeqCst);
                 let pid = INJECTED_TREE_KILL_CHILD_PID.swap(0, Ordering::SeqCst);
@@ -1351,35 +1597,36 @@ mod tests {
         let _tracking_guard = TrackingGuard;
         INJECTED_TREE_KILL_CHILD_PID.store(0, Ordering::SeqCst);
         INJECTED_TREE_KILL_HITS.store(0, Ordering::SeqCst);
-        assert_eq!(LIVE_IO_WORKERS.load(Ordering::SeqCst), 0);
 
+        // Re-exec helper + post-deadline drain need more headroom than the
+        // shell-based Inherited path; keep the wall-clock guard tight enough to
+        // catch an unbounded stdin join.
+        let run_timeout = Duration::from_secs(1);
+        let wall_guard = Duration::from_secs(5);
         let started = Instant::now();
         let (result_tx, result_rx) = mpsc::channel();
         let worker = thread::spawn(move || {
-            TRACK_IO_WORKERS.set(true);
             INJECT_TERMINATE_REMAINING_TREE_ERROR.set(Some(INJECTED));
-            let command = descendant_spawner_command(HelperPlan::Inherited);
-            let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
+            let command = descendant_spawner_command(HelperPlan::StdinHold);
+            let limits = ProcessLimits::new(run_timeout, 1024, 1024);
             let _ = result_tx.send(run_bounded(
                 command,
-                b"",
+                BLOCKING_STDIN,
                 limits,
                 "injected tree-kill failure mutation",
             ));
         });
 
-        let result = match result_rx.recv_timeout(descendant_test_guard()) {
+        let result = match result_rx.recv_timeout(wall_guard) {
             Ok(result) => result,
             Err(error) => panic!("runner escaped its wall-clock bound: {error}"),
         };
         worker.join().expect("bounded runner worker");
         assert!(
-            started.elapsed() < descendant_test_guard(),
-            "persistent kill failure must return inside the wall-clock guard"
+            started.elapsed() < wall_guard,
+            "persistent kill failure with blocked stdin must return inside the wall-clock guard"
         );
 
-        let live_after_return = LIVE_IO_WORKERS.load(Ordering::SeqCst);
-        let injected_child_pid = INJECTED_TREE_KILL_CHILD_PID.load(Ordering::SeqCst);
         let injected_hits = INJECTED_TREE_KILL_HITS.load(Ordering::SeqCst);
 
         let error = result
@@ -1400,12 +1647,6 @@ mod tests {
         assert!(
             error.contains("fallback tree kill after deadline failed"),
             "cleanup failure must be reported rather than ignored: {error}"
-        );
-        assert_eq!(
-            live_after_return, 0,
-            "run_bounded returned while {live_after_return} I/O worker(s) still live \
-             (detached JoinHandles); injected child pid={injected_child_pid}; \
-             hits={injected_hits}; error={error}"
         );
 
         let descendant_pid = descendant_pid_from(&error).unwrap_or_else(|reason| {

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -1,7 +1,11 @@
+// Non-blocking pipe mode needs fcntl (Unix) / SetNamedPipeHandleState (Windows).
+// That FFI is what makes stdout/stderr capture cancelable when every tree-kill
+// attempt fails, so run_bounded can return without joining blocked readers.
+#![allow(unsafe_code)]
+
 use std::ffi::OsStr;
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::process::{Command, ExitStatus, Output, Stdio};
-use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -9,6 +13,11 @@ use std::time::{Duration, Instant};
 use std::cell::Cell;
 #[cfg(test)]
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 
 #[cfg(windows)]
 use process_wrap::std::JobObject;
@@ -20,9 +29,8 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const REAP_GRACE: Duration = Duration::from_secs(1);
 const MAX_DIAGNOSTIC_BYTES: usize = 4096;
 
-// Test-only: when set, every tree-kill attempt returns this error without
-// sending a tree kill, so the first attempt and the deadline retry can both
-// be exercised under a persistent failure.
+// Test-only: when set, every tree-kill attempt (early, deadline retry, and
+// fallback) returns this error without sending a tree kill.
 #[cfg(test)]
 thread_local! {
     static INJECT_TERMINATE_REMAINING_TREE_ERROR: Cell<Option<&'static str>> = const { Cell::new(None) };
@@ -156,28 +164,36 @@ pub fn run_bounded(
         result
     });
 
-    let (overflow_tx, overflow_rx) = mpsc::channel();
-    let stdout_reader = spawn_reader(
+    // Non-blocking spoolers: capture is cancelable by dropping the pipe end, so
+    // return stays bounded even when every tree-kill attempt fails and EOF never
+    // arrives. Blocking read_to_end workers cannot offer that.
+    let mut stdout_capture = CapturedOutput::new(
         child_stdout,
         limits.max_stdout_bytes,
         CapturedStream::Stdout,
-        overflow_tx.clone(),
-    );
-    let stderr_reader = spawn_reader(
+    )
+    .map_err(|error| format!("{context}: {command_display}: stdout capture: {error}"))?;
+    let mut stderr_capture = CapturedOutput::new(
         child_stderr,
         limits.max_stderr_bytes,
         CapturedStream::Stderr,
-        overflow_tx,
-    );
+    )
+    .map_err(|error| format!("{context}: {command_display}: stderr capture: {error}"))?;
 
     let deadline = Instant::now() + limits.timeout;
     let mut early_failure = None;
     let mut tree_termination_error = None;
     let mut observed_status = None;
     let status = loop {
+        stdout_capture.drain();
+        stderr_capture.drain();
+
         if early_failure.is_none() {
-            if let Ok(stream) = overflow_rx.try_recv() {
-                // The reader closes its pipe after limit + 1 bytes. Keep the
+            if let Some(stream) = stdout_capture
+                .overflowed_stream()
+                .or_else(|| stderr_capture.overflowed_stream())
+            {
+                // The capture closes its pipe after limit + 1 bytes. Keep the
                 // child under this same deadline while it observes the close.
                 early_failure = Some(format!(
                     "{} exceeded its {}-byte ceiling",
@@ -191,18 +207,18 @@ pub fn run_bounded(
             match child.try_wait() {
                 Ok(Some(status)) => {
                     observed_status = Some(status);
-                    // Descendants that still hold inherited pipes keep readers
+                    // Descendants that still hold inherited pipes keep captures
                     // from EOF. Terminate the remaining tree now — before
                     // treating reader EOF as the success condition — then drain
                     // buffered output within the same total deadline.
                     let io_outstanding = !stdin_writer.is_finished()
-                        || !stdout_reader.is_finished()
-                        || !stderr_reader.is_finished();
+                        || !stdout_capture.is_finished()
+                        || !stderr_capture.is_finished();
                     if io_outstanding {
                         // Preserve a tree-kill failure, but do not return while
-                        // JoinHandles and descendants may still be live. Keep
-                        // draining under the same deadline; terminate_and_reap
-                        // below retries termination before joins.
+                        // the stdin worker or open captures may still be live.
+                        // Keep draining under the same deadline; terminate_and_reap
+                        // below retries termination before finalizing captures.
                         if let Err(error) =
                             terminate_remaining_tree(child.as_mut(), context, &command_display)
                         {
@@ -213,6 +229,9 @@ pub fn run_bounded(
                 Ok(None) => {}
                 Err(error) => {
                     let reap = terminate_and_reap(child.as_mut(), None, context, &command_display);
+                    stdout_capture.abandon();
+                    stderr_capture.abandon();
+                    let _ = stdin_writer.join();
                     return Err(format!(
                         "{context}: poll {command_display}: {error}; terminate/reap: {reap:?}"
                     ));
@@ -222,8 +241,8 @@ pub fn run_bounded(
 
         if observed_status.is_some()
             && stdin_writer.is_finished()
-            && stdout_reader.is_finished()
-            && stderr_reader.is_finished()
+            && stdout_capture.is_finished()
+            && stderr_capture.is_finished()
         {
             // After I/O completion this may accept post-IO quiescence (including
             // macOS EPERM on an empty group) that terminate_remaining_tree does
@@ -239,9 +258,9 @@ pub fn run_bounded(
             if early_failure.is_none() && tree_termination_error.is_none() {
                 early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
             }
-            // Never return here on terminate/reap failure: JoinHandles and
-            // descendants may still be live. Preserve the first error, best-
-            // effort kill so readers can EOF, then join below before surfacing.
+            // Preserve the first error, attempt one more tree kill through the
+            // same seam, drain whatever is already readable, then abandon any
+            // capture that still lacks EOF so return never waits unboundedly.
             let prior_status = observed_status.take();
             let status = match terminate_and_reap(
                 child.as_mut(),
@@ -254,10 +273,17 @@ pub fn run_bounded(
                     if tree_termination_error.is_none() {
                         tree_termination_error = Some(error);
                     }
-                    // terminate_and_reap may have skipped OS kill under a
-                    // persistent injected failure; a direct start_kill is
-                    // outside that seam so joins below stay bounded.
-                    let _ = child.start_kill();
+                    if let Err(fallback_error) = request_tree_kill(child.as_mut()) {
+                        let detail =
+                            format!("fallback tree kill after deadline failed: {fallback_error}");
+                        match &mut tree_termination_error {
+                            Some(error) => {
+                                error.push_str("; ");
+                                error.push_str(&detail);
+                            }
+                            None => tree_termination_error = Some(detail),
+                        }
+                    }
                     let _ = child.inner_mut().start_kill();
                     if let Some(status) = prior_status {
                         status
@@ -273,6 +299,9 @@ pub fn run_bounded(
                     }
                 }
             };
+            drain_captures_briefly(&mut stdout_capture, &mut stderr_capture);
+            stdout_capture.abandon();
+            stderr_capture.abandon();
             break status;
         }
         thread::sleep(POLL_INTERVAL);
@@ -281,8 +310,12 @@ pub fn run_bounded(
     let stdin_result = stdin_writer
         .join()
         .map_err(|_| format!("{context}: {command_display}: stdin writer panicked"))?;
-    let stdout = join_reader(stdout_reader, context, &command_display, "stdout")?;
-    let stderr = join_reader(stderr_reader, context, &command_display, "stderr")?;
+    let stdout = stdout_capture
+        .into_bytes()
+        .map_err(|error| format!("{context}: read stdout from {command_display}: {error}"))?;
+    let stderr = stderr_capture
+        .into_bytes()
+        .map_err(|error| format!("{context}: read stderr from {command_display}: {error}"))?;
 
     if let Some(error) = tree_termination_error {
         return Err(format!(
@@ -351,38 +384,176 @@ pub fn run_bounded(
     })
 }
 
-fn spawn_reader<R: Read + Send + 'static>(
-    reader: R,
+/// Bounded stdout/stderr capture that never blocks the helper on EOF.
+///
+/// Pipes are set non-blocking so `drain` returns when the kernel has no bytes
+/// ready. Dropping the reader (`abandon` / overflow / EOF) cancels capture
+/// without a joinable worker that can hang after a persistent tree-kill failure.
+struct CapturedOutput<R> {
+    reader: Option<R>,
+    bytes: Vec<u8>,
     limit: usize,
     stream: CapturedStream,
-    overflow: mpsc::Sender<CapturedStream>,
-) -> thread::JoinHandle<std::io::Result<Vec<u8>>> {
-    #[cfg(test)]
-    let track_io_workers = TRACK_IO_WORKERS.get();
-    thread::spawn(move || {
-        #[cfg(test)]
-        let _worker_guard = track_io_workers.then(IoWorkerGuard::enter);
-        let mut bytes = Vec::with_capacity(limit.saturating_add(1));
-        reader
-            .take(limit.saturating_add(1) as u64)
-            .read_to_end(&mut bytes)?;
-        if bytes.len() > limit {
-            let _ = overflow.send(stream);
-        }
-        Ok(bytes)
-    })
+    overflowed: bool,
+    read_error: Option<std::io::Error>,
 }
 
-fn join_reader(
-    reader: thread::JoinHandle<std::io::Result<Vec<u8>>>,
-    context: &str,
-    command: &str,
-    stream: &str,
-) -> Result<Vec<u8>, String> {
-    reader
-        .join()
-        .map_err(|_| format!("{context}: {command}: {stream} reader panicked"))?
-        .map_err(|error| format!("{context}: read {stream} from {command}: {error}"))
+impl<R: Read> CapturedOutput<R> {
+    #[cfg(unix)]
+    fn new(reader: R, limit: usize, stream: CapturedStream) -> std::io::Result<Self>
+    where
+        R: AsRawFd,
+    {
+        set_nonblocking(&reader)?;
+        Ok(Self {
+            reader: Some(reader),
+            bytes: Vec::with_capacity(limit.saturating_add(1)),
+            limit,
+            stream,
+            overflowed: false,
+            read_error: None,
+        })
+    }
+
+    #[cfg(windows)]
+    fn new(reader: R, limit: usize, stream: CapturedStream) -> std::io::Result<Self>
+    where
+        R: AsRawHandle,
+    {
+        set_nonblocking(&reader)?;
+        Ok(Self {
+            reader: Some(reader),
+            bytes: Vec::with_capacity(limit.saturating_add(1)),
+            limit,
+            stream,
+            overflowed: false,
+            read_error: None,
+        })
+    }
+
+    fn drain(&mut self) {
+        let Some(reader) = self.reader.as_mut() else {
+            return;
+        };
+        let mut chunk = [0u8; 8192];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => {
+                    self.reader = None;
+                    return;
+                }
+                Ok(n) => {
+                    let room = self
+                        .limit
+                        .saturating_add(1)
+                        .saturating_sub(self.bytes.len());
+                    let take = room.min(n);
+                    self.bytes.extend_from_slice(&chunk[..take]);
+                    if self.bytes.len() > self.limit {
+                        self.overflowed = true;
+                        self.reader = None;
+                        return;
+                    }
+                }
+                Err(error)
+                    if error.kind() == ErrorKind::WouldBlock
+                        || error.kind() == ErrorKind::Interrupted =>
+                {
+                    return;
+                }
+                Err(error) => {
+                    self.read_error = Some(error);
+                    self.reader = None;
+                    return;
+                }
+            }
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        self.reader.is_none()
+    }
+
+    fn overflowed_stream(&self) -> Option<CapturedStream> {
+        self.overflowed.then_some(self.stream)
+    }
+
+    fn abandon(&mut self) {
+        self.reader = None;
+    }
+
+    fn into_bytes(mut self) -> std::io::Result<Vec<u8>> {
+        self.reader = None;
+        if let Some(error) = self.read_error.take() {
+            return Err(error);
+        }
+        Ok(self.bytes)
+    }
+}
+
+/// After deadline termination, pull any already-readable bytes without waiting
+/// unboundedly for EOF that a failed tree kill will never deliver.
+fn drain_captures_briefly(
+    stdout: &mut CapturedOutput<impl Read>,
+    stderr: &mut CapturedOutput<impl Read>,
+) {
+    let drain_deadline = Instant::now() + REAP_GRACE;
+    loop {
+        stdout.drain();
+        stderr.drain();
+        if stdout.is_finished() && stderr.is_finished() {
+            return;
+        }
+        if Instant::now() >= drain_deadline {
+            return;
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(unix)]
+fn set_nonblocking(pipe: &impl AsRawFd) -> std::io::Result<()> {
+    let raw = pipe.as_raw_fd();
+    // SAFETY: fcntl F_GETFL/F_SETFL on a live pipe fd owned by this helper.
+    let flags = unsafe { libc::fcntl(raw, libc::F_GETFL) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: same fd; O_NONBLOCK is a valid flag for pipes.
+    if unsafe { libc::fcntl(raw, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn set_nonblocking(pipe: &impl AsRawHandle) -> std::io::Result<()> {
+    const PIPE_NOWAIT: u32 = 0x0000_0001;
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn SetNamedPipeHandleState(
+            h_named_pipe: *mut core::ffi::c_void,
+            lp_mode: *const u32,
+            lp_max_collection_count: *const u32,
+            lp_collect_data_timeout: *const u32,
+        ) -> i32;
+    }
+    let mode = PIPE_NOWAIT;
+    // SAFETY: handle is the ChildStdout/ChildStderr pipe we own; PIPE_NOWAIT is
+    // a valid named-pipe mode for anonymous stdio pipes on Windows.
+    let ok = unsafe {
+        SetNamedPipeHandleState(
+            pipe.as_raw_handle(),
+            &mode,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if ok == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 fn terminate_and_reap(
@@ -391,22 +562,7 @@ fn terminate_and_reap(
     context: &str,
     command: &str,
 ) -> Result<ExitStatus, String> {
-    #[cfg(test)]
-    if let Some(injected) = injected_tree_kill_failure(child.id()) {
-        // Persistent injected failure skips the OS kill, matching
-        // terminate_remaining_tree, so the deadline retry can still return Err
-        // while descendants hold inherited pipes.
-        let status = reap_after_tree_kill(child, observed_status).map_err(|reap_error| {
-            format!(
-                "{context}: failed to reap {command} after tree termination; tree=Some({injected}); direct_kill=None; reap={reap_error}"
-            )
-        })?;
-        return Err(format!(
-            "{context}: failed to terminate process tree for {command}: {injected}; direct_kill=None; status={status}"
-        ));
-    }
-    let tree_error = child
-        .start_kill()
+    let tree_error = request_tree_kill(child)
         .err()
         .filter(|error| !process_tree_absent(error));
     let direct_kill_error = tree_error
@@ -449,7 +605,7 @@ fn finish_process_tree(
     context: &str,
     command: &str,
 ) -> Result<(), String> {
-    match child.start_kill() {
+    match request_tree_kill(child) {
         Ok(()) => Ok(()),
         Err(error) if process_tree_quiescent_after_io(&error) => Ok(()),
         Err(error) => Err(format!(
@@ -467,13 +623,7 @@ fn terminate_remaining_tree(
     context: &str,
     command: &str,
 ) -> Result<(), String> {
-    #[cfg(test)]
-    if let Some(injected) = injected_tree_kill_failure(child.id()) {
-        return Err(format!(
-            "{context}: failed to terminate remaining process tree for {command}: {injected}"
-        ));
-    }
-    match child.start_kill() {
+    match request_tree_kill(child) {
         Ok(()) => Ok(()),
         Err(error) if process_tree_absent(&error) => Ok(()),
         Err(error) => {
@@ -485,17 +635,16 @@ fn terminate_remaining_tree(
     }
 }
 
-/// Test-only: observe a persistent injected tree-kill failure without clearing it.
-///
-/// Unlike a one-shot `take()`, this stays armed across the early
-/// `terminate_remaining_tree` attempt and the deadline `terminate_and_reap`
-/// retry so both arms can fail the same way.
-#[cfg(test)]
-fn injected_tree_kill_failure(child_id: u32) -> Option<&'static str> {
-    INJECT_TERMINATE_REMAINING_TREE_ERROR.get().inspect(|_| {
-        INJECTED_TREE_KILL_CHILD_PID.store(child_id, Ordering::SeqCst);
+/// Single seam for process-tree kill so test injection covers every attempt,
+/// including the deadline fallback. Production always calls `start_kill`.
+fn request_tree_kill(child: &mut dyn ChildWrapper) -> std::io::Result<()> {
+    #[cfg(test)]
+    if let Some(injected) = INJECT_TERMINATE_REMAINING_TREE_ERROR.get() {
+        INJECTED_TREE_KILL_CHILD_PID.store(child.id(), Ordering::SeqCst);
         INJECTED_TREE_KILL_HITS.fetch_add(1, Ordering::SeqCst);
-    })
+        return Err(std::io::Error::other(injected));
+    }
+    child.start_kill()
 }
 
 #[cfg(unix)]
@@ -1173,10 +1322,12 @@ mod tests {
         assert!(!process_tree_quiescent_after_io(&error));
     }
 
-    /// Contract: a persistent tree-kill failure (first attempt and deadline
-    /// retry) must not let `run_bounded` return while I/O workers or
-    /// process-tree descendants are still live. The original termination error
-    /// is preserved after bounded cleanup and joins.
+    /// Contract: when every tree-kill attempt fails (early, deadline retry, and
+    /// fallback), `run_bounded` must still return inside the wall-clock guard
+    /// without leaving blocked I/O workers joined forever. The first termination
+    /// error is preserved and cleanup failure is reported. Descendant reaping
+    /// after a true persistent OS kill failure is outside this helper's power
+    /// and is left to the test guard.
     #[test]
     fn early_tree_kill_failure_preserves_error_after_bounded_cleanup() {
         use super::{
@@ -1202,6 +1353,7 @@ mod tests {
         INJECTED_TREE_KILL_HITS.store(0, Ordering::SeqCst);
         assert_eq!(LIVE_IO_WORKERS.load(Ordering::SeqCst), 0);
 
+        let started = Instant::now();
         let (result_tx, result_rx) = mpsc::channel();
         let worker = thread::spawn(move || {
             TRACK_IO_WORKERS.set(true);
@@ -1221,6 +1373,10 @@ mod tests {
             Err(error) => panic!("runner escaped its wall-clock bound: {error}"),
         };
         worker.join().expect("bounded runner worker");
+        assert!(
+            started.elapsed() < descendant_test_guard(),
+            "persistent kill failure must return inside the wall-clock guard"
+        );
 
         let live_after_return = LIVE_IO_WORKERS.load(Ordering::SeqCst);
         let injected_child_pid = INJECTED_TREE_KILL_CHILD_PID.load(Ordering::SeqCst);
@@ -1229,9 +1385,9 @@ mod tests {
         let error = result
             .expect_err("persistent injected tree-kill failure must surface as Err after cleanup");
         assert!(
-            injected_hits >= 2,
-            "injection must arm both the early terminate_remaining_tree attempt and the \
-             deadline terminate_and_reap retry; hits={injected_hits}; error={error}"
+            injected_hits >= 3,
+            "injection must arm early terminate_remaining_tree, deadline terminate_and_reap, \
+             and the fallback request_tree_kill; hits={injected_hits}; error={error}"
         );
         assert!(
             error.contains(INJECTED),
@@ -1241,6 +1397,10 @@ mod tests {
             error.contains("failed to terminate remaining process tree"),
             "first tree-kill failure wording must be preserved: {error}"
         );
+        assert!(
+            error.contains("fallback tree kill after deadline failed"),
+            "cleanup failure must be reported rather than ignored: {error}"
+        );
         assert_eq!(
             live_after_return, 0,
             "run_bounded returned while {live_after_return} I/O worker(s) still live \
@@ -1249,11 +1409,13 @@ mod tests {
         );
 
         let descendant_pid = descendant_pid_from(&error).unwrap_or_else(|reason| {
-            panic!("descendant pid must be recoverable after cleanup joins: {reason}; {error}")
+            panic!("descendant pid must be recoverable from spooled diagnostics: {reason}; {error}")
         });
+        // Persistent kill failure leaves the descendant alive; the tracking
+        // guard reaps it. Returning while it lives is required, not a defect.
         assert!(
-            wait_for_descendant_exit(descendant_pid),
-            "descendant {descendant_pid} still live after run_bounded returned; error={error}"
+            descendant_is_alive(descendant_pid) || wait_for_descendant_exit(descendant_pid),
+            "descendant pid {descendant_pid} must remain addressable for guard cleanup; error={error}"
         );
     }
 

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -5,6 +5,11 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
+use std::cell::Cell;
+#[cfg(test)]
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
 #[cfg(windows)]
 use process_wrap::std::JobObject;
 #[cfg(unix)]
@@ -14,6 +19,45 @@ use process_wrap::std::{ChildWrapper, CommandWrap};
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const REAP_GRACE: Duration = Duration::from_secs(1);
 const MAX_DIAGNOSTIC_BYTES: usize = 4096;
+
+// Test-only: when set, the next `terminate_remaining_tree` returns this error
+// without sending a tree kill, so the early-failure path can be exercised.
+#[cfg(test)]
+thread_local! {
+    static INJECT_TERMINATE_REMAINING_TREE_ERROR: Cell<Option<&'static str>> = const { Cell::new(None) };
+}
+
+// Test-only: process id observed when an injected tree-kill failure fires.
+#[cfg(test)]
+static INJECTED_TREE_KILL_CHILD_PID: AtomicU32 = AtomicU32::new(0);
+
+// Test-only: when set on the `run_bounded` caller thread, spawned I/O workers
+// register in `LIVE_IO_WORKERS` for the duration of their closure.
+#[cfg(test)]
+thread_local! {
+    static TRACK_IO_WORKERS: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+static LIVE_IO_WORKERS: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+struct IoWorkerGuard;
+
+#[cfg(test)]
+impl IoWorkerGuard {
+    fn enter() -> Self {
+        LIVE_IO_WORKERS.fetch_add(1, Ordering::SeqCst);
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for IoWorkerGuard {
+    fn drop(&mut self) {
+        LIVE_IO_WORKERS.fetch_sub(1, Ordering::SeqCst);
+    }
+}
 
 #[derive(Clone, Copy)]
 pub struct ProcessLimits {
@@ -97,7 +141,11 @@ pub fn run_bounded(
         .ok_or_else(|| format!("{context}: {command_display}: child stderr was not piped"))?;
 
     let stdin = stdin.to_vec();
+    #[cfg(test)]
+    let track_io_workers = TRACK_IO_WORKERS.get();
     let stdin_writer = thread::spawn(move || {
+        #[cfg(test)]
+        let _worker_guard = track_io_workers.then(IoWorkerGuard::enter);
         let result = child_stdin.write_all(&stdin);
         drop(child_stdin);
         result
@@ -119,6 +167,7 @@ pub fn run_bounded(
 
     let deadline = Instant::now() + limits.timeout;
     let mut early_failure = None;
+    let mut tree_termination_error = None;
     let mut observed_status = None;
     let status = loop {
         if early_failure.is_none() {
@@ -145,7 +194,15 @@ pub fn run_bounded(
                         || !stdout_reader.is_finished()
                         || !stderr_reader.is_finished();
                     if io_outstanding {
-                        terminate_remaining_tree(child.as_mut(), context, &command_display)?;
+                        // Preserve a tree-kill failure, but do not return while
+                        // JoinHandles and descendants may still be live. Keep
+                        // draining under the same deadline; terminate_and_reap
+                        // below retries termination before joins.
+                        if let Err(error) =
+                            terminate_remaining_tree(child.as_mut(), context, &command_display)
+                        {
+                            tree_termination_error = Some(error);
+                        }
                     }
                 }
                 Ok(None) => {}
@@ -174,7 +231,7 @@ pub fn run_bounded(
         }
 
         if Instant::now() >= deadline {
-            if early_failure.is_none() {
+            if early_failure.is_none() && tree_termination_error.is_none() {
                 early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
             }
             break terminate_and_reap(
@@ -192,6 +249,14 @@ pub fn run_bounded(
         .map_err(|_| format!("{context}: {command_display}: stdin writer panicked"))?;
     let stdout = join_reader(stdout_reader, context, &command_display, "stdout")?;
     let stderr = join_reader(stderr_reader, context, &command_display, "stderr")?;
+
+    if let Some(error) = tree_termination_error {
+        return Err(format!(
+            "{error}; status={status}; stdout={}; stderr={}",
+            excerpt(&stdout),
+            excerpt(&stderr),
+        ));
+    }
 
     if let Some(failure) = early_failure {
         return Err(failure_diagnostic(
@@ -258,7 +323,11 @@ fn spawn_reader<R: Read + Send + 'static>(
     stream: CapturedStream,
     overflow: mpsc::Sender<CapturedStream>,
 ) -> thread::JoinHandle<std::io::Result<Vec<u8>>> {
+    #[cfg(test)]
+    let track_io_workers = TRACK_IO_WORKERS.get();
     thread::spawn(move || {
+        #[cfg(test)]
+        let _worker_guard = track_io_workers.then(IoWorkerGuard::enter);
         let mut bytes = Vec::with_capacity(limit.saturating_add(1));
         reader
             .take(limit.saturating_add(1) as u64)
@@ -350,6 +419,13 @@ fn terminate_remaining_tree(
     context: &str,
     command: &str,
 ) -> Result<(), String> {
+    #[cfg(test)]
+    if let Some(injected) = INJECT_TERMINATE_REMAINING_TREE_ERROR.take() {
+        INJECTED_TREE_KILL_CHILD_PID.store(child.id(), Ordering::SeqCst);
+        return Err(format!(
+            "{context}: failed to terminate remaining process tree for {command}: {injected}"
+        ));
+    }
     match child.start_kill() {
         Ok(()) => Ok(()),
         Err(error) if process_tree_absent(&error) => Ok(()),
@@ -1035,5 +1111,105 @@ mod tests {
         assert!(process_tree_quiescent_after_io(&error));
         #[cfg(not(target_os = "macos"))]
         assert!(!process_tree_quiescent_after_io(&error));
+    }
+
+    /// Contract: an early `terminate_remaining_tree` failure must not let
+    /// `run_bounded` return while I/O workers or process-tree descendants are
+    /// still live. The original termination error is preserved after cleanup.
+    #[test]
+    fn early_tree_kill_failure_preserves_error_after_bounded_cleanup() {
+        use super::{
+            INJECTED_TREE_KILL_CHILD_PID, INJECT_TERMINATE_REMAINING_TREE_ERROR, LIVE_IO_WORKERS,
+            TRACK_IO_WORKERS,
+        };
+        use std::sync::atomic::Ordering;
+
+        const INJECTED: &str = "injected tree-kill failure";
+
+        struct TrackingGuard;
+        impl Drop for TrackingGuard {
+            fn drop(&mut self) {
+                TRACK_IO_WORKERS.set(false);
+                INJECT_TERMINATE_REMAINING_TREE_ERROR.set(None);
+                let pid = INJECTED_TREE_KILL_CHILD_PID.swap(0, Ordering::SeqCst);
+                best_effort_kill_tree_for_test(pid);
+            }
+        }
+        let _tracking_guard = TrackingGuard;
+        INJECTED_TREE_KILL_CHILD_PID.store(0, Ordering::SeqCst);
+        assert_eq!(LIVE_IO_WORKERS.load(Ordering::SeqCst), 0);
+
+        let (result_tx, result_rx) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            TRACK_IO_WORKERS.set(true);
+            INJECT_TERMINATE_REMAINING_TREE_ERROR.set(Some(INJECTED));
+            let command = descendant_spawner_command(HelperPlan::Inherited);
+            let limits = ProcessLimits::new(descendant_run_timeout(), 1024, 1024);
+            let _ = result_tx.send(run_bounded(
+                command,
+                b"",
+                limits,
+                "injected tree-kill failure mutation",
+            ));
+        });
+
+        let result = match result_rx.recv_timeout(descendant_test_guard()) {
+            Ok(result) => result,
+            Err(error) => panic!("runner escaped its wall-clock bound: {error}"),
+        };
+        worker.join().expect("bounded runner worker");
+
+        let live_after_return = LIVE_IO_WORKERS.load(Ordering::SeqCst);
+        let injected_child_pid = INJECTED_TREE_KILL_CHILD_PID.load(Ordering::SeqCst);
+
+        let error = result.expect_err(
+            "injected terminate_remaining_tree failure must surface as Err after cleanup",
+        );
+        assert!(
+            error.contains(INJECTED),
+            "original termination error must be preserved: {error}"
+        );
+        assert!(
+            error.contains("failed to terminate remaining process tree"),
+            "tree-kill failure wording must be preserved: {error}"
+        );
+        assert_eq!(
+            live_after_return, 0,
+            "run_bounded returned while {live_after_return} I/O worker(s) still live \
+             (detached JoinHandles); injected child pid={injected_child_pid}; error={error}"
+        );
+
+        let descendant_pid = descendant_pid_from(&error).unwrap_or_else(|reason| {
+            panic!("descendant pid must be recoverable after cleanup joins: {reason}; {error}")
+        });
+        assert!(
+            wait_for_descendant_exit(descendant_pid),
+            "descendant {descendant_pid} still live after run_bounded returned; error={error}"
+        );
+    }
+
+    #[cfg(unix)]
+    fn best_effort_kill_tree_for_test(pid: u32) {
+        if pid == 0 {
+            return;
+        }
+        // ProcessGroup::leader uses the child pid as the process-group id.
+        let _ = Command::new("kill")
+            .args(["-KILL", &format!("-{pid}")])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+
+    #[cfg(windows)]
+    fn best_effort_kill_tree_for_test(pid: u32) {
+        if pid == 0 {
+            return;
+        }
+        let _ = Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
     }
 }

--- a/tests/support/bounded_process.rs
+++ b/tests/support/bounded_process.rs
@@ -20,8 +20,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const REAP_GRACE: Duration = Duration::from_secs(1);
 const MAX_DIAGNOSTIC_BYTES: usize = 4096;
 
-// Test-only: when set, the next `terminate_remaining_tree` returns this error
-// without sending a tree kill, so the early-failure path can be exercised.
+// Test-only: when set, every tree-kill attempt returns this error without
+// sending a tree kill, so the first attempt and the deadline retry can both
+// be exercised under a persistent failure.
 #[cfg(test)]
 thread_local! {
     static INJECT_TERMINATE_REMAINING_TREE_ERROR: Cell<Option<&'static str>> = const { Cell::new(None) };
@@ -30,6 +31,10 @@ thread_local! {
 // Test-only: process id observed when an injected tree-kill failure fires.
 #[cfg(test)]
 static INJECTED_TREE_KILL_CHILD_PID: AtomicU32 = AtomicU32::new(0);
+
+// Test-only: how many injected tree-kill failures fired on this thread's run.
+#[cfg(test)]
+static INJECTED_TREE_KILL_HITS: AtomicUsize = AtomicUsize::new(0);
 
 // Test-only: when set on the `run_bounded` caller thread, spawned I/O workers
 // register in `LIVE_IO_WORKERS` for the duration of their closure.
@@ -234,12 +239,41 @@ pub fn run_bounded(
             if early_failure.is_none() && tree_termination_error.is_none() {
                 early_failure = Some(format!("deadline of {:?} expired", limits.timeout));
             }
-            break terminate_and_reap(
+            // Never return here on terminate/reap failure: JoinHandles and
+            // descendants may still be live. Preserve the first error, best-
+            // effort kill so readers can EOF, then join below before surfacing.
+            let prior_status = observed_status.take();
+            let status = match terminate_and_reap(
                 child.as_mut(),
-                observed_status.take(),
+                prior_status,
                 context,
                 &command_display,
-            )?;
+            ) {
+                Ok(status) => status,
+                Err(error) => {
+                    if tree_termination_error.is_none() {
+                        tree_termination_error = Some(error);
+                    }
+                    // terminate_and_reap may have skipped OS kill under a
+                    // persistent injected failure; a direct start_kill is
+                    // outside that seam so joins below stay bounded.
+                    let _ = child.start_kill();
+                    let _ = child.inner_mut().start_kill();
+                    if let Some(status) = prior_status {
+                        status
+                    } else {
+                        reap_after_tree_kill(child.as_mut(), None).map_err(|reap_error| {
+                            match tree_termination_error.take() {
+                                Some(error) => format!("{error}; reap={reap_error}"),
+                                None => format!(
+                                    "{context}: failed to reap {command_display} after deadline termination: {reap_error}"
+                                ),
+                            }
+                        })?
+                    }
+                }
+            };
+            break status;
         }
         thread::sleep(POLL_INTERVAL);
     };
@@ -357,6 +391,20 @@ fn terminate_and_reap(
     context: &str,
     command: &str,
 ) -> Result<ExitStatus, String> {
+    #[cfg(test)]
+    if let Some(injected) = injected_tree_kill_failure(child.id()) {
+        // Persistent injected failure skips the OS kill, matching
+        // terminate_remaining_tree, so the deadline retry can still return Err
+        // while descendants hold inherited pipes.
+        let status = reap_after_tree_kill(child, observed_status).map_err(|reap_error| {
+            format!(
+                "{context}: failed to reap {command} after tree termination; tree=Some({injected}); direct_kill=None; reap={reap_error}"
+            )
+        })?;
+        return Err(format!(
+            "{context}: failed to terminate process tree for {command}: {injected}; direct_kill=None; status={status}"
+        ));
+    }
     let tree_error = child
         .start_kill()
         .err()
@@ -420,8 +468,7 @@ fn terminate_remaining_tree(
     command: &str,
 ) -> Result<(), String> {
     #[cfg(test)]
-    if let Some(injected) = INJECT_TERMINATE_REMAINING_TREE_ERROR.take() {
-        INJECTED_TREE_KILL_CHILD_PID.store(child.id(), Ordering::SeqCst);
+    if let Some(injected) = injected_tree_kill_failure(child.id()) {
         return Err(format!(
             "{context}: failed to terminate remaining process tree for {command}: {injected}"
         ));
@@ -436,6 +483,19 @@ fn terminate_remaining_tree(
             ))
         }
     }
+}
+
+/// Test-only: observe a persistent injected tree-kill failure without clearing it.
+///
+/// Unlike a one-shot `take()`, this stays armed across the early
+/// `terminate_remaining_tree` attempt and the deadline `terminate_and_reap`
+/// retry so both arms can fail the same way.
+#[cfg(test)]
+fn injected_tree_kill_failure(child_id: u32) -> Option<&'static str> {
+    INJECT_TERMINATE_REMAINING_TREE_ERROR.get().inspect(|_| {
+        INJECTED_TREE_KILL_CHILD_PID.store(child_id, Ordering::SeqCst);
+        INJECTED_TREE_KILL_HITS.fetch_add(1, Ordering::SeqCst);
+    })
 }
 
 #[cfg(unix)]
@@ -1113,14 +1173,15 @@ mod tests {
         assert!(!process_tree_quiescent_after_io(&error));
     }
 
-    /// Contract: an early `terminate_remaining_tree` failure must not let
-    /// `run_bounded` return while I/O workers or process-tree descendants are
-    /// still live. The original termination error is preserved after cleanup.
+    /// Contract: a persistent tree-kill failure (first attempt and deadline
+    /// retry) must not let `run_bounded` return while I/O workers or
+    /// process-tree descendants are still live. The original termination error
+    /// is preserved after bounded cleanup and joins.
     #[test]
     fn early_tree_kill_failure_preserves_error_after_bounded_cleanup() {
         use super::{
-            INJECTED_TREE_KILL_CHILD_PID, INJECT_TERMINATE_REMAINING_TREE_ERROR, LIVE_IO_WORKERS,
-            TRACK_IO_WORKERS,
+            INJECTED_TREE_KILL_CHILD_PID, INJECTED_TREE_KILL_HITS,
+            INJECT_TERMINATE_REMAINING_TREE_ERROR, LIVE_IO_WORKERS, TRACK_IO_WORKERS,
         };
         use std::sync::atomic::Ordering;
 
@@ -1131,12 +1192,14 @@ mod tests {
             fn drop(&mut self) {
                 TRACK_IO_WORKERS.set(false);
                 INJECT_TERMINATE_REMAINING_TREE_ERROR.set(None);
+                INJECTED_TREE_KILL_HITS.store(0, Ordering::SeqCst);
                 let pid = INJECTED_TREE_KILL_CHILD_PID.swap(0, Ordering::SeqCst);
                 best_effort_kill_tree_for_test(pid);
             }
         }
         let _tracking_guard = TrackingGuard;
         INJECTED_TREE_KILL_CHILD_PID.store(0, Ordering::SeqCst);
+        INJECTED_TREE_KILL_HITS.store(0, Ordering::SeqCst);
         assert_eq!(LIVE_IO_WORKERS.load(Ordering::SeqCst), 0);
 
         let (result_tx, result_rx) = mpsc::channel();
@@ -1161,9 +1224,14 @@ mod tests {
 
         let live_after_return = LIVE_IO_WORKERS.load(Ordering::SeqCst);
         let injected_child_pid = INJECTED_TREE_KILL_CHILD_PID.load(Ordering::SeqCst);
+        let injected_hits = INJECTED_TREE_KILL_HITS.load(Ordering::SeqCst);
 
-        let error = result.expect_err(
-            "injected terminate_remaining_tree failure must surface as Err after cleanup",
+        let error = result
+            .expect_err("persistent injected tree-kill failure must surface as Err after cleanup");
+        assert!(
+            injected_hits >= 2,
+            "injection must arm both the early terminate_remaining_tree attempt and the \
+             deadline terminate_and_reap retry; hits={injected_hits}; error={error}"
         );
         assert!(
             error.contains(INJECTED),
@@ -1171,12 +1239,13 @@ mod tests {
         );
         assert!(
             error.contains("failed to terminate remaining process tree"),
-            "tree-kill failure wording must be preserved: {error}"
+            "first tree-kill failure wording must be preserved: {error}"
         );
         assert_eq!(
             live_after_return, 0,
             "run_bounded returned while {live_after_return} I/O worker(s) still live \
-             (detached JoinHandles); injected child pid={injected_child_pid}; error={error}"
+             (detached JoinHandles); injected child pid={injected_child_pid}; \
+             hits={injected_hits}; error={error}"
         );
 
         let descendant_pid = descendant_pid_from(&error).unwrap_or_else(|reason| {


### PR DESCRIPTION
## Summary
- Once `try_wait` observes the direct child exit, terminate remaining Job Object / process-group members **before** treating reader EOF as the success condition; then drain buffered stdout/stderr to EOF within the same total deadline and return the preserved parent status.
- Replace PowerShell / env-controlled pid-file descendant fixtures with READY-record helpers (`READY pid=<u32>` / `READY solo`), a re-exec helper (Windows bounded child; Unix shell speaking the same protocol), and a solo control.
- Flip the inherited-output contract from `expect_err`/deadline to one cross-platform quiet-success contract for inherited and detached descendants. Addresses [#2249](https://github.com/Rul1an/assay/issues/2249). Does **not** close it (Windows CI evidence still required). Leaves #2253 measurement out of scope.

## Contract change
**Before:** success required `observed_status` **and** stdin/stdout/stderr reader EOF, then `finish_process_tree`. A descendant holding inherited pipes forced the deadline even when the parent had already exited 0 with READY bytes captured.

**After:** on `try_wait → Some(parent_status)`, if any I/O is still outstanding, call `terminate_remaining_tree` (accepts only `process_tree_absent` / ESRCH — **not** macOS EPERM before I/O completion), then continue draining readers within the same deadline, then `finish_process_tree` (post-IO quiescence path unchanged), return saved parent status. Timeout / output-ceiling / stdin-BrokenPipe fail-closed behavior unchanged.

## Base / head
- Base: `161b968fb723d5ea794a9bda40913055567b9391`
- Head: `73ddce963bd08a850fb1fe0122aadb4f12a3a66f`
- Branch: `cursor/fix-bounded-process-kill-before-eof`
- Worktree: `/tmp/assay-wt-bounded-kill-before-eof`

## RED evidence (Unix, production wait loop unchanged)
```
cargo test -p assay-mcp-server --test agent_golden_path_contract bounded_process::tests:: -- --nocapture
```
Failure (expected):
```
parent_exit_with_inherited_output_descendant_returns_ok_before_deadline ... FAILED
inherited output mutation: ... deadline of 250ms expired; status=exit status: 0;
stdout="READY pid=72765" (15 bytes); stderr="READY pid=72765" (15 bytes)
```
Solo control and quiet/detached already passed; only the inherited holder forced the deadline.

## GREEN commands (Unix local)
```
cargo test -p assay-mcp-server --test agent_golden_path_contract bounded_process::tests:: -- --nocapture
cargo test -p assay-cli --test agent_golden_path_contract bounded_process::tests:: -- --nocapture
# also: init_stdout_contract, doctor_config_check_contract, doctor_exit_class_contract,
#       policy_validate_machine_contract, config_recovery_argv_contract,
#       assay-mcp-server enforcement_sarif_cli
cargo test -p assay-mcp-server --test agent_golden_path_contract --test enforcement_sarif_cli
cargo test -p assay-cli --test agent_golden_path_contract --test init_stdout_contract \
  --test doctor_config_check_contract --test doctor_exit_class_contract \
  --test policy_validate_machine_contract --test config_recovery_argv_contract
# 20× descendant + solo filters on assay-mcp-server agent_golden_path_contract: all ok
cargo fmt --all -- --check
cargo clippy -p assay-mcp-server -p assay-cli --all-targets -- -D warnings
git diff --check
```

## Windows non-claim
Unix GREEN is recorded above. Windows Job Object behavior and CI `windows-latest` for this head are **not** claimed until CI runs on this PR. No Windows-expects-deadline split was introduced.

## Test plan
- [x] RED: inherited descendant fails with deadline + exit 0 + READY bytes (Unix)
- [x] GREEN: inherited + quiet + solo Ok across embedding binaries (Unix)
- [x] fmt / clippy `-D warnings` / `git diff --check`
- [ ] CI `windows-latest` on this head
- [ ] Non-building agent review quorum before merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running time-limited processes, including cleaner handling of stalled or unresponsive processes.
  * More consistently captures delayed output from standard input and output streams.
  * Strengthened cleanup of child processes after failures or timeouts.
  * Improved behavior across Unix and Windows environments, including better handling of setup and termination failures.
* **Tests**
  * Expanded coverage for process cleanup, delayed output, readiness detection, and cross-platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->