### PR TITLE
ci: migrate Kernel Matrix lint Rust setup to setup-rust (Batch E10)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -72,6 +72,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt, clippy
+
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -84,11 +88,6 @@ jobs:
           key: precommit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             precommit-${{ runner.os }}-
-
-      - name: Set up Rust (fmt + clippy)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: rustfmt, clippy
 
       - name: Install pre-commit (pinned)
         shell: bash

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family + Split Wave 0 + CI clippy/rustdoc caller surfaces.
+# Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family + Split Wave 0 + CI clippy/rustdoc + Kernel Matrix lint caller surfaces.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -217,7 +217,7 @@ print(
 )
 PY
 
-python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" "${PERF_MAIN}" "${PERF_PR}" "${PERF_NIGHTLY}" "${SPLIT_WAVE0}" "${CI_YML}" <<'PY' || fail "simple-caller setup-rust contract failed"
+python3 - "${FUZZ_SMOKE}" "${ADR025}" "${SMOKE_INSTALL}" "${RUNNER_SPIKE}" "${PERF_MAIN}" "${PERF_PR}" "${PERF_NIGHTLY}" "${SPLIT_WAVE0}" "${CI_YML}" "${KERNEL_MATRIX}" <<'PY' || fail "simple-caller setup-rust contract failed"
 import re, sys
 from pathlib import Path
 
@@ -230,6 +230,7 @@ perf_pr_text = Path(sys.argv[6]).read_text(encoding="utf-8")
 perf_nightly_text = Path(sys.argv[7]).read_text(encoding="utf-8")
 split_wave0_text = Path(sys.argv[8]).read_text(encoding="utf-8")
 ci_text = Path(sys.argv[9]).read_text(encoding="utf-8")
+kernel_matrix_text = Path(sys.argv[10]).read_text(encoding="utf-8")
 
 
 def jobs_by_id(text: str) -> dict[str, str]:
@@ -566,6 +567,49 @@ for job_id, block in ci_jobs.items():
 print(
     "ok   ci.yml: clippy with-map exact {components: clippy}; rustdoc empty with-map; "
     "setup-rust only in clippy/rustdoc; job-scoped no direct pins"
+)
+
+# --- Kernel Matrix: lint only (build-artifacts keeps direct eBPF toolchain/cache-on-failure) ---
+km_jobs = jobs_by_id(kernel_matrix_text)
+if "lint" not in km_jobs:
+    raise SystemExit("kernel-matrix.yml missing job lint")
+if "build-artifacts" not in km_jobs:
+    raise SystemExit("kernel-matrix.yml missing job build-artifacts")
+
+assert_job_scoped_setup_rust(
+    "lint", km_jobs["lint"], {"components": "rustfmt, clippy"}
+)
+
+allowed_km_setup = {"lint"}
+for job_id, block in km_jobs.items():
+    if job_id in allowed_km_setup:
+        continue
+    if "./.github/actions/setup-rust" in block:
+        raise SystemExit(
+            f"kernel-matrix.yml: setup-rust only allowed in lint for this slice, found in {job_id}"
+        )
+
+build_block = km_jobs["build-artifacts"]
+if not re.search(r"dtolnay/rust-toolchain@", build_block):
+    raise SystemExit(
+        "build-artifacts: must retain direct dtolnay/rust-toolchain (custom eBPF boundary)"
+    )
+if "install-ebpf-toolchain.sh" not in build_block:
+    raise SystemExit(
+        "build-artifacts: must retain pinned eBPF toolchain install script"
+    )
+if not re.search(r"Swatinem/rust-cache@", build_block):
+    raise SystemExit(
+        "build-artifacts: must retain direct Swatinem/rust-cache (cache-on-failure boundary)"
+    )
+if not re.search(r"(?m)^\s*cache-on-failure:\s*true\s*$", build_block):
+    raise SystemExit(
+        "build-artifacts: must retain Swatinem cache-on-failure: true"
+    )
+
+print(
+    "ok   kernel-matrix.yml: lint with-map exact {components: rustfmt, clippy}; "
+    "setup-rust only in lint; build-artifacts keeps direct toolchain + eBPF + cache-on-failure"
 )
 
 PY


### PR DESCRIPTION
## Summary
- Migrate only the Kernel Matrix **lint** job (`Lint (pre-commit)`) in `.github/workflows/kernel-matrix.yml` from direct pinned `dtolnay/rust-toolchain` to `./.github/actions/setup-rust` immediately after checkout with exact with-map `{components: \"rustfmt, clippy\"}`.
- Preserve `setup-python` and the existing pre-commit `actions/cache` step (and all other lint commands).
- Do **not** migrate `build-artifacts` (the Kernel Matrix eBPF/ARM build job; instructions named this boundary \"build-ebpf\") or any other Kernel Matrix job: it retains direct dtolnay + pinned eBPF toolchain install + Swatinem `cache-on-failure: true`.
- Extend `scripts/ci/test-setup-rust-composite-contract.sh` with a compact job-scoped Kernel Matrix lint assertion; reuse `jobs_by_id` / `assert_immediate_setup_rust` / `setup_rust_with_map` / `assert_job_scoped_setup_rust`; preserve E1–E9 guards.
- Do **not** add `kernel-matrix.yml` again to its own `pull_request.paths` (already present; self-listing would be redundant).

## Scope / SHAs
- **Base:** `origin/main` @ `6a4bf3ff1b5fcf3dd1e00cf27bcc72597c02c9aa`
- **Head:** `66114ce590463d69332a92e539fc1369395fc2bb`
- **Branch:** `cursor/ci-setup-rust-e10`
- Allowed files only: `.github/workflows/kernel-matrix.yml`, `scripts/ci/test-setup-rust-composite-contract.sh`.

## Naming note (measured repo)
- There is no job id `build-ebpf` in `kernel-matrix.yml`. The eBPF build / custom-toolchain boundary is job id `build-artifacts` (runs `cargo xtask build-ebpf --release` and owns the direct toolchain + `install-ebpf-toolchain.sh` + Swatinem `cache-on-failure`). Contract guards use `build-artifacts`.

## Setup-order / cache non-claims
- **Intentional order delta:** Rust toolchain / default Rust cache now initialize immediately after checkout, **before** Python / pre-commit setup.
- **No claim** that the pre-commit cache or final binaries move into `setup-rust`; pre-commit continues to use its existing `actions/cache` step.
- Triggers, permissions, paths entries, conditions, needs/outputs, runners, Python/pre-commit cache behavior, commands, comments, public strings, and job ordering are preserved aside from the lint Rust setup step and the intentional order delta above.

## RED / GREEN
- **RED** (contract extended first; `kernel-matrix.yml` unchanged): `lint: still calls dtolnay/rust-toolchain directly` (exit 1; simple-caller / job-scoped failure).
- **GREEN** (lint migrated): contract all checks passed, including lint exact `{components: rustfmt, clippy}`, setup-rust only in lint, `build-artifacts` keeps direct toolchain + eBPF + cache-on-failure, and existing KM `pull_request.paths` exact-once guards (E1–E9 surfaces).

## Mutation table (temp copies; tree restored; each must FAIL)
| Probe | Outcome |
|-------|---------|
| Restore direct toolchain in lint | FAIL: `lint: still calls dtolnay/rust-toolchain directly` |
| Remove setup-rust call | FAIL: `lint: expected one setup-rust call, found 0` |
| Insert `run` between checkout and setup | FAIL: adjacency / step kinds |
| Missing components / empty with-map | FAIL: with-map exact `{components: rustfmt, clippy}` got `{}` |
| Wrong components (`clippy` only) | FAIL: with-map exact |
| Extra `toolchain` key | FAIL: with-map exact |
| Trailing-slash setup uses | FAIL: with-map exact got `{}` |
| Add setup-rust to `build-artifacts` | FAIL: `setup-rust only allowed in lint ... found in build-artifacts` |
| Remove `build-artifacts` direct custom toolchain/cache-on-failure | FAIL: retain direct dtolnay / Swatinem / `cache-on-failure: true` (or forbidden setup-rust in that job) |
| E9 representative: ci clippy wrong components | FAIL: `clippy: setup-rust with-map must be exactly {'components': 'clippy'}` |
| E8 representative: split-wave0 quality-gates wrong components | FAIL: `quality-gates: setup-rust with-map must be exactly {'components': 'clippy'}` |

Post-mutation contract: **PASS**.

## Validation
- [x] `./scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `shellcheck scripts/ci/test-setup-rust-composite-contract.sh`
- [x] `actionlint .github/workflows/kernel-matrix.yml`: same pre-existing `concurrency.queue` (and self-hosted label under bare actionlint) findings as base — **non-claims**; no new finding class from this slice. Pre-commit actionlint config passes.
- [x] `pre-commit run setup-rust-composite-contract-self-test` on touched files
- [x] `pre-commit run --files` on the two touched files
- [x] `git diff --check` / EOF newlines / public strings
- [x] No extra local Cargo beyond repository hooks

## Live proof (head-bound)
- [x] PR-triggered Kernel Matrix run [`31503011779`](https://github.com/Rul1an/assay/actions/runs/31503011779) on exact head `66114ce590463d69332a92e539fc1369395fc2bb`:
  - [Lint (pre-commit)](https://github.com/Rul1an/assay/actions/runs/31503011779/job/93817527527) — success
- Draft retained; do not ready/merge from this writer role.

## Changed files
- `.github/workflows/kernel-matrix.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`

Made with [Cursor](https://cursor.com)