### PR TITLE
ci: migrate Runner Spike SDK Rust setup to setup-rust (Batch E6)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -43,6 +43,8 @@ on:
       - ".github/workflows/adr025-nightly-evidence.yml"
       # Smoke Install assay calls setup-rust (empty with-map / composite defaults).
       - ".github/workflows/smoke-install.yml"
+      # Runner Spike SDK calls setup-rust (empty with-map / composite defaults).
+      - ".github/workflows/runner-spike-sdk.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/.github/workflows/runner-spike-sdk.yml
+++ b/.github/workflows/runner-spike-sdk.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Set up Rust toolchain and cache
+        uses: ./.github/actions/setup-rust
 
       - name: Install Linux deps
         shell: bash
@@ -42,9 +42,6 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -14,6 +14,7 @@ WAVE6="${ROOT}/.github/workflows/wave6-nightly-safety.yml"
 FUZZ_SMOKE="${ROOT}/.github/workflows/fuzz-smoke.yml"
 ADR025="${ROOT}/.github/workflows/adr025-nightly-evidence.yml"
 SMOKE_INSTALL="${ROOT}/.github/workflows/smoke-install.yml"
+RUNNER_SPIKE="${ROOT}/.github/workflows/runner-spike-sdk.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -33,6 +34,7 @@ trap 'abort_is_failure "$?"' ERR
 [[ -f "${FUZZ_SMOKE}" ]] || fail "missing .github/workflows/fuzz-smoke.yml"
 [[ -f "${ADR025}" ]] || fail "missing .github/workflows/adr025-nightly-evidence.yml"
 [[ -f "${SMOKE_INSTALL}" ]] || fail "missing .github/workflows/smoke-install.yml"
+[[ -f "${RUNNER_SPIKE}" ]] || fail "missing .github/workflows/runner-spike-sdk.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -205,13 +207,14 @@ print(
 )
 PY
 
-python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" <<'PY' || fail "simple-caller setup-rust contract failed"
+python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" <<'PY' || fail "simple-caller setup-rust contract failed"
 import re, sys
 from pathlib import Path
 
 fuzz_text = Path(sys.argv[1]).read_text(encoding="utf-8")
 adr025_text = Path(sys.argv[2]).read_text(encoding="utf-8")
 smoke_text = Path(sys.argv[3]).read_text(encoding="utf-8")
+spike_text = Path(sys.argv[4]).read_text(encoding="utf-8")
 
 
 def jobs_by_id(text: str) -> dict[str, str]:
@@ -403,6 +406,14 @@ print(
     "no direct pins"
 )
 
+# --- Runner Spike SDK (default-caller / composite defaults) ---
+assert_default_setup_rust_caller("runner-spike-sdk", spike_text, "sdk-policy-determinism")
+
+print(
+    "ok   runner-spike-sdk: sdk-policy-determinism one setup-rust after checkout; "
+    "with-map empty; no direct pins"
+)
+
 PY
 
 python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
@@ -435,6 +446,7 @@ required = (
     ".github/workflows/fuzz-smoke.yml",
     ".github/workflows/adr025-nightly-evidence.yml",
     ".github/workflows/smoke-install.yml",
+    ".github/workflows/runner-spike-sdk.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -442,7 +454,7 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary

- Migrate only the `sdk-policy-determinism` job in `.github/workflows/runner-spike-sdk.yml` from standalone default Swatinem/rust-cache + stable dtolnay/rust-toolchain to one `./.github/actions/setup-rust` call using composite defaults (no `with:` map).
- Reuse `assert_default_setup_rust_caller` in the existing simple-caller Python block; add one Runner Spike assertion (no copied parser).
- Add `.github/workflows/runner-spike-sdk.yml` exactly once to Kernel Matrix `pull_request.paths`.

## Exact SHAs

- Base: `origin/main` @ `143ba2f427c53370a7cd1da72f2fb9dd09d33ba6`
- Head: `af6d8c2ed4ca8d635f0530aa4c47b9bc73dcb57e` (`cursor/ci-setup-rust-e6`)

## Scope

**Allowed / changed files only**

- `.github/workflows/runner-spike-sdk.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`
- `.github/workflows/kernel-matrix.yml`

**Unchanged by design**

- `.github/actions/setup-rust/action.yml` (composite itself)
- ci.yml, release, parity, docs, perf workflows
- Cargo / product code / fixtures / SDK scripts / docs
- Every Node/npm/build/acceptance/determinism step, command, timeout, trigger, permission, concurrency setting, and public string in Runner Spike SDK (except the Rust setup step name/`uses` and removal of the two direct pins)

## Behavioral delta / non-claims

- Prior cache was already default Swatinem and sat immediately after checkout; prior stable dtolnay toolchain ran after apt.
- The composite preserves default cargo/target caching but installs the stable/repository toolchain **before** cache restore and **before** apt. This is intentional setup-order centralization, not byte-for-byte equivalence with the prior step order.
- No SDK, product, schema, fixture, test, or determinism semantic change — setup wiring only.
- Live proof must report actual rust-cache hit/miss/save logs; do **not** claim npm caching or final assay binary caching.

## Intended caller shape

- Named checkout with `persist-credentials: false` preserved
- Immediate next top-level step: `Set up Rust toolchain and cache` → `uses: ./.github/actions/setup-rust`
- No `with:` map at all (composite defaults)
- Install Linux deps remains immediately after the composite
- Direct Swatinem and dtolnay removed from this workflow

## TDD

### RED (contract extended on base tree before migration)

- Contract failed: `runner-spike-sdk still calls dtolnay/rust-toolchain directly`
- Kernel Matrix `runner-spike-sdk.yml` path count was `0` (required exactly once)

### GREEN

- `sdk-policy-determinism` migrated to setup-rust (defaults only)
- KM path added once near other setup-rust trigger paths
- Focused contract passed end-to-end

## Mutation table (each independent; tree restored; clean contract PASS afterward)

| Mutation | Result |
|----------|--------|
| restore separate direct Swatinem + dtolnay | FAIL (`runner-spike-sdk still calls dtolnay...`) |
| remove setup-rust | FAIL (`sdk-policy-determinism: expected one setup-rust call, found 0`) |
| insert run between checkout/setup | FAIL (adjacency / step kinds) |
| add `with:` after `uses:` | FAIL (`must not declare a with: map`) |
| add `with:` before `uses:` | FAIL (`must not declare a with: map`) |
| trailing-slash uses + `with:` | FAIL (`must not declare a with: map`) |
| duplicate KM runner-spike path | FAIL (exact-once count 2) |
| remove KM runner-spike path | FAIL (exact-once count 0) |
| ADR025 `with:` after `uses:` | FAIL (`soak: ... with: map`) |
| Smoke Install `with:` before `uses:` | FAIL (`assay: ... with: map`) |
| E3 fuzz exact-map (strip `cache-workspaces`) | FAIL (with-map mismatch) |

## Validation

- `bash scripts/ci/test-setup-rust-composite-contract.sh` PASS
- `shellcheck` on contract PASS
- `actionlint` runner-spike-sdk PASS
- `actionlint` Kernel Matrix: pre-existing `assay-bpf-runner` / `concurrency.queue` findings only (lines shifted +2 vs base 315/320/365/370 → 317/322/367/372); no new head-only substantive findings from this path add
- EOF/trailing whitespace, `git diff --check` PASS
- `pre-commit run setup-rust-composite-contract-self-test --all-files` PASS (also ran under commit hooks)
- Cargo **not** run locally (per batch instructions)

## Live proof

- Exact-head GitHub **Runner Spike SDK** workflow run on `af6d8c2ed4ca8d635f0530aa4c47b9bc73dcb57e`: **pending**
- Report actual rust-cache hit/miss/save logs from that run; do not claim npm or final assay binary caching
- Draft PR: not marked ready / not merged

## Test plan

- [x] Focused setup-rust composite contract
- [x] Mutation proofs listed above
- [x] shellcheck + actionlint (runner-spike-sdk clean; KM pre-existing separated)
- [ ] Live Runner Spike SDK on this head (pending) — report rust-cache restore/save outcome
- [ ] Non-building review quorum before ready-for-review / merge


Made with [Cursor](https://cursor.com)