### PR TITLE
ci: reconcile live required contexts with ruleset (CI-2B / #2243)

### DIFF
--- a/.github/workflows/required-context-reconciliation.yml
+++ b/.github/workflows/required-context-reconciliation.yml
@@ -37,19 +37,20 @@ jobs:
         run: python3 scripts/ci/check-required-contexts.py --self-test
 
       - name: Fetch live required status checks
-        id: fetch
         env:
           GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          out="${RUNNER_TEMP}/live-required-status-checks.json"
+          live_json="${RUNNER_TEMP}/live-required-status-checks.json"
           gh api \
-            "repos/${{ github.repository }}/branches/${{ github.event.repository.default_branch }}/protection/required_status_checks" \
-            >"${out}"
-          echo "path=${out}" >>"${GITHUB_OUTPUT}"
+            "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/required_status_checks" \
+            >"${live_json}"
 
       - name: Reconcile ruleset against live protection
         run: |
           set -euo pipefail
+          live_json="${RUNNER_TEMP}/live-required-status-checks.json"
           python3 scripts/ci/check-required-contexts.py --live-response \
-            < "${{ steps.fetch.outputs.path }}"
+            < "${live_json}"

--- a/.github/workflows/required-context-reconciliation.yml
+++ b/.github/workflows/required-context-reconciliation.yml
@@ -52,4 +52,4 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/ci/check-required-contexts.py --live-response \
-            "${{ steps.fetch.outputs.path }}"
+            < "${{ steps.fetch.outputs.path }}"

--- a/.github/workflows/required-context-reconciliation.yml
+++ b/.github/workflows/required-context-reconciliation.yml
@@ -1,0 +1,55 @@
+# Reconcile checked-in required contexts with live classic branch protection.
+# Not a required check. Operates only after BRANCH_PROTECTION_READ_TOKEN is set.
+name: Required Context Reconciliation
+
+on:
+  schedule:
+    # Every 6 hours, offset to minute 17.
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  reconcile:
+    name: reconcile-live-required-contexts
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Require BRANCH_PROTECTION_READ_TOKEN
+        env:
+          BRANCH_PROTECTION_READ_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BRANCH_PROTECTION_READ_TOKEN}" ]; then
+            echo "::error::BRANCH_PROTECTION_READ_TOKEN is not set. Create a fine-grained PAT for this repository with Administration: Read-only, store it as that repository secret, then re-run. See docs/BRANCH-PROTECTION-SETUP.md."
+            exit 1
+          fi
+
+      - name: Self-test required-contexts guard
+        run: python3 scripts/ci/check-required-contexts.py --self-test
+
+      - name: Fetch live required status checks
+        id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          out="${RUNNER_TEMP}/live-required-status-checks.json"
+          gh api \
+            "repos/${{ github.repository }}/branches/${{ github.event.repository.default_branch }}/protection/required_status_checks" \
+            >"${out}"
+          echo "path=${out}" >>"${GITHUB_OUTPUT}"
+
+      - name: Reconcile ruleset against live protection
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check-required-contexts.py --live-response \
+            "${{ steps.fetch.outputs.path }}"

--- a/docs/BRANCH-PROTECTION-SETUP.md
+++ b/docs/BRANCH-PROTECTION-SETUP.md
@@ -173,13 +173,14 @@ hours) and `workflow_dispatch` on the default branch only. A red run means live
 protection drifted from the checked-in artifact, or the read failed (auth, API,
 or malformed evidence).
 
-Local check against a saved API response:
+Local check against a saved API response (**stdin-only**; the checker does not
+accept a path argument):
 
 ```bash
 gh api repos/OWNER/REPO/branches/main/protection/required_status_checks \
   > /tmp/live-required-status-checks.json
-python3 scripts/ci/check-required-contexts.py \
-  --live-response /tmp/live-required-status-checks.json
+python3 scripts/ci/check-required-contexts.py --live-response \
+  < /tmp/live-required-status-checks.json
 ```
 
 Exit codes for `--live-response`: `0` match, `1` semantic drift, `2` unreadable

--- a/docs/BRANCH-PROTECTION-SETUP.md
+++ b/docs/BRANCH-PROTECTION-SETUP.md
@@ -137,11 +137,53 @@ To **inspect** current protection:
 gh api repos/OWNER/REPO/branches/main/protection
 ```
 
+To inspect only the required status checks subresource (what the reconciliation
+monitor reads):
+
+```bash
+gh api repos/OWNER/REPO/branches/main/protection/required_status_checks
+```
+
 To **remove** protection (use with care):
 
 ```bash
 gh api repos/OWNER/REPO/branches/main/protection -X DELETE
 ```
+
+---
+
+## Live reconciliation monitor (required contexts)
+
+`.github/rulesets/main-required-ci-contexts.json` is the sole machine-readable
+expected set. Classic branch protection on the default branch is what actually
+enforces merges. The scheduled workflow
+`.github/workflows/required-context-reconciliation.yml` compares those two on
+context names and `strict` only (it ignores `app_id` / `integration_id`, review
+settings, force-push, and deletion rules).
+
+**Prerequisite (owner action):** create a fine-grained personal access token for
+**this repository only** with **Administration: Read-only**, and store it as the
+repository secret `BRANCH_PROTECTION_READ_TOKEN`. The workflow does not fall
+back to `github.token`. Until that secret exists, scheduled and manual runs fail
+closed at preflight with an explicit missing-secret error; they do not silently
+skip reconciliation.
+
+The monitor is **not** a required status check. It runs on a schedule (every six
+hours) and `workflow_dispatch` on the default branch only. A red run means live
+protection drifted from the checked-in artifact, or the read failed (auth, API,
+or malformed evidence).
+
+Local check against a saved API response:
+
+```bash
+gh api repos/OWNER/REPO/branches/main/protection/required_status_checks \
+  > /tmp/live-required-status-checks.json
+python3 scripts/ci/check-required-contexts.py \
+  --live-response /tmp/live-required-status-checks.json
+```
+
+Exit codes for `--live-response`: `0` match, `1` semantic drift, `2` unreadable
+or missing live evidence.
 
 ---
 

--- a/scripts/ci/check-required-contexts.py
+++ b/scripts/ci/check-required-contexts.py
@@ -28,9 +28,12 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -171,17 +174,6 @@ def main_live(path: str) -> int:
         return EXIT_DRIFT
 
     print("required-contexts-live=match")
-    return EXIT_MATCH
-
-
-def run_live_exit(live_text: str, baseline: dict) -> int:
-    """Exercise check_live exit mapping without going through argparse/filesystem."""
-    try:
-        problems = check_live(baseline.__getitem__, live_text)
-    except DriftError:
-        return EXIT_UNREADABLE
-    if problems:
-        return EXIT_DRIFT
     return EXIT_MATCH
 
 
@@ -405,27 +397,68 @@ def _baseline_live_json(contexts: list[str], *, strict: bool = True, app_id=1536
     )
 
 
+DEFAULT_BRANCH_GUARD = "if: github.ref_name == github.event.repository.default_branch"
+
+
+def _apply_text(baseline: str, mutate, label: str) -> str | None:
+    """Reject no-op mutations: unchanged output means the case never bit."""
+    mutated = mutate(baseline)
+    if mutated == baseline:
+        print(f"self-test: mutation {label} did not apply", file=sys.stderr)
+        return None
+    return mutated
+
+
+def _invoke_main_live(live_text: str) -> int:
+    """Exercise the production exit path: tempfile + main_live() (stdout/stderr redirected)."""
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(live_text)
+        path = handle.name
+    try:
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+            io.StringIO()
+        ):
+            return main_live(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
 def live_self_test(baseline: dict) -> int:
     """Prove live-response mode detects semantic drift and unreadable evidence separately."""
     expected = ruleset_contexts(baseline[RULESET])
     expected_strict = ruleset_strict(baseline[RULESET])
     live_ok = _baseline_live_json(expected, strict=expected_strict)
 
-    # Match, including reordered contexts and an app_id that disagrees with the ruleset.
+    def apply_live(mutate, label: str) -> str | None:
+        return _apply_text(live_ok, mutate, label)
+
+    # Identity must be rejected by the applicator (real no-op bite).
+    if (lambda t: t)(live_ok) != live_ok:
+        print("self-test: identity no-op unexpectedly changed live JSON", file=sys.stderr)
+        return 1
+    with contextlib.redirect_stderr(io.StringIO()):
+        identity_applied = apply_live(lambda t: t, "identity_noop")
+    if identity_applied is not None:
+        print("self-test: identity no-op was not rejected by apply helper", file=sys.stderr)
+        return 1
+
+    # Match cases, including reorder and app_id noise, via production main_live().
     reordered = list(reversed(expected))
     assert set(reordered) == set(expected)
-    for label, live_text in (
+    match_cases = [
         ("baseline", live_ok),
         ("reordered", _baseline_live_json(reordered, strict=expected_strict)),
         ("app_id_ignored", _baseline_live_json(expected, strict=expected_strict, app_id=None)),
-    ):
-        try:
-            problems = check_live(baseline.__getitem__, live_text)
-        except DriftError as exc:
-            print(f"self-test: live {label} should match, got unreadable: {exc}", file=sys.stderr)
-            return 1
-        if problems:
-            print(f"self-test: live {label} should match, got drift: {problems}", file=sys.stderr)
+    ]
+    for label, live_text in match_cases:
+        code = _invoke_main_live(live_text)
+        if code != EXIT_MATCH:
+            print(
+                f"self-test: live {label} must exit {EXIT_MATCH} via main_live, got {code}",
+                file=sys.stderr,
+            )
             return 1
 
     drift_cases = [
@@ -443,20 +476,15 @@ def live_self_test(baseline: dict) -> int:
         ),
     ]
     for label, mutate in drift_cases:
-        mutated = mutate(live_ok)
-        if mutated == live_ok:
-            print(f"self-test: live drift mutation {label} did not apply", file=sys.stderr)
+        mutated = apply_live(mutate, label)
+        if mutated is None:
             return 1
-        try:
-            problems = check_live(baseline.__getitem__, mutated)
-        except DriftError as exc:
+        code = _invoke_main_live(mutated)
+        if code != EXIT_DRIFT:
             print(
-                f"self-test: live drift {label} was unreadable, expected semantic drift: {exc}",
+                f"self-test: live drift {label} must exit {EXIT_DRIFT} via main_live, got {code}",
                 file=sys.stderr,
             )
-            return 1
-        if not problems:
-            print(f"self-test: live drift {label} went undetected", file=sys.stderr)
             return 1
 
     unreadable_live = [
@@ -466,64 +494,58 @@ def live_self_test(baseline: dict) -> int:
         ("missing_strict", lambda t: json.dumps({"contexts": expected})),
     ]
     for label, mutate in unreadable_live:
-        mutated = mutate(live_ok)
-        if mutated == live_ok:
-            print(f"self-test: live unreadable mutation {label} did not apply", file=sys.stderr)
+        mutated = apply_live(mutate, label)
+        if mutated is None:
             return 1
-        try:
-            check_live(baseline.__getitem__, mutated)
-        except DriftError:
-            continue
-        print(
-            f"self-test: live unreadable {label} did not raise; the guard accepted bad evidence",
-            file=sys.stderr,
-        )
-        return 1
+        code = _invoke_main_live(mutated)
+        if code != EXIT_UNREADABLE:
+            print(
+                f"self-test: live unreadable {label} must exit {EXIT_UNREADABLE} "
+                f"via main_live, got {code}",
+                file=sys.stderr,
+            )
+            return 1
 
-    # Harness bite: a true no-op must be rejected by the mutation applicator, not silent.
-    noop = (lambda t: t)(live_ok)
-    if noop != live_ok:
-        print("self-test: no-op mutation unexpectedly changed live JSON", file=sys.stderr)
+    # app_id-only change must apply (text differs) and still match through main_live.
+    app_only = apply_live(
+        lambda t: _baseline_live_json(expected, strict=expected_strict, app_id=99999),
+        "app_id_only",
+    )
+    if app_only is None:
         return 1
-    # And changing only app_id must not be treated as drift (already covered) while still
-    # changing the file so a harness would accept the mutation as applied.
-    app_only = _baseline_live_json(expected, strict=expected_strict, app_id=99999)
-    if app_only == live_ok:
-        print("self-test: app_id-only mutation did not apply", file=sys.stderr)
-        return 1
-    try:
-        problems = check_live(baseline.__getitem__, app_only)
-    except DriftError as exc:
-        print(f"self-test: app_id-only change must be ignored, got unreadable: {exc}", file=sys.stderr)
-        return 1
-    if problems:
-        print(f"self-test: app_id-only change must be ignored, got drift: {problems}", file=sys.stderr)
-        return 1
-
-    # CLI exit codes: 0 match, 1 drift, 2 unreadable.
-    if run_live_exit(live_ok, baseline) != EXIT_MATCH:
-        print("self-test: live CLI match must exit 0", file=sys.stderr)
-        return 1
-    if run_live_exit(
-        _baseline_live_json(expected + ["extra"], strict=expected_strict), baseline
-    ) != EXIT_DRIFT:
-        print("self-test: live CLI drift must exit 1", file=sys.stderr)
-        return 1
-    if run_live_exit("{", baseline) != EXIT_UNREADABLE:
-        print("self-test: live CLI unreadable must exit 2", file=sys.stderr)
+    if _invoke_main_live(app_only) != EXIT_MATCH:
+        print("self-test: app_id-only change must exit 0 via main_live", file=sys.stderr)
         return 1
 
     return 0
 
 
-def workflow_contract_self_test() -> int:
-    """Thin string contracts for the reconciliation workflow — not a YAML parser."""
-    path = REPO_ROOT / RECONCILE_WORKFLOW
-    if not path.is_file():
-        print(f"self-test: missing workflow {RECONCILE_WORKFLOW}", file=sys.stderr)
-        return 1
-    text = path.read_text(encoding="utf-8")
+def _workflow_on_event_keys(text: str) -> list[str]:
+    """Top-level keys under the workflow `on:` mapping (line-based, not a YAML parser)."""
+    keys: list[str] = []
+    in_on = False
+    for line in text.splitlines():
+        if not in_on:
+            if line.rstrip() == "on:":
+                in_on = True
+            continue
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = re.match(r"^([ \t]*)([A-Za-z0-9_-]+):\s*(?:#.*)?$", line)
+        if not match:
+            continue
+        indent = match.group(1)
+        key = match.group(2)
+        if len(indent) == 0:
+            break
+        if indent in ("  ", "\t"):
+            keys.append(key)
+    return keys
 
+
+def workflow_contract_problems(text: str) -> list[str]:
+    """Return contract violations for reconcile-workflow text (no YAML parse)."""
+    problems: list[str] = []
     required_substrings = [
         "schedule:",
         "workflow_dispatch:",
@@ -534,12 +556,12 @@ def workflow_contract_self_test() -> int:
         "protection/required_status_checks",
         "github.repository",
         "github.event.repository.default_branch",
+        DEFAULT_BRANCH_GUARD,
         "set -euo pipefail",
     ]
     for needle in required_substrings:
         if needle not in text:
-            print(f"self-test: workflow missing {needle!r}", file=sys.stderr)
-            return 1
+            problems.append(f"missing {needle!r}")
 
     forbidden = [
         "pull_request:",
@@ -554,21 +576,80 @@ def workflow_contract_self_test() -> int:
     ]
     for needle in forbidden:
         if needle in text:
-            print(f"self-test: workflow must not contain {needle!r}", file=sys.stderr)
-            return 1
+            problems.append(f"forbidden {needle!r}")
 
-    # Exactly one GET via gh api (no method flag => GET). Count gh api invocations.
+    on_keys = _workflow_on_event_keys(text)
+    if set(on_keys) != {"schedule", "workflow_dispatch"}:
+        problems.append(
+            "on: events must be exactly schedule + workflow_dispatch, "
+            f"found {on_keys}"
+        )
+
+    # Exactly one job-level default-branch guard line (secret boundary).
+    guard_lines = [
+        line for line in text.splitlines() if line.strip() == DEFAULT_BRANCH_GUARD
+    ]
+    if len(guard_lines) != 1:
+        problems.append(
+            f"exact default-branch guard must appear once, found {len(guard_lines)}"
+        )
+
     gh_api_lines = [
         line for line in text.splitlines() if re.search(r"(^|[^\w-])gh(\s+|$)api\b", line)
     ]
     if len(gh_api_lines) != 1:
+        problems.append(f"exactly one gh api call required, found {len(gh_api_lines)}")
+    elif re.search(r"-X\s+(PUT|PATCH|DELETE|POST)\b", gh_api_lines[0]):
+        problems.append("the sole gh api call must be a GET")
+
+    return problems
+
+
+def workflow_contract_self_test() -> int:
+    """Thin string contracts for the reconciliation workflow — not a YAML parser."""
+    path = REPO_ROOT / RECONCILE_WORKFLOW
+    if not path.is_file():
+        print(f"self-test: missing workflow {RECONCILE_WORKFLOW}", file=sys.stderr)
+        return 1
+    text = path.read_text(encoding="utf-8")
+
+    problems = workflow_contract_problems(text)
+    if problems:
+        print("self-test: workflow contract failed:", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+
+    # Mutation: drop or rewrite the default-branch secret boundary — must go red.
+    removed = _apply_text(
+        text,
+        lambda t: "\n".join(
+            line for line in t.splitlines() if line.strip() != DEFAULT_BRANCH_GUARD
+        )
+        + ("\n" if t.endswith("\n") else ""),
+        "default_branch_guard_removed",
+    )
+    if removed is None:
+        return 1
+    if not workflow_contract_problems(removed):
         print(
-            f"self-test: workflow must contain exactly one gh api call, found {len(gh_api_lines)}",
+            "self-test: removing default-branch guard went undetected",
             file=sys.stderr,
         )
         return 1
-    if re.search(r"-X\s+(PUT|PATCH|DELETE|POST)\b", gh_api_lines[0]):
-        print("self-test: the sole gh api call must be a GET", file=sys.stderr)
+
+    rewritten = _apply_text(
+        text,
+        lambda t: t.replace(DEFAULT_BRANCH_GUARD, "if: github.ref == 'refs/heads/main'", 1),
+        "default_branch_guard_rewritten",
+    )
+    if rewritten is None:
+        return 1
+    if not workflow_contract_problems(rewritten):
+        print(
+            "self-test: rewriting default-branch guard went undetected",
+            file=sys.stderr,
+        )
         return 1
 
     return 0

--- a/scripts/ci/check-required-contexts.py
+++ b/scripts/ci/check-required-contexts.py
@@ -21,8 +21,7 @@ still is, and a guard that cannot tell that from a stale requirement would be tu
 Usage:
     check-required-contexts.py             # verify the three locations agree
     check-required-contexts.py --self-test # prove each parser detects a drift
-    check-required-contexts.py --live-response PATH  # reconcile ruleset vs live API JSON
-    check-required-contexts.py --live-response -     # same, reading stdin
+    check-required-contexts.py --live-response < live.json  # stdin-only live reconcile
 """
 
 from __future__ import annotations
@@ -32,8 +31,8 @@ import contextlib
 import io
 import json
 import re
+import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -149,19 +148,9 @@ def check_live(read, live_text: str) -> list[str]:
     return problems
 
 
-def read_live_response(path: str) -> str:
-    if path == "-":
-        return sys.stdin.read()
-    live_path = Path(path)
+def main_live(live_text: str) -> int:
+    """Production evaluator: already-loaded live JSON text → exit 0/1/2."""
     try:
-        return live_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise DriftError(f"cannot read live response {path}: {exc}") from exc
-
-
-def main_live(path: str) -> int:
-    try:
-        live_text = read_live_response(path)
         problems = check_live(read_repo, live_text)
     except DriftError as exc:
         print(f"required-contexts-live=unreadable\n{exc}", file=sys.stderr)
@@ -175,6 +164,11 @@ def main_live(path: str) -> int:
 
     print("required-contexts-live=match")
     return EXIT_MATCH
+
+
+def main_live_from_stdin() -> int:
+    """CLI route: read stdin exactly once, then evaluate via main_live."""
+    return main_live(sys.stdin.read())
 
 
 def ci_contract_contexts(text: str) -> list[str]:
@@ -410,19 +404,11 @@ def _apply_text(baseline: str, mutate, label: str) -> str | None:
 
 
 def _invoke_main_live(live_text: str) -> int:
-    """Exercise the production exit path: tempfile + main_live() (stdout/stderr redirected)."""
-    with tempfile.NamedTemporaryFile(
-        "w", suffix=".json", delete=False, encoding="utf-8"
-    ) as handle:
-        handle.write(live_text)
-        path = handle.name
-    try:
-        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
-            io.StringIO()
-        ):
-            return main_live(path)
-    finally:
-        Path(path).unlink(missing_ok=True)
+    """Exercise production main_live() on already-loaded text (stdout/stderr redirected)."""
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+        io.StringIO()
+    ):
+        return main_live(live_text)
 
 
 def live_self_test(baseline: dict) -> int:
@@ -517,6 +503,45 @@ def live_self_test(baseline: dict) -> int:
         print("self-test: app_id-only change must exit 0 via main_live", file=sys.stderr)
         return 1
 
+    # CLI is stdin-only: a path argv must be rejected (no arbitrary Path read).
+    script = REPO_ROOT / "scripts" / "ci" / "check-required-contexts.py"
+    path_argv = subprocess.run(
+        [sys.executable, str(script), "--live-response", "/tmp/not-a-live-response.json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if path_argv.returncode == 0:
+        print(
+            "self-test: --live-response with a path argv must be rejected, got exit 0",
+            file=sys.stderr,
+        )
+        return 1
+
+    # CLI route reads stdin once and calls main_live (match / drift / unreadable).
+    for label, payload, want in (
+        ("stdin_match", live_ok, EXIT_MATCH),
+        (
+            "stdin_drift",
+            _baseline_live_json(expected + ["extra"], strict=expected_strict),
+            EXIT_DRIFT,
+        ),
+        ("stdin_unreadable", "{", EXIT_UNREADABLE),
+    ):
+        cli = subprocess.run(
+            [sys.executable, str(script), "--live-response"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if cli.returncode != want:
+            print(
+                f"self-test: CLI {label} must exit {want}, got {cli.returncode}",
+                file=sys.stderr,
+            )
+            return 1
+
     return 0
 
 
@@ -563,6 +588,16 @@ def workflow_contract_problems(text: str) -> list[str]:
         if needle not in text:
             problems.append(f"missing {needle!r}")
 
+    # Stdin redirection into the checker (shell opens the file; Python never takes a path argv).
+    if not re.search(
+        r"check-required-contexts\.py --live-response\s*\\\s*\n\s*<\s*\"",
+        text,
+    ):
+        problems.append(
+            "checker must be invoked with stdin redirection "
+            "(--live-response \\< newline < \"...\")"
+        )
+
     forbidden = [
         "pull_request:",
         "merge_group:",
@@ -573,6 +608,9 @@ def workflow_contract_problems(text: str) -> list[str]:
         " -X DELETE",
         "|| github.token",
         "|| secrets.GITHUB_TOKEN",
+        # Path argv to the checker (the CodeQL py/path-injection shape).
+        '--live-response \\\n            "${{ steps.fetch.outputs.path }}"',
+        "--live-response /",
     ]
     for needle in forbidden:
         if needle in text:
@@ -652,6 +690,27 @@ def workflow_contract_self_test() -> int:
         )
         return 1
 
+    # Mutation: drop stdin redirection back to a path argv — must go red.
+    path_argv = _apply_text(
+        text,
+        lambda t: t.replace(
+            'python3 scripts/ci/check-required-contexts.py --live-response \\\n'
+            '            < "${{ steps.fetch.outputs.path }}"',
+            'python3 scripts/ci/check-required-contexts.py --live-response \\\n'
+            '            "${{ steps.fetch.outputs.path }}"',
+            1,
+        ),
+        "live_response_path_argv",
+    )
+    if path_argv is None:
+        return 1
+    if not workflow_contract_problems(path_argv):
+        print(
+            "self-test: replacing stdin redirect with path argv went undetected",
+            file=sys.stderr,
+        )
+        return 1
+
     return 0
 
 
@@ -660,16 +719,16 @@ def main() -> int:
     parser.add_argument("--self-test", action="store_true", help="prove the parsers detect drift")
     parser.add_argument(
         "--live-response",
-        metavar="PATH",
-        help="reconcile ruleset against live required_status_checks JSON (PATH or - for stdin)",
+        action="store_true",
+        help="reconcile ruleset against live required_status_checks JSON from stdin",
     )
     args = parser.parse_args()
 
     if args.self_test:
         return self_test()
 
-    if args.live_response is not None:
-        return main_live(args.live_response)
+    if args.live_response:
+        return main_live_from_stdin()
 
     try:
         problems = check(read_repo)

--- a/scripts/ci/check-required-contexts.py
+++ b/scripts/ci/check-required-contexts.py
@@ -568,6 +568,27 @@ def _workflow_on_event_keys(text: str) -> list[str]:
     return keys
 
 
+# Step-level env is the only place GitHub expressions may appear (Zizmor template-injection).
+ENV_REPOSITORY = "REPOSITORY: ${{ github.repository }}"
+ENV_DEFAULT_BRANCH = "DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}"
+ENV_GH_TOKEN = "GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}"
+ENV_SECRET_TOKEN = "BRANCH_PROTECTION_READ_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}"
+API_PATH_QUOTED = (
+    '"repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/required_status_checks"'
+)
+LIVE_JSON_ASSIGN = 'live_json="${RUNNER_TEMP}/live-required-status-checks.json"'
+STDIN_REDIRECT = '< "${live_json}"'
+
+_ALLOWED_TEMPLATE_ENV_LINES = frozenset(
+    {
+        ENV_REPOSITORY,
+        ENV_DEFAULT_BRANCH,
+        ENV_GH_TOKEN,
+        ENV_SECRET_TOKEN,
+    }
+)
+
+
 def workflow_contract_problems(text: str) -> list[str]:
     """Return contract violations for reconcile-workflow text (no YAML parse)."""
     problems: list[str] = []
@@ -578,9 +599,11 @@ def workflow_contract_problems(text: str) -> list[str]:
         "contents: read",
         "secrets.BRANCH_PROTECTION_READ_TOKEN",
         "check-required-contexts.py --live-response",
-        "protection/required_status_checks",
-        "github.repository",
-        "github.event.repository.default_branch",
+        ENV_REPOSITORY,
+        ENV_DEFAULT_BRANCH,
+        API_PATH_QUOTED,
+        LIVE_JSON_ASSIGN,
+        STDIN_REDIRECT,
         DEFAULT_BRANCH_GUARD,
         "set -euo pipefail",
     ]
@@ -588,15 +611,34 @@ def workflow_contract_problems(text: str) -> list[str]:
         if needle not in text:
             problems.append(f"missing {needle!r}")
 
-    # Stdin redirection into the checker (shell opens the file; Python never takes a path argv).
+    # Stdin redirection into the checker via RUNNER_TEMP-derived live_json.
     if not re.search(
-        r"check-required-contexts\.py --live-response\s*\\\s*\n\s*<\s*\"",
+        r"check-required-contexts\.py --live-response\s*\\\s*\n\s*<\s*\"\$\{live_json\}\"",
         text,
     ):
         problems.append(
             "checker must be invoked with stdin redirection "
-            "(--live-response \\< newline < \"...\")"
+            "(--live-response \\< newline < \"${live_json}\")"
         )
+
+    # Both steps must independently derive the same fixed RUNNER_TEMP path.
+    if text.count(LIVE_JSON_ASSIGN) < 2:
+        problems.append(
+            f"{LIVE_JSON_ASSIGN!r} must appear in both fetch and reconcile steps"
+        )
+
+    # Reject GitHub/${{ steps.* }} expansions outside allowlisted step-level env lines.
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "${{" not in stripped:
+            continue
+        if stripped in _ALLOWED_TEMPLATE_ENV_LINES:
+            continue
+        if re.search(r"\$\{\{\s*(github\.|steps\.)", stripped):
+            problems.append(
+                "direct template expansion outside step env "
+                f"(Zizmor template-injection shape): {stripped!r}"
+            )
 
     forbidden = [
         "pull_request:",
@@ -608,12 +650,27 @@ def workflow_contract_problems(text: str) -> list[str]:
         " -X DELETE",
         "|| github.token",
         "|| secrets.GITHUB_TOKEN",
-        # Path argv to the checker (the CodeQL py/path-injection shape).
-        '--live-response \\\n            "${{ steps.fetch.outputs.path }}"',
+        # Path argv / step-output shapes (CodeQL + Zizmor).
         "--live-response /",
+        "steps.fetch.outputs.path",
+        'repos/${{ github.repository }}',
+        "${{ github.event.repository.default_branch }}/protection",
+        # Unquoted API path (shell-injection adjacent).
+        "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/required_status_checks",
     ]
     for needle in forbidden:
         if needle in text:
+            # The quoted form contains the unquoted form as a substring; only flag
+            # the unquoted needle when the quoted API path is absent or when the
+            # unquoted literal appears outside the quoted occurrence.
+            if needle == (
+                "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}/"
+                "protection/required_status_checks"
+            ):
+                if API_PATH_QUOTED in text and text.count(needle) == text.count(
+                    API_PATH_QUOTED
+                ):
+                    continue
             problems.append(f"forbidden {needle!r}")
 
     on_keys = _workflow_on_event_keys(text)
@@ -695,9 +752,9 @@ def workflow_contract_self_test() -> int:
         text,
         lambda t: t.replace(
             'python3 scripts/ci/check-required-contexts.py --live-response \\\n'
-            '            < "${{ steps.fetch.outputs.path }}"',
+            '            < "${live_json}"',
             'python3 scripts/ci/check-required-contexts.py --live-response \\\n'
-            '            "${{ steps.fetch.outputs.path }}"',
+            '            "${live_json}"',
             1,
         ),
         "live_response_path_argv",
@@ -707,6 +764,65 @@ def workflow_contract_self_test() -> int:
     if not workflow_contract_problems(path_argv):
         print(
             "self-test: replacing stdin redirect with path argv went undetected",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Mutation: remove REPOSITORY env binding — must go red.
+    env_removed = _apply_text(
+        text,
+        lambda t: "\n".join(
+            line for line in t.splitlines() if line.strip() != ENV_REPOSITORY
+        )
+        + ("\n" if t.endswith("\n") else ""),
+        "repository_env_removed",
+    )
+    if env_removed is None:
+        return 1
+    if not workflow_contract_problems(env_removed):
+        print(
+            "self-test: removing REPOSITORY env binding went undetected",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Mutation: restore direct github.* template in the gh api path — must go red.
+    direct_template = _apply_text(
+        text,
+        lambda t: t.replace(
+            API_PATH_QUOTED,
+            '"repos/${{ github.repository }}/branches/'
+            '${{ github.event.repository.default_branch }}/'
+            'protection/required_status_checks"',
+            1,
+        ),
+        "direct_github_template_restored",
+    )
+    if direct_template is None:
+        return 1
+    if not workflow_contract_problems(direct_template):
+        print(
+            "self-test: restoring direct github.* templates in run went undetected",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Mutation: drop quoting around the API path — must go red.
+    unquoted = _apply_text(
+        text,
+        lambda t: t.replace(
+            API_PATH_QUOTED,
+            "repos/${REPOSITORY}/branches/${DEFAULT_BRANCH}/"
+            "protection/required_status_checks",
+            1,
+        ),
+        "api_path_unquoted",
+    )
+    if unquoted is None:
+        return 1
+    if not workflow_contract_problems(unquoted):
+        print(
+            "self-test: unquoting API path went undetected",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/check-required-contexts.py
+++ b/scripts/ci/check-required-contexts.py
@@ -21,6 +21,8 @@ still is, and a guard that cannot tell that from a stale requirement would be tu
 Usage:
     check-required-contexts.py             # verify the three locations agree
     check-required-contexts.py --self-test # prove each parser detects a drift
+    check-required-contexts.py --live-response PATH  # reconcile ruleset vs live API JSON
+    check-required-contexts.py --live-response -     # same, reading stdin
 """
 
 from __future__ import annotations
@@ -36,32 +38,151 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 RULESET = Path(".github/rulesets/main-required-ci-contexts.json")
 CI_CONTRACT = Path("CI-CONTRACT.md")
 RUNBOOK = Path("docs/BRANCH-PROTECTION-SETUP.md")
+RECONCILE_WORKFLOW = Path(".github/workflows/required-context-reconciliation.yml")
 
 CI_CONTRACT_ANCHOR = "Currently required live branch-protection contexts:"
 CI_CONTRACT_SENTINEL = "<!-- required-contexts:end"
 BULLET_RE = re.compile(r"^-\s+`([^`]+)`")
 CONTEXTS_ARRAY_RE = re.compile(r'"contexts"\s*:\s*(\[[^\]]*\])')
 
+EXIT_MATCH = 0
+EXIT_DRIFT = 1
+EXIT_UNREADABLE = 2
+
 
 class DriftError(Exception):
     """A location disagrees with the ruleset, or its anchor is gone."""
 
 
-def ruleset_contexts(text: str) -> list[str]:
-    """The importable artifact is the source of truth: it is the one that can be applied."""
+def _ruleset_required_status_parameters(text: str) -> dict:
+    """Shared ruleset parser: the required_status_checks rule parameters object."""
     doc = json.loads(text)
-    found: list[str] = []
     for rule in doc.get("rules", []):
         if rule.get("type") != "required_status_checks":
             continue
-        for check in rule.get("parameters", {}).get("required_status_checks", []):
-            found.append(check["context"])
+        params = rule.get("parameters")
+        if not isinstance(params, dict):
+            raise DriftError(
+                f"{RULESET}: required_status_checks rule has no parameters object"
+            )
+        return params
+    raise DriftError(
+        f"{RULESET}: no required_status_checks rule found; the guard cannot "
+        "determine the required set"
+    )
+
+
+def ruleset_contexts(text: str) -> list[str]:
+    """The importable artifact is the source of truth: it is the one that can be applied."""
+    params = _ruleset_required_status_parameters(text)
+    found: list[str] = []
+    for check in params.get("required_status_checks", []):
+        found.append(check["context"])
     if not found:
         raise DriftError(
-            f"{RULESET}: no required_status_checks rule found; the guard cannot "
+            f"{RULESET}: no required_status_checks entries; the guard cannot "
             "determine the required set"
         )
     return found
+
+
+def ruleset_strict(text: str) -> bool:
+    """Strictness comes from the same ruleset artifact as the context list."""
+    params = _ruleset_required_status_parameters(text)
+    if "strict_required_status_checks_policy" not in params:
+        raise DriftError(
+            f"{RULESET}: missing strict_required_status_checks_policy; the guard "
+            "cannot determine the required strict setting"
+        )
+    value = params["strict_required_status_checks_policy"]
+    if not isinstance(value, bool):
+        raise DriftError(
+            f"{RULESET}: strict_required_status_checks_policy must be a boolean"
+        )
+    return value
+
+
+def live_protection(text: str) -> tuple[list[str], bool]:
+    """Parse classic branch-protection required_status_checks JSON (contexts + strict).
+
+    app_id on individual checks is ignored on purpose: live and the ruleset already
+    disagree there for CI, and this slice reconciles only context set and strictness.
+    """
+    if not text or not text.strip():
+        raise DriftError("live response is empty")
+    try:
+        doc = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise DriftError(f"live response is not JSON: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise DriftError("live response must be a JSON object")
+    missing = [key for key in ("contexts", "strict") if key not in doc]
+    if missing:
+        raise DriftError(
+            "live response missing required_status_checks fields: "
+            + ", ".join(missing)
+        )
+    contexts = doc["contexts"]
+    strict = doc["strict"]
+    if not isinstance(contexts, list) or not all(isinstance(c, str) for c in contexts):
+        raise DriftError("live response contexts must be a list of strings")
+    if not isinstance(strict, bool):
+        raise DriftError("live response strict must be a boolean")
+    return contexts, strict
+
+
+def check_live(read, live_text: str) -> list[str]:
+    """Compare live classic protection to the ruleset (contexts set + strict only)."""
+    expected = ruleset_contexts(read(RULESET))
+    expected_strict = ruleset_strict(read(RULESET))
+    actual, actual_strict = live_protection(live_text)
+    problems = compare(expected, actual, "live required_status_checks.contexts")
+    if expected_strict != actual_strict:
+        problems.append(
+            "live required_status_checks.strict="
+            f"{actual_strict!r} but ruleset strict_required_status_checks_policy="
+            f"{expected_strict!r}"
+        )
+    return problems
+
+
+def read_live_response(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    live_path = Path(path)
+    try:
+        return live_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DriftError(f"cannot read live response {path}: {exc}") from exc
+
+
+def main_live(path: str) -> int:
+    try:
+        live_text = read_live_response(path)
+        problems = check_live(read_repo, live_text)
+    except DriftError as exc:
+        print(f"required-contexts-live=unreadable\n{exc}", file=sys.stderr)
+        return EXIT_UNREADABLE
+
+    if problems:
+        print("required-contexts-live=drift", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return EXIT_DRIFT
+
+    print("required-contexts-live=match")
+    return EXIT_MATCH
+
+
+def run_live_exit(live_text: str, baseline: dict) -> int:
+    """Exercise check_live exit mapping without going through argparse/filesystem."""
+    try:
+        problems = check_live(baseline.__getitem__, live_text)
+    except DriftError:
+        return EXIT_UNREADABLE
+    if problems:
+        return EXIT_DRIFT
+    return EXIT_MATCH
 
 
 def ci_contract_contexts(text: str) -> list[str]:
@@ -262,17 +383,212 @@ def self_test() -> int:
         )
         return 1
 
+    if live_self_test(baseline) != 0:
+        return 1
+
+    if workflow_contract_self_test() != 0:
+        return 1
+
     print("check-required-contexts self-test=passed")
+    return 0
+
+
+def _baseline_live_json(contexts: list[str], *, strict: bool = True, app_id=15368) -> str:
+    """Shape of GET .../protection/required_status_checks, including ignored app_id."""
+    return json.dumps(
+        {
+            "strict": strict,
+            "contexts": list(contexts),
+            "checks": [{"context": c, "app_id": app_id} for c in contexts],
+        },
+        indent=2,
+    )
+
+
+def live_self_test(baseline: dict) -> int:
+    """Prove live-response mode detects semantic drift and unreadable evidence separately."""
+    expected = ruleset_contexts(baseline[RULESET])
+    expected_strict = ruleset_strict(baseline[RULESET])
+    live_ok = _baseline_live_json(expected, strict=expected_strict)
+
+    # Match, including reordered contexts and an app_id that disagrees with the ruleset.
+    reordered = list(reversed(expected))
+    assert set(reordered) == set(expected)
+    for label, live_text in (
+        ("baseline", live_ok),
+        ("reordered", _baseline_live_json(reordered, strict=expected_strict)),
+        ("app_id_ignored", _baseline_live_json(expected, strict=expected_strict, app_id=None)),
+    ):
+        try:
+            problems = check_live(baseline.__getitem__, live_text)
+        except DriftError as exc:
+            print(f"self-test: live {label} should match, got unreadable: {exc}", file=sys.stderr)
+            return 1
+        if problems:
+            print(f"self-test: live {label} should match, got drift: {problems}", file=sys.stderr)
+            return 1
+
+    drift_cases = [
+        (
+            "context_added",
+            lambda t: _baseline_live_json(expected + ["extra-context"], strict=expected_strict),
+        ),
+        (
+            "context_removed",
+            lambda t: _baseline_live_json(expected[:-1], strict=expected_strict),
+        ),
+        (
+            "strict_flip",
+            lambda t: _baseline_live_json(expected, strict=not expected_strict),
+        ),
+    ]
+    for label, mutate in drift_cases:
+        mutated = mutate(live_ok)
+        if mutated == live_ok:
+            print(f"self-test: live drift mutation {label} did not apply", file=sys.stderr)
+            return 1
+        try:
+            problems = check_live(baseline.__getitem__, mutated)
+        except DriftError as exc:
+            print(
+                f"self-test: live drift {label} was unreadable, expected semantic drift: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        if not problems:
+            print(f"self-test: live drift {label} went undetected", file=sys.stderr)
+            return 1
+
+    unreadable_live = [
+        ("empty", lambda t: ""),
+        ("malformed", lambda t: "{not-json"),
+        ("missing_contexts", lambda t: json.dumps({"strict": True})),
+        ("missing_strict", lambda t: json.dumps({"contexts": expected})),
+    ]
+    for label, mutate in unreadable_live:
+        mutated = mutate(live_ok)
+        if mutated == live_ok:
+            print(f"self-test: live unreadable mutation {label} did not apply", file=sys.stderr)
+            return 1
+        try:
+            check_live(baseline.__getitem__, mutated)
+        except DriftError:
+            continue
+        print(
+            f"self-test: live unreadable {label} did not raise; the guard accepted bad evidence",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Harness bite: a true no-op must be rejected by the mutation applicator, not silent.
+    noop = (lambda t: t)(live_ok)
+    if noop != live_ok:
+        print("self-test: no-op mutation unexpectedly changed live JSON", file=sys.stderr)
+        return 1
+    # And changing only app_id must not be treated as drift (already covered) while still
+    # changing the file so a harness would accept the mutation as applied.
+    app_only = _baseline_live_json(expected, strict=expected_strict, app_id=99999)
+    if app_only == live_ok:
+        print("self-test: app_id-only mutation did not apply", file=sys.stderr)
+        return 1
+    try:
+        problems = check_live(baseline.__getitem__, app_only)
+    except DriftError as exc:
+        print(f"self-test: app_id-only change must be ignored, got unreadable: {exc}", file=sys.stderr)
+        return 1
+    if problems:
+        print(f"self-test: app_id-only change must be ignored, got drift: {problems}", file=sys.stderr)
+        return 1
+
+    # CLI exit codes: 0 match, 1 drift, 2 unreadable.
+    if run_live_exit(live_ok, baseline) != EXIT_MATCH:
+        print("self-test: live CLI match must exit 0", file=sys.stderr)
+        return 1
+    if run_live_exit(
+        _baseline_live_json(expected + ["extra"], strict=expected_strict), baseline
+    ) != EXIT_DRIFT:
+        print("self-test: live CLI drift must exit 1", file=sys.stderr)
+        return 1
+    if run_live_exit("{", baseline) != EXIT_UNREADABLE:
+        print("self-test: live CLI unreadable must exit 2", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def workflow_contract_self_test() -> int:
+    """Thin string contracts for the reconciliation workflow — not a YAML parser."""
+    path = REPO_ROOT / RECONCILE_WORKFLOW
+    if not path.is_file():
+        print(f"self-test: missing workflow {RECONCILE_WORKFLOW}", file=sys.stderr)
+        return 1
+    text = path.read_text(encoding="utf-8")
+
+    required_substrings = [
+        "schedule:",
+        "workflow_dispatch:",
+        "cron:",
+        "contents: read",
+        "secrets.BRANCH_PROTECTION_READ_TOKEN",
+        "check-required-contexts.py --live-response",
+        "protection/required_status_checks",
+        "github.repository",
+        "github.event.repository.default_branch",
+        "set -euo pipefail",
+    ]
+    for needle in required_substrings:
+        if needle not in text:
+            print(f"self-test: workflow missing {needle!r}", file=sys.stderr)
+            return 1
+
+    forbidden = [
+        "pull_request:",
+        "merge_group:",
+        "github.token",
+        "GITHUB_TOKEN",
+        " -X PUT",
+        " -X PATCH",
+        " -X DELETE",
+        "|| github.token",
+        "|| secrets.GITHUB_TOKEN",
+    ]
+    for needle in forbidden:
+        if needle in text:
+            print(f"self-test: workflow must not contain {needle!r}", file=sys.stderr)
+            return 1
+
+    # Exactly one GET via gh api (no method flag => GET). Count gh api invocations.
+    gh_api_lines = [
+        line for line in text.splitlines() if re.search(r"(^|[^\w-])gh(\s+|$)api\b", line)
+    ]
+    if len(gh_api_lines) != 1:
+        print(
+            f"self-test: workflow must contain exactly one gh api call, found {len(gh_api_lines)}",
+            file=sys.stderr,
+        )
+        return 1
+    if re.search(r"-X\s+(PUT|PATCH|DELETE|POST)\b", gh_api_lines[0]):
+        print("self-test: the sole gh api call must be a GET", file=sys.stderr)
+        return 1
+
     return 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--self-test", action="store_true", help="prove the parsers detect drift")
+    parser.add_argument(
+        "--live-response",
+        metavar="PATH",
+        help="reconcile ruleset against live required_status_checks JSON (PATH or - for stdin)",
+    )
     args = parser.parse_args()
 
     if args.self_test:
         return self_test()
+
+    if args.live_response is not None:
+        return main_live(args.live_response)
 
     try:
         problems = check(read_repo)


### PR DESCRIPTION
3d06defef02abfb167796700549b018933acc7a6
body_bytes 5250
py` with stdin-only `--live-response` that reconciles classic branch-protection `contexts` + `strict` against `.github/rulesets/main-required-ci-contexts.json` (sole expected set; same ruleset parser; `app_id` ignored).
- Add thin scheduled monitor `.github/workflows/required-context-reconciliation.yml` (`schedule` + `workflow_dispatch` only; not required; one read-only `gh api` GET; secret `BRANCH_PROTECTION_READ_TOKEN` with no `github.token` fallback; job `if: github.ref_name == github.event.repository.default_branch`; checker fed via stdin redirection from a fixed `RUNNER_TEMP` path).
- Document the token prerequisite and stdin-only live mode in `docs/BRANCH-PROTECTION-SETUP.md`.

Implements #2243; activation remains tracked on #2243 until the first authenticated manual run is green.

## Provenance

| Field | Value |
|-------|-------|
| Head SHA | `3d06defef02abfb167796700549b018933acc7a6` |
| Base | `origin/main` @ `1ab76fad2ac1f28ab3d97f6ed905893840ac3aee` |
| Worktree | `/private/tmp/assay-wt-ci2-required-context-reconciliation` |
| Branch | `cursor/ci2-required-context-reconciliation` |
| Writer | Cursor (sole writer) |

## RED → GREEN (initial slice)

1. **RED:** Extended `--self-test` with live-mode cases calling `ruleset_strict` / `check_live` before they existed → `NameError`.
2. **GREEN:** Implemented shared ruleset parameter parser, live JSON parser, live CLI (exit `0`/`1`/`2`), workflow + docs.

## RED → GREEN (P1 review follow-up)

1. **Exit-code path:** Self-test invokes production `main_live()` for match/drift/unreadable.
2. **Default-branch secret boundary:** Contract requires exact job `if`; removal/rewrite mutations go red. `on:` pinned to exactly `schedule` + `workflow_dispatch`.
3. **No-op harness:** `_apply_text` rejects unchanged output; identity-as-no-op proven rejected.

## RED → GREEN (CodeQL `py/path-injection` #739)

**RED:** Path-argv workflow failed stdin-redirect contract. **GREEN:** `--live-response` is `store_true` only; CLI reads stdin; workflow redirects via `"${live_json}"`. No suppression.

## RED → GREEN (Zizmor template-injection #738 on `f9c554e6`)

**Blocker:** Zizmor alert #738 — GitHub expressions for repository/default-branch (and later step outputs) expanded directly inside `run:` scripts.

1. **RED:** Workflow contract required step-level `REPOSITORY` / `DEFAULT_BRANCH` env bindings, quoted `repos/$REPOSITORY/...` API path using shell vars, dual `live_json` derivation under `RUNNER_TEMP`, and rejected direct `github.*` / `steps.*` templates in run; on-disk workflow failed those checks.
2. **GREEN:** Fetch step binds `REPOSITORY` / `DEFAULT_BRANCH` / `GH_TOKEN` via env and uses quoted shell vars in `gh api`; both steps independently set `live_json` under `RUNNER_TEMP`; reconcile uses stdin redirection from that path. Local `zizmor` on the workflow: **No findings**. **No suppression.**

## Mutations (each bites separately)

| Mutation | Expected | Observed |
|----------|----------|----------|
| live context added / removed / strict flip | exit 1 via `main_live` | exit 1 |
| empty / malformed / missing fields | exit 2 via `main_live` | exit 2 |
| reorder / `app_id` only | exit 0 via `main_live` | exit 0 |
| identity no-op through apply helper | rejected | rejected |
| `main_live` drift→match | self-test red | red |
| job default-branch `if` removed/rewritten | self-test red | red |
| CLI `--live-response /path` | rejected | exit 2 |
| workflow path-argv instead of stdin redirect | self-test red | red |
| `REPOSITORY` env binding removed | self-test red | red |
| direct `github.*` templates restored in `gh api` | self-test red | red |
| API path unquoted | self-test red | red |

## Threat model / fail posture

- **Fail-closed** on missing secret, API/auth failure, malformed/empty live JSON, or semantic drift.
- **No fail-open fallback** to `github.token`.
- **No user-controlled path read** in the checker (stdin only).
- **No GitHub template expansion inside run scripts** (step env + quoted shell vars only).
- **Read-only transport:** exactly one `gh api` GET; no PUT/PATCH/DELETE.
- **Default-branch secret boundary:** load-bearing job `if`.
- Monitor is **not** a required status check.

## Token prerequisite (owner)

Create a fine-grained PAT for this repo only with **Administration: Read-only**, store as repository secret `BRANCH_PROTECTION_READ_TOKEN`. See `docs/BRANCH-PROTECTION-SETUP.md`.

## Non-claim

This PR only ships the monitor and docs. **Live green runs only after the owner sets `BRANCH_PROTECTION_READ_TOKEN`.** Until then, scheduled/manual runs fail closed at preflight.

## Scope

Touched only:
- `scripts/ci/check-required-contexts.py`
- `.github/workflows/required-context-reconciliation.yml`
- `docs/BRANCH-PROTECTION-SETUP.md`

## Test plan

- [x] `python3 scripts/ci/check-required-contexts.py --self-test`
- [x] `python3 -m py_compile scripts/ci/check-required-contexts.py`
- [x] Live match via stdin; malformed=2; drift=1
- [x] Mutation table above
- [x] Local `zizmor` on reconcile workflow → no findings
- [ ] Owner sets `BRANCH_PROTECTION_READ_TOKEN`, then `workflow_dispatch` on default branch goes green
- [ ] CI CodeQL/Zizmor clear on this head
- [ ] Do not ready/merge until non-building review quorum is satisfied on **this** head

