### PR TITLE
ci: migrate perf family Rust setup to setup-rust (Batch E7)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -45,6 +45,10 @@ on:
       - ".github/workflows/smoke-install.yml"
       # Runner Spike SDK calls setup-rust (empty with-map / composite defaults).
       - ".github/workflows/runner-spike-sdk.yml"
+      # Perf family calls setup-rust (rustfmt with-map / forensic defaults).
+      - ".github/workflows/perf_main.yml"
+      - ".github/workflows/perf_pr.yml"
+      - ".github/workflows/perf_nightly.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/.github/workflows/perf_main.yml
+++ b/.github/workflows/perf_main.yml
@@ -52,8 +52,9 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt
       - name: Install Linux deps
         shell: bash
         run: |
@@ -62,9 +63,6 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -o Acquire::Retries=10 -o Acquire::http::Timeout=60 -o Acquire::https::Timeout=60
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: rustfmt
       - uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8 # v0.6.2
       # stdin/pipe mode: cargo bench output piped to bencher run (no command after --)
       # This is more reliable than exec mode for capturing Criterion output.

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -28,15 +28,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Set up Rust toolchain and cache
+        uses: ./.github/actions/setup-rust
 
       - name: Install Linux deps
         run: |
           sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev bc jq
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8 # v0.6.2
 

--- a/.github/workflows/perf_pr.yml
+++ b/.github/workflows/perf_pr.yml
@@ -88,8 +88,9 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt
       - name: Install Linux deps
         shell: bash
         run: |
@@ -98,9 +99,6 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -o Acquire::Retries=10 -o Acquire::http::Timeout=60 -o Acquire::https::Timeout=60
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: rustfmt
       - uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8 # v0.6.2
       # stdin/pipe mode: cargo bench output piped to bencher run (no command after --)
       #

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -15,6 +15,9 @@ FUZZ_SMOKE="${ROOT}/.github/workflows/fuzz-smoke.yml"
 ADR025="${ROOT}/.github/workflows/adr025-nightly-evidence.yml"
 SMOKE_INSTALL="${ROOT}/.github/workflows/smoke-install.yml"
 RUNNER_SPIKE="${ROOT}/.github/workflows/runner-spike-sdk.yml"
+PERF_MAIN="${ROOT}/.github/workflows/perf_main.yml"
+PERF_PR="${ROOT}/.github/workflows/perf_pr.yml"
+PERF_NIGHTLY="${ROOT}/.github/workflows/perf_nightly.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -35,6 +38,9 @@ trap 'abort_is_failure "$?"' ERR
 [[ -f "${ADR025}" ]] || fail "missing .github/workflows/adr025-nightly-evidence.yml"
 [[ -f "${SMOKE_INSTALL}" ]] || fail "missing .github/workflows/smoke-install.yml"
 [[ -f "${RUNNER_SPIKE}" ]] || fail "missing .github/workflows/runner-spike-sdk.yml"
+[[ -f "${PERF_MAIN}" ]] || fail "missing .github/workflows/perf_main.yml"
+[[ -f "${PERF_PR}" ]] || fail "missing .github/workflows/perf_pr.yml"
+[[ -f "${PERF_NIGHTLY}" ]] || fail "missing .github/workflows/perf_nightly.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -207,7 +213,7 @@ print(
 )
 PY
 
-python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" <<'PY' || fail "simple-caller setup-rust contract failed"
+python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" "${PERF_MAIN}" "${PERF_PR}" "${PERF_NIGHTLY}" <<'PY' || fail "simple-caller setup-rust contract failed"
 import re, sys
 from pathlib import Path
 
@@ -215,6 +221,9 @@ fuzz_text = Path(sys.argv[1]).read_text(encoding="utf-8")
 adr025_text = Path(sys.argv[2]).read_text(encoding="utf-8")
 smoke_text = Path(sys.argv[3]).read_text(encoding="utf-8")
 spike_text = Path(sys.argv[4]).read_text(encoding="utf-8")
+perf_main_text = Path(sys.argv[5]).read_text(encoding="utf-8")
+perf_pr_text = Path(sys.argv[6]).read_text(encoding="utf-8")
+perf_nightly_text = Path(sys.argv[7]).read_text(encoding="utf-8")
 
 
 def jobs_by_id(text: str) -> dict[str, str]:
@@ -414,6 +423,62 @@ print(
     "with-map empty; no direct pins"
 )
 
+
+def assert_setup_rust_exact_with(
+    wf_label: str, text: str, job_id: str, expected: dict[str, str]
+) -> None:
+    """Immediate setup-rust after checkout with an exact with-map (reuse parsers)."""
+    if re.search(r"dtolnay/rust-toolchain@", text):
+        raise SystemExit(f"{wf_label} still calls dtolnay/rust-toolchain directly")
+    if re.search(r"Swatinem/rust-cache@", text):
+        raise SystemExit(f"{wf_label} still calls Swatinem/rust-cache directly")
+    jobs = jobs_by_id(text)
+    if job_id not in jobs:
+        raise SystemExit(f"{wf_label} missing job {job_id}")
+    block = jobs[job_id]
+    setup = assert_immediate_setup_rust(job_id, block)
+    got = setup_rust_with_map(block)
+    if got != expected:
+        raise SystemExit(
+            f"{job_id}: setup-rust with-map must be exactly {expected}, got {got}"
+        )
+    if re.search(r"(?m)^\s+uses:\s*(?:dtolnay/rust-toolchain@|Swatinem/rust-cache@)", setup):
+        raise SystemExit(f"{job_id}: setup step must not call dtolnay/Swatinem directly")
+
+
+# --- Perf Main benches (components: rustfmt) ---
+assert_setup_rust_exact_with(
+    "perf_main", perf_main_text, "benches", {"components": "rustfmt"}
+)
+print(
+    "ok   perf_main: benches one setup-rust after checkout; "
+    "with-map exact {components: rustfmt}; no direct pins"
+)
+
+# --- Perf PR benches only (components: rustfmt); leave detect job alone ---
+perf_pr_jobs = jobs_by_id(perf_pr_text)
+if "benches" not in perf_pr_jobs:
+    raise SystemExit("perf_pr missing job benches")
+assert_setup_rust_exact_with(
+    "perf_pr", perf_pr_text, "benches", {"components": "rustfmt"}
+)
+for job_id, block in perf_pr_jobs.items():
+    if job_id == "benches":
+        continue
+    if "./.github/actions/setup-rust" in block:
+        raise SystemExit(f"perf_pr: setup-rust only allowed in benches, found in {job_id}")
+print(
+    "ok   perf_pr: benches one setup-rust after checkout; "
+    "with-map exact {components: rustfmt}; no setup-rust in other jobs; no direct pins"
+)
+
+# --- Perf Nightly forensic (default-caller / composite defaults) ---
+assert_default_setup_rust_caller("perf_nightly", perf_nightly_text, "forensic")
+print(
+    "ok   perf_nightly: forensic one setup-rust after checkout; "
+    "with-map empty; no direct pins"
+)
+
 PY
 
 python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
@@ -447,6 +512,9 @@ required = (
     ".github/workflows/adr025-nightly-evidence.yml",
     ".github/workflows/smoke-install.yml",
     ".github/workflows/runner-spike-sdk.yml",
+    ".github/workflows/perf_main.yml",
+    ".github/workflows/perf_pr.yml",
+    ".github/workflows/perf_nightly.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -454,7 +522,7 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk + perf_main + perf_pr + perf_nightly")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary
- Migrate compatible performance-family Rust setup to `./.github/actions/setup-rust`:
  - `perf_main.yml` `benches`: one composite call immediately after checkout with `components: rustfmt` (replaces direct Swatinem + dtolnay).
  - `perf_pr.yml` `benches` only: same shape; `detect-benchmark-relevance` untouched.
  - `perf_nightly.yml` `forensic`: one default composite call (named step, **no with-map**) immediately after checkout.
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` with a compact exact-with-map helper reusing existing parsers; preserve E1–E6 guards.
- Add each perf workflow path exactly once to Kernel Matrix `pull_request.paths`.

## Scope / SHAs
- **Base:** `origin/main` @ `e4fd6f22fe7f23e124f325569e5ec3bfb801c285`
- **Head:** `f2a5b4dbdb38943e4cbe653f7726c681c2f22689`
- **Branch:** `cursor/ci-setup-rust-e7`
- Allowed files only: the three perf workflows, the contract script, and `kernel-matrix.yml`.

## Setup-order / cache non-claims
- **Intentional order delta:** toolchain now runs before cache and before apt (composite owns toolchain+cache immediately after checkout). Cache remains the composite default.
- **No benchmark semantics change:** triggers, permissions, conditions, secrets, Bencher commands/thresholds, apt steps, filters, forensic iterations, artifacts, and public strings are preserved aside from setup step names/uses and removal of direct pins.
- **Non-claim:** this PR does **not** claim benchmark outputs or final binaries are cached.

## RED / GREEN
- **RED** (contract extended first; workflows unchanged): `perf_main still calls dtolnay/rust-toolchain directly` (simple-caller failure). The three KM perf paths were also absent from `pull_request.paths` under the extended contract.
- **GREEN** (workflows migrated + KM paths added): contract all checks passed, including perf_main/perf_pr exact `{components: rustfmt}`, perf_nightly empty with-map, and KM exact-once paths through perf_nightly.

## Mutation table (temp copies; tree restored; each must FAIL)
| Probe | Outcome |
|-------|---------|
| Direct Swatinem+dtolnay pair restore in perf_main | FAIL: direct pin |
| Direct pair restore in perf_pr | FAIL: direct pin |
| Direct pair restore in perf_nightly | FAIL: direct pin |
| Remove setup-rust (perf_main / perf_pr / perf_nightly) | FAIL: expected one call |
| Intervening `run` between checkout and setup (perf_main) | FAIL: adjacency |
| Wrong rustfmt (`components: clippy`) | FAIL: with-map exact |
| Missing rustfmt with-map | FAIL: with-map exact |
| Extra `toolchain` key on perf_pr | FAIL: with-map exact |
| Nightly `with:` after uses | FAIL: empty with-map / defaults-only |
| Nightly `with:` before uses | FAIL: defaults-only |
| Nightly trailing-slash uses + `with:` | FAIL: defaults-only |
| Duplicate / remove each KM perf_* path | FAIL: exact-once paths |
| E3 representative: FUZZ_TOOLCHAIN drift | FAIL (guard preserved) |
| E4 representative: ADR025 soak with-map | FAIL (guard preserved) |
| E5 representative: setup-rust outside smoke `assay` | FAIL (guard preserved) |
| E6 representative: remove Runner Spike setup | FAIL (guard preserved) |

Post-mutation contract: **PASS**.

## Validation
- [x] `./scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `shellcheck scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `actionlint` on `perf_main.yml`, `perf_pr.yml`, `perf_nightly.yml` (clean)
- [x] `actionlint` on `kernel-matrix.yml`: same pre-existing `concurrency.queue` syntax findings as base (line shift only from path additions); no new finding class
- [x] `pre-commit run setup-rust-composite-contract-self-test --all-files`
- [x] `pre-commit run --files` on the five touched files
- [x] `git diff --check` / EOF newlines
- [x] No local Cargo

## Live proofs pending (not claimed here)
- [ ] PR-triggered **Perf PR** on exact head `f2a5b4dbdb38943e4cbe653f7726c681c2f22689` — state whether `benches` ran or relevance skipped
- [ ] `workflow_dispatch` **Perf Nightly** on exact head `f2a5b4dbdb38943e4cbe653f7726c681c2f22689` with `iterations=1`
- [ ] **Perf main** pre-merge non-claim; automatic push run after merge will be inspected (do not treat absence of a pre-merge perf_main run as proof)

## Changed files
- `.github/workflows/perf_main.yml`
- `.github/workflows/perf_pr.yml`
- `.github/workflows/perf_nightly.yml`
- `.github/workflows/kernel-matrix.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`


Made with [Cursor](https://cursor.com)