### PR TITLE
ci: fail-closed inventory for remaining direct Rust setup actions (Batch E11)

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -53,6 +53,11 @@ on:
       - ".github/workflows/split-wave0-gates.yml"
       # CI clippy/rustdoc call setup-rust (clippy with-map / empty defaults).
       - ".github/workflows/ci.yml"
+      # Direct-action exception inventory covers these workflows; keep contract hook on that surface.
+      - ".github/workflows/demo.yml"
+      - ".github/workflows/docs-auto-update.yml"
+      - ".github/workflows/parity.yml"
+      - ".github/workflows/release.yml"
       # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
   push:
     branches: [ "main", "debug/**" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -283,7 +283,7 @@ repos:
         entry: bash scripts/ci/test-setup-rust-composite-contract.sh
         language: system
         pass_filenames: false
-        files: ^(\.github/actions/setup-rust/action\.yml|\.github/workflows/week8-sota-gates\.yml|scripts/ci/test-setup-rust-composite-contract\.sh|\.pre-commit-config\.yaml)$
+        files: ^(\.github/actions/setup-rust/action\.yml|scripts/ci/test-setup-rust-composite-contract\.sh|\.pre-commit-config\.yaml|\.github/workflows/[^/]+\.ya?ml)$
 
       - id: mcp-registry-release-txn-self-test
         name: MCP Registry release transaction self-test

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -666,250 +666,111 @@ print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 +
 PY
 
 
-python3 - "${ROOT}/.pre-commit-config.yaml" <<'PY' || fail "setup-rust pre-commit files regex contract failed"
+python3 - "${ROOT}" <<'PY' || fail "direct-action exception inventory / pre-commit files regex failed"
 import re, sys
+from collections import Counter
 from pathlib import Path
 
-text = Path(sys.argv[1]).read_text(encoding="utf-8")
-in_hook = False
-files_line = None
-for line in text.splitlines():
+root = Path(sys.argv[1])
+TC = "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
+RC = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+
+def jobs_by_id(text: str) -> dict[str, str]:
+    return {j: b for j, b in re.findall(
+        r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)", text, re.S)}
+
+# uses: unquoted / 'single' / "double" (incl. named-step indent)
+USES_RE = re.compile(
+    r"(?m)^(?:      - uses:|        uses:)\s*(?:'|\")?"
+    r"((?:dtolnay/rust-toolchain|Swatinem/rust-cache)@[^\s#'\"]+)(?:'|\")?")
+
+# (workflow, job, pin, reason) — composite cannot preserve named behavior
+ALLOWED = [
+    (".github/workflows/ci.yml", "public-msrv", TC, "dynamic ASSAY_PUBLIC_MSRV toolchain; no composite Swatinem key"),
+    (".github/workflows/ci.yml", "public-msrv", RC, "Swatinem key public-msrv-${{ env.ASSAY_PUBLIC_MSRV }}; no composite key"),
+    (".github/workflows/ci.yml", "public-crate-policy", TC, "no-cache policy validation; composite always caches"),
+    (".github/workflows/ci.yml", "perf", RC, "Swatinem id/output cache-hit; composite has no step id / fixed order"),
+    (".github/workflows/ci.yml", "perf", TC, "paired with direct Swatinem id/output; composite forces toolchain-then-cache"),
+    (".github/workflows/ci.yml", "test", TC, "paired with sccache cache-directories + cache-on-failure"),
+    (".github/workflows/ci.yml", "test", RC, "Swatinem cache-directories (~/.sccache) + cache-on-failure; composite lacks both"),
+    (".github/workflows/ci.yml", "ebpf-smoke-ubuntu", TC, "rust-src + install-ebpf-toolchain.sh; composite would inject rust-cache"),
+    (".github/workflows/demo.yml", "regenerate", TC, "no-cache demo rebuild; composite always caches"),
+    (".github/workflows/docs-auto-update.yml", "generate-docs", TC, "no-cache docs generation; composite always caches"),
+    (".github/workflows/kernel-matrix.yml", "build-artifacts", TC, "host toolchain before install-ebpf-toolchain.sh"),
+    (".github/workflows/kernel-matrix.yml", "build-artifacts", RC, "Swatinem cache-on-failure for eBPF builds; composite lacks input"),
+    (".github/workflows/parity.yml", "parity", TC, "actions/cache not Swatinem; composite would inject Swatinem"),
+    (".github/workflows/parity.yml", "integration-parity", TC, "toolchain without Swatinem; composite always caches"),
+    (".github/workflows/release.yml", "build", TC, "dtolnay targets: ${{ matrix.target }}; composite has no targets"),
+    (".github/workflows/release.yml", "build-mcp-server-linux", TC, "dtolnay targets: ${{ matrix.target }}; composite has no targets"),
+    (".github/workflows/release.yml", "release", TC, "no-cache release SBOM toolchain; composite always caches"),
+    (".github/workflows/release.yml", "verify-lsm-blocking", TC, "self-hosted no-cache LSM gate; composite always caches"),
+    (".github/workflows/release.yml", "publish-crates", TC, "no-cache crates.io publish; composite always caches"),
+]
+if any(not r.strip() for *_, r in ALLOWED):
+    raise SystemExit("allowlist reason must be non-empty/non-whitespace")
+keys = [(w, j, p) for w, j, p, _ in ALLOWED]
+if len(keys) != len(set(keys)):
+    raise SystemExit("allowlist contains duplicate (workflow, job, ref) entries")
+
+measured = []
+wf = root / ".github" / "workflows"
+for path in sorted(wf.glob("*.yml")) + sorted(wf.glob("*.yaml")):
+    body = re.search(r"(?m)^jobs:\n(.*)\Z", path.read_text(encoding="utf-8"), re.S)
+    if not body:
+        continue
+    rel = str(path.relative_to(root))
+    for job_id, block in jobs_by_id(body.group(1)).items():
+        measured.extend((rel, job_id, ref) for ref in USES_RE.findall(block))
+
+mc, ac = Counter(measured), Counter(keys)
+if mc != ac:
+    parts = []
+    unreg = sorted(k for k in mc if mc[k] > ac[k])
+    miss = sorted(k for k in ac if ac[k] > mc[k])
+    if unreg:
+        parts.append("unregistered direct actions: " + ", ".join(
+            f"{w} job {j} uses {r}" for w, j, r in unreg))
+    if miss:
+        parts.append("allowlisted but absent: " + ", ".join(
+            f"{w} job {j} uses {r}" for w, j, r in miss))
+    if not parts:
+        drift = [(k, mc[k], ac[k]) for k in sorted(set(mc) | set(ac)) if mc[k] != ac[k]]
+        parts.append("count drift: " + ", ".join(
+            f"{w}/{j}/{r} measured={m} allowlisted={a}" for (w, j, r), m, a in drift))
+    raise SystemExit("; ".join(parts) if parts else "direct-action inventory mismatch")
+print(f"ok   direct-action exception inventory: {sum(mc.values())} pinned calls "
+      f"across {len({w for w, _, _ in mc})} workflows (fail-closed allowlist)")
+
+pc = (root / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+in_hook, files_line = False, None
+for line in pc.splitlines():
     if re.search(r"id:\s*setup-rust-composite-contract-self-test\s*$", line):
         in_hook = True
         continue
     if in_hook and re.match(r"^\s+- id:\s*", line):
         break
-    if in_hook:
-        m = re.match(r"^\s+files:\s*(.+)\s*$", line)
-        if m:
-            files_line = m.group(1).strip()
-            break
+    if in_hook and (m := re.match(r"^\s+files:\s*(.+)\s*$", line)):
+        files_line = m.group(1).strip()
+        break
 if files_line is None:
     raise SystemExit("setup-rust-composite-contract-self-test files: line missing")
 expected = (
     r"^(\.github/actions/setup-rust/action\.yml|"
     r"scripts/ci/test-setup-rust-composite-contract\.sh|"
     r"\.pre-commit-config\.yaml|"
-    r"\.github/workflows/[^/]+\.ya?ml)$"
-)
+    r"\.github/workflows/[^/]+\.ya?ml)$")
 if files_line != expected:
     raise SystemExit(
-        f"setup-rust pre-commit files regex must be exactly {expected!r}, got {files_line!r}"
-    )
-sample = [
-    ".github/workflows/demo.yml",
-    ".github/workflows/docs-auto-update.yml",
-    ".github/workflows/parity.yml",
-    ".github/workflows/release.yml",
-    ".github/workflows/ci.yml",
-    ".github/workflows/kernel-matrix.yml",
-]
+        f"setup-rust pre-commit files regex must be exactly {expected!r}, got {files_line!r}")
 cre = re.compile(files_line)
-bad = [s for s in sample if not cre.search(s)]
-if bad:
-    raise SystemExit(f"pre-commit files regex must match exception workflows; missed {bad}")
+missed = [s for s in (
+    ".github/workflows/demo.yml", ".github/workflows/docs-auto-update.yml",
+    ".github/workflows/parity.yml", ".github/workflows/release.yml",
+    ".github/workflows/ci.yml", ".github/workflows/kernel-matrix.yml",
+) if not cre.search(s)]
+if missed:
+    raise SystemExit(f"pre-commit files regex must match exception workflows; missed {missed}")
 print("ok   setup-rust pre-commit files regex covers action, contract, pre-commit config, and workflows")
-PY
-
-
-python3 - "${ROOT}" <<'PY' || fail "direct-action exception inventory failed"
-import re, sys
-from pathlib import Path
-from collections import Counter
-
-root = Path(sys.argv[1])
-workflows_dir = root / ".github" / "workflows"
-toolchain_pin = "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
-cache_pin = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
-
-
-def jobs_by_id(text: str) -> dict[str, str]:
-    return {
-        job_id: block
-        for job_id, block in re.findall(
-            r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
-            text,
-            re.S,
-        )
-    }
-
-
-USES_RE = re.compile(
-    r"(?m)^(?:      - uses:|        uses:)\s*"
-    r"((?:dtolnay/rust-toolchain|Swatinem/rust-cache)@[^\s#]+)"
-)
-
-# Fail-closed allowlist: (workflow relpath, top-level job id, exact pinned ref).
-# Reasons name behavior setup-rust cannot preserve (toolchain/components/workspaces only).
-ALLOWED_DIRECT: list[tuple[str, str, str, str]] = [
-    (
-        ".github/workflows/ci.yml",
-        "public-msrv",
-        toolchain_pin,
-        "dynamic ASSAY_PUBLIC_MSRV toolchain; composite has no Swatinem key input",
-    ),
-    (
-        ".github/workflows/ci.yml",
-        "public-msrv",
-        cache_pin,
-        "Swatinem key public-msrv-${{ env.ASSAY_PUBLIC_MSRV }}; composite has no key input",
-    ),
-    (
-        ".github/workflows/ci.yml",
-        "public-crate-policy",
-        toolchain_pin,
-        "policy validation installs toolchain without cache; composite always caches",
-    ),
-    (
-        ".github/workflows/ci.yml",
-        "perf",
-        cache_pin,
-        "Swatinem id/output cache-hit; composite cache step has no id and fixed order",
-    ),
-    (
-        ".github/workflows/ci.yml",
-        "perf",
-        toolchain_pin,
-        "paired with direct Swatinem id/output; composite forces toolchain-then-cache",
-    ),
-    (
-        ".github/workflows/ci.yml",
-        "test",
-        toolchain_pin,
-        "paired with sccache cache-directories + cache-on-failure Swatinem inputs",
-    ),
-    (
-        ".github/workflows/ci.yml",
-        "test",
-        cache_pin,
-        "Swatinem cache-directories (~/.sccache) and cache-on-failure; composite lacks both",
-    ),
-    (
-        ".github/workflows/ci.yml",
-        "ebpf-smoke-ubuntu",
-        toolchain_pin,
-        "rust-src plus install-ebpf-toolchain.sh; composite would inject unwanted rust-cache",
-    ),
-    (
-        ".github/workflows/demo.yml",
-        "regenerate",
-        toolchain_pin,
-        "demo tape rebuild installs toolchain without cache; composite always caches",
-    ),
-    (
-        ".github/workflows/docs-auto-update.yml",
-        "generate-docs",
-        toolchain_pin,
-        "docs generation installs toolchain without cache; composite always caches",
-    ),
-    (
-        ".github/workflows/kernel-matrix.yml",
-        "build-artifacts",
-        toolchain_pin,
-        "host toolchain before install-ebpf-toolchain.sh; not composite defaults",
-    ),
-    (
-        ".github/workflows/kernel-matrix.yml",
-        "build-artifacts",
-        cache_pin,
-        "Swatinem cache-on-failure for eBPF artifact builds; composite lacks that input",
-    ),
-    (
-        ".github/workflows/parity.yml",
-        "parity",
-        toolchain_pin,
-        "uses actions/cache paths, not Swatinem; composite would inject Swatinem",
-    ),
-    (
-        ".github/workflows/parity.yml",
-        "integration-parity",
-        toolchain_pin,
-        "toolchain without Swatinem; composite always runs rust-cache",
-    ),
-    (
-        ".github/workflows/release.yml",
-        "build",
-        toolchain_pin,
-        "dtolnay targets: ${{ matrix.target }}; composite has no targets input",
-    ),
-    (
-        ".github/workflows/release.yml",
-        "build-mcp-server-linux",
-        toolchain_pin,
-        "dtolnay targets: ${{ matrix.target }}; composite has no targets input",
-    ),
-    (
-        ".github/workflows/release.yml",
-        "release",
-        toolchain_pin,
-        "release SBOM job installs toolchain without cache; composite always caches",
-    ),
-    (
-        ".github/workflows/release.yml",
-        "verify-lsm-blocking",
-        toolchain_pin,
-        "self-hosted LSM gate installs toolchain without cache; composite always caches",
-    ),
-    (
-        ".github/workflows/release.yml",
-        "publish-crates",
-        toolchain_pin,
-        "crates.io publish installs toolchain without cache; composite always caches",
-    ),
-]
-
-allowed_keys = [(w, j, r) for w, j, r, _reason in ALLOWED_DIRECT]
-if len(allowed_keys) != len(set(allowed_keys)):
-    raise SystemExit("allowlist contains duplicate (workflow, job, ref) entries")
-
-measured: list[tuple[str, str, str]] = []
-for path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
-    text = path.read_text(encoding="utf-8")
-    jobs_m = re.search(r"(?m)^jobs:\n(.*)\Z", text, re.S)
-    if not jobs_m:
-        continue
-    rel = str(path.relative_to(root))
-    for job_id, block in jobs_by_id(jobs_m.group(1)).items():
-        for ref in USES_RE.findall(block):
-            measured.append((rel, job_id, ref))
-
-measured_sorted = sorted(measured)
-allowed_sorted = sorted(allowed_keys)
-
-if measured_sorted != allowed_sorted:
-    measured_set = set(measured)
-    allowed_set = set(allowed_keys)
-    unregistered = sorted(measured_set - allowed_set)
-    missing = sorted(allowed_set - measured_set)
-    mc, ac = Counter(measured), Counter(allowed_keys)
-    count_drift = sorted(
-        (k, mc[k], ac[k]) for k in sorted(set(mc) | set(ac)) if mc[k] != ac[k]
-    )
-    parts = []
-    if unregistered:
-        parts.append(
-            "unregistered direct actions: "
-            + ", ".join(f"{w} job {j} uses {r}" for w, j, r in unregistered)
-        )
-    if missing:
-        parts.append(
-            "allowlisted but absent: "
-            + ", ".join(f"{w} job {j} uses {r}" for w, j, r in missing)
-        )
-    if count_drift and not (unregistered or missing):
-        parts.append(
-            "count drift: "
-            + ", ".join(
-                f"{w}/{j}/{r} measured={m} allowlisted={a}"
-                for (w, j, r), m, a in count_drift
-            )
-        )
-    raise SystemExit("; ".join(parts) if parts else "direct-action inventory mismatch")
-
-print(
-    f"ok   direct-action exception inventory: {len(measured)} pinned calls "
-    f"across {len({w for w, _, _ in measured})} workflows (fail-closed allowlist)"
-)
 PY
 
 

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Contract for .github/actions/setup-rust and its week8 + wave6 + fuzz-smoke + ADR025 soak + smoke-install assay + Runner Spike SDK + perf family + Split Wave 0 + CI clippy/rustdoc + Kernel Matrix lint caller surfaces.
+# Also fail-closed inventory of intentional direct dtolnay/Swatinem exceptions.
 # Guards only the new boundary; actionlint + diff review cover unchanged workflow structure.
 #
 # Empty optional forwarding is safe for the pinned upstream versions measured in this
@@ -650,6 +651,10 @@ required = (
     ".github/workflows/perf_nightly.yml",
     ".github/workflows/split-wave0-gates.yml",
     ".github/workflows/ci.yml",
+    ".github/workflows/demo.yml",
+    ".github/workflows/docs-auto-update.yml",
+    ".github/workflows/parity.yml",
+    ".github/workflows/release.yml",
 )
 bad = [p for p in required if paths.count(p) != 1]
 if bad:
@@ -657,7 +662,255 @@ if bad:
         "pull_request.paths must list each trigger path exactly once; "
         + ", ".join(f"{p!r} appears {paths.count(p)} time(s)" for p in bad)
     )
-print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk + perf_main + perf_pr + perf_nightly + split-wave0 + ci.yml")
+print("ok   kernel-matrix pull_request.paths exact-once for setup-rust + week8 + wave6 + fuzz-smoke + adr025 + smoke-install + runner-spike-sdk + perf_main + perf_pr + perf_nightly + split-wave0 + ci.yml + demo + docs-auto-update + parity + release")
 PY
+
+
+python3 - "${ROOT}/.pre-commit-config.yaml" <<'PY' || fail "setup-rust pre-commit files regex contract failed"
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+in_hook = False
+files_line = None
+for line in text.splitlines():
+    if re.search(r"id:\s*setup-rust-composite-contract-self-test\s*$", line):
+        in_hook = True
+        continue
+    if in_hook and re.match(r"^\s+- id:\s*", line):
+        break
+    if in_hook:
+        m = re.match(r"^\s+files:\s*(.+)\s*$", line)
+        if m:
+            files_line = m.group(1).strip()
+            break
+if files_line is None:
+    raise SystemExit("setup-rust-composite-contract-self-test files: line missing")
+expected = (
+    r"^(\.github/actions/setup-rust/action\.yml|"
+    r"scripts/ci/test-setup-rust-composite-contract\.sh|"
+    r"\.pre-commit-config\.yaml|"
+    r"\.github/workflows/[^/]+\.ya?ml)$"
+)
+if files_line != expected:
+    raise SystemExit(
+        f"setup-rust pre-commit files regex must be exactly {expected!r}, got {files_line!r}"
+    )
+sample = [
+    ".github/workflows/demo.yml",
+    ".github/workflows/docs-auto-update.yml",
+    ".github/workflows/parity.yml",
+    ".github/workflows/release.yml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/kernel-matrix.yml",
+]
+cre = re.compile(files_line)
+bad = [s for s in sample if not cre.search(s)]
+if bad:
+    raise SystemExit(f"pre-commit files regex must match exception workflows; missed {bad}")
+print("ok   setup-rust pre-commit files regex covers action, contract, pre-commit config, and workflows")
+PY
+
+
+python3 - "${ROOT}" <<'PY' || fail "direct-action exception inventory failed"
+import re, sys
+from pathlib import Path
+from collections import Counter
+
+root = Path(sys.argv[1])
+workflows_dir = root / ".github" / "workflows"
+toolchain_pin = "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
+cache_pin = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+
+
+def jobs_by_id(text: str) -> dict[str, str]:
+    return {
+        job_id: block
+        for job_id, block in re.findall(
+            r"(?m)^  ([A-Za-z0-9_-]+):\n(.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+            text,
+            re.S,
+        )
+    }
+
+
+USES_RE = re.compile(
+    r"(?m)^(?:      - uses:|        uses:)\s*"
+    r"((?:dtolnay/rust-toolchain|Swatinem/rust-cache)@[^\s#]+)"
+)
+
+# Fail-closed allowlist: (workflow relpath, top-level job id, exact pinned ref).
+# Reasons name behavior setup-rust cannot preserve (toolchain/components/workspaces only).
+ALLOWED_DIRECT: list[tuple[str, str, str, str]] = [
+    (
+        ".github/workflows/ci.yml",
+        "public-msrv",
+        toolchain_pin,
+        "dynamic ASSAY_PUBLIC_MSRV toolchain; composite has no Swatinem key input",
+    ),
+    (
+        ".github/workflows/ci.yml",
+        "public-msrv",
+        cache_pin,
+        "Swatinem key public-msrv-${{ env.ASSAY_PUBLIC_MSRV }}; composite has no key input",
+    ),
+    (
+        ".github/workflows/ci.yml",
+        "public-crate-policy",
+        toolchain_pin,
+        "policy validation installs toolchain without cache; composite always caches",
+    ),
+    (
+        ".github/workflows/ci.yml",
+        "perf",
+        cache_pin,
+        "Swatinem id/output cache-hit; composite cache step has no id and fixed order",
+    ),
+    (
+        ".github/workflows/ci.yml",
+        "perf",
+        toolchain_pin,
+        "paired with direct Swatinem id/output; composite forces toolchain-then-cache",
+    ),
+    (
+        ".github/workflows/ci.yml",
+        "test",
+        toolchain_pin,
+        "paired with sccache cache-directories + cache-on-failure Swatinem inputs",
+    ),
+    (
+        ".github/workflows/ci.yml",
+        "test",
+        cache_pin,
+        "Swatinem cache-directories (~/.sccache) and cache-on-failure; composite lacks both",
+    ),
+    (
+        ".github/workflows/ci.yml",
+        "ebpf-smoke-ubuntu",
+        toolchain_pin,
+        "rust-src plus install-ebpf-toolchain.sh; composite would inject unwanted rust-cache",
+    ),
+    (
+        ".github/workflows/demo.yml",
+        "regenerate",
+        toolchain_pin,
+        "demo tape rebuild installs toolchain without cache; composite always caches",
+    ),
+    (
+        ".github/workflows/docs-auto-update.yml",
+        "generate-docs",
+        toolchain_pin,
+        "docs generation installs toolchain without cache; composite always caches",
+    ),
+    (
+        ".github/workflows/kernel-matrix.yml",
+        "build-artifacts",
+        toolchain_pin,
+        "host toolchain before install-ebpf-toolchain.sh; not composite defaults",
+    ),
+    (
+        ".github/workflows/kernel-matrix.yml",
+        "build-artifacts",
+        cache_pin,
+        "Swatinem cache-on-failure for eBPF artifact builds; composite lacks that input",
+    ),
+    (
+        ".github/workflows/parity.yml",
+        "parity",
+        toolchain_pin,
+        "uses actions/cache paths, not Swatinem; composite would inject Swatinem",
+    ),
+    (
+        ".github/workflows/parity.yml",
+        "integration-parity",
+        toolchain_pin,
+        "toolchain without Swatinem; composite always runs rust-cache",
+    ),
+    (
+        ".github/workflows/release.yml",
+        "build",
+        toolchain_pin,
+        "dtolnay targets: ${{ matrix.target }}; composite has no targets input",
+    ),
+    (
+        ".github/workflows/release.yml",
+        "build-mcp-server-linux",
+        toolchain_pin,
+        "dtolnay targets: ${{ matrix.target }}; composite has no targets input",
+    ),
+    (
+        ".github/workflows/release.yml",
+        "release",
+        toolchain_pin,
+        "release SBOM job installs toolchain without cache; composite always caches",
+    ),
+    (
+        ".github/workflows/release.yml",
+        "verify-lsm-blocking",
+        toolchain_pin,
+        "self-hosted LSM gate installs toolchain without cache; composite always caches",
+    ),
+    (
+        ".github/workflows/release.yml",
+        "publish-crates",
+        toolchain_pin,
+        "crates.io publish installs toolchain without cache; composite always caches",
+    ),
+]
+
+allowed_keys = [(w, j, r) for w, j, r, _reason in ALLOWED_DIRECT]
+if len(allowed_keys) != len(set(allowed_keys)):
+    raise SystemExit("allowlist contains duplicate (workflow, job, ref) entries")
+
+measured: list[tuple[str, str, str]] = []
+for path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
+    text = path.read_text(encoding="utf-8")
+    jobs_m = re.search(r"(?m)^jobs:\n(.*)\Z", text, re.S)
+    if not jobs_m:
+        continue
+    rel = str(path.relative_to(root))
+    for job_id, block in jobs_by_id(jobs_m.group(1)).items():
+        for ref in USES_RE.findall(block):
+            measured.append((rel, job_id, ref))
+
+measured_sorted = sorted(measured)
+allowed_sorted = sorted(allowed_keys)
+
+if measured_sorted != allowed_sorted:
+    measured_set = set(measured)
+    allowed_set = set(allowed_keys)
+    unregistered = sorted(measured_set - allowed_set)
+    missing = sorted(allowed_set - measured_set)
+    mc, ac = Counter(measured), Counter(allowed_keys)
+    count_drift = sorted(
+        (k, mc[k], ac[k]) for k in sorted(set(mc) | set(ac)) if mc[k] != ac[k]
+    )
+    parts = []
+    if unregistered:
+        parts.append(
+            "unregistered direct actions: "
+            + ", ".join(f"{w} job {j} uses {r}" for w, j, r in unregistered)
+        )
+    if missing:
+        parts.append(
+            "allowlisted but absent: "
+            + ", ".join(f"{w} job {j} uses {r}" for w, j, r in missing)
+        )
+    if count_drift and not (unregistered or missing):
+        parts.append(
+            "count drift: "
+            + ", ".join(
+                f"{w}/{j}/{r} measured={m} allowlisted={a}"
+                for (w, j, r), m, a in count_drift
+            )
+        )
+    raise SystemExit("; ".join(parts) if parts else "direct-action inventory mismatch")
+
+print(
+    f"ok   direct-action exception inventory: {len(measured)} pinned calls "
+    f"across {len({w for w, _, _ in measured})} workflows (fail-closed allowlist)"
+)
+PY
+
 
 echo "setup-rust composite contract: all checks passed"


### PR DESCRIPTION
## Summary

Closes the setup-rust programme with a **fail-closed inventory** of intentional direct `dtolnay/rust-toolchain` / `Swatinem/rust-cache` exceptions. No remaining caller is migrated; the composite is not extended.

Closes #2300

- **Base:** `origin/main` @ `f042052bb8738bf3e8f6c23467130994338bbee0` (Batch E10)
- **Head:** `275ec1e8ec9073747a204bd2958b2527873c698a`
- **Measured inventory:** **19** direct pinned action calls across **six** workflows
- **Contract net vs base:** +114 lines (`115` insertions / `1` deletion; ≤120 target)

### Measured 19-entry inventory (by semantic exception)

Composite inputs are only `toolchain` / `components` / `cache-workspaces`; reasons name behavior it cannot preserve.

1. **Dynamic MSRV + custom Swatinem key** (`ci.yml` / `public-msrv`) — 2  
2. **No-cache validation / docs / demo / publish** — 6 (`public-crate-policy`, `demo/regenerate`, `docs-auto-update/generate-docs`, `release`/`publish-crates`/`verify-lsm-blocking`)  
3. **Perf cache id / output** (`ci.yml` / `perf`) — 2  
4. **Test sccache / directories / cache-on-failure** (`ci.yml` / `test`) — 2  
5. **eBPF rust-src / pinned eBPF / cache-on-failure** — 3 (`ebpf-smoke-ubuntu`, `kernel-matrix/build-artifacts`)  
6. **Parity custom actions/cache** (`parity.yml`) — 2  
7. **Release target matrices** (`build`, `build-mcp-server-linux`) — 2  

### Review follow-up (this head)

- Scanner matches unquoted / single-quoted / double-quoted `uses:` (incl. named-step indent)
- Every allowlist reason asserted non-empty / non-whitespace
- Compacted inventory representation (one record per line + Counter compare)

## TDD

- **RED (original):** omit `public-crate-policy` → unregistered  
- **RED (review):** double-quoted unallowlisted caller still green on prior head; blank reason still green  
- **GREEN:** quoted forms detected; blank/whitespace reasons fail; 19-entry allowlist passes  

## Mutations (each FAIL, then clean PASS)

- new unquoted / **single-quoted** / **double-quoted** / named-step-quoted direct caller  
- blank / whitespace-only allowlist reason  
- move / duplicate / remove / rename / repin  
- new Swatinem caller  
- remove/duplicate each new KM path  
- narrow pre-commit `files` regex  
- E9/E10 setup-rust loss guards  

## Validation

- focused contract PASS (19 / 6 workflows)  
- shellcheck PASS  
- pre-commit hook on contract + `demo.yml` PASS  
- `git diff --check` PASS  
- contract net +114 lines vs base  

## Live proof

- Kernel Matrix Lint (pre-commit) on exact head — pending after this push  
- Draft; do not ready/merge. Fresh independent review required on new head.

## Test plan

- [x] Local contract + mutations (incl. quoted uses + blank reason)  
- [x] shellcheck / pre-commit hook / line-budget  
- [ ] Kernel Matrix Lint green on exact head  
- [ ] Fresh non-building exact-head review  