### PR TITLE
Carry the claim ceiling into verify-side-effects, and share the fold

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/verify_side_effects.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_side_effects.rs
@@ -27,8 +27,9 @@ use crate::exit_codes;
 use anyhow::{Context, Result};
 use assay_evidence::bundle::BundleReader;
 use assay_evidence::{
-    coding_agent_claim_decision, CodingAgentClaimKind, CodingAgentCoverageState,
-    CodingAgentGateDecision, CodingAgentSourceClass,
+    coding_agent_claim_decision, coding_agent_weakest_ceiling, CodingAgentClaimCeiling,
+    CodingAgentClaimDecision, CodingAgentClaimKind, CodingAgentCoverageState,
+    CodingAgentGateDecision, CodingAgentSourceClass, CodingAgentWeakestCeiling,
 };
 use assay_mcp_server::side_effect::{
     check_audit_record, AuditBinding, SideEffectLevel, PROVIDER_AUDIT_RECORD_SCHEMA,
@@ -93,6 +94,21 @@ struct CallRow {
     /// rule. `occurrence` asks "did this effect happen"; `bounded_negative` asks "did it not".
     occurrence_claim: CodingAgentGateDecision,
     bounded_negative_claim: CodingAgentGateDecision,
+    /// How strong the occurrence claim is allowed to be, on the published ceiling ladder.
+    ///
+    /// The gate has always computed this and this report used to drop it, which made the ladder's
+    /// ordering unobservable: `asserted` and `verified` both surfaced as a bare `Allowed`/`Degraded`
+    /// and a consumer could not tell a provider's own word from an independent record. Carrying the
+    /// rung is what makes `producer_reported < ... < independently_confirmed` mean something outside
+    /// the type system.
+    ///
+    /// Absent on two kinds of row, and they are different. A call that asserted no side effect gets
+    /// no rung because it made no occurrence claim to grade — publishing one there would attach a
+    /// ladder position to a claim nobody made. And a call whose occurrence claim is `Blocked` gets
+    /// none because a block is the statement that no rung applies. `asserted` distinguishes the two
+    /// for a reader, which is why this stays an `Option` here while the run-level answer does not.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    occurrence_ceiling: Option<CodingAgentClaimCeiling>,
     /// What a below-harness observer could say about the claimed egress, when one was supplied.
     #[serde(skip_serializing_if = "Option::is_none")]
     egress: Option<EgressRefutation>,
@@ -108,6 +124,20 @@ struct Report {
     audit_records_unmatched: usize,
     calls: Vec<CallRow>,
     promoted: usize,
+    /// The strongest occurrence claim this report as a whole supports: the **weakest** rung across
+    /// every call that asserted a side effect.
+    ///
+    /// A fold and never a maximum. One independently corroborated call does not raise what the run
+    /// as a whole supports, and a reader who takes the strongest row away has learnt the wrong
+    /// thing.
+    ///
+    /// Always emitted, and three-state rather than an `Option`, because an absent field would say
+    /// two different things at once: that a refutation collapsed the run, and that no call in the
+    /// bundle asserted anything. Those are the occurrence-versus-absence cases this command exists
+    /// to keep apart, and the first draft of this field lost the distinction in the very field meant
+    /// to carry it. The fold itself lives in `assay-evidence` and is shared with the coverage
+    /// report's per-dimension version rather than copied.
+    weakest_occurrence_ceiling: CodingAgentWeakestCeiling,
     claims_not_made: &'static [&'static str],
 }
 
@@ -148,15 +178,34 @@ fn source_class_for(level: SideEffectLevel) -> CodingAgentSourceClass {
 /// audit record for a single call cannot support. `Partial` says exactly what is true: this
 /// occurrence is corroborated, the dimension is not covered, so occurrence claims pass and absence
 /// claims are blocked by `partial_coverage_blocks_absence_claim`.
+///
+/// Returns the whole decision rather than just its verdict. An earlier version took `.decision` here
+/// and threw the rung away, which left the ceiling ladder computed on every call and read by nobody
+/// — a rule that runs but decides nothing. The caller now takes the part it needs.
 fn claim_decision_for(
     level: SideEffectLevel,
     kind: CodingAgentClaimKind,
-) -> CodingAgentGateDecision {
+) -> CodingAgentClaimDecision {
     let coverage = match level {
         SideEffectLevel::Asserted => CodingAgentCoverageState::SelfReported,
         _ => CodingAgentCoverageState::Partial,
     };
-    coding_agent_claim_decision(source_class_for(level), coverage, kind).decision
+    coding_agent_claim_decision(source_class_for(level), coverage, kind)
+}
+
+/// The weakest occurrence rung across the calls that asserted a side effect.
+///
+/// Only asserting calls count. A tool that never claimed to change anything outside the process has
+/// nothing to corroborate, and folding its floor into the run's answer would report a weak run
+/// because it did some reading. That filter is exactly why this set can be empty and why the shared
+/// fold has to distinguish empty from blocked.
+fn weakest_occurrence_ceiling(calls: &[CallRow]) -> CodingAgentWeakestCeiling {
+    coding_agent_weakest_ceiling(
+        calls
+            .iter()
+            .filter(|c| c.asserted)
+            .map(|c| c.occurrence_ceiling),
+    )
 }
 
 /// Load `assay.provider_audit_record.v0` files from an import directory.
@@ -265,6 +314,7 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
                 binding: None,
                 occurrence_claim: CodingAgentGateDecision::Blocked,
                 bounded_negative_claim: CodingAgentGateDecision::Blocked,
+                occurrence_ceiling: None,
                 egress: None,
             };
 
@@ -304,8 +354,12 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
                     refute_egress(observation_health.as_ref(), &observed_peers, expected)
                 });
             }
-            row.occurrence_claim =
-                claim_decision_for(row.level, CodingAgentClaimKind::PositiveExistence);
+            let occurrence = claim_decision_for(row.level, CodingAgentClaimKind::PositiveExistence);
+            row.occurrence_claim = occurrence.decision;
+            // Only a call that asserted a side effect gets a rung. `occurrence_claim` is computed for
+            // every row and that predates this change, but a ladder position is a stronger thing to
+            // publish: it grades a claim, and a call that asserted nothing has not made one.
+            row.occurrence_ceiling = occurrence.ceiling.filter(|_| row.asserted);
 
             // A refutation overrides the ladder, including `verified`. If an imported audit record
             // says the call happened and a watching kernel observer says nothing left the cgroup,
@@ -315,12 +369,18 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
             // gap overturn real corroboration. The conflict is the finding.
             if row.egress.as_ref().is_some_and(EgressRefutation::refutes) {
                 row.occurrence_claim = CodingAgentGateDecision::Blocked;
+                // The rung goes with it. A blocked claim that still advertised
+                // `independently_confirmed` would let a reader take the number and drop the verdict,
+                // which is the exact misreading the refutation exists to prevent.
+                row.occurrence_ceiling = None;
             }
             row.bounded_negative_claim =
-                claim_decision_for(row.level, CodingAgentClaimKind::BoundedNegative);
+                claim_decision_for(row.level, CodingAgentClaimKind::BoundedNegative).decision;
             calls.push(row);
         }
     }
+
+    let weakest_occurrence_ceiling = weakest_occurrence_ceiling(&calls);
 
     let report = Report {
         schema: "assay.side_effect_verification.v0",
@@ -329,6 +389,7 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
         audit_records_unmatched: matched_records.iter().filter(|m| !**m).count(),
         calls,
         promoted,
+        weakest_occurrence_ceiling,
         claims_not_made: CLAIMS_NOT_MADE,
     };
 
@@ -340,14 +401,25 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
                 "imported audit records: {} ({} matched no observed call)",
                 report.audit_records_imported, report.audit_records_unmatched
             );
+            println!(
+                "weakest occurrence ceiling: {}",
+                match report.weakest_occurrence_ceiling {
+                    CodingAgentWeakestCeiling::NothingClaimed =>
+                        "nothing_claimed (no call asserted a side effect)".to_string(),
+                    CodingAgentWeakestCeiling::Blocked =>
+                        "blocked (an asserting call is contradicted or unsupported)".to_string(),
+                    CodingAgentWeakestCeiling::Rung { ceiling } => format!("{ceiling:?}"),
+                }
+            );
             for c in &report.calls {
                 let level = serde_json::to_value(c.level)?;
                 println!(
-                    "  {:40} asserted={:5} level={:18} occurrence={:?} absence={:?}",
+                    "  {:40} asserted={:5} level={:18} occurrence={:?} ceiling={:?} absence={:?}",
                     c.tool,
                     c.asserted,
                     level.as_str().unwrap_or("?"),
                     c.occurrence_claim,
+                    c.occurrence_ceiling,
                     c.bounded_negative_claim
                 );
                 if let Some(e) = &c.egress {

--- a/crates/assay-cli/tests/verify_side_effects_cli.rs
+++ b/crates/assay-cli/tests/verify_side_effects_cli.rs
@@ -410,3 +410,219 @@ fn a_peer_set_from_a_different_run_cannot_refute() {
         "a mismatched run pair must refuse, not refute"
     );
 }
+
+// ------------------------------------------------- the ceiling ladder, made observable in output
+
+#[test]
+fn the_ladder_ordering_is_visible_in_the_report_and_not_only_in_the_type_system() {
+    // The gate has always computed a rung and this report used to drop it, so `asserted` and
+    // `verified` reached a consumer as a bare verdict and the ordering
+    // `producer_reported < ... < independently_confirmed` decided nothing anyone could read.
+    //
+    // This test fails two ways on purpose. It fails if the rung stops being carried, and it fails if
+    // someone flattens the ladder so an independently produced record grades no higher than the
+    // provider's own word — the mutation `rge-bench`'s liveness check kills on the same axis.
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("b.tar.gz");
+    bundle_with_asserted_decision(&bundle);
+    let import = import_dir(dir.path(), "audit_record_github_deploy_key.json");
+
+    let asserted = run(&bundle, None);
+    let verified = run(&bundle, Some(&import));
+
+    assert_eq!(
+        asserted["calls"][0]["occurrence_ceiling"],
+        json!("asserted"),
+        "a provider's own word caps at `asserted`, whatever else is true of the run"
+    );
+    assert_eq!(
+        verified["calls"][0]["occurrence_ceiling"],
+        json!("independently_confirmed"),
+        "a bound record from the system that would know is what the top rung is for"
+    );
+    assert_ne!(
+        asserted["calls"][0]["occurrence_ceiling"], verified["calls"][0]["occurrence_ceiling"],
+        "if these ever agree the ladder has been flattened and buys nothing"
+    );
+}
+
+/// Two asserting calls in one bundle, only one of which an imported record can bind.
+///
+/// A single-call bundle cannot tell a fold from a maximum — with one row they are the same number —
+/// so a test written against the committed one-call surface would pass under either rule and prove
+/// nothing. This builds the input that can discriminate: the second call targets a different repo,
+/// so the deploy-key record binds the first and leaves the second at the provider's own word.
+fn bundle_with_one_bindable_and_one_unbindable_call(path: &std::path::Path) {
+    let mut surface = fixture("verified.json");
+    let mut first = surface["observed_tool_decisions"][0].clone();
+    first["response"]["side_effect"] = json!({ "asserted": true, "level": "asserted" });
+    first["response"]["side_effect_verified"] = json!(false);
+
+    let mut second = first.clone();
+    second["tool"]["name"] = json!("github.add_deploy_key_other");
+    second["action"]["target"]["repo"] = json!("some-other-repo");
+
+    surface["observed_tool_decisions"] = json!([first, second]);
+
+    let mut event = EvidenceEvent::new(
+        DECISION_EVENT_TYPE,
+        "urn:assay:test:side-effects-cli",
+        "run-side-effects-two",
+        0,
+        surface,
+    );
+    event.time = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(event);
+    writer.finish().unwrap();
+}
+
+#[test]
+fn the_run_level_ceiling_is_the_weakest_rung_and_never_the_strongest() {
+    // A fold, not a maximum. One corroborated call does not raise what the run as a whole supports,
+    // and a reader who takes the best row home has learnt the wrong thing.
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("two.tar.gz");
+    bundle_with_one_bindable_and_one_unbindable_call(&bundle);
+    let import = import_dir(dir.path(), "audit_record_github_deploy_key.json");
+
+    let report = run(&bundle, Some(&import));
+    let rows: Vec<&Value> = report["calls"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|c| c["asserted"] == json!(true))
+        .collect();
+    assert_eq!(rows.len(), 2, "the discriminating input must survive");
+
+    let strongest = rows
+        .iter()
+        .map(|c| &c["occurrence_ceiling"])
+        .max_by_key(|c| ladder_index(c))
+        .unwrap();
+    let weakest = rows
+        .iter()
+        .map(|c| &c["occurrence_ceiling"])
+        .min_by_key(|c| ladder_index(c))
+        .unwrap();
+    assert_ne!(
+        strongest, weakest,
+        "without two different rungs this test cannot tell a fold from a maximum"
+    );
+
+    assert_eq!(
+        report["weakest_occurrence_ceiling"],
+        json!({ "state": "rung", "ceiling": weakest }),
+        "the run-level rung must be the weakest of its asserting calls"
+    );
+}
+
+#[test]
+fn a_refutation_takes_the_rung_with_it_rather_than_leaving_a_strong_number_behind() {
+    // `Blocked` is not the bottom rung, it is the statement that no rung applies. Leaving
+    // `independently_confirmed` next to a blocked claim would let a consumer read the number and
+    // drop the verdict, which is precisely what the refutation exists to stop.
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("b.tar.gz");
+    bundle_with_asserted_decision(&bundle);
+    let import = import_dir(dir.path(), "audit_record_github_deploy_key.json");
+    let oh = health(dir.path(), "connect_only", "clean");
+
+    let report = run_with_health(&bundle, Some(&import), &oh);
+
+    assert_eq!(report["calls"][0]["occurrence_claim"], json!("blocked"));
+    assert_eq!(
+        report["calls"][0]["occurrence_ceiling"],
+        Value::Null,
+        "a blocked occurrence must not advertise a rung"
+    );
+    assert_eq!(
+        report["weakest_occurrence_ceiling"],
+        json!({ "state": "blocked" }),
+        "and one blocked asserting call collapses the run-level answer, rather than lowering it"
+    );
+}
+
+/// A bundle whose only observed call asserted no side effect.
+fn bundle_with_no_asserted_side_effect(path: &std::path::Path) {
+    let mut surface = fixture("verified.json");
+    let decision = &mut surface["observed_tool_decisions"][0];
+    decision["response"]["side_effect"] = json!({ "asserted": false, "level": "asserted" });
+    decision["response"]["side_effect_asserted"] = json!(false);
+    decision["response"]["side_effect_verified"] = json!(false);
+
+    let mut event = EvidenceEvent::new(
+        DECISION_EVENT_TYPE,
+        "urn:assay:test:side-effects-cli",
+        "run-side-effects-none",
+        0,
+        surface,
+    );
+    event.time = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(event);
+    writer.finish().unwrap();
+}
+
+#[test]
+fn a_run_that_claimed_nothing_is_distinguishable_from_a_run_that_was_contradicted() {
+    // The finding an adversarial review caught, pinned so it cannot come back. The first version of
+    // the run-level field was an `Option` skipped when empty, so it was ABSENT both when a refutation
+    // collapsed the run and when no call asserted anything at all. A consumer could not tell "we
+    // watched and the evidence was contradicted" from "nothing here ever claimed an effect" — which
+    // is the occurrence-versus-absence conflation this whole command exists to prevent, reintroduced
+    // by the field meant to carry the rule.
+    let dir = tempdir().unwrap();
+
+    let quiet = dir.path().join("quiet.tar.gz");
+    bundle_with_no_asserted_side_effect(&quiet);
+    let quiet_report = run(&quiet, None);
+
+    let contradicted = dir.path().join("contradicted.tar.gz");
+    bundle_with_asserted_decision(&contradicted);
+    let import = import_dir(dir.path(), "audit_record_github_deploy_key.json");
+    let oh = health(dir.path(), "connect_only", "clean");
+    let contradicted_report = run_with_health(&contradicted, Some(&import), &oh);
+
+    assert_eq!(
+        quiet_report["weakest_occurrence_ceiling"],
+        json!({ "state": "nothing_claimed" })
+    );
+    assert_eq!(
+        contradicted_report["weakest_occurrence_ceiling"],
+        json!({ "state": "blocked" })
+    );
+    assert_ne!(
+        quiet_report["weakest_occurrence_ceiling"],
+        contradicted_report["weakest_occurrence_ceiling"],
+        "silence and contradiction must not serialize to the same thing"
+    );
+
+    // And the row-level half: a call that asserted nothing carries no rung, because a ladder
+    // position grades a claim and this call did not make one.
+    assert_eq!(quiet_report["calls"][0]["asserted"], json!(false));
+    assert_eq!(quiet_report["calls"][0]["occurrence_ceiling"], Value::Null);
+}
+
+/// Position on the published ladder, defined here rather than imported so the test does not agree
+/// with the implementation by construction. A rung the binary emits that this list does not know is
+/// a hard failure: it means the vocabulary grew and this test stopped covering it.
+///
+/// `Null` gets its own arm rather than falling into the panic. It is a legitimate value — a blocked
+/// or non-asserting row carries no rung — and reporting it as an unknown rung would misdiagnose an
+/// ordinary state as a vocabulary change.
+fn ladder_index(v: &Value) -> usize {
+    match v.as_str() {
+        Some("asserted") => 0,
+        Some("asserted_signed") => 1,
+        Some("observed_at_receiver") => 2,
+        Some("observed_in_path") => 3,
+        Some("independently_confirmed") => 4,
+        None if v.is_null() => panic!("no rung on this row; the caller must filter before ranking"),
+        other => panic!("unknown ceiling rung in report: {other:?}"),
+    }
+}

--- a/crates/assay-evidence/src/coding_agent.rs
+++ b/crates/assay-evidence/src/coding_agent.rs
@@ -289,17 +289,63 @@ pub struct CodingAgentCoverageReport {
     pub test: Option<CodingAgentClaimDecision>,
 }
 
+/// The result of folding a set of per-item ceilings into one answer for the whole set.
+///
+/// Three states rather than an `Option`, because an `Option` conflates two of them. A caller whose
+/// set can be empty and a caller whose set never is were both served by `Option` returning `None`,
+/// and the first caller then could not tell "nothing here made a claim" from "something here is
+/// blocked". That is the occurrence-versus-absence distinction this module exists to keep, so the
+/// fold is not allowed to lose it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum CodingAgentWeakestCeiling {
+    /// Nothing in the set claimed anything, so there is no rung to report and no gap either.
+    NothingClaimed,
+    /// At least one member is blocked. A block is not the bottom rung; it is the statement that no
+    /// rung applies, and there is nothing to take a minimum with.
+    Blocked,
+    /// The weakest rung across every member, all of which carried one.
+    Rung { ceiling: CodingAgentClaimCeiling },
+}
+
+/// Fold per-item ceilings into the strongest claim the whole set supports: the **weakest** rung
+/// across its members.
+///
+/// A fold and never a maximum. One member at the top rung does not raise what the set as a whole
+/// supports, and a reader who takes the strongest member away has learnt the wrong thing.
+///
+/// This is the single implementation of that rule. It used to exist twice — here over coverage
+/// dimensions and again in the CLI over side-effect calls — and the copy had already drifted at the
+/// moment it was written, because this container is never empty and that one can be.
+pub fn coding_agent_weakest_ceiling(
+    ceilings: impl IntoIterator<Item = Option<CodingAgentClaimCeiling>>,
+) -> CodingAgentWeakestCeiling {
+    let mut weakest: Option<CodingAgentClaimCeiling> = None;
+    for ceiling in ceilings {
+        let Some(ceiling) = ceiling else {
+            return CodingAgentWeakestCeiling::Blocked;
+        };
+        weakest = Some(weakest.map_or(ceiling, |w| w.min(ceiling)));
+    }
+    match weakest {
+        Some(ceiling) => CodingAgentWeakestCeiling::Rung { ceiling },
+        None => CodingAgentWeakestCeiling::NothingClaimed,
+    }
+}
+
 impl CodingAgentCoverageReport {
     /// The strongest claim this report as a whole supports: the **weakest** rung across every
     /// dimension the run claims. `None` when any claimed dimension is `Blocked` — a block binds
     /// harder than any rung, because there is no rung to take a minimum with.
+    ///
+    /// `NothingClaimed` also maps to `None`, and that arm is unreachable here: [`Self::claimed`]
+    /// always yields the four fixed dimensions. The mapping is stated rather than assumed, because
+    /// it is precisely the assumption that made a copy of this fold wrong elsewhere.
     pub fn weakest_ceiling(&self) -> Option<CodingAgentClaimCeiling> {
-        let mut weakest: Option<CodingAgentClaimCeiling> = None;
-        for decision in self.claimed() {
-            let ceiling = decision.ceiling?;
-            weakest = Some(weakest.map_or(ceiling, |w| w.min(ceiling)));
+        match coding_agent_weakest_ceiling(self.claimed().into_iter().map(|d| d.ceiling)) {
+            CodingAgentWeakestCeiling::Rung { ceiling } => Some(ceiling),
+            CodingAgentWeakestCeiling::Blocked | CodingAgentWeakestCeiling::NothingClaimed => None,
         }
-        weakest
     }
 
     /// Whether every claimed dimension supports at least `required` without degradation.

--- a/crates/assay-evidence/src/coding_agent.rs
+++ b/crates/assay-evidence/src/coding_agent.rs
@@ -338,7 +338,7 @@ impl CodingAgentCoverageReport {
     /// dimension the run claims. `None` when any claimed dimension is `Blocked` — a block binds
     /// harder than any rung, because there is no rung to take a minimum with.
     ///
-    /// `NothingClaimed` also maps to `None`, and that arm is unreachable here: [`Self::claimed`]
+    /// `NothingClaimed` also maps to `None`, and that arm is unreachable here: `Self::claimed`
     /// always yields the four fixed dimensions. The mapping is stated rather than assumed, because
     /// it is precisely the assumption that made a copy of this fold wrong elsewhere.
     pub fn weakest_ceiling(&self) -> Option<CodingAgentClaimCeiling> {

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -22,11 +22,12 @@ pub use bundle::{
 };
 pub use coding_agent::{
     coding_agent_claim_ceiling, coding_agent_claim_decision, coding_agent_evidence_event,
-    CodingAgentClaimCeiling, CodingAgentClaimDecision, CodingAgentClaimKind, CodingAgentCoverage,
-    CodingAgentCoverageGap, CodingAgentCoverageReport, CodingAgentCoverageState,
-    CodingAgentDeclaredScope, CodingAgentEvidencePayload, CodingAgentGateDecision,
-    CodingAgentNetworkPolicy, CodingAgentObservedEffects, CodingAgentSourceClass,
-    CODING_AGENT_EVIDENCE_EVENT_TYPE, CODING_AGENT_EVIDENCE_SOURCE,
+    coding_agent_weakest_ceiling, CodingAgentClaimCeiling, CodingAgentClaimDecision,
+    CodingAgentClaimKind, CodingAgentCoverage, CodingAgentCoverageGap, CodingAgentCoverageReport,
+    CodingAgentCoverageState, CodingAgentDeclaredScope, CodingAgentEvidencePayload,
+    CodingAgentGateDecision, CodingAgentNetworkPolicy, CodingAgentObservedEffects,
+    CodingAgentSourceClass, CodingAgentWeakestCeiling, CODING_AGENT_EVIDENCE_EVENT_TYPE,
+    CODING_AGENT_EVIDENCE_SOURCE,
 };
 pub use lint::packs::{load_pack, load_packs, LoadedPack, PackError, PackSource};
 pub use ndjson::{read_events, write_events, NdjsonEvents};


### PR DESCRIPTION
`verify-side-effects` called the coding-agent claim gate, took `.decision`, and dropped the ceiling rung that came with it. A `verified` call and an `asserted` one therefore reached a consumer as a bare verdict, and the ordering the gate exists to encode decided nothing anyone could read.

Each asserting call now reports `occurrence_ceiling`, and the report carries `weakest_occurrence_ceiling` across the calls that asserted a side effect — a fold, never a maximum, because one corroborated call does not raise what the run as a whole supports.

## What an adversarial review changed, and it was the better half of this PR

**The run-level field conflated two opposite states.** As an `Option` skipped when empty it was absent both when a refutation collapsed the run and when no call asserted anything at all. That is the occurrence-versus-absence distinction this command exists to keep, lost inside the field meant to carry it. It is now three-state (`nothing_claimed` / `blocked` / `rung`) and always emitted.

**The fold was a copy, and it had already drifted when it was written.** `CodingAgentCoverageReport::weakest_ceiling` iterates a container that is never empty, so `?`-means-blocked is sound there; the copy filtered on `asserted` and could be empty, so it was not. There is now one implementation, `coding_agent_weakest_ceiling` in `assay-evidence`, used by both callers — per the one-rule-one-function rule in AGENTS.md.

**A rung was published on rows that asserted nothing.** `occurrence_claim` has been computed for every row since before this change, but a ladder position grades a claim, and a call that asserted no side effect has not made one.

## Measurements

Worktree off `origin/main` `e07b93d44`, rustc 1.96.0, darwin, `cargo test -p assay-cli --test verify_side_effects_cli`, 17 tests.

| Mutation | Result |
|---|---|
| ladder flattened, `verified` → `producer_reported` | 15 pass, **2 fail** |
| shared fold `min` → `max` | 16 pass, **1 fail** |
| `blocked` collapsed into `nothing_claimed` | 15 pass, **2 fail** |
| rung published on non-asserting rows | 16 pass, **1 fail** |
| `asserted` arm raised | 17 pass, **survives** |
| `observed_confirmed` arm changed | 17 pass, **survives** |

The last two survive and no test will kill them: the `SelfReported` branch caps at `Asserted` whatever source class it is handed, and `row.level` is never `ObservedConfirmed` in this command. Equivalent mutants rather than coverage gaps — which also narrows the claim: the ladder is now observable for the `Verified` arm, not for all three.

An earlier draft of the commit message reported 15-of-16 for the first row. That was wrong; it was 14 of 16 against the then-16-test file, and the correction is in the commit message rather than quietly dropped.

## Scope

Nothing gates on this and the command still exits 0. This makes the ladder observable, not binding; an exit code is a separate decision with its own compatibility question. Both new fields carry `skip_serializing_if` or are additive, and nothing outside the producing crate parses this report.

`cargo test -p assay-evidence` 317 passed; full `assay-cli` suite green; `cargo fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)