### PR TITLE
docs(mcp): plan policy-input safety slices

### DIFF
--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -1,0 +1,318 @@
+# MCP Policy Bounded Ingest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #2389 by enforcing a configurable inclusive policy-file byte ceiling before any of
+the five advertised MCP tools materialises or parses a local policy.
+
+**Architecture:** Add `max_policy_bytes` to `ServerConfig` and one `ToolContext::read_policy_bounded`
+entry point. The entry point performs secure path resolution, then uses
+`assay_common::limits::LimitReader<std::fs::File>` inside `tokio::task::spawn_blocking`; it maps
+typed limit, not-found, and other I/O errors once. Add a bytes-in `McpPolicy` parser and make both
+`from_file` and `assay_check_args` call it, so full-policy semantics have one implementation.
+
+**Tech Stack:** Rust 1.96, Tokio, `assay_common::limits`, serde YAML, tempfile/sparse files, real
+stdio JSON-RPC tests, pre-commit, GitHub Actions.
+
+## Global Constraints
+
+- Baseline is the `main` SHA containing #2387; record it before creating the branch.
+- Implement in one isolated `codex/2389-policy-bounded-ingest` worktree owned by Codex.
+- Default `max_policy_bytes` is `1_000_000`; only `ASSAY_MCP_MAX_POLICY_BYTES` overrides it.
+- The ceiling is inclusive: exactly limit is accepted; limit plus one is refused.
+- Read through `LimitReader`; file metadata may optimize nothing and is not authoritative.
+- All five advertised policy tools use the same reader entry point.
+- Limit failures occur before parse and cache insertion and publish `E_LIMIT_EXCEEDED`.
+- Keep every tool's existing policy dialect and verdict semantics after successful reading.
+- Exclude proxy startup, declared manifests, trust policy, CLI readers, nesting depth, aliases,
+  remote transport, and target-tool execution.
+- Stage only named paths; never use a whole-tree staging command.
+
+---
+
+## File Structure
+
+- Modify `crates/assay-mcp-server/src/config.rs`: independent policy-byte configuration.
+- Modify `crates/assay-mcp-server/src/tools/mod.rs`: shared async bounded reader and error mapping.
+- Modify five tool files under `crates/assay-mcp-server/src/tools/`: remove unbounded reads.
+- Modify `crates/assay-core/src/mcp/policy/mod.rs` and `policy/legacy.rs`: one bytes-in parser.
+- Modify `crates/assay-core/src/mcp/tests.rs`: file/bytes/string parser parity table.
+- Add `crates/assay-mcp-server/tests/policy_ingest_limits.rs`: real-stdio five-tool boundary table.
+
+### Task 1: Freeze configuration and reader boundaries
+
+**Files:**
+- Modify: `crates/assay-mcp-server/src/config.rs` (tests only first)
+- Modify: `crates/assay-mcp-server/src/tools/mod.rs` (tests only first)
+
+- [ ] **Step 1: Add independent configuration RED tests**
+
+Use one process-scoped mutex and restore every changed variable before releasing it; do not let
+parallel tests observe transient process environment. Pin:
+
+```text
+default max_policy_bytes == 1_000_000
+ASSAY_MCP_MAX_POLICY_BYTES=1234 -> max_policy_bytes == 1234
+ASSAY_MCP_MAX_BYTES=4321 changes max_msg_bytes but not max_policy_bytes
+invalid ASSAY_MCP_MAX_POLICY_BYTES leaves the default
+```
+
+- [ ] **Step 2: Add pure reader RED tests**
+
+Design the blocking primitive so tests can pass any `Read`, then cover:
+
+```text
+exactly limit bytes -> complete Vec
+limit + 1 bytes -> typed LimitExceeded(SourceBytes)
+chunked reader that crosses after multiple reads -> limit error
+reader that returns an ordinary I/O error -> read error
+```
+
+Use `LimitExceeded::from_io` for classification; never match rendered error text.
+
+- [ ] **Step 3: Add file-level RED tests**
+
+Through `ToolContext::read_policy_bounded`, cover missing file, directory read failure, an
+exact-limit regular file, and a sparse limit-plus-one file. Avoid a Unix-mode permission fixture,
+which is not portable and may pass under a privileged runner. The sparse test plus the metadata-only
+mutation in Task 4 must prove the implementation reads through the ceiling rather than trusting or
+allocating from metadata.
+
+- [ ] **Step 4: Run RED**
+
+```bash
+cargo test --locked -p assay-mcp-server config:: -- --nocapture
+cargo test --locked -p assay-mcp-server tools::tests::bounded_policy -- --nocapture
+```
+
+- [ ] **Step 5: Commit only RED tests**
+
+```bash
+git add -- \
+  crates/assay-mcp-server/src/config.rs \
+  crates/assay-mcp-server/src/tools/mod.rs
+git commit -m "test(mcp): expose unbounded policy-file ingest"
+```
+
+### Task 2: Implement configuration and shared bounded reader
+
+**Files:**
+- Modify: `crates/assay-mcp-server/src/config.rs`
+- Modify: `crates/assay-mcp-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Add the single configuration value**
+
+Add `pub max_policy_bytes: usize` to `ServerConfig`, default it to `1_000_000`, and parse only
+`ASSAY_MCP_MAX_POLICY_BYTES` in `from_env`. Log the value alongside existing limits in `main.rs`
+without introducing a second literal.
+
+- [ ] **Step 2: Extract the blocking primitive**
+
+Implement a helper using:
+
+```rust
+let file = std::fs::File::open(path)?;
+let mut reader = assay_common::limits::LimitReader::new(
+    file,
+    limit as u64,
+    assay_common::limits::LimitKind::SourceBytes,
+);
+let mut bytes = Vec::new();
+std::io::Read::read_to_end(&mut reader, &mut bytes)?;
+```
+
+The helper returns bytes or a typed internal read classification. It must not preallocate from
+`metadata().len()`.
+
+- [ ] **Step 3: Add the async context entry point**
+
+`ToolContext::read_policy_bounded(user_path)` first calls the existing secure
+`resolve_policy_path`, then moves the owned path and limit into `tokio::task::spawn_blocking`.
+Centralize mapping:
+
+```text
+NotFound -> E_POLICY_NOT_FOUND with the relative request path only
+LimitExceeded -> E_LIMIT_EXCEEDED with a fixed value-free message
+other I/O or JoinError -> E_POLICY_READ with a fixed value-free message
+```
+
+Do not include canonical roots, OS diagnostics, or policy contents.
+
+- [ ] **Step 4: Run GREEN reader/config tests**
+
+```bash
+cargo test --locked -p assay-mcp-server config:: -- --nocapture
+cargo test --locked -p assay-mcp-server tools::tests::bounded_policy -- --nocapture
+```
+
+- [ ] **Step 5: Commit the shared reader**
+
+```bash
+git add -- \
+  crates/assay-mcp-server/src/config.rs \
+  crates/assay-mcp-server/src/main.rs \
+  crates/assay-mcp-server/src/tools/mod.rs
+git commit -m "feat(mcp): bound shared policy-file reads"
+```
+
+### Task 3: Create one full-policy bytes parser
+
+**Files:**
+- Modify: `crates/assay-core/src/mcp/policy/mod.rs`
+- Modify: `crates/assay-core/src/mcp/policy/legacy.rs`
+- Modify: `crates/assay-core/src/mcp/tests.rs`
+
+- [ ] **Step 1: Add a parser parity RED table**
+
+For each fixture, compare the semantic result of the public bytes/string entry point with a temp
+file loaded through `McpPolicy::from_file`:
+
+```text
+V2 tools/schema policy
+legacy root allow/deny
+V1 constraints and migration
+unknown field (accepted with warning)
+strict-deprecations rejection
+malformed YAML
+non-UTF-8 bytes
+validation failure (for example invalid referenced rule)
+```
+
+Compare normalized serialized policy for successes and stable success/error class for failures;
+do not assert raw parser wording.
+
+- [ ] **Step 2: Move the rule, do not copy it**
+
+Move deserialize-with-`serde_ignored`, unknown-field warning, strict-deprecation check, legacy
+normalization, constraint migration, and validation into one bytes-in function in `legacy.rs`.
+Expose it from `McpPolicy` as `from_slice(&[u8])` (and `from_str` only if a real caller needs it).
+
+- [ ] **Step 3: Make `from_file` delegate**
+
+`from_file` performs only the file read and `McpPolicy::from_slice(&bytes)`. It must not retain a
+second deserialize/normalize/validate sequence.
+
+- [ ] **Step 4: Run core GREEN**
+
+```bash
+cargo test --locked -p assay-core mcp::tests -- --nocapture
+```
+
+- [ ] **Step 5: Commit parser extraction**
+
+```bash
+git add -- \
+  crates/assay-core/src/mcp/policy/mod.rs \
+  crates/assay-core/src/mcp/policy/legacy.rs \
+  crates/assay-core/src/mcp/tests.rs
+git commit -m "refactor(mcp): share full-policy bytes parser"
+```
+
+### Task 4: Route all five tools through the bound
+
+**Files:**
+- Modify: `crates/assay-mcp-server/src/tools/policy_decide.rs`
+- Modify: `crates/assay-mcp-server/src/tools/check_sequence.rs`
+- Modify: `crates/assay-mcp-server/src/tools/check_coverage.rs`
+- Modify: `crates/assay-mcp-server/src/tools/explain_trace.rs`
+- Modify: `crates/assay-mcp-server/src/tools/check_args.rs`
+- Add: `crates/assay-mcp-server/tests/policy_ingest_limits.rs`
+
+- [ ] **Step 1: Add a real-stdio RED matrix**
+
+Start the server with `ASSAY_MCP_MAX_POLICY_BYTES=<small fixture limit>`. For each advertised tool,
+call a limit-plus-one policy and assert `result.isError:true`, `allowed:false`, and
+`E_LIMIT_EXCEEDED`. Call an exactly-limit valid policy in that tool's own dialect and assert it
+reaches the normal non-limit result. Pad valid YAML with comments to the exact byte boundary; do not
+pretend one unpadded fixture can have identical valid semantics in all five dialects.
+
+- [ ] **Step 2: Pin cache-bearing repeat behavior**
+
+For `assay_policy_decide` and `assay_check_sequence`, call the oversized input twice and assert both
+remain limit failures. Capture stderr or expose test-only cache counters only if needed; prefer the
+observable repeat contract over adding production introspection.
+
+- [ ] **Step 3: Replace every direct read**
+
+Replace the four `tokio::fs::read` blocks with `ctx.read_policy_bounded(policy_rel_path).await`.
+Keep hashing, parsing, cache lookup/insertion, and evaluation after successful bytes exactly where
+they are.
+
+- [ ] **Step 4: Remove `check_args`' file bypass**
+
+Have `check_args` call the same context reader and pass returned bytes to `McpPolicy::from_slice`.
+It must not call `McpPolicy::from_file` or open the path itself.
+
+- [ ] **Step 5: Run GREEN**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
+cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
+cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
+```
+
+- [ ] **Step 6: Run discriminating mutations**
+
+In disposable copies, separately replace one callsite at a time with `tokio::fs::read`; make
+`check_args` call `from_file`; make `from_file` deserialize independently; replace the reader with a
+metadata-only check; and change the inclusive boundary to reject exactly-limit. Each mutation must
+fail a named matrix/parity/boundary assertion.
+
+- [ ] **Step 7: Commit all five migrations**
+
+```bash
+git add -- \
+  crates/assay-mcp-server/src/tools/policy_decide.rs \
+  crates/assay-mcp-server/src/tools/check_sequence.rs \
+  crates/assay-mcp-server/src/tools/check_coverage.rs \
+  crates/assay-mcp-server/src/tools/explain_trace.rs \
+  crates/assay-mcp-server/src/tools/check_args.rs \
+  crates/assay-mcp-server/tests/policy_ingest_limits.rs
+git commit -m "fix(mcp): route policy tools through bounded ingest"
+```
+
+### Task 5: Verify and publish #2389
+
+- [ ] **Step 1: Prove no server-tool bypass remains**
+
+```bash
+rg -n 'tokio::fs::read|std::fs::read(_to_string)?|McpPolicy::from_file' \
+  crates/assay-mcp-server/src/tools
+```
+
+Expected: no policy-reader bypass in the five tool modules. Test fixtures may still write files.
+
+- [ ] **Step 2: Run affected suites and static checks**
+
+```bash
+cargo test --locked -p assay-core mcp::tests -- --nocapture
+cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
+cargo test --locked -p assay-mcp-server
+cargo fmt --all -- --check
+cargo clippy -p assay-core -p assay-mcp-server --all-targets -- -D warnings
+git diff --check
+git status --short
+```
+
+- [ ] **Step 3: Inspect scope and non-claims**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Confirm proxy startup, manifest/trust readers, CLI readers, parse depth/aliases, remote transport,
+and verdict dialects are untouched.
+
+- [ ] **Step 4: Push, open the PR, and record #2388**
+
+Push `codex/2389-policy-bounded-ingest`, open against current `main`, and record branch, PR, exact
+head, tests, mutation evidence, non-claims, and findings in the programme ledger.
+
+- [ ] **Step 5: Obtain exact-head quorum**
+
+Use one fresh non-building reviewer who authored neither the governing spec/plan nor the code. Any
+push invalidates the review. Merge only after required checks, exact-head review, and exact-head
+delegated proof when triggered.

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -219,6 +219,9 @@ git commit -m "refactor(mcp): share full-policy bytes parser"
 - Modify: `crates/assay-mcp-server/src/tools/explain_trace.rs`
 - Modify: `crates/assay-mcp-server/src/tools/check_args.rs`
 - Add: `crates/assay-mcp-server/tests/policy_ingest_limits.rs`
+- Add: `scripts/ci/check-mcp-policy-parser-delegation.py`
+- Add: `scripts/ci/test-check-mcp-policy-parser-delegation.sh`
+- Modify: `.pre-commit-config.yaml`
 
 - [ ] **Step 1: Add a real-stdio RED matrix**
 
@@ -227,6 +230,10 @@ call a limit-plus-one policy and assert `result.isError:true`, `allowed:false`, 
 `E_LIMIT_EXCEEDED`. Call an exactly-limit valid policy in that tool's own dialect and assert it
 reaches the normal non-limit result. Pad valid YAML with comments to the exact byte boundary; do not
 pretend one unpadded fixture can have identical valid semantics in all five dialects.
+
+Add a separate invalid-UTF-8 file for `assay_check_args`. Assert the complete real-stdio response
+has `result.isError:true`, `allowed:false`, `E_POLICY_PARSE`, and exactly
+`Policy YAML is invalid`. This is a parse-classification contract, not a size-limit case.
 
 - [ ] **Step 2: Pin cache-bearing repeat behavior**
 
@@ -255,10 +262,16 @@ cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
 
 - [ ] **Step 6: Run discriminating mutations**
 
-In disposable copies, separately replace one callsite at a time with `tokio::fs::read`; make
-`check_args` call `from_file`; make `from_file` deserialize independently; replace the reader with a
-metadata-only check; and change the inclusive boundary to reject exactly-limit. Each mutation must
-fail a named matrix/parity/boundary assertion.
+Add a structural delegation guard that identifies the `from_file` function body and requires it to
+call the single bytes parser while rejecting deserialize/parser construction inside that body. Its
+self-test must mutate a disposable source fixture so a faithful duplicated deserializer fails even
+when semantic parity would remain green.
+
+In disposable copies, separately replace one tool callsite with `tokio::fs::read`; make
+`check_args` call `from_file`; map invalid UTF-8 to `E_POLICY_READ` or `E_INTERNAL`; duplicate
+deserialization inside `from_file`; replace the reader with a metadata-only check; and change the
+inclusive boundary to reject exactly-limit. Each mutation must fail a named
+matrix/classification/structural/boundary assertion.
 
 - [ ] **Step 7: Commit all five migrations**
 
@@ -269,7 +282,10 @@ git add -- \
   crates/assay-mcp-server/src/tools/check_coverage.rs \
   crates/assay-mcp-server/src/tools/explain_trace.rs \
   crates/assay-mcp-server/src/tools/check_args.rs \
-  crates/assay-mcp-server/tests/policy_ingest_limits.rs
+  crates/assay-mcp-server/tests/policy_ingest_limits.rs \
+  scripts/ci/check-mcp-policy-parser-delegation.py \
+  scripts/ci/test-check-mcp-policy-parser-delegation.sh \
+  .pre-commit-config.yaml
 git commit -m "fix(mcp): route policy tools through bounded ingest"
 ```
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -35,80 +35,66 @@ stdio JSON-RPC tests, pre-commit, GitHub Actions.
 ## File Structure
 
 - Modify `crates/assay-mcp-server/src/config.rs`: independent policy-byte configuration.
+- Modify `crates/assay-mcp-server/src/main.rs`: log the configured policy ceiling from `ServerConfig`.
 - Modify `crates/assay-mcp-server/src/tools/mod.rs`: shared async bounded reader and error mapping.
 - Modify five tool files under `crates/assay-mcp-server/src/tools/`: remove unbounded reads.
 - Modify `crates/assay-core/src/mcp/policy/mod.rs` and `policy/legacy.rs`: one bytes-in parser.
-- Modify `crates/assay-core/src/mcp/tests.rs`: file/bytes/string parser parity table.
+- Modify `crates/assay-core/src/mcp/tests.rs`: file/bytes/string parser contract table.
 - Add `crates/assay-mcp-server/tests/policy_ingest_limits.rs`: real-stdio five-tool boundary table.
+- Add `scripts/ci/check-mcp-policy-reader-routing.py` and its self-test: pin `LimitReader` and all five callsites.
+- Add `scripts/ci/check-mcp-policy-parser-delegation.py` and its self-test: pin both full-policy delegation hops.
+- Modify `.pre-commit-config.yaml`: wire both routing guards to all guarded source paths.
+- Modify `CHANGELOG.md` and the MCP server/operator reference: document the default ceiling and override.
 
-### Task 1: Freeze configuration and reader boundaries
+### Task 1: Establish the behavioral RED
 
 **Files:**
-- Modify: `crates/assay-mcp-server/src/config.rs` (tests only first)
-- Modify: `crates/assay-mcp-server/src/tools/mod.rs` (tests only first)
+- Add: `crates/assay-mcp-server/tests/policy_ingest_limits.rs` (black-box RED first)
 
-- [ ] **Step 1: Add independent configuration RED tests**
+- [ ] **Step 1: Add and run one compilable black-box RED**
 
-Use one process-scoped mutex and restore every changed variable before releasing it; do not let
-parallel tests observe transient process environment. Pin:
-
-```text
-default max_policy_bytes == 1_000_000
-ASSAY_MCP_MAX_POLICY_BYTES=1234 -> max_policy_bytes == 1234
-ASSAY_MCP_MAX_BYTES=4321 changes max_msg_bytes but not max_policy_bytes
-invalid ASSAY_MCP_MAX_POLICY_BYTES leaves the default
-```
-
-- [ ] **Step 2: Add pure reader RED tests**
-
-Design the blocking primitive so tests can pass any `Read`, then cover:
-
-```text
-exactly limit bytes -> complete Vec
-limit + 1 bytes -> typed LimitExceeded(SourceBytes)
-chunked reader that crosses after multiple reads -> limit error
-reader that returns an ordinary I/O error -> read error
-```
-
-Use `LimitExceeded::from_io` for classification; never match rendered error text.
-
-- [ ] **Step 3: Add file-level RED tests**
-
-Through `ToolContext::read_policy_bounded`, cover missing file, directory read failure, an
-exact-limit regular file, and a sparse limit-plus-one file. Avoid a Unix-mode permission fixture,
-which is not portable and may pass under a privileged runner. The sparse test plus the metadata-only
-mutation in Task 4 must prove the implementation reads through the ceiling rather than trusting or
-allocating from metadata.
-
-- [ ] **Step 4: Run RED**
+Using only the existing public binary surface, start the server with a small
+`ASSAY_MCP_MAX_POLICY_BYTES`. Call every advertised tool with a limit-plus-one policy and expect
+`E_LIMIT_EXCEEDED`; the current server ignores that variable and the assertions must fail while the
+test compiles and runs. In the same test, pin the already-shipped #2387 invalid-UTF-8
+`assay_check_args` response as a GREEN regression control. Run and record the assertion failures:
 
 ```bash
-cargo test --locked -p assay-mcp-server config:: -- --nocapture
-cargo test --locked -p assay-mcp-server tools::tests::bounded_policy -- --nocapture
-```
-
-- [ ] **Step 5: Commit only RED tests**
-
-```bash
-git add -- \
-  crates/assay-mcp-server/src/config.rs \
-  crates/assay-mcp-server/src/tools/mod.rs
+cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
+git add -- crates/assay-mcp-server/tests/policy_ingest_limits.rs
 git commit -m "test(mcp): expose unbounded policy-file ingest"
 ```
+
+This is the behavioral RED required before any production interface or reader change. Later unit
+cycles may initially fail to compile against an absent private seam, but those failures are not
+reported as the RED proof.
 
 ### Task 2: Implement configuration and shared bounded reader
 
 **Files:**
 - Modify: `crates/assay-mcp-server/src/config.rs`
+- Modify: `crates/assay-mcp-server/src/main.rs`
 - Modify: `crates/assay-mcp-server/src/tools/mod.rs`
+- Add: `scripts/ci/check-mcp-policy-reader-routing.py`
+- Add: `scripts/ci/test-check-mcp-policy-reader-routing.sh`
+- Modify: `.pre-commit-config.yaml`
 
-- [ ] **Step 1: Add the single configuration value**
+- [ ] **Step 1: Test, then add, the single configuration value**
+
+Add configuration tests immediately before the field change. Use one process-scoped mutex and
+restore every changed variable before releasing it. Pin the `1_000_000` default, the independent
+`ASSAY_MCP_MAX_POLICY_BYTES=1234` override, non-interference from `ASSAY_MCP_MAX_BYTES=4321`, and
+invalid override fallback. Then add the field and make those tests pass.
 
 Add `pub max_policy_bytes: usize` to `ServerConfig`, default it to `1_000_000`, and parse only
 `ASSAY_MCP_MAX_POLICY_BYTES` in `from_env`. Log the value alongside existing limits in `main.rs`
 without introducing a second literal.
 
-- [ ] **Step 2: Extract the blocking primitive**
+- [ ] **Step 2: Test, then extract, the blocking primitive**
+
+Before implementing the private primitive, add focused tests for exactly-limit, limit-plus-one,
+chunked crossing, and ordinary I/O failure using an arbitrary `Read`. Classify through
+`LimitExceeded::from_io`; never match rendered text. Then implement the smallest passing helper:
 
 Implement a helper using:
 
@@ -126,7 +112,10 @@ std::io::Read::read_to_end(&mut reader, &mut bytes)?;
 The helper returns bytes or a typed internal read classification. It must not preallocate from
 `metadata().len()`.
 
-- [ ] **Step 3: Add the async context entry point**
+- [ ] **Step 3: Test, then add, the async context entry point**
+
+Before adding the context method, test missing file, directory read failure, exact-limit regular
+file, and sparse limit-plus-one file. Avoid Unix-mode permission fixtures. Then implement:
 
 `ToolContext::read_policy_bounded(user_path)` first calls the existing secure
 `resolve_policy_path`, then moves the owned path and limit into `tokio::task::spawn_blocking`.
@@ -140,20 +129,34 @@ other I/O or JoinError -> E_POLICY_READ with a fixed value-free message
 
 Do not include canonical roots, OS diagnostics, or policy contents.
 
-- [ ] **Step 4: Run GREEN reader/config tests**
+- [ ] **Step 4: Add and self-test the reader-routing guard**
+
+Require the blocking primitive to construct `LimitReader` and forbid `metadata()`-based acceptance
+or direct `File::read_to_end` outside that wrapper. Require `ToolContext::read_policy_bounded` to
+call the primitive. Disposable fixtures must fail for a faithful metadata-size check followed by an
+unbounded read, and for a context method that bypasses the primitive. Wire the guard to pre-commit
+for `config.rs`, `main.rs`, `tools/mod.rs`, all five tool modules, the guard, and its self-test. This
+structural proof, not sparse-file metadata alone, discriminates the metadata-only mutation.
+
+- [ ] **Step 5: Run GREEN reader/config tests and guard**
 
 ```bash
 cargo test --locked -p assay-mcp-server config:: -- --nocapture
 cargo test --locked -p assay-mcp-server tools::tests::bounded_policy -- --nocapture
+python3 scripts/ci/check-mcp-policy-reader-routing.py
+bash scripts/ci/test-check-mcp-policy-reader-routing.sh
 ```
 
-- [ ] **Step 5: Commit the shared reader**
+- [ ] **Step 6: Commit the shared reader**
 
 ```bash
 git add -- \
   crates/assay-mcp-server/src/config.rs \
   crates/assay-mcp-server/src/main.rs \
-  crates/assay-mcp-server/src/tools/mod.rs
+  crates/assay-mcp-server/src/tools/mod.rs \
+  scripts/ci/check-mcp-policy-reader-routing.py \
+  scripts/ci/test-check-mcp-policy-reader-routing.sh \
+  .pre-commit-config.yaml
 git commit -m "feat(mcp): bound shared policy-file reads"
 ```
 
@@ -167,54 +170,78 @@ git commit -m "feat(mcp): bound shared policy-file reads"
 - Add: `scripts/ci/test-check-mcp-policy-parser-delegation.sh`
 - Modify: `.pre-commit-config.yaml`
 
-- [ ] **Step 1: Add a parser parity RED table**
+- [ ] **Step 1: Freeze current file-parser behavior before extraction**
 
-For each fixture, first pin an independent expected outcome, then compare the public bytes/string
-entry point with a temp file loaded through `McpPolicy::from_file`:
+For each fixture, pin an independent expected outcome through the existing
+`McpPolicy::from_file` API:
 
 ```text
 V2 tools/schema policy
 legacy root allow/deny
 V1 constraints and migration
 unknown field (accepted with warning)
+non-strict V1 input (accepted with the existing deprecation warning)
 strict-deprecations rejection
 malformed YAML
-non-UTF-8 bytes
 validation failure (for example invalid referenced rule)
 ```
 
 Expected outcomes must name the normalized allow/deny/schema result for V2 and legacy fixtures,
 the migrated schema produced from V1 constraints, the unknown-field warning captured with a test
-tracing subscriber, strict-mode rejection, syntax/UTF-8/validation failure kind, and whether
-validation ran. Then compare entry points. Do not assert raw parser wording; parity is additional
-evidence, not the oracle.
-
-- [ ] **Step 2: Run parser RED and commit tests only**
+tracing subscriber, the separate non-strict V1 deprecation warning, strict-mode rejection,
+syntax/validation failure kind, and whether validation ran. Run this table GREEN and commit it as a
+behavior freeze; it is not RED evidence.
 
 ```bash
-cargo test --locked -p assay-core mcp::tests::policy_from_slice_contract -- --nocapture
+cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
+git add -- crates/assay-core/src/mcp/tests.rs
+git commit -m "test(mcp): freeze full-policy file parser behavior"
 ```
 
-Expected: compile failure because `McpPolicy::from_slice` does not exist. Record the failure, stage
-only `crates/assay-core/src/mcp/tests.rs`, and commit the RED test before parser production changes.
+- [ ] **Step 2: Add an interface-only stub, then run a behavioral RED**
+
+Add `McpPolicy::from_slice(&[u8])` and required `McpPolicy::from_str(&str)` methods that return one
+explicit temporary unsupported error without parsing. This is an interface seam, not a second
+parser. Then extend the fixture table to call file, bytes, and string entry points, plus non-UTF-8
+bytes for `from_slice`, and assert each independent expected outcome before asserting parity.
+
+```bash
+cargo test --locked -p assay-core mcp::tests::policy_parser_contract -- --nocapture
+```
+
+Expected: the test compiles and fails assertions because the bytes/string stub returns unsupported.
+Record that behavioral failure and commit the interface-only stub plus test before moving parser
+behavior:
+
+```bash
+git add -- \
+  crates/assay-core/src/mcp/policy/mod.rs \
+  crates/assay-core/src/mcp/policy/legacy.rs \
+  crates/assay-core/src/mcp/tests.rs
+git commit -m "test(mcp): expose missing full-policy bytes parser"
+```
 
 - [ ] **Step 3: Move the rule, do not copy it**
 
-Move deserialize-with-`serde_ignored`, unknown-field warning, strict-deprecation check, legacy
-normalization, constraint migration, and validation into one bytes-in function in `legacy.rs`.
-Expose it from `McpPolicy` as `from_slice(&[u8])` (and `from_str` only if a real caller needs it).
+Move UTF-8 decode, deserialize-with-`serde_ignored`, unknown-field warning, non-strict V1
+deprecation warning, strict-deprecation check, legacy normalization, constraint migration, and
+validation into one bytes-in function in `legacy.rs`. Make both public bytes/string methods call
+that one function; `from_str` must not duplicate its stages.
 
 - [ ] **Step 4: Make `from_file` delegate**
 
-`from_file` performs only the file read and `McpPolicy::from_slice(&bytes)`. It must not retain a
-second deserialize/normalize/validate sequence.
+The public `McpPolicy::from_file` in `policy/mod.rs` delegates only to `legacy::from_file`.
+`legacy::from_file` performs only the file read and `McpPolicy::from_slice(&bytes)`. Neither function
+may retain a deserialize/normalize/validate sequence.
 
 - [ ] **Step 5: Add and self-test the structural delegation guard**
 
-Add a source guard that identifies the `from_file` function body, requires its call to
-`McpPolicy::from_slice`, and rejects deserialize/parser construction in that body. The self-test
-uses disposable source fixtures and must fail when a faithful duplicate deserializer is inserted.
-Wire the guard into pre-commit for changes to `legacy.rs` or the guard itself.
+Add a source guard that identifies both exact delegation hops: the public `McpPolicy::from_file`
+body in `policy/mod.rs` must call `legacy::from_file`, and `legacy::from_file` must call
+`McpPolicy::from_slice`. Reject parser/deserializer construction in either body. The self-test uses
+disposable source fixtures and must fail when a faithful duplicate deserializer is inserted at
+either hop. Wire the guard into pre-commit for changes to `policy/mod.rs`, `legacy.rs`, the guard,
+or its self-test.
 
 - [ ] **Step 6: Run core GREEN and the structural guard**
 
@@ -226,9 +253,10 @@ bash scripts/ci/test-check-mcp-policy-parser-delegation.sh
 
 - [ ] **Step 7: Run semantic mutations and commit parser extraction**
 
-In disposable copies, separately skip strict-deprecation detection, legacy normalization,
-constraint migration, unknown-field reporting, and validation. Each must fail its own expected-
-outcome assertion even though `from_file` and `from_slice` still agree.
+In disposable copies, separately skip the non-strict V1 deprecation warning, strict-deprecation
+detection, legacy normalization, constraint migration, unknown-field reporting, and validation.
+Each must fail its own expected-outcome assertion even though file, bytes, and string entry points
+still agree.
 
 ```bash
 git add -- \
@@ -249,64 +277,61 @@ git commit -m "refactor(mcp): share full-policy bytes parser"
 - Modify: `crates/assay-mcp-server/src/tools/check_coverage.rs`
 - Modify: `crates/assay-mcp-server/src/tools/explain_trace.rs`
 - Modify: `crates/assay-mcp-server/src/tools/check_args.rs`
-- Add: `crates/assay-mcp-server/tests/policy_ingest_limits.rs`
+- Modify: `crates/assay-mcp-server/tests/policy_ingest_limits.rs`
 
-- [ ] **Step 1: Add a real-stdio RED matrix**
+- [ ] **Step 1: Complete the already-RED real-stdio matrix**
 
-Start the server with `ASSAY_MCP_MAX_POLICY_BYTES=<small fixture limit>`. For each advertised tool,
-call a limit-plus-one policy and assert `result.isError:true`, `allowed:false`, and
-`E_LIMIT_EXCEEDED`. Call an exactly-limit valid policy in that tool's own dialect and assert it
-reaches the normal non-limit result. Pad valid YAML with comments to the exact byte boundary; do not
-pretend one unpadded fixture can have identical valid semantics in all five dialects.
+The Task 1 test already proves limit-plus-one fails behaviorally on the unmodified server. Extend it
+with an exactly-limit valid policy in each tool's own dialect and assert it reaches the normal
+non-limit result. Pad valid YAML with comments to the exact byte boundary; do not pretend one
+unpadded fixture can have identical valid semantics in all five dialects. For
+`assay_policy_decide` and `assay_check_sequence`, call oversized input twice and assert both remain
+limit failures.
 
-Add a separate invalid-UTF-8 file for `assay_check_args`. Assert the complete real-stdio response
-has `result.isError:true`, `allowed:false`, `E_POLICY_PARSE`, and exactly
-`Policy YAML is invalid`. This is a parse-classification contract, not a size-limit case.
+Retain the invalid-UTF-8 `assay_check_args` regression control from Task 1. It must remain GREEN with
+`result.isError:true`, `allowed:false`, `E_POLICY_PARSE`, and exactly `Policy YAML is invalid`; it is
+not claimed as a new RED in this slice.
 
-- [ ] **Step 2: Run stdio RED and commit tests only**
+- [ ] **Step 2: Re-run the behavioral RED and commit the completed matrix**
 
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
 ```
 
-Expected: limit-plus-one calls reach parsing instead of `E_LIMIT_EXCEEDED`, and the invalid-UTF-8
-case does not yet publish the stable summary. Record both failures and commit only
-`policy_ingest_limits.rs` before migrating tool reads.
+Expected: limit-plus-one assertions still fail because no tool is routed through the reader;
+exact-limit and invalid-UTF-8 controls stay green. Record the discriminating failures and commit
+only `policy_ingest_limits.rs` before migrating tool reads.
 
-- [ ] **Step 3: Pin cache-bearing repeat behavior**
-
-For `assay_policy_decide` and `assay_check_sequence`, call the oversized input twice and assert both
-remain limit failures. Capture stderr or expose test-only cache counters only if needed; prefer the
-observable repeat contract over adding production introspection.
-
-- [ ] **Step 4: Replace every direct read**
+- [ ] **Step 3: Replace every direct read**
 
 Replace the four `tokio::fs::read` blocks with `ctx.read_policy_bounded(policy_rel_path).await`.
 Keep hashing, parsing, cache lookup/insertion, and evaluation after successful bytes exactly where
 they are.
 
-- [ ] **Step 5: Remove `check_args`' file bypass**
+- [ ] **Step 4: Remove `check_args`' file bypass**
 
 Have `check_args` call the same context reader and pass returned bytes to `McpPolicy::from_slice`.
 It must not call `McpPolicy::from_file` or open the path itself.
 
-- [ ] **Step 6: Run GREEN**
+- [ ] **Step 5: Run GREEN, including the routing guard**
 
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
 cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
 cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
+python3 scripts/ci/check-mcp-policy-reader-routing.py
+bash scripts/ci/test-check-mcp-policy-reader-routing.sh
 ```
 
-- [ ] **Step 7: Run discriminating mutations**
+- [ ] **Step 6: Run discriminating mutations**
 
 In disposable copies, separately replace one tool callsite with `tokio::fs::read`; make
 `check_args` call `from_file`; map invalid UTF-8 to `E_POLICY_READ` or `E_INTERNAL`; replace the
-reader with a metadata-only check; and change the inclusive boundary to reject exactly-limit. Each
-mutation must fail a named
-matrix/classification/structural/boundary assertion.
+reader with a metadata-only check; and change the inclusive boundary to reject exactly-limit. The
+metadata-only mutation must fail the structural reader guard even when file metadata matches the
+fixture size. Each mutation must fail a named matrix/classification/structural/boundary assertion.
 
-- [ ] **Step 8: Commit all five migrations**
+- [ ] **Step 7: Commit all five migrations**
 
 ```bash
 git add -- \
@@ -319,7 +344,29 @@ git add -- \
 git commit -m "fix(mcp): route policy tools through bounded ingest"
 ```
 
-### Task 5: Verify and publish #2389
+### Task 5: Document the operator-visible ceiling
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/reference/cli/mcp-server.md`
+
+- [ ] **Step 1: Record behavior and migration**
+
+Document the inclusive `1_000_000`-byte default, `ASSAY_MCP_MAX_POLICY_BYTES`, the fixed
+`E_LIMIT_EXCEEDED` result, and that operators with previously accepted larger local policy files
+must either reduce the file or set an explicit bounded override. State that the limit applies before
+parse/cache and is independent from the JSON-RPC message ceiling. Do not claim nesting-depth or
+remote-input protection.
+
+- [ ] **Step 2: Verify docs and commit**
+
+```bash
+pre-commit run --files CHANGELOG.md docs/reference/cli/mcp-server.md
+git add -- CHANGELOG.md docs/reference/cli/mcp-server.md
+git commit -m "docs(mcp): document policy ingest ceiling"
+```
+
+### Task 6: Verify and publish #2389
 
 - [ ] **Step 1: Prove no server-tool bypass remains**
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -57,8 +57,9 @@ stdio JSON-RPC tests, pre-commit, GitHub Actions.
 
 Using only the existing public binary surface, start the server with a small
 `ASSAY_MCP_MAX_POLICY_BYTES`. Call every advertised tool with a limit-plus-one policy and expect
-`E_LIMIT_EXCEEDED`; the current server ignores that variable and the assertions must fail while the
-test compiles and runs. In the same test, pin the already-shipped #2387 invalid-UTF-8
+MCP `result.isError:true`, body `allowed:false`, and `E_LIMIT_EXCEEDED`; the current server ignores
+that variable and the assertions must fail while the test compiles and runs. In the same test, pin
+the already-shipped #2387 invalid-UTF-8
 `assay_check_args` response as a GREEN regression control. Run and record the assertion failures:
 
 ```bash
@@ -300,7 +301,9 @@ with an exactly-limit valid policy in each tool's own dialect and assert it reac
 non-limit result. Pad valid YAML with comments to the exact byte boundary; do not pretend one
 unpadded fixture can have identical valid semantics in all five dialects. For
 `assay_policy_decide` and `assay_check_sequence`, call oversized input twice and assert both remain
-limit failures.
+limit failures. Keep the complete per-tool oversized envelope assertions from Task 1:
+`result.isError:true`, body `allowed:false`, and `error.code == E_LIMIT_EXCEEDED`; no aggregate-only
+assertion may replace the five individual triples.
 
 Retain the invalid-UTF-8 `assay_check_args` regression control from Task 1. It must remain GREEN with
 `result.isError:true`, `allowed:false`, `E_POLICY_PARSE`, and exactly `Policy YAML is invalid`; it is

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -313,11 +313,13 @@ not claimed as a new RED in this slice.
 
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
+git add -- crates/assay-mcp-server/tests/policy_ingest_limits.rs
+git commit -m "test(mcp): pin five-tool policy ingest limits"
 ```
 
 Expected: limit-plus-one assertions still fail because no tool is routed through the reader;
 exact-limit and invalid-UTF-8 controls stay green. Record the discriminating failures and commit
-only `policy_ingest_limits.rs` before migrating tool reads.
+only `policy_ingest_limits.rs` with the exact pathspec above before migrating tool reads.
 
 - [ ] **Step 3: Replace every direct read**
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -41,10 +41,10 @@ stdio JSON-RPC tests, pre-commit, GitHub Actions.
 - Modify five tool files under `crates/assay-mcp-server/src/tools/`: remove unbounded reads.
 - Modify `crates/assay-core/src/mcp/policy/mod.rs` and `policy/legacy.rs`: one bytes-in parser.
 - Modify `crates/assay-core/src/mcp/tests.rs`: file/bytes/string parser contract table.
-- Add `crates/assay-core/tests/mcp_policy_warning_contract.rs`: subprocess warning contract.
+- Verify `crates/assay-core/tests/mcp_policy_warning_contract.rs`: inherited subprocess warning contract.
 - Add `crates/assay-mcp-server/tests/policy_ingest_limits.rs`: real-stdio five-tool boundary table.
 - Add `scripts/ci/check-mcp-policy-reader-routing.py` and its self-test: pin `LimitReader` and all five callsites.
-- Add `scripts/ci/check-mcp-policy-parser-delegation.py` and its self-test: pin both full-policy delegation hops.
+- Add `scripts/ci/check-mcp-policy-parser-delegation.py` and its self-test: pin all four full-policy delegation hops.
 - Modify `.pre-commit-config.yaml`: wire both routing guards to all guarded source paths.
 - Modify `CHANGELOG.md` and the MCP server/operator reference: document the default ceiling and override.
 
@@ -171,7 +171,7 @@ git commit -m "feat(mcp): bound shared policy-file reads"
 - Modify: `crates/assay-core/src/mcp/policy/mod.rs`
 - Modify: `crates/assay-core/src/mcp/policy/legacy.rs`
 - Modify: `crates/assay-core/src/mcp/tests.rs`
-- Add: `crates/assay-core/tests/mcp_policy_warning_contract.rs`
+- Verify: `crates/assay-core/tests/mcp_policy_warning_contract.rs` (landed by #2387)
 - Add: `scripts/ci/check-mcp-policy-parser-delegation.py`
 - Add: `scripts/ci/test-check-mcp-policy-parser-delegation.sh`
 - Modify: `.pre-commit-config.yaml`
@@ -198,19 +198,14 @@ tracing subscriber, the separate non-strict V1 deprecation warning, strict-mode 
 syntax/validation failure kind, and whether validation ran. Run this table GREEN and commit it as a
 behavior freeze; it is not RED evidence.
 
-Test the process-global deprecation warning in the dedicated integration-test binary. Its parent
-test spawns `current_exe()` with an ignored exact child test and deterministic no-timestamp tracing;
-the child parses one V1 fixture with an unknown field twice. Capture stderr and assert the unknown-
-field warning precedes the deprecation warning, the deprecation text occurs exactly once, and the
-child exits successfully. A separate child process resets `OnceLock`; never reset or mutate it in
-process. Removing or reordering `emit_deprecation_warning` must fail this subprocess contract.
+Re-run the inherited #2387 subprocess warning contract before extraction; do not recreate or weaken
+its `OnceLock`, ordering, or once-per-process assertions in this slice.
 
 ```bash
 cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
 cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
 git add -- \
-  crates/assay-core/src/mcp/tests.rs \
-  crates/assay-core/tests/mcp_policy_warning_contract.rs
+  crates/assay-core/src/mcp/tests.rs
 git commit -m "test(mcp): freeze full-policy file parser behavior"
 ```
 
@@ -241,8 +236,8 @@ git commit -m "test(mcp): expose missing full-policy bytes parser"
 
 Move UTF-8 decode, deserialize-with-`serde_ignored`, unknown-field warning, non-strict V1
 deprecation warning, strict-deprecation check, legacy normalization, constraint migration, and
-validation into one bytes-in function in `legacy.rs`. Make both public bytes/string methods call
-that one function; `from_str` must not duplicate its stages.
+validation into one bytes-in function in `legacy.rs`. Public `McpPolicy::from_slice` must delegate
+to that legacy function; public `from_str` must delegate to public `from_slice`.
 
 - [ ] **Step 4: Make `from_file` delegate**
 
@@ -252,10 +247,11 @@ may retain a deserialize/normalize/validate sequence.
 
 - [ ] **Step 5: Add and self-test the structural delegation guard**
 
-Add a source guard that identifies all three exact delegation hops: the public `McpPolicy::from_file`
+Add a source guard that identifies all four exact delegation hops: the public `McpPolicy::from_file`
 body in `policy/mod.rs` must call `legacy::from_file`, and `legacy::from_file` must call
-`McpPolicy::from_slice`; public `McpPolicy::from_str` must call `McpPolicy::from_slice` and perform no
-parser/deserializer construction. Reject parser/deserializer construction in all three bodies. The self-test uses
+`McpPolicy::from_slice`; public `McpPolicy::from_slice` must call the single legacy bytes function;
+public `McpPolicy::from_str` must call `McpPolicy::from_slice`. Reject parser/deserializer
+construction in all four bodies. The self-test uses
 disposable source fixtures and must fail when a faithful duplicate deserializer is inserted at
 any hop. Wire the guard into pre-commit for changes to `policy/mod.rs`, `legacy.rs`, the guard,
 or its self-test.
@@ -264,6 +260,7 @@ or its self-test.
 
 ```bash
 cargo test --locked -p assay-core mcp::tests -- --nocapture
+cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
 python3 scripts/ci/check-mcp-policy-parser-delegation.py
 bash scripts/ci/test-check-mcp-policy-parser-delegation.sh
 ```
@@ -280,7 +277,6 @@ git add -- \
   crates/assay-core/src/mcp/policy/mod.rs \
   crates/assay-core/src/mcp/policy/legacy.rs \
   crates/assay-core/src/mcp/tests.rs \
-  crates/assay-core/tests/mcp_policy_warning_contract.rs \
   scripts/ci/check-mcp-policy-parser-delegation.py \
   scripts/ci/test-check-mcp-policy-parser-delegation.sh \
   .pre-commit-config.yaml
@@ -399,6 +395,7 @@ Expected: no policy-reader bypass in the five tool modules. Test fixtures may st
 
 ```bash
 cargo test --locked -p assay-core mcp::tests -- --nocapture
+cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
 cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
 cargo test --locked -p assay-mcp-server
 cargo fmt --all -- --check

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -8,10 +8,11 @@
 the five advertised MCP tools materialises or parses a local policy.
 
 **Architecture:** Add `max_policy_bytes` to `ServerConfig` and one `ToolContext::read_policy_bounded`
-entry point. The entry point performs secure path resolution, then uses
-`assay_common::limits::LimitReader<std::fs::File>` inside `tokio::task::spawn_blocking`; it maps
-typed limit, not-found, and other I/O errors once. Add a bytes-in `McpPolicy` parser and make both
-`from_file` and `assay_check_args` call it, so full-policy semantics have one implementation.
+entry point. The entry point performs secure path resolution, then calls a file-opening wrapper
+inside `tokio::task::spawn_blocking`; that wrapper delegates to one generic
+`LimitReader<R: Read>` primitive. It maps typed limit, not-found, and other I/O errors once. Add a
+bytes-in `McpPolicy` parser and make file/string/check_args entry points delegate to it, so
+full-policy semantics have one implementation.
 
 **Tech Stack:** Rust 1.96, Tokio, `assay_common::limits`, serde YAML, tempfile/sparse files, real
 stdio JSON-RPC tests, pre-commit, GitHub Actions.
@@ -40,6 +41,7 @@ stdio JSON-RPC tests, pre-commit, GitHub Actions.
 - Modify five tool files under `crates/assay-mcp-server/src/tools/`: remove unbounded reads.
 - Modify `crates/assay-core/src/mcp/policy/mod.rs` and `policy/legacy.rs`: one bytes-in parser.
 - Modify `crates/assay-core/src/mcp/tests.rs`: file/bytes/string parser contract table.
+- Add `crates/assay-core/tests/mcp_policy_warning_contract.rs`: subprocess warning contract.
 - Add `crates/assay-mcp-server/tests/policy_ingest_limits.rs`: real-stdio five-tool boundary table.
 - Add `scripts/ci/check-mcp-policy-reader-routing.py` and its self-test: pin `LimitReader` and all five callsites.
 - Add `scripts/ci/check-mcp-policy-parser-delegation.py` and its self-test: pin both full-policy delegation hops.
@@ -94,14 +96,16 @@ without introducing a second literal.
 
 Before implementing the private primitive, add focused tests for exactly-limit, limit-plus-one,
 chunked crossing, and ordinary I/O failure using an arbitrary `Read`. Classify through
-`LimitExceeded::from_io`; never match rendered text. Then implement the smallest passing helper:
+`LimitExceeded::from_io`; never match rendered text. Then implement two exact layers: generic
+`read_bounded<R: Read>(reader, limit)` owns `LimitReader` and byte accumulation; file-only
+`read_file_bounded(path, limit)` opens `File` and immediately delegates to the generic primitive.
+The async context method may call only the file wrapper. The generic layer uses:
 
 Implement a helper using:
 
 ```rust
-let file = std::fs::File::open(path)?;
 let mut reader = assay_common::limits::LimitReader::new(
-    file,
+    reader,
     limit as u64,
     assay_common::limits::LimitKind::SourceBytes,
 );
@@ -109,8 +113,8 @@ let mut bytes = Vec::new();
 std::io::Read::read_to_end(&mut reader, &mut bytes)?;
 ```
 
-The helper returns bytes or a typed internal read classification. It must not preallocate from
-`metadata().len()`.
+Both layers return bytes or the same typed internal read classification. Neither may preallocate
+from `metadata().len()`.
 
 - [ ] **Step 3: Test, then add, the async context entry point**
 
@@ -131,10 +135,11 @@ Do not include canonical roots, OS diagnostics, or policy contents.
 
 - [ ] **Step 4: Add and self-test the reader-routing guard**
 
-Require the blocking primitive to construct `LimitReader` and forbid `metadata()`-based acceptance
-or direct `File::read_to_end` outside that wrapper. Require `ToolContext::read_policy_bounded` to
-call the primitive. Disposable fixtures must fail for a faithful metadata-size check followed by an
-unbounded read, and for a context method that bypasses the primitive. Wire the guard to pre-commit
+Require the generic primitive to construct `LimitReader`; require the file wrapper to open and call
+only that primitive; require `ToolContext::read_policy_bounded` to call only the file wrapper. Forbid
+`metadata()`-based acceptance and direct `File::read_to_end` elsewhere. Disposable fixtures must
+fail for a faithful metadata-size check followed by an unbounded read, a file wrapper that duplicates
+the read, and a context method that bypasses either layer. Wire the guard to pre-commit
 for `config.rs`, `main.rs`, `tools/mod.rs`, all five tool modules, the guard, and its self-test. This
 structural proof, not sparse-file metadata alone, discriminates the metadata-only mutation.
 
@@ -166,6 +171,7 @@ git commit -m "feat(mcp): bound shared policy-file reads"
 - Modify: `crates/assay-core/src/mcp/policy/mod.rs`
 - Modify: `crates/assay-core/src/mcp/policy/legacy.rs`
 - Modify: `crates/assay-core/src/mcp/tests.rs`
+- Add: `crates/assay-core/tests/mcp_policy_warning_contract.rs`
 - Add: `scripts/ci/check-mcp-policy-parser-delegation.py`
 - Add: `scripts/ci/test-check-mcp-policy-parser-delegation.sh`
 - Modify: `.pre-commit-config.yaml`
@@ -192,9 +198,19 @@ tracing subscriber, the separate non-strict V1 deprecation warning, strict-mode 
 syntax/validation failure kind, and whether validation ran. Run this table GREEN and commit it as a
 behavior freeze; it is not RED evidence.
 
+Test the process-global deprecation warning in the dedicated integration-test binary. Its parent
+test spawns `current_exe()` with an ignored exact child test and deterministic no-timestamp tracing;
+the child parses one V1 fixture with an unknown field twice. Capture stderr and assert the unknown-
+field warning precedes the deprecation warning, the deprecation text occurs exactly once, and the
+child exits successfully. A separate child process resets `OnceLock`; never reset or mutate it in
+process. Removing or reordering `emit_deprecation_warning` must fail this subprocess contract.
+
 ```bash
 cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
-git add -- crates/assay-core/src/mcp/tests.rs
+cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
+git add -- \
+  crates/assay-core/src/mcp/tests.rs \
+  crates/assay-core/tests/mcp_policy_warning_contract.rs
 git commit -m "test(mcp): freeze full-policy file parser behavior"
 ```
 
@@ -236,11 +252,12 @@ may retain a deserialize/normalize/validate sequence.
 
 - [ ] **Step 5: Add and self-test the structural delegation guard**
 
-Add a source guard that identifies both exact delegation hops: the public `McpPolicy::from_file`
+Add a source guard that identifies all three exact delegation hops: the public `McpPolicy::from_file`
 body in `policy/mod.rs` must call `legacy::from_file`, and `legacy::from_file` must call
-`McpPolicy::from_slice`. Reject parser/deserializer construction in either body. The self-test uses
+`McpPolicy::from_slice`; public `McpPolicy::from_str` must call `McpPolicy::from_slice` and perform no
+parser/deserializer construction. Reject parser/deserializer construction in all three bodies. The self-test uses
 disposable source fixtures and must fail when a faithful duplicate deserializer is inserted at
-either hop. Wire the guard into pre-commit for changes to `policy/mod.rs`, `legacy.rs`, the guard,
+any hop. Wire the guard into pre-commit for changes to `policy/mod.rs`, `legacy.rs`, the guard,
 or its self-test.
 
 - [ ] **Step 6: Run core GREEN and the structural guard**
@@ -263,6 +280,7 @@ git add -- \
   crates/assay-core/src/mcp/policy/mod.rs \
   crates/assay-core/src/mcp/policy/legacy.rs \
   crates/assay-core/src/mcp/tests.rs \
+  crates/assay-core/tests/mcp_policy_warning_contract.rs \
   scripts/ci/check-mcp-policy-parser-delegation.py \
   scripts/ci/test-check-mcp-policy-parser-delegation.sh \
   .pre-commit-config.yaml

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-bounded-ingest.md
@@ -163,11 +163,14 @@ git commit -m "feat(mcp): bound shared policy-file reads"
 - Modify: `crates/assay-core/src/mcp/policy/mod.rs`
 - Modify: `crates/assay-core/src/mcp/policy/legacy.rs`
 - Modify: `crates/assay-core/src/mcp/tests.rs`
+- Add: `scripts/ci/check-mcp-policy-parser-delegation.py`
+- Add: `scripts/ci/test-check-mcp-policy-parser-delegation.sh`
+- Modify: `.pre-commit-config.yaml`
 
 - [ ] **Step 1: Add a parser parity RED table**
 
-For each fixture, compare the semantic result of the public bytes/string entry point with a temp
-file loaded through `McpPolicy::from_file`:
+For each fixture, first pin an independent expected outcome, then compare the public bytes/string
+entry point with a temp file loaded through `McpPolicy::from_file`:
 
 ```text
 V2 tools/schema policy
@@ -180,33 +183,61 @@ non-UTF-8 bytes
 validation failure (for example invalid referenced rule)
 ```
 
-Compare normalized serialized policy for successes and stable success/error class for failures;
-do not assert raw parser wording.
+Expected outcomes must name the normalized allow/deny/schema result for V2 and legacy fixtures,
+the migrated schema produced from V1 constraints, the unknown-field warning captured with a test
+tracing subscriber, strict-mode rejection, syntax/UTF-8/validation failure kind, and whether
+validation ran. Then compare entry points. Do not assert raw parser wording; parity is additional
+evidence, not the oracle.
 
-- [ ] **Step 2: Move the rule, do not copy it**
+- [ ] **Step 2: Run parser RED and commit tests only**
+
+```bash
+cargo test --locked -p assay-core mcp::tests::policy_from_slice_contract -- --nocapture
+```
+
+Expected: compile failure because `McpPolicy::from_slice` does not exist. Record the failure, stage
+only `crates/assay-core/src/mcp/tests.rs`, and commit the RED test before parser production changes.
+
+- [ ] **Step 3: Move the rule, do not copy it**
 
 Move deserialize-with-`serde_ignored`, unknown-field warning, strict-deprecation check, legacy
 normalization, constraint migration, and validation into one bytes-in function in `legacy.rs`.
 Expose it from `McpPolicy` as `from_slice(&[u8])` (and `from_str` only if a real caller needs it).
 
-- [ ] **Step 3: Make `from_file` delegate**
+- [ ] **Step 4: Make `from_file` delegate**
 
 `from_file` performs only the file read and `McpPolicy::from_slice(&bytes)`. It must not retain a
 second deserialize/normalize/validate sequence.
 
-- [ ] **Step 4: Run core GREEN**
+- [ ] **Step 5: Add and self-test the structural delegation guard**
+
+Add a source guard that identifies the `from_file` function body, requires its call to
+`McpPolicy::from_slice`, and rejects deserialize/parser construction in that body. The self-test
+uses disposable source fixtures and must fail when a faithful duplicate deserializer is inserted.
+Wire the guard into pre-commit for changes to `legacy.rs` or the guard itself.
+
+- [ ] **Step 6: Run core GREEN and the structural guard**
 
 ```bash
 cargo test --locked -p assay-core mcp::tests -- --nocapture
+python3 scripts/ci/check-mcp-policy-parser-delegation.py
+bash scripts/ci/test-check-mcp-policy-parser-delegation.sh
 ```
 
-- [ ] **Step 5: Commit parser extraction**
+- [ ] **Step 7: Run semantic mutations and commit parser extraction**
+
+In disposable copies, separately skip strict-deprecation detection, legacy normalization,
+constraint migration, unknown-field reporting, and validation. Each must fail its own expected-
+outcome assertion even though `from_file` and `from_slice` still agree.
 
 ```bash
 git add -- \
   crates/assay-core/src/mcp/policy/mod.rs \
   crates/assay-core/src/mcp/policy/legacy.rs \
-  crates/assay-core/src/mcp/tests.rs
+  crates/assay-core/src/mcp/tests.rs \
+  scripts/ci/check-mcp-policy-parser-delegation.py \
+  scripts/ci/test-check-mcp-policy-parser-delegation.sh \
+  .pre-commit-config.yaml
 git commit -m "refactor(mcp): share full-policy bytes parser"
 ```
 
@@ -219,9 +250,6 @@ git commit -m "refactor(mcp): share full-policy bytes parser"
 - Modify: `crates/assay-mcp-server/src/tools/explain_trace.rs`
 - Modify: `crates/assay-mcp-server/src/tools/check_args.rs`
 - Add: `crates/assay-mcp-server/tests/policy_ingest_limits.rs`
-- Add: `scripts/ci/check-mcp-policy-parser-delegation.py`
-- Add: `scripts/ci/test-check-mcp-policy-parser-delegation.sh`
-- Modify: `.pre-commit-config.yaml`
 
 - [ ] **Step 1: Add a real-stdio RED matrix**
 
@@ -235,24 +263,34 @@ Add a separate invalid-UTF-8 file for `assay_check_args`. Assert the complete re
 has `result.isError:true`, `allowed:false`, `E_POLICY_PARSE`, and exactly
 `Policy YAML is invalid`. This is a parse-classification contract, not a size-limit case.
 
-- [ ] **Step 2: Pin cache-bearing repeat behavior**
+- [ ] **Step 2: Run stdio RED and commit tests only**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
+```
+
+Expected: limit-plus-one calls reach parsing instead of `E_LIMIT_EXCEEDED`, and the invalid-UTF-8
+case does not yet publish the stable summary. Record both failures and commit only
+`policy_ingest_limits.rs` before migrating tool reads.
+
+- [ ] **Step 3: Pin cache-bearing repeat behavior**
 
 For `assay_policy_decide` and `assay_check_sequence`, call the oversized input twice and assert both
 remain limit failures. Capture stderr or expose test-only cache counters only if needed; prefer the
 observable repeat contract over adding production introspection.
 
-- [ ] **Step 3: Replace every direct read**
+- [ ] **Step 4: Replace every direct read**
 
 Replace the four `tokio::fs::read` blocks with `ctx.read_policy_bounded(policy_rel_path).await`.
 Keep hashing, parsing, cache lookup/insertion, and evaluation after successful bytes exactly where
 they are.
 
-- [ ] **Step 4: Remove `check_args`' file bypass**
+- [ ] **Step 5: Remove `check_args`' file bypass**
 
 Have `check_args` call the same context reader and pass returned bytes to `McpPolicy::from_slice`.
 It must not call `McpPolicy::from_file` or open the path itself.
 
-- [ ] **Step 5: Run GREEN**
+- [ ] **Step 6: Run GREEN**
 
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
@@ -260,20 +298,15 @@ cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --noca
 cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
 ```
 
-- [ ] **Step 6: Run discriminating mutations**
-
-Add a structural delegation guard that identifies the `from_file` function body and requires it to
-call the single bytes parser while rejecting deserialize/parser construction inside that body. Its
-self-test must mutate a disposable source fixture so a faithful duplicated deserializer fails even
-when semantic parity would remain green.
+- [ ] **Step 7: Run discriminating mutations**
 
 In disposable copies, separately replace one tool callsite with `tokio::fs::read`; make
-`check_args` call `from_file`; map invalid UTF-8 to `E_POLICY_READ` or `E_INTERNAL`; duplicate
-deserialization inside `from_file`; replace the reader with a metadata-only check; and change the
-inclusive boundary to reject exactly-limit. Each mutation must fail a named
+`check_args` call `from_file`; map invalid UTF-8 to `E_POLICY_READ` or `E_INTERNAL`; replace the
+reader with a metadata-only check; and change the inclusive boundary to reject exactly-limit. Each
+mutation must fail a named
 matrix/classification/structural/boundary assertion.
 
-- [ ] **Step 7: Commit all five migrations**
+- [ ] **Step 8: Commit all five migrations**
 
 ```bash
 git add -- \
@@ -282,10 +315,7 @@ git add -- \
   crates/assay-mcp-server/src/tools/check_coverage.rs \
   crates/assay-mcp-server/src/tools/explain_trace.rs \
   crates/assay-mcp-server/src/tools/check_args.rs \
-  crates/assay-mcp-server/tests/policy_ingest_limits.rs \
-  scripts/ci/check-mcp-policy-parser-delegation.py \
-  scripts/ci/test-check-mcp-policy-parser-delegation.sh \
-  .pre-commit-config.yaml
+  crates/assay-mcp-server/tests/policy_ingest_limits.rs
 git commit -m "fix(mcp): route policy tools through bounded ingest"
 ```
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-decision-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-decision-safety.md
@@ -114,10 +114,11 @@ Add a helper parameter for the proposed tool name so the literal-wildcard contro
 cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
 ```
 
-Expected: existing #2385 field-shape cases, including present `blocklist: null`, still pass.
-Malformed roots and canonical mappings fail RED because they currently produce clean allows. Mixed
-dialects fail RED when they deny or allow instead of returning the required structure error. Record
-the discriminating assertion names in #2388.
+Expected: every newly exact stable-message assertion for malformed `blocklist` values, including
+present `blocklist: null`, fails because the baseline publishes raw serde wording. Malformed roots
+and canonical mappings fail RED because they currently produce clean allows. Mixed dialects fail
+RED when they deny or allow instead of returning the required structure error. Existing verdict-only
+controls remain green. Record the discriminating assertion names in #2388.
 
 - [ ] **Step 6: Commit only the RED test**
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-decision-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-decision-safety.md
@@ -1,0 +1,334 @@
+# MCP Policy Decision Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #2386 by making `assay_policy_decide` reject malformed roots, canonical name-policy
+documents, and mixed dialects before cache insertion while preserving its exact-name 5.x
+`blocklist` compatibility contract.
+
+**Architecture:** Parse YAML once into `serde_json::Value`, require an object root, classify the
+private blocklist dialect before typed field deserialization, and insert only a successfully parsed
+`Vec<String>` into the existing digest cache. Keep exact membership and route full-policy callers to
+`assay_check_args`; do not import the full policy engine into this tool.
+
+**Tech Stack:** Rust 1.96, Tokio, serde/serde_yaml/serde_json, real stdio JSON-RPC integration tests,
+pre-commit, GitHub Actions.
+
+## Global Constraints
+
+- Do not create the writer branch until PR #2390 has merged. Baseline is the resulting exact
+  `origin/main` SHA; record it before creating the branch.
+- Implement in one isolated `cursor/2386-policy-decision-safety` worktree owned by Cursor.
+- Root `blocklist` uses exact `Vec<String>::contains`; wildcard-looking strings remain literal.
+- Root `allow`, root `deny`, `tools`, or a mixture with `blocklist` returns `E_POLICY_PARSE`.
+- Non-mapping roots return exactly `Policy root must be a mapping` without source-derived text.
+- Unsupported, ambiguous, and malformed field shapes return exactly `Policy structure is invalid`.
+- Invalid input returns before cache insertion; first and repeat calls must both fail.
+- Do not change `McpPolicy`, proxy enforcement, schemas, sequence semantics, or target-tool behavior.
+- Stage only named paths; never use a whole-tree staging command.
+
+---
+
+## File Structure
+
+- Modify `crates/assay-mcp-server/src/tools/policy_decide.rs`: private dialect parser and cache-safe call path.
+- Modify `crates/assay-mcp-server/tests/policy_decide_blocklist.rs`: driven contract table and cache assertions.
+- Modify `docs/reference/mcp-api.md`: distinguish name-only blocklist from full-policy evaluation.
+- Modify `docs/AIcontext/entry-points.md`: stop presenting root `blocklist` as full `McpPolicy`.
+- Modify `docs/AIcontext/quick-reference.md`: split the mixed policy example into explicit dialects.
+- Modify `docs/mcp/self-correction.md`: align stale `assay_policy_decide` input/output claims.
+- Modify `docs/use-cases/self-correction.md`: replace the stale combined-check request/response.
+- Modify `CHANGELOG.md`: record the intentional rejection and migration path.
+
+### Task 1: Freeze malformed-root and dialect behavior
+
+**Files:**
+- Modify: `crates/assay-mcp-server/tests/policy_decide_blocklist.rs`
+
+**Interfaces:**
+- Consumes: existing `spawn_server`, `initialize`, `call_policy_decide`, `assert_parse_error`, and `assert_allowed` helpers.
+- Produces: a real-stdio test table that distinguishes root shape, field shape, dialect, matching, and repeat-call cache behavior.
+
+- [ ] **Step 1: Add exact parse-message assertions**
+
+Extend `assert_parse_error` with an expected message argument and assert:
+
+```rust
+assert_eq!(
+    body.pointer("/error/message").and_then(Value::as_str),
+    Some(expected_message),
+    "{label}: wrong stable parse summary; body={body}"
+);
+```
+
+Keep the existing `allowed:false`, `E_POLICY_PARSE`, and MCP `isError:true` assertions.
+
+- [ ] **Step 2: Add malformed-root RED fixtures**
+
+Write scalar, deny-shaped sequence (`- dangerous_tool`), null-document, empty-document, and
+200,000-byte scalar-root files. Use fixture names such as `root-null-document.yaml` and
+`root-empty-document.yaml` so they cannot collide with the existing #2385 field-shape fixtures.
+Construct the large root as one syntactically valid YAML scalar containing `BEGIN_SECRET`, filler,
+and `END_SECRET`; do not accidentally exercise the YAML-syntax branch. For first and repeat calls
+assert `Policy root must be a mapping`; assert the response contains neither sentinel.
+
+- [ ] **Step 3: Add canonical and mixed dialect RED fixtures**
+
+Use this table:
+
+```rust
+let unsupported_dialects = [
+    ("root-allow.yaml", "allow:\n  - dangerous_tool\n"),
+    ("root-deny.yaml", "deny:\n  - dangerous_tool\n"),
+    ("tools-deny.yaml", "tools:\n  deny:\n    - dangerous_tool\n"),
+    ("mixed-root-deny.yaml", "blocklist:\n  - dangerous_tool\ndeny:\n  - other_tool\n"),
+    ("mixed-tools.yaml", "blocklist:\n  - dangerous_tool\ntools:\n  deny:\n    - other_tool\n"),
+];
+```
+
+For first and repeat calls assert `Policy structure is invalid` and the existing error envelope.
+
+- [ ] **Step 4: Add compatibility controls**
+
+Pin all of these:
+
+```text
+version: 1                                  -> allow
+name: metadata-only                        -> allow
+blocklist: []                              -> allow
+blocklist: [dangerous_tool]                -> deny dangerous_tool
+blocklist: ["dangerous_*"]                -> allow dangerous_tool
+blocklist: ["dangerous_*"]                -> deny a literal tool named dangerous_*
+blocklist: null                            -> Policy structure is invalid
+blocklist:                                 -> Policy structure is invalid
+blocklist: [dangerous_tool, 7]             -> Policy structure is invalid
+```
+
+Add a helper parameter for the proposed tool name so the literal-wildcard control uses the same server connection.
+
+- [ ] **Step 5: Run the focused RED test**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
+```
+
+Expected: existing #2385 field-shape cases, including present `blocklist: null`, still pass.
+Malformed roots and canonical mappings fail RED because they currently produce clean allows. Mixed
+dialects fail RED when they deny or allow instead of returning the required structure error. Record
+the discriminating assertion names in #2388.
+
+- [ ] **Step 6: Commit only the RED test**
+
+```bash
+git add -- crates/assay-mcp-server/tests/policy_decide_blocklist.rs
+git commit -m "test(mcp): expose policy_decide root and dialect fail-open"
+```
+
+### Task 2: Implement the private dialect parser
+
+**Files:**
+- Modify: `crates/assay-mcp-server/src/tools/policy_decide.rs`
+
+**Interfaces:**
+- Consumes: YAML bytes and existing `ToolError`/cache types.
+- Produces: `fn parse_policy_decision_document(bytes: &[u8]) -> Result<Vec<String>, ToolError>` and private `PolicyDecisionDocument`.
+
+- [ ] **Step 1: Add the typed private document**
+
+```rust
+#[derive(serde::Deserialize)]
+struct PolicyDecisionDocument {
+    #[serde(default)]
+    blocklist: Vec<String>,
+}
+```
+
+Do not add `deny_unknown_fields`; metadata-only mappings remain compatible.
+
+- [ ] **Step 2: Add root and dialect classification**
+
+Implement one parser with this order:
+
+```rust
+fn parse_policy_decision_document(bytes: &[u8]) -> Result<Vec<String>, ToolError> {
+    let root: Value = serde_yaml::from_slice(bytes)
+        .map_err(|_| ToolError::new("E_POLICY_PARSE", "Policy YAML is invalid"))?;
+    let object = root.as_object().ok_or_else(|| {
+        ToolError::new("E_POLICY_PARSE", "Policy root must be a mapping")
+    })?;
+
+    if ["allow", "deny", "tools"]
+        .iter()
+        .any(|key| object.contains_key(*key))
+    {
+        return Err(ToolError::new("E_POLICY_PARSE", "Policy structure is invalid"));
+    }
+
+    serde_json::from_value::<PolicyDecisionDocument>(root)
+        .map(|document| document.blocklist)
+        .map_err(|_| ToolError::new("E_POLICY_PARSE", "Policy structure is invalid"))
+}
+```
+
+The canonical marker check runs whether or not `blocklist` is present, so mixed dialects fail through the same branch.
+
+- [ ] **Step 3: Replace the ad-hoc extraction**
+
+In the cache-miss branch call only:
+
+```rust
+let list = match parse_policy_decision_document(&policy_bytes) {
+    Ok(list) => list,
+    Err(error) => return error.result(),
+};
+```
+
+Construct and insert the `Arc<Vec<String>>` only after this returns `Ok`. Keep the SHA/cache key and exact `contains` evaluation unchanged.
+
+- [ ] **Step 4: Run GREEN tests**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
+cargo test --locked -p assay-mcp-server --test stdio_edge_cases
+cargo test --locked -p assay-mcp-server --test project_install_surfaces
+```
+
+Expected: all pass. The large root response contains neither sentinel and remains a stable root summary.
+
+- [ ] **Step 5: Run discriminating mutations**
+
+In disposable copies, separately remove root validation, remove the canonical marker guard, replace
+exact membership with wildcard matching, and insert the cache before validation. Run the focused
+test after each. Each mutation must fail its own table/control. Restore from `HEAD` after every
+mutation and verify only intended files remain changed.
+
+- [ ] **Step 6: Commit the minimal implementation**
+
+```bash
+git add -- crates/assay-mcp-server/src/tools/policy_decide.rs
+git commit -m "fix(mcp): reject invalid policy_decide dialects before cache"
+```
+
+### Task 3: Correct the outward contract
+
+**Files:**
+- Modify: `docs/reference/mcp-api.md`
+- Modify: `docs/AIcontext/entry-points.md`
+- Modify: `docs/AIcontext/quick-reference.md`
+- Modify: `docs/mcp/self-correction.md`
+- Modify: `docs/use-cases/self-correction.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the landed tool schema wording in `tools/mod.rs` and implemented exact-name behavior.
+- Produces: one consistent public explanation of the two policy dialects.
+
+- [ ] **Step 1: State the name-only contract**
+
+Use this normative wording:
+
+```text
+assay_policy_decide performs an exact-name check against its compatibility-only root `blocklist`.
+It does not parse full `McpPolicy` controls such as `tools.allow` or `tools.deny`; use
+assay_check_args for full, argument-aware policy evaluation. Passing canonical name-policy fields
+to assay_policy_decide is an error, not a clean allow.
+```
+
+- [ ] **Step 2: Split mixed examples**
+
+Any example combining root `blocklist` with `tools`, `schemas`, root `allow`, or root `deny` becomes
+two explicitly labelled examples. This is documentation cleanup: `schemas` is not a dialect marker
+and must not be added to the parser's marker list. Do not silently rewrite the compatibility dialect
+into `tools.deny`.
+
+- [ ] **Step 3: Record the intentional hardening change**
+
+Add a changelog entry and a migration example. State that canonical or mixed policy documents may
+previously have returned a false clean allow or ignored canonical fields; after this change they
+return `E_POLICY_PARSE`. Route full-policy callers to `assay_check_args`. Do not call this input class
+"unsupported with no impact" because the CLI accepted it before this slice.
+
+- [ ] **Step 4: Run documentation guards**
+
+```bash
+pre-commit run --files \
+  docs/reference/mcp-api.md \
+  docs/AIcontext/entry-points.md \
+  docs/AIcontext/quick-reference.md \
+  docs/mcp/self-correction.md \
+  docs/use-cases/self-correction.md \
+  CHANGELOG.md
+rg -n "assay_policy_decide|blocklist|tools\.deny" \
+  docs/reference/mcp-api.md \
+  docs/AIcontext/entry-points.md \
+  docs/AIcontext/quick-reference.md \
+  docs/mcp/self-correction.md \
+  docs/use-cases/self-correction.md \
+  CHANGELOG.md
+```
+
+Expected: hooks pass; every hit is consistent with the two-dialect decision.
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add -- \
+  docs/reference/mcp-api.md \
+  docs/AIcontext/entry-points.md \
+  docs/AIcontext/quick-reference.md \
+  docs/mcp/self-correction.md \
+  docs/use-cases/self-correction.md \
+  CHANGELOG.md
+git commit -m "docs(mcp): distinguish blocklist and full policy evaluation"
+```
+
+### Task 4: Verify and publish the slice
+
+**Files:**
+- Verify only; no new production files.
+
+**Interfaces:**
+- Produces: exact-head verification and PR review packet for #2386/#2388.
+
+- [ ] **Step 1: Run the affected suite**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
+cargo test --locked -p assay-mcp-server
+cargo fmt --all -- --check
+cargo clippy -p assay-mcp-server --all-targets -- -D warnings
+git diff --check
+git status --short
+```
+
+Expected: all pass; only intended committed changes exist.
+
+- [ ] **Step 2: Inspect public strings and diff scope**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- \
+  crates/assay-mcp-server/src/tools/policy_decide.rs \
+  crates/assay-mcp-server/tests/policy_decide_blocklist.rs \
+  docs/reference/mcp-api.md \
+  docs/AIcontext/entry-points.md \
+  docs/AIcontext/quick-reference.md \
+  docs/mcp/self-correction.md \
+  docs/use-cases/self-correction.md \
+  CHANGELOG.md
+```
+
+Confirm no full-policy evaluation, wildcard matcher, proxy change, or raw source-derived parse text.
+
+- [ ] **Step 3: Push and open the PR**
+
+Push `cursor/2386-policy-decision-safety`, open a PR to current `main`, and record branch, PR, exact
+head SHA, tests, mutation evidence, non-claims, and open findings in #2388.
+
+- [ ] **Step 4: Obtain exact-head quorum**
+
+Use one fresh non-building reviewer who authored neither this plan/spec nor the implementation.
+Fix or technically disposition all findings. Any push invalidates the prior review. Enable
+auto-merge only after required checks, exact-head review, and any delegated proof are valid.

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-decision-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-decision-safety.md
@@ -260,16 +260,14 @@ pre-commit run --files \
   docs/mcp/self-correction.md \
   docs/use-cases/self-correction.md \
   CHANGELOG.md
-rg -n "assay_policy_decide|blocklist|tools\.deny" \
-  docs/reference/mcp-api.md \
-  docs/AIcontext/entry-points.md \
-  docs/AIcontext/quick-reference.md \
-  docs/mcp/self-correction.md \
-  docs/use-cases/self-correction.md \
-  CHANGELOG.md
+rg -n --glob '*.md' \
+  "assay_policy_decide|blocklist|tools\.deny|argument-aware|full policy" \
+  README.md CHANGELOG.md docs
 ```
 
-Expected: hooks pass; every hit is consistent with the two-dialect decision.
+Expected: hooks pass; classify every repository-wide hit before fixing the final file list. Every
+remaining current-product hit must be consistent with the two-dialect decision. Historical or
+generated exclusions must be named in the PR body rather than silently omitted from the search.
 
 - [ ] **Step 5: Commit documentation**
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -126,9 +126,13 @@ ToolError { code: "E_TEST".into(), message: message.clone(), details: None }
 let mut error = ToolError::new("E_TEST", "short"); error.message = message;
 ```
 
-Assert serialized `/message` is valid UTF-8 and at most 4,096 bytes. The direct construction and
-post-construction mutation are load-bearing: they prove the publication boundary, not only the
-constructor, applies the rule.
+For the constructor case, inspect `error.message` before serialization and assert it equals the
+exact UTF-8-safe prefix and is at most 4,096 bytes; removing the constructor bound must fail here
+even if serialization still bounds. Then serialize all three forms and assert `/message` is the
+same valid UTF-8 bounded prefix. Finally publish the direct and post-construction-mutated structs
+through `ToolError::result` and assert `/error/message` is bounded. If `result` repacks public fields
+instead of serializing `ToolError`, those tests must fail. The three paths separately prove the
+constructor, serializer, and result publication boundary.
 
 - [ ] **Step 6: Add an interface-only classifier seam**
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -11,8 +11,9 @@ serialization boundary.
 **Architecture:** Keep tool failures as MCP tool results. Add one private `bound_public_message`
 function in `tools/mod.rs`, use it in both `ToolError::new` and a manual `Serialize` implementation,
 and add one policy-parse constructor that accepts only a fixed failure class plus optional numeric
-location. Migrate the four raw parser sinks; leave the already-fixed sequence diagnostic on the
-general constructor.
+location. Direct YAML consumers use one two-stage value/root/typed helper; the full-policy parser
+tags syntax, shape, and validation failures at source for `check_args`. Migrate the four raw parser
+sinks; leave the already-fixed sequence diagnostic on the general constructor.
 
 **Tech Stack:** Rust 1.96, serde/serde_json/serde_yaml, real stdio JSON-RPC tests, pre-commit,
 GitHub Actions.
@@ -43,12 +44,16 @@ GitHub Actions.
 - Modify `crates/assay-mcp-server/src/tools/check_coverage.rs`: value-free YAML parser errors.
 - Modify `crates/assay-mcp-server/src/tools/explain_trace.rs`: value-free YAML parser errors.
 - Add `crates/assay-mcp-server/tests/policy_diagnostic_safety.rs`: real-stdio hostile-input contract.
+- Modify `crates/assay-core/src/mcp/policy/mod.rs`: expose the typed full-policy failure kind.
+- Modify `crates/assay-core/src/mcp/policy/legacy.rs`: tag syntax, shape, and validation failures at source.
+- Modify `crates/assay-core/src/mcp/tests.rs`: pin full-policy error classification.
 
 ### Task 1: Freeze the public diagnostic boundary
 
 **Files:**
 - Add: `crates/assay-mcp-server/tests/policy_diagnostic_safety.rs`
 - Modify: `crates/assay-mcp-server/src/tools/mod.rs` (unit tests only in this task)
+- Modify: `crates/assay-core/src/mcp/tests.rs` (tests only in this task)
 
 - [ ] **Step 1: Add a real-stdio helper covering four raw sinks**
 
@@ -103,6 +108,7 @@ constructor, applies the rule.
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
 cargo test --locked -p assay-mcp-server tools::tests -- --nocapture
+cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
 ```
 
 Expected: hostile parser values appear in responses and direct/mutated `ToolError` serialization is
@@ -113,7 +119,8 @@ unbounded. Record the exact failures in #2388.
 ```bash
 git add -- \
   crates/assay-mcp-server/tests/policy_diagnostic_safety.rs \
-  crates/assay-mcp-server/src/tools/mod.rs
+  crates/assay-mcp-server/src/tools/mod.rs \
+  crates/assay-core/src/mcp/tests.rs
 git commit -m "test(mcp): expose unbounded policy diagnostics"
 ```
 
@@ -182,6 +189,10 @@ git commit -m "fix(mcp): bound public tool error messages"
 ### Task 3: Migrate every raw policy-parse sink
 
 **Files:**
+- Modify: `crates/assay-core/src/mcp/policy/mod.rs`
+- Modify: `crates/assay-core/src/mcp/policy/legacy.rs`
+- Modify: `crates/assay-core/src/mcp/tests.rs`
+- Modify: `crates/assay-mcp-server/src/tools/mod.rs`
 - Modify: `crates/assay-mcp-server/src/tools/policy_decide.rs`
 - Modify: `crates/assay-mcp-server/src/tools/check_args.rs`
 - Modify: `crates/assay-mcp-server/src/tools/check_coverage.rs`
@@ -199,18 +210,23 @@ because it is fixed and value-free, but it must not become a second parse-policy
 
 - [ ] **Step 2: Map syntax and structure without raw text**
 
-For `serde_yaml::Error`, extract only `location().map(|loc| (loc.line(), loc.column()))` and pass it
-to `ToolError::policy_parse`. Use `YamlSyntax` where syntax decoding fails and `Structure` where a
-typed mapping has the wrong shape. In `policy_decide`, retain #2386's explicit root class.
+Add one generic direct-tool helper in `tools/mod.rs`: first decode bytes to `serde_yaml::Value`,
+then require a mapping root, then deserialize the value into the tool's typed policy. Classify the
+three stages as `YamlSyntax`, `RootNotMapping`, and `Structure`; extract only safe numeric location
+from the first-stage error. `check_coverage` and `explain_trace` must call this helper rather than
+classify `serde_yaml::Error` by its `Display` text. In `policy_decide`, retain #2386's explicit root
+and dialect checks while using the same syntax classification.
 
 - [ ] **Step 3: Handle `check_args` without widening into the reader/parser slice**
 
-Keep the existing not-found/read branches as a separate concern until #2389 centralizes them. Add
-RED core cases that distinguish malformed syntax from well-formed typed-shape and validation
-failures. Tag that distinction at the parser source with a typed error kind; `check_args` must query
-or downcast that kind rather than match `Display` text. Map syntax to `PolicyParseFailure::YamlSyntax`
-and typed-shape/validation failures to `PolicyParseFailure::Structure` without publishing
-`e.to_string()`.
+Keep the existing not-found/read branches as a separate concern until #2389 centralizes them. In
+`assay-core`, add a public non-exhaustive `McpPolicyErrorKind` and a typed error wrapper whose source
+is retained but whose kind is queryable without parsing `Display`. The existing file parser first
+decodes to `serde_yaml::Value`, then runs the current ignored-field-aware typed deserialize,
+normalization, migration, and validation sequence. Tag first-stage decode as `Syntax`, typed
+deserialize as `Structure`, and validation as `Validation`; I/O errors remain outside this wrapper.
+`check_args` downcasts this wrapper and maps `Syntax` to `PolicyParseFailure::YamlSyntax`, and
+`Structure`/`Validation` to `PolicyParseFailure::Structure`.
 
 Do not add a parallel bytes/string `McpPolicy` parser here. #2389 moves this same tagged parse rule
 behind the bytes API, preserves file/bytes parity, and removes `from_file` from the `check_args`
@@ -223,6 +239,7 @@ server-side approximation.
 cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
 cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
 cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
+cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
 rg -n 'E_POLICY_PARSE.*(e\.to_string|format!)|Failed to parse policy' \
   crates/assay-mcp-server/src/tools
 ```
@@ -231,14 +248,20 @@ Expected: tests pass and the grep finds no source-derived public parse sink.
 
 - [ ] **Step 5: Run discriminating mutations**
 
-In disposable copies, separately: return a raw parser string from one sink; remove the constructor
-bound; remove the serializer bound; and replace the UTF-8 boundary loop with a byte slice. Each
-mutation must fail a different sentinel, direct-struct, post-mutation, or multibyte assertion.
+In disposable copies, separately: return a raw parser string from one sink; collapse syntax and
+typed-shape to one class; make a direct YAML consumer bypass the two-stage helper; remove the
+constructor bound; remove the serializer bound; and replace the UTF-8 boundary loop with a byte
+slice. Each mutation must fail a different sentinel, classification, direct-struct, post-mutation,
+or multibyte assertion.
 
 - [ ] **Step 6: Commit migrated sinks and integration test**
 
 ```bash
 git add -- \
+  crates/assay-core/src/mcp/policy/mod.rs \
+  crates/assay-core/src/mcp/policy/legacy.rs \
+  crates/assay-core/src/mcp/tests.rs \
+  crates/assay-mcp-server/src/tools/mod.rs \
   crates/assay-mcp-server/src/tools/policy_decide.rs \
   crates/assay-mcp-server/src/tools/check_args.rs \
   crates/assay-mcp-server/src/tools/check_coverage.rs \
@@ -253,9 +276,10 @@ git commit -m "fix(mcp): normalise public policy parse diagnostics"
 
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
+cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
 cargo test --locked -p assay-mcp-server
 cargo fmt --all -- --check
-cargo clippy -p assay-mcp-server --all-targets -- -D warnings
+cargo clippy -p assay-core -p assay-mcp-server --all-targets -- -D warnings
 git diff --check
 git status --short
 ```

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -66,12 +66,16 @@ sentinels embedded in a 200,000-byte invalid scalar. For each tool assert:
 result.isError == true
 body.allowed == false
 body.error.code == E_POLICY_PARSE
-body.error.message is one fixed summary
+body.error.message equals the summary for the exercised failure class
 body.error.message.as_bytes().len() <= 4096
 complete response contains none of the three sentinels
 ```
 
 Use distinct files or requests so one failure cannot mask another position.
+Include malformed syntax that must return `Policy YAML is invalid`, a well-formed mapping with a
+typed field-shape error that must return `Policy structure is invalid`, and the non-mapping control
+from #2386 that must return `Policy root must be a mapping`. Do not let one generic fixed-summary
+assertion stand in for these three classes.
 
 - [ ] **Step 3: Add path and location controls**
 
@@ -201,11 +205,17 @@ typed mapping has the wrong shape. In `policy_decide`, retain #2386's explicit r
 
 - [ ] **Step 3: Handle `check_args` without widening into the reader/parser slice**
 
-Keep the existing not-found/read branches as a separate concern until #2389 centralizes them. Map
-the current fall-through parse/validation error to `PolicyParseFailure::Structure` without
-publishing `e.to_string()`. Do not add a bytes/string `McpPolicy` parser here: extracting that
-single parse rule, preserving file/bytes parity, and removing `from_file` from this callsite are the
-explicit work of #2389.
+Keep the existing not-found/read branches as a separate concern until #2389 centralizes them. Add
+RED core cases that distinguish malformed syntax from well-formed typed-shape and validation
+failures. Tag that distinction at the parser source with a typed error kind; `check_args` must query
+or downcast that kind rather than match `Display` text. Map syntax to `PolicyParseFailure::YamlSyntax`
+and typed-shape/validation failures to `PolicyParseFailure::Structure` without publishing
+`e.to_string()`.
+
+Do not add a parallel bytes/string `McpPolicy` parser here. #2389 moves this same tagged parse rule
+behind the bytes API, preserves file/bytes parity, and removes `from_file` from the `check_args`
+callsite. The diagnostic slice must therefore leave one classifier for #2389 to reuse, not a second
+server-side approximation.
 
 - [ ] **Step 4: Run GREEN and inspect public text**
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -52,6 +52,7 @@ GitHub Actions.
 - Add `crates/assay-core/tests/mcp_policy_warning_contract.rs`: subprocess warning/ordering contract.
 - Add `scripts/ci/check-mcp-policy-yaml-routing.py`: enforce the single mapping/parser boundary.
 - Add `scripts/ci/test-check-mcp-policy-yaml-routing.sh`: mutation-test the routing guard.
+- Add `scripts/ci/check-mcp-tool-error-publication.py` and its self-test: bind `result` to `Serialize`.
 - Modify `.pre-commit-config.yaml`: run the guard for every guarded parser or consumer.
 
 ### Task 1: Freeze the public diagnostic boundary
@@ -174,6 +175,9 @@ git commit -m "test(mcp): expose unbounded policy diagnostics"
 
 **Files:**
 - Modify: `crates/assay-mcp-server/src/tools/mod.rs`
+- Add: `scripts/ci/check-mcp-tool-error-publication.py`
+- Add: `scripts/ci/test-check-mcp-tool-error-publication.sh`
+- Modify: `.pre-commit-config.yaml`
 
 - [ ] **Step 1: Add the UTF-8-safe bound**
 
@@ -205,7 +209,15 @@ the existing field names and `skip_serializing_if` behavior.
 `ToolError::new` stores `bound_public_message(message).to_owned()`. Keep the serializer bound too;
 public fields can bypass or mutate constructor state.
 
-- [ ] **Step 4: Add a fixed parse constructor**
+- [ ] **Step 4: Guard the result publication edge**
+
+Add a structural guard that identifies `ToolError::result`, requires it to serialize `self` through
+the `ToolError` `Serialize` implementation, and forbids rebuilding `error` from public fields or a
+second bounded view. Its disposable self-test must fail both an unbounded repack and a faithful
+bounded repack that calls `bound_public_message` but bypasses `Serialize`. Wire it to pre-commit for
+`tools/mod.rs`, the guard, and its self-test.
+
+- [ ] **Step 5: Add a fixed parse constructor**
 
 Add a private or `pub(crate)` enum with only the three approved classes and a constructor such as:
 
@@ -219,16 +231,22 @@ pub(crate) fn policy_parse(
 Map the enum to fixed summaries. Populate `details` only as `{"line": line, "column": column}`.
 Do not accept a raw parser `Display` string.
 
-- [ ] **Step 5: Run the serialization tests GREEN**
+- [ ] **Step 6: Run the serialization tests and guard GREEN**
 
 ```bash
 cargo test --locked -p assay-mcp-server tools::tests -- --nocapture
+python3 scripts/ci/check-mcp-tool-error-publication.py
+bash scripts/ci/test-check-mcp-tool-error-publication.sh
 ```
 
-- [ ] **Step 6: Commit the shared boundary**
+- [ ] **Step 7: Commit the shared boundary**
 
 ```bash
-git add -- crates/assay-mcp-server/src/tools/mod.rs
+git add -- \
+  crates/assay-mcp-server/src/tools/mod.rs \
+  scripts/ci/check-mcp-tool-error-publication.py \
+  scripts/ci/test-check-mcp-tool-error-publication.sh \
+  .pre-commit-config.yaml
 git commit -m "fix(mcp): bound public tool error messages"
 ```
 
@@ -348,6 +366,10 @@ cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --n
 cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
 cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
 cargo test --locked -p assay-mcp-server
+python3 scripts/ci/check-mcp-tool-error-publication.py
+bash scripts/ci/test-check-mcp-tool-error-publication.sh
+python3 scripts/ci/check-mcp-policy-yaml-routing.py
+bash scripts/ci/test-check-mcp-policy-yaml-routing.sh
 cargo fmt --all -- --check
 cargo clippy -p assay-core -p assay-mcp-server --all-targets -- -D warnings
 git diff --check

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -31,7 +31,9 @@ GitHub Actions.
 - Keep `ToolError` and its fields public for semver compatibility.
 - Do not absorb the outer server's separately constructed `E_INTERNAL` fallback or caller-selected
   `on_error`; #2391 owns that generic dispatch boundary.
-- Do not change verdict semantics, reason codes, JSON-RPC errors, policy readers, or cache order.
+- Do not change verdict semantics, reason codes, JSON-RPC errors, reader paths/bounds, or cache
+  order. The full-policy reader may switch from `read_to_string` to bytes only to classify invalid
+  UTF-8 as parse input while preserving ordinary file-I/O behavior.
 - Stage only named paths; never use a whole-tree staging command.
 
 ---
@@ -57,6 +59,8 @@ GitHub Actions.
 - Add: `crates/assay-mcp-server/tests/policy_diagnostic_safety.rs`
 - Modify: `crates/assay-mcp-server/src/tools/mod.rs` (unit tests only in this task)
 - Modify: `crates/assay-core/src/mcp/tests.rs` (tests only in this task)
+- Modify: `crates/assay-core/src/mcp/policy/mod.rs` (interface-only typed seam)
+- Modify: `crates/assay-core/src/mcp/policy/legacy.rs` (interface-only typed seam)
 
 - [ ] **Step 1: Add a real-stdio helper covering four raw sinks**
 
@@ -93,6 +97,10 @@ temporary root and policy path. Add a malformed multibyte input whose bounded me
 valid UTF-8. Separately construct a long message whose byte 4,096 falls inside a multibyte code
 point; reuse that exact message in every serializer-bypass case below.
 
+Add a separate policy file containing invalid UTF-8 bytes and exercise `assay_check_args`. Assert
+the public class is `E_POLICY_PARSE` with exactly `Policy YAML is invalid`, not `E_POLICY_READ`,
+`E_INTERNAL`, or an OS/UTF-8 diagnostic.
+
 - [ ] **Step 4: Pin constructor and serializer bypasses**
 
 In `tools/mod.rs` tests serialize all three forms with that same boundary-bisecting message:
@@ -107,7 +115,14 @@ Assert serialized `/message` is valid UTF-8 and at most 4,096 bytes. The direct 
 post-construction mutation are load-bearing: they prove the publication boundary, not only the
 constructor, applies the rule.
 
-- [ ] **Step 5: Run RED**
+- [ ] **Step 5: Add an interface-only classifier seam**
+
+Declare the public non-exhaustive `McpPolicyErrorKind` and typed wrapper, but do not yet make the
+parser construct it. This changes no parser result; it only lets the core classification test
+compile and downcast the existing `anyhow::Error`. The test must then fail its kind assertions rather
+than fail compilation.
+
+- [ ] **Step 6: Run behavioral RED**
 
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
@@ -116,15 +131,19 @@ cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --n
 ```
 
 Expected: hostile parser values appear in responses and direct/mutated `ToolError` serialization is
-unbounded. Record the exact failures in #2388.
+unbounded; typed downcasts fail because the parser does not construct the seam; invalid UTF-8 is
+still classified as a read failure. Record the exact assertion failures in #2388. A compile failure
+does not count as RED evidence.
 
-- [ ] **Step 6: Commit only RED tests**
+- [ ] **Step 7: Commit the interface seam and RED tests**
 
 ```bash
 git add -- \
   crates/assay-mcp-server/tests/policy_diagnostic_safety.rs \
   crates/assay-mcp-server/src/tools/mod.rs \
-  crates/assay-core/src/mcp/tests.rs
+  crates/assay-core/src/mcp/tests.rs \
+  crates/assay-core/src/mcp/policy/mod.rs \
+  crates/assay-core/src/mcp/policy/legacy.rs
 git commit -m "test(mcp): expose unbounded policy diagnostics"
 ```
 
@@ -227,13 +246,14 @@ direct consumer may construct a YAML deserializer or duplicate the mapping-root 
 
 - [ ] **Step 3: Handle `check_args` without widening into the reader/parser slice**
 
-Keep the existing not-found/read branches as a separate concern until #2389 centralizes them. In
-`assay-core`, add a public non-exhaustive `McpPolicyErrorKind` with `Syntax`, `RootNotMapping`,
-`Structure`, and `Validation`, plus a typed error wrapper whose source is retained but whose kind is
-queryable without parsing `Display`. The existing file parser first decodes to
-`serde_yaml::Value`, checks that the root is a mapping, then runs the current ignored-field-aware
-typed deserialize, normalization, migration, and validation sequence. Tag those stages
-respectively; I/O errors remain outside this wrapper. `check_args` maps `Syntax` to
+Keep not-found and ordinary file-I/O branches separate until #2389 centralizes their bounded read.
+Complete the interface-only wrapper from Task 1. Change `legacy::from_file` from
+`read_to_string` to `std::fs::read`: file-open/read errors remain ordinary I/O errors, while
+`std::str::from_utf8` failure is wrapped as `McpPolicyErrorKind::Syntax` before YAML decode. Then
+decode to `serde_yaml::Value`, check that the root is a mapping, and run the current
+ignored-field-aware typed deserialize, normalization, migration, and validation sequence. Tag those
+stages `Syntax`, `RootNotMapping`, `Structure`, and `Validation` respectively. Never classify by
+`Display`. `check_args` maps `Syntax` to
 `PolicyParseFailure::YamlSyntax`, `RootNotMapping` to `PolicyParseFailure::RootNotMapping`, and
 `Structure`/`Validation` to `PolicyParseFailure::Structure`. The core test pins all four kinds,
 including a scalar-root fixture.
@@ -264,7 +284,9 @@ Add and self-test a structural source guard that permits YAML parser/deserialize
 inside the shared mapping/generic helpers and the `assay-core` full-policy parser, and requires
 `policy_decide`, `check_coverage`, and `explain_trace` to call the approved helper. Disposable
 fixtures must fail when a faithful duplicate two-stage parser is inserted at a consumer. Wire it to
-pre-commit for `tools/mod.rs`, the three direct consumers, the guard, and its self-test.
+pre-commit for `tools/mod.rs`, `policy_decide.rs`, `check_args.rs`, `check_coverage.rs`,
+`explain_trace.rs`, `policy/mod.rs`, `policy/legacy.rs`, the guard, and its self-test. Self-test a
+bypass in the direct-consumer class and the full-policy-parser class.
 
 Then, in disposable copies, separately: return a raw parser string from one sink; collapse syntax,
 root, and typed-shape classes; bypass the helper; remove the constructor bound; remove the serializer

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -49,6 +49,7 @@ GitHub Actions.
 - Modify `crates/assay-core/src/mcp/policy/mod.rs`: expose the typed full-policy failure kind.
 - Modify `crates/assay-core/src/mcp/policy/legacy.rs`: tag syntax, root, shape, and validation failures at source.
 - Modify `crates/assay-core/src/mcp/tests.rs`: pin full-policy error classification.
+- Add `crates/assay-core/tests/mcp_policy_warning_contract.rs`: subprocess warning/ordering contract.
 - Add `scripts/ci/check-mcp-policy-yaml-routing.py`: enforce the single mapping/parser boundary.
 - Add `scripts/ci/test-check-mcp-policy-yaml-routing.sh`: mutation-test the routing guard.
 - Modify `.pre-commit-config.yaml`: run the guard for every guarded parser or consumer.
@@ -59,6 +60,7 @@ GitHub Actions.
 - Add: `crates/assay-mcp-server/tests/policy_diagnostic_safety.rs`
 - Modify: `crates/assay-mcp-server/src/tools/mod.rs` (unit tests only in this task)
 - Modify: `crates/assay-core/src/mcp/tests.rs` (tests only in this task)
+- Add: `crates/assay-core/tests/mcp_policy_warning_contract.rs`
 - Modify: `crates/assay-core/src/mcp/policy/mod.rs` (interface-only typed seam)
 - Modify: `crates/assay-core/src/mcp/policy/legacy.rs` (interface-only typed seam)
 
@@ -101,7 +103,20 @@ Add a separate policy file containing invalid UTF-8 bytes and exercise `assay_ch
 the public class is `E_POLICY_PARSE` with exactly `Policy YAML is invalid`, not `E_POLICY_READ`,
 `E_INTERNAL`, or an OS/UTF-8 diagnostic.
 
-- [ ] **Step 4: Pin constructor and serializer bypasses**
+- [ ] **Step 4: Freeze successful full-policy semantics and warnings**
+
+Before changing `legacy::from_file`, add independent controls for V2 tools/schema, legacy root
+allow/deny normalization, V1 constraint migration, validation failure, unknown-field warning,
+non-strict V1 deprecation warning, and strict-deprecations rejection. Pin normalized results and
+warning behavior, not parser strings.
+
+Test the process-global deprecation warning in a dedicated integration-test binary. A parent test
+spawns `current_exe()` with an ignored exact child and no-timestamp tracing; the child parses one V1
+fixture with an unknown field twice. Assert unknown-field warning precedes deprecation warning, the
+deprecation text occurs exactly once, and the child succeeds. A child process resets `OnceLock`;
+never mutate it in-process. Run these controls GREEN on the baseline before continuing.
+
+- [ ] **Step 5: Pin constructor and serializer bypasses**
 
 In `tools/mod.rs` tests serialize all three forms with that same boundary-bisecting message:
 
@@ -115,33 +130,37 @@ Assert serialized `/message` is valid UTF-8 and at most 4,096 bytes. The direct 
 post-construction mutation are load-bearing: they prove the publication boundary, not only the
 constructor, applies the rule.
 
-- [ ] **Step 5: Add an interface-only classifier seam**
+- [ ] **Step 6: Add an interface-only classifier seam**
 
 Declare the public non-exhaustive `McpPolicyErrorKind` and typed wrapper, but do not yet make the
 parser construct it. This changes no parser result; it only lets the core classification test
 compile and downcast the existing `anyhow::Error`. The test must then fail its kind assertions rather
 than fail compilation.
 
-- [ ] **Step 6: Run behavioral RED**
+- [ ] **Step 7: Run baseline controls and behavioral RED**
 
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
 cargo test --locked -p assay-mcp-server tools::tests -- --nocapture
 cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
+cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
+cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
 ```
 
 Expected: hostile parser values appear in responses and direct/mutated `ToolError` serialization is
-unbounded; typed downcasts fail because the parser does not construct the seam; invalid UTF-8 is
-still classified as a read failure. Record the exact assertion failures in #2388. A compile failure
-does not count as RED evidence.
+unbounded; typed downcasts fail because the parser does not construct the seam; invalid UTF-8 still
+publishes `E_POLICY_PARSE` but leaks the raw UTF-8 diagnostic and lacks the typed `Syntax` kind.
+Successful parser/warning controls remain green. Record the exact assertion failures in #2388. A
+compile failure does not count as RED evidence.
 
-- [ ] **Step 7: Commit the interface seam and RED tests**
+- [ ] **Step 8: Commit the interface seam, behavior freeze, and RED tests**
 
 ```bash
 git add -- \
   crates/assay-mcp-server/tests/policy_diagnostic_safety.rs \
   crates/assay-mcp-server/src/tools/mod.rs \
   crates/assay-core/src/mcp/tests.rs \
+  crates/assay-core/tests/mcp_policy_warning_contract.rs \
   crates/assay-core/src/mcp/policy/mod.rs \
   crates/assay-core/src/mcp/policy/legacy.rs
 git commit -m "test(mcp): expose unbounded policy diagnostics"
@@ -270,6 +289,8 @@ cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --noc
 cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
 cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
 cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
+cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
+cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
 python3 scripts/ci/check-mcp-policy-yaml-routing.py
 bash scripts/ci/test-check-mcp-policy-yaml-routing.sh
 rg -n 'E_POLICY_PARSE.*(e\.to_string|format!)|Failed to parse policy' \
@@ -300,6 +321,7 @@ git add -- \
   crates/assay-core/src/mcp/policy/mod.rs \
   crates/assay-core/src/mcp/policy/legacy.rs \
   crates/assay-core/src/mcp/tests.rs \
+  crates/assay-core/tests/mcp_policy_warning_contract.rs \
   crates/assay-mcp-server/src/tools/mod.rs \
   crates/assay-mcp-server/src/tools/policy_decide.rs \
   crates/assay-mcp-server/src/tools/check_args.rs \
@@ -319,6 +341,8 @@ git commit -m "fix(mcp): normalise public policy parse diagnostics"
 ```bash
 cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
 cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
+cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
+cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
 cargo test --locked -p assay-mcp-server
 cargo fmt --all -- --check
 cargo clippy -p assay-core -p assay-mcp-server --all-targets -- -D warnings

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -12,7 +12,7 @@ serialization boundary.
 function in `tools/mod.rs`, use it in both `ToolError::new` and a manual `Serialize` implementation,
 and add one policy-parse constructor that accepts only a fixed failure class plus optional numeric
 location. Direct YAML consumers use one two-stage value/root/typed helper; the full-policy parser
-tags syntax, shape, and validation failures at source for `check_args`. Migrate the four raw parser
+tags syntax, root, shape, and validation failures at source for `check_args`. Migrate the four raw parser
 sinks; leave the already-fixed sequence diagnostic on the general constructor.
 
 **Tech Stack:** Rust 1.96, serde/serde_json/serde_yaml, real stdio JSON-RPC tests, pre-commit,
@@ -45,8 +45,11 @@ GitHub Actions.
 - Modify `crates/assay-mcp-server/src/tools/explain_trace.rs`: value-free YAML parser errors.
 - Add `crates/assay-mcp-server/tests/policy_diagnostic_safety.rs`: real-stdio hostile-input contract.
 - Modify `crates/assay-core/src/mcp/policy/mod.rs`: expose the typed full-policy failure kind.
-- Modify `crates/assay-core/src/mcp/policy/legacy.rs`: tag syntax, shape, and validation failures at source.
+- Modify `crates/assay-core/src/mcp/policy/legacy.rs`: tag syntax, root, shape, and validation failures at source.
 - Modify `crates/assay-core/src/mcp/tests.rs`: pin full-policy error classification.
+- Add `scripts/ci/check-mcp-policy-yaml-routing.py`: enforce the single mapping/parser boundary.
+- Add `scripts/ci/test-check-mcp-policy-yaml-routing.sh`: mutation-test the routing guard.
+- Modify `.pre-commit-config.yaml`: run the guard for every guarded parser or consumer.
 
 ### Task 1: Freeze the public diagnostic boundary
 
@@ -87,11 +90,12 @@ assertion stand in for these three classes.
 For malformed syntax at a known line/column, assert `details.line` and `details.column` are positive
 integers when that parser supplies location. Assert the complete response excludes the canonical
 temporary root and policy path. Add a malformed multibyte input whose bounded message must remain
-valid UTF-8.
+valid UTF-8. Separately construct a long message whose byte 4,096 falls inside a multibyte code
+point; reuse that exact message in every serializer-bypass case below.
 
 - [ ] **Step 4: Pin constructor and serializer bypasses**
 
-In `tools/mod.rs` tests serialize all three forms with a message longer than 4,096 bytes:
+In `tools/mod.rs` tests serialize all three forms with that same boundary-bisecting message:
 
 ```rust
 ToolError::new("E_TEST", &message)
@@ -197,6 +201,9 @@ git commit -m "fix(mcp): bound public tool error messages"
 - Modify: `crates/assay-mcp-server/src/tools/check_args.rs`
 - Modify: `crates/assay-mcp-server/src/tools/check_coverage.rs`
 - Modify: `crates/assay-mcp-server/src/tools/explain_trace.rs`
+- Add: `scripts/ci/check-mcp-policy-yaml-routing.py`
+- Add: `scripts/ci/test-check-mcp-policy-yaml-routing.sh`
+- Modify: `.pre-commit-config.yaml`
 
 - [ ] **Step 1: Inventory and pin the baseline**
 
@@ -210,23 +217,26 @@ because it is fixed and value-free, but it must not become a second parse-policy
 
 - [ ] **Step 2: Map syntax and structure without raw text**
 
-Add one generic direct-tool helper in `tools/mod.rs`: first decode bytes to `serde_yaml::Value`,
-then require a mapping root, then deserialize the value into the tool's typed policy. Classify the
-three stages as `YamlSyntax`, `RootNotMapping`, and `Structure`; extract only safe numeric location
-from the first-stage error. `check_coverage` and `explain_trace` must call this helper rather than
-classify `serde_yaml::Error` by its `Display` text. In `policy_decide`, retain #2386's explicit root
-and dialect checks while using the same syntax classification.
+Add one generic direct-tool helper in `tools/mod.rs` around a shared mapping-stage function: decode
+bytes to `serde_yaml::Value`, require a mapping root, and return the mapping-stage value plus the
+approved syntax/root classification. The generic helper then deserializes that value into the
+tool's typed policy and classifies typed failure as `Structure`; extract only safe numeric location
+from the first-stage error. `check_coverage` and `explain_trace` must call the generic helper.
+`policy_decide` must call the same mapping-stage function before its private dialect check. No
+direct consumer may construct a YAML deserializer or duplicate the mapping-root rule.
 
 - [ ] **Step 3: Handle `check_args` without widening into the reader/parser slice**
 
 Keep the existing not-found/read branches as a separate concern until #2389 centralizes them. In
-`assay-core`, add a public non-exhaustive `McpPolicyErrorKind` and a typed error wrapper whose source
-is retained but whose kind is queryable without parsing `Display`. The existing file parser first
-decodes to `serde_yaml::Value`, then runs the current ignored-field-aware typed deserialize,
-normalization, migration, and validation sequence. Tag first-stage decode as `Syntax`, typed
-deserialize as `Structure`, and validation as `Validation`; I/O errors remain outside this wrapper.
-`check_args` downcasts this wrapper and maps `Syntax` to `PolicyParseFailure::YamlSyntax`, and
-`Structure`/`Validation` to `PolicyParseFailure::Structure`.
+`assay-core`, add a public non-exhaustive `McpPolicyErrorKind` with `Syntax`, `RootNotMapping`,
+`Structure`, and `Validation`, plus a typed error wrapper whose source is retained but whose kind is
+queryable without parsing `Display`. The existing file parser first decodes to
+`serde_yaml::Value`, checks that the root is a mapping, then runs the current ignored-field-aware
+typed deserialize, normalization, migration, and validation sequence. Tag those stages
+respectively; I/O errors remain outside this wrapper. `check_args` maps `Syntax` to
+`PolicyParseFailure::YamlSyntax`, `RootNotMapping` to `PolicyParseFailure::RootNotMapping`, and
+`Structure`/`Validation` to `PolicyParseFailure::Structure`. The core test pins all four kinds,
+including a scalar-root fixture.
 
 Do not add a parallel bytes/string `McpPolicy` parser here. #2389 moves this same tagged parse rule
 behind the bytes API, preserves file/bytes parity, and removes `from_file` from the `check_args`
@@ -240,6 +250,8 @@ cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --noc
 cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
 cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
 cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
+python3 scripts/ci/check-mcp-policy-yaml-routing.py
+bash scripts/ci/test-check-mcp-policy-yaml-routing.sh
 rg -n 'E_POLICY_PARSE.*(e\.to_string|format!)|Failed to parse policy' \
   crates/assay-mcp-server/src/tools
 ```
@@ -248,11 +260,16 @@ Expected: tests pass and the grep finds no source-derived public parse sink.
 
 - [ ] **Step 5: Run discriminating mutations**
 
-In disposable copies, separately: return a raw parser string from one sink; collapse syntax and
-typed-shape to one class; make a direct YAML consumer bypass the two-stage helper; remove the
-constructor bound; remove the serializer bound; and replace the UTF-8 boundary loop with a byte
-slice. Each mutation must fail a different sentinel, classification, direct-struct, post-mutation,
-or multibyte assertion.
+Add and self-test a structural source guard that permits YAML parser/deserializer construction only
+inside the shared mapping/generic helpers and the `assay-core` full-policy parser, and requires
+`policy_decide`, `check_coverage`, and `explain_trace` to call the approved helper. Disposable
+fixtures must fail when a faithful duplicate two-stage parser is inserted at a consumer. Wire it to
+pre-commit for `tools/mod.rs`, the three direct consumers, the guard, and its self-test.
+
+Then, in disposable copies, separately: return a raw parser string from one sink; collapse syntax,
+root, and typed-shape classes; bypass the helper; remove the constructor bound; remove the serializer
+bound; and replace the UTF-8 boundary loop with a byte slice. Each mutation must fail a different
+structural, sentinel, classification, direct-struct, post-mutation, or multibyte assertion.
 
 - [ ] **Step 6: Commit migrated sinks and integration test**
 
@@ -266,7 +283,10 @@ git add -- \
   crates/assay-mcp-server/src/tools/check_args.rs \
   crates/assay-mcp-server/src/tools/check_coverage.rs \
   crates/assay-mcp-server/src/tools/explain_trace.rs \
-  crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+  crates/assay-mcp-server/tests/policy_diagnostic_safety.rs \
+  scripts/ci/check-mcp-policy-yaml-routing.py \
+  scripts/ci/test-check-mcp-policy-yaml-routing.sh \
+  .pre-commit-config.yaml
 git commit -m "fix(mcp): normalise public policy parse diagnostics"
 ```
 

--- a/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-policy-diagnostic-safety.md
@@ -1,0 +1,272 @@
+# MCP Policy Diagnostic Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #2387 by replacing source-derived public policy-parse messages with stable,
+value-free summaries and by enforcing one 4,096-byte UTF-8-safe ceiling at every `ToolError`
+serialization boundary.
+
+**Architecture:** Keep tool failures as MCP tool results. Add one private `bound_public_message`
+function in `tools/mod.rs`, use it in both `ToolError::new` and a manual `Serialize` implementation,
+and add one policy-parse constructor that accepts only a fixed failure class plus optional numeric
+location. Migrate the four raw parser sinks; leave the already-fixed sequence diagnostic on the
+general constructor.
+
+**Tech Stack:** Rust 1.96, serde/serde_json/serde_yaml, real stdio JSON-RPC tests, pre-commit,
+GitHub Actions.
+
+## Global Constraints
+
+- Baseline is the `main` SHA containing #2386; record it before creating the branch.
+- Implement in one isolated `claude/2387-policy-diagnostic-safety` worktree owned by Claude.
+- Public parse summaries are exactly `Policy YAML is invalid`, `Policy root must be a mapping`, or
+  `Policy structure is invalid`; do not append parser text.
+- The 4,096-byte ceiling applies to serialized `error.message`, not the complete MCP envelope.
+- Truncation must preserve valid UTF-8 and must not add a suffix beyond the ceiling.
+- Optional location is numeric `details.line` and `details.column`; no source line, path, or error
+  chain enters `message` or `details`.
+- Keep `ToolError` and its fields public for semver compatibility.
+- Do not absorb the outer server's separately constructed `E_INTERNAL` fallback or caller-selected
+  `on_error`; #2391 owns that generic dispatch boundary.
+- Do not change verdict semantics, reason codes, JSON-RPC errors, policy readers, or cache order.
+- Stage only named paths; never use a whole-tree staging command.
+
+---
+
+## File Structure
+
+- Modify `crates/assay-mcp-server/src/tools/mod.rs`: shared bound, parse failure class, custom serialization.
+- Modify `crates/assay-mcp-server/src/tools/policy_decide.rs`: value-free parser errors.
+- Modify `crates/assay-mcp-server/src/tools/check_args.rs`: value-free full-policy parser errors.
+- Modify `crates/assay-mcp-server/src/tools/check_coverage.rs`: value-free YAML parser errors.
+- Modify `crates/assay-mcp-server/src/tools/explain_trace.rs`: value-free YAML parser errors.
+- Add `crates/assay-mcp-server/tests/policy_diagnostic_safety.rs`: real-stdio hostile-input contract.
+
+### Task 1: Freeze the public diagnostic boundary
+
+**Files:**
+- Add: `crates/assay-mcp-server/tests/policy_diagnostic_safety.rs`
+- Modify: `crates/assay-mcp-server/src/tools/mod.rs` (unit tests only in this task)
+
+- [ ] **Step 1: Add a real-stdio helper covering four raw sinks**
+
+Spawn `CARGO_BIN_EXE_assay-mcp-server` with a temporary `--policy-root`, initialize protocol
+`2024-11-05`, call `assay_policy_decide`, `assay_check_args`, `assay_check_coverage`, and
+`assay_explain_trace`, and decode `result.content[0].text` as JSON. Every assertion must inspect the
+complete response string as well as `/error/message`.
+
+- [ ] **Step 2: Add three hostile sentinel positions**
+
+Create separate malformed policies with unique `BEGIN_SECRET`, `MIDDLE_SECRET`, and `END_SECRET`
+sentinels embedded in a 200,000-byte invalid scalar. For each tool assert:
+
+```text
+result.isError == true
+body.allowed == false
+body.error.code == E_POLICY_PARSE
+body.error.message is one fixed summary
+body.error.message.as_bytes().len() <= 4096
+complete response contains none of the three sentinels
+```
+
+Use distinct files or requests so one failure cannot mask another position.
+
+- [ ] **Step 3: Add path and location controls**
+
+For malformed syntax at a known line/column, assert `details.line` and `details.column` are positive
+integers when that parser supplies location. Assert the complete response excludes the canonical
+temporary root and policy path. Add a malformed multibyte input whose bounded message must remain
+valid UTF-8.
+
+- [ ] **Step 4: Pin constructor and serializer bypasses**
+
+In `tools/mod.rs` tests serialize all three forms with a message longer than 4,096 bytes:
+
+```rust
+ToolError::new("E_TEST", &message)
+ToolError { code: "E_TEST".into(), message: message.clone(), details: None }
+let mut error = ToolError::new("E_TEST", "short"); error.message = message;
+```
+
+Assert serialized `/message` is valid UTF-8 and at most 4,096 bytes. The direct construction and
+post-construction mutation are load-bearing: they prove the publication boundary, not only the
+constructor, applies the rule.
+
+- [ ] **Step 5: Run RED**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
+cargo test --locked -p assay-mcp-server tools::tests -- --nocapture
+```
+
+Expected: hostile parser values appear in responses and direct/mutated `ToolError` serialization is
+unbounded. Record the exact failures in #2388.
+
+- [ ] **Step 6: Commit only RED tests**
+
+```bash
+git add -- \
+  crates/assay-mcp-server/tests/policy_diagnostic_safety.rs \
+  crates/assay-mcp-server/src/tools/mod.rs
+git commit -m "test(mcp): expose unbounded policy diagnostics"
+```
+
+### Task 2: Implement one bounded publication boundary
+
+**Files:**
+- Modify: `crates/assay-mcp-server/src/tools/mod.rs`
+
+- [ ] **Step 1: Add the UTF-8-safe bound**
+
+Define `const MAX_PUBLIC_MESSAGE_BYTES: usize = 4096` and one function:
+
+```rust
+fn bound_public_message(message: &str) -> &str {
+    if message.len() <= MAX_PUBLIC_MESSAGE_BYTES {
+        return message;
+    }
+    let mut end = MAX_PUBLIC_MESSAGE_BYTES;
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    &message[..end]
+}
+```
+
+Do not duplicate this character-boundary rule in constructor and serializer.
+
+- [ ] **Step 2: Replace derived serialization**
+
+Remove `#[derive(serde::Serialize)]` from `ToolError`. Implement `serde::Serialize` manually through
+a private serializable view that borrows `code`, the bounded message slice, and `details`. Preserve
+the existing field names and `skip_serializing_if` behavior.
+
+- [ ] **Step 3: Make the constructor call the same function**
+
+`ToolError::new` stores `bound_public_message(message).to_owned()`. Keep the serializer bound too;
+public fields can bypass or mutate constructor state.
+
+- [ ] **Step 4: Add a fixed parse constructor**
+
+Add a private or `pub(crate)` enum with only the three approved classes and a constructor such as:
+
+```rust
+pub(crate) fn policy_parse(
+    class: PolicyParseFailure,
+    location: Option<(usize, usize)>,
+) -> Self
+```
+
+Map the enum to fixed summaries. Populate `details` only as `{"line": line, "column": column}`.
+Do not accept a raw parser `Display` string.
+
+- [ ] **Step 5: Run the serialization tests GREEN**
+
+```bash
+cargo test --locked -p assay-mcp-server tools::tests -- --nocapture
+```
+
+- [ ] **Step 6: Commit the shared boundary**
+
+```bash
+git add -- crates/assay-mcp-server/src/tools/mod.rs
+git commit -m "fix(mcp): bound public tool error messages"
+```
+
+### Task 3: Migrate every raw policy-parse sink
+
+**Files:**
+- Modify: `crates/assay-mcp-server/src/tools/policy_decide.rs`
+- Modify: `crates/assay-mcp-server/src/tools/check_args.rs`
+- Modify: `crates/assay-mcp-server/src/tools/check_coverage.rs`
+- Modify: `crates/assay-mcp-server/src/tools/explain_trace.rs`
+
+- [ ] **Step 1: Inventory and pin the baseline**
+
+```bash
+rg -n 'E_POLICY_PARSE|Failed to parse policy|e\.to_string\(\)' \
+  crates/assay-mcp-server/src/tools
+```
+
+Record every hit in the PR body. `check_sequence` may retain `Invalid sequence policy format`
+because it is fixed and value-free, but it must not become a second parse-policy constructor.
+
+- [ ] **Step 2: Map syntax and structure without raw text**
+
+For `serde_yaml::Error`, extract only `location().map(|loc| (loc.line(), loc.column()))` and pass it
+to `ToolError::policy_parse`. Use `YamlSyntax` where syntax decoding fails and `Structure` where a
+typed mapping has the wrong shape. In `policy_decide`, retain #2386's explicit root class.
+
+- [ ] **Step 3: Handle `check_args` without widening into the reader/parser slice**
+
+Keep the existing not-found/read branches as a separate concern until #2389 centralizes them. Map
+the current fall-through parse/validation error to `PolicyParseFailure::Structure` without
+publishing `e.to_string()`. Do not add a bytes/string `McpPolicy` parser here: extracting that
+single parse rule, preserving file/bytes parity, and removing `from_file` from this callsite are the
+explicit work of #2389.
+
+- [ ] **Step 4: Run GREEN and inspect public text**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
+cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
+cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
+rg -n 'E_POLICY_PARSE.*(e\.to_string|format!)|Failed to parse policy' \
+  crates/assay-mcp-server/src/tools
+```
+
+Expected: tests pass and the grep finds no source-derived public parse sink.
+
+- [ ] **Step 5: Run discriminating mutations**
+
+In disposable copies, separately: return a raw parser string from one sink; remove the constructor
+bound; remove the serializer bound; and replace the UTF-8 boundary loop with a byte slice. Each
+mutation must fail a different sentinel, direct-struct, post-mutation, or multibyte assertion.
+
+- [ ] **Step 6: Commit migrated sinks and integration test**
+
+```bash
+git add -- \
+  crates/assay-mcp-server/src/tools/policy_decide.rs \
+  crates/assay-mcp-server/src/tools/check_args.rs \
+  crates/assay-mcp-server/src/tools/check_coverage.rs \
+  crates/assay-mcp-server/src/tools/explain_trace.rs \
+  crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+git commit -m "fix(mcp): normalise public policy parse diagnostics"
+```
+
+### Task 4: Verify and publish #2387
+
+- [ ] **Step 1: Run required local verification**
+
+```bash
+cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
+cargo test --locked -p assay-mcp-server
+cargo fmt --all -- --check
+cargo clippy -p assay-mcp-server --all-targets -- -D warnings
+git diff --check
+git status --short
+```
+
+- [ ] **Step 2: Inspect scope and strings**
+
+```bash
+git diff --stat origin/main...HEAD
+rg -n 'E_POLICY_PARSE|Policy (YAML|root|structure)' crates/assay-mcp-server/src/tools
+```
+
+Confirm no absolute path, source fragment, parser implementation text, verdict change, or reader
+limit entered this slice.
+
+- [ ] **Step 3: Push, open the PR, and record the ledger**
+
+Push `claude/2387-policy-diagnostic-safety`, open against current `main`, and record branch, PR,
+exact head SHA, tests, mutations, non-claims, and findings in #2388.
+
+- [ ] **Step 4: Obtain exact-head quorum**
+
+Use one fresh non-building reviewer who authored neither the governing spec/plan nor the code. Any
+push invalidates the review. Merge only after required checks, exact-head review, and delegated
+proof (when triggered) all bind to the final SHA.


### PR DESCRIPTION
## Summary

- add executable TDD plan for #2386 root/dialect/cache safety
- add executable TDD plan for #2387 value-free bounded diagnostics
- add executable TDD plan for #2389 bounded five-tool policy ingest
- bind all three plans to the owner-approved design merged in #2390

## Scope

Documentation and implementation planning only. No production behavior changes.

The plans preserve the programme boundaries:
- #2386 intentionally rejects canonical/mixed policy documents in `assay_policy_decide`, with changelog and migration guidance
- #2387 centralizes value-free `E_POLICY_PARSE` summaries and bounds serialized `ToolError.message`
- #2389 centralizes bounded reads, preserves full-policy parse order, and pins invalid UTF-8 as public `E_POLICY_PARSE`
- #2391 remains outside these slices

## Baseline

- base: `9426f836a4f52becd79441de69346b7850f1077c` (`main`, merged spec #2390)
- head: `387dcc81595aef1626e9235efe1bf5fb393b15d8`
- branch contains three plan commits and three new files

## Verification

- file-scoped pre-commit / pre-push hooks: pass
- `git diff --check origin/main...HEAD`: pass
- workspace clippy with `-D warnings`: pass (`rustc 1.96.0`, `cargo 1.96.0`)
- Linux cross-target compile gate: pass (`rustc 1.96.0`, `cargo 1.96.0`)
- first prior-head review gaps fixed: syntax/shape classification, public invalid-UTF-8 stdio case, structural delegation mutation guard, repository-wide docs inventory
- second prior-head review gaps fixed: explicit assay-core classifier scope, two-stage direct-consumer parsing, mutation-sensitive parser expectations, executed RED phases
- third prior-head review gaps fixed: four-class full-policy errors, metadata-bypass proof, behavioral RED sequencing, single YAML-routing guard, UTF-8 boundary mutation, non-strict warning preservation, required `from_str`, both parser delegation hops, accurate slice-1 RED, and ceiling migration docs
- fourth prior-head review gaps fixed: behavioral classifier seam, Slice-2 invalid UTF-8 ownership, three-hop parser delegation, deterministic deprecation-warning subprocess, complete YAML guard triggers, and explicit generic/file reader layers
- fifth prior-head review gaps fixed: Slice-2 parser/warning freeze, four-hop parser delegation, post-extraction/final warning verification, and corrected invalid-UTF-8 RED evidence
- sixth prior-head review gaps fixed: constructor-state assertion, `ToolError::result` bypass coverage, and full per-tool oversized error envelopes
- seventh prior-head review gaps fixed: structural `ToolError::result` delegation guard with faithful-repack mutation and explicit RED matrix commit pathspec
- independent exact-head review: pending on current head

## Non-claims

This PR does not implement the slices, provide their RED/GREEN evidence, or supply implementation review quorum. It does not expand into proxy enforcement, outer `tools/call` fallback behavior, MCP 2026-07-28, or general CLI readers.
