### PR TITLE
docs(agents): allow Ruley-owned writer branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ including its explicit non-claims, or amend the decision through a new ADR.
 
 - One writer owns a branch and worktree. Other agents review the diff without editing that branch.
 - At most two ADR-042/043 implementation branches may be active at once.
-- Use `codex/`, `claude/`, or `cursor/` branch prefixes matching the writer.
+- Use `codex/`, `claude/`, `cursor/`, or `ruley/` branch prefixes matching the writer.
 - Do not implement on `main`.
 - Build in the worktree's own `target/`. Cargo creates one per worktree on first build, so
   worktrees do not share one unless told to, and `/target` is git-ignored so an in-tree build
@@ -165,6 +165,9 @@ so that display and round-trip "can never drift apart".
   plan/read-only mode.
 - Cursor may implement locally in its own worktree. Cursor Background Agents must not mutate auth
   or evidence-boundary code.
+- Ruley (GrokBot) may implement a bounded slice in its own worktree and may post issue and PR
+  updates. It must not write directly to `main` or use repository mutations as permission probes;
+  verify access through read-only API metadata and perform writes only on its owned branch.
 - Bugbot, CodeRabbit, and Copilot are optional reviewers, not authorities. Their findings require
   technical verification; their absence does not block the non-building-agent quorum above.
 - Heartbeats may monitor status only. They must not generate, edit, commit, push, or merge code.


### PR DESCRIPTION
## Summary

- permit `ruley/` branches when Ruley is the sole writer
- define Ruley's bounded implementation and issue/PR update permissions
- prohibit direct `main` writes and write-based permission probes

## Why

Ruley now has repository write permissions and has a completed local #2185 test slice, but the shared agent contract currently permits only `codex/`, `claude/`, and `cursor/` writer prefixes. This small contract update enables attributable Ruley-owned branches without weakening branch, worktree, review, or merge controls.

## Verification

- `git diff --check`
- commit hooks passed
- pre-push hooks passed, including workspace clippy and Linux cross-target compile

## Non-claims

- does not publish or modify Ruley's #2185 implementation
- does not make Ruley an automatic quorum reviewer
- does not change GitHub permissions or branch protection

## Final-head record

- Reviewed and gated head: `b0ead71334d9b3358c298212b08dd02f72153827`