### PR TITLE
ci: define host-proof doctor boundary

### DIFF
--- a/docs/reference/runner/host-capability-proof.md
+++ b/docs/reference/runner/host-capability-proof.md
@@ -41,6 +41,7 @@ trigger:
 
 never trigger:
   *.md anywhere (including under crates/assay-cli/src/diagnostics/)
+  crates/assay-cli/src/cli/commands/doctor/**
   docs/**
   CHANGELOG.md
   scripts/ci/assay_host_capability_check.py      (technical exemption, see below)
@@ -51,6 +52,17 @@ never trigger:
 Rendering (`format.rs`) and tests inside `diagnostics/` trigger deliberately: rendering determines how
 a claim reaches the reader, and tests determine how it is validated. The cost per trigger is one
 `assay doctor` run on the host.
+
+Doctor command orchestration is an explicit non-trigger. Changes under
+`crates/assay-cli/src/cli/commands/doctor/**` can alter the command envelope, preflight fields, or exit
+code, but those are host-independent CLI contracts covered by the ordinary cross-platform binary
+tests. This gate proves only that the host-dependent Landlock diagnostics surface was produced on the
+exact host and head; it does not certify the whole `assay doctor` command contract. The classifier
+self-test pins that boundary to this concrete example and fails if this contract row disappears:
+
+```text
+crates/assay-cli/src/cli/commands/doctor/implementation.rs -> not required
+```
 
 The checker script and the two workflows are exempt from this gate as a technical exemption, not a
 trust statement: a change to the gate cannot be proven by the gate it is changing. They receive
@@ -90,15 +102,15 @@ persistent host's `rustup`, `cargo`, or `rustc` shims. It keeps the workflow-lev
 job's Actions runtime token and does not justify repository Actions write
 access. Failed builds are not cached.
 
-The job has a 90-minute ceiling. This is a provisional cold-start budget: a
-30-minute run on Assay 5.0.0 timed out inside `cargo build`, while the existing
-delegated peer lane already uses a 90-minute bound on the same singleton host.
-The number is not a measured cold-build duration. A change to this producer
-must obtain an exact-head cold run followed by a warm run and tighten or retain
-the ceiling from that evidence. A deliberately cold run uses an empty workspace
-`target/` plus a proof-workflow cache-key miss; it must not delete unrelated
-global Cargo caches. Timeout, cancelled build, absent output, and failed upload
-remain non-success.
+The job has a 90-minute ceiling. Exact-head measurements on
+`b902bc87f4817b7b605a55edfd1c2c3d73596f56` recorded a 41m34s cold cache-miss run and an 18m41s
+warm cache-hit run. The warm path included a 10m10s restore of the 573 MB cache and a 6m01s build,
+so the cache is an availability mechanism, not a fast-path claim. One cold/warm pair is not a
+latency distribution or SLA; the 90-minute ceiling remains bounded headroom rather than a promised
+duration. A change to this producer must obtain an exact-head cold run followed by a warm run and
+tighten or retain the ceiling from that evidence. A deliberately cold run uses an empty workspace
+`target/` plus a proof-workflow cache-key miss; it must not delete unrelated global Cargo caches.
+Timeout, cancelled build, absent output, and failed upload remain non-success.
 
 Starting a `workflow_dispatch` run requires write access to the repository, so who-may-produce-proof
 is enforced by GitHub's own permission model, not by comment-author filtering.
@@ -203,6 +215,7 @@ crates/assay-cli/src/diagnostics/probes.rs              -> proof required
 crates/assay-cli/src/diagnostics/landlock_net_smoke.rs  -> proof required
 crates/assay-cli/src/diagnostics/format.rs              -> proof required
 crates/assay-cli/src/diagnostics/README.md              -> not required (Markdown exemption)
+crates/assay-cli/src/cli/commands/doctor/implementation.rs -> not required
 crates/assay-cli/src/cli/commands/run.rs                -> not required
 CHANGELOG.md                                            -> not required
 docs/reference/runner/host-capability-proof.md          -> not required

--- a/scripts/ci/assay_host_capability_check.py
+++ b/scripts/ci/assay_host_capability_check.py
@@ -33,6 +33,7 @@ import urllib.request
 import zipfile
 from collections.abc import Iterable
 from dataclasses import dataclass
+from pathlib import Path
 
 PROOF_WORKFLOW_NAME = "host-capability-proof"
 # Producer identity is validated by workflow PATH, not only display name: names are
@@ -45,6 +46,7 @@ CONTRACT_DOC = "docs/reference/runner/host-capability-proof.md"
 COMMENT_MARKER = "<!-- assay-host-capability-check -->"
 
 TRIGGER_PREFIX = "crates/assay-cli/src/diagnostics/"
+DOCTOR_ORCHESTRATION_EXAMPLE = "crates/assay-cli/src/cli/commands/doctor/implementation.rs"
 
 # Technical exemption, not a trust statement: a change to the gate cannot be proven by the
 # gate it is changing (see the RFC). These files get normal CI like any other file.
@@ -361,6 +363,7 @@ def self_test() -> int:
         (["crates/assay-cli/src/diagnostics/landlock_net_smoke.rs"], True),
         (["crates/assay-cli/src/diagnostics/format.rs"], True),
         (["crates/assay-cli/src/diagnostics/README.md"], False),
+        ([DOCTOR_ORCHESTRATION_EXAMPLE], False),
         (["crates/assay-cli/src/cli/commands/run.rs"], False),
         (["CHANGELOG.md"], False),
         (["docs/reference/runner/host-capability-proof.md"], False),
@@ -374,6 +377,19 @@ def self_test() -> int:
         required, _ = proof_required(files)
         if required != expected:
             failures.append(f"classification: {files} -> {required}, expected {expected}")
+
+    contract_path = Path(__file__).resolve().parents[2] / CONTRACT_DOC
+    doctor_contract_row = f"{DOCTOR_ORCHESTRATION_EXAMPLE} -> not required"
+    try:
+        contract_text = contract_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        failures.append(f"contract parity: cannot read {CONTRACT_DOC}: {exc}")
+    else:
+        if doctor_contract_row not in contract_text:
+            failures.append(
+                "contract parity: doctor orchestration non-trigger is not stated as "
+                f"{doctor_contract_row!r}"
+            )
 
     good = {
         "landlock": {


### PR DESCRIPTION
## Summary

- state the host-capability gate boundary behaviorally: exact-head production of the host-dependent Landlock diagnostics surface
- explicitly exclude `cli/commands/doctor/**` orchestration, envelope, and exit semantics from the manual host-proof trigger
- bind the concrete doctor exclusion to the checker self-test and contract document
- replace the stale unmeasured-cost text with the exact-head cold/warm measurements from #2312

Closes #2252.

## Decision

Do not widen the expensive manual proof trigger.

The checker validates typed fields inside the `landlock` object. Changes to doctor command orchestration, preflight fields, and exit behavior are host-independent CLI contracts already covered by cross-platform binary tests. Requiring a serialized self-hosted proof for those changes would spend host capacity without proving the changed property.

## TDD

RED on `origin/main` `3d88c579602aae30d83d69e0ba269ec41968fea9` after adding parity coverage:

```text
SELF-TEST FAIL: contract parity: doctor orchestration non-trigger is not stated as
'crates/assay-cli/src/cli/commands/doctor/implementation.rs -> not required'
exit=1
```

GREEN on `cdd8103db1d58d9fa21b6de098f38b96fd7fc8fe`:

```text
self-test: all cases passed
```

Removing the concrete contract row makes the real checker self-test fail again.

## Verification

- `python3 scripts/ci/assay_host_capability_check.py --self-test`
- `python3 -m py_compile scripts/ci/assay_host_capability_check.py`
- focused `pre-commit run --files ...`
- full pre-push suite, including workspace clippy and Linux cross-target compile
- `git diff --check`

## Cost evidence

Exact head `b902bc87f4817b7b605a55edfd1c2c3d73596f56`:

- cold v2 miss: 41m34s total
- warm v2 hit: 18m41s total
- warm cache restore alone: 10m10s for 573 MB

These are one exact-head pair, not a latency distribution or SLA.

## Non-claims

- no host-capability trigger or workflow behavior changes
- no claim that the entire doctor JSON contract was produced on a real host
- no host-health or SLA claim
- no delegated host proof is expected for this checker/docs-only boundary change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the doctor command is host-independent and covered by standard tests.
  * Documented measured cold and warm run timings, cache performance, and the 90-minute limit as bounded headroom rather than an SLA.

* **Tests**
  * Added validation confirming the doctor command does not require host-capability proof.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->