### PR TITLE
fix(ci): remove unsupported concurrency queue keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,7 +788,6 @@ jobs:
     concurrency:
       group: assay-bpf-runner-host
       cancel-in-progress: false
-      queue: max
     permissions:
       contents: read
     # Self-hosted runner has Rust in /opt/rust; jobs run with --noprofile so PATH can be minimal.

--- a/.github/workflows/host-capability-proof.yml
+++ b/.github/workflows/host-capability-proof.yml
@@ -28,7 +28,6 @@ concurrency:
   # moved to an ephemeral runner model.
   group: assay-bpf-runner-host
   cancel-in-progress: false
-  queue: max
 
 jobs:
   proof:

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -331,7 +331,6 @@ jobs:
     concurrency:
       group: assay-bpf-runner-host
       cancel-in-progress: false
-      queue: max
     steps:
       - name: Nuke _actions cache (force fresh download for next job)
         shell: bash
@@ -381,7 +380,6 @@ jobs:
     concurrency:
       group: assay-bpf-runner-host
       cancel-in-progress: false
-      queue: max
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -20,7 +20,6 @@ permissions:
 concurrency:
   group: assay-bpf-runner-host
   cancel-in-progress: false
-  queue: max
 
 jobs:
   smoke:

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -28,7 +28,6 @@ concurrency:
   # downloaded-action cache state cannot race between back-to-back dispatches.
   group: assay-bpf-runner-host
   cancel-in-progress: false
-  queue: max
 
 jobs:
   prepare-delegated-runner:


### PR DESCRIPTION
## Summary
- remove unsupported `queue: max` keys from all GitHub Actions `concurrency` blocks
- preserve existing concurrency groups and `cancel-in-progress: false` behavior
- make repository-wide `actionlint` pass again

## Why
GitHub Actions only accepts `group` and `cancel-in-progress` under `concurrency`. The six `queue` keys were pre-existing and silently invalid; fixing only the originally reported `ci.yml` occurrence would leave the same schema defect in four other workflows.

## Verification
- RED on base `13aaf009f233dc2a583699b641ce38e4593bb6ad`: repository-wide `actionlint` reports six `unexpected key "queue"` errors
- GREEN on head `c128690f93a3a875c2177fdd97652ed8067326df`: `actionlint`
- `pre-commit run check-yaml --files <five changed workflows>`
- `git diff --check`
- commit and pre-push hooks passed, including CI gate contracts and workspace clippy

## Non-claims
- does not change runner capacity or introduce queue limits
- does not change concurrency groups or cancellation behavior
