### PR TITLE
fix(installer): normalize explicit ASSAY_VERSION to the release v-tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -437,6 +437,13 @@ repos:
         # binaries on PATH, so it costs no network and no install.
         files: ^(scripts/ci/(install-cargo-deny|test-install-cargo-deny)\.sh|\.pre-commit-config\.yaml)$
 
+      - id: install-version-normalization-self-test
+        name: installer version normalization contract
+        entry: bash scripts/ci/test-install-version-normalization.sh
+        language: system
+        pass_filenames: false
+        files: ^(scripts/install\.sh|scripts/ci/test-install-version-normalization\.sh|\.pre-commit-config\.yaml)$
+
       - id: deps-security-toolchain-contract-self-test
         name: deps-security toolchain contract
         entry: bash scripts/ci/test-deps-security-toolchain-contract.sh

--- a/scripts/ci/test-install-version-normalization.sh
+++ b/scripts/ci/test-install-version-normalization.sh
@@ -61,6 +61,9 @@ done
 printf '%s\n' "${url:-<missing-url>}" >>"${CURL_URLS:?}"
 if [[ "$url" == *"/repos/Rul1an/assay/releases/latest" ]]; then
   payload='{"tag_name":"v9.9.9"}'
+  if [[ -n "${LATEST_API_PAYLOAD:-}" ]]; then
+    payload="$LATEST_API_PAYLOAD"
+  fi
   if [[ -n "$out" ]]; then
     printf '%s\n' "$payload" >"$out"
   else
@@ -176,6 +179,34 @@ expect_latest_path() {
   ok "$label resolves via the latest API (exit $rc)"
 }
 
+# A latest-API body with more than one tag_name line extracts to a multiline
+# VERSION. Line-oriented grep would treat that as stable and curl the asset
+# with the full invalid tag. Fail closed; the latest query is not an asset curl.
+expect_latest_rejects_multiline_tags() {
+  local label="latest-multiline-tags"
+  local payload
+  payload=$'{"tag_name":"evil-not-a-tag"}\n{"tag_name":"v9.9.9"}'
+  local run_dir="$SCRATCH/latest-multiline"
+  local rc
+  rc="$(LATEST_API_PAYLOAD="$payload" run_installer "latest" "$run_dir")"
+  if [[ "$rc" -eq 0 ]]; then
+    fail "$label: installer accepted a multiline latest-API tag (exit 0)"
+    sed 's/^/      /' "$run_dir/installer.log" >&2 || true
+    return
+  fi
+  if ! grep -Fq -- "/repos/Rul1an/assay/releases/latest" "$run_dir/urls"; then
+    fail "$label: did not query the latest-release API (exit $rc)"
+    sed 's/^/      /' "$run_dir/urls" >&2 || true
+    return
+  fi
+  if grep -Fq -- "/releases/download/" "$run_dir/urls"; then
+    fail "$label: multiline latest-API tag proceeded to asset curl"
+    sed 's/^/      /' "$run_dir/urls" >&2
+    return
+  fi
+  ok "$label fails closed with no asset curl (exit $rc)"
+}
+
 expect_cmdsubst_does_not_create_sentinel() {
   local run_dir="$SCRATCH/deny-cmdsubst"
   local sentinel="$run_dir/PWNED"
@@ -205,6 +236,7 @@ run_contract() {
   expect_same_v_tag_url "prefixed" "v5.2.0"
   expect_latest_path "literal-latest" "latest"
   expect_latest_path "unset" "unset"
+  expect_latest_rejects_multiline_tags
   expect_fail_before_network "empty" "empty"
   expect_fail_before_network "bare-v" "v"
   expect_fail_before_network "dotdot" ".."
@@ -279,6 +311,10 @@ mutations = {
         'if [ "$1" = "latest" ]; then\n        printf \'%s\\n\' "latest"',
         'if [ "$1" = "latest" ]; then\n        printf \'%s\\n\' "vlatest"',
     ),
+    "drop-tag-prefilter": (
+        '    case "$1" in\n        ""|*[[:space:]]*|*/*|*..*)\n            return 1\n            ;;\n    esac\n    printf \'%s\\n\' "$1" | grep -Eq \'^v[0-9]+[.][0-9]+[.][0-9]+$\'',
+        '    printf \'%s\\n\' "$1" | grep -Eq \'^v[0-9]+[.][0-9]+[.][0-9]+$\'',
+    ),
 }
 if name not in mutations:
     raise SystemExit(f"unknown mutation {name!r}")
@@ -308,6 +344,7 @@ if [[ "$failures" -eq 0 ]]; then
   expect_mutation_bites "unprefixed-archive"
   expect_mutation_bites "malformed-as-latest"
   expect_mutation_bites "latest-v-prefix"
+  expect_mutation_bites "drop-tag-prefilter"
 fi
 
 if [[ "$failures" -ne 0 ]]; then

--- a/scripts/ci/test-install-version-normalization.sh
+++ b/scripts/ci/test-install-version-normalization.sh
@@ -179,8 +179,9 @@ expect_latest_path() {
 expect_cmdsubst_does_not_create_sentinel() {
   local run_dir="$SCRATCH/deny-cmdsubst"
   local sentinel="$run_dir/PWNED"
+  # Literal dollar-paren, not an expansion: the installer must not create $sentinel.
   local version
-  version='$(touch '"$sentinel"')'
+  version="\$(touch ${sentinel})"
   local rc
   rc="$(run_installer "$version" "$run_dir")"
   if [[ "$rc" -eq 0 ]]; then

--- a/scripts/ci/test-install-version-normalization.sh
+++ b/scripts/ci/test-install-version-normalization.sh
@@ -152,39 +152,72 @@ expect_fail_before_network() {
   ok "$label fails closed before network (exit $rc)"
 }
 
-expect_latest_preserved() {
-  local run_dir="$SCRATCH/latest"
+expect_latest_path() {
+  local label="$1"
+  local version="$2"
+  local run_dir="$SCRATCH/latest-$label"
   local rc
-  rc="$(run_installer "latest" "$run_dir")"
+  rc="$(run_installer "$version" "$run_dir")"
   if ! grep -Fq -- "/repos/Rul1an/assay/releases/latest" "$run_dir/urls"; then
-    fail "latest: did not query the latest-release API (exit $rc)"
+    fail "$label: did not query the latest-release API (exit $rc)"
     sed 's/^/      /' "$run_dir/urls" >&2 || true
     return
   fi
   if grep -Eq -- '/download/vlatest|/download/latest/|/assay-vlatest-' "$run_dir/urls"; then
-    fail "latest: acquired a v prefix or was used as a tag"
+    fail "$label: acquired a v prefix or was used as a tag"
     sed 's/^/      /' "$run_dir/urls" >&2
     return
   fi
   if ! grep -Fq -- "/releases/download/v9.9.9/assay-v9.9.9-" "$run_dir/urls"; then
-    fail "latest: resolved tag/archive were not derived from the API tag"
+    fail "$label: resolved tag/archive were not derived from the API tag"
     sed 's/^/      /' "$run_dir/urls" >&2
     return
   fi
-  ok "latest is preserved and resolves via the API (exit $rc)"
+  ok "$label resolves via the latest API (exit $rc)"
+}
+
+expect_cmdsubst_does_not_create_sentinel() {
+  local run_dir="$SCRATCH/deny-cmdsubst"
+  local sentinel="$run_dir/PWNED"
+  local version
+  version='$(touch '"$sentinel"')'
+  local rc
+  rc="$(run_installer "$version" "$run_dir")"
+  if [[ "$rc" -eq 0 ]]; then
+    fail "cmdsubst: installer exited 0 for a command-substitution string"
+    return
+  fi
+  if [[ -s "$run_dir/urls" ]] || [[ -s "$run_dir/curl.log" ]]; then
+    fail "cmdsubst: command-substitution string reached curl"
+    sed 's/^/      /' "$run_dir/curl.log" >&2 || true
+    return
+  fi
+  if [[ -e "$sentinel" ]]; then
+    fail "cmdsubst: literal \$(touch ...) created sentinel $sentinel"
+    return
+  fi
+  ok "cmdsubst fails closed and does not create a sentinel (exit $rc)"
 }
 
 run_contract() {
   expect_same_v_tag_url "unprefixed" "5.2.0"
   expect_same_v_tag_url "prefixed" "v5.2.0"
-  expect_latest_preserved
+  expect_latest_path "literal-latest" "latest"
+  expect_latest_path "unset" "unset"
   expect_fail_before_network "empty" "empty"
   expect_fail_before_network "bare-v" "v"
   expect_fail_before_network "dotdot" ".."
   expect_fail_before_network "url" "https://example.com/v5.2.0"
-  expect_fail_before_network "spaces" "5.2.0 "
+  expect_fail_before_network "trailing-space" "5.2.0 "
+  expect_fail_before_network "leading-space" " 5.2.0"
   expect_fail_before_network "latest-foo" "latest-foo"
   expect_fail_before_network "double-v" "vv5.2.0"
+  expect_fail_before_network "two-part" "5.2"
+  expect_fail_before_network "prerelease" "5.2.0-rc.1"
+  expect_fail_before_network "percent" "5.2.0%2f"
+  expect_fail_before_network "semicolon" "5.2.0;id"
+  expect_fail_before_network "newline" $'5.2.0\nextra'
+  expect_cmdsubst_does_not_create_sentinel
 
   if [[ "$INSTALLER" == "$ROOT/scripts/install.sh" ]]; then
     if ! grep -qE '^normalize_install_version[[:space:]]*\(\)' "$INSTALLER"; then
@@ -202,21 +235,10 @@ run_contract() {
     else
       ok "stable-tag regex remains the latest-channel literal"
     fi
-    if ! (
-      export ASSAY_INSTALL_SOURCE_ONLY=1
-      # shellcheck disable=SC1090
-      . "$INSTALLER"
-      [[ "$(normalize_install_version "5.2.0")" == "v5.2.0" ]] || exit 1
-      [[ "$(normalize_install_version "v5.2.0")" == "v5.2.0" ]] || exit 1
-      [[ "$(normalize_install_version "latest")" == "latest" ]] || exit 1
-      normalize_install_version "" && exit 1
-      normalize_install_version "v" && exit 1
-      normalize_install_version "latest-foo" && exit 1
-      true
-    ); then
-      fail "sourced normalize_install_version table disagreed"
+    if grep -Fq -- "ASSAY_INSTALL_SOURCE_ONLY" "$INSTALLER"; then
+      fail "install.sh grew a test-only source/skip escape"
     else
-      ok "sourced normalize_install_version agrees for 5.2.0, v5.2.0, latest, malformed"
+      ok "install.sh has no source-only production escape"
     fi
   fi
 }

--- a/scripts/ci/test-install-version-normalization.sh
+++ b/scripts/ci/test-install-version-normalization.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Offline contract for scripts/install.sh version normalization (#2375).
+#
+# Explicit ASSAY_VERSION values 5.2.0 and v5.2.0 must derive the same GitHub
+# tag and archive prefix (v5.2.0). latest stays latest. Malformed input must
+# fail before any curl invocation. A stub curl records every call; nothing
+# reaches the network.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALLER="${INSTALLER:-$ROOT/scripts/install.sh}"
+MODE="${1:-}"
+
+abort_is_failure() {
+  local rc="$1"
+  if [[ "${rc}" -ne 0 ]]; then
+    echo "install-version-normalization contract aborted (exit ${rc}); treat as failure" >&2
+  fi
+}
+trap 'abort_is_failure "$?"' ERR
+
+if [[ ! -f "$INSTALLER" ]]; then
+  echo "missing installer: $INSTALLER" >&2
+  exit 1
+fi
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+failures=0
+
+fail() {
+  echo "FAIL $*" >&2
+  failures=$((failures + 1))
+}
+
+ok() {
+  echo "ok   $*"
+}
+
+make_curl_stub() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat >"$bin_dir/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\n' "$*" >>"${CURL_LOG:?}"
+out=""
+write_fmt=""
+url=""
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -o) out="$arg" ;;
+    -w) write_fmt="$arg" ;;
+  esac
+  case "$arg" in
+    http://*|https://*) url="$arg" ;;
+  esac
+  prev="$arg"
+done
+printf '%s\n' "${url:-<missing-url>}" >>"${CURL_URLS:?}"
+if [[ "$url" == *"/repos/Rul1an/assay/releases/latest" ]]; then
+  payload='{"tag_name":"v9.9.9"}'
+  if [[ -n "$out" ]]; then
+    printf '%s\n' "$payload" >"$out"
+  else
+    printf '%s\n' "$payload"
+  fi
+  if [[ -n "$write_fmt" ]]; then
+    printf '200'
+  fi
+  exit 0
+fi
+if [[ -n "$out" ]]; then
+  : >"$out"
+fi
+if [[ -n "$write_fmt" ]]; then
+  printf '404'
+fi
+exit 0
+STUB
+  chmod +x "$bin_dir/curl"
+}
+
+run_installer() {
+  local version_mode="$1"
+  local run_dir="$2"
+  local log="$run_dir/installer.log"
+  local urls="$run_dir/urls"
+  local curl_log="$run_dir/curl.log"
+  mkdir -p "$run_dir"
+  : >"$urls"
+  : >"$curl_log"
+  make_curl_stub "$run_dir/bin"
+  local rc=0
+  local env_cmd=(env -u ASSAY_VERSION)
+  case "$version_mode" in
+    unset) ;;
+    empty) env_cmd=(env ASSAY_VERSION=) ;;
+    *) env_cmd=(env "ASSAY_VERSION=$version_mode") ;;
+  esac
+  "${env_cmd[@]}" \
+    CURL_LOG="$curl_log" CURL_URLS="$urls" \
+    ASSAY_INSTALL_DIR="$run_dir/prefix" \
+    PATH="$run_dir/bin:/usr/bin:/bin" \
+    HOME="$run_dir/home" \
+    sh "$INSTALLER" >"$log" 2>&1 || rc=$?
+  printf '%s\n' "$rc"
+}
+
+expect_same_v_tag_url() {
+  local label="$1"
+  local version="$2"
+  local run_dir="$SCRATCH/url-$label"
+  local rc
+  rc="$(run_installer "$version" "$run_dir")"
+  local urls="$run_dir/urls"
+  if [[ ! -s "$urls" ]]; then
+    fail "$label: installer never constructed a download URL (exit $rc)"
+    sed 's/^/      /' "$run_dir/installer.log" >&2 || true
+    return
+  fi
+  if ! grep -Fq -- "/releases/download/v5.2.0/assay-v5.2.0-" "$urls"; then
+    fail "$label: expected tag+archive v5.2.0, got:"
+    sed 's/^/      /' "$urls" >&2
+    return
+  fi
+  if grep -Eq -- '/releases/download/5[.]2[.]0/|/assay-5[.]2[.]0-' "$urls"; then
+    fail "$label: unprefixed 5.2.0 leaked into tag or archive:"
+    sed 's/^/      /' "$urls" >&2
+    return
+  fi
+  ok "$label derives /download/v5.2.0/assay-v5.2.0- (exit $rc)"
+}
+
+expect_fail_before_network() {
+  local label="$1"
+  local version="$2"
+  local run_dir="$SCRATCH/deny-$label"
+  local rc
+  rc="$(run_installer "$version" "$run_dir")"
+  if [[ "$rc" -eq 0 ]]; then
+    fail "$label: installer exited 0 for malformed ASSAY_VERSION=$version"
+    return
+  fi
+  if [[ -s "$run_dir/urls" ]] || [[ -s "$run_dir/curl.log" ]]; then
+    fail "$label: malformed ASSAY_VERSION=$version reached curl before failing"
+    sed 's/^/      /' "$run_dir/curl.log" >&2 || true
+    sed 's/^/      /' "$run_dir/urls" >&2 || true
+    return
+  fi
+  ok "$label fails closed before network (exit $rc)"
+}
+
+expect_latest_preserved() {
+  local run_dir="$SCRATCH/latest"
+  local rc
+  rc="$(run_installer "latest" "$run_dir")"
+  if ! grep -Fq -- "/repos/Rul1an/assay/releases/latest" "$run_dir/urls"; then
+    fail "latest: did not query the latest-release API (exit $rc)"
+    sed 's/^/      /' "$run_dir/urls" >&2 || true
+    return
+  fi
+  if grep -Eq -- '/download/vlatest|/download/latest/|/assay-vlatest-' "$run_dir/urls"; then
+    fail "latest: acquired a v prefix or was used as a tag"
+    sed 's/^/      /' "$run_dir/urls" >&2
+    return
+  fi
+  if ! grep -Fq -- "/releases/download/v9.9.9/assay-v9.9.9-" "$run_dir/urls"; then
+    fail "latest: resolved tag/archive were not derived from the API tag"
+    sed 's/^/      /' "$run_dir/urls" >&2
+    return
+  fi
+  ok "latest is preserved and resolves via the API (exit $rc)"
+}
+
+run_contract() {
+  expect_same_v_tag_url "unprefixed" "5.2.0"
+  expect_same_v_tag_url "prefixed" "v5.2.0"
+  expect_latest_preserved
+  expect_fail_before_network "empty" "empty"
+  expect_fail_before_network "bare-v" "v"
+  expect_fail_before_network "dotdot" ".."
+  expect_fail_before_network "url" "https://example.com/v5.2.0"
+  expect_fail_before_network "spaces" "5.2.0 "
+  expect_fail_before_network "latest-foo" "latest-foo"
+  expect_fail_before_network "double-v" "vv5.2.0"
+
+  if [[ "$INSTALLER" == "$ROOT/scripts/install.sh" ]]; then
+    if ! grep -qE '^normalize_install_version[[:space:]]*\(\)' "$INSTALLER"; then
+      fail "install.sh does not define normalize_install_version()"
+    else
+      ok "install.sh defines normalize_install_version()"
+    fi
+    if ! grep -qE '^is_stable_release_tag[[:space:]]*\(\)' "$INSTALLER"; then
+      fail "install.sh does not define is_stable_release_tag()"
+    else
+      ok "install.sh defines is_stable_release_tag()"
+    fi
+    if ! grep -Fq -- '^v[0-9]+[.][0-9]+[.][0-9]+$' "$INSTALLER"; then
+      fail "install.sh lost the stable-tag regex required by the latest-channel contract"
+    else
+      ok "stable-tag regex remains the latest-channel literal"
+    fi
+    if ! (
+      export ASSAY_INSTALL_SOURCE_ONLY=1
+      # shellcheck disable=SC1090
+      . "$INSTALLER"
+      [[ "$(normalize_install_version "5.2.0")" == "v5.2.0" ]] || exit 1
+      [[ "$(normalize_install_version "v5.2.0")" == "v5.2.0" ]] || exit 1
+      [[ "$(normalize_install_version "latest")" == "latest" ]] || exit 1
+      normalize_install_version "" && exit 1
+      normalize_install_version "v" && exit 1
+      normalize_install_version "latest-foo" && exit 1
+      true
+    ); then
+      fail "sourced normalize_install_version table disagreed"
+    else
+      ok "sourced normalize_install_version agrees for 5.2.0, v5.2.0, latest, malformed"
+    fi
+  fi
+}
+
+if [[ "$MODE" == "--no-mutations" ]]; then
+  run_contract
+  if [[ "$failures" -ne 0 ]]; then
+    echo "install-version-normalization contract: ${failures} failure(s)" >&2
+    exit 1
+  fi
+  echo "install-version-normalization contract: all cases passed"
+  exit 0
+fi
+
+run_contract
+
+echo "== mutations must make this contract fail =="
+
+apply_mutation() {
+  local name="$1"
+  local mutant="$2"
+  python3 - "$INSTALLER" "$mutant" "$name" <<'PY'
+import pathlib, sys
+
+src, dest, name = sys.argv[1], sys.argv[2], sys.argv[3]
+text = pathlib.Path(src).read_text()
+mutations = {
+    "unprefixed-archive": (
+        'ARCHIVE_NAME="assay-${VERSION}-${TARGET}.tar.gz"',
+        'ARCHIVE_NAME="assay-${VERSION#v}-${TARGET}.tar.gz"',
+    ),
+    "malformed-as-latest": (
+        'VERSION="$(normalize_install_version "$VERSION")" || log_error "ASSAY_VERSION must be latest or a stable X.Y.Z (optional leading v)"',
+        'if ! VERSION="$(normalize_install_version "$VERSION")"; then VERSION="latest"; fi',
+    ),
+    "latest-v-prefix": (
+        'if [ "$1" = "latest" ]; then\n        printf \'%s\\n\' "latest"',
+        'if [ "$1" = "latest" ]; then\n        printf \'%s\\n\' "vlatest"',
+    ),
+}
+if name not in mutations:
+    raise SystemExit(f"unknown mutation {name!r}")
+old, new = mutations[name]
+count = text.count(old)
+if count != 1:
+    raise SystemExit(f"mutation {name!r} anchor matched {count} times, expected once")
+pathlib.Path(dest).write_text(text.replace(old, new, 1))
+PY
+}
+
+expect_mutation_bites() {
+  local name="$1"
+  local mutant="$SCRATCH/mutant-$name.sh"
+  apply_mutation "$name" "$mutant"
+  chmod +x "$mutant"
+  local log="$SCRATCH/mutant-$name.log"
+  if INSTALLER="$mutant" bash "$0" --no-mutations >"$log" 2>&1; then
+    fail "mutation $name stayed green"
+    sed 's/^/      /' "$log" >&2
+    return
+  fi
+  ok "mutation $name bites"
+}
+
+if [[ "$failures" -eq 0 ]]; then
+  expect_mutation_bites "unprefixed-archive"
+  expect_mutation_bites "malformed-as-latest"
+  expect_mutation_bites "latest-v-prefix"
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "install-version-normalization contract: ${failures} failure(s)" >&2
+  exit 1
+fi
+echo "install-version-normalization contract: all cases passed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -211,8 +211,4 @@ main() {
     printf "Run %bassay --help%b to get started.\n" "${BOLD}" "${NC}"
 }
 
-# When sourced by the contract test, define helpers only.
-if [ "${ASSAY_INSTALL_SOURCE_ONLY:-}" = "1" ]; then
-    return 0 2>/dev/null || exit 0
-fi
 main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,9 +40,16 @@ log_success() { printf "${GREEN}${BOLD}[OK]${NC} %s\n" "$1"; }
 log_warn() { printf "${YELLOW}${BOLD}[WARN]${NC} %s\n" "$1"; }
 log_error() { printf "${RED}${BOLD}[ERROR]${NC} %s\n" "$1"; exit 1; }
 
-# One predicate for "this is a published stable software tag". The latest
-# resolver and explicit ASSAY_VERSION both use it so they cannot drift.
+# One predicate for "this is a published stable software tag". Total /
+# fail-closed for empty, whitespace, slash, and `..` so line-oriented
+# grep cannot accept a multiline extraction. Explicit and latest both
+# use this function; normalize does not repeat the reject rule.
 is_stable_release_tag() {
+    case "$1" in
+        ""|*[[:space:]]*|*/*|*..*)
+            return 1
+            ;;
+    esac
     printf '%s\n' "$1" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+$'
 }
 
@@ -53,11 +60,6 @@ normalize_install_version() {
         printf '%s\n' "latest"
         return 0
     fi
-    case "$1" in
-        ""|*[[:space:]]*|*/*|*..*)
-            return 1
-            ;;
-    esac
     _candidate="$1"
     case "$_candidate" in
         v*) ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,10 @@
 #   curl -fsSL https://getassay.dev/install.sh | sh
 #   curl -fsSL https://getassay.dev/install.sh | ASSAY_VERSION=1.3.0 sh
 #
+# Canonical explicit input is X.Y.Z (no leading v). ASSAY_VERSION=1.3.0 and
+# ASSAY_VERSION=v1.3.0 both install the v1.3.0 release tag and archive.
+# `latest` is unchanged. Any other value is rejected before network access.
+#
 
 set -e
 
@@ -14,7 +18,13 @@ set -e
 GITHUB_REPO="Rul1an/assay"
 
 INSTALL_DIR="${ASSAY_INSTALL_DIR:-$HOME/.local/bin}"
-VERSION="${ASSAY_VERSION:-latest}"
+# Unset defaults to latest. An explicitly empty value is malformed and must
+# not be rewritten to latest (that would hit the network).
+if [ -z "${ASSAY_VERSION+x}" ]; then
+    VERSION="latest"
+else
+    VERSION="$ASSAY_VERSION"
+fi
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -29,6 +39,35 @@ log_info() { printf "${BLUE}${BOLD}[INFO]${NC} %s\n" "$1"; }
 log_success() { printf "${GREEN}${BOLD}[OK]${NC} %s\n" "$1"; }
 log_warn() { printf "${YELLOW}${BOLD}[WARN]${NC} %s\n" "$1"; }
 log_error() { printf "${RED}${BOLD}[ERROR]${NC} %s\n" "$1"; exit 1; }
+
+# One predicate for "this is a published stable software tag". The latest
+# resolver and explicit ASSAY_VERSION both use it so they cannot drift.
+is_stable_release_tag() {
+    printf '%s\n' "$1" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+$'
+}
+
+# latest is preserved. Exactly one optional leading v is accepted; the
+# result is the vX.Y.Z tag/archive form, or a failure before any download.
+normalize_install_version() {
+    if [ "$1" = "latest" ]; then
+        printf '%s\n' "latest"
+        return 0
+    fi
+    case "$1" in
+        ""|*[[:space:]]*|*/*|*..*)
+            return 1
+            ;;
+    esac
+    _candidate="$1"
+    case "$_candidate" in
+        v*) ;;
+        *) _candidate="v${_candidate}" ;;
+    esac
+    if ! is_stable_release_tag "$_candidate"; then
+        return 1
+    fi
+    printf '%s\n' "$_candidate"
+}
 
 # --- Main ---
 main() {
@@ -71,6 +110,8 @@ main() {
     log_info "Detected platform: $OS/$ARCH ($TARGET)"
 
     # 2. Resolve Version
+    VERSION="$(normalize_install_version "$VERSION")" || log_error "ASSAY_VERSION must be latest or a stable X.Y.Z (optional leading v)"
+
     if [ "$VERSION" = "latest" ]; then
         log_info "Resolving latest version..."
         # Fetch latest release tag from GitHub API
@@ -82,7 +123,7 @@ main() {
         if [ -z "$VERSION" ]; then
             log_error "Failed to resolve latest version."
         fi
-        if ! printf '%s\n' "$VERSION" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+$'; then
+        if ! is_stable_release_tag "$VERSION"; then
             log_error "latest Assay release is not a stable software tag: $VERSION"
         fi
     fi
@@ -170,4 +211,8 @@ main() {
     printf "Run %bassay --help%b to get started.\n" "${BOLD}" "${NC}"
 }
 
+# When sourced by the contract test, define helpers only.
+if [ "${ASSAY_INSTALL_SOURCE_ONLY:-}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
 main "$@"


### PR DESCRIPTION
## Description
Refs #2375.

Unprefixed `ASSAY_VERSION=5.2.0` was used verbatim as the GitHub release tag and archive prefix, so the documented explicit-version install requested a nonexistent URL. This normalizes an optional leading `v` through one function and one stable-tag predicate so `5.2.0` and `v5.2.0` derive the same `v5.2.0` tag/archive, preserves `latest` (including unset → latest), and rejects malformed input before any network call.

`is_stable_release_tag` is now total / fail-closed for empty, whitespace/newline, slash, and `..`. Both the explicit and latest paths use that one function. `normalize_install_version` no longer repeats the whitespace/tag reject rule. A multiline latest-API body such as `evil-not-a-tag` plus `v9.9.9` is rejected after the latest query and does not proceed to an asset curl.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Base / head
- Base: `origin/main` `74a5ad53ac92a282a9583ca6d2eadf32a92d5cde`
- Head: `cursor/2375-installer-version-normalization` `3dbdc327625fce0d3c42f529ef55a2ed48a64047`

Prior CI and reviews measured on `fda5bb9125f500df78a36ae93e9be584f15b8976` are invalid for this head.

## RED → GREEN
RED (head `fda5bb912`, harness-only, installer unpatched):
- `bash scripts/ci/test-install-version-normalization.sh --no-mutations`
- `latest-multiline-tags`: latest API payload `{"tag_name":"evil-not-a-tag"}\n{"tag_name":"v9.9.9"}` was accepted by line-oriented grep
- installer proceeded to asset curl with the full invalid VERSION (`/releases/download/evil-not-a-tag` + `v9.9.9/assay-evil-not-a-tag` + `v9.9.9-…`)

GREEN (this head `3dbdc327625fce0d3c42f529ef55a2ed48a64047`):
- `bash scripts/ci/test-install-version-normalization.sh` — pass (including `drop-tag-prefilter` mutation)
- `shellcheck scripts/install.sh scripts/ci/test-install-version-normalization.sh` — pass (exit 0)
- `sh -n` and `bash -n` on those two scripts — pass
- `pre-commit run install-version-normalization-self-test` — pass
- `git diff --check` — pass
- named pre-commit hook `install-version-normalization-self-test` also passed on commit
- pre-push hooks — pass (did not invoke the release-channel Ruby gate)

## Mutations
The contract fails if a mutant:
- derives the archive from `${VERSION#v}` while the tag keeps `v5.2.0`
- treats a failed normalize as `latest` (hits the network)
- prefixes `latest` to `vlatest`
- drops the fail-closed prefilter from `is_stable_release_tag` (multiline latest proceeds to asset curl)

## Files
- `scripts/install.sh`
- `scripts/ci/test-install-version-normalization.sh`
- `.pre-commit-config.yaml` (hook id `install-version-normalization-self-test`; unchanged in this commit)

## Verification
- [x] Focused offline installer contract
- [x] `shellcheck` on the two touched scripts
- [x] `sh -n` / `bash -n` on the two touched scripts
- [x] named pre-commit hook `install-version-normalization-self-test`
- [x] `git diff --check`
- [ ] Local `scripts/ci/test-release-channel-separation.sh` — **not claimed**

Local release-channel non-claim: the release-channel test on this host aborts in `check-assay-version-line` before installer assertions because host Ruby is 3.3.3 / Psych 5.1.2 while the gate requires Ruby 3.3.12 / Psych 5.1.2. No mise. Docker daemon unavailable. action-tests CI has `ruby/setup-ruby` 3.3.12 and is the integration proof.

## Non-claims
- Does not invalidate `v5.2.0` assets, checksums, crates.io publications, or the unpinned release-notes one-liner.
- Does not change product docs, release tags, golden-path, or issues #2372 / #2374 / #2206.
- Does not verify the live/published install shape on this host.
- Does not add a production source/skip escape (`ASSAY_INSTALL_SOURCE_ONLY` is absent).
- Local release-channel / `check-assay-version-line` is not a pass on this host (see above).

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.


Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installer version handling for stable versions with or without a leading `v`.
  - Preserved automatic installation of the latest release when no version is specified.
  - Added validation to reject malformed or unsafe version values before downloads begin.

- **Tests**
  - Added comprehensive offline checks covering version normalization, latest-release resolution, invalid inputs, and regression detection.
  - Added an automated pre-commit check for installer version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->