### PR TITLE
fix(ci): decouple install pin from source release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,13 @@ jobs:
 
       - name: Verify CI hardening contracts
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          bash scripts/ci/test-check-assay-release-pin.sh
+          bash scripts/ci/check-assay-release-pin.sh --published
           bash scripts/ci/test-ci-hardening-b1.sh
           bash scripts/ci/test-structurizr-export-docker.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           bash scripts/ci/test-check-assay-release-pin.sh

--- a/scripts/ci/check-assay-release-pin.sh
+++ b/scripts/ci/check-assay-release-pin.sh
@@ -113,12 +113,14 @@ if pin != latest:
         )
     raise SystemExit(f"install pin {pin} {relation} latest published release {latest}")
 
-expected_asset = f"assay-{latest}-x86_64-unknown-linux-gnu.tar.gz"
+expected_archive = f"assay-{latest}-x86_64-unknown-linux-gnu.tar.gz"
 assets = release.get("assets")
-if not isinstance(assets, list) or expected_asset not in {
+asset_names = {
     asset.get("name") for asset in assets if isinstance(asset, dict)
-}:
-    raise SystemExit(f"latest published release {latest} lacks {expected_asset}")
+} if isinstance(assets, list) else set()
+for expected_asset in (expected_archive, f"{expected_archive}.sha256"):
+    if expected_asset not in asset_names:
+        raise SystemExit(f"latest published release {latest} lacks {expected_asset}")
 PY
 
 printf 'assay published release pin: %s (workspace %s)\n' "${pin}" "${workspace_version}"

--- a/scripts/ci/check-assay-release-pin.sh
+++ b/scripts/ci/check-assay-release-pin.sh
@@ -57,7 +57,8 @@ if [[ -n "${ASSAY_RELEASE_METADATA_FILE:-}" ]]; then
   metadata="$(cat "${ASSAY_RELEASE_METADATA_FILE}")"
 else
   repo="${GITHUB_REPOSITORY:-Rul1an/assay}"
-  if ! metadata="$(gh api "repos/${repo}/releases/latest")"; then
+  gh_bin="${ASSAY_GH_BIN:-gh}"
+  if ! metadata="$("${gh_bin}" api "repos/${repo}/releases/latest")"; then
     echo "failed to obtain latest published release metadata for ${repo}" >&2
     exit 1
   fi

--- a/scripts/ci/check-assay-release-pin.sh
+++ b/scripts/ci/check-assay-release-pin.sh
@@ -64,7 +64,8 @@ if [[ -n "${ASSAY_RELEASE_METADATA_FILE:-}" ]]; then
   fi
   metadata_path="${ASSAY_RELEASE_METADATA_FILE}"
 else
-  repo="${GITHUB_REPOSITORY:-Rul1an/assay}"
+  # Release existence is an upstream property, including when this runs on a fork.
+  repo="${ASSAY_RELEASE_REPOSITORY:-Rul1an/assay}"
   gh_bin="${ASSAY_GH_BIN:-gh}"
   metadata_path="$(mktemp)"
   metadata_is_temporary=true

--- a/scripts/ci/check-assay-release-pin.sh
+++ b/scripts/ci/check-assay-release-pin.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+READER="${ROOT}/scripts/ci/read-assay-release-tag.sh"
+MANIFEST="${ASSAY_WORKSPACE_MANIFEST:-${ROOT}/Cargo.toml}"
+MODE="${1:-}"
+
+if [[ -n "${MODE}" && "${MODE}" != "--published" ]]; then
+  echo "usage: $0 [--published]" >&2
+  exit 2
+fi
+
+pin="$(${READER})"
+workspace_version="$(
+  python3 - "${ROOT}/scripts/ci/lib" "${MANIFEST}" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from workspace_version import read_workspace_version
+
+print(read_workspace_version(Path(sys.argv[2])))
+PY
+)"
+
+python3 - "${pin}" "${workspace_version}" <<'PY'
+import re
+import sys
+
+pin, workspace = sys.argv[1:]
+stable = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+$")
+if not stable.fullmatch(workspace):
+    raise SystemExit(f"workspace version is not stable semver: {workspace}")
+
+def version(value: str) -> tuple[int, int, int]:
+    return tuple(map(int, value.removeprefix("v").split(".")))
+
+if version(pin) > version(workspace):
+    raise SystemExit(
+        f"install pin {pin} leads workspace version {workspace}; "
+        "publish the release before advancing the install pin"
+    )
+PY
+
+if [[ "${MODE}" != "--published" ]]; then
+  printf 'assay release pin: %s (workspace %s)\n' "${pin}" "${workspace_version}"
+  exit 0
+fi
+
+metadata=""
+if [[ -n "${ASSAY_RELEASE_METADATA_FILE:-}" ]]; then
+  if [[ ! -f "${ASSAY_RELEASE_METADATA_FILE}" ]]; then
+    echo "failed to obtain latest published release metadata: ${ASSAY_RELEASE_METADATA_FILE} is missing" >&2
+    exit 1
+  fi
+  metadata="$(cat "${ASSAY_RELEASE_METADATA_FILE}")"
+else
+  repo="${GITHUB_REPOSITORY:-Rul1an/assay}"
+  if ! metadata="$(gh api "repos/${repo}/releases/latest")"; then
+    echo "failed to obtain latest published release metadata for ${repo}" >&2
+    exit 1
+  fi
+fi
+
+python3 - "${pin}" "${metadata}" <<'PY'
+import json
+import re
+import sys
+
+pin = sys.argv[1]
+try:
+    release = json.loads(sys.argv[2])
+except (json.JSONDecodeError, TypeError) as error:
+    raise SystemExit(f"failed to obtain latest published release metadata: {error}")
+
+latest = release.get("tag_name")
+if not isinstance(latest, str) or not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", latest):
+    raise SystemExit(f"latest published release has an invalid stable tag: {latest!r}")
+if release.get("draft") is not False or release.get("prerelease") is not False:
+    raise SystemExit(f"latest published release {latest} is draft or prerelease")
+
+def version(value: str) -> tuple[int, int, int]:
+    return tuple(map(int, value.removeprefix("v").split(".")))
+
+if version(pin) > version(latest):
+    raise SystemExit(f"install pin {pin} leads latest published release {latest}")
+if version(pin) < version(latest):
+    raise SystemExit(f"install pin {pin} trails latest published release {latest}")
+
+expected_asset = f"assay-{latest}-x86_64-unknown-linux-gnu.tar.gz"
+assets = release.get("assets")
+if not isinstance(assets, list) or expected_asset not in {
+    asset.get("name") for asset in assets if isinstance(asset, dict)
+}:
+    raise SystemExit(f"latest published release {latest} lacks {expected_asset}")
+PY
+
+printf 'assay published release pin: %s (workspace %s)\n' "${pin}" "${workspace_version}"

--- a/scripts/ci/check-assay-release-pin.sh
+++ b/scripts/ci/check-assay-release-pin.sh
@@ -101,10 +101,16 @@ if release.get("draft") is not False or release.get("prerelease") is not False:
 def version(value: str) -> tuple[int, int, int]:
     return tuple(map(int, value.removeprefix("v").split(".")))
 
-if version(pin) > version(latest):
-    raise SystemExit(f"install pin {pin} leads latest published release {latest}")
-if version(pin) < version(latest):
-    raise SystemExit(f"install pin {pin} trails latest published release {latest}")
+if pin != latest:
+    if version(pin) > version(latest):
+        relation = "leads"
+    elif version(pin) < version(latest):
+        relation = "trails"
+    else:
+        raise SystemExit(
+            f"install pin {pin} does not exactly match latest published release {latest}"
+        )
+    raise SystemExit(f"install pin {pin} {relation} latest published release {latest}")
 
 expected_asset = f"assay-{latest}-x86_64-unknown-linux-gnu.tar.gz"
 assets = release.get("assets")

--- a/scripts/ci/check-assay-release-pin.sh
+++ b/scripts/ci/check-assay-release-pin.sh
@@ -48,31 +48,48 @@ if [[ "${MODE}" != "--published" ]]; then
   exit 0
 fi
 
-metadata=""
+metadata_path=""
+metadata_is_temporary=false
+cleanup() {
+  if [[ "${metadata_is_temporary}" == "true" ]]; then
+    rm -f "${metadata_path}"
+  fi
+}
+trap cleanup EXIT
+
 if [[ -n "${ASSAY_RELEASE_METADATA_FILE:-}" ]]; then
   if [[ ! -f "${ASSAY_RELEASE_METADATA_FILE}" ]]; then
     echo "failed to obtain latest published release metadata: ${ASSAY_RELEASE_METADATA_FILE} is missing" >&2
     exit 1
   fi
-  metadata="$(cat "${ASSAY_RELEASE_METADATA_FILE}")"
+  metadata_path="${ASSAY_RELEASE_METADATA_FILE}"
 else
   repo="${GITHUB_REPOSITORY:-Rul1an/assay}"
   gh_bin="${ASSAY_GH_BIN:-gh}"
-  if ! metadata="$("${gh_bin}" api "repos/${repo}/releases/latest")"; then
+  metadata_path="$(mktemp)"
+  metadata_is_temporary=true
+  if ! "${gh_bin}" api "repos/${repo}/releases/latest" >"${metadata_path}"; then
     echo "failed to obtain latest published release metadata for ${repo}" >&2
     exit 1
   fi
 fi
 
-python3 - "${pin}" "${metadata}" <<'PY'
+metadata_size="$(wc -c <"${metadata_path}" | tr -d '[:space:]')"
+if [[ ! "${metadata_size}" =~ ^[0-9]+$ ]] || ((metadata_size > 1048576)); then
+  echo "latest published release metadata exceeds 1048576-byte limit" >&2
+  exit 1
+fi
+
+python3 - "${pin}" "${metadata_path}" <<'PY'
 import json
 import re
 import sys
+from pathlib import Path
 
 pin = sys.argv[1]
 try:
-    release = json.loads(sys.argv[2])
-except (json.JSONDecodeError, TypeError) as error:
+    release = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+except (OSError, UnicodeError, json.JSONDecodeError, TypeError) as error:
     raise SystemExit(f"failed to obtain latest published release metadata: {error}")
 
 latest = release.get("tag_name")

--- a/scripts/ci/test-check-assay-release-pin.sh
+++ b/scripts/ci/test-check-assay-release-pin.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "${scratch}"' EXIT
 manifest="${scratch}/Cargo.toml"
 pin_file="${scratch}/assay-release-tag"
 metadata="${scratch}/release.json"
+fake_gh="${scratch}/gh"
 
 write_manifest() {
   printf '[workspace.package]\nversion = "%s"\n' "$1" >"${manifest}"
@@ -31,6 +32,14 @@ run_check() {
     ASSAY_RELEASE_TAG_FILE="${pin_file}" \
     ASSAY_RELEASE_METADATA_FILE="${metadata}" \
     "${CHECKER}" "$@"
+}
+
+run_api_check() {
+  ASSAY_WORKSPACE_MANIFEST="${manifest}" \
+    ASSAY_RELEASE_TAG_FILE="${pin_file}" \
+    ASSAY_GH_BIN="${fake_gh}" \
+    GITHUB_REPOSITORY="Rul1an/assay" \
+    "${CHECKER}" --published
 }
 
 expect_fail() {
@@ -88,5 +97,13 @@ expect_fail "latest published release v5.2.0 lacks assay-v5.2.0-x86_64-unknown-l
 echo "== unavailable release metadata fails closed =="
 rm -f "${metadata}"
 expect_fail "failed to obtain latest published release metadata" run_check --published
+
+echo "== failed GitHub API call fails closed =="
+cat >"${fake_gh}" <<'EOF'
+#!/usr/bin/env bash
+exit 71
+EOF
+chmod +x "${fake_gh}"
+expect_fail "failed to obtain latest published release metadata for Rul1an/assay" run_api_check
 
 echo "assay release pin contract: PASS"

--- a/scripts/ci/test-check-assay-release-pin.sh
+++ b/scripts/ci/test-check-assay-release-pin.sh
@@ -114,7 +114,9 @@ expect_fail "workspace version is not stable semver: 5.2.0-rc.1" run_check
 echo "== missing install asset fails closed =="
 write_manifest "5.2.0"
 write_pin "v5.2.0"
-write_release "v5.2.0" "unrelated.txt"
+write_release "v5.2.0" \
+  "assay-v5.2.0-x86_64-unknown-linux-gnu.tar.gz.sha256" \
+  "unrelated.txt"
 expect_fail "latest published release v5.2.0 lacks assay-v5.2.0-x86_64-unknown-linux-gnu.tar.gz" run_check --published
 
 echo "== missing checksum sidecar fails closed =="

--- a/scripts/ci/test-check-assay-release-pin.sh
+++ b/scripts/ci/test-check-assay-release-pin.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="${ROOT}/scripts/ci/check-assay-release-pin.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+
+manifest="${scratch}/Cargo.toml"
+pin_file="${scratch}/assay-release-tag"
+metadata="${scratch}/release.json"
+
+write_manifest() {
+  printf '[workspace.package]\nversion = "%s"\n' "$1" >"${manifest}"
+}
+
+write_pin() {
+  printf '%s\n' "$1" >"${pin_file}"
+}
+
+write_release() {
+  local tag="$1"
+  local asset="${2:-assay-${tag}-x86_64-unknown-linux-gnu.tar.gz}"
+  cat >"${metadata}" <<EOF
+{"tag_name":"${tag}","draft":false,"prerelease":false,"assets":[{"name":"${asset}"}]}
+EOF
+}
+
+run_check() {
+  ASSAY_WORKSPACE_MANIFEST="${manifest}" \
+    ASSAY_RELEASE_TAG_FILE="${pin_file}" \
+    ASSAY_RELEASE_METADATA_FILE="${metadata}" \
+    "${CHECKER}" "$@"
+}
+
+expect_fail() {
+  local expected="$1"
+  shift
+  if "$@" >"${scratch}/out" 2>"${scratch}/err"; then
+    echo "expected failure containing: ${expected}" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- "${expected}" "${scratch}/err"; then
+    echo "failure did not contain '${expected}':" >&2
+    cat "${scratch}/err" >&2
+    exit 1
+  fi
+}
+
+echo "== offline steady state =="
+write_manifest "5.1.0"
+write_pin "v5.1.0"
+run_check
+
+echo "== offline release preparation may trail workspace =="
+write_manifest "5.2.0"
+write_pin "v5.1.0"
+run_check
+
+echo "== offline pin may not lead workspace =="
+write_manifest "5.1.0"
+write_pin "v5.2.0"
+expect_fail "install pin v5.2.0 leads workspace version 5.1.0" run_check
+
+echo "== published steady state =="
+write_manifest "5.1.0"
+write_pin "v5.1.0"
+write_release "v5.1.0"
+run_check --published
+
+echo "== unpublished release pin fails distinctly =="
+write_manifest "5.2.0"
+write_pin "v5.2.0"
+write_release "v5.1.0"
+expect_fail "install pin v5.2.0 leads latest published release v5.1.0" run_check --published
+
+echo "== forgotten post-publish pin fails distinctly =="
+write_manifest "5.2.0"
+write_pin "v5.1.0"
+write_release "v5.2.0"
+expect_fail "install pin v5.1.0 trails latest published release v5.2.0" run_check --published
+
+echo "== missing install asset fails closed =="
+write_pin "v5.2.0"
+write_release "v5.2.0" "unrelated.txt"
+expect_fail "latest published release v5.2.0 lacks assay-v5.2.0-x86_64-unknown-linux-gnu.tar.gz" run_check --published
+
+echo "== unavailable release metadata fails closed =="
+rm -f "${metadata}"
+expect_fail "failed to obtain latest published release metadata" run_check --published
+
+echo "assay release pin contract: PASS"

--- a/scripts/ci/test-check-assay-release-pin.sh
+++ b/scripts/ci/test-check-assay-release-pin.sh
@@ -38,7 +38,6 @@ run_api_check() {
   ASSAY_WORKSPACE_MANIFEST="${manifest}" \
     ASSAY_RELEASE_TAG_FILE="${pin_file}" \
     ASSAY_GH_BIN="${fake_gh}" \
-    GITHUB_REPOSITORY="Rul1an/assay" \
     "${CHECKER}" --published
 }
 
@@ -128,6 +127,22 @@ exit 71
 EOF
 chmod +x "${fake_gh}"
 expect_fail "failed to obtain latest published release metadata for Rul1an/assay" run_api_check
+
+echo "== fork CI still queries the authoritative upstream release =="
+write_manifest "5.1.0"
+write_pin "v5.1.0"
+write_release "v5.1.0"
+cat >"${fake_gh}" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" != "api repos/Rul1an/assay/releases/latest" ]]; then
+  exit 72
+fi
+cat "${ASSAY_RELEASE_METADATA_FIXTURE}"
+EOF
+chmod +x "${fake_gh}"
+GITHUB_REPOSITORY="contributor/assay" \
+  ASSAY_RELEASE_METADATA_FIXTURE="${metadata}" \
+  run_api_check
 
 echo "== oversized release metadata fails before parsing =="
 python3 - "${metadata}" <<'PY'

--- a/scripts/ci/test-check-assay-release-pin.sh
+++ b/scripts/ci/test-check-assay-release-pin.sh
@@ -106,4 +106,13 @@ EOF
 chmod +x "${fake_gh}"
 expect_fail "failed to obtain latest published release metadata for Rul1an/assay" run_api_check
 
+echo "== oversized release metadata fails before parsing =="
+python3 - "${metadata}" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_bytes(b"x" * (1048576 + 1))
+PY
+expect_fail "latest published release metadata exceeds 1048576-byte limit" run_check --published
+
 echo "assay release pin contract: PASS"

--- a/scripts/ci/test-check-assay-release-pin.sh
+++ b/scripts/ci/test-check-assay-release-pin.sh
@@ -89,7 +89,30 @@ write_pin "v5.1.0"
 write_release "v5.2.0"
 expect_fail "install pin v5.1.0 trails latest published release v5.2.0" run_check --published
 
+echo "== published pin must match the literal release tag =="
+write_manifest "5.1.0"
+write_pin "v05.1.0"
+write_release "v5.1.0"
+expect_fail "install pin v05.1.0 does not exactly match latest published release v5.1.0" run_check --published
+
+echo "== draft release metadata fails closed =="
+write_pin "v5.1.0"
+cat >"${metadata}" <<'EOF'
+{"tag_name":"v5.1.0","draft":true,"prerelease":false,"assets":[{"name":"assay-v5.1.0-x86_64-unknown-linux-gnu.tar.gz"}]}
+EOF
+expect_fail "latest published release v5.1.0 is draft or prerelease" run_check --published
+
+echo "== invalid published tag fails closed =="
+write_release "latest" "assay-latest-x86_64-unknown-linux-gnu.tar.gz"
+expect_fail "latest published release has an invalid stable tag: 'latest'" run_check --published
+
+echo "== prerelease workspace version fails closed =="
+write_manifest "5.2.0-rc.1"
+write_pin "v5.1.0"
+expect_fail "workspace version is not stable semver: 5.2.0-rc.1" run_check
+
 echo "== missing install asset fails closed =="
+write_manifest "5.2.0"
 write_pin "v5.2.0"
 write_release "v5.2.0" "unrelated.txt"
 expect_fail "latest published release v5.2.0 lacks assay-v5.2.0-x86_64-unknown-linux-gnu.tar.gz" run_check --published

--- a/scripts/ci/test-check-assay-release-pin.sh
+++ b/scripts/ci/test-check-assay-release-pin.sh
@@ -22,8 +22,9 @@ write_pin() {
 write_release() {
   local tag="$1"
   local asset="${2:-assay-${tag}-x86_64-unknown-linux-gnu.tar.gz}"
+  local checksum="${3:-${asset}.sha256}"
   cat >"${metadata}" <<EOF
-{"tag_name":"${tag}","draft":false,"prerelease":false,"assets":[{"name":"${asset}"}]}
+{"tag_name":"${tag}","draft":false,"prerelease":false,"assets":[{"name":"${asset}"},{"name":"${checksum}"}]}
 EOF
 }
 
@@ -115,6 +116,12 @@ write_manifest "5.2.0"
 write_pin "v5.2.0"
 write_release "v5.2.0" "unrelated.txt"
 expect_fail "latest published release v5.2.0 lacks assay-v5.2.0-x86_64-unknown-linux-gnu.tar.gz" run_check --published
+
+echo "== missing checksum sidecar fails closed =="
+write_release "v5.2.0" \
+  "assay-v5.2.0-x86_64-unknown-linux-gnu.tar.gz" \
+  "unrelated.txt"
+expect_fail "latest published release v5.2.0 lacks assay-v5.2.0-x86_64-unknown-linux-gnu.tar.gz.sha256" run_check --published
 
 echo "== unavailable release metadata fails closed =="
 rm -f "${metadata}"

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -2,14 +2,15 @@
 # Wave B1 contract: single-source Assay release-tag pin, Structurizr image pin,
 # timeouts on touched jobs, and a version-independent CI infra doc header.
 #
-# Expected release tag is derived from Cargo.toml [workspace.package].version
-# (independent of the production pin reader). Digests live only in the
-# Structurizr pin file — never as test or consumer literals.
+# The install pin names the latest published release and may trail the source
+# version during release preparation. Digests live only in the Structurizr pin
+# file — never as test or consumer literals.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PIN_FILE="${ROOT}/.github/assay-release-tag"
 READER="${ROOT}/scripts/ci/read-assay-release-tag.sh"
+RELEASE_PIN_CHECK="${ROOT}/scripts/ci/check-assay-release-pin.sh"
 ASSAY_WF="${ROOT}/.github/workflows/assay.yml"
 SECURITY_WF="${ROOT}/.github/workflows/assay-security.yml"
 STRUCTURIZR_WF="${ROOT}/.github/workflows/structurizr-validate.yml"
@@ -42,25 +43,6 @@ scratch="$(mktemp -d)"
 trap 'abort_is_failure "$?"' ERR
 trap 'rm -rf "${scratch}"' EXIT
 
-# Independent of the production pin reader: the release line is v + workspace version.
-workspace_version="$(
-  awk '
-    $0 == "[workspace.package]" { in_workspace_package = 1; next }
-    /^\[/ && $0 != "[workspace.package]" { in_workspace_package = 0 }
-    in_workspace_package && $1 == "version" {
-      gsub(/"/, "", $3)
-      print $3
-      exit
-    }
-  ' "${ROOT}/Cargo.toml"
-)"
-if [[ ! "${workspace_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  fail "could not read [workspace.package].version from Cargo.toml (got '${workspace_version}')"
-  echo "ci-hardening-b1 contract: ${failures} failure(s)" >&2
-  exit 1
-fi
-EXPECTED_TAG="v${workspace_version}"
-
 job_has_timeout() {
   local wf="$1" job="$2"
   python3 - "$wf" "$job" <<'PY'
@@ -83,13 +65,13 @@ is_digest_image_ref() {
   [[ "${ref}" =~ ^structurizr/cli@sha256:[0-9a-f]{64}$ ]]
 }
 
-echo "== pin file matches workspace release line ${EXPECTED_TAG} =="
+echo "== checked-in install pin is valid and does not lead workspace =="
 if [[ -f "${PIN_FILE}" ]]; then
-  pin_raw="$(tr -d '[:space:]' <"${PIN_FILE}")"
-  if [[ "${pin_raw}" == "${EXPECTED_TAG}" ]]; then
-    ok "pin file is ${EXPECTED_TAG} (v + workspace.package.version)"
+  assay_pin="$(tr -d '[:space:]' <"${PIN_FILE}")"
+  if "${RELEASE_PIN_CHECK}" >/dev/null; then
+    ok "pin file ${assay_pin} is valid for the workspace release line"
   else
-    fail "pin file content is '${pin_raw}', expected ${EXPECTED_TAG} from Cargo.toml"
+    fail "pin file ${assay_pin} is invalid for the workspace release line"
   fi
 else
   fail "missing ${PIN_FILE#"${ROOT}"/}"
@@ -105,10 +87,10 @@ fi
 echo "== reader accepts the checked-in pin =="
 if [[ -f "${READER}" ]]; then
   got="$("${READER}" 2>/dev/null || true)"
-  if [[ "${got}" == "${EXPECTED_TAG}" ]]; then
-    ok "reader returns ${EXPECTED_TAG}"
+  if [[ "${got}" == "${assay_pin:-}" ]]; then
+    ok "reader returns checked-in pin ${got}"
   else
-    fail "reader returned '${got}', expected ${EXPECTED_TAG}"
+    fail "reader returned '${got}', expected checked-in pin '${assay_pin:-<missing>}'"
   fi
 else
   fail "cannot exercise reader; script missing"
@@ -483,22 +465,27 @@ else
   ok "contract test has no digest literal"
 fi
 
-echo "== derived release tag is not a second pin literal outside the pin file =="
-# Scan B1 production/contract paths for the derived tag. Allow the pin file and
-# Cargo.toml; ignore GitHub Actions SHA-pin version comments (# vX.Y.Z).
-if python3 - "${EXPECTED_TAG}" "${ROOT}" <<'PY'
+echo "== install and workspace tags are not second pin literals =="
+# Scan B1 production/contract paths for both release-line values. During release
+# preparation they differ; neither may become a second install-pin source.
+if python3 - "${assay_pin}" "${ROOT}" <<'PY'
 import re
 import sys
 from pathlib import Path
 
-tag = sys.argv[1]
+pin_tag = sys.argv[1]
 root = Path(sys.argv[2])
+sys.path.insert(0, str(root / "scripts" / "ci" / "lib"))
+from workspace_version import read_workspace_version
+
+tags = {pin_tag, "v" + read_workspace_version(root / "Cargo.toml")}
 allow_files = {
     root / ".github" / "assay-release-tag",
     root / "Cargo.toml",
 }
 scan = [
     root / "scripts" / "ci" / "test-ci-hardening-b1.sh",
+    root / "scripts" / "ci" / "check-assay-release-pin.sh",
     root / "scripts" / "ci" / "read-assay-release-tag.sh",
     root / "scripts" / "ci" / "test-structurizr-export-docker.sh",
     root / "scripts" / "structurizr-cli-image.sh",
@@ -508,43 +495,36 @@ scan = [
     root / ".github" / "workflows" / "assay-security.yml",
     root / ".github" / "workflows" / "structurizr-validate.yml",
 ]
-action_ver_comment = re.compile(
-    r"^\s*(?:-[^\n]*|uses:[^\n]*)#\s*" + re.escape(tag) + r"\s*$"
-)
-# Variable/name references that mention the derived value only as EXPECTED_TAG=.
-expected_assign = re.compile(r"^EXPECTED_TAG=")
 bad = []
 for path in scan:
     if not path.exists() or path in allow_files:
         continue
     for i, line in enumerate(path.read_text().splitlines(), 1):
-        if tag not in line:
-            continue
-        if action_ver_comment.match(line):
-            continue
-        if expected_assign.match(line.strip()):
-            continue
-        # Allow printing/comparing the derived variable, not a quoted literal pin.
-        if f'"{tag}"' in line or f"'{tag}'" in line or f"{tag}\\n" in line or line.strip() == tag:
-            bad.append(f"{path.relative_to(root)}:{i}:{line.strip()}")
-            continue
-        # Bare occurrence in prose/example (e.g. "e.g. <tag>") still counts.
-        if re.search(r"(?:e\.g\.|example|fixture|want|got|is)\s+" + re.escape(tag), line):
-            bad.append(f"{path.relative_to(root)}:{i}:{line.strip()}")
-            continue
-        if re.search(r"\b" + re.escape(tag) + r"\b", line):
-            # References via ${EXPECTED_TAG} are fine.
-            if "EXPECTED_TAG" in line and tag not in line.replace("${EXPECTED_TAG}", "").replace("$EXPECTED_TAG", ""):
+        for tag in tags:
+            if tag not in line:
                 continue
-            bad.append(f"{path.relative_to(root)}:{i}:{line.strip()}")
+            action_ver_comment = re.compile(
+                r"^\s*(?:-[^\n]*|uses:[^\n]*)#\s*" + re.escape(tag) + r"\s*$"
+            )
+            if action_ver_comment.match(line):
+                continue
+            if f'"{tag}"' in line or f"'{tag}'" in line or f"{tag}\\n" in line or line.strip() == tag:
+                bad.append(f"{path.relative_to(root)}:{i}:{line.strip()}")
+                continue
+            # Bare occurrence in prose/example (e.g. "e.g. <tag>") still counts.
+            if re.search(r"(?:e\.g\.|example|fixture|want|got|is)\s+" + re.escape(tag), line):
+                bad.append(f"{path.relative_to(root)}:{i}:{line.strip()}")
+                continue
+            if re.search(r"\b" + re.escape(tag) + r"\b", line):
+                bad.append(f"{path.relative_to(root)}:{i}:{line.strip()}")
 if bad:
     print("\n".join(bad), file=sys.stderr)
     sys.exit(1)
 PY
 then
-  ok "no stray ${EXPECTED_TAG} release-pin literals outside .github/assay-release-tag"
+  ok "no stray install/workspace release-pin literals outside .github/assay-release-tag"
 else
-  fail "derived tag ${EXPECTED_TAG} appears as a release-pin literal outside the pin file"
+  fail "install/workspace tag appears as a release-pin literal outside the pin file"
 fi
 
 echo "== touched jobs declare timeout-minutes =="
@@ -604,12 +584,21 @@ body = step.group("body")
 for forbidden in ("if:", "continue-on-error:"):
     if re.search(rf"(?m)^        {re.escape(forbidden)}", body):
         sys.exit(f"hardening step must not use {forbidden}")
+required_env = (
+    "GH_TOKEN: ${{ github.token }}",
+    "GITHUB_REPOSITORY: ${{ github.repository }}",
+)
+missing_env = [entry for entry in required_env if entry not in body]
+if missing_env:
+    sys.exit("hardening step environment missing: " + ", ".join(missing_env))
 active = [
     line.strip()
     for line in body.splitlines()
     if line.startswith("          ") and not line.lstrip().startswith("#")
 ]
 required = (
+    "bash scripts/ci/test-check-assay-release-pin.sh",
+    "bash scripts/ci/check-assay-release-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
     "bash scripts/ci/test-structurizr-export-docker.sh",
 )

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -584,10 +584,7 @@ body = step.group("body")
 for forbidden in ("if:", "continue-on-error:"):
     if re.search(rf"(?m)^        {re.escape(forbidden)}", body):
         sys.exit(f"hardening step must not use {forbidden}")
-required_env = (
-    "GH_TOKEN: ${{ github.token }}",
-    "GITHUB_REPOSITORY: ${{ github.repository }}",
-)
+required_env = ("GH_TOKEN: ${{ github.token }}",)
 missing_env = [entry for entry in required_env if entry not in body]
 if missing_env:
     sys.exit("hardening step environment missing: " + ", ".join(missing_env))


### PR DESCRIPTION
## Summary

- separate the forward-looking workspace version from the last-published CI install pin
- allow release preparation with workspace `5.2.0` while CI still installs published `v5.1.0`
- verify in required `CI` that the pin exactly equals GitHub's latest stable release and carries the Linux x86_64 CLI archive and checksum sidecar
- retain #2287's single-reader and no-second-literal guarantees
- bound external release metadata to 1 MiB before JSON materialization

Fixes #2363.

## Why

Before this change B1 required `.github/assay-release-tag == v<workspace version>`. A release PR therefore had only two states:

| Release-prep state | Required `CI` | Install consumers |
|---|---|---|
| workspace `5.2.0`, pin `v5.1.0` | fail | published asset works |
| workspace `5.2.0`, pin `v5.2.0` | pass | unpublished asset 404s |

The install pin now models the latest release that actually exists. Source/docs continue to model the source being prepared.

## Contract

- Offline: stable install pin may equal or trail the workspace; it may never lead.
- Required GitHub CI: pin must exactly equal `/releases/latest`, be stable/non-draft/non-prerelease, and include `assay-<tag>-x86_64-unknown-linux-gnu.tar.gz` and its `.sha256` sidecar.
- Metadata/API failure and oversized metadata are hard failures.
- No new required context and no path-filter or fail-open change.

## RED -> GREEN

RED before production code:

```text
exit=127
scripts/ci/test-check-assay-release-pin.sh: .../check-assay-release-pin.sh: No such file or directory
```

GREEN on exact head `39c943d2e1ec5ddcac35d31c812c01a6e5f3d777`:

```text
assay release pin contract: PASS
assay published release pin: v5.1.0 (workspace 5.1.0)
ci-hardening-b1 contract: PASS
exact-head verification: PASS
```

Mutation checks on the same committed tree caught:

- removed offline pin-ahead guard
- replaced exact published-tag identity with numeric equality
- removed draft/prerelease refusal
- removed latest-tag shape validation
- removed workspace stable-semver validation
- removed required Linux archive
- removed required Linux checksum sidecar
- removed required Linux archive while retaining its sidecar
- removed published verifier from required `CI`

## Verification

```bash
bash scripts/ci/test-check-assay-release-pin.sh
bash scripts/ci/check-assay-release-pin.sh --published
bash scripts/ci/test-ci-hardening-b1.sh
shellcheck scripts/ci/check-assay-release-pin.sh scripts/ci/test-check-assay-release-pin.sh scripts/ci/test-ci-hardening-b1.sh
pre-commit run --files .github/workflows/ci.yml scripts/ci/check-assay-release-pin.sh scripts/ci/test-check-assay-release-pin.sh scripts/ci/test-ci-hardening-b1.sh
git diff --check
```

Pre-commit and pre-push hooks passed, including actionlint, clippy deny-warnings, Linux cross-target compile gate, and required-gate contracts.

## Review packet

| Item | Value |
|---|---|
| Base | `7401d92d69b5bad19e2a6b43ec8a7fd338c908ff` |
| Head | `39c943d2e1ec5ddcac35d31c812c01a6e5f3d777` |
| Branch | `codex/ci-install-pin-last-published` |
| Worktree | `/Users/roelschuurkes/wt-ci-install-pin-last-published` |
| Changed files | 4 |
| Required contexts | unchanged |
| Security behavior | fail closed on metadata, exact tag, version, and asset mismatch |

## Review findings addressed

The independent review of the prior head found a false-green for a zero-padded tag and missing mutation coverage for three checks. This head requires literal tag identity and adds fixtures for zero-padded tags, draft metadata, invalid latest tags, and prerelease workspace versions. The prior review is invalidated by this push; a fresh exact-head review is required. A subsequent exact-head review found that fork `push` runs queried the fork release API; this head now pins release authority to upstream and includes a fork-environment regression test. Every prior review is invalidated by this push. The final delta also closes the release-installer gap identified on the prior head by requiring the `.sha256` sidecar consumed by `assay-action`.

## Non-claims

- Does not publish or tag `v5.2.0`.
- Does not change the existing v5.1.0 install pin.
- Does not prove every release platform asset; it checks the Linux archive and checksum sidecar consumed by these CI jobs.
- Does not make optional security workflows required.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Added automated validation to ensure the checked-in Assay release pin matches the workspace version.
  * Added checks for published release metadata, stable versions, exact tags, required assets, and checksums.
  * CI now validates release pins against the latest published release when available.

* **Tests**
  * Added comprehensive coverage for valid pins, release mismatches, draft or prerelease releases, API failures, and metadata limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->