### PR TITLE
fix(cli): classify doctor argument refusals as invalid args

### DIFF
--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -28,6 +28,7 @@ exclude = [
     "tests/doctor_config_check_contract.rs",
     "tests/init_stdout_contract.rs",
     "tests/doctor_exit_class_contract.rs",
+    "tests/doctor_argument_contract.rs",
     "tests/recovery_argv_publisher_parity.rs",
 ]
 

--- a/crates/assay-cli/src/cli/commands/doctor/implementation.rs
+++ b/crates/assay-cli/src/cli/commands/doctor/implementation.rs
@@ -8,7 +8,7 @@ use crate::cli::args::DoctorArgs;
 use crate::cli::helpers::decide_exit;
 use crate::diagnostics;
 use crate::diagnostics::format::format_text;
-use crate::exit_codes::{reason_for_unloadable_explicit_config, RunOutcome};
+use crate::exit_codes::{reason_for_unloadable_explicit_config, ReasonCode, RunOutcome};
 
 use super::fixes::run_doctor_fix;
 use super::parse_error::try_fix_parse_error;
@@ -51,6 +51,13 @@ const NO_CONFIG_FOUND: &str = "No config found; run inside project or use --conf
 /// mean what. `reason` accompanies the two states that produced no diagnostics; on `failed` it
 /// restates `config_error.message` from the same value rather than deriving a second one, because
 /// the registered diagnosis stays the carrier a consumer branches on.
+fn config_check_skipped(reason: &str) -> serde_json::Value {
+    serde_json::json!({
+        "status": "skipped",
+        "reason": reason,
+    })
+}
+
 fn config_check_marker(checked: bool, error: Option<&str>) -> serde_json::Value {
     match (checked, error) {
         (_, Some(message)) => serde_json::json!({
@@ -58,21 +65,77 @@ fn config_check_marker(checked: bool, error: Option<&str>) -> serde_json::Value 
             "reason": message,
         }),
         (true, None) => serde_json::json!({ "status": "checked" }),
-        (false, None) => serde_json::json!({
-            "status": "skipped",
-            "reason": NO_CONFIG_FOUND,
-        }),
+        (false, None) => config_check_skipped(NO_CONFIG_FOUND),
     }
 }
 
-pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
-    if args.fix && args.format == OutputFormat::Json {
-        eprintln!("doctor --fix currently supports text output only; use --format text");
-        return Ok(1);
+fn insert_outcome_fields(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    outcome: &RunOutcome,
+) {
+    obj.insert(
+        "reason_code".to_string(),
+        serde_json::json!(outcome.reason_code),
+    );
+    obj.insert(
+        "next_step".to_string(),
+        serde_json::json!(outcome.next_step),
+    );
+}
+
+/// The one decision for a combination this command refuses itself.
+///
+/// Both channels read this outcome. The text path keeps the existing rejection line on stderr;
+/// the JSON path publishes the same identity on `assay.doctor_report.v0`. The class comes from
+/// `EInvalidArgs`, so a clap refusal and a command refusal of the same category no longer
+/// disagree about the integer.
+fn invalid_argument_outcome(args: &DoctorArgs) -> Option<RunOutcome> {
+    let message = if args.fix && args.format == OutputFormat::Json {
+        "doctor --fix currently supports text output only; use --format text"
+    } else if (args.yes || args.dry_run) && !args.fix {
+        "doctor: --yes/--dry-run require --fix"
+    } else {
+        return None;
+    };
+    Some(RunOutcome::from_reason(
+        ReasonCode::EInvalidArgs,
+        Some(message.to_string()),
+        None,
+    ))
+}
+
+fn reject_invalid_args(format: OutputFormat, outcome: RunOutcome) -> anyhow::Result<i32> {
+    if format == OutputFormat::Json {
+        let report = diagnostics::probe_system();
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        let mut json_out = serde_json::to_value(&report)?;
+        if let Some(obj) = json_out.as_object_mut() {
+            obj.insert("generated_at".to_string(), serde_json::json!(timestamp));
+            let skip_reason = outcome
+                .message
+                .as_deref()
+                .unwrap_or(outcome.reason_code.as_str());
+            obj.insert(
+                "config_check".to_string(),
+                config_check_skipped(skip_reason),
+            );
+            insert_outcome_fields(obj, &outcome);
+            if let Some(message) = &outcome.message {
+                obj.insert("message".to_string(), serde_json::json!(message));
+            }
+        }
+        println!("{}", serde_json::to_string_pretty(&json_out)?);
+        return Ok(outcome.exit_code);
     }
-    if (args.yes || args.dry_run) && !args.fix {
-        eprintln!("doctor: --yes/--dry-run require --fix");
-        return Ok(1);
+    if let Some(message) = &outcome.message {
+        eprintln!("{message}");
+    }
+    Ok(outcome.exit_code)
+}
+
+pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
+    if let Some(outcome) = invalid_argument_outcome(&args) {
+        return reject_invalid_args(args.format, outcome);
     }
 
     // 1. Unified System Diagnostics
@@ -118,14 +181,7 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
 
             if let Some(err) = &cfg_err {
                 let outcome = config_failure(&target_path, err);
-                obj.insert(
-                    "reason_code".to_string(),
-                    serde_json::json!(outcome.reason_code),
-                );
-                obj.insert(
-                    "next_step".to_string(),
-                    serde_json::json!(outcome.next_step),
-                );
+                insert_outcome_fields(obj, &outcome);
                 obj.insert(
                     "config_error".to_string(),
                     serde_json::json!({

--- a/crates/assay-cli/tests/doctor_argument_contract.rs
+++ b/crates/assay-cli/tests/doctor_argument_contract.rs
@@ -1,0 +1,152 @@
+//! `assay doctor` argument rejections use the invalid-args class (#2208).
+//!
+//! Three combinations are refused by the command rather than by clap, and each used to return
+//! the test-failure class (`1`) with empty stdout. The same binary, refusing `--format nonsense`
+//! one layer earlier, already returns the config/usage class (`2`). The class must come from
+//! `ReasonCode::EInvalidArgs`, not from a literal, and must not depend on which layer refused.
+//!
+//! All three process channels are watched. `--fix --format json` asked for Doctor's machine
+//! document, which `diagnostics::report` names `assay.doctor_report.v0`; that request gets
+//! exactly one such report on stdout, empty stderr, and the invalid-args exit. `--yes` and
+//! `--dry-run` did not request a machine format, so they keep the human rejection line and
+//! empty stdout.
+
+#[path = "../../../tests/support/bounded_process.rs"]
+#[allow(dead_code)]
+mod bounded_process;
+
+use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
+use serde_json::Value;
+use std::process::{Command, Output};
+
+const DOCTOR_REPORT_SCHEMA: &str = "assay.doctor_report.v0";
+
+fn doctor(args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command.env("NO_COLOR", "1").arg("doctor").args(args);
+    run_bounded(command, b"", GOLDEN_PATH_LIMITS, "assay doctor").expect("doctor ran")
+}
+
+fn exit_code(output: &Output) -> i32 {
+    output
+        .status
+        .code()
+        .expect("doctor exited by code rather than by signal")
+}
+
+/// Parses the whole of stdout, not a fragment of it.
+fn sole_report(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "doctor --fix --format json stdout is not one JSON document: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[test]
+fn fix_format_json_publishes_the_doctor_report_invalid_args_outcome() {
+    let output = doctor(&["--fix", "--format", "json"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        exit_code(&output),
+        2,
+        "doctor --fix --format json must return the invalid-args class; stderr={stderr}"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "machine rejection must not also write a human line; stderr={stderr}"
+    );
+    let document = sole_report(&output);
+    assert_eq!(
+        document["schema"], DOCTOR_REPORT_SCHEMA,
+        "machine rejection must stay on Doctor's existing report identity; stdout={stdout}"
+    );
+    assert_eq!(document["reason_code"], "E_INVALID_ARGS");
+    let next_step = document["next_step"]
+        .as_str()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    assert!(
+        !next_step.is_empty(),
+        "doctor report must carry a non-empty next_step; document={document}"
+    );
+    assert_eq!(
+        document["config_check"]["status"], "skipped",
+        "invalid args must not be reported as a config that was read; document={document}"
+    );
+    let skip_reason = document["config_check"]["reason"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        !skip_reason.trim().is_empty(),
+        "a skipped check must name why it was skipped; document={document}"
+    );
+    assert_ne!(
+        skip_reason, "No config found; run inside project or use --config",
+        "skipped because the combination is invalid, not because no config was found"
+    );
+    assert!(
+        skip_reason.contains("--fix") || skip_reason.contains("format"),
+        "skipped reason must name the invalid combination; reason={skip_reason:?}"
+    );
+}
+
+#[test]
+fn text_channel_rejections_keep_prose_and_empty_stdout() {
+    for args in [&["--yes"][..], &["--dry-run"][..]] {
+        let output = doctor(args);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            exit_code(&output),
+            2,
+            "doctor {} must return the invalid-args class; stderr={stderr}",
+            args.join(" ")
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "doctor {} requested no machine format; stdout={stdout}",
+            args.join(" ")
+        );
+        assert!(
+            stderr.contains("doctor: --yes/--dry-run require --fix"),
+            "doctor {} must keep the existing rejection line; stderr={stderr}",
+            args.join(" ")
+        );
+    }
+}
+
+/// Clap already refuses `doctor --format nonsense` with the config/usage class. The three
+/// command-layer refusals must share that process exit, not merely the literal `2` today's
+/// registry maps `EInvalidArgs` to — a remapping that updated the literals here would still
+/// leave clap and the command disagreeing.
+#[test]
+fn command_rejections_share_claps_invalid_format_class() {
+    let clap_exit = exit_code(&doctor(&["--format", "nonsense"]));
+    for args in [
+        &["--fix", "--format", "json"][..],
+        &["--yes"][..],
+        &["--dry-run"][..],
+    ] {
+        let got = exit_code(&doctor(args));
+        assert_eq!(
+            got,
+            clap_exit,
+            "doctor {} must share clap's class for doctor --format nonsense ({clap_exit})",
+            args.join(" ")
+        );
+    }
+}

--- a/crates/assay-cli/tests/doctor_fix_e2e.rs
+++ b/crates/assay-cli/tests/doctor_fix_e2e.rs
@@ -121,7 +121,7 @@ fn doctor_yes_without_fix_fails_fast() {
         .arg(&trace)
         .arg("--yes")
         .assert()
-        .code(1);
+        .code(2);
 
     assert!(
         !trace.exists(),

--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -78,8 +78,8 @@ invocation reaches, the row says so rather than describing it as behaviour.
 | Code | Meaning |
 |------|---------|
 | `0` | No error-severity diagnostic remains, or the fixes resolved them. Measured identical on the text channel, under `--format json` and under `--fix --yes`, because all three read the class from one function. It also covers the run that checked no config at all, so read `config_check.status` before `data_diagnostics[]`; see below. |
-| `1` | Argument misuse: `--fix` under `--format json`, or `--yes`/`--dry-run` without `--fix`. Both return `1` with nothing at all on stdout, from a literal rather than from the class table, and [#2208](https://github.com/Rul1an/assay/issues/2208) owns them — the same binary exits `2` for an argument it rejects one command over (`assay init --preset nonsense`). Also a config that will not load under `--fix` when no repair was applied: nothing auto-fixable, no safe replacement found, the offer declined, or a dry-run preview. That is [#2209](https://github.com/Rul1an/assay/issues/2209). |
-| `2` | Four conditions, and the same class in each case comes from something outside this command: an explicit `--config` that will not load with no `--fix`, or an error-severity diagnostic whose registered class is a config fault — what `assay validate` and `assay run` return for the same input; `--fix` unable to write a repair — what `assay fix` returns for a patch that fails to apply; and a repair that rewrote the config and left it still unloadable — the reason code for an unloadable config, which the parse-repair path reads too. |
+| `1` | A config that will not load under `--fix` when no repair was applied: nothing auto-fixable, no safe replacement found, the offer declined, or a dry-run preview. That is [#2209](https://github.com/Rul1an/assay/issues/2209). |
+| `2` | Five conditions. Argument misuse — `--fix` under `--format json`, or `--yes`/`--dry-run` without `--fix` — exits the invalid-args class. The JSON request publishes one `assay.doctor_report.v0` with `E_INVALID_ARGS`; the text request keeps the existing rejection on stderr and empty stdout. The other four come from something outside this command: an explicit `--config` that will not load with no `--fix`, or an error-severity diagnostic whose registered class is a config fault — what `assay validate` and `assay run` return for the same input; `--fix` unable to write a repair — what `assay fix` returns for a patch that fails to apply; and a repair that rewrote the config and left it still unloadable — the reason code for an unloadable config, which the parse-repair path reads too. |
 
 Four things the table does not say, which a reader would otherwise have to find out:
 
@@ -87,7 +87,7 @@ Four things the table does not say, which a reader would otherwise have to find 
   diagnostic whose registered class is not a config fault, and every code doctor names deliberately
   is registered a config fault. That leaves the bare `E_UNKNOWN` raised as a fallback for a trace
   error the mapper does not recognise, and no input reaching it has been constructed. So `1` means
-  argument misuse or #2209, not a verdict about a tree.
+  #2209, not a verdict about a tree. Argument misuse is the invalid-args class on `2`.
 - **One flag-dependence remains, and it is the config no repair changed.** `doctor --config nope.yaml`
   exits `2`; the same config under `--fix --yes` exits `1`, because that return reports the outcome
   of a repair offer rather than the state of the config. #2209 owns it. Every other pairing measured


### PR DESCRIPTION
## Summary

- classify Doctor's command-layer argument refusals through `ReasonCode::EInvalidArgs`
- keep human refusals on stderr while returning exit class `2`
- emit `assay.doctor_report.v0` with `E_INVALID_ARGS`, remediation, and an honest skipped config marker when JSON was requested
- update the existing E2E expectation and Doctor exit-code reference

Closes #2208.

## Contract

- `doctor --fix --format json`: exit `2`, empty stderr, exactly one Doctor report on stdout
- `doctor --yes` / `doctor --dry-run`: exit `2`, empty stdout, existing human stderr
- clap and command-layer argument refusals share the same exit class
- no new flags, global failure envelope, repair behavior, or #2209 behavior

## TDD and verification

Measured in `/Users/roelschuurkes/wt-2208-doctor-argument-contract`.

- RED on base `9ab42807b5ee2b1535d45e7e6ec07d32cdf274a6`: both new channel tests observed exit `1`
- GREEN on head `1a8af49787cffe955986cfa3125e3dbe46c0af8c`
- `cargo test -p assay-cli --test doctor_argument_contract -- --nocapture`
- `cargo test -p assay-cli`
- `cargo fmt --all -- --check`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `git diff --check`
- pre-push hooks, including workspace clippy and Linux cross-target compile gate

## Review focus

- Doctor report identity and `config_check` semantics
- registry-derived exit parity rather than a new literal
- unchanged config-failure and `--fix` repair paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `assay doctor` now returns the correct invalid-arguments exit code (`2`) for unsupported or conflicting options.
  - Human-readable errors remain clear for `--yes` and `--dry-run` misuse.
  - JSON output now consistently reports invalid arguments and configuration-loading failures with structured outcome details.
  - `--yes` without `--fix` now fails fast with exit code `2`.

- **Documentation**
  - Updated CLI reference documentation to clarify exit-code meanings, including argument errors, repair failures, and configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->