### PR TITLE
ci: isolate cargo-audit/deny advisory DBs (CI-4F / #2188)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,10 @@ jobs:
         # install asserted.
         run: cargo-deny check advisories bans licenses sources
       - name: cargo audit (RustSec)
-        run: |
-          rm -rf ~/.cargo/advisory-db
-          cargo-audit audit
+        # CI-4F / #2188: isolate cargo-audit's advisory DB from cargo-deny's plural root.
+        # Same runner as the pre-push hook and the fuzz audit below; do not restore
+        # `rm -rf ~/.cargo/advisory-db` — that deletes a shared global cache.
+        run: bash scripts/ci/cargo-audit-with-isolated-db.sh
       - name: rsa advisory-removal contract
         # CI-4C (#2231): rsa must stay out of the resolved tree, and the four ignore sites
         # (deny.toml, .cargo/audit.toml, this workflow, .pre-commit-config.yaml) must not
@@ -233,7 +234,8 @@ jobs:
           # repo cwd. That would defeat the reason this step exists. An advisory that matches only
           # the fuzz tree is then a deliberate decision, not a silent pass; there is nowhere for it
           # to be quietly excused, which is the point.
-          ( cd "${RUNNER_TEMP}" && cargo-audit audit --file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock" )
+          # Same isolated-db runner as the root audit / pre-push hook (CI-4F / #2188).
+          ( cd "${RUNNER_TEMP}" && bash "${GITHUB_WORKSPACE}/scripts/ci/cargo-audit-with-isolated-db.sh" --file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock" )
 
   clippy:
     name: Clippy (deny warnings)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -348,21 +348,30 @@ repos:
 
       - id: cargo-audit
         name: cargo audit (RustSec)
-        # `cargo-audit audit` rather than `cargo audit`, for the reason the neighbouring cargo-deny
-        # hook states: through cargo the toolchain resolves from rust-toolchain.toml. CI's dependency
-        # job now sets RUSTUP_TOOLCHAIN for every step, but a hook runs on a developer machine where
-        # nothing does, so this site was the one left uncovered (#2237). The two hooks answered the
-        # same question differently, which is how the answer drifts.
+        # Isolated advisory DB via scripts/ci/cargo-audit-with-isolated-db.sh (CI-4F / #2188).
+        # Same runner as both CI cargo-audit steps; do not call bare `cargo-audit audit` here.
+        # The runner invokes `cargo-audit audit` (not `cargo audit`) so rust-toolchain.toml
+        # resolution does not select a toolchain the developer never installed (#2237).
         # Keep any ignore list in lockstep with the three peer locations that carry it:
         # deny.toml, .github/workflows/ci.yml and .cargo/audit.toml. Naming all of them matters —
         # an incomplete peer list is how this hook drifted in the first place. The list is empty
         # after CI-4C (#2231) removed the last matching exception; do not reintroduce ignores here
         # without updating those peers and the rsa-removal contract check.
-        entry: bash -lc 'cargo-audit audit'
+        entry: bash scripts/ci/cargo-audit-with-isolated-db.sh
         language: system
         pass_filenames: false
         files: ^Cargo\.lock$
         stages: [pre-push]
+
+      - id: cargo-audit-isolated-db-self-test
+        name: cargo-audit isolated advisory DB
+        entry: bash scripts/ci/test-cargo-audit-with-isolated-db.sh
+        language: system
+        pass_filenames: false
+        # CI-4F / #2188: one runner for hook + both CI audits; deny.toml plural root;
+        # no global rm -rf of ~/.cargo/advisory-db. Mutations cover stripping --db,
+        # restoring the shared singular deny path, restoring rm -rf, and bare-audit bypass.
+        files: ^(scripts/ci/(cargo-audit-with-isolated-db|test-cargo-audit-with-isolated-db)\.sh|deny\.toml|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
 
       - id: install-cargo-deny-self-test
         name: cargo-deny install pin self-test

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,10 @@ exclude = [
 # [advisories] - RustSec advisory database checks
 # =============================================================================
 [advisories]
-db-path = "~/.cargo/advisory-db"
+# cargo-deny 0.20 default / supported root (plural). Do not point this at the
+# cargo-audit singular default (~/.cargo/advisory-db): deny nests a hashed clone
+# there and audit then refuses to initialize the non-empty directory (#2188).
+db-path = "$CARGO_HOME/advisory-dbs"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # Ignore specific advisories (add RUSTSEC-YYYY-NNNN here if needed)
 # Only list advisories that currently match a crate in the tree; remove when dep is upgraded or removed.

--- a/scripts/ci/cargo-audit-with-isolated-db.sh
+++ b/scripts/ci/cargo-audit-with-isolated-db.sh
@@ -9,8 +9,8 @@
 # specific path (tests, or an operator-chosen cache).
 #
 # Bash 3.2 compatible (macOS /bin/bash). Source-safe: sourcing defines helpers
-# only; executing runs the audit.
-set -euo pipefail
+# only and must not change the caller's shell options; executing enables
+# strict mode then runs the audit.
 
 # Resolve the advisory DB path. Prefer an explicit override; otherwise a bounded
 # assay-owned leaf under CARGO_HOME (outside any worktree). Fall back to TMPDIR
@@ -40,6 +40,9 @@ run_cargo_audit_with_isolated_db() {
   exec cargo-audit audit --db "${db}" "$@"
 }
 
+# Strict mode belongs to execution only. A top-level `set -euo pipefail` would
+# mutate a caller's options on `source` and break source-safety.
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
   run_cargo_audit_with_isolated_db "$@"
 fi

--- a/scripts/ci/cargo-audit-with-isolated-db.sh
+++ b/scripts/ci/cargo-audit-with-isolated-db.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run cargo-audit against an isolated advisory DB (CI-4F / #2188).
+#
+# cargo-deny's default root is $CARGO_HOME/advisory-dbs (plural). cargo-audit's
+# default is ~/.cargo/advisory-db (singular). Sharing the singular root makes
+# sequential hooks fail: deny nests a hashed clone, audit refuses the non-empty
+# directory. This runner is the one --db rule for the local pre-push hook and
+# both CI audits. Override with ASSAY_CARGO_AUDIT_DB when a caller needs a
+# specific path (tests, or an operator-chosen cache).
+#
+# Bash 3.2 compatible (macOS /bin/bash). Source-safe: sourcing defines helpers
+# only; executing runs the audit.
+set -euo pipefail
+
+# Resolve the advisory DB path. Prefer an explicit override; otherwise a bounded
+# assay-owned leaf under CARGO_HOME (outside any worktree). Fall back to TMPDIR
+# when neither CARGO_HOME nor HOME is available.
+assay_cargo_audit_db_path() {
+  if [[ -n "${ASSAY_CARGO_AUDIT_DB:-}" ]]; then
+    printf '%s\n' "${ASSAY_CARGO_AUDIT_DB}"
+    return 0
+  fi
+
+  local base
+  if [[ -n "${CARGO_HOME:-}" ]]; then
+    base="${CARGO_HOME}"
+  elif [[ -n "${HOME:-}" ]]; then
+    base="${HOME}/.cargo"
+  else
+    base="${TMPDIR:-/tmp}/assay-cargo-audit"
+  fi
+  printf '%s\n' "${base}/assay/cargo-audit/advisory-db"
+}
+
+run_cargo_audit_with_isolated_db() {
+  local db parent
+  db="$(assay_cargo_audit_db_path)"
+  parent="$(dirname "${db}")"
+  mkdir -p "${parent}"
+  exec cargo-audit audit --db "${db}" "$@"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  run_cargo_audit_with_isolated_db "$@"
+fi

--- a/scripts/ci/test-cargo-audit-with-isolated-db.sh
+++ b/scripts/ci/test-cargo-audit-with-isolated-db.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 # Self-test for scripts/ci/cargo-audit-with-isolated-db.sh (CI-4F / #2188).
-#
-# cargo-deny nests under ~/.cargo/advisory-db; cargo-audit refuses that non-empty
-# root. CI used `rm -rf` globally; the local hook did not. This gate proves one
-# runner isolates --db, preserves a planted hostile deny layout, and is the only
-# active audit path in CI + pre-commit.
-#
-# shellcheck disable=SC2016,SC2088 # intentional literal YAML/toml/shell spellings under test
+# shellcheck disable=SC2016,SC2088 # intentional literal YAML/toml/shell spellings
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -18,13 +12,8 @@ RUNNER_REL='scripts/ci/cargo-audit-with-isolated-db.sh'
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "ok   $*"; }
-abort_is_failure() {
-  local rc="$1"
-  [[ "${rc}" -eq 0 ]] || echo "cargo-audit isolated-db self-test aborted (exit ${rc}); treat as failure" >&2
-}
-trap 'abort_is_failure "$?"' ERR
+trap 'rc=$?; [[ $rc -eq 0 ]] || echo "cargo-audit isolated-db self-test aborted (exit ${rc}); treat as failure" >&2' ERR
 
-# macOS /bin/bash 3.2: refuse bash-4.4 @Q in active code.
 if awk '
   /^[[:space:]]*#/ { next }
   /\$\{[^}]+@Q\}/ { found=1; print NR ":" $0 }
@@ -32,21 +21,52 @@ if awk '
 ' "${BASH_SOURCE[0]}"; then
   fail "self-test uses bash-4.4 @Q quoting; macOS bash 3.2 aborts with bad substitution"
 fi
+[[ -f "${RUNNER}" && -f "${DENY_TOML}" && -f "${WORKFLOW}" && -f "${PRECOMMIT}" ]] \
+  || fail "missing runner or wiring files"
 
-[[ -f "${RUNNER}" ]] || fail "missing runner ${RUNNER_REL}"
-[[ -f "${DENY_TOML}" && -f "${WORKFLOW}" && -f "${PRECOMMIT}" ]] || fail "missing wiring files"
+# Shared runner assertion (live GREEN + --db mutant RED).
+assert_runner_exec_uses_db() {
+  local path="$1"
+  grep -q 'BASH_SOURCE\[0\]' "${path}" \
+    || { echo "FAIL [runner-db]: ${path}: missing BASH_SOURCE execute guard" >&2; return 1; }
+  grep -qE '^assay_cargo_audit_db_path[[:space:]]*\(\)' "${path}" \
+    || { echo "FAIL [runner-db]: ${path}: missing assay_cargo_audit_db_path()" >&2; return 1; }
+  grep -qE '^run_cargo_audit_with_isolated_db[[:space:]]*\(\)' "${path}" \
+    || { echo "FAIL [runner-db]: ${path}: missing run_cargo_audit_with_isolated_db()" >&2; return 1; }
+  if awk '
+    /^[[:space:]]*#/ { next }
+    /BASH_SOURCE\[0\]/ { guarded=1 }
+    !guarded && /^[[:space:]]*set[[:space:]]+-[a-z]*[euo]/ { found=1 }
+    END { exit found ? 0 : 1 }
+  ' "${path}"; then
+    echo "FAIL [runner-db]: ${path}: strict mode before execute guard" >&2
+    return 1
+  fi
+  grep -qF 'exec cargo-audit audit --db' "${path}" \
+    || { echo "FAIL [runner-db]: ${path}: must exec cargo-audit audit --db \"\$db\"" >&2; return 1; }
+}
 
-grep -q 'BASH_SOURCE\[0\]' "${RUNNER}" \
-  || fail "runner is not source-safe (missing BASH_SOURCE execute guard)"
-grep -qE '^assay_cargo_audit_db_path[[:space:]]*\(\)' "${RUNNER}" \
-  || fail "runner must define assay_cargo_audit_db_path()"
-grep -qE '^run_cargo_audit_with_isolated_db[[:space:]]*\(\)' "${RUNNER}" \
-  || fail "runner must define run_cargo_audit_with_isolated_db()"
-grep -qF 'exec cargo-audit audit --db' "${RUNNER}" \
-  || fail "runner must exec cargo-audit audit --db \"\$db\""
+assert_runner_exec_uses_db "${RUNNER}" || fail "live runner failed [runner-db]"
 
+# Option probe in a non-strict shell so a leaked top-level set -euo bites.
+bash -c '
+  set +e; set +u; set +o pipefail
+  before="$(set +o; printf "DASH:%s\n" "$-")"
+  source "$1"
+  after="$(set +o; printf "DASH:%s\n" "$-")"
+  [[ "${before}" == "${after}" ]] || {
+    echo "FAIL: sourcing runner mutated shell options" >&2
+    printf "before:\n%s\nafter:\n%s\n" "${before}" "${after}" >&2
+    exit 1
+  }
+  type assay_cargo_audit_db_path >/dev/null 2>&1 \
+    || { echo "FAIL: assay_cargo_audit_db_path missing after source" >&2; exit 1; }
+  type run_cargo_audit_with_isolated_db >/dev/null 2>&1 \
+    || { echo "FAIL: run_cargo_audit_with_isolated_db missing after source" >&2; exit 1; }
+' bash "${RUNNER}" || fail "source-safety option probe failed"
 # shellcheck source=scripts/ci/cargo-audit-with-isolated-db.sh
 source "${RUNNER}"
+ok "source-safe: options unchanged; helpers defined"
 
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "${SCRATCH}"' EXIT
@@ -76,10 +96,10 @@ plant_hostile_deny_layout() {
 assert_sentinel_intact() {
   local singular_root="$1"
   [[ -f "${singular_root}/advisory-db-deadbeefcafe/SENTINEL" ]] \
-    || fail "hostile deny layout sentinel was deleted (global cleanup must not run)"
+    || fail "hostile deny sentinel deleted"
   [[ "$(cat "${singular_root}/advisory-db-deadbeefcafe/SENTINEL")" == "deny-owned-sentinel" ]] \
-    || fail "hostile deny layout sentinel contents changed"
-  [[ -f "${singular_root}/db.lock" ]] || fail "hostile deny db.lock was deleted"
+    || fail "hostile deny sentinel contents changed"
+  [[ -f "${singular_root}/db.lock" ]] || fail "hostile deny db.lock deleted"
 }
 
 parse_db_arg() {
@@ -91,54 +111,41 @@ run_runner_case() {
   shift 2
   local case_dir="${SCRATCH}/${name}"
   local home="${case_dir}/home" cargo_home="${case_dir}/cargo-home" bin="${case_dir}/bin"
-  local log="${case_dir}/stub.log" singular="${home}/.cargo/advisory-db"
+  local log="${case_dir}/stub.log" singular="${home}/.cargo/advisory-db" rc=0
   mkdir -p "${home}" "${cargo_home}" "${bin}" "${case_dir}/tmp"
   : >"${log}"
   plant_hostile_deny_layout "${singular}"
   make_stub_cargo_audit "${bin}" "${expect_exit}"
-  local rc=0
-  env -i \
-    PATH="${bin}:/usr/bin:/bin" HOME="${home}" CARGO_HOME="${cargo_home}" \
+  env -i PATH="${bin}:/usr/bin:/bin" HOME="${home}" CARGO_HOME="${cargo_home}" \
     STUB_LOG="${log}" TMPDIR="${case_dir}/tmp" "$@" \
     bash "${RUNNER}" --quiet --file "${case_dir}/lock" \
     >"${case_dir}/out.txt" 2>&1 || rc=$?
-  [[ "${rc}" -eq "${expect_exit}" ]] \
-    || fail "${name}: expected exit ${expect_exit}, got ${rc}; out:
+  [[ "${rc}" -eq "${expect_exit}" ]] || fail "${name}: exit ${rc} want ${expect_exit}
 $(cat "${case_dir}/out.txt")
-log:
 $(cat "${log}")"
   assert_sentinel_intact "${singular}"
   printf '%s\n' "${log}"
 }
 
 log="$(run_runner_case default_isolated 0)"
-grep -q 'argv: audit --db ' "${log}" || fail "default run must reach cargo-audit with audit --db; log:
-$(cat "${log}")"
+grep -q 'argv: audit --db ' "${log}" || fail "missing audit --db; log: $(cat "${log}")"
 db_arg="$(parse_db_arg "${log}")"
-[[ -n "${db_arg}" ]] || fail "could not parse --db from stub log"
-[[ "${db_arg}" != *'/.cargo/advisory-db' ]] \
-  || fail "default --db must not be the shared singular root; got ${db_arg}"
-case "${db_arg}" in
-  */assay/*|"${SCRATCH}"/*) ;;
-  *) fail "default --db must be assay-owned under CARGO_HOME or temp; got ${db_arg}" ;;
-esac
-[[ -d "$(dirname "${db_arg}")" ]] || fail "runner must mkdir parent of --db"
-grep -qF -- '--quiet --file ' "${log}" || fail "runner must pass through caller args; log:
-$(cat "${log}")"
-ok "default isolated --db reaches audit; hostile singular root preserved"
+[[ -n "${db_arg}" && "${db_arg}" != *'/.cargo/advisory-db' ]] \
+  || fail "bad default --db: ${db_arg:-<empty>}"
+case "${db_arg}" in */assay/*|"${SCRATCH}"/*) ;; *) fail "default --db not assay-owned: ${db_arg}" ;; esac
+[[ -d "$(dirname "${db_arg}")" ]] || fail "missing --db parent"
+grep -qF -- '--quiet --file ' "${log}" || fail "args not passed through"
+ok "default isolated --db; hostile singular root preserved"
 
 override_db="${SCRATCH}/override-db/custom-advisory-db"
 log="$(run_runner_case override_env 0 ASSAY_CARGO_AUDIT_DB="${override_db}")"
-grep -qF "argv: audit --db ${override_db}" "${log}" \
-  || fail "ASSAY_CARGO_AUDIT_DB must become --db; log:
-$(cat "${log}")"
-[[ -d "$(dirname "${override_db}")" ]] || fail "override path parent must be created"
+grep -qF "argv: audit --db ${override_db}" "${log}" || fail "override ignored"
+[[ -d "$(dirname "${override_db}")" ]] || fail "override parent missing"
 ok "ASSAY_CARGO_AUDIT_DB override respected"
 
 log="$(run_runner_case exit_passthrough 7)"
-ok "cargo-audit exit code passed through (7)"
+ok "exit code passthrough (7)"
 
-# Fuzz cwd/--file: runner must not cd away from caller cwd.
 fuzz_cwd="${SCRATCH}/fuzz-cwd"
 mkdir -p "${fuzz_cwd}" "${SCRATCH}/fuzz-home" "${SCRATCH}/fuzz-bin" "${SCRATCH}/fuzz-cargo"
 : >"${SCRATCH}/fuzz.log"
@@ -147,21 +154,16 @@ make_stub_cargo_audit "${SCRATCH}/fuzz-bin" 0
 fuzz_rc=0
 (
   cd "${fuzz_cwd}"
-  env -i \
-    PATH="${SCRATCH}/fuzz-bin:/usr/bin:/bin" \
+  env -i PATH="${SCRATCH}/fuzz-bin:/usr/bin:/bin" \
     HOME="${SCRATCH}/fuzz-home" CARGO_HOME="${SCRATCH}/fuzz-cargo" \
     STUB_LOG="${SCRATCH}/fuzz.log" ASSAY_CARGO_AUDIT_DB="${SCRATCH}/fuzz-db/advisory-db" \
     bash "${RUNNER}" --file "${ROOT}/fuzz/Cargo.lock"
 ) || fuzz_rc=$?
-[[ "${fuzz_rc}" -eq 0 ]] || fail "fuzz-cwd runner failed (exit ${fuzz_rc})"
-grep -qF "cwd=$(cd "${fuzz_cwd}" && pwd -P)" "${SCRATCH}/fuzz.log" \
-  || fail "runner must preserve caller cwd; log:
-$(cat "${SCRATCH}/fuzz.log")"
-grep -qF -- "--file ${ROOT}/fuzz/Cargo.lock" "${SCRATCH}/fuzz.log" \
-  || fail "fuzz --file arg must pass through; log:
-$(cat "${SCRATCH}/fuzz.log")"
+[[ "${fuzz_rc}" -eq 0 ]] || fail "fuzz-cwd exit ${fuzz_rc}"
+grep -qF "cwd=$(cd "${fuzz_cwd}" && pwd -P)" "${SCRATCH}/fuzz.log" || fail "cwd not preserved"
+grep -qF -- "--file ${ROOT}/fuzz/Cargo.lock" "${SCRATCH}/fuzz.log" || fail "--file not passed"
 assert_sentinel_intact "${SCRATCH}/fuzz-home/.cargo/advisory-db"
-ok "fuzz cwd/--file semantics preserved"
+ok "fuzz cwd/--file preserved"
 
 deps_security_job() {
   awk '
@@ -171,48 +173,79 @@ deps_security_job() {
   ' "$1"
 }
 
-job="$(deps_security_job "${WORKFLOW}")"
-[[ -n "${job}" ]] || fail "could not find deps-security job"
-active_job="$(printf '%s\n' "${job}" | grep -v '^[[:space:]]*#' || true)"
-if printf '%s\n' "${active_job}" | grep -qE 'rm[[:space:]]+-rf[[:space:]]+.*advisory-db'; then
-  fail "deps-security still has active rm -rf …advisory-db"
-fi
-root_hits="$(printf '%s\n' "${active_job}" | grep -cF "${RUNNER_REL}" || true)"
-[[ "${root_hits}" -ge 2 ]] \
-  || fail "deps-security must invoke ${RUNNER_REL} for both audits; active hits=${root_hits}"
-if printf '%s\n' "${active_job}" | grep -E '^[[:space:]]*cargo-audit[[:space:]]+audit([[:space:]]|$)'; then
-  fail "deps-security still has a bare cargo-audit audit line"
-fi
-printf '%s\n' "${active_job}" | grep -qF 'cd "${RUNNER_TEMP}"' \
-  || fail "fuzz audit must still cd to RUNNER_TEMP"
-printf '%s\n' "${active_job}" | grep -qF -- '--file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock"' \
-  || fail "fuzz audit must still pass --file for fuzz/Cargo.lock"
+deny_db_path_of() {
+  awk '
+    /^\[advisories\]/ { in_adv=1; next }
+    in_adv && /^\[/ { exit }
+    in_adv && /^db-path[[:space:]]*=/ {
+      sub(/^db-path[[:space:]]*=[[:space:]]*/, "")
+      gsub(/^"/, ""); gsub(/"$/, "")
+      print; exit
+    }
+  ' "$1"
+}
 
-hook_entry="$(awk '
-  /^[[:space:]]*- id: cargo-audit[[:space:]]*$/ { in_hook=1; next }
-  in_hook && /^[[:space:]]*- id:/ { exit }
-  in_hook && /^[[:space:]]*entry:/ { print; exit }
-' "${PRECOMMIT}")"
-[[ "${hook_entry}" == *"${RUNNER_REL}"* ]] \
-  || fail "pre-commit cargo-audit entry must use ${RUNNER_REL}; got:
-${hook_entry:-<missing>}"
-if grep -qE "entry:[[:space:]]*bash -lc 'cargo-audit audit'" "${PRECOMMIT}"; then
-  fail "pre-commit still has bare bash -lc 'cargo-audit audit'"
-fi
-ok "CI + pre-commit share the isolated runner; no global rm"
+# One contract over deny/workflow/precommit paths. Classes:
+# deny-db-path | workflow-rm | workflow-runner | workflow-bare-audit | precommit-entry
+check_isolated_advisory_cache_contract() {
+  local deny_toml="$1" workflow="$2" precommit="$3"
+  local job active_job root_hits hook_entry deny_db_path
 
-deny_db_path="$(awk '
-  /^\[advisories\]/ { in_adv=1; next }
-  in_adv && /^\[/ { exit }
-  in_adv && /^db-path[[:space:]]*=/ {
-    sub(/^db-path[[:space:]]*=[[:space:]]*/, "")
-    gsub(/^"/, ""); gsub(/"$/, "")
-    print; exit
-  }
-' "${DENY_TOML}")"
-[[ "${deny_db_path}" == '$CARGO_HOME/advisory-dbs' ]] \
-  || fail "deny.toml db-path must be \$CARGO_HOME/advisory-dbs (plural); got '${deny_db_path:-<missing>}'"
-ok "deny.toml uses plural \$CARGO_HOME/advisory-dbs"
+  deny_db_path="$(deny_db_path_of "${deny_toml}")"
+  if [[ "${deny_db_path}" != '$CARGO_HOME/advisory-dbs' ]]; then
+    echo "FAIL [deny-db-path]: want \$CARGO_HOME/advisory-dbs; got '${deny_db_path:-<missing>}'" >&2
+    return 1
+  fi
+
+  job="$(deps_security_job "${workflow}")"
+  [[ -n "${job}" ]] || { echo "FAIL [workflow-runner]: no deps-security job" >&2; return 1; }
+  active_job="$(printf '%s\n' "${job}" | grep -v '^[[:space:]]*#' || true)"
+  if printf '%s\n' "${active_job}" | grep -qE 'rm[[:space:]]+-rf[[:space:]]+.*advisory-db'; then
+    echo "FAIL [workflow-rm]: active rm -rf …advisory-db" >&2
+    return 1
+  fi
+  root_hits="$(printf '%s\n' "${active_job}" | grep -cF "${RUNNER_REL}" || true)"
+  if [[ "${root_hits}" -lt 2 ]]; then
+    echo "FAIL [workflow-runner]: need ${RUNNER_REL} twice; hits=${root_hits}" >&2
+    return 1
+  fi
+  if printf '%s\n' "${active_job}" | grep -E '^[[:space:]]*cargo-audit[[:space:]]+audit([[:space:]]|$)'; then
+    echo "FAIL [workflow-bare-audit]: bare cargo-audit audit line" >&2
+    return 1
+  fi
+  printf '%s\n' "${active_job}" | grep -qF 'cd "${RUNNER_TEMP}"' \
+    || { echo "FAIL [workflow-runner]: fuzz must cd RUNNER_TEMP" >&2; return 1; }
+  printf '%s\n' "${active_job}" | grep -qF -- '--file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock"' \
+    || { echo "FAIL [workflow-runner]: fuzz must pass --file" >&2; return 1; }
+
+  hook_entry="$(awk '
+    /^[[:space:]]*- id: cargo-audit[[:space:]]*$/ { in_hook=1; next }
+    in_hook && /^[[:space:]]*- id:/ { exit }
+    in_hook && /^[[:space:]]*entry:/ { print; exit }
+  ' "${precommit}")"
+  if [[ "${hook_entry}" != *"${RUNNER_REL}"* ]]; then
+    echo "FAIL [precommit-entry]: want ${RUNNER_REL}; got:
+${hook_entry:-<missing>}" >&2
+    return 1
+  fi
+  if grep -qE "entry:[[:space:]]*bash -lc 'cargo-audit audit'" "${precommit}"; then
+    echo "FAIL [precommit-entry]: bare bash -lc 'cargo-audit audit'" >&2
+    return 1
+  fi
+}
+
+expect_contract_red() {
+  local class="$1" deny="$2" wf="$3" pc="$4" out rc=0
+  out="$(check_isolated_advisory_cache_contract "${deny}" "${wf}" "${pc}" 2>&1)" && rc=$? || rc=$?
+  [[ "${rc}" -ne 0 ]] || fail "expected RED [${class}] but GREEN"
+  printf '%s\n' "${out}" | grep -qF "[${class}]" \
+    || fail "expected [${class}]; got:
+${out}"
+}
+
+check_isolated_advisory_cache_contract "${DENY_TOML}" "${WORKFLOW}" "${PRECOMMIT}" \
+  || fail "live wiring contract RED"
+ok "live wiring contract GREEN"
 
 if awk '
   /^\[advisories\]/ { in_adv=1; next }
@@ -220,17 +253,45 @@ if awk '
   in_adv && /RUSTSEC-2023-0071/ { found=1 }
   END { exit found ? 0 : 1 }
 ' "${DENY_TOML}" "${ROOT}/.cargo/audit.toml"; then
-  fail "RUSTSEC-2023-0071 reintroduced in deny.toml or .cargo/audit.toml"
+  fail "RUSTSEC-2023-0071 reintroduced"
 fi
-ok "RUSTSEC-2023-0071 ignore remains absent"
+ok "RUSTSEC-2023-0071 ignore absent"
 
-# --- Mutations that must bite ---
+python3 - "${PRECOMMIT}" <<'PY'
+import re, sys
+from pathlib import Path
+pc, in_hook, files_line = Path(sys.argv[1]).read_text(encoding="utf-8"), False, None
+for line in pc.splitlines():
+    if re.search(r"id:\s*cargo-audit-isolated-db-self-test\s*$", line):
+        in_hook = True; continue
+    if in_hook and re.match(r"^\s+- id:\s*", line):
+        break
+    m = re.match(r"^\s+files:\s*(.+)\s*$", line) if in_hook else None
+    if m:
+        files_line = m.group(1).strip(); break
+if not files_line:
+    raise SystemExit("FAIL: files: line missing")
+cre = re.compile(files_line)
+need = ("scripts/ci/cargo-audit-with-isolated-db.sh",
+        "scripts/ci/test-cargo-audit-with-isolated-db.sh", "deny.toml",
+        ".github/workflows/ci.yml", ".pre-commit-config.yaml")
+missed = [p for p in need if cre.fullmatch(p) is None]
+if missed:
+    raise SystemExit(f"FAIL: files: fullmatch missed {missed}; pattern={files_line!r}")
+if cre.fullmatch("not/.pre-commit-config.yaml") or cre.fullmatch("x/.github/workflows/ci.yml"):
+    raise SystemExit("FAIL: files: fullmatched non-root path")
+print("ok   files: regex fullmatches wiring paths")
+PY
 
+# Mutations: same assertions must RED with the right class.
 mut_runner="${SCRATCH}/mut-runner-no-db.sh"
 sed 's/exec cargo-audit audit --db "${db}"/exec cargo-audit audit/' "${RUNNER}" >"${mut_runner}"
-grep -qF 'exec cargo-audit audit --db' "${mut_runner}" && fail "mutant still contains --db"
-mut_bin="${SCRATCH}/mut-nodb/bin"
-mut_log="${SCRATCH}/mut-nodb/stub.log"
+chmod +x "${mut_runner}"
+mut_out="$(assert_runner_exec_uses_db "${mut_runner}" 2>&1)" && mut_rc=0 || mut_rc=$?
+[[ "${mut_rc}" -ne 0 ]] || fail "--db mutant stayed GREEN under assert_runner_exec_uses_db"
+printf '%s\n' "${mut_out}" | grep -qF '[runner-db]' || fail "want [runner-db]; got:
+${mut_out}"
+mut_bin="${SCRATCH}/mut-nodb/bin"; mut_log="${SCRATCH}/mut-nodb/stub.log"
 mkdir -p "${SCRATCH}/mut-nodb/home" "${SCRATCH}/mut-nodb/cargo-home" "${mut_bin}"
 : >"${mut_log}"
 plant_hostile_deny_layout "${SCRATCH}/mut-nodb/home/.cargo/advisory-db"
@@ -238,56 +299,30 @@ make_stub_cargo_audit "${mut_bin}" 0
 env -i PATH="${mut_bin}:/usr/bin:/bin" HOME="${SCRATCH}/mut-nodb/home" \
   CARGO_HOME="${SCRATCH}/mut-nodb/cargo-home" STUB_LOG="${mut_log}" \
   bash "${mut_runner}" >"${SCRATCH}/mut-nodb/out.txt" 2>&1 || true
-grep -q 'argv: audit --db ' "${mut_log}" \
-  && fail "mutation removing --db still showed --db in argv"
+grep -q 'argv: audit --db ' "${mut_log}" && fail "mutant still passed --db"
+grep -q '^argv: audit' "${mut_log}" || fail "mutant never reached cargo-audit"
 assert_sentinel_intact "${SCRATCH}/mut-nodb/home/.cargo/advisory-db"
-ok "mutation: removing --db from runner is detectable"
+ok "mutation: --db strip fails [runner-db] + behavioural stub"
 
 mut_deny="${SCRATCH}/mut-deny.toml"
 sed 's|db-path = "\$CARGO_HOME/advisory-dbs"|db-path = "~/.cargo/advisory-db"|' "${DENY_TOML}" >"${mut_deny}"
-mut_deny_path="$(awk '
-  /^\[advisories\]/ { in_adv=1; next }
-  in_adv && /^\[/ { exit }
-  in_adv && /^db-path[[:space:]]*=/ {
-    sub(/^db-path[[:space:]]*=[[:space:]]*/, "")
-    gsub(/^"/, ""); gsub(/"$/, "")
-    print; exit
-  }
-' "${mut_deny}")"
-[[ "${mut_deny_path}" == '~/.cargo/advisory-db' ]] \
-  || fail "deny.toml singular mutation did not apply; got '${mut_deny_path}'"
-ok "mutation: deny.toml shared singular db-path is detectable"
+expect_contract_red deny-db-path "${mut_deny}" "${WORKFLOW}" "${PRECOMMIT}"
+ok "mutation: singular deny fails [deny-db-path]"
 
 mut_wf="${SCRATCH}/mut-ci.yml"
-deps_security_job "${WORKFLOW}" >"${mut_wf}"
-python3 - "${mut_wf}" <<'PY'
+cp "${WORKFLOW}" "${mut_wf}"
+python3 -c '
 from pathlib import Path
 import sys
-path = Path(sys.argv[1])
-text = path.read_text()
-needle = "bash scripts/ci/cargo-audit-with-isolated-db.sh"
-if needle not in text:
-    raise SystemExit("could not find runner invocation to mutate")
-path.write_text(text.replace(needle, "rm -rf ~/.cargo/advisory-db\n          cargo-audit audit", 1))
-PY
-grep -v '^[[:space:]]*#' "${mut_wf}" | grep -qE 'rm[[:space:]]+-rf[[:space:]]+.*advisory-db' \
-  || fail "workflow rm -rf mutation did not apply"
-ok "mutation: restoring rm -rf ~/.cargo/advisory-db is detectable"
+p = Path(sys.argv[1]); t = p.read_text(); n = "bash scripts/ci/cargo-audit-with-isolated-db.sh"
+assert n in t, "runner invocation missing"
+p.write_text(t.replace(n, "rm -rf ~/.cargo/advisory-db\n          cargo-audit audit", 1))
+' "${mut_wf}"
+expect_contract_red workflow-rm "${DENY_TOML}" "${mut_wf}" "${PRECOMMIT}"
+ok "mutation: rm -rf fails [workflow-rm]"
 
 mut_pc="${SCRATCH}/mut-pre-commit.yaml"
 sed "s|entry: bash ${RUNNER_REL}|entry: bash -lc 'cargo-audit audit'|" "${PRECOMMIT}" >"${mut_pc}"
-grep -qE "entry:[[:space:]]*bash -lc 'cargo-audit audit'" "${mut_pc}" \
-  || fail "pre-commit bare-audit mutation did not apply"
-ok "mutation: pre-commit bare cargo-audit bypass is detectable"
-
-# Hostile cargo-audit layout control for deny separation (config/static, no network).
-case "${deny_db_path}" in
-  '~/.cargo/advisory-db'|*/advisory-db)
-    fail "deny.toml collides with cargo-audit default singular root (${deny_db_path})"
-    ;;
-  '$CARGO_HOME/advisory-dbs') ;;
-  *) fail "deny.toml db-path unexpected: ${deny_db_path}" ;;
-esac
-ok "hostile layout control: deny plural root separated from cargo-audit singular"
-
+expect_contract_red precommit-entry "${DENY_TOML}" "${WORKFLOW}" "${mut_pc}"
+ok "mutation: bare pre-commit audit fails [precommit-entry]"
 echo "ALL cargo-audit isolated-db self-tests passed"

--- a/scripts/ci/test-cargo-audit-with-isolated-db.sh
+++ b/scripts/ci/test-cargo-audit-with-isolated-db.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci/cargo-audit-with-isolated-db.sh (CI-4F / #2188).
+#
+# cargo-deny nests under ~/.cargo/advisory-db; cargo-audit refuses that non-empty
+# root. CI used `rm -rf` globally; the local hook did not. This gate proves one
+# runner isolates --db, preserves a planted hostile deny layout, and is the only
+# active audit path in CI + pre-commit.
+#
+# shellcheck disable=SC2016,SC2088 # intentional literal YAML/toml/shell spellings under test
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="${ROOT}/scripts/ci/cargo-audit-with-isolated-db.sh"
+DENY_TOML="${ROOT}/deny.toml"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+PRECOMMIT="${ROOT}/.pre-commit-config.yaml"
+RUNNER_REL='scripts/ci/cargo-audit-with-isolated-db.sh'
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "ok   $*"; }
+abort_is_failure() {
+  local rc="$1"
+  [[ "${rc}" -eq 0 ]] || echo "cargo-audit isolated-db self-test aborted (exit ${rc}); treat as failure" >&2
+}
+trap 'abort_is_failure "$?"' ERR
+
+# macOS /bin/bash 3.2: refuse bash-4.4 @Q in active code.
+if awk '
+  /^[[:space:]]*#/ { next }
+  /\$\{[^}]+@Q\}/ { found=1; print NR ":" $0 }
+  END { exit found ? 0 : 1 }
+' "${BASH_SOURCE[0]}"; then
+  fail "self-test uses bash-4.4 @Q quoting; macOS bash 3.2 aborts with bad substitution"
+fi
+
+[[ -f "${RUNNER}" ]] || fail "missing runner ${RUNNER_REL}"
+[[ -f "${DENY_TOML}" && -f "${WORKFLOW}" && -f "${PRECOMMIT}" ]] || fail "missing wiring files"
+
+grep -q 'BASH_SOURCE\[0\]' "${RUNNER}" \
+  || fail "runner is not source-safe (missing BASH_SOURCE execute guard)"
+grep -qE '^assay_cargo_audit_db_path[[:space:]]*\(\)' "${RUNNER}" \
+  || fail "runner must define assay_cargo_audit_db_path()"
+grep -qE '^run_cargo_audit_with_isolated_db[[:space:]]*\(\)' "${RUNNER}" \
+  || fail "runner must define run_cargo_audit_with_isolated_db()"
+grep -qF 'exec cargo-audit audit --db' "${RUNNER}" \
+  || fail "runner must exec cargo-audit audit --db \"\$db\""
+
+# shellcheck source=scripts/ci/cargo-audit-with-isolated-db.sh
+source "${RUNNER}"
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+make_stub_cargo_audit() {
+  local bin_dir="$1" exit_code="$2"
+  mkdir -p "${bin_dir}"
+  cat >"${bin_dir}/cargo-audit" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'argv:' >>"\${STUB_LOG}"
+for arg in "\$@"; do printf ' %s' "\$arg" >>"\${STUB_LOG}"; done
+printf '\n' >>"\${STUB_LOG}"
+printf 'cwd=%s\n' "\$(pwd -P)" >>"\${STUB_LOG}"
+exit ${exit_code}
+STUB
+  chmod +x "${bin_dir}/cargo-audit"
+}
+
+plant_hostile_deny_layout() {
+  local singular_root="$1"
+  mkdir -p "${singular_root}/advisory-db-deadbeefcafe"
+  printf 'deny-owned-sentinel\n' >"${singular_root}/advisory-db-deadbeefcafe/SENTINEL"
+  printf 'lock\n' >"${singular_root}/db.lock"
+}
+
+assert_sentinel_intact() {
+  local singular_root="$1"
+  [[ -f "${singular_root}/advisory-db-deadbeefcafe/SENTINEL" ]] \
+    || fail "hostile deny layout sentinel was deleted (global cleanup must not run)"
+  [[ "$(cat "${singular_root}/advisory-db-deadbeefcafe/SENTINEL")" == "deny-owned-sentinel" ]] \
+    || fail "hostile deny layout sentinel contents changed"
+  [[ -f "${singular_root}/db.lock" ]] || fail "hostile deny db.lock was deleted"
+}
+
+parse_db_arg() {
+  awk '/^argv: audit --db / { for (i = 1; i <= NF; i++) if ($i == "--db") { print $(i+1); exit } }' "$1"
+}
+
+run_runner_case() {
+  local name="$1" expect_exit="$2"
+  shift 2
+  local case_dir="${SCRATCH}/${name}"
+  local home="${case_dir}/home" cargo_home="${case_dir}/cargo-home" bin="${case_dir}/bin"
+  local log="${case_dir}/stub.log" singular="${home}/.cargo/advisory-db"
+  mkdir -p "${home}" "${cargo_home}" "${bin}" "${case_dir}/tmp"
+  : >"${log}"
+  plant_hostile_deny_layout "${singular}"
+  make_stub_cargo_audit "${bin}" "${expect_exit}"
+  local rc=0
+  env -i \
+    PATH="${bin}:/usr/bin:/bin" HOME="${home}" CARGO_HOME="${cargo_home}" \
+    STUB_LOG="${log}" TMPDIR="${case_dir}/tmp" "$@" \
+    bash "${RUNNER}" --quiet --file "${case_dir}/lock" \
+    >"${case_dir}/out.txt" 2>&1 || rc=$?
+  [[ "${rc}" -eq "${expect_exit}" ]] \
+    || fail "${name}: expected exit ${expect_exit}, got ${rc}; out:
+$(cat "${case_dir}/out.txt")
+log:
+$(cat "${log}")"
+  assert_sentinel_intact "${singular}"
+  printf '%s\n' "${log}"
+}
+
+log="$(run_runner_case default_isolated 0)"
+grep -q 'argv: audit --db ' "${log}" || fail "default run must reach cargo-audit with audit --db; log:
+$(cat "${log}")"
+db_arg="$(parse_db_arg "${log}")"
+[[ -n "${db_arg}" ]] || fail "could not parse --db from stub log"
+[[ "${db_arg}" != *'/.cargo/advisory-db' ]] \
+  || fail "default --db must not be the shared singular root; got ${db_arg}"
+case "${db_arg}" in
+  */assay/*|"${SCRATCH}"/*) ;;
+  *) fail "default --db must be assay-owned under CARGO_HOME or temp; got ${db_arg}" ;;
+esac
+[[ -d "$(dirname "${db_arg}")" ]] || fail "runner must mkdir parent of --db"
+grep -qF -- '--quiet --file ' "${log}" || fail "runner must pass through caller args; log:
+$(cat "${log}")"
+ok "default isolated --db reaches audit; hostile singular root preserved"
+
+override_db="${SCRATCH}/override-db/custom-advisory-db"
+log="$(run_runner_case override_env 0 ASSAY_CARGO_AUDIT_DB="${override_db}")"
+grep -qF "argv: audit --db ${override_db}" "${log}" \
+  || fail "ASSAY_CARGO_AUDIT_DB must become --db; log:
+$(cat "${log}")"
+[[ -d "$(dirname "${override_db}")" ]] || fail "override path parent must be created"
+ok "ASSAY_CARGO_AUDIT_DB override respected"
+
+log="$(run_runner_case exit_passthrough 7)"
+ok "cargo-audit exit code passed through (7)"
+
+# Fuzz cwd/--file: runner must not cd away from caller cwd.
+fuzz_cwd="${SCRATCH}/fuzz-cwd"
+mkdir -p "${fuzz_cwd}" "${SCRATCH}/fuzz-home" "${SCRATCH}/fuzz-bin" "${SCRATCH}/fuzz-cargo"
+: >"${SCRATCH}/fuzz.log"
+plant_hostile_deny_layout "${SCRATCH}/fuzz-home/.cargo/advisory-db"
+make_stub_cargo_audit "${SCRATCH}/fuzz-bin" 0
+fuzz_rc=0
+(
+  cd "${fuzz_cwd}"
+  env -i \
+    PATH="${SCRATCH}/fuzz-bin:/usr/bin:/bin" \
+    HOME="${SCRATCH}/fuzz-home" CARGO_HOME="${SCRATCH}/fuzz-cargo" \
+    STUB_LOG="${SCRATCH}/fuzz.log" ASSAY_CARGO_AUDIT_DB="${SCRATCH}/fuzz-db/advisory-db" \
+    bash "${RUNNER}" --file "${ROOT}/fuzz/Cargo.lock"
+) || fuzz_rc=$?
+[[ "${fuzz_rc}" -eq 0 ]] || fail "fuzz-cwd runner failed (exit ${fuzz_rc})"
+grep -qF "cwd=$(cd "${fuzz_cwd}" && pwd -P)" "${SCRATCH}/fuzz.log" \
+  || fail "runner must preserve caller cwd; log:
+$(cat "${SCRATCH}/fuzz.log")"
+grep -qF -- "--file ${ROOT}/fuzz/Cargo.lock" "${SCRATCH}/fuzz.log" \
+  || fail "fuzz --file arg must pass through; log:
+$(cat "${SCRATCH}/fuzz.log")"
+assert_sentinel_intact "${SCRATCH}/fuzz-home/.cargo/advisory-db"
+ok "fuzz cwd/--file semantics preserved"
+
+deps_security_job() {
+  awk '
+    /^  deps-security:[[:space:]]*$/ { in_job=1; print; next }
+    in_job && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    in_job { print }
+  ' "$1"
+}
+
+job="$(deps_security_job "${WORKFLOW}")"
+[[ -n "${job}" ]] || fail "could not find deps-security job"
+active_job="$(printf '%s\n' "${job}" | grep -v '^[[:space:]]*#' || true)"
+if printf '%s\n' "${active_job}" | grep -qE 'rm[[:space:]]+-rf[[:space:]]+.*advisory-db'; then
+  fail "deps-security still has active rm -rf …advisory-db"
+fi
+root_hits="$(printf '%s\n' "${active_job}" | grep -cF "${RUNNER_REL}" || true)"
+[[ "${root_hits}" -ge 2 ]] \
+  || fail "deps-security must invoke ${RUNNER_REL} for both audits; active hits=${root_hits}"
+if printf '%s\n' "${active_job}" | grep -E '^[[:space:]]*cargo-audit[[:space:]]+audit([[:space:]]|$)'; then
+  fail "deps-security still has a bare cargo-audit audit line"
+fi
+printf '%s\n' "${active_job}" | grep -qF 'cd "${RUNNER_TEMP}"' \
+  || fail "fuzz audit must still cd to RUNNER_TEMP"
+printf '%s\n' "${active_job}" | grep -qF -- '--file "${GITHUB_WORKSPACE}/fuzz/Cargo.lock"' \
+  || fail "fuzz audit must still pass --file for fuzz/Cargo.lock"
+
+hook_entry="$(awk '
+  /^[[:space:]]*- id: cargo-audit[[:space:]]*$/ { in_hook=1; next }
+  in_hook && /^[[:space:]]*- id:/ { exit }
+  in_hook && /^[[:space:]]*entry:/ { print; exit }
+' "${PRECOMMIT}")"
+[[ "${hook_entry}" == *"${RUNNER_REL}"* ]] \
+  || fail "pre-commit cargo-audit entry must use ${RUNNER_REL}; got:
+${hook_entry:-<missing>}"
+if grep -qE "entry:[[:space:]]*bash -lc 'cargo-audit audit'" "${PRECOMMIT}"; then
+  fail "pre-commit still has bare bash -lc 'cargo-audit audit'"
+fi
+ok "CI + pre-commit share the isolated runner; no global rm"
+
+deny_db_path="$(awk '
+  /^\[advisories\]/ { in_adv=1; next }
+  in_adv && /^\[/ { exit }
+  in_adv && /^db-path[[:space:]]*=/ {
+    sub(/^db-path[[:space:]]*=[[:space:]]*/, "")
+    gsub(/^"/, ""); gsub(/"$/, "")
+    print; exit
+  }
+' "${DENY_TOML}")"
+[[ "${deny_db_path}" == '$CARGO_HOME/advisory-dbs' ]] \
+  || fail "deny.toml db-path must be \$CARGO_HOME/advisory-dbs (plural); got '${deny_db_path:-<missing>}'"
+ok "deny.toml uses plural \$CARGO_HOME/advisory-dbs"
+
+if awk '
+  /^\[advisories\]/ { in_adv=1; next }
+  in_adv && /^\[/ { in_adv=0 }
+  in_adv && /RUSTSEC-2023-0071/ { found=1 }
+  END { exit found ? 0 : 1 }
+' "${DENY_TOML}" "${ROOT}/.cargo/audit.toml"; then
+  fail "RUSTSEC-2023-0071 reintroduced in deny.toml or .cargo/audit.toml"
+fi
+ok "RUSTSEC-2023-0071 ignore remains absent"
+
+# --- Mutations that must bite ---
+
+mut_runner="${SCRATCH}/mut-runner-no-db.sh"
+sed 's/exec cargo-audit audit --db "${db}"/exec cargo-audit audit/' "${RUNNER}" >"${mut_runner}"
+grep -qF 'exec cargo-audit audit --db' "${mut_runner}" && fail "mutant still contains --db"
+mut_bin="${SCRATCH}/mut-nodb/bin"
+mut_log="${SCRATCH}/mut-nodb/stub.log"
+mkdir -p "${SCRATCH}/mut-nodb/home" "${SCRATCH}/mut-nodb/cargo-home" "${mut_bin}"
+: >"${mut_log}"
+plant_hostile_deny_layout "${SCRATCH}/mut-nodb/home/.cargo/advisory-db"
+make_stub_cargo_audit "${mut_bin}" 0
+env -i PATH="${mut_bin}:/usr/bin:/bin" HOME="${SCRATCH}/mut-nodb/home" \
+  CARGO_HOME="${SCRATCH}/mut-nodb/cargo-home" STUB_LOG="${mut_log}" \
+  bash "${mut_runner}" >"${SCRATCH}/mut-nodb/out.txt" 2>&1 || true
+grep -q 'argv: audit --db ' "${mut_log}" \
+  && fail "mutation removing --db still showed --db in argv"
+assert_sentinel_intact "${SCRATCH}/mut-nodb/home/.cargo/advisory-db"
+ok "mutation: removing --db from runner is detectable"
+
+mut_deny="${SCRATCH}/mut-deny.toml"
+sed 's|db-path = "\$CARGO_HOME/advisory-dbs"|db-path = "~/.cargo/advisory-db"|' "${DENY_TOML}" >"${mut_deny}"
+mut_deny_path="$(awk '
+  /^\[advisories\]/ { in_adv=1; next }
+  in_adv && /^\[/ { exit }
+  in_adv && /^db-path[[:space:]]*=/ {
+    sub(/^db-path[[:space:]]*=[[:space:]]*/, "")
+    gsub(/^"/, ""); gsub(/"$/, "")
+    print; exit
+  }
+' "${mut_deny}")"
+[[ "${mut_deny_path}" == '~/.cargo/advisory-db' ]] \
+  || fail "deny.toml singular mutation did not apply; got '${mut_deny_path}'"
+ok "mutation: deny.toml shared singular db-path is detectable"
+
+mut_wf="${SCRATCH}/mut-ci.yml"
+deps_security_job "${WORKFLOW}" >"${mut_wf}"
+python3 - "${mut_wf}" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+needle = "bash scripts/ci/cargo-audit-with-isolated-db.sh"
+if needle not in text:
+    raise SystemExit("could not find runner invocation to mutate")
+path.write_text(text.replace(needle, "rm -rf ~/.cargo/advisory-db\n          cargo-audit audit", 1))
+PY
+grep -v '^[[:space:]]*#' "${mut_wf}" | grep -qE 'rm[[:space:]]+-rf[[:space:]]+.*advisory-db' \
+  || fail "workflow rm -rf mutation did not apply"
+ok "mutation: restoring rm -rf ~/.cargo/advisory-db is detectable"
+
+mut_pc="${SCRATCH}/mut-pre-commit.yaml"
+sed "s|entry: bash ${RUNNER_REL}|entry: bash -lc 'cargo-audit audit'|" "${PRECOMMIT}" >"${mut_pc}"
+grep -qE "entry:[[:space:]]*bash -lc 'cargo-audit audit'" "${mut_pc}" \
+  || fail "pre-commit bare-audit mutation did not apply"
+ok "mutation: pre-commit bare cargo-audit bypass is detectable"
+
+# Hostile cargo-audit layout control for deny separation (config/static, no network).
+case "${deny_db_path}" in
+  '~/.cargo/advisory-db'|*/advisory-db)
+    fail "deny.toml collides with cargo-audit default singular root (${deny_db_path})"
+    ;;
+  '$CARGO_HOME/advisory-dbs') ;;
+  *) fail "deny.toml db-path unexpected: ${deny_db_path}" ;;
+esac
+ok "hostile layout control: deny plural root separated from cargo-audit singular"
+
+echo "ALL cargo-audit isolated-db self-tests passed"


### PR DESCRIPTION
## Summary
- Closes the cargo-deny / cargo-audit advisory-cache collision from #2188 (CI-4F): restore `deny.toml` to `$CARGO_HOME/advisory-dbs` (plural) and route every cargo-audit call through one source-safe runner with an isolated `--db`.
- Same runner for the local pre-push hook and both CI audits (root + fuzz); removes `rm -rf ~/.cargo/advisory-db`.
- Merged `origin/main` at `7276ac92` (#2325 concurrency.queue removal) with a clean merge commit; actionlint is green on this head.

## Exact SHAs
- **Base:** `7276ac92fa1080822b8c5836c03b2d13afd2759a`
- **Head:** `47a5aea5da934da37d48b41c4cc5bb7b1daab3e9`

## RED → GREEN
- **RED:** self-test failed with `missing runner scripts/ci/cargo-audit-with-isolated-db.sh` before the runner existed.
- **GREEN:** `bash` + `/bin/bash` 3.2 `scripts/ci/test-cargo-audit-with-isolated-db.sh`, `shellcheck -x`, focused pre-commit hook, `git diff --check`, rsa-advisory-removed contract, and `actionlint` all exit 0 on this head (after #2325 merge).

## Hostile-cache mutations
Self-test plants a cargo-deny nested layout under the old singular root and proves the sentinel survives (no global delete). Mutants go RED through one live wiring contract / shared runner assertion:
- strip `--db` → `[runner-db]` (+ behavioural stub reaches audit without `--db`)
- restore `deny.toml` singular `~/.cargo/advisory-db` → `[deny-db-path]`
- restore `rm -rf ~/.cargo/advisory-db` in CI → `[workflow-rm]`
- bare pre-commit `cargo-audit audit` → `[precommit-entry]`

## Real isolated cargo-audit proof
Runner chooses `ASSAY_CARGO_AUDIT_DB` if set, else `$CARGO_HOME/assay/cargo-audit/advisory-db` (temp fallback), `mkdir`s the parent, then `exec cargo-audit audit --db "$db" "$@"`. Stubbed self-test proves audit-exec is reached with isolated `--db`, override respected, args/exit passed through, and fuzz cwd/`--file` semantics preserved. Pre-push hooks on push also ran the new isolated-db path (cargo-audit hook skipped only because `Cargo.lock` was not in the push file set; the focused self-test hook passed).

## Non-claims
- No dependency bump.
- No advisory suppression / ignore reintroduction (RUSTSEC-2023-0071 remains absent; CI-4C parity held).
- Existing allowed/yanked warning posture elsewhere is unchanged by this slice.
- Does not claim a clean dependency tree beyond what cargo-deny/cargo-audit already enforce.

## Review quorum
Fresh exact-head quorum review is still required after push. Any prior Codex READY was independent of GitHub and must be posted/bound on GitHub for head `47a5aea5da934da37d48b41c4cc5bb7b1daab3e9`.

## Test plan
- [x] `bash` + `/bin/bash scripts/ci/test-cargo-audit-with-isolated-db.sh`
- [x] `shellcheck -x` on the runner + self-test
- [x] `pre-commit run cargo-audit-isolated-db-self-test --all-files`
- [x] `actionlint .github/workflows/ci.yml`
- [x] `python3 scripts/ci/check_rsa_advisory_removed.py`
- [x] `git diff --check`
- [ ] GitHub Actions deps-security job on this PR head

Closes #2188

Made with [Cursor](https://cursor.com)