### PR TITLE
fix(mcp): bound policy-file ingest before materialisation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,6 +189,20 @@ repos:
         pass_filenames: false
         files: ^(crates/assay-core/src/mcp/policy/.*\.rs|crates/assay-mcp-server/src/tools/.*\.rs|scripts/ci/(check-mcp-policy-yaml-routing\.py|test-check-mcp-policy-yaml-routing\.sh)|\.pre-commit-config\.yaml)$
 
+      - id: mcp-policy-reader-routing-self-test
+        name: MCP policy reader routing guard self-test
+        entry: bash -c 'python3 scripts/ci/check-mcp-policy-reader-routing.py && bash scripts/ci/test-check-mcp-policy-reader-routing.sh'
+        language: system
+        pass_filenames: false
+        files: ^(crates/assay-mcp-server/src/(config\.rs|main\.rs|tools/.*\.rs)|scripts/ci/(check-mcp-policy-reader-routing\.py|test-check-mcp-policy-reader-routing\.sh)|\.pre-commit-config\.yaml)$
+
+      - id: mcp-policy-parser-delegation-self-test
+        name: MCP policy parser delegation guard self-test
+        entry: bash -c 'python3 scripts/ci/check-mcp-policy-parser-delegation.py && bash scripts/ci/test-check-mcp-policy-parser-delegation.sh'
+        language: system
+        pass_filenames: false
+        files: ^(crates/assay-core/src/mcp/policy/(mod|legacy)\.rs|scripts/ci/(check-mcp-policy-parser-delegation\.py|test-check-mcp-policy-parser-delegation\.sh)|\.pre-commit-config\.yaml)$
+
       - id: evidence-vocabulary
         name: Evidence vocabulary guard
         entry: python3 scripts/ci/check-evidence-vocabulary.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- The five advertised MCP policy tools now read local policy files through one
+  inclusive byte ceiling (`ServerConfig.max_policy_bytes`, default 1,000,000,
+  override `ASSAY_MCP_MAX_POLICY_BYTES`) before parse or cache insertion.
+  Exactly the limit is accepted; one extra byte returns `E_LIMIT_EXCEEDED`.
+  The ceiling is independent of the JSON-RPC `ASSAY_MCP_MAX_BYTES` message
+  limit. Operators with previously accepted larger local policy files must
+  shrink the file or set an explicit bounded override. This does not bound
+  parser nesting, YAML aliases, proxy startup policy, manifests, trust
+  policy, or CLI readers (#2389).
 - `assay_policy_decide` now rejects non-mapping roots and canonical or mixed name-policy
   documents (`allow`, `deny`, `tools`, or those markers mixed with root `blocklist`) with
   `E_POLICY_PARSE` before cache insertion. Those inputs previously returned a false clean

--- a/crates/assay-core/src/mcp/policy/legacy.rs
+++ b/crates/assay-core/src/mcp/policy/legacy.rs
@@ -3,11 +3,13 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 pub(super) fn from_file(path: &Path) -> anyhow::Result<McpPolicy> {
-    // Read raw bytes so we can classify UTF-8 failure as Syntax.
     let bytes = std::fs::read(path)?;
+    McpPolicy::from_slice(&bytes)
+}
 
+pub(super) fn from_slice(bytes: &[u8]) -> anyhow::Result<McpPolicy> {
     // UTF-8 decode — failure is Syntax, not an I/O error.
-    let content = match std::str::from_utf8(&bytes) {
+    let content = match std::str::from_utf8(bytes) {
         Ok(s) => s,
         Err(e) => {
             return Err(McpPolicyError {

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -141,6 +141,20 @@ impl McpPolicy {
         legacy::from_file(path)
     }
 
+    pub fn from_slice(bytes: &[u8]) -> anyhow::Result<Self> {
+        legacy::from_slice(bytes)
+    }
+}
+
+impl std::str::FromStr for McpPolicy {
+    type Err = anyhow::Error;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        Self::from_slice(text.as_bytes())
+    }
+}
+
+impl McpPolicy {
     pub fn validate(&self) -> anyhow::Result<()> {
         legacy::validate(self)
     }

--- a/crates/assay-core/src/mcp/tests.rs
+++ b/crates/assay-core/src/mcp/tests.rs
@@ -1,6 +1,7 @@
 use super::policy::*;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::str::FromStr;
 
 // ── Full-policy error classification tests ──────────────────────────────────
 
@@ -525,4 +526,176 @@ fn test_strict_deprecation_env_var() {
     unsafe {
         std::env::remove_var("ASSAY_STRICT_DEPRECATIONS");
     }
+}
+
+#[derive(Debug)]
+enum ParserOutcome {
+    V2Allow(&'static str),
+    LegacyAllowDeny(&'static str, &'static str),
+    V1MigratedPattern(&'static str),
+    Accepted,
+    Syntax,
+    RootNotMapping,
+    Structure,
+    Validation,
+    StrictDeprecation,
+}
+
+fn classify_policy_err(err: anyhow::Error) -> ParserOutcome {
+    if let Some(typed) = err.downcast_ref::<McpPolicyError>() {
+        return match typed.kind {
+            McpPolicyErrorKind::Syntax { .. } => ParserOutcome::Syntax,
+            McpPolicyErrorKind::RootNotMapping => ParserOutcome::RootNotMapping,
+            McpPolicyErrorKind::Structure => ParserOutcome::Structure,
+            McpPolicyErrorKind::Validation => ParserOutcome::Validation,
+        };
+    }
+    if err.to_string().contains("Strict mode") {
+        return ParserOutcome::StrictDeprecation;
+    }
+    panic!("unclassified policy error: {err}");
+}
+
+fn outcome_from_policy(policy: McpPolicy, expected: &ParserOutcome) -> ParserOutcome {
+    match expected {
+        ParserOutcome::V2Allow(name) => {
+            assert_eq!(policy.version, "2.0");
+            assert!(policy
+                .tools
+                .allow
+                .as_ref()
+                .is_some_and(|allow| allow.iter().any(|tool| tool == name)));
+            ParserOutcome::V2Allow(name)
+        }
+        ParserOutcome::LegacyAllowDeny(allow, deny) => {
+            assert!(policy
+                .tools
+                .allow
+                .as_ref()
+                .is_some_and(|tools| tools.iter().any(|tool| tool == *allow)));
+            assert!(policy
+                .tools
+                .deny
+                .as_ref()
+                .is_some_and(|tools| tools.iter().any(|tool| tool == *deny)));
+            assert!(policy.allow.is_none());
+            assert!(policy.deny.is_none());
+            ParserOutcome::LegacyAllowDeny(allow, deny)
+        }
+        ParserOutcome::V1MigratedPattern(pattern) => {
+            let schema = policy
+                .schemas
+                .get("read_file")
+                .expect("V1 constraints must migrate");
+            assert_eq!(
+                schema
+                    .pointer("/properties/path/pattern")
+                    .and_then(Value::as_str),
+                Some(*pattern)
+            );
+            ParserOutcome::V1MigratedPattern(pattern)
+        }
+        ParserOutcome::Accepted => ParserOutcome::Accepted,
+        other => panic!("success is not a {other:?} outcome"),
+    }
+}
+
+fn parse_all_entry_points(bytes: &[u8], expected: ParserOutcome) {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), bytes).unwrap();
+    let file = McpPolicy::from_file(tmp.path());
+    let slice = McpPolicy::from_slice(bytes);
+    let via_str = std::str::from_utf8(bytes).ok().map(McpPolicy::from_str);
+
+    let file_out = match file {
+        Ok(policy) => outcome_from_policy(policy, &expected),
+        Err(err) => classify_policy_err(err),
+    };
+    let slice_out = match slice {
+        Ok(policy) => outcome_from_policy(policy, &expected),
+        Err(err) => classify_policy_err(err),
+    };
+    assert!(
+        matches_outcome(&file_out, &expected),
+        "from_file={file_out:?} expected={expected:?}"
+    );
+    assert!(
+        matches_outcome(&slice_out, &expected),
+        "from_slice={slice_out:?} expected={expected:?}"
+    );
+    if let Some(via_str) = via_str {
+        let str_out = match via_str {
+            Ok(policy) => outcome_from_policy(policy, &expected),
+            Err(err) => classify_policy_err(err),
+        };
+        assert!(
+            matches_outcome(&str_out, &expected),
+            "from_str={str_out:?} expected={expected:?}"
+        );
+    } else {
+        assert!(
+            matches!(&expected, ParserOutcome::Syntax),
+            "non-UTF-8 must be a syntax failure"
+        );
+    }
+}
+
+fn matches_outcome(actual: &ParserOutcome, expected: &ParserOutcome) -> bool {
+    match (actual, expected) {
+        (ParserOutcome::V2Allow(a), ParserOutcome::V2Allow(b)) => a == b,
+        (ParserOutcome::LegacyAllowDeny(a1, d1), ParserOutcome::LegacyAllowDeny(a2, d2)) => {
+            a1 == a2 && d1 == d2
+        }
+        (ParserOutcome::V1MigratedPattern(a), ParserOutcome::V1MigratedPattern(b)) => a == b,
+        (ParserOutcome::Accepted, ParserOutcome::Accepted)
+        | (ParserOutcome::Syntax, ParserOutcome::Syntax)
+        | (ParserOutcome::RootNotMapping, ParserOutcome::RootNotMapping)
+        | (ParserOutcome::Structure, ParserOutcome::Structure)
+        | (ParserOutcome::Validation, ParserOutcome::Validation)
+        | (ParserOutcome::StrictDeprecation, ParserOutcome::StrictDeprecation) => true,
+        _ => false,
+    }
+}
+
+#[test]
+#[serial_test::serial]
+#[allow(unsafe_code)]
+fn policy_parser_contract_file_bytes_string_parity() {
+    unsafe { std::env::remove_var("ASSAY_STRICT_DEPRECATIONS") };
+
+    parse_all_entry_points(
+        b"version: \"2.0\"\nname: test\ntools:\n  allow:\n    - read_file\n",
+        ParserOutcome::V2Allow("read_file"),
+    );
+    parse_all_entry_points(
+        b"version: \"1.0\"\nallow:\n  - tool_a\ndeny:\n  - tool_b\n",
+        ParserOutcome::LegacyAllowDeny("tool_a", "tool_b"),
+    );
+    parse_all_entry_points(
+        b"version: \"1.0\"\nconstraints:\n  - tool: read_file\n    params:\n      path:\n        matches: \"^/safe/.*\"\n",
+        ParserOutcome::V1MigratedPattern("^/safe/.*"),
+    );
+    parse_all_entry_points(
+        b"version: \"2.0\"\ntools:\n  allow:\n    - read_file\n  unknown_field_xyz: true\n",
+        ParserOutcome::Accepted,
+    );
+    parse_all_entry_points(
+        b"version: \"1.0\"\nconstraints: []\n",
+        ParserOutcome::Accepted,
+    );
+    parse_all_entry_points(b"version: \"\n  bad: [", ParserOutcome::Syntax);
+    parse_all_entry_points(b"- item1\n- item2\n", ParserOutcome::RootNotMapping);
+    parse_all_entry_points(b"version: \"2.0\"\ntools: 42\n", ParserOutcome::Structure);
+    parse_all_entry_points(
+        b"version: \"2.0\"\ntool_pins:\n  test_tool:\n    schema_hash: \"bad\"\n    meta_hash: \"bad\"\n    server_id: s\n    tool_name: n\n",
+        ParserOutcome::Validation,
+    );
+    parse_all_entry_points(&[0xFF, 0xFE, b'v', b':', b' ', b'1'], ParserOutcome::Syntax);
+
+    unsafe { std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1") };
+    parse_all_entry_points(
+        b"version: \"1.0\"\nconstraints: []\n",
+        ParserOutcome::StrictDeprecation,
+    );
+    unsafe { std::env::remove_var("ASSAY_STRICT_DEPRECATIONS") };
 }

--- a/crates/assay-mcp-server/src/config.rs
+++ b/crates/assay-mcp-server/src/config.rs
@@ -30,6 +30,7 @@ pub fn reject_unsupported_stdio_auth_env() -> anyhow::Result<()> {
 pub struct ServerConfig {
     pub timeout_ms: u64,
     pub max_msg_bytes: usize,
+    pub max_policy_bytes: usize,
     pub max_tool_calls: usize,
     pub max_field_bytes: usize,
     pub cache_entries: u64,
@@ -49,6 +50,7 @@ impl Default for ServerConfig {
         Self {
             timeout_ms: 2000,
             max_msg_bytes: 1_000_000,
+            max_policy_bytes: 1_000_000,
             max_tool_calls: 2000,
             max_field_bytes: 64_000,
             cache_entries: 128,
@@ -71,6 +73,11 @@ impl ServerConfig {
                 cfg.max_msg_bytes = n;
             }
         }
+        if let Ok(v) = env::var("ASSAY_MCP_MAX_POLICY_BYTES") {
+            if let Ok(n) = v.parse() {
+                cfg.max_policy_bytes = n;
+            }
+        }
         if let Ok(v) = env::var("ASSAY_MCP_MAX_FIELD_BYTES") {
             if let Ok(n) = v.parse() {
                 cfg.max_field_bytes = n;
@@ -90,5 +97,120 @@ impl ServerConfig {
             cfg.log_level = v;
         }
         cfg
+    }
+}
+
+#[cfg(test)]
+#[allow(unsafe_code)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvRestore {
+        _guard: MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvRestore {
+        fn apply(pairs: &[(&'static str, Option<&str>)]) -> Self {
+            let guard = ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let saved = pairs
+                .iter()
+                .map(|(name, _)| (*name, env::var(name).ok()))
+                .collect();
+            for (name, value) in pairs {
+                match value {
+                    Some(value) => unsafe { env::set_var(name, value) },
+                    None => unsafe { env::remove_var(name) },
+                }
+            }
+            Self {
+                _guard: guard,
+                saved,
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in &self.saved {
+                match value {
+                    Some(value) => unsafe { env::set_var(name, value) },
+                    None => unsafe { env::remove_var(name) },
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn default_policy_ceiling_is_one_million() {
+        let _env = EnvRestore::apply(&[
+            ("ASSAY_MCP_MAX_POLICY_BYTES", None),
+            ("ASSAY_MCP_MAX_BYTES", None),
+        ]);
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.max_policy_bytes, 1_000_000);
+        assert_eq!(cfg.max_msg_bytes, 1_000_000);
+    }
+
+    #[test]
+    fn policy_and_message_ceilings_diverge_in_both_directions() {
+        let _env = EnvRestore::apply(&[
+            ("ASSAY_MCP_MAX_POLICY_BYTES", Some("1234")),
+            ("ASSAY_MCP_MAX_BYTES", Some("4321")),
+        ]);
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.max_policy_bytes, 1234);
+        assert_eq!(cfg.max_msg_bytes, 4321);
+
+        drop(_env);
+        let _env = EnvRestore::apply(&[
+            ("ASSAY_MCP_MAX_POLICY_BYTES", Some("4321")),
+            ("ASSAY_MCP_MAX_BYTES", Some("1234")),
+        ]);
+        let cfg = ServerConfig::from_env();
+        assert_eq!(
+            cfg.max_policy_bytes, 4321,
+            "policy override must not follow ASSAY_MCP_MAX_BYTES"
+        );
+        assert_eq!(
+            cfg.max_msg_bytes, 1234,
+            "message override must not follow ASSAY_MCP_MAX_POLICY_BYTES"
+        );
+    }
+
+    #[test]
+    fn each_ceiling_override_leaves_the_other_at_default() {
+        let _env = EnvRestore::apply(&[
+            ("ASSAY_MCP_MAX_POLICY_BYTES", Some("1234")),
+            ("ASSAY_MCP_MAX_BYTES", None),
+        ]);
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.max_policy_bytes, 1234);
+        assert_eq!(cfg.max_msg_bytes, 1_000_000);
+
+        drop(_env);
+        let _env = EnvRestore::apply(&[
+            ("ASSAY_MCP_MAX_POLICY_BYTES", None),
+            ("ASSAY_MCP_MAX_BYTES", Some("4321")),
+        ]);
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.max_policy_bytes, 1_000_000);
+        assert_eq!(cfg.max_msg_bytes, 4321);
+    }
+
+    #[test]
+    fn invalid_policy_override_keeps_default_and_does_not_touch_message_ceiling() {
+        let _env = EnvRestore::apply(&[
+            ("ASSAY_MCP_MAX_POLICY_BYTES", Some("not-a-number")),
+            ("ASSAY_MCP_MAX_BYTES", Some("4321")),
+        ]);
+        let cfg = ServerConfig::from_env();
+        assert_eq!(cfg.max_policy_bytes, 1_000_000);
+        assert_eq!(cfg.max_msg_bytes, 4321);
     }
 }

--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -272,6 +272,7 @@ async fn main() -> Result<()> {
                 policy_root = ?args.policy_root,
                 timeout_ms = cfg.timeout_ms,
                 max_msg_bytes = cfg.max_msg_bytes,
+                max_policy_bytes = cfg.max_policy_bytes,
                 max_tool_calls = cfg.max_tool_calls,
                 max_field_bytes = cfg.max_field_bytes,
                 cache_entries = cfg.cache_entries,

--- a/crates/assay-mcp-server/src/tools/check_args.rs
+++ b/crates/assay-mcp-server/src/tools/check_args.rs
@@ -28,13 +28,6 @@ pub async fn check_args(ctx: &ToolContext, args: &Value) -> Result<Value> {
         return ToolError::new("E_LIMIT_EXCEEDED", "arguments too large").result();
     }
 
-    // 2. Load Policy (Unified Engine)
-    // Secure resolve
-    let policy_path = match ctx.resolve_policy_path(policy_rel_path).await {
-        Ok(p) => p,
-        Err(e) => return e.result(),
-    };
-
     // Slow hook for timeout testing (Strict preservation for tests)
     #[cfg(debug_assertions)]
     if policy_rel_path.contains("slow") {
@@ -48,11 +41,14 @@ pub async fn check_args(ctx: &ToolContext, args: &Value) -> Result<Value> {
     // Ideally, the Server struct would hold persistent PolicyState.
     let mut state = assay_core::mcp::policy::PolicyState::default();
 
-    // Load policy (handles V1->V2 migration automatically)
-    let policy = match McpPolicy::from_file(&policy_path) {
+    let policy_bytes = match ctx.read_policy_bounded(policy_rel_path).await {
+        Ok(b) => b,
+        Err(e) => return e.result(),
+    };
+
+    let policy = match McpPolicy::from_slice(&policy_bytes) {
         Ok(p) => p,
         Err(e) => {
-            // Classify by McpPolicyError kind when available.
             if let Some(typed) = e.downcast_ref::<McpPolicyError>() {
                 let (class, location) = match &typed.kind {
                     McpPolicyErrorKind::Syntax { line, column } => {
@@ -68,22 +64,6 @@ pub async fn check_args(ctx: &ToolContext, args: &Value) -> Result<Value> {
                 };
                 return ToolError::policy_parse(class, location).result();
             }
-            // I/O errors: Not Found, Permission Denied, etc.
-            let msg = e.to_string();
-            if msg.to_lowercase().contains("no such file")
-                || msg.to_lowercase().contains("system cannot find")
-            {
-                return ToolError::new(
-                    "E_POLICY_NOT_FOUND",
-                    &format!("Policy not found: {}", policy_rel_path),
-                )
-                .result();
-            } else if msg.to_lowercase().contains("permission denied")
-                || msg.to_lowercase().contains("is a directory")
-            {
-                return ToolError::new("E_POLICY_READ", &msg).result();
-            }
-            // Fallback: generic parse error with bounded message.
             return ToolError::policy_parse(PolicyParseFailure::Structure, None).result();
         }
     };

--- a/crates/assay-mcp-server/src/tools/check_coverage.rs
+++ b/crates/assay-mcp-server/src/tools/check_coverage.rs
@@ -57,22 +57,9 @@ pub async fn check_coverage(ctx: &ToolContext, args: &Value) -> Result<Value> {
             .result();
     }
 
-    // Load policy
-    let policy_path = match ctx.resolve_policy_path(&input.policy).await {
-        Ok(p) => p,
-        Err(e) => return e.result(),
-    };
-
-    let policy_bytes = match tokio::fs::read(&policy_path).await {
+    let policy_bytes = match ctx.read_policy_bounded(&input.policy).await {
         Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ToolError::new(
-                "E_POLICY_NOT_FOUND",
-                &format!("Policy not found: {}", input.policy),
-            )
-            .result();
-        }
-        Err(e) => return ToolError::new("E_POLICY_READ", &e.to_string()).result(),
+        Err(e) => return e.result(),
     };
 
     // Parse policy through the shared mapping-stage helper.

--- a/crates/assay-mcp-server/src/tools/check_sequence.rs
+++ b/crates/assay-mcp-server/src/tools/check_sequence.rs
@@ -33,16 +33,9 @@ pub async fn check_sequence(ctx: &ToolContext, args: &Value) -> Result<Value> {
         Err(e) => return e.result(),
     };
 
-    let policy_bytes = match tokio::fs::read(&policy_path).await {
+    let policy_bytes = match ctx.read_policy_bounded(policy_rel_path).await {
         Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ToolError::new(
-                "E_POLICY_NOT_FOUND",
-                &format!("Policy not found: {}", policy_rel_path),
-            )
-            .result();
-        }
-        Err(e) => return ToolError::new("E_POLICY_READ", &e.to_string()).result(),
+        Err(e) => return e.result(),
     };
 
     let sha = crate::cache::sha256_hex(&policy_bytes);

--- a/crates/assay-mcp-server/src/tools/explain_trace.rs
+++ b/crates/assay-mcp-server/src/tools/explain_trace.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides step-by-step explanation of trace evaluation against a policy.
 
-use crate::tools::{ToolContext, ToolError};
+use crate::tools::ToolContext;
 use anyhow::{Context, Result};
 use assay_core::explain;
 use serde_json::Value;
@@ -41,22 +41,9 @@ pub async fn explain_trace(ctx: &ToolContext, args: &Value) -> Result<Value> {
     let input: ExplainInput =
         serde_json::from_value(args.clone()).context("Invalid explain input")?;
 
-    // Load policy
-    let policy_path = match ctx.resolve_policy_path(&input.policy).await {
-        Ok(p) => p,
-        Err(e) => return e.result(),
-    };
-
-    let policy_bytes = match tokio::fs::read(&policy_path).await {
+    let policy_bytes = match ctx.read_policy_bounded(&input.policy).await {
         Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ToolError::new(
-                "E_POLICY_NOT_FOUND",
-                &format!("Policy not found: {}", input.policy),
-            )
-            .result();
-        }
-        Err(e) => return ToolError::new("E_POLICY_READ", &e.to_string()).result(),
+        Err(e) => return e.result(),
     };
 
     let policy: assay_core::model::Policy = match super::parse_tool_policy(&policy_bytes) {

--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -163,6 +163,7 @@ pub mod check_coverage;
 pub mod check_sequence;
 pub mod explain_trace;
 pub mod policy_decide;
+mod policy_read;
 
 #[cfg(feature = "test-outbound")]
 pub mod test_outbound;

--- a/crates/assay-mcp-server/src/tools/policy_decide.rs
+++ b/crates/assay-mcp-server/src/tools/policy_decide.rs
@@ -50,18 +50,9 @@ pub async fn policy_decide(ctx: &ToolContext, args: &Value) -> Result<Value> {
         Ok(p) => p,
         Err(e) => return e.result(),
     };
-
-    // Read logic
-    let policy_bytes = match tokio::fs::read(&policy_path).await {
+    let policy_bytes = match ctx.read_policy_bounded(policy_rel_path).await {
         Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ToolError::new(
-                "E_POLICY_NOT_FOUND",
-                &format!("Policy not found: {}", policy_rel_path),
-            )
-            .result();
-        }
-        Err(e) => return ToolError::new("E_POLICY_READ", &e.to_string()).result(),
+        Err(e) => return e.result(),
     };
 
     let sha = crate::cache::sha256_hex(&policy_bytes);

--- a/crates/assay-mcp-server/src/tools/policy_read.rs
+++ b/crates/assay-mcp-server/src/tools/policy_read.rs
@@ -32,7 +32,7 @@ fn map_read_error(err: io::Error, rel_path: &str) -> ToolError {
 }
 
 impl ToolContext {
-    /// Resolve `user_path`, then read the file through [`read_bounded`] on a
+    /// Resolve `user_path`, then read the file through `read_bounded` on a
     /// blocking thread. The `File` is opened inside `spawn_blocking`.
     pub async fn read_policy_bounded(&self, user_path: &str) -> Result<Vec<u8>, ToolError> {
         let path = self.resolve_policy_path(user_path).await?;

--- a/crates/assay-mcp-server/src/tools/policy_read.rs
+++ b/crates/assay-mcp-server/src/tools/policy_read.rs
@@ -1,0 +1,238 @@
+//! One bounded policy-byte reader. The inclusive ceiling lives in
+//! `assay_common::limits::LimitReader`; this module owns accumulation and the
+//! server mapping onto that primitive.
+
+use super::{ToolContext, ToolError};
+use assay_common::limits::{LimitExceeded, LimitKind, LimitReader};
+use std::fs::File;
+use std::io::{self, Read};
+
+/// Read at most `limit` bytes from an arbitrary `Read`. Metadata is not consulted.
+pub(super) fn read_bounded<R: Read>(reader: R, limit: usize) -> io::Result<Vec<u8>> {
+    let mut reader = LimitReader::new(reader, limit as u64, LimitKind::SourceBytes);
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn map_read_error(err: io::Error, rel_path: &str) -> ToolError {
+    if err.kind() == io::ErrorKind::NotFound {
+        return ToolError::new(
+            "E_POLICY_NOT_FOUND",
+            &format!("Policy not found: {rel_path}"),
+        );
+    }
+    if LimitExceeded::from_io(&err).is_some() {
+        return ToolError::new(
+            "E_LIMIT_EXCEEDED",
+            "policy file exceeds the configured byte limit",
+        );
+    }
+    ToolError::new("E_POLICY_READ", &err.to_string())
+}
+
+impl ToolContext {
+    /// Resolve `user_path`, then read the file through [`read_bounded`] on a
+    /// blocking thread. The `File` is opened inside `spawn_blocking`.
+    pub async fn read_policy_bounded(&self, user_path: &str) -> Result<Vec<u8>, ToolError> {
+        let path = self.resolve_policy_path(user_path).await?;
+        let limit = self.cfg.max_policy_bytes;
+        let rel_path = user_path.to_string();
+        match tokio::task::spawn_blocking(move || {
+            let file = File::open(&path)?;
+            read_bounded(file, limit)
+        })
+        .await
+        {
+            Ok(Ok(bytes)) => Ok(bytes),
+            Ok(Err(err)) => Err(map_read_error(err, &rel_path)),
+            Err(join) => Err(ToolError::new("E_POLICY_READ", &join.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::PolicyCaches;
+    use crate::config::ServerConfig;
+    use crate::tools::ToolContext;
+    use std::io::{self, Read, Seek, SeekFrom, Write};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    struct OneByteAtATime<R>(R);
+
+    impl<R: Read> Read for OneByteAtATime<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            self.0.read(&mut buf[..1])
+        }
+    }
+
+    struct GrowingReader {
+        first: Vec<u8>,
+        rest: Vec<u8>,
+        stage: u8,
+    }
+
+    impl Read for GrowingReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            match self.stage {
+                0 => {
+                    self.stage = 1;
+                    let n = self.first.len().min(buf.len());
+                    buf[..n].copy_from_slice(&self.first[..n]);
+                    Ok(n)
+                }
+                1 => {
+                    self.stage = 2;
+                    let n = self.rest.len().min(buf.len());
+                    buf[..n].copy_from_slice(&self.rest[..n]);
+                    Ok(n)
+                }
+                _ => Ok(0),
+            }
+        }
+    }
+
+    struct FailingReader;
+
+    impl Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("injected read failure"))
+        }
+    }
+
+    fn classify(err: &io::Error) -> Option<LimitExceeded> {
+        LimitExceeded::from_io(err)
+    }
+
+    #[test]
+    fn read_bounded_accepts_exact_limit_and_refuses_one_more() {
+        let exact = read_bounded(io::Cursor::new(vec![b'a'; 8]), 8).expect("exact limit");
+        assert_eq!(exact.len(), 8);
+        let err = read_bounded(io::Cursor::new(vec![b'a'; 9]), 8).expect_err("limit+1");
+        let cause = classify(&err).expect("typed limit cause");
+        assert_eq!(cause.kind, LimitKind::SourceBytes);
+        assert_eq!(cause.limit, 8);
+    }
+
+    #[test]
+    fn read_bounded_chunked_crossing_trips_the_same_rule() {
+        let err = read_bounded(OneByteAtATime(io::Cursor::new(vec![b'x'; 5])), 4)
+            .expect_err("chunked limit+1");
+        assert!(
+            classify(&err).is_some(),
+            "must classify via LimitExceeded::from_io"
+        );
+        let exact =
+            read_bounded(OneByteAtATime(io::Cursor::new(vec![b'x'; 4])), 4).expect("chunked exact");
+        assert_eq!(exact.len(), 4);
+    }
+
+    #[test]
+    fn read_bounded_growing_reader_trips_after_the_first_chunk() {
+        let err = read_bounded(
+            GrowingReader {
+                first: vec![b'a'; 4],
+                rest: vec![b'b'; 2],
+                stage: 0,
+            },
+            4,
+        )
+        .expect_err("growth past limit");
+        assert!(classify(&err).is_some(), "growth must be a typed limit");
+    }
+
+    #[test]
+    fn read_bounded_ordinary_io_is_not_a_limit() {
+        let err = read_bounded(FailingReader, 16).expect_err("injected io");
+        assert!(
+            classify(&err).is_none(),
+            "ordinary I/O must not look like LimitExceeded"
+        );
+        assert!(err.to_string().contains("injected read failure"));
+    }
+
+    async fn context_with_limit(root: PathBuf, limit: usize) -> ToolContext {
+        let cfg = ServerConfig {
+            max_policy_bytes: limit,
+            ..ServerConfig::default()
+        };
+        let canon = tokio::fs::canonicalize(&root).await.unwrap();
+        ToolContext {
+            policy_root: root,
+            policy_root_canon: canon,
+            cfg,
+            caches: PolicyCaches::new(8),
+        }
+    }
+
+    #[tokio::test]
+    async fn async_entry_maps_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = context_with_limit(tmp.path().to_path_buf(), 32).await;
+        let err = ctx
+            .read_policy_bounded("missing.yaml")
+            .await
+            .expect_err("missing");
+        assert_eq!(err.code, "E_POLICY_NOT_FOUND");
+        assert_eq!(err.message, "Policy not found: missing.yaml");
+        assert!(
+            !err.message.contains(tmp.path().to_string_lossy().as_ref()),
+            "must not publish the canonical root"
+        );
+    }
+
+    #[tokio::test]
+    async fn async_entry_maps_directory_read_as_other_io() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("not-a-file")).unwrap();
+        let ctx = context_with_limit(tmp.path().to_path_buf(), 32).await;
+        let err = ctx
+            .read_policy_bounded("not-a-file")
+            .await
+            .expect_err("directory");
+        assert_eq!(err.code, "E_POLICY_READ");
+        assert!(
+            !err.message.is_empty(),
+            "other I/O keeps the current diagnostic text"
+        );
+    }
+
+    #[tokio::test]
+    async fn async_entry_accepts_exact_limit_file() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("exact.yaml"), vec![b'e'; 16]).unwrap();
+        let ctx = context_with_limit(tmp.path().to_path_buf(), 16).await;
+        let bytes = ctx
+            .read_policy_bounded("exact.yaml")
+            .await
+            .unwrap_or_else(|err| {
+                panic!("exact file must be accepted: {} {}", err.code, err.message)
+            });
+        assert_eq!(bytes.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn async_entry_refuses_sparse_limit_plus_one() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("sparse.yaml");
+        let mut file = File::create(&path).unwrap();
+        file.seek(SeekFrom::Start(16)).unwrap();
+        file.write_all(&[0u8]).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        let ctx = context_with_limit(tmp.path().to_path_buf(), 16).await;
+        let err = ctx
+            .read_policy_bounded("sparse.yaml")
+            .await
+            .expect_err("sparse limit+1");
+        assert_eq!(err.code, "E_LIMIT_EXCEEDED");
+        assert_eq!(err.message, "policy file exceeds the configured byte limit");
+    }
+}

--- a/crates/assay-mcp-server/tests/policy_ingest_limits.rs
+++ b/crates/assay-mcp-server/tests/policy_ingest_limits.rs
@@ -237,6 +237,120 @@ fn five_tools_refuse_limit_plus_one_policy_file() {
     let _ = conn.shutdown();
 }
 
+fn assert_not_limit_error(label: &str, result: &Value, body: &Value) {
+    assert_ne!(
+        body.pointer("/error/code").and_then(Value::as_str),
+        Some("E_LIMIT_EXCEEDED"),
+        "{label}: exact-limit file must not be a limit failure; result={result} body={body}"
+    );
+}
+
+#[test]
+fn five_tools_accept_exact_limit_valid_policy_files() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+
+    write_policy(
+        root,
+        "decide-exact.yaml",
+        &pad_yaml_to("blocklist: []\n", POLICY_LIMIT),
+    );
+    write_policy(
+        root,
+        "args-exact.yaml",
+        &pad_yaml_to(
+            "version: \"2.0\"\ntools:\n  allow:\n    - read_file\n",
+            POLICY_LIMIT,
+        ),
+    );
+    write_policy(
+        root,
+        "seq-exact.yaml",
+        &pad_yaml_to("- read_file\n", POLICY_LIMIT),
+    );
+    write_policy(
+        root,
+        "cov-exact.yaml",
+        &pad_yaml_to(
+            "version: \"1.1\"\nname: t\ntools:\n  allow: [Search]\nsequences: []\n",
+            POLICY_LIMIT,
+        ),
+    );
+    write_policy(
+        root,
+        "explain-exact.yaml",
+        &pad_yaml_to("version: \"1.1\"\nname: t\nsequences: []\n", POLICY_LIMIT),
+    );
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+
+    let (decide_result, decide_body) = call_tool(
+        &mut conn,
+        "assay_policy_decide",
+        policy_decide_args("decide-exact.yaml"),
+        2,
+    );
+    assert_not_limit_error("assay_policy_decide exact", &decide_result, &decide_body);
+    assert_eq!(
+        decide_body.get("allowed").and_then(Value::as_bool),
+        Some(true),
+        "assay_policy_decide exact: {decide_body}"
+    );
+
+    let (args_result, args_body) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("args-exact.yaml"),
+        3,
+    );
+    assert_not_limit_error("assay_check_args exact", &args_result, &args_body);
+    assert_eq!(
+        args_body.get("allowed").and_then(Value::as_bool),
+        Some(true),
+        "assay_check_args exact: {args_body}"
+    );
+
+    let (seq_result, seq_body) = call_tool(
+        &mut conn,
+        "assay_check_sequence",
+        check_sequence_args("seq-exact.yaml"),
+        4,
+    );
+    assert_not_limit_error("assay_check_sequence exact", &seq_result, &seq_body);
+    assert_eq!(
+        seq_body.get("allowed").and_then(Value::as_bool),
+        Some(true),
+        "assay_check_sequence exact: {seq_body}"
+    );
+
+    let (cov_result, cov_body) = call_tool(
+        &mut conn,
+        "assay_check_coverage",
+        check_coverage_args("cov-exact.yaml"),
+        5,
+    );
+    assert_not_limit_error("assay_check_coverage exact", &cov_result, &cov_body);
+    assert!(
+        cov_body.get("overall_coverage_pct").is_some() || cov_body.get("meets_threshold").is_some(),
+        "assay_check_coverage exact must reach the coverage report; body={cov_body}"
+    );
+
+    let (explain_result, explain_body) = call_tool(
+        &mut conn,
+        "assay_explain_trace",
+        explain_trace_args("explain-exact.yaml"),
+        6,
+    );
+    assert_not_limit_error("assay_explain_trace exact", &explain_result, &explain_body);
+    assert!(
+        explain_body.get("total_steps").is_some() || explain_body.get("blocked_steps").is_some(),
+        "assay_explain_trace exact must reach the explanation; body={explain_body}"
+    );
+
+    let _ = conn.shutdown();
+}
+
 #[test]
 fn check_args_invalid_utf8_stays_policy_parse() {
     let dir = tempfile::tempdir().expect("policy-root");

--- a/crates/assay-mcp-server/tests/policy_ingest_limits.rs
+++ b/crates/assay-mcp-server/tests/policy_ingest_limits.rs
@@ -1,0 +1,277 @@
+//! Real-stdio contract for bounded MCP policy-file ingest (#2389).
+//!
+//! The five advertised policy tools must refuse a local policy of `limit + 1`
+//! bytes with `isError:true`, `allowed:false`, and `E_LIMIT_EXCEEDED` before
+//! parse or cache insertion. First/repeat cache-limit cases apply only to
+//! `assay_policy_decide` and `assay_check_sequence`; the other three tools
+//! have no policy cache. Invalid UTF-8 through `assay_check_args` remains
+//! the #2387 parse classification.
+//!
+//! Inventory on `249e8160`: four tools call `tokio::fs::read`; `assay_check_args`
+//! calls `McpPolicy::from_file`, which uses unbounded `std::fs::read` in
+//! `legacy.rs` (not `read_to_string`).
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
+
+const POLICY_LIMIT: usize = 128;
+const YAML_INVALID: &str = "Policy YAML is invalid";
+
+fn spawn_server(policy_root: &Path) -> Conn {
+    let child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "--policy-root",
+            policy_root.to_str().expect("utf-8 policy-root"),
+        ])
+        .env("ASSAY_MCP_MAX_POLICY_BYTES", POLICY_LIMIT.to_string())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn assay-mcp-server");
+    Conn::attach(child)
+}
+
+fn initialize(conn: &mut Conn) {
+    conn.request(
+        "initialize",
+        serde_json::json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "policy-ingest-limits", "version": "1.0"}
+        }),
+        1,
+    );
+}
+
+fn call_tool(conn: &mut Conn, tool: &str, arguments: Value, id: u64) -> (Value, Value) {
+    let resp = conn.request(
+        "tools/call",
+        serde_json::json!({"name": tool, "arguments": arguments}),
+        id,
+    );
+    let result = resp
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| panic!("tools/call {id} missing result: {resp}"));
+    let text = result["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("tools/call {id} missing text: {result}"));
+    let body: Value = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("tools/call {id} body is not JSON ({e}): {text}"));
+    (result, body)
+}
+
+fn write_policy(dir: &Path, name: &str, contents: &[u8]) {
+    fs::write(dir.join(name), contents).unwrap_or_else(|e| panic!("write {name}: {e}"));
+}
+
+fn pad_yaml_to(body: &str, target: usize) -> Vec<u8> {
+    let mut out = body.as_bytes().to_vec();
+    assert!(
+        out.len() < target,
+        "fixture body is already {len} bytes; cannot pad to {target}",
+        len = out.len()
+    );
+    if !out.ends_with(b"\n") {
+        out.push(b'\n');
+    }
+    if out.len() < target {
+        out.push(b'#');
+    }
+    while out.len() < target {
+        out.push(b'p');
+    }
+    assert_eq!(out.len(), target);
+    out
+}
+
+fn assert_limit_exceeded(label: &str, result: &Value, body: &Value) {
+    assert_eq!(
+        result.get("isError").and_then(Value::as_bool),
+        Some(true),
+        "{label}: result.isError must be true; result={result} body={body}"
+    );
+    assert_eq!(
+        body.get("allowed").and_then(Value::as_bool),
+        Some(false),
+        "{label}: allowed must be false; body={body}"
+    );
+    assert_eq!(
+        body.pointer("/error/code").and_then(Value::as_str),
+        Some("E_LIMIT_EXCEEDED"),
+        "{label}: error.code must be E_LIMIT_EXCEEDED; body={body}"
+    );
+}
+
+fn policy_decide_args(policy: &str) -> Value {
+    serde_json::json!({"tool": "read_file", "policy": policy})
+}
+
+fn check_args_args(policy: &str) -> Value {
+    serde_json::json!({
+        "tool": "read_file",
+        "arguments": {"path": "/tmp/safe.txt"},
+        "policy": policy
+    })
+}
+
+fn check_sequence_args(policy: &str) -> Value {
+    serde_json::json!({
+        "history": [],
+        "next_tool": "read_file",
+        "policy": policy
+    })
+}
+
+fn check_coverage_args(policy: &str) -> Value {
+    serde_json::json!({
+        "policy": policy,
+        "traces": [{"tools": ["Search"]}]
+    })
+}
+
+fn explain_trace_args(policy: &str) -> Value {
+    serde_json::json!({
+        "policy": policy,
+        "trace": [{"tool": "Search"}]
+    })
+}
+
+#[test]
+fn five_tools_refuse_limit_plus_one_policy_file() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    let oversized = POLICY_LIMIT + 1;
+
+    write_policy(
+        root,
+        "decide-over.yaml",
+        &pad_yaml_to("blocklist: []\n", oversized),
+    );
+    write_policy(
+        root,
+        "args-over.yaml",
+        &pad_yaml_to(
+            "version: \"2.0\"\ntools:\n  allow:\n    - read_file\n",
+            oversized,
+        ),
+    );
+    write_policy(
+        root,
+        "seq-over.yaml",
+        &pad_yaml_to("- read_file\n", oversized),
+    );
+    write_policy(
+        root,
+        "cov-over.yaml",
+        &pad_yaml_to(
+            "version: \"1.1\"\nname: t\ntools:\n  allow: [Search]\nsequences: []\n",
+            oversized,
+        ),
+    );
+    write_policy(
+        root,
+        "explain-over.yaml",
+        &pad_yaml_to("version: \"1.1\"\nname: t\nsequences: []\n", oversized),
+    );
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+
+    let cases = [
+        (
+            "assay_policy_decide",
+            policy_decide_args("decide-over.yaml"),
+            2u64,
+        ),
+        ("assay_check_args", check_args_args("args-over.yaml"), 3),
+        (
+            "assay_check_sequence",
+            check_sequence_args("seq-over.yaml"),
+            4,
+        ),
+        (
+            "assay_check_coverage",
+            check_coverage_args("cov-over.yaml"),
+            5,
+        ),
+        (
+            "assay_explain_trace",
+            explain_trace_args("explain-over.yaml"),
+            6,
+        ),
+    ];
+
+    for (tool, arguments, id) in cases {
+        let (result, body) = call_tool(&mut conn, tool, arguments, id);
+        assert_limit_exceeded(tool, &result, &body);
+    }
+
+    // Cache-bearing tools only: a second oversized call must still be a limit
+    // failure, proving the first call did not insert a compiled policy.
+    let (decide_repeat, decide_repeat_body) = call_tool(
+        &mut conn,
+        "assay_policy_decide",
+        policy_decide_args("decide-over.yaml"),
+        7,
+    );
+    assert_limit_exceeded(
+        "assay_policy_decide repeat",
+        &decide_repeat,
+        &decide_repeat_body,
+    );
+    let (seq_repeat, seq_repeat_body) = call_tool(
+        &mut conn,
+        "assay_check_sequence",
+        check_sequence_args("seq-over.yaml"),
+        8,
+    );
+    assert_limit_exceeded("assay_check_sequence repeat", &seq_repeat, &seq_repeat_body);
+
+    let _ = conn.shutdown();
+}
+
+#[test]
+fn check_args_invalid_utf8_stays_policy_parse() {
+    let dir = tempfile::tempdir().expect("policy-root");
+    let root = dir.path();
+    write_policy(root, "bad-utf8.yaml", &[0xFF, 0xFE, b'v', b':', b' ', b'1']);
+
+    let mut conn = spawn_server(root);
+    initialize(&mut conn);
+    let (result, body) = call_tool(
+        &mut conn,
+        "assay_check_args",
+        check_args_args("bad-utf8.yaml"),
+        2,
+    );
+
+    assert_eq!(
+        result.get("isError").and_then(Value::as_bool),
+        Some(true),
+        "invalid-utf8: result.isError must be true; result={result} body={body}"
+    );
+    assert_eq!(
+        body.get("allowed").and_then(Value::as_bool),
+        Some(false),
+        "invalid-utf8: allowed must be false; body={body}"
+    );
+    assert_eq!(
+        body.pointer("/error/code").and_then(Value::as_str),
+        Some("E_POLICY_PARSE"),
+        "invalid-utf8: error.code must be E_POLICY_PARSE; body={body}"
+    );
+    assert_eq!(
+        body.pointer("/error/message").and_then(Value::as_str),
+        Some(YAML_INVALID),
+        "invalid-utf8: message must stay Policy YAML is invalid; body={body}"
+    );
+
+    let _ = conn.shutdown();
+}

--- a/docs/reference/cli/mcp-server.md
+++ b/docs/reference/cli/mcp-server.md
@@ -72,6 +72,22 @@ assay-mcp-server --policy-root <DIR>
 |--------|-------------|
 | `--policy-root <PATH>` | Policy root directory (default: `policies`) |
 
+### Policy-file ingest ceiling
+
+The five advertised policy tools (`assay_policy_decide`, `assay_check_args`,
+`assay_check_sequence`, `assay_check_coverage`, `assay_explain_trace`) read
+local policy files through one inclusive byte ceiling before parse or cache
+insertion. The default is 1,000,000 bytes. Override it with
+`ASSAY_MCP_MAX_POLICY_BYTES`. Exactly the configured size is accepted; one
+extra byte returns `E_LIMIT_EXCEEDED` and is not parsed or cached.
+
+This ceiling is independent of `ASSAY_MCP_MAX_BYTES`, which bounds inbound
+JSON-RPC messages. It does not limit YAML nesting, alias expansion, proxy
+startup policy, declared manifests, trust policy, or CLI policy readers.
+
+Operators whose local policy files previously exceeded 1,000,000 bytes must
+either reduce the file or set an explicit bounded override.
+
 ---
 
 ## Agent Integration Note

--- a/scripts/ci/check-mcp-policy-parser-delegation.py
+++ b/scripts/ci/check-mcp-policy-parser-delegation.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Architecture drift guard for the one full-policy bytes parser (#2389)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+MOD = Path("crates/assay-core/src/mcp/policy/mod.rs")
+LEGACY = Path("crates/assay-core/src/mcp/policy/legacy.rs")
+PARSER_RE = re.compile(
+    r"(?:serde_yaml::(?:from_slice|from_str|from_reader|from_value|Deserializer)|"
+    r"serde_ignored::deserialize)"
+)
+
+
+def code_only(source: str) -> str:
+    out = list(source)
+    state = "code"
+    block_depth = 0
+    escaped = False
+    raw_hashes = 0
+    index = 0
+    while index < len(source):
+        char = source[index]
+        pair = source[index : index + 2]
+        if state == "code":
+            raw = re.match(r'r(#{0,16})"', source[index:])
+            if raw:
+                raw_hashes = len(raw.group(1))
+                end = index + len(raw.group(0))
+                for pos in range(index, end):
+                    out[pos] = " "
+                index = end
+                state = "raw"
+                continue
+            if pair == "//":
+                out[index] = out[index + 1] = " "
+                index += 2
+                state = "line"
+                continue
+            if pair == "/*":
+                out[index] = out[index + 1] = " "
+                index += 2
+                block_depth = 1
+                state = "block"
+                continue
+            if char == '"':
+                out[index] = " "
+                state = "string"
+        elif state == "line":
+            if char == "\n":
+                state = "code"
+            else:
+                out[index] = " "
+        elif state == "block":
+            out[index] = " "
+            if pair == "/*":
+                out[index + 1] = " "
+                block_depth += 1
+                index += 1
+            elif pair == "*/":
+                out[index + 1] = " "
+                block_depth -= 1
+                index += 1
+                if block_depth == 0:
+                    state = "code"
+        elif state == "string":
+            out[index] = " "
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                state = "code"
+        elif state == "raw":
+            out[index] = " "
+            closing = '"' + ("#" * raw_hashes)
+            if source.startswith(closing, index):
+                for pos in range(index, index + len(closing)):
+                    out[pos] = " "
+                index += len(closing) - 1
+                state = "code"
+        index += 1
+    return "".join(out)
+
+
+def compact(source: str) -> str:
+    return re.sub(r"\s+", "", code_only(source))
+
+
+def impl_method(source: str, name: str) -> str | None:
+    pattern = re.compile(rf"(?:pub(?:\(super\))?\s+)?fn {name}\s*\(")
+    match = pattern.search(source)
+    if not match:
+        return None
+    brace = source.find("{", match.start())
+    if brace < 0:
+        return None
+    depth = 0
+    for index, char in enumerate(source[brace:], brace):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : index + 1]
+    return None
+
+
+def check(root: Path) -> bool:
+    errors: list[str] = []
+    mod_src = (root / MOD).read_text()
+    legacy_src = (root / LEGACY).read_text()
+
+    public_file = impl_method(mod_src, "from_file")
+    public_slice = impl_method(mod_src, "from_slice")
+    public_str = impl_method(mod_src, "from_str")
+    legacy_file = impl_method(legacy_src, "from_file")
+    legacy_slice = impl_method(legacy_src, "from_slice")
+
+    hops = [
+        (public_file, "legacy::from_file(", "public from_file -> legacy::from_file"),
+        (legacy_file, "McpPolicy::from_slice(", "legacy::from_file -> McpPolicy::from_slice"),
+        (public_slice, "legacy::from_slice(", "public from_slice -> legacy::from_slice"),
+        (public_str, "Self::from_slice(", "public from_str -> from_slice"),
+    ]
+    for body, fragment, label in hops:
+        if body is None:
+            errors.append(f"{label}: missing method")
+            continue
+        if compact(body).count(re.sub(r"\s+", "", fragment)) != 1:
+            errors.append(f"{label}: expected one {fragment}")
+        if PARSER_RE.search(code_only(body)):
+            errors.append(f"{label}: hop must not construct a parser")
+
+    if legacy_slice is None:
+        errors.append("legacy::from_slice is missing")
+    elif "serde_ignored::deserialize" not in compact(legacy_slice):
+        errors.append("legacy::from_slice must own the deserialize sequence")
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return False
+    print("OK: full-policy parser hops delegate to one bytes-in function")
+    return True
+
+
+if __name__ == "__main__":
+    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    raise SystemExit(0 if check(repo_root) else 1)

--- a/scripts/ci/check-mcp-policy-parser-delegation.py
+++ b/scripts/ci/check-mcp-policy-parser-delegation.py
@@ -110,10 +110,10 @@ def impl_method(source: str, name: str) -> str | None:
     return None
 
 
-def check(root: Path) -> bool:
+def check() -> bool:
     errors: list[str] = []
-    mod_src = (root / MOD).read_text()
-    legacy_src = (root / LEGACY).read_text()
+    mod_src = MOD.read_text()
+    legacy_src = LEGACY.read_text()
 
     public_file = impl_method(mod_src, "from_file")
     public_slice = impl_method(mod_src, "from_slice")
@@ -150,5 +150,7 @@ def check(root: Path) -> bool:
 
 
 if __name__ == "__main__":
-    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
-    raise SystemExit(0 if check(repo_root) else 1)
+    if len(sys.argv) != 1:
+        print(f"usage: {Path(sys.argv[0]).name}", file=sys.stderr)
+        raise SystemExit(1)
+    raise SystemExit(0 if check() else 1)

--- a/scripts/ci/check-mcp-policy-reader-routing.py
+++ b/scripts/ci/check-mcp-policy-reader-routing.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Architecture drift guard for the MCP bounded policy reader (#2389).
+
+Behavioral safety is proved by real-stdio and unit tests. This guard pins the
+one generic Read helper, the spawn_blocking File open, and the five tool
+callsites. It is not Rust data-flow analysis.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+SERVER_TOOLS = Path("crates/assay-mcp-server/src/tools")
+READER = SERVER_TOOLS / "policy_read.rs"
+TOOL_FILES = [
+    SERVER_TOOLS / "policy_decide.rs",
+    SERVER_TOOLS / "check_sequence.rs",
+    SERVER_TOOLS / "check_coverage.rs",
+    SERVER_TOOLS / "explain_trace.rs",
+    SERVER_TOOLS / "check_args.rs",
+]
+
+
+def code_only(source: str) -> str:
+    out = list(source)
+    state = "code"
+    block_depth = 0
+    escaped = False
+    raw_hashes = 0
+    index = 0
+    while index < len(source):
+        char = source[index]
+        pair = source[index : index + 2]
+        if state == "code":
+            raw = re.match(r'r(#{0,16})"', source[index:])
+            if raw:
+                raw_hashes = len(raw.group(1))
+                end = index + len(raw.group(0))
+                for pos in range(index, end):
+                    out[pos] = " "
+                index = end
+                state = "raw"
+                continue
+            if pair == "//":
+                out[index] = out[index + 1] = " "
+                index += 2
+                state = "line"
+                continue
+            if pair == "/*":
+                out[index] = out[index + 1] = " "
+                index += 2
+                block_depth = 1
+                state = "block"
+                continue
+            if char == '"':
+                out[index] = " "
+                state = "string"
+        elif state == "line":
+            if char == "\n":
+                state = "code"
+            else:
+                out[index] = " "
+        elif state == "block":
+            out[index] = " "
+            if pair == "/*":
+                out[index + 1] = " "
+                block_depth += 1
+                index += 1
+            elif pair == "*/":
+                out[index + 1] = " "
+                block_depth -= 1
+                index += 1
+                if block_depth == 0:
+                    state = "code"
+        elif state == "string":
+            out[index] = " "
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                state = "code"
+        elif state == "raw":
+            out[index] = " "
+            closing = '"' + ("#" * raw_hashes)
+            if source.startswith(closing, index):
+                for pos in range(index, index + len(closing)):
+                    out[pos] = " "
+                index += len(closing) - 1
+                state = "code"
+        index += 1
+    return "".join(out)
+
+
+def compact(source: str) -> str:
+    return re.sub(r"\s+", "", code_only(source))
+
+
+def function_body(source: str, signature: str) -> str | None:
+    start = source.find(signature)
+    if start < 0:
+        return None
+    brace = source.find("{", start)
+    if brace < 0:
+        return None
+    depth = 0
+    for index, char in enumerate(source[brace:], brace):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : index + 1]
+    return None
+
+
+def check(root: Path) -> bool:
+    errors: list[str] = []
+    reader_path = root / READER
+    if not reader_path.is_file():
+        print("FAIL: policy reader module not found", file=sys.stderr)
+        return False
+    reader = reader_path.read_text()
+    bounded = function_body(reader, "fn read_bounded")
+    async_entry = function_body(reader, "async fn read_policy_bounded")
+    if bounded is None:
+        errors.append("read_bounded is missing")
+    else:
+        body = compact(bounded)
+        if "LimitReader::new(" not in body:
+            errors.append("read_bounded must construct LimitReader")
+        if "metadata(" in body or ".len()" in body and "metadata" in body:
+            errors.append("read_bounded must not accept via metadata")
+        if "read_to_end" not in body:
+            errors.append("read_bounded must accumulate through the LimitReader")
+    if async_entry is None:
+        errors.append("read_policy_bounded is missing")
+    else:
+        body = compact(async_entry)
+        if "spawn_blocking" not in body:
+            errors.append("read_policy_bounded must read inside spawn_blocking")
+        if "File::open(" not in body:
+            errors.append("read_policy_bounded must open std::fs::File")
+        if "read_bounded(" not in body:
+            errors.append("read_policy_bounded must call read_bounded")
+        if "metadata(" in body:
+            errors.append("read_policy_bounded must not consult metadata")
+        if "read_to_end" in body:
+            errors.append("read_policy_bounded must not duplicate the read")
+
+    for rel in TOOL_FILES:
+        path = root / rel
+        if not path.is_file():
+            errors.append(f"{rel}: missing")
+            continue
+        source = path.read_text()
+        effective = code_only(source)
+        if "read_policy_bounded(" not in compact(source):
+            errors.append(f"{rel}: must call read_policy_bounded")
+        if re.search(r"tokio::fs::read(?:_to_string)?\s*\(", effective):
+            errors.append(f"{rel}: direct tokio::fs::read bypass")
+        if rel.name == "check_args.rs":
+            if "McpPolicy::from_file(" in compact(source):
+                errors.append("check_args must not call McpPolicy::from_file")
+            if "McpPolicy::from_slice(" not in compact(source):
+                errors.append("check_args must parse through McpPolicy::from_slice")
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return False
+    print("OK: MCP policy reader routes through one LimitReader helper")
+    return True
+
+
+if __name__ == "__main__":
+    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    raise SystemExit(0 if check(repo_root) else 1)

--- a/scripts/ci/check-mcp-policy-reader-routing.py
+++ b/scripts/ci/check-mcp-policy-reader-routing.py
@@ -117,13 +117,12 @@ def function_body(source: str, signature: str) -> str | None:
     return None
 
 
-def check(root: Path) -> bool:
+def check() -> bool:
     errors: list[str] = []
-    reader_path = root / READER
-    if not reader_path.is_file():
+    if not READER.is_file():
         print("FAIL: policy reader module not found", file=sys.stderr)
         return False
-    reader = reader_path.read_text()
+    reader = READER.read_text()
     bounded = function_body(reader, "fn read_bounded")
     async_entry = function_body(reader, "async fn read_policy_bounded")
     if bounded is None:
@@ -152,11 +151,10 @@ def check(root: Path) -> bool:
             errors.append("read_policy_bounded must not duplicate the read")
 
     for rel in TOOL_FILES:
-        path = root / rel
-        if not path.is_file():
+        if not rel.is_file():
             errors.append(f"{rel}: missing")
             continue
-        source = path.read_text()
+        source = rel.read_text()
         effective = code_only(source)
         if "read_policy_bounded(" not in compact(source):
             errors.append(f"{rel}: must call read_policy_bounded")
@@ -177,5 +175,7 @@ def check(root: Path) -> bool:
 
 
 if __name__ == "__main__":
-    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
-    raise SystemExit(0 if check(repo_root) else 1)
+    if len(sys.argv) != 1:
+        print(f"usage: {Path(sys.argv[0]).name}", file=sys.stderr)
+        raise SystemExit(1)
+    raise SystemExit(0 if check() else 1)

--- a/scripts/ci/check-mcp-policy-yaml-routing.py
+++ b/scripts/ci/check-mcp-policy-yaml-routing.py
@@ -158,7 +158,7 @@ def check(root: Path) -> bool:
     require(errors, decide, "serde_json::from_value::<PolicyDecisionDocument>(root)", "policy_decide typed stage")
     require(errors, coverage, "super::parse_tool_policy(&policy_bytes)", "check_coverage route")
     require(errors, explain, "super::parse_tool_policy(&policy_bytes)", "explain_trace route")
-    require(errors, args, "McpPolicy::from_file(&policy_path)", "check_args full parser route")
+    require(errors, args, "McpPolicy::from_slice(&policy_bytes)", "check_args full parser route")
     require(errors, legacy, "letvalue:serde_yaml::Value=matchserde_yaml::from_str(content)", "core syntax stage")
     require(errors, legacy, "if!value.is_mapping()", "core root stage")
     require(errors, legacy, "serde_ignored::deserialize(value,|path|", "core typed stage")

--- a/scripts/ci/test-check-mcp-policy-parser-delegation.sh
+++ b/scripts/ci/test-check-mcp-policy-parser-delegation.sh
@@ -1,14 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GUARD="scripts/ci/check-mcp-policy-parser-delegation.py"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/check-mcp-policy-parser-delegation.py"
 FILES=(
   crates/assay-core/src/mcp/policy/mod.rs
   crates/assay-core/src/mcp/policy/legacy.rs
 )
 
-python3 "$GUARD"
-echo "PASS: parser guard accepts the production hops"
+if ! python3 "$GUARD"; then
+  echo "FAIL: parser guard must accept zero args from the allowlisted cwd" >&2
+  exit 1
+fi
+echo "PASS: parser guard accepts zero args from the allowlisted cwd"
+
+if python3 "$GUARD" extra 2>/dev/null; then
+  echo "FAIL: parser guard must reject an extra argument" >&2
+  exit 1
+fi
+echo "PASS: parser guard rejects an extra argument"
+
+if python3 "$GUARD" --stdin </dev/null 2>/dev/null; then
+  echo "FAIL: parser guard must reject --stdin" >&2
+  exit 1
+fi
+echo "PASS: parser guard rejects --stdin"
+
+if python3 "$GUARD" . 2>/dev/null; then
+  echo "FAIL: parser guard must reject a positional path" >&2
+  exit 1
+fi
+echo "PASS: parser guard rejects a positional path"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -24,7 +46,10 @@ mutant() {
   "$mutation" "$TMPDIR/current"
   local output status
   set +e
-  output=$(python3 "$GUARD" "$TMPDIR/current" 2>&1)
+  output=$(
+    cd "$TMPDIR/current"
+    python3 "$GUARD" 2>&1
+  )
   status=$?
   set -e
   if [ "$status" -eq 0 ]; then

--- a/scripts/ci/test-check-mcp-policy-parser-delegation.sh
+++ b/scripts/ci/test-check-mcp-policy-parser-delegation.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GUARD="scripts/ci/check-mcp-policy-parser-delegation.py"
+FILES=(
+  crates/assay-core/src/mcp/policy/mod.rs
+  crates/assay-core/src/mcp/policy/legacy.rs
+)
+
+python3 "$GUARD"
+echo "PASS: parser guard accepts the production hops"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/base/crates/assay-core/src/mcp/policy"
+cp "${FILES[0]}" "$TMPDIR/base/crates/assay-core/src/mcp/policy/"
+cp "${FILES[1]}" "$TMPDIR/base/crates/assay-core/src/mcp/policy/"
+
+mutant() {
+  local name=$1
+  local mutation=$2
+  rm -rf "$TMPDIR/current"
+  cp -R "$TMPDIR/base" "$TMPDIR/current"
+  "$mutation" "$TMPDIR/current"
+  local output status
+  set +e
+  output=$(python3 "$GUARD" "$TMPDIR/current" 2>&1)
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "FAIL: parser guard accepted mutation: $name" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$output" | grep -q '^FAIL: '; then
+    echo "FAIL: parser guard exited $status without a FAIL reason: $name" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+  echo "PASS: parser guard rejects $name"
+}
+
+mutate_duplicate_deserializer() {
+  python3 - "$1/crates/assay-core/src/mcp/policy/mod.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "pub fn from_slice(bytes: &[u8]) -> anyhow::Result<Self> {\n        legacy::from_slice(bytes)\n    }"
+new = """pub fn from_slice(bytes: &[u8]) -> anyhow::Result<Self> {
+        let _ = serde_yaml::from_slice::<serde_yaml::Value>(bytes);
+        legacy::from_slice(bytes)
+    }"""
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutate_from_file_reparse() {
+  python3 - "$1/crates/assay-core/src/mcp/policy/legacy.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "let bytes = std::fs::read(path)?;\n    McpPolicy::from_slice(&bytes)"
+new = """let bytes = std::fs::read(path)?;
+    let _ = serde_yaml::from_slice::<serde_yaml::Value>(&bytes);
+    McpPolicy::from_slice(&bytes)"""
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutant "public from_slice duplicates deserializer" mutate_duplicate_deserializer
+mutant "legacy from_file reparses" mutate_from_file_reparse
+
+echo "All MCP policy parser delegation mutations caught."

--- a/scripts/ci/test-check-mcp-policy-reader-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-reader-routing.sh
@@ -1,13 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GUARD="scripts/ci/check-mcp-policy-reader-routing.py"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/check-mcp-policy-reader-routing.py"
 FILES=(
   crates/assay-mcp-server/src/tools
 )
 
-python3 "$GUARD"
-echo "PASS: reader guard accepts the production routes"
+if ! python3 "$GUARD"; then
+  echo "FAIL: reader guard must accept zero args from the allowlisted cwd" >&2
+  exit 1
+fi
+echo "PASS: reader guard accepts zero args from the allowlisted cwd"
+
+if python3 "$GUARD" extra 2>/dev/null; then
+  echo "FAIL: reader guard must reject an extra argument" >&2
+  exit 1
+fi
+echo "PASS: reader guard rejects an extra argument"
+
+if python3 "$GUARD" --stdin </dev/null 2>/dev/null; then
+  echo "FAIL: reader guard must reject --stdin" >&2
+  exit 1
+fi
+echo "PASS: reader guard rejects --stdin"
+
+if python3 "$GUARD" . 2>/dev/null; then
+  echo "FAIL: reader guard must reject a positional path" >&2
+  exit 1
+fi
+echo "PASS: reader guard rejects a positional path"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -22,7 +44,10 @@ mutant() {
   "$mutation" "$TMPDIR/current"
   local output status
   set +e
-  output=$(python3 "$GUARD" "$TMPDIR/current" 2>&1)
+  output=$(
+    cd "$TMPDIR/current"
+    python3 "$GUARD" 2>&1
+  )
   status=$?
   set -e
   if [ "$status" -eq 0 ]; then

--- a/scripts/ci/test-check-mcp-policy-reader-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-reader-routing.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GUARD="scripts/ci/check-mcp-policy-reader-routing.py"
+FILES=(
+  crates/assay-mcp-server/src/tools
+)
+
+python3 "$GUARD"
+echo "PASS: reader guard accepts the production routes"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/base/crates/assay-mcp-server/src"
+cp -R "${FILES[0]}" "$TMPDIR/base/crates/assay-mcp-server/src/"
+
+mutant() {
+  local name=$1
+  local mutation=$2
+  rm -rf "$TMPDIR/current"
+  cp -R "$TMPDIR/base" "$TMPDIR/current"
+  "$mutation" "$TMPDIR/current"
+  local output status
+  set +e
+  output=$(python3 "$GUARD" "$TMPDIR/current" 2>&1)
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "FAIL: reader guard accepted mutation: $name" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$output" | grep -q '^FAIL: '; then
+    echo "FAIL: reader guard exited $status without a FAIL reason: $name" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+  echo "PASS: reader guard rejects $name"
+}
+
+mutate_metadata_accept() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/policy_read.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "let file = File::open(&path)?;"
+new = """let file = File::open(&path)?;
+            if file.metadata()?.len() as usize <= limit {
+                let mut bytes = Vec::new();
+                std::io::Read::read_to_end(&mut file, &mut bytes)?;
+                return Ok(bytes);
+            }"""
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutate_direct_tokio() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/policy_decide.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "ctx.read_policy_bounded(policy_rel_path).await"
+new = "tokio::fs::read(&policy_path).await"
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutate_check_args_from_file() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/check_args.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "McpPolicy::from_slice(&policy_bytes)"
+new = "McpPolicy::from_file(&policy_path)"
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutate_skip_helper() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/policy_read.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "read_bounded(file, limit)"
+new = "std::io::Read::read_to_end(&mut file, &mut Vec::new()).map(|_| Vec::new())"
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
+mutant "metadata-only accept then unbounded read" mutate_metadata_accept
+mutant "direct tokio::fs::read bypass" mutate_direct_tokio
+mutant "check_args from_file bypass" mutate_check_args_from_file
+mutant "async entry skips read_bounded" mutate_skip_helper
+
+echo "All MCP policy reader routing mutations caught."

--- a/scripts/ci/test-check-mcp-policy-yaml-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-yaml-routing.sh
@@ -87,9 +87,9 @@ mutate_full_parser_bypass() {
 import sys
 from pathlib import Path
 p = Path(sys.argv[1]); s = p.read_text()
-old = "McpPolicy::from_file(&policy_path)"
+old = "McpPolicy::from_slice(&policy_bytes)"
 assert old in s
-p.write_text(s.replace(old, "load_policy_alternate(&policy_path)", 1))
+p.write_text(s.replace(old, "load_policy_alternate(&policy_bytes)", 1))
 PY
 }
 


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: no programme is active (AGENTS.md). Parent tracking issue: #2388
- Slice: #2389 — bounded MCP policy-file ingest
- Builder: Cursor (`cursor/2389-bounded-policy-ingest`)
- Reviewers: one non-building agent required on this exact head; builder self-review does not count. The prior review on `ed0f9188` is invalidated by this push.
- Final head SHA: `886008b9e5df4acb4f2c0aaa34d102fbbfe6c1db`
- Worktree: `/Users/roelschuurkes/wt-2389-bounded-policy-ingest`
- Base: `origin/main` `bb1bbc5a43d9e3f737d22cf0cb8bc4ef307fc05f`
- Merge: clean `--no-ff` of `bb1bbc5a` into `e6f8c926e9ecd94649015c72ce68a0ae4973d2c5`. Parents of that merge: `e6f8c926e9ecd94649015c72ce68a0ae4973d2c5` `bb1bbc5a43d9e3f737d22cf0cb8bc4ef307fc05f`. Incoming file: only `crates/assay-mcp-server/tests/tools_list_wire.rs`. RED commit `a3b92c70d3eb593afc1e08b82e920b984f0c7963` was not rewritten.
- Follow-up on this head: CodeQL `py/path-injection` (#748–#753) — both architecture guards now accept exactly zero args and read only cwd-relative compile-time allowlisted paths. Mutation harnesses `cd` into the temp tree and invoke the absolute guard with no path argument. Rustdoc `private-intra-doc-links` — `read_policy_bounded` now names `read_bounded` as plain code text; visibility was not widened and no `allow` was added.
- Toolchain: rustc 1.96.0 (ac68faa20 2026-05-25), cargo 1.96.0 (30a34c682 2026-05-25)
- Binary: worktree `target/debug/assay-mcp-server` (no shared `CARGO_TARGET_DIR`)
- ADR invariants affected: ADR-043 §1 bounded ingest (`LimitReader` before materialisation). ADR-042 stop list unchanged.

Refs #2389. Does not close the issue. Draft only; do not mark ready or merge.

## Behavior

The five advertised MCP policy tools read local policy files through one generic `read_bounded<R: Read>` helper that wraps `assay_common::limits::LimitReader`. The async entry opens `std::fs::File` inside `spawn_blocking` and calls that helper. The inclusive ceiling is `ServerConfig.max_policy_bytes` (default 1,000,000), overridden only by `ASSAY_MCP_MAX_POLICY_BYTES`, and is independent of `ASSAY_MCP_MAX_BYTES`.

Exactly `limit` bytes are accepted; `limit + 1` returns `allowed:false`, `E_LIMIT_EXCEEDED`, `isError:true` before parse or cache insertion. Reason mapping is centralized (not-found / limit / other I/O). Other I/O keeps current `e.to_string()` diagnostics and the existing 4,096-byte public-message bound.

`McpPolicy` now has one bytes-in parser. `from_file` still uses unbounded `std::fs::read` in `legacy.rs` and delegates to `from_slice`. `assay_check_args` consumes bounded bytes and calls `from_slice`; it does not call `from_file`. Other tools keep their dialects and cache order.

Architecture guards take no caller-selected path. Extra argument, `--stdin`, or a positional path (including `.`) exits 1.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- Does not bound proxy-enforcement startup policy, declared MCP manifests, trust policy, or CLI readers
- Does not add parser nesting-depth or YAML alias-expansion limits
- Does not change `policy_decide` private dialect, cache-before-error order, or public MCP summaries
- Does not edit Ruley #2185 / `tools_list_wire.rs`; that file arrived only via the clean merge of #2396
- Does not implement remote transport, MCP 2026-07-28 negotiation, or target-tool enforcement
- Does not claim review quorum (builder self-review does not count). Draft only; do not mark ready or merge

## Test Evidence

### RED

```bash
cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
```

On RED commit `a3b92c70d3eb593afc1e08b82e920b984f0c7963` (1 passed / 1 failed):

- `five_tools_refuse_limit_plus_one_policy_file` — `assay_policy_decide` returned `allowed:true`, `isError:false` for a `limit+1` valid file because `ASSAY_MCP_MAX_POLICY_BYTES` was ignored
- `check_args_invalid_utf8_stays_policy_parse` remained green (`E_POLICY_PARSE` / `Policy YAML is invalid`)

Invocation RED on the pre-fix guards (parent `ed0f9188cf026f5a498cb2c9cf377c354eb04653`): `python3 GUARD .` exited 0 because argv was treated as a repo root. Extra-arg / `--stdin` failures against a missing path were vacuous and were not treated as proof.

### GREEN

```bash
bash scripts/ci/test-check-mcp-policy-parser-delegation.sh
bash scripts/ci/test-check-mcp-policy-reader-routing.sh
cargo test --locked -p assay-mcp-server --test policy_ingest_limits -- --nocapture
git diff --check
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
```

Measured on `886008b9e5df4acb4f2c0aaa34d102fbbfe6c1db` (worktree `/Users/roelschuurkes/wt-2389-bounded-policy-ingest`, rustc/cargo 1.96.0): both guard self-tests passed (zero-arg accept; extra / `--stdin` / `.` exit 1; all existing mutations still bite); ingest suite 3 passed; `git diff --check` clean; `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS='-D warnings'` finished 0.

### Mutations

| Mutation | Discriminating failure |
|---|---|
| Guard invoked with extra arg / `--stdin` / positional `.` | invocation tests (exit 1, no path read) |
| Metadata-only size check then unbounded read | reader routing guard |
| `tokio::fs::read` bypass in `policy_decide` | reader routing guard + five-tool `E_LIMIT_EXCEEDED` table |
| `check_args` calls `McpPolicy::from_file` | reader routing guard |
| Async entry skips `read_bounded` | reader routing guard |
| `from_slice` / `from_file` hop duplicates a deserializer | parser delegation guard |
| Invalid UTF-8 remapped to read/internal | `check_args_invalid_utf8_stays_policy_parse` |
| Inclusive boundary rejects exact-limit | `five_tools_accept_exact_limit_valid_policy_files` |
| Config compared only at shared 1_000_000 default | `policy_and_message_ceilings_diverge_in_both_directions` (1234/4321 and 4321/1234) |
| Growth/chunked `Read` that is not `LimitReader` in isolation | `read_bounded_growing_reader_trips_after_the_first_chunk`, `read_bounded_chunked_crossing_trips_the_same_rule` |

First/repeat oversized calls are asserted only for `assay_policy_decide` and `assay_check_sequence` (the only cache-bearing tools). Coverage and explain have no policy cache.

## Review Quorum

- [ ] One non-building agent review
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Optional automated reviews can add evidence, but do not count toward or block quorum.

## Clarifications applied before production

A1 generic `Read` helper; A2 divergent config in both directions; A3 keep `e.to_string()` for other I/O; A4 `from_file` uses unbounded `std::fs::read` (not `read_to_string`); A5 cache-limit repeats only for `policy_decide` and `check_sequence`.

## Open findings

None from the builder. Draft only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable byte limit for policy files used by MCP policy tools.
  - Files up to 1,000,000 bytes are accepted by default; larger files return `E_LIMIT_EXCEEDED`.
  - Added support for configuring the limit with `ASSAY_MCP_MAX_POLICY_BYTES`.

- **Documentation**
  - Documented policy-file size limits, configuration, and error behavior.

- **Tests**
  - Added coverage for size boundaries, parsing behavior, invalid files, and tool integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->