### PR TITLE
ci: close cargo-plugin toolchain hygiene (CI-4D4)

### DIFF
--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -195,7 +195,8 @@ jobs:
 
       # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). `--locked` alone is
       # not a pin: it locks each tool's own dependencies, not the tool version. RUSTUP_TOOLCHAIN
-      # is step-scoped so workspace cargo check/nextest/hack below still follow rust-toolchain.toml.
+      # is step-scoped for the install; plugin invocations bind stable explicitly, while
+      # ordinary workspace cargo follows rust-toolchain.toml.
       - name: Install cargo-nextest and cargo-hack
         shell: bash
         env:
@@ -397,8 +398,9 @@ jobs:
       - name: Set up Rust toolchain and cache
         uses: ./.github/actions/setup-rust
 
-      # Pin lives in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). Step-scoped
-      # RUSTUP_TOOLCHAIN so check-release below still follows rust-toolchain.toml.
+      # Pin lives in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). RUSTUP_TOOLCHAIN is
+      # step-scoped for the install; plugin invocations bind stable explicitly, while
+      # ordinary workspace cargo follows rust-toolchain.toml.
       - name: Install cargo-semver-checks
         shell: bash
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -391,18 +391,21 @@ repos:
         entry: bash scripts/ci/test-cargo-plugin-versions-contract.sh
         language: system
         pass_filenames: false
-        # CI-4D1 / #2224: pin cargo-audit from one shared source. Mutations cover removing
-        # --version, restating the pin in the workflow, PATH decoys, and dropping source/assert.
-        files: ^(scripts/ci/(cargo-plugin-versions|test-cargo-plugin-versions-contract)\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
+        # CI-4D1 / #2224: pin cargo-audit from one shared source. CI-4D4 also pins the review
+        # helper's direct cargo-deny invocation. Mutations cover removing --version, restating
+        # the pin, PATH decoys, dropping source/assert, and reverting the helper to cargo deny.
+        files: ^(scripts/ci/(cargo-plugin-versions|test-cargo-plugin-versions-contract|review-dependency-perf-hygiene-pr4)\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
 
       - id: split-wave-plugin-versions-contract-self-test
         name: split-wave plugin versions contract
         entry: bash scripts/ci/test-split-wave-plugin-versions-contract.sh
         language: system
         pass_filenames: false
-        # CI-4D2 / #2224: pin nextest/hack/semver-checks from the same shared source. Mutations
-        # cover missing pins, restated literals, missing source/assert, unpinned/duplicate
-        # install (including cargo +toolchain), PATH decoys, and optional-helper unpin.
+        # CI-4D2 / #2224: pin nextest/hack/semver-checks from the same shared source. CI-4D4
+        # also pins install-step comment semantics (step-scoped install; plugins bind stable;
+        # workspace cargo follows rust-toolchain.toml). Mutations cover missing pins, restated
+        # literals, missing source/assert, unpinned/duplicate install (including cargo
+        # +toolchain), PATH decoys, optional-helper unpin, and stale toolchain comments.
         files: ^(scripts/ci/(cargo-plugin-versions|test-split-wave-plugin-versions-contract|optional-public-api-drift)\.sh|\.github/workflows/split-wave0-gates\.yml|\.pre-commit-config\.yaml)$
 
       - id: optional-plugin-versions-contract-self-test

--- a/scripts/ci/review-dependency-perf-hygiene-pr4.sh
+++ b/scripts/ci/review-dependency-perf-hygiene-pr4.sh
@@ -32,8 +32,8 @@ if ! rg -q 'serde_yaml' docs/architecture/PLAN-DEPENDENCY-PERF-HYGIENE-PR4-2026q
   exit 1
 fi
 
-echo "[review] cargo deny scope"
-cargo deny check advisories bans sources
+echo "[review] cargo-deny scope"
+cargo-deny check advisories bans sources
 
 echo "[review] format/check/clippy"
 cargo fmt --check

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -171,69 +171,25 @@ ${install_run}"
   ok "deps-security cargo-audit pin contract holds for ${wf##*/}"
 }
 
-# CI-4D4 / #2224 close-out: the human review helper must name the same direct
-# cargo-deny binary CI and the hook use. `cargo deny` re-enters rust-toolchain.toml
-# resolution (#2214); deny.toml already documents the binary form.
+# CI-4D4 / #2224: review helper uses direct cargo-deny (not `cargo deny`); D1 hook watches it.
 check_review_helper_cargo_deny() {
   local helper="$1"
-  local active
-
-  [[ -f "${helper}" ]] || fail "missing review helper ${helper#"${ROOT}"/}"
-
-  active="$(awk '
-    /^[[:space:]]*#/ { next }
-    {
-      tmp = $0
-      sub(/^[[:space:]]+/, "", tmp)
-      if (tmp == "") next
-      print
-    }
-  ' "${helper}")"
-
-  grep -qE '^[[:space:]]*cargo-deny[[:space:]]+check[[:space:]]+advisories[[:space:]]+bans[[:space:]]+sources[[:space:]]*$' <<<"${active}" \
-    || fail "review-dependency-perf-hygiene-pr4.sh must have an active complete line: cargo-deny check advisories bans sources; got:
-${active}"
-
-  # Command form only (line starts with cargo deny). Echo/string mentions are not invocations.
-  if grep -qE '^[[:space:]]*cargo[[:space:]]+deny([[:space:]]|$)' <<<"${active}"; then
-    fail "review-dependency-perf-hygiene-pr4.sh still invokes cargo deny; use the cargo-deny binary (#2214 / #2224)"
+  [[ -f "${helper}" ]] || fail "missing ${helper#"${ROOT}"/}"
+  grep -qE '^[[:space:]]*cargo-deny[[:space:]]+check[[:space:]]+advisories[[:space:]]+bans[[:space:]]+sources[[:space:]]*$' "${helper}" \
+    || fail "review-dependency-perf-hygiene-pr4.sh must have complete line: cargo-deny check advisories bans sources"
+  if grep -qE '^[[:space:]]*cargo[[:space:]]+deny([[:space:]]|$)' "${helper}"; then
+    fail "review-dependency-perf-hygiene-pr4.sh still invokes cargo deny; use cargo-deny (#2214)"
   fi
-
-  ok "review helper uses direct cargo-deny"
-}
-
-# The D1 pre-commit hook must watch the review helper so a drift back to
-# `cargo deny` runs this contract in Lint (pre-commit).
-check_d1_precommit_watches_review_helper() {
-  local pc="$1"
-  local files_line
-
-  [[ -f "${pc}" ]] || fail "missing ${pc#"${ROOT}"/}"
-
-  files_line="$(awk '
-    /^[[:space:]]*- id:[[:space:]]*cargo-plugin-versions-contract-self-test[[:space:]]*$/ { in_hook=1; next }
-    in_hook && /^[[:space:]]*- id:/ { exit }
-    in_hook && /^[[:space:]]*files:[[:space:]]*/ {
-      sub(/^[[:space:]]*files:[[:space:]]*/, "")
-      print
-      exit
-    }
-  ' "${pc}")"
-
-  [[ -n "${files_line}" ]] \
-    || fail "cargo-plugin-versions-contract-self-test is missing a files: line in .pre-commit-config.yaml"
-
-  # Require the review helper path inside the files regex (as a script stem or path).
-  grep -qE 'review-dependency-perf-hygiene-pr4' <<<"${files_line}" \
-    || fail "cargo-plugin-versions-contract-self-test files: must watch review-dependency-perf-hygiene-pr4.sh; got:
-${files_line}"
-
-  ok "D1 pre-commit hook watches the review helper"
 }
 
 check_workflow "${WORKFLOW}"
 check_review_helper_cargo_deny "${REVIEW_HELPER}"
-check_d1_precommit_watches_review_helper "${PRECOMMIT}"
+ok "review helper uses direct cargo-deny"
+# Hook section: id line then files: must include the review script stem.
+grep -A8 '^[[:space:]]*- id:[[:space:]]*cargo-plugin-versions-contract-self-test[[:space:]]*$' "${PRECOMMIT}" \
+  | grep -qE '^[[:space:]]*files:.*review-dependency-perf-hygiene-pr4' \
+  || fail "cargo-plugin-versions-contract-self-test files: must watch review-dependency-perf-hygiene-pr4.sh"
+ok "D1 pre-commit hook watches the review helper"
 
 # --- Behavioral: assertion binds install location, not PATH --------------------
 
@@ -608,65 +564,13 @@ expect_second_cargo_install_red plus_nightly 'cargo +nightly install --locked ca
 
 echo "== mutation: review helper reverts to cargo deny =="
 deny_mut="$(mktemp "${SANDBOX_ROOT}/deny.XXXXXX.sh")"
-python3 - "${REVIEW_HELPER}" "${deny_mut}" <<'PY'
-import pathlib, sys
-
-src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
-text = src.read_text()
-old = "cargo-deny check advisories bans sources"
-new = "cargo deny check advisories bans sources"
-if old not in text:
-    # Production may still be on the stale form; seed the binary form then weaken it.
-    if "cargo deny check advisories bans sources" in text:
-        text = text.replace("cargo deny check advisories bans sources", old, 1)
-    else:
-        raise SystemExit("could not find cargo-deny/cargo deny check line to mutate")
-if old not in text:
-    raise SystemExit("could not normalize to cargo-deny before weakening")
-dst.write_text(text.replace(old, new, 1))
-PY
+sed 's/^cargo-deny check /cargo deny check /' "${REVIEW_HELPER}" >"${deny_mut}"
 grep -qE '^[[:space:]]*cargo[[:space:]]+deny[[:space:]]+check' "${deny_mut}" \
   || fail "cargo deny mutation did not apply"
 if ( check_review_helper_cargo_deny "${deny_mut}" ) >/dev/null 2>&1; then
   fail "reverting review helper to cargo deny left the contract green"
 fi
 ok "reverting review helper to cargo deny turns the contract red"
-
-echo "== mutation: D1 pre-commit drops review helper from files: =="
-pc_mut="$(mktemp "${SANDBOX_ROOT}/pc.XXXXXX.yaml")"
-python3 - "${PRECOMMIT}" "${pc_mut}" <<'PY'
-import pathlib, re, sys
-
-src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
-text = src.read_text()
-pat = re.compile(
-    r"(^[ \t]*- id:[ \t]*cargo-plugin-versions-contract-self-test[ \t]*\n"
-    r"(?:.*\n)*?"
-    r"[ \t]*files:[ \t]*)"
-    r"(.+)$",
-    re.M,
-)
-
-def drop_review(m: re.Match) -> str:
-    files = m.group(2)
-    weakened = files.replace("review-dependency-perf-hygiene-pr4|", "")
-    weakened = weakened.replace("|review-dependency-perf-hygiene-pr4", "")
-    weakened = weakened.replace("review-dependency-perf-hygiene-pr4", "")
-    if weakened == files and "review-dependency-perf-hygiene-pr4" not in files:
-        return m.group(0)
-    return m.group(1) + weakened
-
-new, n = pat.subn(drop_review, text, count=1)
-if n != 1:
-    raise SystemExit(f"could not locate cargo-plugin-versions-contract-self-test files: line (n={n})")
-dst.write_text(new)
-PY
-grep -q 'review-dependency-perf-hygiene-pr4' "${pc_mut}" \
-  && fail "D1 pre-commit files: mutation did not drop review-dependency-perf-hygiene-pr4"
-if ( check_d1_precommit_watches_review_helper "${pc_mut}" ) >/dev/null 2>&1; then
-  fail "dropping review helper from D1 pre-commit files: left the contract green"
-fi
-ok "dropping review helper from D1 pre-commit files: turns the contract red"
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-cargo-plugin-versions-contract.sh
+++ b/scripts/ci/test-cargo-plugin-versions-contract.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VERSIONS="${ROOT}/scripts/ci/cargo-plugin-versions.sh"
 WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+REVIEW_HELPER="${ROOT}/scripts/ci/review-dependency-perf-hygiene-pr4.sh"
+PRECOMMIT="${ROOT}/.pre-commit-config.yaml"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -169,7 +171,69 @@ ${install_run}"
   ok "deps-security cargo-audit pin contract holds for ${wf##*/}"
 }
 
+# CI-4D4 / #2224 close-out: the human review helper must name the same direct
+# cargo-deny binary CI and the hook use. `cargo deny` re-enters rust-toolchain.toml
+# resolution (#2214); deny.toml already documents the binary form.
+check_review_helper_cargo_deny() {
+  local helper="$1"
+  local active
+
+  [[ -f "${helper}" ]] || fail "missing review helper ${helper#"${ROOT}"/}"
+
+  active="$(awk '
+    /^[[:space:]]*#/ { next }
+    {
+      tmp = $0
+      sub(/^[[:space:]]+/, "", tmp)
+      if (tmp == "") next
+      print
+    }
+  ' "${helper}")"
+
+  grep -qE '^[[:space:]]*cargo-deny[[:space:]]+check[[:space:]]+advisories[[:space:]]+bans[[:space:]]+sources[[:space:]]*$' <<<"${active}" \
+    || fail "review-dependency-perf-hygiene-pr4.sh must have an active complete line: cargo-deny check advisories bans sources; got:
+${active}"
+
+  # Command form only (line starts with cargo deny). Echo/string mentions are not invocations.
+  if grep -qE '^[[:space:]]*cargo[[:space:]]+deny([[:space:]]|$)' <<<"${active}"; then
+    fail "review-dependency-perf-hygiene-pr4.sh still invokes cargo deny; use the cargo-deny binary (#2214 / #2224)"
+  fi
+
+  ok "review helper uses direct cargo-deny"
+}
+
+# The D1 pre-commit hook must watch the review helper so a drift back to
+# `cargo deny` runs this contract in Lint (pre-commit).
+check_d1_precommit_watches_review_helper() {
+  local pc="$1"
+  local files_line
+
+  [[ -f "${pc}" ]] || fail "missing ${pc#"${ROOT}"/}"
+
+  files_line="$(awk '
+    /^[[:space:]]*- id:[[:space:]]*cargo-plugin-versions-contract-self-test[[:space:]]*$/ { in_hook=1; next }
+    in_hook && /^[[:space:]]*- id:/ { exit }
+    in_hook && /^[[:space:]]*files:[[:space:]]*/ {
+      sub(/^[[:space:]]*files:[[:space:]]*/, "")
+      print
+      exit
+    }
+  ' "${pc}")"
+
+  [[ -n "${files_line}" ]] \
+    || fail "cargo-plugin-versions-contract-self-test is missing a files: line in .pre-commit-config.yaml"
+
+  # Require the review helper path inside the files regex (as a script stem or path).
+  grep -qE 'review-dependency-perf-hygiene-pr4' <<<"${files_line}" \
+    || fail "cargo-plugin-versions-contract-self-test files: must watch review-dependency-perf-hygiene-pr4.sh; got:
+${files_line}"
+
+  ok "D1 pre-commit hook watches the review helper"
+}
+
 check_workflow "${WORKFLOW}"
+check_review_helper_cargo_deny "${REVIEW_HELPER}"
+check_d1_precommit_watches_review_helper "${PRECOMMIT}"
 
 # --- Behavioral: assertion binds install location, not PATH --------------------
 
@@ -541,6 +605,68 @@ expect_second_cargo_install_red trailing_hash 'cargo install --locked cargo-audi
 expect_second_cargo_install_red other_pkg 'cargo install --locked cargo-deny'
 expect_second_cargo_install_red plus_stable 'cargo +stable install --locked cargo-audit'
 expect_second_cargo_install_red plus_nightly 'cargo +nightly install --locked cargo-audit'
+
+echo "== mutation: review helper reverts to cargo deny =="
+deny_mut="$(mktemp "${SANDBOX_ROOT}/deny.XXXXXX.sh")"
+python3 - "${REVIEW_HELPER}" "${deny_mut}" <<'PY'
+import pathlib, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+old = "cargo-deny check advisories bans sources"
+new = "cargo deny check advisories bans sources"
+if old not in text:
+    # Production may still be on the stale form; seed the binary form then weaken it.
+    if "cargo deny check advisories bans sources" in text:
+        text = text.replace("cargo deny check advisories bans sources", old, 1)
+    else:
+        raise SystemExit("could not find cargo-deny/cargo deny check line to mutate")
+if old not in text:
+    raise SystemExit("could not normalize to cargo-deny before weakening")
+dst.write_text(text.replace(old, new, 1))
+PY
+grep -qE '^[[:space:]]*cargo[[:space:]]+deny[[:space:]]+check' "${deny_mut}" \
+  || fail "cargo deny mutation did not apply"
+if ( check_review_helper_cargo_deny "${deny_mut}" ) >/dev/null 2>&1; then
+  fail "reverting review helper to cargo deny left the contract green"
+fi
+ok "reverting review helper to cargo deny turns the contract red"
+
+echo "== mutation: D1 pre-commit drops review helper from files: =="
+pc_mut="$(mktemp "${SANDBOX_ROOT}/pc.XXXXXX.yaml")"
+python3 - "${PRECOMMIT}" "${pc_mut}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+pat = re.compile(
+    r"(^[ \t]*- id:[ \t]*cargo-plugin-versions-contract-self-test[ \t]*\n"
+    r"(?:.*\n)*?"
+    r"[ \t]*files:[ \t]*)"
+    r"(.+)$",
+    re.M,
+)
+
+def drop_review(m: re.Match) -> str:
+    files = m.group(2)
+    weakened = files.replace("review-dependency-perf-hygiene-pr4|", "")
+    weakened = weakened.replace("|review-dependency-perf-hygiene-pr4", "")
+    weakened = weakened.replace("review-dependency-perf-hygiene-pr4", "")
+    if weakened == files and "review-dependency-perf-hygiene-pr4" not in files:
+        return m.group(0)
+    return m.group(1) + weakened
+
+new, n = pat.subn(drop_review, text, count=1)
+if n != 1:
+    raise SystemExit(f"could not locate cargo-plugin-versions-contract-self-test files: line (n={n})")
+dst.write_text(new)
+PY
+grep -q 'review-dependency-perf-hygiene-pr4' "${pc_mut}" \
+  && fail "D1 pre-commit files: mutation did not drop review-dependency-perf-hygiene-pr4"
+if ( check_d1_precommit_watches_review_helper "${pc_mut}" ) >/dev/null 2>&1; then
+  fail "dropping review helper from D1 pre-commit files: left the contract green"
+fi
+ok "dropping review helper from D1 pre-commit files: turns the contract red"
 
 ok "cargo-plugin-versions contract mutations bite"
 echo "PASS: cargo-plugin-versions contract"

--- a/scripts/ci/test-split-wave-plugin-versions-contract.sh
+++ b/scripts/ci/test-split-wave-plugin-versions-contract.sh
@@ -310,70 +310,26 @@ check_d2_plugin_invocation_bindings() {
   done <<<"${body}"
 }
 
-# Contiguous `#` comments immediately above a named workflow step (CI-4D4 / #2224).
-step_preamble_comments() {
-  local wf="$1" step_name="$2"
-  awk -v step="${step_name}" '
-    {
-      if ($0 ~ /^[[:space:]]*#/) {
-        buf = buf $0 ORS
-        next
-      }
-      if ($0 ~ /^[[:space:]]*$/) {
-        next
-      }
-      name = $0
-      sub(/^[[:space:]]*- name:[[:space:]]*/, "", name)
-      sub(/[[:space:]]*$/, "", name)
-      if (name == step) {
-        printf "%s", buf
-        exit
-      }
-      buf = ""
-    }
-  ' "${wf}"
-}
-
-# Install-step comments must not teach that plugin invocations follow rust-toolchain.toml.
-# Correct semantics: install RUSTUP_TOOLCHAIN is step-scoped; plugin invocations bind stable
-# explicitly; ordinary workspace cargo follows rust-toolchain.toml.
-check_one_d2_install_preamble() {
-  local label="$1" comments="$2"
-
-  grep -qF 'step-scoped' <<<"${comments}" \
-    || fail "${label} install comments must state RUSTUP_TOOLCHAIN is step-scoped; got:
-${comments}"
-  grep -qF 'plugin invocations bind stable explicitly' <<<"${comments}" \
-    || fail "${label} install comments must state plugin invocations bind stable explicitly; got:
-${comments}"
-  grep -qF 'ordinary workspace cargo follows rust-toolchain.toml' <<<"${comments}" \
-    || fail "${label} install comments must state ordinary workspace cargo follows rust-toolchain.toml; got:
-${comments}"
-}
-
+# CI-4D4 / #2224: install-step comments pin three claims near the two known step names.
+# step-scoped install; plugin invocations bind stable explicitly; ordinary workspace cargo
+# follows rust-toolchain.toml. Reject the pre-D4 "still follow(s) rust-toolchain.toml" wording.
 check_d2_install_comment_semantics() {
-  local wf="$1"
-  local nextest_comments semver_comments
-
-  nextest_comments="$(step_preamble_comments "${wf}" "Install cargo-nextest and cargo-hack")"
-  [[ -n "${nextest_comments}" ]] \
-    || fail "missing preamble comments above Install cargo-nextest and cargo-hack"
-
-  semver_comments="$(step_preamble_comments "${wf}" "Install cargo-semver-checks")"
-  [[ -n "${semver_comments}" ]] \
-    || fail "missing preamble comments above Install cargo-semver-checks"
-
-  # Stale D2 wording (pre-CI-4D4): grouped plugins with workspace cargo under rust-toolchain.toml.
-  if grep -qF 'still follow rust-toolchain.toml' <<<"${nextest_comments}"; then
-    fail "nextest/hack install comments still claim later steps follow rust-toolchain.toml; plugin invocations bind stable explicitly"
-  fi
-  if grep -qF 'still follows rust-toolchain.toml' <<<"${semver_comments}"; then
-    fail "semver-checks install comments still claim check-release follows rust-toolchain.toml; plugin invocations bind stable explicitly"
-  fi
-
-  check_one_d2_install_preamble "nextest/hack" "${nextest_comments}"
-  check_one_d2_install_preamble "semver-checks" "${semver_comments}"
-
+  local wf="$1" step window
+  for step in \
+    "Install cargo-nextest and cargo-hack" \
+    "Install cargo-semver-checks"; do
+    window="$(grep -B5 -F -- "- name: ${step}" "${wf}" || true)"
+    [[ -n "${window}" ]] || fail "missing step: ${step}"
+    grep -qF 'step-scoped' <<<"${window}" \
+      || fail "${step}: comments must state step-scoped install"
+    grep -qF 'plugin invocations bind stable explicitly' <<<"${window}" \
+      || fail "${step}: comments must state plugin invocations bind stable explicitly"
+    grep -qF 'ordinary workspace cargo follows rust-toolchain.toml' <<<"${window}" \
+      || fail "${step}: comments must state ordinary workspace cargo follows rust-toolchain.toml"
+    if grep -qE 'still follow(s)?[[:space:]]+rust-toolchain\.toml' <<<"${window}"; then
+      fail "${step}: stale still follow(s) rust-toolchain.toml claim"
+    fi
+  done
   ok "D2 install-step comment semantics hold for ${wf##*/}"
 }
 
@@ -821,90 +777,48 @@ if ( check_optional_helper "${opt_unbound}" ) >/dev/null 2>&1; then
 fi
 ok "removing optional semver check-release binding turns the helper contract red"
 
-echo "== mutation: restore stale nextest/hack rust-toolchain.toml comment =="
-stale_nextest="$(mktemp "${SANDBOX_ROOT}/stale-nextest.XXXXXX.yml")"
-python3 - "${WORKFLOW}" "${stale_nextest}" <<'PY'
-import pathlib, re, sys
+# Table-driven: replace the comment block above a named install step with stale text; must bite.
+# Stale body is read from stdin (heredoc at the call site).
+expect_stale_install_comment_red() {
+  local label="$1" step="$2" mutant stale
+  stale="$(cat)"
+  mutant="$(mktemp "${SANDBOX_ROOT}/stale-${label}.XXXXXX.yml")"
+  STEP="${step}" STALE="${stale}" python3 - "${WORKFLOW}" "${mutant}" <<'PY'
+import os, pathlib, re, sys
 
 src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+step, stale = os.environ["STEP"], os.environ["STALE"]
+if not stale.endswith("\n"):
+    stale += "\n"
 text = src.read_text()
-# Replace the contiguous preamble above Install cargo-nextest and cargo-hack.
 pat = re.compile(
-    r"(?:^[ \t]*#.*\n)+(?=^[ \t]*- name: Install cargo-nextest and cargo-hack[ \t]*$)",
+    r"(?:^[ \t]*#.*\n)+(?=^[ \t]*- name: " + re.escape(step) + r"[ \t]*$)",
     re.M,
-)
-stale = (
-    "      # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). `--locked` alone is\n"
-    "      # not a pin: it locks each tool's own dependencies, not the tool version. RUSTUP_TOOLCHAIN\n"
-    "      # is step-scoped so workspace cargo check/nextest/hack below still follow rust-toolchain.toml.\n"
 )
 new, n = pat.subn(stale, text, count=1)
 if n != 1:
-    raise SystemExit(f"could not rewrite nextest/hack preamble (n={n})")
+    raise SystemExit(f"could not rewrite preamble for {step!r} (n={n})")
 dst.write_text(new)
 PY
-grep -qF 'still follow rust-toolchain.toml' \
-  <<<"$(step_preamble_comments "${stale_nextest}" "Install cargo-nextest and cargo-hack")" \
-  || fail "stale nextest/hack comment mutation did not apply"
-if ( check_d2_install_comment_semantics "${stale_nextest}" ) >/dev/null 2>&1; then
-  fail "restoring stale nextest/hack rust-toolchain.toml comment left the contract green"
-fi
-ok "restoring stale nextest/hack comment turns the contract red"
+  if ( check_d2_install_comment_semantics "${mutant}" ) >/dev/null 2>&1; then
+    fail "stale ${label} install comment left the contract green"
+  fi
+  ok "stale ${label} install comment turns the contract red"
+}
 
-echo "== mutation: restore stale semver check-release rust-toolchain.toml comment =="
-stale_semver="$(mktemp "${SANDBOX_ROOT}/stale-semver.XXXXXX.yml")"
-python3 - "${WORKFLOW}" "${stale_semver}" <<'PY'
-import pathlib, re, sys
-
-src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
-text = src.read_text()
-pat = re.compile(
-    r"(?:^[ \t]*#.*\n)+(?=^[ \t]*- name: Install cargo-semver-checks[ \t]*$)",
-    re.M,
-)
-stale = (
-    "      # Pin lives in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). Step-scoped\n"
-    "      # RUSTUP_TOOLCHAIN so check-release below still follows rust-toolchain.toml.\n"
-)
-new, n = pat.subn(stale, text, count=1)
-if n != 1:
-    raise SystemExit(f"could not rewrite semver preamble (n={n})")
-dst.write_text(new)
-PY
-grep -qF 'still follows rust-toolchain.toml' \
-  <<<"$(step_preamble_comments "${stale_semver}" "Install cargo-semver-checks")" \
-  || fail "stale semver comment mutation did not apply"
-if ( check_d2_install_comment_semantics "${stale_semver}" ) >/dev/null 2>&1; then
-  fail "restoring stale semver rust-toolchain.toml comment left the contract green"
-fi
-ok "restoring stale semver comment turns the contract red"
-
-echo "== mutation: drop explicit plugin-bind claim from nextest/hack comments =="
-no_bind="$(mktemp "${SANDBOX_ROOT}/no-bind.XXXXXX.yml")"
-python3 - "${WORKFLOW}" "${no_bind}" <<'PY'
-import pathlib, re, sys
-
-src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
-text = src.read_text()
-pat = re.compile(
-    r"(?:^[ \t]*#.*\n)+(?=^[ \t]*- name: Install cargo-nextest and cargo-hack[ \t]*$)",
-    re.M,
-)
-weak = (
-    "      # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). `--locked` alone is\n"
-    "      # not a pin: it locks each tool's own dependencies, not the tool version. RUSTUP_TOOLCHAIN\n"
-    "      # is step-scoped for the install, while\n"
-    "      # ordinary workspace cargo follows rust-toolchain.toml.\n"
-)
-new, n = pat.subn(weak, text, count=1)
-if n != 1:
-    raise SystemExit(f"could not weaken nextest/hack preamble (n={n})")
-dst.write_text(new)
-PY
-if ( check_d2_install_comment_semantics "${no_bind}" ) >/dev/null 2>&1; then
-  fail "dropping plugin-bind claim from nextest/hack comments left the contract green"
-fi
-ok "dropping plugin-bind claim from nextest/hack comments turns the contract red"
+echo "== mutation: stale install-step comments =="
+expect_stale_install_comment_red nextest "Install cargo-nextest and cargo-hack" <<'EOF'
+      # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). RUSTUP_TOOLCHAIN
+      # is step-scoped so workspace cargo check/nextest/hack below still follow rust-toolchain.toml.
+EOF
+expect_stale_install_comment_red semver "Install cargo-semver-checks" <<'EOF'
+      # Pin lives in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). Step-scoped
+      # RUSTUP_TOOLCHAIN so check-release below still follows rust-toolchain.toml.
+EOF
+expect_stale_install_comment_red nobind "Install cargo-nextest and cargo-hack" <<'EOF'
+      # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). RUSTUP_TOOLCHAIN
+      # is step-scoped for the install, while ordinary workspace cargo follows rust-toolchain.toml.
+EOF
 
 ok "split-wave plugin-versions contract mutations bite"
 echo "PASS: split-wave plugin-versions contract"

--- a/scripts/ci/test-split-wave-plugin-versions-contract.sh
+++ b/scripts/ci/test-split-wave-plugin-versions-contract.sh
@@ -310,10 +310,78 @@ check_d2_plugin_invocation_bindings() {
   done <<<"${body}"
 }
 
+# Contiguous `#` comments immediately above a named workflow step (CI-4D4 / #2224).
+step_preamble_comments() {
+  local wf="$1" step_name="$2"
+  awk -v step="${step_name}" '
+    {
+      if ($0 ~ /^[[:space:]]*#/) {
+        buf = buf $0 ORS
+        next
+      }
+      if ($0 ~ /^[[:space:]]*$/) {
+        next
+      }
+      name = $0
+      sub(/^[[:space:]]*- name:[[:space:]]*/, "", name)
+      sub(/[[:space:]]*$/, "", name)
+      if (name == step) {
+        printf "%s", buf
+        exit
+      }
+      buf = ""
+    }
+  ' "${wf}"
+}
+
+# Install-step comments must not teach that plugin invocations follow rust-toolchain.toml.
+# Correct semantics: install RUSTUP_TOOLCHAIN is step-scoped; plugin invocations bind stable
+# explicitly; ordinary workspace cargo follows rust-toolchain.toml.
+check_one_d2_install_preamble() {
+  local label="$1" comments="$2"
+
+  grep -qF 'step-scoped' <<<"${comments}" \
+    || fail "${label} install comments must state RUSTUP_TOOLCHAIN is step-scoped; got:
+${comments}"
+  grep -qF 'plugin invocations bind stable explicitly' <<<"${comments}" \
+    || fail "${label} install comments must state plugin invocations bind stable explicitly; got:
+${comments}"
+  grep -qF 'ordinary workspace cargo follows rust-toolchain.toml' <<<"${comments}" \
+    || fail "${label} install comments must state ordinary workspace cargo follows rust-toolchain.toml; got:
+${comments}"
+}
+
+check_d2_install_comment_semantics() {
+  local wf="$1"
+  local nextest_comments semver_comments
+
+  nextest_comments="$(step_preamble_comments "${wf}" "Install cargo-nextest and cargo-hack")"
+  [[ -n "${nextest_comments}" ]] \
+    || fail "missing preamble comments above Install cargo-nextest and cargo-hack"
+
+  semver_comments="$(step_preamble_comments "${wf}" "Install cargo-semver-checks")"
+  [[ -n "${semver_comments}" ]] \
+    || fail "missing preamble comments above Install cargo-semver-checks"
+
+  # Stale D2 wording (pre-CI-4D4): grouped plugins with workspace cargo under rust-toolchain.toml.
+  if grep -qF 'still follow rust-toolchain.toml' <<<"${nextest_comments}"; then
+    fail "nextest/hack install comments still claim later steps follow rust-toolchain.toml; plugin invocations bind stable explicitly"
+  fi
+  if grep -qF 'still follows rust-toolchain.toml' <<<"${semver_comments}"; then
+    fail "semver-checks install comments still claim check-release follows rust-toolchain.toml; plugin invocations bind stable explicitly"
+  fi
+
+  check_one_d2_install_preamble "nextest/hack" "${nextest_comments}"
+  check_one_d2_install_preamble "semver-checks" "${semver_comments}"
+
+  ok "D2 install-step comment semantics hold for ${wf##*/}"
+}
+
 check_workflow() {
   local wf="$1"
   check_feature_matrix_install "${wf}"
   check_semver_public_install "${wf}"
+  check_d2_install_comment_semantics "${wf}"
 }
 
 # --- Optional helper: semver-checks pin (public-api pin/bind owned by CI-4D3) -----------
@@ -752,6 +820,91 @@ if ( check_optional_helper "${opt_unbound}" ) >/dev/null 2>&1; then
   fail "removing optional semver check-release binding left the helper contract green"
 fi
 ok "removing optional semver check-release binding turns the helper contract red"
+
+echo "== mutation: restore stale nextest/hack rust-toolchain.toml comment =="
+stale_nextest="$(mktemp "${SANDBOX_ROOT}/stale-nextest.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${stale_nextest}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+# Replace the contiguous preamble above Install cargo-nextest and cargo-hack.
+pat = re.compile(
+    r"(?:^[ \t]*#.*\n)+(?=^[ \t]*- name: Install cargo-nextest and cargo-hack[ \t]*$)",
+    re.M,
+)
+stale = (
+    "      # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). `--locked` alone is\n"
+    "      # not a pin: it locks each tool's own dependencies, not the tool version. RUSTUP_TOOLCHAIN\n"
+    "      # is step-scoped so workspace cargo check/nextest/hack below still follow rust-toolchain.toml.\n"
+)
+new, n = pat.subn(stale, text, count=1)
+if n != 1:
+    raise SystemExit(f"could not rewrite nextest/hack preamble (n={n})")
+dst.write_text(new)
+PY
+grep -qF 'still follow rust-toolchain.toml' \
+  <<<"$(step_preamble_comments "${stale_nextest}" "Install cargo-nextest and cargo-hack")" \
+  || fail "stale nextest/hack comment mutation did not apply"
+if ( check_d2_install_comment_semantics "${stale_nextest}" ) >/dev/null 2>&1; then
+  fail "restoring stale nextest/hack rust-toolchain.toml comment left the contract green"
+fi
+ok "restoring stale nextest/hack comment turns the contract red"
+
+echo "== mutation: restore stale semver check-release rust-toolchain.toml comment =="
+stale_semver="$(mktemp "${SANDBOX_ROOT}/stale-semver.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${stale_semver}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+pat = re.compile(
+    r"(?:^[ \t]*#.*\n)+(?=^[ \t]*- name: Install cargo-semver-checks[ \t]*$)",
+    re.M,
+)
+stale = (
+    "      # Pin lives in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). Step-scoped\n"
+    "      # RUSTUP_TOOLCHAIN so check-release below still follows rust-toolchain.toml.\n"
+)
+new, n = pat.subn(stale, text, count=1)
+if n != 1:
+    raise SystemExit(f"could not rewrite semver preamble (n={n})")
+dst.write_text(new)
+PY
+grep -qF 'still follows rust-toolchain.toml' \
+  <<<"$(step_preamble_comments "${stale_semver}" "Install cargo-semver-checks")" \
+  || fail "stale semver comment mutation did not apply"
+if ( check_d2_install_comment_semantics "${stale_semver}" ) >/dev/null 2>&1; then
+  fail "restoring stale semver rust-toolchain.toml comment left the contract green"
+fi
+ok "restoring stale semver comment turns the contract red"
+
+echo "== mutation: drop explicit plugin-bind claim from nextest/hack comments =="
+no_bind="$(mktemp "${SANDBOX_ROOT}/no-bind.XXXXXX.yml")"
+python3 - "${WORKFLOW}" "${no_bind}" <<'PY'
+import pathlib, re, sys
+
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text()
+pat = re.compile(
+    r"(?:^[ \t]*#.*\n)+(?=^[ \t]*- name: Install cargo-nextest and cargo-hack[ \t]*$)",
+    re.M,
+)
+weak = (
+    "      # Pins live in scripts/ci/cargo-plugin-versions.sh (#2224 / CI-4D2). `--locked` alone is\n"
+    "      # not a pin: it locks each tool's own dependencies, not the tool version. RUSTUP_TOOLCHAIN\n"
+    "      # is step-scoped for the install, while\n"
+    "      # ordinary workspace cargo follows rust-toolchain.toml.\n"
+)
+new, n = pat.subn(weak, text, count=1)
+if n != 1:
+    raise SystemExit(f"could not weaken nextest/hack preamble (n={n})")
+dst.write_text(new)
+PY
+if ( check_d2_install_comment_semantics "${no_bind}" ) >/dev/null 2>&1; then
+  fail "dropping plugin-bind claim from nextest/hack comments left the contract green"
+fi
+ok "dropping plugin-bind claim from nextest/hack comments turns the contract red"
 
 ok "split-wave plugin-versions contract mutations bite"
 echo "PASS: split-wave plugin-versions contract"


### PR DESCRIPTION
## Summary

- close the remaining cargo-plugin invocation drift in the Wave0 workflow documentation
- invoke the pinned cargo-deny binary directly in the dependency/performance review helper
- extend the existing plugin-version contract tests and pre-commit ownership so both rules fail loudly on drift

## Scope

This is the bounded CI-4D4 closure for #2224. It changes no workflow triggers, runtime product behavior, security policy, or ADR-042/043 boundary.

Changed files:

- `.github/workflows/split-wave0-gates.yml`
- `.pre-commit-config.yaml`
- `scripts/ci/review-dependency-perf-hygiene-pr4.sh`
- `scripts/ci/test-cargo-plugin-versions-contract.sh`
- `scripts/ci/test-split-wave-plugin-versions-contract.sh`

## Contract

- plugin commands use their directly installed, pinned binaries
- ordinary workspace Cargo commands continue to follow `rust-toolchain.toml`
- comments describe the actual step-scoped toolchain behavior rather than implying all later commands inherit it
- changes to the review helper retrigger the owning pre-commit contract

## TDD evidence

RED:

- the expanded cargo-plugin contract rejected `cargo deny` in the review helper
- the split-wave contract rejected the stale comments that claimed later plugin invocations followed `rust-toolchain.toml`

GREEN:

- helper now executes `cargo-deny`
- comments distinguish stable-bound plugin calls from ordinary workspace Cargo calls
- focused contracts pass under both macOS Bash 3.2 (`/bin/bash`) and the active shell

Mutation evidence:

- replacing `cargo-deny` with `cargo deny` is rejected by the direct-command assertion
- stale comment variants are injected table-wise and rejected for both affected workflow steps

## Maintainability decision

The first test implementation was rejected during builder review at +295/-11 because it duplicated parsing and mutation scaffolding. The final head is +113/-11 and keeps the same behavioral coverage by reusing one table-driven mutation helper and the existing contract scripts.

## Verification

Measured on exact head `0f55c4ce5273656fa56403a2e9e4129e794d92c4`:

- `bash scripts/ci/test-cargo-plugin-versions-contract.sh`
- `/bin/bash scripts/ci/test-cargo-plugin-versions-contract.sh`
- `bash scripts/ci/test-split-wave-plugin-versions-contract.sh`
- `/bin/bash scripts/ci/test-split-wave-plugin-versions-contract.sh`
- `shellcheck -x scripts/ci/review-dependency-perf-hygiene-pr4.sh scripts/ci/test-cargo-plugin-versions-contract.sh scripts/ci/test-split-wave-plugin-versions-contract.sh`
- `actionlint .github/workflows/split-wave0-gates.yml`
- `pre-commit validate-config`
- focused pre-commit hooks for both contracts
- `git diff --check 3e5d4cdfe0fe1996da1c90ba1f320d0ad2994e97...HEAD`
- full pre-push hook suite

## Review and non-claims

Codex specified and reviewed this slice, so that review does not count toward quorum. A separate non-building reviewer must review the exact final head.

This PR does not claim plugin availability, execute upstream network probes, or alter delegated/self-hosted runner policy.

Closes #2224
