### PR TITLE
ci: pin cargo-audit from shared plugin version source (CI-4D1 / #2224)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,12 +183,17 @@ jobs:
       - name: Install cargo-deny
         run: ./scripts/ci/install-cargo-deny.sh
       - name: Install cargo-audit
-        # Version deliberately unpinned, unlike the sibling install two lines up. An advisory scanner
-        # is the one tool where floating is arguably right: a pinned scanner stops learning about new
-        # advisories, so the pin would age into a silent gap rather than a loud failure. Stated here
-        # because an unexplained asymmetry beside a pinned sibling reads as an oversight, and #2237
-        # holds the question of whether this reasoning survives scrutiny.
-        run: cargo install --locked cargo-audit
+        # Pin lives in scripts/ci/cargo-plugin-versions.sh (shared owner for later CI-4D2/3 plugins).
+        # Advisory freshness comes from refreshing the advisory DB in the audit steps below, not from
+        # resolving a new scanner binary on every run (#2224 / CI-4D1). `--locked` alone is not a pin:
+        # it locks cargo-audit's own dependencies from its published lockfile, not the tool version.
+        run: |
+          set -euo pipefail
+          # shellcheck source=scripts/ci/cargo-plugin-versions.sh
+          source ./scripts/ci/cargo-plugin-versions.sh
+          echo "installing cargo-audit ${CARGO_AUDIT_VERSION}"
+          cargo install --locked --version "${CARGO_AUDIT_VERSION}" cargo-audit
+          assert_cargo_plugin_version cargo-audit "${CARGO_AUDIT_VERSION}"
       - name: Check Aya/eBPF dependency alignment
         run: ./scripts/ci/check-aya-ebpf-alignment.sh
       - name: cargo deny (advisories, licenses, bans, sources)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -374,6 +374,15 @@ repos:
         # deps-security's RUSTUP_TOOLCHAIN, and restoring the false "never compiles a crate" claim.
         # files: includes ci.yml so a workflow-only edit still runs this gate in Lint (pre-commit).
         files: ^(scripts/ci/(install-cargo-deny|test-deps-security-toolchain-contract)\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
+
+      - id: cargo-plugin-versions-contract-self-test
+        name: cargo-plugin versions contract
+        entry: bash scripts/ci/test-cargo-plugin-versions-contract.sh
+        language: system
+        pass_filenames: false
+        # CI-4D1 / #2224: pin cargo-audit from one shared source. Mutations cover removing
+        # --version, restating the pin in the workflow, PATH decoys, and dropping source/assert.
+        files: ^(scripts/ci/(cargo-plugin-versions|test-cargo-plugin-versions-contract)\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
       - id: cargo-clippy
         name: cargo clippy (workspace, deny warnings)
         entry: scripts/precommit/cargo-clippy.sh

--- a/scripts/ci/cargo-plugin-versions.sh
+++ b/scripts/ci/cargo-plugin-versions.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Shared cargo-plugin version pins for CI.
+#
+# Source this file; do not execute it as an installer. Install steps and runtime version
+# assertions must both read the variables defined here so a restated literal cannot drift
+# (AGENTS.md pinning rule). CI-4D1 owns cargo-audit; later CI-4D2/3 slices extend this file
+# with additional CARGO_*_VERSION entries rather than adding another tool-specific installer.
+#
+# Bash 3.2 compatible (macOS /bin/bash): no associative arrays, no ${var@Q}.
+set -euo pipefail
+
+# Exported so a sourcing install step and its version assertion share one value.
+export CARGO_AUDIT_VERSION="0.22.2"
+
+# Where `cargo install` writes binaries: CARGO_INSTALL_ROOT, else CARGO_HOME, else ~/.cargo.
+cargo_plugin_bin_path() {
+  local name="$1"
+  printf '%s\n' "${CARGO_INSTALL_ROOT:-${CARGO_HOME:-${HOME}/.cargo}}/bin/${name}"
+}
+
+# Bind the assertion to Cargo's install location. Resolving through PATH lets an unrelated
+# binary earlier on PATH satisfy the pin while the install wrote nothing (#2226).
+assert_cargo_plugin_version() {
+  local name="$1" expected="$2"
+  local bin reported
+  bin="$(cargo_plugin_bin_path "${name}")"
+  if [[ ! -x "${bin}" ]]; then
+    echo "${name} missing at install location ${bin}" >&2
+    echo "the pin lives in scripts/ci/cargo-plugin-versions.sh and is the only place to change it" >&2
+    return 1
+  fi
+  reported="$("${bin}" --version)"
+  echo "${name} resolved: ${reported} at ${bin}"
+  if [[ "${reported}" != "${name} ${expected}" ]]; then
+    echo "${name} reports '${reported}', which is not the pinned ${expected}" >&2
+    echo "the pin lives in scripts/ci/cargo-plugin-versions.sh and is the only place to change it" >&2
+    return 1
+  fi
+}
+
+# When sourced, define pins and helpers only. When executed, refuse — this is not an installer.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  echo "source scripts/ci/cargo-plugin-versions.sh; it is a version source, not an installer" >&2
+  exit 1
+fi

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Contract for the shared cargo-plugin version source and ci.yml's cargo-audit pin (CI-4D1 / #2224).
+#
+# Before this gate, deps-security installed cargo-audit with `cargo install --locked cargo-audit`
+# and a comment that floating the scanner was deliberate. `--locked` pins the tool's own
+# dependencies, not the tool version, so a new cargo-audit release could redden an unrelated PR.
+# Advisory freshness comes from refreshing the advisory DB, not from resolving a new scanner on
+# every run. The pin and the runtime assertion must read one checked-in value.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSIONS="${ROOT}/scripts/ci/cargo-plugin-versions.sh"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+ok() { echo "ok   $*"; }
+
+abort_is_failure() {
+  local rc="$1"
+  [[ "${rc}" -eq 0 ]] || echo "cargo-plugin-versions contract aborted (exit ${rc}); treat as failure" >&2
+}
+trap 'abort_is_failure "$?"' ERR
+
+# macOS ships /bin/bash 3.2.57. The @Q parameter transformation is bash 4.4+ (#2250).
+if awk '
+  /^[[:space:]]*#/ { next }
+  /\$\{[^}]+@Q\}/ { found=1; print NR ":" $0 }
+  END { exit found ? 0 : 1 }
+' "${BASH_SOURCE[0]}"; then
+  echo "FAIL self-test uses bash-4.4 @Q quoting; macOS bash 3.2 aborts with bad substitution" >&2
+  exit 1
+fi
+
+[[ -f "${WORKFLOW}" ]] || fail "missing ${WORKFLOW#"${ROOT}"/}"
+[[ -f "${VERSIONS}" ]] || fail "missing shared version source ${VERSIONS#"${ROOT}"/} (unpinned cargo-audit install has no single owner)"
+
+# Refuse to source a script that still runs install-like work on source.
+grep -q 'BASH_SOURCE\[0\]' "${VERSIONS}" \
+  || fail "cargo-plugin-versions.sh is not source-safe (missing BASH_SOURCE execute guard)"
+grep -qE '^(export[[:space:]]+)?CARGO_AUDIT_VERSION=' "${VERSIONS}" \
+  || fail "cargo-plugin-versions.sh must define CARGO_AUDIT_VERSION"
+grep -qE '^cargo_plugin_bin_path[[:space:]]*\(\)' "${VERSIONS}" \
+  || fail "cargo-plugin-versions.sh must define cargo_plugin_bin_path()"
+grep -qE '^assert_cargo_plugin_version[[:space:]]*\(\)' "${VERSIONS}" \
+  || fail "cargo-plugin-versions.sh must define assert_cargo_plugin_version()"
+
+# shellcheck source=scripts/ci/cargo-plugin-versions.sh
+source "${VERSIONS}"
+
+PIN="${CARGO_AUDIT_VERSION:-}"
+[[ -n "${PIN}" ]] || fail "CARGO_AUDIT_VERSION is empty after sourcing ${VERSIONS#"${ROOT}"/}"
+
+# Extract the deps-security job body.
+deps_security_job() {
+  local wf="$1"
+  awk '
+    /^  deps-security:[[:space:]]*$/ { in_job=1; print; next }
+    in_job && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    in_job { print }
+  ' "${wf}"
+}
+
+# Active (non-comment) lines of the Install cargo-audit step run block.
+install_cargo_audit_run() {
+  local wf="$1"
+  deps_security_job "${wf}" | awk '
+    /^      - name: Install cargo-audit[[:space:]]*$/ { in_step=1; next }
+    in_step && /^      - name:/ { exit }
+    in_step && /^        run:[[:space:]]*\|[[:space:]]*$/ { in_run=1; next }
+    in_step && /^        run:[[:space:]]+/ {
+      sub(/^        run:[[:space:]]*/, "")
+      print
+      exit
+    }
+    in_run && /^        [^[:space:]]/ { exit }
+    in_run { print }
+  '
+}
+
+check_workflow() {
+  local wf="$1"
+  local job install_run
+
+  job="$(deps_security_job "${wf}")"
+  [[ -n "${job}" ]] || fail "could not find deps-security job in ${wf##*/}"
+
+  install_run="$(install_cargo_audit_run "${wf}")"
+  [[ -n "${install_run}" ]] || fail "could not find Install cargo-audit run block in ${wf##*/}"
+
+  # Must source the shared pin — both install --version and the runtime assertion read it.
+  grep -qE 'source[[:space:]]+("?\./)?scripts/ci/cargo-plugin-versions\.sh"?' <<<"${install_run}" \
+    || grep -qE 'source[[:space:]]+".*cargo-plugin-versions\.sh"' <<<"${install_run}" \
+    || fail "Install cargo-audit must source scripts/ci/cargo-plugin-versions.sh; got:
+${install_run}"
+
+  # Pin must be stated on the install argv via the shared variable, not omitted and not a restated literal.
+  grep -qE 'cargo[[:space:]]+install[[:space:]].*--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"${install_run}" \
+    || fail "Install cargo-audit must pass --version \"\${CARGO_AUDIT_VERSION}\"; got:
+${install_run}"
+
+  # A restated pin in the workflow can drift from the shared source (AGENTS.md pinning rule).
+  if grep -qE -- "--version[[:space:]]+(\"?)(${PIN})(\"?)" <<<"${install_run}"; then
+    fail "Install cargo-audit restates version literal ${PIN}; both install and assertion must read CARGO_AUDIT_VERSION"
+  fi
+  if grep -qF "${PIN}" <<<"${install_run}"; then
+    fail "Install cargo-audit run block contains version literal ${PIN}; use \${CARGO_AUDIT_VERSION} only"
+  fi
+
+  grep -qE 'assert_cargo_plugin_version[[:space:]]+cargo-audit[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"${install_run}" \
+    || fail "Install cargo-audit must call assert_cargo_plugin_version cargo-audit \"\${CARGO_AUDIT_VERSION}\"; got:
+${install_run}"
+
+  # The former floating-scanner rationale must not return; it conflicts with the pin contract.
+  if grep -qiE 'floating is arguably right|Version deliberately unpinned|scanner should float' <<<"${job}"; then
+    fail "deps-security still carries the floating cargo-audit rationale; pin + advisory-DB refresh is the contract"
+  fi
+
+  # Preserve CI-4C: no RUSTSEC ignore on the audit invocations in this job.
+  if grep -qE -- '--ignore[[:space:]]+RUSTSEC-' <<<"${job}"; then
+    fail "deps-security reintroduced a RUSTSEC --ignore; CI-4C removed those exceptions"
+  fi
+
+  ok "deps-security cargo-audit pin contract holds for ${wf##*/}"
+}
+
+check_workflow "${WORKFLOW}"
+
+# --- Behavioral: assertion binds install location, not PATH --------------------
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+expect_in_file() {
+  local file="$1" needle="$2" what="$3"
+  if grep -qF -- "${needle}" "${file}"; then
+    ok "${what}"
+  else
+    echo "FAIL ${what}: '${needle}' not in" >&2
+    sed 's/^/      /' "${file}" >&2
+    fail "${what}"
+  fi
+}
+
+echo "== assert_cargo_plugin_version accepts the install-root binary =="
+pass_dir="${SCRATCH}/assert_pass"
+mkdir -p "${pass_dir}/bin" "${pass_dir}/early"
+cat >"${pass_dir}/bin/cargo-audit" <<STUB
+#!/usr/bin/env bash
+echo "cargo-audit ${PIN}"
+STUB
+chmod +x "${pass_dir}/bin/cargo-audit"
+cat >"${pass_dir}/early/cargo-audit" <<'STUB'
+#!/usr/bin/env bash
+echo "cargo-audit 9.9.9-path-decoy"
+STUB
+chmod +x "${pass_dir}/early/cargo-audit"
+pass_out="${pass_dir}/out"
+pass_exit=0
+PATH="${pass_dir}/early:${PATH}" CARGO_HOME="${pass_dir}" \
+  assert_cargo_plugin_version cargo-audit "${PIN}" >"${pass_out}" 2>&1 || pass_exit=$?
+[[ "${pass_exit}" -eq 0 ]] || fail "assert_cargo_plugin_version failed against install-root pin (exit ${pass_exit})"
+expect_in_file "${pass_out}" "at ${pass_dir}/bin/cargo-audit" "assertion names the install-root binary"
+
+echo "== wrong installed version fails =="
+wrong_dir="${SCRATCH}/assert_wrong"
+mkdir -p "${wrong_dir}/bin"
+cat >"${wrong_dir}/bin/cargo-audit" <<'STUB'
+#!/usr/bin/env bash
+echo "cargo-audit 0.0.0-not-the-pin"
+STUB
+chmod +x "${wrong_dir}/bin/cargo-audit"
+wrong_out="${wrong_dir}/out"
+wrong_exit=0
+CARGO_HOME="${wrong_dir}" \
+  assert_cargo_plugin_version cargo-audit "${PIN}" >"${wrong_out}" 2>&1 || wrong_exit=$?
+[[ "${wrong_exit}" -ne 0 ]] || fail "wrong installed version left assertion green"
+expect_in_file "${wrong_out}" "is not the pinned ${PIN}" "mismatch names the pin"
+expect_in_file "${wrong_out}" "scripts/ci/cargo-plugin-versions.sh" "mismatch names the pin's location"
+
+echo "== PATH decoy cannot satisfy the pin =="
+decoy_dir="${SCRATCH}/path_decoy"
+mkdir -p "${decoy_dir}/early" "${decoy_dir}/cargo-home"
+cat >"${decoy_dir}/early/cargo-audit" <<STUB
+#!/usr/bin/env bash
+echo "cargo-audit ${PIN}"
+STUB
+chmod +x "${decoy_dir}/early/cargo-audit"
+decoy_out="${decoy_dir}/out"
+decoy_exit=0
+PATH="${decoy_dir}/early:${PATH}" CARGO_HOME="${decoy_dir}/cargo-home" \
+  assert_cargo_plugin_version cargo-audit "${PIN}" >"${decoy_out}" 2>&1 || decoy_exit=$?
+[[ "${decoy_exit}" -ne 0 ]] || fail "PATH decoy satisfied assert_cargo_plugin_version"
+expect_in_file "${decoy_out}" "cargo-audit missing at install location" \
+  "path decoy names the missing install-root binary"
+
+# --- Mutations must bite -------------------------------------------------------
+
+SANDBOX_ROOT="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH}" "${SANDBOX_ROOT}"' EXIT
+
+mutant="$(mktemp "${SANDBOX_ROOT}/mut.XXXXXX.yml")"
+
+echo "== mutation: remove --version =="
+# Drop --version and its argument from the install line while keeping source + assert.
+python3 - "${WORKFLOW}" "${mutant}" <<'PY'
+import pathlib, re, sys
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+# Only mutate the cargo-audit install line that uses the shared variable.
+new, n = re.subn(
+    r'(cargo install --locked) --version "\$\{CARGO_AUDIT_VERSION\}" (cargo-audit)',
+    r"\1 \2",
+    text,
+    count=1,
+)
+if n != 1:
+    raise SystemExit(f"could not strip --version (n={n})")
+dst.write_text(new)
+PY
+grep -qE 'cargo install --locked cargo-audit' "${mutant}" \
+  || fail "--version removal mutation did not apply"
+if grep -qE -- '--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' "${mutant}"; then
+  # Still present elsewhere is fine; must be gone from install-audit argv. Re-check install block.
+  if grep -qE -- '--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"$(install_cargo_audit_run "${mutant}")"; then
+    fail "--version removal mutation still leaves --version in Install cargo-audit"
+  fi
+fi
+if ( check_workflow "${mutant}" ) >/dev/null 2>&1; then
+  fail "removing --version left the contract green"
+fi
+ok "removing --version turns the contract red"
+
+echo "== mutation: duplicate workflow literal =="
+literal="$(mktemp "${SANDBOX_ROOT}/lit.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${literal}" "${PIN}" <<'PY'
+import pathlib, sys
+src, dst, pin = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), sys.argv[3]
+text = src.read_text()
+old = 'cargo install --locked --version "${CARGO_AUDIT_VERSION}" cargo-audit'
+new = f'cargo install --locked --version "{pin}" cargo-audit'
+if old not in text:
+    raise SystemExit("could not find versioned install line to literalize")
+dst.write_text(text.replace(old, new, 1))
+PY
+grep -qF -- "--version \"${PIN}\"" "${literal}" \
+  || fail "duplicate-literal mutation did not apply"
+if ( check_workflow "${literal}" ) >/dev/null 2>&1; then
+  fail "restating the version literal in the workflow left the contract green"
+fi
+ok "duplicate workflow literal turns the contract red"
+
+echo "== mutation: remove workflow source =="
+nosource="$(mktemp "${SANDBOX_ROOT}/nosource.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${nosource}" <<'PY'
+import pathlib, re, sys
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+# Drop the active source and its shellcheck directive; leave other mentions untouched.
+new, n = re.subn(
+    r'^[ \t]*# shellcheck source=scripts/ci/cargo-plugin-versions\.sh[ \t]*\n'
+    r'^[ \t]*source[ \t]+\./scripts/ci/cargo-plugin-versions\.sh[ \t]*\n',
+    "",
+    text,
+    count=1,
+    flags=re.M,
+)
+if n != 1:
+    raise SystemExit(f"could not remove source block (n={n})")
+dst.write_text(new)
+PY
+install_after="$(install_cargo_audit_run "${nosource}")"
+if grep -qE '^[[:space:]]*source[[:space:]].*cargo-plugin-versions\.sh' <<<"${install_after}"; then
+  fail "source-removal mutation still leaves an active source of cargo-plugin-versions.sh"
+fi
+if ( check_workflow "${nosource}" ) >/dev/null 2>&1; then
+  fail "removing workflow source left the contract green"
+fi
+ok "removing workflow source turns the contract red"
+
+echo "== mutation: remove version assertion =="
+noassert="$(mktemp "${SANDBOX_ROOT}/noassert.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${noassert}" <<'PY'
+import pathlib, re, sys
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+new, n = re.subn(
+    r'^[ \t]*assert_cargo_plugin_version[ \t]+cargo-audit[ \t]+"\$\{CARGO_AUDIT_VERSION\}"[ \t]*\n',
+    "",
+    text,
+    count=1,
+    flags=re.M,
+)
+if n != 1:
+    raise SystemExit(f"could not remove assert line (n={n})")
+dst.write_text(new)
+PY
+if grep -q 'assert_cargo_plugin_version' <<<"$(install_cargo_audit_run "${noassert}")"; then
+  fail "assertion-removal mutation still leaves assert_cargo_plugin_version in Install cargo-audit"
+fi
+if ( check_workflow "${noassert}" ) >/dev/null 2>&1; then
+  fail "removing version assertion left the contract green"
+fi
+ok "removing version assertion turns the contract red"
+
+ok "cargo-plugin-versions contract mutations bite"
+echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -97,9 +97,12 @@ active_source_line() {
   grep -qE '^[[:space:]]*source[[:space:]]+(\./scripts/ci/cargo-plugin-versions\.sh|"(\./)?scripts/ci/cargo-plugin-versions\.sh")[[:space:]]*$' <<<"$1"
 }
 
-count_active_cargo_audit_installs() {
+# Dedicated Install cargo-audit step: count any active line containing the token
+# sequence `cargo` + whitespace + `install`. No package/flag/shell parser — a second
+# cargo install of any shape fails (#2317 review 4914469947).
+count_active_cargo_installs() {
   # grep -c exits 1 on zero matches; keep zero under set -e.
-  printf '%s\n' "$1" | grep -cE '^[[:space:]]*cargo[[:space:]]+install[[:space:]].*[[:space:]]cargo-audit[[:space:]]*$' || true
+  printf '%s\n' "$1" | grep -cE 'cargo[[:space:]]+install' || true
 }
 
 active_pinned_install_line() {
@@ -130,12 +133,12 @@ check_workflow() {
     || fail "Install cargo-audit must have an active complete line sourcing scripts/ci/cargo-plugin-versions.sh; got:
 ${install_run}"
 
-  # Exactly one active cargo install of cargo-audit, and it must be the pinned argv.
-  # A second install (pinned or unpinned) after assert would overwrite the pin while a
-  # presence-only check stayed green (#2317 review 4914399777).
-  install_count="$(count_active_cargo_audit_installs "${install_run}")"
+  # Exactly one active `cargo install` line in this dedicated step, and it must be the
+  # pinned argv. Rejects @version, --force, flag reorder, env/command prefix, redirect,
+  # quotes, and trailing-# forms without parsing cargo/shell (#2317 review 4914469947).
+  install_count="$(count_active_cargo_installs "${install_run}")"
   [[ "${install_count}" -eq 1 ]] \
-    || fail "Install cargo-audit must have exactly one active cargo install of cargo-audit; found ${install_count}:
+    || fail "Install cargo-audit must have exactly one active line containing cargo install; found ${install_count}:
 ${install_run}"
 
   active_pinned_install_line "${install_run}" \
@@ -487,37 +490,53 @@ if ! ( check_workflow "${keep}" ) >/dev/null 2>&1; then
 fi
 ok "correctly pinned run: |+ stays green"
 
-echo "== mutation: second active unpinned cargo-audit install =="
-# Keep source + pinned install + assert, then append an unpinned install that would overwrite
-# the pin at runtime while a presence-only check stayed green (#2317 review 4914399777).
-dual="$(mktemp "${SANDBOX_ROOT}/dual.XXXXXX.yml")"
-python3 - "${WORKFLOW}" "${dual}" <<'PY'
+echo "== mutation: second active cargo install (any shape) =="
+# Keep source + pinned install + assert, then append a second cargo install. Counting only
+# lines ending in bare cargo-audit left @version/--force/env/redirect/… green while the
+# floating install overwrote the pin (#2317 review 4914469947).
+expect_second_cargo_install_red() {
+  local name="$1" extra="$2"
+  local mutant mutant_run
+  mutant="$(mktemp "${SANDBOX_ROOT}/dual-${name}.XXXXXX.yml")"
+  python3 - "${WORKFLOW}" "${mutant}" "${extra}" <<'PY'
 import pathlib, sys
 
-src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+src, dst, extra = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), sys.argv[3]
 text = src.read_text()
 old = '          assert_cargo_plugin_version cargo-audit "${CARGO_AUDIT_VERSION}"\n'
-new = old + "          cargo install --locked cargo-audit\n"
+new = old + f"          {extra}\n"
 if old not in text:
     raise SystemExit("could not find assert line to append a second install after")
 dst.write_text(text.replace(old, new, 1))
 PY
-dual_run="$(install_cargo_audit_run "${dual}")"
-[[ "$(count_active_cargo_audit_installs "${dual_run}")" -eq 2 ]] \
-  || fail "dual-install mutation did not leave two active cargo-audit installs"
-active_pinned_install_line "${dual_run}" \
-  || fail "dual-install mutation lost the pinned install line"
-active_source_line "${dual_run}" \
-  || fail "dual-install mutation lost the source line"
-active_assert_line "${dual_run}" \
-  || fail "dual-install mutation lost the assert line"
-grep -qE '^[[:space:]]*cargo[[:space:]]+install[[:space:]]+--locked[[:space:]]+cargo-audit[[:space:]]*$' \
-  <<<"${dual_run}" \
-  || fail "dual-install mutation did not append an active unpinned install"
-if ( check_workflow "${dual}" ) >/dev/null 2>&1; then
-  fail "second active unpinned cargo-audit install left the contract green"
-fi
-ok "second active unpinned cargo-audit install turns the contract red"
+  mutant_run="$(install_cargo_audit_run "${mutant}")"
+  [[ "$(count_active_cargo_installs "${mutant_run}")" -eq 2 ]] \
+    || fail "${name}: expected two active cargo install lines; got:
+${mutant_run}"
+  active_pinned_install_line "${mutant_run}" \
+    || fail "${name}: lost the pinned install line"
+  active_source_line "${mutant_run}" \
+    || fail "${name}: lost the source line"
+  active_assert_line "${mutant_run}" \
+    || fail "${name}: lost the assert line"
+  if ( check_workflow "${mutant}" ) >/dev/null 2>&1; then
+    fail "${name}: second cargo install left the contract green"
+  fi
+  ok "second cargo install turns red (${name})"
+}
+
+expect_second_cargo_install_red bare 'cargo install --locked cargo-audit'
+expect_second_cargo_install_red atversion 'cargo install --locked cargo-audit@0.99.0'
+expect_second_cargo_install_red force 'cargo install --locked cargo-audit --force'
+expect_second_cargo_install_red reorder 'cargo install cargo-audit --locked'
+# shellcheck disable=SC2016
+expect_second_cargo_install_red reorder_version 'cargo install --version "${CARGO_AUDIT_VERSION}" --locked cargo-audit'
+expect_second_cargo_install_red envprefix 'CARGO_HOME=/tmp/x cargo install --locked cargo-audit'
+expect_second_cargo_install_red command_prefix 'command cargo install --locked cargo-audit'
+expect_second_cargo_install_red redirect 'cargo install --locked cargo-audit >/dev/null'
+expect_second_cargo_install_red quoted 'cargo install --locked "cargo-audit"'
+expect_second_cargo_install_red trailing_hash 'cargo install --locked cargo-audit # overwrite'
+expect_second_cargo_install_red other_pkg 'cargo install --locked cargo-deny'
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -65,7 +65,9 @@ deps_security_job() {
 }
 
 # Active (non-comment, non-blank) lines of the Install cargo-audit step run block.
-# Comment ghosts must not satisfy source / --version / assert greps (#2317 review).
+# Whole-line `# …` ghosts are dropped here. Trailing `# …` on an active line is still emitted;
+# check_workflow therefore requires complete anchored command lines so those tails cannot satisfy
+# source / --version / assert (#2317 review 4914059003). No shell comment parser.
 install_cargo_audit_run() {
   local wf="$1"
   deps_security_job "${wf}" | awk '
@@ -77,7 +79,8 @@ install_cargo_audit_run() {
     }
     /^      - name: Install cargo-audit[[:space:]]*$/ { in_step=1; next }
     in_step && /^      - name:/ { exit }
-    in_step && /^        run:[[:space:]]*\|[[:space:]]*$/ { in_run=1; next }
+    # Block scalars: run: | / |- / |+ with optional spaces (#2317 review).
+    in_step && /^        run:[[:space:]]*\|[-+]?[[:space:]]*$/ { in_run=1; next }
     in_step && /^        run:[[:space:]]+/ {
       sub(/^        run:[[:space:]]*/, "")
       emit_active($0)
@@ -86,6 +89,25 @@ install_cargo_audit_run() {
     in_run && /^        [^[:space:]]/ { exit }
     in_run { emit_active($0) }
   '
+}
+
+# Complete active command lines only (optional leading/trailing blank). Trailing `# ghosts`
+# on the same line cannot match these end-anchored patterns.
+active_source_line() {
+  grep -qE '^[[:space:]]*source[[:space:]]+(\./scripts/ci/cargo-plugin-versions\.sh|"(\./)?scripts/ci/cargo-plugin-versions\.sh")[[:space:]]*$' <<<"$1"
+}
+
+active_pinned_install_line() {
+  grep -qE '^[[:space:]]*cargo[[:space:]]+install[[:space:]]+--locked[[:space:]]+--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"[[:space:]]+cargo-audit[[:space:]]*$' <<<"$1"
+}
+
+active_literal_install_line() {
+  # Restated pin as a complete install argv (not a # tail after an unpinned install).
+  grep -qE '^[[:space:]]*cargo[[:space:]]+install[[:space:]]+--locked[[:space:]]+--version[[:space:]]+"?'"${PIN}"'"?[[:space:]]+cargo-audit[[:space:]]*$' <<<"$1"
+}
+
+active_assert_line() {
+  grep -qE '^[[:space:]]*assert_cargo_plugin_version[[:space:]]+cargo-audit[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"[[:space:]]*$' <<<"$1"
 }
 
 check_workflow() {
@@ -99,26 +121,22 @@ check_workflow() {
   [[ -n "${install_run}" ]] || fail "could not find Install cargo-audit run block in ${wf##*/}"
 
   # Must source the shared pin — both install --version and the runtime assertion read it.
-  grep -qE 'source[[:space:]]+("?\./)?scripts/ci/cargo-plugin-versions\.sh"?' <<<"${install_run}" \
-    || grep -qE 'source[[:space:]]+".*cargo-plugin-versions\.sh"' <<<"${install_run}" \
-    || fail "Install cargo-audit must source scripts/ci/cargo-plugin-versions.sh; got:
+  active_source_line "${install_run}" \
+    || fail "Install cargo-audit must have an active complete line sourcing scripts/ci/cargo-plugin-versions.sh; got:
 ${install_run}"
 
-  # Pin must be stated on the install argv via the shared variable, not omitted and not a restated literal.
-  grep -qE 'cargo[[:space:]]+install[[:space:]].*--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"${install_run}" \
-    || fail "Install cargo-audit must pass --version \"\${CARGO_AUDIT_VERSION}\"; got:
+  # Pin must be a complete active install argv via the shared variable.
+  active_pinned_install_line "${install_run}" \
+    || fail "Install cargo-audit must have an active complete line: cargo install --locked --version \"\${CARGO_AUDIT_VERSION}\" cargo-audit; got:
 ${install_run}"
 
   # A restated pin in the workflow can drift from the shared source (AGENTS.md pinning rule).
-  if grep -qE -- "--version[[:space:]]+(\"?)(${PIN})(\"?)" <<<"${install_run}"; then
-    fail "Install cargo-audit restates version literal ${PIN}; both install and assertion must read CARGO_AUDIT_VERSION"
-  fi
-  if grep -qF "${PIN}" <<<"${install_run}"; then
-    fail "Install cargo-audit run block contains version literal ${PIN}; use \${CARGO_AUDIT_VERSION} only"
+  if active_literal_install_line "${install_run}"; then
+    fail "Install cargo-audit restates version literal ${PIN} on an active complete install line; both install and assertion must read CARGO_AUDIT_VERSION"
   fi
 
-  grep -qE 'assert_cargo_plugin_version[[:space:]]+cargo-audit[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"${install_run}" \
-    || fail "Install cargo-audit must call assert_cargo_plugin_version cargo-audit \"\${CARGO_AUDIT_VERSION}\"; got:
+  active_assert_line "${install_run}" \
+    || fail "Install cargo-audit must have an active complete assert_cargo_plugin_version line; got:
 ${install_run}"
 
   # The former floating-scanner rationale must not return; it conflicts with the pin contract.
@@ -228,13 +246,11 @@ if n != 1:
     raise SystemExit(f"could not strip --version (n={n})")
 dst.write_text(new)
 PY
-grep -qE 'cargo install --locked cargo-audit' "${mutant}" \
-  || fail "--version removal mutation did not apply"
-if grep -qE -- '--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' "${mutant}"; then
-  # Still present elsewhere is fine; must be gone from install-audit argv. Re-check install block.
-  if grep -qE -- '--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"$(install_cargo_audit_run "${mutant}")"; then
-    fail "--version removal mutation still leaves --version in Install cargo-audit"
-  fi
+grep -qE '^[[:space:]]*cargo[[:space:]]+install[[:space:]]+--locked[[:space:]]+cargo-audit[[:space:]]*$' \
+  <<<"$(install_cargo_audit_run "${mutant}")" \
+  || fail "--version removal mutation did not leave an active unpinned install line"
+if active_pinned_install_line "$(install_cargo_audit_run "${mutant}")"; then
+  fail "--version removal mutation still leaves a complete pinned install line"
 fi
 if ( check_workflow "${mutant}" ) >/dev/null 2>&1; then
   fail "removing --version left the contract green"
@@ -280,8 +296,8 @@ if n != 1:
 dst.write_text(new)
 PY
 install_after="$(install_cargo_audit_run "${nosource}")"
-if grep -qE '^[[:space:]]*source[[:space:]].*cargo-plugin-versions\.sh' <<<"${install_after}"; then
-  fail "source-removal mutation still leaves an active source of cargo-plugin-versions.sh"
+if active_source_line "${install_after}"; then
+  fail "source-removal mutation still leaves a complete active source line"
 fi
 if ( check_workflow "${nosource}" ) >/dev/null 2>&1; then
   fail "removing workflow source left the contract green"
@@ -305,8 +321,8 @@ if n != 1:
     raise SystemExit(f"could not remove assert line (n={n})")
 dst.write_text(new)
 PY
-if grep -q 'assert_cargo_plugin_version' <<<"$(install_cargo_audit_run "${noassert}")"; then
-  fail "assertion-removal mutation still leaves assert_cargo_plugin_version in Install cargo-audit"
+if active_assert_line "$(install_cargo_audit_run "${noassert}")"; then
+  fail "assertion-removal mutation still leaves a complete active assert line"
 fi
 if ( check_workflow "${noassert}" ) >/dev/null 2>&1; then
   fail "removing version assertion left the contract green"
@@ -344,16 +360,17 @@ if n != 1:
 dst.write_text(new)
 PY
 install_ghost="$(install_cargo_audit_run "${ghost}")"
-grep -qE 'cargo install --locked cargo-audit' <<<"${install_ghost}" \
+grep -qE '^[[:space:]]*cargo[[:space:]]+install[[:space:]]+--locked[[:space:]]+cargo-audit[[:space:]]*$' \
+  <<<"${install_ghost}" \
   || fail "ghost mutation did not leave an active unpinned cargo install"
-if grep -qE '^[[:space:]]*source[[:space:]].*cargo-plugin-versions\.sh' <<<"${install_ghost}"; then
-  fail "ghost mutation still leaves an active source line"
+if active_source_line "${install_ghost}"; then
+  fail "ghost mutation still leaves a complete active source line"
 fi
-if grep -qE -- '--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"${install_ghost}"; then
-  fail "ghost mutation still leaves an active --version pin"
+if active_pinned_install_line "${install_ghost}"; then
+  fail "ghost mutation still leaves a complete pinned install line"
 fi
-if grep -qE '^[[:space:]]*assert_cargo_plugin_version[[:space:]]' <<<"${install_ghost}"; then
-  fail "ghost mutation still leaves an active assert_cargo_plugin_version"
+if active_assert_line "${install_ghost}"; then
+  fail "ghost mutation still leaves a complete active assert line"
 fi
 # Comment text must still contain the ghosts — otherwise we tested a different defect.
 grep -q 'source ./scripts/ci/cargo-plugin-versions.sh' "${ghost}" \
@@ -364,6 +381,99 @@ if ( check_workflow "${ghost}" ) >/dev/null 2>&1; then
   fail "comment-ghost pin left the contract green"
 fi
 ok "comment-ghost pin + active unpinned install turns the contract red"
+
+echo "== mutation: trailing inline # ghosts + active unpinned install =="
+# Pin markers survive only as trailing comments on otherwise-active lines (#2317 review 4914059003).
+inline_ghost="$(mktemp "${SANDBOX_ROOT}/inline.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${inline_ghost}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+pat = re.compile(
+    r"(      - name: Install cargo-audit\n"
+    r"(?:        #.*\n)*"
+    r"        run: \|[-+]?\n)"
+    r"(?:          .*\n)+"
+)
+repl = (
+    "\\1"
+    "          set -euo pipefail\n"
+    "          true # source ./scripts/ci/cargo-plugin-versions.sh\n"
+    '          cargo install --locked cargo-audit # --version "${CARGO_AUDIT_VERSION}"\n'
+    '          true # assert_cargo_plugin_version cargo-audit "${CARGO_AUDIT_VERSION}"\n'
+)
+new, n = pat.subn(repl, text, count=1)
+if n != 1:
+    raise SystemExit(f"could not rewrite install block for inline-ghost mutation (n={n})")
+dst.write_text(new)
+PY
+install_inline="$(install_cargo_audit_run "${inline_ghost}")"
+grep -qF 'source ./scripts/ci/cargo-plugin-versions.sh' <<<"${install_inline}" \
+  || fail "inline-ghost mutation did not retain trailing source text on an emitted line"
+# Needle is the literal workflow text `--version "${CARGO_AUDIT_VERSION}"`, not an expanded pin.
+# shellcheck disable=SC2016
+grep -qF -- '--version "${CARGO_AUDIT_VERSION}"' <<<"${install_inline}" \
+  || fail "inline-ghost mutation did not retain trailing --version text on an emitted line"
+if active_source_line "${install_inline}"; then
+  fail "inline-ghost mutation unexpectedly matches a complete active source line"
+fi
+if active_pinned_install_line "${install_inline}"; then
+  fail "inline-ghost mutation unexpectedly matches a complete pinned install line"
+fi
+if active_assert_line "${install_inline}"; then
+  fail "inline-ghost mutation unexpectedly matches a complete active assert line"
+fi
+if ( check_workflow "${inline_ghost}" ) >/dev/null 2>&1; then
+  fail "trailing inline # ghosts left the contract green"
+fi
+ok "trailing inline # ghosts + active unpinned install turns the contract red"
+
+echo "== regression: correctly pinned run: |- stays green =="
+chomp="$(mktemp "${SANDBOX_ROOT}/chomp.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${chomp}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+pat = re.compile(
+    r"(      - name: Install cargo-audit\n(?:        #.*\n)*)"
+    r"        run: \|\n"
+)
+new, n = pat.subn(r"\1        run: |-\n", text, count=1)
+if n != 1:
+    raise SystemExit(f"could not switch Install cargo-audit to run: |- (n={n})")
+dst.write_text(new)
+PY
+grep -qE '^[[:space:]]*run:[[:space:]]*\|-[[:space:]]*$' <<<"$(deps_security_job "${chomp}")" \
+  || fail "run: |- regression did not apply"
+if ! ( check_workflow "${chomp}" ) >/dev/null 2>&1; then
+  fail "correctly pinned run: |- turned the contract red"
+fi
+ok "correctly pinned run: |- stays green"
+
+echo "== regression: correctly pinned run: |+ stays green =="
+keep="$(mktemp "${SANDBOX_ROOT}/keep.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${keep}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+pat = re.compile(
+    r"(      - name: Install cargo-audit\n(?:        #.*\n)*)"
+    r"        run: \|\n"
+)
+new, n = pat.subn(r"\1        run: |+\n", text, count=1)
+if n != 1:
+    raise SystemExit(f"could not switch Install cargo-audit to run: |+ (n={n})")
+dst.write_text(new)
+PY
+grep -qE '^[[:space:]]*run:[[:space:]]*\|\+[[:space:]]*$' <<<"$(deps_security_job "${keep}")" \
+  || fail "run: |+ regression did not apply"
+if ! ( check_workflow "${keep}" ) >/dev/null 2>&1; then
+  fail "correctly pinned run: |+ turned the contract red"
+fi
+ok "correctly pinned run: |+ stays green"
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -97,6 +97,11 @@ active_source_line() {
   grep -qE '^[[:space:]]*source[[:space:]]+(\./scripts/ci/cargo-plugin-versions\.sh|"(\./)?scripts/ci/cargo-plugin-versions\.sh")[[:space:]]*$' <<<"$1"
 }
 
+count_active_cargo_audit_installs() {
+  # grep -c exits 1 on zero matches; keep zero under set -e.
+  printf '%s\n' "$1" | grep -cE '^[[:space:]]*cargo[[:space:]]+install[[:space:]].*[[:space:]]cargo-audit[[:space:]]*$' || true
+}
+
 active_pinned_install_line() {
   grep -qE '^[[:space:]]*cargo[[:space:]]+install[[:space:]]+--locked[[:space:]]+--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"[[:space:]]+cargo-audit[[:space:]]*$' <<<"$1"
 }
@@ -112,7 +117,7 @@ active_assert_line() {
 
 check_workflow() {
   local wf="$1"
-  local job install_run
+  local job install_run install_count
 
   job="$(deps_security_job "${wf}")"
   [[ -n "${job}" ]] || fail "could not find deps-security job in ${wf##*/}"
@@ -125,7 +130,14 @@ check_workflow() {
     || fail "Install cargo-audit must have an active complete line sourcing scripts/ci/cargo-plugin-versions.sh; got:
 ${install_run}"
 
-  # Pin must be a complete active install argv via the shared variable.
+  # Exactly one active cargo install of cargo-audit, and it must be the pinned argv.
+  # A second install (pinned or unpinned) after assert would overwrite the pin while a
+  # presence-only check stayed green (#2317 review 4914399777).
+  install_count="$(count_active_cargo_audit_installs "${install_run}")"
+  [[ "${install_count}" -eq 1 ]] \
+    || fail "Install cargo-audit must have exactly one active cargo install of cargo-audit; found ${install_count}:
+${install_run}"
+
   active_pinned_install_line "${install_run}" \
     || fail "Install cargo-audit must have an active complete line: cargo install --locked --version \"\${CARGO_AUDIT_VERSION}\" cargo-audit; got:
 ${install_run}"
@@ -474,6 +486,38 @@ if ! ( check_workflow "${keep}" ) >/dev/null 2>&1; then
   fail "correctly pinned run: |+ turned the contract red"
 fi
 ok "correctly pinned run: |+ stays green"
+
+echo "== mutation: second active unpinned cargo-audit install =="
+# Keep source + pinned install + assert, then append an unpinned install that would overwrite
+# the pin at runtime while a presence-only check stayed green (#2317 review 4914399777).
+dual="$(mktemp "${SANDBOX_ROOT}/dual.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${dual}" <<'PY'
+import pathlib, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+old = '          assert_cargo_plugin_version cargo-audit "${CARGO_AUDIT_VERSION}"\n'
+new = old + "          cargo install --locked cargo-audit\n"
+if old not in text:
+    raise SystemExit("could not find assert line to append a second install after")
+dst.write_text(text.replace(old, new, 1))
+PY
+dual_run="$(install_cargo_audit_run "${dual}")"
+[[ "$(count_active_cargo_audit_installs "${dual_run}")" -eq 2 ]] \
+  || fail "dual-install mutation did not leave two active cargo-audit installs"
+active_pinned_install_line "${dual_run}" \
+  || fail "dual-install mutation lost the pinned install line"
+active_source_line "${dual_run}" \
+  || fail "dual-install mutation lost the source line"
+active_assert_line "${dual_run}" \
+  || fail "dual-install mutation lost the assert line"
+grep -qE '^[[:space:]]*cargo[[:space:]]+install[[:space:]]+--locked[[:space:]]+cargo-audit[[:space:]]*$' \
+  <<<"${dual_run}" \
+  || fail "dual-install mutation did not append an active unpinned install"
+if ( check_workflow "${dual}" ) >/dev/null 2>&1; then
+  fail "second active unpinned cargo-audit install left the contract green"
+fi
+ok "second active unpinned cargo-audit install turns the contract red"
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -97,12 +97,13 @@ active_source_line() {
   grep -qE '^[[:space:]]*source[[:space:]]+(\./scripts/ci/cargo-plugin-versions\.sh|"(\./)?scripts/ci/cargo-plugin-versions\.sh")[[:space:]]*$' <<<"$1"
 }
 
-# Dedicated Install cargo-audit step: count any active line containing the token
-# sequence `cargo` + whitespace + `install`. No package/flag/shell parser — a second
-# cargo install of any shape fails (#2317 review 4914469947).
+# Dedicated Install cargo-audit step: count any active line containing
+# `cargo` + optional one `+toolchain` token + `install`. No package/flag/shell
+# parser — a second cargo install of any shape fails (#2317 reviews 4914469947,
+# 4914536813). rustup forms like `cargo +stable install` must count.
 count_active_cargo_installs() {
   # grep -c exits 1 on zero matches; keep zero under set -e.
-  printf '%s\n' "$1" | grep -cE 'cargo[[:space:]]+install' || true
+  printf '%s\n' "$1" | grep -cE 'cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?install' || true
 }
 
 active_pinned_install_line() {
@@ -133,9 +134,10 @@ check_workflow() {
     || fail "Install cargo-audit must have an active complete line sourcing scripts/ci/cargo-plugin-versions.sh; got:
 ${install_run}"
 
-  # Exactly one active `cargo install` line in this dedicated step, and it must be the
-  # pinned argv. Rejects @version, --force, flag reorder, env/command prefix, redirect,
-  # quotes, and trailing-# forms without parsing cargo/shell (#2317 review 4914469947).
+  # Exactly one active `cargo [+toolchain] install` line in this dedicated step, and it
+  # must be the pinned argv. Rejects @version, --force, flag reorder, env/command prefix,
+  # redirect, quotes, trailing-#, and rustup `+toolchain` forms without parsing packages
+  # (#2317 reviews 4914469947, 4914536813).
   install_count="$(count_active_cargo_installs "${install_run}")"
   [[ "${install_count}" -eq 1 ]] \
     || fail "Install cargo-audit must have exactly one active line containing cargo install; found ${install_count}:
@@ -537,6 +539,8 @@ expect_second_cargo_install_red redirect 'cargo install --locked cargo-audit >/d
 expect_second_cargo_install_red quoted 'cargo install --locked "cargo-audit"'
 expect_second_cargo_install_red trailing_hash 'cargo install --locked cargo-audit # overwrite'
 expect_second_cargo_install_red other_pkg 'cargo install --locked cargo-deny'
+expect_second_cargo_install_red plus_stable 'cargo +stable install --locked cargo-audit'
+expect_second_cargo_install_red plus_nightly 'cargo +nightly install --locked cargo-audit'
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -64,20 +64,27 @@ deps_security_job() {
   ' "${wf}"
 }
 
-# Active (non-comment) lines of the Install cargo-audit step run block.
+# Active (non-comment, non-blank) lines of the Install cargo-audit step run block.
+# Comment ghosts must not satisfy source / --version / assert greps (#2317 review).
 install_cargo_audit_run() {
   local wf="$1"
   deps_security_job "${wf}" | awk '
+    function emit_active(line,    tmp) {
+      tmp = line
+      sub(/^[[:space:]]+/, "", tmp)
+      if (tmp == "" || tmp ~ /^#/) return
+      print line
+    }
     /^      - name: Install cargo-audit[[:space:]]*$/ { in_step=1; next }
     in_step && /^      - name:/ { exit }
     in_step && /^        run:[[:space:]]*\|[[:space:]]*$/ { in_run=1; next }
     in_step && /^        run:[[:space:]]+/ {
       sub(/^        run:[[:space:]]*/, "")
-      print
+      emit_active($0)
       exit
     }
     in_run && /^        [^[:space:]]/ { exit }
-    in_run { print }
+    in_run { emit_active($0) }
   '
 }
 
@@ -305,6 +312,58 @@ if ( check_workflow "${noassert}" ) >/dev/null 2>&1; then
   fail "removing version assertion left the contract green"
 fi
 ok "removing version assertion turns the contract red"
+
+echo "== mutation: comment ghosts + active unpinned install =="
+# source / pinned install / assert survive only as comments; active argv is unpinned.
+# Before active-line filtering this left check_workflow green (#2317 review).
+ghost="$(mktemp "${SANDBOX_ROOT}/ghost.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${ghost}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+pat = re.compile(
+    r"(      - name: Install cargo-audit\n"
+    r"(?:        #.*\n)*"
+    r"        run: \|\n)"
+    r"(?:          .*\n)+"
+)
+repl = (
+    "\\1"
+    "          set -euo pipefail\n"
+    "          # shellcheck source=scripts/ci/cargo-plugin-versions.sh\n"
+    "          # source ./scripts/ci/cargo-plugin-versions.sh\n"
+    '          # echo "installing cargo-audit ${CARGO_AUDIT_VERSION}"\n'
+    '          # cargo install --locked --version "${CARGO_AUDIT_VERSION}" cargo-audit\n'
+    '          # assert_cargo_plugin_version cargo-audit "${CARGO_AUDIT_VERSION}"\n'
+    "          cargo install --locked cargo-audit\n"
+)
+new, n = pat.subn(repl, text, count=1)
+if n != 1:
+    raise SystemExit(f"could not rewrite install block for ghost mutation (n={n})")
+dst.write_text(new)
+PY
+install_ghost="$(install_cargo_audit_run "${ghost}")"
+grep -qE 'cargo install --locked cargo-audit' <<<"${install_ghost}" \
+  || fail "ghost mutation did not leave an active unpinned cargo install"
+if grep -qE '^[[:space:]]*source[[:space:]].*cargo-plugin-versions\.sh' <<<"${install_ghost}"; then
+  fail "ghost mutation still leaves an active source line"
+fi
+if grep -qE -- '--version[[:space:]]+"\$\{CARGO_AUDIT_VERSION\}"' <<<"${install_ghost}"; then
+  fail "ghost mutation still leaves an active --version pin"
+fi
+if grep -qE '^[[:space:]]*assert_cargo_plugin_version[[:space:]]' <<<"${install_ghost}"; then
+  fail "ghost mutation still leaves an active assert_cargo_plugin_version"
+fi
+# Comment text must still contain the ghosts — otherwise we tested a different defect.
+grep -q 'source ./scripts/ci/cargo-plugin-versions.sh' "${ghost}" \
+  || fail "ghost mutation did not retain commented source"
+grep -q 'assert_cargo_plugin_version cargo-audit' "${ghost}" \
+  || fail "ghost mutation did not retain commented assert"
+if ( check_workflow "${ghost}" ) >/dev/null 2>&1; then
+  fail "comment-ghost pin left the contract green"
+fi
+ok "comment-ghost pin + active unpinned install turns the contract red"
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"


### PR DESCRIPTION
## Summary
- Pin **cargo-audit 0.22.2** for `ci.yml` `deps-security` from one extensible source: `scripts/ci/cargo-plugin-versions.sh` (`CARGO_AUDIT_VERSION`), so install `--version` and the install-root runtime assertion read the same value.
- Replace the floating-scanner rationale: advisory freshness stays with advisory-DB refresh, not an unpinned scanner binary.
- Preserve direct `cargo-audit` invocation, job-level `RUSTUP_TOOLCHAIN: stable`, root/fuzz audit behavior, and CI-4C’s removed `RUSTSEC-2023-0071` exceptions.
- Contract (dedicated Install cargo-audit step): complete end-anchored active `source` / pinned install / `assert`; `run: |` / `|-` / `|+`; and **exactly one** active line containing `cargo` + optional one `+toolchain` token + `install`, which must **exactly** be the pinned argv (no package/shell parser).

**Part of #2224** — CI-4D2/D3 remain.

## Base / head
- Base: `origin/main` = `353e630bf98c4688fa2f6db7eafbf48e8241dc8c`
- Prior reviewed head (BLOCKED): `48614162f3f58fa3fa83b42bdb8dc6915447f870`
- **Current head:** `d9ffd8742899e742bc517ee44617f23cf96ef11c`
- Branch: `cursor/ci4d1-pin-cargo-audit`

A new head invalidates the prior exact-head review; fresh independent non-building review is required on `d9ffd8742`.

## Files
- `.github/workflows/ci.yml`
- `.pre-commit-config.yaml`
- `scripts/ci/cargo-plugin-versions.sh`
- `scripts/ci/test-cargo-plugin-versions-contract.sh`

## RED (review `4914536813` on `48614162f`)
Second active lines `cargo +stable install …` / `cargo +nightly install …` left `count_active_cargo_installs` at 1 → `check_workflow` **green**.

## GREEN
Count pattern allows at most one optional `+toolchain` token between `cargo` and `install`. Pinned argv unchanged as the only accepted install line.  
`bash` / `/bin/bash` 3.2 PASS; deps-security toolchain PASS; shellcheck PASS; `git diff --check` clean.

## Mutations / regressions (bite)
- Prior ghost / block-scalar / pin / second-install suite
- **`cargo +stable install …` / `cargo +nightly install …` as second install** (new)

## Non-claims
- Does not pin nextest/hack/semver/public-api/mutants.
- Does not change advisory policy or reintroduce ignores.
- Does not parse cargo package syntax or general shell.
- Does not close #2224 while D2/D3 remain.
- Host-capability / delegated proof not required for this path set.

## Test plan
- [x] Focused contract (+toolchain RED then GREEN + full mutation suite)
- [x] Bash 3.2 / shellcheck / deps-security toolchain / `git diff --check`
- [ ] CI on new draft head
- [ ] Fresh independent exact-head review on `d9ffd8742`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the automated security-audit tool version across development and continuous integration environments.
  * Added verification to confirm the expected audit tool is installed and reporting the correct version.

* **Tests**
  * Added automated checks for version configuration, installation behavior, workflow consistency, and compatibility across supported shell environments.
  * Added a pre-commit validation hook to catch configuration or script changes that could break these checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->