### PR TITLE
ci: migrate CI clippy/rustdoc Rust setup to setup-rust (Batch E9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,9 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: clippy
       - name: Install Linux deps (for build scripts)
         if: runner.os == 'Linux'
         shell: bash
@@ -252,9 +253,6 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
       # `--all-targets` does not imply `--all-features`, so any test file gated behind a feature is
       # invisible to the sweep above: cfg strips it to an empty crate and clippy lints nothing.
@@ -276,8 +274,8 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Set up Rust toolchain and cache
+        uses: ./.github/actions/setup-rust
       - name: Install Linux deps (for build scripts)
         if: runner.os == 'Linux'
         shell: bash
@@ -293,7 +291,6 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       # Clippy above never sees rustdoc's lints: broken intra-doc links, unclosed HTML tags in doc
       # comments and bare URLs are diagnosed by rustdoc alone, and they are warn-by-default, so
       # nothing failed while a crate's documentation quietly stopped building. `assay-evidence`

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -51,6 +51,8 @@ on:
       - ".github/workflows/perf_nightly.yml"
       # Split Wave 0 Rust jobs call setup-rust (defaults / clippy with-map).
       - ".github/workflows/split-wave0-gates.yml"
+      # CI clippy/rustdoc call setup-rust (clippy with-map / empty defaults).
+      - ".github/workflows/ci.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family + Split Wave 0 caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family + Split Wave 0 + CI clippy/rustdoc caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -19,6 +19,7 @@ PERF_MAIN="${ROOT}/.github/workflows/perf_main.yml"
 PERF_PR="${ROOT}/.github/workflows/perf_pr.yml"
 PERF_NIGHTLY="${ROOT}/.github/workflows/perf_nightly.yml"
 SPLIT_WAVE0="${ROOT}/.github/workflows/split-wave0-gates.yml"
+CI_YML="${ROOT}/.github/workflows/ci.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
 CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
@@ -43,6 +44,7 @@ trap 'abort_is_failure "$?"' ERR
 [[ -f "${PERF_PR}" ]] || fail "missing .github/workflows/perf_pr.yml"
 [[ -f "${PERF_NIGHTLY}" ]] || fail "missing .github/workflows/perf_nightly.yml"
 [[ -f "${SPLIT_WAVE0}" ]] || fail "missing .github/workflows/split-wave0-gates.yml"
+[[ -f "${CI_YML}" ]] || fail "missing .github/workflows/ci.yml"
 [[ -f "${KERNEL_MATRIX}" ]] || fail "missing .github/workflows/kernel-matrix.yml"
 
 grep -qE '^[[:space:]]*using:[[:space:]]*composite[[:space:]]*$' "${ACTION}" \
@@ -215,7 +217,7 @@ print(
 )
 PY
 
-python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" "${PERF_MAIN}" "${PERF_PR}" "${PERF_NIGHTLY}" "${SPLIT_WAVE0}" <<'PY' || fail "simple-caller setup-rust contract failed"
+python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" "${PERF_MAIN}" "${PERF_PR}" "${PERF_NIGHTLY}" "${SPLIT_WAVE0}" "${CI_YML}" <<'PY' || fail "simple-caller setup-rust contract failed"
 import re, sys
 from pathlib import Path
 
@@ -227,6 +229,7 @@ perf_main_text = Path(sys.argv[5]).read_text(encoding="utf-8")
 perf_pr_text = Path(sys.argv[6]).read_text(encoding="utf-8")
 perf_nightly_text = Path(sys.argv[7]).read_text(encoding="utf-8")
 split_wave0_text = Path(sys.argv[8]).read_text(encoding="utf-8")
+ci_text = Path(sys.argv[9]).read_text(encoding="utf-8")
 
 
 def jobs_by_id(text: str) -> dict[str, str]:
@@ -510,6 +513,61 @@ print(
     "no setup-rust in detect-changes/nightly-safety; no direct pins"
 )
 
+
+def assert_job_scoped_setup_rust(
+    job_id: str, block: str, expected: dict[str, str]
+) -> None:
+    """Adjacency, exact with-map, and no direct pins inside this job block only."""
+    if re.search(r"dtolnay/rust-toolchain@", block):
+        raise SystemExit(f"{job_id}: still calls dtolnay/rust-toolchain directly")
+    if re.search(r"Swatinem/rust-cache@", block):
+        raise SystemExit(f"{job_id}: still calls Swatinem/rust-cache directly")
+    setup = assert_immediate_setup_rust(job_id, block)
+    got = setup_rust_with_map(block)
+    if got != expected:
+        raise SystemExit(
+            f"{job_id}: setup-rust with-map must be exactly {expected}, got {got}"
+        )
+    if expected == {}:
+        first = setup.splitlines()[0]
+        if first != "      - name: Set up Rust toolchain and cache":
+            raise SystemExit(
+                f"{job_id}: setup step must be named exactly "
+                f"'Set up Rust toolchain and cache', got {first!r}"
+            )
+        if re.search(r"(?m)^        with:\s*$", setup):
+            raise SystemExit(
+                f"{job_id}: setup-rust must not declare a with: map (composite defaults only)"
+            )
+    if re.search(
+        r"(?m)^\s+uses:\s*(?:dtolnay/rust-toolchain@|Swatinem/rust-cache@)", setup
+    ):
+        raise SystemExit(f"{job_id}: setup step must not call dtolnay/Swatinem directly")
+
+
+# --- CI: clippy / rustdoc only (job-scoped; other jobs keep direct pins) ---
+ci_jobs = jobs_by_id(ci_text)
+for required in ("clippy", "rustdoc"):
+    if required not in ci_jobs:
+        raise SystemExit(f"ci.yml missing job {required}")
+
+assert_job_scoped_setup_rust("clippy", ci_jobs["clippy"], {"components": "clippy"})
+assert_job_scoped_setup_rust("rustdoc", ci_jobs["rustdoc"], {})
+
+allowed_ci_setup = {"clippy", "rustdoc"}
+for job_id, block in ci_jobs.items():
+    if job_id in allowed_ci_setup:
+        continue
+    if "./.github/actions/setup-rust" in block:
+        raise SystemExit(
+            f"ci.yml: setup-rust only allowed in clippy/rustdoc for this slice, found in {job_id}"
+        )
+
+print(
+    "ok   ci.yml: clippy with-map exact {components: clippy}; rustdoc empty with-map; "
+    "setup-rust only in clippy/rustdoc; job-scoped no direct pins"
+)
+
 PY
 
 python3 - "${KERNEL_MATRIX}" <<'PY' || fail "kernel-matrix hook-trigger paths missing"
@@ -547,6 +605,7 @@ required = (
     ".github/workflows/perf_pr.yml",
     ".github/workflows/perf_nightly.yml",
     ".github/workflows/split-wave0-gates.yml",
+    ".github/workflows/ci.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -554,7 +613,7 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk + perf_main + perf_pr + perf_nightly + split-wave0")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk + perf_main + perf_pr + perf_nightly + split-wave0 + ci.yml")
 PY
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary
- Migrate two compatible CI Rust-consuming jobs in `ci.yml` to `./.github/actions/setup-rust`:
  - `clippy`: one composite call immediately after checkout with exact with-map `{components: clippy}`.
  - `rustdoc`: one named default composite call immediately after checkout (**empty with-map** / composite defaults).
- Do **not** migrate intentional exception jobs that retain direct pins: `public-msrv`, `public-crate-policy`, `perf`, `test`, `dependency-security`, eBPF jobs, `scope`, and any other non-clippy/rustdoc CI job (custom toolchains / cache keys / cache outputs / sccache / cache-on-failure / no-cache semantics).
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` with a compact **job-scoped** assertion (adjacency + exact with-map + no direct dtolnay/Swatinem inside the job block); reuse `jobs_by_id` / `assert_immediate_setup_rust` / `setup_rust_with_map`; do **not** apply whole-workflow direct-pin helpers to `ci.yml`; preserve E1–E8 guards.
- Add `.github/workflows/ci.yml` exactly once to Kernel Matrix `pull_request.paths`.

## Scope / SHAs
- **Base:** `origin/main` @ `6d8e1b994a9a264981c3730c3fc2658010528d6d`
- **Head:** `2c6219cb2c7d37c0f828690b35059b9f28169372`
- **Branch:** `cursor/ci-setup-rust-e9`
- Allowed files only: `.github/workflows/ci.yml`, `scripts/ci/test-setup-rust-composite-contract.sh`, `.github/workflows/kernel-matrix.yml`.

## Intentional exception list (not migrated)
- `public-msrv` — custom toolchain / MSRV semantics
- `public-crate-policy` — custom setup
- `perf` — custom cache / sccache-style semantics
- `test` — custom cache keys / outputs / cache-on-failure (or equivalent non-default cache)
- `dependency-security` — non-default / no shared composite cache path
- eBPF / kernel / self-hosted jobs — custom runners and toolchains
- `scope` and other non-Rust-setup jobs — out of slice

## Setup-order / cache non-claims
- **Intentional order delta:** in both `clippy` and `rustdoc`, toolchain/cache now precede apt (composite owns toolchain+cache immediately after checkout).
- **Composite default caching only;** this PR does **not** claim job outputs or final binaries are cached.
- Triggers, permissions, conditions, needs/outputs, apt commands, cargo/clippy/rustdoc commands, lint flags, comments, and public strings are preserved aside from setup step names/uses and removal of the two direct Swatinem+dtolnay pairs.

## RED / GREEN
- **RED** (contract extended first; workflows unchanged): `clippy: still calls dtolnay/rust-toolchain directly` (simple-caller / job-scoped failure). KM `ci.yml` path was also absent from `pull_request.paths` under the extended contract.
- **GREEN** (workflows migrated + KM path added): contract all checks passed, including clippy exact `{components: clippy}`, rustdoc empty with-map, setup-rust only in clippy/rustdoc, job-scoped no direct pins in those jobs, exception jobs untouched, and KM exact-once path including `ci.yml`.

## Mutation table (temp copies; tree restored; each must FAIL)
| Probe | Outcome |
|-------|---------|
| Restore direct Swatinem+dtolnay pair in clippy | FAIL: `clippy: still calls dtolnay/rust-toolchain directly` |
| Restore direct pair in rustdoc | FAIL: direct pin in job |
| Remove setup-rust (clippy / rustdoc) | FAIL: `expected one setup-rust call, found 0` |
| Intervening `run` between checkout and setup (each) | FAIL: adjacency / step kinds |
| clippy missing with-map | FAIL: with-map exact |
| clippy wrong components (`rustfmt`) | FAIL: with-map exact |
| clippy extra `toolchain` key | FAIL: with-map exact |
| rustdoc `with:` after uses | FAIL: empty with-map / defaults-only |
| rustdoc `with:` before uses | FAIL: defaults-only |
| rustdoc trailing-slash uses + `with:` | FAIL: defaults-only |
| Add setup-rust to forbidden CI job `test` | FAIL: `setup-rust only allowed in clippy/rustdoc` |
| Duplicate / remove KM `ci.yml` path | FAIL: exact-once paths |
| E8 representative: remove quality-gates setup | FAIL (guard preserved) |
| E7 representative: wrong rustfmt on perf_main | FAIL (guard preserved) |

Post-mutation contract: **PASS**.

## Validation
- [x] `./scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `shellcheck scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `actionlint` on `ci.yml`: same pre-existing `concurrency.queue` syntax finding as base (standalone actionlint; pre-commit actionlint config passes); no new finding class from this slice
- [x] `actionlint` on `kernel-matrix.yml`: same pre-existing `concurrency.queue` syntax findings as base (line shift 328/378 → 330/380 from path additions); no new finding class
- [x] `pre-commit run setup-rust-composite-contract-self-test --all-files`
- [x] `pre-commit run --files` on the three touched files
- [x] `git diff --check` / EOF newlines / public strings
- [x] No extra local Cargo beyond repository hooks

## Live proof (head-bound)
- [x] PR-triggered **CI** run [`31501545982`](https://github.com/Rul1an/assay/actions/runs/31501545982) on exact head `2c6219cb2c7d37c0f828690b35059b9f28169372`:
  - [Clippy (deny warnings)](https://github.com/Rul1an/assay/actions/runs/31501545982/job/93812645944) — success
  - [Rustdoc (deny warnings)](https://github.com/Rul1an/assay/actions/runs/31501545982/job/93812645966) — success
- Draft retained; do not ready/merge from this writer role (review quorum still required).

## Changed files
- `.github/workflows/ci.yml`
- `.github/workflows/kernel-matrix.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`

Made with [Cursor](https://cursor.com)
