### PR TITLE
ci: migrate Smoke Install assay Rust setup to setup-rust (Batch E5)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -41,6 +41,8 @@ on:
       - ".github/workflows/fuzz-smoke.yml"
       # ADR025 soak calls setup-rust (empty with-map / composite defaults).
       - ".github/workflows/adr025-nightly-evidence.yml"
+      # Smoke Install assay calls setup-rust (empty with-map / composite defaults).
+      - ".github/workflows/smoke-install.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up Rust toolchain and cache
+        uses: ./.github/actions/setup-rust
 
       - name: Build and Install Assay (from source)
         run: |

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -13,6 +13,7 @@ WEEK8="${ROOT}/.github/workflows/week8-sota-gates.yml"
 WAVE6="${ROOT}/.github/workflows/wave6-nightly-safety.yml"
 FUZZ_SMOKE="${ROOT}/.github/workflows/fuzz-smoke.yml"
 ADR025="${ROOT}/.github/workflows/adr025-nightly-evidence.yml"
+SMOKE_INSTALL="${ROOT}/.github/workflows/smoke-install.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -31,6 +32,7 @@ trap 'abort_is_failure "$?"' ERR
 [[ -f "${WAVE6}" ]] || fail "missing .github/workflows/wave6-nightly-safety.yml"
 [[ -f "${FUZZ_SMOKE}" ]] || fail "missing .github/workflows/fuzz-smoke.yml"
 [[ -f "${ADR025}" ]] || fail "missing .github/workflows/adr025-nightly-evidence.yml"
+[[ -f "${SMOKE_INSTALL}" ]] || fail "missing .github/workflows/smoke-install.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -203,12 +205,13 @@ print(
 )
 PY
 
-python3 - "${FUZZ_SMOKE}" "${ADR025}" <<'PY' || fail "simple-caller setup-rust contract failed"
+python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" <<'PY' || fail "simple-caller setup-rust contract failed"
 import re, sys
 from pathlib import Path
 
 fuzz_text = Path(sys.argv[1]).read_text(encoding="utf-8")
 adr025_text = Path(sys.argv[2]).read_text(encoding="utf-8")
+smoke_text = Path(sys.argv[3]).read_text(encoding="utf-8")
 
 
 def jobs_by_id(text: str) -> dict[str, str]:
@@ -306,6 +309,32 @@ def assert_immediate_setup_rust(job_id: str, block: str) -> str:
     return bodies[setup_idxs[0]]
 
 
+def assert_default_setup_rust_caller(wf_label: str, text: str, job_id: str) -> None:
+    """Named setup-rust immediately after checkout; composite defaults only; no direct pins."""
+    if re.search(r"dtolnay/rust-toolchain@", text):
+        raise SystemExit(f"{wf_label} still calls dtolnay/rust-toolchain directly")
+    if re.search(r"Swatinem/rust-cache@", text):
+        raise SystemExit(f"{wf_label} still calls Swatinem/rust-cache directly")
+    jobs = jobs_by_id(text)
+    if job_id not in jobs:
+        raise SystemExit(f"{wf_label} missing job {job_id}")
+    setup = assert_immediate_setup_rust(job_id, jobs[job_id])
+    first = setup.splitlines()[0]
+    if first != "      - name: Set up Rust toolchain and cache":
+        raise SystemExit(
+            f"{job_id}: setup step must be named exactly "
+            f"'Set up Rust toolchain and cache', got {first!r}"
+        )
+    # Reject any with: in the actual setup step body (with before/after uses, any keys).
+    if re.search(r"(?m)^        with:\s*$", setup):
+        raise SystemExit(
+            f"{job_id}: setup-rust must not declare a with: map (composite defaults only)"
+        )
+    # Trailing-slash uses still classify as setup-rust; with-map rejection above still applies.
+    if re.search(r"(?m)^\s+uses:\s*(?:dtolnay/rust-toolchain@|Swatinem/rust-cache@)", setup):
+        raise SystemExit(f"{job_id}: setup step must not call dtolnay/Swatinem directly")
+
+
 # --- fuzz-smoke ---
 if re.search(r"dtolnay/rust-toolchain@", fuzz_text):
     raise SystemExit("fuzz-smoke still calls dtolnay/rust-toolchain directly")
@@ -341,25 +370,13 @@ print(
     "FUZZ_TOOLCHAIN=nightly-2026-07-28; no direct pins"
 )
 
-# --- ADR025 soak (simple empty with-map caller) ---
-if re.search(r"dtolnay/rust-toolchain@", adr025_text):
-    raise SystemExit("adr025 still calls dtolnay/rust-toolchain directly")
-if re.search(r"Swatinem/rust-cache@", adr025_text):
-    raise SystemExit("adr025 still calls Swatinem/rust-cache directly")
-
+# --- ADR025 soak (default-caller / composite defaults) ---
 adr_jobs = jobs_by_id(adr025_text)
 for required in ("soak", "readiness", "closure", "otel_bridge"):
     if required not in adr_jobs:
         raise SystemExit(f"adr025 missing job {required}")
 
-soak_setup = assert_immediate_setup_rust("soak", adr_jobs["soak"])
-# Reject any top-level with: in the actual setup step body. Do not parse the
-# with-map via uses-line regex: that conflates parse miss with {} and misses
-# trailing-slash uses / with-before-uses reorderings.
-if re.search(r"(?m)^        with:\s*$", soak_setup):
-    raise SystemExit(
-        "soak: setup-rust must not declare a with: map (composite defaults only)"
-    )
+assert_default_setup_rust_caller("adr025", adr025_text, "soak")
 
 for job_id in ("readiness", "closure", "otel_bridge"):
     if "./.github/actions/setup-rust" in adr_jobs[job_id]:
@@ -369,6 +386,23 @@ print(
     "ok   adr025: soak one setup-rust after checkout; with-map empty; "
     "no setup-rust in readiness/closure/otel_bridge; no direct pins"
 )
+
+# --- Smoke Install assay (default-caller / composite defaults) ---
+smoke_jobs = jobs_by_id(smoke_text)
+if "assay" not in smoke_jobs:
+    raise SystemExit("smoke-install missing job assay")
+assert_default_setup_rust_caller("smoke-install", smoke_text, "assay")
+for job_id, block in smoke_jobs.items():
+    if job_id == "assay":
+        continue
+    if "./.github/actions/setup-rust" in block:
+        raise SystemExit(f"smoke-install: setup-rust only allowed in assay, found in {job_id}")
+
+print(
+    "ok   smoke-install: assay one setup-rust after checkout; with-map empty; "
+    "no direct pins"
+)
+
 PY
 
 python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
@@ -400,6 +434,7 @@ required = (
     ".github/workflows/wave6-nightly-safety.yml",
     ".github/workflows/fuzz-smoke.yml",
     ".github/workflows/adr025-nightly-evidence.yml",
+    ".github/workflows/smoke-install.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -407,7 +442,7 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary

- Migrate only the **assay** job in `.github/workflows/smoke-install.yml` from direct `dtolnay/rust-toolchain` to `./.github/actions/setup-rust` using composite defaults (no `with:` map).
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` with a small shared **default-caller** helper in the existing fuzz/simple-caller Python block; ADR025 soak and Smoke Install assay both use it (no copied parser block).
- Add `.github/workflows/smoke-install.yml` exactly once to Kernel Matrix `pull_request.paths`.

## Exact SHAs

- Base: `origin/main` @ `8625b277d1dd1bcd132505d85c23043ca8d8856f`
- Head: `1afa153d77a9b6c301fab3ffe3b76071697c9a37` (`cursor/ci-setup-rust-e5`)

## Scope

**Allowed / changed files only**

- `.github/workflows/smoke-install.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`
- `.github/workflows/kernel-matrix.yml`

**Unchanged by design**

- `.github/actions/setup-rust/action.yml` (composite itself)
- ci.yml, release, parity, docs workflows
- Cargo / product code / docs
- aee_seal, semantic_vcr, and other unrelated surfaces
- Every build/install/migrate/ci/JUnit/report step, trigger, permission, and public string in smoke-install (except the Rust setup step name/`uses`)

## Behavioral delta / non-claims

- The assay caller previously installed **stable** Rust **without** rust-cache. The composite **intentionally** adds default cargo/target cache restoration for this always-on source-install E2E. That is a real setup delta, not a silent no-op.
- Do **not** treat this as byte-for-byte / mechanical equivalence with the prior direct toolchain step.
- No claim that `cargo install` output itself is cached; live proof must report what rust-cache actually says (hit/miss/restore keys).
- No schema, product, or test semantic change — setup wiring only.

## Intended assay caller shape

- Named checkout with `persist-credentials: false` preserved
- Immediate next top-level step: `Set up Rust toolchain and cache` → `uses: ./.github/actions/setup-rust`
- No `with:` map at all (composite defaults)
- Direct `dtolnay/rust-toolchain` (and any direct Swatinem) removed from smoke-install

## TDD

### RED (contract extended on base tree before migration)

- Contract failed: `smoke-install still calls dtolnay/rust-toolchain directly`
- Kernel Matrix smoke-install path count was `0` (required exactly once)

### GREEN

- Smoke Install assay migrated to setup-rust (defaults only)
- KM path added once near other setup-rust trigger paths
- Focused contract passed end-to-end

## Mutation table (each independent; tree restored; clean contract PASS afterward)

| Mutation | Result |
|----------|--------|
| restore direct dtolnay | FAIL (`smoke-install still calls dtolnay...`) |
| remove setup-rust | FAIL (`assay: expected one setup-rust call, found 0`) |
| insert run between checkout/setup | FAIL (adjacency / step kinds) |
| add `with:` after `uses:` | FAIL (`must not declare a with: map`) |
| add `with:` before `uses:` | FAIL (`must not declare a with: map`) |
| trailing-slash uses + `with:` | FAIL (`must not declare a with: map`) |
| duplicate KM smoke-install path | FAIL (exact-once count 2) |
| remove KM smoke-install path | FAIL (exact-once count 0) |
| E4 ADR `with:` after `uses:` | FAIL (`soak: ... with: map`) |
| E4 ADR `with:` before `uses:` | FAIL (`soak: ... with: map`) |
| E3 fuzz exact-map (strip `cache-workspaces`) | FAIL (with-map mismatch) |

## Validation

- `bash scripts/ci/test-setup-rust-composite-contract.sh` PASS
- `shellcheck` on contract PASS
- `actionlint` smoke-install PASS
- `actionlint` Kernel Matrix: pre-existing `concurrency.queue` findings only (lines shifted +2 vs base 318/368 → 320/370); no new head-only substantive findings from this path add
- EOF/trailing whitespace, `git diff --check` PASS
- `pre-commit run setup-rust-composite-contract-self-test --all-files` PASS
- Cargo **not** run locally (per batch instructions)

## Live proof

- `workflow_dispatch` for Smoke Install (E2E) on exact head `1afa153d77a9b6c301fab3ffe3b76071697c9a37`: **pending**
- Draft PR: not marked ready / not merged

## Test plan

- [x] Focused setup-rust composite contract
- [x] Mutation proofs listed above
- [x] shellcheck + actionlint (smoke-install clean; KM pre-existing separated)
- [ ] Live `workflow_dispatch` of Smoke Install on this head (pending) — report rust-cache restore/save outcome; do not claim cargo-install artifact caching
- [ ] Non-building review quorum before ready-for-review / merge


Made with [Cursor](https://cursor.com)