### PR TITLE
test(ci): protect delegated proof head guard (CI-3A)

### DIFF
--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -2138,6 +2138,7 @@ def self_test() -> None:
     _test_run_check_executes()
     _test_run_check_consults_the_override()
     _test_content_tree_comparison()
+    _test_uncovered_paths_require_exact_head()
 
     valid_run = {
         "name": DELEGATED_WORKFLOW_NAME,
@@ -2653,6 +2654,64 @@ def _test_content_tree_comparison() -> None:
     error = compare_content_path_trees(error_manifest, current)
     assert not error.accepted
     assert "proof tree error" in error.diagnostics[0]
+
+
+def _test_uncovered_paths_require_exact_head() -> None:
+    gated_paths = load_gated_path_config()
+    proof_head = "proof-head"
+    manifest = {
+        "source": {"head_sha": proof_head},
+        "content_provenance": {
+            "path_trees": {
+                path: {"oid": f"oid:{path}", "error": None}
+                for path in gated_paths.content_provenance_paths
+            }
+        },
+    }
+    stale_pr = PullRequest(
+        number=1,
+        title="Dependency update",
+        body="",
+        author_login="dependabot[bot]",
+        head_sha="new-head",
+        files=("Cargo.lock",),
+    )
+
+    old_fetch = globals()["fetch_ref_for_diff"]
+    old_current = globals()["current_content_path_trees"]
+    try:
+        def unexpected_downstream(*_args: object) -> None:
+            raise AssertionError("stale uncovered proof reached content-tree comparison")
+
+        globals()["fetch_ref_for_diff"] = unexpected_downstream
+        globals()["current_content_path_trees"] = unexpected_downstream
+        rejected = content_tree_proof_accepts_head(manifest, stale_pr)
+        assert not rejected.accepted
+        assert rejected.diagnostics == (
+            "Cargo.lock: gated path is not covered by content-provenance trees",
+        )
+
+        globals()["fetch_ref_for_diff"] = lambda *_args: None
+        globals()["current_content_path_trees"] = lambda _head: (
+            {
+                path: f"oid:{path}"
+                for path in gated_paths.content_provenance_paths
+            },
+            (),
+        )
+        exact_pr = PullRequest(
+            number=stale_pr.number,
+            title=stale_pr.title,
+            body=stale_pr.body,
+            author_login=stale_pr.author_login,
+            head_sha=proof_head,
+            files=stale_pr.files,
+        )
+        accepted = content_tree_proof_accepts_head(manifest, exact_pr)
+        assert accepted.accepted, accepted.diagnostics
+    finally:
+        globals()["fetch_ref_for_diff"] = old_fetch
+        globals()["current_content_path_trees"] = old_current
 
 
 def _test_attested_proof_pack_helpers() -> None:


### PR DESCRIPTION
## Summary
- drive the real `content_tree_proof_accepts_head` guard from its self-test
- reject a stale proof when `Cargo.lock` is gated but outside content-provenance trees
- prove the exact-head case still reaches and passes normal content-tree comparison

## Why
The runtime guard is currently correct and fail-closed, but deleting or inverting its exact-head short-circuit was not detected by the self-test. This closes #2212 without changing classifier or acceptance behavior.

## Mutation evidence
- replacing the guard with `if False` fails: stale uncovered proof reaches downstream comparison
- changing `!=` to `==` fails with the same protected boundary
- restoring production code returns the self-test to green

## Verification
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `python3 -m py_compile scripts/ci/assay_runner_lane_check.py`
- `pre-commit run assay-runner-lane-check-self-test --all-files`
- `pre-commit run --files scripts/ci/assay_runner_lane_check.py`
- full `pre-commit run --hook-stage pre-push --all-files` (all hooks passed)
- `git diff --check`

## Non-claims
- no production behavior change
- no change to gated paths or content-provenance coverage
- no claim that stale proof carry has occurred
- delegated exact-head proof, if required by the current classifier, remains pending

Exact head: `cea8d4678bcb0ef42cf912e2eccaaed42cea6288`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that outdated proofs are rejected when required files lack content-provenance coverage.
  * Confirmed that proofs matching the pull request’s current revision proceed successfully through validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->