### PR TITLE
fix(mcp): reject file policy roots at startup

### DIFF
--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -228,6 +228,11 @@ impl Server {
         // Canonicalize root once
         let policy_root_canon = std::fs::canonicalize(&policy_root)
             .map_err(|e| anyhow::anyhow!("invalid --policy-root: {e}"))?;
+        anyhow::ensure!(
+            policy_root_canon.is_dir(),
+            "invalid --policy-root: not a directory: {}",
+            policy_root.display()
+        );
 
         let ctx = tools::ToolContext {
             policy_root,

--- a/crates/assay-mcp-server/tests/policy_root_startup.rs
+++ b/crates/assay-mcp-server/tests/policy_root_startup.rs
@@ -1,0 +1,17 @@
+use assay_mcp_server::config::ServerConfig;
+use assay_mcp_server::server::Server;
+
+#[tokio::test]
+async fn server_rejects_regular_file_as_policy_root() {
+    let root = tempfile::NamedTempFile::new().expect("temporary policy-root file");
+
+    let error = Server::run(root.path().to_path_buf(), ServerConfig::default())
+        .await
+        .expect_err("a policy root must be a directory");
+    let diagnostic = format!("{error:#}");
+
+    assert!(
+        diagnostic.contains("invalid --policy-root") && diagnostic.contains("not a directory"),
+        "diagnostic must classify the regular-file root: {diagnostic}"
+    );
+}


### PR DESCRIPTION
## Summary

- reject a regular file passed as `assay-mcp-server --policy-root` during startup
- preserve the existing auth-before-root refusal order
- add a behavioral regression test pinned to the public `Server::run` entrypoint

Closes #2408.

## Why

`canonicalize()` accepts files as well as directories. The server therefore exited 0 on closed stdin for a regular-file root and deferred failure to every later policy lookup. Startup now validates the canonical path is a directory.

## TDD evidence

Exact head: `d176c2a9f572a477dde0cee7995c80aeca0b526b`

RED before production change:

```text
server_rejects_regular_file_as_policy_root ... FAILED
a policy root must be a directory: ()
```

GREEN:

```text
cargo test -p assay-mcp-server --test policy_root_startup
cargo test -p assay-mcp-server --test server_run_auth_boundary
cargo test -p assay-mcp-server
cargo clippy -p assay-mcp-server --all-targets -- -D warnings
cargo fmt --all -- --check
git diff --check origin/main...HEAD
```

The full crate suite passed before the final rebase; focused behavior, auth-order, fmt, clippy, and diff checks were rerun after rebasing onto `main` merge `11d73dba4`.

## Contract

- roots that fail canonicalization keep the existing `invalid --policy-root: <io error>` path; directory readability is not validated by this slice;
- existing non-directory roots fail with `invalid --policy-root: not a directory: <path>`;
- valid directories and MCP tool semantics are unchanged;
- unsupported `ASSAY_AUTH_*` is still rejected before policy-root access.

## Non-claims

- no MCP preflight command (tracked in #2195);
- no path/PATHEXT or editor-host discovery claim;
- no change to policy lookup semantics after successful startup;
- `server_start` remains a process-start event emitted before policy-root validation, not a readiness signal (follow-up recorded on #2177).


