### PR TITLE
ci: drop rsa via jsonwebtoken aws_lc_rs backend (CI-4C / #2231)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,5 @@
 # Align with the three peer locations that carry this list: deny.toml,
 # .github/workflows/ci.yml and the pre-push cargo-audit hook in .pre-commit-config.yaml.
-# Allow RUSTSEC-2023-0071 (rsa Marvin Attack, via jsonwebtoken; no fixed release).
+# Keep empty unless an advisory currently matches the tree and has a recorded reason.
 [advisories]
-ignore = ["RUSTSEC-2023-0071"]
+ignore = []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,8 +201,14 @@ jobs:
       - name: cargo audit (RustSec)
         run: |
           rm -rf ~/.cargo/advisory-db
-          # RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upgrade; assay-mcp-server JWT (see deny.toml)
-          cargo-audit audit --ignore RUSTSEC-2023-0071
+          cargo-audit audit
+      - name: rsa advisory-removal contract
+        # CI-4C (#2231): rsa must stay out of the resolved tree, and the four ignore sites
+        # (deny.toml, .cargo/audit.toml, this workflow, .pre-commit-config.yaml) must not
+        # reintroduce the retired rsa Marvin-attack exception.
+        run: |
+          python3 scripts/ci/test_check_rsa_advisory_removed.py
+          python3 scripts/ci/check_rsa_advisory_removed.py
 
       - name: cargo audit (RustSec) — fuzz lockfile
         # Runs when the root audit above fails, so coverage does not drop out exactly when the tree
@@ -218,10 +224,10 @@ jobs:
           #
           # Run from a directory with no `.cargo/audit.toml`. cargo-audit reads that config from the
           # cwd, so invoking this from the repo root would silently inherit the root's ignore list —
-          # measured: RUSTSEC-2023-0071 is suppressed from the root and reported from elsewhere. That
-          # would defeat the reason this step exists. An advisory that matches only the fuzz tree is
-          # then a deliberate decision, not a silent pass; there is nowhere for it to be quietly
-          # excused, which is the point.
+          # measured: a root-suppressed advisory was reported from elsewhere when this step used the
+          # repo cwd. That would defeat the reason this step exists. An advisory that matches only
+          # the fuzz tree is then a deliberate decision, not a silent pass; there is nowhere for it
+          # to be quietly excused, which is the point.
           ( cd "${RUNNER_TEMP}" && cargo-audit audit --file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock" )
 
   clippy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,15 +342,12 @@ repos:
         # job now sets RUSTUP_TOOLCHAIN for every step, but a hook runs on a developer machine where
         # nothing does, so this site was the one left uncovered (#2237). The two hooks answered the
         # same question differently, which is how the answer drifts.
-        # Keep the ignore list in lockstep with the three peer locations that carry it:
+        # Keep any ignore list in lockstep with the three peer locations that carry it:
         # deny.toml, .github/workflows/ci.yml and .cargo/audit.toml. Naming all of them matters —
-        # an incomplete peer list is how this hook drifted in the first place.
-        # Only RUSTSEC-2023-0071 (rsa Marvin Attack, reached via jsonwebtoken) still matches a
-        # crate in the tree and has no fixed release. The pyo3 pair (RUSTSEC-2026-0176/0177) was
-        # retired by the pyo3 0.29 migration (#1651) and the quick-xml pair
-        # (RUSTSEC-2026-0194/0195) by object_store 0.14.1; both were left here after they stopped
-        # matching anything, which is what let the list drift out of lockstep.
-        entry: bash -lc 'cargo-audit audit --ignore RUSTSEC-2023-0071'
+        # an incomplete peer list is how this hook drifted in the first place. The list is empty
+        # after CI-4C (#2231) removed the last matching exception; do not reintroduce ignores here
+        # without updating those peers and the rsa-removal contract check.
+        entry: bash -lc 'cargo-audit audit'
         language: system
         pass_filenames: false
         files: ^Cargo\.lock$

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "dirs",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "env_logger",
  "futures",
  "getrandom 0.4.3",
@@ -314,7 +314,7 @@ dependencies = [
  "chrono",
  "criterion",
  "dirs",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "flate2",
  "getrandom 0.4.3",
  "globset",
@@ -375,7 +375,7 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "flate2",
  "futures",
  "getrandom 0.4.3",
@@ -418,6 +418,7 @@ dependencies = [
  "assay-common",
  "assay-core",
  "assay-metrics",
+ "aws-lc-rs",
  "base64",
  "clap",
  "hex",
@@ -425,9 +426,7 @@ dependencies = [
  "libc",
  "moka",
  "process-wrap",
- "rand 0.8.7",
  "reqwest 0.12.28",
- "rsa",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -497,7 +496,7 @@ dependencies = [
  "chrono",
  "dirs",
  "ecdsa",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "getrandom 0.4.3",
  "hex",
  "p256",
@@ -673,6 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1213,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin",
 ]
 
 [[package]]
@@ -1386,22 +1386,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
@@ -1410,7 +1394,7 @@ dependencies = [
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.2",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rand_core 0.10.0",
  "rustc_version",
  "subtle",
@@ -1680,16 +1664,6 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
@@ -1700,26 +1674,12 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
+ "curve25519-dalek",
+ "ed25519",
  "rand_core 0.10.0",
  "serde",
  "sha2 0.11.0",
@@ -1746,7 +1706,6 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -1892,12 +1851,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -2310,15 +2263,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "hmac"
@@ -2847,19 +2791,13 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
+ "aws-lc-rs",
  "base64",
- "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
- "hmac 0.12.1",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.7",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
  "zeroize",
@@ -2898,9 +2836,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "libc"
@@ -3196,22 +3131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.7",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,7 +3200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3437,18 +3355,6 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3653,17 +3559,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
 
 [[package]]
 name = "pkcs8"
@@ -4461,28 +4356,8 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4609,7 +4484,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5007,12 +4882,6 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spin"
@@ -5633,6 +5502,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/crates/assay-mcp-server/Cargo.toml
+++ b/crates/assay-mcp-server/Cargo.toml
@@ -35,7 +35,10 @@ moka = { version = "0.12", features = ["sync"] }
 
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }
-jsonwebtoken = { version = "11.0", default-features = false, features = ["rust_crypto", "use_pem"] }
+# aws_lc_rs (not rust_crypto): drops the rsa crate / RUSTSEC-2023-0071 from the tree.
+# aws-lc-rs is already resolved in this workspace via rustls/object_store; standalone
+# assay-mcp-server builds may compile it through this feature selection.
+jsonwebtoken = { version = "11.0", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 url = { version = "2.5", features = ["serde"] }
@@ -46,11 +49,11 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 tempfile.workspace = true
 wiremock = "0.6"
-jsonwebtoken = { version = "11.0", default-features = false, features = ["rust_crypto", "use_pem"] }
+jsonwebtoken = { version = "11.0", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 base64 = "0.22"
 # uuid = { version = "1.0", features = ["v4"] } # Removed in favor of SystemTime
-rsa = "0.9"
-rand = "0.8"
+# Runtime RSA keygen for the legacy RS256 compatibility test (no checked-in PEM).
+aws-lc-rs = "1.16"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"

--- a/crates/assay-mcp-server/src/auth/tests.rs
+++ b/crates/assay-mcp-server/src/auth/tests.rs
@@ -170,26 +170,30 @@ fn test_ssrf_ip_blocking() {
     }
 }
 
+fn pem_encode(label: &str, der: &[u8]) -> String {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let b64 = STANDARD.encode(der);
+    let mut out = format!("-----BEGIN {label}-----\n");
+    for chunk in b64.as_bytes().chunks(64) {
+        out.push_str(std::str::from_utf8(chunk).expect("base64 is ascii"));
+        out.push('\n');
+    }
+    out.push_str(&format!("-----END {label}-----\n"));
+    out
+}
+
 #[tokio::test]
 async fn test_security_jwt_rs256_full_path() {
-    // Generate transient test keys at runtime
-    use rsa::{pkcs8::EncodePrivateKey, pkcs8::EncodePublicKey, RsaPrivateKey};
-    let mut rng = rand::thread_rng();
-    let bits = 2048;
-    let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate key");
-    let pub_key = priv_key.to_public_key();
+    // Generate transient RSA keys at runtime with aws-lc-rs (no checked-in PEM).
+    use aws_lc_rs::encoding::{AsDer, Pkcs8V1Der, PublicKeyX509Der};
+    use aws_lc_rs::rsa::{KeyPair, KeySize};
+    use aws_lc_rs::signature::KeyPair as _;
 
-    let priv_pem_str = priv_key
-        .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
-        .unwrap()
-        .to_string();
-    let pub_pem_str = pub_key
-        .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
-        .unwrap()
-        .to_string();
-
-    let priv_pem = priv_pem_str.as_bytes();
-    let pub_pem = pub_pem_str.as_bytes();
+    let key_pair = KeyPair::generate(KeySize::Rsa2048).expect("failed to generate RSA key");
+    let priv_der: Pkcs8V1Der<'_> = key_pair.as_der().expect("pkcs8 der");
+    let pub_der: PublicKeyX509Der<'_> = key_pair.public_key().as_der().expect("spki der");
+    let priv_pem_str = pem_encode("PRIVATE KEY", priv_der.as_ref());
+    let pub_pem_str = pem_encode("PUBLIC KEY", pub_der.as_ref());
 
     let header = Header::new(Algorithm::RS256);
     let claims = valid_claims();
@@ -197,12 +201,12 @@ async fn test_security_jwt_rs256_full_path() {
     let token = encode(
         &header,
         &claims,
-        &EncodingKey::from_rsa_pem(priv_pem).unwrap(),
+        &EncodingKey::from_rsa_pem(priv_pem_str.as_bytes()).unwrap(),
     )
     .unwrap();
 
-    // Setup Validator with Mock JWKS containing our public key
-    let validator = TokenValidator::new_with_static_key(pub_pem).unwrap();
+    // Setup Validator with the matching public SPKI PEM.
+    let validator = TokenValidator::new_with_static_key(pub_pem_str.as_bytes()).unwrap();
     let config = AuthConfig {
         mode: AuthMode::Strict,
         audience: vec!["assay-mcp".to_string()],

--- a/deny.toml
+++ b/deny.toml
@@ -24,11 +24,7 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # Ignore specific advisories (add RUSTSEC-YYYY-NNNN here if needed)
 # Only list advisories that currently match a crate in the tree; remove when dep is upgraded or removed.
-ignore = [
-    # rsa: transitive via jsonwebtoken (assay-mcp-server). No safe upgrade; timing sidechannel.
-    # JWT verification is server-side; accept risk for MCP auth until jsonwebtoken/rsa offer a fix.
-    "RUSTSEC-2023-0071",
-]
+ignore = []
 
 # =============================================================================
 # [bans] - Crate bans and duplicate detection

--- a/scripts/ci/check_rsa_advisory_removed.py
+++ b/scripts/ci/check_rsa_advisory_removed.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Fail closed when the rsa crate or RUSTSEC-2023-0071 exceptions return.
+
+Pins two properties that must stay true together after CI-4C (#2231):
+
+1. No resolved package named ``rsa`` in workspace ``cargo metadata``.
+2. No ``RUSTSEC-2023-0071`` exception text in the four policy/invocation sites
+   that previously carried the ignore in lockstep.
+
+The check reads metadata from stdin (JSON) or runs ``cargo metadata --locked``
+itself. Policy files are read from the repository root.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ADVISORY_ID = "RUSTSEC-2023-0071"
+
+POLICY_SITES = (
+    "deny.toml",
+    ".cargo/audit.toml",
+    ".github/workflows/ci.yml",
+    ".pre-commit-config.yaml",
+)
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def load_metadata(raw: str | None) -> dict:
+    if raw is not None:
+        return json.loads(raw)
+    proc = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--locked"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "cargo metadata --locked failed:\n"
+            + (proc.stderr.strip() or proc.stdout.strip() or "(no output)")
+        )
+    return json.loads(proc.stdout)
+
+
+def packages_named_rsa(metadata: dict) -> list[str]:
+    names: list[str] = []
+    for package in metadata.get("packages", []):
+        name = package.get("name")
+        if name == "rsa":
+            version = package.get("version", "?")
+            names.append(f"{name} {version}")
+    return names
+
+
+def advisory_hits(root: Path, sites: tuple[str, ...] = POLICY_SITES) -> list[str]:
+    hits: list[str] = []
+    for rel in sites:
+        path = root / rel
+        if not path.is_file():
+            hits.append(f"{rel}: missing (cannot prove absence of {ADVISORY_ID})")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if ADVISORY_ID in text:
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if ADVISORY_ID in line:
+                    hits.append(f"{rel}:{lineno}: {line.strip()}")
+    return hits
+
+
+def evaluate(root: Path, metadata: dict) -> list[str]:
+    failures: list[str] = []
+    rsa_pkgs = packages_named_rsa(metadata)
+    if rsa_pkgs:
+        failures.append(
+            "resolved workspace metadata still contains package named rsa: "
+            + ", ".join(rsa_pkgs)
+        )
+    ignore_hits = advisory_hits(root)
+    if ignore_hits:
+        failures.append(
+            f"{ADVISORY_ID} still referenced in policy/invocation sites:\n  - "
+            + "\n  - ".join(ignore_hits)
+        )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    root = repo_root()
+    raw: str | None = None
+    if args and args[0] == "--metadata-file":
+        raw = Path(args[1]).read_text(encoding="utf-8")
+    elif not sys.stdin.isatty():
+        stdin = sys.stdin.read()
+        if stdin.strip():
+            raw = stdin
+    try:
+        metadata = load_metadata(raw)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 2
+    failures = evaluate(root, metadata)
+    if failures:
+        for item in failures:
+            print(f"FAIL: {item}", file=sys.stderr)
+        return 1
+    print(
+        "PASS: no package named rsa in resolved metadata; "
+        f"no {ADVISORY_ID} exception in the four policy sites"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_rsa_advisory_removed.py
+++ b/scripts/ci/check_rsa_advisory_removed.py
@@ -99,11 +99,17 @@ def evaluate(root: Path, metadata: dict) -> list[str]:
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
+    if args:
+        # No argv path surface: metadata arrives on stdin or from cargo metadata.
+        print(
+            "FAIL: unexpected arguments "
+            f"{args!r}; pass metadata JSON on stdin or run with no args",
+            file=sys.stderr,
+        )
+        return 2
     root = repo_root()
     raw: str | None = None
-    if args and args[0] == "--metadata-file":
-        raw = Path(args[1]).read_text(encoding="utf-8")
-    elif not sys.stdin.isatty():
+    if not sys.stdin.isatty():
         stdin = sys.stdin.read()
         if stdin.strip():
             raw = stdin

--- a/scripts/ci/test_check_rsa_advisory_removed.py
+++ b/scripts/ci/test_check_rsa_advisory_removed.py
@@ -10,6 +10,7 @@ than for a missing file or a vacuous assertion.
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -143,6 +144,79 @@ class CheckRsaAdvisoryRemovedTests(unittest.TestCase):
             f"{MODULE.ADVISORY_ID} exceptions are removed:\n"
             f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
         )
+
+    def test_cli_rejects_metadata_file_argv_and_does_not_read_path(self) -> None:
+        """CLI must reject path argv; arbitrary paths must not be opened/read."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "must_not_be_read.json"
+            # If the CLI still opened this path, evaluate would report rsa from it.
+            probe.write_text(json.dumps(metadata_with_rsa()), encoding="utf-8")
+            before = probe.read_text(encoding="utf-8")
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    "--metadata-file",
+                    str(probe),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            after = probe.read_text(encoding="utf-8")
+            self.assertEqual(before, after, "argv path contents must be untouched")
+            self.assertNotEqual(proc.returncode, 0, proc.stderr)
+            err = proc.stderr
+            self.assertRegex(
+                err,
+                r"(?i)unexpected|unsupported|unknown|reject",
+                msg=f"must reject argv path surface, got:\n{err}",
+            )
+            self.assertNotIn(
+                "rsa 0.9.10",
+                err,
+                "failure must not come from reading the argv path as metadata",
+            )
+
+    def test_cli_rejects_unexpected_args(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(MODULE_PATH), "--not-a-real-flag"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0, proc.stderr)
+        self.assertRegex(proc.stderr, r"(?i)unexpected|unsupported|unknown|reject")
+
+    def test_cli_accepts_metadata_on_stdin(self) -> None:
+        """Stdin metadata injection remains the supported non-live path."""
+        # Clean metadata + live clean policy sites → PASS.
+        proc = subprocess.run(
+            [sys.executable, str(MODULE_PATH)],
+            cwd=REPO_ROOT,
+            input=json.dumps(metadata_without_rsa()),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"stdin clean metadata must pass:\n{proc.stdout}\n{proc.stderr}",
+        )
+        # rsa on stdin must still fail closed on the package property.
+        bad = subprocess.run(
+            [sys.executable, str(MODULE_PATH)],
+            cwd=REPO_ROOT,
+            input=json.dumps(metadata_with_rsa()),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(bad.returncode, 1, bad.stderr)
+        self.assertIn("package named rsa", bad.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_check_rsa_advisory_removed.py
+++ b/scripts/ci/test_check_rsa_advisory_removed.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Contract + mutation tests for scripts/ci/check_rsa_advisory_removed.py.
+
+The live check against the repository is the durable gate. The fixture mutations
+prove the checker fails for the two properties it pins — reintroducing ``rsa``
+in resolved metadata, and reintroducing a ``RUSTSEC-2023-0071`` ignore — rather
+than for a missing file or a vacuous assertion.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("check_rsa_advisory_removed.py")
+SPEC = importlib.util.spec_from_file_location("check_rsa_advisory_removed", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+)
+
+
+def metadata_without_rsa() -> dict:
+    return {
+        "packages": [
+            {"name": "assay-mcp-server", "version": "5.1.0"},
+            {"name": "jsonwebtoken", "version": "11.0.0"},
+            {"name": "aws-lc-rs", "version": "1.16.2"},
+        ]
+    }
+
+
+def metadata_with_rsa() -> dict:
+    meta = metadata_without_rsa()
+    meta["packages"].append({"name": "rsa", "version": "0.9.10"})
+    return meta
+
+
+class CheckRsaAdvisoryRemovedTests(unittest.TestCase):
+    def test_clean_metadata_and_policy_sites_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for rel in MODULE.POLICY_SITES:
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# clean policy site\n", encoding="utf-8")
+            failures = MODULE.evaluate(root, metadata_without_rsa())
+            self.assertEqual(failures, [])
+
+    def test_rejects_rsa_package_in_resolved_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for rel in MODULE.POLICY_SITES:
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# clean\n", encoding="utf-8")
+            failures = MODULE.evaluate(root, metadata_with_rsa())
+            self.assertEqual(len(failures), 1)
+            self.assertIn("package named rsa", failures[0])
+            self.assertIn("rsa 0.9.10", failures[0])
+
+    def test_rejects_advisory_ignore_in_each_policy_site(self) -> None:
+        for site in MODULE.POLICY_SITES:
+            with self.subTest(site=site):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    for rel in MODULE.POLICY_SITES:
+                        path = root / rel
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        body = (
+                            f'ignore = ["{MODULE.ADVISORY_ID}"]\n'
+                            if rel == site
+                            else "# clean\n"
+                        )
+                        path.write_text(body, encoding="utf-8")
+                    failures = MODULE.evaluate(root, metadata_without_rsa())
+                    self.assertEqual(len(failures), 1, failures)
+                    self.assertIn(MODULE.ADVISORY_ID, failures[0])
+                    self.assertIn(site, failures[0])
+
+    def test_mutation_reintroducing_rsa_package_is_caught(self) -> None:
+        """Mutation: put package name rsa back into resolved metadata."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for rel in MODULE.POLICY_SITES:
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# clean\n", encoding="utf-8")
+            clean = MODULE.evaluate(root, metadata_without_rsa())
+            self.assertEqual(clean, [])
+            bitten = MODULE.evaluate(root, metadata_with_rsa())
+            self.assertTrue(bitten, "reintroducing rsa must fail the check")
+            self.assertIn("rsa", bitten[0])
+
+    def test_mutation_reintroducing_ignore_reference_is_caught(self) -> None:
+        """Mutation: restore a RUSTSEC-2023-0071 ignore in deny.toml."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for rel in MODULE.POLICY_SITES:
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# clean\n", encoding="utf-8")
+            deny = root / "deny.toml"
+            original = deny.read_text(encoding="utf-8")
+            self.assertEqual(MODULE.evaluate(root, metadata_without_rsa()), [])
+            deny.write_text(
+                original + f'\nignore = ["{MODULE.ADVISORY_ID}"]\n',
+                encoding="utf-8",
+            )
+            bitten = MODULE.evaluate(root, metadata_without_rsa())
+            self.assertTrue(
+                bitten,
+                "reintroducing a RUSTSEC-2023-0071 ignore must fail the check",
+            )
+            self.assertIn(MODULE.ADVISORY_ID, bitten[0])
+            self.assertIn("deny.toml", bitten[0])
+
+    def test_live_repository_has_no_rsa_and_no_advisory_exception(self) -> None:
+        """Durable gate: fails on base while rsa/ignore remain; passes after CI-4C."""
+        proc = subprocess.run(
+            [sys.executable, str(MODULE_PATH)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            "live check must pass only when rsa is gone and all four "
+            f"{MODULE.ADVISORY_ID} exceptions are removed:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: **No programme is active** (AGENTS.md). Standalone CI-4C slice for #2231; tracked under planning #2302.
- Slice: CI-4C — remove `rsa` / RUSTSEC-2023-0071 advisory exception via jsonwebtoken `aws_lc_rs` backend
- Builder: Cursor (`cursor/ci4c-remove-rsa-advisory`)
- Reviewers: pending independent non-building agent review
- Final head SHA: `8fd7bca8811ea37b41eb49f873de355f890a1059`
- Base SHA: `35c9c44f1325f11fbb03109c5842ff241180f857` (`origin/main` after conflict-free merge of main into `6553446f176629b95245716cb9f14f82a392d874`)
- Main-advance carry: merge commit `8fd7bca8811ea37b41eb49f873de355f890a1059` = parents `6553446f176629b95245716cb9f14f82a392d874` + `35c9c44f1325f11fbb03109c5842ff241180f857`; CI-4C nine reviewed files disjoint from upstream advance file `crates/assay-cli/tests/spec_reason_code_registry.rs` (intersection empty). CodeQL argv-path fix remains on lineage via `6553446f176629b95245716cb9f14f82a392d874`.
- ADR invariants affected: ADR-043 §4 (stdio authorization boundary) — compatibility surface retained; no new auth capability
- Template: `.github/PULL_REQUEST_TEMPLATE/adr-boundary.md` (body inlined; `gh` rejects `--template` with `--body`)

Closes #2231

## Behavior

- `assay-mcp-server` selects `jsonwebtoken` features `aws_lc_rs` + `use_pem` (dependency and dev-dependency), dropping the `rsa` crate from the resolved workspace tree.
- Direct `rsa` / `rand` dev-dependencies removed; legacy RS256 full-path test still generates a key at runtime with `aws-lc-rs`, signs via jsonwebtoken RS256, and validates through `TokenValidator::new_with_static_key` (no checked-in PEM).
- Every `RUSTSEC-2023-0071` ignore / rationale removed from `deny.toml`, `.cargo/audit.toml`, `.github/workflows/ci.yml`, and `.pre-commit-config.yaml`. cargo-deny and cargo-audit remain fail-closed (no ignore flag).
- Durable contract: `scripts/ci/check_rsa_advisory_removed.py` (+ mutation unittest) pinned in the deps-security job.

**Unchanged (binding design):** public deprecated `assay_mcp_server::auth` types and `ServerConfig.auth` remain for the 5.1 minor line; stdio auth stays startup-rejected / compatibility-only. Removal of that public surface is a major-line break (#2283 neighbour).

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- Does **not** establish transport authentication for stdio (ADR-043 §4 non-claim unchanged).
- Does **not** close #2283 — auth normalization / public compatibility surface cleanup remains open.
- Does **not** claim aws-lc-rs is a new workspace crypto product; it was already resolved via rustls/object_store. Standalone `assay-mcp-server` builds may now compile it through this feature choice.
- macOS local backend check done here; Linux/Windows left to CI.

## Test Evidence

### RED

Measured on base `c9b036de8198d3bfa7f9752d414863b20c9b7c18` before the production change:

```
$ python3 scripts/ci/check_rsa_advisory_removed.py
FAIL: resolved workspace metadata still contains package named rsa: rsa 0.9.10
FAIL: RUSTSEC-2023-0071 still referenced in policy/invocation sites:
  - deny.toml:30
  - .cargo/audit.toml:3,5
  - .github/workflows/ci.yml:204,205,221
  - .pre-commit-config.yaml:348,353
exit=1
```

Failure reason: `rsa` present **and** advisory ignores still configured — not a missing-file miss.

### Mutations demonstrated

- Reintroduce package named `rsa` in resolved metadata → check fails (`test_mutation_reintroducing_rsa_package_is_caught`).
- Reintroduce `RUSTSEC-2023-0071` ignore in `deny.toml` → check fails (`test_mutation_reintroducing_ignore_reference_is_caught`).
- Per-site ignore rejection covered for all four policy files.

### GREEN

On head `8fd7bca8811ea37b41eb49f873de355f890a1059` (worktree `/Users/roelschuurkes/wt-ci4c-remove-rsa-advisory`, macOS):

- `cargo tree -i rsa --workspace` → `package ID specification `rsa` did not match any packages`
- `python3 scripts/ci/check_rsa_advisory_removed.py` → PASS
- `python3 scripts/ci/test_check_rsa_advisory_removed.py` → 6/6 OK
- `cargo-deny check advisories licenses bans sources` → advisories/bans/licenses/sources ok
- `cargo-audit audit` → `vuln_count 0` (no replacement advisory; pre-existing allowed warnings only)
- `cargo test -p assay-mcp-server --lib auth::` → 10/10 ok (incl. RS256 full path)
- `cargo test -p assay-mcp-server --all-targets` → ok
- `cargo test -p assay-mcp-server --features test-outbound --test no_passthrough_e2e --test stdio_auth_boundary --test server_run_auth_boundary` → ok
- `cargo fmt --all -- --check` → ok
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings` → ok
- `git diff --check` → ok

## Review Quorum

- [ ] One non-building agent review
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Optional automated reviews can add evidence, but do not count toward or block quorum.

## Dependency-tree proof

```
# before (base): rsa v0.9.10 ← jsonwebtoken ← assay-mcp-server
# after (head):  cargo tree -i rsa --workspace → no package named rsa
```

Draft only — do not mark ready or merge until independent exact-head review and required checks are green.

Made with [Cursor](https://cursor.com)
