### PR TITLE
ci: hold eBPF toolchain pins in parity (CI-4E)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -418,6 +418,17 @@ repos:
         # cargo +toolchain install, PATH decoys, missing invocation toolchain binding, and
         # opt-in/opt-out skip semantics.
         files: ^(scripts/ci/(cargo-plugin-versions|test-optional-plugin-versions-contract|optional-public-api-drift|mutation-smoke-pure-modules)\.sh|\.pre-commit-config\.yaml)$
+
+      - id: ebpf-pin-parity-contract-self-test
+        name: eBPF pin parity contract
+        entry: python3 scripts/ci/test-ebpf-pin-parity-contract.py
+        language: system
+        pass_filenames: false
+        # CI-4E / #2225: parity fallback over five eBPF pin consumers. Canonical defaults live in
+        # install-ebpf-toolchain.sh; missing/ambiguous/divergent pins fail. No shared manifest and
+        # no upstream-availability claim.
+        files: ^(scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py)|crates/assay-xtask/src/main\.rs|infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder|\.pre-commit-config\.yaml)$
+
       - id: cargo-clippy
         name: cargo clippy (workspace, deny warnings)
         entry: scripts/precommit/cargo-clippy.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -427,7 +427,8 @@ repos:
         # CI-4E / #2225: parity fallback over five eBPF pin consumers. Canonical defaults live in
         # install-ebpf-toolchain.sh; missing/ambiguous/divergent pins fail. No shared manifest and
         # no upstream-availability claim.
-        files: ^(scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py)|crates/assay-xtask/src/main\.rs|infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder|\.pre-commit-config\.yaml)$
+        # Root .pre-commit-config.yaml is a top-level alternative (not under scripts/ci/).
+        files: ^(\.pre-commit-config\.yaml|scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py)|crates/assay-xtask/src/main\.rs|infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder)$
 
       - id: cargo-clippy
         name: cargo clippy (workspace, deny warnings)

--- a/scripts/ci/test-ebpf-pin-parity-contract.py
+++ b/scripts/ci/test-ebpf-pin-parity-contract.py
@@ -197,26 +197,35 @@ def assert_precommit_ownership() -> None:
     ok("pre-commit files: owns owners; broken grouping and .* go red")
 
 def main() -> None:
-    try:
-        extract_provisioning("no pins here\n", "synth")
-        fail("missing-pin synth stayed green")
-    except ContractError as exc:
-        if "missing toolchain" not in str(exc):
-            fail(f"missing synth wrong error: {exc}")
-    ok("synthetic missing toolchain is rejected")
-
-    ambiguous = (
-        "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
-        "rustup toolchain install nightly-2099-01-01 --profile minimal\n"
-        "cargo install bpf-linker --version 0.10.3 --locked\n"
-    )
-    try:
-        extract_provisioning(ambiguous, "synth")
-        fail("ambiguous-pin synth stayed green")
-    except ContractError as exc:
-        if "ambiguous toolchain" not in str(exc):
-            fail(f"ambiguous synth wrong error: {exc}")
-    ok("synthetic ambiguous toolchain is rejected")
+    for label, text, needle in (
+        ("missing toolchain", "no pins here\n", "missing toolchain"),
+        (
+            "missing bpf-linker",
+            "rustup toolchain install nightly-2026-01-01 --profile minimal\n",
+            "missing bpf-linker",
+        ),
+        (
+            "ambiguous toolchain",
+            "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
+            "rustup toolchain install nightly-2099-01-01 --profile minimal\n"
+            "cargo install bpf-linker --version 0.10.3 --locked\n",
+            "ambiguous toolchain",
+        ),
+        (
+            "ambiguous bpf-linker",
+            "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
+            "cargo install bpf-linker --version 0.10.3 --locked\n"
+            "cargo install bpf-linker --version 9.9.9 --locked\n",
+            "ambiguous bpf-linker",
+        ),
+    ):
+        try:
+            extract_provisioning(text, "synth")
+            fail(f"{label} synth stayed green")
+        except ContractError as exc:
+            if needle not in str(exc):
+                fail(f"{label} synth wrong error: {exc}")
+        ok(f"synthetic {label} is rejected")
 
     try:
         toolchain, bpf_linker = check_parity(default_paths(ROOT))
@@ -226,17 +235,22 @@ def main() -> None:
 
     scratch = Path(tempfile.mkdtemp(prefix="ebpf-pin-parity-"))
     try:
+        fields = (
+            ("toolchain", toolchain, "nightly-2099-12-31"),
+            ("bpf-linker", bpf_linker, "9.9.9"),
+        )
         for cid, rel, _kind in CONSUMERS:
-            mutant_path = scratch / Path(rel).name
-            mutant_path.write_text(
-                mutate_first((ROOT / rel).read_text(encoding="utf-8"), toolchain, "nightly-2099-12-31", cid),
-                encoding="utf-8",
-            )
-            mutant_paths = default_paths(ROOT)
-            mutant_paths[cid] = mutant_path
-            msg = expect_red(mutant_paths, cid)
-            cls = next(k for k in ("divergent", "ambiguous", "missing") if k in msg)
-            ok(f"mutating {cid} toolchain pin turns red ({cls})")
+            src = (ROOT / rel).read_text(encoding="utf-8")
+            for field, old, new in fields:
+                mutant_path = scratch / f"{cid}-{field}-{Path(rel).name}"
+                mutant_path.write_text(
+                    mutate_first(src, old, new, cid), encoding="utf-8"
+                )
+                mutant_paths = default_paths(ROOT)
+                mutant_paths[cid] = mutant_path
+                msg = expect_red(mutant_paths, f"{cid}/{field}")
+                cls = next(k for k in ("divergent", "ambiguous", "missing") if k in msg)
+                ok(f"mutating {cid} {field} pin turns red ({cls})")
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
 

--- a/scripts/ci/test-ebpf-pin-parity-contract.py
+++ b/scripts/ci/test-ebpf-pin-parity-contract.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""CI-4E / #2225: eBPF pin parity fallback (no shared manifest, no upstream claim).
+
+Canonical defaults: `:-…` values in scripts/ci/install-ebpf-toolchain.sh.
+One table-driven parser; rejects missing / ambiguous / divergent pins.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PRECOMMIT = ROOT / ".pre-commit-config.yaml"
+TC = r"nightly-\d{4}-\d{2}-\d{2}"
+LV = r"\d+\.\d+\.\d+"
+
+# (id, repo-relative path, extractor name)
+CONSUMERS = [
+    ("install", "scripts/ci/install-ebpf-toolchain.sh", "install_script"),
+    ("xtask", "crates/assay-xtask/src/main.rs", "xtask_rs"),
+    ("setup", "infra/bpf-runner/setup.sh", "provisioning"),
+    ("cloud-init", "infra/bpf-runner/cloud-init.yaml", "provisioning"),
+    ("dockerfile", "docker/Dockerfile.ebpf-builder", "provisioning"),
+]
+
+
+class ContractError(Exception):
+    pass
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def ok(msg: str) -> None:
+    print(f"ok   {msg}")
+
+
+def _unique(values: set[str], kind: str, consumer: str) -> str:
+    if not values:
+        raise ContractError(f"{consumer}: missing {kind} pin")
+    if len(values) > 1:
+        raise ContractError(
+            f"{consumer}: ambiguous {kind} pins: {', '.join(sorted(values))}"
+        )
+    return next(iter(values))
+
+
+def extract_install_script(text: str, consumer: str) -> tuple[str, str]:
+    return (
+        _unique(set(re.findall(rf"ASSAY_EBPF_RUST_TOOLCHAIN:-({TC})", text)), "toolchain", consumer),
+        _unique(set(re.findall(rf"ASSAY_BPF_LINKER_VERSION:-({LV})", text)), "bpf-linker", consumer),
+    )
+
+
+def extract_xtask_rs(text: str, consumer: str) -> tuple[str, str]:
+    return (
+        _unique(
+            set(re.findall(rf'const DEFAULT_EBPF_RUST_TOOLCHAIN:\s*&str\s*=\s*"({TC})"', text)),
+            "toolchain",
+            consumer,
+        ),
+        _unique(
+            set(re.findall(rf'const DEFAULT_BPF_LINKER_VERSION:\s*&str\s*=\s*"({LV})"', text)),
+            "bpf-linker",
+            consumer,
+        ),
+    )
+
+
+def extract_provisioning(text: str, consumer: str) -> tuple[str, str]:
+    toolchains = set(re.findall(rf"toolchain install ({TC})", text))
+    toolchains.update(re.findall(rf"--toolchain ({TC})", text))
+    toolchains.update(re.findall(rf"rustup run ({TC})", text))
+    toolchains.update(re.findall(rf"cargo \+({TC})", text))
+    linkers = set(re.findall(rf"bpf-linker ({LV})", text))
+    linkers.update(re.findall(rf"cargo install bpf-linker --version ({LV})", text))
+    return (
+        _unique(toolchains, "toolchain", consumer),
+        _unique(linkers, "bpf-linker", consumer),
+    )
+
+
+EXTRACTORS = {
+    "install_script": extract_install_script,
+    "xtask_rs": extract_xtask_rs,
+    "provisioning": extract_provisioning,
+}
+
+
+def check_parity(paths: dict[str, Path]) -> tuple[str, str]:
+    """One rule: every consumer's semantic pins equal install-script defaults."""
+    wanted = {c[0] for c in CONSUMERS}
+    if set(paths) != wanted:
+        raise ContractError(f"consumer set mismatch: got {sorted(paths)}, want {sorted(wanted)}")
+    install_path = paths["install"]
+    if not install_path.is_file():
+        raise ContractError(f"install: missing file {install_path}")
+    canonical = EXTRACTORS["install_script"](
+        install_path.read_text(encoding="utf-8"), "install"
+    )
+    for cid, _rel, kind in CONSUMERS:
+        path = paths[cid]
+        if not path.is_file():
+            raise ContractError(f"{cid}: missing file {path}")
+        pins = EXTRACTORS[kind](path.read_text(encoding="utf-8"), cid)
+        if pins[0] != canonical[0]:
+            raise ContractError(
+                f"{cid}: divergent toolchain {pins[0]!r} != canonical {canonical[0]!r}"
+            )
+        if pins[1] != canonical[1]:
+            raise ContractError(
+                f"{cid}: divergent bpf-linker {pins[1]!r} != canonical {canonical[1]!r}"
+            )
+    return canonical
+
+
+def default_paths(root: Path) -> dict[str, Path]:
+    return {cid: root / rel for cid, rel, _ in CONSUMERS}
+
+
+def expect_red(paths: dict[str, Path], consumer: str) -> str:
+    try:
+        check_parity(paths)
+    except ContractError as exc:
+        msg = str(exc)
+        if not any(k in msg for k in ("divergent", "ambiguous", "missing")):
+            fail(f"{consumer}: red error lacked pin failure class: {msg!r}")
+        return msg
+    fail(f"{consumer}: pin mutation left the contract green")
+
+
+def mutate_first(text: str, old: str, new: str, consumer: str) -> str:
+    if old not in text:
+        fail(f"{consumer}: mutation search {old!r} not found")
+    out = text.replace(old, new, 1)
+    if out == text:
+        fail(f"{consumer}: mutation did not change text")
+    return out
+
+
+def assert_precommit_ownership() -> None:
+    pc = PRECOMMIT.read_text(encoding="utf-8")
+    if "id: ebpf-pin-parity-contract-self-test" not in pc:
+        fail("pre-commit missing ebpf-pin-parity-contract-self-test hook")
+    block_m = re.search(
+        r"(?m)^      - id:\s*ebpf-pin-parity-contract-self-test\s*\n(?:.*\n){0,12}?"
+        r"^        files:\s*(.+)\s*$",
+        pc,
+    )
+    if not block_m:
+        fail("ebpf-pin-parity-contract-self-test files: line missing")
+    files_pat = block_m.group(1)
+    for stem in (
+        "install-ebpf-toolchain",
+        "test-ebpf-pin-parity-contract",
+        "assay-xtask/src/main",
+        "setup\\.sh",
+        "cloud-init\\.yaml",
+        "Dockerfile\\.ebpf-builder",
+        "pre-commit-config",
+    ):
+        if stem not in files_pat:
+            fail(f"files: must watch {stem!r}; got {files_pat}")
+    ok("pre-commit hook watches the five consumers and this test")
+
+
+def main() -> None:
+    try:
+        extract_provisioning("no pins here\n", "synth")
+        fail("missing-pin synth stayed green")
+    except ContractError as exc:
+        if "missing toolchain" not in str(exc):
+            fail(f"missing synth wrong error: {exc}")
+    ok("synthetic missing toolchain is rejected")
+
+    ambiguous = (
+        "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
+        "rustup toolchain install nightly-2099-01-01 --profile minimal\n"
+        "cargo install bpf-linker --version 0.10.3 --locked\n"
+    )
+    try:
+        extract_provisioning(ambiguous, "synth")
+        fail("ambiguous-pin synth stayed green")
+    except ContractError as exc:
+        if "ambiguous toolchain" not in str(exc):
+            fail(f"ambiguous synth wrong error: {exc}")
+    ok("synthetic ambiguous toolchain is rejected")
+
+    try:
+        toolchain, bpf_linker = check_parity(default_paths(ROOT))
+    except ContractError as exc:
+        fail(f"current consumers are not aligned: {exc}")
+    ok(f"five consumers agree on toolchain={toolchain} bpf-linker={bpf_linker}")
+
+    scratch = Path(tempfile.mkdtemp(prefix="ebpf-pin-parity-"))
+    try:
+        for cid, rel, _kind in CONSUMERS:
+            mutant_path = scratch / Path(rel).name
+            mutant_path.write_text(
+                mutate_first((ROOT / rel).read_text(encoding="utf-8"), toolchain, "nightly-2099-12-31", cid),
+                encoding="utf-8",
+            )
+            mutant_paths = default_paths(ROOT)
+            mutant_paths[cid] = mutant_path
+            msg = expect_red(mutant_paths, cid)
+            cls = next(k for k in ("divergent", "ambiguous", "missing") if k in msg)
+            ok(f"mutating {cid} toolchain pin turns red ({cls})")
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    assert_precommit_ownership()
+    print("PASS: eBPF pin parity contract")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-ebpf-pin-parity-contract.py
+++ b/scripts/ci/test-ebpf-pin-parity-contract.py
@@ -144,6 +144,20 @@ def mutate_first(text: str, old: str, new: str, consumer: str) -> str:
     return out
 
 
+def _assert_files_regex_owns(rx: re.Pattern[str], label: str) -> None:
+    """Compile-time ownership: exact positives + one nearby non-owner negative."""
+    must_own = [rel for _cid, rel, _kind in CONSUMERS]
+    must_own.append("scripts/ci/test-ebpf-pin-parity-contract.py")
+    must_own.append(".pre-commit-config.yaml")
+    for path in must_own:
+        if rx.fullmatch(path) is None:
+            raise ContractError(f"{label}: must own {path!r}")
+    # Nearby non-owner: over-broad `.*` would match this and stay green otherwise.
+    non_owner = "scripts/ci/test-cargo-plugin-versions-contract.sh"
+    if rx.fullmatch(non_owner) is not None:
+        raise ContractError(f"{label}: must not own nearby non-owner {non_owner!r}")
+
+
 def assert_precommit_ownership() -> None:
     pc = PRECOMMIT.read_text(encoding="utf-8")
     if "id: ebpf-pin-parity-contract-self-test" not in pc:
@@ -155,20 +169,32 @@ def assert_precommit_ownership() -> None:
     )
     if not block_m:
         fail("ebpf-pin-parity-contract-self-test files: line missing")
-    files_pat = block_m.group(1)
-    for stem in (
-        "install-ebpf-toolchain",
-        "test-ebpf-pin-parity-contract",
-        "assay-xtask/src/main",
-        "setup\\.sh",
-        "cloud-init\\.yaml",
-        "Dockerfile\\.ebpf-builder",
-        "pre-commit-config",
+    files_pat = block_m.group(1).strip()
+    try:
+        rx = re.compile(files_pat)
+    except re.error as exc:
+        fail(f"files: regex does not compile: {exc}: {files_pat}")
+    try:
+        _assert_files_regex_owns(rx, "files")
+    except ContractError as exc:
+        fail(str(exc))
+    # Controls: root nested under scripts/ci/(...) fails; overbroad .* fails non-owner.
+    broken = (
+        r"^(scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py|"
+        r"\.pre-commit-config\.yaml)|crates/assay-xtask/src/main\.rs|"
+        r"infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder)$"
+    )
+    for label, pat, needle in (
+        ("broken-grouping", broken, ".pre-commit-config.yaml"),
+        ("overbroad", r".*", "must not own"),
     ):
-        if stem not in files_pat:
-            fail(f"files: must watch {stem!r}; got {files_pat}")
-    ok("pre-commit hook watches the five consumers and this test")
-
+        try:
+            _assert_files_regex_owns(re.compile(pat), label)
+            fail(f"{label} files: control left ownership green")
+        except ContractError as exc:
+            if needle not in str(exc):
+                fail(f"{label} control wrong error: {exc}")
+    ok("pre-commit files: owns owners; broken grouping and .* go red")
 
 def main() -> None:
     try:


### PR DESCRIPTION
## Summary

- add one table-driven parity contract for the eBPF Rust nightly and `bpf-linker` pins restated by five heterogeneous consumers
- treat `scripts/ci/install-ebpf-toolchain.sh` defaults as the reference without introducing a new provisioning manifest
- wire the contract to pre-commit with exact owner-path matching

## Scope

CI-4E closes #2225 with the issue's sanctioned parity fallback. Production consumers are unchanged.

Changed files: `.pre-commit-config.yaml` and `scripts/ci/test-ebpf-pin-parity-contract.py`.

## Contract

The single parser covers the install script, assay-xtask, runner setup, cloud-init, and the eBPF builder Dockerfile. For both pins it rejects missing, ambiguous, or divergent values. The hook regex is compiled and tested against seven owner paths plus a nearby non-owner.

## TDD and mutation evidence

Measured on exact head `db37be3af1acc1574314b5d30f60066a19b9be13`.

- RED controls: missing and ambiguous values for both pins
- RED controls: malformed and overbroad pre-commit ownership
- mutation matrix: five consumers x two fields = ten scratch mutations
- unchanged consumers agree on `nightly-2026-01-01` / `0.10.3`

## Verification

- `python3 scripts/ci/test-ebpf-pin-parity-contract.py`
- `python3 -m py_compile scripts/ci/test-ebpf-pin-parity-contract.py`
- `pre-commit validate-config`
- `pre-commit run ebpf-pin-parity-contract-self-test --all-files`
- `git diff --check 7bcc72b0fc48b39823b328c3f34bbacaccaf419c...HEAD`
- full pre-push suite, including workspace clippy and Linux cross-target gate

## Review history

Codex found and caused correction of two local blockers before push: root pre-commit ownership was incorrectly grouped, and controls initially covered only the Rust toolchain rather than both pins. Both are fixed. Codex specified this slice, so its review does not count toward quorum; a separate non-building exact-head review remains required.

## Non-claims

- no proof that either pinned artifact is currently available upstream
- no execution of the eBPF build on every consumer environment
- no shared-manifest or provisioning redesign
- no workflow-trigger, runtime-product, security-policy, or ADR-042/043 change

Closes #2225
