### PR TITLE
fix(mcp): reject invalid policy_decide dialects before cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `assay_policy_decide` now rejects non-mapping roots and canonical or mixed name-policy
+  documents (`allow`, `deny`, `tools`, or those markers mixed with root `blocklist`) with
+  `E_POLICY_PARSE` before cache insertion. Those inputs previously returned a false clean
+  allow or ignored the canonical fields. This is an intentional hardening change, not
+  "unsupported with no impact." Route full, argument-aware policy evaluation to
+  `assay_check_args`. Migration: keep a root-`blocklist` file for the name-only tool, and
+  move `tools.allow` / `tools.deny` documents to `assay_check_args` (#2386).
+
+  ```yaml
+  # assay_policy_decide compatibility dialect only
+  blocklist:
+    - dangerous_tool
+  ```
+
+  ```yaml
+  # full McpPolicy for assay_check_args — do not pass this to assay_policy_decide
+  tools:
+    deny:
+      - dangerous_tool
+  ```
+
 ## [5.2.0] - 2026-08-14
 
 This release hardens the evidence verifier and makes the Linux monitor's declared observation

--- a/crates/assay-mcp-server/src/tools/policy_decide.rs
+++ b/crates/assay-mcp-server/src/tools/policy_decide.rs
@@ -2,6 +2,34 @@ use super::{ToolContext, ToolError};
 use anyhow::{Context, Result};
 use serde_json::Value;
 
+#[derive(serde::Deserialize)]
+struct PolicyDecisionDocument {
+    #[serde(default)]
+    blocklist: Vec<String>,
+}
+
+fn parse_policy_decision_document(bytes: &[u8]) -> Result<Vec<String>, ToolError> {
+    let root: Value = serde_yaml::from_slice(bytes)
+        .map_err(|_| ToolError::new("E_POLICY_PARSE", "Policy YAML is invalid"))?;
+    let object = root
+        .as_object()
+        .ok_or_else(|| ToolError::new("E_POLICY_PARSE", "Policy root must be a mapping"))?;
+
+    if ["allow", "deny", "tools"]
+        .iter()
+        .any(|key| object.contains_key(*key))
+    {
+        return Err(ToolError::new(
+            "E_POLICY_PARSE",
+            "Policy structure is invalid",
+        ));
+    }
+
+    serde_json::from_value::<PolicyDecisionDocument>(root)
+        .map(|document| document.blocklist)
+        .map_err(|_| ToolError::new("E_POLICY_PARSE", "Policy structure is invalid"))
+}
+
 pub async fn policy_decide(ctx: &ToolContext, args: &Value) -> Result<Value> {
     // 1. Unpack args & Checks
     let tool_name = args
@@ -47,21 +75,9 @@ pub async fn policy_decide(ctx: &ToolContext, args: &Value) -> Result<Value> {
         list
     } else {
         tracing::debug!(event="cache_miss", key=%cache_key, cache="blocklist");
-        // Compile
-        let policy_yaml: Value = match serde_yaml::from_slice(&policy_bytes) {
-            Ok(v) => v,
-            Err(e) => return ToolError::new("E_POLICY_PARSE", &e.to_string()).result(),
-        };
-
-        // Extract blocklist. Absent stays empty (allow). A present value that is
-        // not a string sequence is a parse error and must not be cached.
-        let list: Vec<String> = if let Some(l) = policy_yaml.get("blocklist") {
-            match serde_json::from_value(l.clone()) {
-                Ok(list) => list,
-                Err(e) => return ToolError::new("E_POLICY_PARSE", &e.to_string()).result(),
-            }
-        } else {
-            vec![]
+        let list = match parse_policy_decision_document(&policy_bytes) {
+            Ok(list) => list,
+            Err(error) => return error.result(),
         };
 
         let arc = std::sync::Arc::new(list);

--- a/crates/assay-mcp-server/tests/policy_decide_blocklist.rs
+++ b/crates/assay-mcp-server/tests/policy_decide_blocklist.rs
@@ -3,7 +3,8 @@
 //! A present `blocklist` that is not a string sequence must fail closed
 //! (`allowed: false`, `E_POLICY_PARSE`, `isError: true`) and must not be
 //! cached as an empty list. Absent and `[]` remain allow; a valid string
-//! list still denies.
+//! list still denies. Non-mapping roots and canonical/mixed dialects fail
+//! closed before cache insertion.
 
 use serde_json::Value;
 use std::fs;
@@ -12,6 +13,12 @@ use std::process::{Command, Stdio};
 
 mod jsonrpc_conn;
 use jsonrpc_conn::Conn;
+
+const ROOT_MUST_BE_MAPPING: &str = "Policy root must be a mapping";
+const STRUCTURE_INVALID: &str = "Policy structure is invalid";
+const BEGIN_SECRET: &str = "BEGIN_SECRET";
+const END_SECRET: &str = "END_SECRET";
+const LARGE_ROOT_BYTES: usize = 200_000;
 
 fn spawn_server(policy_root: &Path) -> Conn {
     let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
@@ -39,13 +46,13 @@ fn initialize(conn: &mut Conn) {
     );
 }
 
-fn call_policy_decide(conn: &mut Conn, policy: &str, id: u64) -> (Value, Value) {
+fn call_policy_decide(conn: &mut Conn, policy: &str, tool: &str, id: u64) -> (Value, Value) {
     let resp = conn.request(
         "tools/call",
         serde_json::json!({
             "name": "assay_policy_decide",
             "arguments": {
-                "tool": "dangerous_tool",
+                "tool": tool,
                 "policy": policy
             }
         }),
@@ -63,7 +70,7 @@ fn call_policy_decide(conn: &mut Conn, policy: &str, id: u64) -> (Value, Value) 
     (result, body)
 }
 
-fn assert_parse_error(label: &str, result: &Value, body: &Value) {
+fn assert_parse_error(label: &str, result: &Value, body: &Value, expected_message: &str) {
     assert_eq!(
         result.get("isError").and_then(Value::as_bool),
         Some(true),
@@ -78,6 +85,11 @@ fn assert_parse_error(label: &str, result: &Value, body: &Value) {
         body.pointer("/error/code").and_then(Value::as_str),
         Some("E_POLICY_PARSE"),
         "{label}: error.code must be E_POLICY_PARSE; body={body}"
+    );
+    assert_eq!(
+        body.pointer("/error/message").and_then(Value::as_str),
+        Some(expected_message),
+        "{label}: wrong stable parse summary; body={body}"
     );
 }
 
@@ -98,15 +110,94 @@ fn assert_allowed(label: &str, result: &Value, body: &Value) {
     );
 }
 
+fn assert_denied(label: &str, result: &Value, body: &Value, tool: &str) {
+    assert_eq!(
+        result.get("isError").and_then(Value::as_bool),
+        Some(true),
+        "{label}: MCP isError must be true; result={result} body={body}"
+    );
+    assert_eq!(
+        body.get("allowed").and_then(Value::as_bool),
+        Some(false),
+        "{label}: allowed must be false; body={body}"
+    );
+    assert!(
+        body.get("error").is_none(),
+        "{label}: valid deny must not carry a parse error; body={body}"
+    );
+    let matches = body["matches"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{label}: valid deny should return matches; body={body}"));
+    assert!(
+        matches.iter().any(|m| m
+            .as_str()
+            .is_some_and(|s| s.contains(tool) && s.contains("blocked"))),
+        "{label}: valid deny matches missing blocked-tool text: {body}"
+    );
+}
+
 fn write_policy(dir: &Path, name: &str, contents: &str) {
     fs::write(dir.join(name), contents).unwrap_or_else(|e| panic!("write {name}: {e}"));
 }
 
-#[test]
-fn present_malformed_blocklist_fails_closed_and_is_not_cached() {
-    let dir = tempfile::tempdir().expect("policy-root");
-    let root = dir.path();
+fn large_scalar_root() -> String {
+    let wrapper = 2; // surrounding YAML double quotes
+    let filler = LARGE_ROOT_BYTES
+        .checked_sub(wrapper + BEGIN_SECRET.len() + END_SECRET.len())
+        .expect("sentinel overhead fits in 200k");
+    let mut contents = String::with_capacity(LARGE_ROOT_BYTES);
+    contents.push('"');
+    contents.push_str(BEGIN_SECRET);
+    contents.extend(std::iter::repeat_n('A', filler));
+    contents.push_str(END_SECRET);
+    contents.push('"');
+    assert_eq!(
+        contents.len(),
+        LARGE_ROOT_BYTES,
+        "large root must be a 200,000-byte syntactically valid YAML scalar"
+    );
+    contents
+}
 
+fn assert_no_sentinels(label: &str, result: &Value, body: &Value) {
+    let blob = format!("{result}{body}");
+    assert!(
+        !blob.contains(BEGIN_SECRET),
+        "{label}: response reflected {BEGIN_SECRET}; body={body}"
+    );
+    assert!(
+        !blob.contains(END_SECRET),
+        "{label}: response reflected {END_SECRET}; body={body}"
+    );
+}
+
+fn assert_repeat_parse_error(
+    conn: &mut Conn,
+    policy: &str,
+    tool: &str,
+    id: &mut u64,
+    expected_message: &str,
+) {
+    let (first_result, first_body) = call_policy_decide(conn, policy, tool, *id);
+    *id += 1;
+    assert_parse_error(
+        &format!("{policy} first call"),
+        &first_result,
+        &first_body,
+        expected_message,
+    );
+
+    let (second_result, second_body) = call_policy_decide(conn, policy, tool, *id);
+    *id += 1;
+    assert_parse_error(
+        &format!("{policy} repeat call"),
+        &second_result,
+        &second_body,
+        expected_message,
+    );
+}
+
+fn write_field_shape_fixtures(root: &Path) {
     write_policy(root, "string.yaml", "blocklist: dangerous_tool\n");
     write_policy(root, "mapping.yaml", "blocklist:\n  dangerous_tool: true\n");
     write_policy(root, "number.yaml", "blocklist: 7\n");
@@ -117,63 +208,182 @@ fn present_malformed_blocklist_fails_closed_and_is_not_cached() {
         "mixed.yaml",
         "blocklist:\n  - dangerous_tool\n  - 7\n",
     );
+    write_policy(root, "bare.yaml", "blocklist:\n");
+}
+
+fn write_compatibility_fixtures(root: &Path) {
     write_policy(root, "absent.yaml", "version: 1\n");
     write_policy(root, "empty.yaml", "blocklist: []\n");
     write_policy(root, "deny.yaml", "blocklist:\n  - dangerous_tool\n");
+    write_policy(root, "metadata.yaml", "name: metadata-only\n");
+    write_policy(root, "wildcard.yaml", "blocklist:\n  - \"dangerous_*\"\n");
+}
+
+const UNSUPPORTED_DIALECTS: [(&str, &str); 5] = [
+    ("root-allow.yaml", "allow:\n  - dangerous_tool\n"),
+    ("root-deny.yaml", "deny:\n  - dangerous_tool\n"),
+    ("tools-deny.yaml", "tools:\n  deny:\n    - dangerous_tool\n"),
+    (
+        "mixed-root-deny.yaml",
+        "blocklist:\n  - dangerous_tool\ndeny:\n  - other_tool\n",
+    ),
+    (
+        "mixed-tools.yaml",
+        "blocklist:\n  - dangerous_tool\ntools:\n  deny:\n    - other_tool\n",
+    ),
+];
+
+#[test]
+fn present_malformed_blocklist_fails_closed_and_is_not_cached() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_field_shape_fixtures(root);
 
     let mut conn = spawn_server(root);
     initialize(&mut conn);
-
-    let malformed = [
+    let mut id = 2;
+    for policy in [
         "string.yaml",
         "mapping.yaml",
         "number.yaml",
         "null.yaml",
         "bool.yaml",
         "mixed.yaml",
-    ];
-    let mut id = 2;
-    for policy in malformed {
-        let (first_result, first_body) = call_policy_decide(&mut conn, policy, id);
-        id += 1;
-        assert_parse_error(&format!("{policy} first call"), &first_result, &first_body);
+        "bare.yaml",
+    ] {
+        assert_repeat_parse_error(
+            &mut conn,
+            policy,
+            "dangerous_tool",
+            &mut id,
+            STRUCTURE_INVALID,
+        );
+    }
+    let _ = conn.shutdown();
+}
 
-        let (second_result, second_body) = call_policy_decide(&mut conn, policy, id);
+#[test]
+fn non_mapping_roots_fail_closed_without_source_reflection() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_policy(root, "root-scalar.yaml", "dangerous_tool\n");
+    write_policy(root, "root-sequence.yaml", "- dangerous_tool\n");
+    write_policy(root, "root-null-document.yaml", "null\n");
+    write_policy(root, "root-empty-document.yaml", "");
+    write_policy(root, "root-large-scalar.yaml", &large_scalar_root());
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let mut id = 2;
+    for policy in [
+        "root-scalar.yaml",
+        "root-sequence.yaml",
+        "root-null-document.yaml",
+        "root-empty-document.yaml",
+        "root-large-scalar.yaml",
+    ] {
+        let (first_result, first_body) =
+            call_policy_decide(&mut conn, policy, "dangerous_tool", id);
+        id += 1;
+        assert_parse_error(
+            &format!("{policy} first call"),
+            &first_result,
+            &first_body,
+            ROOT_MUST_BE_MAPPING,
+        );
+        assert_no_sentinels(&format!("{policy} first call"), &first_result, &first_body);
+
+        let (second_result, second_body) =
+            call_policy_decide(&mut conn, policy, "dangerous_tool", id);
         id += 1;
         assert_parse_error(
             &format!("{policy} repeat call"),
             &second_result,
             &second_body,
+            ROOT_MUST_BE_MAPPING,
+        );
+        assert_no_sentinels(
+            &format!("{policy} repeat call"),
+            &second_result,
+            &second_body,
         );
     }
+    let _ = conn.shutdown();
+}
 
-    let (absent_result, absent_body) = call_policy_decide(&mut conn, "absent.yaml", id);
+#[test]
+fn canonical_and_mixed_dialects_fail_closed() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    for (name, contents) in UNSUPPORTED_DIALECTS {
+        write_policy(root, name, contents);
+    }
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let mut id = 2;
+    for (policy, _) in UNSUPPORTED_DIALECTS {
+        assert_repeat_parse_error(
+            &mut conn,
+            policy,
+            "dangerous_tool",
+            &mut id,
+            STRUCTURE_INVALID,
+        );
+    }
+    let _ = conn.shutdown();
+}
+
+#[test]
+fn exact_name_blocklist_compatibility_controls() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_compatibility_fixtures(root);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let mut id = 2;
+
+    let (absent_result, absent_body) =
+        call_policy_decide(&mut conn, "absent.yaml", "dangerous_tool", id);
     id += 1;
     assert_allowed("absent blocklist", &absent_result, &absent_body);
 
-    let (empty_result, empty_body) = call_policy_decide(&mut conn, "empty.yaml", id);
+    let (metadata_result, metadata_body) =
+        call_policy_decide(&mut conn, "metadata.yaml", "dangerous_tool", id);
+    id += 1;
+    assert_allowed("metadata-only mapping", &metadata_result, &metadata_body);
+
+    let (empty_result, empty_body) =
+        call_policy_decide(&mut conn, "empty.yaml", "dangerous_tool", id);
     id += 1;
     assert_allowed("empty blocklist []", &empty_result, &empty_body);
 
-    let (deny_result, deny_body) = call_policy_decide(&mut conn, "deny.yaml", id);
-    assert_eq!(
-        deny_result.get("isError").and_then(Value::as_bool),
-        Some(true),
-        "valid [dangerous_tool] must set isError; result={deny_result} body={deny_body}"
+    let (deny_result, deny_body) = call_policy_decide(&mut conn, "deny.yaml", "dangerous_tool", id);
+    id += 1;
+    assert_denied(
+        "valid [dangerous_tool]",
+        &deny_result,
+        &deny_body,
+        "dangerous_tool",
     );
-    assert_eq!(
-        deny_body.get("allowed").and_then(Value::as_bool),
-        Some(false),
-        "valid [dangerous_tool] must deny; body={deny_body}"
+
+    let (wildcard_allow_result, wildcard_allow_body) =
+        call_policy_decide(&mut conn, "wildcard.yaml", "dangerous_tool", id);
+    id += 1;
+    assert_allowed(
+        "literal wildcard does not match dangerous_tool",
+        &wildcard_allow_result,
+        &wildcard_allow_body,
     );
-    let matches = deny_body["matches"]
-        .as_array()
-        .expect("valid deny should return matches");
-    assert!(
-        matches.iter().any(|m| m
-            .as_str()
-            .is_some_and(|s| s.contains("dangerous_tool") && s.contains("blocked"))),
-        "valid deny matches missing blocked-tool text: {deny_body}"
+
+    let (wildcard_deny_result, wildcard_deny_body) =
+        call_policy_decide(&mut conn, "wildcard.yaml", "dangerous_*", id);
+    assert_denied(
+        "literal wildcard denies exact dangerous_*",
+        &wildcard_deny_result,
+        &wildcard_deny_body,
+        "dangerous_*",
     );
 
     let _ = conn.shutdown();

--- a/docs/AIcontext/entry-points.md
+++ b/docs/AIcontext/entry-points.md
@@ -512,11 +512,16 @@ The MCP server (`assay-mcp-server`) exposes tools via JSON-RPC over stdio.
 
 ### Tool: `assay_policy_decide`
 
-**Purpose**: General policy decision endpoint
+**Purpose**: Exact-name check against a compatibility-only root `blocklist`
 
-**Request**: Tool call with arguments
+`assay_policy_decide` performs an exact-name check against its compatibility-only root `blocklist`.
+It does not parse full `McpPolicy` controls such as `tools.allow` or `tools.deny`; use
+`assay_check_args` for full, argument-aware policy evaluation. Passing canonical name-policy fields
+to `assay_policy_decide` is an error, not a clean allow.
 
-**Response**: Allow/deny decision with violations
+**Request**: `{ "tool": "string", "policy": "path.yaml" }`
+
+**Response**: Allow/deny for that exact tool name, or `E_POLICY_PARSE` for an invalid root or dialect
 
 ## Configuration Files
 
@@ -537,12 +542,15 @@ The MCP server (`assay-mcp-server`) exposes tools via JSON-RPC over stdio.
 
 **Purpose**: Policy constraints
 **Location**: Specified in `eval.yaml` or default `policy.yaml`
-**Schema**: Defined in `assay-core::policy_engine`
+**Schema**: Full argument-aware evaluation uses `McpPolicy` (`tools`, `sequences`).
+`assay_policy_decide` reads only a private root-`blocklist` dialect and rejects
+canonical name-policy fields.
 
 **Key Sections**:
-- `tools`: Tool-specific constraints
-- `sequences`: Sequence rules
-- `blocklist`: Blocked tools/patterns
+- `tools`: Tool-specific constraints for `assay_check_args` / full `McpPolicy`
+- `sequences`: Sequence rules for `assay_check_sequence`
+- Root `blocklist`: Exact-name compatibility list for `assay_policy_decide` only.
+  Do not mix it with `tools`, `allow`, or `deny` in that tool.
 
 ### Trace Files (`.jsonl`)
 

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -128,7 +128,7 @@ Seeds are **decimal strings or null** (no JSON number) for JS/TS precision safet
 ## Policy Quick Reference
 
 ```yaml
-# policy.yaml structure
+# Full McpPolicy for assay_check_args / assay_check_sequence
 version: "1"
 
 tools:
@@ -148,7 +148,12 @@ sequences:
   - name: auth_before_data
     pattern: [authenticate, fetch_data]
     required: true
+```
 
+```yaml
+# Name-only compatibility dialect for assay_policy_decide
+# Exact string membership; wildcard-looking names stay literal.
+# Do not add tools, allow, or deny here — that is E_POLICY_PARSE.
 blocklist:
   - "rm_rf"
   - "drop_database"

--- a/docs/mcp/self-correction.md
+++ b/docs/mcp/self-correction.md
@@ -135,26 +135,32 @@ Validate if a tool call is allowed given prior calls.
 
 ### assay_policy_decide
 
-Combined check: arguments + sequence + blocklist.
+`assay_policy_decide` performs an exact-name check against its compatibility-only root `blocklist`.
+It does not parse full `McpPolicy` controls such as `tools.allow` or `tools.deny`; use
+`assay_check_args` for full, argument-aware policy evaluation. Passing canonical name-policy fields
+to `assay_policy_decide` is an error, not a clean allow.
 
 **Input:**
 ```json
 {
-  "target_tool": "process_refund",
-  "args": {"amount": 500, "order_id": "ord_123"},
-  "previous_calls": ["get_order", "verify_identity"]
+  "tool": "process_refund",
+  "policy": "blocklist.yaml"
 }
 ```
 
-**Output:**
+**Output (allow):**
 ```json
 {
-  "decision": "allow",
-  "checks": {
-    "args_valid": {"passed": true},
-    "sequence_valid": {"passed": true},
-    "blocklist": {"passed": true}
-  }
+  "allowed": true,
+  "reason": "Allowed by policy"
+}
+```
+
+**Output (exact-name deny):**
+```json
+{
+  "allowed": false,
+  "matches": ["Tool 'process_refund' is blocked by policy"]
 }
 ```
 

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -46,6 +46,10 @@ Validates sequence rules.
 **Output**: Same structure as `check_args`.
 
 ### `assay_policy_decide`
-Checks blocklists.
+`assay_policy_decide` performs an exact-name check against its compatibility-only root `blocklist`.
+It does not parse full `McpPolicy` controls such as `tools.allow` or `tools.deny`; use
+`assay_check_args` for full, argument-aware policy evaluation. Passing canonical name-policy fields
+to `assay_policy_decide` is an error, not a clean allow.
 **Input**: `{ "tool": "string", "policy": "path.yaml" }`
-**Output**: Same structure as `check_args` (allowed/denied).
+**Output**: `{ "allowed": boolean }` plus a short reason or match. Invalid roots and unsupported
+dialects return `allowed: false` with `error.code: E_POLICY_PARSE`.

--- a/docs/use-cases/self-correction.md
+++ b/docs/use-cases/self-correction.md
@@ -164,24 +164,22 @@ Validate if a tool is allowed given prior calls.
 
 ### assay_policy_decide
 
-Combined check (args + sequence + blocklist).
+`assay_policy_decide` performs an exact-name check against its compatibility-only root `blocklist`.
+It does not parse full `McpPolicy` controls such as `tools.allow` or `tools.deny`; use
+`assay_check_args` for full, argument-aware policy evaluation. Passing canonical name-policy fields
+to `assay_policy_decide` is an error, not a clean allow.
 
 ```json
 // Request
 {
-  "target_tool": "process_refund",
-  "args": { "amount": 100 },
-  "previous_calls": ["get_order", "verify_identity"]
+  "tool": "process_refund",
+  "policy": "blocklist.yaml"
 }
 
 // Response
 {
-  "decision": "allow",
-  "checks": {
-    "args_valid": { "passed": true },
-    "sequence_valid": { "passed": true },
-    "blocklist": { "passed": true }
-  }
+  "allowed": true,
+  "reason": "Allowed by policy"
 }
 ```
 
@@ -234,12 +232,8 @@ async def tool_with_retry(tool_name, args, max_retries=3):
 async def plan_and_execute(plan: List[ToolCall]):
     # Validate entire plan first
     for call in plan:
-        result = await assay_policy_decide(
-            call.tool,
-            call.args,
-            [c.tool for c in plan[:plan.index(call)]]
-        )
-        if result["decision"] != "allow":
+        result = await assay_check_args(call.tool, call.args)
+        if not result["allowed"]:
             return {"error": "Plan validation failed", "details": result}
 
     # Execute validated plan


### PR DESCRIPTION
## Description

`assay_policy_decide` now parses a private exact-name `blocklist` dialect, rejects non-mapping roots and canonical/mixed name-policy documents before cache insertion, and keeps absent/`[]` blocklists allow-compatible.

Closes none. Implements #2386. Programme ledger: #2388.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Refactor

Intentional hardening: canonical or mixed policy documents that previously returned a false clean allow (or ignored canonical fields) now return `E_POLICY_PARSE`. Route full-policy callers to `assay_check_args`.

## Base / head

- Base: `origin/main` `16716b056b4b909c5b6326d9080949b99dbf77a9`
- Head: `e9a1fa025842dc43a55efca701d47d63fd7c657a`
- Branch: `cursor/2386-policy-decision-safety`
- Worktree: `/Users/roelschuurkes/wt-2386-policy-decision-safety`
- Toolchain: rustc 1.96.0 (ac68faa20 2026-05-25), cargo 1.96.0 (30a34c682 2026-05-25)
- Binary: worktree `target/debug/assay-mcp-server` (no shared `CARGO_TARGET_DIR`)

## RED

```bash
cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
```

On the RED commit `03b46a9f00f4ee8f936710bc898e31e707559e64` (1 passed / 3 failed):

- `present_malformed_blocklist_fails_closed_and_is_not_cached` — `string.yaml first call: wrong stable parse summary` (raw serde `invalid type: string "dangerous_tool", expected a sequence` vs `Policy structure is invalid`)
- `non_mapping_roots_fail_closed_without_source_reflection` — `root-scalar.yaml first call` clean allow (`allowed:true`)
- `canonical_and_mixed_dialects_fail_closed` — `root-allow.yaml first call` clean allow (`allowed:true`)
- `exact_name_blocklist_compatibility_controls` remained green

## GREEN

```bash
cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
cargo test --locked -p assay-mcp-server --test stdio_edge_cases
cargo test --locked -p assay-mcp-server --test project_install_surfaces
cargo test --locked -p assay-mcp-server
cargo fmt --all -- --check
cargo clippy -p assay-mcp-server --all-targets -- -D warnings
git diff --check
```

All passed on head `e9a1fa025842dc43a55efca701d47d63fd7c657a`. Focused: 4 passed. Crate suite: all `test result: ok`.

## Mutations

Disposable copies of `policy_decide.rs`, restored after each:

| Mutation | Discriminating failure |
|---|---|
| Remove root validation | `root-scalar.yaml first call` clean allow |
| Remove canonical marker guard | `root-allow.yaml first call` clean allow |
| Replace exact membership with `*` prefix match | `literal wildcard does not match dangerous_tool` denied |
| Insert empty cache before validation | `string.yaml repeat call` clean allow |

## Verification
- [x] Focused `policy_decide_blocklist` RED then GREEN
- [x] Affected crate suite
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`
- [x] `git diff --check`
- [ ] Ran a demo suite (e.g. `examples/rag-grounding`)

## Docs search classification

`rg -n --glob '*.md' "assay_policy_decide|blocklist|tools\\.deny|argument-aware|full policy" README.md CHANGELOG.md docs`

Remaining current-product hits that are consistent with the two-dialect decision (not edited):

- `docs/mcp/index.md` — slogan `"Should I proceed?"`; does not claim full-policy or argument-aware evaluation
- `docs/guides/editor-mcp-recipe.md` — `allowed=false` is an Assay policy verdict, not a dialect claim
- Sequence/`tool_blocklist` metric docs — different product surface (`type: blocklist` / eval metrics)

Historical / generated / programme exclusions (named, not silently omitted):

- `docs/superpowers/specs/2026-08-15-mcp-policy-input-safety-design.md` and sibling plans
- `docs/superpowers/plans/2026-08-15-mcp-policy-*.md`
- `docs/archive/*`
- `docs/architecture/adr/001-unify-policy-engines-final.md` and other ADRs/RFCs about full `McpPolicy`
- Historical `CHANGELOG.md` `tool_blocklist` entries

## Non-claims

- Does not reopen PR #2385 (`empty.yaml` remains `blocklist: []`; `null.yaml` remains `blocklist: null`).
- Does not unify this tool with `McpPolicy`, `assay_core::model::Policy`, or `proxy-enforce`.
- Does not evaluate arguments, schemas, sequences, runtime delivery, or provider behavior.
- Does not reuse `assay-core` `agent_assertions` matchers.
- Does not add a shared “present array, all strings” extractor.
- Does not change the generic server-level `on_error` / raw `E_INTERNAL` fallback (#2391).
- Does not implement crate-wide diagnostic bounding (#2387), except the new root path is value-free immediately.
- Does not claim review quorum (builder self-review does not count). Draft only; do not mark ready or merge.

## Checklist
- [x] Code follows the code style of this project.
- [x] Documentation updated for the two-dialect contract.
- [x] Tests cover the changed stdio/MCP boundary.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid policy documents now fail safely with consistent `E_POLICY_PARSE` errors.
  * Unsupported policy formats and malformed roots are rejected before caching.
  * Blocklist checks now provide stable exact-name matching, including literal wildcard behavior.

* **Documentation**
  * Clarified compatibility blocklist usage and policy format restrictions.
  * Directed argument-aware and sequence-based policy evaluation to `assay_check_args`.
  * Added migration guidance and updated examples for allowed and denied decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->