### PR TITLE
fix(mcp): fail closed at the outer tool boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- The built-in stdio MCP policy tools now fail closed on outer dispatch errors
+  and timeouts. Caller `arguments.on_error` no longer selects fail-open;
+  responses use fixed value-free `E_INTERNAL` / `E_TIMEOUT` messages and
+  `isError: true`. Clients following the former gateway example must remove
+  that argument. Suite `settings.on_error` remains an `assay run` setting
+  (#2391).
 - The five advertised MCP policy tools now read local policy files through one
   inclusive byte ceiling (`ServerConfig.max_policy_bytes`, default 1,000,000,
   override `ASSAY_MCP_MAX_POLICY_BYTES`) before parse or cache insertion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to this project will be documented in this file.
   responses use fixed value-free `E_INTERNAL` / `E_TIMEOUT` messages and
   `isError: true`. Clients following the former gateway example must remove
   that argument. Suite `settings.on_error` remains an `assay run` setting
-  (#2391).
+  (#2391). Outer dispatch failures emit `tool_execution_error`; `tool_call_*`
+  events no longer copy caller-controlled tool or policy strings. The separate
+  `tool_decision` evidence event retains its existing redaction contract.
 - The five advertised MCP policy tools now read local policy files through one
   inclusive byte ceiling (`ServerConfig.max_policy_bytes`, default 1,000,000,
   override `ASSAY_MCP_MAX_POLICY_BYTES`) before parse or cache insertion.

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -19,7 +19,7 @@ fn fail_closed_tool_result(code: &'static str, message: &'static str) -> Result<
 fn classify_tool_result(result: &Value) -> (bool, bool) {
     let has_error = result.get("error").is_some();
     let explicit_allowed = result.get("allowed").and_then(Value::as_bool);
-    let allowed = explicit_allowed.unwrap_or(!has_error);
+    let allowed = explicit_allowed.unwrap_or(false);
     let is_error = has_error || explicit_allowed == Some(false);
     (allowed, is_error)
 }
@@ -462,7 +462,24 @@ impl Server {
 
 #[cfg(test)]
 mod claims_boundary_tests {
-    use super::{initialize_result, LegacyProtocolVersion};
+    use super::{classify_tool_result, initialize_result, LegacyProtocolVersion};
+
+    #[test]
+    fn tool_result_classification_separates_decision_from_mcp_error() {
+        for (result, expected) in [
+            (serde_json::json!({"allowed": true}), (true, false)),
+            (serde_json::json!({"allowed": false}), (false, true)),
+            (
+                serde_json::json!({"allowed": false, "error": {"code": "E_INTERNAL"}}),
+                (false, true),
+            ),
+            // Report tools return data rather than a policy decision. Preserve the existing
+            // decision telemetry while keeping their successful MCP result non-error.
+            (serde_json::json!({"report": {}}), (false, false)),
+        ] {
+            assert_eq!(classify_tool_result(&result), expected, "result: {result}");
+        }
+    }
 
     /// ADR-042 stop list, ADR-043 §2. The handshake must not assert a status the server
     /// cannot substantiate. A denylist over the serialized response catches a claim

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -16,6 +16,14 @@ fn fail_closed_tool_result(code: &'static str, message: &'static str) -> Result<
     tools::ToolError::new(code, message).result()
 }
 
+fn classify_tool_result(result: &Value) -> (bool, bool) {
+    let has_error = result.get("error").is_some();
+    let explicit_allowed = result.get("allowed").and_then(Value::as_bool);
+    let allowed = explicit_allowed.unwrap_or(!has_error);
+    let is_error = has_error || explicit_allowed == Some(false);
+    (allowed, is_error)
+}
+
 fn next_rid() -> String {
     let n = RID.fetch_add(1, Ordering::Relaxed);
     format!("r-{n:06}")
@@ -368,10 +376,7 @@ impl Server {
 
                         let dur = start.elapsed().as_millis() as u64;
                         // Log outcome
-                        let allowed = result
-                            .get("allowed")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
+                        let (allowed, is_error) = classify_tool_result(&result);
                         if let Some(err) = result.get("error") {
                             let code = err.get("code").and_then(|v| v.as_str()).unwrap_or("");
                             tracing::info!(
@@ -432,7 +437,6 @@ impl Server {
                         }
 
                         // MCP Compliance: wrap every tool outcome in CallToolResult.
-                        let is_error = !allowed;
                         let json_text = serde_json::to_string_pretty(&result).unwrap_or_default();
                         let mcp_result = serde_json::json!({
                             "content": [{"type": "text", "text": json_text}],

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -12,6 +12,10 @@ static RID: AtomicU64 = AtomicU64::new(1);
 const INVALID_INITIALIZE_PARAMS: &str =
     "Invalid initialize params: expected the required legacy MCP fields";
 
+fn fail_closed_tool_result(code: &'static str, message: &'static str) -> Result<Value> {
+    tools::ToolError::new(code, message).result()
+}
+
 fn next_rid() -> String {
     let n = RID.fetch_add(1, Ordering::Relaxed);
     format!("r-{n:06}")
@@ -318,13 +322,6 @@ impl Server {
                         let default_args = serde_json::json!({});
                         let args = params.get("arguments").unwrap_or(&default_args);
 
-                        let on_error_str = args
-                            .get("on_error")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("block");
-                        let allow_on_error = on_error_str.eq_ignore_ascii_case("allow");
-
-                        let policy = args.get("policy").and_then(|v| v.as_str()).unwrap_or("");
                         let bytes_in = line.len();
                         let args_bytes = serde_json::to_vec(args).map(|b| b.len()).unwrap_or(0);
 
@@ -334,9 +331,6 @@ impl Server {
                            event="tool_call_start",
                            rid=%rid,
                            rpc_id=?req.id,
-                           tool=name,
-                           policy=policy,
-                           on_error=on_error_str,
                            bytes_in=bytes_in,
                            args_bytes=args_bytes,
                         );
@@ -348,76 +342,56 @@ impl Server {
                         let fut = tools::handle_call(&ctx, name, args);
                         let result = match timeout(Duration::from_millis(cfg.timeout_ms), fut).await
                         {
-                            Ok(res) => res, // Tool finished
+                            Ok(Ok(value)) => value,
+                            Ok(Err(_error)) => {
+                                tracing::error!(
+                                    event = "tool_execution_error",
+                                    rid = %rid,
+                                    rpc_id = ?req.id,
+                                    duration_ms = start.elapsed().as_millis() as u64,
+                                    code = "E_INTERNAL"
+                                );
+                                fail_closed_tool_result("E_INTERNAL", "Tool execution failed")?
+                            }
                             Err(_) => {
                                 let dur = start.elapsed().as_millis() as u64;
                                 tracing::warn!(
                                    event="tool_call_timeout",
                                    rid=%rid,
                                    rpc_id=?req.id,
-                                   tool=name,
-                                   policy=policy,
                                    duration_ms=dur,
-                                   code="E_TIMEOUT",
-                                   fallback=on_error_str
+                                   code="E_TIMEOUT"
                                 );
-                                // Timed out
-                                Ok(serde_json::json!({
-                                    "allowed": allow_on_error,
-                                    "error": {
-                                        "code": "E_TIMEOUT",
-                                        "message": format!("Request exceeded {}ms", cfg.timeout_ms)
-                                    }
-                                }))
+                                fail_closed_tool_result("E_TIMEOUT", "Tool execution timed out")?
                             }
                         };
 
                         let dur = start.elapsed().as_millis() as u64;
                         // Log outcome
-                        match &result {
-                            Ok(val) => {
-                                let allowed = val
-                                    .get("allowed")
-                                    .and_then(|v| v.as_bool())
-                                    .unwrap_or(false);
-                                if let Some(err) = val.get("error") {
-                                    let code =
-                                        err.get("code").and_then(|v| v.as_str()).unwrap_or("");
-                                    tracing::info!(
-                                      event="tool_call_done",
-                                      rid=%rid,
-                                      rpc_id=?req.id,
-                                      tool=name,
-                                      policy=policy,
-                                      duration_ms=dur,
-                                      outcome="app_error",
-                                      allowed=allowed,
-                                      code=code
-                                    );
-                                } else {
-                                    tracing::info!(
-                                      event="tool_call_done",
-                                      rid=%rid,
-                                      rpc_id=?req.id,
-                                      tool=name,
-                                      policy=policy,
-                                      duration_ms=dur,
-                                      outcome="ok",
-                                      allowed=allowed
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                  event="tool_call_crash",
-                                  rid=%rid,
-                                  rpc_id=?req.id,
-                                  tool=name,
-                                  policy=policy,
-                                  duration_ms=dur,
-                                  error=%e
-                                );
-                            }
+                        let allowed = result
+                            .get("allowed")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        if let Some(err) = result.get("error") {
+                            let code = err.get("code").and_then(|v| v.as_str()).unwrap_or("");
+                            tracing::info!(
+                              event="tool_call_done",
+                              rid=%rid,
+                              rpc_id=?req.id,
+                              duration_ms=dur,
+                              outcome="app_error",
+                              allowed=allowed,
+                              code=code
+                            );
+                        } else {
+                            tracing::info!(
+                              event="tool_call_done",
+                              rid=%rid,
+                              rpc_id=?req.id,
+                              duration_ms=dur,
+                              outcome="ok",
+                              allowed=allowed
+                            );
                         }
 
                         // P57b: emit the observed tool decision (assay.tool_decision_surface.v0) as
@@ -425,25 +399,16 @@ impl Server {
                         // enforced inside build_decision; this site never has SaaS-verified evidence.
                         {
                             use crate::tool_decision::{build_decision, Effect, ObservedCall};
-                            let (effect, status) = match &result {
-                                Ok(val) => {
-                                    let allowed = val
-                                        .get("allowed")
-                                        .and_then(|v| v.as_bool())
-                                        .unwrap_or(false);
-                                    if let Some(code) = val
-                                        .get("error")
-                                        .and_then(|e| e.get("code"))
-                                        .and_then(|v| v.as_str())
-                                    {
-                                        (Effect::Error, code.to_string())
-                                    } else if allowed {
-                                        (Effect::Allow, "success".to_string())
-                                    } else {
-                                        (Effect::Deny, "blocked".to_string())
-                                    }
-                                }
-                                Err(_) => (Effect::Error, "crash".to_string()),
+                            let (effect, status) = if let Some(code) = result
+                                .get("error")
+                                .and_then(|e| e.get("code"))
+                                .and_then(|v| v.as_str())
+                            {
+                                (Effect::Error, code.to_string())
+                            } else if allowed {
+                                (Effect::Allow, "success".to_string())
+                            } else {
+                                (Effect::Deny, "blocked".to_string())
                             };
                             let decision = build_decision(&ObservedCall {
                                 server_id: "mcp",
@@ -466,71 +431,19 @@ impl Server {
                             );
                         }
 
-                        match result {
-                            Ok(res) => {
-                                // MCP Compliance: Wrap result in CallToolResult structure
-                                // Spec: { content: [{ type: "text", text: "..." }], isError: bool }
-                                let is_error =
-                                    !res.get("allowed").and_then(|v| v.as_bool()).unwrap_or(true);
-                                let json_text =
-                                    serde_json::to_string_pretty(&res).unwrap_or_default();
-
-                                let mcp_result = serde_json::json!({
-                                    "content": [
-                                        {
-                                            "type": "text",
-                                            "text": json_text
-                                        }
-                                    ],
-                                    "isError": is_error
-                                });
-                                JsonRpcResponse::ok(req.id.clone(), mcp_result)
-                            }
-                            Err(e) => {
-                                // Fail-safe handling for internal errors
-                                tracing::error!(
-                                    event="tool_execution_error",
-                                    rid=%rid,
-                                    error=%e,
-                                    fallback=on_error_str
-                                );
-                                let mut safe_resp = serde_json::json!({
-                                    "allowed": allow_on_error,
-                                    "error": {
-                                        "code": "E_INTERNAL",
-                                        "message": e.to_string()
-                                    }
-                                });
-
-                                // Agent Awareness
-                                // If we fail open, warn the agent so it can self-regulate (e.g. switch to Safe Mode).
-                                if allow_on_error {
-                                    safe_resp["warning"] = serde_json::json!("FAIL-SAFE ACTIVE: Policy engine offline. Proceed with caution (Safe Mode).");
-                                }
-                                // Keep consistent wrapping even for internal fail-safe responses
-                                let json_text =
-                                    serde_json::to_string_pretty(&safe_resp).unwrap_or_default();
-                                let mcp_result = serde_json::json!({
-                                    "content": [
-                                        {
-                                            "type": "text",
-                                            "text": json_text
-                                        }
-                                    ],
-                                    "isError": !allow_on_error
-                                });
-                                JsonRpcResponse::ok(req.id.clone(), mcp_result)
-                            }
-                        }
+                        // MCP Compliance: wrap every tool outcome in CallToolResult.
+                        let is_error = !allowed;
+                        let json_text = serde_json::to_string_pretty(&result).unwrap_or_default();
+                        let mcp_result = serde_json::json!({
+                            "content": [{"type": "text", "text": json_text}],
+                            "isError": is_error
+                        });
+                        JsonRpcResponse::ok(req.id.clone(), mcp_result)
                     } else {
                         JsonRpcResponse::error(req.id.clone(), -32602, "Missing params".to_string())
                     }
                 }
-                _ => JsonRpcResponse::error(
-                    req.id.clone(),
-                    -32601,
-                    format!("Method not found: {}", req.method),
-                ),
+                _ => JsonRpcResponse::error(req.id.clone(), -32601, "Method not found".to_string()),
             };
 
             // Send Response

--- a/crates/assay-mcp-server/tests/outer_fallback_contract.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_contract.rs
@@ -1,0 +1,129 @@
+//! Wire-level contract for failures outside an individual MCP tool implementation.
+
+use serde_json::Value;
+use std::process::{Command, Stdio};
+
+mod jsonrpc_conn;
+use jsonrpc_conn::Conn;
+
+const HEAD: &str = "HEAD_SENTINEL";
+const MID: &str = "MID_SENTINEL";
+const TAIL: &str = "TAIL_SENTINEL";
+
+fn spawn_server(timeout_ms: Option<&str>) -> (Conn, tempfile::TempDir) {
+    let policy_root = tempfile::tempdir().expect("temporary policy root");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    command
+        .args(["--policy-root", policy_root.path().to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Some(timeout_ms) = timeout_ms {
+        command.env("ASSAY_MCP_TIMEOUT_MS", timeout_ms);
+    }
+    let child = command.spawn().expect("spawn assay-mcp-server");
+    (Conn::attach(child), policy_root)
+}
+
+fn initialize(conn: &mut Conn) {
+    let response = conn.request(
+        "initialize",
+        serde_json::json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "outer-fallback-contract", "version": "1"}
+        }),
+        1,
+    );
+    assert!(response.get("result").is_some(), "initialize: {response}");
+}
+
+fn call_tool(conn: &mut Conn, name: &str, arguments: Value, id: u64) -> Value {
+    conn.request(
+        "tools/call",
+        serde_json::json!({"name": name, "arguments": arguments}),
+        id,
+    )
+}
+
+fn tool_payload(response: &Value) -> Value {
+    let result = response.get("result").expect("CallToolResult response");
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    serde_json::from_str(text).expect("JSON tool payload")
+}
+
+fn assert_fixed_failure(response: &Value, code: &str, message: &str) {
+    let result = response.get("result").expect("CallToolResult response");
+    assert_eq!(result["isError"], true, "response: {response}");
+    let payload = tool_payload(response);
+    assert_eq!(payload["allowed"], false, "payload: {payload}");
+    assert_eq!(payload["error"]["code"], code, "payload: {payload}");
+    assert_eq!(payload["error"]["message"], message, "payload: {payload}");
+    assert!(payload.get("warning").is_none(), "payload: {payload}");
+}
+
+#[test]
+fn caller_cannot_fail_open_handler_errors() {
+    let (mut conn, _root) = spawn_server(None);
+    initialize(&mut conn);
+
+    let blocked = call_tool(&mut conn, "assay_check_args", serde_json::json!({}), 2);
+    let attempted_allow = call_tool(
+        &mut conn,
+        "assay_check_args",
+        serde_json::json!({"on_error": "allow"}),
+        3,
+    );
+
+    assert_fixed_failure(&blocked, "E_INTERNAL", "Tool execution failed");
+    assert_fixed_failure(&attempted_allow, "E_INTERNAL", "Tool execution failed");
+    assert_eq!(tool_payload(&blocked), tool_payload(&attempted_allow));
+    assert!(conn.shutdown().success());
+}
+
+#[test]
+fn unknown_names_are_value_free() {
+    let (mut conn, _root) = spawn_server(None);
+    initialize(&mut conn);
+    let hostile = format!(
+        "{HEAD}{}\u{1f642}{MID}{}{TAIL}",
+        "x".repeat(5_000),
+        "y".repeat(5_000)
+    );
+
+    let unknown_tool = call_tool(&mut conn, &hostile, serde_json::json!({}), 2);
+    assert_fixed_failure(&unknown_tool, "E_INTERNAL", "Tool execution failed");
+
+    let unknown_method = conn.request(&hostile, serde_json::json!({}), 3);
+    assert_eq!(unknown_method["error"]["code"], -32601);
+    assert_eq!(unknown_method["error"]["message"], "Method not found");
+
+    for response in [&unknown_tool, &unknown_method] {
+        let wire = serde_json::to_string(response).unwrap();
+        for sentinel in [HEAD, MID, TAIL] {
+            assert!(!wire.contains(sentinel), "response reflected {sentinel}");
+        }
+    }
+    assert!(conn.shutdown().success());
+}
+
+#[test]
+fn caller_cannot_fail_open_timeouts() {
+    let (mut conn, _root) = spawn_server(Some("1"));
+    initialize(&mut conn);
+
+    let response = call_tool(
+        &mut conn,
+        "assay_check_args",
+        serde_json::json!({
+            "tool": "any",
+            "arguments": {},
+            "policy": "slow.yaml",
+            "on_error": "allow"
+        }),
+        2,
+    );
+
+    assert_fixed_failure(&response, "E_TIMEOUT", "Tool execution timed out");
+    assert!(conn.shutdown().success());
+}

--- a/crates/assay-mcp-server/tests/outer_fallback_contract.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_contract.rs
@@ -1,6 +1,7 @@
 //! Wire-level contract for failures outside an individual MCP tool implementation.
 
 use serde_json::Value;
+use std::fs;
 use std::process::{Command, Stdio};
 
 mod jsonrpc_conn;
@@ -60,6 +61,42 @@ fn assert_fixed_failure(response: &Value, code: &str, message: &str) {
     assert_eq!(payload["error"]["code"], code, "payload: {payload}");
     assert_eq!(payload["error"]["message"], message, "payload: {payload}");
     assert!(payload.get("warning").is_none(), "payload: {payload}");
+}
+
+#[test]
+fn report_tools_keep_successful_mcp_results() {
+    let (mut conn, root) = spawn_server(None);
+    fs::write(
+        root.path().join("policy.yaml"),
+        "version: \"1.1\"\nname: report-tools\ntools:\n  allow: [Search]\nsequences: []\n",
+    )
+    .expect("write report policy");
+    initialize(&mut conn);
+
+    let coverage = call_tool(
+        &mut conn,
+        "assay_check_coverage",
+        serde_json::json!({
+            "policy": "policy.yaml",
+            "traces": [{"tools": ["Search"]}]
+        }),
+        2,
+    );
+    let explanation = call_tool(
+        &mut conn,
+        "assay_explain_trace",
+        serde_json::json!({
+            "policy": "policy.yaml",
+            "trace": [{"tool": "Search"}]
+        }),
+        3,
+    );
+
+    for response in [&coverage, &explanation] {
+        assert_eq!(response["result"]["isError"], false, "response: {response}");
+        assert!(tool_payload(response).get("error").is_none());
+    }
+    assert!(conn.shutdown().success());
 }
 
 #[test]

--- a/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
+++ b/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
@@ -228,10 +228,7 @@ fn discovery_is_an_explicit_legacy_fallback_signal() {
     let output = run_session(&[request]);
     let response = responses(&output).pop().expect("discover response");
     assert_eq!(response["error"]["code"].as_i64(), Some(-32601));
-    assert_eq!(
-        response["error"]["message"],
-        "Method not found: server/discover"
-    );
+    assert_eq!(response["error"]["message"], "Method not found");
     assert!(response.get("result").is_none());
 }
 

--- a/docs/concepts/fail-safe.md
+++ b/docs/concepts/fail-safe.md
@@ -1,6 +1,7 @@
 # Error Handling & Fail-Safe Configuration
 
-Assay can operate in two error-handling modes. This page explains when to use each and how to configure them.
+`assay run` can operate in two error-handling modes. The built-in stdio MCP
+server has a separate, always-fail-closed boundary.
 
 ## The Problem
 
@@ -125,35 +126,43 @@ tests:
 | Check fails | ✗ Fail | ✗ Fail |
 | Check errors | ✗ Error (blocks CI) | ⚠ Warn (CI continues) |
 
-### In Streaming Mode (`assay-mcp-server`)
+### In the stdio MCP server (`assay-mcp-server`)
 
-| Scenario | `on_error: block` | `on_error: allow` |
-|----------|-------------------|-------------------|
-| Check passes | → Allow action | → Allow action |
-| Check fails | → Block action | → Block action |
-| Check errors | → Block action | → Allow action |
+Suite, test, and assertion `on_error` settings are not MCP server settings.
+The five built-in policy tools fail closed when dispatch fails or times out:
+
+- the tool payload has `allowed: false`;
+- the MCP `CallToolResult` has `isError: true`;
+- dispatch failures use `E_INTERNAL` and a fixed message;
+- timeouts use `E_TIMEOUT` and a fixed message.
+
+Caller-supplied `arguments.on_error` has no authority and is absent from the
+advertised tool schemas. Use bounded client retry, supervised restart, and
+alerting for availability; do not convert an unavailable policy decision into
+permission.
 
 ---
 
 ## Audit Trail
 
-Regardless of mode, all errors are logged:
+`assay-mcp-server` emits structured stderr events with a request id, duration,
+outcome, and reason code. Public failure messages do not include caller values
+or raw internal errors. For example, a timeout result contains:
 
 ```json
 {
-  "event": "policy_check_error",
-  "test_id": "discount_check",
-  "error": "Schema parse failed: invalid regex",
-  "action_taken": "blocked",  // or "allowed"
-  "on_error_mode": "block",
-  "timestamp": "2025-12-28T10:30:00Z"
+  "allowed": false,
+  "error": {
+    "code": "E_TIMEOUT",
+    "message": "Tool execution timed out"
+  }
 }
 ```
 
-Use these logs to:
+Use structured results and logs to:
 1. Monitor error rates
 2. Debug configuration issues
-3. Demonstrate compliance (errors were handled correctly)
+3. Verify that the configured failure policy was applied
 
 ---
 

--- a/docs/guides/gateway-pattern.md
+++ b/docs/guides/gateway-pattern.md
@@ -4,7 +4,9 @@ This guide documents the reference architecture for the "Gateway Pattern" config
 
 ## 1. Architecture Overview
 
-The Gateway Pattern positions Assay as an authoritative, non-blocking "Decision Gateway" or sidecar in the runtime path.
+The Gateway Pattern positions Assay as a decision point in the runtime path.
+The client remains responsible for enforcing the returned decision before it
+invokes a target tool.
 
 ```mermaid
 graph TD
@@ -15,47 +17,53 @@ graph TD
 
         Assay -->|Policy Eval < 1ms| PolicyDB[(Ruleset)]
 
-        Assay -- "❌ BLOCK (Violation)" --> Client
-        Assay -- "✅ ALLOW" --> Backend[System of Record]
+        Assay -- "BLOCK decision" --> Client
+        Assay -- "ALLOW decision" --> Client
     end
 
-    Client -->|2. Feedback Loop| User
-    Assay -.->|3. Audit Trail| OTLP[Observability]
+    Client -->|2. Enforced allowed action| Backend[System of Record]
+    Client -->|3. Feedback Loop| User
+    Assay -.->|4. Audit Trail| OTLP[Observability]
 
     style Assay fill:#00d97e,stroke:#333,stroke-width:2px,color:white
 ```
 
 ## 2. Configuration Strategy
 
-For initial deployment, utilize a "Fail-Open with Warning" strategy to ensure business continuity while gathering telemetry.
+The built-in stdio server always fails closed when tool dispatch fails or times
+out. Availability must not silently become authorization.
 
-### Fail-Safe Mode (`on_error: allow`)
+### Failure behavior
 
-Configure the MCP server to allow operations even if the policy engine experiences failure (e.g., config corruption), but explicitly warn the client.
+Do not send `arguments.on_error`; it is not part of the advertised schemas and
+does not control server behavior. A dispatch failure returns an MCP tool error:
 
 **Client Request:**
 ```json
 {
   "method": "tools/call",
   "params": {
-    "name": "approve_transaction",
-    "arguments": {
-      "amount": 500,
-      "on_error": "allow",
-      "policy": "finance_v1"
-    }
+    "name": "assay_check_args",
+    "arguments": {"tool": "approve_transaction", "arguments": {"amount": 500}, "policy": "finance_v1.yaml"}
   }
 }
 ```
 
-**System Response (on Internal Failure):**
+**System Response (on an outer dispatch failure):**
 ```json
 {
-  "content": [],
-  "isError": false,
-  "warning": "FAIL-SAFE ACTIVE: Policy engine offline. Proceed with caution."
+  "content": [{
+    "type": "text",
+    "text": "{\"allowed\":false,\"error\":{\"code\":\"E_INTERNAL\",\"message\":\"Tool execution failed\"}}"
+  }],
+  "isError": true
 }
 ```
+
+For availability, use bounded retry for retryable transport failures,
+supervise and restart the local server, run redundant instances where the host
+supports that safely, and alert on `E_TIMEOUT` and `E_INTERNAL`. Never forward
+the protected target action merely because the policy decision is unavailable.
 
 ## 3. Telemetry & Accounting
 
@@ -73,13 +81,16 @@ Ingest these logs to calculate governance usage volume.
 }
 ```
 
-### Fail-Safe Alert
-Trigger P1 alerts on this event id.
+### Failure alert
+
+Trigger an alert from the structured completion event and its reason code. The
+server does not emit caller values or raw internal errors in this path.
 
 ```json
 {
-  "event": "assay.failsafe.triggered",
-  "error": "config_load_error",
-  "fallback": "allow"
+  "event": "tool_call_done",
+  "outcome": "app_error",
+  "allowed": false,
+  "code": "E_INTERNAL"
 }
 ```

--- a/docs/reference/cli/mcp-server.md
+++ b/docs/reference/cli/mcp-server.md
@@ -72,6 +72,22 @@ assay-mcp-server --policy-root <DIR>
 |--------|-------------|
 | `--policy-root <PATH>` | Policy root directory (default: `policies`) |
 
+### Outer failure contract
+
+Tool dispatch failures and timeouts always fail closed. The returned tool
+payload has `allowed: false`; the MCP `CallToolResult` has `isError: true`.
+Dispatch failures use `E_INTERNAL` with `Tool execution failed`, and timeouts
+use `E_TIMEOUT` with `Tool execution timed out`.
+
+`arguments.on_error` is not an operator control and is absent from the
+advertised input schemas. Remove it from clients that followed an older gateway
+example. `settings.on_error` remains available to `assay run`; it is not a
+server setting.
+
+Unknown methods remain JSON-RPC `-32601` with the fixed message `Method not
+found`. Unknown tool names currently return the fail-closed `CallToolResult`;
+this does not claim JSON-RPC `-32602` routing for unknown tools.
+
 ### Policy-file ingest ceiling
 
 The five advertised policy tools (`assay_policy_decide`, `assay_check_args`,

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -34,7 +34,7 @@ change that behavior. Unknown JSON-RPC methods use protocol error `-32601`.
 | `E_POLICY_NOT_FOUND` | The specified policy file does not exist. |
 | `E_POLICY_READ` | Failed to read the policy file (permissions, etc.). |
 | `E_PERMISSION_DENIED` | Access denied (e.g., policy path is outside the allowed root). |
-| `E_INTERNAL` | The outer tool dispatch failed; details are retained only in operator telemetry. |
+| `E_INTERNAL` | The outer tool dispatch failed; raw internal error details are not emitted. |
 | `E_TIMEOUT` | The outer tool dispatch exceeded the configured timeout. |
 
 ## Tools

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -1,4 +1,4 @@
-# Assay MCP API Reference (v0.5.0)
+# Assay MCP API Reference
 
 The Assay MCP Server exposes tools for agent self-verification.
 
@@ -7,17 +7,26 @@ All tools return a standardized error structure if the operation cannot be perfo
 Note: This is an **Application-Level Error**, returned within the JSON-RPC `result`. Protocol-level errors (invalid JSON) return a JSON-RPC `error`.
 
 ### Error Shape
+
+Tool results use the MCP `CallToolResult` envelope. The first text content item
+contains the Assay payload:
+
 ```json
 {
   "result": {
-    "error": {
-      "code": "E_CODE_STRING",
-      "message": "Human readable message",
-      "details": { ... } // Optional
-    }
+    "content": [{
+      "type": "text",
+      "text": "{\"allowed\":false,\"error\":{\"code\":\"E_CODE_STRING\",\"message\":\"Bounded message\"}}"
+    }],
+    "isError": true
   }
 }
 ```
+
+Outer dispatch failures use fixed, value-free messages. `E_INTERNAL` means
+`Tool execution failed`; `E_TIMEOUT` means `Tool execution timed out`. Both
+have `allowed: false` and `isError: true`. Caller `arguments.on_error` cannot
+change that behavior. Unknown JSON-RPC methods use protocol error `-32601`.
 
 ### Common Error Codes
 | Code | Description |
@@ -25,6 +34,8 @@ Note: This is an **Application-Level Error**, returned within the JSON-RPC `resu
 | `E_POLICY_NOT_FOUND` | The specified policy file does not exist. |
 | `E_POLICY_READ` | Failed to read the policy file (permissions, etc.). |
 | `E_PERMISSION_DENIED` | Access denied (e.g., policy path is outside the allowed root). |
+| `E_INTERNAL` | The outer tool dispatch failed; details are retained only in operator telemetry. |
+| `E_TIMEOUT` | The outer tool dispatch exceeded the configured timeout. |
 
 ## Tools
 

--- a/docs/superpowers/plans/2026-08-16-mcp-outer-fallback-hardening.md
+++ b/docs/superpowers/plans/2026-08-16-mcp-outer-fallback-hardening.md
@@ -122,14 +122,18 @@ let tool_result = match timeout(Duration::from_millis(cfg.timeout_ms), fut).awai
 };
 ```
 
-Do not publish or log `_error`, the caller tool name, caller policy path, or caller-selected fallback. Preserve non-sensitive timing and request-id telemetry. Feed `tool_result` through the existing outcome/evidence logic, then wrap it once:
+Do not publish `_error` or include caller-controlled values in the outer-fallback
+`tool_call_*` telemetry. The separate pre-existing `tool_decision` evidence event keeps its own
+redaction contract. Preserve non-sensitive timing and request-id telemetry. Feed `tool_result`
+through one classification function before emitting evidence and wrapping the MCP result:
 
 ```rust
-let is_error = !tool_result
-    .get("allowed")
-    .and_then(Value::as_bool)
-    .unwrap_or(false);
+let (allowed, is_error) = classify_tool_result(&tool_result);
 ```
+
+An explicit `allowed: false` is both a denial and an MCP tool error. A payload with `error` is an
+MCP tool error. Report tools without either field keep their pre-existing non-allow decision
+telemetry but return a successful MCP result.
 
 Use the fixed JSON-RPC message `"Method not found"` for the unknown-method branch. Do not add a fail-open warning because no fail-open state remains.
 

--- a/docs/superpowers/plans/2026-08-16-mcp-outer-fallback-hardening.md
+++ b/docs/superpowers/plans/2026-08-16-mcp-outer-fallback-hardening.md
@@ -1,0 +1,275 @@
+# MCP Outer Fallback Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the built-in stdio MCP policy tools fail closed on dispatch errors and timeouts, remove caller-selected fail-open, and publish only fixed bounded diagnostics.
+
+**Architecture:** Normalize timeout and handler failures into one `ToolError`-backed value before logging, decision evidence, and `CallToolResult` wrapping. The stdio server has no fail-open mode: suite-level `on_error` remains an `assay run` concern, while caller-supplied `arguments.on_error` has no authority. Keep the existing MCP 2025-era response shape and the landed 4,096-byte `ToolError` serialization bound; do not add configuration, an error-mode enum, schema validation, or 2026-07-28 fields.
+
+**Tech Stack:** Rust 2024, Tokio, serde/serde_json, MCP JSON-RPC over stdio, existing `tests/jsonrpc_conn` harness, MkDocs Markdown.
+
+## Global Constraints
+
+- Base SHA: `d1bfd36a11b857222d9c43f291a8011eaeee23e6`.
+- The stdio MCP server always fails closed for handler errors and timeouts: `allowed:false`, `isError:true`.
+- `arguments.on_error` never changes server behavior and remains absent from every advertised input schema.
+- Reuse `ToolError` serialization; do not add a second message ceiling or sanitizer.
+- Unknown methods retain JSON-RPC `-32601`, but their public message is fixed and value-free.
+- Unknown tools remain an MCP `CallToolResult` in this slice; moving them to JSON-RPC `-32602` is a separate protocol-shape decision.
+- Do not change proxy enforcement, authentication, policy parsing, policy ingest, tool schemas, `resultType`, or `structuredContent`.
+- Every commit stages explicit paths only.
+
+---
+
+### Task 1: Freeze the hostile stdio contract
+
+**Files:**
+- Create: `crates/assay-mcp-server/tests/outer_fallback_contract.rs`
+- Reuse: `crates/assay-mcp-server/tests/jsonrpc_conn/mod.rs`
+
+**Interfaces:**
+- Consumes: built `CARGO_BIN_EXE_assay-mcp-server`, `Conn`, `ASSAY_MCP_TIMEOUT_MS`.
+- Produces: exact wire assertions for `allowed`, `isError`, code, message, warning absence, response shape, and full-response sentinel absence.
+
+- [ ] **Step 1: Write the failing real-stdio tests**
+
+Add three tests using a fresh temporary `--policy-root` and a valid legacy `initialize` request:
+
+```rust
+#[test]
+fn caller_cannot_fail_open_handler_errors() {
+    // Drive assay_check_args with missing required fields once with no on_error and once with
+    // {"on_error":"allow"}. Both must publish the same fixed E_INTERNAL failure:
+    // allowed=false, isError=true, message="Tool execution failed", no warning.
+}
+
+#[test]
+fn unknown_names_are_value_free() {
+    // Use one unknown tool/method string containing HEAD_SENTINEL, MID_SENTINEL, and
+    // TAIL_SENTINEL separated by long UTF-8 content. Assert none appears anywhere in each
+    // serialized response. Unknown tool is fixed E_INTERNAL; unknown method is fixed -32601.
+}
+
+#[test]
+fn caller_cannot_fail_open_timeouts() {
+    // Spawn with ASSAY_MCP_TIMEOUT_MS=1 and call assay_check_args with policy slow.yaml,
+    // including on_error=allow. Assert E_TIMEOUT, allowed=false, isError=true,
+    // message="Tool execution timed out", and no warning.
+}
+```
+
+The helper that decodes `CallToolResult.content[0].text` must assert the complete key semantics rather than only checking the error code.
+
+- [ ] **Step 2: Run the tests and record RED**
+
+Run:
+
+```bash
+cargo test --locked -p assay-mcp-server --test outer_fallback_contract -- --nocapture
+```
+
+Expected RED on the base:
+
+- caller `on_error:allow` produces `allowed:true / isError:false`;
+- unknown tool/method responses contain all three sentinels;
+- timeout fail-open produces no warning and reports success;
+- handler/timeout messages are not the fixed target strings.
+
+- [ ] **Step 3: Commit only the RED contract**
+
+```bash
+git add -- crates/assay-mcp-server/tests/outer_fallback_contract.rs
+git commit -m "test(mcp): freeze outer fallback authority contract"
+```
+
+### Task 2: Normalize every outer failure through one fail-closed path
+
+**Files:**
+- Modify: `crates/assay-mcp-server/src/server.rs:315-533`
+- Test: `crates/assay-mcp-server/tests/outer_fallback_contract.rs`
+
+**Interfaces:**
+- Consumes: `tools::ToolError::new(...).result()` and existing `ServerConfig.timeout_ms`.
+- Produces: private `fail_closed_tool_result(code, message) -> anyhow::Result<Value>` and one common `CallToolResult` wrapper.
+
+- [ ] **Step 1: Add the single publication helper**
+
+In `server.rs`, add:
+
+```rust
+fn fail_closed_tool_result(code: &'static str, message: &'static str) -> Result<Value> {
+    tools::ToolError::new(code, message).result()
+}
+```
+
+This helper contains no truncation logic. `ToolError` remains the only message-boundary implementation.
+
+- [ ] **Step 2: Remove caller authority and normalize dispatch outcomes**
+
+Delete the `args.get("on_error")` read and every derived `allow_on_error` branch. Restructure the timeout result into one `Value` before common logging and wrapping:
+
+```rust
+let tool_result = match timeout(Duration::from_millis(cfg.timeout_ms), fut).await {
+    Ok(Ok(value)) => value,
+    Ok(Err(_error)) => {
+        tracing::error!(event = "tool_execution_error", rid = %rid, code = "E_INTERNAL");
+        fail_closed_tool_result("E_INTERNAL", "Tool execution failed")?
+    }
+    Err(_) => {
+        tracing::warn!(event = "tool_call_timeout", rid = %rid, code = "E_TIMEOUT");
+        fail_closed_tool_result("E_TIMEOUT", "Tool execution timed out")?
+    }
+};
+```
+
+Do not publish or log `_error`, the caller tool name, caller policy path, or caller-selected fallback. Preserve non-sensitive timing and request-id telemetry. Feed `tool_result` through the existing outcome/evidence logic, then wrap it once:
+
+```rust
+let is_error = !tool_result
+    .get("allowed")
+    .and_then(Value::as_bool)
+    .unwrap_or(false);
+```
+
+Use the fixed JSON-RPC message `"Method not found"` for the unknown-method branch. Do not add a fail-open warning because no fail-open state remains.
+
+- [ ] **Step 3: Run GREEN and adjacent suites**
+
+```bash
+cargo test --locked -p assay-mcp-server --test outer_fallback_contract -- --nocapture
+cargo test --locked -p assay-mcp-server --test stdio_edge_cases -- --nocapture
+cargo test --locked -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture
+cargo test --locked -p assay-mcp-server tools::tests -- --nocapture
+```
+
+Expected: all pass; stderr remains structured and does not contain the hostile sentinels.
+
+- [ ] **Step 4: Run distinct mutation checks**
+
+On disposable copies, prove the contract fails independently when:
+
+1. caller `arguments.on_error` controls `allowed` again;
+2. handler `e.to_string()` is published again;
+3. timeout returns `allowed:true`;
+4. unknown method interpolates `req.method`;
+5. `isError` is hardcoded false for an error result;
+6. the fallback bypasses `ToolError` and emits an over-ceiling test message.
+
+Record each failing test name and panic/assertion; restore the worktree from the committed paths, never with a destructive whole-tree command.
+
+- [ ] **Step 5: Commit the minimal production change**
+
+```bash
+git add -- crates/assay-mcp-server/src/server.rs
+git commit -m "fix(mcp): fail closed at the outer tool boundary"
+```
+
+### Task 3: Correct outward failure-policy documentation
+
+**Files:**
+- Modify: `docs/concepts/fail-safe.md`
+- Modify: `docs/guides/gateway-pattern.md`
+- Modify: `docs/reference/cli/mcp-server.md`
+- Modify: `docs/reference/mcp-api.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the Task 2 wire contract.
+- Produces: one truthful distinction between batch-suite `on_error` and stdio MCP dispatch behavior.
+
+- [ ] **Step 1: Correct the conceptual boundary**
+
+State explicitly that suite/test/assertion `on_error` applies to `assay run`. Replace the streaming-mode table with the shipped stdio invariant: tool execution errors and timeouts fail closed, and caller `arguments.on_error` is not an authority.
+
+Remove the fictional `policy_check_error / on_error_mode` audit sample. Describe only current machine-readable results and structured stderr events, without inventing field names.
+
+- [ ] **Step 2: Replace the gateway fail-open recipe**
+
+Delete the caller-controlled JSON example and the recommendation to begin production deployment fail-open. Document availability without bypass: bounded client retry, supervised restart, redundant instances where appropriate, and alerting on `E_TIMEOUT` / `E_INTERNAL`. Do not claim the built-in stdio server forwards target actions; it returns policy decisions only.
+
+- [ ] **Step 3: Pin the CLI/API contract and migration**
+
+Document that:
+
+- `assay-mcp-server` always returns `allowed:false / isError:true` for outer failures;
+- `arguments.on_error` is ignored and is absent from advertised schemas;
+- users who followed the old gateway recipe must remove that argument;
+- `settings.on_error` remains supported by `assay run` and is not an MCP server setting;
+- unknown tool remains a tool result in this slice, while unknown method is `-32601`.
+
+Add an `[Unreleased]` changelog entry naming #2391 and the intentional security-hardening compatibility change.
+
+- [ ] **Step 4: Verify docs and commit**
+
+```bash
+pre-commit run --files \
+  CHANGELOG.md \
+  docs/concepts/fail-safe.md \
+  docs/guides/gateway-pattern.md \
+  docs/reference/cli/mcp-server.md \
+  docs/reference/mcp-api.md
+git diff --check
+git add -- \
+  CHANGELOG.md \
+  docs/concepts/fail-safe.md \
+  docs/guides/gateway-pattern.md \
+  docs/reference/cli/mcp-server.md \
+  docs/reference/mcp-api.md
+git commit -m "docs(mcp): document fail-closed dispatch semantics"
+```
+
+### Task 4: Final verification and review packet
+
+**Files:**
+- Verify all files changed in Tasks 1-3.
+
+**Interfaces:**
+- Produces: a clean exact-head commit, draft PR, primary-source-linked review packet, and an independent non-building review request.
+
+- [ ] **Step 1: Run the full affected verification**
+
+```bash
+cargo test --locked -p assay-mcp-server
+cargo fmt --all -- --check
+cargo clippy --locked -p assay-mcp-server --all-targets -- -D warnings
+RUSTDOCFLAGS='-D warnings' cargo doc --locked -p assay-mcp-server --no-deps
+git diff --check origin/main...HEAD
+git status --short
+```
+
+- [ ] **Step 2: Inspect public strings and final scope**
+
+```bash
+rg -n 'on_error|FAIL-SAFE ACTIVE|e\.to_string\(\)|Method not found:' \
+  crates/assay-mcp-server/src/server.rs \
+  docs/concepts/fail-safe.md \
+  docs/guides/gateway-pattern.md \
+  docs/reference/cli/mcp-server.md \
+  docs/reference/mcp-api.md
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Expected: no caller authority, no raw error publication, no caller interpolation, and only the planned paths.
+
+- [ ] **Step 3: Push and open a draft PR**
+
+Push `codex/2391-outer-fallback`, open a draft PR referencing #2391, and include:
+
+- exact base/head SHA and worktree;
+- RED/GREEN and mutation witnesses;
+- real-stdio before/after smoking-gun rows;
+- MCP 2025-06-18 error taxonomy and OWASP least-agency/complete-mediation rationale;
+- compatibility note for the removed gateway recipe;
+- explicit non-claims from Global Constraints.
+
+- [ ] **Step 4: Obtain exact-head independent review**
+
+Claude's main chat and Cursor participated in the design and do not count. Ask Claude to spawn a fresh subagent with no access to this design conversation, or use another non-building reviewer. Merge only after the exact-head review is READY, all actionable findings are disposed, and all required contexts are green.
+
+## Self-Review
+
+- Spec coverage: authority inversion, raw diagnostic leak, timeout behavior, caller/method reflection, UTF-8 bound reuse, migration, docs, and non-claims each map to a task.
+- Placeholder scan: no TBD/TODO or unspecified implementation step remains.
+- Type consistency: the plan adds only `fail_closed_tool_result(&'static str, &'static str) -> anyhow::Result<Value>` and otherwise reuses existing `ToolError`, `Value`, and `Conn` interfaces.
+- Simplicity check: rejected env/CLI knobs, a second error-policy enum, precedence logic, schema validation, and a new sanitizer because no measured requirement justifies them.


### PR DESCRIPTION
## Summary

- remove caller-controlled `arguments.on_error` authority from built-in stdio tool dispatch
- normalize handler failures and timeouts through bounded, value-free `ToolError` results
- keep unknown methods as fixed-message JSON-RPC `-32601` and unknown tools as fail-closed tool results
- correct gateway, fail-safe, CLI, API, and changelog guidance

Closes #2391.

## Scope and non-claims

No new configuration, operator fail-open, schema validation, proxy/auth behavior, tool schema, `resultType`, `structuredContent`, or MCP 2026-07-28 conformance. Suite `settings.on_error` remains an `assay run` setting.

## Review packet

- base / merge-base: `a63a012ba9c8b994649b334d4872afe600b563b1`
- final reviewed head: `bbf3f61e803ea2de55a35d602b8c89ac887bbd3b`
- worktree: `/Users/roelschuurkes/wt-2391-outer-fallback`
- RED: `cargo test --locked -p assay-mcp-server --test outer_fallback_contract -- --nocapture` failed 0/3 for the intended old behaviors
- GREEN: the same test passes 3/3
- mutations caught: raw handler error, timeout allow, unknown-method reflection, forced `isError:false`, restored caller authority, report-tool `isError` regression, and report decision-telemetry drift
- full: `cargo test --locked -p assay-mcp-server`
- quality: fmt, clippy all-targets with `-D warnings`, rustdoc with `-D warnings`, and `git diff --check` all pass

Primary protocol references: MCP [tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) and [schema](https://modelcontextprotocol.io/specification/2025-06-18/schema).


## Review disposition

Independent exact-head verdict: **READY** at `bbf3f61e803ea2de55a35d602b8c89ac887bbd3b` ([record](https://github.com/Rul1an/assay/pull/2401#issuecomment-5304769465)). The non-blocking telemetry/documentation findings are consolidated in #2402; they do not weaken or alter this PR's caller-authority removal and fixed wire-failure boundary.
