### PR TITLE
fix(release): bind candidate tag to source identity

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -28,6 +28,10 @@ on:
       - "docs/generated/**"
       - "docs/AIcontext/architecture-diagrams.md"
       - "docs/guides/agent-golden-path.md"
+      # Candidate source identity is checked by the pre-commit leg below.
+      - "Cargo.toml"
+      - "CHANGELOG.md"
+      - "docs/reference/release.md"
       # The editor MCP recipe is judged by the editor-mcp-recipe-truth hook, which runs
       # under Lint (pre-commit) here. `scripts/**` covers a guard change; a recipe-only drift
       # touches no script, so the recipe needs its own entry or the guard never executes in CI.
@@ -65,7 +69,7 @@ on:
       - ".github/workflows/docs-auto-update.yml"
       - ".github/workflows/parity.yml"
       - ".github/workflows/release.yml"
-      # Note: Cargo.toml/Cargo.lock removed - check-ebpf-changes job handles skip logic
+      # Cargo.lock remains excluded; check-ebpf-changes handles its eBPF skip logic.
   push:
     branches: [ "main", "debug/**" ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,13 @@ jobs:
           version="$(bash scripts/ci/resolve-release-version.sh)"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
+      - name: Verify candidate source-tree identity
+        shell: bash
+        env:
+          CANDIDATE_TAG: ${{ steps.version.outputs.version }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: bash scripts/ci/check-tag-tree-outward-truth.sh
+
       # A release gate that lives only in an issue's prose is not a gate. v3.37.0 shipped with a
       # blocker open because the only place the gate existed was one sentence, and nothing could
       # read it.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -325,6 +325,15 @@ repos:
         # no `target/` build it still verifies source and published-release truth independently.
         files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
 
+      - id: tag-tree-outward-truth
+        name: Candidate tag tree identifies its source version
+        entry: bash scripts/ci/test-check-tag-tree-outward-truth.sh
+        language: system
+        pass_filenames: false
+        # The ordinary release-surface guard owns installability and the last-published pin. This
+        # hook owns only candidate/source identity and the release workflow that consumes it.
+        files: ^(Cargo\.toml|CHANGELOG\.md|docs/(generated/agent-golden-path\.json|guides/agent-golden-path\.md|reference/release\.md)|scripts/(docs/generate-agent-golden-path\.py|ci/((check|test-check)-tag-tree-outward-truth\.sh|lib/(workspace_version\.py|clear-git-repository-env\.sh)))|\.github/workflows/release\.yml|\.pre-commit-config\.yaml)$
+
       - id: editor-mcp-recipe-truth
         name: Editor MCP recipe describes only the shipped transport
         entry: bash -c 'bash scripts/ci/test-check-editor-mcp-recipe-truth.sh && bash scripts/ci/check-editor-mcp-recipe-truth.sh'

--- a/docs/generated/agent-golden-path.json
+++ b/docs/generated/agent-golden-path.json
@@ -2,6 +2,8 @@
   "schema": "assay.agent_golden_path.v1",
   "schema_version": 1,
   "generated_by": "scripts/docs/generate-agent-golden-path.py",
+  "source_version": "5.2.0",
+  "source_tag": "v5.2.0",
   "release_version": "5.2.0",
   "release_tag": "v5.2.0",
   "source_issue": 2154,

--- a/docs/guides/agent-golden-path.md
+++ b/docs/guides/agent-golden-path.md
@@ -17,6 +17,7 @@ angle brackets are replaced with temporary files or committed fixtures.
 <!-- agent-golden-path-release:start -->
 ## Release-pinned start
 
+This source tree declares Assay `5.2.0` (`v5.2.0`).
 This journey is pinned to Assay `5.2.0` ([`v5.2.0`](https://github.com/Rul1an/assay/releases/tag/v5.2.0)).
 Install the CLI from a verified channel, then require `assay version` to print `5.2.0` before using the table below. Behavior merged after that tag is `Unreleased` and is not part of this release claim.
 

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -27,6 +27,15 @@ This document outlines the canonical checklist for releasing new versions of Ass
   The Harness default is an independently proven compatibility pin and may
   intentionally lag the latest Assay release. The VM remains bound to the
   current GitHub Latest release until the new tag is published.
+- [ ] **Candidate-tree identity**: Verify the exact commit that will be tagged:
+  ```bash
+  CANDIDATE_TAG=vX.Y.Z EXPECTED_SHA="$(git rev-parse HEAD)" \
+    bash scripts/ci/check-tag-tree-outward-truth.sh
+  ```
+  This binds the workspace, changelog, and generated golden-path source identity
+  to the candidate tag and commit. The published install pin may still name the
+  previous release until the candidate assets exist; installability and source
+  identity are separate checks.
 
 ### 2. Permissions Check (Crucial)
 - [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the release tag on every current crates.io crate:

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -27,15 +27,18 @@ This document outlines the canonical checklist for releasing new versions of Ass
   The Harness default is an independently proven compatibility pin and may
   intentionally lag the latest Assay release. The VM remains bound to the
   current GitHub Latest release until the new tag is published.
-- [ ] **Candidate-tree identity**: Verify the exact commit that will be tagged:
+- [ ] **Candidate source declaration**: Verify the checked-out candidate source and record its commit:
   ```bash
   CANDIDATE_TAG=vX.Y.Z EXPECTED_SHA="$(git rev-parse HEAD)" \
     bash scripts/ci/check-tag-tree-outward-truth.sh
   ```
   This binds the workspace, changelog, and generated golden-path source identity
-  to the candidate tag and commit. The published install pin may still name the
+  to the candidate tag, and verifies the caller-provided checkout SHA. It does not
+  prove that a not-yet-created tag already points at that commit. The published install pin may still name the
   previous release until the candidate assets exist; installability and source
   identity are separate checks.
+  Published release tags are immutable and are never moved or rewritten; a bad
+  published tag requires a new version.
 
 ### 2. Permissions Check (Crucial)
 - [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the release tag on every current crates.io crate:

--- a/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
+++ b/packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json
@@ -2,6 +2,8 @@
   "schema": "assay.agent_golden_path.v1",
   "schema_version": 1,
   "generated_by": "scripts/docs/generate-agent-golden-path.py",
+  "source_version": "5.2.0",
+  "source_tag": "v5.2.0",
   "release_version": "5.2.0",
   "release_tag": "v5.2.0",
   "source_issue": 2154,

--- a/scripts/ci/check-tag-tree-outward-truth.sh
+++ b/scripts/ci/check-tag-tree-outward-truth.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Bind a release request to the exact source tree without coupling it to downloadable assets.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CANDIDATE_TAG="${CANDIDATE_TAG:-}"
+EXPECTED_SHA="${EXPECTED_SHA:-}"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+[[ "$CANDIDATE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-(rc|beta)[.][0-9]+)?$ ]] ||
+  fail "candidate tag must be vX.Y.Z, vX.Y.Z-rc.N, or vX.Y.Z-beta.N"
+[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "expected SHA must be 40 lowercase hex characters"
+
+actual_sha="$(git -C "$ROOT" rev-parse HEAD)"
+[ "$actual_sha" = "$EXPECTED_SHA" ] ||
+  fail "checked-out HEAD $actual_sha does not match requested release SHA $EXPECTED_SHA"
+
+source_version="$({
+  PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$ROOT/scripts/ci/lib" \
+    python3 - "$ROOT/Cargo.toml" <<'PY'
+from pathlib import Path
+import sys
+from workspace_version import read_workspace_version
+
+print(read_workspace_version(Path(sys.argv[1])))
+PY
+})"
+source_tag="v${source_version}"
+[ "$CANDIDATE_TAG" = "$source_tag" ] ||
+  fail "candidate tag $CANDIDATE_TAG does not match workspace source tag $source_tag"
+
+IFS=$'\t' read -r contract_source_version contract_source_tag < <(
+  python3 - "$ROOT/docs/generated/agent-golden-path.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+try:
+    value = json.loads(path.read_text(encoding="utf-8"))
+except Exception as exc:
+    raise SystemExit(f"golden-path contract is not readable JSON: {exc}")
+fields = []
+for key in ("source_version", "source_tag"):
+    field = value.get(key)
+    if not isinstance(field, str) or not field:
+        raise SystemExit(f"golden-path {key} must be a non-empty string")
+    fields.append(field)
+print("\t".join(fields))
+PY
+)
+
+[ "$contract_source_version" = "$source_version" ] ||
+  fail "golden-path source_version $contract_source_version does not match $source_version"
+[ "$contract_source_tag" = "$source_tag" ] ||
+  fail "golden-path source_tag $contract_source_tag does not match $source_tag"
+
+guide_declaration="This source tree declares Assay \`$source_version\` (\`$source_tag\`)."
+[ "$(grep -Fxc "$guide_declaration" "$ROOT/docs/guides/agent-golden-path.md" || true)" -eq 1 ] ||
+  fail "golden-path guide source-tree declaration does not match $source_tag"
+
+changelog_pattern="^## \\[${source_version}\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$"
+[ "$(grep -Ec "$changelog_pattern" "$ROOT/CHANGELOG.md" || true)" -eq 1 ] ||
+  fail "CHANGELOG.md must contain exactly one dated release heading for $source_version"
+
+printf 'tag-tree outward truth: source %s, candidate %s, sha %s\n' \
+  "$source_version" "$CANDIDATE_TAG" "$actual_sha"

--- a/scripts/ci/check-tag-tree-outward-truth.sh
+++ b/scripts/ci/check-tag-tree-outward-truth.sh
@@ -8,6 +8,10 @@ EXPECTED_SHA="${EXPECTED_SHA:-}"
 
 fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 
+for required_file in Cargo.toml CHANGELOG.md docs/generated/agent-golden-path.json docs/guides/agent-golden-path.md; do
+  [ -f "$ROOT/$required_file" ] || fail "required candidate source file is missing: $required_file"
+done
+
 [[ "$CANDIDATE_TAG" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-(rc|beta)[.][0-9]+)?$ ]] ||
   fail "candidate tag must be vX.Y.Z, vX.Y.Z-rc.N, or vX.Y.Z-beta.N"
 [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "expected SHA must be 40 lowercase hex characters"
@@ -60,9 +64,10 @@ guide_declaration="This source tree declares Assay \`$source_version\` (\`$sourc
 [ "$(grep -Fxc "$guide_declaration" "$ROOT/docs/guides/agent-golden-path.md" || true)" -eq 1 ] ||
   fail "golden-path guide source-tree declaration does not match $source_tag"
 
-changelog_pattern="^## \\[${source_version}\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$"
+changelog_version="${source_version//./[.]}"
+changelog_pattern="^## \\[${changelog_version}\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$"
 [ "$(grep -Ec "$changelog_pattern" "$ROOT/CHANGELOG.md" || true)" -eq 1 ] ||
   fail "CHANGELOG.md must contain exactly one dated release heading for $source_version"
 
-printf 'tag-tree outward truth: source %s, candidate %s, sha %s\n' \
+printf 'tag-tree outward truth: source %s, candidate %s, checkout %s\n' \
   "$source_version" "$CANDIDATE_TAG" "$actual_sha"

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -10,9 +10,13 @@ import os
 import re
 from pathlib import Path
 import subprocess
+import sys
 
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(ROOT / "scripts/ci/lib"))
+from workspace_version import read_workspace_version  # noqa: E402
 
 CONTRACT_PATH = ROOT / "docs/generated/agent-golden-path.json"
 GUIDE_PATH = ROOT / "docs/guides/agent-golden-path.md"
@@ -1095,6 +1099,12 @@ def main() -> None:
         fail("failed to read published release tag: " + release_tag_result.stderr.strip())
     release_tag = release_tag_result.stdout.strip()
     release_version = release_tag.removeprefix("v")
+    source_version = read_workspace_version(ROOT / "Cargo.toml")
+    source_tag = f"v{source_version}"
+    if contract.get("source_version") != source_version:
+        fail("golden-path source_version must match the workspace version")
+    if contract.get("source_tag") != source_tag:
+        fail("golden-path source_tag must match the workspace version")
     if contract.get("release_version") != release_version:
         fail("golden-path release_version must match the published release pin")
     if contract.get("release_tag") != release_tag:

--- a/scripts/ci/test-check-tag-tree-outward-truth.sh
+++ b/scripts/ci/test-check-tag-tree-outward-truth.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # Assertions intentionally match literal Markdown and Actions syntax.
+set -euo pipefail
+
+# shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/scripts/ci/lib" "$TMP/docs/generated" "$TMP/docs/guides" "$TMP/.github"
+cp "$ROOT/scripts/ci/check-tag-tree-outward-truth.sh" "$TMP/scripts/ci/"
+cp "$ROOT/scripts/ci/lib/workspace_version.py" "$TMP/scripts/ci/lib/"
+cat > "$TMP/Cargo.toml" <<'EOF'
+[workspace.package]
+version = "5.3.0"
+EOF
+cat > "$TMP/docs/generated/agent-golden-path.json" <<'EOF'
+{
+  "source_version": "5.3.0",
+  "source_tag": "v5.3.0",
+  "release_version": "5.2.0",
+  "release_tag": "v5.2.0"
+}
+EOF
+cat > "$TMP/docs/guides/agent-golden-path.md" <<'EOF'
+This source tree declares Assay `5.3.0` (`v5.3.0`).
+This journey is pinned to Assay `5.2.0` (`v5.2.0`).
+EOF
+cat > "$TMP/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [5.3.0] - 2026-08-16
+EOF
+printf '%s\n' 'v5.2.0' > "$TMP/.github/assay-release-tag"
+
+(
+  cd "$TMP"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name test
+  git add -- Cargo.toml CHANGELOG.md .github docs scripts
+  git commit -qm fixture
+)
+
+head_sha="$(git -C "$TMP" rev-parse HEAD)"
+run_check() {
+  (cd "$TMP" && CANDIDATE_TAG=v5.3.0 EXPECTED_SHA="$head_sha" \
+    bash scripts/ci/check-tag-tree-outward-truth.sh)
+}
+
+run_check >/dev/null
+
+mutations=0
+mutate_and_fail() {
+  local name="$1" file="$2" old="$3" new="$4" diagnostic="$5"
+  local backup="$TMP/$file.$name"
+  cp "$TMP/$file" "$backup"
+  sed "s/$old/$new/g" "$backup" > "$TMP/$file"
+  if run_check >"$TMP/$name.out" 2>&1; then
+    echo "FAIL: mutation $name was not observed" >&2
+    exit 1
+  fi
+  grep -Fq "$diagnostic" "$TMP/$name.out" || {
+    cat "$TMP/$name.out" >&2
+    echo "FAIL: mutation $name missed diagnostic: $diagnostic" >&2
+    exit 1
+  }
+  mv "$backup" "$TMP/$file"
+  mutations=$((mutations + 1))
+  printf 'PASS: %s\n' "$name"
+}
+
+mutate_and_fail stale-source-version docs/generated/agent-golden-path.json \
+  '"source_version": "5.3.0"' '"source_version": "5.2.0"' 'source_version'
+mutate_and_fail stale-source-tag docs/generated/agent-golden-path.json \
+  '"source_tag": "v5.3.0"' '"source_tag": "v5.2.0"' 'source_tag'
+mutate_and_fail stale-guide-source docs/guides/agent-golden-path.md \
+  'source tree declares Assay `5.3.0` (`v5.3.0`)' \
+  'source tree declares Assay `5.2.0` (`v5.2.0`)' 'source-tree declaration'
+mutate_and_fail stale-changelog CHANGELOG.md \
+  '\[5.3.0\]' '[5.2.0]' 'release heading'
+
+if (cd "$TMP" && CANDIDATE_TAG=v5.2.0 EXPECTED_SHA="$head_sha" \
+  bash scripts/ci/check-tag-tree-outward-truth.sh) >"$TMP/tag-mismatch.out" 2>&1; then
+  echo "FAIL: candidate tag mismatch was not observed" >&2
+  exit 1
+fi
+grep -Fq 'candidate tag v5.2.0 does not match workspace source tag v5.3.0' \
+  "$TMP/tag-mismatch.out"
+mutations=$((mutations + 1))
+printf 'PASS: candidate-tag-mismatch\n'
+
+if (cd "$TMP" && CANDIDATE_TAG=v5.3.0 EXPECTED_SHA=0000000000000000000000000000000000000000 \
+  bash scripts/ci/check-tag-tree-outward-truth.sh) >"$TMP/sha-mismatch.out" 2>&1; then
+  echo "FAIL: exact SHA mismatch was not observed" >&2
+  exit 1
+fi
+grep -Fq 'checked-out HEAD' "$TMP/sha-mismatch.out"
+mutations=$((mutations + 1))
+printf 'PASS: exact-sha-mismatch\n'
+
+# Candidate identity and install availability are deliberately separate contracts.
+printf '%s\n' 'v4.9.0' > "$TMP/.github/assay-release-tag"
+run_check >/dev/null
+printf 'PASS: install-pin-does-not-govern-candidate-identity\n'
+
+if [ "$mutations" -ne 6 ]; then
+  echo "FAIL: expected 6 observed mutations, got $mutations" >&2
+  exit 1
+fi
+printf 'tag-tree outward-truth mutations: %s observed\n' "$mutations"
+
+workflow="$ROOT/.github/workflows/release.yml"
+for required in \
+  'CANDIDATE_TAG: ${{ steps.version.outputs.version }}' \
+  'EXPECTED_SHA: ${{ github.sha }}' \
+  'bash scripts/ci/check-tag-tree-outward-truth.sh'; do
+  grep -Fq "$required" "$workflow" || {
+    echo "FAIL: release workflow does not invoke the exact-tree guard: $required" >&2
+    exit 1
+  }
+done
+printf 'PASS: release workflow invokes exact-tree guard\n'
+
+python3 - "$ROOT/.pre-commit-config.yaml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+try:
+    start = next(i for i, line in enumerate(lines) if line.strip() == "- id: tag-tree-outward-truth")
+except StopIteration as exc:
+    raise SystemExit("tag-tree outward-truth pre-commit hook is missing") from exc
+end = next(
+    (i for i in range(start + 1, len(lines)) if lines[i].lstrip().startswith("- id:")),
+    len(lines),
+)
+section = lines[start:end]
+selectors = [line.strip().removeprefix("files: ") for line in section if line.strip().startswith("files: ")]
+if len(selectors) != 1:
+    raise SystemExit("tag-tree outward-truth hook must have exactly one files selector")
+pattern = re.compile(selectors[0])
+for required in (
+    "Cargo.toml",
+    "CHANGELOG.md",
+    "docs/generated/agent-golden-path.json",
+    "docs/guides/agent-golden-path.md",
+    "docs/reference/release.md",
+    ".github/workflows/release.yml",
+    "scripts/ci/check-tag-tree-outward-truth.sh",
+    "scripts/ci/test-check-tag-tree-outward-truth.sh",
+    "scripts/ci/lib/clear-git-repository-env.sh",
+):
+    if not pattern.search(required):
+        raise SystemExit(f"tag-tree outward-truth hook omits {required}")
+PY
+printf 'PASS: pre-commit hook covers candidate identity inputs\n'
+
+release_docs="$ROOT/docs/reference/release.md"
+required='CANDIDATE_TAG=vX.Y.Z EXPECTED_SHA="$(git rev-parse HEAD)"'
+grep -Fq "$required" "$release_docs" || {
+  echo "FAIL: release docs omit candidate/install separation: $required" >&2
+  exit 1
+}
+python3 - "$release_docs" <<'PY'
+from pathlib import Path
+import sys
+
+normalized = " ".join(Path(sys.argv[1]).read_text(encoding="utf-8").split())
+required = "The published install pin may still name the previous release"
+if required not in normalized:
+    raise SystemExit(f"release docs omit candidate/install separation: {required}")
+PY
+printf 'PASS: release docs distinguish candidate identity from installability\n'

--- a/scripts/ci/test-check-tag-tree-outward-truth.sh
+++ b/scripts/ci/test-check-tag-tree-outward-truth.sh
@@ -112,17 +112,64 @@ if [ "$mutations" -ne 6 ]; then
 fi
 printf 'tag-tree outward-truth mutations: %s observed\n' "$mutations"
 
+check_release_workflow() {
+ruby - "$1" <<'RUBY'
+require "yaml"
+
+workflow = YAML.safe_load_file(ARGV.fetch(0), aliases: false)
+steps = workflow.fetch("jobs", {}).fetch("release-contract", {}).fetch("steps", [])
+matching = steps.select { |step| step["name"] == "Verify candidate source-tree identity" }
+abort "release workflow must contain one active candidate source-tree guard" unless matching.length == 1
+step = matching.fetch(0)
+abort "release workflow candidate source-tree guard invokes the wrong command" unless
+  step["run"] == "bash scripts/ci/check-tag-tree-outward-truth.sh"
+expected_env = {
+  "CANDIDATE_TAG" => "${{ steps.version.outputs.version }}",
+  "EXPECTED_SHA" => "${{ github.sha }}",
+}
+abort "release workflow candidate source-tree guard has the wrong environment" unless
+  step["env"] == expected_env
+abort "release workflow candidate source-tree guard must be unconditional and blocking" if
+  step.key?("if") || step.key?("continue-on-error")
+RUBY
+}
+
 workflow="$ROOT/.github/workflows/release.yml"
-for required in \
-  'CANDIDATE_TAG: ${{ steps.version.outputs.version }}' \
-  'EXPECTED_SHA: ${{ github.sha }}' \
-  'bash scripts/ci/check-tag-tree-outward-truth.sh'; do
-  grep -Fq "$required" "$workflow" || {
-    echo "FAIL: release workflow does not invoke the exact-tree guard: $required" >&2
-    exit 1
-  }
-done
-printf 'PASS: release workflow invokes exact-tree guard\n'
+check_release_workflow "$workflow"
+printf 'PASS: release workflow structurally invokes blocking source-tree guard\n'
+
+python3 - "$workflow" "$TMP/release-disabled.yml" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+needle = "      - name: Verify candidate source-tree identity\n"
+if text.count(needle) != 1:
+    raise SystemExit("candidate source-tree guard fixture is ambiguous")
+Path(sys.argv[2]).write_text(text.replace(needle, needle + "        if: false\n"), encoding="utf-8")
+PY
+if check_release_workflow "$TMP/release-disabled.yml" >/dev/null 2>&1; then
+  echo "FAIL: disabled release guard was not observed" >&2
+  exit 1
+fi
+printf 'PASS: disabled release guard mutation rejected\n'
+
+python3 - "$workflow" "$TMP/release-commented.yml" <<'PY'
+from pathlib import Path
+import sys
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+start = next(i for i, line in enumerate(lines) if line == "      - name: Verify candidate source-tree identity")
+end = next(i for i in range(start + 1, len(lines)) if lines[i].startswith("      - name:"))
+for i in range(start, end):
+    lines[i] = "# " + lines[i]
+Path(sys.argv[2]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+if check_release_workflow "$TMP/release-commented.yml" >/dev/null 2>&1; then
+  echo "FAIL: commented release guard was not observed" >&2
+  exit 1
+fi
+printf 'PASS: commented release guard mutation rejected\n'
 
 python3 - "$ROOT/.pre-commit-config.yaml" <<'PY'
 from pathlib import Path
@@ -159,6 +206,24 @@ for required in (
 PY
 printf 'PASS: pre-commit hook covers candidate identity inputs\n'
 
+python3 - "$ROOT/.github/workflows/kernel-matrix.yml" <<'PY'
+from pathlib import Path
+import sys
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+start = next(i for i, line in enumerate(lines) if line.strip() == "paths:")
+end = next(i for i in range(start + 1, len(lines)) if lines[i].startswith("  push:"))
+paths = {
+    line.strip().removeprefix("- ").strip('"')
+    for line in lines[start:end]
+    if line.strip().startswith("- ")
+}
+for required in ("Cargo.toml", "CHANGELOG.md", "docs/reference/release.md"):
+    if required not in paths:
+        raise SystemExit(f"kernel-matrix lint trigger omits candidate identity input: {required}")
+PY
+printf 'PASS: lint workflow triggers on candidate identity inputs\n'
+
 release_docs="$ROOT/docs/reference/release.md"
 required='CANDIDATE_TAG=vX.Y.Z EXPECTED_SHA="$(git rev-parse HEAD)"'
 grep -Fq "$required" "$release_docs" || {
@@ -173,5 +238,8 @@ normalized = " ".join(Path(sys.argv[1]).read_text(encoding="utf-8").split())
 required = "The published install pin may still name the previous release"
 if required not in normalized:
     raise SystemExit(f"release docs omit candidate/install separation: {required}")
+immutable = "Published release tags are immutable and are never moved or rewritten"
+if immutable not in normalized:
+    raise SystemExit(f"release docs omit tag immutability rule: {immutable}")
 PY
 printf 'PASS: release docs distinguish candidate identity from installability\n'

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -11,6 +11,9 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(ROOT / "scripts/ci/lib"))
+from workspace_version import read_workspace_version  # noqa: E402
 
 JSON_OUTPUT = ROOT / "docs/generated/agent-golden-path.json"
 MARKDOWN_OUTPUT = ROOT / "docs/guides/agent-golden-path.md"
@@ -93,6 +96,8 @@ def read_published_release_tag() -> str:
 
 RELEASE_TAG = read_published_release_tag()
 RELEASE_VERSION = RELEASE_TAG.removeprefix("v")
+SOURCE_VERSION = read_workspace_version(ROOT / "Cargo.toml")
+SOURCE_TAG = f"v{SOURCE_VERSION}"
 
 
 def stdout(kind: str, document: str | None = None) -> dict[str, object]:
@@ -595,6 +600,8 @@ CONTRACT: dict[str, object] = {
     "schema": "assay.agent_golden_path.v1",
     "schema_version": 1,
     "generated_by": "scripts/docs/generate-agent-golden-path.py",
+    "source_version": SOURCE_VERSION,
+    "source_tag": SOURCE_TAG,
     "release_version": RELEASE_VERSION,
     "release_tag": RELEASE_TAG,
     "source_issue": 2154,
@@ -673,6 +680,7 @@ def render_release() -> str:
         (
             "## Release-pinned start",
             "",
+            f"This source tree declares Assay `{SOURCE_VERSION}` (`{SOURCE_TAG}`).",
             f"This journey is pinned to Assay `{RELEASE_VERSION}` "
             f"([`{RELEASE_TAG}`](https://github.com/Rul1an/assay/releases/tag/{RELEASE_TAG})).",
             f"Install the CLI from a verified channel, then require `assay version` to print "


### PR DESCRIPTION
## Summary

- separate candidate/source identity from the last-published install pin
- add an exact-tree pre-tag guard for candidate tag, SHA, generated source metadata, guide, and changelog
- keep `.github/assay-release-tag` independently pinned to the last installable release
- wire the guard into release validation and pre-commit with mutation-sensitive tests

## Why

The v5.2.0 release exposed a circularity: equating the candidate source version with the install pin either made CI download unpublished assets or prevented the release-preparation PR from passing. The durable contract treats these as separate facts and verifies both at their correct lifecycle stage.

Closes #2381.

## Contract

- `source_version` / `source_tag`: workspace-derived candidate identity
- `release_version` / `release_tag`: last-published installable asset identity
- release workflow passes both the exact candidate tag and `github.sha` to the pre-tag checker
- changing only the install pin does not fail candidate-tree validation

## TDD and mutations

RED first:
- generated golden-path test rejected missing source identity
- checker contract rejected the missing checker

Mutations rejected independently:
- stale generated source version
- stale generated source tag
- stale guide source declaration
- stale changelog release heading
- candidate-tag mismatch
- exact-SHA mismatch

Allowed mutation:
- changing only `.github/assay-release-tag` does not affect candidate-tree truth

## Verification

- `bash scripts/ci/test-check-tag-tree-outward-truth.sh`
- `python3 scripts/ci/test-agent-golden-path-skill.py`
- `bash scripts/ci/check-tag-tree-outward-truth.sh`
- release-surface mutation suite: 41 mutations
- golden-path hardening suite: 96 cases / 23 structural probes
- generated-doc drift: 12 files
- selected pre-commit hooks, shellcheck, actionlint, fmt/clippy-related hooks: pass

## Non-claims

- does not rewrite or move the published `v5.2.0` tag
- does not claim existing release assets are incorrect
- does not fetch candidate assets before publication
- does not change release immutability, provenance generation, signing, or the post-publish install-pin update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Added stronger validation to ensure release tags match the exact source revision and declared version.
  * Release checks now detect mismatches across version metadata, documentation, changelog entries, and generated release information.
  * Added source version and tag details for the 5.2.0 release.

* **Documentation**
  * Clarified release preparation, candidate tag verification, published install references, and tag immutability.
  * Updated the agent golden path to identify version 5.2.0 and tag v5.2.0.

* **Quality Improvements**
  * Added automated checks covering release identity, metadata consistency, and workflow safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->