### PR TITLE
feat(monitor): fail closed on BPF program-set drift

### DIFF
--- a/crates/assay-monitor/src/error.rs
+++ b/crates/assay-monitor/src/error.rs
@@ -42,6 +42,13 @@ pub enum MonitorError {
         guidance: &'static str,
     },
 
+    /// P2: Aya program-name set disagrees with the declared inventory (post-`Ebpf::load`).
+    #[error("monitor program set: {detail}. {guidance}")]
+    ProgramSet {
+        detail: String,
+        guidance: &'static str,
+    },
+
     #[error("invalid event size (got={got}, need={need})")]
     InvalidEvent { got: usize, need: usize },
 

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -8,6 +8,8 @@ pub mod events;
 #[cfg(any(test, target_os = "linux"))]
 mod object_abi;
 pub mod probes;
+#[cfg(any(test, target_os = "linux"))]
+mod program_set;
 pub mod tree;
 
 #[cfg(target_os = "linux")]

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -1,8 +1,9 @@
 use crate::config_flags::{apply_dedup_open_paths, apply_emit_observed_connect, FlagConfigSink};
 use crate::events::{self, EventStream};
-use crate::object_abi::verify_object_abi_marker;
+use crate::object_abi::{verify_object_abi_marker, REBUILD_EBPF_GUIDANCE};
 use crate::probes::{
-    connect4_update, Connect4Fault, ModeUpdate, ProbeAttachment, EGRESS_PEER_PROBE, EXPECTED_PROBES,
+    connect4_update, Connect4Fault, ModeUpdate, ProbeAttachment, ProbeProgram, EGRESS_PEER_PROBE,
+    EXPECTED_PROBES,
 };
 use crate::{MonitorError, MonitorStatsSnapshot};
 use assay_common::{
@@ -28,6 +29,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
+
+fn unknown_probe() -> MonitorError {
+    MonitorError::ProgramSet {
+        detail: "unknown program table row".into(),
+        guidance: REBUILD_EBPF_GUIDANCE,
+    }
+}
 
 fn attach_kernel_lacks_point(err: &ProgramError) -> bool {
     // ENOENT=2, EOPNOTSUPP=95 on Linux.
@@ -97,6 +105,8 @@ impl LinuxMonitor {
         // P1: named CONFIG object-ABI symbol before Aya load (never set_global).
         verify_object_abi_marker(ebpf_data)?;
         let bpf = Ebpf::load(ebpf_data).map_err(|e| MonitorError::LoadError(e.to_string()))?;
+        // P2: exact Aya program-name set before any program load/attach.
+        crate::program_set::compare_program_names(bpf.programs().map(|(name, _)| name))?;
         Ok(Self {
             bpf: Arc::new(Mutex::new(bpf)),
             links: Vec::new(),
@@ -229,85 +239,91 @@ impl LinuxMonitor {
         }
 
         // 1. Tracepoints
-        if let Some(prog) = bpf.program_mut("assay_monitor_openat") {
+        let r = ProbeProgram::by_elf("assay_monitor_openat").ok_or_else(unknown_probe)?;
+        if let Some(prog) = bpf.program_mut(r.elf_name) {
             if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
                 tp.load()?;
-                let link_id = tp.attach("syscalls", "sys_enter_openat")?;
+                let link_id = tp.attach(r.tp().0, r.tp().1)?;
                 let link = tp.take_link(link_id)?;
-                self.probe_attachment.attached("sys_enter_openat");
+                self.probe_attachment.attached(r.surface_name);
                 self.links.push(MonitorLink::TracePoint(link));
                 println!("DEBUG: Attached Tracepoint sys_enter_openat");
             }
         }
-        if let Some(prog) = bpf.program_mut("assay_monitor_openat2") {
+        let r = ProbeProgram::by_elf("assay_monitor_openat2").ok_or_else(unknown_probe)?;
+        if let Some(prog) = bpf.program_mut(r.elf_name) {
             if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
                 tp.load()?;
-                let link_id = tp.attach("syscalls", "sys_enter_openat2")?;
+                let link_id = tp.attach(r.tp().0, r.tp().1)?;
                 let link = tp.take_link(link_id)?;
-                self.probe_attachment.attached("sys_enter_openat2");
+                self.probe_attachment.attached(r.surface_name);
                 self.links.push(MonitorLink::TracePoint(link));
                 println!("DEBUG: Attached Tracepoint sys_enter_openat2");
             }
         }
-        if let Some(prog) = bpf.program_mut("assay_monitor_openat_exit") {
+        let r = ProbeProgram::by_elf("assay_monitor_openat_exit").ok_or_else(unknown_probe)?;
+        if let Some(prog) = bpf.program_mut(r.elf_name) {
             if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
                 tp.load()?;
-                match tp.attach("syscalls", "sys_exit_openat") {
+                match tp.attach(r.tp().0, r.tp().1) {
                     Ok(link_id) => {
                         if let Ok(link) = tp.take_link(link_id) {
-                            self.probe_attachment.attached("sys_exit_openat");
+                            self.probe_attachment.attached(r.surface_name);
                             self.links.push(MonitorLink::TracePoint(link));
                             println!("DEBUG: Attached Tracepoint sys_exit_openat");
                         }
                     }
                     Err(e) => {
-                        self.probe_attachment.skipped("sys_exit_openat");
+                        self.probe_attachment.skipped(r.surface_name);
                         eprintln!("WARN: Failed to attach sys_exit_openat: {}", e);
                     }
                 }
             }
         }
-        if let Some(prog) = bpf.program_mut("assay_monitor_openat2_exit") {
+        let r = ProbeProgram::by_elf("assay_monitor_openat2_exit").ok_or_else(unknown_probe)?;
+        if let Some(prog) = bpf.program_mut(r.elf_name) {
             if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
                 tp.load()?;
-                match tp.attach("syscalls", "sys_exit_openat2") {
+                match tp.attach(r.tp().0, r.tp().1) {
                     Ok(link_id) => {
                         if let Ok(link) = tp.take_link(link_id) {
-                            self.probe_attachment.attached("sys_exit_openat2");
+                            self.probe_attachment.attached(r.surface_name);
                             self.links.push(MonitorLink::TracePoint(link));
                             println!("DEBUG: Attached Tracepoint sys_exit_openat2");
                         }
                     }
                     Err(e) => {
-                        self.probe_attachment.skipped("sys_exit_openat2");
+                        self.probe_attachment.skipped(r.surface_name);
                         eprintln!("WARN: Failed to attach sys_exit_openat2: {}", e);
                     }
                 }
             }
         }
-        if let Some(prog) = bpf.program_mut("assay_monitor_connect") {
+        let r = ProbeProgram::by_elf("assay_monitor_connect").ok_or_else(unknown_probe)?;
+        if let Some(prog) = bpf.program_mut(r.elf_name) {
             if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
                 tp.load()?;
-                let link_id = tp.attach("syscalls", "sys_enter_connect")?;
+                let link_id = tp.attach(r.tp().0, r.tp().1)?;
                 let link = tp.take_link(link_id)?;
-                self.probe_attachment.attached("sys_enter_connect");
+                self.probe_attachment.attached(r.surface_name);
                 self.links.push(MonitorLink::TracePoint(link));
                 println!("DEBUG: Attached Tracepoint sys_enter_connect");
             }
         }
-        if let Some(prog) = bpf.program_mut("assay_monitor_fork") {
+        let r = ProbeProgram::by_elf("assay_monitor_fork").ok_or_else(unknown_probe)?;
+        if let Some(prog) = bpf.program_mut(r.elf_name) {
             if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
                 tp.load()?;
-                match tp.attach("syscalls", "sys_enter_fork") {
+                match tp.attach(r.tp().0, r.tp().1) {
                     Ok(link_id) => {
                         if let Ok(link) = tp.take_link(link_id) {
-                            self.probe_attachment.attached("sys_enter_fork");
+                            self.probe_attachment.attached(r.surface_name);
                             self.links.push(MonitorLink::TracePoint(link));
                             println!("DEBUG: Attached Tracepoint sys_enter_fork");
                         }
                     }
                     Err(e) => {
-                        self.probe_attachment.skipped("sys_enter_fork");
+                        self.probe_attachment.skipped(r.surface_name);
                         eprintln!("WARN: Failed to attach sys_enter_fork: {}", e);
                     }
                 }
@@ -316,13 +332,14 @@ impl LinuxMonitor {
 
         // 2. LSM
         {
-            if let Some(prog) = bpf.program_mut("file_open_lsm") {
+            let r = ProbeProgram::by_elf("file_open_lsm").ok_or_else(unknown_probe)?;
+            if let Some(prog) = bpf.program_mut(r.elf_name) {
                 if let Ok(lsm) = TryInto::<&mut Lsm>::try_into(&mut *prog) {
                     let btf = Btf::from_sys_fs()?;
-                    lsm.load("file_open", &btf)?;
+                    lsm.load(r.lsm(), &btf)?;
                     let link_id = lsm.attach()?;
                     let link = lsm.take_link(link_id)?;
-                    self.probe_attachment.attached("lsm:file_open");
+                    self.probe_attachment.attached(r.surface_name);
                     self.links.push(MonitorLink::Lsm(link));
                     println!("DEBUG: Attached LSM file_open");
                 }
@@ -463,9 +480,10 @@ impl LinuxMonitor {
         let mut bpf = self.bpf.lock().unwrap();
         // Fail-closed. Inventory via connect4_update: missing→Unavailable, wrong-kind/load→Failed,
         // attach ENOENT/EOPNOTSUPP→Unsupported, other attach→Failed.
-        let Some(prog) = bpf.program_mut("connect4_hook") else {
+        let r = ProbeProgram::by_elf("connect4_hook").ok_or_else(unknown_probe)?;
+        let Some(prog) = bpf.program_mut(r.elf_name) else {
             self.probe_attachment.record_mode(
-                EGRESS_PEER_PROBE,
+                r.surface_name,
                 connect4_update(Connect4Fault::MissingProgram),
             );
             return Err(MonitorError::EnforcementUnavailable(
@@ -476,7 +494,7 @@ impl LinuxMonitor {
             Ok(csa) => csa,
             Err(e) => {
                 self.probe_attachment.record_mode(
-                    EGRESS_PEER_PROBE,
+                    r.surface_name,
                     connect4_update(Connect4Fault::WrongProgramKind),
                 );
                 return Err(MonitorError::EnforcementUnavailable(format!(
@@ -485,10 +503,8 @@ impl LinuxMonitor {
             }
         };
         if let Err(e) = csa.load() {
-            self.probe_attachment.record_mode(
-                EGRESS_PEER_PROBE,
-                connect4_update(Connect4Fault::LoadFailed),
-            );
+            self.probe_attachment
+                .record_mode(r.surface_name, connect4_update(Connect4Fault::LoadFailed));
             return Err(e.into());
         }
         let link_id = match csa.attach(cgroup_file, CgroupAttachMode::Single) {
@@ -496,7 +512,7 @@ impl LinuxMonitor {
             Err(e) => {
                 let lacks = attach_kernel_lacks_point(&e);
                 self.probe_attachment.record_mode(
-                    EGRESS_PEER_PROBE,
+                    r.surface_name,
                     connect4_update(Connect4Fault::AttachFailed {
                         kernel_lacks_point: lacks,
                     }),
@@ -506,13 +522,13 @@ impl LinuxMonitor {
         };
         let link = csa.take_link(link_id).inspect_err(|_| {
             self.probe_attachment.record_mode(
-                EGRESS_PEER_PROBE,
+                r.surface_name,
                 connect4_update(Connect4Fault::AttachFailed {
                     kernel_lacks_point: false,
                 }),
             );
         })?;
-        self.probe_attachment.attached(EGRESS_PEER_PROBE);
+        self.probe_attachment.attached(r.surface_name);
         self.links.push(MonitorLink::CgroupSockAddr(link));
         println!("DEBUG: Attached cgroup connect4 egress enforcement");
         Ok(())

--- a/crates/assay-monitor/src/probes.rs
+++ b/crates/assay-monitor/src/probes.rs
@@ -1,18 +1,82 @@
 //! Probe attachment + mode-aware inventory (`not_requested`≠`unavailable`≠`failed`≠`unsupported`).
-//! Always probes: [`EXPECTED_PROBES`] + [`ProbeAttachment::reconcile`].
-//! Mode-aware: `default_status` / `apply_mode_update`; Linux loader seams via `connect4_update`.
+//! [`PROBE_PROGRAMS`] owns ELF names, surfaces, class, and attach spec; [`EXPECTED_PROBES`] is derived.
 
-pub const EXPECTED_PROBES: &[&str] = &[
-    "sys_enter_openat",
-    "sys_enter_openat2",
-    "sys_exit_openat",
-    "sys_exit_openat2",
-    "sys_enter_connect",
-    "sys_enter_fork",
-    "lsm:file_open",
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeClass {
+    Always,
+    Mode(ProbeCondition),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttachSpec {
+    Tp(&'static str, &'static str),
+    Lsm(&'static str),
+    Cgroup4,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProbeProgram {
+    pub elf_name: &'static str,
+    pub surface_name: &'static str,
+    pub class: ProbeClass,
+    pub attach: AttachSpec,
+}
+
+#[rustfmt::skip]
+pub(crate) const PROBE_PROGRAMS: &[ProbeProgram] = &[
+    ProbeProgram { elf_name: "assay_monitor_openat", surface_name: "sys_enter_openat", class: ProbeClass::Always, attach: AttachSpec::Tp("syscalls", "sys_enter_openat") },
+    ProbeProgram { elf_name: "assay_monitor_openat2", surface_name: "sys_enter_openat2", class: ProbeClass::Always, attach: AttachSpec::Tp("syscalls", "sys_enter_openat2") },
+    ProbeProgram { elf_name: "assay_monitor_openat_exit", surface_name: "sys_exit_openat", class: ProbeClass::Always, attach: AttachSpec::Tp("syscalls", "sys_exit_openat") },
+    ProbeProgram { elf_name: "assay_monitor_openat2_exit", surface_name: "sys_exit_openat2", class: ProbeClass::Always, attach: AttachSpec::Tp("syscalls", "sys_exit_openat2") },
+    ProbeProgram { elf_name: "assay_monitor_connect", surface_name: "sys_enter_connect", class: ProbeClass::Always, attach: AttachSpec::Tp("syscalls", "sys_enter_connect") },
+    ProbeProgram { elf_name: "assay_monitor_sendto", surface_name: "sys_enter_sendto", class: ProbeClass::Mode(ProbeCondition::Unsupported), attach: AttachSpec::None },
+    ProbeProgram { elf_name: "assay_monitor_sendmsg", surface_name: "sys_enter_sendmsg", class: ProbeClass::Mode(ProbeCondition::Unsupported), attach: AttachSpec::None },
+    ProbeProgram { elf_name: "assay_monitor_fork", surface_name: "sys_enter_fork", class: ProbeClass::Always, attach: AttachSpec::Tp("syscalls", "sys_enter_fork") },
+    ProbeProgram { elf_name: "file_open_lsm", surface_name: "lsm:file_open", class: ProbeClass::Always, attach: AttachSpec::Lsm("file_open") },
+    ProbeProgram { elf_name: "connect4_hook", surface_name: "cgroup_sock_addr:connect4", class: ProbeClass::Mode(ProbeCondition::RequiresNetworkPolicy), attach: AttachSpec::Cgroup4 },
+    ProbeProgram { elf_name: "connect6_hook", surface_name: "cgroup_sock_addr:connect6", class: ProbeClass::Mode(ProbeCondition::Unsupported), attach: AttachSpec::None },
 ];
 
+#[rustfmt::skip]
+const ALWAYS_N: usize = {
+    let mut n = 0; let mut i = 0;
+    while i < PROBE_PROGRAMS.len() {
+        if matches!(PROBE_PROGRAMS[i].class, ProbeClass::Always) { n += 1; }
+        i += 1;
+    }
+    n
+};
+
+#[rustfmt::skip]
+const fn always_surfaces() -> [&'static str; ALWAYS_N] {
+    let mut out = [""; ALWAYS_N]; let mut i = 0; let mut j = 0;
+    while i < PROBE_PROGRAMS.len() {
+        if matches!(PROBE_PROGRAMS[i].class, ProbeClass::Always) {
+            out[j] = PROBE_PROGRAMS[i].surface_name; j += 1;
+        }
+        i += 1;
+    }
+    out
+}
+
+pub const EXPECTED_PROBES: &[&str] = &always_surfaces();
+
 pub const EGRESS_PEER_PROBE: &str = "cgroup_sock_addr:connect4";
+
+#[cfg(any(test, target_os = "linux"))]
+#[rustfmt::skip]
+impl ProbeProgram {
+    pub(crate) fn by_elf(elf: &str) -> Option<&'static Self> {
+        PROBE_PROGRAMS.iter().find(|p| p.elf_name == elf)
+    }
+    pub(crate) fn tp(&self) -> (&'static str, &'static str) {
+        match self.attach { AttachSpec::Tp(c, n) => (c, n), _ => panic!("{}", self.elf_name) }
+    }
+    pub(crate) fn lsm(&self) -> &'static str {
+        match self.attach { AttachSpec::Lsm(h) => h, _ => panic!("{}", self.elf_name) }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProbeCondition {
@@ -34,31 +98,6 @@ pub struct ProbeStatus {
     pub outcome: ProbeOutcome,
     pub reason: &'static str,
 }
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ProbeSpec {
-    pub name: &'static str,
-    pub condition: ProbeCondition,
-}
-
-pub(crate) const MODE_AWARE_PROBES: &[ProbeSpec] = &[
-    ProbeSpec {
-        name: EGRESS_PEER_PROBE,
-        condition: ProbeCondition::RequiresNetworkPolicy,
-    },
-    ProbeSpec {
-        name: "cgroup_sock_addr:connect6",
-        condition: ProbeCondition::Unsupported,
-    },
-    ProbeSpec {
-        name: "sys_enter_sendto",
-        condition: ProbeCondition::Unsupported,
-    },
-    ProbeSpec {
-        name: "sys_enter_sendmsg",
-        condition: ProbeCondition::Unsupported,
-    },
-];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ModeUpdate {
@@ -146,8 +185,10 @@ pub(crate) fn apply_mode_update(
     }
 }
 
-fn mode_spec(name: &str) -> Option<&'static ProbeSpec> {
-    MODE_AWARE_PROBES.iter().find(|s| s.name == name)
+fn mode_row(name: &str) -> Option<&'static ProbeProgram> {
+    PROBE_PROGRAMS
+        .iter()
+        .find(|p| p.surface_name == name && matches!(p.class, ProbeClass::Mode(_)))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,8 +205,10 @@ impl Default for ProbeAttachment {
             skipped: Vec::new(),
             statuses: Vec::new(),
         };
-        for spec in MODE_AWARE_PROBES {
-            a.set_status(spec.name, default_status(spec.condition));
+        for p in PROBE_PROGRAMS {
+            if let ProbeClass::Mode(c) = p.class {
+                a.set_status(p.surface_name, default_status(c));
+            }
         }
         a
     }
@@ -181,20 +224,23 @@ impl ProbeAttachment {
     }
 
     pub(crate) fn record_mode(&mut self, probe: &'static str, update: ModeUpdate) {
-        let Some(spec) = mode_spec(probe) else {
+        let Some(row) = mode_row(probe) else {
+            return;
+        };
+        let ProbeClass::Mode(condition) = row.class else {
             return;
         };
         let current = self
             .status(probe)
-            .unwrap_or_else(|| default_status(spec.condition));
-        self.set_status(probe, apply_mode_update(spec.condition, current, update));
+            .unwrap_or_else(|| default_status(condition));
+        self.set_status(probe, apply_mode_update(condition, current, update));
     }
 
     pub fn attached(&mut self, probe: &'static str) {
         if !self.attached.contains(&probe) {
             self.attached.push(probe);
         }
-        if mode_spec(probe).is_some() {
+        if mode_row(probe).is_some() {
             self.record_mode(probe, ModeUpdate::Attached);
         }
     }
@@ -221,11 +267,13 @@ impl ProbeAttachment {
         if !network_policy_requested {
             return Ok(());
         }
-        for spec in MODE_AWARE_PROBES
-            .iter()
-            .filter(|s| s.condition == ProbeCondition::RequiresNetworkPolicy)
-        {
-            match self.outcome(spec.name) {
+        for p in PROBE_PROGRAMS.iter().filter(|p| {
+            matches!(
+                p.class,
+                ProbeClass::Mode(ProbeCondition::RequiresNetworkPolicy)
+            )
+        }) {
+            match self.outcome(p.surface_name) {
                 Some(
                     ProbeOutcome::Attached
                     | ProbeOutcome::Unavailable
@@ -374,5 +422,32 @@ mod tests {
             a.outcome("sys_enter_sendto"),
             Some(ProbeOutcome::Unsupported)
         );
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn program_table_is_the_inventory_owner() {
+        assert_eq!(PROBE_PROGRAMS.len(), 11);
+        assert_eq!(ALWAYS_N, 7);
+        let always: Vec<_> = PROBE_PROGRAMS.iter().filter(|p| matches!(p.class, ProbeClass::Always)).map(|p| p.surface_name).collect();
+        assert_eq!(EXPECTED_PROBES, always.as_slice());
+        assert_eq!(EGRESS_PEER_PROBE, PROBE_PROGRAMS.iter().find(|p| p.elf_name == "connect4_hook").unwrap().surface_name);
+        assert_eq!(PROBE_PROGRAMS.iter().map(|p| p.elf_name).collect::<Vec<_>>(), [
+            "assay_monitor_openat", "assay_monitor_openat2", "assay_monitor_openat_exit",
+            "assay_monitor_openat2_exit", "assay_monitor_connect", "assay_monitor_sendto",
+            "assay_monitor_sendmsg", "assay_monitor_fork", "file_open_lsm", "connect4_hook",
+            "connect6_hook",
+        ]);
+        for p in PROBE_PROGRAMS {
+            match (p.elf_name, p.class, p.attach) {
+                ("assay_monitor_sendto" | "assay_monitor_sendmsg" | "connect6_hook", ProbeClass::Mode(ProbeCondition::Unsupported), AttachSpec::None) => {
+                    assert!(!EXPECTED_PROBES.contains(&p.surface_name));
+                }
+                ("file_open_lsm", ProbeClass::Always, AttachSpec::Lsm("file_open")) => {}
+                ("connect4_hook", ProbeClass::Mode(ProbeCondition::RequiresNetworkPolicy), AttachSpec::Cgroup4) => {}
+                (_, ProbeClass::Always, AttachSpec::Tp("syscalls", n)) if n == p.surface_name => {}
+                other => panic!("{other:?}"),
+            }
+        }
     }
 }

--- a/crates/assay-monitor/src/probes.rs
+++ b/crates/assay-monitor/src/probes.rs
@@ -1,5 +1,5 @@
 //! Probe attachment + mode-aware inventory (`not_requested`≠`unavailable`≠`failed`≠`unsupported`).
-//! [`PROBE_PROGRAMS`] owns ELF names, surfaces, class, and attach spec; [`EXPECTED_PROBES`] is derived.
+//! `PROBE_PROGRAMS` owns ELF names, surfaces, class, and attach spec; [`EXPECTED_PROBES`] is derived.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProbeClass {

--- a/crates/assay-monitor/src/program_set.rs
+++ b/crates/assay-monitor/src/program_set.rs
@@ -1,0 +1,89 @@
+//! P2: exact Aya program-name set vs declared inventory (after `Ebpf::load`, before attach).
+use crate::object_abi::REBUILD_EBPF_GUIDANCE;
+use crate::probes::PROBE_PROGRAMS;
+use crate::MonitorError;
+use std::collections::BTreeSet;
+
+#[rustfmt::skip]
+fn ps_err(detail: impl Into<String>) -> MonitorError {
+    MonitorError::ProgramSet { detail: detail.into(), guidance: REBUILD_EBPF_GUIDANCE }
+}
+
+/// Exact-set compare of observed program names (Aya `programs()`) against [`PROBE_PROGRAMS`].
+pub(crate) fn compare_program_names<'a, I>(observed: I) -> Result<(), MonitorError>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let observed: BTreeSet<&str> = observed.into_iter().collect();
+    let expected: BTreeSet<&str> = PROBE_PROGRAMS.iter().map(|p| p.elf_name).collect();
+    if observed == expected {
+        return Ok(());
+    }
+    let missing: Vec<_> = expected.difference(&observed).copied().collect();
+    let extra: Vec<_> = observed.difference(&expected).copied().collect();
+    Err(ps_err(format!(
+        "missing [{}]; extra [{}]",
+        missing.join(", "),
+        extra.join(", ")
+    )))
+}
+
+#[cfg(test)]
+#[rustfmt::skip]
+mod tests {
+    use super::*;
+    use crate::probes::{AttachSpec, ProbeProgram, PROBE_PROGRAMS};
+
+    fn names() -> Vec<&'static str> { PROBE_PROGRAMS.iter().map(|p| p.elf_name).collect() }
+
+    #[test]
+    fn missing_bpf_program_section_is_rejected() {
+        let n: Vec<_> = names().into_iter().filter(|n| *n != "assay_monitor_sendto").collect();
+        let e = compare_program_names(n).unwrap_err().to_string();
+        assert!(e.contains("missing") && e.contains("assay_monitor_sendto") && e.contains("build-ebpf"), "{e}");
+    }
+
+    #[test]
+    fn extra_bpf_program_section_is_rejected() {
+        let mut n = names(); n.push("rogue_probe");
+        let e = compare_program_names(n).unwrap_err().to_string();
+        assert!(e.contains("extra") && e.contains("rogue_probe") && !e.contains("ELF parse failed"), "{e}");
+    }
+
+    #[test]
+    fn exact_name_set_is_accepted() {
+        assert!(compare_program_names(names()).is_ok());
+    }
+
+    #[test]
+    fn p2_enumerates_aya_programs_not_elf_sections() {
+        let loader = include_str!("loader.rs");
+        let prod = include_str!("program_set.rs").split("#[cfg(test)]").next().unwrap();
+        assert!(
+            loader.contains(".programs()") && !prod.contains("File::parse") && !prod.contains("starts_with('.')"),
+            "P2 must compare Aya programs() names, not reparse ELF sections"
+        );
+    }
+
+    #[test]
+    fn loader_attach_sites_use_table_fields_not_literals() {
+        let src = include_str!("loader.rs");
+        for p in PROBE_PROGRAMS {
+            let row = ProbeProgram::by_elf(p.elf_name).expect(p.elf_name);
+            let lookup = format!("by_elf(\"{}\")", p.elf_name);
+            assert!(!src.contains(&format!("program_mut(\"{}\")", p.elf_name)), "hardcoded program_mut({:?})", p.elf_name);
+            if matches!(p.attach, AttachSpec::None) {
+                assert!(!src.contains(&lookup), "unattached lookup {}", p.elf_name);
+                continue;
+            }
+            assert!(src.contains(&lookup), "missing by_elf {}", p.elf_name);
+            assert!(!src.contains(&format!("attached(\"{}\")", p.surface_name)), "hardcoded attached({:?})", p.surface_name);
+            assert!(!src.contains(&format!("skipped(\"{}\")", p.surface_name)), "hardcoded skipped({:?})", p.surface_name);
+            match p.attach {
+                AttachSpec::Tp(..) => assert!(!src.contains(&format!("attach(\"{}\", \"{}\")", row.tp().0, row.tp().1)), "hardcoded tp {}", p.elf_name),
+                AttachSpec::Lsm(_) => assert!(!src.contains(&format!("load(\"{}\"", row.lsm())), "hardcoded lsm {}", p.elf_name),
+                AttachSpec::Cgroup4 | AttachSpec::None => {}
+            }
+        }
+    }
+}

--- a/scripts/ci/assay_runner_gating_map.txt
+++ b/scripts/ci/assay_runner_gating_map.txt
@@ -36,6 +36,7 @@ all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/as
 all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/assay-monitor/src/loader.rs
 all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/assay-monitor/src/object_abi.rs
 all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/assay-monitor/src/probes.rs
+all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/assay-monitor/src/program_set.rs
 all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/assay-monitor/src/tracepoint.rs
 all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/assay-monitor/src/tree/mod.rs
 all	addressed	shared runner/eBPF/monitor/xtask code requires gates=all	crates/assay-monitor/src/tree/node.rs


### PR DESCRIPTION
## Summary

Private [assay-tunnel-experiments#187](https://github.com/Rul1an/assay-tunnel-experiments/issues/187) M3b: fail closed when the loaded BPF program-name set drifts from the declared inventory.

- **Base SHA:** `1b1e4ac9ff1625882b392339944540c90df65d9b` (M3a #2340)
- **Head SHA:** `68f3d34b9d496ad5fe9b0a7decac81bf6491bec6`

Any proof or review measured on `9ff9f9da07084df053aa16d6c61e30ae1867c0e7` is invalid after this push.

One private `PROBE_PROGRAMS` table owns the 11 release ELF names. After `Ebpf::load`, production collects names from Aya `bpf.programs()` and passes them to a pure exact-set comparator. That is the single enumerator: there is no local ELF section-name heuristic and no second object parser for P2. Attach sites consume table lookups; sendto/sendmsg/connect6 stay in the ELF set without being attached.

## TDD (RED → GREEN)

RED (`cargo test -p assay-monitor --lib program_set::tests`, stub comparator + ELF reparse still in production):

- `missing_bpf_program_section_is_rejected` / `extra_bpf_program_section_is_rejected`: `unwrap_err()` on `Ok(())`
- `p2_enumerates_aya_programs_not_elf_sections`: `P2 must compare Aya programs() names, not reparse ELF sections`

GREEN: comparator rejects missing/extra name sets; loader contains `.programs()`; production `program_set` does not reparse ELF or classify via section-name strings. `loader_attach_sites_use_table_fields_not_literals` keeps attach sites on table fields rather than `program_mut("…")` / attach-target literals.

## Rustdoc (RED → GREEN)

CI gate (`.github/workflows/ci.yml`): `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`. Crate-scoped equivalent used locally: `RUSTDOCFLAGS='-D warnings' cargo doc -p assay-monitor --no-deps`.

RED on `9ff9f9da`:

```
error: public documentation for `probes` links to private item `PROBE_PROGRAMS`
 --> crates/assay-monitor/src/probes.rs:2:7
  |
2 | //! [`PROBE_PROGRAMS`] owns ELF names, surfaces, class, and attach spec; [`EXPECTED_PROBES`] is derived.
  |       ^^^^^^^^^^^^^^ this item is private
  |
  = note: `-D rustdoc::private-intra-doc-links` implied by `-D warnings`
```

GREEN: public module docs use plain `` `PROBE_PROGRAMS` `` (table stays private). Same command exits 0.

## Net LOC vs base `1b1e4ac9`

Prior committed tree: **+275 / −85 (net +190)** across 6 files. This follow-up is a 1-line docs change (net 0).

Pre-commit required classifying the new module on the runner gating map (`scripts/ci/assay_runner_gating_map.txt`, +1 line). Implementation-only count before that hook fix was +189 (tracked +185/−85 + `program_set.rs` 89). STOP ceiling was +200; not exceeded.

## Aya `programs()` rationale

P2 runs after `Ebpf::load` and before attach because Aya's loaded view is the set that would actually attach. A local ELF symbol/section heuristic duplicated Aya's classification and made that timing arbitrary. Missing/extra tests are over the comparator (name sets), not over a second ELF parser.

## Non-claims

- No new attaches. `assay_monitor_sendto`, `assay_monitor_sendmsg`, and `connect6_hook` remain `Unsupported` / `AttachSpec::None`.
- No ObservationHealth / `is_complete` change.
- M3a CONFIG object-ABI gate (`verify_object_abi_marker`) remains a separate pre-`Ebpf::load` check.
- This does not claim completeness, certification, or that kernel consumers are proven.
- Real-object / delegated exact-head proof **remains pending**.

## Verification (fresh, on this head)

- `RUSTDOCFLAGS='-D warnings' cargo doc -p assay-monitor --no-deps` — pass
- `cargo test -p assay-monitor --lib program_set::tests` — 5 passed
- `cargo test -p assay-monitor` — 45 passed, 1 ignored
- `cargo fmt --all -- --check` — pass
- `cargo clippy -p assay-monitor --all-targets -- -D warnings` — pass
- `git diff --check` — pass

Draft only. Not marked ready. Not merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to confirm all expected monitoring programs are loaded.
  * Improved error messages for missing or unexpected programs, including rebuild guidance.
  * Centralized probe definitions to improve consistency across tracepoint, LSM, and cgroup monitoring.

* **Bug Fixes**
  * Prevented attachment configuration from becoming inconsistent with declared probe programs.
  * Added checks for incomplete or unexpected program inventories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->