### PR TITLE
ci: cargo-deny / deps-security toolchain contract (CI-4B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,9 @@ jobs:
       # the selection there too rather than being shadowed by the script's own default.
       #
       # Scope, deliberately: no step in this job builds or tests the workspace -- checkout, two tool
-      # installs, a `sed`-only alignment check, `cargo-deny check` and two `cargo audit` runs. This
-      # selects the toolchain that runs the dependency tooling, never one that compiles a crate, and
-      # `rust-toolchain.toml` stays the source for every job that does compile.
+      # installs, a `sed`-only alignment check, `cargo-deny check` and two `cargo audit` runs. The
+      # only crates this job compiles are the dependency tools themselves, installed from source.
+      # `rust-toolchain.toml` stays the source for every job that compiles workspace code.
       RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -360,6 +360,16 @@ repos:
         # a version line that reads as evidence of a pin. The self-test drives stub cargo/cargo-deny
         # binaries on PATH, so it costs no network and no install.
         files: ^(scripts/ci/(install-cargo-deny|test-install-cargo-deny)\.sh|\.pre-commit-config\.yaml)$
+
+      - id: deps-security-toolchain-contract-self-test
+        name: deps-security toolchain contract
+        entry: bash scripts/ci/test-deps-security-toolchain-contract.sh
+        language: system
+        pass_filenames: false
+        # Protects the workflow half the install self-test cannot see: deleting or weakening
+        # deps-security's RUSTUP_TOOLCHAIN, and restoring the false "never compiles a crate" claim.
+        # files: includes ci.yml so a workflow-only edit still runs this gate in Lint (pre-commit).
+        files: ^(scripts/ci/(install-cargo-deny|test-deps-security-toolchain-contract)\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
       - id: cargo-clippy
         name: cargo clippy (workspace, deny warnings)
         entry: scripts/precommit/cargo-clippy.sh

--- a/scripts/ci/install-cargo-deny.sh
+++ b/scripts/ci/install-cargo-deny.sh
@@ -24,15 +24,21 @@ cargo_deny_bin_path() {
 }
 
 # Resolve the alias RUSTUP_TOOLCHAIN names. Echoing only `stable` records the request, not what ran
-# (AGENTS.md pinning rule). rustc -vV's release line is the checkable half.
+# (AGENTS.md pinning rule). rustc -vV's release line is the checkable half. Absence or failure is
+# not an identity: returning a placeholder and continuing would make the log look resolved while
+# naming nothing.
 resolved_toolchain_label() {
-  local release
-  release="$(rustc -vV 2>/dev/null | sed -n 's/^release: //p' | head -n 1)" || true
-  if [[ -n "${release}" ]]; then
-    printf '%s\n' "${release}"
-  else
-    printf '%s\n' "unresolved"
+  local out release
+  if ! out="$(rustc -vV 2>&1)"; then
+    echo "rustc -vV failed; cannot resolve toolchain identity" >&2
+    return 1
   fi
+  release="$(printf '%s\n' "${out}" | sed -n 's/^release: //p' | head -n 1)"
+  if [[ -z "${release}" ]]; then
+    echo "rustc -vV produced no release line; cannot resolve toolchain identity" >&2
+    return 1
+  fi
+  printf '%s\n' "${release}"
 }
 
 install_cargo_deny() {
@@ -57,7 +63,9 @@ install_cargo_deny() {
   export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-stable}"
 
   local resolved
-  resolved="$(resolved_toolchain_label)"
+  # Assignment alone does not trip `set -e` on a failing command substitution in all bash
+  # versions; keep the failure explicit.
+  resolved="$(resolved_toolchain_label)" || exit 1
   echo "installing cargo-deny ${CARGO_DENY_VERSION} using toolchain ${RUSTUP_TOOLCHAIN} (resolved ${resolved})"
   cargo install --locked --version "${CARGO_DENY_VERSION}" cargo-deny
 

--- a/scripts/ci/install-cargo-deny.sh
+++ b/scripts/ci/install-cargo-deny.sh
@@ -11,47 +11,81 @@
 # pin: it pins cargo-deny's *own dependency versions* from its published lockfile, not the version
 # of cargo-deny being installed. Anyone removing `--version` below because `--locked` looks
 # sufficient will reintroduce the drift.
+#
+# Helpers below are sourced by scripts/ci/test-install-cargo-deny.sh so the pin check and the
+# self-test share one bin-path formula (one rule, one function).
 set -euo pipefail
 
 CARGO_DENY_VERSION="0.20.2"
 
-# Select the toolchain explicitly rather than letting rustup choose.
-#
-# Both jobs run inside the repository, where `rust-toolchain.toml` pins 1.96.0. rustup honours that
-# file, so `cargo install` selected 1.96.0 -- a toolchain neither job installs. The lint job installs
-# `stable` (observed as 1.97.1 in its own log) and the dependency job installs nothing at all, so
-# whether the step worked depended on what the runner image happened to carry:
-#
-#   error: 'cargo' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'
-#
-# The same branch passed at 11:43 and failed at 11:48 on 2026-08-10 with no code change. The log
-# named 1.97.1 while 1.96.0 ran, which is why reading the log gave the wrong answer about what was
-# selected. RUSTUP_TOOLCHAIN overrides the file, so the selection is now stated rather than inferred.
-#
-# An inherited value wins. ci.yml's dependency job states the selection once for every cargo command
-# it runs; overriding that here would make the job's statement decorative for this step, and would
-# make `stable` a value written in two places that have to agree -- the defect this script exists to
-# remove. `stable` below is the fallback for a caller that states nothing, which is the lint job in
-# kernel-matrix.yml and anyone running the script by hand.
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-stable}"
+# Where `cargo install` writes binaries: CARGO_INSTALL_ROOT, else CARGO_HOME, else ~/.cargo.
+cargo_deny_bin_path() {
+  printf '%s\n' "${CARGO_INSTALL_ROOT:-${CARGO_HOME:-${HOME}/.cargo}}/bin/cargo-deny"
+}
 
-echo "installing cargo-deny ${CARGO_DENY_VERSION} using toolchain ${RUSTUP_TOOLCHAIN}"
-cargo install --locked --version "${CARGO_DENY_VERSION}" cargo-deny
+# Resolve the alias RUSTUP_TOOLCHAIN names. Echoing only `stable` records the request, not what ran
+# (AGENTS.md pinning rule). rustc -vV's release line is the checkable half.
+resolved_toolchain_label() {
+  local release
+  release="$(rustc -vV 2>/dev/null | sed -n 's/^release: //p' | head -n 1)" || true
+  if [[ -n "${release}" ]]; then
+    printf '%s\n' "${release}"
+  else
+    printf '%s\n' "unresolved"
+  fi
+}
 
-# Echo the resolved version and hold it against the pin, so the number in the log is one that was
-# checked rather than one that was printed. An install that silently produced a different version
-# would otherwise leave a log that looks like evidence of the pin.
-#
-# The path is echoed with it because the version alone does not say which binary answered. This
-# resolves through `PATH`, with no relationship to where `cargo install` wrote, so an unrelated
-# `cargo-deny` reporting the pinned version would satisfy the check below while the install did
-# nothing. Asserting the path instead would be stricter, and it was not done because
-# `CARGO_INSTALL_ROOT` is unset in both jobs and shadowing `~/.cargo/bin` on a runner is not a
-# condition this repository has met; recording it means the next reader knows the check's reach.
-resolved="$(cargo-deny --version)"
-echo "cargo-deny resolved: ${resolved} at $(command -v cargo-deny)"
-if [[ "${resolved}" != "cargo-deny ${CARGO_DENY_VERSION}" ]]; then
-  echo "cargo-deny reports '${resolved}', which is not the pinned ${CARGO_DENY_VERSION}" >&2
-  echo "the pin lives in scripts/ci/install-cargo-deny.sh and is the only place to change it" >&2
-  exit 1
+install_cargo_deny() {
+  # Select the toolchain explicitly rather than letting rustup choose.
+  #
+  # Both jobs run inside the repository, where `rust-toolchain.toml` pins 1.96.0. rustup honours that
+  # file, so `cargo install` selected 1.96.0 -- a toolchain neither job installs. The lint job installs
+  # `stable` (observed as 1.97.1 in its own log) and the dependency job installs nothing at all, so
+  # whether the step worked depended on what the runner image happened to carry:
+  #
+  #   error: 'cargo' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'
+  #
+  # The same branch passed at 11:43 and failed at 11:48 on 2026-08-10 with no code change. The log
+  # named 1.97.1 while 1.96.0 ran, which is why reading the log gave the wrong answer about what was
+  # selected. RUSTUP_TOOLCHAIN overrides the file, so the selection is now stated rather than inferred.
+  #
+  # An inherited value wins. ci.yml's dependency job states the selection once for every cargo command
+  # it runs; overriding that here would make the job's statement decorative for this step, and would
+  # make `stable` a value written in two places that have to agree -- the defect this script exists to
+  # remove. `stable` below is the fallback for a caller that states nothing, which is the lint job in
+  # kernel-matrix.yml and anyone running the script by hand.
+  export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-stable}"
+
+  local resolved
+  resolved="$(resolved_toolchain_label)"
+  echo "installing cargo-deny ${CARGO_DENY_VERSION} using toolchain ${RUSTUP_TOOLCHAIN} (resolved ${resolved})"
+  cargo install --locked --version "${CARGO_DENY_VERSION}" cargo-deny
+
+  # Echo the resolved version and hold it against the pin, so the number in the log is one that was
+  # checked rather than one that was printed. An install that silently produced a different version
+  # would otherwise leave a log that looks like evidence of the pin.
+  #
+  # Bind the binary Cargo's install location owns. Resolving through PATH lets an unrelated
+  # cargo-deny earlier on PATH satisfy the pin while the install wrote nothing (#2226).
+  local deny_bin
+  deny_bin="$(cargo_deny_bin_path)"
+  if [[ ! -x "${deny_bin}" ]]; then
+    echo "cargo-deny missing at install location ${deny_bin}" >&2
+    echo "the pin lives in scripts/ci/install-cargo-deny.sh and is the only place to change it" >&2
+    exit 1
+  fi
+
+  local reported
+  reported="$("${deny_bin}" --version)"
+  echo "cargo-deny resolved: ${reported} at ${deny_bin}"
+  if [[ "${reported}" != "cargo-deny ${CARGO_DENY_VERSION}" ]]; then
+    echo "cargo-deny reports '${reported}', which is not the pinned ${CARGO_DENY_VERSION}" >&2
+    echo "the pin lives in scripts/ci/install-cargo-deny.sh and is the only place to change it" >&2
+    exit 1
+  fi
+}
+
+# When sourced by the self-test, define helpers only. When executed, run the install.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  install_cargo_deny
 fi

--- a/scripts/ci/test-deps-security-toolchain-contract.sh
+++ b/scripts/ci/test-deps-security-toolchain-contract.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Contract for ci.yml's deps-security toolchain statement and its accuracy claims.
+#
+# install-cargo-deny.sh already self-tests the shell half of the pin. Nothing read the workflow:
+# deleting `RUSTUP_TOOLCHAIN: stable` from the job, or restoring the false "never one that compiles
+# a crate" claim, stayed green across actionlint (when YAML stayed valid), the install self-test,
+# and the CI gate expectations harness. This gate reads the job the way those mutations edit it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+INSTALL="${ROOT}/scripts/ci/install-cargo-deny.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+ok() { echo "ok   $*"; }
+
+abort_is_failure() {
+  local rc="$1"
+  [[ "${rc}" -eq 0 ]] || echo "deps-security toolchain contract aborted (exit ${rc}); treat as failure" >&2
+}
+trap 'abort_is_failure "$?"' ERR
+
+[[ -f "${WORKFLOW}" ]] || fail "missing ${WORKFLOW#"${ROOT}"/}"
+[[ -f "${INSTALL}" ]] || fail "missing ${INSTALL#"${ROOT}"/}"
+
+SANDBOX_ROOT="$(mktemp -d)"
+trap 'rm -rf "${SANDBOX_ROOT}"' EXIT
+
+# Extract the deps-security job body (from its key through the next top-level job key).
+deps_security_job() {
+  local wf="$1"
+  awk '
+    /^  deps-security:[[:space:]]*$/ { in_job=1; print; next }
+    in_job && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    in_job { print }
+  ' "${wf}"
+}
+
+# Active (non-comment) job-level env lines under deps-security.
+# Job-level `env:` sits at 4 spaces; its entries at 6. Step env blocks are deeper and ignored.
+deps_security_job_env_lines() {
+  local wf="$1"
+  deps_security_job "${wf}" | awk '
+    /^    env:[[:space:]]*$/ { in_env=1; next }
+    in_env && /^    [A-Za-z0-9_-]+:/ { in_env=0 }
+    in_env && /^    [A-Za-z]/ { in_env=0 }
+    in_env && /^      [^#[:space:]]/ { print }
+  '
+}
+
+check_workflow() {
+  local wf="$1"
+  local job env_lines
+
+  job="$(deps_security_job "${wf}")"
+  [[ -n "${job}" ]] || fail "could not find deps-security job in ${wf##*/}"
+
+  env_lines="$(deps_security_job_env_lines "${wf}")"
+  # Trim leading spaces; YAML indent is not part of the key/value contract.
+  trimmed_env="$(sed 's/^[[:space:]]*//' <<<"${env_lines}")"
+  grep -qx 'RUSTUP_TOOLCHAIN: stable' <<<"${trimmed_env}" \
+    || fail "deps-security job env must state \`RUSTUP_TOOLCHAIN: stable\` as an active line; got:
+${env_lines:-<empty>}"
+
+  # #2235: the job compiles the dependency tools from source. Claiming it never compiles a crate
+  # is false and teaches the next editor the wrong scope for RUSTUP_TOOLCHAIN.
+  if grep -qF 'never one that compiles a crate' <<<"${job}"; then
+    fail "deps-security comment still claims the job never compiles a crate; cargo install builds tools from source"
+  fi
+
+  grep -qF 'dependency tools' <<<"${job}" \
+    || fail "deps-security comment must state that the job compiles the dependency tools from source"
+
+  grep -qF 'rust-toolchain.toml' <<<"${job}" \
+    || fail "deps-security comment must keep rust-toolchain.toml as the source for workspace compile jobs"
+
+  # Resolved-toolchain echo lives in the install script (one place for both workflows that install).
+  grep -qE '^resolved_toolchain_label[[:space:]]*\(\)' "${INSTALL}" \
+    || fail "install-cargo-deny.sh must define resolved_toolchain_label()"
+  grep -qF '(resolved ' "${INSTALL}" \
+    || fail "install-cargo-deny.sh must echo the resolved toolchain beside the requested alias"
+  grep -qF 'rustc -vV' "${INSTALL}" \
+    || fail "install-cargo-deny.sh must resolve the toolchain via rustc -vV"
+
+  # Bound binary: PATH must not answer the pin check.
+  grep -qE '^cargo_deny_bin_path[[:space:]]*\(\)' "${INSTALL}" \
+    || fail "install-cargo-deny.sh must define cargo_deny_bin_path for the pin check"
+  grep -qF '"$(cargo_deny_bin_path)"' "${INSTALL}" || grep -qF '$(cargo_deny_bin_path)' "${INSTALL}" \
+    || fail "install-cargo-deny.sh must call cargo_deny_bin_path for the version assertion"
+
+  ok "deps-security toolchain contract holds for ${wf##*/}"
+}
+
+check_workflow "${WORKFLOW}"
+
+# --- Mutations must bite -------------------------------------------------------
+
+mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX.yml")"
+
+# R2: delete the active toolchain statement but keep a dummy env entry so YAML/actionlint stay valid.
+awk '
+  /^  deps-security:[[:space:]]*$/ { in_job=1 }
+  in_job && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ && !/^  deps-security:/ { in_job=0 }
+  in_job && /^    env:[[:space:]]*$/ { in_env=1; print; print "      CI_PLACEHOLDER: 1"; next }
+  in_env && /^      RUSTUP_TOOLCHAIN:[[:space:]]*stable[[:space:]]*$/ { next }
+  in_env && /^    [A-Za-z0-9_-]+:/ { in_env=0 }
+  in_env && /^    [A-Za-z]/ { in_env=0 }
+  { print }
+' "${WORKFLOW}" >"${mutant}"
+grep -q 'CI_PLACEHOLDER: 1' "${mutant}" \
+  || fail "RUSTUP_TOOLCHAIN deletion mutation did not apply"
+if grep -q '^[[:space:]]*RUSTUP_TOOLCHAIN:[[:space:]]*stable[[:space:]]*$' "${mutant}"; then
+  # Only accept absence inside deps-security env; a mention in a comment is fine.
+  env_after="$(deps_security_job_env_lines "${mutant}")"
+  if grep -qx 'RUSTUP_TOOLCHAIN: stable' <<<"$(sed 's/^[[:space:]]*//' <<<"${env_after}")"; then
+    fail "RUSTUP_TOOLCHAIN deletion mutation still leaves an active env line"
+  fi
+fi
+if ( check_workflow "${mutant}" ) >/dev/null 2>&1; then
+  fail "deleting deps-security RUSTUP_TOOLCHAIN left the contract green"
+fi
+ok "deleting deps-security RUSTUP_TOOLCHAIN turns the contract red"
+
+# Weakening: name a toolchain the job does not install (the original incident value).
+weak="$(mktemp "${SANDBOX_ROOT}/weak.XXXXXX.yml")"
+sed 's/^      RUSTUP_TOOLCHAIN: stable$/      RUSTUP_TOOLCHAIN: 1.96.0/' "${WORKFLOW}" >"${weak}"
+grep -q '^      RUSTUP_TOOLCHAIN: 1.96.0$' "${weak}" \
+  || fail "RUSTUP_TOOLCHAIN weakening mutation did not apply"
+if ( check_workflow "${weak}" ) >/dev/null 2>&1; then
+  fail "changing deps-security RUSTUP_TOOLCHAIN to 1.96.0 left the contract green"
+fi
+ok "weakening deps-security RUSTUP_TOOLCHAIN to 1.96.0 turns the contract red"
+
+# R4: restore the false compiles-nothing claim.
+false_comment="$(mktemp "${SANDBOX_ROOT}/false.XXXXXX.yml")"
+sed 's/dependency tools themselves, installed from source/dependency tooling, never one that compiles a crate/' \
+  "${WORKFLOW}" >"${false_comment}"
+# If the green comment is not yet in place, seed the false phrase explicitly for the mutation proof.
+if ! grep -qF 'never one that compiles a crate' "${false_comment}"; then
+  sed 's/rust-toolchain.toml stays the source/never one that compiles a crate, and rust-toolchain.toml stays the source/' \
+    "${WORKFLOW}" >"${false_comment}"
+fi
+grep -qF 'never one that compiles a crate' "${false_comment}" \
+  || fail "false-comment mutation did not apply"
+if ( check_workflow "${false_comment}" ) >/dev/null 2>&1; then
+  fail "restoring the false compiles-nothing claim left the contract green"
+fi
+ok "restoring the false compiles-nothing claim turns the contract red"
+
+# R3: strip resolved-toolchain echo from the install script. check_workflow reads global INSTALL.
+check_install_resolved() {
+  local install="$1"
+  grep -qE '^resolved_toolchain_label[[:space:]]*\(\)' "${install}" || return 1
+  grep -qF '(resolved ' "${install}" || return 1
+  grep -qF 'rustc -vV' "${install}" || return 1
+  return 0
+}
+
+if ! check_install_resolved "${INSTALL}"; then
+  fail "install-cargo-deny.sh does not yet echo a resolved toolchain beside the requested alias"
+fi
+
+install_mutant="${SANDBOX_ROOT}/install-mutant.sh"
+cp "${INSTALL}" "${install_mutant}"
+sed -i.bak \
+  -e 's/resolved_toolchain_label/disabled_resolved_toolchain_label/g' \
+  -e 's/(resolved /(/g' \
+  -e '/rustc -vV/d' \
+  "${install_mutant}"
+rm -f "${install_mutant}.bak"
+if check_install_resolved "${install_mutant}"; then
+  fail "resolved-toolchain echo mutation left reporting intact — mutation did not apply"
+fi
+INSTALL_SAVE="${INSTALL}"
+INSTALL="${install_mutant}"
+if ( check_workflow "${WORKFLOW}" ) >/dev/null 2>&1; then
+  INSTALL="${INSTALL_SAVE}"
+  fail "removing resolved-toolchain echo left the contract green"
+fi
+INSTALL="${INSTALL_SAVE}"
+ok "removing resolved-toolchain echo turns the contract red"
+
+ok "deps-security toolchain contract mutations bite"
+echo "PASS: deps-security toolchain contract"

--- a/scripts/ci/test-deps-security-toolchain-contract.sh
+++ b/scripts/ci/test-deps-security-toolchain-contract.sh
@@ -85,6 +85,16 @@ ${env_lines:-<empty>}"
     || fail "install-cargo-deny.sh must echo the resolved toolchain beside the requested alias"
   grep -qF 'rustc -vV' "${INSTALL}" \
     || fail "install-cargo-deny.sh must resolve the toolchain via rustc -vV"
+  grep -qF 'resolved="$(resolved_toolchain_label)" || exit 1' "${INSTALL}" \
+    || fail "install-cargo-deny.sh must fail closed when toolchain identity cannot be resolved"
+  # Success must not invent an identity. Active-code `unresolved` fallback is the defect under test.
+  if awk '
+    /^[[:space:]]*#/ { next }
+    /printf.*unresolved/ || /echo.*unresolved/ { found=1 }
+    END { exit found ? 0 : 1 }
+  ' "${INSTALL}"; then
+    fail "install-cargo-deny.sh still has an unresolved success fallback"
+  fi
 
   # Bound binary: PATH must not answer the pin check.
   grep -qE '^cargo_deny_bin_path[[:space:]]*\(\)' "${INSTALL}" \
@@ -183,6 +193,45 @@ if ( check_workflow "${WORKFLOW}" ) >/dev/null 2>&1; then
 fi
 INSTALL="${INSTALL_SAVE}"
 ok "removing resolved-toolchain echo turns the contract red"
+
+# Restoring the unresolved-success fallback must turn the contract red.
+fallback_mutant="${SANDBOX_ROOT}/install-fallback.sh"
+cp "${INSTALL}" "${fallback_mutant}"
+python3 - "${fallback_mutant}" <<'PY'
+import pathlib, re, sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+fail_open = '''resolved_toolchain_label() {
+  local release
+  release="$(rustc -vV 2>/dev/null | sed -n 's/^release: //p' | head -n 1)" || true
+  if [[ -n "${release}" ]]; then
+    printf '%s\\n' "${release}"
+  else
+    printf '%s\\n' "unresolved"
+  fi
+}'''
+# lambda replacement: a plain string would let re.sub turn `\n` into a real newline.
+replaced, n = re.subn(
+    r'^resolved_toolchain_label\(\) \{.*?\n\}',
+    lambda _m: fail_open,
+    text,
+    count=1,
+    flags=re.M | re.S,
+)
+if n != 1:
+    raise SystemExit(f"could not rewrite resolved_toolchain_label (n={n})")
+path.write_text(replaced)
+PY
+grep -qF 'printf' "${fallback_mutant}" && grep -qF '"unresolved"' "${fallback_mutant}" \
+  || fail "unresolved-success fallback mutation did not apply"
+INSTALL="${fallback_mutant}"
+if ( check_workflow "${WORKFLOW}" ) >/dev/null 2>&1; then
+  INSTALL="${INSTALL_SAVE}"
+  fail "restoring unresolved-success fallback left the contract green"
+fi
+INSTALL="${INSTALL_SAVE}"
+ok "restoring unresolved-success fallback turns the contract red"
 
 ok "deps-security toolchain contract mutations bite"
 echo "PASS: deps-security toolchain contract"

--- a/scripts/ci/test-install-cargo-deny.sh
+++ b/scripts/ci/test-install-cargo-deny.sh
@@ -7,8 +7,9 @@
 # green -- and would stay green until upstream published a new release, at which point the failure
 # would point at the install rather than at the deletion that caused it.
 #
-# A stub `cargo` and `cargo-deny` on PATH make each guarantee cheap to check for real. No network, no
-# toolchain, no minutes-long install.
+# A stub `cargo`, `cargo-deny`, and `rustc` on PATH make each guarantee cheap to check for real. No
+# network, no toolchain, no minutes-long install. The stub `cargo` writes the binary into Cargo's
+# install location so an unrelated `cargo-deny` earlier on PATH cannot satisfy the pin check.
 set -euo pipefail
 
 # Any abort is a failure, never a pass. Found the hard way: a mutation that removed the install
@@ -32,12 +33,42 @@ if [[ -z "${PIN}" ]]; then
   exit 1
 fi
 
+# macOS ships /bin/bash 3.2.57. The @Q parameter transformation is bash 4.4+ and turns the
+# failure path into `bad substitution` instead of naming the assertion (#2250). Refuse that
+# spelling in active code (comments may mention it).
+if awk '
+  /^[[:space:]]*#/ { next }
+  /\$\{[^}]+@Q\}/ { found=1; print NR ":" $0 }
+  END { exit found ? 0 : 1 }
+' "${BASH_SOURCE[0]}"; then
+  echo "FAIL self-test uses bash-4.4 @Q quoting; macOS bash 3.2 aborts with bad substitution" >&2
+  exit 1
+fi
+
+# One rule, one function: the install script owns the bin-path formula. Source it (it does not run
+# its body when sourced) and call the same helper the production check uses.
+if ! grep -qE '^cargo_deny_bin_path[[:space:]]*\(\)' "${UNDER_TEST}"; then
+  echo "FAIL install-cargo-deny.sh does not define cargo_deny_bin_path()" >&2
+  exit 1
+fi
+if ! grep -qE '^resolved_toolchain_label[[:space:]]*\(\)' "${UNDER_TEST}"; then
+  echo "FAIL install-cargo-deny.sh does not define resolved_toolchain_label()" >&2
+  exit 1
+fi
+# Refuse to source a script that still runs its body on source — that would invoke a real install.
+if ! grep -q 'BASH_SOURCE\[0\]' "${UNDER_TEST}"; then
+  echo "FAIL install-cargo-deny.sh is not source-safe (missing BASH_SOURCE execute guard)" >&2
+  exit 1
+fi
+# shellcheck source=scripts/ci/install-cargo-deny.sh
+source "${UNDER_TEST}"
+
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "${SCRATCH}"' EXIT
 failures=0
 
-# Build a stub PATH. `cargo` records its argv and the toolchain it saw; `cargo-deny` reports whatever
-# version the case asks for, which is how a mismatching install is simulated without one.
+# Build a stub PATH. `cargo` records argv/toolchain and writes `cargo-deny` into Cargo's install
+# location. A separate early PATH entry can hold a decoy binary that must not satisfy the pin.
 make_stubs() {
   local dir="$1" reported="$2"
   mkdir -p "${dir}"
@@ -45,12 +76,40 @@ make_stubs() {
 #!/usr/bin/env bash
 echo "argv: $*" >>"${STUB_LOG}"
 echo "toolchain: ${RUSTUP_TOOLCHAIN:-<unset>}" >>"${STUB_LOG}"
+root="${CARGO_INSTALL_ROOT:-${CARGO_HOME:-${HOME}/.cargo}}"
+mkdir -p "${root}/bin"
+cat >"${root}/bin/cargo-deny" <<INNER
+#!/usr/bin/env bash
+echo "cargo-deny ${STUB_DENY_VERSION}"
+INNER
+chmod +x "${root}/bin/cargo-deny"
 STUB
+  cat >"${dir}/rustc" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-vV" ]]; then
+  cat <<EOF
+rustc 1.77.0-stub
+binary: rustc
+commit-hash: stub
+commit-date: stub
+host: stub
+release: 1.77.0-stub
+EOF
+  exit 0
+fi
+echo "rustc stub: unexpected args: $*" >&2
+exit 1
+STUB
+  chmod +x "${dir}/cargo" "${dir}/rustc"
+  # Keep a PATH-visible cargo-deny that reports a *different* version so a PATH-first check cannot
+  # accidentally pass. The install must read the binary cargo wrote into the install root.
   cat >"${dir}/cargo-deny" <<STUB
 #!/usr/bin/env bash
-echo "cargo-deny ${reported}"
+echo "cargo-deny 9.9.9-path-decoy"
 STUB
-  chmod +x "${dir}/cargo" "${dir}/cargo-deny"
+  chmod +x "${dir}/cargo-deny"
+  # Exported for the cargo stub's here-doc expansion at install time.
+  export STUB_DENY_VERSION="${reported}"
 }
 
 # Each case runs the script under stubs and reports the exit code plus the recorded argv.
@@ -58,6 +117,8 @@ run_case() {
   local name="$1" reported="$2" expected_exit="$3"
   shift 3
   local dir="${SCRATCH}/${name}"
+  local cargo_home="${dir}/cargo-home"
+  mkdir -p "${cargo_home}"
   make_stubs "${dir}" "${reported}"
   local log="${dir}/log"
   : >"${log}"
@@ -67,10 +128,16 @@ run_case() {
   # failure -- which is how a FAIL could coexist with exit 0.
   CASE_LOG="${log}"
   CASE_OUT="${dir}/out"
+  CASE_HOME="${dir}/case-home"
+  CASE_CARGO_HOME="${cargo_home}"
+  mkdir -p "${CASE_HOME}"
 
   local actual_exit=0
-  # `env -i` would drop too much; the point is a controlled PATH and a controlled toolchain value.
-  STUB_LOG="${log}" PATH="${dir}:${PATH}" "$@" bash "${UNDER_TEST}" >"${dir}/out" 2>&1 || actual_exit=$?
+  # Controlled PATH + toolchain + Cargo home. HOME is isolated so a missing CARGO_HOME still
+  # resolves under this case rather than the operator's real ~/.cargo.
+  STUB_LOG="${log}" STUB_DENY_VERSION="${reported}" \
+    HOME="${CASE_HOME}" CARGO_HOME="${cargo_home}" \
+    PATH="${dir}:${PATH}" "$@" bash "${UNDER_TEST}" >"${dir}/out" 2>&1 || actual_exit=$?
 
   if [[ "${actual_exit}" -ne "${expected_exit}" ]]; then
     echo "FAIL ${name}: exit ${actual_exit}, expected ${expected_exit}"
@@ -86,7 +153,8 @@ expect_in_file() {
   if grep -qF -- "${needle}" "${file}"; then
     echo "ok   ${what}"
   else
-    echo "FAIL ${what}: ${needle@Q} not in"
+    # Plain quoting only — bash 4.4 @Q aborts macOS bash 3.2 (#2250).
+    echo "FAIL ${what}: '${needle}' not in"
     sed 's/^/      /' "${file}"
     failures=$((failures + 1))
   fi
@@ -107,15 +175,84 @@ expect_in_file "${CASE_OUT}" "scripts/ci/install-cargo-deny.sh" "mismatch names 
 echo "== the toolchain is stated, and an inherited value wins =="
 run_case default_toolchain "${PIN}" 0
 expect_in_file "${CASE_LOG}" "toolchain: stable" "defaults to stable when the caller states nothing"
+expect_in_file "${CASE_OUT}" "using toolchain stable (resolved 1.77.0-stub)" \
+  "requested alias and resolved toolchain are both logged"
 
 run_case inherited_toolchain "${PIN}" 0 env RUSTUP_TOOLCHAIN=1.2.3-inherited
 expect_in_file "${CASE_LOG}" "toolchain: 1.2.3-inherited" "an inherited RUSTUP_TOOLCHAIN is honoured"
+expect_in_file "${CASE_OUT}" "using toolchain 1.2.3-inherited (resolved 1.77.0-stub)" \
+  "inherited alias is logged beside the resolved toolchain"
 
-echo "== the log says which binary answered, not only which version =="
-# Without the path, a version line is not evidence about the install: an unrelated cargo-deny on
-# PATH reporting the pinned version would produce an identical log.
-expect_in_file "${CASE_OUT}" "at ${SCRATCH}/inherited_toolchain/cargo-deny" \
-  "the resolved path is reported"
+echo "== the pin check binds the install-root binary, not PATH =="
+# Same formula the install uses. An earlier PATH decoy reports 9.9.9; only the install-root binary
+# carries the pin. Passing here means PATH did not answer the version check.
+expect_in_file "${CASE_OUT}" "at $(CARGO_HOME="${CASE_CARGO_HOME}" cargo_deny_bin_path)" \
+  "the resolved path is the install-root binary"
+
+# Decoy-only: cargo writes nothing useful; PATH still has the pin. Must fail.
+echo "== an unrelated PATH cargo-deny cannot satisfy the pin =="
+decoy_dir="${SCRATCH}/path_decoy"
+mkdir -p "${decoy_dir}/early" "${decoy_dir}/tools" "${decoy_dir}/cargo-home" "${decoy_dir}/home"
+cat >"${decoy_dir}/early/cargo-deny" <<STUB
+#!/usr/bin/env bash
+echo "cargo-deny ${PIN}"
+STUB
+chmod +x "${decoy_dir}/early/cargo-deny"
+cat >"${decoy_dir}/tools/cargo" <<'STUB'
+#!/usr/bin/env bash
+echo "argv: $*" >>"${STUB_LOG}"
+echo "toolchain: ${RUSTUP_TOOLCHAIN:-<unset>}" >>"${STUB_LOG}"
+# Deliberately do not write an install-root binary.
+STUB
+cat >"${decoy_dir}/tools/rustc" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-vV" ]]; then
+  echo "release: 1.77.0-stub"
+  exit 0
+fi
+exit 1
+STUB
+chmod +x "${decoy_dir}/tools/cargo" "${decoy_dir}/tools/rustc"
+decoy_log="${decoy_dir}/log"
+decoy_out="${decoy_dir}/out"
+: >"${decoy_log}"
+decoy_exit=0
+STUB_LOG="${decoy_log}" HOME="${decoy_dir}/home" CARGO_HOME="${decoy_dir}/cargo-home" \
+  PATH="${decoy_dir}/early:${decoy_dir}/tools:${PATH}" \
+  bash "${UNDER_TEST}" >"${decoy_out}" 2>&1 || decoy_exit=$?
+if [[ "${decoy_exit}" -eq 0 ]]; then
+  echo "FAIL path decoy: install exited 0 while only PATH carried the pin"
+  sed 's/^/      /' "${decoy_out}"
+  failures=$((failures + 1))
+else
+  echo "ok   path decoy refused (exit ${decoy_exit})"
+fi
+expect_in_file "${decoy_out}" "cargo-deny missing at install location" \
+  "path decoy names the missing install-root binary"
+
+echo "== CARGO_INSTALL_ROOT wins over CARGO_HOME for the bound binary =="
+root_dir="${SCRATCH}/install_root_case"
+mkdir -p "${root_dir}/tools" "${root_dir}/cargo-home" "${root_dir}/install-root" "${root_dir}/home"
+make_stubs "${root_dir}/tools" "${PIN}"
+# Override make_stubs' PATH decoy — keep it, but point install root elsewhere.
+root_log="${root_dir}/log"
+root_out="${root_dir}/out"
+: >"${root_log}"
+root_exit=0
+STUB_LOG="${root_log}" STUB_DENY_VERSION="${PIN}" \
+  HOME="${root_dir}/home" CARGO_HOME="${root_dir}/cargo-home" \
+  CARGO_INSTALL_ROOT="${root_dir}/install-root" \
+  PATH="${root_dir}/tools:${PATH}" \
+  bash "${UNDER_TEST}" >"${root_out}" 2>&1 || root_exit=$?
+if [[ "${root_exit}" -ne 0 ]]; then
+  echo "FAIL CARGO_INSTALL_ROOT: exit ${root_exit}, expected 0"
+  sed 's/^/      /' "${root_out}"
+  failures=$((failures + 1))
+else
+  echo "ok   CARGO_INSTALL_ROOT (exit 0)"
+fi
+expect_in_file "${root_out}" "at ${root_dir}/install-root/bin/cargo-deny" \
+  "CARGO_INSTALL_ROOT selects the bound binary"
 
 if [[ "${failures}" -ne 0 ]]; then
   echo "install-cargo-deny self-test: ${failures} failure(s)" >&2

--- a/scripts/ci/test-install-cargo-deny.sh
+++ b/scripts/ci/test-install-cargo-deny.sh
@@ -254,6 +254,156 @@ fi
 expect_in_file "${root_out}" "at ${root_dir}/install-root/bin/cargo-deny" \
   "CARGO_INSTALL_ROOT selects the bound binary"
 
+echo "== unresolved toolchain identity fails closed =="
+# rustc -vV that exits 0 but omits the release line used to print "(resolved unresolved)" and
+# continue — a success that names no identity. The pin check can still pass; the log cannot.
+unres_dir="${SCRATCH}/unresolved_rustc"
+mkdir -p "${unres_dir}/tools" "${unres_dir}/cargo-home" "${unres_dir}/home"
+make_stubs "${unres_dir}/tools" "${PIN}"
+cat >"${unres_dir}/tools/rustc" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-vV" ]]; then
+  echo "rustc mystery-build"
+  echo "host: stub"
+  exit 0
+fi
+exit 1
+STUB
+chmod +x "${unres_dir}/tools/rustc"
+unres_log="${unres_dir}/log"
+unres_out="${unres_dir}/out"
+: >"${unres_log}"
+unres_exit=0
+STUB_LOG="${unres_log}" STUB_DENY_VERSION="${PIN}" \
+  HOME="${unres_dir}/home" CARGO_HOME="${unres_dir}/cargo-home" \
+  PATH="${unres_dir}/tools:${PATH}" \
+  bash "${UNDER_TEST}" >"${unres_out}" 2>&1 || unres_exit=$?
+if [[ "${unres_exit}" -eq 0 ]]; then
+  echo "FAIL unresolved rustc: install exited 0 without a release line"
+  sed 's/^/      /' "${unres_out}"
+  failures=$((failures + 1))
+else
+  echo "ok   unresolved rustc refused (exit ${unres_exit})"
+fi
+expect_in_file "${unres_out}" "no release line" \
+  "unresolved rustc names the missing release line"
+# Must not claim a fake identity and continue.
+if grep -qF '(resolved unresolved)' "${unres_out}"; then
+  echo "FAIL unresolved rustc: log still contains '(resolved unresolved)' success spelling"
+  sed 's/^/      /' "${unres_out}"
+  failures=$((failures + 1))
+else
+  echo "ok   unresolved rustc does not print a fake resolved identity"
+fi
+
+echo "== rustc -vV failure fails closed =="
+fail_dir="${SCRATCH}/rustc_fails"
+mkdir -p "${fail_dir}/tools" "${fail_dir}/cargo-home" "${fail_dir}/home"
+make_stubs "${fail_dir}/tools" "${PIN}"
+cat >"${fail_dir}/tools/rustc" <<'STUB'
+#!/usr/bin/env bash
+echo "rustc: stub failure" >&2
+exit 1
+STUB
+chmod +x "${fail_dir}/tools/rustc"
+fail_log="${fail_dir}/log"
+fail_out="${fail_dir}/out"
+: >"${fail_log}"
+fail_exit=0
+STUB_LOG="${fail_log}" STUB_DENY_VERSION="${PIN}" \
+  HOME="${fail_dir}/home" CARGO_HOME="${fail_dir}/cargo-home" \
+  PATH="${fail_dir}/tools:${PATH}" \
+  bash "${UNDER_TEST}" >"${fail_out}" 2>&1 || fail_exit=$?
+if [[ "${fail_exit}" -eq 0 ]]; then
+  echo "FAIL rustc failure: install exited 0 when rustc -vV failed"
+  sed 's/^/      /' "${fail_out}"
+  failures=$((failures + 1))
+else
+  echo "ok   rustc failure refused (exit ${fail_exit})"
+fi
+expect_in_file "${fail_out}" "rustc -vV failed" \
+  "rustc failure names the command that could not identify the toolchain"
+
+echo "== restoring unresolved-success fallback turns the probe green (mutation bites) =="
+# If someone reintroduces `printf … unresolved` / `|| true`, the no-release probe exits 0 again.
+# Prove that mutation by applying it to a copy; production must not contain the success fallback.
+mut_install="${SCRATCH}/install-unresolved-fallback.sh"
+cp "${UNDER_TEST}" "${mut_install}"
+python3 - "${mut_install}" <<'PY'
+import pathlib, re, sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+fail_open = '''resolved_toolchain_label() {
+  local release
+  release="$(rustc -vV 2>/dev/null | sed -n 's/^release: //p' | head -n 1)" || true
+  if [[ -n "${release}" ]]; then
+    printf '%s\\n' "${release}"
+  else
+    printf '%s\\n' "unresolved"
+  fi
+}'''
+# lambda replacement: a plain string would let re.sub turn `\n` into a real newline.
+replaced, n = re.subn(
+    r'^resolved_toolchain_label\(\) \{.*?\n\}',
+    lambda _m: fail_open,
+    text,
+    count=1,
+    flags=re.M | re.S,
+)
+if n != 1:
+    raise SystemExit(f"could not rewrite resolved_toolchain_label (n={n})")
+replaced, n2 = re.subn(
+    r'resolved="\$\(resolved_toolchain_label\)" \|\| exit 1',
+    'resolved="$(resolved_toolchain_label)"',
+    replaced,
+    count=1,
+)
+if n2 != 1:
+    raise SystemExit(f"could not drop || exit 1 after resolved_toolchain_label (n={n2})")
+path.write_text(replaced)
+PY
+mut_dir="${SCRATCH}/fallback_mutant_probe"
+mkdir -p "${mut_dir}/tools" "${mut_dir}/cargo-home" "${mut_dir}/home"
+make_stubs "${mut_dir}/tools" "${PIN}"
+cat >"${mut_dir}/tools/rustc" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-vV" ]]; then
+  echo "rustc mystery-build"
+  echo "host: stub"
+  exit 0
+fi
+exit 1
+STUB
+chmod +x "${mut_dir}/tools/rustc"
+mut_out="${mut_dir}/out"
+mut_exit=0
+STUB_DENY_VERSION="${PIN}" HOME="${mut_dir}/home" CARGO_HOME="${mut_dir}/cargo-home" \
+  PATH="${mut_dir}/tools:${PATH}" \
+  bash "${mut_install}" >"${mut_out}" 2>&1 || mut_exit=$?
+if [[ "${mut_exit}" -ne 0 ]]; then
+  echo "FAIL fallback mutation: probe still exited ${mut_exit}; mutation did not restore fail-open"
+  sed 's/^/      /' "${mut_out}"
+  failures=$((failures + 1))
+elif ! grep -qF '(resolved unresolved)' "${mut_out}"; then
+  echo "FAIL fallback mutation: expected '(resolved unresolved)' on the mutant"
+  sed 's/^/      /' "${mut_out}"
+  failures=$((failures + 1))
+else
+  echo "ok   restoring unresolved-success fallback turns the probe green"
+fi
+# Production must not keep the success fallback spelling in active code.
+if awk '
+  /^[[:space:]]*#/ { next }
+  /printf.*unresolved/ || /echo.*unresolved/ { found=1; print NR ":" $0 }
+  END { exit found ? 0 : 1 }
+' "${UNDER_TEST}"; then
+  echo "FAIL production install still contains an unresolved success fallback" >&2
+  failures=$((failures + 1))
+else
+  echo "ok   production install has no unresolved success fallback"
+fi
+
 if [[ "${failures}" -ne 0 ]]; then
   echo "install-cargo-deny self-test: ${failures} failure(s)" >&2
   exit 1


### PR DESCRIPTION
## Summary

CI-4B hardens the cargo-deny install pin and the `deps-security` toolchain claim so silent removals and inaccurate comments cannot land again.

- **#2250:** self-test failure diagnostics are bash 3.2-safe (no `@Q`); mutations name the assertion and print a failure summary under `/bin/bash` 3.2.57 and bash 5.
- **#2226:** pin check binds Cargo's install-root binary (`CARGO_INSTALL_ROOT` / `CARGO_HOME` / `~/.cargo`); an unrelated PATH `cargo-deny` cannot satisfy the pin. New workflow contract fails if `deps-security` loses or weakens `RUSTUP_TOOLCHAIN: stable`, wired in pre-commit with `files:` covering `ci.yml`.
- **#2235:** `deps-security` comment states that only dependency tools are compiled from source; install log echoes requested alias and resolved toolchain (`rustc -vV`).
- **P1 follow-up (this head):** toolchain identity is fail-closed — `rustc -vV` failure or a missing `release:` line refuses the install instead of logging `(resolved unresolved)` and continuing.

Closes #2250 #2226 #2235

## Non-claims / out of scope

- Does **not** address #2224 (other plugin installs, pinning `cargo-audit`, installing a toolchain into `deps-security`).
- Does **not** change which toolchain compiles workspace crates (`rust-toolchain.toml` still governs those jobs).
- Does **not** set a repo-wide bash 3.2 / shellcheck floor.

## Review packet

| Item | Value |
|---|---|
| Branch | `cursor/ci4b-cargo-deny-toolchain-contract` |
| Worktree base | `6ed6e7b7ac908c072a0bb48ed2f4fb074c33d636` |
| Prior reviewed head (BLOCKED) | `ed6cb91c14a2a4f1d95fb72de03ba1bedfdddd86` |
| **Head SHA (re-review)** | `f5a713ef01657d4ae961b4a687036794c6d75feb` |
| Worktree | `/private/tmp/assay-wt-ci4b-cargo-deny-toolchain-contract` |
| Builder | Cursor (sole writer) |
| Allowlist | `scripts/ci/{install,test-install}-cargo-deny.sh`, `scripts/ci/test-deps-security-toolchain-contract.sh`, `.github/workflows/ci.yml`, `.pre-commit-config.yaml` |
| Files in P1 fix commit | install + two self-tests only |

### RED → GREEN (P1 unresolved identity)

| Control | RED at `ed6cb91c14a2a4f1d95fb72de03ba1bedfdddd86` | GREEN at `f5a713ef01657d4ae961b4a687036794c6d75feb` |
|---|---|---|
| `rustc -vV` without `release:` + good pin | exit 0, `(resolved unresolved)` | exit 1, `no release line` diagnostic |
| `rustc -vV` fails | exit 0, fake resolved | exit 1, `rustc -vV failed` |
| Restore unresolved-success fallback | — | probe goes green on mutant; production + contract refuse the spelling |

### Prior RED/GREEN (still holding)

PATH decoy, install-root / `CARGO_INSTALL_ROOT`, bash 3.2 `@Q` diagnostics, `RUSTUP_TOOLCHAIN` delete/weaken, false comment, resolved-echo strip — all still green under bash 3.2 and bash 5.

### Checks at `f5a713ef01657d4ae961b4a687036794c6d75feb`

- `/bin/bash` + Homebrew bash 5 self-test → pass
- `test-deps-security-toolchain-contract.sh` → PASS (incl. fallback mutation)
- `shellcheck -x -S warning` → 0
- `pre-commit run --files` on touched scripts → 0
- `git diff --check` → clean
- Pre-push (clippy, linux compile gate, contracts) → passed on push

### One rule / one function

`cargo_deny_bin_path` and `resolved_toolchain_label` live in `install-cargo-deny.sh`; the self-test sources that file. Identity failure is `return 1` + `|| exit 1` — no success placeholder.

## Test plan

- [x] Focused self-test + contract under bash 3.2 and bash 5
- [x] Mutation battery including unresolved-success fallback restore
- [x] shellcheck + pre-commit on touched files + `git diff --check`
- [ ] Independent non-building review on exact head `f5a713ef01657d4ae961b4a687036794c6d75feb` (prior review on `ed6cb91c14a2a4f1d95fb72de03ba1bedfdddd86` invalidated)
- [ ] Do not ready/merge until quorum