### PR TITLE
ci: migrate ADR025 soak Rust setup to setup-rust (Batch E4)

### DIFF
--- a/.github/workflows/adr025-nightly-evidence.yml
+++ b/.github/workflows/adr025-nightly-evidence.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up Rust toolchain and cache
+        uses: ./.github/actions/setup-rust
 
       - name: Build (assay-cli)
         run: cargo build -p assay-cli

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -39,6 +39,8 @@ on:
       - ".github/workflows/wave6-nightly-safety.yml"
       # fuzz-smoke calls setup-rust with cache-workspaces; keep contract hook on that surface.
       - ".github/workflows/fuzz-smoke.yml"
+      # ADR025 soak calls setup-rust (empty with-map / composite defaults).
+      - ".github/workflows/adr025-nightly-evidence.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -291,8 +291,9 @@ def setup_rust_with_map(job_block: str) -> dict[str, str]:
     return vals
 
 
-def assert_immediate_setup_rust(job_id: str, block: str) -> None:
-    kinds = [step_kind(b) for b in top_level_step_bodies(block)]
+def assert_immediate_setup_rust(job_id: str, block: str) -> str:
+    bodies = top_level_step_bodies(block)
+    kinds = [step_kind(b) for b in bodies]
     setup_idxs = [i for i, k in enumerate(kinds) if k == "setup-rust"]
     if len(setup_idxs) != 1:
         raise SystemExit(f"{job_id}: expected one setup-rust call, found {len(setup_idxs)}")
@@ -302,6 +303,7 @@ def assert_immediate_setup_rust(job_id: str, block: str) -> None:
             f"{job_id}: setup-rust must be the immediate next top-level step after checkout "
             f"(step kinds: {kinds})"
         )
+    return bodies[setup_idxs[0]]
 
 
 # --- fuzz-smoke ---
@@ -350,11 +352,13 @@ for required in ("soak", "readiness", "closure", "otel_bridge"):
     if required not in adr_jobs:
         raise SystemExit(f"adr025 missing job {required}")
 
-assert_immediate_setup_rust("soak", adr_jobs["soak"])
-if setup_rust_with_map(adr_jobs["soak"]) != {}:
+soak_setup = assert_immediate_setup_rust("soak", adr_jobs["soak"])
+# Reject any top-level with: in the actual setup step body. Do not parse the
+# with-map via uses-line regex: that conflates parse miss with {} and misses
+# trailing-slash uses / with-before-uses reorderings.
+if re.search(r"(?m)^        with:\s*$", soak_setup):
     raise SystemExit(
-        f"soak: setup-rust with-map must be exactly {{}}, "
-        f"got {setup_rust_with_map(adr_jobs['soak'])}"
+        "soak: setup-rust must not declare a with: map (composite defaults only)"
     )
 
 for job_id in ("readiness", "closure", "otel_bridge"):

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -12,6 +12,7 @@ ACTION="${ROOT}/.github/actions/setup-rust/action.yml"
 WEEK8="${ROOT}/.github/workflows/week8-sota-gates.yml"
 WAVE6="${ROOT}/.github/workflows/wave6-nightly-safety.yml"
 FUZZ_SMOKE="${ROOT}/.github/workflows/fuzz-smoke.yml"
+ADR025="${ROOT}/.github/workflows/adr025-nightly-evidence.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -29,6 +30,7 @@ trap 'abort_is_failure "$?"' ERR
 [[ -f "${WEEK8}" ]] || fail "missing .github/workflows/week8-sota-gates.yml"
 [[ -f "${WAVE6}" ]] || fail "missing .github/workflows/wave6-nightly-safety.yml"
 [[ -f "${FUZZ_SMOKE}" ]] || fail "missing .github/workflows/fuzz-smoke.yml"
+[[ -f "${ADR025}" ]] || fail "missing .github/workflows/adr025-nightly-evidence.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -201,38 +203,24 @@ print(
 )
 PY
 
-python3 - "${FUZZ_SMOKE}" <<'PY' || fail "fuzz-smoke setup-rust caller contract failed"
+python3 - "${FUZZ_SMOKE}" "${ADR025}" <<'PY' || fail "simple-caller setup-rust contract failed"
 import re, sys
 from pathlib import Path
 
-text = Path(sys.argv[1]).read_text(encoding="utf-8")
+fuzz_text = Path(sys.argv[1]).read_text(encoding="utf-8")
+adr025_text = Path(sys.argv[2]).read_text(encoding="utf-8")
 
-# Direct toolchain/cache callers (mutable tags or SHA pins) are forbidden after migration.
-if re.search(r"dtolnay/rust-toolchain@", text):
-    raise SystemExit("fuzz-smoke still calls dtolnay/rust-toolchain directly")
-if re.search(r"Swatinem/rust-cache@", text):
-    raise SystemExit("fuzz-smoke still calls Swatinem/rust-cache directly")
 
-# Toolchain pin env must stay the measured nightly; install and run share FUZZ_TOOLCHAIN.
-m = re.search(r"(?m)^  FUZZ_TOOLCHAIN:\s*(\S+)\s*$", text)
-if not m or m.group(1) != "nightly-2026-07-28":
-    raise SystemExit(
-        f"FUZZ_TOOLCHAIN must be exactly nightly-2026-07-28, got "
-        f"{m.group(1) if m else None!r}"
-    )
+def jobs_by_id(text: str) -> dict[str, str]:
+    return {
+        job_id: block
+        for job_id, block in re.findall(
+            r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+            text,
+            re.S,
+        )
+    }
 
-jobs = {
-    job_id: block
-    for job_id, block in re.findall(
-        r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
-        text,
-        re.S,
-    )
-}
-if "fuzz-smoke" not in jobs:
-    raise SystemExit("fuzz-smoke missing job fuzz-smoke")
-
-block = jobs["fuzz-smoke"]
 
 # Top-level step sequence (every `^      - ` item), not merely `- uses:` lines —
 # a `run:`/`name:` step between checkout and setup-rust must fail this guard.
@@ -266,24 +254,20 @@ def step_kind(body: str) -> str:
     return "other"
 
 
-kinds = [step_kind(b) for b in top_level_step_bodies(block)]
-setup_idxs = [i for i, k in enumerate(kinds) if k == "setup-rust"]
-if len(setup_idxs) != 1:
-    raise SystemExit(f"fuzz-smoke: expected one setup-rust call, found {len(setup_idxs)}")
-checkout_idxs = [i for i, k in enumerate(kinds) if k == "checkout"]
-if not checkout_idxs or setup_idxs[0] != checkout_idxs[0] + 1:
-    raise SystemExit(
-        "fuzz-smoke: setup-rust must be the immediate next top-level step after checkout "
-        f"(step kinds: {kinds})"
-    )
-
-
 def setup_rust_with_map(job_block: str) -> dict[str, str]:
     m = re.search(
         r"(?m)^      - uses:\s*\./\.github/actions/setup-rust\s*\n"
         r"((?:        .*\n)*)",
         job_block,
     )
+    if not m:
+        # Named step form: `- name:` then `uses:` (ADR025 soak).
+        m = re.search(
+            r"(?m)^      - name:\s*.*\n"
+            r"        uses:\s*\./\.github/actions/setup-rust\s*\n"
+            r"((?:        .*\n)*)",
+            job_block,
+        )
     if not m:
         return {}
     tail = m.group(1)
@@ -307,20 +291,79 @@ def setup_rust_with_map(job_block: str) -> dict[str, str]:
     return vals
 
 
-expected = {
+def assert_immediate_setup_rust(job_id: str, block: str) -> None:
+    kinds = [step_kind(b) for b in top_level_step_bodies(block)]
+    setup_idxs = [i for i, k in enumerate(kinds) if k == "setup-rust"]
+    if len(setup_idxs) != 1:
+        raise SystemExit(f"{job_id}: expected one setup-rust call, found {len(setup_idxs)}")
+    checkout_idxs = [i for i, k in enumerate(kinds) if k == "checkout"]
+    if not checkout_idxs or setup_idxs[0] != checkout_idxs[0] + 1:
+        raise SystemExit(
+            f"{job_id}: setup-rust must be the immediate next top-level step after checkout "
+            f"(step kinds: {kinds})"
+        )
+
+
+# --- fuzz-smoke ---
+if re.search(r"dtolnay/rust-toolchain@", fuzz_text):
+    raise SystemExit("fuzz-smoke still calls dtolnay/rust-toolchain directly")
+if re.search(r"Swatinem/rust-cache@", fuzz_text):
+    raise SystemExit("fuzz-smoke still calls Swatinem/rust-cache directly")
+
+m = re.search(r"(?m)^  FUZZ_TOOLCHAIN:\s*(\S+)\s*$", fuzz_text)
+if not m or m.group(1) != "nightly-2026-07-28":
+    raise SystemExit(
+        f"FUZZ_TOOLCHAIN must be exactly nightly-2026-07-28, got "
+        f"{m.group(1) if m else None!r}"
+    )
+
+fuzz_jobs = jobs_by_id(fuzz_text)
+if "fuzz-smoke" not in fuzz_jobs:
+    raise SystemExit("fuzz-smoke missing job fuzz-smoke")
+fuzz_block = fuzz_jobs["fuzz-smoke"]
+assert_immediate_setup_rust("fuzz-smoke", fuzz_block)
+
+fuzz_expected = {
     "toolchain": "${{ env.FUZZ_TOOLCHAIN }}",
     "cache-workspaces": "fuzz -> target",
 }
-got = setup_rust_with_map(block)
-if got != expected:
+got = setup_rust_with_map(fuzz_block)
+if got != fuzz_expected:
     raise SystemExit(
-        f"fuzz-smoke: setup-rust with-map must be exactly {expected}, got {got}"
+        f"fuzz-smoke: setup-rust with-map must be exactly {fuzz_expected}, got {got}"
     )
 
 print(
     "ok   fuzz-smoke: one setup-rust after checkout; with-map exact "
     "(toolchain=${{ env.FUZZ_TOOLCHAIN }}, cache-workspaces=fuzz -> target); "
     "FUZZ_TOOLCHAIN=nightly-2026-07-28; no direct pins"
+)
+
+# --- ADR025 soak (simple empty with-map caller) ---
+if re.search(r"dtolnay/rust-toolchain@", adr025_text):
+    raise SystemExit("adr025 still calls dtolnay/rust-toolchain directly")
+if re.search(r"Swatinem/rust-cache@", adr025_text):
+    raise SystemExit("adr025 still calls Swatinem/rust-cache directly")
+
+adr_jobs = jobs_by_id(adr025_text)
+for required in ("soak", "readiness", "closure", "otel_bridge"):
+    if required not in adr_jobs:
+        raise SystemExit(f"adr025 missing job {required}")
+
+assert_immediate_setup_rust("soak", adr_jobs["soak"])
+if setup_rust_with_map(adr_jobs["soak"]) != {}:
+    raise SystemExit(
+        f"soak: setup-rust with-map must be exactly {{}}, "
+        f"got {setup_rust_with_map(adr_jobs['soak'])}"
+    )
+
+for job_id in ("readiness", "closure", "otel_bridge"):
+    if "./.github/actions/setup-rust" in adr_jobs[job_id]:
+        raise SystemExit(f"adr025 job {job_id} must not call setup-rust")
+
+print(
+    "ok   adr025: soak one setup-rust after checkout; with-map empty; "
+    "no setup-rust in readiness/closure/otel_bridge; no direct pins"
 )
 PY
 
@@ -352,6 +395,7 @@ required = (
     ".github/workflows/week8-sota-gates.yml",
     ".github/workflows/wave6-nightly-safety.yml",
     ".github/workflows/fuzz-smoke.yml",
+    ".github/workflows/adr025-nightly-evidence.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -359,7 +403,7 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary

- Migrate only the **soak** job in `.github/workflows/adr025-nightly-evidence.yml` from direct `dtolnay/rust-toolchain` to `./.github/actions/setup-rust` with composite defaults (no `with:` map).
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` so fuzz-smoke and ADR025 soak share one actual-step / with-map helper (no second copy-pasted parser).
- Add `.github/workflows/adr025-nightly-evidence.yml` exactly once to Kernel Matrix `pull_request.paths`.

## Exact SHAs

- Base: `origin/main` @ `f6dfb36317495d81006423a45057487fedaa2ae4`
- Head: `da92ddfc4d5757caf7e58ae4deba3a0ed3f45857` (`cursor/ci-setup-rust-e4`)

## Scope

**Allowed / changed files only**

- `.github/workflows/adr025-nightly-evidence.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`
- `.github/workflows/kernel-matrix.yml`

**Unchanged by design**

- `.github/actions/setup-rust/action.yml`
- readiness / closure / otel_bridge (they do not install Rust)
- ci.yml, release, Cargo, aee_seal, semantic_vcr, week8/wave6/fuzz workflows (except contract coverage of prior callers)

## Behavioral delta / non-claims

- The soak caller previously installed **stable** Rust **without** rust-cache. The composite **intentionally** restores the default cargo cache (Swatinem) to reduce repeated nightly build cost. This is a real setup delta, not a silent no-op.
- Do **not** treat this as byte-for-byte / mechanical equivalence with the prior direct toolchain step.
- No claim about release-readiness semantics, soak correctness, or informational-lane outcomes — only setup wiring changes.
- readiness / closure / otel_bridge were not migrated because they do not install Rust.

## Intended soak caller shape

- Named checkout with `persist-credentials: false` preserved
- Immediate next top-level step: `Set up Rust toolchain and cache` → `uses: ./.github/actions/setup-rust`
- Empty with-map (composite defaults: stable toolchain, empty optional inputs)
- Direct `dtolnay/rust-toolchain` removed from soak

## TDD

### RED (contract extended on base tree before migration)

- Contract failed: `adr025 still calls dtolnay/rust-toolchain directly`
- Kernel Matrix ADR025 path count was `0` (required exactly once)

### GREEN

- Soak migrated to setup-rust (defaults only)
- KM path added once near other setup-rust trigger paths
- Focused contract passed end-to-end

## Mutation table (each independent; tree restored; clean contract PASS afterward)

| Mutation | Result |
|----------|--------|
| trailing-slash uses + `with: toolchain: nightly` | FAIL (`must not declare a with: map`) |
| `with:` before `uses:` (`toolchain: nightly`) | FAIL (`must not declare a with: map`) |
| restore direct dtolnay ref | FAIL (`adr025 still calls dtolnay...`) |
| remove setup-rust | FAIL (`soak: expected one setup-rust call, found 0`) |
| insert run between checkout/setup | FAIL (adjacency / step kinds) |
| add any `with:` input | FAIL (`with-map must be exactly {}`) |
| add setup-rust to readiness | FAIL (`readiness must not call setup-rust`) |
| duplicate KM ADR025 path | FAIL (exact-once count 2) |
| remove KM ADR025 path | FAIL (exact-once count 0) |
| E3 intervening-step (fuzz) | FAIL (adjacency) |
| E3 exact-map (fuzz strip with) | FAIL (with-map mismatch) |
| E3/wave6 exact-map (proptest add with) | FAIL (empty-map guard) |


### Follow-up (empty-map parse miss)

- Head after guard fix: `da92ddfc4d5757caf7e58ae4deba3a0ed3f45857`
- ADR025 no longer treats uses-line with-map parse failure as `{}`; it rejects any top-level `with:` on the actual setup step body from the shared adjacency helper.
- Before this commit, trailing-slash+with and with-before-uses incorrectly exited 0; both now FAIL.
## Validation

- `bash scripts/ci/test-setup-rust-composite-contract.sh` PASS
- `shellcheck` on contract PASS
- `actionlint` ADR025 PASS
- `actionlint` Kernel Matrix: pre-existing `concurrency.queue` findings at lines 318 and 368 only (not introduced here)
- YAML load, EOF/trailing whitespace, `git diff --check` PASS
- `pre-commit run setup-rust-composite-contract-self-test --all-files` PASS
- Soak **not** run locally

## Live proof

- `workflow_dispatch` for ADR-025 Nightly Evidence: **pending** (not marked ready/merge on this draft)

## Test plan

- [x] Focused setup-rust composite contract
- [x] Mutation proofs listed above
- [x] shellcheck + actionlint (ADR025 clean; KM pre-existing separated)
- [ ] Live `workflow_dispatch` of ADR-025 Nightly Evidence on this head (pending)
- [ ] Non-building review quorum before ready-for-review / merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Rust environment setup across nightly evidence checks.
  * Updated validation to ensure continuous integration workflows use the approved setup consistently.
  * Changes to the nightly evidence workflow now trigger the relevant kernel verification checks.
  * Added safeguards to detect configuration drift and ensure workflow integration remains reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->