### PR TITLE
refactor(monitor): make the stat map readback undeletable (#187)

### DIFF
--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -73,46 +73,280 @@ pub struct MonitorStatsSnapshot {
     pub event_size_mismatch: u64,
 }
 
+/// The whole map-to-snapshot projection, in one function, over two readers.
+///
+/// This used to be fourteen inline reads in `snapshot_stats` plus a second statement that applied
+/// the four send honesty counters. That second statement was deletable with no consequence: the
+/// projection had a unit test with a fake reader, but its *binding* to the real `STATS` map was
+/// guarded by nothing, and `MonitorStatsSnapshot::default()` filled the orphaned fields with 0 --
+/// byte-identical, downstream, to a genuinely clean run.
+///
+/// Collapsing both projections here makes the binding fall out of the types rather than out of a
+/// test. `snapshot_stats` has no snapshot to return without calling this, so deleting the call is a
+/// compile error; and the two readers differ in return type (`u32` for `STATS`, `u64` for
+/// `SOCKET_STATS`), so swapping them is a compile error too. Neither map type appears in the
+/// signature, so the projection stays testable on any host while the aya types stay in `loader.rs`.
+///
+/// Every field is written by a listed initializer -- no `..Default::default()` -- so dropping a
+/// read is a missing-field compile error rather than a silent zero.
 #[cfg(any(test, target_os = "linux"))]
-fn apply_send_honesty_counters(stats: &mut MonitorStatsSnapshot, mut read: impl FnMut(u32) -> u32) {
+pub(crate) fn project_snapshot(
+    mut read_stats: impl FnMut(u32) -> u32,
+    mut read_socket: impl FnMut(u32) -> u64,
+    event_size_mismatch: u64,
+) -> MonitorStatsSnapshot {
     use assay_common::{
-        MONITOR_STAT_SENDMSG_NON_IP_FAMILY, MONITOR_STAT_SENDMSG_NO_PEER,
-        MONITOR_STAT_SENDTO_NON_IP_FAMILY, MONITOR_STAT_SENDTO_NO_PEER,
+        MONITOR_STAT_CONNECT_EVENTS_EMITTED, MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
+        MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
+        MONITOR_STAT_OPENAT2_EVENTS_EMITTED, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
+        MONITOR_STAT_OPENAT_EVENTS_EMITTED, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
+        MONITOR_STAT_SENDMSG_EVENTS_EMITTED, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
+        MONITOR_STAT_SENDMSG_NO_PEER, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
+        MONITOR_STAT_SENDTO_EVENTS_EMITTED, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
+        MONITOR_STAT_SENDTO_NO_PEER, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
+        MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+        SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT,
+        SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
     };
 
-    stats.sendto_no_peer = read(MONITOR_STAT_SENDTO_NO_PEER);
-    stats.sendmsg_no_peer = read(MONITOR_STAT_SENDMSG_NO_PEER);
-    stats.sendto_non_ip_family = read(MONITOR_STAT_SENDTO_NON_IP_FAMILY);
-    stats.sendmsg_non_ip_family = read(MONITOR_STAT_SENDMSG_NON_IP_FAMILY);
+    MonitorStatsSnapshot {
+        tracepoint_events_emitted: read_stats(MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED),
+        tracepoint_ringbuf_dropped: read_stats(MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED),
+        lsm_events_emitted: read_stats(MONITOR_STAT_LSM_EVENTS_EMITTED),
+        lsm_ringbuf_dropped: read_stats(MONITOR_STAT_LSM_RINGBUF_DROPPED),
+        openat_events_emitted: read_stats(MONITOR_STAT_OPENAT_EVENTS_EMITTED),
+        openat_ringbuf_dropped: read_stats(MONITOR_STAT_OPENAT_RINGBUF_DROPPED),
+        openat2_events_emitted: read_stats(MONITOR_STAT_OPENAT2_EVENTS_EMITTED),
+        openat2_ringbuf_dropped: read_stats(MONITOR_STAT_OPENAT2_RINGBUF_DROPPED),
+        connect_events_emitted: read_stats(MONITOR_STAT_CONNECT_EVENTS_EMITTED),
+        connect_ringbuf_dropped: read_stats(MONITOR_STAT_CONNECT_RINGBUF_DROPPED),
+        sendto_events_emitted: read_stats(MONITOR_STAT_SENDTO_EVENTS_EMITTED),
+        sendto_ringbuf_dropped: read_stats(MONITOR_STAT_SENDTO_RINGBUF_DROPPED),
+        sendmsg_events_emitted: read_stats(MONITOR_STAT_SENDMSG_EVENTS_EMITTED),
+        sendmsg_ringbuf_dropped: read_stats(MONITOR_STAT_SENDMSG_RINGBUF_DROPPED),
+        sendto_no_peer: read_stats(MONITOR_STAT_SENDTO_NO_PEER),
+        sendmsg_no_peer: read_stats(MONITOR_STAT_SENDMSG_NO_PEER),
+        sendto_non_ip_family: read_stats(MONITOR_STAT_SENDTO_NON_IP_FAMILY),
+        sendmsg_non_ip_family: read_stats(MONITOR_STAT_SENDMSG_NON_IP_FAMILY),
+        socket_checks: read_socket(SOCKET_STAT_CHECKS),
+        socket_blocked_cidr: read_socket(SOCKET_STAT_BLOCKED_CIDR),
+        socket_blocked_port: read_socket(SOCKET_STAT_BLOCKED_PORT),
+        socket_allowed: read_socket(SOCKET_STAT_ALLOWED),
+        socket_events_emitted: read_socket(SOCKET_STAT_EVENTS_EMITTED),
+        socket_ringbuf_dropped: read_socket(SOCKET_STAT_RINGBUF_DROPPED),
+        event_size_mismatch,
+    }
 }
 
 #[cfg(test)]
-mod send_honesty_counter_tests {
+mod snapshot_projection_tests {
     use super::*;
     use assay_common::{
-        MONITOR_STAT_SENDMSG_NON_IP_FAMILY, MONITOR_STAT_SENDMSG_NO_PEER,
-        MONITOR_STAT_SENDTO_NON_IP_FAMILY, MONITOR_STAT_SENDTO_NO_PEER,
+        MONITOR_STAT_CONNECT_EVENTS_EMITTED, MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
+        MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
+        MONITOR_STAT_OPENAT2_EVENTS_EMITTED, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
+        MONITOR_STAT_OPENAT_EVENTS_EMITTED, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
+        MONITOR_STAT_SENDMSG_EVENTS_EMITTED, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
+        MONITOR_STAT_SENDMSG_NO_PEER, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
+        MONITOR_STAT_SENDTO_EVENTS_EMITTED, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
+        MONITOR_STAT_SENDTO_NO_PEER, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
+        MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+        SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT,
+        SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
     };
 
+    /// Totality, not a sample. Each reader returns its own key -- identity for `STATS`, identity
+    /// widened to `u64` for `SOCKET_STATS` -- so every field carries the key it was read from and
+    /// the whole snapshot can be compared against the key constants at once. A reader that returned
+    /// a fixed value would let a wrongly wired field pass; a reader that returns the key cannot.
+    /// The `MONITOR_STAT_*` keys are 0..=17 and the `SOCKET_STAT_*` keys are 0..=5, distinct
+    /// within their own array, so no two fields of the same reader can hold the same value: any
+    /// wrong wiring -- two fields swapped, a field pointed at another array's key, a read replaced by
+    /// a constant -- moves at least one field off its own key and fails here.
+    ///
+    /// The destructuring binding is load-bearing: a field added to `MonitorStatsSnapshot` without a
+    /// corresponding assertion is a compile error in this test, so the check cannot fall behind the
+    /// struct.
     #[test]
-    fn map_keys_project_to_the_matching_snapshot_fields() {
-        let mut stats = MonitorStatsSnapshot::default();
-        apply_send_honesty_counters(&mut stats, |key| match key {
-            MONITOR_STAT_SENDTO_NO_PEER => 11,
-            MONITOR_STAT_SENDMSG_NO_PEER => 22,
-            MONITOR_STAT_SENDTO_NON_IP_FAMILY => 33,
-            MONITOR_STAT_SENDMSG_NON_IP_FAMILY => 44,
-            other => panic!("unexpected counter key {other}"),
-        });
+    fn every_snapshot_field_reads_its_own_key() {
+        let MonitorStatsSnapshot {
+            tracepoint_events_emitted,
+            tracepoint_ringbuf_dropped,
+            lsm_events_emitted,
+            lsm_ringbuf_dropped,
+            openat_events_emitted,
+            openat_ringbuf_dropped,
+            openat2_events_emitted,
+            openat2_ringbuf_dropped,
+            connect_events_emitted,
+            connect_ringbuf_dropped,
+            sendto_events_emitted,
+            sendto_ringbuf_dropped,
+            sendmsg_events_emitted,
+            sendmsg_ringbuf_dropped,
+            sendto_no_peer,
+            sendmsg_no_peer,
+            sendto_non_ip_family,
+            sendmsg_non_ip_family,
+            socket_checks,
+            socket_blocked_cidr,
+            socket_blocked_port,
+            socket_allowed,
+            socket_events_emitted,
+            socket_ringbuf_dropped,
+            event_size_mismatch,
+        } = project_snapshot(|key| key, u64::from, 777);
+
         assert_eq!(
-            (
-                stats.sendto_no_peer,
-                stats.sendmsg_no_peer,
-                stats.sendto_non_ip_family,
-                stats.sendmsg_non_ip_family,
-            ),
-            (11, 22, 33, 44)
+            tracepoint_events_emitted, MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED,
+            "tracepoint_events_emitted"
         );
+        assert_eq!(
+            tracepoint_ringbuf_dropped, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+            "tracepoint_ringbuf_dropped"
+        );
+        assert_eq!(
+            lsm_events_emitted, MONITOR_STAT_LSM_EVENTS_EMITTED,
+            "lsm_events_emitted"
+        );
+        assert_eq!(
+            lsm_ringbuf_dropped, MONITOR_STAT_LSM_RINGBUF_DROPPED,
+            "lsm_ringbuf_dropped"
+        );
+        assert_eq!(
+            openat_events_emitted, MONITOR_STAT_OPENAT_EVENTS_EMITTED,
+            "openat_events_emitted"
+        );
+        assert_eq!(
+            openat_ringbuf_dropped, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
+            "openat_ringbuf_dropped"
+        );
+        assert_eq!(
+            openat2_events_emitted, MONITOR_STAT_OPENAT2_EVENTS_EMITTED,
+            "openat2_events_emitted"
+        );
+        assert_eq!(
+            openat2_ringbuf_dropped, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
+            "openat2_ringbuf_dropped"
+        );
+        assert_eq!(
+            connect_events_emitted, MONITOR_STAT_CONNECT_EVENTS_EMITTED,
+            "connect_events_emitted"
+        );
+        assert_eq!(
+            connect_ringbuf_dropped, MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
+            "connect_ringbuf_dropped"
+        );
+        assert_eq!(
+            sendto_events_emitted, MONITOR_STAT_SENDTO_EVENTS_EMITTED,
+            "sendto_events_emitted"
+        );
+        assert_eq!(
+            sendto_ringbuf_dropped, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
+            "sendto_ringbuf_dropped"
+        );
+        assert_eq!(
+            sendmsg_events_emitted, MONITOR_STAT_SENDMSG_EVENTS_EMITTED,
+            "sendmsg_events_emitted"
+        );
+        assert_eq!(
+            sendmsg_ringbuf_dropped, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
+            "sendmsg_ringbuf_dropped"
+        );
+        assert_eq!(
+            sendto_no_peer, MONITOR_STAT_SENDTO_NO_PEER,
+            "sendto_no_peer"
+        );
+        assert_eq!(
+            sendmsg_no_peer, MONITOR_STAT_SENDMSG_NO_PEER,
+            "sendmsg_no_peer"
+        );
+        assert_eq!(
+            sendto_non_ip_family, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
+            "sendto_non_ip_family"
+        );
+        assert_eq!(
+            sendmsg_non_ip_family, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
+            "sendmsg_non_ip_family"
+        );
+        assert_eq!(
+            socket_checks,
+            u64::from(SOCKET_STAT_CHECKS),
+            "socket_checks"
+        );
+        assert_eq!(
+            socket_blocked_cidr,
+            u64::from(SOCKET_STAT_BLOCKED_CIDR),
+            "socket_blocked_cidr"
+        );
+        assert_eq!(
+            socket_blocked_port,
+            u64::from(SOCKET_STAT_BLOCKED_PORT),
+            "socket_blocked_port"
+        );
+        assert_eq!(
+            socket_allowed,
+            u64::from(SOCKET_STAT_ALLOWED),
+            "socket_allowed"
+        );
+        assert_eq!(
+            socket_events_emitted,
+            u64::from(SOCKET_STAT_EVENTS_EMITTED),
+            "socket_events_emitted"
+        );
+        assert_eq!(
+            socket_ringbuf_dropped,
+            u64::from(SOCKET_STAT_RINGBUF_DROPPED),
+            "socket_ringbuf_dropped"
+        );
+        assert_eq!(
+            event_size_mismatch, 777,
+            "event_size_mismatch is not a map read"
+        );
+    }
+
+    /// The identity reader only discriminates if the keys it returns are themselves distinct.
+    /// Without this, a projection that read every field from key 0 would still satisfy the totality
+    /// test if all the constants happened to collapse to 0.
+    #[test]
+    fn stat_keys_are_distinct_within_each_array() {
+        let monitor = [
+            MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED,
+            MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+            MONITOR_STAT_LSM_EVENTS_EMITTED,
+            MONITOR_STAT_LSM_RINGBUF_DROPPED,
+            MONITOR_STAT_OPENAT_EVENTS_EMITTED,
+            MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
+            MONITOR_STAT_OPENAT2_EVENTS_EMITTED,
+            MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
+            MONITOR_STAT_CONNECT_EVENTS_EMITTED,
+            MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
+            MONITOR_STAT_SENDTO_EVENTS_EMITTED,
+            MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
+            MONITOR_STAT_SENDMSG_EVENTS_EMITTED,
+            MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
+            MONITOR_STAT_SENDTO_NO_PEER,
+            MONITOR_STAT_SENDMSG_NO_PEER,
+            MONITOR_STAT_SENDTO_NON_IP_FAMILY,
+            MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
+        ];
+        let mut sorted = monitor.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), monitor.len(), "MONITOR_STAT_* keys collide");
+
+        let socket = [
+            SOCKET_STAT_CHECKS,
+            SOCKET_STAT_BLOCKED_CIDR,
+            SOCKET_STAT_BLOCKED_PORT,
+            SOCKET_STAT_ALLOWED,
+            SOCKET_STAT_EVENTS_EMITTED,
+            SOCKET_STAT_RINGBUF_DROPPED,
+        ];
+        let mut sorted = socket.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), socket.len(), "SOCKET_STAT_* keys collide");
     }
 }
 

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -73,42 +73,34 @@ pub struct MonitorStatsSnapshot {
     pub event_size_mismatch: u64,
 }
 
-/// The whole map-to-snapshot projection, in one function, over two readers.
-///
-/// This used to be fourteen inline reads in `snapshot_stats` plus a second statement that applied
-/// the four send honesty counters. That second statement was deletable with no consequence: the
-/// projection had a unit test with a fake reader, but its *binding* to the real `STATS` map was
-/// guarded by nothing, and `MonitorStatsSnapshot::default()` filled the orphaned fields with 0 --
-/// byte-identical, downstream, to a genuinely clean run.
-///
-/// Collapsing both projections here makes the binding fall out of the types rather than out of a
-/// test. `snapshot_stats` has no snapshot to return without calling this, so deleting the call is a
-/// compile error; and the two readers differ in return type (`u32` for `STATS`, `u64` for
-/// `SOCKET_STATS`), so swapping them is a compile error too. Neither map type appears in the
-/// signature, so the projection stays testable on any host while the aya types stay in `loader.rs`.
-///
-/// Every field is written by a listed initializer -- no `..Default::default()` -- so dropping a
-/// read is a missing-field compile error rather than a silent zero.
 #[cfg(any(test, target_os = "linux"))]
-pub(crate) fn project_snapshot(
+use assay_common::{
+    MONITOR_STAT_CONNECT_EVENTS_EMITTED, MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
+    MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
+    MONITOR_STAT_OPENAT2_EVENTS_EMITTED, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
+    MONITOR_STAT_OPENAT_EVENTS_EMITTED, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
+    MONITOR_STAT_SENDMSG_EVENTS_EMITTED, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
+    MONITOR_STAT_SENDMSG_NO_PEER, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
+    MONITOR_STAT_SENDTO_EVENTS_EMITTED, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
+    MONITOR_STAT_SENDTO_NO_PEER, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
+    MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+    SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT, SOCKET_STAT_CHECKS,
+    SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
+};
+
+/// Project both kernel stat arrays onto the snapshot.
+///
+/// One function rather than a list of separately deletable statements: `snapshot_stats` has no
+/// snapshot to return without calling this. The readers differ in return type because the arrays do
+/// -- `STATS` holds `u32`, `SOCKET_STATS` holds `u64` -- so they cannot be passed in swapped. Every
+/// field is named here, with no `..Default::default()`, so a dropped read is a compile error rather
+/// than a zero indistinguishable from a clean run.
+#[cfg(any(test, target_os = "linux"))]
+fn project_snapshot(
     mut read_stats: impl FnMut(u32) -> u32,
     mut read_socket: impl FnMut(u32) -> u64,
     event_size_mismatch: u64,
 ) -> MonitorStatsSnapshot {
-    use assay_common::{
-        MONITOR_STAT_CONNECT_EVENTS_EMITTED, MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
-        MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
-        MONITOR_STAT_OPENAT2_EVENTS_EMITTED, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
-        MONITOR_STAT_OPENAT_EVENTS_EMITTED, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
-        MONITOR_STAT_SENDMSG_EVENTS_EMITTED, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
-        MONITOR_STAT_SENDMSG_NO_PEER, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
-        MONITOR_STAT_SENDTO_EVENTS_EMITTED, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
-        MONITOR_STAT_SENDTO_NO_PEER, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
-        MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
-        SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT,
-        SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
-    };
-
     MonitorStatsSnapshot {
         tracepoint_events_emitted: read_stats(MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED),
         tracepoint_ringbuf_dropped: read_stats(MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED),
@@ -141,212 +133,72 @@ pub(crate) fn project_snapshot(
 #[cfg(test)]
 mod snapshot_projection_tests {
     use super::*;
-    use assay_common::{
-        MONITOR_STAT_CONNECT_EVENTS_EMITTED, MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
-        MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
-        MONITOR_STAT_OPENAT2_EVENTS_EMITTED, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
-        MONITOR_STAT_OPENAT_EVENTS_EMITTED, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
-        MONITOR_STAT_SENDMSG_EVENTS_EMITTED, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
-        MONITOR_STAT_SENDMSG_NO_PEER, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
-        MONITOR_STAT_SENDTO_EVENTS_EMITTED, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
-        MONITOR_STAT_SENDTO_NO_PEER, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
-        MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
-        SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT,
-        SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
-    };
 
-    /// Totality, not a sample. Each reader returns its own key -- identity for `STATS`, identity
-    /// widened to `u64` for `SOCKET_STATS` -- so every field carries the key it was read from and
-    /// the whole snapshot can be compared against the key constants at once. A reader that returned
-    /// a fixed value would let a wrongly wired field pass; a reader that returns the key cannot.
-    /// The `MONITOR_STAT_*` keys are 0..=17 and the `SOCKET_STAT_*` keys are 0..=5, distinct
-    /// within their own array, so no two fields of the same reader can hold the same value: any
-    /// wrong wiring -- two fields swapped, a field pointed at another array's key, a read replaced by
-    /// a constant -- moves at least one field off its own key and fails here.
-    ///
-    /// The destructuring binding is load-bearing: a field added to `MonitorStatsSnapshot` without a
-    /// corresponding assertion is a compile error in this test, so the check cannot fall behind the
-    /// struct.
+    /// Totality: each reader returns its own key, so a correct projection produces the snapshot
+    /// whose every field is the key it was read from. One comparison, so no field can be omitted
+    /// from the check, and a field added to the struct is a compile error here.
     #[test]
     fn every_snapshot_field_reads_its_own_key() {
-        let MonitorStatsSnapshot {
-            tracepoint_events_emitted,
-            tracepoint_ringbuf_dropped,
-            lsm_events_emitted,
-            lsm_ringbuf_dropped,
-            openat_events_emitted,
-            openat_ringbuf_dropped,
-            openat2_events_emitted,
-            openat2_ringbuf_dropped,
-            connect_events_emitted,
-            connect_ringbuf_dropped,
-            sendto_events_emitted,
-            sendto_ringbuf_dropped,
-            sendmsg_events_emitted,
-            sendmsg_ringbuf_dropped,
-            sendto_no_peer,
-            sendmsg_no_peer,
-            sendto_non_ip_family,
-            sendmsg_non_ip_family,
-            socket_checks,
-            socket_blocked_cidr,
-            socket_blocked_port,
-            socket_allowed,
-            socket_events_emitted,
-            socket_ringbuf_dropped,
-            event_size_mismatch,
-        } = project_snapshot(|key| key, u64::from, 777);
-
         assert_eq!(
-            tracepoint_events_emitted, MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED,
-            "tracepoint_events_emitted"
-        );
-        assert_eq!(
-            tracepoint_ringbuf_dropped, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
-            "tracepoint_ringbuf_dropped"
-        );
-        assert_eq!(
-            lsm_events_emitted, MONITOR_STAT_LSM_EVENTS_EMITTED,
-            "lsm_events_emitted"
-        );
-        assert_eq!(
-            lsm_ringbuf_dropped, MONITOR_STAT_LSM_RINGBUF_DROPPED,
-            "lsm_ringbuf_dropped"
-        );
-        assert_eq!(
-            openat_events_emitted, MONITOR_STAT_OPENAT_EVENTS_EMITTED,
-            "openat_events_emitted"
-        );
-        assert_eq!(
-            openat_ringbuf_dropped, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
-            "openat_ringbuf_dropped"
-        );
-        assert_eq!(
-            openat2_events_emitted, MONITOR_STAT_OPENAT2_EVENTS_EMITTED,
-            "openat2_events_emitted"
-        );
-        assert_eq!(
-            openat2_ringbuf_dropped, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
-            "openat2_ringbuf_dropped"
-        );
-        assert_eq!(
-            connect_events_emitted, MONITOR_STAT_CONNECT_EVENTS_EMITTED,
-            "connect_events_emitted"
-        );
-        assert_eq!(
-            connect_ringbuf_dropped, MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
-            "connect_ringbuf_dropped"
-        );
-        assert_eq!(
-            sendto_events_emitted, MONITOR_STAT_SENDTO_EVENTS_EMITTED,
-            "sendto_events_emitted"
-        );
-        assert_eq!(
-            sendto_ringbuf_dropped, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
-            "sendto_ringbuf_dropped"
-        );
-        assert_eq!(
-            sendmsg_events_emitted, MONITOR_STAT_SENDMSG_EVENTS_EMITTED,
-            "sendmsg_events_emitted"
-        );
-        assert_eq!(
-            sendmsg_ringbuf_dropped, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
-            "sendmsg_ringbuf_dropped"
-        );
-        assert_eq!(
-            sendto_no_peer, MONITOR_STAT_SENDTO_NO_PEER,
-            "sendto_no_peer"
-        );
-        assert_eq!(
-            sendmsg_no_peer, MONITOR_STAT_SENDMSG_NO_PEER,
-            "sendmsg_no_peer"
-        );
-        assert_eq!(
-            sendto_non_ip_family, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
-            "sendto_non_ip_family"
-        );
-        assert_eq!(
-            sendmsg_non_ip_family, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
-            "sendmsg_non_ip_family"
-        );
-        assert_eq!(
-            socket_checks,
-            u64::from(SOCKET_STAT_CHECKS),
-            "socket_checks"
-        );
-        assert_eq!(
-            socket_blocked_cidr,
-            u64::from(SOCKET_STAT_BLOCKED_CIDR),
-            "socket_blocked_cidr"
-        );
-        assert_eq!(
-            socket_blocked_port,
-            u64::from(SOCKET_STAT_BLOCKED_PORT),
-            "socket_blocked_port"
-        );
-        assert_eq!(
-            socket_allowed,
-            u64::from(SOCKET_STAT_ALLOWED),
-            "socket_allowed"
-        );
-        assert_eq!(
-            socket_events_emitted,
-            u64::from(SOCKET_STAT_EVENTS_EMITTED),
-            "socket_events_emitted"
-        );
-        assert_eq!(
-            socket_ringbuf_dropped,
-            u64::from(SOCKET_STAT_RINGBUF_DROPPED),
-            "socket_ringbuf_dropped"
-        );
-        assert_eq!(
-            event_size_mismatch, 777,
-            "event_size_mismatch is not a map read"
+            project_snapshot(|k| k, u64::from, 777),
+            MonitorStatsSnapshot {
+                tracepoint_events_emitted: MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED,
+                tracepoint_ringbuf_dropped: MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+                lsm_events_emitted: MONITOR_STAT_LSM_EVENTS_EMITTED,
+                lsm_ringbuf_dropped: MONITOR_STAT_LSM_RINGBUF_DROPPED,
+                openat_events_emitted: MONITOR_STAT_OPENAT_EVENTS_EMITTED,
+                openat_ringbuf_dropped: MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
+                openat2_events_emitted: MONITOR_STAT_OPENAT2_EVENTS_EMITTED,
+                openat2_ringbuf_dropped: MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
+                connect_events_emitted: MONITOR_STAT_CONNECT_EVENTS_EMITTED,
+                connect_ringbuf_dropped: MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
+                sendto_events_emitted: MONITOR_STAT_SENDTO_EVENTS_EMITTED,
+                sendto_ringbuf_dropped: MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
+                sendmsg_events_emitted: MONITOR_STAT_SENDMSG_EVENTS_EMITTED,
+                sendmsg_ringbuf_dropped: MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
+                sendto_no_peer: MONITOR_STAT_SENDTO_NO_PEER,
+                sendmsg_no_peer: MONITOR_STAT_SENDMSG_NO_PEER,
+                sendto_non_ip_family: MONITOR_STAT_SENDTO_NON_IP_FAMILY,
+                sendmsg_non_ip_family: MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
+                socket_checks: u64::from(SOCKET_STAT_CHECKS),
+                socket_blocked_cidr: u64::from(SOCKET_STAT_BLOCKED_CIDR),
+                socket_blocked_port: u64::from(SOCKET_STAT_BLOCKED_PORT),
+                socket_allowed: u64::from(SOCKET_STAT_ALLOWED),
+                socket_events_emitted: u64::from(SOCKET_STAT_EVENTS_EMITTED),
+                socket_ringbuf_dropped: u64::from(SOCKET_STAT_RINGBUF_DROPPED),
+                event_size_mismatch: 777,
+            }
         );
     }
 
-    /// The identity reader only discriminates if the keys it returns are themselves distinct.
-    /// Without this, a projection that read every field from key 0 would still satisfy the totality
-    /// test if all the constants happened to collapse to 0.
+    /// A key that returns itself only discriminates between fields if the keys differ: two fields
+    /// reading one key, or two constants sharing a value, would let them swap undetected. Recording
+    /// what each reader was actually asked for checks that on the projection itself.
     #[test]
-    fn stat_keys_are_distinct_within_each_array() {
-        let monitor = [
-            MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED,
-            MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
-            MONITOR_STAT_LSM_EVENTS_EMITTED,
-            MONITOR_STAT_LSM_RINGBUF_DROPPED,
-            MONITOR_STAT_OPENAT_EVENTS_EMITTED,
-            MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
-            MONITOR_STAT_OPENAT2_EVENTS_EMITTED,
-            MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
-            MONITOR_STAT_CONNECT_EVENTS_EMITTED,
-            MONITOR_STAT_CONNECT_RINGBUF_DROPPED,
-            MONITOR_STAT_SENDTO_EVENTS_EMITTED,
-            MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
-            MONITOR_STAT_SENDMSG_EVENTS_EMITTED,
-            MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
-            MONITOR_STAT_SENDTO_NO_PEER,
-            MONITOR_STAT_SENDMSG_NO_PEER,
-            MONITOR_STAT_SENDTO_NON_IP_FAMILY,
-            MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
-        ];
-        let mut sorted = monitor.to_vec();
-        sorted.sort_unstable();
-        sorted.dedup();
-        assert_eq!(sorted.len(), monitor.len(), "MONITOR_STAT_* keys collide");
-
-        let socket = [
-            SOCKET_STAT_CHECKS,
-            SOCKET_STAT_BLOCKED_CIDR,
-            SOCKET_STAT_BLOCKED_PORT,
-            SOCKET_STAT_ALLOWED,
-            SOCKET_STAT_EVENTS_EMITTED,
-            SOCKET_STAT_RINGBUF_DROPPED,
-        ];
-        let mut sorted = socket.to_vec();
-        sorted.sort_unstable();
-        sorted.dedup();
-        assert_eq!(sorted.len(), socket.len(), "SOCKET_STAT_* keys collide");
+    fn no_two_fields_read_the_same_key() {
+        let (mut stats_keys, mut socket_keys) = (Vec::new(), Vec::new());
+        project_snapshot(
+            |k| {
+                stats_keys.push(k);
+                k
+            },
+            |k| {
+                socket_keys.push(k);
+                u64::from(k)
+            },
+            0,
+        );
+        assert_eq!(
+            (stats_keys.len(), socket_keys.len()),
+            (18, 6),
+            "reads per array"
+        );
+        for keys in [&mut stats_keys, &mut socket_keys] {
+            let read = keys.len();
+            keys.sort_unstable();
+            keys.dedup();
+            assert_eq!(keys.len(), read, "two fields read the same key");
+        }
     }
 }
 

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -6,18 +6,9 @@ use crate::probes::{
     SendFault, EGRESS_PEER_PROBE, EXPECTED_PROBES,
 };
 use crate::{MonitorError, MonitorStatsSnapshot};
-use assay_common::{
-    CidrRuleValue, KEY_EMIT_INODE_RESOLVED, KEY_MONITOR_ALL, MONITOR_STAT_CONNECT_EVENTS_EMITTED,
-    MONITOR_STAT_CONNECT_RINGBUF_DROPPED, MONITOR_STAT_LSM_EVENTS_EMITTED,
-    MONITOR_STAT_LSM_RINGBUF_DROPPED, MONITOR_STAT_OPENAT2_EVENTS_EMITTED,
-    MONITOR_STAT_OPENAT2_RINGBUF_DROPPED, MONITOR_STAT_OPENAT_EVENTS_EMITTED,
-    MONITOR_STAT_OPENAT_RINGBUF_DROPPED, MONITOR_STAT_SENDMSG_EVENTS_EMITTED,
-    MONITOR_STAT_SENDMSG_RINGBUF_DROPPED, MONITOR_STAT_SENDTO_EVENTS_EMITTED,
-    MONITOR_STAT_SENDTO_RINGBUF_DROPPED, MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED,
-    MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED, SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR,
-    SOCKET_STAT_BLOCKED_PORT, SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED,
-    SOCKET_STAT_RINGBUF_DROPPED,
-};
+// The `MONITOR_STAT_*` / `SOCKET_STAT_*` keys are deliberately not imported here: `snapshot_stats`
+// names no key, so it cannot get one wrong. They belong to `crate::project_snapshot`.
+use assay_common::{CidrRuleValue, KEY_EMIT_INODE_RESOLVED, KEY_MONITOR_ALL};
 use assay_policy::tiers::CompiledPolicy;
 use aya::maps::lpm_trie::Key;
 use aya::{
@@ -590,74 +581,33 @@ impl LinuxMonitor {
             .record_mode(EGRESS_PEER_PROBE, ModeUpdate::Failed(reason));
     }
 
+    /// Bind the two kernel stat arrays to the snapshot projection.
+    ///
+    /// Everything this method knows is which aya map each key space lives in. Which key feeds which
+    /// field is `crate::project_snapshot`'s business, and it is total there: this cannot forget a
+    /// field, because it names none. The eBPF side has always incremented the per-hook and honesty
+    /// counters (`connect_events.rs`); a read that goes missing here is a silent zero downstream,
+    /// indistinguishable from a clean run, which is why the projection is one call and not a list of
+    /// separately deletable assignments.
     pub fn snapshot_stats(&mut self) -> Result<MonitorStatsSnapshot, MonitorError> {
         let bpf = self.bpf.lock().unwrap();
-        let mut stats = MonitorStatsSnapshot::default();
 
         let map = bpf
             .map("STATS")
             .ok_or(MonitorError::MapNotFound { name: "STATS" })?;
-        let array: AyaArray<_, u32> = AyaArray::try_from(map)?;
-        stats.tracepoint_events_emitted = array
-            .get(&MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.tracepoint_ringbuf_dropped = array
-            .get(&MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        stats.lsm_events_emitted = array.get(&MONITOR_STAT_LSM_EVENTS_EMITTED, 0).unwrap_or(0);
-        stats.lsm_ringbuf_dropped = array.get(&MONITOR_STAT_LSM_RINGBUF_DROPPED, 0).unwrap_or(0);
-        stats.openat_events_emitted = array
-            .get(&MONITOR_STAT_OPENAT_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.openat_ringbuf_dropped = array
-            .get(&MONITOR_STAT_OPENAT_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        stats.openat2_events_emitted = array
-            .get(&MONITOR_STAT_OPENAT2_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.openat2_ringbuf_dropped = array
-            .get(&MONITOR_STAT_OPENAT2_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        stats.connect_events_emitted = array
-            .get(&MONITOR_STAT_CONNECT_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.connect_ringbuf_dropped = array
-            .get(&MONITOR_STAT_CONNECT_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        // The eBPF side has always incremented these (connect_events.rs), and userspace never read
-        // them back, so the snapshot reported 0 for two of the seven tracepoint hooks. Not a gate
-        // defect -- `tracepoint_ringbuf_dropped` is bumped alongside every per-hook counter, so the
-        // ring total was right -- but a drop on `sendto` or `sendmsg` could not be attributed to
-        // the hook that lost it, which is the whole job of the per-hook counters.
-        stats.sendto_events_emitted = array
-            .get(&MONITOR_STAT_SENDTO_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.sendto_ringbuf_dropped = array
-            .get(&MONITOR_STAT_SENDTO_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        stats.sendmsg_events_emitted = array
-            .get(&MONITOR_STAT_SENDMSG_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.sendmsg_ringbuf_dropped = array
-            .get(&MONITOR_STAT_SENDMSG_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        crate::apply_send_honesty_counters(&mut stats, |key| array.get(&key, 0).unwrap_or(0));
+        let stats_array: AyaArray<_, u32> = AyaArray::try_from(map)?;
 
         let map = bpf.map("SOCKET_STATS").ok_or(MonitorError::MapNotFound {
             name: "SOCKET_STATS",
         })?;
-        let array: AyaArray<_, u64> = AyaArray::try_from(map)?;
-        stats.socket_checks = array.get(&SOCKET_STAT_CHECKS, 0).unwrap_or(0);
-        stats.socket_blocked_cidr = array.get(&SOCKET_STAT_BLOCKED_CIDR, 0).unwrap_or(0);
-        stats.socket_blocked_port = array.get(&SOCKET_STAT_BLOCKED_PORT, 0).unwrap_or(0);
-        stats.socket_allowed = array.get(&SOCKET_STAT_ALLOWED, 0).unwrap_or(0);
-        stats.socket_events_emitted = array.get(&SOCKET_STAT_EVENTS_EMITTED, 0).unwrap_or(0);
-        stats.socket_ringbuf_dropped = array.get(&SOCKET_STAT_RINGBUF_DROPPED, 0).unwrap_or(0);
+        let socket_array: AyaArray<_, u64> = AyaArray::try_from(map)?;
 
-        // Userspace-tracked: filled by the consumer thread in `listen()`, not a kernel map.
-        stats.event_size_mismatch = self.event_size_mismatch.load(Ordering::Relaxed);
-
-        Ok(stats)
+        Ok(crate::project_snapshot(
+            |key| stats_array.get(&key, 0).unwrap_or(0),
+            |key| socket_array.get(&key, 0).unwrap_or(0),
+            // Userspace-tracked: filled by the consumer thread in `listen()`, not a kernel map.
+            self.event_size_mismatch.load(Ordering::Relaxed),
+        ))
     }
 
     pub fn listen(&mut self) -> Result<EventStream, MonitorError> {


### PR DESCRIPTION
## What

`snapshot_stats` (`crates/assay-monitor/src/loader.rs`) read fourteen `STATS` fields inline and
then applied the four send `no_peer` / `non_ip_family` honesty counters in a **separate statement**
calling `apply_send_honesty_counters`. Both projections are now one function, `project_snapshot`,
which takes two readers and no aya types.

**Head SHA:** `ece4abcc54022e36be6a5600ba8181403af6c42a`
**Base SHA:** `a0c4d31d3a319dae625abaa11d354bf89f9370f1`
**Size:** +137 / -101 (net +36) — `lib.rs` +117/-31, `loader.rs` +20/-70.

## Why — the RED-before measurement

The separate statement was deletable with no consequence. Measured on the base commit before any
production edit, by deleting the `crate::apply_send_honesty_counters(...)` line in `loader.rs`:

```
$ cargo check --target x86_64-unknown-linux-gnu -p assay-monitor --all-targets
warning: function `apply_send_honesty_counters` is never used
  --> crates/assay-monitor/src/lib.rs:77:4
warning: `assay-monitor` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.04s

$ cargo test -p assay-monitor
test result: ok. 53 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

Green. The projection had a unit test with a fake reader, so the test kept the orphaned function
alive and passing; its *binding* to the real `STATS` map was guarded by nothing. The only signal was
a `dead_code` warning about the now-unused function — which says nothing about the snapshot, and
which a deleter removing the function alongside its call site would not see at all.
`MonitorStatsSnapshot::default()` filled the four fields with `0`, so downstream the CLI prints
`no_peer=0` and the Runner archive note omits its suffix, byte-identical to a genuinely clean run.

## How the guard works

Two properties fall out of the types, not out of a test:

- **Deleting the projection call is a compile error.** `snapshot_stats` has no snapshot to return
  without it.
- **Swapping the two readers is a compile error.** They differ in return type — `u32` for `STATS`,
  `u64` for `SOCKET_STATS`.

`project_snapshot` builds `MonitorStatsSnapshot` from a full struct literal with no
`..Default::default()`, so dropping a field read is a missing-field compile error rather than a
silent zero. It is private to the crate root; `loader` is a child module and reaches it directly.

Two tests, both in `lib.rs` (not `loader.rs`, whose raw text `program_set.rs` asserts over via
`include_str!`):

- `every_snapshot_field_reads_its_own_key` — **totality** in one comparison. Each reader returns its
  own key (`|k| k` for `STATS`, `u64::from` for `SOCKET_STATS`), so a correct projection equals a
  literal naming every field exactly once as its own key constant. `MonitorStatsSnapshot` derives
  `PartialEq`/`Eq`, so no field can be omitted from the check, and a field added to the struct is a
  compile error in the test.
- `no_two_fields_read_the_same_key` — the identity reader only discriminates if the keys differ. This
  records what each reader is actually asked for and asserts 18 and 6 reads with no repeats per
  array, which checks distinctness on the projection itself rather than against a second
  hand-maintained list of the constants. (Verified separately against
  `crates/assay-common/src/lib.rs`: `MONITOR_STAT_*` are `0..=17`, `SOCKET_STAT_*` are `0..=5`.)

No live aya object, no kernel, no mock of `AyaArray`, and no source-text scan.

`MonitorStatsSnapshot` is unchanged, `#[derive(Default)]` included — no ripple into `assay-cli` or
`assay-runner-core` test code. `snapshot_stats`' signature is unchanged and `project_snapshot` is
private, so there is no public API change.

## RED criteria — five mutations, each applied and reverted

Re-run in full against the current head. All commands run from the worktree root.

| # | Mutation | Command | Observed |
|---|---|---|---|
| 1 | Delete the `Ok(crate::project_snapshot(...))` call in `snapshot_stats` | `cargo check --target x86_64-unknown-linux-gnu -p assay-monitor --all-targets` | **compile error** `error[E0308]: mismatched types` at `loader.rs:592` — "implicitly returns `()` as its body has no tail or `return` expression", expected `Result<MonitorStatsSnapshot, ...>`, found `()` |
| 2 | Swap the two reader arguments at the call site | `cargo check --target x86_64-unknown-linux-gnu -p assay-monitor --all-targets` | **compile error** — two `error[E0308]`: at `loader.rs:606` "expected `u32`, found `u64`", at `loader.rs:607` "expected `u64`, found `u32`" |
| 3a | Delete the `sendto_no_peer:` initializer in `project_snapshot` | `cargo test -p assay-monitor` | **compile error** `error[E0063]: missing field `sendto_no_peer` in initializer of `MonitorStatsSnapshot`` at `lib.rs:104` |
| 3b | Same field, softer form: replace the read with the constant `0` | `cargo test -p assay-monitor` | **test RED, both tests** — `test result: FAILED. 52 passed; 2 failed`. Totality: `left: … sendto_no_peer: 0 …` vs `right: … sendto_no_peer: 14 …`. Read-count: 17 `STATS` reads instead of 18 |
| 4 | Swap `MONITOR_STAT_SENDTO_NO_PEER` ↔ `MONITOR_STAT_SENDMSG_NO_PEER` | `cargo test -p assay-monitor` | **test RED** — `every_snapshot_field_reads_its_own_key … FAILED`, `test result: FAILED. 53 passed; 1 failed`; `left: … sendto_no_peer: 15, sendmsg_no_peer: 14 …` vs `right: … sendto_no_peer: 14, sendmsg_no_peer: 15 …` |
| 5 | Point `sendto_no_peer` at `SOCKET_STAT_EVENTS_EMITTED` | `cargo test -p assay-monitor` | **test RED, both tests** — `test result: FAILED. 52 passed; 2 failed`. Totality: `left: … sendto_no_peer: 4 …` vs `right: … sendto_no_peer: 14 …`. Read-count: `assertion left == right failed: two fields read the same key` (key `4` now read twice, colliding with `MONITOR_STAT_OPENAT_EVENTS_EMITTED`) |

Criterion 3 was specified as "test RED"; the full struct literal makes it strictly stronger — a
compile error. 3b is the same mutation in the form that would still compile, and it is caught. Every
mutation was reverted immediately after measurement; the committed tree is the unmutated one.

## GREEN — and what ran on which platform

`assay-monitor`'s `loader.rs` is `#[cfg(target_os = "linux")]` for `aya`, so it is not compiled at
all in a native macOS build. What was actually run, on **macOS (aarch64-apple-darwin, rustc/clippy
1.96.0)**:

- `cargo test -p assay-monitor` → `54 passed; 0 failed; 1 ignored` (was 53; one test replaced by two)
- `cargo clippy -p assay-monitor --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

For the Linux-only path, on the same macOS host by cross-compilation to
**`x86_64-unknown-linux-gnu`** (type-check only, no linking, no execution):

- `cargo check --target x86_64-unknown-linux-gnu -p assay-monitor --all-targets` → clean, no warnings
- `cargo clippy --target x86_64-unknown-linux-gnu -p assay-monitor --all-targets -- -D warnings` → clean

Mutations 1 and 2 are compile-time properties of the Linux-gated code, so the cross-target check is
the right instrument for them and is what was used. Mutations 3–5 are properties of
`project_snapshot`, which is `#[cfg(any(test, target_os = "linux"))]` and therefore genuinely
executed on macOS.

**Not run:** no test binary was executed on Linux at all. `cargo check --target
x86_64-unknown-linux-gnu -p assay-cli` fails on this host for an unrelated reason (a dependency's
build script needs `x86_64-linux-gnu-gcc`, absent here), so the downstream consumer was not
cross-checked; the change is crate-internal with an unchanged public surface, but that is an
argument, not a measurement. A macOS pass is **not** coverage of the Linux-only path.

## Non-claims

- This establishes **nothing** about whether the `STATS` map exists in the loaded eBPF object,
  whether aya successfully binds `AyaArray::try_from` to it, or whether the kernel writes what we
  read. All three still require a live kernel and a real load; nothing here substitutes for that.
- `unwrap_or(0)` still converts a map-read failure into a zero. A missing or unreadable key remains
  indistinguishable from a genuine zero at every call site. This change only guarantees that the
  read is *attempted* for every field and lands in the *right* field.
- The tests prove the key→field wiring, not that any `MONITOR_STAT_*` constant matches what the eBPF
  side actually increments. Userspace and kernel share the constants from `assay-common`, so they
  cannot disagree about the number, but nothing here checks that a given hook bumps the counter its
  name implies.
- No behaviour change is claimed. The projection reads the same keys into the same fields as before;
  this is a refactor that changes what a future deletion costs, not what a current run reports.
