### PR TITLE
ci: migrate Split Wave 0 Rust setup to setup-rust (Batch E8)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -49,6 +49,8 @@ on:
       - ".github/workflows/perf_main.yml"
       - ".github/workflows/perf_pr.yml"
       - ".github/workflows/perf_nightly.yml"
+      # Split Wave 0 Rust jobs call setup-rust (defaults / clippy with-map).
+      - ".github/workflows/split-wave0-gates.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -175,8 +175,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Set up Rust toolchain and cache
+        uses: ./.github/actions/setup-rust
 
       - name: Install Linux deps
         shell: bash
@@ -192,8 +192,6 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-nextest and cargo-hack
         shell: bash
@@ -320,8 +318,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: clippy
 
       - name: Install Linux deps
         shell: bash
@@ -337,10 +336,6 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: clippy
 
       - name: Clippy (deny placeholder paths)
         run: cargo clippy --workspace --all-targets -- -D warnings -D clippy::todo -D clippy::unimplemented
@@ -387,10 +382,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up Rust toolchain and cache
+        uses: ./.github/actions/setup-rust
 
       - name: Install cargo-semver-checks
         run: cargo install --locked cargo-semver-checks

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family + Split Wave 0 caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -18,6 +18,7 @@ RUNNER_SPIKE="${ROOT}/.github/workflows/runner-spike-sdk.yml"
 PERF_MAIN="${ROOT}/.github/workflows/perf_main.yml"
 PERF_PR="${ROOT}/.github/workflows/perf_pr.yml"
 PERF_NIGHTLY="${ROOT}/.github/workflows/perf_nightly.yml"
+SPLIT_WAVE0="${ROOT}/.github/workflows/split-wave0-gates.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -41,6 +42,7 @@ trap 'abort_is_failure "$?"' ERR
 [[ -f "${PERF_MAIN}" ]] || fail "missing .github/workflows/perf_main.yml"
 [[ -f "${PERF_PR}" ]] || fail "missing .github/workflows/perf_pr.yml"
 [[ -f "${PERF_NIGHTLY}" ]] || fail "missing .github/workflows/perf_nightly.yml"
+[[ -f "${SPLIT_WAVE0}" ]] || fail "missing .github/workflows/split-wave0-gates.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -213,7 +215,7 @@ print(
 )
 PY
 
-python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" "${PERF_MAIN}" "${PERF_PR}" "${PERF_NIGHTLY}" <<'PY' || fail "simple-caller setup-rust contract failed"
+python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" "${PERF_MAIN}" "${PERF_PR}" "${PERF_NIGHTLY}" "${SPLIT_WAVE0}" <<'PY' || fail "simple-caller setup-rust contract failed"
 import re, sys
 from pathlib import Path
 
@@ -224,6 +226,7 @@ spike_text = Path(sys.argv[4]).read_text(encoding="utf-8")
 perf_main_text = Path(sys.argv[5]).read_text(encoding="utf-8")
 perf_pr_text = Path(sys.argv[6]).read_text(encoding="utf-8")
 perf_nightly_text = Path(sys.argv[7]).read_text(encoding="utf-8")
+split_wave0_text = Path(sys.argv[8]).read_text(encoding="utf-8")
 
 
 def jobs_by_id(text: str) -> dict[str, str]:
@@ -479,6 +482,34 @@ print(
     "with-map empty; no direct pins"
 )
 
+# --- Split Wave 0: feature-matrix / quality-gates / semver-public only ---
+split_wave0_jobs = jobs_by_id(split_wave0_text)
+for required in ("feature-matrix", "quality-gates", "semver-public", "detect-changes", "nightly-safety"):
+    if required not in split_wave0_jobs:
+        raise SystemExit(f"split-wave0 missing job {required}")
+
+assert_default_setup_rust_caller("split-wave0", split_wave0_text, "feature-matrix")
+assert_setup_rust_exact_with(
+    "split-wave0", split_wave0_text, "quality-gates", {"components": "clippy"}
+)
+assert_default_setup_rust_caller("split-wave0", split_wave0_text, "semver-public")
+
+allowed_setup = {"feature-matrix", "quality-gates", "semver-public"}
+for job_id, block in split_wave0_jobs.items():
+    if job_id in allowed_setup:
+        continue
+    if "./.github/actions/setup-rust" in block:
+        raise SystemExit(
+            f"split-wave0: setup-rust only allowed in "
+            f"feature-matrix/quality-gates/semver-public, found in {job_id}"
+        )
+
+print(
+    "ok   split-wave0: feature-matrix + semver-public default setup-rust after checkout; "
+    "quality-gates with-map exact {components: clippy}; "
+    "no setup-rust in detect-changes/nightly-safety; no direct pins"
+)
+
 PY
 
 python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
@@ -515,6 +546,7 @@ required = (
     ".github/workflows/perf_main.yml",
     ".github/workflows/perf_pr.yml",
     ".github/workflows/perf_nightly.yml",
+    ".github/workflows/split-wave0-gates.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -522,7 +554,7 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk + perf_main + perf_pr + perf_nightly")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk + perf_main + perf_pr + perf_nightly + split-wave0")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary
- Migrate three compatible Split Wave 0 Rust-consuming jobs in `split-wave0-gates.yml` to `./.github/actions/setup-rust`:
  - `feature-matrix`: one default composite call immediately after checkout (**no with-map**).
  - `quality-gates`: one composite call immediately after checkout with exact with-map `{components: clippy}`.
  - `semver-public`: one default composite call immediately after checkout (**no with-map**).
- Do **not** add setup-rust to `detect-changes` or `nightly-safety`.
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` reusing `jobs_by_id` / `assert_immediate_setup_rust` / `setup_rust_with_map` / default-caller / exact-with helpers; preserve E1–E7 guards.
- Add `.github/workflows/split-wave0-gates.yml` exactly once to Kernel Matrix `pull_request.paths`.

## Scope / SHAs
- **Base:** `origin/main` @ `22df4507ec673fb5a6aa3d5113cbf8eb99b193dc`
- **Head:** `a6c1477d8426c522025e0f5fec42e7334febbaa7`
- **Branch:** `cursor/ci-setup-rust-e8`
- Allowed files only: `.github/workflows/split-wave0-gates.yml`, `scripts/ci/test-setup-rust-composite-contract.sh`, `.github/workflows/kernel-matrix.yml`.

## Setup-order / cache non-claims
- **Intentional order delta:** toolchain/cache now precede apt (composite owns toolchain+cache immediately after checkout).
- **Composite default caching only;** this PR does **not** claim outputs or final binaries are cached.
- Triggers, permissions, conditions, fetch-depth, apt commands, install commands, feature matrix, semver baseline behavior, public strings, job dependencies and outputs are preserved aside from setup step names/uses and removal of direct pins.

## RED / GREEN
- **RED** (contract extended first; workflows unchanged): `split-wave0 still calls dtolnay/rust-toolchain directly` (simple-caller failure). The KM `split-wave0-gates.yml` path was also absent from `pull_request.paths` under the extended contract (would fail after the simple-caller guard).
- **GREEN** (workflows migrated + KM path added): contract all checks passed, including feature-matrix/semver-public empty with-maps, quality-gates exact `{components: clippy}`, no setup-rust in detect-changes/nightly-safety, and KM exact-once path including split-wave0.

## Mutation table (temp copies; tree restored; each must FAIL)
| Probe | Outcome |
|-------|---------|
| Direct Swatinem+dtolnay pair restore in feature-matrix | FAIL: direct pin |
| Direct pair restore in quality-gates | FAIL: direct pin |
| Direct pair restore in semver-public | FAIL: direct pin |
| Remove setup-rust (feature-matrix / quality-gates / semver-public) | FAIL: expected one call |
| Intervening `run` between checkout and setup (each of three) | FAIL: adjacency |
| quality-gates wrong components (`rustfmt`) | FAIL: with-map exact |
| quality-gates missing with-map | FAIL: with-map exact |
| quality-gates extra `toolchain` key | FAIL: with-map exact |
| feature-matrix / semver-public `with:` after uses | FAIL: defaults-only |
| feature-matrix / semver-public `with:` before uses | FAIL: defaults-only |
| feature-matrix / semver-public trailing-slash uses + `with:` | FAIL: defaults-only |
| Add setup-rust to detect-changes | FAIL: job allow-list |
| Add setup-rust to nightly-safety | FAIL: job allow-list |
| Duplicate / remove KM split-wave0 path | FAIL: exact-once paths |
| E6 representative: remove Runner Spike setup | FAIL (guard preserved) |
| E7 representative: wrong rustfmt on perf_main | FAIL (guard preserved) |

Post-mutation contract: **PASS**.

## Validation
- [x] `./scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `shellcheck scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `actionlint` on `split-wave0-gates.yml` (clean)
- [x] `actionlint` on `kernel-matrix.yml`: same pre-existing `concurrency.queue` syntax findings as base (line shift 326/376 → 328/378 from path additions); no new finding class
- [x] `pre-commit run setup-rust-composite-contract-self-test --all-files`
- [x] `pre-commit run --files` on the three touched files
- [x] `git diff --check` / EOF newlines / public strings
- [x] No local Cargo

## Live proofs pending (not claimed here)
- [ ] `workflow_dispatch` **Split Wave 0** on exact head `a6c1477d8426c522025e0f5fec42e7334febbaa7` with `simulated_changed_files=crates/assay-core/src/lib.rs`, requiring `feature-matrix`, `quality-gates`, and `semver-public` to actually run and pass
- [ ] PR-triggered Split Wave 0 on this head may legitimately **skip** these jobs because workflow-only changes are not relevant under `detect-changes`; treat skip as non-proof, not as success

## Changed files
- `.github/workflows/split-wave0-gates.yml`
- `.github/workflows/kernel-matrix.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration triggers to include Split Wave 0 gate workflow changes.
  - Standardized Rust toolchain and caching setup across Split Wave 0 validation jobs.
  - Added Clippy configuration to quality checks.

- **Tests**
  - Expanded CI contract validation to verify required jobs, setup configuration, permitted workflow usage, and pull-request triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->