### PR TITLE
ci: reconcile required check app bindings

### DIFF
--- a/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
+++ b/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
@@ -22,12 +22,15 @@ The delegated workflow runs the Linux/eBPF gates that hosted CI cannot prove:
 | `kernel-only` | `scripts/ci/runner-spike-kernel-only-three-run-determinism.sh` | kernel observation, cgroup correlation, bundle verification, three-run determinism |
 | `kernel-policy` | `scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh` | kernel plus policy correlation, bundle verification, three-run determinism |
 | `openai-agents-kernel-policy` | `scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh` | kernel plus policy plus real `@openai/agents` SDK runtime correlation, bundle verification, three-run determinism |
-| `gemini-google-genai-kernel-policy` | `scripts/ci/runner-spike-gemini-google-genai-acceptance.sh` | Gemini Python `google-genai` fixture correlation and cassette-backed acceptance |
-| `all` | all of the above, plus `scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh` | full delegated proof, including Gemini and the post-closure hidden-write semantic-gap expansion gate |
+| `all` | all of the above, plus `scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh` and `scripts/ci/runner-spike-gemini-google-genai-three-run-determinism.sh` | full delegated proof, including Gemini and the post-closure hidden-write semantic-gap expansion gate |
 
 Each three-run script executes its single-run acceptance three times and then
 compares the deterministic artifacts. Kernel raw event ordering is not used as
 a causal-ordering claim; the bundle claim remains set/window based.
+
+`gemini-google-genai-kernel-policy` is an internal constituent of `all`, not a
+selectable `gates` input. Its three-run wrapper executes
+`scripts/ci/runner-spike-gemini-google-genai-acceptance.sh` internally.
 
 ## Host Requirements
 
@@ -99,8 +102,7 @@ Recommended progression during diagnosis:
 1. `kernel-only`
 2. `kernel-policy`
 3. `openai-agents-kernel-policy`
-4. `gemini-google-genai-kernel-policy`
-5. `all`
+4. `all`
 
 Use `all` once the narrower failing gate has been fixed. This avoids mixing
 multiple failure signals in the same diagnostic run.
@@ -391,6 +393,7 @@ PASS: runner-spike kernel+policy three-run determinism
 PASS: runner-spike OpenAI Agents kernel+policy acceptance
 PASS: runner-spike OpenAI Agents kernel+policy three-run determinism
 PASS: runner-spike Gemini google-genai kernel+policy acceptance
+PASS: runner-spike Gemini google-genai kernel+policy three-run determinism
 ```
 
 Each acceptance line appears once per run inside its three-run wrapper. The

--- a/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
+++ b/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
@@ -22,7 +22,8 @@ The delegated workflow runs the Linux/eBPF gates that hosted CI cannot prove:
 | `kernel-only` | `scripts/ci/runner-spike-kernel-only-three-run-determinism.sh` | kernel observation, cgroup correlation, bundle verification, three-run determinism |
 | `kernel-policy` | `scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh` | kernel plus policy correlation, bundle verification, three-run determinism |
 | `openai-agents-kernel-policy` | `scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh` | kernel plus policy plus real `@openai/agents` SDK runtime correlation, bundle verification, three-run determinism |
-| `all` | all of the above, plus `scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh` | full delegated proof, including the post-closure hidden-write semantic-gap expansion gate |
+| `gemini-google-genai-kernel-policy` | `scripts/ci/runner-spike-gemini-google-genai-acceptance.sh` | Gemini Python `google-genai` fixture correlation and cassette-backed acceptance |
+| `all` | all of the above, plus `scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh` | full delegated proof, including Gemini and the post-closure hidden-write semantic-gap expansion gate |
 
 Each three-run script executes its single-run acceptance three times and then
 compares the deterministic artifacts. Kernel raw event ordering is not used as
@@ -98,7 +99,8 @@ Recommended progression during diagnosis:
 1. `kernel-only`
 2. `kernel-policy`
 3. `openai-agents-kernel-policy`
-4. `all`
+4. `gemini-google-genai-kernel-policy`
+5. `all`
 
 Use `all` once the narrower failing gate has been fixed. This avoids mixing
 multiple failure signals in the same diagnostic run.
@@ -388,6 +390,7 @@ PASS: runner-spike kernel+policy acceptance
 PASS: runner-spike kernel+policy three-run determinism
 PASS: runner-spike OpenAI Agents kernel+policy acceptance
 PASS: runner-spike OpenAI Agents kernel+policy three-run determinism
+PASS: runner-spike Gemini google-genai kernel+policy acceptance
 ```
 
 Each acceptance line appears once per run inside its three-run wrapper. The

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -85,6 +85,10 @@ cleanup and checkout.
    attested lane -- dispatch `Assay-Runner Lane Check` with `override_reason`.
    That records who decided and why in the commit status. It does not make
    proceeding without evidence safe; it makes it attributable.
+   No clock-skew tolerance is part of this verification contract: the attestation
+   checks no wall-clock field. A timestamp difference is therefore neither accepted
+   nor rejected by lane-check; subject digests, workflow identity, source head, and
+   invocation bind the proof instead.
 4. Do not treat a delegated skip as success. In the delegated lane, exit `40`
    means the runner contract has drifted.
 5. Do not bypass required repository checks for runner-impacting changes.

--- a/scripts/ci/check-required-contexts.py
+++ b/scripts/ci/check-required-contexts.py
@@ -88,6 +88,23 @@ def ruleset_contexts(text: str) -> list[str]:
     return found
 
 
+def ruleset_checks(text: str) -> dict[str, int | None]:
+    """Required context -> integration binding from the importable ruleset."""
+    params = _ruleset_required_status_parameters(text)
+    checks: dict[str, int | None] = {}
+    for check in params.get("required_status_checks", []):
+        context = check.get("context")
+        integration_id = check.get("integration_id")
+        if not isinstance(context, str) or not context:
+            raise DriftError(f"{RULESET}: required status check has no context")
+        if integration_id is not None and not isinstance(integration_id, int):
+            raise DriftError(f"{RULESET}: integration_id for {context!r} must be an integer or null")
+        checks[context] = integration_id
+    if not checks:
+        raise DriftError(f"{RULESET}: no required status checks to bind")
+    return checks
+
+
 def ruleset_strict(text: str) -> bool:
     """Strictness comes from the same ruleset artifact as the context list."""
     params = _ruleset_required_status_parameters(text)
@@ -104,12 +121,8 @@ def ruleset_strict(text: str) -> bool:
     return value
 
 
-def live_protection(text: str) -> tuple[list[str], bool]:
-    """Parse classic branch-protection required_status_checks JSON (contexts + strict).
-
-    app_id on individual checks is ignored on purpose: live and the ruleset already
-    disagree there for CI, and this slice reconciles only context set and strictness.
-    """
+def live_protection(text: str) -> tuple[list[str], bool, dict[str, int | None]]:
+    """Parse classic branch-protection context names, strictness, and app bindings."""
     if not text or not text.strip():
         raise DriftError("live response is empty")
     try:
@@ -118,7 +131,7 @@ def live_protection(text: str) -> tuple[list[str], bool]:
         raise DriftError(f"live response is not JSON: {exc}") from exc
     if not isinstance(doc, dict):
         raise DriftError("live response must be a JSON object")
-    missing = [key for key in ("contexts", "strict") if key not in doc]
+    missing = [key for key in ("contexts", "strict", "checks") if key not in doc]
     if missing:
         raise DriftError(
             "live response missing required_status_checks fields: "
@@ -126,18 +139,32 @@ def live_protection(text: str) -> tuple[list[str], bool]:
         )
     contexts = doc["contexts"]
     strict = doc["strict"]
+    raw_checks = doc["checks"]
     if not isinstance(contexts, list) or not all(isinstance(c, str) for c in contexts):
         raise DriftError("live response contexts must be a list of strings")
     if not isinstance(strict, bool):
         raise DriftError("live response strict must be a boolean")
-    return contexts, strict
+    if not isinstance(raw_checks, list):
+        raise DriftError("live response checks must be a list")
+    checks: dict[str, int | None] = {}
+    for check in raw_checks:
+        if not isinstance(check, dict):
+            raise DriftError("live response checks must contain objects")
+        context = check.get("context")
+        app_id = check.get("app_id")
+        if not isinstance(context, str) or not context:
+            raise DriftError("live response check context must be a non-empty string")
+        if app_id is not None and not isinstance(app_id, int):
+            raise DriftError(f"live response app_id for {context!r} must be an integer or null")
+        checks[context] = app_id
+    return contexts, strict, checks
 
 
 def check_live(read, live_text: str) -> list[str]:
     """Compare live classic protection to the ruleset (contexts set + strict only)."""
     expected = ruleset_contexts(read(RULESET))
     expected_strict = ruleset_strict(read(RULESET))
-    actual, actual_strict = live_protection(live_text)
+    actual, actual_strict, actual_checks = live_protection(live_text)
     problems = compare(expected, actual, "live required_status_checks.contexts")
     if expected_strict != actual_strict:
         problems.append(
@@ -145,6 +172,16 @@ def check_live(read, live_text: str) -> list[str]:
             f"{actual_strict!r} but ruleset strict_required_status_checks_policy="
             f"{expected_strict!r}"
         )
+    expected_checks = ruleset_checks(read(RULESET))
+    for context in sorted(set(expected_checks) & set(actual_checks)):
+        if expected_checks[context] != actual_checks[context]:
+            problems.append(
+                f"live required status check {context!r} app_id={actual_checks[context]!r} "
+                f"but ruleset integration_id={expected_checks[context]!r}"
+            )
+    missing_checks = sorted(set(expected_checks) - set(actual_checks))
+    if missing_checks:
+        problems.append(f"live required_status_checks.checks missing {missing_checks}")
     return problems
 
 
@@ -380,7 +417,7 @@ def self_test() -> int:
 
 
 def _baseline_live_json(contexts: list[str], *, strict: bool = True, app_id=15368) -> str:
-    """Shape of GET .../protection/required_status_checks, including ignored app_id."""
+    """Shape of GET .../protection/required_status_checks."""
     return json.dumps(
         {
             "strict": strict,
@@ -430,13 +467,12 @@ def live_self_test(baseline: dict) -> int:
         print("self-test: identity no-op was not rejected by apply helper", file=sys.stderr)
         return 1
 
-    # Match cases, including reorder and app_id noise, via production main_live().
+    # Match cases, including harmless ordering differences, via production main_live().
     reordered = list(reversed(expected))
     assert set(reordered) == set(expected)
     match_cases = [
         ("baseline", live_ok),
         ("reordered", _baseline_live_json(reordered, strict=expected_strict)),
-        ("app_id_ignored", _baseline_live_json(expected, strict=expected_strict, app_id=None)),
     ]
     for label, live_text in match_cases:
         code = _invoke_main_live(live_text)
@@ -476,8 +512,9 @@ def live_self_test(baseline: dict) -> int:
     unreadable_live = [
         ("empty", lambda t: ""),
         ("malformed", lambda t: "{not-json"),
-        ("missing_contexts", lambda t: json.dumps({"strict": True})),
-        ("missing_strict", lambda t: json.dumps({"contexts": expected})),
+        ("missing_contexts", lambda t: json.dumps({"strict": True, "checks": []})),
+        ("missing_strict", lambda t: json.dumps({"contexts": expected, "checks": []})),
+        ("missing_checks", lambda t: json.dumps({"contexts": expected, "strict": True})),
     ]
     for label, mutate in unreadable_live:
         mutated = apply_live(mutate, label)
@@ -492,15 +529,15 @@ def live_self_test(baseline: dict) -> int:
             )
             return 1
 
-    # app_id-only change must apply (text differs) and still match through main_live.
+    # An app_id-only change is real protection drift: the ruleset pins who may report each check.
     app_only = apply_live(
         lambda t: _baseline_live_json(expected, strict=expected_strict, app_id=99999),
         "app_id_only",
     )
     if app_only is None:
         return 1
-    if _invoke_main_live(app_only) != EXIT_MATCH:
-        print("self-test: app_id-only change must exit 0 via main_live", file=sys.stderr)
+    if _invoke_main_live(app_only) != EXIT_DRIFT:
+        print("self-test: app_id-only change must exit 1 via main_live", file=sys.stderr)
         return 1
 
     # CLI is stdin-only: a path argv must be rejected (no arbitrary Path read).


### PR DESCRIPTION
## Summary

- compare live required-check `app_id` values with ruleset `integration_id` values
- make app-binding drift mutation-sensitive in the existing reconciler self-test
- document the Gemini gate in the delegated `gates=all` runbook
- state explicitly that lane attestation verification evaluates no wall-clock field

Closes #2259

## Why

The checked-in ruleset pins all three required contexts to GitHub Actions (`15368`), while live protection leaves `CI` unpinned. The scheduled reconciler reported `match` because it deliberately ignored app IDs. This change makes that security-relevant metadata part of the existing read-only reconciliation contract; it does not mutate branch protection.

## RED -> GREEN

At RED, changing only the self-test expectation produced:

```text
self-test: app_id-only change must exit 1 via main_live
```

At GREEN:

```text
check-required-contexts self-test=passed
required-contexts-live=drift
  live required status check 'CI' app_id=None but ruleset integration_id=15368
```

## Verification

Measured on `b8257256fd1ea976cf467d72fa4459e208ef830e` in `/private/tmp/assay-ci3b-required-context-metadata`:

- `python3 scripts/ci/check-required-contexts.py --self-test`
- `python3 scripts/ci/check-required-contexts.py`
- live branch-protection response piped to `--live-response` returns drift (exit 1)
- touched-file pre-commit suite
- full pre-push suite, including workspace clippy and Linux cross-target gate
- `git diff --check`

## Operational follow-up

After merge, the repository owner must apply/pin the live `CI` check to GitHub Actions app id `15368`, then dispatch `Required Context Reconciliation`. The checker remains read-only by design.

## Non-claims

- no automatic write to branch protection
- no attestation clock-skew acceptance threshold; lane-check validates no clock field
- no change to delegated gate selection or runtime behavior
