### PR TITLE
Fail closed on malformed claim decisions, one-to-one audit allocation, typed ceiling fold

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/verify_side_effects.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_side_effects.rs
@@ -109,6 +109,11 @@ struct CallRow {
     /// for a reader, which is why this stays an `Option` here while the run-level answer does not.
     #[serde(skip_serializing_if = "Option::is_none")]
     occurrence_ceiling: Option<CodingAgentClaimCeiling>,
+    /// The full occurrence decision for this call, used by the ceiling fold. Kept alongside the
+    /// serialized `occurrence_claim` and `occurrence_ceiling` so the fold consumes the decision
+    /// directly (Blocker 3: no more `Option<Ceiling>` ambiguity).
+    #[serde(skip)]
+    occurrence_decision: CodingAgentClaimDecision,
     /// What a below-harness observer could say about the claimed egress, when one was supplied.
     #[serde(skip_serializing_if = "Option::is_none")]
     egress: Option<EgressRefutation>,
@@ -200,12 +205,12 @@ fn claim_decision_for(
 /// because it did some reading. That filter is exactly why this set can be empty and why the shared
 /// fold has to distinguish empty from blocked.
 fn weakest_occurrence_ceiling(calls: &[CallRow]) -> CodingAgentWeakestCeiling {
-    coding_agent_weakest_ceiling(
-        calls
-            .iter()
-            .filter(|c| c.asserted)
-            .map(|c| c.occurrence_ceiling),
-    )
+    let asserting_decisions: Vec<&CodingAgentClaimDecision> = calls
+        .iter()
+        .filter(|c| c.asserted)
+        .map(|c| &c.occurrence_decision)
+        .collect();
+    coding_agent_weakest_ceiling(asserting_decisions)
 }
 
 /// Load `assay.provider_audit_record.v0` files from an import directory.
@@ -287,22 +292,67 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
         None => Vec::new(),
     };
 
+    // Require at least one decision surface event. A bundle with no decision events has nothing to
+    // verify, and reporting an empty NothingClaimed would mask the fact that the bundle is not a
+    // decision-surface bundle at all.
+    let decision_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.type_ == DECISION_EVENT_TYPE)
+        .collect();
+    if decision_events.is_empty() {
+        anyhow::bail!(
+            "bundle contains no {DECISION_EVENT_TYPE} events: \
+             nothing to verify (supply a bundle that carries observed tool decisions)"
+        );
+    }
+
     let mut calls = Vec::new();
     let mut promoted = 0usize;
     let mut matched_records = vec![false; records.len()];
 
-    for event in events.iter().filter(|e| e.type_ == DECISION_EVENT_TYPE) {
-        let Some(decisions) = event
+    for event in &decision_events {
+        // Require observed_tool_decisions to be an array. The previous code silently continued on
+        // missing/mistyped values, which turned a malformed bundle into an empty set and then
+        // NothingClaimed — absence masquerading as clean.
+        let decisions = event
             .payload
             .get("observed_tool_decisions")
-            .and_then(Value::as_array)
-        else {
-            continue;
-        };
+            .with_context(|| {
+                format!(
+                    "{DECISION_EVENT_TYPE} event is missing observed_tool_decisions field \
+                     (event id: {})",
+                    event.id
+                )
+            })?
+            .as_array()
+            .with_context(|| {
+                format!(
+                    "{DECISION_EVENT_TYPE} event has observed_tool_decisions that is not an array \
+                     (event id: {})",
+                    event.id
+                )
+            })?;
         for decision in decisions {
-            let asserted = decision["response"]["side_effect_asserted"]
+            // Require side_effect_asserted to be a bool. The previous code defaulted to false on
+            // missing/non-bool, which made a malformed response look like a call that asserted
+            // nothing — the exact conflation this ladder exists to prevent.
+            let asserted = decision
+                .get("response")
+                .and_then(|r| r.get("side_effect_asserted"))
+                .with_context(|| {
+                    format!(
+                        "decision for tool {:?} is missing response.side_effect_asserted",
+                        decision["tool"]["name"].as_str().unwrap_or("?")
+                    )
+                })?
                 .as_bool()
-                .unwrap_or(false);
+                .with_context(|| {
+                    format!(
+                        "decision for tool {:?} has response.side_effect_asserted \
+                         that is not a boolean",
+                        decision["tool"]["name"].as_str().unwrap_or("?")
+                    )
+                })?;
             let tool = decision["tool"]["name"].as_str().unwrap_or("?").to_string();
             let action = &decision["action"];
 
@@ -315,11 +365,23 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
                 occurrence_claim: CodingAgentGateDecision::Blocked,
                 bounded_negative_claim: CodingAgentGateDecision::Blocked,
                 occurrence_ceiling: None,
+                occurrence_decision: CodingAgentClaimDecision {
+                    decision: CodingAgentGateDecision::Blocked,
+                    ceiling: None,
+                    gap: None,
+                    rule: String::new(),
+                },
                 egress: None,
             };
 
             if asserted {
+                // One-to-one allocation: skip records already matched to a prior call. Two
+                // otherwise identical asserting calls each need their own audit record; letting
+                // one record vouch for both would overcount corroboration.
                 for (i, record) in records.iter().enumerate() {
+                    if matched_records[i] {
+                        continue;
+                    }
                     let binding = check_audit_record(record, action);
                     match &binding {
                         AuditBinding::Bound { subject_digest } => {
@@ -374,6 +436,15 @@ pub fn cmd_verify_side_effects(args: &VerifySideEffectsArgs) -> Result<i32> {
                 // which is the exact misreading the refutation exists to prevent.
                 row.occurrence_ceiling = None;
             }
+
+            // Carry the full decision for the ceiling fold. After a refutation override, rebuild
+            // the decision so the fold sees the blocked state rather than the pre-refutation rung.
+            row.occurrence_decision = CodingAgentClaimDecision {
+                decision: row.occurrence_claim,
+                ceiling: row.occurrence_ceiling,
+                gap: occurrence.gap,
+                rule: occurrence.rule,
+            };
             row.bounded_negative_claim =
                 claim_decision_for(row.level, CodingAgentClaimKind::BoundedNegative).decision;
             calls.push(row);

--- a/crates/assay-cli/tests/verify_side_effects_cli.rs
+++ b/crates/assay-cli/tests/verify_side_effects_cli.rs
@@ -608,6 +608,256 @@ fn a_run_that_claimed_nothing_is_distinguishable_from_a_run_that_was_contradicte
     assert_eq!(quiet_report["calls"][0]["occurrence_ceiling"], Value::Null);
 }
 
+// ------------------------------------------------- Blocker 1: fail closed on malformed input
+
+/// A bundle carrying an event that is NOT a decision surface (wrong type).
+fn bundle_with_no_decision_events(path: &std::path::Path) {
+    let event = EvidenceEvent::new(
+        "assay.some_other_event.v0",
+        "urn:assay:test:side-effects-cli",
+        "run-no-decisions",
+        0,
+        json!({"irrelevant": true}),
+    );
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(event);
+    writer.finish().unwrap();
+}
+
+#[test]
+fn a_bundle_with_no_decision_events_fails_rather_than_reporting_nothing_claimed() {
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("empty.tar.gz");
+    bundle_with_no_decision_events(&bundle);
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("verify-side-effects")
+        .arg(&bundle)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(out).unwrap();
+    assert!(
+        stderr.contains("no") && stderr.contains(DECISION_EVENT_TYPE),
+        "the error must name the missing event type: {stderr}"
+    );
+}
+
+/// A bundle whose decision event has `observed_tool_decisions` as a string instead of an array.
+fn bundle_with_non_array_decisions(path: &std::path::Path) {
+    let mut surface = fixture("verified.json");
+    surface["observed_tool_decisions"] = json!("not_an_array");
+
+    let mut event = EvidenceEvent::new(
+        DECISION_EVENT_TYPE,
+        "urn:assay:test:side-effects-cli",
+        "run-bad-decisions",
+        0,
+        surface,
+    );
+    event.time = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(event);
+    writer.finish().unwrap();
+}
+
+#[test]
+fn a_non_array_observed_tool_decisions_fails_rather_than_silently_skipping() {
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("bad.tar.gz");
+    bundle_with_non_array_decisions(&bundle);
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("verify-side-effects")
+        .arg(&bundle)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(out).unwrap();
+    assert!(
+        stderr.contains("not an array"),
+        "the error must explain what went wrong: {stderr}"
+    );
+}
+
+/// A bundle where response.side_effect_asserted is a string instead of a bool.
+fn bundle_with_non_bool_asserted(path: &std::path::Path) {
+    let mut surface = fixture("verified.json");
+    let decision = &mut surface["observed_tool_decisions"][0];
+    decision["response"]["side_effect_asserted"] = json!("yes");
+
+    let mut event = EvidenceEvent::new(
+        DECISION_EVENT_TYPE,
+        "urn:assay:test:side-effects-cli",
+        "run-bad-asserted",
+        0,
+        surface,
+    );
+    event.time = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(event);
+    writer.finish().unwrap();
+}
+
+#[test]
+fn a_non_bool_side_effect_asserted_fails_rather_than_defaulting_to_false() {
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("bad.tar.gz");
+    bundle_with_non_bool_asserted(&bundle);
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("verify-side-effects")
+        .arg(&bundle)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(out).unwrap();
+    assert!(
+        stderr.contains("not a boolean"),
+        "the error must explain what went wrong: {stderr}"
+    );
+}
+
+/// A bundle where response.side_effect_asserted is missing entirely.
+fn bundle_with_missing_asserted(path: &std::path::Path) {
+    let mut surface = fixture("verified.json");
+    let decision = &mut surface["observed_tool_decisions"][0];
+    if let Some(resp) = decision.get_mut("response").and_then(Value::as_object_mut) {
+        resp.remove("side_effect_asserted");
+    }
+
+    let mut event = EvidenceEvent::new(
+        DECISION_EVENT_TYPE,
+        "urn:assay:test:side-effects-cli",
+        "run-missing-asserted",
+        0,
+        surface,
+    );
+    event.time = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(event);
+    writer.finish().unwrap();
+}
+
+#[test]
+fn a_missing_side_effect_asserted_fails_rather_than_defaulting_to_false() {
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("bad.tar.gz");
+    bundle_with_missing_asserted(&bundle);
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("verify-side-effects")
+        .arg(&bundle)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(out).unwrap();
+    assert!(
+        stderr.contains("side_effect_asserted"),
+        "the error must name the missing field: {stderr}"
+    );
+}
+
+// ------------------------------------------------- Blocker 2: one-to-one audit allocation
+
+/// Two identical asserting calls in one bundle (same tool, same target).
+fn bundle_with_two_identical_asserting_calls(path: &std::path::Path) {
+    let mut surface = fixture("verified.json");
+    let mut call = surface["observed_tool_decisions"][0].clone();
+    call["response"]["side_effect"] = json!({ "asserted": true, "level": "asserted" });
+    call["response"]["side_effect_verified"] = json!(false);
+    // Two identical calls targeting the same resource.
+    surface["observed_tool_decisions"] = json!([call.clone(), call]);
+
+    let mut event = EvidenceEvent::new(
+        DECISION_EVENT_TYPE,
+        "urn:assay:test:side-effects-cli",
+        "run-two-identical",
+        0,
+        surface,
+    );
+    event.time = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(event);
+    writer.finish().unwrap();
+}
+
+#[test]
+fn one_audit_record_cannot_vouch_for_two_identical_calls() {
+    // Two otherwise identical asserting calls plus one audit record that binds must yield exactly
+    // one verified promotion and one that stays asserted. Reusing the record would overcount
+    // corroboration: two receipts for one piece of paper.
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("two.tar.gz");
+    bundle_with_two_identical_asserting_calls(&bundle);
+    let import = import_dir(dir.path(), "audit_record_github_deploy_key.json");
+
+    let report = run(&bundle, Some(&import));
+    let calls = report["calls"].as_array().unwrap();
+    assert_eq!(calls.len(), 2, "both calls must appear");
+
+    let verified_count = calls
+        .iter()
+        .filter(|c| c["level"] == json!("verified"))
+        .count();
+    let asserted_count = calls
+        .iter()
+        .filter(|c| c["level"] == json!("asserted"))
+        .count();
+    assert_eq!(
+        verified_count, 1,
+        "exactly one call may be promoted by one record"
+    );
+    assert_eq!(
+        asserted_count, 1,
+        "the second call stays at asserted because its record was consumed"
+    );
+    assert_eq!(report["promoted"], json!(1));
+
+    // The run-level ceiling must be the weakest rung (asserted), not the strongest
+    // (independently_confirmed). One verified call does not raise the whole run.
+    assert_eq!(
+        report["weakest_occurrence_ceiling"],
+        json!({ "state": "rung", "ceiling": "asserted" }),
+        "the weakest rung governs when one record is consumed and one call is left at asserted"
+    );
+}
+
+// ------------------------------------------------- ladder helpers
+
 /// Position on the published ladder, defined here rather than imported so the test does not agree
 /// with the implementation by construction. A rung the binary emits that this list does not know is
 /// a hard failure: it means the vocabulary grew and this test stopped covering it.

--- a/crates/assay-evidence/src/coding_agent.rs
+++ b/crates/assay-evidence/src/coding_agent.rs
@@ -308,8 +308,8 @@ pub enum CodingAgentWeakestCeiling {
     Rung { ceiling: CodingAgentClaimCeiling },
 }
 
-/// Fold per-item ceilings into the strongest claim the whole set supports: the **weakest** rung
-/// across its members.
+/// Fold per-decision ceilings into the strongest claim the whole set supports: the **weakest**
+/// rung across its members.
 ///
 /// A fold and never a maximum. One member at the top rung does not raise what the set as a whole
 /// supports, and a reader who takes the strongest member away has learnt the wrong thing.
@@ -317,12 +317,38 @@ pub enum CodingAgentWeakestCeiling {
 /// This is the single implementation of that rule. It used to exist twice — here over coverage
 /// dimensions and again in the CLI over side-effect calls — and the copy had already drifted at the
 /// moment it was written, because this container is never empty and that one can be.
-pub fn coding_agent_weakest_ceiling(
-    ceilings: impl IntoIterator<Item = Option<CodingAgentClaimCeiling>>,
+///
+/// Consumes `CodingAgentClaimDecision` references so `Blocked` is encoded by the decision's own
+/// verdict and `NothingClaimed` only by an empty iterator. The previous signature accepted
+/// `Option<CodingAgentClaimCeiling>`, which conflated blocked (the decision says no rung applies)
+/// with absent (the caller passed `None` for its own reasons), and a caller with both states had
+/// no way to tell them apart.
+///
+/// # The verdict decides, not the rung
+///
+/// `CodingAgentClaimDecision` derives `Deserialize`, so a decision can arrive from outside this
+/// crate carrying any combination of its fields. The two inconsistent combinations are handled
+/// explicitly rather than left to whichever field happens to be read first:
+///
+/// * `Blocked` with a rung attached is **blocked**. Reading the rung and ignoring the verdict would
+///   let a crafted or corrupted record promote itself, which is the whole failure this fold exists
+///   to prevent. The doc above says the verdict encodes the block, so the verdict is what is read.
+/// * `Allowed` or `Degraded` with no rung is **blocked**, which is the fail-closed answer. It is
+///   deliberately not `NothingClaimed`: a claim was made and cannot be graded, and reporting a
+///   non-claim would invent an absence that the input does not state. Only an empty iterator ever
+///   yields `NothingClaimed`.
+pub fn coding_agent_weakest_ceiling<'a>(
+    decisions: impl IntoIterator<Item = &'a CodingAgentClaimDecision>,
 ) -> CodingAgentWeakestCeiling {
     let mut weakest: Option<CodingAgentClaimCeiling> = None;
-    for ceiling in ceilings {
-        let Some(ceiling) = ceiling else {
+    for decision in decisions {
+        // The verdict is read before the rung. A block is not the bottom rung; it is the statement
+        // that no rung applies, and there is nothing to take a minimum with.
+        if decision.decision == CodingAgentGateDecision::Blocked {
+            return CodingAgentWeakestCeiling::Blocked;
+        }
+        // Allowed or Degraded, so this decision owes a rung. Fail closed when it does not have one.
+        let Some(ceiling) = decision.ceiling else {
             return CodingAgentWeakestCeiling::Blocked;
         };
         weakest = Some(weakest.map_or(ceiling, |w| w.min(ceiling)));
@@ -342,7 +368,8 @@ impl CodingAgentCoverageReport {
     /// always yields the four fixed dimensions. The mapping is stated rather than assumed, because
     /// it is precisely the assumption that made a copy of this fold wrong elsewhere.
     pub fn weakest_ceiling(&self) -> Option<CodingAgentClaimCeiling> {
-        match coding_agent_weakest_ceiling(self.claimed().into_iter().map(|d| d.ceiling)) {
+        let claimed = self.claimed();
+        match coding_agent_weakest_ceiling(claimed.iter()) {
             CodingAgentWeakestCeiling::Rung { ceiling } => Some(ceiling),
             CodingAgentWeakestCeiling::Blocked | CodingAgentWeakestCeiling::NothingClaimed => None,
         }
@@ -470,4 +497,154 @@ pub fn coding_agent_evidence_event(
     );
     event.content_hash = Some(compute_content_hash(&event)?);
     Ok(event)
+}
+
+#[cfg(test)]
+mod weakest_ceiling_tests {
+    use super::*;
+
+    /// Helper: build a decision carrying a rung.
+    fn allowed(ceiling: CodingAgentClaimCeiling) -> CodingAgentClaimDecision {
+        CodingAgentClaimDecision {
+            decision: CodingAgentGateDecision::Allowed,
+            ceiling: Some(ceiling),
+            gap: None,
+            rule: "test".to_string(),
+        }
+    }
+
+    /// Helper: build a blocked decision (no rung).
+    fn blocked() -> CodingAgentClaimDecision {
+        CodingAgentClaimDecision {
+            decision: CodingAgentGateDecision::Blocked,
+            ceiling: None,
+            gap: Some(CodingAgentCoverageGap::NotObserved),
+            rule: "test_blocked".to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_iterator_is_nothing_claimed() {
+        let empty: [CodingAgentClaimDecision; 0] = [];
+        assert_eq!(
+            coding_agent_weakest_ceiling(empty.iter()),
+            CodingAgentWeakestCeiling::NothingClaimed,
+        );
+    }
+
+    #[test]
+    fn single_blocked_decision_is_blocked() {
+        let decisions = [blocked()];
+        assert_eq!(
+            coding_agent_weakest_ceiling(decisions.iter()),
+            CodingAgentWeakestCeiling::Blocked,
+        );
+    }
+
+    #[test]
+    fn single_rung_is_that_rung() {
+        let decisions = [allowed(CodingAgentClaimCeiling::ObservedInPath)];
+        assert_eq!(
+            coding_agent_weakest_ceiling(decisions.iter()),
+            CodingAgentWeakestCeiling::Rung {
+                ceiling: CodingAgentClaimCeiling::ObservedInPath
+            },
+        );
+    }
+
+    #[test]
+    fn fold_takes_weakest_not_strongest() {
+        let decisions = [
+            allowed(CodingAgentClaimCeiling::IndependentlyConfirmed),
+            allowed(CodingAgentClaimCeiling::Asserted),
+        ];
+        assert_eq!(
+            coding_agent_weakest_ceiling(decisions.iter()),
+            CodingAgentWeakestCeiling::Rung {
+                ceiling: CodingAgentClaimCeiling::Asserted
+            },
+        );
+    }
+
+    #[test]
+    fn blocked_among_rungs_collapses_to_blocked() {
+        let decisions = [
+            allowed(CodingAgentClaimCeiling::IndependentlyConfirmed),
+            blocked(),
+            allowed(CodingAgentClaimCeiling::Asserted),
+        ];
+        assert_eq!(
+            coding_agent_weakest_ceiling(decisions.iter()),
+            CodingAgentWeakestCeiling::Blocked,
+        );
+    }
+
+    /// A blocked verdict that still carries a rung must read as blocked.
+    ///
+    /// This combination cannot be produced by `coding_agent_claim_decision`, but the type derives
+    /// `Deserialize`, so it can arrive from outside this crate. A fold that reads the rung and
+    /// ignores the verdict lets such a record promote itself past the gate that blocked it. The
+    /// rung here is the top one on purpose: if the verdict were ignored, this test would report
+    /// `IndependentlyConfirmed`, the strongest possible answer, from the input least entitled to it.
+    #[test]
+    fn a_blocked_verdict_carrying_a_rung_is_still_blocked() {
+        let inconsistent = CodingAgentClaimDecision {
+            decision: CodingAgentGateDecision::Blocked,
+            ceiling: Some(CodingAgentClaimCeiling::IndependentlyConfirmed),
+            gap: Some(CodingAgentCoverageGap::NotObserved),
+            rule: "hostile_or_corrupted".to_string(),
+        };
+        let decisions = [inconsistent];
+        assert_eq!(
+            coding_agent_weakest_ceiling(decisions.iter()),
+            CodingAgentWeakestCeiling::Blocked,
+        );
+    }
+
+    /// The mirror inconsistency: a claim that was allowed but carries no rung to grade it.
+    ///
+    /// Fail closed to `Blocked`, and specifically not to `NothingClaimed`. The set is not empty and
+    /// a claim was made, so reporting a non-claim would invent an absence the input never stated.
+    #[test]
+    fn an_allowed_verdict_without_a_rung_fails_closed_rather_than_reading_as_nothing_claimed() {
+        for verdict in [
+            CodingAgentGateDecision::Allowed,
+            CodingAgentGateDecision::Degraded,
+        ] {
+            let rungless = CodingAgentClaimDecision {
+                decision: verdict,
+                ceiling: None,
+                gap: None,
+                rule: "hostile_or_corrupted".to_string(),
+            };
+            let decisions = [rungless];
+            assert_eq!(
+                coding_agent_weakest_ceiling(decisions.iter()),
+                CodingAgentWeakestCeiling::Blocked,
+                "{verdict:?} without a rung must fail closed",
+            );
+        }
+    }
+
+    /// A degraded verdict that does carry a rung still participates as that rung.
+    ///
+    /// The guard above must not turn "not Allowed" into "blocked": `Degraded` is the gate's way of
+    /// saying the claim survives at a reduced ceiling, and folding it away would silently discard
+    /// the case the ladder is most useful for.
+    #[test]
+    fn a_degraded_verdict_with_a_rung_still_folds_as_that_rung() {
+        let degraded = CodingAgentClaimDecision {
+            decision: CodingAgentGateDecision::Degraded,
+            ceiling: Some(CodingAgentClaimCeiling::Asserted),
+            gap: Some(CodingAgentCoverageGap::SelfReportedOnly),
+            rule: "self_reported_degrades_positive_claim".to_string(),
+        };
+        let decisions = [degraded, allowed(CodingAgentClaimCeiling::ObservedInPath)];
+        assert_eq!(
+            coding_agent_weakest_ceiling(decisions.iter()),
+            CodingAgentWeakestCeiling::Rung {
+                ceiling: CodingAgentClaimCeiling::Asserted
+            },
+        );
+    }
 }


### PR DESCRIPTION
Refs #2354

Follow-up to #2352. The claim-ceiling work merged as `b34bc2f8e`; an independent review of it then produced three verified blockers, and the fixes were never pushed. This is that fix, plus a fourth found while writing it.

## Provenance

| | |
|---|---|
| Base | `b34bc2f8ef5d97d2ec3d4988852cba90ff9b396f` (origin/main) |
| Head | `709cc965e39d5b7c5bb107530edcf7b87edf2a2c` |
| Cherry-picked from | local `01b9ea76022d8bc460e909e41a94a8e3bf3a9048`, then amended |

`01b9ea760` was authored against `b9f8f1f8b`, the pre-squash head of #2352, and was never pushed. It cherry-picked onto `b34bc2f8e` with no conflicts, since the squash merge preserved that tree. The amend adds the fourth fix below and nothing else.

## The three blockers

**1. Malformed decision evidence read as clean.** A decision event whose `observed_tool_decisions` was missing or not an array was skipped, and `response.side_effect_asserted` defaulted to `false` when missing or not a boolean. Each turned a malformed bundle into an empty or non-asserting set, which then reported as a run that claimed nothing. Absence masquerading as clean is the conflation this command exists to prevent. All four now fail with the event id or tool name in the message, and a bundle carrying no decision-surface events at all is rejected rather than reported empty.

**2. One audit record could vouch for several calls.** The record loop did not skip records already bound to an earlier call, so two otherwise identical asserting calls could both reach `verified` on the same imported record. Corroboration was overcounted by construction. Allocation is now one-to-one.

**3. The fold could not tell blocked from absent.** `coding_agent_weakest_ceiling` took `Option<CodingAgentClaimCeiling>`, so `None` meant either "this decision is blocked" or "the caller had no ceiling to give". It now takes `&CodingAgentClaimDecision` and reads the state from the decision itself.

## The fourth, found while fixing the third

The new signature still decided on `decision.ceiling` alone. `CodingAgentClaimDecision` derives `Deserialize`, so a record arriving from outside the crate can carry `Blocked` together with a rung, and the fold would have read the rung and ignored the verdict that blocked it.

The verdict is now read first. The mirror case, `Allowed` or `Degraded` with no rung, fails closed to `Blocked` and deliberately **not** to `NothingClaimed`: a claim was made and could not be graded, so reporting a non-claim would invent an absence the input never stated. Only an empty iterator yields `NothingClaimed`.

One rule, one function: the decision lives in `coding_agent_weakest_ceiling` and both callers inherit it.

## Evidence that the tests bite

`a_blocked_verdict_carrying_a_rung_is_still_blocked` carries the top rung on purpose. With the verdict check removed it reports `IndependentlyConfirmed`, the strongest possible answer, from the input least entitled to it.

Removing that check fails **exactly that test and no other**:

```
test a_blocked_verdict_carrying_a_rung_is_still_blocked ... FAILED
test result: FAILED. 7 passed; 1 failed
```

Its sibling `an_allowed_verdict_without_a_rung_fails_closed_rather_than_reading_as_nothing_claimed` **survives** that same mutation, because the prior code also returned `Blocked` on a missing ceiling. It guards the behaviour rather than the new branch, and is kept on that basis rather than counted as coverage it does not provide.

## Verification at `709cc965e`

| Check | Result |
|---|---|
| `cargo test -p assay-evidence` | 325 passed, 0 failed |
| `cargo test -p assay-cli --test verify_side_effects_cli` | 22 passed, 0 failed |
| `cargo clippy -p assay-evidence -p assay-cli --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --all -- --check` | exit 0 |
| `git diff --check origin/main...HEAD` | clean |
| Files touched | 3 |

macOS, rustc 1.96.0. Local runs; CI on this head is the authority.

## Not claimed

- No wire field, serialization, or exit-code changes.
- Nothing here gates a run. `verify-side-effects` still exits 0 on a completed report; the ladder is observable, not binding.
- The new failures are refusals to report on input that cannot be read. They are not verdicts about an agent.
- The report schema string stays `assay.side_effect_verification.v0`.

Draft, and `Refs` rather than `Closes` so #2354 stays open until this is reviewed and merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Side-effect verification now fails safely when evidence is missing or malformed.
  - Each audit record can corroborate only one matching call, preventing duplicate validation.
  - Refuted assertions are correctly treated as blocked.
  - Run-level results now preserve the weakest applicable verification ceiling.
- **Tests**
  - Added coverage for malformed evidence, missing decisions, invalid fields, duplicate audit matches, blocked decisions, and ceiling calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->