### PR TITLE
ci: runner-health explicit state contract (silence ≠ health)

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Exercise the release-blocking gate
         run: bash scripts/ci/test-release-blocking-gate.sh
 
+      # Runner-health used to publish healthy=true for expected_offline. Keep the state contract
+      # and its biting mutations on the PR path (#2256).
+      - name: Exercise the runner-health state contract
+        run: bash scripts/ci/test-check-runner-health.sh
+
       - name: Build CLI once
         run: cargo build --release --workspace --exclude assay-ebpf
 

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -1,5 +1,6 @@
-# Self-hosted runner health monitor
-# Runs every 15 minutes to check runner status and alert if offline
+# Self-hosted runner control-plane monitor
+# Samples runner registration and label-specific demand every 6 hours.
+# Does not claim host functionality or SLA. expected_offline is not health.
 name: Runner Health
 
 on:
@@ -35,8 +36,8 @@ jobs:
         run: |
           bash scripts/ci/check-runner-health.sh
 
-      - name: Create issue if unhealthy
-        if: steps.check.outcome == 'failure'
+      - name: Create issue if alert required
+        if: always() && steps.check.outputs.alert_required == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -49,6 +50,8 @@ jobs:
           INSPECTED_WORKFLOW_RUNS: ${{ steps.check.outputs.inspected_workflow_runs }}
           MATCHING_QUEUED_JOBS: ${{ steps.check.outputs.matching_queued_jobs }}
           QUEUE_STATUS_ERROR: ${{ steps.check.outputs.queue_status_error }}
+          RUNNER_STATE: ${{ steps.check.outputs.runner_state }}
+          ALERT_REQUIRED: ${{ steps.check.outputs.alert_required }}
           HEALTH_REASON: ${{ steps.check.outputs.health_reason }}
         run: |
           set -euo pipefail
@@ -73,12 +76,16 @@ jobs:
           if [[ "$EXISTING" -eq 0 ]]; then
             detected_at="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
             ISSUE_BODY="$(cat <<EOF
-          ## Runner Health Alert
+          ## Runner Alert
 
-          The self-hosted runner \`assay-bpf-runner\` needs attention for label-specific queue health.
+          The self-hosted runner \`assay-bpf-runner\` needs attention for control-plane registration or label-specific demand.
+
+          This alert samples GitHub runner registration and queue labels only. It does not claim host functionality or SLA.
 
           ### Details
           - **Runner:** assay-bpf-runner
+          - **Runner State:** ${RUNNER_STATE}
+          - **Alert Required:** ${ALERT_REQUIRED}
           - **Status:** ${RUNNER_STATUS}
           - **Status Error:** ${RUNNER_STATUS_ERROR}
           - **Busy:** ${RUNNER_BUSY}
@@ -114,7 +121,7 @@ jobs:
           - Runner token expired
           - Network issues
 
-          This issue will auto-close when the label-specific health alert condition clears.
+          This issue will auto-close when alert_required clears for the exact alert title.
           EOF
           )"
 
@@ -135,8 +142,8 @@ jobs:
             echo "Health alert issue already exists"
           fi
 
-      - name: Close issue if healthy
-        if: success()
+      - name: Close issue if alert not required
+        if: always() && steps.check.outputs.alert_required == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -155,6 +162,6 @@ jobs:
 
           for ISSUE in $ISSUES; do
             gh issue close "$ISSUE" --repo "$REPO" \
-              --comment "✅ Runner health alert condition cleared. Auto-closing this alert."
+              --comment "✅ Runner alert_required cleared. Auto-closing this alert."
             echo "Closed issue #$ISSUE"
           done

--- a/scripts/ci/check-runner-health.sh
+++ b/scripts/ci/check-runner-health.sh
@@ -42,21 +42,47 @@ count_nonempty_lines() {
   sed '/^[[:space:]]*$/d' | wc -l | tr -d ' '
 }
 
+# Centralized jq capture for hostile/malformed API bodies.
+# On success: prints jq stdout. On failure: appends a value-free marker to
+# err_file (never echoes jq diagnostics that may include payload fragments)
+# and returns 1 so callers can continue into classification_unknown.
+jq_try() {
+  local err_file="$1"
+  local marker="$2"
+  shift 2
+  local out_file="$tmpdir/jq.out"
+  if jq "$@" >"$out_file" 2>/dev/null; then
+    cat "$out_file"
+    return 0
+  fi
+  printf '%s\n' "$marker" >>"$err_file"
+  return 1
+}
+
 runner_status="unknown"
 runner_status_error=""
 runner_busy="unknown"
 runner_labels=""
 
 runner_status_stderr="$tmpdir/runner-status.stderr"
+runner_parse_err="$tmpdir/runner-parse.err"
+: >"$runner_parse_err"
 runner_json="$tmpdir/runners.json"
 if GH_TOKEN="$runner_status_token" gh api --paginate "repos/$repo/actions/runners?per_page=100" >"$runner_json" 2>"$runner_status_stderr"; then
-  selected_runner="$(jq -sc --arg name "$runner_name" '[.[].runners[]? | select(.name == $name)] | .[0] // empty' "$runner_json")"
-  if [[ -z "$selected_runner" ]]; then
-    runner_status="not_found"
-  else
-    runner_status="$(jq -r '.status // "unknown"' <<<"$selected_runner")"
-    runner_busy="$(jq -r 'if has("busy") then (.busy | tostring) else "unknown" end' <<<"$selected_runner")"
-    runner_labels="$(jq -r '[.labels[]?.name] | join(",")' <<<"$selected_runner")"
+  # jq program: $name is a jq --arg, not a shell expansion.
+  # shellcheck disable=SC2016
+  if selected_runner="$(jq_try "$runner_parse_err" "runner_json_parse_failed" -sc --arg name "$runner_name" '[.[].runners[]? | select(.name == $name)] | .[0] // empty' "$runner_json")"; then
+    if [[ -z "$selected_runner" ]]; then
+      runner_status="not_found"
+    else
+      runner_status="$(jq -r '.status // "unknown"' <<<"$selected_runner")"
+      runner_busy="$(jq -r 'if has("busy") then (.busy | tostring) else "unknown" end' <<<"$selected_runner")"
+      runner_labels="$(jq -r '[.labels[]?.name] | join(",")' <<<"$selected_runner")"
+    fi
+  fi
+  if [[ -s "$runner_parse_err" ]]; then
+    runner_status_error="$(sanitize_error <"$runner_parse_err")"
+    echo "::warning::Unable to classify self-hosted runner status: ${runner_status_error}" >&2
   fi
 else
   runner_status_error="$(sanitize_error <"$runner_status_stderr")"
@@ -74,32 +100,39 @@ inspected_workflow_runs=0
 for run_status in queued in_progress; do
   runs_json="$tmpdir/runs-${run_status}.json"
   if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs?status=${run_status}&per_page=100" >"$runs_json" 2>>"$queue_stderr"; then
-    run_rows="$(jq -r '.workflow_runs[]? | [.id, .name, .status, .html_url] | @tsv' "$runs_json")"
-    if [[ "$run_status" == "queued" ]]; then
-      general_queued_runs="$(jq -r '.workflow_runs[]?.id' "$runs_json" | count_nonempty_lines)"
-    fi
-
-    while IFS=$'\t' read -r run_id run_name _status run_url; do
-      [[ -n "${run_id:-}" ]] || continue
-      inspected_workflow_runs=$((inspected_workflow_runs + 1))
-
-      jobs_json="$tmpdir/jobs-${run_id}.json"
-      if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs/${run_id}/jobs?filter=latest&per_page=100" >"$jobs_json" 2>>"$queue_stderr"; then
-        jq -r \
-          --arg label "$required_runner_label" \
-          --arg run_name "$run_name" \
-          --arg run_url "$run_url" \
-          '
-          .jobs[]?
-          | select((.status == "queued" or .status == "waiting" or .status == "pending" or .status == "requested")
-              and ((.labels // []) | index($label)))
-          | [$run_name, .name, .status, ((.labels // []) | join(",")), (.html_url // $run_url)]
-          | @tsv
-          ' "$jobs_json" >>"$matching_jobs"
-      else
-        echo "Unable to query jobs for run ${run_id}" >>"$queue_stderr"
+    if run_rows="$(jq_try "$queue_stderr" "queue_json_parse_failed" -r '.workflow_runs[]? | [.id, .name, .status, .html_url] | @tsv' "$runs_json")"; then
+      if [[ "$run_status" == "queued" ]]; then
+        if queued_ids="$(jq_try "$queue_stderr" "queue_json_parse_failed" -r '.workflow_runs[]?.id' "$runs_json")"; then
+          general_queued_runs="$(printf '%s\n' "$queued_ids" | count_nonempty_lines)"
+        fi
       fi
-    done <<<"$run_rows"
+
+      while IFS=$'\t' read -r run_id run_name _status run_url; do
+        [[ -n "${run_id:-}" ]] || continue
+        inspected_workflow_runs=$((inspected_workflow_runs + 1))
+
+        jobs_json="$tmpdir/jobs-${run_id}.json"
+        if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs/${run_id}/jobs?filter=latest&per_page=100" >"$jobs_json" 2>>"$queue_stderr"; then
+          # jq program: $label/$run_name/$run_url are jq --arg bindings.
+          # shellcheck disable=SC2016
+          if ! jq_try "$queue_stderr" "queue_json_parse_failed" -r \
+            --arg label "$required_runner_label" \
+            --arg run_name "$run_name" \
+            --arg run_url "$run_url" \
+            '
+            .jobs[]?
+            | select((.status == "queued" or .status == "waiting" or .status == "pending" or .status == "requested")
+                and ((.labels // []) | index($label)))
+            | [$run_name, .name, .status, ((.labels // []) | join(",")), (.html_url // $run_url)]
+            | @tsv
+            ' "$jobs_json" >>"$matching_jobs"; then
+            :
+          fi
+        else
+          echo "Unable to query jobs for run ${run_id}" >>"$queue_stderr"
+        fi
+      done <<<"$run_rows"
+    fi
   fi
 done
 

--- a/scripts/ci/check-runner-health.sh
+++ b/scripts/ci/check-runner-health.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Sample GitHub control-plane runner registration and label-specific demand.
+# Emits runner_state + alert_required. Does not claim host functionality or SLA.
+# expected_offline is not health: never publish healthy=true for that state.
 set -euo pipefail
 
 repo="${GITHUB_REPOSITORY:-${REPO:-}}"
@@ -61,7 +64,9 @@ else
 fi
 
 matching_jobs="$tmpdir/matching-jobs.tsv"
+: >"$matching_jobs"
 queue_stderr="$tmpdir/queue.stderr"
+: >"$queue_stderr"
 queue_status_error=""
 general_queued_runs=0
 inspected_workflow_runs=0
@@ -104,19 +109,48 @@ if [[ -s "$queue_stderr" ]]; then
 fi
 
 matching_queued_jobs="$(count_nonempty_lines <"$matching_jobs")"
-health_reason="clear"
-healthy="true"
 
-if [[ "$runner_status" == "online" ]]; then
-  health_reason="runner_online"
-elif [[ "$matching_queued_jobs" =~ ^[0-9]+$ && "$matching_queued_jobs" -gt 0 ]]; then
+# Explicit state contract (issue #2256). Do not overload healthy for offline.
+runner_state="classification_unknown"
+alert_required="true"
+healthy="false"
+health_reason="runner_classification_unknown"
+
+if [[ -n "$runner_status_error" ]]; then
+  runner_state="classification_unknown"
+  alert_required="true"
   healthy="false"
-  health_reason="runner_${runner_status}_with_matching_backlog"
-elif [[ -n "$queue_status_error" && "$runner_status" != "online" ]]; then
+  health_reason="runner_status_classification_failed"
+elif [[ "$runner_status" == "online" ]]; then
+  runner_state="available"
+  alert_required="false"
+  healthy="true"
+  health_reason="runner_online"
+elif [[ "$runner_status" == "not_found" ]]; then
+  runner_state="unavailable"
+  alert_required="true"
+  healthy="false"
+  health_reason="runner_not_found"
+elif [[ -n "$queue_status_error" ]]; then
+  runner_state="classification_unknown"
+  alert_required="true"
   healthy="false"
   health_reason="runner_${runner_status}_queue_classification_unknown"
-elif [[ "$runner_status" == "offline" || "$runner_status" == "not_found" || "$runner_status" == "unknown" ]]; then
-  health_reason="runner_${runner_status}_without_matching_backlog"
+elif [[ "$matching_queued_jobs" =~ ^[0-9]+$ && "$matching_queued_jobs" -gt 0 ]]; then
+  runner_state="demand_backed_outage"
+  alert_required="true"
+  healthy="false"
+  health_reason="runner_${runner_status}_with_matching_backlog"
+elif [[ "$runner_status" == "offline" ]]; then
+  runner_state="expected_offline"
+  alert_required="false"
+  healthy="false"
+  health_reason="runner_offline_without_matching_backlog"
+else
+  runner_state="classification_unknown"
+  alert_required="true"
+  healthy="false"
+  health_reason="runner_${runner_status}_classification_unknown"
 fi
 
 write_output "runner_status" "$runner_status"
@@ -128,11 +162,13 @@ write_output "general_queued_runs" "$general_queued_runs"
 write_output "inspected_workflow_runs" "$inspected_workflow_runs"
 write_output "matching_queued_jobs" "$matching_queued_jobs"
 write_output "queue_status_error" "$queue_status_error"
+write_output "runner_state" "$runner_state"
+write_output "alert_required" "$alert_required"
 write_output "healthy" "$healthy"
 write_output "health_reason" "$health_reason"
 
 {
-  echo "## Runner Health"
+  echo "## Runner control-plane sample"
   echo "- runner: ${runner_name}"
   echo "- runner_status: ${runner_status}"
   echo "- runner_busy: ${runner_busy}"
@@ -141,8 +177,11 @@ write_output "health_reason" "$health_reason"
   echo "- general_queued_workflow_runs: ${general_queued_runs}"
   echo "- inspected_workflow_runs: ${inspected_workflow_runs}"
   echo "- matching_queued_jobs: ${matching_queued_jobs}"
+  echo "- runner_state: ${runner_state}"
+  echo "- alert_required: ${alert_required}"
   echo "- healthy: ${healthy}"
   echo "- health_reason: ${health_reason}"
+  echo "- note: samples registration and label demand only; not host functionality or SLA"
   if [[ -n "$runner_status_error" ]]; then
     echo "- runner_status_error: ${runner_status_error}"
   fi
@@ -158,9 +197,9 @@ write_output "health_reason" "$health_reason"
   fi
 } >>"$summary_file"
 
-if [[ "$healthy" != "true" ]]; then
-  echo "Runner health alert: ${health_reason}" >&2
+if [[ "$alert_required" == "true" ]]; then
+  echo "Runner alert required: state=${runner_state} reason=${health_reason}" >&2
   exit 1
 fi
 
-echo "Runner health clear: ${health_reason}"
+echo "Runner alert not required: state=${runner_state} reason=${health_reason}"

--- a/scripts/ci/check-runner-health.sh
+++ b/scripts/ci/check-runner-health.sh
@@ -59,6 +59,43 @@ jq_try() {
   return 1
 }
 
+# Validate a paginated gh api stream before extraction.
+# Requires >=1 JSON document and every page to be an object whose expected key
+# is an array (empty arrays are valid). Empty bodies and wrong shapes are
+# incomplete classification inputs, not "no matching rows".
+require_json_pages() {
+  local file="$1"
+  local array_key="$2"
+  local err_file="$3"
+  local marker="$4"
+
+  if [[ ! -s "$file" ]]; then
+    printf '%s\n' "$marker" >>"$err_file"
+    return 1
+  fi
+
+  # jq program: $key is a jq --arg, not a shell expansion.
+  # shellcheck disable=SC2016
+  if jq_try "$err_file" "$marker" -se --arg key "$array_key" '
+    if length < 1 then
+      error("incomplete")
+    else
+      map(
+        if (type != "object")
+          or ((has($key) | not))
+          or ((.[$key] | type) != "array")
+        then error("incomplete")
+        else true
+        end
+      )
+      | length
+    end
+  ' "$file" >/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
 runner_status="unknown"
 runner_status_error=""
 runner_busy="unknown"
@@ -69,15 +106,17 @@ runner_parse_err="$tmpdir/runner-parse.err"
 : >"$runner_parse_err"
 runner_json="$tmpdir/runners.json"
 if GH_TOKEN="$runner_status_token" gh api --paginate "repos/$repo/actions/runners?per_page=100" >"$runner_json" 2>"$runner_status_stderr"; then
-  # jq program: $name is a jq --arg, not a shell expansion.
-  # shellcheck disable=SC2016
-  if selected_runner="$(jq_try "$runner_parse_err" "runner_json_parse_failed" -sc --arg name "$runner_name" '[.[].runners[]? | select(.name == $name)] | .[0] // empty' "$runner_json")"; then
-    if [[ -z "$selected_runner" ]]; then
-      runner_status="not_found"
-    else
-      runner_status="$(jq -r '.status // "unknown"' <<<"$selected_runner")"
-      runner_busy="$(jq -r 'if has("busy") then (.busy | tostring) else "unknown" end' <<<"$selected_runner")"
-      runner_labels="$(jq -r '[.labels[]?.name] | join(",")' <<<"$selected_runner")"
+  if require_json_pages "$runner_json" "runners" "$runner_parse_err" "runner_json_incomplete"; then
+    # jq program: $name is a jq --arg, not a shell expansion.
+    # shellcheck disable=SC2016
+    if selected_runner="$(jq_try "$runner_parse_err" "runner_json_parse_failed" -sc --arg name "$runner_name" '[.[].runners[]? | select(.name == $name)] | .[0] // empty' "$runner_json")"; then
+      if [[ -z "$selected_runner" ]]; then
+        runner_status="not_found"
+      else
+        runner_status="$(jq -r '.status // "unknown"' <<<"$selected_runner")"
+        runner_busy="$(jq -r 'if has("busy") then (.busy | tostring) else "unknown" end' <<<"$selected_runner")"
+        runner_labels="$(jq -r '[.labels[]?.name] | join(",")' <<<"$selected_runner")"
+      fi
     fi
   fi
   if [[ -s "$runner_parse_err" ]]; then
@@ -100,38 +139,42 @@ inspected_workflow_runs=0
 for run_status in queued in_progress; do
   runs_json="$tmpdir/runs-${run_status}.json"
   if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs?status=${run_status}&per_page=100" >"$runs_json" 2>>"$queue_stderr"; then
-    if run_rows="$(jq_try "$queue_stderr" "queue_json_parse_failed" -r '.workflow_runs[]? | [.id, .name, .status, .html_url] | @tsv' "$runs_json")"; then
-      if [[ "$run_status" == "queued" ]]; then
-        if queued_ids="$(jq_try "$queue_stderr" "queue_json_parse_failed" -r '.workflow_runs[]?.id' "$runs_json")"; then
-          general_queued_runs="$(printf '%s\n' "$queued_ids" | count_nonempty_lines)"
-        fi
-      fi
-
-      while IFS=$'\t' read -r run_id run_name _status run_url; do
-        [[ -n "${run_id:-}" ]] || continue
-        inspected_workflow_runs=$((inspected_workflow_runs + 1))
-
-        jobs_json="$tmpdir/jobs-${run_id}.json"
-        if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs/${run_id}/jobs?filter=latest&per_page=100" >"$jobs_json" 2>>"$queue_stderr"; then
-          # jq program: $label/$run_name/$run_url are jq --arg bindings.
-          # shellcheck disable=SC2016
-          if ! jq_try "$queue_stderr" "queue_json_parse_failed" -r \
-            --arg label "$required_runner_label" \
-            --arg run_name "$run_name" \
-            --arg run_url "$run_url" \
-            '
-            .jobs[]?
-            | select((.status == "queued" or .status == "waiting" or .status == "pending" or .status == "requested")
-                and ((.labels // []) | index($label)))
-            | [$run_name, .name, .status, ((.labels // []) | join(",")), (.html_url // $run_url)]
-            | @tsv
-            ' "$jobs_json" >>"$matching_jobs"; then
-            :
+    if require_json_pages "$runs_json" "workflow_runs" "$queue_stderr" "queue_json_incomplete"; then
+      if run_rows="$(jq_try "$queue_stderr" "queue_json_parse_failed" -r '.workflow_runs[]? | [.id, .name, .status, .html_url] | @tsv' "$runs_json")"; then
+        if [[ "$run_status" == "queued" ]]; then
+          if queued_ids="$(jq_try "$queue_stderr" "queue_json_parse_failed" -r '.workflow_runs[]?.id' "$runs_json")"; then
+            general_queued_runs="$(printf '%s\n' "$queued_ids" | count_nonempty_lines)"
           fi
-        else
-          echo "Unable to query jobs for run ${run_id}" >>"$queue_stderr"
         fi
-      done <<<"$run_rows"
+
+        while IFS=$'\t' read -r run_id run_name _status run_url; do
+          [[ -n "${run_id:-}" ]] || continue
+          inspected_workflow_runs=$((inspected_workflow_runs + 1))
+
+          jobs_json="$tmpdir/jobs-${run_id}.json"
+          if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs/${run_id}/jobs?filter=latest&per_page=100" >"$jobs_json" 2>>"$queue_stderr"; then
+            if require_json_pages "$jobs_json" "jobs" "$queue_stderr" "queue_json_incomplete"; then
+              # jq program: $label/$run_name/$run_url are jq --arg bindings.
+              # shellcheck disable=SC2016
+              if ! jq_try "$queue_stderr" "queue_json_parse_failed" -r \
+                --arg label "$required_runner_label" \
+                --arg run_name "$run_name" \
+                --arg run_url "$run_url" \
+                '
+                .jobs[]?
+                | select((.status == "queued" or .status == "waiting" or .status == "pending" or .status == "requested")
+                    and ((.labels // []) | index($label)))
+                | [$run_name, .name, .status, ((.labels // []) | join(",")), (.html_url // $run_url)]
+                | @tsv
+                ' "$jobs_json" >>"$matching_jobs"; then
+                :
+              fi
+            fi
+          else
+            echo "Unable to query jobs for run ${run_id}" >>"$queue_stderr"
+          fi
+        done <<<"$run_rows"
+      fi
     fi
   fi
 done

--- a/scripts/ci/check-runner-health.sh
+++ b/scripts/ci/check-runner-health.sh
@@ -121,6 +121,12 @@ if [[ -n "$runner_status_error" ]]; then
   alert_required="true"
   healthy="false"
   health_reason="runner_status_classification_failed"
+elif [[ -n "$queue_status_error" ]]; then
+  # Queue classification incomplete/failed is unknown even when the runner is online.
+  runner_state="classification_unknown"
+  alert_required="true"
+  healthy="false"
+  health_reason="runner_${runner_status}_queue_classification_unknown"
 elif [[ "$runner_status" == "online" ]]; then
   runner_state="available"
   alert_required="false"
@@ -131,11 +137,6 @@ elif [[ "$runner_status" == "not_found" ]]; then
   alert_required="true"
   healthy="false"
   health_reason="runner_not_found"
-elif [[ -n "$queue_status_error" ]]; then
-  runner_state="classification_unknown"
-  alert_required="true"
-  healthy="false"
-  health_reason="runner_${runner_status}_queue_classification_unknown"
 elif [[ "$matching_queued_jobs" =~ ^[0-9]+$ && "$matching_queued_jobs" -gt 0 ]]; then
   runner_state="demand_backed_outage"
   alert_required="true"

--- a/scripts/ci/test-check-runner-health-mutations.sh
+++ b/scripts/ci/test-check-runner-health-mutations.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Biting mutations for the runner-health state contract.
+# Each mutation must be rejected by test-check-runner-health.sh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONTRACT="${ROOT}/scripts/ci/test-check-runner-health.sh"
+SCRIPT="${ROOT}/scripts/ci/check-runner-health.sh"
+WORKFLOW="${ROOT}/.github/workflows/runner-health.yml"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+expect_rejected() {
+  local name="$1"
+  local target="$2"
+  local mutated="${TMP_DIR}/${name}.mut"
+
+  python3 - "$target" "$mutated" "$name" <<'PY'
+import pathlib
+import sys
+
+source, destination, name = sys.argv[1:]
+text = pathlib.Path(source).read_text()
+mutations = {
+    # Offline/no-demand must not silently become healthy=true.
+    "offline-to-healthy": (
+        'elif [[ "$runner_status" == "offline" ]]; then\n'
+        '  runner_state="expected_offline"\n'
+        '  alert_required="false"\n'
+        '  healthy="false"\n',
+        'elif [[ "$runner_status" == "offline" ]]; then\n'
+        '  runner_state="expected_offline"\n'
+        '  alert_required="false"\n'
+        '  healthy="true"\n',
+    ),
+    # API/classification failure must not become a clean available result.
+    "api-error-to-clean": (
+        'if [[ -n "$runner_status_error" ]]; then\n'
+        '  runner_state="classification_unknown"\n'
+        '  alert_required="true"\n'
+        '  healthy="false"\n',
+        'if [[ -n "$runner_status_error" ]]; then\n'
+        '  runner_state="available"\n'
+        '  alert_required="false"\n'
+        '  healthy="true"\n',
+    ),
+    # Workflow must not fall back to step-outcome routing.
+    "alert-from-step-outcome": (
+        "        if: always() && steps.check.outputs.alert_required == 'true'\n",
+        "        if: steps.check.outcome == 'failure'\n",
+    ),
+}
+old, new = mutations[name]
+if text.count(old) != 1:
+    raise SystemExit(f"mutation anchor matched {text.count(old)} times, expected once: {old!r}")
+pathlib.Path(destination).write_text(text.replace(old, new, 1))
+PY
+
+  if [[ "$target" == "$SCRIPT" ]]; then
+    if SCRIPT="$mutated" ASSAY_CONTRACT_MUTATION=1 bash "$CONTRACT" >/dev/null 2>&1; then
+      echo "FAIL: contract accepted mutation: $name" >&2
+      exit 1
+    fi
+  else
+    if WORKFLOW="$mutated" ASSAY_CONTRACT_MUTATION=1 bash "$CONTRACT" >/dev/null 2>&1; then
+      echo "FAIL: contract accepted mutation: $name" >&2
+      exit 1
+    fi
+  fi
+}
+
+expect_rejected offline-to-healthy "$SCRIPT"
+expect_rejected api-error-to-clean "$SCRIPT"
+expect_rejected alert-from-step-outcome "$WORKFLOW"
+
+echo "ok: check-runner-health contract rejects inert substitutes"

--- a/scripts/ci/test-check-runner-health-mutations.sh
+++ b/scripts/ci/test-check-runner-health-mutations.sh
@@ -44,6 +44,31 @@ mutations = {
         '  alert_required="false"\n'
         '  healthy="true"\n',
     ),
+    # Online must not mask a failed queue classification as available.
+    "online-masks-queue-error": (
+        'elif [[ -n "$queue_status_error" ]]; then\n'
+        '  # Queue classification incomplete/failed is unknown even when the runner is online.\n'
+        '  runner_state="classification_unknown"\n'
+        '  alert_required="true"\n'
+        '  healthy="false"\n'
+        '  health_reason="runner_${runner_status}_queue_classification_unknown"\n'
+        'elif [[ "$runner_status" == "online" ]]; then\n'
+        '  runner_state="available"\n'
+        '  alert_required="false"\n'
+        '  healthy="true"\n'
+        '  health_reason="runner_online"\n',
+        'elif [[ "$runner_status" == "online" ]]; then\n'
+        '  runner_state="available"\n'
+        '  alert_required="false"\n'
+        '  healthy="true"\n'
+        '  health_reason="runner_online"\n'
+        'elif [[ -n "$queue_status_error" ]]; then\n'
+        '  # Queue classification incomplete/failed is unknown even when the runner is online.\n'
+        '  runner_state="classification_unknown"\n'
+        '  alert_required="true"\n'
+        '  healthy="false"\n'
+        '  health_reason="runner_${runner_status}_queue_classification_unknown"\n',
+    ),
     # Workflow must not fall back to step-outcome routing.
     "alert-from-step-outcome": (
         "        if: always() && steps.check.outputs.alert_required == 'true'\n",
@@ -71,6 +96,7 @@ PY
 
 expect_rejected offline-to-healthy "$SCRIPT"
 expect_rejected api-error-to-clean "$SCRIPT"
+expect_rejected online-masks-queue-error "$SCRIPT"
 expect_rejected alert-from-step-outcome "$WORKFLOW"
 
 echo "ok: check-runner-health contract rejects inert substitutes"

--- a/scripts/ci/test-check-runner-health-mutations.sh
+++ b/scripts/ci/test-check-runner-health-mutations.sh
@@ -84,10 +84,41 @@ mutations = {
         '  # mutation: swallow parse failure without recording a marker\n'
         '  return 0\n',
     ),
-    # Raw jq must not replace jq_try (abort before outputs / alert routing).
+    # Skipping shape validation + raw jq restores empty/malformed abort-or-misclassify paths.
     "parse-failure-uncaught": (
-        '  if selected_runner="$(jq_try "$runner_parse_err" "runner_json_parse_failed" -sc --arg name "$runner_name" \'[.[].runners[]? | select(.name == $name)] | .[0] // empty\' "$runner_json")"; then\n',
-        '  if selected_runner="$(jq -sc --arg name "$runner_name" \'[.[].runners[]? | select(.name == $name)] | .[0] // empty\' "$runner_json")"; then\n',
+        '  if require_json_pages "$runner_json" "runners" "$runner_parse_err" "runner_json_incomplete"; then\n'
+        '    # jq program: $name is a jq --arg, not a shell expansion.\n'
+        '    # shellcheck disable=SC2016\n'
+        '    if selected_runner="$(jq_try "$runner_parse_err" "runner_json_parse_failed" -sc --arg name "$runner_name" \'[.[].runners[]? | select(.name == $name)] | .[0] // empty\' "$runner_json")"; then\n',
+        '  if true; then\n'
+        '    # mutation: skip shape gate and use raw jq\n'
+        '    # shellcheck disable=SC2016\n'
+        '    if selected_runner="$(jq -sc --arg name "$runner_name" \'[.[].runners[]? | select(.name == $name)] | .[0] // empty\' "$runner_json")"; then\n',
+    ),
+    # Shape validation must not be weakened to a no-op (empty/wrong bodies ≠ clean).
+    "shape-validation-removed": (
+        'require_json_pages() {\n'
+        '  local file="$1"\n'
+        '  local array_key="$2"\n'
+        '  local err_file="$3"\n'
+        '  local marker="$4"\n'
+        '\n'
+        '  if [[ ! -s "$file" ]]; then\n'
+        '    printf \'%s\\n\' "$marker" >>"$err_file"\n'
+        '    return 1\n'
+        '  fi\n',
+        'require_json_pages() {\n'
+        '  local file="$1"\n'
+        '  local array_key="$2"\n'
+        '  local err_file="$3"\n'
+        '  local marker="$4"\n'
+        '\n'
+        '  # mutation: accept any body, including empty/wrong-shape streams\n'
+        '  return 0\n'
+        '  if [[ ! -s "$file" ]]; then\n'
+        '    printf \'%s\\n\' "$marker" >>"$err_file"\n'
+        '    return 1\n'
+        '  fi\n',
     ),
     # Workflow must not fall back to step-outcome routing.
     "alert-from-step-outcome": (
@@ -119,6 +150,7 @@ expect_rejected api-error-to-clean "$SCRIPT"
 expect_rejected online-masks-queue-error "$SCRIPT"
 expect_rejected parse-failure-to-clean "$SCRIPT"
 expect_rejected parse-failure-uncaught "$SCRIPT"
+expect_rejected shape-validation-removed "$SCRIPT"
 expect_rejected alert-from-step-outcome "$WORKFLOW"
 
 echo "ok: check-runner-health contract rejects inert substitutes"

--- a/scripts/ci/test-check-runner-health-mutations.sh
+++ b/scripts/ci/test-check-runner-health-mutations.sh
@@ -69,6 +69,26 @@ mutations = {
         '  healthy="false"\n'
         '  health_reason="runner_${runner_status}_queue_classification_unknown"\n',
     ),
+    # Parse failure must not become a silent clean/available result.
+    "parse-failure-to-clean": (
+        '  if jq "$@" >"$out_file" 2>/dev/null; then\n'
+        '    cat "$out_file"\n'
+        '    return 0\n'
+        '  fi\n'
+        '  printf \'%s\\n\' "$marker" >>"$err_file"\n'
+        '  return 1\n',
+        '  if jq "$@" >"$out_file" 2>/dev/null; then\n'
+        '    cat "$out_file"\n'
+        '    return 0\n'
+        '  fi\n'
+        '  # mutation: swallow parse failure without recording a marker\n'
+        '  return 0\n',
+    ),
+    # Raw jq must not replace jq_try (abort before outputs / alert routing).
+    "parse-failure-uncaught": (
+        '  if selected_runner="$(jq_try "$runner_parse_err" "runner_json_parse_failed" -sc --arg name "$runner_name" \'[.[].runners[]? | select(.name == $name)] | .[0] // empty\' "$runner_json")"; then\n',
+        '  if selected_runner="$(jq -sc --arg name "$runner_name" \'[.[].runners[]? | select(.name == $name)] | .[0] // empty\' "$runner_json")"; then\n',
+    ),
     # Workflow must not fall back to step-outcome routing.
     "alert-from-step-outcome": (
         "        if: always() && steps.check.outputs.alert_required == 'true'\n",
@@ -97,6 +117,8 @@ PY
 expect_rejected offline-to-healthy "$SCRIPT"
 expect_rejected api-error-to-clean "$SCRIPT"
 expect_rejected online-masks-queue-error "$SCRIPT"
+expect_rejected parse-failure-to-clean "$SCRIPT"
+expect_rejected parse-failure-uncaught "$SCRIPT"
 expect_rejected alert-from-step-outcome "$WORKFLOW"
 
 echo "ok: check-runner-health contract rejects inert substitutes"

--- a/scripts/ci/test-check-runner-health.sh
+++ b/scripts/ci/test-check-runner-health.sh
@@ -179,6 +179,17 @@ expect_case() {
     fail "${name}: alert_required=true must not exit 0"
     return
   fi
+  # Parse/API failures must emit outputs (workflow alert routing) and stay value-free.
+  if [[ "${want_state}" == "classification_unknown" ]]; then
+    if [[ -z "${got_state}" || -z "${got_alert}" ]]; then
+      fail "${name}: classification_unknown must publish runner_state/alert_required outputs"
+      return
+    fi
+    if printf '%s\n%s\n' "${CHECK_OUTPUT}" "${CHECK_STDERR}" | grep -qF '{not-json'; then
+      fail "${name}: leaked raw malformed payload into output/stderr"
+      return
+    fi
+  fi
   ok "${name}"
 }
 
@@ -245,6 +256,30 @@ FAKE_RUNS_FAIL=1
 run_check "${TEST_TEMP_DIR}/out-online-queue-api.txt" "${TEST_TEMP_DIR}/sum-online-queue-api.txt"
 expect_case "queue API failure (online) → classification_unknown" "classification_unknown" "true" 1 "false"
 FAKE_RUNS_FAIL=
+
+# --- malformed runner JSON (gh exits 0) → classification_unknown, value-free -------------
+write_defaults
+printf '%s\n' '{not-json' >"${FAKE_RUNNERS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-bad-runner-json.txt" "${TEST_TEMP_DIR}/sum-bad-runner-json.txt"
+expect_case "malformed runner JSON → classification_unknown" "classification_unknown" "true" 1 "false"
+if [[ "$(output_value runner_status_error)" != *runner_json_parse_failed* ]]; then
+  fail "malformed runner JSON: runner_status_error must name runner_json_parse_failed (got: $(output_value runner_status_error))"
+else
+  ok "malformed runner JSON reports value-free runner_json_parse_failed"
+fi
+
+# --- malformed queue JSON while online → classification_unknown, value-free --------------
+write_defaults
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"online","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+printf '%s\n' '{not-json' >"${FAKE_QUEUED_RUNS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-bad-queue-json.txt" "${TEST_TEMP_DIR}/sum-bad-queue-json.txt"
+expect_case "malformed queue JSON → classification_unknown" "classification_unknown" "true" 1 "false"
+if [[ "$(output_value queue_status_error)" != *queue_json_parse_failed* ]]; then
+  fail "malformed queue JSON: queue_status_error must name queue_json_parse_failed (got: $(output_value queue_status_error))"
+else
+  ok "malformed queue JSON reports value-free queue_json_parse_failed"
+fi
 
 # --- workflow: schedule + alert_required routing + stale header --------------------------
 if grep -qE 'Runs every 15 minutes' "${WORKFLOW}"; then

--- a/scripts/ci/test-check-runner-health.sh
+++ b/scripts/ci/test-check-runner-health.sh
@@ -234,7 +234,16 @@ printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"
   >"${FAKE_RUNNERS_JSON}"
 FAKE_RUNS_FAIL=1
 run_check "${TEST_TEMP_DIR}/out-queue-api.txt" "${TEST_TEMP_DIR}/sum-queue-api.txt"
-expect_case "queue API failure → classification_unknown" "classification_unknown" "true" 1 "false"
+expect_case "queue API failure (offline) → classification_unknown" "classification_unknown" "true" 1 "false"
+FAKE_RUNS_FAIL=
+
+# --- queue API failure while online → classification_unknown (must not mask as available) -
+write_defaults
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"online","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+FAKE_RUNS_FAIL=1
+run_check "${TEST_TEMP_DIR}/out-online-queue-api.txt" "${TEST_TEMP_DIR}/sum-online-queue-api.txt"
+expect_case "queue API failure (online) → classification_unknown" "classification_unknown" "true" 1 "false"
 FAKE_RUNS_FAIL=
 
 # --- workflow: schedule + alert_required routing + stale header --------------------------

--- a/scripts/ci/test-check-runner-health.sh
+++ b/scripts/ci/test-check-runner-health.sh
@@ -262,10 +262,11 @@ write_defaults
 printf '%s\n' '{not-json' >"${FAKE_RUNNERS_JSON}"
 run_check "${TEST_TEMP_DIR}/out-bad-runner-json.txt" "${TEST_TEMP_DIR}/sum-bad-runner-json.txt"
 expect_case "malformed runner JSON → classification_unknown" "classification_unknown" "true" 1 "false"
-if [[ "$(output_value runner_status_error)" != *runner_json_parse_failed* ]]; then
-  fail "malformed runner JSON: runner_status_error must name runner_json_parse_failed (got: $(output_value runner_status_error))"
+# Shape gate runs before extraction; unparsable bodies surface as incomplete.
+if [[ "$(output_value runner_status_error)" != *runner_json_incomplete* ]]; then
+  fail "malformed runner JSON: runner_status_error must name runner_json_incomplete (got: $(output_value runner_status_error))"
 else
-  ok "malformed runner JSON reports value-free runner_json_parse_failed"
+  ok "malformed runner JSON reports value-free runner_json_incomplete"
 fi
 
 # --- malformed queue JSON while online → classification_unknown, value-free --------------
@@ -275,11 +276,71 @@ printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"
 printf '%s\n' '{not-json' >"${FAKE_QUEUED_RUNS_JSON}"
 run_check "${TEST_TEMP_DIR}/out-bad-queue-json.txt" "${TEST_TEMP_DIR}/sum-bad-queue-json.txt"
 expect_case "malformed queue JSON → classification_unknown" "classification_unknown" "true" 1 "false"
-if [[ "$(output_value queue_status_error)" != *queue_json_parse_failed* ]]; then
-  fail "malformed queue JSON: queue_status_error must name queue_json_parse_failed (got: $(output_value queue_status_error))"
+# Shape gate runs before extraction; unparsable bodies surface as incomplete.
+if [[ "$(output_value queue_status_error)" != *queue_json_incomplete* ]]; then
+  fail "malformed queue JSON: queue_status_error must name queue_json_incomplete (got: $(output_value queue_status_error))"
 else
-  ok "malformed queue JSON reports value-free queue_json_parse_failed"
+  ok "malformed queue JSON reports value-free queue_json_incomplete"
 fi
+
+# --- empty-body queue while online → classification_unknown (incomplete, not available) --
+write_defaults
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"online","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+: >"${FAKE_QUEUED_RUNS_JSON}"
+: >"${FAKE_IN_PROGRESS_RUNS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-empty-queue.txt" "${TEST_TEMP_DIR}/sum-empty-queue.txt"
+expect_case "empty-body queue → classification_unknown" "classification_unknown" "true" 1 "false"
+if [[ "$(output_value queue_status_error)" != *queue_json_incomplete* ]]; then
+  fail "empty-body queue: queue_status_error must name queue_json_incomplete (got: $(output_value queue_status_error))"
+else
+  ok "empty-body queue reports value-free queue_json_incomplete"
+fi
+
+# --- wrong-shape queue while online → classification_unknown -----------------------------
+write_defaults
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"online","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+printf '%s\n' '{"message":"unexpected"}' >"${FAKE_QUEUED_RUNS_JSON}"
+printf '%s\n' '{"message":"unexpected"}' >"${FAKE_IN_PROGRESS_RUNS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-wrong-queue-shape.txt" "${TEST_TEMP_DIR}/sum-wrong-queue-shape.txt"
+expect_case "wrong-shape queue → classification_unknown" "classification_unknown" "true" 1 "false"
+if [[ "$(output_value queue_status_error)" != *queue_json_incomplete* ]]; then
+  fail "wrong-shape queue: queue_status_error must name queue_json_incomplete (got: $(output_value queue_status_error))"
+else
+  ok "wrong-shape queue reports value-free queue_json_incomplete"
+fi
+
+# --- empty-body runner → classification_unknown (must not be not_found/unavailable) ------
+write_defaults
+: >"${FAKE_RUNNERS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-empty-runner.txt" "${TEST_TEMP_DIR}/sum-empty-runner.txt"
+expect_case "empty-body runner → classification_unknown" "classification_unknown" "true" 1 "false"
+if [[ "$(output_value runner_status_error)" != *runner_json_incomplete* ]]; then
+  fail "empty-body runner: runner_status_error must name runner_json_incomplete (got: $(output_value runner_status_error))"
+else
+  ok "empty-body runner reports value-free runner_json_incomplete"
+fi
+
+# --- wrong-shape runner → classification_unknown ----------------------------------------
+write_defaults
+printf '%s\n' '{"message":"unexpected"}' >"${FAKE_RUNNERS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-wrong-runner-shape.txt" "${TEST_TEMP_DIR}/sum-wrong-runner-shape.txt"
+expect_case "wrong-shape runner → classification_unknown" "classification_unknown" "true" 1 "false"
+if [[ "$(output_value runner_status_error)" != *runner_json_incomplete* ]]; then
+  fail "wrong-shape runner: runner_status_error must name runner_json_incomplete (got: $(output_value runner_status_error))"
+else
+  ok "wrong-shape runner reports value-free runner_json_incomplete"
+fi
+
+# --- legitimate empty arrays remain classifiable (online + no demand → available) -------
+write_defaults
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"online","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+printf '%s\n' '{"total_count":0,"workflow_runs":[]}' >"${FAKE_QUEUED_RUNS_JSON}"
+printf '%s\n' '{"total_count":0,"workflow_runs":[]}' >"${FAKE_IN_PROGRESS_RUNS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-empty-arrays.txt" "${TEST_TEMP_DIR}/sum-empty-arrays.txt"
+expect_case "empty-array queue pages → available" "available" "false" 0 "true"
 
 # --- workflow: schedule + alert_required routing + stale header --------------------------
 if grep -qE 'Runs every 15 minutes' "${WORKFLOW}"; then

--- a/scripts/ci/test-check-runner-health.sh
+++ b/scripts/ci/test-check-runner-health.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# Behavioral contract for scripts/ci/check-runner-health.sh + runner-health.yml.
+#
+# The monitor samples control-plane runner registration and label-specific demand.
+# It does not prove host functionality or SLA. Silence / expected_offline is not health.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${SCRIPT:-${ROOT}/scripts/ci/check-runner-health.sh}"
+WORKFLOW="${WORKFLOW:-${ROOT}/.github/workflows/runner-health.yml}"
+MUTATION_TEST="${ROOT}/scripts/ci/test-check-runner-health-mutations.sh"
+FAILURES=0
+TEST_TEMP_DIR=""
+
+cleanup() { [[ -n "$TEST_TEMP_DIR" ]] && rm -rf "$TEST_TEMP_DIR"; }
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+ok() { echo "ok   $*"; }
+
+abort_is_failure() {
+  local rc="$1"
+  [[ "${rc}" -eq 0 ]] || echo "check-runner-health contract aborted (exit ${rc}); treat as failure" >&2
+}
+trap 'abort_is_failure "$?"' ERR
+
+[[ -f "$SCRIPT" ]] || { echo "FAIL: missing $SCRIPT" >&2; exit 1; }
+[[ -f "$WORKFLOW" ]] || { echo "FAIL: missing $WORKFLOW" >&2; exit 1; }
+[[ -f "$MUTATION_TEST" ]] || { echo "FAIL: missing $MUTATION_TEST" >&2; exit 1; }
+
+make_fake_gh() {
+  cat >"$1" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_GH_LOG}"
+
+# Drop flags; keep the resource path as the last non-option argument.
+path=""
+for arg in "$@"; do
+  case "$arg" in
+    -* ) ;;
+    * ) path="$arg" ;;
+  esac
+done
+
+case "$path" in
+  repos/*/actions/runners*)
+    if [[ "${FAKE_RUNNERS_FAIL:-}" == "1" ]]; then
+      echo "runner list failed" >&2
+      exit 1
+    fi
+    cat "${FAKE_RUNNERS_JSON}"
+    ;;
+  repos/*/actions/runs/*/jobs*)
+    if [[ "${FAKE_JOBS_FAIL:-}" == "1" ]]; then
+      echo "jobs list failed" >&2
+      exit 1
+    fi
+    run_id="$(printf '%s' "$path" | sed -n 's|.*/actions/runs/\([0-9][0-9]*\)/jobs.*|\1|p')"
+    jobs_file="${FAKE_JOBS_DIR}/${run_id}.json"
+    if [[ -f "$jobs_file" ]]; then
+      cat "$jobs_file"
+    else
+      printf '%s\n' '{"jobs":[]}'
+    fi
+    ;;
+  repos/*/actions/runs*)
+    if [[ "${FAKE_RUNS_FAIL:-}" == "1" ]]; then
+      echo "runs list failed" >&2
+      exit 1
+    fi
+    # status=queued|in_progress is query-string; serve empty unless a fixture overrides.
+    if [[ "$path" == *status=queued* ]]; then
+      cat "${FAKE_QUEUED_RUNS_JSON}"
+    else
+      cat "${FAKE_IN_PROGRESS_RUNS_JSON}"
+    fi
+    ;;
+  *)
+    echo "unexpected gh api path: ${path}" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$1"
+}
+
+write_defaults() {
+  printf '%s\n' '{"total_count":0,"runners":[]}' >"${FAKE_RUNNERS_JSON}"
+  # Include one non-matching queued run so the current script materializes
+  # matching-jobs.tsv (it only creates that file while inspecting runs). Empty
+  # queues would abort before classification and hide the healthy=true defect.
+  printf '%s\n' '{"total_count":1,"workflow_runs":[{"id":99,"name":"CI","status":"queued","html_url":"https://example.test/run/99"}]}' \
+    >"${FAKE_QUEUED_RUNS_JSON}"
+  printf '%s\n' '{"total_count":0,"workflow_runs":[]}' >"${FAKE_IN_PROGRESS_RUNS_JSON}"
+  mkdir -p "${FAKE_JOBS_DIR}"
+  printf '%s\n' '{"jobs":[{"name":"lint","status":"queued","labels":["ubuntu-latest"],"html_url":"https://example.test/job/99"}]}' \
+    >"${FAKE_JOBS_DIR}/99.json"
+}
+
+run_check() {
+  local out_file="$1"
+  local summary_file="$2"
+  shift 2
+  : >"${FAKE_GH_LOG}"
+  : >"${out_file}"
+  : >"${summary_file}"
+  set +e
+  PATH="${TEST_TEMP_DIR}/bin:${PATH}" \
+    GITHUB_REPOSITORY="Rul1an/assay" \
+    RUNNER_STATUS_TOKEN="runner-token" \
+    QUEUE_TOKEN="queue-token" \
+    RUNNER_NAME="assay-bpf-runner" \
+    REQUIRED_RUNNER_LABEL="assay-bpf-runner" \
+    GITHUB_OUTPUT="${out_file}" \
+    GITHUB_STEP_SUMMARY="${summary_file}" \
+    FAKE_GH_LOG="${FAKE_GH_LOG}" \
+    FAKE_RUNNERS_JSON="${FAKE_RUNNERS_JSON}" \
+    FAKE_QUEUED_RUNS_JSON="${FAKE_QUEUED_RUNS_JSON}" \
+    FAKE_IN_PROGRESS_RUNS_JSON="${FAKE_IN_PROGRESS_RUNS_JSON}" \
+    FAKE_JOBS_DIR="${FAKE_JOBS_DIR}" \
+    FAKE_RUNNERS_FAIL="${FAKE_RUNNERS_FAIL:-}" \
+    FAKE_RUNS_FAIL="${FAKE_RUNS_FAIL:-}" \
+    FAKE_JOBS_FAIL="${FAKE_JOBS_FAIL:-}" \
+    bash "${SCRIPT}" "$@" >"${TEST_TEMP_DIR}/stdout.txt" 2>"${TEST_TEMP_DIR}/stderr.txt"
+  CHECK_STATUS=$?
+  set -e
+  CHECK_STDERR="$(cat "${TEST_TEMP_DIR}/stderr.txt")"
+  CHECK_OUTPUT="$(cat "${out_file}")"
+}
+
+output_value() {
+  local key="$1"
+  printf '%s\n' "${CHECK_OUTPUT}" | awk -F= -v k="$key" '$1==k {print substr($0, index($0,"=")+1); exit}'
+}
+
+expect_case() {
+  local name="$1"
+  local want_state="$2"
+  local want_alert="$3"
+  local want_exit="$4"
+  local want_healthy="${5-}"
+
+  local got_state got_alert got_healthy
+  got_state="$(output_value runner_state)"
+  got_alert="$(output_value alert_required)"
+  got_healthy="$(output_value healthy)"
+
+  if [[ "${CHECK_STATUS}" -ne "${want_exit}" ]]; then
+    fail "${name}: exit ${CHECK_STATUS}, wanted ${want_exit} (stderr: ${CHECK_STDERR})"
+    return
+  fi
+  if [[ "${got_state}" != "${want_state}" ]]; then
+    fail "${name}: runner_state=${got_state:-<missing>}, wanted ${want_state}"
+    return
+  fi
+  if [[ "${got_alert}" != "${want_alert}" ]]; then
+    fail "${name}: alert_required=${got_alert:-<missing>}, wanted ${want_alert}"
+    return
+  fi
+  if [[ -n "${want_healthy}" && "${got_healthy}" != "${want_healthy}" ]]; then
+    fail "${name}: healthy=${got_healthy:-<missing>}, wanted ${want_healthy}"
+    return
+  fi
+  # Silence / offline-without-demand must never publish healthy=true.
+  if [[ "${want_state}" == "expected_offline" && "${got_healthy}" == "true" ]]; then
+    fail "${name}: expected_offline published healthy=true (silence is not health)"
+    return
+  fi
+  if [[ "${want_alert}" == "false" && "${CHECK_STATUS}" -ne 0 ]]; then
+    fail "${name}: alert_required=false must exit 0"
+    return
+  fi
+  if [[ "${want_alert}" == "true" && "${CHECK_STATUS}" -eq 0 ]]; then
+    fail "${name}: alert_required=true must not exit 0"
+    return
+  fi
+  ok "${name}"
+}
+
+TEST_TEMP_DIR="$(mktemp -d)"
+mkdir -p "${TEST_TEMP_DIR}/bin"
+FAKE_GH_LOG="${TEST_TEMP_DIR}/gh.log"
+FAKE_RUNNERS_JSON="${TEST_TEMP_DIR}/runners.json"
+FAKE_QUEUED_RUNS_JSON="${TEST_TEMP_DIR}/queued-runs.json"
+FAKE_IN_PROGRESS_RUNS_JSON="${TEST_TEMP_DIR}/in-progress-runs.json"
+FAKE_JOBS_DIR="${TEST_TEMP_DIR}/jobs"
+make_fake_gh "${TEST_TEMP_DIR}/bin/gh"
+write_defaults
+
+# --- online → available ------------------------------------------------------------------
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"online","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-online.txt" "${TEST_TEMP_DIR}/sum-online.txt"
+expect_case "online → available" "available" "false" 0 "true"
+
+# --- offline / no demand → expected_offline (must NOT publish healthy=true) --------------
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"offline","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+write_defaults
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"offline","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-offline.txt" "${TEST_TEMP_DIR}/sum-offline.txt"
+expect_case "offline/no-demand → expected_offline" "expected_offline" "false" 0 "false"
+
+# --- offline / matching demand → demand_backed_outage ------------------------------------
+printf '%s\n' '{"total_count":1,"workflow_runs":[{"id":101,"name":"Kernel Matrix","status":"queued","html_url":"https://example.test/run/101"}]}' \
+  >"${FAKE_QUEUED_RUNS_JSON}"
+printf '%s\n' '{"jobs":[{"name":"matrix-test","status":"queued","labels":["assay-bpf-runner"],"html_url":"https://example.test/job/1"}]}' \
+  >"${FAKE_JOBS_DIR}/101.json"
+run_check "${TEST_TEMP_DIR}/out-demand.txt" "${TEST_TEMP_DIR}/sum-demand.txt"
+expect_case "offline/demand → demand_backed_outage" "demand_backed_outage" "true" 1 "false"
+
+# --- not_found → unavailable -------------------------------------------------------------
+write_defaults
+printf '%s\n' '{"total_count":0,"runners":[]}' >"${FAKE_RUNNERS_JSON}"
+run_check "${TEST_TEMP_DIR}/out-missing.txt" "${TEST_TEMP_DIR}/sum-missing.txt"
+expect_case "not_found → unavailable" "unavailable" "true" 1 "false"
+
+# --- runner API failure → classification_unknown -----------------------------------------
+write_defaults
+FAKE_RUNNERS_FAIL=1
+run_check "${TEST_TEMP_DIR}/out-runner-api.txt" "${TEST_TEMP_DIR}/sum-runner-api.txt"
+expect_case "runner API failure → classification_unknown" "classification_unknown" "true" 1 "false"
+FAKE_RUNNERS_FAIL=
+
+# --- queue API failure while offline → classification_unknown ----------------------------
+write_defaults
+printf '%s\n' '{"total_count":1,"runners":[{"name":"assay-bpf-runner","status":"offline","busy":false,"labels":[{"name":"assay-bpf-runner"}]}]}' \
+  >"${FAKE_RUNNERS_JSON}"
+FAKE_RUNS_FAIL=1
+run_check "${TEST_TEMP_DIR}/out-queue-api.txt" "${TEST_TEMP_DIR}/sum-queue-api.txt"
+expect_case "queue API failure → classification_unknown" "classification_unknown" "true" 1 "false"
+FAKE_RUNS_FAIL=
+
+# --- workflow: schedule + alert_required routing + stale header --------------------------
+if grep -qE 'Runs every 15 minutes' "${WORKFLOW}"; then
+  fail "workflow header still claims 15 minutes"
+else
+  ok "workflow header does not claim 15 minutes"
+fi
+
+grep -qE "cron: '0 \\*/6 \\* \\* \\*'" "${WORKFLOW}" \
+  || fail "workflow must keep the six-hour schedule"
+ok "six-hour schedule preserved"
+
+# Intentional literal workflow expressions (not shell expansions).
+# shellcheck disable=SC2016
+grep -q 'RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_HEALTH_TOKEN || github.token }}' "${WORKFLOW}" \
+  || fail "workflow must keep RUNNER_STATUS_TOKEN separation"
+# shellcheck disable=SC2016
+grep -q 'QUEUE_TOKEN: ${{ github.token }}' "${WORKFLOW}" \
+  || fail "workflow must keep QUEUE_TOKEN separation"
+ok "token separation preserved"
+
+if grep -q "steps.check.outcome == 'failure'" "${WORKFLOW}"; then
+  fail "workflow must not create alerts from steps.check.outcome"
+else
+  ok "create step is not keyed on step outcome"
+fi
+
+if grep -qE 'if: success\(\)' "${WORKFLOW}"; then
+  fail "workflow must not close alerts from success()"
+else
+  ok "close step is not keyed on success()"
+fi
+
+grep -q "steps.check.outputs.alert_required == 'true'" "${WORKFLOW}" \
+  || fail "create step must key on alert_required == true"
+grep -q "steps.check.outputs.alert_required == 'false'" "${WORKFLOW}" \
+  || fail "close step must key on alert_required == false"
+ok "alert issue create/close keyed on alert_required"
+
+# Public-string non-claim: allow explicit disclaimers; reject affirmative health/SLA claims.
+if grep -qiE 'runner is healthy|meets SLA|proves host functionality' "${WORKFLOW}"; then
+  fail "workflow must not make broad health/SLA claims"
+else
+  ok "workflow avoids broad health/SLA claims"
+fi
+if ! grep -q 'Does not claim host functionality or SLA' "${WORKFLOW}"; then
+  fail "workflow must state the control-plane non-claim"
+else
+  ok "workflow states control-plane non-claim"
+fi
+
+if [[ "${ASSAY_CONTRACT_MUTATION:-}" != "1" ]]; then
+  if ! bash "${MUTATION_TEST}"; then
+    fail "mutation suite failed"
+  else
+    ok "mutation suite rejected inert substitutes"
+  fi
+fi
+
+if [[ "${FAILURES}" -ne 0 ]]; then
+  echo "FAIL: ${FAILURES} check-runner-health contract assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "ok: check-runner-health state contract"


### PR DESCRIPTION
## Summary
- Fixes #2256 by replacing overloaded `healthy` with an explicit `runner_state` + `alert_required` contract from the implementation decision comment.
- `expected_offline` (registered offline, no matching demand) no longer publishes `healthy=true`; alert issue create/close keys on `alert_required`, not step outcome.
- Keeps the six-hour schedule, token separation, value-free errors, and fail-closed API/classification behavior; fixes the stale "15 minutes" header.

### States
| state | alert |
|---|---|
| `available` | no |
| `expected_offline` | no |
| `unavailable` | yes |
| `demand_backed_outage` | yes |
| `classification_unknown` | yes |

## Test plan
- [x] RED: offline/no-demand previously emitted `healthy=true` + exit 0
- [x] GREEN: `bash scripts/ci/test-check-runner-health.sh` (fixtures + mutations)
- [x] Mutations reject offline→healthy and API-error→clean
- [x] `shellcheck` on touched scripts
- [x] `git diff --check`
- [ ] CI `assay-action-contract-tests` exercises the new contract step

## Non-claims
- Does not prove host functionality, SLA, or runner workload health.
- Does not change #2312 / host-capability-proof cold-path files.
- `expected_offline` is not a health signal; absence of an alert is not evidence the host works.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runner monitoring accuracy by distinguishing unavailable runners, demand-backed outages, expected offline states, and unknown conditions.
  * Alerts now reflect confirmed control-plane issues and automatically close when alert conditions clear.
  * Malformed, incomplete, or empty monitoring data is handled safely instead of being misclassified.

* **Chores**
  * Added comprehensive validation to ensure monitoring and alert behavior remains reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->