### PR TITLE
ci: evidence-based job timeouts (CI-5B / #2244)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
   scope:
     name: Detect CI scope
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -157,6 +158,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.lightweight_only != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     env:
@@ -242,6 +244,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.lightweight_only != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -281,6 +284,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.lightweight_only != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -329,6 +333,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.lightweight_only != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -364,6 +369,7 @@ jobs:
   distribution-boundary:
     name: Distribution boundary check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -385,6 +391,7 @@ jobs:
     # or target a workspace crate with `publish = true`.
     name: Publish-shape guardrail (assay-cli)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -409,6 +416,7 @@ jobs:
     # before tag, not after.
     name: Public crate policy
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -422,6 +430,7 @@ jobs:
   vendored-packs:
     name: Vendored Pack Sync
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -434,6 +443,7 @@ jobs:
   release-asset-contract:
     name: Release asset contract (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     permissions:
       contents: read
     strategy:
@@ -458,6 +468,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.mcp_registry_touched == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -476,6 +487,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.lightweight_only != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -541,6 +553,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.lightweight_only != 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:
@@ -948,6 +961,7 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: always()
     needs: [scope, deps-security, clippy, rustdoc, public-msrv, distribution-boundary, publish-shape-cli, public-crate-policy, vendored-packs, release-asset-contract, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -280,6 +280,15 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/test-ci-gate-expectations\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
 
+      - id: ci-job-timeouts-contract-self-test
+        name: CI job timeout-minutes contract
+        entry: bash scripts/ci/test-ci-job-timeouts-contract.sh --self-test
+        language: system
+        pass_filenames: false
+        # Pins every ci.yml job's timeout class (#2244 / CI-5B). Missing ceilings inherit GitHub's
+        # 360-minute default; this hook rejects that, wrong classes, and eBPF drift.
+        files: ^(scripts/ci/test-ci-job-timeouts-contract\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
+
       - id: ci-gate-coverage
         name: Required CI gate waits on every gating job
         entry: bash -c 'python3 scripts/ci/check-ci-gate-coverage.py --self-test && python3 scripts/ci/check-ci-gate-coverage.py'

--- a/scripts/ci/test-ci-job-timeouts-contract.sh
+++ b/scripts/ci/test-ci-job-timeouts-contract.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Contract for evidence-based timeout-minutes on every job in .github/workflows/ci.yml (CI-5B / #2244).
+#
+# Fourteen jobs inherited GitHub's 360-minute default. This gate pins the complete 16-job set and
+# the per-job timeout class so a missing ceiling, a wrong class, or a restored 360 cannot stay green.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${1:-${ROOT}/.github/workflows/ci.yml}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+validate() {
+  local wf="$1"
+  [[ -f "${wf}" ]] || fail "missing workflow ${wf}"
+
+  ruby -ryaml - "${wf}" <<'RUBY'
+path = ARGV.fetch(0)
+doc = YAML.safe_load_file(path, aliases: false)
+abort "ci.yml must be a mapping" unless doc.is_a?(Hash)
+
+jobs = doc.fetch("jobs")
+abort "ci.yml jobs must be a mapping" unless jobs.is_a?(Hash)
+
+# Authoritative CI-5B mapping (#2244 clarification): short=10, hosted heavy=20,
+# eBPF smoke preserved at 15/60.
+expected = {
+  "scope" => 10,
+  "clippy" => 10,
+  "rustdoc" => 10,
+  "public-msrv" => 10,
+  "distribution-boundary" => 10,
+  "publish-shape-cli" => 10,
+  "public-crate-policy" => 10,
+  "vendored-packs" => 10,
+  "release-asset-contract" => 10,
+  "mcp-registry-foundation" => 10,
+  "ci" => 10,
+  "deps-security" => 20,
+  "perf" => 20,
+  "test" => 20,
+  "ebpf-smoke-ubuntu" => 15,
+  "ebpf-smoke-self-hosted" => 60,
+}.freeze
+
+actual_ids = jobs.keys.map(&:to_s).sort
+expected_ids = expected.keys.sort
+unless actual_ids == expected_ids
+  missing = expected_ids - actual_ids
+  extra = actual_ids - expected_ids
+  abort(
+    "ci.yml job set drifted from the pinned 16-job contract; " \
+    "missing=#{missing.inspect} extra=#{extra.inspect}"
+  )
+end
+
+expected.each do |job_id, want|
+  job = jobs.fetch(job_id)
+  abort "#{job_id}: job body must be a mapping" unless job.is_a?(Hash)
+  unless job.key?("timeout-minutes")
+    abort "#{job_id}: missing timeout-minutes (would inherit GitHub's 360-minute default)"
+  end
+  got = job["timeout-minutes"]
+  unless got.is_a?(Integer) && got.positive?
+    abort "#{job_id}: timeout-minutes must be a positive integer literal, got #{got.inspect}"
+  end
+  if got == 360
+    abort "#{job_id}: timeout-minutes must not be the 360-minute GitHub fallback"
+  end
+  unless got == want
+    abort "#{job_id}: timeout-minutes class mismatch: expected #{want}, got #{got}"
+  end
+end
+
+rollup = jobs.fetch("ci")
+expected_needs = %w[
+  scope
+  deps-security
+  clippy
+  rustdoc
+  public-msrv
+  distribution-boundary
+  publish-shape-cli
+  public-crate-policy
+  vendored-packs
+  release-asset-contract
+  mcp-registry-foundation
+  perf
+  test
+  ebpf-smoke-ubuntu
+]
+got_needs = Array(rollup["needs"]).map(&:to_s)
+unless got_needs == expected_needs
+  abort "CI rollup needs drifted; expected #{expected_needs.inspect}, got #{got_needs.inspect}"
+end
+unless rollup["if"] == "always()"
+  abort "CI rollup must stay fail-closed with if: always(); got #{rollup['if'].inspect}"
+end
+
+puts "ci-job-timeouts contract=passed (16 jobs; rollup bounded at 10m)"
+RUBY
+}
+
+self_test() {
+  validate "$WORKFLOW" >/dev/null
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+
+  run_mutation() {
+    local name="$1"
+    local ruby_mutation="$2"
+    local mutated="${tmp}/${name}.yml"
+    cp "$WORKFLOW" "$mutated"
+    ruby -ryaml - "$mutated" "$ruby_mutation" <<'RUBY'
+path, mutation = ARGV
+doc = YAML.safe_load_file(path, aliases: false)
+jobs = doc.fetch("jobs")
+case mutation
+when "missing-timeout"
+  jobs.fetch("scope").delete("timeout-minutes")
+when "wrong-class-short-as-heavy"
+  jobs.fetch("scope")["timeout-minutes"] = 20
+when "wrong-class-heavy-as-short"
+  jobs.fetch("test")["timeout-minutes"] = 10
+when "fallback-360"
+  jobs.fetch("ci")["timeout-minutes"] = 360
+when "ebpf-ubuntu-changed"
+  jobs.fetch("ebpf-smoke-ubuntu")["timeout-minutes"] = 30
+when "ebpf-self-hosted-changed"
+  jobs.fetch("ebpf-smoke-self-hosted")["timeout-minutes"] = 90
+when "unpinned-new-job"
+  jobs["rogue-unpinned"] = {
+    "name" => "Rogue",
+    "runs-on" => "ubuntu-latest",
+    "timeout-minutes" => 10,
+    "steps" => [{"run" => "true"}],
+  }
+else
+  abort "unknown mutation #{mutation}"
+end
+File.write(path, YAML.dump(doc))
+RUBY
+    if validate "$mutated" >/dev/null 2>&1; then
+      echo "mutation did not bite: $name" >&2
+      exit 1
+    fi
+    echo "ok    $name"
+  }
+
+  run_mutation missing-timeout missing-timeout
+  run_mutation wrong-class-short-as-heavy wrong-class-short-as-heavy
+  run_mutation wrong-class-heavy-as-short wrong-class-heavy-as-short
+  run_mutation fallback-360 fallback-360
+  run_mutation ebpf-ubuntu-changed ebpf-ubuntu-changed
+  run_mutation ebpf-self-hosted-changed ebpf-self-hosted-changed
+  run_mutation unpinned-new-job unpinned-new-job
+  echo "ci-job-timeouts contract self-test=passed"
+}
+
+if [[ "${2:-}" == "--self-test" || "${1:-}" == "--self-test" ]]; then
+  [[ "${1:-}" == "--self-test" ]] && WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+  self_test
+else
+  validate "$WORKFLOW"
+fi


### PR DESCRIPTION
## Summary
- Pins every job in `.github/workflows/ci.yml` to an evidence-based `timeout-minutes` class so hung jobs no longer inherit GitHub's 360-minute default (#2244 / CI-5B).
- Adds a biting behavioral contract for the complete 16-job set, with mutations for missing/wrong-class/360/eBPF drift/unpinned jobs, wired into pre-commit.

## Base / head
- Base: `origin/main` `ca7e39545f0a967b593eea8cd65c816dc9ab8691`
- Head: `35dd356ae750d73fc6fd2101a841c1455ceb6278`
- Branch: `cursor/ci5b-evidence-timeouts`
- Worktree: `/Users/roelschuurkes/wt-ci5b-evidence-timeouts`

## Timeout classes (authoritative)
- **10** (short): `scope`, `clippy`, `rustdoc`, `public-msrv`, `distribution-boundary`, `publish-shape-cli`, `public-crate-policy`, `vendored-packs`, `release-asset-contract`, `mcp-registry-foundation`, `ci`
- **20** (hosted heavy): `deps-security`, `perf`, `test`
- **preserve**: `ebpf-smoke-ubuntu=15`, `ebpf-smoke-self-hosted=60`

Rationale: clippy/rustdoc/public-msrv measured maxima 103s/62s/81s (≥5.8× headroom at 10).

## RED evidence (before YAML change)
```
$ bash scripts/ci/test-ci-job-timeouts-contract.sh
EXIT=1
scope: missing timeout-minutes (would inherit GitHub's 360-minute default)
```

## Mutations covered
- missing timeout
- wrong class (short→20, heavy→10)
- 360-minute fallback
- changed eBPF ubuntu/self-hosted values
- unpinned/new job

## Verification (worktree)
- Contract GREEN + `--self-test` mutations GREEN
- `actionlint .github/workflows/ci.yml`
- `shellcheck -x -S warning scripts/ci/test-ci-job-timeouts-contract.sh`
- `bash scripts/ci/test-ci-gate-expectations.sh`
- `bash scripts/ci/test-setup-rust-composite-contract.sh`
- `bash scripts/ci/test-deps-security-toolchain-contract.sh`
- `python3 scripts/ci/check-ci-gate-coverage.py`
- `pre-commit run --files` on the three touched paths
- `git diff --check`
- Pre-push hooks (including clippy / linux compile gate) passed on push

## Non-claims
- No workflow redesign; rollup `needs` and fail-closed `if: always()` untouched.
- Not marking ready for review; not merging; not enabling auto-merge.
- Not CI-5C, CI-4F, cargo-hack, runner-health, or SARIF / PR #2327 scope.
- No full workspace build.

Tracks #2244. Awaiting independent non-building review on final head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * CI jobs now have defined execution time limits, helping prevent stalled checks.
  * Security, performance, and test jobs receive extended limits where needed.

* **Quality Assurance**
  * Added automated validation to ensure CI timeout settings remain complete and accurate.
  * Added pre-commit checks to detect invalid or missing timeout configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->