### PR TITLE
docs(mcp): the executable recipe advertised a transport we do not ship

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -28,6 +28,10 @@ on:
       - "docs/generated/**"
       - "docs/AIcontext/architecture-diagrams.md"
       - "docs/guides/agent-golden-path.md"
+      # The editor MCP recipe is judged by the editor-mcp-recipe-truth hook, which runs
+      # under Lint (pre-commit) here. `scripts/**` covers a guard change; a recipe-only drift
+      # touches no script, so the recipe needs its own entry or the guard never executes in CI.
+      - "docs/guides/editor-mcp-recipe.md"
       - ".github/workflows/kernel-matrix.yml"
       # S1b coverage-gate hook runs under Lint (pre-commit) in this workflow.
       - ".github/workflows/monitor-attach-smoke.yml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -297,6 +297,15 @@ repos:
         # no `target/` build it still verifies source and published-release truth independently.
         files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
 
+      - id: editor-mcp-recipe-truth
+        name: Editor MCP recipe describes only the shipped transport
+        entry: bash -c 'bash scripts/ci/test-check-editor-mcp-recipe-truth.sh && bash scripts/ci/check-editor-mcp-recipe-truth.sh'
+        language: system
+        pass_filenames: false
+        # Triggers on the recipe it judges, the guard and its self-test, and itself. The self-test
+        # runs first so a guard whose rules match nothing fails here rather than passing quietly.
+        files: ^(scripts/ci/(check|test-check)-editor-mcp-recipe-truth\.sh|docs/guides/editor-mcp-recipe\.md|\.pre-commit-config\.yaml)$
+
       - id: ci-gate-expectations-self-test
         name: CI gate expectation contract
         entry: bash scripts/ci/test-ci-gate-expectations.sh

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -161,15 +161,18 @@ In your `AGENTS.md` / Codex MCP config, register the same wrapped command as the
 server entry. Codex uses project `.codex/config.toml` or user
 `~/.codex/config.toml`; `assay mcp config-path` does not discover Codex config.
 
-## Remote servers (provisional, MCP 2026-07-28)
+## Remote servers
 
-The MCP specification finalising on 28 July 2026 aligns remote authorization with
-OAuth 2.1 / OIDC (PKCE, scoped tokens, consent), and renders server UIs in a
-sandboxed iframe with every UI action going through the same audit and consent path
-as a direct tool call. For remote MCP servers, align the wrapped server to that
-OAuth 2.1 flow and keep scopes least-privilege. This section is provisional against
-the release candidate and will be finalised once the spec is final; the local
-stdio wrap above is stable today.
+This recipe covers local stdio servers only, because that is the transport Assay
+enforces today. `assay-mcp-server` negotiates the legacy revisions `2024-11-05` and
+`2025-11-25` over stdio; a request declaring MCP revision `2026-07-28` is refused with
+JSON-RPC error `-32022` rather than accepted, and the constant naming that revision is
+deprecated and read by no dispatch path.
+
+Assay ships no remote HTTP transport for the wrapped server, so there is nothing here
+to point an editor at for a remote endpoint. The negotiated modern surface is tracked
+in [#2358](https://github.com/Rul1an/assay/issues/2358) and is not delivered; treat any
+remote-transport guidance as design work under that issue, not as a step in this recipe.
 
 ## Honest limits
 

--- a/scripts/ci/check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/check-editor-mcp-recipe-truth.sh
@@ -89,9 +89,9 @@ forbid 'future-tense specification promise' \
 # Assay ships none of these. Naming them as something to align a wrapped server to turns an
 # unshipped design into an instruction.
 forbid 'remote OAuth/OIDC instruction in the executable path' \
-  '(OAuth|OIDC|PKCE)'
+  '(OAuth|OIDC|OpenID|PKCE)'
 forbid 'MCP UI / sandboxed-iframe instruction in the executable path' \
-  '(sandboxed iframe|server UIs|MCP UI)'
+  '(sandboxed[ -]iframe|server UIs?|MCP UIs?)'
 
 # --- Drift 4: the modern revision must not read as delivered -----------------------------
 # The revision may be named, but only as work that is tracked elsewhere and not shipped. If the

--- a/scripts/ci/check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/check-editor-mcp-recipe-truth.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# The executable editor MCP recipe may only describe the transport Assay actually ships.
+#
+# WHY THIS EXISTS (#2360)
+#
+# `docs/guides/editor-mcp-recipe.md` is an *executable* recipe: a reader runs its commands
+# against a real editor. That makes every sentence in it a claim about shipped behaviour, and
+# the shipped MCP boundary is the legacy stdio handshake. `assay-mcp-server` keeps
+# `MODERN_PROTOCOL_VERSION` deprecated and out of negotiation on purpose, and Assay ships no
+# remote HTTP transport, no OAuth/OIDC, and no MCP UI.
+#
+# The recipe nevertheless carried release-candidate wording ("provisional", "will be finalised
+# once the spec is final") plus OAuth 2.1 / sandboxed-iframe instructions, which reads as an
+# Assay transport capability that exists. This guard keeps the four drifts out.
+#
+# WHY THIS IS OFFLINE AND UNCONDITIONAL
+#
+# The acceptance row asks that the recipe cannot claim the modern revision "until the full
+# implementation issue is closed with driven evidence". Keying that off live issue state would
+# put a network call on a required gate and make the check fail for reasons unrelated to the
+# tree. So the forbidden-claim rules below are unconditional and hermetic. Lifting them is a
+# deliberate edit to this file, and the only thing that earns it is #2358 closed with driven
+# evidence — not a version bump, and not this guard going quiet.
+#
+# WHAT THIS DELIBERATELY DOES NOT TOUCH
+#
+# Historical records (CHANGELOG entries, ADR-036, dated measurement baselines) are supposed to
+# keep saying what was true when written; this guard reads one file. The local `assay mcp wrap`
+# and `proxy-enforce` claims are shipped behaviour and are asserted PRESENT below, so a future
+# edit cannot satisfy this guard by deleting them.
+#
+# Usage: scripts/ci/check-editor-mcp-recipe-truth.sh
+#        ASSAY_EDITOR_RECIPE=path/to/recipe.md scripts/ci/check-editor-mcp-recipe-truth.sh  (tests only)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+RECIPE="${ASSAY_EDITOR_RECIPE:-docs/guides/editor-mcp-recipe.md}"
+MODERN_REVISION='2026-07-28'
+IMPL_ISSUE='2358'
+
+failures=0
+fail() {
+  failures=$((failures + 1))
+  printf 'FAIL: %s\n' "$*"
+}
+ok() { printf 'ok   %s\n' "$*"; }
+
+if [ ! -f "$RECIPE" ]; then
+  printf 'FAIL: executable editor recipe missing: %s\n' "$RECIPE"
+  exit 1
+fi
+
+# A forbidden pattern is reported with the offending line so the failure names the sentence,
+# not just the rule.
+forbid() {
+  local label="$1" pattern="$2"
+  local hits
+  hits="$(grep -nEi -- "$pattern" "$RECIPE" || true)"
+  if [ -n "$hits" ]; then
+    fail "$RECIPE: $label"
+    printf '%s\n' "$hits" | sed 's/^/      /'
+  else
+    ok "$label: absent"
+  fi
+}
+
+require() {
+  local label="$1" pattern="$2"
+  if grep -qEi -- "$pattern" "$RECIPE"; then
+    ok "$label: present"
+  else
+    fail "$RECIPE: $label"
+  fi
+}
+
+# --- Drift 1: stale release-candidate copy -----------------------------------------------
+forbid 'stale release-candidate wording (provisional / release candidate)' \
+  '(provisional|release[ -]candidate)'
+
+# --- Drift 2: future-tense finalisation --------------------------------------------------
+# "will be finalised", "finalising on", "once the spec is final" — a recipe describes what a
+# reader can run now, so a promise about a future specification does not belong in it.
+forbid 'future-tense specification promise' \
+  '(will be finali[sz]ed|finali[sz]ing on|once the spec(ification)? is final|is not yet final)'
+
+# --- Drift 3: remote OAuth / OIDC / UI recipe instructions -------------------------------
+# Assay ships none of these. Naming them as something to align a wrapped server to turns an
+# unshipped design into an instruction.
+forbid 'remote OAuth/OIDC instruction in the executable path' \
+  '(OAuth|OIDC|PKCE)'
+forbid 'MCP UI / sandboxed-iframe instruction in the executable path' \
+  '(sandboxed iframe|server UIs|MCP UI)'
+
+# --- Drift 4: the modern revision must not read as delivered -----------------------------
+# The revision may be named, but only as work that is tracked elsewhere and not shipped. If the
+# recipe mentions it at all, it must also point at the implementation issue, so a reader cannot
+# take the mention for a capability.
+if grep -qF -- "$MODERN_REVISION" "$RECIPE"; then
+  if grep -qE -- "#${IMPL_ISSUE}|issues/${IMPL_ISSUE}" "$RECIPE"; then
+    ok "modern revision $MODERN_REVISION mentioned with #${IMPL_ISSUE} tracked"
+  else
+    fail "$RECIPE: names MCP $MODERN_REVISION without linking the implementation issue #${IMPL_ISSUE}"
+  fi
+  forbid "MCP $MODERN_REVISION described as shipped or supported" \
+    "(supports?|implements?|ships?|available|enabled)[^.]{0,40}${MODERN_REVISION}|${MODERN_REVISION}[^.]{0,40}(is (now )?(supported|implemented|available|shipped)|support)"
+else
+  ok "modern revision $MODERN_REVISION not named"
+fi
+
+# --- Shipped claims that must survive any future edit of this file -----------------------
+# Asserted PRESENT so the forbidden-pattern rules above cannot be satisfied by gutting the
+# recipe's real content.
+require 'local stdio wrap claim retained' '(assay mcp wrap|`assay mcp wrap`)'
+require 'proxy-enforce claim retained' 'proxy-enforce'
+
+printf '\n'
+if [ "$failures" -gt 0 ]; then
+  printf 'editor MCP recipe truth: %s drift(s) from shipped transport\n' "$failures"
+  printf '\n'
+  printf 'The executable recipe describes what a reader can run against a real editor today.\n'
+  printf 'Assay ships the legacy stdio handshake; it does not ship remote HTTP, OAuth/OIDC or\n'
+  printf 'MCP UI. Move unshipped design material out of the executable path and link #%s\n' "$IMPL_ISSUE"
+  printf 'rather than implying delivery. Do not rewrite historical records to satisfy this guard.\n'
+  exit 1
+fi
+
+printf 'editor MCP recipe truth: %s describes the shipped stdio boundary\n' "$RECIPE"

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Self-test for check-editor-mcp-recipe-truth.sh.
+#
+# A guard that only ever passes proves nothing about its own sensitivity, and the drifts this
+# one exists to catch are prose, so the failure mode is a rule that matches nothing. Every case
+# below mutates a fixture recipe and asserts the guard fails with the specific diagnostic that
+# names the rule. The two "must survive" cases assert the guard also fails when the shipped
+# claims are deleted, so a future edit cannot satisfy it by gutting the recipe.
+#
+# Each case drives the guard through ASSAY_EDITOR_RECIPE against a fixture in a temp dir, so no
+# case reads or writes the real doc.
+
+set -euo pipefail
+
+# shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$ROOT/scripts/ci/check-editor-mcp-recipe-truth.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cases=0
+failures=0
+
+# A fixture that passes: shipped stdio boundary, #2358 linked, both shipped claims present.
+write_clean() {
+  cat > "$TMP/recipe.md" <<'MD'
+# Editor MCP Recipe
+
+## The wrap command
+
+Run `assay mcp wrap` to enforce policy at the protocol boundary.
+Use `assay-mcp-server proxy-enforce` for the enforcing path.
+
+## Remote servers
+
+Local stdio only. `assay-mcp-server` negotiates `2024-11-05` and `2025-11-25`; a request
+declaring MCP revision 2026-07-28 is refused with JSON-RPC error -32022. The negotiated
+modern surface is tracked in https://github.com/Rul1an/assay/issues/2358 and is not delivered.
+MD
+}
+
+run_guard() { ASSAY_EDITOR_RECIPE="$TMP/recipe.md" bash "$GUARD" 2>&1; }
+
+expect_pass() {
+  local label="$1"
+  cases=$((cases + 1))
+  if out="$(run_guard)"; then
+    printf 'ok   %s\n' "$label"
+  else
+    failures=$((failures + 1))
+    printf 'FAIL: %s — guard rejected input it should accept\n%s\n' "$label" "$out"
+  fi
+}
+
+# expect_fail asserts BOTH a non-zero exit and the exact diagnostic, so a case cannot pass
+# because some unrelated rule happened to fire.
+expect_fail() {
+  local label="$1" expected="$2"
+  cases=$((cases + 1))
+  if out="$(run_guard)"; then
+    failures=$((failures + 1))
+    printf 'FAIL: %s — guard accepted input it should reject\n' "$label"
+  elif printf '%s' "$out" | grep -Fq -- "$expected"; then
+    printf 'ok   %s\n' "$label"
+  else
+    failures=$((failures + 1))
+    printf 'FAIL: %s — rejected, but not for the stated reason (wanted %s)\n%s\n' \
+      "$label" "$expected" "$out"
+  fi
+}
+
+echo '== baseline: a truthful recipe passes =='
+write_clean
+expect_pass 'clean fixture passes'
+
+echo '== drift 1: stale release-candidate copy =='
+write_clean
+printf 'This section is provisional against the release candidate.\n' >> "$TMP/recipe.md"
+expect_fail 'provisional wording rejected' 'stale release-candidate wording'
+
+echo '== drift 2: future-tense specification promise =='
+write_clean
+printf 'It will be finalised once the spec is final.\n' >> "$TMP/recipe.md"
+expect_fail 'future-tense promise rejected' 'future-tense specification promise'
+
+echo '== drift 3a: remote OAuth/OIDC instruction =='
+write_clean
+printf 'Align the wrapped server to that OAuth 2.1 / OIDC flow with PKCE.\n' >> "$TMP/recipe.md"
+expect_fail 'OAuth instruction rejected' 'remote OAuth/OIDC instruction'
+
+echo '== drift 3b: MCP UI / sandboxed-iframe instruction =='
+write_clean
+printf 'It renders server UIs in a sandboxed iframe.\n' >> "$TMP/recipe.md"
+expect_fail 'MCP UI instruction rejected' 'MCP UI / sandboxed-iframe instruction'
+
+echo '== drift 4a: modern revision named without the tracking issue =='
+cat > "$TMP/recipe.md" <<'MD'
+# Editor MCP Recipe
+Run `assay mcp wrap`; use proxy-enforce for the enforcing path.
+Remote work targets MCP revision 2026-07-28.
+MD
+expect_fail 'unlinked modern revision rejected' 'without linking the implementation issue #2358'
+
+echo '== drift 4b: modern revision advertised as shipped =='
+write_clean
+printf 'Assay now supports MCP revision 2026-07-28 over remote transport.\n' >> "$TMP/recipe.md"
+expect_fail 'shipped-claim wording rejected' 'described as shipped or supported'
+
+echo '== the modern revision may be named when tracked (no false positive) =='
+write_clean
+expect_pass 'linked, non-shipped mention accepted'
+
+echo '== shipped claims must survive: deleting them fails the guard =='
+write_clean
+grep -v 'assay mcp wrap' "$TMP/recipe.md" > "$TMP/recipe.tmp" && mv "$TMP/recipe.tmp" "$TMP/recipe.md"
+expect_fail 'deleted wrap claim rejected' 'local stdio wrap claim retained'
+
+write_clean
+grep -v 'proxy-enforce' "$TMP/recipe.md" > "$TMP/recipe.tmp" && mv "$TMP/recipe.tmp" "$TMP/recipe.md"
+expect_fail 'deleted proxy-enforce claim rejected' 'proxy-enforce claim retained'
+
+echo '== a missing recipe fails closed =='
+cases=$((cases + 1))
+if ASSAY_EDITOR_RECIPE="$TMP/does-not-exist.md" bash "$GUARD" >/dev/null 2>&1; then
+  failures=$((failures + 1))
+  printf 'FAIL: missing recipe was accepted\n'
+else
+  printf 'ok   missing recipe fails closed\n'
+fi
+
+printf '\n'
+if [ "$failures" -gt 0 ]; then
+  printf 'editor MCP recipe guard self-test: %s of %s case(s) failed\n' "$failures" "$cases"
+  exit 1
+fi
+printf 'editor MCP recipe guard self-test: %s case(s) PASS\n' "$cases"

--- a/scripts/ci/test-check-editor-mcp-recipe-truth.sh
+++ b/scripts/ci/test-check-editor-mcp-recipe-truth.sh
@@ -121,6 +121,89 @@ write_clean
 grep -v 'proxy-enforce' "$TMP/recipe.md" > "$TMP/recipe.tmp" && mv "$TMP/recipe.tmp" "$TMP/recipe.md"
 expect_fail 'deleted proxy-enforce claim rejected' 'proxy-enforce claim retained'
 
+echo '== false negatives: spelled-out and punctuation variants must be caught =='
+# The forbidden-pattern rules are prose matches, so a variant spelling is a silent hole rather
+# than a visible failure. Each case below is a real way the same claim gets written.
+write_clean
+printf 'Align the wrapped server to that OpenID Connect flow.\n' >> "$TMP/recipe.md"
+expect_fail 'spelled-out OpenID Connect rejected' 'remote OAuth/OIDC instruction'
+
+write_clean
+printf 'It renders a server UI for each tool.\n' >> "$TMP/recipe.md"
+expect_fail 'singular "server UI" rejected' 'MCP UI / sandboxed-iframe instruction'
+
+write_clean
+printf 'Rendered in a sandboxed-iframe host.\n' >> "$TMP/recipe.md"
+expect_fail 'hyphenated sandboxed-iframe rejected' 'MCP UI / sandboxed-iframe instruction'
+
+echo '== CI wiring: a recipe-only change must execute this guard =='
+# The guard is only worth its rules if a drift actually reaches it. The pre-commit hook covers
+# the local path; CI coverage depends on the one workflow that runs `pre-commit run --all-files`
+# selecting the recipe, and `scripts/**` does not help because a recipe-only drift touches no
+# script. Asserted here rather than in a workflow-wide contract so the rule that judges this
+# file also owns the wiring that reaches it.
+cases=$((cases + 1))
+if RECIPE_PATH='docs/guides/editor-mcp-recipe.md' python3 - "$ROOT" <<'PY'
+import os, re, sys
+
+root = sys.argv[1]
+recipe = os.environ["RECIPE_PATH"]
+problems = []
+
+# 1. Exactly one workflow runs the full pre-commit pass; find it rather than assuming its name.
+wf_dir = os.path.join(root, ".github", "workflows")
+runners = [
+    name
+    for name in sorted(os.listdir(wf_dir))
+    if "pre-commit run --all-files" in open(os.path.join(wf_dir, name), encoding="utf-8").read()
+]
+if len(runners) != 1:
+    problems.append(
+        f"expected exactly one workflow running `pre-commit run --all-files`, found {runners}"
+    )
+
+# 2. That workflow's pull_request.paths must select the recipe, or a recipe-only drift never
+#    reaches the guard in CI.
+for name in runners:
+    text = open(os.path.join(wf_dir, name), encoding="utf-8").read()
+    block = re.search(r"(?ms)^  pull_request:\n((?:    .+\n|\n)*)", text)
+    if not block:
+        problems.append(f"{name}: no pull_request trigger block found")
+        continue
+    listed = re.findall(r'^\s*-\s*"([^"]+)"', block.group(1), re.M)
+    if recipe not in listed:
+        problems.append(
+            f"{name}: pull_request.paths does not select {recipe}; "
+            "a recipe-only drift would not execute the guard in CI"
+        )
+
+# 3. The pre-commit hook that runs the guard must also select the recipe locally.
+cfg = open(os.path.join(root, ".pre-commit-config.yaml"), encoding="utf-8").read()
+hook = re.search(
+    r"(?ms)^      - id: editor-mcp-recipe-truth\n(.*?)(?=^      - id: |\Z)", cfg
+)
+if not hook:
+    problems.append(".pre-commit-config.yaml: hook editor-mcp-recipe-truth not found")
+else:
+    files = re.search(r"^\s*files:\s*(\S+)\s*$", hook.group(1), re.M)
+    if not files:
+        problems.append("editor-mcp-recipe-truth: no files: selector")
+    elif not re.search(files.group(1), recipe):
+        problems.append(
+            f"editor-mcp-recipe-truth: files: selector does not match {recipe}"
+        )
+
+if problems:
+    print("\n".join(problems), file=sys.stderr)
+    sys.exit(1)
+PY
+then
+  printf 'ok   a recipe-only change reaches the guard locally and in CI\n'
+else
+  failures=$((failures + 1))
+  printf 'FAIL: recipe-only change would not execute the guard\n'
+fi
+
 echo '== a missing recipe fails closed =='
 cases=$((cases + 1))
 if ASSAY_EDITOR_RECIPE="$TMP/does-not-exist.md" bash "$GUARD" >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #2360

## Exact head

| | |
|---|---|
| Head | `a2bccc16c19b688e125e3699b5db7c95f1db643c` |
| Base | `origin/main` = `1d82aada5ce6e773c708bb747cb7230191ab36f2` (verified ancestor; unchanged at branch, commit and push) |
| Branch / worktree | `claude/2360-mcp-recipe-v5.2-truth` in its own worktree, sole writer |
| Scope | 4 files, +288/−9 |

## What was wrong

`docs/guides/editor-mcp-recipe.md` is an *executable* recipe — a reader runs its commands against a real editor — so every sentence in it is a claim about shipped behaviour. Its remote section carried four drifts:

1. **Stale RC copy** — section titled "Remote servers (provisional, MCP 2026-07-28)"; "provisional against the release candidate".
2. **Future tense** — "will be finalised once the spec is final", "The MCP specification finalising on 28 July 2026".
3. **OAuth / UI recipe** — instructed operators to "align the wrapped server to that OAuth 2.1 flow", and described PKCE, scoped tokens, consent and sandboxed-iframe server UIs.
4. **#2358 implied delivered** — named MCP `2026-07-28` with nothing telling a reader it is untracked-in-this-page and undelivered.

## The shipped boundary, read from source not prose

- `crates/assay-mcp-server/src/server.rs:37` — `SUPPORTED_LEGACY_PROTOCOL_VERSIONS = ["2024-11-05", "2025-11-25"]`
- `:29-31` — `MODERN_PROTOCOL_VERSION` is `#[deprecated]`, "does not implement MCP revision 2026-07-28", read by no dispatch path
- `:40` — a request declaring `2026-07-28` is refused with `-32022`

Assay ships no remote HTTP transport, no OAuth/OIDC and no MCP UI, so there was nothing in that section a reader could actually point an editor at.

## What changed

The section now states that boundary and links [#2358](https://github.com/Rul1an/assay/issues/2358) as the tracked, **undelivered** modern surface. The OAuth/UI material is **removed** from the executable path rather than reworded — `docs/architecture/ADR-036-editor-mcp-wrap-recipe.md` keeps it as the historical decision record, which is where it belongs and which this PR does not touch.

## Guard first, and it failed first

`scripts/ci/check-editor-mcp-recipe-truth.sh` reported **all four drifts on the unmodified doc (5 failures)** before any edit was made.

It is **offline and unconditional by design.** The acceptance row asks that the recipe cannot claim the modern revision "until the full implementation issue is closed with driven evidence". Keying that off live issue state would put a network call on a gate and make it fail for reasons unrelated to the tree, so the rules are hermetic: lifting them is a deliberate edit to that file, and only #2358 closed with driven evidence earns it — not a version bump, and not the guard going quiet.

It also asserts `assay mcp wrap` and `proxy-enforce` are **PRESENT**, so no future edit can satisfy the forbidden-pattern rules by gutting the recipe's real content.

`scripts/ci/test-check-editor-mcp-recipe-truth.sh` — **11 cases, all pass**: one per drift, a no-false-positive case where the revision is named but tracked, both shipped-claim deletions, and a missing recipe failing closed. Every failure case asserts the **exact diagnostic**, not merely a non-zero exit, so a case cannot pass because an unrelated rule fired.

Wired as pre-commit hook `editor-mcp-recipe-truth`, self-test first, `files:` covering the recipe, both scripts and the config.

## Evidence

| Check | Result |
|---|---|
| `check-editor-mcp-recipe-truth.sh` on **unfixed** doc | **exit 1**, 5 drifts named with line numbers |
| same, after the fix | exit 0 |
| `test-check-editor-mcp-recipe-truth.sh` | 11/11 PASS |
| pre-commit hook on a re-drifted recipe (negative control) | **Failed** |
| `pre-commit run --files <4 changed>` | 30 hooks, **0 Failed** |
| `mkdocs build --strict` (pinned `docs/requirements-ci.txt`, mkdocs 1.6.1) | **exit 0** |
| rendered page after build | `provisional` 0, `release candidate` 0, `OAuth` 0, `iframe` 0; `issues/2358` present |
| `check-release-surface.sh` + self-test | PASS |
| `check-assay-release-pin.sh`, `check-claims-boundary.py`, `check-public-artifact-sanitization.py`, `check-docs-generated-drift.sh` | PASS |
| `git diff --check` | clean |
| `shellcheck -x -S warning` on both new scripts | clean |
| pre-push clippy + Linux cross-target gate | Passed |
| `https://github.com/Rul1an/assay/issues/2358` | 200 |

Concurrency: `origin/main` re-checked at branch, before commit and before push — unchanged at `1d82aada5` each time. No competing branch or PR touching the recipe.

## Deliberately untouched

- Historical `v5.1` records, including `CHANGELOG.md`
- `ADR-036` (historical decision record; still carries the remote/OAuth text as the decision it was)
- The `assay mcp wrap` and `proxy-enforce` claims — asserted present by the guard
- The existing correct statements that `2026-07-28` is **not** implemented

## Non-claims

This is a docs correction. It does **not** implement MCP `2026-07-28` or any remote transport, does not close or advance #2358, does not claim OAuth/OIDC or MCP UI support, and does not rewrite any already-published `v5.1` page — consumers of the `v5.1.0` tag keep the old wording until a later release republishes. The guard proves the recipe cannot re-acquire these claims; it does not prove the prose is otherwise true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the editor MCP recipe supports local stdio servers only.
  - Documented supported MCP revisions and the error returned for unsupported revision `2026-07-28`.
  - Clarified that remote HTTP transport, including OAuth/OIDC/PKCE and MCP UI guidance, is not currently available.
  - Added safeguards to keep the published recipe accurate and prevent outdated or unsupported instructions from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->