### PR TITLE
ci: migrate fuzz-smoke Rust setup to setup-rust (Batch E3)

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -64,7 +64,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # setup-rust installs the FUZZ_TOOLCHAIN pin then restores the fuzz workspace cache.
+      # Prior layout already placed cache immediately after toolchain with no steps between;
+      # the composite keeps that pair. This migration does not claim ordering equivalence for
+      # lanes that had apt or other work between those two steps (this lane did not).
+      - uses: ./.github/actions/setup-rust
         with:
           # Date-pinned, not floating `nightly`. Pinning cargo-fuzz alone does not freeze the
           # compiler that produced a reported run, and a sanitizer-instrumented build is exactly
@@ -74,11 +78,7 @@ jobs:
           # alias, which resolves to the newest nightly and will install one if it is missing --
           # silently defeating the pin while the log still says the dated toolchain was installed.
           toolchain: ${{ env.FUZZ_TOOLCHAIN }}
-
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: fuzz -> target
+          cache-workspaces: fuzz -> target
 
       - name: Install cargo-fuzz
         # Version-pinned, not just `--locked`: `--locked` fixes the tool's dependencies but still

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -37,6 +37,8 @@ on:
       - ".github/workflows/week8-sota-gates.yml"
       # wave6 Rust jobs call setup-rust; keep contract hook on that surface.
       - ".github/workflows/wave6-nightly-safety.yml"
+      # fuzz-smoke calls setup-rust with cache-workspaces; keep contract hook on that surface.
+      - ".github/workflows/fuzz-smoke.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -233,13 +233,49 @@ if "fuzz-smoke" not in jobs:
     raise SystemExit("fuzz-smoke missing job fuzz-smoke")
 
 block = jobs["fuzz-smoke"]
-uses = re.findall(r"(?m)^      - uses:\s*(\S+)", block)
-setup_idxs = [i for i, u in enumerate(uses) if u.rstrip("/") == "./.github/actions/setup-rust"]
+
+# Top-level step sequence (every `^      - ` item), not merely `- uses:` lines —
+# a `run:`/`name:` step between checkout and setup-rust must fail this guard.
+def top_level_step_bodies(job_block: str) -> list[str]:
+    lines = job_block.splitlines()
+    bodies: list[str] = []
+    i = 0
+    while i < len(lines):
+        if re.match(r"^      - ", lines[i]):
+            start = i
+            i += 1
+            while i < len(lines) and not re.match(r"^      - ", lines[i]):
+                i += 1
+            bodies.append("\n".join(lines[start:i]))
+        else:
+            i += 1
+    return bodies
+
+
+def step_kind(body: str) -> str:
+    m = re.match(r"^      - uses:\s*(\S+)", body)
+    if not m:
+        m = re.search(r"(?m)^        uses:\s*(\S+)", body)
+    if m:
+        uses = m.group(1).rstrip("/")
+        if uses.startswith("actions/checkout@"):
+            return "checkout"
+        if uses == "./.github/actions/setup-rust":
+            return "setup-rust"
+        return "other-uses"
+    return "other"
+
+
+kinds = [step_kind(b) for b in top_level_step_bodies(block)]
+setup_idxs = [i for i, k in enumerate(kinds) if k == "setup-rust"]
 if len(setup_idxs) != 1:
     raise SystemExit(f"fuzz-smoke: expected one setup-rust call, found {len(setup_idxs)}")
-checkout_idxs = [i for i, u in enumerate(uses) if u.startswith("actions/checkout@")]
+checkout_idxs = [i for i, k in enumerate(kinds) if k == "checkout"]
 if not checkout_idxs or setup_idxs[0] != checkout_idxs[0] + 1:
-    raise SystemExit("fuzz-smoke: setup-rust must follow checkout in that job")
+    raise SystemExit(
+        "fuzz-smoke: setup-rust must be the immediate next top-level step after checkout "
+        f"(step kinds: {kinds})"
+    )
 
 
 def setup_rust_with_map(job_block: str) -> dict[str, str]:

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -11,6 +11,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ACTION="${ROOT}/.github/actions/setup-rust/action.yml"
 WEEK8="${ROOT}/.github/workflows/week8-sota-gates.yml"
 WAVE6="${ROOT}/.github/workflows/wave6-nightly-safety.yml"
+FUZZ_SMOKE="${ROOT}/.github/workflows/fuzz-smoke.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -27,6 +28,7 @@ trap 'abort_is_failure "$?"' ERR
 [[ -f "${ACTION}" ]] || fail "missing .github/actions/setup-rust/action.yml"
 [[ -f "${WEEK8}" ]] || fail "missing .github/workflows/week8-sota-gates.yml"
 [[ -f "${WAVE6}" ]] || fail "missing .github/workflows/wave6-nightly-safety.yml"
+[[ -f "${FUZZ_SMOKE}" ]] || fail "missing .github/workflows/fuzz-smoke.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -199,6 +201,93 @@ print(
 )
 PY
 
+python3 - "${FUZZ_SMOKE}" <<'PY' || fail "fuzz-smoke setup-rust caller contract failed"
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+# Direct toolchain/cache callers (mutable tags or SHA pins) are forbidden after migration.
+if re.search(r"dtolnay/rust-toolchain@", text):
+    raise SystemExit("fuzz-smoke still calls dtolnay/rust-toolchain directly")
+if re.search(r"Swatinem/rust-cache@", text):
+    raise SystemExit("fuzz-smoke still calls Swatinem/rust-cache directly")
+
+# Toolchain pin env must stay the measured nightly; install and run share FUZZ_TOOLCHAIN.
+m = re.search(r"(?m)^  FUZZ_TOOLCHAIN:\s*(\S+)\s*$", text)
+if not m or m.group(1) != "nightly-2026-07-28":
+    raise SystemExit(
+        f"FUZZ_TOOLCHAIN must be exactly nightly-2026-07-28, got "
+        f"{m.group(1) if m else None!r}"
+    )
+
+jobs = {
+    job_id: block
+    for job_id, block in re.findall(
+        r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        re.S,
+    )
+}
+if "fuzz-smoke" not in jobs:
+    raise SystemExit("fuzz-smoke missing job fuzz-smoke")
+
+block = jobs["fuzz-smoke"]
+uses = re.findall(r"(?m)^      - uses:\s*(\S+)", block)
+setup_idxs = [i for i, u in enumerate(uses) if u.rstrip("/") == "./.github/actions/setup-rust"]
+if len(setup_idxs) != 1:
+    raise SystemExit(f"fuzz-smoke: expected one setup-rust call, found {len(setup_idxs)}")
+checkout_idxs = [i for i, u in enumerate(uses) if u.startswith("actions/checkout@")]
+if not checkout_idxs or setup_idxs[0] != checkout_idxs[0] + 1:
+    raise SystemExit("fuzz-smoke: setup-rust must follow checkout in that job")
+
+
+def setup_rust_with_map(job_block: str) -> dict[str, str]:
+    m = re.search(
+        r"(?m)^      - uses:\s*\./\.github/actions/setup-rust\s*\n"
+        r"((?:        .*\n)*)",
+        job_block,
+    )
+    if not m:
+        return {}
+    tail = m.group(1)
+    if not re.match(r"^        with:\s*$", tail, re.M):
+        return {}
+    vals: dict[str, str] = {}
+    in_with = False
+    for line in tail.splitlines():
+        if re.match(r"^        with:\s*$", line):
+            in_with = True
+            continue
+        if not in_with:
+            continue
+        if re.match(r"^\s*(?:#.*)?$", line):
+            continue
+        km = re.match(r"^          ([A-Za-z0-9_-]+):\s*(.*?)\s*$", line)
+        if km:
+            vals[km.group(1)] = km.group(2)
+            continue
+        break
+    return vals
+
+
+expected = {
+    "toolchain": "${{ env.FUZZ_TOOLCHAIN }}",
+    "cache-workspaces": "fuzz -> target",
+}
+got = setup_rust_with_map(block)
+if got != expected:
+    raise SystemExit(
+        f"fuzz-smoke: setup-rust with-map must be exactly {expected}, got {got}"
+    )
+
+print(
+    "ok   fuzz-smoke: one setup-rust after checkout; with-map exact "
+    "(toolchain=${{ env.FUZZ_TOOLCHAIN }}, cache-workspaces=fuzz -> target); "
+    "FUZZ_TOOLCHAIN=nightly-2026-07-28; no direct pins"
+)
+PY
+
 python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
 import re, sys
 from pathlib import Path
@@ -226,6 +315,7 @@ required = (
     ".github/actions/setup-rust/**",
     ".github/workflows/week8-sota-gates.yml",
     ".github/workflows/wave6-nightly-safety.yml",
+    ".github/workflows/fuzz-smoke.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -233,7 +323,7 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Scope
- Migrate **only** `.github/workflows/fuzz-smoke.yml` from direct `dtolnay/rust-toolchain` + `Swatinem/rust-cache` to `./.github/actions/setup-rust`.
- Caller `with:` map is exactly:
  - `toolchain: ${{ env.FUZZ_TOOLCHAIN }}`
  - `cache-workspaces: fuzz -> target`
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` for fuzz-smoke (E1/E2 week8 + wave6 assertions unchanged).
- Add `.github/workflows/fuzz-smoke.yml` **exactly once** to Kernel Matrix `pull_request.paths` (near other setup-rust trigger paths).
- Does **not** modify `.github/actions/setup-rust/action.yml`, `ci.yml`, release, required contexts, docs, Cargo, fuzz implementation, or other workflows.

## Non-claims
- **Cache/toolchain ordering:** In pre-migration fuzz-smoke, `Swatinem/rust-cache` already sat immediately after toolchain install with **no** apt or other steps between them. The composite keeps that contiguous toolchain→cache pair. This PR does **not** claim ordering equivalence for lanes that previously had intervening steps (this lane did not).
- Does not claim live fuzz campaign results, corpus growth, or sanitizer behavior changes.
- Does not claim Kernel Matrix `concurrency.queue` actionlint cleanliness (pre-existing findings remain).
- Live Verifier Fuzz Smoke workflow run is **pending CI / manual `workflow_dispatch`** after merge or dispatch; this PR only proves the setup-rust contract and workflow wiring.

## RED / GREEN evidence
- **Exact base:** `origin/main` @ `9e5a8e59822951c2d390a946e235bc5980be3285`
- **RED** (contract extended first; workflows still on direct pins / no KM fuzz path):
  - Failed with `fuzz-smoke still calls dtolnay/rust-toolchain directly`
  - Also lacked a setup-rust call / exact with-map; Kernel Matrix lacked `.github/workflows/fuzz-smoke.yml` in `pull_request.paths` (fails exact-once once fuzz caller is green).
- **Adjacency-gap fix** (this head `b9ac5437b5324a134321d17081a414150e52dc73`): fuzz guard now parses the job's top-level step sequence (not only `- uses:` indices). Intervening `run:` between checkout and setup-rust FAILS; previously that mutation exited 0 while the PR claimed immediate adjacency.
- **GREEN** (fuzz-smoke migrated + KM path added): contract all checks passed, including fuzz-smoke one setup-rust after checkout, exact with-map, `FUZZ_TOOLCHAIN=nightly-2026-07-28`, zero direct toolchain/cache refs, and KM exact-once for setup-rust + week8 + wave6 + fuzz-smoke.

## Mutation table (temp copies; tree restored)
| Probe | Outcome |
|-------|---------|
| Insert top-level `run:` between checkout and setup-rust | FAIL: not immediate next top-level step (was silent PASS before this head) |
| Restore direct `dtolnay/rust-toolchain@` ref | FAIL: direct pin |
| Restore direct `Swatinem/rust-cache@` ref | FAIL: direct pin |
| Remove setup-rust call | FAIL: expected one setup-rust |
| Change / remove `toolchain` input | FAIL: with-map inequality |
| Change / remove `cache-workspaces` | FAIL: with-map inequality |
| Add extra setup-rust input (`components`) | FAIL: with-map inequality |
| Duplicate KM fuzz-smoke path | FAIL: exact-once |
| Remove KM fuzz-smoke path | FAIL: exact-once |
| Change `FUZZ_TOOLCHAIN` away from `nightly-2026-07-28` | FAIL: pin guard |
| E1/E2 probes: remove week8 KM path / dup wave6 KM path / change miri with-map | FAIL (prior guards intact) |
| Clean tree after restores | PASS |

## Validation
- `bash scripts/ci/test-setup-rust-composite-contract.sh` — PASS (GREEN)
- `shellcheck -x scripts/ci/test-setup-rust-composite-contract.sh` — PASS
- `actionlint .github/workflows/fuzz-smoke.yml` — PASS
- `actionlint .github/workflows/kernel-matrix.yml` — pre-existing `concurrency.queue` syntax findings only (lines ~316, ~366); not introduced by this PR
- `pre-commit run check-yaml|trailing-whitespace|end-of-file-fixer` on touched files — PASS
- `pre-commit run setup-rust-composite-contract-self-test --all-files` — PASS
- `git diff --check` — PASS
- Pre-commit on commit (incl. Setup-rust composite contract, Fuzz lane contract, shellcheck) — PASS
- Did **not** run local `cargo fuzz` / campaign execution

## SHAs
- Base: `9e5a8e59822951c2d390a946e235bc5980be3285`
- Head: `b9ac5437b5324a134321d17081a414150e52dc73`

## Test plan
- [x] Contract RED then GREEN locally
- [x] Mutation matrix locally
- [ ] CI on this draft PR (Kernel Matrix lint / contract via paths)
- [ ] Live fuzz-smoke run pending CI or manual `workflow_dispatch` (not claimed here)

Made with [Cursor](https://cursor.com)
