### PR TITLE
ci: migrate wave6 Rust jobs to setup-rust (Batch E2)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -35,6 +35,8 @@ on:
       # setup-rust contract hook runs under Lint (pre-commit) in this workflow.
       - ".github/actions/setup-rust/**"
       - ".github/workflows/week8-sota-gates.yml"
+      # wave6 Rust jobs call setup-rust; keep contract hook on that surface.
+      - ".github/workflows/wave6-nightly-safety.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/.github/workflows/wave6-nightly-safety.yml
+++ b/.github/workflows/wave6-nightly-safety.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: nightly
           components: miri
@@ -42,9 +42,6 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Miri smoke test (verify fail-closed anchor)
         shell: bash
@@ -65,7 +62,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust
 
       - name: Install Linux deps
         shell: bash
@@ -81,9 +78,6 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Proptest smoke anchor
         shell: bash

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -179,25 +179,23 @@ def setup_rust_with_map(block: str) -> dict[str, str]:
     return vals
 
 miri_with = setup_rust_with_map(jobs["miri-registry-smoke"])
-if miri_with.get("toolchain") != "nightly":
+miri_expected = {"toolchain": "nightly", "components": "miri"}
+if miri_with != miri_expected:
     raise SystemExit(
-        f"miri-registry-smoke: toolchain must be nightly, got {miri_with.get('toolchain')!r}"
-    )
-if miri_with.get("components") != "miri":
-    raise SystemExit(
-        f"miri-registry-smoke: components must be miri, got {miri_with.get('components')!r}"
+        f"miri-registry-smoke: setup-rust with-map must be exactly {miri_expected}, "
+        f"got {miri_with}"
     )
 
 proptest_with = setup_rust_with_map(jobs["proptest-cli-smoke"])
-if "toolchain" in proptest_with or "components" in proptest_with:
+if proptest_with != {}:
     raise SystemExit(
-        "proptest-cli-smoke: setup-rust must use composite defaults "
-        f"(no toolchain/components overrides); got {proptest_with}"
+        "proptest-cli-smoke: setup-rust with-map must be exactly {} "
+        f"(composite defaults); got {proptest_with}"
     )
 
 print(
     f"ok   wave6: setup-rust after checkout for {', '.join(setup_jobs)}; "
-    "miri nightly+miri; proptest defaults; no direct pins"
+    "miri with-map exact; proptest with-map empty; no direct pins"
 )
 PY
 
@@ -229,10 +227,13 @@ required = (
     ".github/workflows/week8-sota-gates.yml",
     ".github/workflows/wave6-nightly-safety.yml",
 )
-missing = [p for p in required if p not in paths]
-if missing:
-    raise SystemExit(f"pull_request.paths missing {missing}")
-print("ok   kernel-matrix pull_request.paths cover setup-rust + week8 + wave6 triggers")
+bad = [p for p in required if paths.count(p) != 1]
+if bad:
+    raise SystemExit(
+        "pull_request.paths must list each trigger path exactly once; "
+        + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
+    )
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6")
 PY
 
 echo "setup-rust composite contract: all checks passed"

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 first-slice callers.
-# Guards only the new boundary; actionlint + diff review cover unchanged week8 structure.
+# Contract for .github/actions/setup-rust and its week8 + wave6 caller surfaces.
+# Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
 # slice: dtolnay/rust-toolchain@29eef... adds no --component flags for empty
@@ -10,6 +10,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ACTION="${ROOT}/.github/actions/setup-rust/action.yml"
 WEEK8="${ROOT}/.github/workflows/week8-sota-gates.yml"
+WAVE6="${ROOT}/.github/workflows/wave6-nightly-safety.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -25,6 +26,7 @@ trap 'abort_is_failure "$?"' ERR
 
 [[ -f "${ACTION}" ]] || fail "missing .github/actions/setup-rust/action.yml"
 [[ -f "${WEEK8}" ]] || fail "missing .github/workflows/week8-sota-gates.yml"
+[[ -f "${WAVE6}" ]] || fail "missing .github/workflows/wave6-nightly-safety.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -77,39 +79,6 @@ if not re.search(r"(?m)^\s+workspaces:\s*\$\{\{\s*inputs\.cache-workspaces\s*\}\
 print("ok   inputs/defaults; one pin each; empty inputs forwarded")
 PY
 
-python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
-import re, sys
-from pathlib import Path
-
-text = Path(sys.argv[1]).read_text(encoding="utf-8")
-in_pr = in_paths = False
-paths: list[str] = []
-for line in text.splitlines():
-    if re.match(r"^  pull_request:\s*$", line):
-        in_pr, in_paths = True, False
-        continue
-    if in_pr and re.match(r"^  \S", line):
-        in_pr = in_paths = False
-    if in_pr and re.match(r"^    paths:\s*$", line):
-        in_paths = True
-        continue
-    if in_pr and in_paths and re.match(r"^    \S", line):
-        in_paths = False
-    if in_paths:
-        m = re.match(r'^      - "([^"]+)"\s*(?:#.*)?$', line)
-        if m:
-            paths.append(m.group(1))
-
-required = (
-    ".github/actions/setup-rust/**",
-    ".github/workflows/week8-sota-gates.yml",
-)
-missing = [p for p in required if p not in paths]
-if missing:
-    raise SystemExit(f"pull_request.paths missing {missing}")
-print("ok   kernel-matrix pull_request.paths cover setup-rust + week8 triggers")
-PY
-
 python3 - "${WEEK8}" <<'PY' || fail "week8 setup-rust caller contract failed"
 import re, sys
 from pathlib import Path
@@ -141,6 +110,129 @@ for job_id, block in jobs:
 if len(setup_jobs) != 2:
     raise SystemExit(f"expected exactly two jobs calling setup-rust, found {setup_jobs}")
 print(f"ok   week8: two setup-rust calls after checkout ({', '.join(setup_jobs)}); no direct pins")
+PY
+
+python3 - "${WAVE6}" <<'PY' || fail "wave6 setup-rust caller contract failed"
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+if re.search(r"dtolnay/rust-toolchain@", text):
+    raise SystemExit("wave6 still calls dtolnay/rust-toolchain directly")
+if re.search(r"Swatinem/rust-cache@", text):
+    raise SystemExit("wave6 still calls Swatinem/rust-cache directly")
+
+jobs = {
+    job_id: block
+    for job_id, block in re.findall(
+        r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        re.S,
+    )
+}
+
+required_jobs = ("miri-registry-smoke", "proptest-cli-smoke")
+for job_id in required_jobs:
+    if job_id not in jobs:
+        raise SystemExit(f"wave6 missing job {job_id}")
+
+setup_jobs = []
+for job_id in required_jobs:
+    block = jobs[job_id]
+    uses = re.findall(r"(?m)^      - uses:\s*(\S+)", block)
+    setup_idxs = [i for i, u in enumerate(uses) if u.rstrip("/") == "./.github/actions/setup-rust"]
+    if len(setup_idxs) != 1:
+        raise SystemExit(f"{job_id}: expected one setup-rust call, found {len(setup_idxs)}")
+    checkout_idxs = [i for i, u in enumerate(uses) if u.startswith("actions/checkout@")]
+    if not checkout_idxs or setup_idxs[0] != checkout_idxs[0] + 1:
+        raise SystemExit(f"{job_id}: setup-rust must follow checkout in that job")
+    setup_jobs.append(job_id)
+
+# Parse with: for the setup-rust step in a job block (immediately after its uses line).
+def setup_rust_with_map(block: str) -> dict[str, str]:
+    m = re.search(
+        r"(?m)^      - uses:\s*\./\.github/actions/setup-rust\s*\n"
+        r"((?:        .*\n)*)",
+        block,
+    )
+    if not m:
+        return {}
+    tail = m.group(1)
+    if not re.match(r"^        with:\s*$", tail, re.M):
+        # No with: block (defaults) — or unrelated indented lines that are not with:
+        return {}
+    # Collect key: value under with: until indentation drops below 10 spaces for keys
+    vals: dict[str, str] = {}
+    in_with = False
+    for line in tail.splitlines():
+        if re.match(r"^        with:\s*$", line):
+            in_with = True
+            continue
+        if not in_with:
+            continue
+        km = re.match(r"^          ([A-Za-z0-9_-]+):\s*(.*?)\s*$", line)
+        if km:
+            vals[km.group(1)] = km.group(2)
+            continue
+        # end of with: block
+        break
+    return vals
+
+miri_with = setup_rust_with_map(jobs["miri-registry-smoke"])
+if miri_with.get("toolchain") != "nightly":
+    raise SystemExit(
+        f"miri-registry-smoke: toolchain must be nightly, got {miri_with.get('toolchain')!r}"
+    )
+if miri_with.get("components") != "miri":
+    raise SystemExit(
+        f"miri-registry-smoke: components must be miri, got {miri_with.get('components')!r}"
+    )
+
+proptest_with = setup_rust_with_map(jobs["proptest-cli-smoke"])
+if "toolchain" in proptest_with or "components" in proptest_with:
+    raise SystemExit(
+        "proptest-cli-smoke: setup-rust must use composite defaults "
+        f"(no toolchain/components overrides); got {proptest_with}"
+    )
+
+print(
+    f"ok   wave6: setup-rust after checkout for {', '.join(setup_jobs)}; "
+    "miri nightly+miri; proptest defaults; no direct pins"
+)
+PY
+
+python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+in_pr = in_paths = False
+paths: list[str] = []
+for line in text.splitlines():
+    if re.match(r"^  pull_request:\s*$", line):
+        in_pr, in_paths = True, False
+        continue
+    if in_pr and re.match(r"^  \S", line):
+        in_pr = in_paths = False
+    if in_pr and re.match(r"^    paths:\s*$", line):
+        in_paths = True
+        continue
+    if in_pr and in_paths and re.match(r"^    \S", line):
+        in_paths = False
+    if in_paths:
+        m = re.match(r'^      - "([^"]+)"\s*(?:#.*)?$', line)
+        if m:
+            paths.append(m.group(1))
+
+required = (
+    ".github/actions/setup-rust/**",
+    ".github/workflows/week8-sota-gates.yml",
+    ".github/workflows/wave6-nightly-safety.yml",
+)
+missing = [p for p in required if p not in paths]
+if missing:
+    raise SystemExit(f"pull_request.paths missing {missing}")
+print("ok   kernel-matrix pull_request.paths cover setup-rust + week8 + wave6 triggers")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary
- Migrate Wave6 Nightly Safety Rust jobs (`miri-registry-smoke`, `proptest-cli-smoke`) from direct `dtolnay/rust-toolchain` + `Swatinem/rust-cache` to `./.github/actions/setup-rust`.
- `miri-registry-smoke` passes `toolchain: nightly` and `components: miri`; `proptest-cli-smoke` uses composite defaults (no toolchain/components overrides).
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` for wave6 as a second caller surface (week8 checks unchanged).
- Add `.github/workflows/wave6-nightly-safety.yml` once to Kernel Matrix `pull_request.paths` so the contract hook stays durable.
- Follow-up: tighten contract to exact setup-rust `with:` map equality (miri / proptest) and exact-once Kernel Matrix path counts (rejects extras and duplicates).

## Non-claim (cache / apt ordering)
This PR does **not** claim step ordering is identical to pre-migration Wave6. Cache now runs immediately after toolchain (inside the composite), **before** the apt Install Linux deps step. Previously Wave6 installed apt deps, then ran `Swatinem/rust-cache`. That reorder is intentional because the composite owns toolchain + cache; it is recorded here as an ordering fact, not a behavioral identity claim.

## RED / GREEN evidence
- **Base:** `origin/main` @ `fb549934489840c21c2455a4a13e5cf70b6be627`
- **RED** (contract extended first; workflows unchanged): failed with `wave6 still calls dtolnay/rust-toolchain directly` (also confirmed Swatinem direct pin present; KM path for wave6 missing as a second failure once wave6 is green).
- **GREEN** (wave6 migrated + KM path added): contract all checks passed, including wave6 setup-rust after checkout, miri nightly+miri, proptest defaults, and KM paths covering setup-rust + week8 + wave6.
- **Contract gap RED** (at `093f75d7f35c1f753a28ee2890399e55b49ec909`, before guard tighten): contract still **PASSED** with (a) `cache-workspaces: other` under miri setup-rust `with:` and (b) duplicated KM `wave6-nightly-safety.yml` path — proving membership-only / key-subset checks were insufficient.
- **Contract gap GREEN** (this head): exact with-map equality + exact-once path counts; mutations (a)/(b) and extras below FAIL; clean tree contract PASS.

## Mutation probes (temp copies; tree restored)
Each must fail the contract:
| Probe | Outcome |
|-------|---------|
| Reintroduce `dtolnay/rust-toolchain@stable` in wave6 | FAIL: direct pin |
| Reintroduce SHA-pinned `dtolnay/rust-toolchain@29eef...` | FAIL: direct pin |
| Remove miri job `setup-rust` call | FAIL: expected one call, found 0 |
| Remove proptest job `setup-rust` call | FAIL: expected one call, found 0 |
| Drop nightly (toolchain: stable) on miri | FAIL: with-map must be exactly nightly+miri |
| Drop miri component (components: rustfmt) | FAIL: with-map must be exactly nightly+miri |
| Remove KM `wave6-nightly-safety.yml` path | FAIL: path appears 0 time(s) |
| Add `cache-workspaces: other` under miri setup-rust `with:` (keep nightly+miri) | FAIL: with-map not exactly `{toolchain, components}` |
| Add only `cache-workspaces: other` under proptest setup-rust `with:` | FAIL: with-map must be exactly `{}` |
| Duplicate KM `wave6-nightly-safety.yml` path | FAIL: path appears 2 time(s) |
| Duplicate KM `week8-sota-gates.yml` path | FAIL: path appears 2 time(s) |
| Duplicate KM `.github/actions/setup-rust/**` path | FAIL: path appears 2 time(s) |

## Head SHA
`e924d804dfc2a1e2aaf1af37962535eb61197d9c`

## Test plan
- [x] `./scripts/ci/test-setup-rust-composite-contract.sh` (GREEN)
- [x] `shellcheck scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `actionlint` on wave6 + kernel-matrix (wave6 clean; kernel-matrix pre-existing `concurrency.queue` syntax findings at lines 314/364 noted separately — not introduced here)
- [x] `pre-commit run --files` on the three touched files (yaml/EOF/whitespace/shellcheck/contract)
- [x] `pre-commit run setup-rust-composite-contract-self-test --all-files`
- [x] `git diff --check`
- [x] Mutation probes above (including exact with-map / exact-once)
- [ ] CI on this draft PR

## Changed files
- `.github/workflows/wave6-nightly-safety.yml`
- `.github/workflows/kernel-matrix.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`

Made with [Cursor](https://cursor.com)