### PR TITLE
docs(mcp): define policy-input safety programme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ this contract.
 ## Canonical State
 
 - Repository truth is the checked-in code and documentation.
-- The public execution ledger for the active programme is named on this line: [issue
-  #2388](https://github.com/Rul1an/assay/issues/2388). Name the new ledger here when one opens, and
+- The public execution ledger for the active programme is named on this line: [issue #2388](https://github.com/Rul1an/assay/issues/2388).
+  Name the new ledger here when one opens, and
   say so plainly here when none is active. Keep
   the number to this one line; everywhere else the contract names the role, so the next programme
   costs one edit here rather than one in every section. Nothing enforces that, so it is an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@ this contract.
 ## Canonical State
 
 - Repository truth is the checked-in code and documentation.
-- The public execution ledger for the active programme is named on this line. **No programme is
-  active.** The previous one, [issue #1866](https://github.com/Rul1an/assay/issues/1866), closed on
-  2026-08-01; name the new ledger here when one opens, and say so plainly here when none is. Keep
+- The public execution ledger for the active programme is named on this line: [issue
+  #2388](https://github.com/Rul1an/assay/issues/2388). Name the new ledger here when one opens, and
+  say so plainly here when none is active. Keep
   the number to this one line; everywhere else the contract names the role, so the next programme
   costs one edit here rather than one in every section. Nothing enforces that, so it is an
   instruction and not a guarantee — and the way it fails is quiet: the line kept pointing at a

--- a/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
+++ b/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
@@ -17,13 +17,17 @@ being mixed with verdict semantics. Resource limiting lands last through a separ
 
 ## Measured Baseline
 
-Two independent stdio audits on the baseline SHA established:
+Two independent stdio audits on the baseline SHA established the findings below. The retained
+driven-audit provenance is a clean detached checkout at `/tmp/assay-addfda3b`, binary
+`/tmp/assay-addfda3b/target/debug/assay-mcp-server`, and Rust/Cargo 1.96.0. The audit did not retain
+a binary digest, so this record attributes behavior to the source SHA and toolchain, not byte
+identity:
 
 - scalar, sequence, and empty YAML roots return `allowed:true` and `isError:false`;
 - the first malformed-root call logs a blocklist cache miss and inserts an empty list, while the
   repeat call is a cache hit;
-- a malformed 200,000-byte scalar produces approximately 200,044 to 200,071 bytes of public
-  `E_POLICY_PARSE` message text in four tools;
+- a malformed policy field containing a 200,000-byte scalar produces approximately 200,044 to
+  200,071 bytes of public `E_POLICY_PARSE` message text in four tools;
 - `assay_policy_decide`, `assay_check_args`, `assay_check_coverage`, and `assay_explain_trace`
   expose raw parser diagnostics, while `assay_check_sequence` already uses fixed wording; and
 - policy files are fully materialised by the affected tools outside the inbound JSON-RPC message
@@ -40,9 +44,10 @@ The reproduction is local-policy evidence. It does not demonstrate remote exploi
 
 ## Standards And Design Basis
 
-The MCP tools contract requires tool outputs to be sanitised. Tool execution failures remain tool
-results with `isError:true`; malformed protocol messages remain JSON-RPC errors. This design keeps
-that boundary and does not adopt an HTTP Problem Details wire format.
+The MCP tools contract exposes actionable tool-execution failures to models as tool results with
+`isError:true`; malformed protocol messages remain JSON-RPC errors. Source-derived parser text
+therefore crosses a model-facing trust boundary. This design keeps the protocol boundary and does
+not adopt an HTTP Problem Details wire format.
 
 RFC 9457 supplies a useful field taxonomy by analogy: stable machine code, stable short summary,
 bounded occurrence detail, and optional structured context. Consumers must not parse occurrence
@@ -56,11 +61,11 @@ does not implement or advertise that revision.
 
 ### 0. Policy-Dialect Decision
 
-This programme preserves `assay_policy_decide` as a deliberately narrow 5.x compatibility
-surface. Its root-level `blocklist` remains the contract exercised by the published tool schema,
-stdio integration tests, and project-install proof. It is not an alias for `McpPolicy.tools.deny`,
-and Slice 1 must not make `assay_policy_decide` evaluate `tools.deny`, legacy root `deny`, schemas,
-sequence rules, or the full policy engine.
+This programme preserves the valid root-level `blocklist` subset of `assay_policy_decide` as a
+deliberately narrow 5.x compatibility surface. That subset is exercised by the published tool
+schema, stdio integration tests, and project-install proof. It is not an alias for
+`McpPolicy.tools.deny`, and Slice 1 must not make `assay_policy_decide` evaluate `tools.deny`, legacy
+root `deny`, schemas, sequence rules, or the full policy engine.
 
 The compatibility boundary must not turn recognised canonical name-policy intent into a clean
 allow. A mapping containing root `allow`, root `deny`, or `tools` is an unsupported full-policy
@@ -68,6 +73,11 @@ dialect for this tool and returns `E_POLICY_PARSE` with `Policy structure is inv
 mixing any of those markers with `blocklist` is ambiguous and returns the same failure. Neither
 case reaches cache insertion. Mappings that contain no `blocklist` and no canonical name-policy
 marker remain allow-compatible for 5.x compatibility.
+
+Rejecting canonical or mixed documents is an intentional hardening change: those inputs currently
+return a false clean allow (or evaluate only the blocklist while ignoring the canonical fields).
+Slice 1 must publish a changelog entry and migration note routing full-policy callers to
+`assay_check_args`; it must not describe this input class as previously unsupported without impact.
 
 `assay_check_args` remains the full `McpPolicy` evaluator. Documentation and tool descriptions must
 call the distinction explicit: `assay_policy_decide` is a name-only blocklist check, while
@@ -131,8 +141,9 @@ The summary selection is fixed rather than inferred by each caller:
 
 Truncation alone is insufficient because it can expose a secret prefix. The specialised parse path
 must avoid source-derived text. In addition, `ToolError` will apply an absolute 4,096-byte ceiling to
-every public `message` as defence in depth. This intentionally widens #2387 beyond policy parse
-errors. The ceiling is measured in UTF-8 bytes and must not split a code point.
+every serialized `ToolError.message` as defence in depth. This intentionally widens #2387 beyond
+policy parse errors but does not cover the outer server's separately constructed `E_INTERNAL`
+fallback, tracked in #2391. The ceiling is measured in UTF-8 bytes and must not split a code point.
 
 `ToolError` is a public Rust type whose fields are already public. This programme does not remove
 that API in a minor release. Instead, one `bound_public_message` function is used both by
@@ -142,8 +153,10 @@ mutation before the server publishes the value. `ToolError::result` must continu
 type rather than repacking its fields. Safe line and column numbers use the existing `details`
 object rather than message text.
 
-The four current raw policy-parse sinks migrate to this shared path. Fixed, value-free errors may
-continue to use the general constructor, but no raw parser error may bypass the parse constructor.
+All five public policy-parse tool surfaces are inventoried in Slice 2. The four that currently expose
+raw parser text migrate to the shared path; `assay_check_sequence` retains fixed, value-free wording.
+Fixed errors may continue to use the general constructor, but no raw parser error may bypass the
+parse constructor.
 
 ### 3. Bounded Policy Reader
 
@@ -154,7 +167,8 @@ materialisation. It uses the existing `assay_common::limits::LimitReader` mechan
 
 The initial default is 1,000,000 bytes, matching the existing inbound message ceiling while
 remaining a separate named configuration value. The environment override is
-`ASSAY_MCP_MAX_POLICY_BYTES`. Install and invocation read this single value from `ServerConfig`.
+`ASSAY_MCP_MAX_POLICY_BYTES`. Configuration parsing and every policy reader use the single resolved
+`ServerConfig.max_policy_bytes` value.
 
 The reader must:
 
@@ -169,10 +183,11 @@ The measured inventory is four direct `tokio::fs::read` call sites in `assay_pol
 `McpPolicy::from_file` / `std::fs::read_to_string` path in `assay_check_args`.
 
 The tools retain their distinct parse dialects after the shared read. `McpPolicy` gains one
-bytes-in parse API containing the current deserialize, legacy-normalisation, migration, and
-validation sequence. `McpPolicy::from_file` delegates to that API, and `assay_check_args` passes the
-bytes returned by `read_policy_bounded` to the same API. A tool may not retain a parallel unbounded
-read or a second implementation of the full-policy parse rule.
+bytes-in parse API containing the current deserialize and unknown-field collection, `is_v1_format`
+and `ASSAY_STRICT_DEPRECATIONS` decision, deprecation warning, legacy normalisation, constraints
+migration, and validation sequence in that order. `McpPolicy::from_file` delegates to that API, and
+`assay_check_args` passes the bytes returned by `read_policy_bounded` to the same API. A tool may not
+retain a parallel unbounded read or a second implementation of the full-policy parse rule.
 
 The server-tool slice does not silently absorb proxy-enforcement startup policies, declared MCP
 manifests, trust policies, general CLI policy readers, parser-depth limits, or YAML alias-expansion
@@ -194,8 +209,10 @@ tools/call arguments
      -> allowed true/false result
 ```
 
-Absence of a valid parse, unavailable infrastructure, or a resource-limit failure never becomes a
-clean allow.
+Within the policy handlers, absence of a valid parse or a resource-limit failure returns a
+`ToolError` result and never reaches cache insertion. This statement does not cover the outer
+server-level `on_error` fallback for handler `Err` or timeout; its caller authority and raw
+`E_INTERNAL` diagnostic are tracked together in #2391.
 
 ## Delivery Slices
 
@@ -208,22 +225,27 @@ deny-shaped root sequence. First and repeat calls must return `allowed:false`, `
 Controls must pin mapping-without-blocklist, mapping-with-unrelated-keys, `blocklist: []`, a present
 null/bare `blocklist:` parse error, a valid exact-name deny, and a wildcard-looking literal. Root
 `allow`, root `deny`, nested `tools`, and mixed `blocklist` plus canonical markers must fail as an
-unsupported or ambiguous dialect on first and repeat calls. The malformed-root path already uses
-`Policy root must be a mapping`; it must not wait for Slice 2 or expose a large scalar. A mutation
+unsupported or ambiguous dialect on first and repeat calls. Slice 1 introduces
+`Policy root must be a mapping` on the malformed-root path; it must not wait for Slice 2 or expose a
+large scalar. A mutation
 removing `require_mapping_root` must make the malformed-root table fail. Mutations that remove the
 dialect guard, switch to wildcard matching, or cache an empty list before returning the error must
 fail their corresponding contract assertions.
 
-Update the stale MCP references that present root `blocklist` as part of the full `McpPolicy`
-schema. The tool description continues to advertise name-only blocklist semantics and explicitly
-routes full-policy and argument-aware evaluation to `assay_check_args`.
+Update the complete measured MCP reference inventory that presents root `blocklist` as part of the
+full `McpPolicy` schema or presents `assay_policy_decide` as argument-aware. At minimum this includes
+`docs/reference/mcp-api.md`, both MCP and use-case self-correction guides,
+`docs/AIcontext/entry-points.md`, and `docs/AIcontext/quick-reference.md`; use `rg` to prove no stale
+equivalent remains. The tool description continues to advertise name-only blocklist semantics and
+routes full-policy and argument-aware evaluation to `assay_check_args`. Add a changelog entry and a
+migration example for callers that previously passed canonical full-policy files.
 
 ### Slice 2: #2387 — Diagnostic Safety
 
-Inventory every public policy-parse sink and migrate all of them in one PR. Tests send distinct
-sentinels at the beginning, middle, and end of a large malformed value. Assert that none appears in
-the complete MCP response and that `error.message` remains at or below 4,096 UTF-8 bytes. The full
-MCP envelope is expected to be larger than the message ceiling.
+Write RED tests first, then inventory every public policy-parse sink and migrate all of them in one
+PR. Tests send distinct sentinels at the beginning, middle, and end of a large malformed value.
+Assert that none appears in the complete MCP response and that `error.message` remains at or below
+4,096 UTF-8 bytes. The full MCP envelope is expected to be larger than the message ceiling.
 
 Add tests for safe syntax location, absolute-path exclusion, policy-root exclusion, multibyte UTF-8,
 and all affected tools. Constructor, direct-struct, and post-construction-mutation tests must all
@@ -231,26 +253,22 @@ serialize a message of at most 4,096 bytes. Mutations removing the value-free co
 shared bound, or the custom serializer must fail distinct assertions. Verdict fields and reason
 code remain unchanged.
 
-### Slice 3: Bounded Policy Ingest
+### Slice 3: #2389 — Bounded Policy Ingest
 
-Create a child issue with the final call-site inventory before implementation. RED tests cover a
-sparse oversized file, an exact-limit file, a limit-plus-one file, and a reader that observes growth
-while reading. Oversized input returns `E_LIMIT_EXCEEDED` and never reaches parsing or cache
-insertion.
+#2389 already carries the final five-tool call-site inventory and is the Slice 3 child. RED tests
+cover a sparse oversized file, an exact-limit file, a limit-plus-one file, and a reader that observes
+growth while reading. Oversized input returns `E_LIMIT_EXCEEDED` and never reaches parsing or cache
+insertion. Core parser-parity tests must include strict V1 deprecation so the bytes API cannot omit
+the `is_v1_format` / `ASSAY_STRICT_DEPRECATIONS` branch.
 
 Mutation tests must catch a metadata-only size check and a direct `tokio::fs::read` bypass. Valid
 files at or below the limit preserve current behaviour.
 
 ## Verification Per Slice
 
-Before each push:
-
-- run the focused RED/GREEN contract test;
-- run the affected `assay-mcp-server` integration and crate tests;
-- run `cargo fmt --all -- --check`;
-- run `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`;
-- run `git diff --check` and inspect public strings; and
-- record exact SHA, worktree, toolchain, tests, mutations, non-claims, and findings in #2388.
+Each slice follows the repository-wide verification and measurement-provenance contract in
+`AGENTS.md`. In addition, run its focused RED/GREEN and mutation tests, the affected
+`assay-mcp-server` integration/crate tests, and record the exact-head evidence in #2388.
 
 GitHub Actions remains the integration proof. Each final PR head requires one non-building-agent
 review under `AGENTS.md`. Agents that authored this design or an implementation slice cannot supply
@@ -258,14 +276,9 @@ that slice's quorum review.
 
 ## Issue Disposition
 
-- #2386 and #2387 remain P1 children of #2388 until their merge evidence is recorded.
-- Slice 3 receives a new child issue after its inventory is measured.
-- #2385 remains closed as the correct baseline for malformed present `blocklist` values.
-- #2359 and #2384 form the next adoption and packaging cluster.
-- #2185 remains wire observability and is measured per protocol era when #2358 advances.
-- #2358 requires a separate stateless MCP 2026-07-28 design.
-- #2177 remains a failure-envelope epic delivered one failure family per PR.
-- #2178 is not scheduled without a demonstrated blocked workflow.
+- #2386, #2387, and #2389 remain P1 children of #2388 until their merge evidence is recorded.
+- PR #2385 remains the correct baseline for malformed present `blocklist` values.
+- #2391 tracks the adjacent outer `tools/call` fallback and is not absorbed into these parser slices.
 
 The #2386 issue body must be amended before implementation: its existing non-claim against
 `McpPolicy` unification remains correct, but its DoD must pin the private compatibility dialect,
@@ -273,10 +286,11 @@ present-null behaviour, value-free root diagnostic, and documentation correction
 
 ## Non-Claims
 
-This programme does not add target-tool enforcement, proxy unification, modern MCP negotiation,
-remote transport, OAuth, marketplace approval, portable MCP packaging, generic retryability,
-provider-outcome verification, compliance, certification, a scalar trust score, or a safe-agent
-claim.
+This programme does not change the generic server-level `on_error` authority or raw `E_INTERNAL`
+fallback (#2391), and does not add target-tool enforcement, proxy unification, modern MCP
+negotiation, remote transport, OAuth, marketplace approval, portable MCP packaging, generic
+retryability, provider-outcome verification, compliance, certification, a scalar trust score, or a
+safe-agent claim.
 
 ## Primary References
 

--- a/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
+++ b/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
@@ -1,6 +1,6 @@
 # MCP Policy-Input Safety Design
 
-**Status:** Revised after written-spec review, awaiting owner reconfirmation
+**Status:** Owner-approved for implementation (2026-08-15)
 **Programme ledger:** [#2388](https://github.com/Rul1an/assay/issues/2388)
 **Baseline:** `addfda3b3f695f11a7dba90f7c1ae24ff442b034` (`origin/main`, 2026-08-15)
 

--- a/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
+++ b/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
@@ -280,9 +280,9 @@ that slice's quorum review.
 - PR #2385 remains the correct baseline for malformed present `blocklist` values.
 - #2391 tracks the adjacent outer `tools/call` fallback and is not absorbed into these parser slices.
 
-The #2386 issue body must be amended before implementation: its existing non-claim against
-`McpPolicy` unification remains correct, but its DoD must pin the private compatibility dialect,
-present-null behaviour, value-free root diagnostic, and documentation correction above.
+The #2386 issue body has been amended for implementation. Its non-claim against `McpPolicy`
+unification remains correct, and its DoD pins the private compatibility dialect, present-null
+behaviour, value-free root diagnostic, and documentation correction above.
 
 ## Non-Claims
 

--- a/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
+++ b/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
@@ -50,8 +50,9 @@ therefore crosses a model-facing trust boundary. This design keeps the protocol 
 not adopt an HTTP Problem Details wire format.
 
 RFC 9457 supplies a useful field taxonomy by analogy: stable machine code, stable short summary,
-bounded occurrence detail, and optional structured context. Consumers must not parse occurrence
-text. It does not require a generic retryability field, and this design adds none.
+occurrence-specific detail, and optional structured context. It also warns against exposing
+debugging information. Assay independently bounds occurrence detail, and consumers must not parse
+that text. RFC 9457 does not require a generic retryability field, and this design adds none.
 
 MCP 2026-07-28 is a stateless, per-request protocol revision. Its `resultType`, discovery, and
 cacheable-result semantics are separate from Assay's internal parsed-policy cache. This programme

--- a/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
+++ b/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
@@ -1,6 +1,6 @@
 # MCP Policy-Input Safety Design
 
-**Status:** Approved design, awaiting written-spec review
+**Status:** Revised after written-spec review, awaiting owner reconfirmation
 **Programme ledger:** [#2388](https://github.com/Rul1an/assay/issues/2388)
 **Baseline:** `addfda3b3f695f11a7dba90f7c1ae24ff442b034` (`origin/main`, 2026-08-15)
 
@@ -29,6 +29,12 @@ Two independent stdio audits on the baseline SHA established:
 - policy files are fully materialised by the affected tools outside the inbound JSON-RPC message
   ceiling.
 
+The tools do not all parse the same policy dialect. `assay_check_args` loads the full `McpPolicy`
+schema, whose canonical name rules are `tools.allow` and `tools.deny` (plus the legacy root-level
+`allow` and `deny`). `assay_policy_decide` is a narrower, name-only compatibility surface whose
+public input is a root-level `blocklist`. A `blocklist`-only file is therefore not a full
+`McpPolicy`. Existing documentation that presents these dialects as one schema is stale.
+
 The reproduction is local-policy evidence. It does not demonstrate remote exploitability,
 `proxy-enforce` bypass, target-tool execution, or an external side effect.
 
@@ -48,27 +54,58 @@ does not implement or advertise that revision.
 
 ## Architecture
 
+### 0. Policy-Dialect Decision
+
+This programme preserves `assay_policy_decide` as a deliberately narrow 5.x compatibility
+surface. Its root-level `blocklist` remains the contract exercised by the published tool schema,
+stdio integration tests, and project-install proof. It is not an alias for `McpPolicy.tools.deny`,
+and Slice 1 must not make `assay_policy_decide` evaluate `tools.deny`, legacy root `deny`, schemas,
+sequence rules, or the full policy engine.
+
+The compatibility boundary must not turn recognised canonical name-policy intent into a clean
+allow. A mapping containing root `allow`, root `deny`, or `tools` is an unsupported full-policy
+dialect for this tool and returns `E_POLICY_PARSE` with `Policy structure is invalid`. A document
+mixing any of those markers with `blocklist` is ambiguous and returns the same failure. Neither
+case reaches cache insertion. Mappings that contain no `blocklist` and no canonical name-policy
+marker remain allow-compatible for 5.x compatibility.
+
+`assay_check_args` remains the full `McpPolicy` evaluator. Documentation and tool descriptions must
+call the distinction explicit: `assay_policy_decide` is a name-only blocklist check, while
+`assay_check_args` is the argument-aware full-policy check. Consolidating these dialects would be a
+breaking contract decision and is outside this programme.
+
 ### 1. Typed Policy-Decision Document
 
 `assay_policy_decide` will deserialize into a private document type equivalent to:
 
 ```rust
 struct PolicyDecisionDocument {
-    blocklist: Option<Vec<String>>,
+    #[serde(default)]
+    blocklist: Vec<String>,
 }
 ```
 
 The type must not use `deny_unknown_fields`. Existing mapping documents may contain unrelated
 policy fields. The states are therefore explicit:
 
-- mapping plus absent `blocklist`: valid, empty blocklist, allow-compatible;
+- mapping plus absent `blocklist`: valid, default empty blocklist, allow-compatible;
 - mapping plus `blocklist: []`: valid, empty blocklist, allow-compatible;
-- mapping plus string sequence: valid and evaluated;
-- mapping plus malformed `blocklist`: `E_POLICY_PARSE`;
+- mapping plus string sequence: valid and evaluated with exact string membership; wildcard-looking
+  strings remain literal;
+- mapping plus explicit null, bare `blocklist:`, or any other malformed `blocklist`:
+  `E_POLICY_PARSE`;
+- mapping plus root `allow`, root `deny`, or `tools`: unsupported canonical dialect,
+  `E_POLICY_PARSE`;
+- mapping that mixes `blocklist` with one of those canonical markers: ambiguous dialect,
+  `E_POLICY_PARSE`;
 - scalar, sequence, null, or empty root: `E_POLICY_PARSE`.
 
-Only a successfully deserialized blocklist may be inserted into the cache. Invalid documents return
-before cache insertion. The cache key and valid cache-hit behaviour remain unchanged.
+Parsing has two explicit stages. A shared `require_mapping_root` check rejects non-mapping roots
+with the stable, value-free root summary before typed field deserialization. The private document
+then distinguishes absent `blocklist` from a present null or malformed value without reflecting
+source text. Only a successfully deserialized blocklist may be inserted into the cache. Invalid
+documents return before cache insertion. The cache key and valid cache-hit behaviour remain
+unchanged.
 
 ### 2. Public Parse-Diagnostic Boundary
 
@@ -84,18 +121,36 @@ The public error contains:
 - no raw policy fragment, secret sentinel, policy-root path, absolute path, debug chain, or parser
   implementation wording.
 
+The summary selection is fixed rather than inferred by each caller:
+
+| Failure class | Public summary |
+|---|---|
+| YAML/JSON syntax cannot be parsed | `Policy YAML is invalid` |
+| parsed document root is not a mapping | `Policy root must be a mapping` |
+| mapping has a field with an invalid type or shape | `Policy structure is invalid` |
+
 Truncation alone is insufficient because it can expose a secret prefix. The specialised parse path
 must avoid source-derived text. In addition, `ToolError` will apply an absolute 4,096-byte ceiling to
-every public message as defence in depth. The ceiling is measured in UTF-8 bytes and must not split
-a code point.
+every public `message` as defence in depth. This intentionally widens #2387 beyond policy parse
+errors. The ceiling is measured in UTF-8 bytes and must not split a code point.
+
+`ToolError` is a public Rust type whose fields are already public. This programme does not remove
+that API in a minor release. Instead, one `bound_public_message` function is used both by
+`ToolError::new` and by a custom `Serialize` implementation that replaces the current derive. The
+serialization boundary therefore catches direct struct construction and post-construction field
+mutation before the server publishes the value. `ToolError::result` must continue to serialize the
+type rather than repacking its fields. Safe line and column numbers use the existing `details`
+object rather than message text.
 
 The four current raw policy-parse sinks migrate to this shared path. Fixed, value-free errors may
 continue to use the general constructor, but no raw parser error may bypass the parse constructor.
 
 ### 3. Bounded Policy Reader
 
-Policy-file resource limiting is a separate concern and reason path. A shared asynchronous reader
-will enforce a configured `max_policy_bytes` before full materialisation.
+Policy-file resource limiting is a separate concern and reason path. A shared asynchronous
+`read_policy_bounded` entry point will enforce a configured `max_policy_bytes` before full
+materialisation. It uses the existing `assay_common::limits::LimitReader` mechanism around
+`std::fs::File` in a blocking task rather than reimplementing the inclusive `limit + 1` rule.
 
 The initial default is 1,000,000 bytes, matching the existing inbound message ceiling while
 remaining a separate named configuration value. The environment override is
@@ -109,8 +164,20 @@ The reader must:
 - never include file contents in the diagnostic; and
 - be used by every MCP tool that reads a policy file.
 
-The implementation plan must first pin the full reader call-site inventory. A tool may not retain a
-parallel unbounded implementation.
+The measured inventory is four direct `tokio::fs::read` call sites in `assay_policy_decide`,
+`assay_check_coverage`, `assay_check_sequence`, and `assay_explain_trace`, plus the indirect
+`McpPolicy::from_file` / `std::fs::read_to_string` path in `assay_check_args`.
+
+The tools retain their distinct parse dialects after the shared read. `McpPolicy` gains one
+bytes-in parse API containing the current deserialize, legacy-normalisation, migration, and
+validation sequence. `McpPolicy::from_file` delegates to that API, and `assay_check_args` passes the
+bytes returned by `read_policy_bounded` to the same API. A tool may not retain a parallel unbounded
+read or a second implementation of the full-policy parse rule.
+
+The server-tool slice does not silently absorb proxy-enforcement startup policies, declared MCP
+manifests, trust policies, general CLI policy readers, parser-depth limits, or YAML alias-expansion
+limits. Those have different configuration and lifecycle contracts and require separate measured
+issues if they remain actionable.
 
 ## Data And Error Flow
 
@@ -138,20 +205,31 @@ Write RED real-stdio tests before production changes. Cover scalar, sequence, em
 deny-shaped root sequence. First and repeat calls must return `allowed:false`, `E_POLICY_PARSE`, and
 `isError:true`.
 
-Controls must pin mapping-without-blocklist, mapping-with-unrelated-keys, `blocklist: []`, and a
-valid deny. A mutation removing typed root validation must make the malformed-root table fail. A
-mutation that caches an empty list before returning the error must make the repeat-call assertion
-fail.
+Controls must pin mapping-without-blocklist, mapping-with-unrelated-keys, `blocklist: []`, a present
+null/bare `blocklist:` parse error, a valid exact-name deny, and a wildcard-looking literal. Root
+`allow`, root `deny`, nested `tools`, and mixed `blocklist` plus canonical markers must fail as an
+unsupported or ambiguous dialect on first and repeat calls. The malformed-root path already uses
+`Policy root must be a mapping`; it must not wait for Slice 2 or expose a large scalar. A mutation
+removing `require_mapping_root` must make the malformed-root table fail. Mutations that remove the
+dialect guard, switch to wildcard matching, or cache an empty list before returning the error must
+fail their corresponding contract assertions.
+
+Update the stale MCP references that present root `blocklist` as part of the full `McpPolicy`
+schema. The tool description continues to advertise name-only blocklist semantics and explicitly
+routes full-policy and argument-aware evaluation to `assay_check_args`.
 
 ### Slice 2: #2387 — Diagnostic Safety
 
 Inventory every public policy-parse sink and migrate all of them in one PR. Tests send distinct
 sentinels at the beginning, middle, and end of a large malformed value. Assert that none appears in
-the complete MCP response and that the response remains below the named ceiling.
+the complete MCP response and that `error.message` remains at or below 4,096 UTF-8 bytes. The full
+MCP envelope is expected to be larger than the message ceiling.
 
 Add tests for safe syntax location, absolute-path exclusion, policy-root exclusion, multibyte UTF-8,
-and all affected tools. Mutations removing the value-free constructor or general ceiling must fail.
-Verdict fields and reason code remain unchanged.
+and all affected tools. Constructor, direct-struct, and post-construction-mutation tests must all
+serialize a message of at most 4,096 bytes. Mutations removing the value-free constructor, the
+shared bound, or the custom serializer must fail distinct assertions. Verdict fields and reason
+code remain unchanged.
 
 ### Slice 3: Bounded Policy Ingest
 
@@ -188,6 +266,10 @@ that slice's quorum review.
 - #2358 requires a separate stateless MCP 2026-07-28 design.
 - #2177 remains a failure-envelope epic delivered one failure family per PR.
 - #2178 is not scheduled without a demonstrated blocked workflow.
+
+The #2386 issue body must be amended before implementation: its existing non-claim against
+`McpPolicy` unification remains correct, but its DoD must pin the private compatibility dialect,
+present-null behaviour, value-free root diagnostic, and documentation correction above.
 
 ## Non-Claims
 

--- a/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
+++ b/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
@@ -137,6 +137,7 @@ The summary selection is fixed rather than inferred by each caller:
 | Failure class | Public summary |
 |---|---|
 | YAML/JSON syntax cannot be parsed | `Policy YAML is invalid` |
+| input bytes are not valid UTF-8 | `Policy YAML is invalid` |
 | parsed document root is not a mapping | `Policy root must be a mapping` |
 | mapping has a field with an invalid type or shape | `Policy structure is invalid` |
 
@@ -261,6 +262,10 @@ cover a sparse oversized file, an exact-limit file, a limit-plus-one file, and a
 growth while reading. Oversized input returns `E_LIMIT_EXCEEDED` and never reaches parsing or cache
 insertion. Core parser-parity tests must include strict V1 deprecation so the bytes API cannot omit
 the `is_v1_format` / `ASSAY_STRICT_DEPRECATIONS` branch.
+
+The `assay_check_args` real-stdio table also pins invalid UTF-8 as `allowed:false`,
+`E_POLICY_PARSE`, `isError:true`, with the stable `Policy YAML is invalid` summary. A mutation that
+maps invalid UTF-8 to a read or internal error must fail this assertion.
 
 Mutation tests must catch a metadata-only size check and a direct `tokio::fs::read` bypass. Valid
 files at or below the limit preserve current behaviour.

--- a/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
+++ b/docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md
@@ -1,0 +1,205 @@
+# MCP Policy-Input Safety Design
+
+**Status:** Approved design, awaiting written-spec review
+**Programme ledger:** [#2388](https://github.com/Rul1an/assay/issues/2388)
+**Baseline:** `addfda3b3f695f11a7dba90f7c1ae24ff442b034` (`origin/main`, 2026-08-15)
+
+## Purpose
+
+Close the MCP policy-input safety gap in three independently reviewable slices:
+
+1. reject structurally invalid policy roots before they can become cached allows;
+2. publish bounded, value-free policy-parse diagnostics through one shared boundary; and
+3. enforce a policy-file byte ceiling before materialisation.
+
+The sequence is deliberate. Verdict correctness lands first. Diagnostic policy then changes without
+being mixed with verdict semantics. Resource limiting lands last through a separate shared reader.
+
+## Measured Baseline
+
+Two independent stdio audits on the baseline SHA established:
+
+- scalar, sequence, and empty YAML roots return `allowed:true` and `isError:false`;
+- the first malformed-root call logs a blocklist cache miss and inserts an empty list, while the
+  repeat call is a cache hit;
+- a malformed 200,000-byte scalar produces approximately 200,044 to 200,071 bytes of public
+  `E_POLICY_PARSE` message text in four tools;
+- `assay_policy_decide`, `assay_check_args`, `assay_check_coverage`, and `assay_explain_trace`
+  expose raw parser diagnostics, while `assay_check_sequence` already uses fixed wording; and
+- policy files are fully materialised by the affected tools outside the inbound JSON-RPC message
+  ceiling.
+
+The reproduction is local-policy evidence. It does not demonstrate remote exploitability,
+`proxy-enforce` bypass, target-tool execution, or an external side effect.
+
+## Standards And Design Basis
+
+The MCP tools contract requires tool outputs to be sanitised. Tool execution failures remain tool
+results with `isError:true`; malformed protocol messages remain JSON-RPC errors. This design keeps
+that boundary and does not adopt an HTTP Problem Details wire format.
+
+RFC 9457 supplies a useful field taxonomy by analogy: stable machine code, stable short summary,
+bounded occurrence detail, and optional structured context. Consumers must not parse occurrence
+text. It does not require a generic retryability field, and this design adds none.
+
+MCP 2026-07-28 is a stateless, per-request protocol revision. Its `resultType`, discovery, and
+cacheable-result semantics are separate from Assay's internal parsed-policy cache. This programme
+does not implement or advertise that revision.
+
+## Architecture
+
+### 1. Typed Policy-Decision Document
+
+`assay_policy_decide` will deserialize into a private document type equivalent to:
+
+```rust
+struct PolicyDecisionDocument {
+    blocklist: Option<Vec<String>>,
+}
+```
+
+The type must not use `deny_unknown_fields`. Existing mapping documents may contain unrelated
+policy fields. The states are therefore explicit:
+
+- mapping plus absent `blocklist`: valid, empty blocklist, allow-compatible;
+- mapping plus `blocklist: []`: valid, empty blocklist, allow-compatible;
+- mapping plus string sequence: valid and evaluated;
+- mapping plus malformed `blocklist`: `E_POLICY_PARSE`;
+- scalar, sequence, null, or empty root: `E_POLICY_PARSE`.
+
+Only a successfully deserialized blocklist may be inserted into the cache. Invalid documents return
+before cache insertion. The cache key and valid cache-hit behaviour remain unchanged.
+
+### 2. Public Parse-Diagnostic Boundary
+
+Raw `Display` output from YAML, JSON, or typed deserialization is not a public compatibility
+contract. All public policy-parse failures will use one shared constructor or function.
+
+The public error contains:
+
+- code `E_POLICY_PARSE`;
+- one short, stable, value-free summary selected from `Policy YAML is invalid`,
+  `Policy root must be a mapping`, or `Policy structure is invalid`;
+- optional structured line and column values when the parser provides them safely; and
+- no raw policy fragment, secret sentinel, policy-root path, absolute path, debug chain, or parser
+  implementation wording.
+
+Truncation alone is insufficient because it can expose a secret prefix. The specialised parse path
+must avoid source-derived text. In addition, `ToolError` will apply an absolute 4,096-byte ceiling to
+every public message as defence in depth. The ceiling is measured in UTF-8 bytes and must not split
+a code point.
+
+The four current raw policy-parse sinks migrate to this shared path. Fixed, value-free errors may
+continue to use the general constructor, but no raw parser error may bypass the parse constructor.
+
+### 3. Bounded Policy Reader
+
+Policy-file resource limiting is a separate concern and reason path. A shared asynchronous reader
+will enforce a configured `max_policy_bytes` before full materialisation.
+
+The initial default is 1,000,000 bytes, matching the existing inbound message ceiling while
+remaining a separate named configuration value. The environment override is
+`ASSAY_MCP_MAX_POLICY_BYTES`. Install and invocation read this single value from `ServerConfig`.
+
+The reader must:
+
+- read at most `limit + 1` bytes rather than trusting metadata alone;
+- reject oversized or concurrently growing files with `E_LIMIT_EXCEEDED`;
+- preserve existing not-found and read-error classifications;
+- never include file contents in the diagnostic; and
+- be used by every MCP tool that reads a policy file.
+
+The implementation plan must first pin the full reader call-site inventory. A tool may not retain a
+parallel unbounded implementation.
+
+## Data And Error Flow
+
+```text
+tools/call arguments
+  -> bounded path resolution
+  -> shared bounded policy reader
+     -> not found/read/limit error (no parse, no cache)
+  -> typed or tool-specific parse through shared public diagnostic policy
+     -> E_POLICY_PARSE (no cache)
+  -> successful compiled representation
+     -> cache insert
+  -> policy observation
+     -> allowed true/false result
+```
+
+Absence of a valid parse, unavailable infrastructure, or a resource-limit failure never becomes a
+clean allow.
+
+## Delivery Slices
+
+### Slice 1: #2386 — Root Shape And Cache Safety
+
+Write RED real-stdio tests before production changes. Cover scalar, sequence, empty/null, and a
+deny-shaped root sequence. First and repeat calls must return `allowed:false`, `E_POLICY_PARSE`, and
+`isError:true`.
+
+Controls must pin mapping-without-blocklist, mapping-with-unrelated-keys, `blocklist: []`, and a
+valid deny. A mutation removing typed root validation must make the malformed-root table fail. A
+mutation that caches an empty list before returning the error must make the repeat-call assertion
+fail.
+
+### Slice 2: #2387 — Diagnostic Safety
+
+Inventory every public policy-parse sink and migrate all of them in one PR. Tests send distinct
+sentinels at the beginning, middle, and end of a large malformed value. Assert that none appears in
+the complete MCP response and that the response remains below the named ceiling.
+
+Add tests for safe syntax location, absolute-path exclusion, policy-root exclusion, multibyte UTF-8,
+and all affected tools. Mutations removing the value-free constructor or general ceiling must fail.
+Verdict fields and reason code remain unchanged.
+
+### Slice 3: Bounded Policy Ingest
+
+Create a child issue with the final call-site inventory before implementation. RED tests cover a
+sparse oversized file, an exact-limit file, a limit-plus-one file, and a reader that observes growth
+while reading. Oversized input returns `E_LIMIT_EXCEEDED` and never reaches parsing or cache
+insertion.
+
+Mutation tests must catch a metadata-only size check and a direct `tokio::fs::read` bypass. Valid
+files at or below the limit preserve current behaviour.
+
+## Verification Per Slice
+
+Before each push:
+
+- run the focused RED/GREEN contract test;
+- run the affected `assay-mcp-server` integration and crate tests;
+- run `cargo fmt --all -- --check`;
+- run `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`;
+- run `git diff --check` and inspect public strings; and
+- record exact SHA, worktree, toolchain, tests, mutations, non-claims, and findings in #2388.
+
+GitHub Actions remains the integration proof. Each final PR head requires one non-building-agent
+review under `AGENTS.md`. Agents that authored this design or an implementation slice cannot supply
+that slice's quorum review.
+
+## Issue Disposition
+
+- #2386 and #2387 remain P1 children of #2388 until their merge evidence is recorded.
+- Slice 3 receives a new child issue after its inventory is measured.
+- #2385 remains closed as the correct baseline for malformed present `blocklist` values.
+- #2359 and #2384 form the next adoption and packaging cluster.
+- #2185 remains wire observability and is measured per protocol era when #2358 advances.
+- #2358 requires a separate stateless MCP 2026-07-28 design.
+- #2177 remains a failure-envelope epic delivered one failure family per PR.
+- #2178 is not scheduled without a demonstrated blocked workflow.
+
+## Non-Claims
+
+This programme does not add target-tool enforcement, proxy unification, modern MCP negotiation,
+remote transport, OAuth, marketplace approval, portable MCP packaging, generic retryability,
+provider-outcome verification, compliance, certification, a scalar trust score, or a safe-agent
+claim.
+
+## Primary References
+
+- MCP 2026-07-28 release: <https://blog.modelcontextprotocol.io/posts/2026-07-28/>
+- MCP tools: <https://modelcontextprotocol.io/specification/2026-07-28/server/tools>
+- MCP caching: <https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching>
+- RFC 9457: <https://www.rfc-editor.org/rfc/rfc9457.html>
+- JSON-RPC 2.0: <https://www.jsonrpc.org/specification>


### PR DESCRIPTION
## Summary

- activate #2388 as the public programme ledger in `AGENTS.md`
- record the owner-approved policy-input safety design after independent written-spec review
- split delivery into #2386 root/dialect/cache safety, #2387 diagnostic safety, and existing child #2389 bounded ingest
- track the adjacent generic `tools/call` fallback separately in #2391

## Contract decisions

- `assay_policy_decide` preserves valid exact-name root `blocklist` inputs
- canonical name-policy markers and mixed dialects intentionally change from false allow/partial evaluation to `E_POLICY_PARSE`; Slice 1 requires changelog and migration guidance
- present null remains invalid; unrelated mappings and absent blocklist remain compatible
- policy-parse diagnostics become value-free and serialized `ToolError.message` is bounded at 4,096 UTF-8 bytes
- all five MCP policy readers converge on one `LimitReader`-backed server boundary
- the bytes parser preserves unknown-field handling, strict V1 deprecation, legacy normalization, migration, and validation order
- generic caller-selected `on_error` and raw outer `E_INTERNAL` are explicitly outside this programme and tracked in #2391

## Approval and review disposition

The owner explicitly approved the revised specification on 2026-08-15. Final head: `288ed99a91bc4e3eee0681b1f9ca0e76a263aad7`.

Independent review of prior head `93ca4ae8e44cd1d00e059378def308515d246e1d` was `BLOCKED` and is invalid after later pushes. Its six blockers were addressed before owner approval:

- narrowed fail-closed and message-ceiling claims to the handler/`ToolError` boundaries actually implemented;
- linked existing child #2389 and restored strict V1 deprecation parity;
- disclosed the intentional 5.x behavior change and migration obligation;
- expanded the outward-documentation inventory;
- removed duplicated generic verification prose in favor of `AGENTS.md`;
- added exact checkout, binary, and toolchain provenance without inventing a missing binary digest.

The two CodeRabbit findings (single-line ledger link and measurement provenance) are also addressed. Three prior-head `BLOCKED` reviews found stale issue bindings/process prose, an incorrect RFC attribution, and an unpinned invalid-UTF-8 public classification. Those findings are fixed. A fresh independent review is required on final head `288ed99a91bc4e3eee0681b1f9ca0e76a263aad7`; no earlier review is carried forward.

## Verification on final head

- exact head: `288ed99a91bc4e3eee0681b1f9ca0e76a263aad7`
- worktree: `/Users/roelschuurkes/wt-mcp-policy-input-safety-spec`
- file-scoped pre-commit: pass
- `git diff --check`: pass
- pre-push workspace clippy (`-D warnings`): pass (`rustc 1.96.0`, `cargo 1.96.0`)
- Linux cross-target compile gate: pass (`rustc 1.96.0`, `cargo 1.96.0`)
- required `CI`: pass
- required `host-capability-check`: pass
- required `lane-check/proof`: pass, bound to final head
- independent review quorum: pending final-head verdict

## Non-claims

This PR changes no production behavior and provides no implementation review quorum. It does not implement or change the generic server-level `on_error`/`E_INTERNAL` fallback, target-tool enforcement, proxy unification, MCP 2026-07-28, packaging, compliance, or provider-outcome verification.
