### PR TITLE
fix(ci): avoid reserved runner name collision

### DIFF
--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -31,7 +31,7 @@ jobs:
           # for queue visibility.
           RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_HEALTH_TOKEN || github.token }}
           QUEUE_TOKEN: ${{ github.token }}
-          RUNNER_NAME: assay-bpf-runner
+          ASSAY_RUNNER_NAME: assay-bpf-runner
           REQUIRED_RUNNER_LABEL: assay-bpf-runner
         run: |
           bash scripts/ci/check-runner-health.sh

--- a/scripts/ci/check-runner-health.sh
+++ b/scripts/ci/check-runner-health.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 repo="${GITHUB_REPOSITORY:-${REPO:-}}"
-runner_name="${RUNNER_NAME:-assay-bpf-runner}"
+runner_name="${ASSAY_RUNNER_NAME:-assay-bpf-runner}"
 required_runner_label="${REQUIRED_RUNNER_LABEL:-assay-bpf-runner}"
 runner_status_token="${RUNNER_STATUS_TOKEN:-${GH_TOKEN:-}}"
 queue_token="${QUEUE_TOKEN:-${GH_TOKEN:-}}"

--- a/scripts/ci/test-check-runner-health.sh
+++ b/scripts/ci/test-check-runner-health.sh
@@ -114,7 +114,8 @@ run_check() {
     GITHUB_REPOSITORY="Rul1an/assay" \
     RUNNER_STATUS_TOKEN="runner-token" \
     QUEUE_TOKEN="queue-token" \
-    RUNNER_NAME="assay-bpf-runner" \
+    RUNNER_NAME="GitHub Actions 1000234011" \
+    ASSAY_RUNNER_NAME="assay-bpf-runner" \
     REQUIRED_RUNNER_LABEL="assay-bpf-runner" \
     GITHUB_OUTPUT="${out_file}" \
     GITHUB_STEP_SUMMARY="${summary_file}" \
@@ -360,6 +361,11 @@ grep -q 'RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_HEALTH_TOKEN || github.token }}
 # shellcheck disable=SC2016
 grep -q 'QUEUE_TOKEN: ${{ github.token }}' "${WORKFLOW}" \
   || fail "workflow must keep QUEUE_TOKEN separation"
+grep -q 'ASSAY_RUNNER_NAME: assay-bpf-runner' "${WORKFLOW}" \
+  || fail "workflow must use a namespaced runner-name variable"
+if grep -qE '^[[:space:]]+RUNNER_NAME:' "${WORKFLOW}"; then
+  fail "workflow must not override GitHub Actions reserved RUNNER_NAME"
+fi
 ok "token separation preserved"
 
 if grep -q "steps.check.outcome == 'failure'" "${WORKFLOW}"; then


### PR DESCRIPTION
## Summary
- use `ASSAY_RUNNER_NAME` instead of GitHub Actions' reserved `RUNNER_NAME`
- reproduce the hosted-runner collision in the contract test
- preserve runner state classification, token separation, and alert routing

## Root cause
GitHub-hosted jobs inject `RUNNER_NAME=GitHub Actions <id>`. The workflow attempted to overwrite that reserved default variable, but the checker still received the hosted runner name and searched for it in the repository self-hosted runner list. The API response correctly contained `assay-bpf-runner`; selection returned empty.

Measured on temporary diagnostic run 31596715177:

```text
runner_total=1 runner_names=assay-bpf-runner
requested_name=GitHub Actions 1000234011 selected_bytes=0
```

## TDD
RED on the pre-fix implementation:

```text
online -> available: exit 1, wanted 0
runner_state=unavailable reason=runner_not_found
workflow must use a namespaced runner-name variable
```

GREEN:

```text
bash scripts/ci/test-check-runner-health.sh
bash scripts/ci/test-check-runner-health-mutations.sh
shellcheck scripts/ci/check-runner-health.sh scripts/ci/test-check-runner-health.sh scripts/ci/test-check-runner-health-mutations.sh
pre-commit run --files .github/workflows/runner-health.yml scripts/ci/check-runner-health.sh scripts/ci/test-check-runner-health.sh
```

All pass.

## Scope
No runner registration, token policy, schedule, state semantics, or alert semantics change. This only removes the collision with a GitHub Actions default environment variable.

Closes #2332 after a successful live Runner Health sample on this head.