### PR TITLE
fix(ci): use Cargo subcommand argv for plugin version assertions

### DIFF
--- a/scripts/ci/cargo-plugin-versions.sh
+++ b/scripts/ci/cargo-plugin-versions.sh
@@ -31,6 +31,10 @@ cargo_plugin_bin_path() {
 # Bind the assertion to Cargo's install location. Resolving through PATH lets an unrelated
 # binary earlier on PATH satisfy the pin while the install wrote nothing (#2226).
 #
+# cargo-hack is a Cargo subcommand and requires its subcommand token even when its installed
+# binary is invoked directly: `cargo-hack hack --version`. Other pinned plugins measured here
+# accept `<installed-binary> --version`.
+#
 # cargo-nextest alone prints a multi-line banner. Measured shape of line 1:
 #   cargo-nextest <semver> (<hex> <YYYY-MM-DD>)
 # Only that tool may take the first line and strip that documented suffix. Other plugins
@@ -45,7 +49,11 @@ assert_cargo_plugin_version() {
     echo "the pin lives in scripts/ci/cargo-plugin-versions.sh and is the only place to change it" >&2
     return 1
   fi
-  reported="$("${bin}" --version)"
+  if [[ "${name}" == "cargo-hack" ]]; then
+    reported="$("${bin}" hack --version)"
+  else
+    reported="$("${bin}" --version)"
+  fi
   if [[ "${name}" == "cargo-nextest" ]]; then
     reported="${reported%%$'\n'*}"
     # Bash 3.2: =~ + BASH_REMATCH. Require hex hash + ISO date inside the parens.

--- a/scripts/ci/cargo-plugin-versions.sh
+++ b/scripts/ci/cargo-plugin-versions.sh
@@ -31,9 +31,10 @@ cargo_plugin_bin_path() {
 # Bind the assertion to Cargo's install location. Resolving through PATH lets an unrelated
 # binary earlier on PATH satisfy the pin while the install wrote nothing (#2226).
 #
-# cargo-hack is a Cargo subcommand and requires its subcommand token even when its installed
-# binary is invoked directly: `cargo-hack hack --version`. Other pinned plugins measured here
-# accept `<installed-binary> --version`.
+# cargo-hack and cargo-mutants require their Cargo subcommand token even when the installed
+# binary is invoked directly: `cargo-hack hack --version` and
+# `cargo-mutants mutants --version`. Other pinned plugins measured here accept
+# `<installed-binary> --version`.
 #
 # cargo-nextest alone prints a multi-line banner. Measured shape of line 1:
 #   cargo-nextest <semver> (<hex> <YYYY-MM-DD>)
@@ -49,11 +50,11 @@ assert_cargo_plugin_version() {
     echo "the pin lives in scripts/ci/cargo-plugin-versions.sh and is the only place to change it" >&2
     return 1
   fi
-  if [[ "${name}" == "cargo-hack" ]]; then
-    reported="$("${bin}" hack --version)"
-  else
-    reported="$("${bin}" --version)"
-  fi
+  case "${name}" in
+    cargo-hack) reported="$("${bin}" hack --version)" ;;
+    cargo-mutants) reported="$("${bin}" mutants --version)" ;;
+    *) reported="$("${bin}" --version)" ;;
+  esac
   if [[ "${name}" == "cargo-nextest" ]]; then
     reported="${reported%%$'\n'*}"
     # Bash 3.2: =~ + BASH_REMATCH. Require hex hash + ISO date inside the parens.

--- a/scripts/ci/test-optional-plugin-versions-contract.sh
+++ b/scripts/ci/test-optional-plugin-versions-contract.sh
@@ -352,6 +352,25 @@ PATH="${decoy_dir}/early:${PATH}" CARGO_HOME="${decoy_dir}/cargo-home" \
 expect_in_file "${decoy_out}" "cargo-mutants missing at install location" \
   "path decoy names the missing install-root binary"
 
+echo "== cargo-mutants receives its Cargo subcommand argv =="
+mutants_argv_dir="${SCRATCH}/mutants_argv"
+mkdir -p "${mutants_argv_dir}/bin"
+cat >"${mutants_argv_dir}/bin/cargo-mutants" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" != "mutants" || "\${2:-}" != "--version" || "\${#}" -ne 2 ]]; then
+  echo "expected cargo-mutants argv: mutants --version; got: \$*" >&2
+  exit 64
+fi
+echo "cargo-mutants ${MUTANTS_PIN}"
+STUB
+chmod +x "${mutants_argv_dir}/bin/cargo-mutants"
+mutants_argv_out="${mutants_argv_dir}/out"
+mutants_argv_exit=0
+CARGO_HOME="${mutants_argv_dir}" \
+  assert_cargo_plugin_version cargo-mutants "${MUTANTS_PIN}" >"${mutants_argv_out}" 2>&1 || mutants_argv_exit=$?
+[[ "${mutants_argv_exit}" -eq 0 ]] \
+  || fail "cargo-mutants version assertion did not use Cargo subcommand argv (exit ${mutants_argv_exit}): $(cat "${mutants_argv_out}")"
+
 echo "== wrong installed mutants version fails =="
 wrong_dir="${SCRATCH}/assert_wrong"
 mkdir -p "${wrong_dir}/bin"

--- a/scripts/ci/test-split-wave-plugin-versions-contract.sh
+++ b/scripts/ci/test-split-wave-plugin-versions-contract.sh
@@ -441,6 +441,25 @@ CARGO_HOME="${audit_dir}" \
   assert_cargo_plugin_version cargo-audit "${AUDIT_PIN}" >"${audit_out}" 2>&1 || audit_exit=$?
 [[ "${audit_exit}" -ne 0 ]] || fail "cargo-audit parenthetical suffix was accepted (global strip weakens CI-4D1)"
 
+echo "== cargo-hack receives its Cargo subcommand argv =="
+hack_argv_dir="${SCRATCH}/hack_argv"
+mkdir -p "${hack_argv_dir}/bin"
+cat >"${hack_argv_dir}/bin/cargo-hack" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" != "hack" || "\${2:-}" != "--version" || "\${#}" -ne 2 ]]; then
+  echo "expected cargo-hack argv: hack --version; got: \$*" >&2
+  exit 64
+fi
+echo "cargo-hack ${HACK_PIN}"
+STUB
+chmod +x "${hack_argv_dir}/bin/cargo-hack"
+hack_argv_out="${hack_argv_dir}/out"
+hack_argv_exit=0
+CARGO_HOME="${hack_argv_dir}" \
+  assert_cargo_plugin_version cargo-hack "${HACK_PIN}" >"${hack_argv_out}" 2>&1 || hack_argv_exit=$?
+[[ "${hack_argv_exit}" -eq 0 ]] \
+  || fail "cargo-hack version assertion did not use Cargo subcommand argv (exit ${hack_argv_exit}): $(cat "${hack_argv_out}")"
+
 echo "== cargo-hack parenthetical suffix must stay RED (no global strip) =="
 hack_paren_dir="${SCRATCH}/hack_paren"
 mkdir -p "${hack_paren_dir}/bin"


### PR DESCRIPTION
## Summary

- invoke installed Cargo-subcommand binaries with their required argv: `cargo-hack hack --version` and `cargo-mutants mutants --version`;
- keep the dispatch in the single shared `assert_cargo_plugin_version` helper;
- add behavioral stubs that reject the old direct `--version` argv for both tools.

Closes #2330.

## Root cause and timeline

PR #2320 merged `c6e5dc1b5dc562cefe330caade689dc1f449f642` at 11:17 local time and extended a generic direct-binary version assertion to cargo-hack. The last Wave 0 success before that merge was #2325's 11:10 run. The first branch incorporating the merge failed at 11:24, and a rerun failed identically:

```text
error: expected subcommand 'hack', found argument '--version'
```

The install completed; the version assertion failed. Earlier same-day green runs did not contain the merged helper and therefore were not counter-evidence.

## RED → GREEN

- **RED:** new real-argv stub received `--version`, exited 64, and the contract failed with `got: --version`.
- **GREEN:** the shared helper dispatches cargo-hack as `"${bin}" hack --version`; both current Bash and macOS `/bin/bash` suites pass.

## Verification

Exact head: `951421fd76099895bd4469a3ba438ff5e50a75b6`  
Base: `644ab57879164d8efdeb8dffb1c4856bf4370075`

- `bash scripts/ci/test-split-wave-plugin-versions-contract.sh`
- `/bin/bash scripts/ci/test-split-wave-plugin-versions-contract.sh`
- `pre-commit run split-wave-plugin-versions-contract-self-test --all-files`
- `pre-commit run cargo-plugin-versions-contract-self-test --all-files`
- `pre-commit run optional-plugin-versions-contract-self-test --all-files`
- `shellcheck scripts/ci/cargo-plugin-versions.sh scripts/ci/test-split-wave-plugin-versions-contract.sh`
- `git diff --check`

All pass. Commit-time hooks also pass.

## Non-claims

- No plugin versions or install commands change.
- No workflow trigger, required context, timeout, advisory policy, or Cargo feature matrix changes.
- Direct `--version` behavior was measured for cargo-audit, cargo-nextest, and cargo-semver-checks; cargo-hack is log/source proven and cargo-mutants is exact-pinned-source proven. cargo-public-api remains on the direct path; this PR does not claim a runtime measurement for its output shape.
- Builder self-review does not count for quorum.
