### PR TITLE
ci: setup-rust composite (Batch E1, week8-only)

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,32 @@
+name: Setup Rust
+description: >
+  Install a SHA-pinned Rust toolchain and restore the cargo cache.
+  Callers keep an explicit checkout; this composite does not check out the repo.
+
+inputs:
+  toolchain:
+    description: Rust toolchain to install (passed to dtolnay/rust-toolchain).
+    required: false
+    default: stable
+  components:
+    description: Comma-separated rustup components (optional; empty adds none).
+    required: false
+    default: ""
+  cache-workspaces:
+    description: Workspace paths for Swatinem/rust-cache (optional; empty keeps action default).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+
+    - name: Cache cargo
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        workspaces: ${{ inputs.cache-workspaces }}

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -32,6 +32,10 @@ on:
       # head-side pre-commit leg when it changes, because the lane workflow
       # itself checks out the PR base and would validate the base copy.
       - ".github/workflows/assay-runner-lane-check.yml"
+      # setup-rust composite + week8 first-slice callers: Lint (pre-commit) owns the
+      # contract hook; these paths must trigger that job when the boundary moves.
+      - ".github/actions/setup-rust/**"
+      - ".github/workflows/week8-sota-gates.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -32,8 +32,7 @@ on:
       # head-side pre-commit leg when it changes, because the lane workflow
       # itself checks out the PR base and would validate the base copy.
       - ".github/workflows/assay-runner-lane-check.yml"
-      # setup-rust composite + week8 first-slice callers: Lint (pre-commit) owns the
-      # contract hook; these paths must trigger that job when the boundary moves.
+      # setup-rust contract hook runs under Lint (pre-commit) in this workflow.
       - ".github/actions/setup-rust/**"
       - ".github/workflows/week8-sota-gates.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic

--- a/.github/workflows/week8-sota-gates.yml
+++ b/.github/workflows/week8-sota-gates.yml
@@ -41,10 +41,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust
 
       - name: Run optional public API drift gate
         shell: bash
@@ -73,10 +70,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust
 
       - name: Run targeted mutation smoke
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -278,6 +278,13 @@ repos:
         # it believes it is checking.
         files: ^(scripts/ci/check-ci-gate-coverage\.py|\.github/workflows/ci\.yml|\.github/rulesets/main-required-ci-contexts\.json|\.pre-commit-config\.yaml)$
 
+      - id: setup-rust-composite-contract-self-test
+        name: Setup-rust composite contract
+        entry: bash scripts/ci/test-setup-rust-composite-contract.sh
+        language: system
+        pass_filenames: false
+        files: ^(\.github/actions/setup-rust/action\.yml|\.github/workflows/week8-sota-gates\.yml|scripts/ci/test-setup-rust-composite-contract\.sh|\.pre-commit-config\.yaml)$
+
       - id: mcp-registry-release-txn-self-test
         name: MCP Registry release transaction self-test
         entry: bash scripts/ci/test-mcp-registry-release-txn.sh

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Contract for .github/actions/setup-rust and its week8 first-slice callers.
+# Guards only the new boundary; actionlint + diff review cover unchanged week8 structure.
+#
+# Empty optional forwarding is safe for the pinned upstream versions measured in this
+# slice: dtolnay/rust-toolchain@29eef... adds no --component flags for empty
+# components; Swatinem/rust-cache@c193... treats empty workspaces as its "." default.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ACTION="${ROOT}/.github/actions/setup-rust/action.yml"
+WEEK8="${ROOT}/.github/workflows/week8-sota-gates.yml"
+TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
+CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "ok   $*"; }
+
+abort_is_failure() {
+  local rc="$1"
+  [[ "${rc}" -eq 0 ]] || echo "setup-rust composite contract aborted (exit ${rc}); treat as failure" >&2
+}
+trap 'abort_is_failure "$?"' ERR
+
+[[ -f "${ACTION}" ]] || fail "missing .github/actions/setup-rust/action.yml"
+[[ -f "${WEEK8}" ]] || fail "missing .github/workflows/week8-sota-gates.yml"
+
+grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
+  || fail "action must declare runs.using: composite"
+ok "composite action present"
+
+grep -qE 'actions/checkout@' "${ACTION}" && fail "composite must not checkout" || ok "no checkout in composite"
+grep -qE 'apt-get|apt install|sudo apt' "${ACTION}" && fail "composite must not apt-install" || ok "no apt in composite"
+
+python3 - "${ACTION}" "${TOOLCHAIN_REF}" "${CACHE_REF}" <<'PY' || fail "composite pin/input contract failed"
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+want_toolchain, want_cache = sys.argv[2], sys.argv[3]
+
+m = re.search(r"(?m)^inputs:\n(.*?)(?=^[a-zA-Z]|\Z)", text, re.S)
+if not m:
+    raise SystemExit("no inputs: block")
+names = re.findall(r"(?m)^  ([A-Za-z0-9_-]+):\s*$", m.group(1))
+if names != ["toolchain", "components", "cache-workspaces"]:
+    raise SystemExit(f"inputs {names}, expected toolchain/components/cache-workspaces")
+if not re.search(r"(?m)^  toolchain:\n(?:.*\n)*?    default:\s*stable\s*$", text):
+    raise SystemExit("toolchain default must be stable")
+for opt in ("components", "cache-workspaces"):
+    if not re.search(rf"(?m)^  {opt}:\n(?:.*\n)*?    default:\s*(\"\"|'')\s*$", text):
+        raise SystemExit(f"{opt} default must be empty")
+
+# Exactly one occurrence of each external action@SHA (single-sourced pins).
+for label, needle in (("toolchain", want_toolchain), ("cache", want_cache)):
+    count = text.count(needle)
+    if count != 1:
+        raise SystemExit(f"{label} ref {needle} occurs {count} times; want exactly 1")
+if not re.search(r"(?m)^\s+components:\s*\$\{\{\s*inputs\.components\s*\}\}\s*$", text):
+    raise SystemExit("must pass components: ${{ inputs.components }}")
+if not re.search(r"(?m)^\s+workspaces:\s*\$\{\{\s*inputs\.cache-workspaces\s*\}\}\s*$", text):
+    raise SystemExit("must pass workspaces: ${{ inputs.cache-workspaces }}")
+print("ok   inputs/defaults; one pin each; empty inputs forwarded")
+PY
+
+python3 - "${WEEK8}" <<'PY' || fail "week8 setup-rust caller contract failed"
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+if re.search(r"dtolnay/rust-toolchain@", text):
+    raise SystemExit("week8 still calls dtolnay/rust-toolchain directly")
+if re.search(r"Swatinem/rust-cache@", text):
+    raise SystemExit("week8 still calls Swatinem/rust-cache directly")
+
+jobs = re.findall(
+    r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+    text,
+    re.S,
+)
+setup_jobs = []
+for job_id, block in jobs:
+    uses = re.findall(r"(?m)^      - uses:\s*(\S+)", block)
+    setup_idxs = [i for i, u in enumerate(uses) if u.rstrip("/") == "./.github/actions/setup-rust"]
+    if not setup_idxs:
+        continue
+    if len(setup_idxs) != 1:
+        raise SystemExit(f"{job_id}: expected one setup-rust call, found {len(setup_idxs)}")
+    checkout_idxs = [i for i, u in enumerate(uses) if u.startswith("actions/checkout@")]
+    if not checkout_idxs or setup_idxs[0] != checkout_idxs[0] + 1:
+        raise SystemExit(f"{job_id}: setup-rust must follow checkout in that job")
+    setup_jobs.append(job_id)
+
+if len(setup_jobs) != 2:
+    raise SystemExit(f"expected exactly two jobs calling setup-rust, found {setup_jobs}")
+print(f"ok   week8: two setup-rust calls after checkout ({', '.join(setup_jobs)}); no direct pins")
+PY
+
+echo "setup-rust composite contract: all checks passed"

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ACTION="${ROOT}/.github/actions/setup-rust/action.yml"
 WEEK8="${ROOT}/.github/workflows/week8-sota-gates.yml"
+KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 
@@ -24,6 +25,7 @@ trap 'abort_is_failure "$?"' ERR
 
 [[ -f "${ACTION}" ]] || fail "missing .github/actions/setup-rust/action.yml"
 [[ -f "${WEEK8}" ]] || fail "missing .github/workflows/week8-sota-gates.yml"
+[[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
   || fail "action must declare runs.using: composite"
@@ -59,12 +61,13 @@ for opt in ("components", "cache-workspaces"):
     if not re.search(rf"(?m)^  {opt}:\n(?:.*\n)*?    default:\s*(\"\"|'')\s*$", text):
         raise SystemExit(f"{opt} default must be empty")
 
-# All action@SHA uses for each name must be exactly the single wanted ref.
+# Every action@ref (SHA, tag, branch) must be exactly the single wanted pin.
+# SHA-only extraction missed mutable refs like @stable beside a correct pin.
 for label, action, wanted in (
     ("toolchain", "dtolnay/rust-toolchain", want_toolchain),
     ("cache", "Swatinem/rust-cache", want_cache),
 ):
-    found = re.findall(rf"{re.escape(action)}@[0-9a-f]{{40}}", text)
+    found = re.findall(rf"{re.escape(action)}@[^\s#]+", text)
     if found != [wanted]:
         raise SystemExit(f"{label} refs {found}, expected [{wanted}]")
 if not re.search(r"(?m)^\s+components:\s*\$\{\{\s*inputs\.components\s*\}\}\s*$", text):
@@ -72,6 +75,42 @@ if not re.search(r"(?m)^\s+components:\s*\$\{\{\s*inputs\.components\s*\}\}\s*$"
 if not re.search(r"(?m)^\s+workspaces:\s*\$\{\{\s*inputs\.cache-workspaces\s*\}\}\s*$", text):
     raise SystemExit("must pass workspaces: ${{ inputs.cache-workspaces }}")
 print("ok   inputs/defaults; one pin each; empty inputs forwarded")
+PY
+
+KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
+[[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
+
+python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+in_pr = in_paths = False
+paths: list[str] = []
+for line in text.splitlines():
+    if re.match(r"^  pull_request:\s*$", line):
+        in_pr, in_paths = True, False
+        continue
+    if in_pr and re.match(r"^  \S", line):
+        in_pr = in_paths = False
+    if in_pr and re.match(r"^    paths:\s*$", line):
+        in_paths = True
+        continue
+    if in_pr and in_paths and re.match(r"^    \S", line):
+        in_paths = False
+    if in_paths:
+        m = re.match(r'^      - "([^"]+)"\s*(?:#.*)?$', line)
+        if m:
+            paths.append(m.group(1))
+
+required = (
+    ".github/actions/setup-rust/**",
+    ".github/workflows/week8-sota-gates.yml",
+)
+missing = [p for p in required if p not in paths]
+if missing:
+    raise SystemExit(f"pull_request.paths missing {missing}")
+print("ok   kernel-matrix pull_request.paths cover setup-rust + week8 triggers")
 PY
 
 python3 - "${WEEK8}" <<'PY' || fail "week8 setup-rust caller contract failed"

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -77,9 +77,6 @@ if not re.search(r"(?m)^\s+workspaces:\s*\$\{\{\s*inputs\.cache-workspaces\s*\}\
 print("ok   inputs/defaults; one pin each; empty inputs forwarded")
 PY
 
-KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
-[[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
-
 python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
 import re, sys
 from pathlib import Path

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -29,8 +29,16 @@ grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
   || fail "action must declare runs.using: composite"
 ok "composite action present"
 
-grep -qE 'actions/checkout@' "${ACTION}" && fail "composite must not checkout" || ok "no checkout in composite"
-grep -qE 'apt-get|apt install|sudo apt' "${ACTION}" && fail "composite must not apt-install" || ok "no apt in composite"
+if grep -qE 'actions/checkout@' "${ACTION}"; then
+  fail "composite must not checkout"
+else
+  ok "no checkout in composite"
+fi
+if grep -qE 'apt-get|apt install|sudo apt' "${ACTION}"; then
+  fail "composite must not apt-install"
+else
+  ok "no apt in composite"
+fi
 
 python3 - "${ACTION}" "${TOOLCHAIN_REF}" "${CACHE_REF}" <<'PY' || fail "composite pin/input contract failed"
 import re, sys
@@ -51,11 +59,14 @@ for opt in ("components", "cache-workspaces"):
     if not re.search(rf"(?m)^  {opt}:\n(?:.*\n)*?    default:\s*(\"\"|'')\s*$", text):
         raise SystemExit(f"{opt} default must be empty")
 
-# Exactly one occurrence of each external action@SHA (single-sourced pins).
-for label, needle in (("toolchain", want_toolchain), ("cache", want_cache)):
-    count = text.count(needle)
-    if count != 1:
-        raise SystemExit(f"{label} ref {needle} occurs {count} times; want exactly 1")
+# All action@SHA uses for each name must be exactly the single wanted ref.
+for label, action, wanted in (
+    ("toolchain", "dtolnay/rust-toolchain", want_toolchain),
+    ("cache", "Swatinem/rust-cache", want_cache),
+):
+    found = re.findall(rf"{re.escape(action)}@[0-9a-f]{{40}}", text)
+    if found != [wanted]:
+        raise SystemExit(f"{label} refs {found}, expected [{wanted}]")
 if not re.search(r"(?m)^\s+components:\s*\$\{\{\s*inputs\.components\s*\}\}\s*$", text):
     raise SystemExit("must pass components: ${{ inputs.components }}")
 if not re.search(r"(?m)^\s+workspaces:\s*\$\{\{\s*inputs\.cache-workspaces\s*\}\}\s*$", text):


### PR DESCRIPTION
## Summary
- Add `.github/actions/setup-rust` composite (pinned `dtolnay/rust-toolchain` + `Swatinem/rust-cache`; no checkout/apt).
- Migrate only two week8 SOTA gate jobs to the composite.
- Enforce the boundary via local pre-commit hook `setup-rust-composite-contract-self-test` (reuses Lint / Kernel Matrix pre-commit).
- Kernel Matrix `pull_request.paths` includes `.github/actions/setup-rust/**` and `.github/workflows/week8-sota-gates.yml` so composite/workflow-only drift still runs the hook.
- Contract extracts every `action@ref` (not only 40-hex) and requires exactly the wanted SHA pin (rejects `@stable` beside a correct pin).

## Exact head
See latest commit on this PR; prior reviews on older SHAs are invalidated.

## Test plan
- [x] RED: Kernel Matrix paths absent; `@stable` mutation survived prior contract
- [x] GREEN: path trigger assertion; `@stable` / SHA drift rejected
- [x] `bash scripts/ci/test-setup-rust-composite-contract.sh`
- [x] shellcheck + check-yaml + `pre-commit run setup-rust-composite-contract-self-test --all-files`
- [x] actionlint week8; kernel-matrix only pre-existing `concurrency.queue` notes
- [ ] Fresh independent exact-head review on this head

Draft only — do not merge until review quorum on the final head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized Rust toolchain setup and dependency caching across automated checks.
  - Added configurable support for Rust versions, components, and workspace paths.
  - Improved workflow change detection so relevant automation updates trigger validation.

- **Tests**
  - Added automated contract checks to verify Rust setup configuration, cache behavior, workflow integration, and required safeguards.
  - Added pre-commit validation for changes affecting CI setup and related configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->