### PR TITLE
test(mcp): harden policy ingest contracts

### DIFF
--- a/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
+++ b/crates/assay-mcp-server/tests/policy_diagnostic_safety.rs
@@ -9,7 +9,7 @@
 //! 4. `error.message` byte length ≤ 4096.
 //! 5. No temporary path or policy path leaks into the full JSON-RPC response.
 //! 6. Positive numeric `details.line`/`details.column` required for syntax errors.
-//! 7. Invalid UTF-8 through real `assay_check_args` → `E_POLICY_PARSE` / `Policy YAML is invalid`.
+//! 7. Invalid UTF-8 through all five policy tools stays value-free `E_POLICY_PARSE`.
 
 use serde_json::Value;
 use std::fs;
@@ -279,6 +279,9 @@ fn policy_decide_args(policy: &str) -> Value {
 }
 fn check_args_args(policy: &str) -> Value {
     serde_json::json!({"tool": "any_tool", "arguments": {}, "policy": policy})
+}
+fn check_sequence_args(policy: &str) -> Value {
+    serde_json::json!({"history": [], "next_tool": "any_tool", "policy": policy})
 }
 fn check_coverage_args(policy: &str) -> Value {
     serde_json::json!({"policy": policy, "traces": [{"tools": ["any_tool"]}]})
@@ -568,35 +571,59 @@ fn syntax_error_requires_positive_numeric_location() {
 // ── Invalid UTF-8 (gap 7 — discriminating, not vacuous) ────────────────
 
 #[test]
-fn invalid_utf8_classifies_as_yaml_syntax_error() {
+fn invalid_utf8_is_value_free_policy_parse_for_all_five_tools() {
     let dir = tempfile::tempdir().expect("policy-root");
     let root = dir.path();
     write_policy(root, "bad-utf8.yaml", &[0xFF, 0xFE, b'v', b':', b' ', b'1']);
 
     let mut conn = spawn_server(root);
     initialize(&mut conn);
-    let (result, body, full) = call_tool(
-        &mut conn,
-        "assay_check_args",
-        check_args_args("bad-utf8.yaml"),
-        2,
-    );
+    let cases: [(&str, Value, &str); 5] = [
+        (
+            "assay_policy_decide",
+            policy_decide_args("bad-utf8.yaml"),
+            YAML_INVALID,
+        ),
+        (
+            "assay_check_args",
+            check_args_args("bad-utf8.yaml"),
+            YAML_INVALID,
+        ),
+        (
+            "assay_check_sequence",
+            check_sequence_args("bad-utf8.yaml"),
+            "Invalid sequence policy format",
+        ),
+        (
+            "assay_check_coverage",
+            check_coverage_args("bad-utf8.yaml"),
+            YAML_INVALID,
+        ),
+        (
+            "assay_explain_trace",
+            explain_trace_args("bad-utf8.yaml"),
+            YAML_INVALID,
+        ),
+    ];
 
-    assert_parse_error(
-        "invalid-utf8",
-        &result,
-        &body,
-        &full,
-        YAML_INVALID,
-        root,
-        "bad-utf8.yaml",
-    );
-
-    // Must not contain raw UTF-8 error diagnostic
-    assert!(
-        !full.contains("invalid utf-8") && !full.contains("Utf8Error"),
-        "response must not contain raw UTF-8 diagnostic"
-    );
+    for (index, (tool, arguments, expected_message)) in cases.into_iter().enumerate() {
+        let (result, body, full) = call_tool(&mut conn, tool, arguments, index as u64 + 2);
+        assert_parse_error(
+            tool,
+            &result,
+            &body,
+            &full,
+            expected_message,
+            root,
+            "bad-utf8.yaml",
+        );
+        assert!(
+            !full.contains("invalid utf-8")
+                && !full.contains("Utf8Error")
+                && !full.contains('\u{fffd}'),
+            "{tool}: response must not contain raw or lossy UTF-8 diagnostics: {full}"
+        );
+    }
 
     let _ = conn.shutdown();
 }

--- a/scripts/ci/check-mcp-policy-yaml-routing.py
+++ b/scripts/ci/check-mcp-policy-yaml-routing.py
@@ -111,14 +111,14 @@ def require(errors: list[str], source: str, fragment: str, label: str) -> None:
         errors.append(f"{label}: expected one effective {fragment!r}, found {actual}")
 
 
-def check(root: Path) -> bool:
-    guarded_roots = [root / SERVER, root / CORE]
+def check() -> bool:
+    guarded_roots = [SERVER, CORE]
     rust_files = sorted(path for base in guarded_roots for path in base.rglob("*.rs"))
     if not rust_files:
         print("FAIL: guarded Rust sources not found", file=sys.stderr)
         return False
 
-    sources = {path.relative_to(root): path.read_text() for path in rust_files}
+    sources = {path: path.read_text() for path in rust_files}
     errors: list[str] = []
     allowed_parser_calls = {
         SERVER / "mod.rs": ["serde_yaml::from_slice", "serde_yaml::from_value"],
@@ -186,5 +186,7 @@ def check(root: Path) -> bool:
 
 
 if __name__ == "__main__":
-    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
-    raise SystemExit(0 if check(repo_root) else 1)
+    if len(sys.argv) != 1:
+        print(f"usage: {Path(sys.argv[0]).name}", file=sys.stderr)
+        raise SystemExit(1)
+    raise SystemExit(0 if check() else 1)

--- a/scripts/ci/test-check-mcp-policy-parser-delegation.sh
+++ b/scripts/ci/test-check-mcp-policy-parser-delegation.sh
@@ -38,6 +38,15 @@ mkdir -p "$TMPDIR/base/crates/assay-core/src/mcp/policy"
 cp "${FILES[0]}" "$TMPDIR/base/crates/assay-core/src/mcp/policy/"
 cp "${FILES[1]}" "$TMPDIR/base/crates/assay-core/src/mcp/policy/"
 
+if ! (
+  cd "$TMPDIR/base"
+  python3 "$GUARD"
+); then
+  echo "FAIL: unmutated parser scratch copy must pass before mutations are scored" >&2
+  exit 1
+fi
+echo "PASS: unmutated parser scratch copy passes from its own cwd"
+
 mutant() {
   local name=$1
   local mutation=$2

--- a/scripts/ci/test-check-mcp-policy-reader-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-reader-routing.sh
@@ -36,6 +36,15 @@ trap 'rm -rf "$TMPDIR"' EXIT
 mkdir -p "$TMPDIR/base/crates/assay-mcp-server/src"
 cp -R "${FILES[0]}" "$TMPDIR/base/crates/assay-mcp-server/src/"
 
+if ! (
+  cd "$TMPDIR/base"
+  python3 "$GUARD"
+); then
+  echo "FAIL: unmutated reader scratch copy must pass before mutations are scored" >&2
+  exit 1
+fi
+echo "PASS: unmutated reader scratch copy passes from its own cwd"
+
 mutant() {
   local name=$1
   local mutation=$2

--- a/scripts/ci/test-check-mcp-policy-yaml-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-yaml-routing.sh
@@ -1,20 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GUARD="scripts/ci/check-mcp-policy-yaml-routing.py"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/check-mcp-policy-yaml-routing.py"
 FILES=(
   crates/assay-mcp-server/src/tools
   crates/assay-core/src/mcp/policy
 )
 
-python3 "$GUARD"
-echo "PASS: guard accepts the production routes"
+if ! python3 "$GUARD"; then
+  echo "FAIL: YAML guard must accept zero args from the allowlisted cwd" >&2
+  exit 1
+fi
+echo "PASS: YAML guard accepts zero args from the allowlisted cwd"
+
+for rejected_arg in extra --stdin .; do
+  if python3 "$GUARD" "$rejected_arg" 2>/dev/null; then
+    echo "FAIL: YAML guard must reject argv value: $rejected_arg" >&2
+    exit 1
+  fi
+done
+echo "PASS: YAML guard rejects every tested argv shape"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 mkdir -p "$TMPDIR/base/crates/assay-mcp-server/src" "$TMPDIR/base/crates/assay-core/src/mcp"
 cp -R "${FILES[0]}" "$TMPDIR/base/crates/assay-mcp-server/src/"
 cp -R "${FILES[1]}" "$TMPDIR/base/crates/assay-core/src/mcp/"
+
+if ! (
+  cd "$TMPDIR/base"
+  python3 "$GUARD"
+); then
+  echo "FAIL: unmutated scratch copy must pass before mutations are scored" >&2
+  exit 1
+fi
+echo "PASS: unmutated scratch copy passes from its own cwd"
 
 mutant() {
   local name=$1
@@ -24,7 +45,10 @@ mutant() {
   "$mutation" "$TMPDIR/current"
   local output status
   set +e
-  output=$(python3 "$GUARD" "$TMPDIR/current" 2>&1)
+  output=$(
+    cd "$TMPDIR/current"
+    python3 "$GUARD" 2>&1
+  )
   status=$?
   set -e
   if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- make the MCP YAML-routing guard zero-argument and cwd-relative, matching its sibling guards
- add unmutated scratch-tree positive controls to all three policy architecture mutation harnesses
- pin invalid UTF-8 to value-free `E_POLICY_PARSE` responses through all five advertised policy tools

Closes #2399.

## Scope

Test and guard hardening only. No production parser, schema, protocol, cache, error-code, or byte-ceiling changes.

## TDD and mutation evidence

Measured at exact head `5a867c53960f31e59f80cf6d28a02dde5317204c` in `/Users/roelschuurkes/wt-2399-mcp-test-hardening` with Rust 1.96.0:

- RED: the strengthened YAML harness failed because the old guard accepted positional `.`.
- GREEN: all three guards accept zero args, reject tested argv shapes, and pass from their copied scratch cwd before mutations.
- Existing routing mutations: reader 4/4, parser delegation 2/2, YAML routing 7/7 caught.
- Discriminating UTF-8 mutation: changing only the `assay_check_sequence` stable parse summary made the five-tool live-stdio test fail with exit 101 on the expected assertion.

## Verification

- `cargo test -p assay-mcp-server --test policy_diagnostic_safety -- --nocapture` (12 passed)
- all three `scripts/ci/test-check-mcp-policy-*.sh` harnesses
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- targeted pre-commit hooks and full pre-push hooks
- `git diff --check`

## Non-claims

- text-shape architecture guards are not Rust data-flow analysis
- no new UTF-8 behavior is introduced; the test pins existing behavior
- no production behavior or public protocol surface changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy-tool error handling for invalid UTF-8 input.
  * Policy parsing errors now return consistent, value-free diagnostics without exposing raw or corrupted input content.
  * Ensured sequence checks provide the appropriate policy parsing summary.

* **Tests**
  * Expanded validation across all policy tools and execution contexts.
  * Added coverage confirming routing and parser checks pass in clean baseline conditions and correctly reject invalid invocation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->