### PR TITLE
fix(cli): publish recovery argv that clap can execute

### DIFF
--- a/crates/assay-cli/src/cli/commands/pipeline_error.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline_error.rs
@@ -284,7 +284,13 @@ mod tests {
         let diagnostic = diagnostic_for(&config, ReasonCode::ECfgParse);
         assert_eq!(
             recovery_argv(&diagnostic.fix_steps[0]),
-            ["assay", "doctor", "--config", "suites/prod.yaml"]
+            [
+                "assay",
+                "doctor",
+                "--config=suites/prod.yaml",
+                "--format",
+                "json"
+            ]
         );
         assert_eq!(
             outcome_as_written(&config, ReasonCode::ECfgParse).next_step,
@@ -311,7 +317,13 @@ mod tests {
         let diagnostic = diagnostic_for(&run_error, ReasonCode::ECfgParse);
         assert_eq!(
             recovery_argv(&diagnostic.fix_steps[0]),
-            ["assay", "doctor", "--config", "<config.yaml>"]
+            [
+                "assay",
+                "doctor",
+                "--config=<config.yaml>",
+                "--format",
+                "json"
+            ]
         );
         assert_eq!(
             outcome_as_written(&run_error, ReasonCode::ECfgParse).next_step,
@@ -460,7 +472,7 @@ mod tests {
             });
         assert_eq!(
             recovery_argv(own_recovery),
-            ["assay", "doctor", "--config", "assay.yaml"]
+            ["assay", "doctor", "--config=assay.yaml", "--format", "json"]
         );
 
         let rendered = folded.format_plain();

--- a/crates/assay-cli/src/exit_codes.rs
+++ b/crates/assay-cli/src/exit_codes.rs
@@ -123,6 +123,15 @@ pub(crate) fn format_recovery_argv(args: &[&str]) -> String {
     format!("Run argv: {}", serde_json::json!(args))
 }
 
+/// Bind a flag to a caller-controlled path as one argv element.
+///
+/// Always `flag=value`, including when `value` does not start with `-`. A split
+/// `--flag` / value pair lets clap reread a `-prefixed` path as an option. A
+/// conditional fuse would be a second place that rule could drift.
+fn fused_option(flag: &str, value: &str) -> String {
+    format!("{flag}={value}")
+}
+
 impl ReasonCode {
     /// Get the corresponding exit code for this reason, respecting version
     pub fn exit_code_for(&self, version: ExitCodeVersion) -> i32 {
@@ -223,18 +232,21 @@ impl ReasonCode {
 
     /// Suggested next step for this error.
     ///
-    /// Executable recovery with caller-controlled values is JSON argv. Dynamic trace-path
-    /// guidance is prose rather than a command; remaining command-like steps are static strings
-    /// and therefore carry no caller-controlled argument boundary.
+    /// Executable recovery with caller-controlled values is JSON argv. Path-bearing
+    /// flags are always fused (`--config=path`) so a `-prefixed` path remains an
+    /// operand. Dynamic recoveries that produce a machine document include
+    /// `--format json` here, not at the call site: one reason has one remediation,
+    /// and a consumer that followed a JSON failure report can parse the result.
+    /// The same string is published on the text channel. Dynamic trace-path
+    /// guidance is prose rather than a command; remaining command-like steps are
+    /// static strings and therefore carry no caller-controlled argument boundary.
     pub fn next_step(&self, context: Option<&str>) -> String {
         match self {
             ReasonCode::Success => String::new(),
-            ReasonCode::ECfgParse => format_recovery_argv(&[
-                "assay",
-                "doctor",
-                "--config",
-                context.unwrap_or("<config.yaml>"),
-            ]),
+            ReasonCode::ECfgParse => {
+                let config = fused_option("--config", context.unwrap_or("<config.yaml>"));
+                format_recovery_argv(&["assay", "doctor", &config, "--format", "json"])
+            }
             ReasonCode::ETraceNotFound => {
                 format!(
                     "Check trace file exists: {}",
@@ -265,13 +277,17 @@ impl ReasonCode {
             ReasonCode::EBaselineInvalid => {
                 "Run: assay baseline record to create a new baseline".to_string()
             }
-            ReasonCode::EPolicyParse => format_recovery_argv(&[
-                "assay",
-                "policy",
-                "validate",
-                "--input",
-                context.unwrap_or("<policy.yaml>"),
-            ]),
+            ReasonCode::EPolicyParse => {
+                let input = fused_option("--input", context.unwrap_or("<policy.yaml>"));
+                format_recovery_argv(&[
+                    "assay",
+                    "policy",
+                    "validate",
+                    &input,
+                    "--format",
+                    "json",
+                ])
+            }
             ReasonCode::EReplayMissingDependency => {
                 "Replay bundle missing required offline dependency; rerun with --live or create a complete bundle".to_string()
             }
@@ -545,7 +561,7 @@ mod tests {
         let config_next_step = ReasonCode::ECfgParse.next_step(Some(config_path));
         assert_eq!(
             config_next_step,
-            r#"Run argv: ["assay","doctor","--config","cfg file;$(touch should-not-exist).yaml"]"#,
+            r#"Run argv: ["assay","doctor","--config=cfg file;$(touch should-not-exist).yaml","--format","json"]"#,
             "the shared recovery formatter must preserve the published compact representation"
         );
         let config_argv: Vec<String> = serde_json::from_str(
@@ -554,7 +570,16 @@ mod tests {
                 .expect("config recovery must publish JSON argv"),
         )
         .expect("config recovery argv must parse");
-        assert_eq!(config_argv, ["assay", "doctor", "--config", config_path]);
+        assert_eq!(
+            config_argv,
+            vec![
+                "assay".to_string(),
+                "doctor".to_string(),
+                format!("--config={config_path}"),
+                "--format".to_string(),
+                "json".to_string()
+            ]
+        );
         assert!(ReasonCode::ETraceNotFound
             .next_step(Some("traces/ci.jsonl"))
             .contains("traces/ci.jsonl"));
@@ -574,7 +599,14 @@ mod tests {
         .expect("policy recovery argv must parse");
         assert_eq!(
             argv,
-            ["assay", "policy", "validate", "--input", policy_path]
+            vec![
+                "assay".to_string(),
+                "policy".to_string(),
+                "validate".to_string(),
+                format!("--input={policy_path}"),
+                "--format".to_string(),
+                "json".to_string()
+            ]
         );
         assert!(ReasonCode::EReplayMissingDependency
             .next_step(None)
@@ -616,15 +648,35 @@ mod tests {
         let cases = [
             (
                 ReasonCode::ECfgParse,
-                vec!["assay", "doctor", "--config", path],
+                vec![
+                    "assay".into(),
+                    "doctor".into(),
+                    format!("--config={path}"),
+                    "--format".into(),
+                    "json".into(),
+                ],
             ),
             (
                 ReasonCode::EPolicyParse,
-                vec!["assay", "policy", "validate", "--input", path],
+                vec![
+                    "assay".into(),
+                    "policy".into(),
+                    "validate".into(),
+                    format!("--input={path}"),
+                    "--format".into(),
+                    "json".into(),
+                ],
             ),
             (
                 ReasonCode::EEvidenceUnreadable,
-                vec!["assay", "evidence", "show", path, "--format", "json"],
+                vec![
+                    "assay".into(),
+                    "evidence".into(),
+                    "show".into(),
+                    path.into(),
+                    "--format".into(),
+                    "json".into(),
+                ],
             ),
         ];
 
@@ -636,6 +688,51 @@ mod tests {
             let argv: Vec<String> =
                 serde_json::from_str(encoded).expect("recovery argv must remain valid JSON");
             assert_eq!(argv, expected, "{reason:?} must preserve one path argument");
+        }
+    }
+
+    #[test]
+    fn path_bearing_recovery_always_fuses_the_flag_and_includes_json_format() {
+        for path in ["-weird.yaml", "--config", "-h", "plain.yaml"] {
+            let config = ReasonCode::ECfgParse.next_step(Some(path));
+            let policy = ReasonCode::EPolicyParse.next_step(Some(path));
+            let config_argv: Vec<String> = serde_json::from_str(
+                config
+                    .strip_prefix("Run argv: ")
+                    .expect("config recovery must publish JSON argv"),
+            )
+            .expect("config recovery argv must parse");
+            let policy_argv: Vec<String> = serde_json::from_str(
+                policy
+                    .strip_prefix("Run argv: ")
+                    .expect("policy recovery must publish JSON argv"),
+            )
+            .expect("policy recovery argv must parse");
+            assert_eq!(
+                config_argv,
+                vec![
+                    "assay".to_string(),
+                    "doctor".to_string(),
+                    fused_option("--config", path),
+                    "--format".to_string(),
+                    "json".to_string()
+                ]
+            );
+            assert_eq!(
+                policy_argv,
+                vec![
+                    "assay".to_string(),
+                    "policy".to_string(),
+                    "validate".to_string(),
+                    fused_option("--input", path),
+                    "--format".to_string(),
+                    "json".to_string()
+                ]
+            );
+            assert!(
+                !config.contains('\u{0007}') && !policy.contains('\u{0007}'),
+                "recovery text must not carry raw BEL"
+            );
         }
     }
 

--- a/crates/assay-cli/tests/config_recovery_argv_contract.rs
+++ b/crates/assay-cli/tests/config_recovery_argv_contract.rs
@@ -93,8 +93,14 @@ fn config_parse_recovery_argv_executes_without_a_shell() {
         serde_json::from_str(encoded).expect("config recovery argv must parse");
     assert_eq!(
         recovery,
-        ["assay", "doctor", "--config", config_name],
-        "the hostile path must remain one argv element"
+        vec![
+            "assay".to_string(),
+            "doctor".to_string(),
+            format!("--config={config_name}"),
+            "--format".to_string(),
+            "json".to_string()
+        ],
+        "the hostile path must remain one fused argv element"
     );
 
     let recovered = assay(dir.path(), &recovery[1..], "execute config recovery");
@@ -104,14 +110,168 @@ fn config_parse_recovery_argv_executes_without_a_shell() {
         "the published recovery must not reclassify the failure it recovers from: {}",
         String::from_utf8_lossy(&recovered.stderr)
     );
-    let recovered_stdout = String::from_utf8_lossy(&recovered.stdout);
-    assert!(
-        recovered_stdout.contains("Config Status: FAILED"),
-        "published argv must reach doctor: {recovered_stdout}"
-    );
-    assert!(!recovered_stdout.contains("Usage:"));
+    assert_recovery_reached_cfg_parse_diagnosis(&recovered, "hostile-path recovery");
+    assert!(!String::from_utf8_lossy(&recovered.stdout).contains("Usage:"));
     assert!(
         !dir.path().join("should-not-exist").exists(),
         "recovery must not execute shell metacharacters"
     );
+}
+
+fn recovery_argv(document: &serde_json::Value) -> Vec<String> {
+    let encoded = document["next_step"]
+        .as_str()
+        .expect("failure next_step")
+        .strip_prefix("Run argv: ")
+        .expect("config recovery must publish JSON argv");
+    serde_json::from_str(encoded).expect("config recovery argv must parse")
+}
+
+fn assert_recovery_reached_cfg_parse_diagnosis(recovered: &Output, context: &str) {
+    let stderr = String::from_utf8_lossy(&recovered.stderr);
+    assert!(
+        !stderr.contains("unexpected argument")
+            && !stderr.contains("a value is required for '--config"),
+        "{context}: published argv was refused by clap before the config was read:\n{stderr}"
+    );
+    assert!(
+        !recovered.stdout.is_empty(),
+        "{context}: recovery produced no diagnosis (empty stdout); stderr:\n{stderr}"
+    );
+    let diagnosis: serde_json::Value =
+        serde_json::from_slice(&recovered.stdout).unwrap_or_else(|error| {
+            panic!(
+                "{context}: recovery must produce a parseable diagnosis, not human text or clap \
+                 usage: {error}\nstdout:\n{}\nstderr:\n{stderr}",
+                String::from_utf8_lossy(&recovered.stdout)
+            )
+        });
+    assert_eq!(
+        diagnosis["reason_code"], "E_CFG_PARSE",
+        "{context}: recovery must reach the config diagnosis, not a different class: {diagnosis}"
+    );
+}
+
+/// A `-prefixed` path publishes a next_step that, when executed without a shell, reaches
+/// the same config diagnosis as a plain path. Exit `2` alone is not enough: clap refusal
+/// is also `2` (#2216).
+#[test]
+fn dash_prefixed_config_recovery_reaches_the_diagnosis() {
+    let cases = ["-weird.yaml", "--config", "-h"];
+    for config_name in cases {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(config_name), "not: [broken\n")
+            .expect("write malformed dash-prefixed config");
+
+        let failed = assay(
+            dir.path(),
+            &[
+                "doctor",
+                "--format",
+                "json",
+                &format!("--config={config_name}"),
+            ],
+            &format!("produce recovery for {config_name}"),
+        );
+        assert_eq!(
+            failed.status.code(),
+            Some(2),
+            "{config_name} must be a config error: {}",
+            String::from_utf8_lossy(&failed.stderr)
+        );
+        let summary: serde_json::Value =
+            serde_json::from_slice(&failed.stdout).expect("failure stdout must be JSON");
+        assert_eq!(summary["reason_code"], "E_CFG_PARSE");
+
+        let recovery = recovery_argv(&summary);
+        let recovered = assay(
+            dir.path(),
+            &recovery[1..],
+            &format!("execute recovery for {config_name}"),
+        );
+        assert_recovery_reached_cfg_parse_diagnosis(
+            &recovered,
+            &format!("doctor recovery for {config_name}"),
+        );
+    }
+}
+
+/// `assay run` and `assay doctor` read one registry string, so a `-prefixed` path
+/// must recover through the same published argv on both commands (#2216).
+#[test]
+fn run_and_doctor_publish_the_same_executable_recovery_for_a_dash_prefixed_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config_name = "-weird.yaml";
+    std::fs::write(dir.path().join(config_name), "not: [broken\n")
+        .expect("write malformed dash-prefixed config");
+    let fused = format!("--config={config_name}");
+
+    let doctor = assay(
+        dir.path(),
+        &["doctor", "--format", "json", &fused],
+        "doctor dash-prefixed config",
+    );
+    let run = assay(
+        dir.path(),
+        &["run", "--format", "json", &fused],
+        "run dash-prefixed config",
+    );
+    let doctor_json: serde_json::Value =
+        serde_json::from_slice(&doctor.stdout).expect("doctor failure is JSON");
+    let run_json: serde_json::Value =
+        serde_json::from_slice(&run.stdout).expect("run failure is JSON");
+    assert_eq!(doctor_json["reason_code"], "E_CFG_PARSE");
+    assert_eq!(run_json["reason_code"], "E_CFG_PARSE");
+    assert_eq!(
+        doctor_json["next_step"], run_json["next_step"],
+        "one registry string: run and doctor must publish the same recovery"
+    );
+
+    let recovery = recovery_argv(&run_json);
+    let recovered = assay(dir.path(), &recovery[1..], "execute shared recovery");
+    assert_recovery_reached_cfg_parse_diagnosis(&recovered, "shared run/doctor recovery");
+}
+
+/// A JSON consumer that follows the published recovery must get a JSON diagnosis
+/// back. The format is decided in the registry, so text and JSON publish the
+/// same argv (#2216).
+#[test]
+fn json_and_text_publish_the_same_recovery_and_executing_it_stays_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config_name = "bad.yaml";
+    std::fs::write(dir.path().join(config_name), "not: [broken\n").expect("write malformed config");
+
+    let json_failed = assay(
+        dir.path(),
+        &["run", "--format", "json", "--config", config_name],
+        "json-format config failure",
+    );
+    let text_failed = assay(
+        dir.path(),
+        &["run", "--format", "text", "--config", config_name],
+        "text-format config failure",
+    );
+    let json_doc: serde_json::Value =
+        serde_json::from_slice(&json_failed.stdout).expect("json failure is JSON");
+    let summary_path = dir.path().join("summary.json");
+    let text_summary: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&summary_path).expect("text run still writes summary.json"),
+    )
+    .expect("summary.json parses");
+    assert_eq!(
+        json_doc["next_step"], text_summary["next_step"],
+        "text and JSON must publish the same registry recovery, not two remediations"
+    );
+    assert!(
+        text_failed.stdout.is_empty(),
+        "text format keeps the diagnosis off stdout; this test reads summary.json"
+    );
+
+    let recovery = recovery_argv(&json_doc);
+    let recovered = assay(
+        dir.path(),
+        &recovery[1..],
+        "execute format-neutral recovery",
+    );
+    assert_recovery_reached_cfg_parse_diagnosis(&recovered, "format-parity recovery");
 }

--- a/crates/assay-cli/tests/policy_validate_machine_contract.rs
+++ b/crates/assay-cli/tests/policy_validate_machine_contract.rs
@@ -178,17 +178,27 @@ fn json_mode_reports_valid_and_malformed_policies_on_stdout() {
     let recovery = recovery_argv(&malformed_json);
     assert_eq!(
         recovery,
-        ["assay", "policy", "validate", "--input", malformed_name],
-        "the hostile path must remain one argv element"
+        vec![
+            "assay".to_string(),
+            "policy".to_string(),
+            "validate".to_string(),
+            format!("--input={malformed_name}"),
+            "--format".to_string(),
+            "json".to_string()
+        ],
+        "the hostile path must remain one fused argv element"
     );
     let recovered = assay(dir.path(), &recovery[1..]);
     assert_eq!(recovered.status.code(), Some(2));
-    let recovered_stderr = String::from_utf8_lossy(&recovered.stderr);
-    assert!(
-        recovered_stderr.contains("E_POLICY_PARSE"),
-        "the published next_step must reach validation, not Clap usage: {recovered_stderr}"
+    let recovered_json: Value =
+        serde_json::from_slice(&recovered.stdout).expect("policy recovery must stay JSON");
+    assert_eq!(
+        recovered_json["reason_code"],
+        "E_POLICY_PARSE",
+        "the published next_step must reach validation, not Clap usage: {}",
+        String::from_utf8_lossy(&recovered.stderr)
     );
-    assert!(!recovered_stderr.contains("Usage:"));
+    assert!(!String::from_utf8_lossy(&recovered.stderr).contains("Usage:"));
 
     let valid_again = assay(dir.path(), &valid_args);
     let malformed_again = assay(dir.path(), &malformed_args);

--- a/docs/AIcontext/decision-trees.md
+++ b/docs/AIcontext/decision-trees.md
@@ -201,7 +201,7 @@ flowchart TD
 | Error | Reason Code | Recovery Action |
 |-------|-------------|-----------------|
 | Trace file not found | `E_TRACE_NOT_FOUND` | Check path, use `assay import` |
-| Config parse error | `E_CFG_PARSE` | Parse `Run argv: ["assay","doctor","--config","<file>"]` and execute the argv directly (no shell) |
+| Config parse error | `E_CFG_PARSE` | Parse `Run argv: ["assay","doctor","--config=<file>","--format","json"]` and execute the argv directly (no shell) |
 | Judge unavailable | `E_JUDGE_UNAVAILABLE` | Check API key, retry later |
 | Rate limited | `E_RATE_LIMIT` | Wait, reduce parallelism |
 | Test failed | `E_TEST_FAILED` | Run `assay explain` |

--- a/docs/AIcontext/entry-points.md
+++ b/docs/AIcontext/entry-points.md
@@ -592,11 +592,11 @@ Reason codes provide precise error identification for automation and debugging.
 #### Config/User Errors (Exit 2)
 | Code | Description | Next Step |
 |------|-------------|-----------|
-| `E_CFG_PARSE` | Config file parse error | argv `["assay","doctor","--config","<file>"]` |
+| `E_CFG_PARSE` | Config file parse error | argv `["assay","doctor","--config=<file>","--format","json"]` |
 | `E_TRACE_NOT_FOUND` | Trace file not found | Check path exists |
 | `E_MISSING_CONFIG` | Required config missing | `assay init` |
 | `E_BASELINE_INVALID` | Baseline file invalid | `assay baseline record` |
-| `E_POLICY_PARSE` | Policy YAML syntax error | argv `["assay","policy","validate","--input","<file>"]` |
+| `E_POLICY_PARSE` | Policy YAML syntax error | argv `["assay","policy","validate","--input=<file>","--format","json"]` |
 | `E_INVALID_ARGS` | Invalid CLI arguments | `assay --help` |
 
 For `Run argv:` recovery steps, parse the JSON array and pass its elements directly to a process

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -54,11 +54,11 @@ assay explain --trace traces.jsonl --policy policy.yaml  # Explain violations
 ### Config Errors (exit 2)
 | Code | Meaning | Next Step |
 |------|---------|-----------|
-| `E_CFG_PARSE` | YAML/JSON parse error | argv `["assay","doctor","--config","<file>"]` |
+| `E_CFG_PARSE` | YAML/JSON parse error | argv `["assay","doctor","--config=<file>","--format","json"]` |
 | `E_TRACE_NOT_FOUND` | Trace file missing | Check path exists |
 | `E_MISSING_CONFIG` | Config file missing | `assay init` |
 | `E_BASELINE_INVALID` | Baseline file invalid | `assay baseline record` |
-| `E_POLICY_PARSE` | Policy YAML syntax error | argv `["assay","policy","validate","--input","<file>"]` |
+| `E_POLICY_PARSE` | Policy YAML syntax error | argv `["assay","policy","validate","--input=<file>","--format","json"]` |
 
 Parse a `Run argv:` JSON array and pass its elements directly to a process API. Never join
 caller-controlled path elements into a shell command.

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -298,7 +298,7 @@ SARIF produced for GitHub Code Scanning MUST satisfy the following so that `uplo
 
 For every non-zero exit, the implementation MUST provide **at least one suggested next step** so that users and CI logs know what to do next.
 
-- **Console:** When exiting with exit_code ≠ 0, the process MUST print at least one line that is a concrete command or hint. Executable recovery containing caller-controlled values MUST use the argument-safe form from §3.1 (for example, `Run argv: ["assay","doctor","--config","path with spaces.yaml"]`). Fully static commands MAY use `Run: assay explain ...`; non-command guidance MAY use `See: ...` or `Fix baseline: ...` prose.
+- **Console:** When exiting with exit_code ≠ 0, the process MUST print at least one line that is a concrete command or hint. Executable recovery containing caller-controlled values MUST use the argument-safe form from §3.1 (for example, `Run argv: ["assay","doctor","--config=path with spaces.yaml","--format","json"]`). Fully static commands MAY use `Run: assay explain ...`; non-command guidance MAY use `See: ...` or `Fix baseline: ...` prose.
 - **summary.json:** The `next_step` field SHOULD be set when exit_code ≠ 0 (see §3.1). It MAY be the same as or a shortened form of the console message.
 
 **Normative:** Contract tests MAY verify that for a set of known error conditions (missing config, missing trace, failing test), the output contains a non-empty next_step (in summary.json) and a console line with a suggested command.

--- a/docs/generated/agent-golden-path.json
+++ b/docs/generated/agent-golden-path.json
@@ -122,7 +122,7 @@
             "document": "assay.doctor_report.v0"
           },
           "reason_code": "E_CFG_PARSE",
-          "next_step": "Run argv: [\"assay\",\"doctor\",\"--config\",\"<config>\"]",
+          "next_step": "Run argv: [\"assay\",\"doctor\",\"--config=<config>\",\"--format\",\"json\"]",
           "gap_issue": null,
           "config_error_code": "E_CFG_PARSE"
         }
@@ -259,7 +259,7 @@
             "document": "assay.run_summary.v1"
           },
           "reason_code": "E_POLICY_PARSE",
-          "next_step": "Run argv: [\"assay\",\"policy\",\"validate\",\"--input\",\"<policy>\"]",
+          "next_step": "Run argv: [\"assay\",\"policy\",\"validate\",\"--input=<policy>\",\"--format\",\"json\"]",
           "gap_issue": null
         }
       ],

--- a/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
+++ b/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
@@ -122,7 +122,7 @@
             "document": "assay.doctor_report.v0"
           },
           "reason_code": "E_CFG_PARSE",
-          "next_step": "Run argv: [\"assay\",\"doctor\",\"--config\",\"<config>\"]",
+          "next_step": "Run argv: [\"assay\",\"doctor\",\"--config=<config>\",\"--format\",\"json\"]",
           "gap_issue": null,
           "config_error_code": "E_CFG_PARSE"
         }
@@ -259,7 +259,7 @@
             "document": "assay.run_summary.v1"
           },
           "reason_code": "E_POLICY_PARSE",
-          "next_step": "Run argv: [\"assay\",\"policy\",\"validate\",\"--input\",\"<policy>\"]",
+          "next_step": "Run argv: [\"assay\",\"policy\",\"validate\",\"--input=<policy>\",\"--format\",\"json\"]",
           "gap_issue": null
         }
       ],

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -190,7 +190,7 @@ STEPS: list[dict[str, object]] = [
                 stdout("json", "assay.doctor_report.v0"),
                 ["doctor", "--format", "json", "--config", "<config>"],
                 reason_code="E_CFG_PARSE",
-                next_step='Run argv: ["assay","doctor","--config","<config>"]',
+                next_step='Run argv: ["assay","doctor","--config=<config>","--format","json"]',
                 config_error_code="E_CFG_PARSE",
             ),
         ],
@@ -307,7 +307,7 @@ STEPS: list[dict[str, object]] = [
                 ],
                 reason_code="E_POLICY_PARSE",
                 next_step=(
-                    'Run argv: ["assay","policy","validate","--input","<policy>"]'
+                    'Run argv: ["assay","policy","validate","--input=<policy>","--format","json"]'
                 ),
             ),
         ],


### PR DESCRIPTION
## Summary

Refs #2216.

Published `E_CFG_PARSE` / `E_POLICY_PARSE` recovery named the failing file and then could not run: a split `--config` / path pair lets clap reread a `-prefixed` operand as an option, and a JSON consumer that followed the recovery was handed text. Both answers came from one registry string, so they move together.

- Path-bearing flags are always fused (`--config=path`, `--input=path`) in one helper. Fusing only when the value starts with `-` would be a second place the rule could drift.
- `--format json` is decided in the registry, not at a call site, matching `E_EVIDENCE_UNREADABLE`. JSON and text publish the same argv. Executing it produces a parseable diagnosis.
- Proven by executing the published argv, not by matching exit `2` (clap refusal is also `2`).

**Base:** `1d82aada5ce6e773c708bb747cb7230191ab36f2` (`origin/main`)
**Head:** `e4bf16f74325623498578d273f53686cba319f51` (`cursor/2216-recovery-argv`)
**Worktree:** `/Users/roelschuurkes/wt-2216-recovery-argv`

## RED → GREEN

RED (exact `origin/main` binary, before the production change):

```text
cargo test -p assay-cli --test config_recovery_argv_contract -- \
  dash_prefixed_config_recovery_reaches_the_diagnosis \
  run_and_doctor_publish_the_same_executable_recovery_for_a_dash_prefixed_path \
  json_and_text_publish_the_same_recovery_and_executing_it_stays_json
```

- `-weird.yaml`: `unexpected argument '-w' found` (clap refused; empty stdout)
- `bad.yaml` format-parity: recovery stdout was human doctor text (`Assay v5.2.0` / `Config Status: FAILED`), not JSON

GREEN (same tests after the registry change): 20 passed in `config_recovery_argv_contract`; policy contract and golden-path contract also green.

## Test plan

- [x] Focused RED tests failed for clap refuse / text recovery, not for fixture setup
- [x] `cargo test -p assay-cli --test config_recovery_argv_contract`
- [x] `cargo test -p assay-cli --test policy_validate_machine_contract`
- [x] `cargo test -p assay-cli --test agent_golden_path_contract`
- [x] `cargo test -p assay-cli --bin assay -- path_bearing_recovery dynamic_recovery_argv test_reason_code_next_step path_bearing_errors pathless_config folding_an_upstream`
- [x] `cargo test -p assay-cli` (full crate)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-cli --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] `python3 scripts/docs/generate-agent-golden-path.py --check`
- [x] `python3 scripts/ci/test-agent-golden-path-skill.py`
- [ ] Non-building agent review on this head (builder self-review does not count)

Hostile cases covered: `-weird.yaml`, `--config`, `-h`, spaces, `$(...)`, quotes, newlines, tabs, BEL. Recovery is JSON-encoded argv (not a shell string); fused `--config=-weird.yaml` is copy-pasteable as one element.

## Non-claims

- Not #2206. Doctor still names a missing file `E_CFG_PARSE` and still advises `doctor` on the same path. This PR only changes how that path is bound and that the recovery stays JSON. The missing-vs-parse identity and the self-loop are #2206's.
- Not a general shell parser. Consumers must parse the `Run argv:` JSON array and exec it without a shell.
- Not a claim that every argv is safe. Encoding and fusion cover the published recovery string; they do not sanitize the file the command then reads.
- Not a claim that a user-typed split `--config -weird.yaml` on the original invocation works. The original command still needs `--config=path` (or equivalent) for clap to accept a `-prefixed` operand. This PR fixes the *published* recovery.
- Positional `-prefixed` paths (for example `assay evidence show -bundle.tar.gz`) are out of scope.
- Static prose remediations (`E_MISSING_CONFIG`, `E_TRACE_NOT_FOUND`, …) are unchanged.

## Review

Draft. Do not merge. Do not mark ready. Do not close #2216.

AGENTS.md review quorum: one non-building agent must review this exact head and record a verdict. This writer's review does not count.


Made with [Cursor](https://cursor.com)