### PR TITLE
Pin the lint help pointers to a tag instead of to today's prose

### DIFF
--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -3,6 +3,43 @@ use crate::types::EvidenceEvent;
 use serde_json::Value;
 use std::collections::BTreeMap;
 
+/// The one place the shape of an emitted help pointer is defined.
+///
+/// Pinned to the release tag of the version this build already reports as `tool_version`, rather
+/// than to the docs site. The site is deployed flat by `mkdocs gh-deploy`, so
+/// `docs.getassay.dev/lint/#assay-w001` resolves against whatever the page says today and a
+/// consumer reading a six-month-old report silently gets today's prose. A tag cannot move, so the
+/// pointer now agrees with the version the report claims to be, and any drift between a working
+/// tree and that tag is drift the report already declares by calling itself that version.
+///
+/// The target is the markdown source rather than the rendered page because the rendered page has
+/// no versioned path to point at: `extra.version.provider: mike` is declared in `mkdocs.yml` but
+/// the deploy runs `mkdocs gh-deploy --force`, and `versions.json`, `/5.1.0/lint/` and
+/// `/latest/lint/` all return 404. Giving the site versioned paths would break every pointer
+/// already shipped in v5.0.0 and v5.1.0 binaries, so that is a separate decision, not a side
+/// effect of this one.
+///
+/// The fragments are `<a id="...">` elements rather than mkdocs `attr_list` (`{#assay-w001}`)
+/// because GitHub does not honour `attr_list`. Verified against the rendered page at `v5.1.0`,
+/// which shows `{#assay-w001}` as literal text in the heading and ids the section
+/// `assay-w001--subject-may-contain-a-secret-assay-w001`.
+///
+/// KNOWN GAP, bounded and self-clearing: a fragment resolves only from the first tag that carries
+/// these `<a id>` anchors onward. `v5.1.0` predates them, so a build from an untagged tree during
+/// this release cycle emits the right document at the right version with a fragment that lands at
+/// the top of the page instead of at its rule. Already-released v5.0.0 and v5.1.0 binaries are
+/// unaffected — they were built with the old unversioned pointer and nothing about them changes.
+macro_rules! lint_help_uri {
+    ($anchor:literal) => {
+        concat!(
+            "https://github.com/Rul1an/assay/blob/v",
+            env!("CARGO_PKG_VERSION"),
+            "/docs/lint/index.md#",
+            $anchor
+        )
+    };
+}
+
 type RuleCheck = for<'a> fn(&EvidenceEvent, &LintContext<'a>) -> Option<LintFinding>;
 
 /// Rule definition for the lint registry.
@@ -79,7 +116,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-W001",
         default_severity: Severity::Warn,
         description: "Subject may contain a secret (API key, token, password pattern)",
-        help_uri: Some("https://docs.getassay.dev/lint/#assay-w001"),
+        help_uri: Some(lint_help_uri!("assay-w001")),
         tags: &["security", "secrets"],
         security_severity: Some("7.0"),
         check: check_secret_in_subject,
@@ -88,7 +125,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-W002",
         default_severity: Severity::Warn,
         description: "Event flagged as containing PII but subject is non-empty",
-        help_uri: Some("https://docs.getassay.dev/lint/#assay-w002"),
+        help_uri: Some(lint_help_uri!("assay-w002")),
         tags: &["privacy", "pii"],
         security_severity: Some("4.0"),
         check: check_pii_flag_consistency,
@@ -97,7 +134,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-I001",
         default_severity: Severity::Info,
         description: "Source format does not follow URN convention",
-        help_uri: Some("https://docs.getassay.dev/lint/#assay-i001"),
+        help_uri: Some(lint_help_uri!("assay-i001")),
         tags: &["convention", "format"],
         security_severity: None,
         check: check_source_format,
@@ -106,7 +143,7 @@ pub static RULES: &[RuleDefinition] = &[
         id: "ASSAY-W003",
         default_severity: Severity::Warn,
         description: "Event flagged as containing secrets but secrets flag is false",
-        help_uri: Some("https://docs.getassay.dev/lint/#assay-w003"),
+        help_uri: Some(lint_help_uri!("assay-w003")),
         tags: &["security", "secrets"],
         security_severity: Some("6.5"),
         check: check_secrets_flag_consistency,
@@ -116,7 +153,7 @@ pub static RULES: &[RuleDefinition] = &[
         default_severity: Severity::Warn,
         description:
             "Observed enforcement marker is not supported by a bound enforcement decision record",
-        help_uri: Some("https://docs.getassay.dev/lint/#assay-w004"),
+        help_uri: Some(lint_help_uri!("assay-w004")),
         tags: &["security", "enforcement", "attribution"],
         security_severity: Some("4.0"),
         check: check_enforcement_attribution_binding,
@@ -127,7 +164,7 @@ pub static RULES: &[RuleDefinition] = &[
         description:
             "Approval basis declares an opaque or unknown retained view — content-review claims \
              over it cap at incomplete",
-        help_uri: Some("https://docs.getassay.dev/lint/#assay-w005"),
+        help_uri: Some(lint_help_uri!("assay-w005")),
         tags: &["retention", "review", "sufficiency"],
         security_severity: None,
         check: check_retained_view_readability,
@@ -172,7 +209,7 @@ fn check_secret_in_subject(event: &EvidenceEvent, ctx: &LintContext<'_>) -> Opti
                     }),
                     vec!["security".into(), "secrets".into()],
                 )
-                .with_help_uri("https://docs.getassay.dev/lint/#assay-w001"),
+                .with_help_uri(lint_help_uri!("assay-w001")),
             );
         }
     }
@@ -193,7 +230,7 @@ fn check_pii_flag_consistency(event: &EvidenceEvent, ctx: &LintContext<'_>) -> O
                 }),
                 vec!["privacy".into(), "pii".into()],
             )
-            .with_help_uri("https://docs.getassay.dev/lint/#assay-w002"),
+            .with_help_uri(lint_help_uri!("assay-w002")),
         );
     }
     None
@@ -217,7 +254,7 @@ fn check_source_format(event: &EvidenceEvent, ctx: &LintContext<'_>) -> Option<L
                 }),
                 vec!["convention".into(), "format".into()],
             )
-            .with_help_uri("https://docs.getassay.dev/lint/#assay-i001"),
+            .with_help_uri(lint_help_uri!("assay-i001")),
         );
     }
     None
@@ -247,7 +284,7 @@ fn check_secrets_flag_consistency(
                     }),
                     vec!["security".into(), "secrets".into()],
                 )
-                .with_help_uri("https://docs.getassay.dev/lint/#assay-w003"),
+                .with_help_uri(lint_help_uri!("assay-w003")),
             );
         }
     }
@@ -293,7 +330,7 @@ fn check_enforcement_attribution_binding(
                 "attribution".into(),
             ],
         )
-        .with_help_uri("https://docs.getassay.dev/lint/#assay-w004"),
+        .with_help_uri(lint_help_uri!("assay-w004")),
     )
 }
 
@@ -374,7 +411,7 @@ fn check_retained_view_readability(
             }),
             vec!["retention".into(), "review".into(), "sufficiency".into()],
         )
-        .with_help_uri("https://docs.getassay.dev/lint/#assay-w005"),
+        .with_help_uri(lint_help_uri!("assay-w005")),
     )
 }
 

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -410,7 +410,11 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
         "name": "assay-evidence-lint",
         "version": report.tool_version,
         "semanticVersion": report.tool_version,
-        "informationUri": "https://docs.getassay.dev/lint/",
+        "informationUri": concat!(
+            "https://github.com/Rul1an/assay/blob/v",
+            env!("CARGO_PKG_VERSION"),
+            "/docs/lint/index.md"
+        ),
         "rules": rules
     });
     if !driver_props.is_empty() {

--- a/crates/assay-evidence/tests/lint_help_uri_targets.rs
+++ b/crates/assay-evidence/tests/lint_help_uri_targets.rs
@@ -18,9 +18,21 @@
 //! keeps resolving and starts lying. That failure is quieter than a dead link, and this test does
 //! not reach it.
 //!
-//! Anchors are pinned explicitly with `attr_list` (`{#assay-w001}`) rather than left to mkdocs'
-//! slugify, so the emitted fragment is a literal that appears in the source rather than something
-//! derived by two implementations that could disagree.
+//! Anchors are pinned explicitly with `<a id="assay-w001"></a>` elements rather than left to a
+//! slugifier, so the emitted fragment is a literal that appears in the source rather than something
+//! derived by two implementations that could disagree. They were mkdocs `attr_list` (`{#assay-w001}`)
+//! until the pointers moved to the tagged markdown: GitHub does not honour `attr_list`, so the brace
+//! form would have rendered as literal text in the heading and slugified to
+//! `assay-w001--subject-may-contain-a-secret`, landing every emitted fragment at the top of the page
+//! instead of at its rule. An `<a id>` is honoured by both renderers.
+//!
+//! The second thing asserted here is that the pointer is version-pinned. An unversioned pointer
+//! resolves against whatever the page says today, so a consumer reading an old report silently gets
+//! today's prose — a failure quieter than a dead link and the one the peer emitters in
+//! `aliksir/claude-code-skill-security-check#24` converged on forbidding. Note what pinning does and
+//! does not buy, because the distinction is the whole reason the scope note above exists: it stops a
+//! later rewrite from retroactively rewriting an old report, and it does not notice that the prose
+//! moved. Nothing here reaches divergence; pinning makes divergence possible to see, not visible.
 
 use assay_evidence::bundle::BundleWriter;
 use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions};
@@ -32,7 +44,25 @@ use std::collections::BTreeSet;
 use std::io::Cursor;
 
 const DOCS_PAGE: &str = "../../docs/lint/index.md";
-const EXPECTED_PREFIX: &str = "https://docs.getassay.dev/lint/#";
+
+/// The tagged source document every emitted pointer must name. Built the same way the emitter builds
+/// it, from this crate's own version, so the test cannot pass by agreeing with a stale copy of the
+/// prefix — if the shape in `rules.rs` changes, this changes with it and only the *anchor* is
+/// compared.
+const EXPECTED_DOC: &str = concat!(
+    "https://github.com/Rul1an/assay/blob/v",
+    env!("CARGO_PKG_VERSION"),
+    "/docs/lint/index.md"
+);
+const EXPECTED_PREFIX: &str = concat!(
+    "https://github.com/Rul1an/assay/blob/v",
+    env!("CARGO_PKG_VERSION"),
+    "/docs/lint/index.md#"
+);
+
+/// Refs that resolve against whatever they point at today. A pointer through any of these is the
+/// defect this file exists to keep out, whichever host it names.
+const MUTABLE_REFS: &[&str] = &["/blob/main/", "/blob/master/", "/main/", "/master/"];
 
 /// A bundle with one clean event. The rule registry is emitted in full regardless of what fired,
 /// so this is enough to see every `helpUri` the producer can ship.
@@ -65,18 +95,17 @@ fn minimal_sarif() -> serde_json::Value {
     to_sarif(&report)
 }
 
-/// Explicit `{#anchor}` targets declared by headings in the committed page.
+/// Explicit `<a id="...">` targets declared in the committed page.
 fn declared_anchors() -> BTreeSet<String> {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(DOCS_PAGE);
     let text = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("the help target page must exist at {}: {e}", path.display()));
 
     text.lines()
-        .filter(|line| line.starts_with('#'))
         .filter_map(|line| {
-            let start = line.find("{#")? + 2;
-            let end = line[start..].find('}')? + start;
-            Some(line[start..end].to_string())
+            let rest = line.trim().strip_prefix("<a id=\"")?;
+            let end = rest.find('"')?;
+            Some(rest[..end].to_string())
         })
         .collect()
 }
@@ -139,10 +168,120 @@ fn the_driver_information_uri_points_at_the_help_page() {
         .as_str()
         .expect("the driver must carry an informationUri");
 
-    assert_eq!(uri, "https://docs.getassay.dev/lint/", "got {uri}");
+    assert_eq!(uri, EXPECTED_DOC, "got {uri}");
     assert!(
         !uri.contains("docs.assay.dev"),
         "docs.assay.dev is NXDOMAIN and assay.dev belongs to a third party: {uri}"
+    );
+}
+
+/// Every pointer in the emitted document must name an immutable target. This is the constraint the
+/// peer emitters in `aliksir/claude-code-skill-security-check#24` settled on after three emitters were
+/// audited and two were found pointing through a branch; ours was one of the two, in the document
+/// describing our own SARIF contract.
+///
+/// Asserted over the serialised document rather than over the fields this file knows about, so a
+/// pointer added later in a place nobody thought to check here is still covered.
+#[test]
+fn no_emitted_pointer_resolves_through_a_mutable_ref() {
+    let serialised = serde_json::to_string(&minimal_sarif()).expect("serialise");
+    for bad in MUTABLE_REFS {
+        assert!(
+            !serialised.contains(bad),
+            "the emitted SARIF carries a pointer through `{bad}`, which resolves against whatever \
+             that ref holds today. Name an immutable target: a release tag for our own documents, a \
+             commit SHA for documents we do not own, a published artifact for a schema."
+        );
+    }
+}
+
+/// The pin has to name *this* build's version, not merely some version. A pointer frozen at an older
+/// tag keeps resolving and quietly serves prose the report was not written against, which is the
+/// same silent-staleness failure as an unpinned pointer with a longer fuse.
+#[test]
+fn every_pointer_is_pinned_to_this_builds_version() {
+    let sarif = minimal_sarif();
+    let expected_tag = concat!("/blob/v", env!("CARGO_PKG_VERSION"), "/");
+
+    let driver = &sarif["runs"][0]["tool"]["driver"];
+    let mut pointers = vec![driver["informationUri"]
+        .as_str()
+        .expect("informationUri")
+        .to_string()];
+    for rule in driver["rules"].as_array().expect("rules") {
+        pointers.push(
+            rule["helpUri"]
+                .as_str()
+                .unwrap_or_else(|| panic!("rule {} ships no helpUri", rule["id"]))
+                .to_string(),
+        );
+    }
+
+    assert!(
+        pointers.len() > 1,
+        "expected the driver pointer plus one per registry rule, got {}",
+        pointers.len()
+    );
+    for uri in &pointers {
+        assert!(
+            uri.contains(expected_tag),
+            "pointer is not pinned to this build's version ({}): {uri}",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+}
+
+/// The registry pointer and the finding pointer for one rule must agree. They are built from the same
+/// macro but named at twelve separate call sites, so a one-sided edit is the live risk — and the two
+/// travel by different routes: the registry pointer reaches SARIF `rules[].helpUri`, while the
+/// finding pointer reaches only the JSON report, since SARIF results carry no `helpUri` member. A
+/// consumer comparing the two formats would see the disagreement before we did.
+#[test]
+fn the_registry_and_finding_pointers_agree_for_the_same_rule() {
+    use assay_evidence::lint::rules::RULES;
+
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    let mut event = EvidenceEvent::new(
+        "assay.test.secret",
+        "urn:assay:test",
+        "run_parity",
+        0,
+        serde_json::json!({}),
+    );
+    event.subject = Some("token=abc123".into());
+    event.time = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    writer.add_event(event);
+    writer.finish().unwrap();
+
+    let report = lint_bundle_with_options(
+        Cursor::new(&buffer),
+        VerifyLimits::default(),
+        LintOptions {
+            packs: Vec::new(),
+            max_results: None,
+            bundle_path: None,
+        },
+    )
+    .expect("lint should succeed")
+    .report;
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "ASSAY-W001")
+        .expect("the secret-in-subject rule must fire on a token= subject");
+    let registry = RULES
+        .iter()
+        .find(|r| r.id == "ASSAY-W001")
+        .and_then(|r| r.help_uri)
+        .expect("ASSAY-W001 must declare a help_uri in the registry");
+
+    assert_eq!(
+        finding.help_uri.as_deref(),
+        Some(registry),
+        "the finding-level pointer and the registry pointer for ASSAY-W001 disagree, so the JSON \
+         report and the SARIF report send a reader to different places"
     );
 }
 

--- a/docs/architecture/SPEC-Pack-Engine-v1.md
+++ b/docs/architecture/SPEC-Pack-Engine-v1.md
@@ -498,7 +498,7 @@ owes a consumer; it is not a construct the format provides for capping.
         "name": "assay-evidence-lint",
         "version": "2.9.0",
         "semanticVersion": "2.9.0",
-        "informationUri": "https://docs.getassay.dev/lint/",
+        "informationUri": "https://github.com/Rul1an/assay/blob/v2.9.0/docs/lint/index.md",
         "properties": {
           "assayPacks": [
             {

--- a/docs/lint/index.md
+++ b/docs/lint/index.md
@@ -34,7 +34,9 @@ basis caps what a review can claim rather than describing an exploitable weaknes
 
 ---
 
-## ASSAY-W001 — Subject may contain a secret {#assay-w001}
+<a id="assay-w001"></a>
+
+## ASSAY-W001 — Subject may contain a secret
 
 **Severity** warning · **security-severity** 7.0 · **Tags** `security`, `secrets`
 
@@ -53,7 +55,9 @@ afterwards changes its content hashes and invalidates the Merkle root.
 **Note.** The match is a literal substring test, not a validator. It has both false positives
 (`token=` in prose) and false negatives (a credential with no recognised prefix).
 
-## ASSAY-W002 — PII flag set with a non-empty subject {#assay-w002}
+<a id="assay-w002"></a>
+
+## ASSAY-W002 — PII flag set with a non-empty subject
 
 **Severity** warning · **security-severity** 4.0 · **Tags** `privacy`, `pii`
 
@@ -67,7 +71,9 @@ clear, and the subject is the field most widely reproduced downstream.
 of personal data, the flag is describing the payload only — that is a legitimate shape, and the
 finding is advisory.
 
-## ASSAY-W003 — Secret pattern present but `contains_secrets` is false {#assay-w003}
+<a id="assay-w003"></a>
+
+## ASSAY-W003 — Secret pattern present but `contains_secrets` is false
 
 **Severity** warning · **security-severity** 6.5 · **Tags** `security`, `secrets`
 
@@ -83,7 +89,9 @@ event as safe, so the flag being wrong is worse than the secret being present an
 **Note.** `ASSAY-W001` and `ASSAY-W003` share one pattern list, so an undeclared secret raises
 both: one for the disclosure, one for the mislabelling. They are not duplicates.
 
-## ASSAY-W004 — Refusal observation not backed by a decision record {#assay-w004}
+<a id="assay-w004"></a>
+
+## ASSAY-W004 — Refusal observation not backed by a decision record
 
 **Severity** warning · **security-severity** 4.0 · **Tags** `security`, `enforcement`,
 `attribution`
@@ -104,7 +112,9 @@ about the same digest, and that conflict is itself the finding.
 same target digest the refusal marker uses. A refusal recorded by one component and a decision
 recorded by another must agree on the digest, or they cannot be joined.
 
-## ASSAY-W005 — Approval basis declares an unreadable retained view {#assay-w005}
+<a id="assay-w005"></a>
+
+## ASSAY-W005 — Approval basis declares an unreadable retained view
 
 **Severity** warning · **Tags** `retention`, `review`, `sufficiency`
 
@@ -130,7 +140,9 @@ over it.
 genuinely must be encrypted, emit `approval_plaintext_commitment` alongside it so a later
 disclosure can be bound to what was approved at the time.
 
-## ASSAY-I001 — Source does not follow the URN convention {#assay-i001}
+<a id="assay-i001"></a>
+
+## ASSAY-I001 — Source does not follow the URN convention
 
 **Severity** note · **Tags** `convention`, `format`
 


### PR DESCRIPTION
Every `helpUri` this producer emits, and the driver `informationUri`, pointed at `https://docs.getassay.dev/lint/#assay-w001` — a URL that resolves against whatever the page says today. A consumer reading a six-month-old report silently got today's prose. That failure is quieter than a dead link: the pointer keeps working while the section it names stops describing the rule that fired.

Ours was the last of the four emitters in [aliksir/claude-code-skill-security-check#24](https://github.com/aliksir/claude-code-skill-security-check/issues/24) still in that state, self-disclosed twice in that thread and unfixed.

## What the pointers name now

```
informationUri = https://github.com/Rul1an/assay/blob/v5.1.0/docs/lint/index.md
ASSAY-W001     = https://github.com/Rul1an/assay/blob/v5.1.0/docs/lint/index.md#assay-w001
```

The tag is the version the report **already declares** as `tool_version`, so the pointer and the report agree about which prose they mean. Any drift between a working tree and that tag is drift the report declares by calling itself that version.

## Why the markdown source and not the rendered page

`extra.version.provider: mike` is declared in `mkdocs.yml`, but the deploy runs `mkdocs gh-deploy --force`. Checked against the live site:

| URL | Status |
|---|---|
| `docs.getassay.dev/lint/` | 200 |
| `docs.getassay.dev/versions.json` | 404 |
| `docs.getassay.dev/5.1.0/lint/` | 404 |
| `docs.getassay.dev/latest/lint/` | 404 |

So there is no versioned path to point at. Giving the site versioned paths would break every pointer already shipped in v5.0.0 and v5.1.0 binaries, which is a separate decision rather than a side effect of this one.

## Why the anchors changed

GitHub does not honour mkdocs `attr_list`. Verified against the rendered page at `v5.1.0`, which displays `{#assay-w001}` as literal text in the heading and ids the section `assay-w001--subject-may-contain-a-secret-assay-w001`. Without an `<a id>`, all six fragments would land at the top of the page.

The page was also rendered through Python-Markdown with mkdocs' extension set: both the bare anchors and the slugified heading ids appear, so existing `docs.getassay.dev/lint/#assay-w001` bookmarks keep resolving. No human-facing regression.

## Known gap, bounded and self-clearing

A fragment resolves only from the first tag carrying these `<a id>` anchors onward. `v5.1.0` predates them, so a build from an untagged tree during this cycle emits the right document at the right version with a fragment that lands at the top of the page instead of at its rule. It clears at the next release.

Already-released v5.0.0 and v5.1.0 binaries are unaffected — they were built with the old unversioned pointer and nothing about them changes. This is recorded in the macro's rustdoc rather than left for someone to discover.

## Thirteen literals become one macro

That duplication was the live risk, because the two families of call site travel by different routes: the registry pointer reaches SARIF `rules[].helpUri`, while the finding pointer reaches only the JSON report, since SARIF results carry no `helpUri` member. A one-sided edit would have sent the two formats to different places with nothing to notice. A parity test pins them together.

## Verification

Four new assertions, each verified to fail on its own mutation, and each caught by **exactly** the intended test and no other:

| Mutation | Caught by |
|---|---|
| pointer through `/blob/main/` | `no_emitted_pointer_resolves_through_a_mutable_ref` |
| pin to `v4.0.0` instead of this build | `every_pointer_is_pinned_to_this_builds_version` |
| one-sided finding-pointer edit | `the_registry_and_finding_pointers_agree_for_the_same_rule` |
| deleted `<a id>` anchor | `every_rule_help_uri_resolves_to_a_declared_anchor` |

A wrong-tag pin correctly does *not* trip the mutable-ref test — `/blob/v4.0.0/` is immutable, just wrong — so the two tests discriminate rather than overlap.

- `assay-evidence`: every suite `ok`, 0 failed
- `assay-cli`: 976 passed, 0 failed, 66 suites
- `clippy --all-targets -D warnings`: clean
- Emitted pointers read out of a real lint run rather than from a grep, per the false-404 caution in that thread

`docs/architecture/SPEC-Pack-Engine-v1.md` also still showed the old `informationUri` for the very driver this changes — the same "spec describes a contract the emitter no longer honours" shape that started the upstream thread — so it is corrected here too.

`assay-mcp-server` emits `informationUri: https://github.com/Rul1an/assay`: repo root, no ref and no fragment, so not this defect class and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)