### PR TITLE
Declare the transport limit instead of leaving a reader to infer it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -418,6 +418,17 @@ repos:
         # cargo +toolchain install, PATH decoys, missing invocation toolchain binding, and
         # opt-in/opt-out skip semantics.
         files: ^(scripts/ci/(cargo-plugin-versions|test-optional-plugin-versions-contract|optional-public-api-drift|mutation-smoke-pure-modules)\.sh|\.pre-commit-config\.yaml)$
+
+      - id: ebpf-pin-parity-contract-self-test
+        name: eBPF pin parity contract
+        entry: python3 scripts/ci/test-ebpf-pin-parity-contract.py
+        language: system
+        pass_filenames: false
+        # CI-4E / #2225: parity fallback over five eBPF pin consumers. Canonical defaults live in
+        # install-ebpf-toolchain.sh; missing/ambiguous/divergent pins fail. No shared manifest and
+        # no upstream-availability claim.
+        files: ^(scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py)|crates/assay-xtask/src/main\.rs|infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder|\.pre-commit-config\.yaml)$
+
       - id: cargo-clippy
         name: cargo clippy (workspace, deny warnings)
         entry: scripts/precommit/cargo-clippy.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -427,7 +427,8 @@ repos:
         # CI-4E / #2225: parity fallback over five eBPF pin consumers. Canonical defaults live in
         # install-ebpf-toolchain.sh; missing/ambiguous/divergent pins fail. No shared manifest and
         # no upstream-availability claim.
-        files: ^(scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py)|crates/assay-xtask/src/main\.rs|infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder|\.pre-commit-config\.yaml)$
+        # Root .pre-commit-config.yaml is a top-level alternative (not under scripts/ci/).
+        files: ^(\.pre-commit-config\.yaml|scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py)|crates/assay-xtask/src/main\.rs|infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder)$
 
       - id: cargo-clippy
         name: cargo clippy (workspace, deny warnings)

--- a/examples/x402-verification-evidence/README.md
+++ b/examples/x402-verification-evidence/README.md
@@ -98,6 +98,23 @@ It does not:
 - imply that Assay independently verified onchain state or settlement finality
 - claim that this sample already defines a stable upstream wire-format contract
 
+### Declared limit: one transport, and it refuses the others
+
+`transport` is closed to `http`. An artifact declaring `mcp` or `a2a` exits
+with `transport must be one of: http` and never reaches a verdict about the
+payment it describes. That is a scope decision rather than a judgement about
+those surfaces, and it is written here because the paragraph above names all
+three as real and the code accepts one, which left a reader to infer the gap.
+
+The consequence is worth stating in the form it takes: the accepting branch of
+this mapper is unreachable for two of the three transports x402 defines, so a
+run over an MCP-transported corpus would reject every artifact and that
+uniform rejection would decide nothing. A refusal can be correct on each input
+and still be vacuous over a corpus. Widening the vocabulary is not the fix on
+its own; fixtures and expected verdicts for those surfaces are, and this sample
+carries neither, so the honest move is to declare the limit rather than to
+accept a token whose semantics are not pinned here.
+
 This sample targets the smallest honest x402 requirement-and-verification
 surface, not a settlement-response, receipt, payer, or fulfillment truth
 surface.

--- a/scripts/ci/test-ebpf-pin-parity-contract.py
+++ b/scripts/ci/test-ebpf-pin-parity-contract.py
@@ -197,26 +197,35 @@ def assert_precommit_ownership() -> None:
     ok("pre-commit files: owns owners; broken grouping and .* go red")
 
 def main() -> None:
-    try:
-        extract_provisioning("no pins here\n", "synth")
-        fail("missing-pin synth stayed green")
-    except ContractError as exc:
-        if "missing toolchain" not in str(exc):
-            fail(f"missing synth wrong error: {exc}")
-    ok("synthetic missing toolchain is rejected")
-
-    ambiguous = (
-        "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
-        "rustup toolchain install nightly-2099-01-01 --profile minimal\n"
-        "cargo install bpf-linker --version 0.10.3 --locked\n"
-    )
-    try:
-        extract_provisioning(ambiguous, "synth")
-        fail("ambiguous-pin synth stayed green")
-    except ContractError as exc:
-        if "ambiguous toolchain" not in str(exc):
-            fail(f"ambiguous synth wrong error: {exc}")
-    ok("synthetic ambiguous toolchain is rejected")
+    for label, text, needle in (
+        ("missing toolchain", "no pins here\n", "missing toolchain"),
+        (
+            "missing bpf-linker",
+            "rustup toolchain install nightly-2026-01-01 --profile minimal\n",
+            "missing bpf-linker",
+        ),
+        (
+            "ambiguous toolchain",
+            "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
+            "rustup toolchain install nightly-2099-01-01 --profile minimal\n"
+            "cargo install bpf-linker --version 0.10.3 --locked\n",
+            "ambiguous toolchain",
+        ),
+        (
+            "ambiguous bpf-linker",
+            "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
+            "cargo install bpf-linker --version 0.10.3 --locked\n"
+            "cargo install bpf-linker --version 9.9.9 --locked\n",
+            "ambiguous bpf-linker",
+        ),
+    ):
+        try:
+            extract_provisioning(text, "synth")
+            fail(f"{label} synth stayed green")
+        except ContractError as exc:
+            if needle not in str(exc):
+                fail(f"{label} synth wrong error: {exc}")
+        ok(f"synthetic {label} is rejected")
 
     try:
         toolchain, bpf_linker = check_parity(default_paths(ROOT))
@@ -226,17 +235,22 @@ def main() -> None:
 
     scratch = Path(tempfile.mkdtemp(prefix="ebpf-pin-parity-"))
     try:
+        fields = (
+            ("toolchain", toolchain, "nightly-2099-12-31"),
+            ("bpf-linker", bpf_linker, "9.9.9"),
+        )
         for cid, rel, _kind in CONSUMERS:
-            mutant_path = scratch / Path(rel).name
-            mutant_path.write_text(
-                mutate_first((ROOT / rel).read_text(encoding="utf-8"), toolchain, "nightly-2099-12-31", cid),
-                encoding="utf-8",
-            )
-            mutant_paths = default_paths(ROOT)
-            mutant_paths[cid] = mutant_path
-            msg = expect_red(mutant_paths, cid)
-            cls = next(k for k in ("divergent", "ambiguous", "missing") if k in msg)
-            ok(f"mutating {cid} toolchain pin turns red ({cls})")
+            src = (ROOT / rel).read_text(encoding="utf-8")
+            for field, old, new in fields:
+                mutant_path = scratch / f"{cid}-{field}-{Path(rel).name}"
+                mutant_path.write_text(
+                    mutate_first(src, old, new, cid), encoding="utf-8"
+                )
+                mutant_paths = default_paths(ROOT)
+                mutant_paths[cid] = mutant_path
+                msg = expect_red(mutant_paths, f"{cid}/{field}")
+                cls = next(k for k in ("divergent", "ambiguous", "missing") if k in msg)
+                ok(f"mutating {cid} {field} pin turns red ({cls})")
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
 

--- a/scripts/ci/test-ebpf-pin-parity-contract.py
+++ b/scripts/ci/test-ebpf-pin-parity-contract.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""CI-4E / #2225: eBPF pin parity fallback (no shared manifest, no upstream claim).
+
+Canonical defaults: `:-…` values in scripts/ci/install-ebpf-toolchain.sh.
+One table-driven parser; rejects missing / ambiguous / divergent pins.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PRECOMMIT = ROOT / ".pre-commit-config.yaml"
+TC = r"nightly-\d{4}-\d{2}-\d{2}"
+LV = r"\d+\.\d+\.\d+"
+
+# (id, repo-relative path, extractor name)
+CONSUMERS = [
+    ("install", "scripts/ci/install-ebpf-toolchain.sh", "install_script"),
+    ("xtask", "crates/assay-xtask/src/main.rs", "xtask_rs"),
+    ("setup", "infra/bpf-runner/setup.sh", "provisioning"),
+    ("cloud-init", "infra/bpf-runner/cloud-init.yaml", "provisioning"),
+    ("dockerfile", "docker/Dockerfile.ebpf-builder", "provisioning"),
+]
+
+
+class ContractError(Exception):
+    pass
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def ok(msg: str) -> None:
+    print(f"ok   {msg}")
+
+
+def _unique(values: set[str], kind: str, consumer: str) -> str:
+    if not values:
+        raise ContractError(f"{consumer}: missing {kind} pin")
+    if len(values) > 1:
+        raise ContractError(
+            f"{consumer}: ambiguous {kind} pins: {', '.join(sorted(values))}"
+        )
+    return next(iter(values))
+
+
+def extract_install_script(text: str, consumer: str) -> tuple[str, str]:
+    return (
+        _unique(set(re.findall(rf"ASSAY_EBPF_RUST_TOOLCHAIN:-({TC})", text)), "toolchain", consumer),
+        _unique(set(re.findall(rf"ASSAY_BPF_LINKER_VERSION:-({LV})", text)), "bpf-linker", consumer),
+    )
+
+
+def extract_xtask_rs(text: str, consumer: str) -> tuple[str, str]:
+    return (
+        _unique(
+            set(re.findall(rf'const DEFAULT_EBPF_RUST_TOOLCHAIN:\s*&str\s*=\s*"({TC})"', text)),
+            "toolchain",
+            consumer,
+        ),
+        _unique(
+            set(re.findall(rf'const DEFAULT_BPF_LINKER_VERSION:\s*&str\s*=\s*"({LV})"', text)),
+            "bpf-linker",
+            consumer,
+        ),
+    )
+
+
+def extract_provisioning(text: str, consumer: str) -> tuple[str, str]:
+    toolchains = set(re.findall(rf"toolchain install ({TC})", text))
+    toolchains.update(re.findall(rf"--toolchain ({TC})", text))
+    toolchains.update(re.findall(rf"rustup run ({TC})", text))
+    toolchains.update(re.findall(rf"cargo \+({TC})", text))
+    linkers = set(re.findall(rf"bpf-linker ({LV})", text))
+    linkers.update(re.findall(rf"cargo install bpf-linker --version ({LV})", text))
+    return (
+        _unique(toolchains, "toolchain", consumer),
+        _unique(linkers, "bpf-linker", consumer),
+    )
+
+
+EXTRACTORS = {
+    "install_script": extract_install_script,
+    "xtask_rs": extract_xtask_rs,
+    "provisioning": extract_provisioning,
+}
+
+
+def check_parity(paths: dict[str, Path]) -> tuple[str, str]:
+    """One rule: every consumer's semantic pins equal install-script defaults."""
+    wanted = {c[0] for c in CONSUMERS}
+    if set(paths) != wanted:
+        raise ContractError(f"consumer set mismatch: got {sorted(paths)}, want {sorted(wanted)}")
+    install_path = paths["install"]
+    if not install_path.is_file():
+        raise ContractError(f"install: missing file {install_path}")
+    canonical = EXTRACTORS["install_script"](
+        install_path.read_text(encoding="utf-8"), "install"
+    )
+    for cid, _rel, kind in CONSUMERS:
+        path = paths[cid]
+        if not path.is_file():
+            raise ContractError(f"{cid}: missing file {path}")
+        pins = EXTRACTORS[kind](path.read_text(encoding="utf-8"), cid)
+        if pins[0] != canonical[0]:
+            raise ContractError(
+                f"{cid}: divergent toolchain {pins[0]!r} != canonical {canonical[0]!r}"
+            )
+        if pins[1] != canonical[1]:
+            raise ContractError(
+                f"{cid}: divergent bpf-linker {pins[1]!r} != canonical {canonical[1]!r}"
+            )
+    return canonical
+
+
+def default_paths(root: Path) -> dict[str, Path]:
+    return {cid: root / rel for cid, rel, _ in CONSUMERS}
+
+
+def expect_red(paths: dict[str, Path], consumer: str) -> str:
+    try:
+        check_parity(paths)
+    except ContractError as exc:
+        msg = str(exc)
+        if not any(k in msg for k in ("divergent", "ambiguous", "missing")):
+            fail(f"{consumer}: red error lacked pin failure class: {msg!r}")
+        return msg
+    fail(f"{consumer}: pin mutation left the contract green")
+
+
+def mutate_first(text: str, old: str, new: str, consumer: str) -> str:
+    if old not in text:
+        fail(f"{consumer}: mutation search {old!r} not found")
+    out = text.replace(old, new, 1)
+    if out == text:
+        fail(f"{consumer}: mutation did not change text")
+    return out
+
+
+def assert_precommit_ownership() -> None:
+    pc = PRECOMMIT.read_text(encoding="utf-8")
+    if "id: ebpf-pin-parity-contract-self-test" not in pc:
+        fail("pre-commit missing ebpf-pin-parity-contract-self-test hook")
+    block_m = re.search(
+        r"(?m)^      - id:\s*ebpf-pin-parity-contract-self-test\s*\n(?:.*\n){0,12}?"
+        r"^        files:\s*(.+)\s*$",
+        pc,
+    )
+    if not block_m:
+        fail("ebpf-pin-parity-contract-self-test files: line missing")
+    files_pat = block_m.group(1)
+    for stem in (
+        "install-ebpf-toolchain",
+        "test-ebpf-pin-parity-contract",
+        "assay-xtask/src/main",
+        "setup\\.sh",
+        "cloud-init\\.yaml",
+        "Dockerfile\\.ebpf-builder",
+        "pre-commit-config",
+    ):
+        if stem not in files_pat:
+            fail(f"files: must watch {stem!r}; got {files_pat}")
+    ok("pre-commit hook watches the five consumers and this test")
+
+
+def main() -> None:
+    try:
+        extract_provisioning("no pins here\n", "synth")
+        fail("missing-pin synth stayed green")
+    except ContractError as exc:
+        if "missing toolchain" not in str(exc):
+            fail(f"missing synth wrong error: {exc}")
+    ok("synthetic missing toolchain is rejected")
+
+    ambiguous = (
+        "rustup toolchain install nightly-2026-01-01 --profile minimal\n"
+        "rustup toolchain install nightly-2099-01-01 --profile minimal\n"
+        "cargo install bpf-linker --version 0.10.3 --locked\n"
+    )
+    try:
+        extract_provisioning(ambiguous, "synth")
+        fail("ambiguous-pin synth stayed green")
+    except ContractError as exc:
+        if "ambiguous toolchain" not in str(exc):
+            fail(f"ambiguous synth wrong error: {exc}")
+    ok("synthetic ambiguous toolchain is rejected")
+
+    try:
+        toolchain, bpf_linker = check_parity(default_paths(ROOT))
+    except ContractError as exc:
+        fail(f"current consumers are not aligned: {exc}")
+    ok(f"five consumers agree on toolchain={toolchain} bpf-linker={bpf_linker}")
+
+    scratch = Path(tempfile.mkdtemp(prefix="ebpf-pin-parity-"))
+    try:
+        for cid, rel, _kind in CONSUMERS:
+            mutant_path = scratch / Path(rel).name
+            mutant_path.write_text(
+                mutate_first((ROOT / rel).read_text(encoding="utf-8"), toolchain, "nightly-2099-12-31", cid),
+                encoding="utf-8",
+            )
+            mutant_paths = default_paths(ROOT)
+            mutant_paths[cid] = mutant_path
+            msg = expect_red(mutant_paths, cid)
+            cls = next(k for k in ("divergent", "ambiguous", "missing") if k in msg)
+            ok(f"mutating {cid} toolchain pin turns red ({cls})")
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    assert_precommit_ownership()
+    print("PASS: eBPF pin parity contract")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-ebpf-pin-parity-contract.py
+++ b/scripts/ci/test-ebpf-pin-parity-contract.py
@@ -144,6 +144,20 @@ def mutate_first(text: str, old: str, new: str, consumer: str) -> str:
     return out
 
 
+def _assert_files_regex_owns(rx: re.Pattern[str], label: str) -> None:
+    """Compile-time ownership: exact positives + one nearby non-owner negative."""
+    must_own = [rel for _cid, rel, _kind in CONSUMERS]
+    must_own.append("scripts/ci/test-ebpf-pin-parity-contract.py")
+    must_own.append(".pre-commit-config.yaml")
+    for path in must_own:
+        if rx.fullmatch(path) is None:
+            raise ContractError(f"{label}: must own {path!r}")
+    # Nearby non-owner: over-broad `.*` would match this and stay green otherwise.
+    non_owner = "scripts/ci/test-cargo-plugin-versions-contract.sh"
+    if rx.fullmatch(non_owner) is not None:
+        raise ContractError(f"{label}: must not own nearby non-owner {non_owner!r}")
+
+
 def assert_precommit_ownership() -> None:
     pc = PRECOMMIT.read_text(encoding="utf-8")
     if "id: ebpf-pin-parity-contract-self-test" not in pc:
@@ -155,20 +169,32 @@ def assert_precommit_ownership() -> None:
     )
     if not block_m:
         fail("ebpf-pin-parity-contract-self-test files: line missing")
-    files_pat = block_m.group(1)
-    for stem in (
-        "install-ebpf-toolchain",
-        "test-ebpf-pin-parity-contract",
-        "assay-xtask/src/main",
-        "setup\\.sh",
-        "cloud-init\\.yaml",
-        "Dockerfile\\.ebpf-builder",
-        "pre-commit-config",
+    files_pat = block_m.group(1).strip()
+    try:
+        rx = re.compile(files_pat)
+    except re.error as exc:
+        fail(f"files: regex does not compile: {exc}: {files_pat}")
+    try:
+        _assert_files_regex_owns(rx, "files")
+    except ContractError as exc:
+        fail(str(exc))
+    # Controls: root nested under scripts/ci/(...) fails; overbroad .* fails non-owner.
+    broken = (
+        r"^(scripts/ci/(install-ebpf-toolchain\.sh|test-ebpf-pin-parity-contract\.py|"
+        r"\.pre-commit-config\.yaml)|crates/assay-xtask/src/main\.rs|"
+        r"infra/bpf-runner/(setup\.sh|cloud-init\.yaml)|docker/Dockerfile\.ebpf-builder)$"
+    )
+    for label, pat, needle in (
+        ("broken-grouping", broken, ".pre-commit-config.yaml"),
+        ("overbroad", r".*", "must not own"),
     ):
-        if stem not in files_pat:
-            fail(f"files: must watch {stem!r}; got {files_pat}")
-    ok("pre-commit hook watches the five consumers and this test")
-
+        try:
+            _assert_files_regex_owns(re.compile(pat), label)
+            fail(f"{label} files: control left ownership green")
+        except ContractError as exc:
+            if needle not in str(exc):
+                fail(f"{label} control wrong error: {exc}")
+    ok("pre-commit files: owns owners; broken grouping and .* go red")
 
 def main() -> None:
     try:


### PR DESCRIPTION
The README names HTTP, MCP and A2A as real x402 surfaces. The mapper accepts one. Nothing said so.

`transport` is closed to `http`, and an artifact declaring `mcp` or `a2a` exits with `artifact: transport must be one of: http` before reaching any verdict about the payment it describes. Verified by running it, not read off the constant.

The consequence is worth stating in the shape it takes: the accepting branch is unreachable for two of the three transports x402 defines, so a run over an MCP-transported corpus would reject every artifact, and that uniform rejection would decide nothing. A refusal can be correct on every input and still be vacuous over a corpus.

Widening the vocabulary is not the fix on its own. Fixtures and expected verdicts for those surfaces would have to come with it and this sample carries neither, so declaring the limit is the honest move while that stays true.

Docs only. Both documented commands still reproduce their checked-in fixtures byte for byte, and the declared error string is the one the code emits.

Prompted by [tersignhq/evidence-record-conformance#1](https://github.com/tersignhq/evidence-record-conformance/issues/1#issuecomment-5265724838), where the same shape appeared as a criterion bound to one identity syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that verification artifacts currently support only HTTP transport.
  - Explained that artifacts using MCP or A2A transports are rejected before payment verification.
  - Documented the requirements for adding support for additional transports.

- **Quality Improvements**
  - Added automated checks to ensure eBPF toolchain versions remain consistent across supported setup paths.
  - Added pre-commit validation to detect configuration drift early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->