### PR TITLE
fix(ci): select nightly for Miri commands (CI-4A)

### DIFF
--- a/.github/workflows/wave6-nightly-safety.yml
+++ b/.github/workflows/wave6-nightly-safety.yml
@@ -47,8 +47,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo miri setup
-          cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract -- --exact --nocapture
+          cargo +nightly miri setup
+          cargo +nightly miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract -- --exact --nocapture
 
   proptest-cli-smoke:
     name: Nightly property smoke (assay-cli)

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -205,6 +205,18 @@ if miri_with != miri_expected:
         f"got {miri_with}"
     )
 
+miri_commands = re.findall(
+    r"(?m)^\s+cargo(?:\s+\+nightly)?\s+miri(?:\s|$).*$",
+    jobs["miri-registry-smoke"],
+)
+if len(miri_commands) != 2 or any(
+    "cargo +nightly miri" not in command for command in miri_commands
+):
+    raise SystemExit(
+        "miri-registry-smoke: every cargo miri invocation must explicitly select +nightly; "
+        f"got {miri_commands}"
+    )
+
 proptest_with = setup_rust_with_map(jobs["proptest-cli-smoke"])
 if proptest_with != {}:
     raise SystemExit(
@@ -214,7 +226,7 @@ if proptest_with != {}:
 
 print(
     f"ok   wave6: setup-rust after checkout for {', '.join(setup_jobs)}; "
-    "miri with-map exact; proptest with-map empty; no direct pins"
+    "miri with-map and +nightly invocations exact; proptest with-map empty; no direct pins"
 )
 PY
 


### PR DESCRIPTION
## Summary
- invoke Miri through explicit `cargo +nightly miri` commands
- keep the installed nightly/component contract unchanged
- make removal of either explicit selector fail the setup-rust workflow contract

## Why
The repository-level `rust-toolchain.toml` overrides an unqualified `cargo miri` invocation to Rust 1.96 even though this workflow installs Miri on nightly. This closes #2291 without changing required contexts or making the informational nightly job gating.

## TDD evidence
- RED: the new contract failed on both existing unqualified Miri commands
- GREEN: `bash scripts/ci/test-setup-rust-composite-contract.sh`
- mutation: removing `+nightly` from one command fails with `every cargo miri invocation must explicitly select +nightly`

## Verification
- `pre-commit run setup-rust-composite-contract-self-test --all-files`
- `bash scripts/ci/test-setup-rust-composite-contract.sh`
- `actionlint .github/workflows/wave6-nightly-safety.yml`
- `git diff --check`
- full pre-push hooks, including workspace clippy and Linux cross-target compile

## Non-claims
- no claim that the scheduled Miri job has run successfully on this head yet
- no change to the job's `continue-on-error` status
- no change to workflow triggers or required contexts

Exact head: `9342e91488a0eaef135d12c2a0a514eb94bfc68c`
