### PR TITLE
fix(release): separate source and published release truth

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -24,6 +24,7 @@ on:
       - ".gitignore"
       - ".gitattributes"
       - ".pre-commit-config.yaml"
+      - ".github/assay-release-tag"
       - "docs/generated/**"
       - "docs/AIcontext/architecture-diagrams.md"
       - "docs/guides/agent-golden-path.md"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,7 +138,7 @@ repos:
         entry: bash -c 'bash scripts/ci/test-agent-golden-path-skill-optimization.sh && bash scripts/ci/test-agent-golden-path-skill-hardening.sh'
         language: system
         pass_filenames: false
-        # The 96 mutation cases prove the validator has teeth, but their cost belongs
+        # The mutation cases prove the validator has teeth, but their cost belongs
         # at the publish boundary rather than in every intermediate commit.
         stages: [pre-push]
         files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,7 @@ repos:
         # Both properties this pins have failed here before: `check-aee-seal-fixture-drift.sh`
         # documents an earlier version that ran its emitter in place and destroyed the fixtures it
         # audited, and `check-linux.sh` returned 0 on every failure (#2076).
-        files: ^(scripts/ci/(check-docs-generated-drift|test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot)\.sh|scripts/ci/lib/workspace_version\.py|scripts/docs/generate-agent-golden-path\.py|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*)$
+        files: ^(scripts/ci/(check-docs-generated-drift|test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot|read-assay-release-tag)\.sh|scripts/ci/lib/workspace_version\.py|scripts/docs/generate-agent-golden-path\.py|\.github/assay-release-tag|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*)$
 
       - id: docs-generated-drift
         name: Generated docs match their generators
@@ -124,24 +124,24 @@ repos:
         # Caught here instead, the diagram edge lands in the pull request that added the dependency,
         # where a reviewer can see why it moved. It also makes the bot's `has_changes` false by
         # construction, so the un-mergeable PR is never created.
-        files: ^(Cargo\.toml|crates/.*/Cargo\.toml|scripts/docs/.*\.(sh|py)|scripts/ci/lib/workspace_version\.py|docs/generated/.*|docs/AIcontext/architecture-diagrams\.md|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|scripts/ci/check-docs-generated-drift\.sh|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|crates/.*/Cargo\.toml|scripts/docs/.*\.(sh|py)|scripts/ci/(read-assay-release-tag\.sh|lib/workspace_version\.py)|\.github/assay-release-tag|docs/generated/.*|docs/AIcontext/architecture-diagrams\.md|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|scripts/ci/check-docs-generated-drift\.sh|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: agent-golden-path-skill-contract
         name: Agent golden-path skill contract
         entry: bash -c 'python3 scripts/ci/test-agent-golden-path-skill.py && python3 scripts/ci/test-golden-path-mock-bounds.py'
         language: system
         pass_filenames: false
-        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: agent-golden-path-skill-mutations
         name: Agent golden-path skill mutations
         entry: bash -c 'bash scripts/ci/test-agent-golden-path-skill-optimization.sh && bash scripts/ci/test-agent-golden-path-skill-hardening.sh'
         language: system
         pass_filenames: false
-        # The 92 mutation cases prove the validator has teeth, but their cost belongs
+        # The 94 mutation cases prove the validator has teeth, but their cost belongs
         # at the publish boundary rather than in every intermediate commit.
         stages: [pre-push]
-        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test
@@ -289,14 +289,13 @@ repos:
         files: ^scripts/ci/(lib/clear-git-repository-env|test-(check-release-surface|git-fixture-env-isolation|perf-pr-event-provenance-contract))\.sh$
 
       - id: release-surface
-        name: Release surface names the current version
+        name: Release surface matches source and published versions
         entry: bash -c 'bash scripts/ci/test-check-release-surface.sh && bash scripts/ci/check-release-surface.sh'
         language: system
         pass_filenames: false
         # Triggers on the files it can be wrong about, plus itself. It does not need a binary: with
-        # no `target/` build it falls back to the manifest version, so a release-prep commit is
-        # checked without waiting on a compile.
-        files: ^(scripts/ci/(check|test-check)-release-surface\.sh|Cargo\.toml|README\.md|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
+        # no `target/` build it still verifies source and published-release truth independently.
+        files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
 
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,7 +138,7 @@ repos:
         entry: bash -c 'bash scripts/ci/test-agent-golden-path-skill-optimization.sh && bash scripts/ci/test-agent-golden-path-skill-hardening.sh'
         language: system
         pass_filenames: false
-        # The 94 mutation cases prove the validator has teeth, but their cost belongs
+        # The 96 mutation cases prove the validator has teeth, but their cost belongs
         # at the publish boundary rather than in every intermediate commit.
         stages: [pre-push]
         files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Every place that must name the current version names it. #1996.
+# Source-version and published-release claims each name their own validated truth. #1996, #2366.
 #
 # A release prep touches a fixed set of files and nothing checked that it did: three of them sat a
 # release behind from v3.37.0 onward, and the internal dependency declarations had drifted as far
@@ -23,9 +23,8 @@
 #
 #   1. Internal dependency declarations. Enumerated from the root Cargo.toml itself, not from a
 #      list kept here, so a new workspace crate is covered the day it is added.
-#   2. The `assay --version` sample output in the installation guide, compared against what the
-#      binary actually prints, so the expectation comes from the program rather than from a
-#      hard-coded string.
+#   2. The source binary against the workspace version, and the installation guide against the
+#      validated published-release pin. A release-prep branch may legitimately make them differ.
 #   3. Every tracked `Cargo.lock` that pins a workspace crate. The root lock is the obvious one and
 #      `fuzz/Cargo.lock` is the one that was missed: it is a separate workspace, so a release bump
 #      that touched only the root lock left it pinning the previous version, and the fuzz job failed
@@ -50,7 +49,7 @@ fail() {
 note() { printf '%s\n' "$*"; }
 
 # ---------------------------------------------------------------------------
-# The one source of truth.
+# Source-build truth and published-release truth.
 # ---------------------------------------------------------------------------
 WORKSPACE_VERSION="$(
   awk '
@@ -69,6 +68,10 @@ if [ -z "$WORKSPACE_VERSION" ]; then
   exit 2
 fi
 note "workspace version: $WORKSPACE_VERSION"
+
+PUBLISHED_TAG="$(bash scripts/ci/read-assay-release-tag.sh)"
+PUBLISHED_VERSION="${PUBLISHED_TAG#v}"
+note "published release pin: $PUBLISHED_TAG"
 
 # ---------------------------------------------------------------------------
 # 1. Internal dependency declarations, enumerated from the manifest.
@@ -110,10 +113,11 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 2. The documented `assay --version` output.
+# 2. The source binary and documented published `assay --version` output.
 #
-# Derived from the binary rather than compared to a literal, so this cannot drift into asserting a
-# version the program does not print.
+# A release-prep branch may build the next workspace version while outward installation docs still
+# name the latest published release. Verify those facts independently rather than forcing one to
+# impersonate the other.
 # ---------------------------------------------------------------------------
 note ""
 note "workspace lockfiles:"
@@ -179,15 +183,14 @@ fi
 if [ -n "$ASSAY_BIN" ]; then
   ACTUAL="$("$ASSAY_BIN" --version | head -1 | tr -d '\r')"
   note "  binary prints: $ACTUAL"
-  if ! grep -qxF "$ACTUAL" "$INSTALL_DOC"; then
-    fail "$INSTALL_DOC does not show \"$ACTUAL\" as the expected \`assay --version\` output"
+  if [ "$ACTUAL" != "assay $WORKSPACE_VERSION" ]; then
+    fail "$ASSAY_BIN prints \"$ACTUAL\", workspace is \"assay $WORKSPACE_VERSION\""
   fi
 else
-  # No binary to ask, so fall back to the manifest. Still derived, one step further removed.
-  note "  no assay binary available; comparing against the manifest version instead"
-  if ! grep -qxF "assay $WORKSPACE_VERSION" "$INSTALL_DOC"; then
-    fail "$INSTALL_DOC does not show \"assay $WORKSPACE_VERSION\" as the expected \`assay --version\` output"
-  fi
+  note "  no assay binary available; workspace binary version not driven"
+fi
+if ! grep -qxF "assay $PUBLISHED_VERSION" "$INSTALL_DOC"; then
+  fail "$INSTALL_DOC does not show \"assay $PUBLISHED_VERSION\" as the published \`assay --version\` output"
 fi
 
 # ---------------------------------------------------------------------------
@@ -244,7 +247,7 @@ check_action_refs_pinned() {
 
 check_install_command_count() {
   local file="$1" expected_count="$2"
-  local expected="cargo install assay-cli --version $WORKSPACE_VERSION --locked"
+  local expected="cargo install assay-cli --version $PUBLISHED_VERSION --locked"
   local all_count current_count
   all_count="$(grep -Ec 'cargo install assay-cli --version [^[:space:]]+ --locked' "$file" || true)"
   current_count="$(grep -Fc "$expected" "$file" || true)"
@@ -269,7 +272,7 @@ check_rust_cli_installs docs/reference/cli/index.md 1
 check_rust_cli_installs docs/AIcontext/user-flows.md 1
 check_rust_cli_installs docs/use-cases/ci-gate.md 1
 
-release_link="Current release: [\`v$WORKSPACE_VERSION\`](https://github.com/Rul1an/assay/releases/tag/v$WORKSPACE_VERSION)"
+release_link="Current release: [\`$PUBLISHED_TAG\`](https://github.com/Rul1an/assay/releases/tag/$PUBLISHED_TAG)"
 check_contains_fixed README.md "$release_link" 'current release link drift'
 check_contains_fixed docs/index.md "$release_link" 'current release link drift'
 
@@ -290,9 +293,9 @@ check_absent_regex docs/getting-started/installation.md \
 for file in docs/getting-started/installation.md docs/getting-started/ci-integration.md docs/use-cases/air-gapped.md; do
   check_absent_regex "$file" 'ghcr\.io/.*/assay' 'unsupported GHCR image'
 done
-linux_archive="assay-v$WORKSPACE_VERSION-x86_64-unknown-linux-gnu.tar.gz"
+linux_archive="assay-$PUBLISHED_TAG-x86_64-unknown-linux-gnu.tar.gz"
 linux_archive_root="${linux_archive%.tar.gz}"
-linux_archive_url="https://github.com/Rul1an/assay/releases/download/v$WORKSPACE_VERSION/$linux_archive"
+linux_archive_url="https://github.com/Rul1an/assay/releases/download/$PUBLISHED_TAG/$linux_archive"
 check_contains_line docs/use-cases/air-gapped.md "curl -fLO $linux_archive_url" \
   'current Linux release archive URL drift'
 check_contains_line docs/use-cases/air-gapped.md "curl -fLO $linux_archive_url.sha256" \
@@ -311,7 +314,7 @@ for file in \
   check_action_refs_pinned "$file"
 done
 
-if ! grep -qxF "# assay $WORKSPACE_VERSION" docs/reference/cli/index.md; then
+if ! grep -qxF "# assay $PUBLISHED_VERSION" docs/reference/cli/index.md; then
   fail "docs/reference/cli/index.md: documented CLI version drift"
 fi
 for file in README.md docs/guides/editor-mcp-recipe.md; do
@@ -322,12 +325,12 @@ done
 # ---------------------------------------------------------------------------
 note ""
 if [ "$failures" -gt 0 ]; then
-  note "release surface: $failures disagreement(s) with [workspace.package] version"
+  note "release surface: $failures disagreement(s) with workspace or published-release truth"
   note ""
-  note "If this fired on a release prep, bump the files it names. If it fired on a line that is"
-  note "supposed to record history, that line should not be derived from the current version and"
-  note "this script should not be looking at it: fix the check, do not suppress it."
+  note "During release prep, source files may lead while outward install claims stay on the"
+  note "published pin. Move that pin only after the release assets exist; do not suppress the"
+  note "distinction or rewrite historical records."
   exit 1
 fi
 
-note "release surface: consistent at $WORKSPACE_VERSION"
+note "release surface: workspace $WORKSPACE_VERSION, published $PUBLISHED_TAG"

--- a/scripts/ci/check-release-surface.sh
+++ b/scripts/ci/check-release-surface.sh
@@ -223,6 +223,20 @@ check_contains_fixed() {
   fi
 }
 
+check_current_release_link() {
+  local file="$1" expected="$2"
+  local claim_count expected_count
+  if [ ! -f "$file" ]; then
+    fail "$file: checked outward document is missing"
+    return
+  fi
+  claim_count="$(grep -Fc 'Current release:' "$file" || true)"
+  expected_count="$(grep -Fc -- "$expected" "$file" || true)"
+  if [ "$claim_count" -ne 1 ] || [ "$expected_count" -ne 1 ]; then
+    fail "$file: current release link drift"
+  fi
+}
+
 check_contains_line() {
   local file="$1" expected="$2" label="$3"
   if [ ! -f "$file" ]; then
@@ -273,8 +287,8 @@ check_rust_cli_installs docs/AIcontext/user-flows.md 1
 check_rust_cli_installs docs/use-cases/ci-gate.md 1
 
 release_link="Current release: [\`$PUBLISHED_TAG\`](https://github.com/Rul1an/assay/releases/tag/$PUBLISHED_TAG)"
-check_contains_fixed README.md "$release_link" 'current release link drift'
-check_contains_fixed docs/index.md "$release_link" 'current release link drift'
+check_current_release_link README.md "$release_link"
+check_current_release_link docs/index.md "$release_link"
 
 for file in \
   docs/getting-started/index.md \

--- a/scripts/ci/lib/golden-path-fixture-staging.sh
+++ b/scripts/ci/lib/golden-path-fixture-staging.sh
@@ -9,6 +9,7 @@ stage_golden_path_fixtures() {
   mkdir -p \
     "$case_root/scripts/ci/lib" \
     "$case_root/scripts/docs" \
+    "$case_root/.github" \
     "$case_root/docs/generated" \
     "$case_root/examples/privileged-action-gate/policies" \
     "$case_root/.agents/skills/assay-golden-path" \
@@ -20,8 +21,10 @@ stage_golden_path_fixtures() {
 
   cp "$repo_root/scripts/ci/test-agent-golden-path-skill.py" "$case_root/scripts/ci/"
   cp "$repo_root/scripts/ci/lib/workspace_version.py" "$case_root/scripts/ci/lib/"
+  cp "$repo_root/scripts/ci/read-assay-release-tag.sh" "$case_root/scripts/ci/"
   cp "$repo_root/scripts/docs/generate-agent-golden-path.py" "$case_root/scripts/docs/"
   cp "$repo_root/Cargo.toml" "$case_root/"
+  cp "$repo_root/.github/assay-release-tag" "$case_root/.github/"
   cp "$repo_root/.gitignore" "$case_root/"
   cp "$repo_root/.gitattributes" "$case_root/"
   cp "$repo_root/.mcp.json" "$case_root/"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -300,14 +300,20 @@ case_root="$SCRATCH/workspace-leads-published-release"
 seed_case "$case_root"
 CASE_ROOT="$case_root" python3 - <<'PY'
 import os
+import re
 from pathlib import Path
 
 path = Path(os.environ["CASE_ROOT"]) / "Cargo.toml"
 text = path.read_text(encoding="utf-8")
-anchor = '[workspace.package]\nversion = "5.1.0"'
-if text.count(anchor) != 1:
+text, count = re.subn(
+    r'(?m)^(\[workspace\.package\]\nversion = ")[^"]+("\s*)$',
+    r'\g<1>999.999.999\2',
+    text,
+    count=1,
+)
+if count != 1:
     raise SystemExit("workspace package version fixture is not unique")
-path.write_text(text.replace(anchor, '[workspace.package]\nversion = "5.2.0"', 1), encoding="utf-8")
+path.write_text(text, encoding="utf-8")
 PY
 if ! (cd "$case_root" && python3 scripts/docs/generate-agent-golden-path.py) \
   >"$case_root/workspace-leads.log" 2>&1
@@ -320,14 +326,26 @@ CASE_ROOT="$case_root" python3 - <<'PY'
 import json
 import os
 from pathlib import Path
+import subprocess
 
 root = Path(os.environ["CASE_ROOT"])
 contract = json.loads(
     (root / "docs/generated/agent-golden-path.json").read_text(encoding="utf-8")
 )
-if contract.get("release_version") != "5.1.0" or contract.get("release_tag") != "v5.1.0":
+release_tag_result = subprocess.run(
+    ["bash", "scripts/ci/read-assay-release-tag.sh"],
+    cwd=root,
+    check=False,
+    capture_output=True,
+    text=True,
+)
+if release_tag_result.returncode != 0:
+    raise SystemExit("failed to read published release tag in hardening fixture")
+release_tag = release_tag_result.stdout.strip()
+release_version = release_tag.removeprefix("v")
+if contract.get("release_version") != release_version or contract.get("release_tag") != release_tag:
     raise SystemExit(
-        "golden path followed workspace 5.2.0 instead of published release v5.1.0"
+        "golden path followed synthetic workspace version instead of published release pin"
     )
 PY
 record_structural_probe_pass "workspace may lead published golden-path release"

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -13,11 +13,11 @@ trap 'rm -rf "$SCRATCH"' EXIT
 # the 58-case durability boundary established by PR B0.
 # CI-5C (#2196): +3 skill generator-destination omissions and +3 packaged-resource
 # destination drifts beyond the original baseline-only packaged drift case.
-EXPECTED_CASES=92
+EXPECTED_CASES=94
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
-EXPECTED_STRUCTURAL_PROBES=22
+EXPECTED_STRUCTURAL_PROBES=23
 case_count=0
 structural_probe_count=0
 
@@ -296,6 +296,72 @@ expect_generator_failure() {
   record_case_pass "$name"
 }
 
+case_root="$SCRATCH/workspace-leads-published-release"
+seed_case "$case_root"
+CASE_ROOT="$case_root" python3 - <<'PY'
+import os
+from pathlib import Path
+
+path = Path(os.environ["CASE_ROOT"]) / "Cargo.toml"
+text = path.read_text(encoding="utf-8")
+anchor = '[workspace.package]\nversion = "5.1.0"'
+if text.count(anchor) != 1:
+    raise SystemExit("workspace package version fixture is not unique")
+path.write_text(text.replace(anchor, '[workspace.package]\nversion = "5.2.0"', 1), encoding="utf-8")
+PY
+if ! (cd "$case_root" && python3 scripts/docs/generate-agent-golden-path.py) \
+  >"$case_root/workspace-leads.log" 2>&1
+then
+  cat "$case_root/workspace-leads.log" >&2
+  echo "FAIL: golden path must remain pinned to the published release when workspace leads" >&2
+  exit 1
+fi
+CASE_ROOT="$case_root" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+root = Path(os.environ["CASE_ROOT"])
+contract = json.loads(
+    (root / "docs/generated/agent-golden-path.json").read_text(encoding="utf-8")
+)
+if contract.get("release_version") != "5.1.0" or contract.get("release_tag") != "v5.1.0":
+    raise SystemExit(
+        "golden path followed workspace 5.2.0 instead of published release v5.1.0"
+    )
+PY
+record_structural_probe_pass "workspace may lead published golden-path release"
+
+case_root="$SCRATCH/published-release-pin-drift"
+seed_case "$case_root"
+printf '%s\n' 'v5.0.0' > "$case_root/.github/assay-release-tag"
+expect_named_failure \
+  "published release pin drift" \
+  "$case_root" \
+  "golden-path release_version must match the published release pin"
+
+case_root="$SCRATCH/published-release-tag-drift"
+seed_case "$case_root"
+CASE_ROOT="$case_root" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+root = Path(os.environ["CASE_ROOT"])
+for relative in (
+    "docs/generated/agent-golden-path.json",
+    "packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json",
+):
+    path = root / relative
+    contract = json.loads(path.read_text(encoding="utf-8"))
+    contract["release_tag"] = "v5.0.0"
+    path.write_text(json.dumps(contract, indent=2) + "\n", encoding="utf-8")
+PY
+expect_named_failure \
+  "published release tag drift" \
+  "$case_root" \
+  "golden-path release_tag must match the published release pin"
+
 mutate_workflow() {
   local case_root="$1" mutation="$2"
   CASE_ROOT="$case_root" MUTATION="$mutation" python3 - <<'PY'
@@ -429,8 +495,9 @@ text = path.read_text(encoding="utf-8")
 mutation = os.environ["MUTATION"]
 hook_files = (
     "        files: ^(scripts/ci/(check-docs-generated-drift|"
-    "test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot)\\.sh|"
-    "scripts/ci/lib/workspace_version\\.py|scripts/docs/generate-agent-golden-path\\.py|"
+    "test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot|"
+    "read-assay-release-tag)\\.sh|scripts/ci/lib/workspace_version\\.py|"
+    "scripts/docs/generate-agent-golden-path\\.py|\\.github/assay-release-tag|"
     "\\.(agents|claude)/skills/"
     "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*)$\n"
 )
@@ -1163,8 +1230,9 @@ from pathlib import Path
 path = Path(os.environ["CASE_ROOT"]) / ".pre-commit-config.yaml"
 source = (
     "        files: ^(scripts/ci/(check-docs-generated-drift|"
-    "test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot)\\.sh|"
-    "scripts/ci/lib/workspace_version\\.py|scripts/docs/generate-agent-golden-path\\.py|"
+    "test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot|"
+    "read-assay-release-tag)\\.sh|scripts/ci/lib/workspace_version\\.py|"
+    "scripts/docs/generate-agent-golden-path\\.py|\\.github/assay-release-tag|"
     "\\.(agents|claude)/skills/"
     "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*)$\n"
 )

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -15,8 +15,9 @@ trap 'rm -rf "$SCRATCH"' EXIT
 # destination drifts beyond the original baseline-only packaged drift case.
 EXPECTED_CASES=96
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
-# 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
-# 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
+# The 23 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode,
+# 1 release-split, and 2 inline-parser checks; pin them so deletion cannot leave
+# the cumulative total green.
 EXPECTED_STRUCTURAL_PROBES=23
 case_count=0
 structural_probe_count=0

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -13,7 +13,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 # the 58-case durability boundary established by PR B0.
 # CI-5C (#2196): +3 skill generator-destination omissions and +3 packaged-resource
 # destination drifts beyond the original baseline-only packaged drift case.
-EXPECTED_CASES=94
+EXPECTED_CASES=96
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # 22 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode, and
 # 2 inline-parser checks; pin them so deletion cannot leave the cumulative total green.
@@ -944,6 +944,7 @@ expect_named_success "public vocabulary novel contract evidence allow case" "$ca
 
 for workflow_path in \
   'scripts/**' \
+  '.github/assay-release-tag' \
   '.github/workflows/kernel-matrix.yml' \
   '.claude-plugin/**' \
   'packaging/claude-plugin/**'

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -1243,6 +1243,7 @@ def main() -> None:
         '.gitignore',
         '.gitattributes',
         '.pre-commit-config.yaml',
+        '.github/assay-release-tag',
         'docs/generated/**',
         'docs/guides/agent-golden-path.md',
         '.github/workflows/kernel-matrix.yml',

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -10,12 +10,9 @@ import os
 import re
 from pathlib import Path
 import subprocess
-import sys
 
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "scripts/ci/lib"))
-from workspace_version import read_workspace_version  # noqa: E402
 
 CONTRACT_PATH = ROOT / "docs/generated/agent-golden-path.json"
 GUIDE_PATH = ROOT / "docs/guides/agent-golden-path.md"
@@ -1087,11 +1084,21 @@ def main() -> None:
         fail("unexpected golden-path contract schema")
     if contract.get("schema_version") != 1:
         fail("unexpected golden-path contract schema version")
-    version = read_workspace_version(ROOT / "Cargo.toml")
-    if contract.get("release_version") != version:
-        fail("golden-path release_version must match the workspace version")
-    if contract.get("release_tag") != f"v{version}":
-        fail("golden-path release_tag must match the workspace version")
+    release_tag_result = subprocess.run(
+        ["bash", str(ROOT / "scripts/ci/read-assay-release-tag.sh")],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if release_tag_result.returncode != 0:
+        fail("failed to read published release tag: " + release_tag_result.stderr.strip())
+    release_tag = release_tag_result.stdout.strip()
+    release_version = release_tag.removeprefix("v")
+    if contract.get("release_version") != release_version:
+        fail("golden-path release_version must match the published release pin")
+    if contract.get("release_tag") != release_tag:
+        fail("golden-path release_tag must match the published release pin")
     validate_plugin_skill(contract)
 
     payloads: list[bytes] = []
@@ -1105,8 +1112,8 @@ def main() -> None:
     guide = read_bounded_evidence(GUIDE_PATH, "guide evidence").decode("utf-8")
     release = generated_release_block(guide)
     for required in (
-        f"Assay `{version}`",
-        f"`v{version}`",
+        f"Assay `{release_version}`",
+        f"`{release_tag}`",
         "assay version",
         "Upgrade",
         "Roll back",

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -251,6 +251,11 @@ for row in \
     'current release-pinned install command(s)'
 done
 
+mutate_and_expect_failure wrong-workspace-binary bin/assay \
+  's/assay 5.2.0/assay 5.1.0/' 'workspace is "assay 5.2.0"'
+mutate_and_expect_failure wrong-published-version-output docs/getting-started/installation.md \
+  's/assay 5.1.0/assay 5.2.0/' 'does not show "assay 5.1.0" as the published'
+
 mutate_and_expect_failure stale-release-readme README.md \
   's/releases\/tag\/v5.1.0/releases\/tag\/v5.0.0/' 'current release link drift'
 mutate_and_expect_failure stale-release-doc-index docs/index.md \
@@ -272,8 +277,8 @@ echo "PASS: duplicate-release"
 mutate_and_expect_failure stale-cli-version docs/reference/cli/index.md \
   's/# assay 5.1.0/# assay 5.0.0/' 'documented CLI version drift'
 
-if [ "$mutation_count" -ne 39 ]; then
-  echo "FAIL: expected 39 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 41 ]; then
+  echo "FAIL: expected 41 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -255,11 +255,25 @@ mutate_and_expect_failure stale-release-readme README.md \
   's/releases\/tag\/v5.1.0/releases\/tag\/v5.0.0/' 'current release link drift'
 mutate_and_expect_failure stale-release-doc-index docs/index.md \
   's/releases\/tag\/v5.1.0/releases\/tag\/v5.0.0/' 'current release link drift'
+
+release_backup="$TMP/README.md.duplicate-release"
+cp "$TMP/README.md" "$release_backup"
+printf '%s\n' 'Current release: [`v5.2.0`](https://github.com/Rul1an/assay/releases/tag/v5.2.0)' \
+  >> "$TMP/README.md"
+if run_check >"$TMP/duplicate-release.out" 2>&1; then
+  echo "FAIL: mutation duplicate-release was not observed" >&2
+  exit 1
+fi
+grep -Fq 'current release link drift' "$TMP/duplicate-release.out"
+mv "$release_backup" "$TMP/README.md"
+mutation_count=$((mutation_count + 1))
+echo "PASS: duplicate-release"
+
 mutate_and_expect_failure stale-cli-version docs/reference/cli/index.md \
   's/# assay 5.1.0/# assay 5.0.0/' 'documented CLI version drift'
 
-if [ "$mutation_count" -ne 38 ]; then
-  echo "FAIL: expected 38 release-surface mutations, observed $mutation_count" >&2
+if [ "$mutation_count" -ne 39 ]; then
+  echo "FAIL: expected 39 release-surface mutations, observed $mutation_count" >&2
   exit 1
 fi
 echo "release-surface mutations: $mutation_count observed"

--- a/scripts/ci/test-check-release-surface.sh
+++ b/scripts/ci/test-check-release-surface.sh
@@ -8,18 +8,20 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-mkdir -p "$TMP/scripts/ci" "$TMP/docs/getting-started" "$TMP/docs/reference/cli" \
+mkdir -p "$TMP/scripts/ci" "$TMP/.github" "$TMP/docs/getting-started" "$TMP/docs/reference/cli" \
   "$TMP/docs/python-sdk" "$TMP/docs/use-cases" "$TMP/docs/AIcontext" "$TMP/docs/guides" \
   "$TMP/crates/assay-x" "$TMP/bin"
 cp "$ROOT/scripts/ci/check-release-surface.sh" "$TMP/scripts/ci/"
+cp "$ROOT/scripts/ci/read-assay-release-tag.sh" "$TMP/scripts/ci/"
 cp "$ROOT/.pre-commit-config.yaml" "$TMP/"
+printf '%s\n' 'v5.1.0' > "$TMP/.github/assay-release-tag"
 cat > "$TMP/Cargo.toml" <<'TOML'
 [workspace]
 members = ["crates/assay-x"]
 [workspace.package]
-version = "5.1.0"
+version = "5.2.0"
 [workspace.dependencies]
-assay-x = { version = "5.1.0", path = "crates/assay-x" }
+assay-x = { version = "5.2.0", path = "crates/assay-x" }
 TOML
 cat > "$TMP/crates/assay-x/Cargo.toml" <<'TOML'
 [package]
@@ -29,11 +31,11 @@ TOML
 cat > "$TMP/Cargo.lock" <<'LOCK'
 [[package]]
 name = "assay-x"
-version = "5.1.0"
+version = "5.2.0"
 LOCK
 cat > "$TMP/bin/assay" <<'EOF_BIN'
 #!/usr/bin/env bash
-printf 'assay 5.1.0\n'
+printf 'assay 5.2.0\n'
 EOF_BIN
 chmod +x "$TMP/bin/assay"
 cat > "$TMP/docs/getting-started/installation.md" <<'DOC'
@@ -90,7 +92,7 @@ printf '%s\n' 'Codex uses .codex/config.toml.' > "$TMP/docs/guides/editor-mcp-re
 (
   cd "$TMP"
   git init -q
-  git add -- Cargo.toml Cargo.lock crates docs scripts
+  git add -- .github/assay-release-tag Cargo.toml Cargo.lock crates docs scripts
 )
 
 run_check() {
@@ -110,13 +112,23 @@ files_lines = [line.strip().removeprefix("files: ") for line in lines[start:end]
 if len(files_lines) != 1:
     raise SystemExit("release-surface hook must have one files selector")
 pattern = re.compile(files_lines[0])
-for path in ("docs/getting-started/ci-integration.md", "docs/use-cases/air-gapped.md", "docs/use-cases/ci-gate.md"):
+for path in (
+    ".github/assay-release-tag",
+    "scripts/ci/read-assay-release-tag.sh",
+    "docs/getting-started/ci-integration.md",
+    "docs/use-cases/air-gapped.md",
+    "docs/use-cases/ci-gate.md",
+):
     if not pattern.search(path):
         raise SystemExit(f"release-surface hook omits {path}")
 PY
 }
 
-run_check >/dev/null
+if ! run_check >"$TMP/baseline.out" 2>&1; then
+  cat "$TMP/baseline.out" >&2
+  echo "FAIL: release surface must allow workspace 5.2.0 to lead published release v5.1.0" >&2
+  exit 1
+fi
 check_release_hook_selector
 
 mutation_count=0

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 
 import json
 import stat
-import sys
+import subprocess
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "scripts/ci/lib"))
-from workspace_version import read_workspace_version  # noqa: E402
 
 JSON_OUTPUT = ROOT / "docs/generated/agent-golden-path.json"
 MARKDOWN_OUTPUT = ROOT / "docs/guides/agent-golden-path.md"
@@ -74,8 +72,26 @@ SOURCE_REPO_CWD_RULE = (
 PYTHON_PLACEHOLDER_RULE = (
     "Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows."
 )
-RELEASE_VERSION = read_workspace_version(ROOT / "Cargo.toml")
-RELEASE_TAG = f"v{RELEASE_VERSION}"
+RELEASE_TAG_READER = ROOT / "scripts/ci/read-assay-release-tag.sh"
+
+
+def read_published_release_tag() -> str:
+    completed = subprocess.run(
+        ["bash", str(RELEASE_TAG_READER)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "failed to read published release tag: " + completed.stderr.strip()
+        )
+    return completed.stdout.strip()
+
+
+RELEASE_TAG = read_published_release_tag()
+RELEASE_VERSION = RELEASE_TAG.removeprefix("v")
 
 
 def stdout(kind: str, document: str | None = None) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- separate workspace/source version truth from the latest published release truth
- keep source builds and internal Cargo/lockfile checks bound to `Cargo.toml`
- bind outward install links, current-release text, CLI examples, and golden-path release metadata to the validated `.github/assay-release-tag`
- reuse `scripts/ci/read-assay-release-tag.sh` as the sole release-tag parser
- add workspace-leading and pin/contract-drift regression coverage

Closes #2366.

## Why

A release-prep branch may legitimately build `5.2.0` while the latest installable release remains `v5.1.0`. The previous guards forced outward docs and generated agent guidance to claim the unpublished workspace version, so consistency checks could be green while public links returned 404.

This change gives each fact one owner:

- workspace/source truth: `[workspace.package].version`
- published/installable truth: validated `.github/assay-release-tag`

## TDD evidence

Measured in `/Users/roelschuurkes/wt-release-published-truth`; committed as exact head `9afbec149fcaa8b94ea6064521533033246f104d`.

RED before production edits:

- workspace `5.2.0` + published pin/outward docs `v5.1.0` produced 15 release-surface disagreements
- the golden-path generator followed workspace `5.2.0` instead of pin `v5.1.0`
- changing only `.github/assay-release-tag` was not detected by the golden-path validator

GREEN on the exact head:

- `bash scripts/ci/test-check-release-surface.sh` (41 mutations, including duplicate current-release and both version-binding assertions)
- `bash scripts/ci/check-release-surface.sh`
- `python3 scripts/docs/generate-agent-golden-path.py`
- `python3 scripts/ci/test-agent-golden-path-skill.py`
- `bash scripts/ci/test-agent-golden-path-skill-optimization.sh`
- `bash scripts/ci/test-agent-golden-path-skill-hardening.sh` (96 cases, 23 structural probes)
- future-release simulation with workspace/pin `5.2.0` (same version-agnostic hardening contract)
- `bash scripts/ci/check-docs-generated-drift.sh` (12 generated files reproduce)
- `python3 -m py_compile scripts/docs/generate-agent-golden-path.py scripts/ci/test-agent-golden-path-skill.py`
- explicit-file `pre-commit run` passed
- pre-push passed, including workspace clippy and cross-target Linux compile
- `git diff --check`

## Contract changes

- outward release claims may no longer lead the validated published-release pin
- workspace source version may lead the published pin during release preparation
- changing the pin now triggers release-surface, generated-docs, and golden-path checks
- pin-only PRs now trigger the workflow that runs those pre-commit guards
- each outward document may carry exactly one `Current release` claim
- deleting either source-binary or published-output version binding makes the self-test fail

## Non-claims

- does not create, tag, publish, or advertise v5.2.0
- does not move the CI install pin
- does not weaken the latest-published/installable validation from #2364
- does not modify release PR #2365; that PR must advance only after this prerequisite lands

## Landing order

1. review and merge this prerequisite
2. advance #2365 onto the resulting `main` and regenerate outward surfaces from the still-published `v5.1.0` pin
3. re-review/re-prove #2365 on its new exact head
4. publish v5.2.0
5. move the published pin and regenerate outward surfaces in a post-publish PR



