### PR TITLE
Name the schema document instead of a branch that resolves to it

### DIFF
--- a/.github/workflows/assay-security.yml
+++ b/.github/workflows/assay-security.yml
@@ -55,7 +55,7 @@ jobs:
           if ! assay validate --config examples/demo/assay-safe.yaml --format sarif --output results.sarif; then
             # If validate fails, create a minimal valid SARIF so upload doesn't fail
             cat > results.sarif << 'SARIF_EOF'
-          {"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"assay"}},"results":[]}]}
+          {"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"assay"}},"results":[]}]}
           SARIF_EOF
             exit 1
           fi

--- a/crates/assay-cli/tests/sarif_schema_parity.rs
+++ b/crates/assay-cli/tests/sarif_schema_parity.rs
@@ -1,0 +1,54 @@
+//! The two `SARIF_SCHEMA` constants must name the same document.
+//!
+//! `assay-core` and `assay-evidence` each declare their own `SARIF_SCHEMA`, and neither
+//! can call the other: `assay-evidence` does not depend on `assay-core` and the arrow does
+//! not run the other way either. Until now the only thing holding them together was a doc
+//! comment on one of them saying to update the sibling, which is a convention rather than a
+//! constraint. Per one-rule-one-function a parity test is the sanctioned fallback when one
+//! rule cannot simply call the other; promoting the constant to `assay-common` so there is
+//! one of it is an ADR question rather than something to decide in a test file.
+//!
+//! What this catches is the partial edit. A change applied to one constant leaves the tree
+//! looking consistent, because every emitter still produces a well-formed document and every
+//! golden fixture still matches the producer that wrote it. The documents just stop agreeing
+//! about which schema they claim to be.
+//!
+//! What no test here can catch is the URI going dead. That failure is not local to this
+//! repository: the target moves when its publisher moves it, and a check that reached the
+//! network would make the build depend on someone else's uptime. The mitigation is the
+//! choice of target rather than a test. `docs.oasis-open.org/.../errata01/os/schemas/...`
+//! is an OASIS-published artifact at a versioned path rather than a git ref, and it is the
+//! URL the schema document names as its own `id`, so the label and the document agree about
+//! what the document is. A `raw.githubusercontent.com/<org>/<repo>/main/...` URL resolves
+//! against whatever that branch holds today, which is how a sibling project in this space
+//! shipped a `$schema` that had 404'd since before its first release without anything
+//! noticing.
+
+use assay_core::report::sarif::SARIF_SCHEMA as CORE_SCHEMA;
+use assay_evidence::lint::sarif::SARIF_SCHEMA as EVIDENCE_SCHEMA;
+
+#[test]
+fn the_two_schema_constants_name_the_same_document() {
+    assert_eq!(
+        CORE_SCHEMA, EVIDENCE_SCHEMA,
+        "assay-core and assay-evidence declare different SARIF schema URIs, so two Assay \
+         producers now claim to conform to different documents. Update both, or move the \
+         constant to a single home."
+    );
+}
+
+#[test]
+fn the_schema_uri_is_not_pinned_to_a_moving_git_ref() {
+    for (crate_name, uri) in [
+        ("assay-core", CORE_SCHEMA),
+        ("assay-evidence", EVIDENCE_SCHEMA),
+    ] {
+        assert!(
+            !uri.contains("raw.githubusercontent.com"),
+            "{crate_name} pins $schema to a raw git URL ({uri}). Those resolve against a \
+             branch, so the document a consumer validates against changes when the \
+             publisher restructures, with no failure on our side. Name a published, \
+             versioned artifact instead."
+        );
+    }
+}

--- a/crates/assay-cli/tests/sarif_schema_parity.rs
+++ b/crates/assay-cli/tests/sarif_schema_parity.rs
@@ -1,12 +1,16 @@
 //! The two `SARIF_SCHEMA` constants must name the same document.
 //!
-//! `assay-core` and `assay-evidence` each declare their own `SARIF_SCHEMA`, and neither
-//! can call the other: `assay-evidence` does not depend on `assay-core` and the arrow does
-//! not run the other way either. Until now the only thing holding them together was a doc
-//! comment on one of them saying to update the sibling, which is a convention rather than a
-//! constraint. Per one-rule-one-function a parity test is the sanctioned fallback when one
-//! rule cannot simply call the other; promoting the constant to `assay-common` so there is
-//! one of it is an ADR question rather than something to decide in a test file.
+//! `assay-core` and `assay-evidence` each declare their own `SARIF_SCHEMA`. Only one
+//! direction is blocked: `assay-evidence` cannot depend on `assay-core`. The other way is
+//! already open, since `assay-core -> assay-adapter-api -> assay-evidence` exists today, so
+//! `assay-core` could call the evidence constant without any new edge. That makes one rule
+//! reachable rather than impossible, and the choice between calling it and testing parity is
+//! a design question about which crate owns the value. Until now neither was done: what held
+//! the two together was a pair of reciprocal doc comments telling each other to update the
+//! sibling, which is a convention rather than a constraint. Per one-rule-one-function the
+//! parity test is the fallback while that question is open; deciding the owner, whether that
+//! is `assay-core` calling through or `assay-common` holding it, is an ADR question rather
+//! than something to settle in a test file.
 //!
 //! What this catches is the partial edit. A change applied to one constant leaves the tree
 //! looking consistent, because every emitter still produces a well-formed document and every
@@ -19,10 +23,13 @@
 //! choice of target rather than a test. `docs.oasis-open.org/.../errata01/os/schemas/...`
 //! is an OASIS-published artifact at a versioned path rather than a git ref, and it is the
 //! URL the schema document names as its own `id`, so the label and the document agree about
-//! what the document is. A `raw.githubusercontent.com/<org>/<repo>/main/...` URL resolves
-//! against whatever that branch holds today, which is how a sibling project in this space
-//! shipped a `$schema` that had 404'd since before its first release without anything
-//! noticing.
+//! what the document is. A `raw.githubusercontent.com/<org>/<repo>/<branch>/...` URL resolves
+//! against whatever that branch holds today, so the document a consumer validates against can
+//! change without any failure on our side. Our own risk here was not hypothetical: a `$schema`
+//! documented in `docs/architecture/SPEC-GitHub-Action-v2.1.md`, under a heading reading "SARIF
+//! Contract", pointed at a path that had already 404'd, and nothing checked it because the link
+//! checker walks markdown links rather than URLs quoted inside fenced examples or Rust
+//! literals.
 
 use assay_core::report::sarif::SARIF_SCHEMA as CORE_SCHEMA;
 use assay_evidence::lint::sarif::SARIF_SCHEMA as EVIDENCE_SCHEMA;

--- a/crates/assay-core/.repro_artifacts/sourceless_sarif.json
+++ b/crates/assay-core/.repro_artifacts/sourceless_sarif.json
@@ -1,6 +1,6 @@
 {
   "version": "2.1.0",
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "runs": [
     {
       "tool": {

--- a/crates/assay-core/src/report/sarif.rs
+++ b/crates/assay-core/src/report/sarif.rs
@@ -164,12 +164,20 @@ pub fn write_sarif_with_limit(
 ///
 /// # SARIF consistency contract
 ///
-/// There are two SARIF producers in the Assay workspace:
+/// There are three SARIF-emitting modules in the Assay workspace, one per crate:
 ///
-/// | Producer | Crate | Purpose |
-/// |----------|-------|---------|
-/// | `write_sarif` / `write_sarif_with_limit` / `build_sarif_diagnostics` (this module) | `assay-core` | Test results & diagnostic reports |
-/// | `to_sarif` | `assay-evidence` | Evidence-bundle lint findings for GitHub Code Scanning |
+/// | Producer | Crate | Purpose | `driver.rules[]` on a clean run |
+/// |----------|-------|---------|--------------------------------|
+/// | `write_sarif` / `write_sarif_with_limit` / `build_sarif_diagnostics` (this module) | `assay-core` | Test results & diagnostic reports | key absent |
+/// | `to_sarif` | `assay-evidence` | Evidence-bundle lint findings for GitHub Code Scanning | full catalog, every registry rule |
+/// | `enforcement_decision_sarif` | `assay-mcp-server` | Policy enforcement decisions | `[]`, since rules derive from deny records |
+///
+/// The rightmost column is deliberate rather than incidental, and the three disagree. A
+/// consumer reading `driver.rules[]` therefore cannot infer from one Assay document what an
+/// empty or absent catalog means in another: absent is not empty, and empty is not "nothing
+/// could have fired". Anything reasoning across producers has to read the producer name
+/// first. A fourth static document is written by hand in `.github/workflows/assay-security.yml`
+/// as a fallback and shares no code with any of these.
 ///
 /// **Shared invariants** (must stay in sync):
 /// - SARIF version: `"2.1.0"`

--- a/crates/assay-core/src/report/sarif.rs
+++ b/crates/assay-core/src/report/sarif.rs
@@ -19,7 +19,7 @@ pub struct SarifWriteOutcome {
 /// the same schema URI and version `"2.1.0"`.  When changing this constant,
 /// update the sibling in `assay-evidence/src/lint/sarif.rs` as well.
 pub const SARIF_SCHEMA: &str =
-    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json";
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json";
 
 /// Synthetic location for results without file context.
 ///

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 /// same schema URI and version `"2.1.0"`.  When changing this constant, update
 /// the sibling in `assay-core/src/report/sarif.rs` as well.
 pub const SARIF_SCHEMA: &str =
-    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json";
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json";
 
 /// SARIF output options.
 #[derive(Debug, Clone, Default)]

--- a/crates/assay-mcp-server/tests/fixtures/enforcement_decision_sarif.v0.json
+++ b/crates/assay-mcp-server/tests/fixtures/enforcement_decision_sarif.v0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/docs/architecture/ADR-013-EU-AI-Act-Pack.md
+++ b/docs/architecture/ADR-013-EU-AI-Act-Pack.md
@@ -225,7 +225,7 @@ Pack metadata uses `properties` bags (SARIF-standard extensibility):
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/...",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [{
     "tool": {

--- a/docs/architecture/SPEC-GitHub-Action-v2.1.md
+++ b/docs/architecture/SPEC-GitHub-Action-v2.1.md
@@ -356,7 +356,7 @@ Packs produce SARIF with the following structure:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [{
     "tool": {

--- a/docs/architecture/SPEC-Pack-Engine-v1.md
+++ b/docs/architecture/SPEC-Pack-Engine-v1.md
@@ -490,7 +490,7 @@ owes a consumer; it is not a construct the format provides for capping.
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [{
     "tool": {


### PR DESCRIPTION
Every Assay SARIF producer labelled its output with `raw.githubusercontent.com/oasis-tcs/sarif-spec/main/...`. That resolves against a branch. This repoints all of them at the OASIS-published errata01 artifact and adds the guard that was standing in as a doc comment.

**The target is not chosen for liveness.** The two documents are byte identical (`sha256 c3b4bb2d…`, 112768 B), and the raw.githubusercontent copy carries `"id": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"` in its own draft-04 header. The schema already declared the OASIS URL to be what it is; we were labelling it with a path. Nothing in this repo validates against the URI, so this is a label change with no consumer risk.

**We had a dead one.** `docs/architecture/SPEC-GitHub-Action-v2.1.md:359`, in a section titled "7.1 SARIF Contract", documented `.../sarif-spec/master/Schemata/sarif-schema-2.1.0.json`. Verified 404. Fixed in the first commit.

**The guard is the part that was missing.** `assay-core` and `assay-evidence` each declare their own `SARIF_SCHEMA` and neither can call the other, so the only thing holding them together was a doc comment on one saying to update the sibling. A partial edit leaves the tree looking consistent: every emitter still produces a well-formed document, every golden fixture still matches the producer that wrote it, and the documents just stop agreeing about which schema they claim to be. Per one-rule-one-function the parity test is the sanctioned fallback; moving the constant to `assay-common` is an ADR question rather than a test-file decision.

A second test refuses a raw git URL outright. The failure it prevents is not local to us: a sibling project shipped a `$schema` that had 404'd since before its first release, after the publisher restructured the branch it pointed at, with nothing on their side to notice.

**Verification.** Both golden fixtures regenerated via their documented paths and then run rather than merely regenerated: `assay-core generate_fixture` 2 passed, and `enforcement_decision_sarif_contract_fixture` passed under `--lib`. Worth noting because the plain filter form exits 0 with `0 passed; 1 filtered out`, which is green without running the test.

Prompted by [aliksir/claude-code-skill-security-check#24](https://github.com/aliksir/claude-code-skill-security-check/issues/24).
