### PR TITLE
feat(monitor): mode-aware declared probe inventory (#187)

### DIFF
--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -488,6 +488,7 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     // like `absent` (not requested), so write the artifact BEFORE the fail-closed exit.
                     // Distinguish enforcement refusal from an infrastructure failure to retain the
                     // requested carrier.
+                    monitor.record_egress_failed("cgroup v2 root unavailable");
                     return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
                 }
             };
@@ -495,6 +496,15 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                 emit_err!(
                     "FATAL: egress enforcement requested but connect4 attach failed: {} (fail-closed, not running audit-only)",
                     e
+                );
+                return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
+            }
+            // Fail-closed: a requested connect4 row must be terminal (Attached/Unavailable/Failed/
+            // kernel-Unsupported), never left NotRequested and never reported as a clean run.
+            if let Err(reason) = monitor.finalize_mode_aware(true) {
+                emit_err!(
+                    "FATAL: egress enforcement requested but mode-aware probe inventory is incomplete: {} (fail-closed)",
+                    reason
                 );
                 return Ok(failed_enforcement_exit(&args, exit_codes::EXIT_WOULD_BLOCK));
             }

--- a/crates/assay-cli/src/cli/commands/monitor_next/observation_health.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/observation_health.rs
@@ -26,32 +26,16 @@
 //! coverage rather than overstating it — so this is a correctness improvement in the safe direction,
 //! not a loosening.
 
-use assay_monitor::probes::ProbeAttachment;
+use assay_monitor::probes::{ProbeAttachment, ProbeOutcome, EGRESS_PEER_PROBE};
 use assay_runner_schema::{
     CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
     NetworkProtocolCoverageStatus, ObservationHealth, PolicyLayerStatus, SdkLayerStatus,
 };
 use std::path::Path;
 
-/// The tracepoint that used to decide the coverage claim, kept only for the tests that pin why it
-/// no longer does.
-///
-/// `#[cfg(test)]` because this commit is what stopped production code reading it: deriving coverage
-/// from `sys_enter_connect` while the peers came from the hook below is the defect being fixed. The
-/// constant stays because the tests need to name the wrong probe to show it is not consulted, and
-/// the doc on `EGRESS_PEER_PROBE` refers to it by name.
+/// Tracepoint that must not earn peer coverage (tests only).
 #[cfg(test)]
 const CONNECT_PROBE: &str = "sys_enter_connect";
-
-/// The cgroup hook that supplies the peer set, which is NOT the probe above.
-///
-/// `sys_enter_connect` is a tracepoint that fires on every connect attempt and is always attached;
-/// `cgroup_sock_addr:connect4` only attaches when a policy is loaded, and is the only source whose
-/// address comes from the kernel's own `bpf_sock_addr`. Deriving the coverage claim from the
-/// tracepoint while the peers come from the hook is what let a run report `connect_only` coverage
-/// with a structurally empty peer set — a combination a consumer reads as "watched and saw nothing",
-/// which is precisely the false refutation the coverage denominator exists to prevent.
-const EGRESS_PEER_PROBE: &str = "cgroup_sock_addr:connect4";
 
 /// A deterministic run id over what the run observed, matching the sandbox convention
 /// (`sandbox_<digest-prefix>`): the same observation produces the same id, and nothing is invented
@@ -90,14 +74,13 @@ pub(crate) fn build(
     ringbuf_drops: u64,
     policy_declared: bool,
 ) -> ObservationHealth {
-    // Keyed on the probe that actually supplies peers, not on the one that merely sees connects.
-    let network_protocol_coverage = if attachment.attached_probes().contains(&EGRESS_PEER_PROBE) {
-        // Connect-time peers only. The monitor attaches no sendto/sendmsg probe, so a datagram peer
-        // set is not observable and must not be claimed.
-        NetworkProtocolCoverageStatus::ConnectOnly
-    } else {
-        NetworkProtocolCoverageStatus::Absent
-    };
+    // Inventory outcome for the cgroup peer-source (not the connect tracepoint, not event counts).
+    let network_protocol_coverage =
+        if attachment.outcome(EGRESS_PEER_PROBE) == Some(ProbeOutcome::Attached) {
+            NetworkProtocolCoverageStatus::ConnectOnly
+        } else {
+            NetworkProtocolCoverageStatus::Absent
+        };
 
     let mut health = ObservationHealth::new(run_id, "linux")
         .with_policy_layer(if policy_declared {

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -200,15 +200,6 @@ impl Monitor {
     ///
     /// On non-Linux targets nothing attaches, so every expected probe is reported as a blind spot
     /// rather than the record being absent: "no observation" is a fact, not a missing field.
-    /// The no-attachment baseline, so the non-Linux branch of `probe_attachment` is exercised by
-    /// tests that can actually run on a developer machine.
-    #[cfg(test)]
-    pub(crate) fn probe_attachment_for_tests() -> probes::ProbeAttachment {
-        let mut attachment = probes::ProbeAttachment::default();
-        attachment.reconcile(probes::EXPECTED_PROBES);
-        attachment
-    }
-
     #[must_use]
     pub fn probe_attachment(&self) -> probes::ProbeAttachment {
         #[cfg(target_os = "linux")]
@@ -280,6 +271,29 @@ impl Monitor {
         {
             let _ = cgroup_file;
             Err(MonitorError::NotSupported)
+        }
+    }
+
+    /// connect4 `Failed` when policy requested but attach never ran (e.g. cgroup root missing).
+    pub fn record_egress_failed(&mut self, reason: &'static str) {
+        #[cfg(target_os = "linux")]
+        self.inner.record_egress_failed(reason);
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = reason;
+        }
+    }
+
+    pub fn finalize_mode_aware(&self, network_policy_requested: bool) -> Result<(), &'static str> {
+        #[cfg(target_os = "linux")]
+        return self
+            .inner
+            .probe_attachment()
+            .finalize_mode_aware(network_policy_requested);
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = network_policy_requested;
+            Ok(())
         }
     }
 

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -501,14 +501,13 @@ impl LinuxMonitor {
                 return Err(e.into());
             }
         };
-        let link = csa.take_link(link_id).map_err(|e| {
+        let link = csa.take_link(link_id).inspect_err(|_| {
             self.probe_attachment.record_mode(
                 EGRESS_PEER_PROBE,
                 connect4_update(Connect4Fault::AttachFailed {
                     kernel_lacks_point: false,
                 }),
             );
-            e
         })?;
         self.probe_attachment.attached(EGRESS_PEER_PROBE);
         self.links.push(MonitorLink::CgroupSockAddr(link));

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -1,6 +1,8 @@
 use crate::config_flags::{apply_dedup_open_paths, apply_emit_observed_connect, FlagConfigSink};
 use crate::events::{self, EventStream};
-use crate::probes::{ProbeAttachment, EXPECTED_PROBES};
+use crate::probes::{
+    connect4_update, Connect4Fault, ModeUpdate, ProbeAttachment, EGRESS_PEER_PROBE, EXPECTED_PROBES,
+};
 use crate::{MonitorError, MonitorStatsSnapshot};
 use assay_common::{
     CidrRuleValue, KEY_EMIT_INODE_RESOLVED, KEY_MONITOR_ALL, MONITOR_STAT_CONNECT_EVENTS_EMITTED,
@@ -18,13 +20,21 @@ use assay_policy::tiers::CompiledPolicy;
 use aya::maps::lpm_trie::Key;
 use aya::{
     maps::{Array as AyaArray, HashMap as AyaHashMap, LpmTrie, RingBuf},
-    programs::{CgroupAttachMode, CgroupSockAddr, Lsm, TracePoint},
+    programs::{CgroupAttachMode, CgroupSockAddr, Lsm, ProgramError, TracePoint},
     Btf, Ebpf,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
+
+fn attach_kernel_lacks_point(err: &ProgramError) -> bool {
+    // ENOENT=2, EOPNOTSUPP=95 on Linux.
+    match err {
+        ProgramError::SyscallError(sy) => matches!(sy.io_error.raw_os_error(), Some(2 | 95)),
+        _ => false,
+    }
+}
 
 #[cfg(target_os = "linux")]
 /// One-shot, actionable warning emitted on the first event-size mismatch of a run. Further
@@ -448,26 +458,67 @@ impl LinuxMonitor {
         cgroup_file: &std::fs::File,
     ) -> Result<(), MonitorError> {
         let mut bpf = self.bpf.lock().unwrap();
-        // Fail-closed: a missing program or a load/attach failure is a hard error, never a silent
-        // degrade. The caller (monitor) must refuse to run enforcement it could not actually install.
-        let prog = bpf.program_mut("connect4_hook").ok_or_else(|| {
-            MonitorError::EnforcementUnavailable(
-                "connect4_hook program not present in eBPF object".to_string(),
-            )
-        })?;
-        let csa: &mut CgroupSockAddr = TryInto::<&mut CgroupSockAddr>::try_into(&mut *prog)
-            .map_err(|e| {
-                MonitorError::EnforcementUnavailable(format!(
+        // Fail-closed. Inventory via connect4_update: missing→Unavailable, wrong-kind/load→Failed,
+        // attach ENOENT/EOPNOTSUPP→Unsupported, other attach→Failed.
+        let Some(prog) = bpf.program_mut("connect4_hook") else {
+            self.probe_attachment.record_mode(
+                EGRESS_PEER_PROBE,
+                connect4_update(Connect4Fault::MissingProgram),
+            );
+            return Err(MonitorError::EnforcementUnavailable(
+                "connect4_hook program not present in eBPF object".into(),
+            ));
+        };
+        let csa: &mut CgroupSockAddr = match TryInto::<&mut CgroupSockAddr>::try_into(&mut *prog) {
+            Ok(csa) => csa,
+            Err(e) => {
+                self.probe_attachment.record_mode(
+                    EGRESS_PEER_PROBE,
+                    connect4_update(Connect4Fault::WrongProgramKind),
+                );
+                return Err(MonitorError::EnforcementUnavailable(format!(
                     "connect4_hook is not a CgroupSockAddr program: {e}"
-                ))
-            })?;
-        csa.load()?;
-        let link_id = csa.attach(cgroup_file, CgroupAttachMode::Single)?;
-        let link = csa.take_link(link_id)?;
-        self.probe_attachment.attached("cgroup_sock_addr:connect4");
+                )));
+            }
+        };
+        if let Err(e) = csa.load() {
+            self.probe_attachment.record_mode(
+                EGRESS_PEER_PROBE,
+                connect4_update(Connect4Fault::LoadFailed),
+            );
+            return Err(e.into());
+        }
+        let link_id = match csa.attach(cgroup_file, CgroupAttachMode::Single) {
+            Ok(id) => id,
+            Err(e) => {
+                let lacks = attach_kernel_lacks_point(&e);
+                self.probe_attachment.record_mode(
+                    EGRESS_PEER_PROBE,
+                    connect4_update(Connect4Fault::AttachFailed {
+                        kernel_lacks_point: lacks,
+                    }),
+                );
+                return Err(e.into());
+            }
+        };
+        let link = csa.take_link(link_id).map_err(|e| {
+            self.probe_attachment.record_mode(
+                EGRESS_PEER_PROBE,
+                connect4_update(Connect4Fault::AttachFailed {
+                    kernel_lacks_point: false,
+                }),
+            );
+            e
+        })?;
+        self.probe_attachment.attached(EGRESS_PEER_PROBE);
         self.links.push(MonitorLink::CgroupSockAddr(link));
         println!("DEBUG: Attached cgroup connect4 egress enforcement");
         Ok(())
+    }
+
+    pub(crate) fn record_egress_failed(&mut self, reason: &'static str) {
+        self.probe_attachment
+            .record_mode(EGRESS_PEER_PROBE, ModeUpdate::Failed(reason));
     }
 
     pub fn snapshot_stats(&mut self) -> Result<MonitorStatsSnapshot, MonitorError> {

--- a/crates/assay-monitor/src/probes.rs
+++ b/crates/assay-monitor/src/probes.rs
@@ -1,6 +1,6 @@
 //! Probe attachment + mode-aware inventory (`not_requested`≠`unavailable`≠`failed`≠`unsupported`).
 //! Always probes: [`EXPECTED_PROBES`] + [`ProbeAttachment::reconcile`].
-//! Mode-aware: [`default_status`] / [`apply_mode_update`]; Linux loader seams via [`connect4_update`].
+//! Mode-aware: `default_status` / `apply_mode_update`; Linux loader seams via `connect4_update`.
 
 pub const EXPECTED_PROBES: &[&str] = &[
     "sys_enter_openat",

--- a/crates/assay-monitor/src/probes.rs
+++ b/crates/assay-monitor/src/probes.rs
@@ -1,19 +1,7 @@
-//! What the monitor actually attached, and what it did not.
-//!
-//! Cross-platform on purpose: the record is plain data, and only its emitter (`loader::LinuxMonitor`)
-//! is Linux-gated — the same split `enforcement_health` uses.
-//!
-//! This exists because `MonitorLink` cannot answer the question. It records a program *kind*, and the
-//! handles are held for RAII only, never inspected. Every attach site is guarded by
-//! `if let Some(prog)` / `if let Ok(tp)`, so a program missing from the object, or failing to
-//! convert, was skipped without a trace. That made an unattached probe and a probe that attached and
-//! saw nothing indistinguishable — and a coverage descriptor built on that would report silence as
-//! coverage, which is the one thing such a descriptor exists to prevent.
+//! Probe attachment + mode-aware inventory (`not_requested`≠`unavailable`≠`failed`≠`unsupported`).
+//! Always probes: [`EXPECTED_PROBES`] + [`ProbeAttachment::reconcile`].
+//! Mode-aware: [`default_status`] / [`apply_mode_update`]; Linux loader seams via [`connect4_update`].
 
-/// The probes `LinuxMonitor::attach` tries to install.
-///
-/// Names are eBPF program attach points, so an entry maps back to a source file in `assay-ebpf`
-/// without guessing.
 pub const EXPECTED_PROBES: &[&str] = &[
     "sys_enter_openat",
     "sys_enter_openat2",
@@ -24,17 +12,190 @@ pub const EXPECTED_PROBES: &[&str] = &[
     "lsm:file_open",
 ];
 
-/// Which probes attached this run, and which did not.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub const EGRESS_PEER_PROBE: &str = "cgroup_sock_addr:connect4";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeCondition {
+    RequiresNetworkPolicy,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    Attached,
+    NotRequested,
+    Unavailable,
+    Failed,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProbeStatus {
+    pub outcome: ProbeOutcome,
+    pub reason: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProbeSpec {
+    pub name: &'static str,
+    pub condition: ProbeCondition,
+}
+
+pub(crate) const MODE_AWARE_PROBES: &[ProbeSpec] = &[
+    ProbeSpec {
+        name: EGRESS_PEER_PROBE,
+        condition: ProbeCondition::RequiresNetworkPolicy,
+    },
+    ProbeSpec {
+        name: "cgroup_sock_addr:connect6",
+        condition: ProbeCondition::Unsupported,
+    },
+    ProbeSpec {
+        name: "sys_enter_sendto",
+        condition: ProbeCondition::Unsupported,
+    },
+    ProbeSpec {
+        name: "sys_enter_sendmsg",
+        condition: ProbeCondition::Unsupported,
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModeUpdate {
+    Attached,
+    #[cfg(any(test, target_os = "linux"))]
+    Unavailable(&'static str),
+    #[cfg(any(test, target_os = "linux"))]
+    Failed(&'static str),
+    #[cfg(any(test, target_os = "linux"))]
+    Unsupported(&'static str),
+}
+
+/// connect4 loader seam → [`ModeUpdate`] (Linux classification owner; also tested on macOS).
+#[cfg(any(test, target_os = "linux"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Connect4Fault {
+    MissingProgram,
+    WrongProgramKind,
+    LoadFailed,
+    AttachFailed { kernel_lacks_point: bool },
+}
+
+#[cfg(any(test, target_os = "linux"))]
+pub(crate) fn connect4_update(fault: Connect4Fault) -> ModeUpdate {
+    match fault {
+        Connect4Fault::MissingProgram => {
+            ModeUpdate::Unavailable("connect4_hook missing from object")
+        }
+        Connect4Fault::WrongProgramKind => {
+            ModeUpdate::Failed("connect4_hook is not a CgroupSockAddr program")
+        }
+        Connect4Fault::LoadFailed => ModeUpdate::Failed("connect4_hook load failed"),
+        Connect4Fault::AttachFailed {
+            kernel_lacks_point: true,
+        } => ModeUpdate::Unsupported("kernel lacks cgroup/connect4 attach point"),
+        Connect4Fault::AttachFailed {
+            kernel_lacks_point: false,
+        } => ModeUpdate::Failed("connect4_hook cgroup attach failed"),
+    }
+}
+
+pub(crate) fn default_status(c: ProbeCondition) -> ProbeStatus {
+    match c {
+        ProbeCondition::RequiresNetworkPolicy => ProbeStatus {
+            outcome: ProbeOutcome::NotRequested,
+            reason: "network policy not requested",
+        },
+        ProbeCondition::Unsupported => ProbeStatus {
+            outcome: ProbeOutcome::Unsupported,
+            reason: "compiled; no attach owner",
+        },
+    }
+}
+
+/// Infallible mode-aware transitions. Declared-`Unsupported` rows keep their seed; policy-gated
+/// rows take the update. Unknown probes are not updated (`record_mode` no-ops).
+pub(crate) fn apply_mode_update(
+    condition: ProbeCondition,
+    current: ProbeStatus,
+    update: ModeUpdate,
+) -> ProbeStatus {
+    match condition {
+        ProbeCondition::Unsupported => current,
+        ProbeCondition::RequiresNetworkPolicy => match update {
+            ModeUpdate::Attached => ProbeStatus {
+                outcome: ProbeOutcome::Attached,
+                reason: "attached",
+            },
+            #[cfg(any(test, target_os = "linux"))]
+            ModeUpdate::Unavailable(reason) => ProbeStatus {
+                outcome: ProbeOutcome::Unavailable,
+                reason,
+            },
+            #[cfg(any(test, target_os = "linux"))]
+            ModeUpdate::Failed(reason) => ProbeStatus {
+                outcome: ProbeOutcome::Failed,
+                reason,
+            },
+            #[cfg(any(test, target_os = "linux"))]
+            ModeUpdate::Unsupported(reason) => ProbeStatus {
+                outcome: ProbeOutcome::Unsupported,
+                reason,
+            },
+        },
+    }
+}
+
+fn mode_spec(name: &str) -> Option<&'static ProbeSpec> {
+    MODE_AWARE_PROBES.iter().find(|s| s.name == name)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProbeAttachment {
     attached: Vec<&'static str>,
     skipped: Vec<&'static str>,
+    statuses: Vec<(&'static str, ProbeStatus)>,
+}
+
+impl Default for ProbeAttachment {
+    fn default() -> Self {
+        let mut a = Self {
+            attached: Vec::new(),
+            skipped: Vec::new(),
+            statuses: Vec::new(),
+        };
+        for spec in MODE_AWARE_PROBES {
+            a.set_status(spec.name, default_status(spec.condition));
+        }
+        a
+    }
 }
 
 impl ProbeAttachment {
+    fn set_status(&mut self, probe: &'static str, status: ProbeStatus) {
+        if let Some((_, s)) = self.statuses.iter_mut().find(|(n, _)| *n == probe) {
+            *s = status;
+        } else {
+            self.statuses.push((probe, status));
+        }
+    }
+
+    pub(crate) fn record_mode(&mut self, probe: &'static str, update: ModeUpdate) {
+        let Some(spec) = mode_spec(probe) else {
+            return;
+        };
+        let current = self
+            .status(probe)
+            .unwrap_or_else(|| default_status(spec.condition));
+        self.set_status(probe, apply_mode_update(spec.condition, current, update));
+    }
+
     pub fn attached(&mut self, probe: &'static str) {
         if !self.attached.contains(&probe) {
             self.attached.push(probe);
+        }
+        if mode_spec(probe).is_some() {
+            self.record_mode(probe, ModeUpdate::Attached);
         }
     }
 
@@ -44,12 +205,6 @@ impl ProbeAttachment {
         }
     }
 
-    /// Reconcile against the probe set the loader tries to attach.
-    ///
-    /// Per-site recording alone is not enough, and enumerating the silent paths is fragile: a guard
-    /// that skips leaves no trace at the site. Reconciling makes the record complete by
-    /// construction — anything expected that did not attach is a skip, whatever the reason and
-    /// whether or not that path was instrumented.
     pub fn reconcile(&mut self, expected: &[&'static str]) {
         for probe in expected {
             if !self.attached.contains(probe) {
@@ -58,22 +213,50 @@ impl ProbeAttachment {
         }
     }
 
-    /// Probes that attached. An effect on a surface no entry here covers is not observable by this
-    /// run, whatever the events say.
+    #[cfg(any(test, target_os = "linux"))]
+    pub(crate) fn finalize_mode_aware(
+        &self,
+        network_policy_requested: bool,
+    ) -> Result<(), &'static str> {
+        if !network_policy_requested {
+            return Ok(());
+        }
+        for spec in MODE_AWARE_PROBES
+            .iter()
+            .filter(|s| s.condition == ProbeCondition::RequiresNetworkPolicy)
+        {
+            match self.outcome(spec.name) {
+                Some(
+                    ProbeOutcome::Attached
+                    | ProbeOutcome::Unavailable
+                    | ProbeOutcome::Failed
+                    | ProbeOutcome::Unsupported,
+                ) => {}
+                _ => return Err("required probe requested but has no terminal status"),
+            }
+        }
+        Ok(())
+    }
+
     #[must_use]
     pub fn attached_probes(&self) -> &[&'static str] {
         &self.attached
     }
-
-    /// Probes the loader tried and did not get. A non-empty list is a blind spot this run can name,
-    /// which is strictly better than one it cannot.
     #[must_use]
     pub fn skipped_probes(&self) -> &[&'static str] {
         &self.skipped
     }
-
-    /// Whether every expected probe attached. `false` means at least one surface is unobserved, so
-    /// an absence claim over it is unsupportable regardless of what the event stream shows.
+    #[must_use]
+    pub fn status(&self, probe: &str) -> Option<ProbeStatus> {
+        self.statuses
+            .iter()
+            .find(|(n, _)| *n == probe)
+            .map(|(_, s)| *s)
+    }
+    #[must_use]
+    pub fn outcome(&self, probe: &str) -> Option<ProbeOutcome> {
+        self.status(probe).map(|s| s.outcome)
+    }
     #[must_use]
     pub fn is_complete(&self) -> bool {
         self.skipped.is_empty()
@@ -85,76 +268,111 @@ mod tests {
     use super::*;
 
     #[test]
-    fn a_probe_that_never_attached_is_reported_as_skipped() {
-        let mut attachment = ProbeAttachment::default();
-        attachment.attached("sys_enter_openat");
-        attachment.reconcile(EXPECTED_PROBES);
+    fn is_complete_unchanged_for_always_probes() {
+        let mut a = ProbeAttachment::default();
+        for p in EXPECTED_PROBES {
+            a.attached(p);
+        }
+        a.reconcile(EXPECTED_PROBES);
+        assert!(a.is_complete());
+        let mut b = ProbeAttachment::default();
+        b.attached("sys_enter_openat");
+        b.reconcile(EXPECTED_PROBES);
+        assert!(b.skipped_probes().contains(&"lsm:file_open"));
+        assert!(!b.is_complete());
+    }
 
-        assert_eq!(attachment.attached_probes(), ["sys_enter_openat"]);
-        assert!(!attachment.is_complete());
-        assert!(attachment.skipped_probes().contains(&"lsm:file_open"));
-        assert!(
-            !attachment.skipped_probes().contains(&"sys_enter_openat"),
-            "an attached probe must never appear as skipped"
+    #[test]
+    fn no_policy_default_is_not_requested() {
+        let a = ProbeAttachment::default();
+        assert_eq!(
+            a.outcome(EGRESS_PEER_PROBE),
+            Some(ProbeOutcome::NotRequested)
+        );
+        assert!(a.finalize_mode_aware(false).is_ok());
+    }
+
+    #[test]
+    fn missing_program_seam_is_unavailable() {
+        let mut a = ProbeAttachment::default();
+        a.record_mode(
+            EGRESS_PEER_PROBE,
+            connect4_update(Connect4Fault::MissingProgram),
+        );
+        assert_eq!(
+            a.outcome(EGRESS_PEER_PROBE),
+            Some(ProbeOutcome::Unavailable)
         );
     }
 
     #[test]
-    fn reconciliation_catches_silent_paths_the_sites_never_recorded() {
-        // The defect this guards: a guard skips without recording, so only reconciliation sees it.
-        let mut attachment = ProbeAttachment::default();
-        for probe in EXPECTED_PROBES.iter().filter(|p| **p != "sys_enter_fork") {
-            attachment.attached(probe);
-        }
-        assert!(
-            attachment.skipped_probes().is_empty(),
-            "nothing recorded at the sites"
+    fn wrong_kind_seam_is_failed() {
+        let u = connect4_update(Connect4Fault::WrongProgramKind);
+        assert!(matches!(u, ModeUpdate::Failed(_)));
+        let mut a = ProbeAttachment::default();
+        a.record_mode(EGRESS_PEER_PROBE, u);
+        assert_eq!(a.outcome(EGRESS_PEER_PROBE), Some(ProbeOutcome::Failed));
+    }
+
+    #[test]
+    fn load_or_attach_failure_seam_is_failed() {
+        let mut a = ProbeAttachment::default();
+        a.record_mode(
+            EGRESS_PEER_PROBE,
+            connect4_update(Connect4Fault::LoadFailed),
         );
-
-        attachment.reconcile(EXPECTED_PROBES);
-        assert_eq!(attachment.skipped_probes(), ["sys_enter_fork"]);
+        assert_eq!(a.outcome(EGRESS_PEER_PROBE), Some(ProbeOutcome::Failed));
+        a.record_mode(
+            EGRESS_PEER_PROBE,
+            connect4_update(Connect4Fault::AttachFailed {
+                kernel_lacks_point: false,
+            }),
+        );
+        assert_eq!(a.outcome(EGRESS_PEER_PROBE), Some(ProbeOutcome::Failed));
     }
 
     #[test]
-    fn a_fully_attached_run_is_complete() {
-        let mut attachment = ProbeAttachment::default();
-        for probe in EXPECTED_PROBES {
-            attachment.attached(probe);
-        }
-        attachment.reconcile(EXPECTED_PROBES);
-        assert!(attachment.is_complete());
-        assert!(attachment.skipped_probes().is_empty());
+    fn unsupported_declared_surface_seeds_unsupported() {
+        let a = ProbeAttachment::default();
+        assert_eq!(
+            a.outcome("sys_enter_sendto"),
+            Some(ProbeOutcome::Unsupported)
+        );
+        assert_eq!(
+            a.outcome("cgroup_sock_addr:connect6"),
+            Some(ProbeOutcome::Unsupported)
+        );
+        assert!(matches!(
+            connect4_update(Connect4Fault::AttachFailed {
+                kernel_lacks_point: true
+            }),
+            ModeUpdate::Unsupported(_)
+        ));
     }
 
     #[test]
-    fn recording_is_idempotent() {
-        // attach() records at the site and reconcile() runs afterwards; a probe must not be listed
-        // twice because both ran.
-        let mut attachment = ProbeAttachment::default();
-        attachment.attached("sys_enter_connect");
-        attachment.attached("sys_enter_connect");
-        attachment.skipped("lsm:file_open");
-        attachment.skipped("lsm:file_open");
-        attachment.reconcile(&["lsm:file_open"]);
-
-        assert_eq!(attachment.attached_probes(), ["sys_enter_connect"]);
-        assert_eq!(attachment.skipped_probes(), ["lsm:file_open"]);
+    fn successful_attach_is_attached() {
+        let mut a = ProbeAttachment::default();
+        a.attached(EGRESS_PEER_PROBE);
+        assert_eq!(a.outcome(EGRESS_PEER_PROBE), Some(ProbeOutcome::Attached));
+        assert!(a.finalize_mode_aware(true).is_ok());
     }
 
     #[test]
-    fn the_monitor_wrapper_reports_blind_spots_where_nothing_can_attach() {
-        // On a target with no eBPF the honest answer is "every surface unobserved", not an absent
-        // record. A missing record reads as "not requested"; a full skip list reads as what it is.
-        let attachment = crate::Monitor::probe_attachment_for_tests();
-        assert!(!attachment.is_complete());
-        assert!(attachment.attached_probes().is_empty() || cfg!(target_os = "linux"));
+    fn requested_without_terminal_finalize_errors() {
+        assert_eq!(
+            ProbeAttachment::default().finalize_mode_aware(true),
+            Err("required probe requested but has no terminal status")
+        );
     }
 
     #[test]
-    fn an_empty_run_reports_every_expected_probe_as_a_blind_spot() {
-        let mut attachment = ProbeAttachment::default();
-        attachment.reconcile(EXPECTED_PROBES);
-        assert_eq!(attachment.skipped_probes().len(), EXPECTED_PROBES.len());
-        assert!(!attachment.is_complete());
+    fn unsupported_surface_ignores_attach_update() {
+        let mut a = ProbeAttachment::default();
+        a.record_mode("sys_enter_sendto", ModeUpdate::Attached);
+        assert_eq!(
+            a.outcome("sys_enter_sendto"),
+            Some(ProbeOutcome::Unsupported)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Mode-aware declared probe inventory for private #187 slice (b): policy-gated `connect4` and compiled-unattached send/connect6 surfaces carry distinct outcomes (`not_requested` / `unavailable` / `failed` / `unsupported`) so audit-only runs no longer conflate “not requested” with a skipped always-probe, and `observation_health` derives `ConnectOnly` from inventory outcome.

## Provenance

| Field | Value |
|---|---|
| Base (exact) | `83188452d9f93c7e899adc0c6ec8d800ce6399a2` |
| Head (exact) | `c3b1ebda87ab39735d1e44aca7f05e6d4d867c5c` |
| Branch | `cursor/187-mode-aware-probe-inventory` |
| Worktree | `/Users/roelschuurkes/wt-187-mode-aware-probe-inventory` |
| Diffstat | 5 files, +412 / −137 (**net +275**) |

## RED

**RED provenance unavailable** (slice began from an overbuilt draft that was restored to HEAD before the slim rewrite; no preserved failing log from that first RED run against main).

Behavioral requirements encoded as GREEN tests below (no invented RED output).

## GREEN

```text
cargo fmt --all -- --check                          # pass (pre-commit + ship gate)
cargo test -p assay-monitor --lib probes::          # 9 passed
cargo test -p assay-cli --bin assay observation_health  # 9 passed
cargo clippy -p assay-monitor -p assay-cli --all-targets -- -D warnings  # pass
RUSTDOCFLAGS="-D warnings" cargo doc -p assay-monitor --no-deps  # pass (final head)
git diff --check                                    # clean
cargo check -p assay-monitor --target x86_64-unknown-linux-gnu  # pass (host Darwin)
```

## Schema / API non-changes

- **No** `ObservationHealth` JSON schema change
- **`is_complete()`** semantics unchanged: still `skipped.is_empty()` over always-requested probes (`EXPECTED_PROBES` + `reconcile`)
- Public probe-inventory types are **not** serialized; CLI consumes `outcome()` / `EGRESS_PEER_PROBE` only

## Complexity ledger (net +275 > 180)

| Type / state | Invariant served | Why simpler attached/skipped fails | Rejected alternative | Biting test | Public / schema impact | Simplification / removal path |
|---|---|---|---|---|---|---|
| `ProbeOutcome` (+ `Unavailable`) | `not_requested` ≠ `unavailable` ≠ `failed` ≠ `unsupported` | Flat `skipped` makes audit-only connect4 look like an always-probe blind spot | Collapse to attached/skipped only | `no_policy_default_is_not_requested`, seam tests | Internal + `outcome()` query; no JSON | Keep while connect4 is mode-gated |
| `ProbeStatus { reason }` | Terminal rows are diagnosable | Outcome alone loses fault class at attach seams | Outcome-only enum | missing / wrong-kind / load seams | Internal reasons only | Drop reasons if a later CLI surface owns them |
| `ModeUpdate` + infallible `apply_mode_update` | One transition owner; no discarded `Result` | Open-coded sets drift; fallible+ignored Result is not ownership | Fallible API with `let _ =` | `unsupported_surface_ignores_attach_update` + seam tests | `pub(crate)` | Already simplified to infallible |
| `Connect4Fault` / `connect4_update` | Loader classification owner (missing→Unavailable, wrong-kind→Failed, …) | Ad-hoc Unavailable/Failed in loader | String match in loader only | `wrong_kind_seam_is_failed`, `missing_program_seam_is_unavailable` | `cfg(any(test, linux))` | Stay behind that cfg |
| `finalize_mode_aware` | Requested connect4 must be terminal; no absence-as-clean | By-construction alone regresses silently | Discard Result / omit check | `requested_without_terminal_finalize_errors` + mod.rs FATAL | Monitor API used by monitor CLI | Keep as belt after attach success |

## Non-claims

- No sendto/sendmsg **attachment** or deletion (declared `unsupported` / not requested only)
- No `connect6` attach
- No deterministic `run_id` pairing fix
- No public serialized probe-inventory schema
- No direct M3 CONFIG/ABI consumer proof
- No ObservationHealth schema bump; no `is_complete` meaning change

## Test plan

- [x] `cargo test -p assay-monitor --lib probes::`
- [x] `cargo test -p assay-cli --bin assay observation_health`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-monitor -p assay-cli --all-targets -- -D warnings`
- [x] `git diff --check`
- [ ] Non-building agent review on final head (draft; not requested here)


Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved egress enforcement failure reporting when required system support is unavailable.
  * Added clearer diagnostics for missing, unsupported, failed, or incorrectly configured monitoring probes.
  * Prevented monitoring from continuing when required probe coverage is incomplete.
  * Improved health and coverage reporting by distinguishing attached, unavailable, failed, unsupported, and unrequested probes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->