### PR TITLE
ci: bound and cache host-capability proof builds

### DIFF
--- a/.github/workflows/host-capability-proof.yml
+++ b/.github/workflows/host-capability-proof.yml
@@ -53,10 +53,34 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve pinned Rust toolchain
+        id: rust-toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import tomllib
+
+          with open("rust-toolchain.toml", "rb") as source:
+              channel = tomllib.load(source)["toolchain"]["channel"]
+          if not isinstance(channel, str) or not channel:
+              raise SystemExit("rust-toolchain.toml has no non-empty toolchain.channel")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"channel={channel}", file=output)
+          PY
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
       - name: Restore bounded Rust build cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          prefix-key: host-capability-proof-v1
+          # Never let cache cleanup or restore mutate rustup/cargo shims on the persistent host.
+          cache-bin: false
+          prefix-key: host-capability-proof-v2
 
       - name: Build assay CLI
         shell: bash

--- a/.github/workflows/host-capability-proof.yml
+++ b/.github/workflows/host-capability-proof.yml
@@ -34,7 +34,9 @@ jobs:
   proof:
     name: Produce host-capability proof
     runs-on: [self-hosted, linux, assay-bpf-runner]
-    timeout-minutes: 30
+    # A cold v5 workspace exceeded 30 minutes. Match the bounded peer lane until
+    # exact-head cold/warm proof provides a tighter measured ceiling.
+    timeout-minutes: 90
     steps:
       - name: Reset workspace ownership
         shell: bash
@@ -50,6 +52,11 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+
+      - name: Restore bounded Rust build cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: host-capability-proof-v1
 
       - name: Build assay CLI
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,6 +161,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/(reconcile-docs-auto-pr|test-reconcile-docs-auto-pr)\.sh|\.github/workflows/(docs-auto-update|ci|assay-runner-lane-check|host-capability-check)\.yml|\.pre-commit-config\.yaml)$
 
+      - id: host-capability-proof-contract
+        name: Host-capability proof cold-start contract
+        entry: bash scripts/ci/test-host-capability-proof-contract.sh --self-test
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/test-host-capability-proof-contract\.sh|\.github/workflows/host-capability-proof\.yml|docs/reference/runner/host-capability-proof\.md|\.pre-commit-config\.yaml)$
+
       - id: aee-seal-producer-mutations
         name: ADR-045 seal producer mutations
         entry: python3 scripts/ci/test_aee_seal_producer_mutations.py

--- a/docs/reference/runner/host-capability-proof.md
+++ b/docs/reference/runner/host-capability-proof.md
@@ -81,6 +81,22 @@ The run builds `assay-cli` from the dispatched ref and uploads an artifact conta
 - the full `assay doctor --format json` output,
 - host metadata (`uname -a`, runner label).
 
+The producer restores a Rust build cache under the isolated
+`host-capability-proof-v1` prefix before compiling. It keeps the workflow-level
+`contents: read` and `actions: read` permissions; cache restore/save uses the
+job's Actions runtime token and does not justify repository Actions write
+access. Failed builds are not cached.
+
+The job has a 90-minute ceiling. This is a provisional cold-start budget: a
+30-minute run on Assay 5.0.0 timed out inside `cargo build`, while the existing
+delegated peer lane already uses a 90-minute bound on the same singleton host.
+The number is not a measured cold-build duration. A change to this producer
+must obtain an exact-head cold run followed by a warm run and tighten or retain
+the ceiling from that evidence. A deliberately cold run uses an empty workspace
+`target/` plus a proof-workflow cache-key miss; it must not delete unrelated
+global Cargo caches. Timeout, cancelled build, absent output, and failed upload
+remain non-success.
+
 Starting a `workflow_dispatch` run requires write access to the repository, so who-may-produce-proof
 is enforced by GitHub's own permission model, not by comment-author filtering.
 

--- a/docs/reference/runner/host-capability-proof.md
+++ b/docs/reference/runner/host-capability-proof.md
@@ -81,8 +81,11 @@ The run builds `assay-cli` from the dispatched ref and uploads an artifact conta
 - the full `assay doctor --format json` output,
 - host metadata (`uname -a`, runner label).
 
-The producer restores a Rust build cache under the isolated
-`host-capability-proof-v1` prefix before compiling. It keeps the workflow-level
+The producer reads the Rust version from the repository's `rust-toolchain.toml`,
+installs it through a commit-pinned action, and then restores a Rust build cache
+under the isolated `host-capability-proof-v2` prefix before compiling. The cache
+excludes `CARGO_HOME/bin`: cache cleanup or restore must never mutate the
+persistent host's `rustup`, `cargo`, or `rustc` shims. It keeps the workflow-level
 `contents: read` and `actions: read` permissions; cache restore/save uses the
 job's Actions runtime token and does not justify repository Actions write
 access. Failed builds are not cached.

--- a/scripts/ci/test-host-capability-proof-contract.sh
+++ b/scripts/ci/test-host-capability-proof-contract.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOW="${1:-${ROOT}/.github/workflows/host-capability-proof.yml}"
-PIN="c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+CACHE_PIN="c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+TOOLCHAIN_PIN="29eef336d9b2848a0b548edc03f92a220660cdb8"
 
 validate() {
-  ruby -ryaml - "$1" "$PIN" <<'RUBY'
-path, pin = ARGV
+  ruby -ryaml - "$1" "$CACHE_PIN" "$TOOLCHAIN_PIN" <<'RUBY'
+path, cache_pin, toolchain_pin = ARGV
 doc = YAML.safe_load_file(path, aliases: false)
 abort "host proof workflow must be a mapping" unless doc.is_a?(Hash)
 
@@ -28,6 +29,8 @@ end
 
 required = [
   "Checkout repository",
+  "Resolve pinned Rust toolchain",
+  "Install pinned Rust toolchain",
   "Restore bounded Rust build cache",
   "Build assay CLI",
   "Run doctor and collect provenance",
@@ -40,11 +43,24 @@ positions = required.map { |name| steps.index(named.fetch(name)) }
 abort "host proof checkout/cache/build/doctor/upload order drifted" unless positions == positions.sort
 
 cache = named.fetch("Restore bounded Rust build cache")
-expected_use = "Swatinem/rust-cache@#{pin}"
+expected_use = "Swatinem/rust-cache@#{cache_pin}"
 abort "host proof rust-cache pin drifted" unless cache["uses"] == expected_use
 cache_with = cache.fetch("with")
-abort "host proof rust-cache key is not isolated" unless cache_with["prefix-key"] == "host-capability-proof-v1"
+abort "host proof rust-cache key is not isolated" unless cache_with["prefix-key"] == "host-capability-proof-v2"
+abort "host proof cache must not mutate Cargo toolchain binaries" unless cache_with["cache-bin"] == false || cache_with["cache-bin"] == "false"
 abort "host proof must not save failed builds" if cache_with["cache-on-failure"] == true || cache_with["cache-on-failure"] == "true"
+
+resolve = named.fetch("Resolve pinned Rust toolchain")
+abort "host proof toolchain resolver needs id rust-toolchain" unless resolve["id"] == "rust-toolchain"
+resolve_run = resolve.fetch("run")
+abort "host proof toolchain must be read from rust-toolchain.toml" unless resolve_run.include?("rust-toolchain.toml")
+abort "host proof toolchain resolver must publish an output" unless resolve_run.include?("GITHUB_OUTPUT")
+
+install = named.fetch("Install pinned Rust toolchain")
+expected_toolchain_use = "dtolnay/rust-toolchain@#{toolchain_pin}"
+abort "host proof rust-toolchain action pin drifted" unless install["uses"] == expected_toolchain_use
+expected_toolchain = "${{ steps.rust-toolchain.outputs.channel }}"
+abort "host proof install must consume the repository toolchain pin" unless install.fetch("with")["toolchain"] == expected_toolchain
 
 ["Restore bounded Rust build cache", "Build assay CLI", "Upload proof artifact"].each do |name|
   value = named.fetch(name)["continue-on-error"]
@@ -87,6 +103,14 @@ when "late-cache"
   steps.insert(build_index + 1, cache)
 when "cache-failure"
   steps.find { |step| step["name"] == "Restore bounded Rust build cache" }.fetch("with")["cache-on-failure"] = true
+when "cache-bin"
+  steps.find { |step| step["name"] == "Restore bounded Rust build cache" }.fetch("with")["cache-bin"] = true
+when "remove-toolchain"
+  steps.reject! { |step| ["Resolve pinned Rust toolchain", "Install pinned Rust toolchain"].include?(step["name"]) }
+when "float-toolchain"
+  steps.find { |step| step["name"] == "Install pinned Rust toolchain" }["uses"] = "dtolnay/rust-toolchain@stable"
+when "hardcode-toolchain"
+  steps.find { |step| step["name"] == "Install pinned Rust toolchain" }.fetch("with")["toolchain"] = "1.96.0"
 when "shrink-timeout"
   job["timeout-minutes"] = 30
 when "widen-permissions"
@@ -114,6 +138,10 @@ RUBY
   run_mutation share-cache share-cache
   run_mutation late-cache late-cache
   run_mutation cache-failure cache-failure
+  run_mutation cache-bin cache-bin
+  run_mutation remove-toolchain remove-toolchain
+  run_mutation float-toolchain float-toolchain
+  run_mutation hardcode-toolchain hardcode-toolchain
   run_mutation shrink-timeout shrink-timeout
   run_mutation widen-permissions widen-permissions
   run_mutation soft-cache soft-cache

--- a/scripts/ci/test-host-capability-proof-contract.sh
+++ b/scripts/ci/test-host-capability-proof-contract.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${1:-${ROOT}/.github/workflows/host-capability-proof.yml}"
+PIN="c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+
+validate() {
+  ruby -ryaml - "$1" "$PIN" <<'RUBY'
+path, pin = ARGV
+doc = YAML.safe_load_file(path, aliases: false)
+abort "host proof workflow must be a mapping" unless doc.is_a?(Hash)
+
+permissions = doc.fetch("permissions")
+expected_permissions = {"contents" => "read", "actions" => "read"}
+abort "host proof permissions must stay read-only" unless permissions == expected_permissions
+
+job = doc.fetch("jobs").fetch("proof")
+abort "host proof cold-start timeout must be 90 minutes" unless job["timeout-minutes"] == 90
+steps = job.fetch("steps")
+
+named = steps.each_with_object({}) do |step, out|
+  name = step["name"]
+  abort "host proof step is missing a name" unless name.is_a?(String) && !name.empty?
+  abort "duplicate host proof step #{name.inspect}" if out.key?(name)
+  out[name] = step
+end
+
+required = [
+  "Checkout repository",
+  "Restore bounded Rust build cache",
+  "Build assay CLI",
+  "Run doctor and collect provenance",
+  "Upload proof artifact",
+]
+missing = required.reject { |name| named.key?(name) }
+abort "host proof steps missing: #{missing.join(', ')}" unless missing.empty?
+
+positions = required.map { |name| steps.index(named.fetch(name)) }
+abort "host proof checkout/cache/build/doctor/upload order drifted" unless positions == positions.sort
+
+cache = named.fetch("Restore bounded Rust build cache")
+expected_use = "Swatinem/rust-cache@#{pin}"
+abort "host proof rust-cache pin drifted" unless cache["uses"] == expected_use
+cache_with = cache.fetch("with")
+abort "host proof rust-cache key is not isolated" unless cache_with["prefix-key"] == "host-capability-proof-v1"
+abort "host proof must not save failed builds" if cache_with["cache-on-failure"] == true || cache_with["cache-on-failure"] == "true"
+
+["Restore bounded Rust build cache", "Build assay CLI", "Upload proof artifact"].each do |name|
+  value = named.fetch(name)["continue-on-error"]
+  abort "#{name} must stay fail-closed" if value == true || value == "true"
+end
+
+upload = named.fetch("Upload proof artifact")
+abort "host proof upload must fail when proof files are absent" unless upload.fetch("with")["if-no-files-found"] == "error"
+
+puts "host-capability-proof contract=passed"
+RUBY
+}
+
+self_test() {
+  validate "$WORKFLOW" >/dev/null
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+
+  run_mutation() {
+    local name="$1"
+    local ruby_mutation="$2"
+    local mutated="${tmp}/${name}.yml"
+    cp "$WORKFLOW" "$mutated"
+    ruby -ryaml - "$mutated" "$ruby_mutation" <<'RUBY'
+path, mutation = ARGV
+doc = YAML.safe_load_file(path, aliases: false)
+job = doc.fetch("jobs").fetch("proof")
+steps = job.fetch("steps")
+case mutation
+when "remove-cache"
+  steps.reject! { |step| step["name"] == "Restore bounded Rust build cache" }
+when "float-cache"
+  steps.find { |step| step["name"] == "Restore bounded Rust build cache" }["uses"] = "Swatinem/rust-cache@v2"
+when "share-cache"
+  steps.find { |step| step["name"] == "Restore bounded Rust build cache" }.fetch("with")["prefix-key"] = "v0-rust"
+when "late-cache"
+  cache = steps.find { |step| step["name"] == "Restore bounded Rust build cache" }
+  steps.delete(cache)
+  build_index = steps.index { |step| step["name"] == "Build assay CLI" }
+  steps.insert(build_index + 1, cache)
+when "cache-failure"
+  steps.find { |step| step["name"] == "Restore bounded Rust build cache" }.fetch("with")["cache-on-failure"] = true
+when "shrink-timeout"
+  job["timeout-minutes"] = 30
+when "widen-permissions"
+  doc.fetch("permissions")["actions"] = "write"
+when "soft-cache"
+  steps.find { |step| step["name"] == "Restore bounded Rust build cache" }["continue-on-error"] = true
+when "soft-build"
+  steps.find { |step| step["name"] == "Build assay CLI" }["continue-on-error"] = true
+when "soft-upload"
+  steps.find { |step| step["name"] == "Upload proof artifact" }.fetch("with")["if-no-files-found"] = "warn"
+else
+  abort "unknown mutation #{mutation}"
+end
+File.write(path, YAML.dump(doc))
+RUBY
+    if validate "$mutated" >/dev/null 2>&1; then
+      echo "mutation did not bite: $name" >&2
+      exit 1
+    fi
+    echo "ok    $name"
+  }
+
+  run_mutation remove-cache remove-cache
+  run_mutation float-cache float-cache
+  run_mutation share-cache share-cache
+  run_mutation late-cache late-cache
+  run_mutation cache-failure cache-failure
+  run_mutation shrink-timeout shrink-timeout
+  run_mutation widen-permissions widen-permissions
+  run_mutation soft-cache soft-cache
+  run_mutation soft-build soft-build
+  run_mutation soft-upload soft-upload
+  echo "host-capability-proof contract self-test=passed"
+}
+
+if [[ "${2:-}" == "--self-test" || "${1:-}" == "--self-test" ]]; then
+  [[ "${1:-}" == "--self-test" ]] && WORKFLOW="${ROOT}/.github/workflows/host-capability-proof.yml"
+  self_test
+else
+  validate "$WORKFLOW"
+fi

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -708,6 +708,7 @@ ALLOWED = [
     (".github/workflows/ci.yml", "ebpf-smoke-ubuntu", TC, "rust-src + install-ebpf-toolchain.sh; composite would inject rust-cache"),
     (".github/workflows/demo.yml", "regenerate", TC, "no-cache demo rebuild; composite always caches"),
     (".github/workflows/docs-auto-update.yml", "generate-docs", TC, "no-cache docs generation; composite always caches"),
+    (".github/workflows/host-capability-proof.yml", "proof", TC, "repository-pinned toolchain paired with isolated direct cache; composite cannot set prefix-key/cache-bin"),
     (".github/workflows/host-capability-proof.yml", "proof", RC, "self-hosted proof uses isolated host-capability prefix-key; composite has no prefix-key input"),
     (".github/workflows/kernel-matrix.yml", "build-artifacts", TC, "host toolchain before install-ebpf-toolchain.sh"),
     (".github/workflows/kernel-matrix.yml", "build-artifacts", RC, "Swatinem cache-on-failure for eBPF builds; composite lacks input"),

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -708,6 +708,7 @@ ALLOWED = [
     (".github/workflows/ci.yml", "ebpf-smoke-ubuntu", TC, "rust-src + install-ebpf-toolchain.sh; composite would inject rust-cache"),
     (".github/workflows/demo.yml", "regenerate", TC, "no-cache demo rebuild; composite always caches"),
     (".github/workflows/docs-auto-update.yml", "generate-docs", TC, "no-cache docs generation; composite always caches"),
+    (".github/workflows/host-capability-proof.yml", "proof", RC, "self-hosted proof uses isolated host-capability prefix-key; composite has no prefix-key input"),
     (".github/workflows/kernel-matrix.yml", "build-artifacts", TC, "host toolchain before install-ebpf-toolchain.sh"),
     (".github/workflows/kernel-matrix.yml", "build-artifacts", RC, "Swatinem cache-on-failure for eBPF builds; composite lacks input"),
     (".github/workflows/parity.yml", "parity", TC, "actions/cache not Swatinem; composite would inject Swatinem"),


### PR DESCRIPTION
## Summary

- bound the host-capability proof job at a provisional 90 minutes
- install the repository-pinned Rust toolchain before cache restore
- cache build state under isolated `host-capability-proof-v2` with `cache-bin: false`
- preserve exact read-only permissions and fail-closed build/upload behavior
- add source-parsed contract coverage plus 14 biting mutations
- document exact-head cold/warm proof and the measured cost/non-claims

Closes #2257.

## Why

The earlier producer timed out at 30 minutes with no cache. The first implementation then exposed a persistent-host failure: rust-cache's default `cache-bin: true` removed the rustup target behind the host's cargo/rustc shims, so the next exact-head warm run failed before build.

The final head fixes the root cause rather than masking it:

- toolchain channel is read from `rust-toolchain.toml`;
- pinned `dtolnay/rust-toolchain` installs it before cache restore;
- `cache-bin: false` prevents cache lifecycle from mutating toolchain shims;
- v2 cache isolation prevents reuse of the poisoned v1 entry.

## Security / failure semantics

- permissions remain `contents: read`, `actions: read`;
- trusted-maintainer `workflow_dispatch` only;
- actions are SHA-pinned;
- failed builds are not cached;
- timeout, cancellation, missing output, and upload failure remain non-success;
- this proves diagnostics execution for an exact SHA, not host health or an SLA.

## TDD and mutation proof

RED after adding the final contract expectations:

```text
missing deterministic repository-pinned toolchain setup
cache-bin must be false
```

GREEN on `b902bc87f4817b7b605a55edfd1c2c3d73596f56`:

```text
host-capability-proof contract=passed
14/14 mutations rejected
setup-rust composite contract: all checks passed
```

Mutations cover cache presence/order/pin/prefix/failure, `cache-bin`, missing/floating/hardcoded toolchain setup, timeout, permissions, and fail-closed cache/build/upload behavior.

## Verification

- `scripts/ci/test-host-capability-proof-contract.sh --self-test`
- `scripts/ci/test-setup-rust-composite-contract.sh`
- `shellcheck` on affected scripts
- focused `pre-commit run --files ...`
- full pre-push suite, including clippy and Linux cross-target compile
- `git diff --check`
- independent non-building exact-head review: READY, no findings

## Exact-head live proof

Both runs target `b902bc87f4817b7b605a55edfd1c2c3d73596f56`.

| Path | Run | Result | Key measurements |
|---|---|---|---|
| cold v2 miss | [31534582077](https://github.com/Rul1an/assay/actions/runs/31534582077) | success | cache miss; build 20m27s; total 41m34s; artifact `9118954290` |
| warm v2 hit | [31538030514](https://github.com/Rul1an/assay/actions/runs/31538030514) | success | full cache-key match; restore 10m10s; build 6m01s; total 18m41s; artifact `9120076517` |

Both artifacts name the exact head and contain a valid `assay.doctor_report.v0` with the required typed Landlock fields.

## Bound decision

Keep 90 minutes. The measured cold total is 41m34s, but one sample is not a defensible tighter SLA for a persistent serialized host. The ceiling is bounded and has >2x observed headroom; tightening can follow after more samples.

## Non-claims

- The cache does not make this lane fast: the 573 MB warm restore took 10m10s and workspace relink/rebuild still took 6m01s.
- The proof does not establish host health, availability, or an SLA.
- The cold/warm pair is one exact-head sample, not a distribution.
