### PR TITLE
fix(mcp): normalise public policy parse diagnostics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,6 +175,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/ci/(check-evidence-vocabulary\.py|test-evidence-vocabulary\.sh)|\.pre-commit-config\.yaml)$
 
+      - id: mcp-tool-error-publication-self-test
+        name: MCP ToolError publication guard self-test
+        entry: bash -c 'python3 scripts/ci/check-mcp-tool-error-publication.py && bash scripts/ci/test-check-mcp-tool-error-publication.sh'
+        language: system
+        pass_filenames: false
+        files: ^(crates/assay-mcp-server/src/tools/mod\.rs|scripts/ci/(check-mcp-tool-error-publication\.py|test-check-mcp-tool-error-publication\.sh)|\.pre-commit-config\.yaml)$
+
       - id: evidence-vocabulary
         name: Evidence vocabulary guard
         entry: python3 scripts/ci/check-evidence-vocabulary.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -182,6 +182,13 @@ repos:
         pass_filenames: false
         files: ^(crates/assay-mcp-server/src/tools/mod\.rs|scripts/ci/(check-mcp-tool-error-publication\.py|test-check-mcp-tool-error-publication\.sh)|\.pre-commit-config\.yaml)$
 
+      - id: mcp-policy-yaml-routing-self-test
+        name: MCP policy YAML routing guard self-test
+        entry: bash -c 'python3 scripts/ci/check-mcp-policy-yaml-routing.py && bash scripts/ci/test-check-mcp-policy-yaml-routing.sh'
+        language: system
+        pass_filenames: false
+        files: ^(crates/assay-core/src/mcp/policy/.*\.rs|crates/assay-mcp-server/src/tools/.*\.rs|scripts/ci/(check-mcp-policy-yaml-routing\.py|test-check-mcp-policy-yaml-routing\.sh)|\.pre-commit-config\.yaml)$
+
       - id: evidence-vocabulary
         name: Evidence vocabulary guard
         entry: python3 scripts/ci/check-evidence-vocabulary.py

--- a/crates/assay-cli/src/cli/commands/policy/validate.rs
+++ b/crates/assay-cli/src/cli/commands/policy/validate.rs
@@ -30,7 +30,10 @@ pub async fn run(args: PolicyValidateArgs) -> Result<i32> {
 }
 
 fn classify_load_error(path: &Path, error: anyhow::Error) -> anyhow::Error {
-    if error.downcast_ref::<serde_yaml::Error>().is_some() {
+    if error
+        .downcast_ref::<assay_core::mcp::policy::McpPolicyError>()
+        .is_some_and(|error| error.is_parse_failure())
+    {
         return CliFailure::policy_parse(path, error).into();
     }
     error.context(format!("failed to load policy {}", path.display()))

--- a/crates/assay-core/src/mcp/policy/legacy.rs
+++ b/crates/assay-core/src/mcp/policy/legacy.rs
@@ -1,19 +1,67 @@
-use super::McpPolicy;
+use super::{McpPolicy, McpPolicyError, McpPolicyErrorKind};
 use std::path::Path;
 use std::sync::OnceLock;
 
 pub(super) fn from_file(path: &Path) -> anyhow::Result<McpPolicy> {
-    let content = std::fs::read_to_string(path)?;
+    // Read raw bytes so we can classify UTF-8 failure as Syntax.
+    let bytes = std::fs::read(path)?;
 
+    // UTF-8 decode — failure is Syntax, not an I/O error.
+    let content = match std::str::from_utf8(&bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(McpPolicyError {
+                kind: McpPolicyErrorKind::Syntax {
+                    line: None,
+                    column: None,
+                },
+                source: anyhow::Error::new(e),
+            }
+            .into());
+        }
+    };
+
+    // YAML decode to Value — failure is Syntax with location.
+    let value: serde_yaml::Value = match serde_yaml::from_str(content) {
+        Ok(v) => v,
+        Err(e) => {
+            let loc = e.location();
+            return Err(McpPolicyError {
+                kind: McpPolicyErrorKind::Syntax {
+                    line: loc.as_ref().map(|l| l.line()),
+                    column: loc.as_ref().map(|l| l.column()),
+                },
+                source: anyhow::Error::new(e),
+            }
+            .into());
+        }
+    };
+
+    // Root must be a mapping.
+    if !value.is_mapping() {
+        return Err(McpPolicyError {
+            kind: McpPolicyErrorKind::RootNotMapping,
+            source: anyhow::anyhow!("policy root is not a YAML mapping"),
+        }
+        .into());
+    }
+
+    // Typed deserialization with unknown-field tracking.
     let mut unknown = Vec::new();
-    let de = serde_yaml::Deserializer::from_str(&content);
-    let mut policy: McpPolicy = serde_ignored::deserialize(de, |path| {
+    let mut policy: McpPolicy = match serde_ignored::deserialize(value, |path| {
         unknown.push(path.to_string());
-    })
-    .map_err(anyhow::Error::from)?;
+    }) {
+        Ok(p) => p,
+        Err(e) => {
+            return Err(McpPolicyError {
+                kind: McpPolicyErrorKind::Structure,
+                source: anyhow::Error::new(e),
+            }
+            .into());
+        }
+    };
 
     if !unknown.is_empty() {
-        // Filter out transient/internal fields if any. For now, log all.
         tracing::warn!(?unknown, "Unknown fields in policy (ignored)");
     }
 
@@ -33,7 +81,14 @@ pub(super) fn from_file(path: &Path) -> anyhow::Result<McpPolicy> {
         policy.migrate_constraints_to_schemas();
     }
 
-    validate(&policy)?;
+    // Validation — failure is Validation kind.
+    if let Err(e) = validate(&policy) {
+        return Err(McpPolicyError {
+            kind: McpPolicyErrorKind::Validation,
+            source: e,
+        }
+        .into());
+    }
 
     Ok(policy)
 }

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -35,6 +35,18 @@ pub struct McpPolicyError {
     source: anyhow::Error,
 }
 
+impl McpPolicyError {
+    /// Whether this load failure means the policy document could not be parsed.
+    pub fn is_parse_failure(&self) -> bool {
+        matches!(
+            self.kind,
+            McpPolicyErrorKind::Syntax { .. }
+                | McpPolicyErrorKind::RootNotMapping
+                | McpPolicyErrorKind::Structure
+        )
+    }
+}
+
 impl std::fmt::Display for McpPolicyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.source)
@@ -65,6 +77,30 @@ mod error_source_contract {
             "stored top layer",
             "source() must expose the stored anyhow error, not skip to its cause"
         );
+    }
+
+    #[test]
+    fn parse_failure_group_excludes_post_parse_validation() {
+        for kind in [
+            McpPolicyErrorKind::Syntax {
+                line: Some(1),
+                column: Some(2),
+            },
+            McpPolicyErrorKind::RootNotMapping,
+            McpPolicyErrorKind::Structure,
+        ] {
+            let error = McpPolicyError {
+                kind,
+                source: anyhow::anyhow!("parse failure"),
+            };
+            assert!(error.is_parse_failure());
+        }
+
+        let validation = McpPolicyError {
+            kind: McpPolicyErrorKind::Validation,
+            source: anyhow::anyhow!("validation failure"),
+        };
+        assert!(!validation.is_parse_failure());
     }
 }
 

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -8,6 +8,45 @@ mod response;
 mod schema;
 mod types;
 
+/// Typed classification of full-policy parse failures.
+///
+/// Non-exhaustive so downstream match arms must use a wildcard.
+/// `check_args` maps these to the three fixed `PolicyParseFailure` summaries.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum McpPolicyErrorKind {
+    /// YAML decode or UTF-8 failure.
+    Syntax {
+        line: Option<usize>,
+        column: Option<usize>,
+    },
+    /// Parsed value is not a YAML mapping at the root.
+    RootNotMapping,
+    /// Typed deserialization (field shape, unknown field rejection) failed.
+    Structure,
+    /// Post-deserialization validation (kill-switch refs, pin hashes) failed.
+    Validation,
+}
+
+/// Wrapper that carries the typed kind alongside the anyhow error chain.
+#[derive(Debug)]
+pub struct McpPolicyError {
+    pub kind: McpPolicyErrorKind,
+    source: anyhow::Error,
+}
+
+impl std::fmt::Display for McpPolicyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.source)
+    }
+}
+
+impl std::error::Error for McpPolicyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.source()
+    }
+}
+
 use super::identity::ToolIdentity;
 use super::jcs;
 use super::jsonrpc::JsonRpcRequest;

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -43,7 +43,28 @@ impl std::fmt::Display for McpPolicyError {
 
 impl std::error::Error for McpPolicyError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.source.source()
+        Some(self.source.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod error_source_contract {
+    use super::{McpPolicyError, McpPolicyErrorKind};
+
+    #[test]
+    fn exposes_the_stored_anyhow_top_layer_as_direct_source() {
+        let stored = anyhow::anyhow!("inner source").context("stored top layer");
+        let wrapped = McpPolicyError {
+            kind: McpPolicyErrorKind::Structure,
+            source: stored,
+        };
+
+        let direct = std::error::Error::source(&wrapped).expect("direct source");
+        assert_eq!(
+            direct.to_string(),
+            "stored top layer",
+            "source() must expose the stored anyhow error, not skip to its cause"
+        );
     }
 }
 

--- a/crates/assay-core/src/mcp/tests.rs
+++ b/crates/assay-core/src/mcp/tests.rs
@@ -19,6 +19,11 @@ fn policy_error_classification_syntax() {
         "syntax error must be Syntax kind, got: {:?}",
         typed.unwrap().kind
     );
+    // (D) McpPolicyError must not skip/drop its direct anyhow source
+    assert!(
+        std::error::Error::source(typed.unwrap()).is_some(),
+        "McpPolicyError must expose its anyhow source via Error::source"
+    );
 }
 
 #[test]
@@ -35,6 +40,11 @@ fn policy_error_classification_root_not_mapping() {
         matches!(typed.unwrap().kind, McpPolicyErrorKind::RootNotMapping),
         "root-not-mapping must be RootNotMapping kind, got: {:?}",
         typed.unwrap().kind
+    );
+    // (D) McpPolicyError must not skip/drop its direct anyhow source
+    assert!(
+        std::error::Error::source(typed.unwrap()).is_some(),
+        "McpPolicyError must expose its anyhow source via Error::source"
     );
 }
 
@@ -54,6 +64,11 @@ fn policy_error_classification_structure() {
         "structure error must be Structure kind, got: {:?}",
         typed.unwrap().kind
     );
+    // (D) McpPolicyError must not skip/drop its direct anyhow source
+    assert!(
+        std::error::Error::source(typed.unwrap()).is_some(),
+        "McpPolicyError must expose its anyhow source via Error::source"
+    );
 }
 
 #[test]
@@ -70,6 +85,11 @@ fn policy_error_classification_invalid_utf8() {
         matches!(typed.unwrap().kind, McpPolicyErrorKind::Syntax { .. }),
         "invalid UTF-8 must be Syntax kind, got: {:?}",
         typed.unwrap().kind
+    );
+    // (D) McpPolicyError must not skip/drop its direct anyhow source
+    assert!(
+        std::error::Error::source(typed.unwrap()).is_some(),
+        "McpPolicyError must expose its anyhow source via Error::source"
     );
 }
 
@@ -95,6 +115,11 @@ fn policy_error_classification_validation() {
         "validation error must be Validation kind, got: {:?}",
         typed.unwrap().kind
     );
+    // (D) McpPolicyError must not skip/drop its direct anyhow source
+    assert!(
+        std::error::Error::source(typed.unwrap()).is_some(),
+        "McpPolicyError must expose its anyhow source via Error::source"
+    );
 }
 
 // ── Scalar root classification ──────────────────────────────────────────
@@ -113,6 +138,11 @@ fn policy_error_classification_scalar_root() {
         matches!(typed.unwrap().kind, McpPolicyErrorKind::RootNotMapping),
         "scalar root must be RootNotMapping kind, got: {:?}",
         typed.unwrap().kind
+    );
+    // (D) McpPolicyError must not skip/drop its direct anyhow source
+    assert!(
+        std::error::Error::source(typed.unwrap()).is_some(),
+        "McpPolicyError must expose its anyhow source via Error::source"
     );
 }
 

--- a/crates/assay-core/src/mcp/tests.rs
+++ b/crates/assay-core/src/mcp/tests.rs
@@ -2,6 +2,227 @@ use super::policy::*;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
+// ── Full-policy error classification tests ──────────────────────────────────
+
+#[test]
+fn policy_error_classification_syntax() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), b"version: \"\n  bad: [").unwrap();
+    let err = McpPolicy::from_file(tmp.path()).unwrap_err();
+    let typed = err.downcast_ref::<McpPolicyError>();
+    assert!(
+        typed.is_some(),
+        "syntax error must be McpPolicyError, got: {err}"
+    );
+    assert!(
+        matches!(typed.unwrap().kind, McpPolicyErrorKind::Syntax { .. }),
+        "syntax error must be Syntax kind, got: {:?}",
+        typed.unwrap().kind
+    );
+}
+
+#[test]
+fn policy_error_classification_root_not_mapping() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), b"- item1\n- item2\n").unwrap();
+    let err = McpPolicy::from_file(tmp.path()).unwrap_err();
+    let typed = err.downcast_ref::<McpPolicyError>();
+    assert!(
+        typed.is_some(),
+        "root-not-mapping must be McpPolicyError, got: {err}"
+    );
+    assert!(
+        matches!(typed.unwrap().kind, McpPolicyErrorKind::RootNotMapping),
+        "root-not-mapping must be RootNotMapping kind, got: {:?}",
+        typed.unwrap().kind
+    );
+}
+
+#[test]
+fn policy_error_classification_structure() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    // A mapping where 'tools' has the wrong shape (number instead of object)
+    std::fs::write(tmp.path(), b"version: \"2.0\"\ntools: 42\n").unwrap();
+    let err = McpPolicy::from_file(tmp.path()).unwrap_err();
+    let typed = err.downcast_ref::<McpPolicyError>();
+    assert!(
+        typed.is_some(),
+        "structure error must be McpPolicyError, got: {err}"
+    );
+    assert!(
+        matches!(typed.unwrap().kind, McpPolicyErrorKind::Structure),
+        "structure error must be Structure kind, got: {:?}",
+        typed.unwrap().kind
+    );
+}
+
+#[test]
+fn policy_error_classification_invalid_utf8() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), [0xFF, 0xFE, b'v', b':', b' ', b'1']).unwrap();
+    let err = McpPolicy::from_file(tmp.path()).unwrap_err();
+    let typed = err.downcast_ref::<McpPolicyError>();
+    assert!(
+        typed.is_some(),
+        "invalid UTF-8 must be McpPolicyError, got: {err}"
+    );
+    assert!(
+        matches!(typed.unwrap().kind, McpPolicyErrorKind::Syntax { .. }),
+        "invalid UTF-8 must be Syntax kind, got: {:?}",
+        typed.unwrap().kind
+    );
+}
+
+// ── Validation kind (gap 4) ──────────────────────────────────────────────
+
+#[test]
+fn policy_error_classification_validation() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    // Valid YAML mapping, valid McpPolicy shape, but bad pin hash → validation error
+    std::fs::write(
+        tmp.path(),
+        b"version: \"2.0\"\ntool_pins:\n  test_tool:\n    schema_hash: \"bad\"\n    meta_hash: \"bad\"\n    server_id: s\n    tool_name: n\n",
+    )
+    .unwrap();
+    let err = McpPolicy::from_file(tmp.path()).unwrap_err();
+    let typed = err.downcast_ref::<McpPolicyError>();
+    assert!(
+        typed.is_some(),
+        "validation error must be McpPolicyError, got: {err}"
+    );
+    assert!(
+        matches!(typed.unwrap().kind, McpPolicyErrorKind::Validation),
+        "validation error must be Validation kind, got: {:?}",
+        typed.unwrap().kind
+    );
+}
+
+// ── Scalar root classification ──────────────────────────────────────────
+
+#[test]
+fn policy_error_classification_scalar_root() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), b"just_a_string\n").unwrap();
+    let err = McpPolicy::from_file(tmp.path()).unwrap_err();
+    let typed = err.downcast_ref::<McpPolicyError>();
+    assert!(
+        typed.is_some(),
+        "scalar root must be McpPolicyError, got: {err}"
+    );
+    assert!(
+        matches!(typed.unwrap().kind, McpPolicyErrorKind::RootNotMapping),
+        "scalar root must be RootNotMapping kind, got: {:?}",
+        typed.unwrap().kind
+    );
+}
+
+// ── Full-policy parser contract: successful parse, warnings, V1 migration ──
+
+#[test]
+fn policy_file_parser_contract_v2_success() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        tmp.path(),
+        b"version: \"2.0\"\nname: test\ntools:\n  allow:\n    - read_file\n",
+    )
+    .unwrap();
+    let policy = McpPolicy::from_file(tmp.path()).unwrap();
+    assert_eq!(policy.version, "2.0");
+    assert!(policy
+        .tools
+        .allow
+        .as_ref()
+        .unwrap()
+        .contains(&"read_file".to_string()));
+}
+
+#[test]
+#[serial_test::serial]
+#[allow(unsafe_code)]
+fn policy_file_parser_contract_v1_legacy_normalization() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        tmp.path(),
+        b"version: \"1.0\"\nallow:\n  - tool_a\ndeny:\n  - tool_b\n",
+    )
+    .unwrap();
+    // Remove strict deprecations for this test
+    unsafe { std::env::remove_var("ASSAY_STRICT_DEPRECATIONS") };
+    let policy = McpPolicy::from_file(tmp.path()).unwrap();
+    // Root allow/deny must be normalized into tools.*
+    assert!(policy
+        .tools
+        .allow
+        .as_ref()
+        .unwrap()
+        .contains(&"tool_a".to_string()));
+    assert!(policy
+        .tools
+        .deny
+        .as_ref()
+        .unwrap()
+        .contains(&"tool_b".to_string()));
+    // Root-level fields consumed
+    assert!(policy.allow.is_none());
+    assert!(policy.deny.is_none());
+}
+
+#[test]
+fn policy_file_parser_contract_validation_error() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    // Bad pin hash (not 64 hex chars)
+    std::fs::write(
+        tmp.path(),
+        b"version: \"2.0\"\ntool_pins:\n  test_tool:\n    schema_hash: \"bad\"\n    meta_hash: \"bad\"\n    server_id: s\n    tool_name: n\n",
+    )
+    .unwrap();
+    let err = McpPolicy::from_file(tmp.path()).unwrap_err();
+    assert!(
+        err.to_string().contains("hexadecimal"),
+        "validation error should mention hex: {err}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+#[allow(unsafe_code)]
+fn policy_file_parser_contract_v1_constraints_migration() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        tmp.path(),
+        b"version: \"1.0\"\nconstraints:\n  - tool: read_file\n    params:\n      path:\n        matches: \"^/safe/.*\"\n",
+    )
+    .unwrap();
+    unsafe { std::env::remove_var("ASSAY_STRICT_DEPRECATIONS") };
+    let policy = McpPolicy::from_file(tmp.path()).unwrap();
+    // Constraints must be auto-migrated to schemas
+    assert!(
+        policy.schemas.contains_key("read_file"),
+        "V1 constraints must auto-migrate to schemas"
+    );
+    let schema = policy.schemas.get("read_file").unwrap();
+    let pattern = schema
+        .pointer("/properties/path/pattern")
+        .and_then(|v| v.as_str());
+    assert_eq!(pattern, Some("^/safe/.*"), "migrated pattern mismatch");
+}
+
+#[test]
+#[serial_test::serial]
+#[allow(unsafe_code)]
+fn policy_file_parser_contract_strict_deprecations_rejects_v1() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), b"version: \"1.0\"\nconstraints: []\n").unwrap();
+    unsafe { std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1") };
+    let err = McpPolicy::from_file(tmp.path());
+    assert!(err.is_err(), "strict deprecations must reject v1");
+    assert!(
+        err.unwrap_err().to_string().contains("Strict mode"),
+        "error must mention Strict mode"
+    );
+    unsafe { std::env::remove_var("ASSAY_STRICT_DEPRECATIONS") };
+}
+
 fn create_v2_policy(schemas: HashMap<String, Value>) -> McpPolicy {
     McpPolicy {
         version: "2.0".to_string(),

--- a/crates/assay-core/tests/mcp_policy_warning_contract.rs
+++ b/crates/assay-core/tests/mcp_policy_warning_contract.rs
@@ -1,0 +1,114 @@
+//! Subprocess warning/ordering contract for the full-policy parser (#2387).
+//!
+//! Shape: parent spawns `current_exe()` with `ASSAY_MCP_POLICY_WARNING_CHILD=1`
+//! and `--ignored --exact` flags. The child installs a no-timestamp tracing
+//! subscriber to stderr, then parses a V1 fixture with an unknown field under
+//! `tools:` (non-flattened, so `serde_ignored` fires) twice. The parent reads
+//! the child's stderr and asserts:
+//!
+//! 1. Unknown-field tracing warning precedes the deprecation `eprintln!`.
+//! 2. "DEPRECATED" appears exactly once (OnceLock single-fire over two parses).
+//! 3. The child succeeds.
+#![allow(unsafe_code)]
+
+fn run_child() {
+    let dir = tempfile::tempdir().unwrap();
+    let fixture = dir.path().join("v1_unknown_under_tools.yaml");
+    // Put the unknown field under `tools:` so serde_ignored catches it;
+    // root-level unknowns are absorbed by the flattened ToolTaxonomy.
+    std::fs::write(
+        &fixture,
+        b"version: \"1.0\"\ntools:\n  allow:\n    - read_file\n  unknown_field_xyz: true\nconstraints: []\n",
+    )
+    .unwrap();
+
+    unsafe { std::env::remove_var("ASSAY_STRICT_DEPRECATIONS") };
+
+    // Install a global tracing subscriber so `tracing::warn!` in from_file
+    // reaches stderr. This is a fresh child process so no prior subscriber.
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("child must own the global subscriber");
+
+    // First parse: unknown-field warning then deprecation warning
+    let _p1 = assay_core::mcp::policy::McpPolicy::from_file(&fixture).unwrap();
+
+    // Second parse: deprecation must NOT repeat (OnceLock)
+    let _p2 = assay_core::mcp::policy::McpPolicy::from_file(&fixture).unwrap();
+}
+
+#[test]
+#[ignore] // only run as a subprocess child
+fn deprecation_warning_fires_exactly_once() {
+    if std::env::var("ASSAY_MCP_POLICY_WARNING_CHILD").is_ok() {
+        run_child();
+    }
+    // If reached without the env var, skip (--ignored prevents this normally).
+}
+
+#[test]
+fn warning_ordering_and_single_fire_contract() {
+    // Parent: spawn self as the ignored exact child
+    let exe = std::env::current_exe().unwrap();
+    let output = std::process::Command::new(&exe)
+        .arg("--ignored")
+        .arg("--exact")
+        .arg("deprecation_warning_fires_exactly_once")
+        .arg("--nocapture")
+        .env("ASSAY_MCP_POLICY_WARNING_CHILD", "1")
+        .output()
+        .expect("spawn child");
+
+    assert!(
+        output.status.success(),
+        "child failed with code {:?}:\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Unknown-field warning (tracing::warn!) must contain the field name
+    let has_unknown = stderr.contains("unknown_field_xyz") || stderr.contains("Unknown fields");
+    assert!(
+        has_unknown,
+        "unknown-field warning not found in child stderr:\n{stderr}"
+    );
+
+    // Deprecation warning (eprintln!) must be present
+    assert!(
+        stderr.contains("DEPRECATED"),
+        "deprecation warning not found in child stderr:\n{stderr}"
+    );
+
+    // Migration instruction must be present
+    assert!(
+        stderr.contains("assay policy migrate"),
+        "migration instruction not found in child stderr:\n{stderr}"
+    );
+
+    // Ordering: unknown-field warning must precede deprecation
+    let unknown_pos = stderr
+        .find("unknown_field_xyz")
+        .or_else(|| stderr.find("Unknown fields"))
+        .unwrap();
+    let deprecation_pos = stderr.find("DEPRECATED").unwrap();
+    assert!(
+        unknown_pos < deprecation_pos,
+        "unknown-field warning (byte {unknown_pos}) must precede deprecation \
+         warning (byte {deprecation_pos}):\n{stderr}"
+    );
+
+    // "DEPRECATED" must appear exactly once (OnceLock fires once, two parses)
+    let deprecated_count = stderr.matches("DEPRECATED").count();
+    assert_eq!(
+        deprecated_count, 1,
+        "DEPRECATED must appear exactly 1 time, found {deprecated_count}:\n{stderr}"
+    );
+}

--- a/crates/assay-mcp-server/src/tools/check_args.rs
+++ b/crates/assay-mcp-server/src/tools/check_args.rs
@@ -1,6 +1,6 @@
-use super::{ToolContext, ToolError};
+use super::{PolicyParseFailure, ToolContext, ToolError};
 use anyhow::{Context, Result};
-use assay_core::mcp::policy::{McpPolicy, PolicyDecision};
+use assay_core::mcp::policy::{McpPolicy, McpPolicyError, McpPolicyErrorKind, PolicyDecision};
 use serde_json::Value;
 
 pub async fn check_args(ctx: &ToolContext, args: &Value) -> Result<Value> {
@@ -52,8 +52,24 @@ pub async fn check_args(ctx: &ToolContext, args: &Value) -> Result<Value> {
     let policy = match McpPolicy::from_file(&policy_path) {
         Ok(p) => p,
         Err(e) => {
+            // Classify by McpPolicyError kind when available.
+            if let Some(typed) = e.downcast_ref::<McpPolicyError>() {
+                let (class, location) = match &typed.kind {
+                    McpPolicyErrorKind::Syntax { line, column } => {
+                        (PolicyParseFailure::YamlSyntax, line.zip(*column))
+                    }
+                    McpPolicyErrorKind::RootNotMapping => {
+                        (PolicyParseFailure::RootNotMapping, None)
+                    }
+                    McpPolicyErrorKind::Structure | McpPolicyErrorKind::Validation => {
+                        (PolicyParseFailure::Structure, None)
+                    }
+                    _ => (PolicyParseFailure::Structure, None),
+                };
+                return ToolError::policy_parse(class, location).result();
+            }
+            // I/O errors: Not Found, Permission Denied, etc.
             let msg = e.to_string();
-            // Handle Not Found specifically if possible, otherwise generic read error
             if msg.to_lowercase().contains("no such file")
                 || msg.to_lowercase().contains("system cannot find")
             {
@@ -67,8 +83,8 @@ pub async fn check_args(ctx: &ToolContext, args: &Value) -> Result<Value> {
             {
                 return ToolError::new("E_POLICY_READ", &msg).result();
             }
-            // Default to PARSE error for any other failure (likely YAML syntax or structure)
-            return ToolError::new("E_POLICY_PARSE", &msg).result();
+            // Fallback: generic parse error with bounded message.
+            return ToolError::policy_parse(PolicyParseFailure::Structure, None).result();
         }
     };
 

--- a/crates/assay-mcp-server/src/tools/check_coverage.rs
+++ b/crates/assay-mcp-server/src/tools/check_coverage.rs
@@ -75,13 +75,10 @@ pub async fn check_coverage(ctx: &ToolContext, args: &Value) -> Result<Value> {
         Err(e) => return ToolError::new("E_POLICY_READ", &e.to_string()).result(),
     };
 
-    // Parse policy
-    let policy: assay_core::model::Policy = match serde_yaml::from_slice(&policy_bytes) {
+    // Parse policy through the shared mapping-stage helper.
+    let policy: assay_core::model::Policy = match super::parse_tool_policy(&policy_bytes) {
         Ok(p) => p,
-        Err(e) => {
-            return ToolError::new("E_POLICY_PARSE", &format!("Failed to parse policy: {}", e))
-                .result();
-        }
+        Err(e) => return e.result(),
     };
 
     // Convert input traces to internal format

--- a/crates/assay-mcp-server/src/tools/explain_trace.rs
+++ b/crates/assay-mcp-server/src/tools/explain_trace.rs
@@ -59,12 +59,9 @@ pub async fn explain_trace(ctx: &ToolContext, args: &Value) -> Result<Value> {
         Err(e) => return ToolError::new("E_POLICY_READ", &e.to_string()).result(),
     };
 
-    let policy: assay_core::model::Policy = match serde_yaml::from_slice(&policy_bytes) {
+    let policy: assay_core::model::Policy = match super::parse_tool_policy(&policy_bytes) {
         Ok(p) => p,
-        Err(e) => {
-            return ToolError::new("E_POLICY_PARSE", &format!("Failed to parse policy: {}", e))
-                .result();
-        }
+        Err(e) => return e.result(),
     };
 
     // Convert input to ToolCall

--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -330,3 +330,132 @@ pub async fn handle_call(ctx: &ToolContext, name: &str, args: &Value) -> anyhow:
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact UTF-8-safe prefix: 4094 ASCII `X` bytes.
+    ///
+    /// The boundary-bisecting message is 4094 `X` + 🔒 (4 bytes, F0 9F 94 92) + ASCII tail.
+    /// Byte 4096 falls inside the emoji. The UTF-8-safe prefix at 4096 bytes is the last
+    /// char boundary at-or-before 4096, which is byte 4094, so the prefix is `"X".repeat(4094)`.
+    fn expected_bounded_prefix() -> String {
+        "X".repeat(4094)
+    }
+
+    /// Build a message whose byte 4096 falls inside a 4-byte code point.
+    fn boundary_bisecting_message() -> String {
+        let prefix = "X".repeat(4094);
+        format!("{prefix}🔒tail_that_must_not_appear")
+    }
+
+    #[test]
+    fn constructor_bounds_message_to_exact_prefix() {
+        let message = boundary_bisecting_message();
+        let error = ToolError::new("E_TEST", &message);
+        let expected = expected_bounded_prefix();
+
+        assert_eq!(
+            error.message, expected,
+            "constructor must produce the exact UTF-8-safe prefix"
+        );
+        assert!(
+            error.message.len() <= 4096,
+            "constructor result exceeds 4096 bytes: {}",
+            error.message.len()
+        );
+    }
+
+    #[test]
+    fn serializer_bounds_direct_struct_to_exact_prefix() {
+        let message = boundary_bisecting_message();
+        let expected = expected_bounded_prefix();
+        let error = ToolError {
+            code: "E_TEST".into(),
+            message: message.clone(),
+            details: None,
+        };
+        let serialized = serde_json::to_value(&error).unwrap();
+        let msg = serialized["message"].as_str().unwrap();
+        assert_eq!(
+            msg, expected,
+            "serializer must produce the exact UTF-8-safe prefix for direct struct"
+        );
+    }
+
+    #[test]
+    fn serializer_bounds_post_mutation_to_exact_prefix() {
+        let message = boundary_bisecting_message();
+        let expected = expected_bounded_prefix();
+        let mut error = ToolError::new("E_TEST", "short");
+        error.message = message;
+        let serialized = serde_json::to_value(&error).unwrap();
+        let msg = serialized["message"].as_str().unwrap();
+        assert_eq!(
+            msg, expected,
+            "serializer must produce the exact UTF-8-safe prefix for post-mutation"
+        );
+    }
+
+    #[test]
+    fn result_publication_bounds_direct_struct() {
+        let message = boundary_bisecting_message();
+        let expected = expected_bounded_prefix();
+        let error = ToolError {
+            code: "E_TEST".into(),
+            message: message.clone(),
+            details: None,
+        };
+        let result = error.result().unwrap();
+        let msg = result
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert_eq!(
+            msg, expected,
+            "result() must produce the exact UTF-8-safe prefix for direct struct"
+        );
+    }
+
+    #[test]
+    fn result_publication_bounds_post_mutation() {
+        let message = boundary_bisecting_message();
+        let expected = expected_bounded_prefix();
+        let mut error = ToolError::new("E_TEST", "short");
+        error.message = message;
+        let result = error.result().unwrap();
+        let msg = result
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert_eq!(
+            msg, expected,
+            "result() must produce the exact UTF-8-safe prefix for post-mutation"
+        );
+    }
+
+    #[test]
+    fn all_three_paths_produce_same_bounded_prefix() {
+        let message = boundary_bisecting_message();
+        let expected = expected_bounded_prefix();
+
+        let via_constructor = ToolError::new("E_TEST", &message);
+        assert_eq!(via_constructor.message, expected);
+
+        let direct = ToolError {
+            code: "E_TEST".into(),
+            message: message.clone(),
+            details: None,
+        };
+        let direct_serialized = serde_json::to_value(&direct).unwrap();
+        let direct_msg = direct_serialized["message"].as_str().unwrap();
+        assert_eq!(direct_msg, expected);
+
+        let mut mutated = ToolError::new("E_TEST", "short");
+        mutated.message = message;
+        let mutated_serialized = serde_json::to_value(&mutated).unwrap();
+        let mutated_msg = mutated_serialized["message"].as_str().unwrap();
+        assert_eq!(mutated_msg, expected);
+    }
+}

--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -67,7 +67,6 @@ impl serde::Serialize for ToolError {
 
 /// The three approved fixed parse summaries.
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)] // Task-2: callers land with the parse-path wiring
 pub(crate) enum PolicyParseFailure {
     YamlSyntax,
     RootNotMapping,
@@ -94,7 +93,6 @@ impl ToolError {
     }
 
     /// Construct a parse error with a fixed summary and optional numeric location.
-    #[allow(dead_code)] // Task-2: callers land with the parse-path wiring
     pub(crate) fn policy_parse(
         class: PolicyParseFailure,
         location: Option<(usize, usize)>,
@@ -114,6 +112,49 @@ impl ToolError {
              "error": self
         }))?)
     }
+}
+
+// ── Shared mapping-stage for direct-tool consumers ────────────────────────
+//
+// The mapping stage decodes bytes to serde_yaml::Mapping, requires a mapping
+// root, and classifies syntax/root errors with preserved serde_yaml location.
+// Direct-tool consumers (check_coverage, explain_trace, policy_decide) call
+// this instead of constructing their own YAML deserializers.
+
+/// Result of the mapping stage: a validated YAML mapping.
+///
+/// Carries `serde_yaml::Mapping` — not `serde_yaml::Value` — so downstream
+/// code cannot accidentally re-check the root kind, and duplicate-root-key
+/// decisions made by serde_yaml's `Mapping` are preserved without a second
+/// parse.
+pub(crate) struct MappingStage(pub(crate) serde_yaml::Mapping);
+
+/// Decode bytes to a YAML mapping. Returns a ToolError with the approved
+/// fixed summary on syntax or root-not-mapping failure, preserving serde_yaml's
+/// location (line/column) for syntax errors.
+pub(crate) fn yaml_mapping_stage(bytes: &[u8]) -> Result<MappingStage, ToolError> {
+    let value: serde_yaml::Value = serde_yaml::from_slice(bytes).map_err(|e| {
+        let loc = e.location().map(|l| (l.line(), l.column()));
+        ToolError::policy_parse(PolicyParseFailure::YamlSyntax, loc)
+    })?;
+    match value {
+        serde_yaml::Value::Mapping(m) => Ok(MappingStage(m)),
+        _ => Err(ToolError::policy_parse(
+            PolicyParseFailure::RootNotMapping,
+            None,
+        )),
+    }
+}
+
+/// Generic tool helper: decode bytes to a YAML mapping, then deserialize the
+/// mapping into a typed policy `T` via `serde_yaml::from_value`. Classifies
+/// typed deserialization failure as `PolicyParseFailure::Structure`.
+pub(crate) fn parse_tool_policy<T: serde::de::DeserializeOwned>(
+    bytes: &[u8],
+) -> Result<T, ToolError> {
+    let MappingStage(mapping) = yaml_mapping_stage(bytes)?;
+    serde_yaml::from_value::<T>(serde_yaml::Value::Mapping(mapping))
+        .map_err(|_| ToolError::policy_parse(PolicyParseFailure::Structure, None))
 }
 
 pub mod check_args;
@@ -527,5 +568,36 @@ mod tests {
         let mutated_serialized = serde_json::to_value(&mutated).unwrap();
         let mutated_msg = mutated_serialized["message"].as_str().unwrap();
         assert_eq!(mutated_msg, expected);
+    }
+
+    #[test]
+    fn ascii_message_ceiling_is_exactly_4096_bytes() {
+        let exact = "A".repeat(4096);
+        let over = "B".repeat(4097);
+
+        let exact_error = ToolError::new("E_TEST", &exact);
+        assert_eq!(exact_error.message, exact);
+
+        let over_error = ToolError::new("E_TEST", &over);
+        assert_eq!(
+            over_error.message.len(),
+            4096,
+            "constructor must enforce the literal public 4096-byte contract"
+        );
+        assert_eq!(over_error.message, "B".repeat(4096));
+
+        let direct = ToolError {
+            code: "E_TEST".into(),
+            message: over,
+            details: None,
+        };
+        let serialized = serde_json::to_value(direct).unwrap();
+        let published = serialized["message"].as_str().unwrap();
+        assert_eq!(
+            published.len(),
+            4096,
+            "serializer must enforce the literal public 4096-byte contract"
+        );
+        assert_eq!(published, "B".repeat(4096));
     }
 }

--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -22,22 +22,92 @@ impl ToolContext {
     }
 }
 
-#[derive(serde::Serialize)]
+const MAX_PUBLIC_MESSAGE_BYTES: usize = 4096;
+
+/// UTF-8-safe prefix of `message` at most `MAX_PUBLIC_MESSAGE_BYTES` bytes.
+/// Returns the full slice when it fits; truncates on a char boundary otherwise.
+/// No suffix is added beyond the ceiling.
+fn bound_public_message(message: &str) -> &str {
+    if message.len() <= MAX_PUBLIC_MESSAGE_BYTES {
+        return message;
+    }
+    let mut end = MAX_PUBLIC_MESSAGE_BYTES;
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    &message[..end]
+}
+
 pub struct ToolError {
     pub code: String,
     pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<Value>,
+}
+
+impl serde::Serialize for ToolError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(serde::Serialize)]
+        struct BoundedView<'a> {
+            code: &'a str,
+            message: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            details: &'a Option<Value>,
+        }
+        let view = BoundedView {
+            code: &self.code,
+            message: bound_public_message(&self.message),
+            details: &self.details,
+        };
+        view.serialize(serializer)
+    }
+}
+
+/// The three approved fixed parse summaries.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Task-2: callers land with the parse-path wiring
+pub(crate) enum PolicyParseFailure {
+    YamlSyntax,
+    RootNotMapping,
+    Structure,
+}
+
+impl PolicyParseFailure {
+    fn summary(self) -> &'static str {
+        match self {
+            Self::YamlSyntax => "Policy YAML is invalid",
+            Self::RootNotMapping => "Policy root must be a mapping",
+            Self::Structure => "Policy structure is invalid",
+        }
+    }
 }
 
 impl ToolError {
     pub fn new(code: &str, message: &str) -> Self {
         Self {
             code: code.to_string(),
-            message: message.to_string(),
+            message: bound_public_message(message).to_owned(),
             details: None,
         }
     }
+
+    /// Construct a parse error with a fixed summary and optional numeric location.
+    #[allow(dead_code)] // Task-2: callers land with the parse-path wiring
+    pub(crate) fn policy_parse(
+        class: PolicyParseFailure,
+        location: Option<(usize, usize)>,
+    ) -> Self {
+        let details =
+            location.map(|(line, column)| serde_json::json!({"line": line, "column": column}));
+        Self {
+            code: "E_POLICY_PARSE".to_string(),
+            message: class.summary().to_string(),
+            details,
+        }
+    }
+
     pub fn result(self) -> anyhow::Result<Value> {
         Ok(serde_json::to_value(serde_json::json!({
              "allowed": false,

--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -97,8 +97,9 @@ impl ToolError {
         class: PolicyParseFailure,
         location: Option<(usize, usize)>,
     ) -> Self {
-        let details =
-            location.map(|(line, column)| serde_json::json!({"line": line, "column": column}));
+        let details = location
+            .filter(|(line, column)| *line > 0 && *column > 0)
+            .map(|(line, column)| serde_json::json!({"line": line, "column": column}));
         Self {
             code: "E_POLICY_PARSE".to_string(),
             message: class.summary().to_string(),
@@ -599,5 +600,22 @@ mod tests {
             "serializer must enforce the literal public 4096-byte contract"
         );
         assert_eq!(published, "B".repeat(4096));
+    }
+
+    #[test]
+    fn policy_parse_publishes_only_positive_locations() {
+        let positive = ToolError::policy_parse(PolicyParseFailure::YamlSyntax, Some((2, 3)));
+        assert_eq!(
+            positive.details,
+            Some(serde_json::json!({"line": 2, "column": 3}))
+        );
+
+        for location in [(0, 3), (2, 0), (0, 0)] {
+            let error = ToolError::policy_parse(PolicyParseFailure::YamlSyntax, Some(location));
+            assert_eq!(
+                error.details, None,
+                "non-positive location {location:?} must not be published"
+            );
+        }
     }
 }

--- a/crates/assay-mcp-server/src/tools/policy_decide.rs
+++ b/crates/assay-mcp-server/src/tools/policy_decide.rs
@@ -1,4 +1,4 @@
-use super::{ToolContext, ToolError};
+use super::{yaml_mapping_stage, PolicyParseFailure, ToolContext, ToolError};
 use anyhow::{Context, Result};
 use serde_json::Value;
 
@@ -9,25 +9,22 @@ struct PolicyDecisionDocument {
 }
 
 fn parse_policy_decision_document(bytes: &[u8]) -> Result<Vec<String>, ToolError> {
-    let root: Value = serde_yaml::from_slice(bytes)
-        .map_err(|_| ToolError::new("E_POLICY_PARSE", "Policy YAML is invalid"))?;
-    let object = root
-        .as_object()
-        .ok_or_else(|| ToolError::new("E_POLICY_PARSE", "Policy root must be a mapping"))?;
+    let super::MappingStage(mapping) = yaml_mapping_stage(bytes)?;
 
-    if ["allow", "deny", "tools"]
-        .iter()
-        .any(|key| object.contains_key(*key))
-    {
-        return Err(ToolError::new(
-            "E_POLICY_PARSE",
-            "Policy structure is invalid",
-        ));
+    // policy_decide's private dialect check: reject allow/deny/tools keys.
+    for key in &["allow", "deny", "tools"] {
+        if mapping.contains_key(serde_yaml::Value::String(key.to_string())) {
+            return Err(ToolError::policy_parse(PolicyParseFailure::Structure, None));
+        }
     }
 
+    // Preserve the existing JSON-compatible private dialect after the shared
+    // YAML syntax/root stage. This value projection is not a string reparse.
+    let root = serde_json::to_value(serde_yaml::Value::Mapping(mapping))
+        .map_err(|_| ToolError::policy_parse(PolicyParseFailure::Structure, None))?;
     serde_json::from_value::<PolicyDecisionDocument>(root)
         .map(|document| document.blocklist)
-        .map_err(|_| ToolError::new("E_POLICY_PARSE", "Policy structure is invalid"))
+        .map_err(|_| ToolError::policy_parse(PolicyParseFailure::Structure, None))
 }
 
 pub async fn policy_decide(ctx: &ToolContext, args: &Value) -> Result<Value> {

--- a/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+++ b/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
@@ -88,6 +88,7 @@ fn assert_parse_error(
     full_response: &str,
     expected_message: &str,
     policy_root: &Path,
+    policy_filename: &str,
 ) {
     assert_parse_error_with_policy(
         label,
@@ -96,7 +97,7 @@ fn assert_parse_error(
         full_response,
         expected_message,
         policy_root,
-        None,
+        Some(policy_filename),
     );
 }
 
@@ -110,6 +111,18 @@ fn assert_parse_error_with_policy(
     policy_root: &Path,
     policy_filename: Option<&str>,
 ) {
+    let mut body_keys: Vec<&str> = body
+        .as_object()
+        .unwrap_or_else(|| panic!("{label}: decoded tool body must be an object; body={body}"))
+        .keys()
+        .map(String::as_str)
+        .collect();
+    body_keys.sort_unstable();
+    assert_eq!(
+        body_keys,
+        ["allowed", "error"],
+        "{label}: tool body must not carry diagnostic side channels; body={body}"
+    );
     assert_eq!(
         result.get("isError").and_then(Value::as_bool),
         Some(true),
@@ -130,6 +143,50 @@ fn assert_parse_error_with_policy(
         Some(expected_message),
         "{label}: wrong stable parse summary; body={body}"
     );
+    let error = body
+        .pointer("/error")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("{label}: error must be an object; body={body}"));
+    let mut error_keys: Vec<&str> = error.keys().map(String::as_str).collect();
+    error_keys.sort_unstable();
+    let details = error.get("details");
+    let expected_error_keys: &[&str] = if details.is_some() {
+        &["code", "details", "message"]
+    } else {
+        &["code", "message"]
+    };
+    assert_eq!(
+        error_keys, expected_error_keys,
+        "{label}: error must not carry raw parser/path fields; error={error:?}"
+    );
+    if expected_message == YAML_INVALID {
+        if let Some(details) = details {
+            let object = details.as_object().unwrap_or_else(|| {
+                panic!("{label}: syntax details must be a numeric object; details={details}")
+            });
+            let mut detail_keys: Vec<&str> = object.keys().map(String::as_str).collect();
+            detail_keys.sort_unstable();
+            assert_eq!(
+                detail_keys,
+                ["column", "line"],
+                "{label}: syntax details may contain only line/column; details={details}"
+            );
+            for key in ["line", "column"] {
+                assert!(
+                    object
+                        .get(key)
+                        .and_then(Value::as_u64)
+                        .is_some_and(|value| value > 0),
+                    "{label}: details.{key} must be a positive integer; details={details}"
+                );
+            }
+        }
+    } else {
+        assert!(
+            details.is_none(),
+            "{label}: root/structure failures must not publish details; error={error:?}"
+        );
+    }
     let msg = body
         .pointer("/error/message")
         .and_then(Value::as_str)
@@ -265,6 +322,7 @@ fn begin_sentinel_absent_from_syntax_error_all_tools() {
             &full,
             YAML_INVALID,
             root,
+            "begin.yaml",
         );
     }
     let _ = conn.shutdown();
@@ -290,6 +348,7 @@ fn middle_sentinel_absent_from_syntax_error_all_tools() {
             &full,
             YAML_INVALID,
             root,
+            "middle.yaml",
         );
     }
     let _ = conn.shutdown();
@@ -315,6 +374,7 @@ fn end_sentinel_absent_from_syntax_error_all_tools() {
             &full,
             YAML_INVALID,
             root,
+            "end.yaml",
         );
     }
     let _ = conn.shutdown();
@@ -344,6 +404,7 @@ fn root_sentinel_absent_from_non_mapping_error_all_tools() {
             &full,
             ROOT_NOT_MAPPING,
             root,
+            "root-scalar.yaml",
         );
     }
     let _ = conn.shutdown();
@@ -376,6 +437,7 @@ fn structure_sentinel_absent_from_policy_decide() {
         &full,
         STRUCTURE_INVALID,
         root,
+        "struct-sentinel.yaml",
     );
     let _ = conn.shutdown();
 }
@@ -387,7 +449,8 @@ fn structure_error_exact_for_check_coverage_and_explain_trace() {
     let dir = tempfile::tempdir().expect("policy-root");
     let root = dir.path();
     // 'tools: 42' is a well-formed mapping with a typed field-shape error
-    write_policy(root, "bad-struct.yaml", b"version: \"2.0\"\ntools: 42\n");
+    let policy = format!("version: \"2.0\"\ntools: \"{MIDDLE_SENTINEL}\"\n");
+    write_policy(root, "bad-struct.yaml", policy.as_bytes());
 
     let mut conn = spawn_server(root);
     initialize(&mut conn);
@@ -407,6 +470,7 @@ fn structure_error_exact_for_check_coverage_and_explain_trace() {
             &full,
             STRUCTURE_INVALID,
             root,
+            "bad-struct.yaml",
         );
     }
     let _ = conn.shutdown();
@@ -416,7 +480,8 @@ fn structure_error_exact_for_check_coverage_and_explain_trace() {
 fn structure_error_exact_for_check_args() {
     let dir = tempfile::tempdir().expect("policy-root");
     let root = dir.path();
-    write_policy(root, "bad-struct.yaml", b"version: \"2.0\"\ntools: 42\n");
+    let policy = format!("version: \"2.0\"\ntools: \"{MIDDLE_SENTINEL}\"\n");
+    write_policy(root, "bad-struct.yaml", policy.as_bytes());
 
     let mut conn = spawn_server(root);
     initialize(&mut conn);
@@ -433,6 +498,7 @@ fn structure_error_exact_for_check_args() {
         &full,
         STRUCTURE_INVALID,
         root,
+        "bad-struct.yaml",
     );
     let _ = conn.shutdown();
 }
@@ -458,7 +524,15 @@ fn syntax_error_requires_positive_numeric_location() {
         2,
     );
 
-    assert_parse_error("syntax-location", &result, &body, &full, YAML_INVALID, root);
+    assert_parse_error(
+        "syntax-location",
+        &result,
+        &body,
+        &full,
+        YAML_INVALID,
+        root,
+        "bad-syntax.yaml",
+    );
 
     // Require details.line and details.column as positive integers
     let details = body.pointer("/error/details");
@@ -508,7 +582,15 @@ fn invalid_utf8_classifies_as_yaml_syntax_error() {
         2,
     );
 
-    assert_parse_error("invalid-utf8", &result, &body, &full, YAML_INVALID, root);
+    assert_parse_error(
+        "invalid-utf8",
+        &result,
+        &body,
+        &full,
+        YAML_INVALID,
+        root,
+        "bad-utf8.yaml",
+    );
 
     // Must not contain raw UTF-8 error diagnostic
     assert!(
@@ -595,5 +677,41 @@ fn path_non_reflection_canonical_and_filename() {
         Some("audit-a.yaml"),
     );
 
+    let _ = conn.shutdown();
+}
+
+#[test]
+fn validation_error_maps_to_value_free_structure_failure() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    let policy = format!(
+        r#"version: "2.0"
+tool_pins:
+  {MIDDLE_SENTINEL}:
+    schema_hash: "bad"
+    meta_hash: "bad"
+    server_id: s
+    tool_name: n
+"#
+    );
+    write_policy(root, "bad-validation.yaml", policy.as_bytes());
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body, full) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("bad-validation.yaml"),
+        2,
+    );
+    assert_parse_error(
+        "check_args/validation",
+        &result,
+        &body,
+        &full,
+        STRUCTURE_INVALID,
+        root,
+        "bad-validation.yaml",
+    );
     let _ = conn.shutdown();
 }

--- a/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+++ b/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
@@ -531,9 +531,11 @@ fn malformed_multibyte_policy_returns_valid_utf8_with_fixed_summary() {
     let root = dir.path();
     // Build a policy file containing multibyte sentinels inside a broken YAML scalar.
     // The server must return valid UTF-8 JSON with the fixed summary and no sentinel.
+    // Wire validity (UTF-8 correctness of the JSON-RPC response) is proven by the
+    // Conn read_line → serde_json::from_str path: from_str rejects invalid UTF-8.
+    // Exact 4096-byte bounding is covered by the synthetic ToolError unit tests.
     let mut content = b"version: \"\n  ".to_vec();
     content.extend(MULTIBYTE_SENTINEL.as_bytes());
-    // Pad to a decent size so truncation is exercised
     content.extend(std::iter::repeat_n(b'Y', 5000));
     write_policy(root, "multibyte.yaml", &content);
 
@@ -544,12 +546,6 @@ fn malformed_multibyte_policy_returns_valid_utf8_with_fixed_summary() {
         "assay_check_args",
         check_args_args("multibyte.yaml"),
         2,
-    );
-
-    // The full response must parse as valid UTF-8 (it's a JSON string)
-    assert!(
-        std::str::from_utf8(full.as_bytes()).is_ok(),
-        "full response must be valid UTF-8"
     );
 
     // Fixed summary

--- a/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+++ b/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
@@ -448,7 +448,7 @@ fn structure_sentinel_absent_from_policy_decide() {
 fn structure_error_exact_for_check_coverage_and_explain_trace() {
     let dir = tempfile::tempdir().expect("policy-root");
     let root = dir.path();
-    // 'tools: 42' is a well-formed mapping with a typed field-shape error
+    // A string value for `tools` is a well-formed mapping with a typed field-shape error.
     let policy = format!("version: \"2.0\"\ntools: \"{MIDDLE_SENTINEL}\"\n");
     write_policy(root, "bad-struct.yaml", policy.as_bytes());
 

--- a/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+++ b/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
@@ -89,6 +89,27 @@ fn assert_parse_error(
     expected_message: &str,
     policy_root: &Path,
 ) {
+    assert_parse_error_with_policy(
+        label,
+        result,
+        body,
+        full_response,
+        expected_message,
+        policy_root,
+        None,
+    );
+}
+
+/// Extended version that also checks the relative policy filename is absent from the response.
+fn assert_parse_error_with_policy(
+    label: &str,
+    result: &Value,
+    body: &Value,
+    full_response: &str,
+    expected_message: &str,
+    policy_root: &Path,
+    policy_filename: Option<&str>,
+) {
     assert_eq!(
         result.get("isError").and_then(Value::as_bool),
         Some(true),
@@ -130,6 +151,7 @@ fn assert_parse_error(
         !full_response.contains(END_SENTINEL),
         "{label}: response reflected {END_SENTINEL}"
     );
+    // (A) Exclude the raw temp root path
     let root_str = policy_root.to_str().unwrap_or("");
     if !root_str.is_empty() {
         assert!(
@@ -137,6 +159,28 @@ fn assert_parse_error(
             "{label}: response contains policy root path '{root_str}'"
         );
     }
+    // (A) Exclude the canonical temp root (macOS /var → /private/var alias)
+    if let Ok(canon) = policy_root.canonicalize() {
+        let canon_str = canon.to_str().unwrap_or("");
+        if !canon_str.is_empty() && canon_str != root_str {
+            assert!(
+                !full_response.contains(canon_str),
+                "{label}: response contains canonical policy root path '{canon_str}'"
+            );
+        }
+    }
+    // (A) Exclude the relative policy filename
+    if let Some(filename) = policy_filename {
+        assert!(
+            !full_response.contains(filename),
+            "{label}: response contains relative policy filename '{filename}'"
+        );
+    }
+    // (B) Exclude baseline UTF-8 error phrase
+    assert!(
+        !full_response.contains("stream did not contain valid UTF-8"),
+        "{label}: response contains raw UTF-8 baseline phrase"
+    );
 }
 
 /// Build a 200k-byte filler with a single sentinel at its actual beginning.
@@ -470,6 +514,89 @@ fn invalid_utf8_classifies_as_yaml_syntax_error() {
     assert!(
         !full.contains("invalid utf-8") && !full.contains("Utf8Error"),
         "response must not contain raw UTF-8 diagnostic"
+    );
+
+    let _ = conn.shutdown();
+}
+
+// ── (C) Real stdio malformed multibyte policy ──────────────────────────
+// Not a synthetic ToolError: exercises the full server path with a policy
+// containing multibyte sequences that must not appear in the response.
+
+const MULTIBYTE_SENTINEL: &str = "\u{1F512}MULTIBYTE_SECRET_2387\u{1F513}";
+
+#[test]
+fn malformed_multibyte_policy_returns_valid_utf8_with_fixed_summary() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    // Build a policy file containing multibyte sentinels inside a broken YAML scalar.
+    // The server must return valid UTF-8 JSON with the fixed summary and no sentinel.
+    let mut content = b"version: \"\n  ".to_vec();
+    content.extend(MULTIBYTE_SENTINEL.as_bytes());
+    // Pad to a decent size so truncation is exercised
+    content.extend(std::iter::repeat_n(b'Y', 5000));
+    write_policy(root, "multibyte.yaml", &content);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body, full) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("multibyte.yaml"),
+        2,
+    );
+
+    // The full response must parse as valid UTF-8 (it's a JSON string)
+    assert!(
+        std::str::from_utf8(full.as_bytes()).is_ok(),
+        "full response must be valid UTF-8"
+    );
+
+    // Fixed summary
+    assert_parse_error_with_policy(
+        "multibyte",
+        &result,
+        &body,
+        &full,
+        YAML_INVALID,
+        root,
+        Some("multibyte.yaml"),
+    );
+
+    // The multibyte sentinel must not appear anywhere
+    assert!(
+        !full.contains(MULTIBYTE_SENTINEL),
+        "response reflected multibyte sentinel"
+    );
+
+    let _ = conn.shutdown();
+}
+
+// ── (A) Path non-reflection with canonical and filename ────────────────
+
+#[test]
+fn path_non_reflection_canonical_and_filename() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_policy(root, "audit-a.yaml", b"version: \"\nbad: [");
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body, full) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("audit-a.yaml"),
+        2,
+    );
+
+    assert_parse_error_with_policy(
+        "path-canonical",
+        &result,
+        &body,
+        &full,
+        YAML_INVALID,
+        root,
+        Some("audit-a.yaml"),
     );
 
     let _ = conn.shutdown();

--- a/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+++ b/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
@@ -1,0 +1,476 @@
+//! Real-stdio hostile-input contract for policy diagnostic safety (#2387).
+//!
+//! Spawns `assay-mcp-server` over stdio, exercises all four raw policy-parse
+//! sinks with malformed inputs, and asserts:
+//!
+//! 1. Exactly three fixed public parse summaries per failure class.
+//! 2. `result.isError == true` on every parse failure.
+//! 3. No sentinel from hostile content reaches the client (independent per position).
+//! 4. `error.message` byte length ≤ 4096.
+//! 5. No temporary path or policy path leaks into the full JSON-RPC response.
+//! 6. Positive numeric `details.line`/`details.column` required for syntax errors.
+//! 7. Invalid UTF-8 through real `assay_check_args` → `E_POLICY_PARSE` / `Policy YAML is invalid`.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
+
+const YAML_INVALID: &str = "Policy YAML is invalid";
+const ROOT_NOT_MAPPING: &str = "Policy root must be a mapping";
+const STRUCTURE_INVALID: &str = "Policy structure is invalid";
+
+const BEGIN_SENTINEL: &str = "BEGIN_SECRET_MARKER_2387";
+const MIDDLE_SENTINEL: &str = "MIDDLE_SECRET_MARKER_2387";
+const END_SENTINEL: &str = "END_SECRET_MARKER_2387";
+
+const MAX_PUBLIC_MESSAGE_BYTES: usize = 4096;
+
+fn spawn_server(policy_root: &Path) -> Conn {
+    let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "--policy-root",
+            policy_root.to_str().expect("utf-8 policy-root"),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn assay-mcp-server");
+    Conn::attach(child)
+}
+
+fn initialize(conn: &mut Conn) {
+    conn.request(
+        "initialize",
+        serde_json::json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "diag-safety", "version": "1.0"}
+        }),
+        1,
+    );
+}
+
+/// Call a tool and return (MCP result object, parsed tool body, full serialized JSON-RPC response).
+fn call_tool(conn: &mut Conn, tool: &str, arguments: Value, id: u64) -> (Value, Value, String) {
+    let resp = conn.request(
+        "tools/call",
+        serde_json::json!({"name": tool, "arguments": arguments}),
+        id,
+    );
+    let full_response = serde_json::to_string(&resp).unwrap_or_default();
+    let result = resp
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| panic!("tools/call {id} missing result: {resp}"));
+    let text = result["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("tools/call {id} missing text: {result}"))
+        .to_string();
+    let body: Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("tools/call {id} body is not JSON ({e}): {text}"));
+    (result, body, full_response)
+}
+
+fn write_policy(dir: &Path, name: &str, contents: &[u8]) {
+    fs::write(dir.join(name), contents).unwrap_or_else(|e| panic!("write {name}: {e}"));
+}
+
+/// Shared assertion: isError, allowed, code, exact message, ceiling, sentinels, path leak.
+fn assert_parse_error(
+    label: &str,
+    result: &Value,
+    body: &Value,
+    full_response: &str,
+    expected_message: &str,
+    policy_root: &Path,
+) {
+    assert_eq!(
+        result.get("isError").and_then(Value::as_bool),
+        Some(true),
+        "{label}: result.isError must be true; result={result}"
+    );
+    assert_eq!(
+        body.get("allowed").and_then(Value::as_bool),
+        Some(false),
+        "{label}: allowed must be false; body={body}"
+    );
+    assert_eq!(
+        body.pointer("/error/code").and_then(Value::as_str),
+        Some("E_POLICY_PARSE"),
+        "{label}: error.code must be E_POLICY_PARSE; body={body}"
+    );
+    assert_eq!(
+        body.pointer("/error/message").and_then(Value::as_str),
+        Some(expected_message),
+        "{label}: wrong stable parse summary; body={body}"
+    );
+    let msg = body
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .unwrap();
+    assert!(
+        msg.len() <= MAX_PUBLIC_MESSAGE_BYTES,
+        "{label}: error.message exceeds {MAX_PUBLIC_MESSAGE_BYTES} bytes ({} bytes)",
+        msg.len()
+    );
+    assert!(
+        !full_response.contains(BEGIN_SENTINEL),
+        "{label}: response reflected {BEGIN_SENTINEL}"
+    );
+    assert!(
+        !full_response.contains(MIDDLE_SENTINEL),
+        "{label}: response reflected {MIDDLE_SENTINEL}"
+    );
+    assert!(
+        !full_response.contains(END_SENTINEL),
+        "{label}: response reflected {END_SENTINEL}"
+    );
+    let root_str = policy_root.to_str().unwrap_or("");
+    if !root_str.is_empty() {
+        assert!(
+            !full_response.contains(root_str),
+            "{label}: response contains policy root path '{root_str}'"
+        );
+    }
+}
+
+/// Build a 200k-byte filler with a single sentinel at its actual beginning.
+fn payload_sentinel_at_begin(sentinel: &str) -> Vec<u8> {
+    let total = 200_000;
+    let mut buf = Vec::with_capacity(total);
+    buf.extend_from_slice(sentinel.as_bytes());
+    buf.extend(std::iter::repeat_n(b'X', total - sentinel.len()));
+    assert_eq!(buf.len(), total);
+    buf
+}
+
+/// Build a 200k-byte filler with a single sentinel at its actual midpoint.
+fn payload_sentinel_at_middle(sentinel: &str) -> Vec<u8> {
+    let total = 200_000;
+    let half = (total - sentinel.len()) / 2;
+    let mut buf = Vec::with_capacity(total);
+    buf.extend(std::iter::repeat_n(b'X', half));
+    buf.extend_from_slice(sentinel.as_bytes());
+    buf.extend(std::iter::repeat_n(b'X', total - buf.len()));
+    assert_eq!(buf.len(), total);
+    buf
+}
+
+/// Build a 200k-byte filler with a single sentinel at its actual end.
+fn payload_sentinel_at_end(sentinel: &str) -> Vec<u8> {
+    let total = 200_000;
+    let mut buf = Vec::with_capacity(total);
+    buf.extend(std::iter::repeat_n(b'X', total - sentinel.len()));
+    buf.extend_from_slice(sentinel.as_bytes());
+    assert_eq!(buf.len(), total);
+    buf
+}
+
+// ── Tool argument builders ─────────────────────────────────────────────
+
+fn policy_decide_args(policy: &str) -> Value {
+    serde_json::json!({"tool": "any_tool", "policy": policy})
+}
+fn check_args_args(policy: &str) -> Value {
+    serde_json::json!({"tool": "any_tool", "arguments": {}, "policy": policy})
+}
+fn check_coverage_args(policy: &str) -> Value {
+    serde_json::json!({"policy": policy, "traces": [{"tools": ["any_tool"]}]})
+}
+fn explain_trace_args(policy: &str) -> Value {
+    serde_json::json!({"policy": policy, "trace": [{"tool": "any_tool"}]})
+}
+
+type ArgsFn = fn(&str) -> Value;
+
+const ALL_TOOLS: &[(&str, ArgsFn)] = &[
+    ("assay_policy_decide", policy_decide_args as ArgsFn),
+    ("assay_check_args", check_args_args as ArgsFn),
+    ("assay_check_coverage", check_coverage_args as ArgsFn),
+    ("assay_explain_trace", explain_trace_args as ArgsFn),
+];
+
+// ── Independent sentinel positions ──────────────────────────────────────
+// Three separate 200k-byte malformed YAML fixtures, each with exactly ONE
+// sentinel at its actual beginning, midpoint, or end.  All three use
+// syntax-error inputs (broken quoted scalar) so position is isolated from
+// failure class.  Each sentinel test exercises all four tools.
+
+#[test]
+fn begin_sentinel_absent_from_syntax_error_all_tools() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    // Sentinel at the physical beginning of the hostile payload
+    let mut content = b"version: \"\n  ".to_vec();
+    content.extend(&payload_sentinel_at_begin(BEGIN_SENTINEL));
+    write_policy(root, "begin.yaml", &content);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    for (i, (tool, args_fn)) in ALL_TOOLS.iter().enumerate() {
+        let (result, body, full) = call_tool(&mut conn, tool, args_fn("begin.yaml"), i as u64 + 2);
+        assert_parse_error(
+            &format!("{tool}/begin"),
+            &result,
+            &body,
+            &full,
+            YAML_INVALID,
+            root,
+        );
+    }
+    let _ = conn.shutdown();
+}
+
+#[test]
+fn middle_sentinel_absent_from_syntax_error_all_tools() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    // Sentinel at the physical midpoint of the hostile payload
+    let mut content = b"version: \"\n  ".to_vec();
+    content.extend(&payload_sentinel_at_middle(MIDDLE_SENTINEL));
+    write_policy(root, "middle.yaml", &content);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    for (i, (tool, args_fn)) in ALL_TOOLS.iter().enumerate() {
+        let (result, body, full) = call_tool(&mut conn, tool, args_fn("middle.yaml"), i as u64 + 2);
+        assert_parse_error(
+            &format!("{tool}/middle"),
+            &result,
+            &body,
+            &full,
+            YAML_INVALID,
+            root,
+        );
+    }
+    let _ = conn.shutdown();
+}
+
+#[test]
+fn end_sentinel_absent_from_syntax_error_all_tools() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    // Sentinel at the physical end of the hostile payload
+    let mut content = b"version: \"\n  ".to_vec();
+    content.extend(&payload_sentinel_at_end(END_SENTINEL));
+    write_policy(root, "end.yaml", &content);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    for (i, (tool, args_fn)) in ALL_TOOLS.iter().enumerate() {
+        let (result, body, full) = call_tool(&mut conn, tool, args_fn("end.yaml"), i as u64 + 2);
+        assert_parse_error(
+            &format!("{tool}/end"),
+            &result,
+            &body,
+            &full,
+            YAML_INVALID,
+            root,
+        );
+    }
+    let _ = conn.shutdown();
+}
+
+// ── Non-mapping root sentinels (separate from syntax) ──────────────────
+
+#[test]
+fn root_sentinel_absent_from_non_mapping_error_all_tools() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    // Large quoted scalar root with sentinel at midpoint
+    let mut content = b"\"".to_vec();
+    content.extend(&payload_sentinel_at_middle(MIDDLE_SENTINEL));
+    content.push(b'"');
+    write_policy(root, "root-scalar.yaml", &content);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    for (i, (tool, args_fn)) in ALL_TOOLS.iter().enumerate() {
+        let (result, body, full) =
+            call_tool(&mut conn, tool, args_fn("root-scalar.yaml"), i as u64 + 2);
+        assert_parse_error(
+            &format!("{tool}/root-scalar"),
+            &result,
+            &body,
+            &full,
+            ROOT_NOT_MAPPING,
+            root,
+        );
+    }
+    let _ = conn.shutdown();
+}
+
+// ── Structure sentinel (policy_decide only, typed field shape) ──────────
+
+#[test]
+fn structure_sentinel_absent_from_policy_decide() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    // Mapping with blocklist as string → structure error; sentinel at end
+    let mut content = b"blocklist: \"".to_vec();
+    content.extend(&payload_sentinel_at_end(END_SENTINEL));
+    content.extend(b"\"\n");
+    write_policy(root, "struct-sentinel.yaml", &content);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body, full) = call_tool(
+        &mut conn,
+        "assay_policy_decide",
+        policy_decide_args("struct-sentinel.yaml"),
+        2,
+    );
+    assert_parse_error(
+        "policy_decide/struct-sentinel",
+        &result,
+        &body,
+        &full,
+        STRUCTURE_INVALID,
+        root,
+    );
+    let _ = conn.shutdown();
+}
+
+// ── Structure class for all four sinks (gap 5) ─────────────────────────
+
+#[test]
+fn structure_error_exact_for_check_coverage_and_explain_trace() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    // 'tools: 42' is a well-formed mapping with a typed field-shape error
+    write_policy(root, "bad-struct.yaml", b"version: \"2.0\"\ntools: 42\n");
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    for (i, (tool, args_fn)) in [
+        ("assay_check_coverage", check_coverage_args as ArgsFn),
+        ("assay_explain_trace", explain_trace_args as ArgsFn),
+    ]
+    .iter()
+    .enumerate()
+    {
+        let (result, body, full) =
+            call_tool(&mut conn, tool, args_fn("bad-struct.yaml"), i as u64 + 2);
+        assert_parse_error(
+            &format!("{tool}/struct"),
+            &result,
+            &body,
+            &full,
+            STRUCTURE_INVALID,
+            root,
+        );
+    }
+    let _ = conn.shutdown();
+}
+
+#[test]
+fn structure_error_exact_for_check_args() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_policy(root, "bad-struct.yaml", b"version: \"2.0\"\ntools: 42\n");
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body, full) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("bad-struct.yaml"),
+        2,
+    );
+    assert_parse_error(
+        "check_args/struct",
+        &result,
+        &body,
+        &full,
+        STRUCTURE_INVALID,
+        root,
+    );
+    let _ = conn.shutdown();
+}
+
+// ── Syntax error requires positive numeric location (gap 1) ────────────
+
+#[test]
+fn syntax_error_requires_positive_numeric_location() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_policy(
+        root,
+        "bad-syntax.yaml",
+        b"version: \"2.0\"\ntools:\n  allow:\n    - ok\nbad_line: [\n",
+    );
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body, full) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("bad-syntax.yaml"),
+        2,
+    );
+
+    assert_parse_error("syntax-location", &result, &body, &full, YAML_INVALID, root);
+
+    // Require details.line and details.column as positive integers
+    let details = body.pointer("/error/details");
+    assert!(
+        details.is_some(),
+        "syntax error must provide details with line/column; body={body}"
+    );
+    let details = details.unwrap();
+    let line = details.get("line");
+    assert!(
+        line.is_some(),
+        "details must include 'line'; details={details}"
+    );
+    assert!(
+        line.unwrap().as_u64().is_some_and(|v| v > 0),
+        "details.line must be a positive integer, got {:?}",
+        line.unwrap()
+    );
+    let col = details.get("column");
+    assert!(
+        col.is_some(),
+        "details must include 'column'; details={details}"
+    );
+    assert!(
+        col.unwrap().as_u64().is_some_and(|v| v > 0),
+        "details.column must be a positive integer, got {:?}",
+        col.unwrap()
+    );
+
+    let _ = conn.shutdown();
+}
+
+// ── Invalid UTF-8 (gap 7 — discriminating, not vacuous) ────────────────
+
+#[test]
+fn invalid_utf8_classifies_as_yaml_syntax_error() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_policy(root, "bad-utf8.yaml", &[0xFF, 0xFE, b'v', b':', b' ', b'1']);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body, full) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("bad-utf8.yaml"),
+        2,
+    );
+
+    assert_parse_error("invalid-utf8", &result, &body, &full, YAML_INVALID, root);
+
+    // Must not contain raw UTF-8 error diagnostic
+    assert!(
+        !full.contains("invalid utf-8") && !full.contains("Utf8Error"),
+        "response must not contain raw UTF-8 diagnostic"
+    );
+
+    let _ = conn.shutdown();
+}

--- a/scripts/ci/check-mcp-policy-yaml-routing.py
+++ b/scripts/ci/check-mcp-policy-yaml-routing.py
@@ -134,7 +134,7 @@ def check(root: Path) -> bool:
 
     for path, source in sources.items():
         effective = code_only(source)
-        if re.search(r"\buse\s+serde_(?:yaml|ignored)\b", effective):
+        if re.search(r"\buse\s+(?:::\s*)?serde_(?:yaml|ignored)\b", effective):
             errors.append(f"{path}: aliases/imported parser constructors are not approved")
         actual = PARSER_RE.findall(effective)
         expected = allowed_parser_calls.get(path, [])

--- a/scripts/ci/check-mcp-policy-yaml-routing.py
+++ b/scripts/ci/check-mcp-policy-yaml-routing.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Architecture drift guard for the MCP policy YAML parsing routes (#2387).
+
+Behavioral safety is proved by real-stdio tests. This guard separately pins the
+approved parser-construction sites and the helper calls that keep classification
+in one place; it is deliberately not presented as Rust data-flow analysis.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+SERVER = Path("crates/assay-mcp-server/src/tools")
+CORE = Path("crates/assay-core/src/mcp/policy")
+PARSER_RE = re.compile(
+    r"(?:serde_yaml::(?:from_slice|from_str|from_reader|from_value|Deserializer)|"
+    r"serde_ignored::deserialize)"
+)
+
+
+def code_only(source: str) -> str:
+    """Replace comments and literals with spaces, preserving code positions."""
+    out = list(source)
+    state = "code"
+    block_depth = 0
+    escaped = False
+    raw_hashes = 0
+    index = 0
+    while index < len(source):
+        char = source[index]
+        pair = source[index : index + 2]
+        if state == "code":
+            raw = re.match(r'r(#{0,16})"', source[index:])
+            if raw:
+                raw_hashes = len(raw.group(1))
+                end = index + len(raw.group(0))
+                for pos in range(index, end):
+                    out[pos] = " "
+                index = end
+                state = "raw"
+                continue
+            if pair == "//":
+                out[index] = out[index + 1] = " "
+                index += 2
+                state = "line"
+                continue
+            if pair == "/*":
+                out[index] = out[index + 1] = " "
+                index += 2
+                block_depth = 1
+                state = "block"
+                continue
+            if char == '"':
+                out[index] = " "
+                state = "string"
+            elif char == "'" and index + 2 < len(source):
+                # Lifetimes do not close within two characters; char literals do.
+                close = source.find("'", index + 1, min(len(source), index + 8))
+                if close != -1:
+                    out[index] = " "
+                    state = "char"
+        elif state == "line":
+            if char == "\n":
+                state = "code"
+            else:
+                out[index] = " "
+        elif state == "block":
+            out[index] = " "
+            if pair == "/*":
+                out[index + 1] = " "
+                block_depth += 1
+                index += 1
+            elif pair == "*/":
+                out[index + 1] = " "
+                block_depth -= 1
+                index += 1
+                if block_depth == 0:
+                    state = "code"
+        elif state in {"string", "char"}:
+            out[index] = " "
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif (state == "string" and char == '"') or (
+                state == "char" and char == "'"
+            ):
+                state = "code"
+        elif state == "raw":
+            out[index] = " "
+            closing = '"' + ("#" * raw_hashes)
+            if source.startswith(closing, index):
+                for pos in range(index, index + len(closing)):
+                    out[pos] = " "
+                index += len(closing) - 1
+                state = "code"
+        index += 1
+    return "".join(out)
+
+
+def compact(source: str) -> str:
+    return re.sub(r"\s+", "", code_only(source))
+
+
+def require(errors: list[str], source: str, fragment: str, label: str) -> None:
+    actual = compact(source).count(fragment)
+    if actual != 1:
+        errors.append(f"{label}: expected one effective {fragment!r}, found {actual}")
+
+
+def check(root: Path) -> bool:
+    guarded_roots = [root / SERVER, root / CORE]
+    rust_files = sorted(path for base in guarded_roots for path in base.rglob("*.rs"))
+    if not rust_files:
+        print("FAIL: guarded Rust sources not found", file=sys.stderr)
+        return False
+
+    sources = {path.relative_to(root): path.read_text() for path in rust_files}
+    errors: list[str] = []
+    allowed_parser_calls = {
+        SERVER / "mod.rs": ["serde_yaml::from_slice", "serde_yaml::from_value"],
+        SERVER / "policy_decide.rs": [],
+        # Fixed and value-free sequence parsing is explicitly outside #2387.
+        SERVER / "check_sequence.rs": [
+            "serde_yaml::from_slice",
+            "serde_yaml::from_slice",
+            "serde_yaml::from_slice",
+        ],
+        CORE / "legacy.rs": ["serde_yaml::from_str", "serde_ignored::deserialize"],
+    }
+
+    for path, source in sources.items():
+        effective = code_only(source)
+        if re.search(r"\buse\s+serde_(?:yaml|ignored)\b", effective):
+            errors.append(f"{path}: aliases/imported parser constructors are not approved")
+        actual = PARSER_RE.findall(effective)
+        expected = allowed_parser_calls.get(path, [])
+        if actual != expected:
+            errors.append(f"{path}: parser calls {actual!r}, expected {expected!r}")
+
+    shared = sources[SERVER / "mod.rs"]
+    decide = sources[SERVER / "policy_decide.rs"]
+    args = sources[SERVER / "check_args.rs"]
+    coverage = sources[SERVER / "check_coverage.rs"]
+    explain = sources[SERVER / "explain_trace.rs"]
+    legacy = sources[CORE / "legacy.rs"]
+
+    require(errors, shared, "pub(crate)structMappingStage(pub(crate)serde_yaml::Mapping);", "mapping typestate")
+    require(errors, shared, "letvalue:serde_yaml::Value=serde_yaml::from_slice(bytes)", "shared syntax stage")
+    require(errors, shared, "serde_yaml::Value::Mapping(m)=>Ok(MappingStage(m))", "shared root stage")
+    require(errors, shared, "letMappingStage(mapping)=yaml_mapping_stage(bytes)?;", "shared typed route")
+    require(errors, shared, "serde_yaml::from_value::<T>(serde_yaml::Value::Mapping(mapping))", "shared typed stage")
+    require(errors, decide, "letsuper::MappingStage(mapping)=yaml_mapping_stage(bytes)?;", "policy_decide route")
+    require(errors, decide, "serde_json::to_value(serde_yaml::Value::Mapping(mapping))", "policy_decide JSON-compatible projection")
+    require(errors, decide, "serde_json::from_value::<PolicyDecisionDocument>(root)", "policy_decide typed stage")
+    require(errors, coverage, "super::parse_tool_policy(&policy_bytes)", "check_coverage route")
+    require(errors, explain, "super::parse_tool_policy(&policy_bytes)", "explain_trace route")
+    require(errors, args, "McpPolicy::from_file(&policy_path)", "check_args full parser route")
+    require(errors, legacy, "letvalue:serde_yaml::Value=matchserde_yaml::from_str(content)", "core syntax stage")
+    require(errors, legacy, "if!value.is_mapping()", "core root stage")
+    require(errors, legacy, "serde_ignored::deserialize(value,|path|", "core typed stage")
+
+    for path in (
+        SERVER / "policy_decide.rs",
+        SERVER / "check_args.rs",
+        SERVER / "check_coverage.rs",
+        SERVER / "explain_trace.rs",
+    ):
+        effective = code_only(sources[path])
+        patterns = [r"\.is_mapping\s*\(", r"\.as_mapping"]
+        if path != SERVER / "policy_decide.rs":
+            patterns.append(r"Value::Mapping")
+        for pattern in patterns:
+            if re.search(pattern, effective):
+                errors.append(f"{path}: duplicates the shared mapping-root decision")
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return False
+    print("OK: MCP policy YAML construction and helper routes match the approved architecture")
+    return True
+
+
+if __name__ == "__main__":
+    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    raise SystemExit(0 if check(repo_root) else 1)

--- a/scripts/ci/check-mcp-tool-error-publication.py
+++ b/scripts/ci/check-mcp-tool-error-publication.py
@@ -128,8 +128,8 @@ def compact_rust(body: str) -> str:
     return "".join(output)
 
 
-def check(path: Path) -> bool:
-    body = extract_result_body(path.read_text())
+def check(source: str) -> bool:
+    body = extract_result_body(source)
     if body is None:
         print("FAIL: ToolError::result(self) body not found", file=sys.stderr)
         return False
@@ -147,5 +147,11 @@ def check(path: Path) -> bool:
 
 
 if __name__ == "__main__":
-    target = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_TARGET
-    raise SystemExit(0 if check(target) else 1)
+    if len(sys.argv) == 1:
+        source = DEFAULT_TARGET.read_text()
+    elif sys.argv[1:] == ["--stdin"]:
+        source = sys.stdin.read()
+    else:
+        print(f"usage: {Path(sys.argv[0]).name} [--stdin]", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(0 if check(source) else 1)

--- a/scripts/ci/check-mcp-tool-error-publication.py
+++ b/scripts/ci/check-mcp-tool-error-publication.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 DEFAULT_TARGET = Path("crates/assay-mcp-server/src/tools/mod.rs")
+MAX_SOURCE_CHARS = 1_000_000
 EXPECTED_BODY = (
     'Ok(serde_json::to_value(serde_json::json!({'
     '"allowed":false,"error":self}))?)'
@@ -20,7 +21,7 @@ def extract_result_body(source: str) -> str | None:
     if not impl_match:
         return None
     result_match = re.search(
-        r"pub\s+fn\s+result\s*\(\s*self\s*\)\s*->\s*[^\{]+\{",
+        r"pub\s+fn\s+result\s*\(\s*self\s*\)\s*->[^{\r\n]+{",
         source[impl_match.end() :],
     )
     if not result_match:
@@ -150,7 +151,10 @@ if __name__ == "__main__":
     if len(sys.argv) == 1:
         source = DEFAULT_TARGET.read_text()
     elif sys.argv[1:] == ["--stdin"]:
-        source = sys.stdin.read()
+        source = sys.stdin.read(MAX_SOURCE_CHARS + 1)
+        if len(source) > MAX_SOURCE_CHARS:
+            print("FAIL: source exceeds guard input limit", file=sys.stderr)
+            raise SystemExit(2)
     else:
         print(f"usage: {Path(sys.argv[0]).name} [--stdin]", file=sys.stderr)
         raise SystemExit(2)

--- a/scripts/ci/check-mcp-tool-error-publication.py
+++ b/scripts/ci/check-mcp-tool-error-publication.py
@@ -1,160 +1,151 @@
 #!/usr/bin/env python3
-"""Guard: ToolError::result must serialize through ToolError's Serialize impl.
+"""Fail closed unless ToolError::result publishes exactly ToolError itself."""
 
-Rejects four bypasses:
-  1. Unbounded repack: rebuilding error from public fields without bounding.
-  2. Bounded repack: calling bound_public_message but constructing a new struct
-     that bypasses ToolError::Serialize.
-  3. Commented decoy: a comment containing `"error": self` satisfying a naive
-     substring check while the real body repacks fields.
-  4. Dead/unrelated decoy: an `"error": self` in a different function or
-     dead code satisfying a naive whole-file search.
+from __future__ import annotations
 
-The guard extracts the result() function body from the ToolError impl block,
-strips line comments, and verifies that the body contains `"error": self` as
-an expression (not inside a comment or string), and does not access individual
-fields or call bound_public_message.
-
-Usage:
-    python3 check-mcp-tool-error-publication.py [SOURCE_PATH]
-
-SOURCE_PATH defaults to crates/assay-mcp-server/src/tools/mod.rs.
-"""
 import re
 import sys
+from pathlib import Path
 
-DEFAULT_TARGET = "crates/assay-mcp-server/src/tools/mod.rs"
 
-
-def strip_line_comments(text: str) -> str:
-    """Remove // comments from each line, preserving strings naively.
-
-    This is intentionally simple: it handles the patterns that appear in
-    tools/mod.rs without trying to be a full Rust lexer. It strips from
-    the first `//` that is not inside a quoted string on each line.
-    """
-    lines = []
-    for line in text.split("\n"):
-        # Walk the line tracking whether we're inside a string
-        in_string = False
-        escape_next = False
-        i = 0
-        while i < len(line):
-            ch = line[i]
-            if escape_next:
-                escape_next = False
-                i += 1
-                continue
-            if ch == "\\":
-                escape_next = True
-                i += 1
-                continue
-            if ch == '"' and not in_string:
-                in_string = True
-                i += 1
-                continue
-            if ch == '"' and in_string:
-                in_string = False
-                i += 1
-                continue
-            if not in_string and i + 1 < len(line) and line[i : i + 2] == "//":
-                line = line[:i]
-                break
-            i += 1
-        lines.append(line)
-    return "\n".join(lines)
+DEFAULT_TARGET = Path("crates/assay-mcp-server/src/tools/mod.rs")
+EXPECTED_BODY = (
+    'Ok(serde_json::to_value(serde_json::json!({'
+    '"allowed":false,"error":self}))?)'
+)
 
 
 def extract_result_body(source: str) -> str | None:
-    """Extract the body of ToolError::result(self) from the impl block.
-
-    Finds `impl ToolError` then `pub fn result(self)` inside it, and
-    extracts the brace-delimited body. Returns None if not found.
-    """
-    # Find the impl ToolError block
     impl_match = re.search(r"impl\s+ToolError\s*\{", source)
     if not impl_match:
         return None
-
-    # From the impl block, find pub fn result(self)
-    impl_start = impl_match.start()
     result_match = re.search(
-        r"pub\s+fn\s+result\s*\(\s*self\s*\)\s*->\s*[^{]+\{",
-        source[impl_start:],
+        r"pub\s+fn\s+result\s*\(\s*self\s*\)\s*->\s*[^\{]+\{",
+        source[impl_match.end() :],
     )
     if not result_match:
         return None
 
-    # Find the matching closing brace by counting braces
-    body_start = impl_start + result_match.end()
+    start = impl_match.end() + result_match.end()
     depth = 1
-    i = body_start
-    while i < len(source) and depth > 0:
-        if source[i] == "{":
+    state = "code"
+    block_depth = 0
+    escaped = False
+    index = start
+    while index < len(source):
+        char = source[index]
+        pair = source[index : index + 2]
+        if state == "line_comment":
+            if char == "\n":
+                state = "code"
+        elif state == "block_comment":
+            if pair == "/*":
+                block_depth += 1
+                index += 1
+            elif pair == "*/":
+                block_depth -= 1
+                index += 1
+                if block_depth == 0:
+                    state = "code"
+        elif state in {"string", "char"}:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif (state == "string" and char == '"') or (
+                state == "char" and char == "'"
+            ):
+                state = "code"
+        elif pair == "//":
+            state = "line_comment"
+            index += 1
+        elif pair == "/*":
+            state = "block_comment"
+            block_depth = 1
+            index += 1
+        elif char == '"':
+            state = "string"
+        elif char == "'":
+            state = "char"
+        elif char == "{":
             depth += 1
-        elif source[i] == "}":
+        elif char == "}":
             depth -= 1
-        i += 1
-
-    if depth != 0:
-        return None
-
-    return source[body_start : i - 1]
+            if depth == 0:
+                return source[start:index]
+        index += 1
+    return None
 
 
-def check(path: str) -> bool:
-    with open(path) as f:
-        source = f.read()
+def compact_rust(body: str) -> str:
+    """Remove comments and code whitespace while preserving literals."""
+    output: list[str] = []
+    state = "code"
+    block_depth = 0
+    escaped = False
+    index = 0
+    while index < len(body):
+        char = body[index]
+        pair = body[index : index + 2]
+        if state == "line_comment":
+            if char == "\n":
+                state = "code"
+        elif state == "block_comment":
+            if pair == "/*":
+                block_depth += 1
+                index += 1
+            elif pair == "*/":
+                block_depth -= 1
+                index += 1
+                if block_depth == 0:
+                    state = "code"
+        elif state in {"string", "char"}:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif (state == "string" and char == '"') or (
+                state == "char" and char == "'"
+            ):
+                state = "code"
+        elif pair == "//":
+            state = "line_comment"
+            index += 1
+        elif pair == "/*":
+            state = "block_comment"
+            block_depth = 1
+            index += 1
+        elif char == '"':
+            output.append(char)
+            state = "string"
+        elif char == "'":
+            output.append(char)
+            state = "char"
+        elif not char.isspace():
+            output.append(char)
+        index += 1
+    return "".join(output)
 
-    errors = []
 
-    raw_body = extract_result_body(source)
-    if raw_body is None:
-        errors.append(
-            "pub fn result(self) not found inside impl ToolError"
-        )
-        for e in errors:
-            print(f"FAIL: {e}", file=sys.stderr)
+def check(path: Path) -> bool:
+    body = extract_result_body(path.read_text())
+    if body is None:
+        print("FAIL: ToolError::result(self) body not found", file=sys.stderr)
         return False
-
-    # Strip comments so a `// "error": self` decoy cannot satisfy the check
-    body = strip_line_comments(raw_body)
-
-    # 1. The body must contain `"error": self` as an expression.
-    #    We require it as a non-comment token in the function body.
-    #    The regex ensures it's not inside a surrounding identifier
-    #    (e.g. `self.something` would be caught by rule 3 below).
-    has_error_self = bool(re.search(r'"error"\s*:\s*self\b(?!\.)', body))
-    if not has_error_self:
-        errors.append(
-            'result() must serialize self directly ("error": self), '
-            "not repack from fields"
+    actual = compact_rust(body)
+    if actual != EXPECTED_BODY:
+        print(
+            "FAIL: ToolError::result must consist only of the approved direct-self "
+            "publication expression",
+            file=sys.stderr,
         )
-
-    # 2. The body must NOT access individual fields, which indicates repacking.
-    for field in ("self.code", "self.message", "self.details"):
-        if field in body:
-            errors.append(
-                f"result() must not access {field} — that bypasses Serialize"
-            )
-
-    # 3. The body must NOT call bound_public_message — bounding is the
-    #    Serialize impl's responsibility, not result()'s.
-    if "bound_public_message" in body:
-        errors.append(
-            "result() must not call bound_public_message — "
-            "the Serialize impl handles bounding"
-        )
-
-    if errors:
-        for e in errors:
-            print(f"FAIL: {e}", file=sys.stderr)
+        print(f"actual: {actual}", file=sys.stderr)
         return False
-
-    print("OK: result() serializes self through ToolError::Serialize")
+    print("OK: ToolError::result publishes self through ToolError::Serialize")
     return True
 
 
 if __name__ == "__main__":
-    path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_TARGET
-    sys.exit(0 if check(path) else 1)
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_TARGET
+    raise SystemExit(0 if check(target) else 1)

--- a/scripts/ci/check-mcp-tool-error-publication.py
+++ b/scripts/ci/check-mcp-tool-error-publication.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Guard: ToolError::result must serialize through ToolError's Serialize impl.
+
+Rejects four bypasses:
+  1. Unbounded repack: rebuilding error from public fields without bounding.
+  2. Bounded repack: calling bound_public_message but constructing a new struct
+     that bypasses ToolError::Serialize.
+  3. Commented decoy: a comment containing `"error": self` satisfying a naive
+     substring check while the real body repacks fields.
+  4. Dead/unrelated decoy: an `"error": self` in a different function or
+     dead code satisfying a naive whole-file search.
+
+The guard extracts the result() function body from the ToolError impl block,
+strips line comments, and verifies that the body contains `"error": self` as
+an expression (not inside a comment or string), and does not access individual
+fields or call bound_public_message.
+
+Usage:
+    python3 check-mcp-tool-error-publication.py [SOURCE_PATH]
+
+SOURCE_PATH defaults to crates/assay-mcp-server/src/tools/mod.rs.
+"""
+import re
+import sys
+
+DEFAULT_TARGET = "crates/assay-mcp-server/src/tools/mod.rs"
+
+
+def strip_line_comments(text: str) -> str:
+    """Remove // comments from each line, preserving strings naively.
+
+    This is intentionally simple: it handles the patterns that appear in
+    tools/mod.rs without trying to be a full Rust lexer. It strips from
+    the first `//` that is not inside a quoted string on each line.
+    """
+    lines = []
+    for line in text.split("\n"):
+        # Walk the line tracking whether we're inside a string
+        in_string = False
+        escape_next = False
+        i = 0
+        while i < len(line):
+            ch = line[i]
+            if escape_next:
+                escape_next = False
+                i += 1
+                continue
+            if ch == "\\":
+                escape_next = True
+                i += 1
+                continue
+            if ch == '"' and not in_string:
+                in_string = True
+                i += 1
+                continue
+            if ch == '"' and in_string:
+                in_string = False
+                i += 1
+                continue
+            if not in_string and i + 1 < len(line) and line[i : i + 2] == "//":
+                line = line[:i]
+                break
+            i += 1
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def extract_result_body(source: str) -> str | None:
+    """Extract the body of ToolError::result(self) from the impl block.
+
+    Finds `impl ToolError` then `pub fn result(self)` inside it, and
+    extracts the brace-delimited body. Returns None if not found.
+    """
+    # Find the impl ToolError block
+    impl_match = re.search(r"impl\s+ToolError\s*\{", source)
+    if not impl_match:
+        return None
+
+    # From the impl block, find pub fn result(self)
+    impl_start = impl_match.start()
+    result_match = re.search(
+        r"pub\s+fn\s+result\s*\(\s*self\s*\)\s*->\s*[^{]+\{",
+        source[impl_start:],
+    )
+    if not result_match:
+        return None
+
+    # Find the matching closing brace by counting braces
+    body_start = impl_start + result_match.end()
+    depth = 1
+    i = body_start
+    while i < len(source) and depth > 0:
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+        i += 1
+
+    if depth != 0:
+        return None
+
+    return source[body_start : i - 1]
+
+
+def check(path: str) -> bool:
+    with open(path) as f:
+        source = f.read()
+
+    errors = []
+
+    raw_body = extract_result_body(source)
+    if raw_body is None:
+        errors.append(
+            "pub fn result(self) not found inside impl ToolError"
+        )
+        for e in errors:
+            print(f"FAIL: {e}", file=sys.stderr)
+        return False
+
+    # Strip comments so a `// "error": self` decoy cannot satisfy the check
+    body = strip_line_comments(raw_body)
+
+    # 1. The body must contain `"error": self` as an expression.
+    #    We require it as a non-comment token in the function body.
+    #    The regex ensures it's not inside a surrounding identifier
+    #    (e.g. `self.something` would be caught by rule 3 below).
+    has_error_self = bool(re.search(r'"error"\s*:\s*self\b(?!\.)', body))
+    if not has_error_self:
+        errors.append(
+            'result() must serialize self directly ("error": self), '
+            "not repack from fields"
+        )
+
+    # 2. The body must NOT access individual fields, which indicates repacking.
+    for field in ("self.code", "self.message", "self.details"):
+        if field in body:
+            errors.append(
+                f"result() must not access {field} — that bypasses Serialize"
+            )
+
+    # 3. The body must NOT call bound_public_message — bounding is the
+    #    Serialize impl's responsibility, not result()'s.
+    if "bound_public_message" in body:
+        errors.append(
+            "result() must not call bound_public_message — "
+            "the Serialize impl handles bounding"
+        )
+
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}", file=sys.stderr)
+        return False
+
+    print("OK: result() serializes self through ToolError::Serialize")
+    return True
+
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_TARGET
+    sys.exit(0 if check(path) else 1)

--- a/scripts/ci/check-mcp-tool-error-publication.py
+++ b/scripts/ci/check-mcp-tool-error-publication.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
 
 DEFAULT_TARGET = Path("crates/assay-mcp-server/src/tools/mod.rs")
-MAX_SOURCE_CHARS = 1_000_000
+IMPL_SIGNATURE = "impl ToolError {"
+RESULT_SIGNATURE = "    pub fn result(self) -> anyhow::Result<Value> {"
 EXPECTED_BODY = (
     'Ok(serde_json::to_value(serde_json::json!({'
     '"allowed":false,"error":self}))?)'
@@ -17,17 +17,14 @@ EXPECTED_BODY = (
 
 
 def extract_result_body(source: str) -> str | None:
-    impl_match = re.search(r"impl\s+ToolError\s*\{", source)
-    if not impl_match:
+    impl_start = source.find(IMPL_SIGNATURE)
+    if impl_start < 0:
         return None
-    result_match = re.search(
-        r"pub\s+fn\s+result\s*\(\s*self\s*\)\s*->[^{\r\n]+{",
-        source[impl_match.end() :],
-    )
-    if not result_match:
+    result_start = source.find(RESULT_SIGNATURE, impl_start + len(IMPL_SIGNATURE))
+    if result_start < 0:
         return None
 
-    start = impl_match.end() + result_match.end()
+    start = result_start + len(RESULT_SIGNATURE)
     depth = 1
     state = "code"
     block_depth = 0
@@ -148,14 +145,8 @@ def check(source: str) -> bool:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
-        source = DEFAULT_TARGET.read_text()
-    elif sys.argv[1:] == ["--stdin"]:
-        source = sys.stdin.read(MAX_SOURCE_CHARS + 1)
-        if len(source) > MAX_SOURCE_CHARS:
-            print("FAIL: source exceeds guard input limit", file=sys.stderr)
-            raise SystemExit(2)
-    else:
-        print(f"usage: {Path(sys.argv[0]).name} [--stdin]", file=sys.stderr)
+    if len(sys.argv) != 1:
+        print(f"usage: {Path(sys.argv[0]).name}", file=sys.stderr)
         raise SystemExit(2)
+    source = DEFAULT_TARGET.read_text()
     raise SystemExit(0 if check(source) else 1)

--- a/scripts/ci/check-mcp-tool-error-publication.py
+++ b/scripts/ci/check-mcp-tool-error-publication.py
@@ -8,12 +8,21 @@ from pathlib import Path
 
 
 DEFAULT_TARGET = Path("crates/assay-mcp-server/src/tools/mod.rs")
+MAX_SOURCE_BYTES = 1_000_000
 IMPL_SIGNATURE = "impl ToolError {"
 RESULT_SIGNATURE = "    pub fn result(self) -> anyhow::Result<Value> {"
 EXPECTED_BODY = (
     'Ok(serde_json::to_value(serde_json::json!({'
     '"allowed":false,"error":self}))?)'
 )
+
+
+def read_bounded_source(path) -> str:
+    with path.open("rb") as stream:
+        data = stream.read(MAX_SOURCE_BYTES + 1)
+    if len(data) > MAX_SOURCE_BYTES:
+        raise ValueError(f"source exceeds {MAX_SOURCE_BYTES}-byte limit")
+    return data.decode("utf-8")
 
 
 def extract_result_body(source: str) -> str | None:
@@ -148,5 +157,9 @@ if __name__ == "__main__":
     if len(sys.argv) != 1:
         print(f"usage: {Path(sys.argv[0]).name}", file=sys.stderr)
         raise SystemExit(2)
-    source = DEFAULT_TARGET.read_text()
+    try:
+        source = read_bounded_source(DEFAULT_TARGET)
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"FAIL: cannot read publication source: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
     raise SystemExit(0 if check(source) else 1)

--- a/scripts/ci/test-check-mcp-policy-yaml-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-yaml-routing.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GUARD="scripts/ci/check-mcp-policy-yaml-routing.py"
+FILES=(
+  crates/assay-mcp-server/src/tools
+  crates/assay-core/src/mcp/policy
+)
+
+python3 "$GUARD"
+echo "PASS: guard accepts the production routes"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/base/crates/assay-mcp-server/src" "$TMPDIR/base/crates/assay-core/src/mcp"
+cp -R "${FILES[0]}" "$TMPDIR/base/crates/assay-mcp-server/src/"
+cp -R "${FILES[1]}" "$TMPDIR/base/crates/assay-core/src/mcp/"
+
+mutant() {
+  local name=$1
+  local mutation=$2
+  rm -rf "$TMPDIR/current"
+  cp -R "$TMPDIR/base" "$TMPDIR/current"
+  "$mutation" "$TMPDIR/current"
+  if python3 "$GUARD" "$TMPDIR/current" >/dev/null 2>&1; then
+    echo "FAIL: routing guard accepted mutation: $name" >&2
+    exit 1
+  fi
+  echo "PASS: routing guard rejects $name"
+}
+
+mutate_consumer_parser() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/check_coverage.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "super::parse_tool_policy(&policy_bytes)"
+new = "serde_yaml::from_slice::<assay_core::model::Policy>(&policy_bytes)"
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutate_duplicate_root() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/policy_decide.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "let super::MappingStage(mapping) = yaml_mapping_stage(bytes)?;"
+new = old + "\n    let _duplicate = serde_yaml::Value::Mapping(mapping.clone()).is_mapping();"
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutate_core_parallel_parser() {
+  cat >> "$1/crates/assay-core/src/mcp/policy/legacy.rs" <<'RS'
+fn _parallel_parser(bytes: &[u8]) {
+    let _ = serde_yaml::from_slice::<serde_yaml::Value>(bytes);
+}
+RS
+}
+
+mutate_missing_route() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/explain_trace.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "super::parse_tool_policy(&policy_bytes)"
+assert old in s
+p.write_text(s.replace(old, "super::alternate_policy_parser(&policy_bytes)", 1))
+PY
+}
+
+mutate_full_parser_bypass() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/check_args.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "McpPolicy::from_file(&policy_path)"
+assert old in s
+p.write_text(s.replace(old, "load_policy_alternate(&policy_path)", 1))
+PY
+}
+
+mutate_alias_parser() {
+  cat >> "$1/crates/assay-mcp-server/src/tools/check_coverage.rs" <<'RS'
+#[allow(dead_code)]
+fn _alias_parser(bytes: &[u8]) {
+    use serde_yaml as sy;
+    let _ = sy::from_slice::<sy::Value>(bytes);
+}
+RS
+}
+
+mutant "direct consumer parser" mutate_consumer_parser
+mutant "duplicate consumer root classifier" mutate_duplicate_root
+mutant "parallel core parser" mutate_core_parallel_parser
+mutant "missing direct helper route" mutate_missing_route
+mutant "full-policy parser bypass" mutate_full_parser_bypass
+mutant "aliased parser constructor" mutate_alias_parser
+
+echo "All MCP policy YAML routing mutations caught."

--- a/scripts/ci/test-check-mcp-policy-yaml-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-yaml-routing.sh
@@ -22,8 +22,18 @@ mutant() {
   rm -rf "$TMPDIR/current"
   cp -R "$TMPDIR/base" "$TMPDIR/current"
   "$mutation" "$TMPDIR/current"
-  if python3 "$GUARD" "$TMPDIR/current" >/dev/null 2>&1; then
+  local output status
+  set +e
+  output=$(python3 "$GUARD" "$TMPDIR/current" 2>&1)
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
     echo "FAIL: routing guard accepted mutation: $name" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$output" | grep -q '^FAIL: '; then
+    echo "FAIL: routing guard exited $status without a FAIL reason: $name" >&2
+    printf '%s\n' "$output" >&2
     exit 1
   fi
   echo "PASS: routing guard rejects $name"
@@ -93,11 +103,22 @@ fn _alias_parser(bytes: &[u8]) {
 RS
 }
 
+mutate_absolute_alias_parser() {
+  cat >> "$1/crates/assay-mcp-server/src/tools/check_coverage.rs" <<'RS'
+#[allow(dead_code)]
+fn _absolute_alias_parser(bytes: &[u8]) {
+    use ::serde_yaml as sy;
+    let _ = sy::from_slice::<sy::Value>(bytes);
+}
+RS
+}
+
 mutant "direct consumer parser" mutate_consumer_parser
 mutant "duplicate consumer root classifier" mutate_duplicate_root
 mutant "parallel core parser" mutate_core_parallel_parser
 mutant "missing direct helper route" mutate_missing_route
 mutant "full-policy parser bypass" mutate_full_parser_bypass
 mutant "aliased parser constructor" mutate_alias_parser
+mutant "absolute aliased parser constructor" mutate_absolute_alias_parser
 
 echo "All MCP policy YAML routing mutations caught."

--- a/scripts/ci/test-check-mcp-tool-error-publication.sh
+++ b/scripts/ci/test-check-mcp-tool-error-publication.sh
@@ -27,6 +27,52 @@ if python3 "$GUARD" --stdin </dev/null 2>/dev/null; then
 fi
 echo "PASS: guard rejects stdin source selection"
 
+# The fixed production source is still PR-controlled, so read it through a
+# bounded stream operation before decoding or materializing the full file.
+python3 - "$GUARD" <<'PY'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("publication_guard", sys.argv[1])
+if spec is None or spec.loader is None:
+    raise SystemExit("failed to load publication guard")
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+class Probe:
+    def __init__(self):
+        self.requested = None
+
+    def open(self, mode):
+        if mode != "rb":
+            raise AssertionError(f"unexpected mode: {mode}")
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, size):
+        self.requested = size
+        return b"x" * size
+
+probe = Probe()
+try:
+    guard.read_bounded_source(probe)
+except ValueError:
+    pass
+else:
+    raise SystemExit("FAIL: bounded reader accepted oversized source")
+expected = guard.MAX_SOURCE_BYTES + 1
+if probe.requested != expected:
+    raise SystemExit(
+        f"FAIL: bounded reader requested {probe.requested}, expected {expected}"
+    )
+PY
+echo "PASS: guard bounds the fixed source before materialization"
+
 # Verify the guard passes on the real file first.
 if ! python3 "$GUARD"; then
     echo "FAIL: guard must pass on the unmodified source" >&2

--- a/scripts/ci/test-check-mcp-tool-error-publication.sh
+++ b/scripts/ci/test-check-mcp-tool-error-publication.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Self-test for check-mcp-tool-error-publication.py.
+#
+# Creates four mutant copies of tools/mod.rs in a temp directory and verifies
+# the guard rejects each. The production file is NEVER written — only read
+# for the baseline check. A sha256 digest comparison before and after proves
+# it was not modified.
+set -euo pipefail
+
+GUARD="scripts/ci/check-mcp-tool-error-publication.py"
+TARGET="crates/assay-mcp-server/src/tools/mod.rs"
+
+# Record digest before anything runs.
+DIGEST_BEFORE=$(shasum -a 256 "$TARGET" | awk '{print $1}')
+
+# Verify the guard passes on the real file first.
+if ! python3 "$GUARD" "$TARGET"; then
+    echo "FAIL: guard must pass on the unmodified source" >&2
+    exit 1
+fi
+echo "PASS: guard accepts unmodified source"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ── Mutation 1: unbounded repack ──────────────────────────────────────────
+# Replace `"error": self` with a field repack that bypasses Serialize.
+sed 's/"error": self/"error": serde_json::json!({"code": self.code, "message": self.message, "details": self.details})/' \
+    "$TARGET" > "$TMPDIR/mut1.rs"
+
+if python3 "$GUARD" "$TMPDIR/mut1.rs" 2>/dev/null; then
+    echo "FAIL: guard must reject unbounded repack mutation" >&2
+    exit 1
+fi
+echo "PASS: guard rejects unbounded repack"
+
+# ── Mutation 2: bounded repack ────────────────────────────────────────────
+# Replace `"error": self` with a bounded repack that calls bound_public_message
+# but constructs a new JSON object, bypassing ToolError::Serialize.
+sed 's/"error": self/"error": serde_json::json!({"code": self.code, "message": bound_public_message(\&self.message), "details": self.details})/' \
+    "$TARGET" > "$TMPDIR/mut2.rs"
+
+if python3 "$GUARD" "$TMPDIR/mut2.rs" 2>/dev/null; then
+    echo "FAIL: guard must reject bounded repack mutation" >&2
+    exit 1
+fi
+echo "PASS: guard rejects bounded repack"
+
+# ── Mutation 3: commented decoy ───────────────────────────────────────────
+# Keep a comment containing `"error": self` but replace the real expression
+# with a field repack. A naive substring check would see the comment and pass.
+sed 's|"error": self|// "error": self  -- decoy comment\n             "error": serde_json::json!({"code": self.code, "message": self.message})|' \
+    "$TARGET" > "$TMPDIR/mut3.rs"
+
+if python3 "$GUARD" "$TMPDIR/mut3.rs" 2>/dev/null; then
+    echo "FAIL: guard must reject commented decoy mutation" >&2
+    exit 1
+fi
+echo "PASS: guard rejects commented decoy"
+
+# ── Mutation 4: dead/unrelated decoy ──────────────────────────────────────
+# Add `"error": self` in a new unrelated function OUTSIDE impl ToolError,
+# while replacing the real one inside result() with a field repack.
+# A naive whole-file search would see the decoy and pass.
+sed 's/"error": self/"error": serde_json::json!({"code": self.code, "message": self.message})/' \
+    "$TARGET" > "$TMPDIR/mut4.rs"
+cat >> "$TMPDIR/mut4.rs" << 'DECOY'
+// Unrelated function — not inside impl ToolError
+fn _decoy_for_guard_test() {
+    let _ = serde_json::json!({"error": self});
+}
+DECOY
+
+if python3 "$GUARD" "$TMPDIR/mut4.rs" 2>/dev/null; then
+    echo "FAIL: guard must reject dead/unrelated decoy mutation" >&2
+    exit 1
+fi
+echo "PASS: guard rejects dead/unrelated decoy"
+
+# ── Verify production file was not modified ───────────────────────────────
+DIGEST_AFTER=$(shasum -a 256 "$TARGET" | awk '{print $1}')
+if [ "$DIGEST_BEFORE" != "$DIGEST_AFTER" ]; then
+    echo "FAIL: production file was modified (before=$DIGEST_BEFORE after=$DIGEST_AFTER)" >&2
+    exit 1
+fi
+echo "PASS: production file unchanged (sha256=$DIGEST_BEFORE)"
+
+echo "All self-test mutations caught."

--- a/scripts/ci/test-check-mcp-tool-error-publication.sh
+++ b/scripts/ci/test-check-mcp-tool-error-publication.sh
@@ -13,8 +13,15 @@ TARGET="crates/assay-mcp-server/src/tools/mod.rs"
 # Record digest before anything runs.
 DIGEST_BEFORE=$(shasum -a 256 "$TARGET" | awk '{print $1}')
 
+# The production guard must not accept caller-selected filesystem paths.
+if python3 "$GUARD" "$TARGET" 2>/dev/null; then
+    echo "FAIL: guard must reject positional filesystem paths" >&2
+    exit 1
+fi
+echo "PASS: guard rejects positional filesystem paths"
+
 # Verify the guard passes on the real file first.
-if ! python3 "$GUARD" "$TARGET"; then
+if ! python3 "$GUARD"; then
     echo "FAIL: guard must pass on the unmodified source" >&2
     exit 1
 fi
@@ -28,7 +35,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 sed 's/"error": self/"error": serde_json::json!({"code": self.code, "message": self.message, "details": self.details})/' \
     "$TARGET" > "$TMPDIR/mut1.rs"
 
-if python3 "$GUARD" "$TMPDIR/mut1.rs" 2>/dev/null; then
+if python3 "$GUARD" --stdin < "$TMPDIR/mut1.rs" 2>/dev/null; then
     echo "FAIL: guard must reject unbounded repack mutation" >&2
     exit 1
 fi
@@ -40,7 +47,7 @@ echo "PASS: guard rejects unbounded repack"
 sed 's/"error": self/"error": serde_json::json!({"code": self.code, "message": bound_public_message(\&self.message), "details": self.details})/' \
     "$TARGET" > "$TMPDIR/mut2.rs"
 
-if python3 "$GUARD" "$TMPDIR/mut2.rs" 2>/dev/null; then
+if python3 "$GUARD" --stdin < "$TMPDIR/mut2.rs" 2>/dev/null; then
     echo "FAIL: guard must reject bounded repack mutation" >&2
     exit 1
 fi
@@ -52,7 +59,7 @@ echo "PASS: guard rejects bounded repack"
 sed 's|"error": self|// "error": self  -- decoy comment\n             "error": serde_json::json!({"code": self.code, "message": self.message})|' \
     "$TARGET" > "$TMPDIR/mut3.rs"
 
-if python3 "$GUARD" "$TMPDIR/mut3.rs" 2>/dev/null; then
+if python3 "$GUARD" --stdin < "$TMPDIR/mut3.rs" 2>/dev/null; then
     echo "FAIL: guard must reject commented decoy mutation" >&2
     exit 1
 fi
@@ -71,7 +78,7 @@ fn _decoy_for_guard_test() {
 }
 DECOY
 
-if python3 "$GUARD" "$TMPDIR/mut4.rs" 2>/dev/null; then
+if python3 "$GUARD" --stdin < "$TMPDIR/mut4.rs" 2>/dev/null; then
     echo "FAIL: guard must reject dead/unrelated decoy mutation" >&2
     exit 1
 fi
@@ -116,7 +123,7 @@ fn publish_repacked_error(error: ToolError) -> anyhow::Result<Value> {
 Path(sys.argv[2]).write_text(source)
 PY
 
-if python3 "$GUARD" "$TMPDIR/mut5.rs" 2>/dev/null; then
+if python3 "$GUARD" --stdin < "$TMPDIR/mut5.rs" 2>/dev/null; then
     echo "FAIL: guard must reject unreachable-direct/helper-repack mutation" >&2
     exit 1
 fi

--- a/scripts/ci/test-check-mcp-tool-error-publication.sh
+++ b/scripts/ci/test-check-mcp-tool-error-publication.sh
@@ -20,50 +20,12 @@ if python3 "$GUARD" "$TARGET" 2>/dev/null; then
 fi
 echo "PASS: guard rejects positional filesystem paths"
 
-# An unterminated result signature must not trigger polynomial regex backtracking.
-python3 - "$GUARD" <<'PY'
-import subprocess
-import sys
-
-source = "impl ToolError { pub fn result(self)->" + (" " * 200_000) + "x"
-try:
-    result = subprocess.run(
-        [sys.executable, sys.argv[1], "--stdin"],
-        input=source,
-        text=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        timeout=2,
-        check=False,
-    )
-except subprocess.TimeoutExpired:
-    raise SystemExit("FAIL: guard regex exceeded adversarial-input deadline")
-if result.returncode != 1:
-    raise SystemExit(
-        f"FAIL: malformed adversarial source returned {result.returncode}, expected 1"
-    )
-PY
-echo "PASS: guard rejects adversarial source within deadline"
-
-# The mutation-only stdin interface has its own fixed resource ceiling.
-python3 - "$GUARD" <<'PY'
-import subprocess
-import sys
-
-result = subprocess.run(
-    [sys.executable, sys.argv[1], "--stdin"],
-    input="x" * 1_000_001,
-    text=True,
-    stdout=subprocess.DEVNULL,
-    stderr=subprocess.DEVNULL,
-    check=False,
-)
-if result.returncode != 2:
-    raise SystemExit(
-        f"FAIL: oversized guard source returned {result.returncode}, expected 2"
-    )
-PY
-echo "PASS: guard bounds stdin source"
+# The production guard has no caller-controlled source interface.
+if python3 "$GUARD" --stdin </dev/null 2>/dev/null; then
+    echo "FAIL: guard must reject stdin source selection" >&2
+    exit 1
+fi
+echo "PASS: guard rejects stdin source selection"
 
 # Verify the guard passes on the real file first.
 if ! python3 "$GUARD"; then
@@ -75,12 +37,59 @@ echo "PASS: guard accepts unmodified source"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
+check_source() {
+    python3 - "$GUARD" "$1" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("publication_guard", sys.argv[1])
+if spec is None or spec.loader is None:
+    raise SystemExit("failed to load publication guard")
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+source = Path(sys.argv[2]).read_text()
+raise SystemExit(0 if guard.check(source) else 1)
+PY
+}
+
+# Repeated near-signatures must be handled in linear time.
+python3 - "$TMPDIR/adversarial.rs" <<'PY'
+import sys
+from pathlib import Path
+
+prefix = "pub fn result(self)->"
+Path(sys.argv[1]).write_text("impl ToolError {" + prefix * 30_000 + "x")
+PY
+python3 - "$GUARD" "$TMPDIR/adversarial.rs" <<'PY'
+import importlib.util
+import signal
+import sys
+from pathlib import Path
+
+def deadline(_signum, _frame):
+    raise SystemExit("FAIL: guard exceeded adversarial-input deadline")
+
+spec = importlib.util.spec_from_file_location("publication_guard", sys.argv[1])
+if spec is None or spec.loader is None:
+    raise SystemExit("failed to load publication guard")
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+signal.signal(signal.SIGALRM, deadline)
+signal.alarm(2)
+accepted = guard.check(Path(sys.argv[2]).read_text())
+signal.alarm(0)
+if accepted:
+    raise SystemExit("FAIL: guard accepted repeated near-signatures")
+PY
+echo "PASS: guard rejects repeated near-signatures within deadline"
+
 # ── Mutation 1: unbounded repack ──────────────────────────────────────────
 # Replace `"error": self` with a field repack that bypasses Serialize.
 sed 's/"error": self/"error": serde_json::json!({"code": self.code, "message": self.message, "details": self.details})/' \
     "$TARGET" > "$TMPDIR/mut1.rs"
 
-if python3 "$GUARD" --stdin < "$TMPDIR/mut1.rs" 2>/dev/null; then
+if check_source "$TMPDIR/mut1.rs" 2>/dev/null; then
     echo "FAIL: guard must reject unbounded repack mutation" >&2
     exit 1
 fi
@@ -92,7 +101,7 @@ echo "PASS: guard rejects unbounded repack"
 sed 's/"error": self/"error": serde_json::json!({"code": self.code, "message": bound_public_message(\&self.message), "details": self.details})/' \
     "$TARGET" > "$TMPDIR/mut2.rs"
 
-if python3 "$GUARD" --stdin < "$TMPDIR/mut2.rs" 2>/dev/null; then
+if check_source "$TMPDIR/mut2.rs" 2>/dev/null; then
     echo "FAIL: guard must reject bounded repack mutation" >&2
     exit 1
 fi
@@ -104,7 +113,7 @@ echo "PASS: guard rejects bounded repack"
 sed 's|"error": self|// "error": self  -- decoy comment\n             "error": serde_json::json!({"code": self.code, "message": self.message})|' \
     "$TARGET" > "$TMPDIR/mut3.rs"
 
-if python3 "$GUARD" --stdin < "$TMPDIR/mut3.rs" 2>/dev/null; then
+if check_source "$TMPDIR/mut3.rs" 2>/dev/null; then
     echo "FAIL: guard must reject commented decoy mutation" >&2
     exit 1
 fi
@@ -123,7 +132,7 @@ fn _decoy_for_guard_test() {
 }
 DECOY
 
-if python3 "$GUARD" --stdin < "$TMPDIR/mut4.rs" 2>/dev/null; then
+if check_source "$TMPDIR/mut4.rs" 2>/dev/null; then
     echo "FAIL: guard must reject dead/unrelated decoy mutation" >&2
     exit 1
 fi
@@ -168,7 +177,7 @@ fn publish_repacked_error(error: ToolError) -> anyhow::Result<Value> {
 Path(sys.argv[2]).write_text(source)
 PY
 
-if python3 "$GUARD" --stdin < "$TMPDIR/mut5.rs" 2>/dev/null; then
+if check_source "$TMPDIR/mut5.rs" 2>/dev/null; then
     echo "FAIL: guard must reject unreachable-direct/helper-repack mutation" >&2
     exit 1
 fi

--- a/scripts/ci/test-check-mcp-tool-error-publication.sh
+++ b/scripts/ci/test-check-mcp-tool-error-publication.sh
@@ -109,9 +109,22 @@ echo "PASS: guard rejects bounded repack"
 
 # ── Mutation 3: commented decoy ───────────────────────────────────────────
 # Keep a comment containing `"error": self` but replace the real expression
-# with a field repack. A naive substring check would see the comment and pass.
-sed 's|"error": self|// "error": self  -- decoy comment\n             "error": serde_json::json!({"code": self.code, "message": self.message})|' \
-    "$TARGET" > "$TMPDIR/mut3.rs"
+# with a live field repack on the following line. Python makes the newline
+# portable across GNU and BSD sed environments.
+python3 - "$TARGET" "$TMPDIR/mut3.rs" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+old = '"error": self'
+new = (
+    '// "error": self  -- decoy comment\n'
+    '             "error": serde_json::json!({"code": self.code, "message": self.message})'
+)
+if old not in source:
+    raise SystemExit("fixture drift: direct publication expression not found")
+Path(sys.argv[2]).write_text(source.replace(old, new, 1))
+PY
 
 if check_source "$TMPDIR/mut3.rs" 2>/dev/null; then
     echo "FAIL: guard must reject commented decoy mutation" >&2

--- a/scripts/ci/test-check-mcp-tool-error-publication.sh
+++ b/scripts/ci/test-check-mcp-tool-error-publication.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Self-test for check-mcp-tool-error-publication.py.
 #
-# Creates four mutant copies of tools/mod.rs in a temp directory and verifies
+# Creates mutant copies of tools/mod.rs in a temp directory and verifies
 # the guard rejects each. The production file is NEVER written — only read
 # for the baseline check. A sha256 digest comparison before and after proves
 # it was not modified.
@@ -76,6 +76,51 @@ if python3 "$GUARD" "$TMPDIR/mut4.rs" 2>/dev/null; then
     exit 1
 fi
 echo "PASS: guard rejects dead/unrelated decoy"
+
+# ── Mutation 5: unreachable direct publication plus helper repack ─────────
+# A presence-only guard can be satisfied by dead code while the reachable
+# branch delegates to a repacking helper.
+python3 - "$TARGET" "$TMPDIR/mut5.rs" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+old = '''    pub fn result(self) -> anyhow::Result<Value> {
+        Ok(serde_json::to_value(serde_json::json!({
+             "allowed": false,
+             "error": self
+        }))?)
+    }
+'''
+new = '''    pub fn result(self) -> anyhow::Result<Value> {
+        if std::hint::black_box(false) {
+            return Ok(serde_json::to_value(serde_json::json!({
+                "allowed": false,
+                "error": self
+            }))?);
+        }
+        publish_repacked_error(self)
+    }
+'''
+if old not in source:
+    raise SystemExit("fixture drift: ToolError::result body not found")
+source = source.replace(old, new, 1)
+source += '''
+fn publish_repacked_error(error: ToolError) -> anyhow::Result<Value> {
+    Ok(serde_json::json!({
+        "allowed": false,
+        "error": {"code": error.code, "message": error.message}
+    }))
+}
+'''
+Path(sys.argv[2]).write_text(source)
+PY
+
+if python3 "$GUARD" "$TMPDIR/mut5.rs" 2>/dev/null; then
+    echo "FAIL: guard must reject unreachable-direct/helper-repack mutation" >&2
+    exit 1
+fi
+echo "PASS: guard rejects unreachable direct publication plus helper repack"
 
 # ── Verify production file was not modified ───────────────────────────────
 DIGEST_AFTER=$(shasum -a 256 "$TARGET" | awk '{print $1}')

--- a/scripts/ci/test-check-mcp-tool-error-publication.sh
+++ b/scripts/ci/test-check-mcp-tool-error-publication.sh
@@ -20,6 +20,51 @@ if python3 "$GUARD" "$TARGET" 2>/dev/null; then
 fi
 echo "PASS: guard rejects positional filesystem paths"
 
+# An unterminated result signature must not trigger polynomial regex backtracking.
+python3 - "$GUARD" <<'PY'
+import subprocess
+import sys
+
+source = "impl ToolError { pub fn result(self)->" + (" " * 200_000) + "x"
+try:
+    result = subprocess.run(
+        [sys.executable, sys.argv[1], "--stdin"],
+        input=source,
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=2,
+        check=False,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit("FAIL: guard regex exceeded adversarial-input deadline")
+if result.returncode != 1:
+    raise SystemExit(
+        f"FAIL: malformed adversarial source returned {result.returncode}, expected 1"
+    )
+PY
+echo "PASS: guard rejects adversarial source within deadline"
+
+# The mutation-only stdin interface has its own fixed resource ceiling.
+python3 - "$GUARD" <<'PY'
+import subprocess
+import sys
+
+result = subprocess.run(
+    [sys.executable, sys.argv[1], "--stdin"],
+    input="x" * 1_000_001,
+    text=True,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    check=False,
+)
+if result.returncode != 2:
+    raise SystemExit(
+        f"FAIL: oversized guard source returned {result.returncode}, expected 2"
+    )
+PY
+echo "PASS: guard bounds stdin source"
+
 # Verify the guard passes on the real file first.
 if ! python3 "$GUARD"; then
     echo "FAIL: guard must pass on the unmodified source" >&2


### PR DESCRIPTION
## Summary

- replace source-derived MCP policy parse diagnostics with three stable, value-free summaries
- preserve syntax location only as positive numeric `details.line` / `details.column`
- enforce a 4,096-byte UTF-8-safe ceiling at the `ToolError` constructor and serialization boundary
- centralize direct-tool YAML syntax/root classification while preserving `policy_decide`'s existing JSON-compatible private dialect
- classify full-policy syntax, root, structure, and validation failures at the core parser source

Closes #2387.

## Review packet

**Base:** `f303a5e609132e22ea25370218b0405befadf18b`  
**Head:** `5760511e100bdcff794515aec91b8e503ff64fb7`  
**Worktree:** `/Users/roelschuurkes/wt-2387-policy-diagnostic-safety`

### Contract changes

- Public parse messages are exactly:
  - `Policy YAML is invalid`
  - `Policy root must be a mapping`
  - `Policy structure is invalid`
- Public parse errors retain `E_POLICY_PARSE`, `allowed: false`, and MCP `isError: true`.
- Syntax details may contain only positive numeric `line` and `column`.
- Root/structure/validation failures publish no `details`.
- `error.message` is bounded to 4,096 UTF-8 bytes through one shared boundary.
- No verdict, reason-code, JSON-RPC, cache-order, or reader-limit contract changes.

### RED evidence

The baseline tests exposed raw parser/source values across the four stdio sinks and unbounded direct/post-construction `ToolError` publication. During final integration, the existing `policy_decide_blocklist` suite also caught a `blocklist: null` compatibility regression; the final implementation preserves the pre-existing JSON-compatible private dialect and the suite is green.

### GREEN evidence

```text
cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
  12 passed
cargo test --locked -p assay-mcp-server --test policy_decide_blocklist -- --nocapture
  4 passed
cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
cargo test --locked -p assay-core mcp::tests::policy_error_classification -- --nocapture
cargo test --locked -p assay-core mcp::tests::policy_file_parser_contract -- --nocapture
  5 passed
cargo test --locked -p assay-core --test mcp_policy_warning_contract -- --nocapture
  1 passed, 1 intentionally ignored child entrypoint
cargo test --locked -p assay-mcp-server
  all test binaries green
cargo fmt --all -- --check
cargo clippy --locked -p assay-core -p assay-mcp-server --all-targets -- -D warnings
python3 scripts/ci/check-mcp-tool-error-publication.py
bash scripts/ci/test-check-mcp-tool-error-publication.sh
python3 scripts/ci/check-mcp-policy-yaml-routing.py
bash scripts/ci/test-check-mcp-policy-yaml-routing.sh
git diff --check
```

Commit and pre-push hooks also passed, including workspace clippy and Linux cross-target compile.


### CI blocker close-out

The prior head exposed two deterministic integration failures. Both are fixed at the source:

- `McpPolicy::from_file` now carries `McpPolicyError`; the CLI consumes the core-owned `is_parse_failure()` grouping instead of downcasting to the displaced `serde_yaml::Error`. Syntax, non-mapping roots, and structure failures retain JSON `E_POLICY_PARSE`; post-parse validation remains an untyped fatal path.
- CodeQL alert #747 identified polynomial retry behavior in the publication guard's unanchored regex over the mutation-only `--stdin` interface. The final guard has no regex and no caller-selected production input. Its self-test imports the pure `check(source)` function in-process, and a repeated-prefix adversarial case is deadline-bounded.

Additional exact-head verification:

```text
cargo test --locked -p assay-cli --test agent_golden_path_contract
  34 passed
cargo test --locked -p assay-cli --test policy_validate_machine_contract
  18 passed, 1 intentionally ignored child entrypoint
cargo test --locked -p assay-cli --test config_recovery_argv_contract
  20 passed, 1 intentionally ignored child entrypoint
cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it
  all test binaries and doctests green
cargo clippy --locked -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
pre-commit run --all-files
  all hooks passed
```

The merge from current `main` was tree-neutral: `git diff --exit-code b2b3d8a95 HEAD` passed before push.

### Current-head review hardening

Verified and fixed five actionable CodeRabbit findings before quorum review:

- central `ToolError::policy_parse` now omits `details` unless both location components are positive, pinned by a table test;
- the routing guard rejects both relative and absolute (`::serde_yaml`) aliases;
- routing mutations count as caught only when the guard emits its explicit `FAIL:` diagnostic, not on an arbitrary crash;
- the commented-decoy mutation uses Python so the live repack survives on both GNU and BSD/macOS environments;
- the structure fixture comment now describes the actual string-valued `tools` field.
- the publication guard now reads at most 1,000,001 bytes, rejects oversized source before decoding, and pins the exact bounded read with an in-process stream probe.

RED was observed for zero-valued locations and the absolute alias before the two production fixes. The complete MCP-server suite, both guard mutation suites, shellcheck, fmt, clippy, commit hooks, workspace pre-push clippy, and Linux cross-target compile are green.

### Mutations caught

Disposable worktree at the exact head; final mutation tree clean and removed:

- `4096 -> 4097` ceiling: ASCII boundary test failed
- constructor bound removed: constructor test failed
- serializer bound removed: direct-struct serializer test failed
- UTF-8 char-boundary loop removed: multibyte test panicked at invalid boundary
- direct `anyhow` source skipped: direct-source test failed
- raw parser text published: hostile stdio test failed
- root class collapsed into syntax: class-specific stdio test failed
- validation mapped to syntax: validation-route stdio test failed
- unreachable direct publication plus reachable helper repack: publication guard failed
- direct/aliased/parallel parser, duplicate root classifier, helper bypass, and full-parser bypass: routing guard failed

### Guard boundaries

`check-mcp-policy-yaml-routing.py` is an architecture drift alarm over the complete current tool/core-policy Rust surface, not a Rust data-flow or security proof. Runtime safety is proved separately by real-stdio hostile-input tests. `check_sequence` retains its existing fixed, value-free parser message and is explicitly outside this slice.

### Non-claims

- no input-size/read ceiling; #2389 owns bounded materialization
- no generic dispatch fallback change; #2391 owns that boundary
- no new MCP protocol-compliance claim
- no change to policy verdict semantics or cache behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent MCP policy error classifications for syntax, structure, root-type, and validation failures.
  * Standardized policy parsing across MCP tools with safer, bounded public diagnostics.
  * Preserved syntax locations where available while hiding sensitive paths and parser details.
  * Added UTF-8-safe limits for published tool error messages.

* **Bug Fixes**
  * Improved handling of malformed YAML, invalid encoding, and unexpected policy shapes.
  * Prevented reserved policy keys from being accepted incorrectly.

* **Tests**
  * Added comprehensive coverage for parsing, diagnostics, warning behavior, and error publication safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




