### PR TITLE
feat(plugin): add portable skills-only Agent Plugin core

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -21,6 +21,7 @@ on:
       - ".claude/**"
       - ".claude-plugin/**"
       - "packaging/claude-plugin/**"
+      - "packaging/agent-plugin/**"
       - ".gitignore"
       - ".gitattributes"
       - ".pre-commit-config.yaml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,7 @@ repos:
         # Both properties this pins have failed here before: `check-aee-seal-fixture-drift.sh`
         # documents an earlier version that ran its emitter in place and destroyed the fixtures it
         # audited, and `check-linux.sh` returned 0 on every failure (#2076).
-        files: ^(scripts/ci/(check-docs-generated-drift|test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot|read-assay-release-tag)\.sh|scripts/ci/lib/workspace_version\.py|scripts/docs/generate-agent-golden-path\.py|\.github/assay-release-tag|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*)$
+        files: ^(scripts/ci/(check-docs-generated-drift|test-check-docs-generated-drift(?:-safety)?|lib/drift-tree-snapshot|read-assay-release-tag)\.sh|scripts/ci/lib/workspace_version\.py|scripts/docs/generate-agent-golden-path\.py|\.github/assay-release-tag|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*)$
 
       - id: docs-generated-drift
         name: Generated docs match their generators
@@ -124,14 +124,14 @@ repos:
         # Caught here instead, the diagram edge lands in the pull request that added the dependency,
         # where a reviewer can see why it moved. It also makes the bot's `has_changes` false by
         # construction, so the un-mergeable PR is never created.
-        files: ^(Cargo\.toml|crates/.*/Cargo\.toml|scripts/docs/.*\.(sh|py)|scripts/ci/(read-assay-release-tag\.sh|lib/workspace_version\.py)|\.github/assay-release-tag|docs/generated/.*|docs/AIcontext/architecture-diagrams\.md|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|scripts/ci/check-docs-generated-drift\.sh|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|crates/.*/Cargo\.toml|scripts/docs/.*\.(sh|py)|scripts/ci/(read-assay-release-tag\.sh|lib/workspace_version\.py)|\.github/assay-release-tag|docs/generated/.*|docs/AIcontext/architecture-diagrams\.md|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*|scripts/ci/check-docs-generated-drift\.sh|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: agent-golden-path-skill-contract
         name: Agent golden-path skill contract
         entry: bash -c 'python3 scripts/ci/test-agent-golden-path-skill.py && python3 scripts/ci/test-golden-path-mock-bounds.py && python3 scripts/ci/test-generate-agent-golden-path-check.py'
         language: system
         pass_filenames: false
-        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|test-generate-agent-golden-path-check\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|test-generate-agent-golden-path-check\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: agent-golden-path-skill-mutations
         name: Agent golden-path skill mutations
@@ -141,7 +141,7 @@ repos:
         # The mutation cases prove the validator has teeth, but their cost belongs
         # at the publish boundary rather than in every intermediate commit.
         stages: [pre-push]
-        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|test-generate-agent-golden-path-check\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|test-generate-agent-golden-path-check\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test

--- a/crates/assay-cli/tests/agent_plugin_package_contract.rs
+++ b/crates/assay-cli/tests/agent_plugin_package_contract.rs
@@ -1,0 +1,175 @@
+use jsonschema::{Draft, Validator};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+const SCHEMA_ID: &str = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const SCHEMA_SHA256: &str = "0a4aad95ce337878ad38802ebf0daa3fde76abe3f65400c86bcbb1ec0b3ab883";
+const PACKAGE_FILES: [&str; 8] = [
+    "plugin.json",
+    "schemas/plugin.schema.json",
+    "schemas/plugin.schema.lock.json",
+    "skills/assay-golden-path/SKILL.md",
+    "skills/assay-golden-path/references/agent-golden-path.json",
+    "skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py",
+    "skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json",
+    "skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml",
+];
+
+struct LocalOnlyRetriever;
+
+impl jsonschema::Retrieve for LocalOnlyRetriever {
+    fn retrieve(
+        &self,
+        uri: &jsonschema::Uri<String>,
+    ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+        Err(format!("external schema retrieval is disabled: {uri}").into())
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("assay-cli must live below the workspace root")
+        .to_path_buf()
+}
+
+fn package_root() -> PathBuf {
+    workspace_root().join("packaging/agent-plugin")
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_slice(
+        &std::fs::read(path)
+            .unwrap_or_else(|error| panic!("read package JSON {}: {error}", path.display())),
+    )
+    .unwrap_or_else(|error| panic!("parse package JSON {}: {error}", path.display()))
+}
+
+fn validator() -> Validator {
+    let schema = read_json(&package_root().join("schemas/plugin.schema.json"));
+    jsonschema::options()
+        .with_draft(Draft::Draft202012)
+        .with_retriever(LocalOnlyRetriever)
+        .build(&schema)
+        .expect("vendored Agent Plugins schema must compile without network access")
+}
+
+fn assert_invalid(validator: &Validator, value: &Value, context: &str) {
+    assert!(
+        !validator.is_valid(value),
+        "schema accepted invalid manifest mutation: {context}"
+    );
+}
+
+fn collect_files(dir: &Path, relative: &Path, out: &mut BTreeSet<String>) {
+    for entry in std::fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("read package directory {}: {error}", dir.display()))
+    {
+        let entry = entry.expect("read package entry");
+        let file_type = entry.file_type().expect("read package entry type");
+        assert!(!file_type.is_symlink(), "package must not contain symlinks");
+        let child_relative = relative.join(entry.file_name());
+        if file_type.is_dir() {
+            collect_files(&entry.path(), &child_relative, out);
+        } else {
+            assert!(file_type.is_file(), "package entries must be regular files");
+            out.insert(child_relative.to_string_lossy().replace('\\', "/"));
+        }
+    }
+}
+
+#[test]
+fn portable_agent_plugin_manifest_validates_offline() {
+    let root = package_root();
+    let schema_bytes = std::fs::read(root.join("schemas/plugin.schema.json"))
+        .expect("vendored Agent Plugins schema must exist");
+    assert_eq!(schema_bytes.len(), 1_805, "vendored schema byte count");
+    let schema_digest = Sha256::digest(&schema_bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    assert_eq!(schema_digest, SCHEMA_SHA256, "vendored schema digest");
+
+    let lock = read_json(&root.join("schemas/plugin.schema.lock.json"));
+    assert_eq!(lock["canonical_url"], SCHEMA_ID);
+    assert_eq!(lock["sha256"], SCHEMA_SHA256);
+    assert_eq!(lock["bytes"], 1_805);
+
+    let manifest = read_json(&root.join("plugin.json"));
+    let validator = validator();
+    if !validator.is_valid(&manifest) {
+        let errors = validator
+            .iter_errors(&manifest)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        panic!("portable Agent Plugin manifest is invalid:\n{errors}");
+    }
+    assert_eq!(manifest["$schema"], SCHEMA_ID);
+    assert_eq!(manifest["name"], "assay");
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(manifest["author"]["name"], "Assay");
+    assert_eq!(manifest["repository"], "https://github.com/Rul1an/assay");
+    assert_eq!(manifest["homepage"], "https://getassay.dev");
+    assert_eq!(manifest["license"], "MIT");
+
+    let mut missing_schema = manifest.clone();
+    missing_schema
+        .as_object_mut()
+        .expect("manifest object")
+        .remove("$schema");
+    assert_invalid(&validator, &missing_schema, "missing $schema");
+
+    let mut unknown_field = manifest.clone();
+    unknown_field["commands"] = serde_json::json!([]);
+    assert_invalid(&validator, &unknown_field, "unknown top-level field");
+
+    let mut invalid_name = manifest;
+    invalid_name["name"] = serde_json::json!("Assay");
+    assert_invalid(&validator, &invalid_name, "uppercase plugin name");
+}
+
+#[test]
+fn portable_agent_plugin_is_skills_only_and_self_contained() {
+    let root = package_root();
+    assert!(!root.join("mcp.json").exists(), "portable MCP is deferred");
+
+    let mut actual = BTreeSet::new();
+    collect_files(&root, Path::new(""), &mut actual);
+    let expected = PACKAGE_FILES
+        .into_iter()
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected, "portable package file inventory drifted");
+
+    let skill_path = root.join("skills/assay-golden-path/SKILL.md");
+    let skill = std::fs::read_to_string(&skill_path)
+        .unwrap_or_else(|error| panic!("read portable skill {}: {error}", skill_path.display()));
+    assert!(skill.is_ascii(), "portable skill must be ASCII");
+    for forbidden in [
+        "${CLAUDE_PLUGIN_ROOT}",
+        "${PLUGIN_ROOT}",
+        ".agents/",
+        ".claude/",
+        "packaging/",
+        "docs/generated/",
+        "examples/privileged-action-gate",
+    ] {
+        assert!(
+            !skill.contains(forbidden),
+            "portable skill leaked host/source path: {forbidden}"
+        );
+    }
+    for required in [
+        "references/agent-golden-path.json",
+        "assets/privileged-action-gate",
+    ] {
+        assert!(
+            skill.contains(required),
+            "portable skill omits package-relative path: {required}"
+        );
+    }
+}

--- a/crates/assay-cli/tests/agent_plugin_package_contract.rs
+++ b/crates/assay-cli/tests/agent_plugin_package_contract.rs
@@ -16,6 +16,16 @@ const PACKAGE_FILES: [&str; 8] = [
     "skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json",
     "skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml",
 ];
+const PACKAGE_DIRS: [&str; 8] = [
+    "",
+    "schemas",
+    "skills",
+    "skills/assay-golden-path",
+    "skills/assay-golden-path/references",
+    "skills/assay-golden-path/assets",
+    "skills/assay-golden-path/assets/privileged-action-gate",
+    "skills/assay-golden-path/assets/privileged-action-gate/policies",
+];
 
 struct LocalOnlyRetriever;
 
@@ -64,21 +74,40 @@ fn assert_invalid(validator: &Validator, value: &Value, context: &str) {
     );
 }
 
-fn collect_files(dir: &Path, relative: &Path, out: &mut BTreeSet<String>) {
-    for entry in std::fs::read_dir(dir)
-        .unwrap_or_else(|error| panic!("read package directory {}: {error}", dir.display()))
-    {
-        let entry = entry.expect("read package entry");
-        let file_type = entry.file_type().expect("read package entry type");
-        assert!(!file_type.is_symlink(), "package must not contain symlinks");
-        let child_relative = relative.join(entry.file_name());
-        if file_type.is_dir() {
-            collect_files(&entry.path(), &child_relative, out);
-        } else {
-            assert!(file_type.is_file(), "package entries must be regular files");
-            out.insert(child_relative.to_string_lossy().replace('\\', "/"));
+fn collect_files(root: &Path) -> BTreeSet<String> {
+    let expected_dirs = PACKAGE_DIRS.into_iter().collect::<BTreeSet<_>>();
+    let mut files = BTreeSet::new();
+
+    // Traverse only compile-time allowlisted directories. Directory entries are
+    // compared as names; they never become paths that this test opens.
+    for relative_dir in PACKAGE_DIRS {
+        let dir = root.join(relative_dir);
+        for entry in std::fs::read_dir(&dir)
+            .unwrap_or_else(|error| panic!("read package directory {}: {error}", dir.display()))
+        {
+            let entry = entry.expect("read package entry");
+            let file_type = entry.file_type().expect("read package entry type");
+            assert!(!file_type.is_symlink(), "package must not contain symlinks");
+            let name = entry.file_name();
+            let name = name.to_str().expect("package names must be UTF-8");
+            let relative = if relative_dir.is_empty() {
+                name.to_string()
+            } else {
+                format!("{relative_dir}/{name}")
+            };
+            if file_type.is_dir() {
+                assert!(
+                    expected_dirs.contains(relative.as_str()),
+                    "unexpected package directory: {relative}"
+                );
+            } else {
+                assert!(file_type.is_file(), "package entries must be regular files");
+                files.insert(relative);
+            }
         }
     }
+
+    files
 }
 
 #[test]
@@ -137,8 +166,7 @@ fn portable_agent_plugin_is_skills_only_and_self_contained() {
     let root = package_root();
     assert!(!root.join("mcp.json").exists(), "portable MCP is deferred");
 
-    let mut actual = BTreeSet::new();
-    collect_files(&root, Path::new(""), &mut actual);
+    let actual = collect_files(&root);
     let expected = PACKAGE_FILES
         .into_iter()
         .map(str::to_string)

--- a/packaging/agent-plugin/plugin.json
+++ b/packaging/agent-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "assay",
+  "version": "5.2.0",
+  "description": "Operate Assay's install-to-evidence golden path with explicit failure boundaries.",
+  "author": {
+    "name": "Assay"
+  },
+  "homepage": "https://getassay.dev",
+  "repository": "https://github.com/Rul1an/assay",
+  "license": "MIT"
+}

--- a/packaging/agent-plugin/schemas/plugin.schema.json
+++ b/packaging/agent-plugin/schemas/plugin.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "title": "Agent Plugins Manifest",
+  "description": "Machine-readable schema for plugin.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      "description": "Canonical identifier of the plugin manifest schema for the Agent Plugins version targeted by this document."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^(?!.*(?:--|\\.\\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$",
+      "description": "Human-readable plugin name."
+    },
+    "version": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "homepage": {
+      "type": "string"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Client-specific manifest data keyed by reverse-domain extension namespace. Agent Plugins assigns no semantics to namespace object contents.",
+      "additionalProperties": {
+        "type": "object"
+      }
+    }
+  },
+  "required": ["$schema", "name"],
+  "additionalProperties": false
+}

--- a/packaging/agent-plugin/schemas/plugin.schema.lock.json
+++ b/packaging/agent-plugin/schemas/plugin.schema.lock.json
@@ -1,0 +1,5 @@
+{
+  "canonical_url": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "sha256": "0a4aad95ce337878ad38802ebf0daa3fde76abe3f65400c86bcbb1ec0b3ab883",
+  "bytes": 1805
+}

--- a/packaging/agent-plugin/skills/assay-golden-path/SKILL.md
+++ b/packaging/agent-plugin/skills/assay-golden-path/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: assay-golden-path
+description: Drive Assay's install-to-evidence golden path and interpret its stdout and exit codes. Use when an agent must operate or diagnose Assay; do not use it to infer provider execution, external side effects, or a clean result from missing output.
+---
+
+# Assay Golden Path
+
+Drive the nine steps below in order. Read stdout and the process exit code
+separately; a policy denial can be a successful JSON-RPC exchange rather than
+a process failure.
+
+`references/agent-golden-path.json` is the authoritative machine contract bundled with this skill.
+Read it when exact argv, fields, or per-outcome metadata are needed.
+Resolve `references/` and `assets/` paths relative to this SKILL.md directory.
+
+When a step has no `working_directory`, run it from the invocation cwd.
+Protected-action fixtures named by the contract are bundled at `assets/privileged-action-gate`.
+A present `working_directory` in the contract resolves through that mapping.
+Replace `<python>` with `python3` on Unix-like hosts or `python` on Windows.
+
+Empty stdout in a gap row is an observed limitation, not permission for a caller to infer success from missing evidence.
+Do not replace a linked gap with an inferred clean result.
+
+This package uses the Agent Plugins 1.0.0 portable skill layout.
+Host discovery and marketplace acceptance require separate evidence.
+
+## Journey
+
+### 1. Install check
+
+Run: `assay version`
+
+Exit: Success `0`.
+
+Stdout: One `MAJOR.MINOR.PATCH` line.
+
+On failure: A missing or unstartable binary is a host spawn failure: no Assay process runs, so Assay produces no stdout or exit code.
+
+### 2. Preflight
+
+Run: `assay doctor --format json --config <config>`
+
+Exit: Success `0`; no config examined `0`; config examined, error-severity diagnostic `2`; absent explicit config `2`; invalid explicit config `2`.
+
+Stdout: Parses as `assay.doctor_report.v0`. Every report carries `config_check.status`, one of `checked`, `skipped` or `failed`. Exit `0` on its own does not mean a config was examined: read `config_check.status` to tell a clean config from no config. A config that was examined and carries an error-severity `data_diagnostics[]` entry exits `2`, the class `decide_exit` gives that diagnostic for `assay validate` and `assay run` too; the text channel returns the same class for the same tree. A config failure remains JSON and carries the top-level `reason_code` and `next_step` alongside `config_error.code`.
+
+On failure: An explicit config that will not load exits `2`. `assay run` gives the same class for the same file. A proven-absent path publishes `E_MISSING_CONFIG` and `assay init`; an unloadable path publishes `E_CFG_PARSE` and the fused doctor argv.
+
+### 3. Starter files
+
+Run: `assay init --preset dev --hello-trace`
+
+Exit: Success `0`; unknown preset `2`; success with `--format json` `0`; unknown preset with `--format json` `2`.
+
+Stdout: Default `text` is human progress; success ends with `Next: assay validate --config=eval.yaml --trace-file=traces/hello.jsonl --format json`, and a failing run writes partial progress text rather than the fatal diagnosis. `--format json` replaces that stream with one `assay.init_report.v0` document naming `reason_code`, `next_step`, and the files created and skipped.
+
+On failure: Under `--format json` a rejected `--preset` publishes `E_INVALID_ARGS` and a `next_step` on stdout. Failures the reason-code registry does not name, such as a filesystem write error, still produce no document: stdout is empty and the diagnosis stays on stderr.
+
+### 4. Policy validation
+
+Run: `assay policy validate --input <policy> --format json`
+
+Exit: Valid `0`; malformed `2`.
+
+Stdout: Both paths parse as `assay.run_summary.v1`; valid has exit `0` and an empty reason, while malformed YAML carries `E_POLICY_PARSE`. Other load or schema failures remain stderr-only until they receive an honest reason code.
+
+On failure: Malformed policy is exit `2` and names the failing policy in a concrete JSON argv next step. Missing files and schema failures are not classified as parse failures.
+
+### 5. Evaluation result
+
+Run: `assay run --config eval.yaml --trace-file traces/hello.jsonl --format json`
+
+Exit: All tests pass `0`; completed run with failed tests `1`.
+
+Stdout: Both completed outcomes parse as `assay.run_report.v1`; failed results carry `status: fail` inside `results`.
+
+On failure: Exit `1` is a completed results report, not an early-failure diagnosis; `reason_code` and `next_step` are absent by design.
+
+### 6. Protected action
+
+Working directory: `assets/privileged-action-gate`
+
+Run: `assay-mcp-server proxy-enforce --upstream-command <python> --upstream-arg -u --upstream-arg mock_github_mcp.py --enforce-policy policies/no-allowance.yaml --declared-mcp-manifest baseline-approved.json`
+
+Exit: Policy-denied call after stdin closes `0`; startup input failure `1`.
+
+Stdout: The denied `tools/call` response pins `error.code: -32042`, `error.data.origin: assay-proxy`, and `error.data.reason: no_declared_allowance`.
+
+On failure: Policy denial is not a process failure. A missing enforcement policy fails startup with empty stdout and no stable reason/next-step object: [gap #2163](https://github.com/Rul1an/assay/issues/2163).
+
+### 7. Evidence inspection
+
+Run: `assay evidence show --format json -- <bundle>`
+
+Exit: Valid `0`; Valid with verification disabled `0`; integrity failure `2`; unreadable bundle `2`; format-contract failure `2`.
+
+Stdout: Success parses as an object containing `manifest`, `events`, and `verify_mode`; the registered values are `enabled` and `disabled`, with `--no-verify` producing `disabled`. A recorded-value mismatch parses as `assay.run_summary.v1` with `E_EVIDENCE_INTEGRITY`; an unreadable path uses `E_EVIDENCE_UNREADABLE`.
+
+On failure: Only the four verifier codes that establish a recorded-value mismatch map to `E_EVIDENCE_INTEGRITY`; I/O, gzip, and tar failures use `E_EVIDENCE_UNREADABLE`. Format-contract failures still exit `2` with empty stdout: [gap #2219](https://github.com/Rul1an/assay/issues/2219).
+
+### 8. Offline profile verification
+
+Run: `assay evidence verify-privileged-mcp-action <bundle> --format json`
+
+Exit: Valid `0`; integrity or profile failure `2`.
+
+Stdout: Both paths parse as `assay.privileged_mcp_action.verify.report.v0`. Success has `bundle_integrity: pass` and `verdict: valid`; tamper has `bundle_integrity: fail`, a bounded finding, and no verdict.
+
+On failure: The failure report has no registered `reason_code` or actionable `next_step`: [gap #2165](https://github.com/Rul1an/assay/issues/2165).
+
+### 9. SARIF projection
+
+Run: `assay-mcp-server enforcement-sarif --input - --output -`
+
+Exit: Valid input `0`; malformed non-empty NDJSON `1`.
+
+Stdout: Valid input produces SARIF `2.1.0`. A malformed non-empty line produces no SARIF document.
+
+On failure: Malformed NDJSON fails before projection and names the invalid input line on stderr. Blank lines remain accepted.
+
+## Non-claims
+
+- The contract records current behavior; gap rows are not clean results.
+- Schema identity conventions outside this narrow contract remain owned by issue #2167.
+- A passing evidence integrity check does not prove an external side effect.
+- An explicit config whose read returns NotFound is E_MISSING_CONFIG; PermissionDenied, IsADirectory, Other, and YAML failures stay E_CFG_PARSE. That class is taken from the config-read I/O kind, not from a second exists() probe. Windows EACCES kind parity is not claimed, and the permission fixture is skipped as root.
+- Read config_check.status before reading data_diagnostics: only the value checked means a config was read, and on skipped the absent data_diagnostics records an unchecked config rather than a clean one.

--- a/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json
+++ b/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json
@@ -1,0 +1,37 @@
+{
+  "note": "operator-pinned per-tool baseline; manifest_digest recomputes from tools via the guard test and equals the committed P60a manifest_digest (same canonical tools)",
+  "schema": "assay.declared_mcp_manifest.v0",
+  "server": {
+    "id": "github"
+  },
+  "canonicalization": "assay.mcp_manifest_projection.v0",
+  "manifest_digest": "sha256:f8a95098345d600f7a2d742c4e941ace5e9594918b2aa82a9a8f48f72f701ffa",
+  "tools": [
+    {
+      "name": "search",
+      "tool_digest": "sha256:2318d9fd63878b81e992300635172e75053e086db757e31b7ebc917a7c721697",
+      "privileged": false,
+      "privilege_classification": "unclassified",
+      "action_class": null,
+      "field_digests": {
+        "description": "sha256:44c1a1350496d95897e53865330ee56cbf07b02ee54450c191d7d72b2d7005ea",
+        "input_schema": "sha256:e0522e896196457208cca527b92ed8155a72673ccb7723ade56ef69f57230290",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
+    },
+    {
+      "name": "github.add_deploy_key",
+      "tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6",
+      "privileged": true,
+      "privilege_classification": "classified",
+      "action_class": "github_deploy_key",
+      "field_digests": {
+        "description": "sha256:7e326787191c47250d1541c8dd2e5c8e9e8c5345ef3da8b66694e32788a29d99",
+        "input_schema": "sha256:52e5c928edb4433b517b5410a20c6a8a2ed87ff90b7931c000ba2a43fca3644c",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
+    }
+  ]
+}

--- a/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
+++ b/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Self-contained mock GitHub MCP server (stdio) for the privileged-action-gate example.
+
+Newline-delimited JSON-RPC over stdin/stdout. It exposes two tools: a read-only `search` and the
+privileged `github.add_deploy_key`. No network, no auth, no real GitHub call. The tool definitions
+are byte-for-byte the ones the shipped approved baselines were computed from, so the proxy's drift
+gate allows the matching mode and denies the drifted one.
+
+  MOCK_MODE=approved  github.add_deploy_key as approved (per-tool digest matches baseline-approved.json)
+  MOCK_MODE=drifted   github.add_deploy_key now DECLARES readOnlyHint:true (a post-approval change):
+                      its digest differs from baseline-approved.json (-> drift) and matches
+                      baseline-approved-readonly.json (-> allowed, with a separate conformance signal,
+                      because the call is still a create/mutating action).
+"""
+import json
+import os
+import sys
+
+MODE = os.environ.get("MOCK_MODE", "approved")
+MAX_REQUEST_BYTES = 1_048_576
+
+
+def _send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def _tool(name, description, input_schema, annotations=None):
+    tool = {"name": name, "description": description, "inputSchema": input_schema}
+    if annotations is not None:
+        tool["annotations"] = annotations
+    return tool
+
+
+_SEARCH = _tool("search", "does a thing", {"type": "object"})
+_DEPLOY_KEY = _tool(
+    "github.add_deploy_key", "Add a deploy key", {"type": "object", "required": ["owner", "repo"]}
+)
+_DEPLOY_KEY_READONLY = _tool(
+    "github.add_deploy_key",
+    "Add a deploy key",
+    {"type": "object", "required": ["owner", "repo"]},
+    annotations={"readOnlyHint": True},
+)
+
+
+def _tools():
+    return [_SEARCH, _DEPLOY_KEY_READONLY if MODE == "drifted" else _DEPLOY_KEY]
+
+
+def _read_request():
+    raw = sys.stdin.buffer.readline(MAX_REQUEST_BYTES + 1)
+    if not raw:
+        return None
+    if len(raw) <= MAX_REQUEST_BYTES:
+        return raw
+
+    while not raw.endswith(b"\n"):
+        raw = sys.stdin.buffer.readline(MAX_REQUEST_BYTES + 1)
+        if not raw:
+            break
+    return b""
+
+
+def main():
+    while True:
+        raw = _read_request()
+        if raw is None:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        method = msg.get("method")
+        mid = msg.get("id")
+        if method == "initialize":
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-github", "version": "0.0.0"},
+                },
+            })
+        elif method == "ping":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        elif method == "tools/list":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {"tools": _tools()}})
+        elif method == "tools/call":
+            # Only the proxy's allow path forwards a tools/call to us. Canned success; no real call.
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "content": [{"type": "text", "text": "forwarded-ok (mock; no real GitHub call)"}],
+                    "isError": False,
+                },
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml
+++ b/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml
@@ -1,0 +1,8 @@
+# No allowance declares github_deploy_key, so the caller-allowance gate denies: the action was never
+# declared for this caller, even though a credential is present.
+caller:
+  id: "ci-agent"
+upstream_credential:
+  alias: "gh-deploy"
+  scopes: ["repo:deploy_key:write"]
+allowances: []

--- a/packaging/agent-plugin/skills/assay-golden-path/references/agent-golden-path.json
+++ b/packaging/agent-plugin/skills/assay-golden-path/references/agent-golden-path.json
@@ -1,0 +1,616 @@
+{
+  "schema": "assay.agent_golden_path.v1",
+  "schema_version": 1,
+  "generated_by": "scripts/docs/generate-agent-golden-path.py",
+  "source_version": "5.2.0",
+  "source_tag": "v5.2.0",
+  "release_version": "5.2.0",
+  "release_tag": "v5.2.0",
+  "source_issue": 2154,
+  "journey_issue": 1975,
+  "non_claims": [
+    "The contract records current behavior; gap rows are not clean results.",
+    "Schema identity conventions outside this narrow contract remain owned by issue #2167.",
+    "A passing evidence integrity check does not prove an external side effect.",
+    "An explicit config whose read returns NotFound is E_MISSING_CONFIG; PermissionDenied, IsADirectory, Other, and YAML failures stay E_CFG_PARSE. That class is taken from the config-read I/O kind, not from a second exists() probe. Windows EACCES kind parity is not claimed, and the permission fixture is skipped as root.",
+    "Read config_check.status before reading data_diagnostics: only the value checked means a config was read, and on skipped the absent data_diagnostics records an unchecked config rather than a clean one."
+  ],
+  "steps": [
+    {
+      "step": 1,
+      "id": "install-check",
+      "label": "Install check",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "Success",
+          "exit_code": 0,
+          "argv": [
+            "version"
+          ],
+          "stdout": {
+            "kind": "text",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        }
+      ],
+      "stdout_summary": "One `MAJOR.MINOR.PATCH` line.",
+      "failure_summary": "A missing or unstartable binary is a host spawn failure: no Assay process runs, so Assay produces no stdout or exit code.",
+      "command": "assay version"
+    },
+    {
+      "step": 2,
+      "id": "preflight",
+      "label": "Preflight",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "Success",
+          "exit_code": 0,
+          "argv": [
+            "doctor",
+            "--format",
+            "json",
+            "--config",
+            "<config>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.doctor_report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null,
+          "config_check": "checked"
+        },
+        {
+          "name": "no-config",
+          "label": "no config examined",
+          "exit_code": 0,
+          "argv": [
+            "doctor",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.doctor_report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null,
+          "config_check": "skipped"
+        },
+        {
+          "name": "diagnostics-error",
+          "label": "config examined, error-severity diagnostic",
+          "exit_code": 2,
+          "argv": [
+            "doctor",
+            "--format",
+            "json",
+            "--config",
+            "<config>",
+            "--trace-file",
+            "<trace>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.doctor_report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null,
+          "config_check": "checked"
+        },
+        {
+          "name": "missing-config",
+          "label": "absent explicit config",
+          "exit_code": 2,
+          "argv": [
+            "doctor",
+            "--format",
+            "json",
+            "--config",
+            "<config>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.doctor_report.v0"
+          },
+          "reason_code": "E_MISSING_CONFIG",
+          "next_step": "Run: assay init to create a config file",
+          "gap_issue": null,
+          "config_error_code": "E_MISSING_CONFIG"
+        },
+        {
+          "name": "invalid-config",
+          "label": "invalid explicit config",
+          "exit_code": 2,
+          "argv": [
+            "doctor",
+            "--format",
+            "json",
+            "--config",
+            "<config>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.doctor_report.v0"
+          },
+          "reason_code": "E_CFG_PARSE",
+          "next_step": "Run argv: [\"assay\",\"doctor\",\"--config=<config>\",\"--format\",\"json\"]",
+          "gap_issue": null,
+          "config_error_code": "E_CFG_PARSE"
+        }
+      ],
+      "stdout_summary": "Parses as `assay.doctor_report.v0`. Every report carries `config_check.status`, one of `checked`, `skipped` or `failed`. Exit `0` on its own does not mean a config was examined: read `config_check.status` to tell a clean config from no config. A config that was examined and carries an error-severity `data_diagnostics[]` entry exits `2`, the class `decide_exit` gives that diagnostic for `assay validate` and `assay run` too; the text channel returns the same class for the same tree. A config failure remains JSON and carries the top-level `reason_code` and `next_step` alongside `config_error.code`.",
+      "failure_summary": "An explicit config that will not load exits `2`. `assay run` gives the same class for the same file. A proven-absent path publishes `E_MISSING_CONFIG` and `assay init`; an unloadable path publishes `E_CFG_PARSE` and the fused doctor argv.",
+      "command": "assay doctor --format json --config <config>"
+    },
+    {
+      "step": 3,
+      "id": "starter-files",
+      "label": "Starter files",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "Success",
+          "exit_code": 0,
+          "argv": [
+            "init",
+            "--preset",
+            "dev",
+            "--hello-trace"
+          ],
+          "stdout": {
+            "kind": "text",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "unknown-preset",
+          "label": "unknown preset",
+          "exit_code": 2,
+          "argv": [
+            "init",
+            "--preset",
+            "not-a-preset"
+          ],
+          "stdout": {
+            "kind": "text",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "success-json",
+          "label": "success with `--format json`",
+          "exit_code": 0,
+          "argv": [
+            "init",
+            "--preset",
+            "dev",
+            "--hello-trace",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.init_report.v0"
+          },
+          "reason_code": "",
+          "next_step": "Run argv: [\"assay\",\"validate\",\"--config=eval.yaml\",\"--trace-file=traces/hello.jsonl\",\"--format\",\"json\"]",
+          "gap_issue": null
+        },
+        {
+          "name": "unknown-preset-json",
+          "label": "unknown preset with `--format json`",
+          "exit_code": 2,
+          "argv": [
+            "init",
+            "--preset",
+            "not-a-preset",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.init_report.v0"
+          },
+          "reason_code": "E_INVALID_ARGS",
+          "next_step": "Run: assay --help for usage",
+          "gap_issue": null
+        }
+      ],
+      "stdout_summary": "Default `text` is human progress; success ends with `Next: assay validate --config=eval.yaml --trace-file=traces/hello.jsonl --format json`, and a failing run writes partial progress text rather than the fatal diagnosis. `--format json` replaces that stream with one `assay.init_report.v0` document naming `reason_code`, `next_step`, and the files created and skipped.",
+      "failure_summary": "Under `--format json` a rejected `--preset` publishes `E_INVALID_ARGS` and a `next_step` on stdout. Failures the reason-code registry does not name, such as a filesystem write error, still produce no document: stdout is empty and the diagnosis stays on stderr.",
+      "command": "assay init --preset dev --hello-trace"
+    },
+    {
+      "step": 4,
+      "id": "policy-validation",
+      "label": "Policy validation",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid",
+          "exit_code": 0,
+          "argv": [
+            "policy",
+            "validate",
+            "--input",
+            "<policy>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_summary.v1"
+          },
+          "reason_code": "",
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "malformed",
+          "label": "malformed",
+          "exit_code": 2,
+          "argv": [
+            "policy",
+            "validate",
+            "--input",
+            "<policy>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_summary.v1"
+          },
+          "reason_code": "E_POLICY_PARSE",
+          "next_step": "Run argv: [\"assay\",\"policy\",\"validate\",\"--input=<policy>\",\"--format\",\"json\"]",
+          "gap_issue": null
+        }
+      ],
+      "stdout_summary": "Both paths parse as `assay.run_summary.v1`; valid has exit `0` and an empty reason, while malformed YAML carries `E_POLICY_PARSE`. Other load or schema failures remain stderr-only until they receive an honest reason code.",
+      "failure_summary": "Malformed policy is exit `2` and names the failing policy in a concrete JSON argv next step. Missing files and schema failures are not classified as parse failures.",
+      "command": "assay policy validate --input <policy> --format json"
+    },
+    {
+      "step": 5,
+      "id": "evaluation-result",
+      "label": "Evaluation result",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "success",
+          "label": "All tests pass",
+          "exit_code": 0,
+          "argv": [
+            "run",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            "traces/hello.jsonl",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_report.v1"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "completed-test-failure",
+          "label": "completed run with failed tests",
+          "exit_code": 1,
+          "argv": [
+            "run",
+            "--config",
+            "<config>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_report.v1"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null,
+          "classification": "completed_test_failure"
+        }
+      ],
+      "stdout_summary": "Both completed outcomes parse as `assay.run_report.v1`; failed results carry `status: fail` inside `results`.",
+      "failure_summary": "Exit `1` is a completed results report, not an early-failure diagnosis; `reason_code` and `next_step` are absent by design.",
+      "command": "assay run --config eval.yaml --trace-file traces/hello.jsonl --format json"
+    },
+    {
+      "step": 6,
+      "id": "protected-action",
+      "label": "Protected action",
+      "binary": "assay-mcp-server",
+      "working_directory": "examples/privileged-action-gate",
+      "outcomes": [
+        {
+          "name": "policy-denied",
+          "label": "Policy-denied call after stdin closes",
+          "exit_code": 0,
+          "argv": [
+            "proxy-enforce",
+            "--upstream-command",
+            "<python>",
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            "mock_github_mcp.py",
+            "--enforce-policy",
+            "policies/no-allowance.yaml",
+            "--declared-mcp-manifest",
+            "baseline-approved.json"
+          ],
+          "stdout": {
+            "kind": "json_lines",
+            "document": "jsonrpc-2.0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null,
+          "jsonrpc_error_code": -32042,
+          "origin": "assay-proxy",
+          "reason": "no_declared_allowance"
+        },
+        {
+          "name": "startup-failure",
+          "label": "startup input failure",
+          "exit_code": 1,
+          "argv": [
+            "proxy-enforce",
+            "--upstream-command",
+            "<python>",
+            "--enforce-policy",
+            "missing.yaml",
+            "--declared-mcp-manifest",
+            "missing.json"
+          ],
+          "stdout": {
+            "kind": "empty",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2163
+        }
+      ],
+      "stdout_summary": "The denied `tools/call` response pins `error.code: -32042`, `error.data.origin: assay-proxy`, and `error.data.reason: no_declared_allowance`.",
+      "failure_summary": "Policy denial is not a process failure. A missing enforcement policy fails startup with empty stdout and no stable reason/next-step object: [gap #2163](https://github.com/Rul1an/assay/issues/2163).",
+      "command": "assay-mcp-server proxy-enforce --upstream-command <python> --upstream-arg -u --upstream-arg mock_github_mcp.py --enforce-policy policies/no-allowance.yaml --declared-mcp-manifest baseline-approved.json"
+    },
+    {
+      "step": 7,
+      "id": "evidence-inspection",
+      "label": "Evidence inspection",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid",
+          "exit_code": 0,
+          "argv": [
+            "evidence",
+            "show",
+            "--format",
+            "json",
+            "--",
+            "<bundle>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "verification-disabled",
+          "label": "Valid with verification disabled",
+          "exit_code": 0,
+          "argv": [
+            "evidence",
+            "show",
+            "--format",
+            "json",
+            "--no-verify",
+            "--",
+            "<bundle>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "tampered",
+          "label": "integrity failure",
+          "exit_code": 2,
+          "argv": [
+            "evidence",
+            "show",
+            "--format",
+            "json",
+            "--",
+            "<bundle>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_summary.v1"
+          },
+          "reason_code": "E_EVIDENCE_INTEGRITY",
+          "next_step": "Obtain an undamaged bundle from its producer; the content this bundle carries does not match what it records",
+          "gap_issue": null
+        },
+        {
+          "name": "unreadable",
+          "label": "unreadable bundle",
+          "exit_code": 2,
+          "argv": [
+            "evidence",
+            "show",
+            "--format",
+            "json",
+            "--",
+            "<bundle>"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.run_summary.v1"
+          },
+          "reason_code": "E_EVIDENCE_UNREADABLE",
+          "next_step": "Run argv: [\"assay\",\"evidence\",\"show\",\"--format\",\"json\",\"--\",\"<bundle>\"]",
+          "gap_issue": null
+        },
+        {
+          "name": "format-contract-failure",
+          "label": "format-contract failure",
+          "exit_code": 2,
+          "argv": [
+            "evidence",
+            "show",
+            "--format",
+            "json",
+            "--",
+            "<bundle>"
+          ],
+          "stdout": {
+            "kind": "empty",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2219
+        }
+      ],
+      "stdout_summary": "Success parses as an object containing `manifest`, `events`, and `verify_mode`; the registered values are `enabled` and `disabled`, with `--no-verify` producing `disabled`. A recorded-value mismatch parses as `assay.run_summary.v1` with `E_EVIDENCE_INTEGRITY`; an unreadable path uses `E_EVIDENCE_UNREADABLE`.",
+      "failure_summary": "Only the four verifier codes that establish a recorded-value mismatch map to `E_EVIDENCE_INTEGRITY`; I/O, gzip, and tar failures use `E_EVIDENCE_UNREADABLE`. Format-contract failures still exit `2` with empty stdout: [gap #2219](https://github.com/Rul1an/assay/issues/2219).",
+      "command": "assay evidence show --format json -- <bundle>"
+    },
+    {
+      "step": 8,
+      "id": "offline-profile-verification",
+      "label": "Offline profile verification",
+      "binary": "assay",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid",
+          "exit_code": 0,
+          "argv": [
+            "evidence",
+            "verify-privileged-mcp-action",
+            "<bundle>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.privileged_mcp_action.verify.report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "tampered",
+          "label": "integrity or profile failure",
+          "exit_code": 2,
+          "argv": [
+            "evidence",
+            "verify-privileged-mcp-action",
+            "<bundle>",
+            "--format",
+            "json"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "assay.privileged_mcp_action.verify.report.v0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": 2165
+        }
+      ],
+      "stdout_summary": "Both paths parse as `assay.privileged_mcp_action.verify.report.v0`. Success has `bundle_integrity: pass` and `verdict: valid`; tamper has `bundle_integrity: fail`, a bounded finding, and no verdict.",
+      "failure_summary": "The failure report has no registered `reason_code` or actionable `next_step`: [gap #2165](https://github.com/Rul1an/assay/issues/2165).",
+      "command": "assay evidence verify-privileged-mcp-action <bundle> --format json"
+    },
+    {
+      "step": 9,
+      "id": "sarif-projection",
+      "label": "SARIF projection",
+      "binary": "assay-mcp-server",
+      "outcomes": [
+        {
+          "name": "valid",
+          "label": "Valid input",
+          "exit_code": 0,
+          "argv": [
+            "enforcement-sarif",
+            "--input",
+            "-",
+            "--output",
+            "-"
+          ],
+          "stdout": {
+            "kind": "json",
+            "document": "sarif-2.1.0"
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        },
+        {
+          "name": "malformed",
+          "label": "malformed non-empty NDJSON",
+          "exit_code": 1,
+          "argv": [
+            "enforcement-sarif",
+            "--input",
+            "-",
+            "--output",
+            "-"
+          ],
+          "stdout": {
+            "kind": "empty",
+            "document": null
+          },
+          "reason_code": null,
+          "next_step": null,
+          "gap_issue": null
+        }
+      ],
+      "stdout_summary": "Valid input produces SARIF `2.1.0`. A malformed non-empty line produces no SARIF document.",
+      "failure_summary": "Malformed NDJSON fails before projection and names the invalid input line on stderr. Blank lines remain accepted.",
+      "command": "assay-mcp-server enforcement-sarif --input - --output -"
+    }
+  ]
+}

--- a/scripts/ci/lib/golden-path-fixture-staging.sh
+++ b/scripts/ci/lib/golden-path-fixture-staging.sh
@@ -17,7 +17,10 @@ stage_golden_path_fixtures() {
     "$case_root/.claude-plugin" \
     "$case_root/packaging/claude-plugin/.claude-plugin" \
     "$case_root/packaging/claude-plugin/skills/assay-golden-path/references" \
-    "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies"
+    "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies" \
+    "$case_root/packaging/agent-plugin/schemas" \
+    "$case_root/packaging/agent-plugin/skills/assay-golden-path/references" \
+    "$case_root/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies"
 
   cp "$repo_root/scripts/ci/test-agent-golden-path-skill.py" "$case_root/scripts/ci/"
   cp "$repo_root/scripts/ci/lib/workspace_version.py" "$case_root/scripts/ci/lib/"
@@ -53,4 +56,20 @@ stage_golden_path_fixtures() {
     "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/"
   cp "$repo_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml" \
     "$case_root/packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/"
+  cp "$repo_root/packaging/agent-plugin/plugin.json" \
+    "$case_root/packaging/agent-plugin/"
+  cp "$repo_root/packaging/agent-plugin/schemas/plugin.schema.json" \
+    "$case_root/packaging/agent-plugin/schemas/"
+  cp "$repo_root/packaging/agent-plugin/schemas/plugin.schema.lock.json" \
+    "$case_root/packaging/agent-plugin/schemas/"
+  cp "$repo_root/packaging/agent-plugin/skills/assay-golden-path/SKILL.md" \
+    "$case_root/packaging/agent-plugin/skills/assay-golden-path/"
+  cp "$repo_root/packaging/agent-plugin/skills/assay-golden-path/references/agent-golden-path.json" \
+    "$case_root/packaging/agent-plugin/skills/assay-golden-path/references/"
+  cp "$repo_root/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py" \
+    "$case_root/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/"
+  cp "$repo_root/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json" \
+    "$case_root/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/"
+  cp "$repo_root/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml" \
+    "$case_root/packaging/agent-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/"
 }

--- a/scripts/ci/test-agent-golden-path-skill-hardening.sh
+++ b/scripts/ci/test-agent-golden-path-skill-hardening.sh
@@ -13,7 +13,7 @@ trap 'rm -rf "$SCRATCH"' EXIT
 # the 58-case durability boundary established by PR B0.
 # CI-5C (#2196): +3 skill generator-destination omissions and +3 packaged-resource
 # destination drifts beyond the original baseline-only packaged drift case.
-EXPECTED_CASES=96
+EXPECTED_CASES=100
 # Parser-layer follow-ups stay outside the approved cumulative case chain. The
 # The 23 probes are 4 workflow-key, 1 stages-key, 14 selector, 1 trigger-mode,
 # 1 release-split, and 2 inline-parser checks; pin them so deletion cannot leave
@@ -518,7 +518,7 @@ hook_files = (
     "read-assay-release-tag)\\.sh|scripts/ci/lib/workspace_version\\.py|"
     "scripts/docs/generate-agent-golden-path\\.py|\\.github/assay-release-tag|"
     "\\.(agents|claude)/skills/"
-    "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*)$\n"
+    "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*)$\n"
 )
 root_anchor = "default_install_hook_types: [pre-commit, pre-push]\n"
 
@@ -948,7 +948,8 @@ for workflow_path in \
   '.github/assay-release-tag' \
   '.github/workflows/kernel-matrix.yml' \
   '.claude-plugin/**' \
-  'packaging/claude-plugin/**'
+  'packaging/claude-plugin/**' \
+  'packaging/agent-plugin/**'
 do
   for mutation in remove comment; do
     case_root="$SCRATCH/workflow-$mutation-$(printf '%s' "$workflow_path" | tr '/.*' '---')"
@@ -989,7 +990,7 @@ end = text.find("      - id: ", start + 1)
 if end < 0:
     end = len(text)
 block = text[start:end]
-source = "|\\.claude-plugin/.*|packaging/claude-plugin/.*"
+source = "|\\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*"
 if block.count(source) != 1:
     raise SystemExit(f"hook plugin surface is not unique: {hook_id}")
 path.write_text(text[:start] + block.replace(source, "", 1) + text[end:], encoding="utf-8")
@@ -998,6 +999,34 @@ PY
     "hook omits plugin surface $hook_id" \
     "$case_root" \
     "${hook_id} does not cover .claude-plugin/marketplace.json"
+done
+
+for hook_id in docs-generated-drift agent-golden-path-skill-contract; do
+  case_root="$SCRATCH/hook-portable-plugin-surface-$hook_id"
+  seed_case "$case_root"
+  CASE_ROOT="$case_root" HOOK_ID="$hook_id" python3 - <<'PY'
+import os
+from pathlib import Path
+
+path = Path(os.environ["CASE_ROOT"]) / ".pre-commit-config.yaml"
+hook_id = os.environ["HOOK_ID"]
+text = path.read_text(encoding="utf-8")
+start = text.find(f"      - id: {hook_id}\n")
+if start < 0:
+    raise SystemExit(f"hook is not declared: {hook_id}")
+end = text.find("      - id: ", start + 1)
+if end < 0:
+    end = len(text)
+block = text[start:end]
+source = "|packaging/agent-plugin/.*"
+if block.count(source) != 1:
+    raise SystemExit(f"portable plugin surface is not unique: {hook_id}")
+path.write_text(text[:start] + block.replace(source, "", 1) + text[end:], encoding="utf-8")
+PY
+  expect_named_failure \
+    "hook omits portable plugin surface $hook_id" \
+    "$case_root" \
+    "${hook_id} does not cover packaging/agent-plugin/plugin.json"
 done
 
 for skill_path in \
@@ -1254,7 +1283,7 @@ source = (
     "read-assay-release-tag)\\.sh|scripts/ci/lib/workspace_version\\.py|"
     "scripts/docs/generate-agent-golden-path\\.py|\\.github/assay-release-tag|"
     "\\.(agents|claude)/skills/"
-    "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*)$\n"
+    "assay-golden-path/SKILL\\.md|\\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*)$\n"
 )
 replacement = "        stages: [pre-push]\n" + source
 text = path.read_text(encoding="utf-8")

--- a/scripts/ci/test-agent-golden-path-skill.py
+++ b/scripts/ci/test-agent-golden-path-skill.py
@@ -1250,6 +1250,7 @@ def main() -> None:
         '.claude/**',
         '.claude-plugin/**',
         'packaging/claude-plugin/**',
+        'packaging/agent-plugin/**',
         '.gitignore',
         '.gitattributes',
         '.pre-commit-config.yaml',
@@ -1280,6 +1281,8 @@ def main() -> None:
         ".claude-plugin/marketplace.json",
         "packaging/claude-plugin/.mcp.json",
         "packaging/claude-plugin/skills/assay-golden-path/SKILL.md",
+        "packaging/agent-plugin/plugin.json",
+        "packaging/agent-plugin/skills/assay-golden-path/SKILL.md",
     )
     for hook_id in ("docs-generated-drift", "agent-golden-path-skill-contract"):
         contract_hook = parse_precommit_hook(precommit_text, hook_id, hook_id)

--- a/scripts/ci/test-generate-agent-golden-path-check.py
+++ b/scripts/ci/test-generate-agent-golden-path-check.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from pathlib import Path
 import subprocess
 import sys
@@ -15,6 +17,10 @@ STAGING = ROOT / "scripts/ci/lib/golden-path-fixture-staging.sh"
 GUIDE = Path("docs/guides/agent-golden-path.md")
 GUIDE_TABLE_START = "<!-- agent-golden-path-table:start -->"
 UNKNOWN_ARGUMENT = "--not-a-real-flag"
+PORTABLE_SCHEMA = Path("packaging/agent-plugin/schemas/plugin.schema.json")
+PORTABLE_SCHEMA_LOCK = Path("packaging/agent-plugin/schemas/plugin.schema.lock.json")
+PORTABLE_SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+PORTABLE_SCHEMA_SHA256 = "0a4aad95ce337878ad38802ebf0daa3fde76abe3f65400c86bcbb1ec0b3ab883"
 # Closed public inventory. Do not build this from rendered_outputs().
 GENERATED_OUTPUTS = (
     Path("docs/generated/agent-golden-path.json"),
@@ -35,6 +41,23 @@ GENERATED_OUTPUTS = (
     ),
     Path(
         "packaging/claude-plugin/skills/assay-golden-path/assets/"
+        "privileged-action-gate/policies/no-allowance.yaml"
+    ),
+    Path("packaging/agent-plugin/plugin.json"),
+    Path("packaging/agent-plugin/skills/assay-golden-path/SKILL.md"),
+    Path(
+        "packaging/agent-plugin/skills/assay-golden-path/references/agent-golden-path.json"
+    ),
+    Path(
+        "packaging/agent-plugin/skills/assay-golden-path/assets/"
+        "privileged-action-gate/mock_github_mcp.py"
+    ),
+    Path(
+        "packaging/agent-plugin/skills/assay-golden-path/assets/"
+        "privileged-action-gate/baseline-approved.json"
+    ),
+    Path(
+        "packaging/agent-plugin/skills/assay-golden-path/assets/"
         "privileged-action-gate/policies/no-allowance.yaml"
     ),
 )
@@ -124,6 +147,20 @@ def check_in_sync_is_clean(root: Path) -> None:
         fail("--check modified an in-sync tree")
 
 
+def check_portable_schema_lock(root: Path) -> None:
+    schema = (root / PORTABLE_SCHEMA).read_bytes()
+    lock = json.loads((root / PORTABLE_SCHEMA_LOCK).read_text(encoding="utf-8"))
+    expected = {
+        "canonical_url": PORTABLE_SCHEMA_URL,
+        "sha256": PORTABLE_SCHEMA_SHA256,
+        "bytes": len(schema),
+    }
+    if lock != expected:
+        fail("portable Agent Plugin schema lock does not match its pinned contract")
+    if hashlib.sha256(schema).hexdigest() != PORTABLE_SCHEMA_SHA256:
+        fail("portable Agent Plugin schema bytes differ from the pinned contract")
+
+
 def check_rejects_unknown_argument(root: Path) -> None:
     before = snapshot_tree(root)
     result = run_generator(root, [UNKNOWN_ARGUMENT])
@@ -163,6 +200,20 @@ def apply_omit_plugin_skill_outputs(root: Path) -> None:
     if text.count(anchor) != 1:
         fail("omission mutation could not find PLUGIN_SKILL_OUTPUTS render line")
     path.write_text(text.replace(anchor, "", 1), encoding="utf-8")
+
+
+def apply_omit_portable_skill_output(root: Path) -> None:
+    path = root / GENERATOR
+    text = path.read_text(encoding="utf-8")
+    anchor = '        (PORTABLE_SKILL_OUTPUT, rendered_portable_skill.encode("ascii")),\n'
+    if text.count(anchor) != 1:
+        fail("omission mutation could not find portable skill render line")
+    path.write_text(text.replace(anchor, "", 1), encoding="utf-8")
+
+
+def apply_portable_schema_byte_mutation(root: Path) -> None:
+    path = root / PORTABLE_SCHEMA
+    path.write_bytes(path.read_bytes() + b"\n")
 
 
 def expect_pins_reject(name: str, mutate) -> None:
@@ -214,11 +265,26 @@ def expect_omission_rejects(name: str, mutate) -> None:
         fail(f"{name}: self-test accepted omitted generated output group")
 
 
+def expect_schema_lock_rejects(name: str, mutate) -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        seed_case(root)
+        mutate(root)
+        try:
+            check_portable_schema_lock(root)
+        except SystemExit as error:
+            if "pinned contract" in str(error):
+                return
+            raise
+        fail(f"{name}: self-test accepted modified portable schema bytes")
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
         seed_case(root)
         check_in_sync_is_clean(root)
+        check_portable_schema_lock(root)
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
         seed_case(root)
@@ -232,6 +298,12 @@ def main() -> None:
     expect_unknown_pin_rejects("ignored unknown argument", apply_silent_repair_mutation)
     expect_omission_rejects(
         "omit PLUGIN_SKILL_OUTPUTS", apply_omit_plugin_skill_outputs
+    )
+    expect_omission_rejects(
+        "omit PORTABLE_SKILL_OUTPUT", apply_omit_portable_skill_output
+    )
+    expect_schema_lock_rejects(
+        "portable schema byte drift", apply_portable_schema_byte_mutation
     )
     print("golden-path generator --check: compares bytes, names drift, rejects unknown argv")
 

--- a/scripts/docs/generate-agent-golden-path.py
+++ b/scripts/docs/generate-agent-golden-path.py
@@ -24,6 +24,10 @@ SKILL_OUTPUTS = (
 PLUGIN_SKILL_OUTPUTS = (
     ROOT / "packaging/claude-plugin/skills/assay-golden-path/SKILL.md",
 )
+PORTABLE_PLUGIN_ROOT = ROOT / "packaging/agent-plugin"
+PORTABLE_SKILL_OUTPUT = (
+    PORTABLE_PLUGIN_ROOT / "skills/assay-golden-path/SKILL.md"
+)
 PLUGIN_CONTRACT_OUTPUT = (
     ROOT
     / "packaging/claude-plugin/skills/assay-golden-path/references/agent-golden-path.json"
@@ -31,6 +35,7 @@ PLUGIN_CONTRACT_OUTPUT = (
 PLUGIN_ASSET_ROOT = (
     "${CLAUDE_PLUGIN_ROOT}/skills/assay-golden-path/assets/privileged-action-gate"
 )
+PORTABLE_ASSET_ROOT = "assets/privileged-action-gate"
 PLUGIN_RESOURCE_COPIES = (
     (JSON_OUTPUT, PLUGIN_CONTRACT_OUTPUT),
     (
@@ -47,6 +52,28 @@ PLUGIN_RESOURCE_COPIES = (
         ROOT / "examples/privileged-action-gate/policies/no-allowance.yaml",
         ROOT
         / "packaging/claude-plugin/skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml",
+    ),
+)
+PORTABLE_RESOURCE_COPIES = (
+    (
+        JSON_OUTPUT,
+        PORTABLE_PLUGIN_ROOT
+        / "skills/assay-golden-path/references/agent-golden-path.json",
+    ),
+    (
+        ROOT / "examples/privileged-action-gate/mock_github_mcp.py",
+        PORTABLE_PLUGIN_ROOT
+        / "skills/assay-golden-path/assets/privileged-action-gate/mock_github_mcp.py",
+    ),
+    (
+        ROOT / "examples/privileged-action-gate/baseline-approved.json",
+        PORTABLE_PLUGIN_ROOT
+        / "skills/assay-golden-path/assets/privileged-action-gate/baseline-approved.json",
+    ),
+    (
+        ROOT / "examples/privileged-action-gate/policies/no-allowance.yaml",
+        PORTABLE_PLUGIN_ROOT
+        / "skills/assay-golden-path/assets/privileged-action-gate/policies/no-allowance.yaml",
     ),
 )
 MAX_PLUGIN_RESOURCE_BYTES = 1024 * 1024
@@ -728,7 +755,9 @@ def render_markdown(current: str) -> str:
     )
 
 
-def render_skill(*, plugin: bool = False) -> str:
+def render_skill(*, plugin: bool = False, portable: bool = False) -> str:
+    if plugin and portable:
+        raise ValueError("a skill cannot be both Claude-specific and portable")
     lines = [
         "---",
         "name: assay-golden-path",
@@ -761,6 +790,27 @@ def render_skill(*, plugin: bool = False) -> str:
                 "",
             ]
         )
+    elif portable:
+        lines.extend(
+            [
+                "`references/agent-golden-path.json` is the authoritative machine contract bundled with this skill.",
+                "Read it when exact argv, fields, or per-outcome metadata are needed.",
+                "Resolve `references/` and `assets/` paths relative to this SKILL.md directory.",
+                "",
+                INVOCATION_CWD_RULE,
+                "Protected-action fixtures named by the contract are bundled at "
+                f"`{PORTABLE_ASSET_ROOT}`.",
+                "A present `working_directory` in the contract resolves through that mapping.",
+                PYTHON_PLACEHOLDER_RULE,
+                "",
+                f"{EMPTY_STDOUT_RULE}",
+                "Do not replace a linked gap with an inferred clean result.",
+                "",
+                "This package uses the Agent Plugins 1.0.0 portable skill layout.",
+                "Host discovery and marketplace acceptance require separate evidence.",
+                "",
+            ]
+        )
     else:
         lines.extend(
             [
@@ -788,7 +838,12 @@ def render_skill(*, plugin: bool = False) -> str:
         lines.extend([f"### {step['step']}. {step['label']}", ""])
         working_directory = step.get("working_directory")
         if working_directory is not None:
-            rendered_working_directory = PLUGIN_ASSET_ROOT if plugin else working_directory
+            if plugin:
+                rendered_working_directory = PLUGIN_ASSET_ROOT
+            elif portable:
+                rendered_working_directory = PORTABLE_ASSET_ROOT
+            else:
+                rendered_working_directory = working_directory
             lines.extend([f"Working directory: `{rendered_working_directory}`", ""])
         lines.extend(
             [
@@ -837,6 +892,7 @@ def rendered_outputs() -> list[tuple[Path, bytes]]:
     rendered_markdown = render_markdown(current)
     rendered_skill = render_skill()
     rendered_plugin_skill = render_skill(plugin=True)
+    rendered_portable_skill = render_skill(portable=True)
     rendered_contract = (json.dumps(CONTRACT, indent=2, ensure_ascii=True) + "\n").encode(
         "ascii"
     )
@@ -845,8 +901,29 @@ def rendered_outputs() -> list[tuple[Path, bytes]]:
         (MARKDOWN_OUTPUT, rendered_markdown.encode("utf-8")),
         *[(output, rendered_skill.encode("ascii")) for output in SKILL_OUTPUTS],
         *[(output, rendered_plugin_skill.encode("ascii")) for output in PLUGIN_SKILL_OUTPUTS],
+        (PORTABLE_SKILL_OUTPUT, rendered_portable_skill.encode("ascii")),
+        (
+            PORTABLE_PLUGIN_ROOT / "plugin.json",
+            (
+                json.dumps(
+                    {
+                        "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+                        "name": "assay",
+                        "version": read_workspace_version(ROOT / "Cargo.toml"),
+                        "description": "Operate Assay's install-to-evidence golden path with explicit failure boundaries.",
+                        "author": {"name": "Assay"},
+                        "homepage": "https://getassay.dev",
+                        "repository": "https://github.com/Rul1an/assay",
+                        "license": "MIT",
+                    },
+                    indent=2,
+                    ensure_ascii=True,
+                )
+                + "\n"
+            ).encode("ascii"),
+        ),
     ]
-    for source, output in PLUGIN_RESOURCE_COPIES:
+    for source, output in (*PLUGIN_RESOURCE_COPIES, *PORTABLE_RESOURCE_COPIES):
         payload = (
             rendered_contract if source == JSON_OUTPUT else read_plugin_resource(source)
         )


### PR DESCRIPTION
## Summary

- add a separate Agent Plugins 1.0.0 skills-only package at `packaging/agent-plugin/`
- generate its manifest, skill, contract and assets from the existing golden-path source
- vendor and lock the official 1.0.0 plugin schema for offline validation
- extend generated-surface, pre-commit and workflow guards to cover the portable package
- deliberately omit `mcp.json` until a portable consumer-project policy-root contract exists

Closes #2384. Clean local Cursor 3.16.21 discovery and manual skill invocation were measured on implementation head `161b72f12d2c0f187bfbbfcbc3b937d1b61fb449`; the package bytes are unchanged on merge head `f2cebd4df78c84d9ada0ff4c31e68a93530c5d70`.

## Contract

- package manifest validates offline against exact 1,805-byte schema SHA-256 `0a4aad95ce337878ad38802ebf0daa3fde76abe3f65400c86bcbb1ec0b3ab883`
- schema loading cannot use the network
- package inventory is closed to 8 regular files and no symlinks
- portable skill contains only package-relative `references/` and `assets/` paths
- no Claude, project-root, source-tree, or host-specific path leaks into the portable skill
- no `mcp.json`, portable MCP, marketplace, or binary-bundling claim

## TDD / mutations

RED was observed after the new Rust contract compiled: both tests failed because `packaging/agent-plugin/` and the vendored schema did not exist.

GREEN on exact head `fd77cb3e1fae182b3b69f743935c82c4e1586d55`:

- missing `$schema` rejected
- unknown closed-schema field rejected
- uppercase plugin name rejected
- generated skill byte drift named and rejected
- portable generated-output omission rejected
- schema byte drift rejected by digest lock
- `mcp.json` or any extra package file rejected by closed inventory
- removal/commenting of `packaging/agent-plugin/**` workflow coverage rejected
- removal of the portable surface from either generated-surface hook rejected

## Verification

- `python3 scripts/docs/generate-agent-golden-path.py --check`
- `python3 scripts/ci/test-generate-agent-golden-path-check.py`
- `python3 scripts/ci/test-agent-golden-path-skill.py`
- `python3 scripts/ci/test-golden-path-mock-bounds.py`
- `bash scripts/ci/test-agent-golden-path-skill-hardening.sh` — 100 cases, 23 structural probes
- `cargo test -p assay-cli --test agent_plugin_package_contract` — 2 passed
- `cargo test -p assay-cli --test agent_golden_path_contract` — 33 passed, 1 ignored helper
- `cargo fmt --all -- --check`
- `cargo clippy -p assay-cli --tests -- -D warnings`
- pre-commit selected-file run — passed
- pre-push hooks — passed, including workspace clippy and Linux cross-target compile
- `git diff --check`

Package archive SHA-256 from this commit: `538f63bba838a552062bb7aff8fe4a5c0d18c9326bc9a0e03b13d299c6fa22c5`.

## Review inputs

Hot files:

- `scripts/docs/generate-agent-golden-path.py`
- `crates/assay-cli/tests/agent_plugin_package_contract.rs`
- `scripts/ci/test-agent-golden-path-skill-hardening.sh`
- `packaging/agent-plugin/plugin.json`
- `packaging/agent-plugin/skills/assay-golden-path/SKILL.md`

Primary specifications rechecked on 2026-08-16:

- https://agent-plugins.org/specification
- https://agent-plugins.org/compatible-clients
- https://cursor.com/docs/plugins

## Pending / non-claims

- clean local Cursor load and skill discovery are pending because the desktop host was locked during final verification
- no Cursor Marketplace listing or approval
- no Claude Code compatibility claim from this Agent Plugin package
- no portable MCP process, project-root inference, MCP Roots dependency, rules, agents, commands, hooks or variables
- no bundled Assay binary



## Final-head evidence

- independent READY review: `161b72f12d2c0f187bfbbfcbc3b937d1b61fb449`
- conflict-free review carry to merge head `f2cebd4df78c84d9ada0ff4c31e68a93530c5d70`: identical merge-tree and zero reviewed-file overlap
- review findings dispositioned in #2406
- required CI, host capability and delegated-proof checks must be green on the merge head before merge
