### PR TITLE
docs(ci): end dual-source action pins and state Cargo.lock lane truth

### DIFF
--- a/docs/PINNED-ACTIONS.md
+++ b/docs/PINNED-ACTIONS.md
@@ -2,7 +2,22 @@
 
 Repo settings: **Allowed actions** should be restricted (e.g. "Allow GitHub-owned and verified creators") and **Require SHA pinning** enabled once workflows are pinned.
 
-**Status:** ✅ All third-party actions are SHA-pinned (2026-01-30).
+## Source of truth
+
+Workflow files under `.github/workflows/` are the only source of truth for
+which third-party actions are used and which commit SHAs pin them. This page
+does not restate those SHAs or tag refs. A duplicated table was a second literal
+that Dependabot never updated and that drifted from the workflows (see #2223).
+
+To inspect the pins currently in use:
+
+```bash
+rg -n --pcre2 'uses:\s*[^\s]+@[0-9a-f]{40}' .github/workflows/
+```
+
+Nothing in this repository regenerates or verifies this page against the
+workflows. Treat the workflows as authoritative; treat this page as procedure
+only.
 
 ## Resolving SHAs
 
@@ -10,28 +25,6 @@ Repo settings: **Allowed actions** should be restricted (e.g. "Allow GitHub-owne
 # Example: get latest commit SHA for a tag/branch
 gh api repos/OWNER/REPO/commits/REF --jq .sha
 ```
-
-## Pinned actions (current)
-
-| Action | Original ref | Pinned SHA |
-|--------|--------------|------------|
-| `actions/attest` | `@v4.1.1` | `a1948c3f048ba23858d222213b7c278aabede763` |
-| `actions/checkout` | `@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
-| `actions/upload-artifact` | `@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
-| `actions/download-artifact` | `@v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
-| `actions/setup-python` | `@v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` |
-| `actions/cache` | `@v4` | `0057852bfaa89a56745cba8c7296529d2fc39830` |
-| `dtolnay/rust-toolchain` | `@stable` | `4be9e76fd7c4901c61fb841f559994984270fce7` |
-| `dtolnay/rust-toolchain` | `@nightly` | `881ba7bf39a41cda34ac9e123fb41b44ed08232f` |
-| `Swatinem/rust-cache` | `@v2` | `779680da715d629ac1d338a641029a2f4372abb5` |
-| `mozilla-actions/sccache-action` | `@v0.0.6` | `9e326ebed976843c9932b3aa0e021c6f50310eb4` |
-| `bencherdev/bencher` | `@v0.6.2` | `0f8f620172ccd6225d40a7590598eb7b41718af8` |
-| `softprops/action-gh-release` | `@v2` | `a06a81a03ee405af7f2048a818ed3f03bbf83c7b` |
-| `github/codeql-action/upload-sarif` | `@v3` | `439137e1b50c27ba9e2f9befc93e43091b449c34` |
-| `dorny/test-reporter` | `@v1` | `d61b558e8df85cb60d09ca3e5b09653b4477cea7` |
-| `rust-lang/crates-io-auth-action` | `@v1` | `b7e9a28eded4986ec6b1fa40eeee8f8f165559ec` |
-| `PyO3/maturin-action` | `@v1` | `86b9d133d34bc1b40018696f782949dac11bd380` |
-| `pypa/gh-action-pypi-publish` | `@release/v1` | `ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e` |
 
 ## Dependabot for SHA updates
 
@@ -48,16 +41,20 @@ updates:
       prefix: "chore(ci)"
 ```
 
-Dependabot will propose PRs to update action refs; with SHA pinning, it will propose SHA bumps when the action repo has new commits on the same tag.
+Dependabot proposes PRs that update action refs in the workflow files. With SHA
+pinning, those PRs bump the SHA when the action repo advances on the same tag.
+Dependabot does not maintain this document.
 
 ## Updating SHAs
 
 When updating SHAs manually:
 
 1. Resolve new SHA: `gh api repos/OWNER/REPO/commits/REF --jq .sha`
-2. Update workflow files: `sed -i '' 's|OLD_SHA|NEW_SHA|g' .github/workflows/*.yml`
-3. Update this document with the new SHA
-4. Commit with message: `chore(ci): pin OWNER/REPO to SHA (was vX)`
+2. Update the workflow files that call the action (for example:
+   `sed -i '' 's|OLD_SHA|NEW_SHA|g' .github/workflows/*.yml`)
+3. Commit with message: `chore(ci): pin OWNER/REPO to SHA (was vX)`
+
+Do not add the SHA back into this document.
 
 ## Security benefits
 

--- a/docs/PINNED-ACTIONS.md
+++ b/docs/PINNED-ACTIONS.md
@@ -4,20 +4,33 @@ Repo settings: **Allowed actions** should be restricted (e.g. "Allow GitHub-owne
 
 ## Source of truth
 
-Workflow files under `.github/workflows/` are the only source of truth for
-which third-party actions are used and which commit SHAs pin them. This page
-does not restate those SHAs or tag refs. A duplicated table was a second literal
-that Dependabot never updated and that drifted from the workflows (see #2223).
+The canonical pin for a third-party action is the `uses:` callsite in the YAML
+that invokes it. This page does not restate those SHAs or tag refs. A duplicated
+table was a second literal that Dependabot never updated and that drifted from
+the callsites (see #2223).
 
-To inspect the pins currently in use:
+Callsite surfaces in this repository include:
+
+- workflow files under `.github/workflows/**/*.yml`
+- composite/action manifests such as `assay-action/action.yml` and
+  `.github/actions/**/action.yml`
+
+A surface can be empty of external `uses:` today (for example
+`.github/actions/**` may have none) and still belongs in the scan set: new
+callsites land there without this page being updated.
+
+To inspect the pins currently in use across those surfaces:
 
 ```bash
-rg -n --pcre2 'uses:\s*[^\s]+@[0-9a-f]{40}' .github/workflows/
+rg -n --pcre2 'uses:\s*[^\s]+@[0-9a-f]{40}' \
+  .github/workflows \
+  assay-action/action.yml \
+  .github/actions
 ```
 
 Nothing in this repository regenerates or verifies this page against the
-workflows. Treat the workflows as authoritative; treat this page as procedure
-only.
+callsite YAML. Treat the callsites as authoritative; treat this page as
+procedure only.
 
 ## Resolving SHAs
 
@@ -41,17 +54,18 @@ updates:
       prefix: "chore(ci)"
 ```
 
-Dependabot proposes PRs that update action refs in the workflow files. With SHA
-pinning, those PRs bump the SHA when the action repo advances on the same tag.
-Dependabot does not maintain this document.
+Dependabot proposes PRs that update action refs in callsite YAML it covers.
+With SHA pinning, those PRs bump the SHA when the action repo advances on the
+same tag. Dependabot does not maintain this document.
 
 ## Updating SHAs
 
 When updating SHAs manually:
 
 1. Resolve new SHA: `gh api repos/OWNER/REPO/commits/REF --jq .sha`
-2. Update the workflow files that call the action (for example:
-   `sed -i '' 's|OLD_SHA|NEW_SHA|g' .github/workflows/*.yml`)
+2. Update every callsite YAML that invokes the action (workflows under
+   `.github/workflows/`, plus composite/action manifests such as
+   `assay-action/action.yml` and `.github/actions/**/action.yml`)
 3. Commit with message: `chore(ci): pin OWNER/REPO to SHA (was vX)`
 
 Do not add the SHA back into this document.

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -35,7 +35,7 @@ dedicated and destructive cleanup is part of the contract.
 | Delegated workflow, runner labels, cleanup, checkout, sudo environment, preflight, or `scripts/ci/runner-spike-*.sh` | yes | yes | yes |
 | `@openai/agents`, `zod`, or fixture `package-lock.json` bump | yes | yes | yes |
 | `aya`, `aya-ebpf`, `aya-log-ebpf`, or BPF/runtime dependency bump | yes | yes | yes |
-| Workspace dependency bump that can affect `assay-runner-spike`, `assay-monitor`, `assay-ebpf`, `assay-cli`, policy correlation, or runner fixtures | yes | yes | yes |
+| `Cargo.lock` (any touch) | yes | yes (`gates=all`) | yes |
 | Delegated runbook wording that only clarifies existing behavior | yes | no | no |
 | Follow-up issue text, planning notes, or extraction-roadmap prose | yes | no | no |
 
@@ -113,6 +113,14 @@ identical tree OIDs for every content-provenance path in
 without another delegated run. This does not claim anything about unrelated
 repository state; it only preserves the proof for the gated content the
 delegated host actually exercised.
+
+`Cargo.lock` is a literal member of `all_gate_paths` and is matched by path
+only: the classifier does not read the lockfile diff, does not ask which
+packages moved, and does not ask whether a bump reaches runner, monitor, eBPF,
+CLI, policy, or fixture surfaces. Every touch therefore requires a fresh
+`gates=all` delegated proof. `Cargo.lock` is also outside
+`content_provenance_paths`, so that proof cannot be reused across a head that
+touches it — content provenance reports the path as `unaddressed`.
 
 The workflow keeps `pull-requests: write` while the transition comment channel
 exists. Empirically, `issues: write` plus `pull-requests: read` is not enough to


### PR DESCRIPTION
## Summary

- Closes #2223 — `docs/PINNED-ACTIONS.md` no longer restates action SHAs/tag refs. Canonical pins live at the `uses:` callsites themselves.
- Closes #2258 — `docs/reference/runner/ci-lanes.md` states the classifier truth: every `Cargo.lock` touch unconditionally requires `gates=all`, and that proof cannot reuse content provenance (`unaddressed`).

## Follow-up on head `81194a149` (unreviewed / invalid)

Prior draft head `81194a149f86a4be25d1b51ac1f6723324314dad` claimed `.github/workflows` was the only pin source. That was a false boundary: `assay-action/action.yml` has 12 SHA-pinned `uses:` call sites. That head is **unreviewed and invalid** for review quorum. This PR advances to the head below.

## Base / head

| | SHA |
|---|---|
| Base | `e1f1f77c1d35edc3e9ed373bc6e7eb47fc22d3a8` |
| Prior head (invalid) | `81194a149f86a4be25d1b51ac1f6723324314dad` |
| Head | `556d35ff5a8304e8e575231291195323ece46142` |

Worktree: `/private/tmp/assay-wt-ci-docs-truth`  
Branch: `cursor/ci-docs-truth`

## Files changed

- `docs/PINNED-ACTIONS.md`
- `docs/reference/runner/ci-lanes.md`

## TDD for docs (RED → GREEN)

### RED (D0, on base `e1f1f77c`)

```text
PINNED: 40-hex SHA table rows present (Pinned SHA / Original ref columns) — dual source
ci-lanes: "Workspace dependency bump that can affect ..." — conditional phrasing
BOTH_RED_CONFIRMED
```

### RED (boundary follow-up, on `81194a149`)

```text
PINNED claimed workflows were the only source of truth / inspection scanned only .github/workflows/
assay-action/action.yml has 12 SHA-pinned uses: call sites
BOUNDARY_RED=1
```

### GREEN (current head)

```text
PINNED: no 40-hex SHA table; no pin columns; no false workflows-only boundary
PINNED: names assay-action/action.yml and .github/actions/** as callsite surfaces
PINNED: inspection command scans workflows + assay-action + .github/actions
PINNED: words robustly that .github/actions may have zero external uses: today
ci-lanes: Cargo.lock any-touch → gates=all + unaddressed reuse; no "can affect"
git diff --check: clean
no unchecked sync/assurance claims
BOTH_GREEN_CONFIRMED
```

## Verification

- Read-only RED/GREEN assertions above
- `git diff --check` clean
- Public-string review: no auto-sync / kept-in-sync / status-assurance claims
- `mkdocs` not available in the worktree environment (skipped)
- Pre-commit + pre-push hooks on commit/push

## Non-claims

- No classifier behavior change (`scripts/ci/assay_runner_lane_check.py` untouched)
- No PINNED-ACTIONS generator or drift check added
- No workflow / composite-action YAML edits
- No branch-protection / ruleset / `deny.toml` edits
- Required live contexts and `CI-CONTRACT.md` §6 untouched
- Does not claim `gates=all` for `Cargo.lock` is wrong — only that the doc no longer describes a condition the classifier never evaluates
- Does not claim content-provenance coverage for `Cargo.lock` would be correct
- Does not claim Dependabot covers every callsite surface
- Does not merge

## Test plan

- [x] RED assertions fail for the pre-edit defects (D0 + false boundary)
- [x] GREEN assertions pass after the doc edits
- [x] Diff limited to the two scoped docs
- [x] Draft PR only; do not merge