### PR TITLE
feat(cli): add assay mcp preflight PATH classifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "rand 0.8.7",
  "ratatui",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -29,6 +29,7 @@ exclude = [
     "tests/init_stdout_contract.rs",
     "tests/doctor_exit_class_contract.rs",
     "tests/doctor_argument_contract.rs",
+    "tests/mcp_preflight_contract.rs",
     "tests/recovery_argv_publisher_parity.rs",
 ]
 

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -105,6 +105,7 @@ tokio-stream = "0.1"
 futures = "0.3"
 globset = "0.4"
 libc = "0.2"
+semver = "1"
 once_cell = "1.21"
 nix = { version = "0.27", features = ["signal", "process", "fs", "ioctl"] }
 ratatui = { workspace = true, optional = true }

--- a/crates/assay-cli/src/cli/args/mcp.rs
+++ b/crates/assay-cli/src/cli/args/mcp.rs
@@ -1,6 +1,6 @@
 use super::ToolArgs;
 use crate::cli::commands::kill::KillArgs;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -23,6 +23,26 @@ pub enum McpSub {
     Kill(KillArgs),
     /// Sign and verify MCP tool definitions
     Tool(ToolArgs),
+    /// Check whether assay-mcp-server on PATH can start with this policy root
+    Preflight(PreflightArgs),
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PreflightFormat {
+    #[default]
+    Terminal,
+    Json,
+}
+
+#[derive(Parser, Clone, Debug)]
+pub struct PreflightArgs {
+    /// Directory the host would pass as --policy-root. Must exist and be a directory.
+    #[arg(long, default_value = ".")]
+    pub policy_root: PathBuf,
+
+    /// Report format
+    #[arg(long, value_enum, default_value_t = PreflightFormat::Terminal)]
+    pub format: PreflightFormat,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -88,10 +88,71 @@ fn mcp_group_accepts_canonical_paths_and_legacy_shims_are_removed() {
         })
     ));
 
+    let preflight = Cli::try_parse_from(["assay", "mcp", "preflight"])
+        .expect("canonical mcp preflight command should parse");
+    assert!(matches!(
+        preflight.cmd,
+        Command::Mcp(McpArgs {
+            cmd: McpSub::Preflight(_)
+        })
+    ));
+
     // The legacy top-level shims were retired; only the canonical `assay mcp ...` paths remain.
     assert!(Cli::try_parse_from(["assay", "discover", "--format", "json"]).is_err());
     assert!(Cli::try_parse_from(["assay", "kill", "proc-123"]).is_err());
     assert!(Cli::try_parse_from(["assay", "tool", "keygen", "--out", "keys"]).is_err());
+}
+
+#[test]
+fn mcp_preflight_defaults_to_dot_root_and_terminal_or_json() {
+    let defaults =
+        Cli::try_parse_from(["assay", "mcp", "preflight"]).expect("bare preflight should parse");
+    match defaults.cmd {
+        Command::Mcp(McpArgs {
+            cmd: McpSub::Preflight(args),
+        }) => {
+            assert_eq!(args.policy_root.as_os_str(), ".");
+            assert_eq!(args.format, PreflightFormat::Terminal);
+        }
+        _ => panic!("expected mcp preflight"),
+    }
+
+    let terminal = Cli::try_parse_from([
+        "assay",
+        "mcp",
+        "preflight",
+        "--policy-root",
+        ".",
+        "--format",
+        "terminal",
+    ])
+    .expect("--format terminal should parse");
+    assert!(matches!(
+        terminal.cmd,
+        Command::Mcp(McpArgs {
+            cmd: McpSub::Preflight(PreflightArgs {
+                format: PreflightFormat::Terminal,
+                ..
+            })
+        })
+    ));
+
+    let json = Cli::try_parse_from(["assay", "mcp", "preflight", "--format", "json"])
+        .expect("--format json should parse");
+    assert!(matches!(
+        json.cmd,
+        Command::Mcp(McpArgs {
+            cmd: McpSub::Preflight(PreflightArgs {
+                format: PreflightFormat::Json,
+                ..
+            })
+        })
+    ));
+
+    assert!(
+        Cli::try_parse_from(["assay", "mcp", "preflight", "--format", "text"]).is_err(),
+        "preflight format is terminal|json, not the global text|json pair"
+    );
 }
 
 #[test]

--- a/crates/assay-cli/src/cli/bounded_child.rs
+++ b/crates/assay-cli/src/cli/bounded_child.rs
@@ -1,0 +1,336 @@
+//! Bounded child wait for production CLI probes.
+//!
+//! The wait_timeout + kill/reap loop is the pattern from
+//! `assay-sim::subprocess` (`ChildExt::wait_timeout` and the timeout arm).
+//! That crate's `subprocess_verify` is not reused: it inherits stdin and
+//! materializes stderr with `read_to_string` before any cap.
+//! `tests/support/bounded_process.rs` stays test-only (Windows JobObject
+//! included) and is not imported here.
+//!
+//! Readers run concurrently and stop at `output_cap`. The same deadline
+//! covers child exit and pipe drain, so a full pipe or a descendant that
+//! keeps a handle open cannot block past it. Timed-out reader threads are
+//! not joined. Timeout still kill()+wait()s the direct child so it is
+//! reaped before return; try_wait after kill can leave it unreaped.
+
+use std::io::{self, Read};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BoundedChildError {
+    NotFound,
+    Spawn(io::ErrorKind),
+    Timeout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedChildOutput {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+}
+
+fn spawn_capped_reader(mut reader: impl Read + Send + 'static, cap: usize) -> Receiver<Vec<u8>> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut buf = vec![0; cap];
+        let mut filled = 0;
+        while filled < cap {
+            match reader.read(&mut buf[filled..]) {
+                Ok(0) => break,
+                Ok(n) => filled += n,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+        buf.truncate(filled);
+        drop(reader);
+        let _ = tx.send(buf);
+    });
+    rx
+}
+
+fn take_reader(rx: &Receiver<Vec<u8>>, slot: &mut Option<Vec<u8>>) {
+    if slot.is_some() {
+        return;
+    }
+    match rx.try_recv() {
+        Ok(bytes) => *slot = Some(bytes),
+        Err(TryRecvError::Disconnected) => *slot = Some(Vec::new()),
+        Err(TryRecvError::Empty) => {}
+    }
+}
+
+fn kill_and_reap(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+pub(crate) fn run_bounded(
+    command: &mut Command,
+    timeout: Duration,
+    output_cap: usize,
+) -> Result<BoundedChildOutput, BoundedChildError> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(BoundedChildError::NotFound);
+        }
+        Err(error) => return Err(BoundedChildError::Spawn(error.kind())),
+    };
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stdout_rx = spawn_capped_reader(
+        stdout.ok_or(BoundedChildError::Spawn(io::ErrorKind::BrokenPipe))?,
+        output_cap,
+    );
+    let stderr_rx = spawn_capped_reader(
+        stderr.ok_or(BoundedChildError::Spawn(io::ErrorKind::BrokenPipe))?,
+        output_cap,
+    );
+
+    let deadline = Instant::now() + timeout;
+    let mut status = None;
+    let mut stdout = None;
+    let mut stderr = None;
+
+    loop {
+        if status.is_none() {
+            match child.try_wait() {
+                Ok(Some(exit)) => status = Some(exit),
+                Ok(None) => {}
+                Err(error) => {
+                    kill_and_reap(&mut child);
+                    return Err(BoundedChildError::Spawn(error.kind()));
+                }
+            }
+        }
+
+        take_reader(&stdout_rx, &mut stdout);
+        take_reader(&stderr_rx, &mut stderr);
+
+        if let (Some(status), Some(stdout), Some(_stderr)) =
+            (status, stdout.as_ref(), stderr.as_ref())
+        {
+            return Ok(BoundedChildOutput {
+                exit_code: status.code().unwrap_or(1),
+                stdout: stdout.clone(),
+            });
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            kill_and_reap(&mut child);
+            return Err(BoundedChildError::Timeout);
+        }
+        thread::sleep(deadline.saturating_duration_since(now).min(POLL_INTERVAL));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::process::Stdio;
+
+    const HELPER_MODE_ENV: &str = "ASSAY_BOUNDED_CHILD_HELPER_MODE";
+    const HELPER_FILTER: &str = "cli::bounded_child::tests::bounded_child_helper_process";
+
+    #[test]
+    #[ignore = "re-executed as the bounded child of the helper mutations"]
+    fn bounded_child_helper_process() {
+        match std::env::var(HELPER_MODE_ENV).as_deref() {
+            Ok("hang") => loop {
+                thread::park();
+            },
+            Ok("flood") => {
+                let chunk = [b'F'; 1024];
+                let mut out = std::io::stdout();
+                loop {
+                    if out.write_all(&chunk).is_err() {
+                        break;
+                    }
+                }
+            }
+            Ok("hold-pipe") => {
+                let mut descendant = helper_command("park");
+                descendant.stdin(Stdio::null());
+                #[allow(clippy::zombie_processes)]
+                let _child = descendant.spawn().expect("spawn pipe-holding descendant");
+            }
+            Ok("park") => thread::sleep(Duration::from_secs(8)),
+            Ok("ok") => {
+                std::io::stdout()
+                    .write_all(b"ok\n")
+                    .expect("write readiness");
+            }
+            other => panic!("{HELPER_MODE_ENV} must be a known plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_re_executed_helper_is_selected_by_exactly_one_filter_match() {
+        let output = Command::new(std::env::current_exe().expect("test binary"))
+            .args(["--list", HELPER_FILTER, "--exact", "--ignored"])
+            .output()
+            .expect("list the helper test");
+        assert!(
+            output.status.success(),
+            "listing the helper test failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let matches: Vec<_> = stdout
+            .lines()
+            .filter(|line| line.contains("bounded_child_helper_process"))
+            .collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "helper filter must select exactly one test, got {}: {stdout}",
+            matches.len()
+        );
+    }
+
+    fn helper_command(mode: &str) -> Command {
+        let mut command = Command::new(std::env::current_exe().expect("test binary"));
+        command
+            .args([
+                HELPER_FILTER,
+                "--exact",
+                "--ignored",
+                "--nocapture",
+                "--format",
+                "terse",
+            ])
+            .env(HELPER_MODE_ENV, mode);
+        command
+    }
+
+    fn run_under_guard(
+        mut command: Command,
+        timeout: Duration,
+        cap: usize,
+        guard: Duration,
+    ) -> Result<BoundedChildOutput, BoundedChildError> {
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let _ = tx.send(run_bounded(&mut command, timeout, cap));
+        });
+        rx.recv_timeout(guard)
+            .unwrap_or_else(|_| panic!("run_bounded escaped the {guard:?} wall-clock bound"))
+    }
+
+    #[test]
+    fn missing_binary_is_not_found() {
+        let mut command = Command::new("2195-bounded-child-not-on-path");
+        let error = run_bounded(&mut command, Duration::from_secs(1), 64).unwrap_err();
+        assert_eq!(error, BoundedChildError::NotFound);
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        // SAFETY: signal 0 is a liveness probe for a pid this test spawned.
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+
+    #[test]
+    fn kill_and_reap_reaps_before_drop() {
+        let mut child = helper_command("hang")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("hang helper");
+        let pid = child.id();
+        kill_and_reap(&mut child);
+        assert!(
+            child.try_wait().ok().flatten().is_some(),
+            "kill+wait must leave pid {pid} already reaped; kill+try_wait can return None"
+        );
+        #[cfg(unix)]
+        assert!(
+            !process_exists(pid),
+            "kill+try_wait can leave pid {pid} unreaped until Drop"
+        );
+    }
+
+    #[test]
+    fn rust_helper_hang_times_out_without_an_external_sleep() {
+        let error = run_under_guard(
+            helper_command("hang"),
+            Duration::from_millis(400),
+            64,
+            Duration::from_secs(2),
+        )
+        .expect_err("a parked helper must hit the deadline");
+        assert_eq!(error, BoundedChildError::Timeout);
+    }
+
+    #[test]
+    fn stdout_flood_stays_cap_bounded_and_returns_before_the_guard() {
+        let result = run_under_guard(
+            helper_command("flood"),
+            Duration::from_secs(2),
+            64,
+            Duration::from_secs(3),
+        );
+        match result {
+            Ok(output) => {
+                assert!(
+                    output.stdout.len() <= 64,
+                    "flood stdout escaped the cap: {} bytes",
+                    output.stdout.len()
+                );
+                assert!(
+                    output.stdout.contains(&b'F'),
+                    "flood helper must actually run; libtest-only stdout={:?}",
+                    String::from_utf8_lossy(&output.stdout)
+                );
+            }
+            Err(error) => assert_eq!(
+                error,
+                BoundedChildError::Timeout,
+                "flood must end as cap-bounded output or the shared deadline"
+            ),
+        }
+    }
+
+    #[test]
+    fn parent_exit_with_descendant_holding_the_pipe_times_out() {
+        let control = run_under_guard(
+            helper_command("ok"),
+            Duration::from_secs(2),
+            1024,
+            Duration::from_secs(4),
+        )
+        .expect("the same helper with no descendant must reach EOF");
+        assert_eq!(control.exit_code, 0);
+        assert!(
+            control.stdout.windows(3).any(|w| w == b"ok\n"),
+            "ok control must run the helper, not an empty libtest filter: {:?}",
+            String::from_utf8_lossy(&control.stdout)
+        );
+
+        let error = run_under_guard(
+            helper_command("hold-pipe"),
+            Duration::from_secs(2),
+            1024,
+            Duration::from_secs(4),
+        )
+        .expect_err(
+            "joining or read_capped after parent exit hangs while the descendant holds the pipe",
+        );
+        assert_eq!(error, BoundedChildError::Timeout);
+    }
+}

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod coverage_input;
+mod preflight;
 mod tdt;
 
 use coverage_input::{collect_declared_tools, normalize_decision_jsonl_to_coverage_jsonl};
@@ -24,6 +25,7 @@ pub async fn run(args: McpArgs) -> anyhow::Result<i32> {
         McpSub::Inventory(inventory_args) => super::inventory::run(inventory_args).await,
         McpSub::Kill(kill_args) => super::kill::run(kill_args).await,
         McpSub::Tool(tool_args) => Ok(super::tool::cmd_tool(tool_args.cmd)),
+        McpSub::Preflight(preflight_args) => preflight::run(preflight_args),
     }
 }
 

--- a/crates/assay-cli/src/cli/commands/mcp/preflight.rs
+++ b/crates/assay-cli/src/cli/commands/mcp/preflight.rs
@@ -1,0 +1,596 @@
+//! Named-phase PATH classifier for `assay-mcp-server` (#2195).
+//!
+//! This command does not start an MCP session for a host and does not change
+//! `assay-mcp-server` startup rules (#2408 / PR #2409 own that tree).
+
+use serde_json::json;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use crate::cli::args::{PreflightArgs, PreflightFormat};
+use crate::cli::bounded_child::{run_bounded, BoundedChildError};
+use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_SUCCESS};
+
+const SCHEMA: &str = "assay.mcp_preflight.v0";
+const SERVER_COMMAND: &str = "assay-mcp-server";
+const PROBE_DEADLINE: Duration = Duration::from_secs(2);
+const PROBE_OUTPUT_CAP: usize = 8 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    Missing,
+    Unstartable,
+    WrongVersion,
+    InvalidRoot,
+    StartupRefused,
+    StartupTimeout,
+    Ready,
+}
+
+impl Phase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Unstartable => "unstartable",
+            Self::WrongVersion => "wrong_version",
+            Self::InvalidRoot => "invalid_root",
+            Self::StartupRefused => "startup_refused",
+            Self::StartupTimeout => "startup_timeout",
+            Self::Ready => "ready",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Report {
+    pub phase: Phase,
+    pub message: String,
+    pub next_step: String,
+    pub expected_version: String,
+    pub actual_version: Option<String>,
+    pub policy_root: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeFailure {
+    NotFound,
+    OtherSpawn(io::ErrorKind),
+    Timeout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProbeOutput {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+}
+
+trait Probe {
+    fn identity(&self) -> Result<ProbeOutput, ProbeFailure>;
+    fn startup(&self, policy_root: &Path) -> Result<ProbeOutput, ProbeFailure>;
+}
+
+fn classify(probe: &impl Probe, policy_root: &Path, expected_version: &str) -> Report {
+    let actual_version = match probe.identity() {
+        Err(ProbeFailure::NotFound) => {
+            return finish(Phase::Missing, policy_root, expected_version, None);
+        }
+        Err(ProbeFailure::OtherSpawn(_) | ProbeFailure::Timeout) => {
+            return finish(Phase::Unstartable, policy_root, expected_version, None);
+        }
+        Ok(output) if output.exit_code != 0 => {
+            return finish(Phase::Unstartable, policy_root, expected_version, None);
+        }
+        Ok(output) => match parse_identity_version(&output.stdout) {
+            Some(actual) if actual == expected_version => actual,
+            Some(actual) => {
+                return finish(
+                    Phase::WrongVersion,
+                    policy_root,
+                    expected_version,
+                    Some(actual),
+                );
+            }
+            None => {
+                return finish(Phase::Unstartable, policy_root, expected_version, None);
+            }
+        },
+    };
+
+    if !policy_root.exists() || !policy_root.is_dir() {
+        return finish(
+            Phase::InvalidRoot,
+            policy_root,
+            expected_version,
+            Some(actual_version),
+        );
+    }
+
+    match probe.startup(policy_root) {
+        Ok(output) if output.exit_code == 0 => finish(
+            Phase::Ready,
+            policy_root,
+            expected_version,
+            Some(actual_version),
+        ),
+        Err(ProbeFailure::Timeout) => finish(
+            Phase::StartupTimeout,
+            policy_root,
+            expected_version,
+            Some(actual_version),
+        ),
+        Ok(_) | Err(_) => finish(
+            Phase::StartupRefused,
+            policy_root,
+            expected_version,
+            Some(actual_version),
+        ),
+    }
+}
+
+fn finish(
+    phase: Phase,
+    policy_root: &Path,
+    expected_version: &str,
+    actual_version: Option<String>,
+) -> Report {
+    let (message, next_step) = diagnosis(phase, expected_version, actual_version.as_deref());
+    Report {
+        phase,
+        message,
+        next_step,
+        expected_version: expected_version.to_string(),
+        actual_version,
+        policy_root: policy_root.to_path_buf(),
+    }
+}
+
+fn diagnosis(phase: Phase, expected: &str, actual: Option<&str>) -> (String, String) {
+    match phase {
+        Phase::Missing => (
+            "assay-mcp-server was not found on PATH".to_string(),
+            format!(
+                "Install assay-mcp-server on PATH ({}), then re-run assay mcp preflight.",
+                install_matching_server(expected)
+            ),
+        ),
+        Phase::Unstartable => (
+            "assay-mcp-server on PATH could not be started or did not report a version".to_string(),
+            "Replace the assay-mcp-server on PATH with a working binary from the same Assay release."
+                .to_string(),
+        ),
+        Phase::WrongVersion => (
+            format!(
+                "assay-mcp-server reported {} but this CLI expects {expected}",
+                actual.unwrap_or("an unexpected version")
+            ),
+            format!(
+                "Install assay-mcp-server {expected} on PATH ({}).",
+                install_matching_server(expected)
+            ),
+        ),
+        Phase::InvalidRoot => (
+            "policy root must be an existing directory".to_string(),
+            "Pass --policy-root to an existing directory.".to_string(),
+        ),
+        Phase::StartupRefused => (
+            "assay-mcp-server refused to start with this policy root".to_string(),
+            "Unset ASSAY_AUTH_* and confirm the server can start with this --policy-root."
+                .to_string(),
+        ),
+        Phase::StartupTimeout => (
+            "assay-mcp-server did not exit before the preflight deadline".to_string(),
+            "Retry after checking that assay-mcp-server is not blocked at startup.".to_string(),
+        ),
+        Phase::Ready => (
+            "assay-mcp-server on PATH matches this CLI and accepted the policy root".to_string(),
+            String::new(),
+        ),
+    }
+}
+
+fn install_matching_server(expected: &str) -> String {
+    format!("cargo install assay-mcp-server --version {expected} --locked")
+}
+
+fn parse_identity_version(stdout: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(stdout).ok()?;
+    let line = text
+        .strip_suffix("\r\n")
+        .or_else(|| text.strip_suffix('\n'))
+        .unwrap_or(text);
+    if line.contains(['\n', '\r']) {
+        return None;
+    }
+    let version = line.strip_prefix(SERVER_COMMAND)?.strip_prefix(' ')?;
+    if version.is_empty()
+        || version.contains([' ', '\t'])
+        || !version.as_bytes().first()?.is_ascii_digit()
+    {
+        return None;
+    }
+    Some(version.to_string())
+}
+
+fn render_json(report: &Report) -> String {
+    let mut document = json!({
+        "schema": SCHEMA,
+        "phase": report.phase.as_str(),
+        "message": report.message,
+        "next_step": report.next_step,
+        "expected_version": report.expected_version,
+        "policy_root": report.policy_root.to_string_lossy(),
+    });
+    if let Some(actual) = &report.actual_version {
+        document
+            .as_object_mut()
+            .expect("object")
+            .insert("actual_version".to_string(), json!(actual));
+    }
+    serde_json::to_string_pretty(&document).expect("preflight report is JSON")
+}
+
+fn render_terminal(report: &Report) -> String {
+    if report.next_step.is_empty() {
+        format!("{}: {}", report.phase.as_str(), report.message)
+    } else {
+        format!(
+            "{}: {}\n{}",
+            report.phase.as_str(),
+            report.message,
+            report.next_step
+        )
+    }
+}
+
+fn emit(report: &Report, format: PreflightFormat) {
+    match format {
+        PreflightFormat::Json => println!("{}", render_json(report)),
+        PreflightFormat::Terminal => println!("{}", render_terminal(report)),
+    }
+}
+
+fn exit_code(phase: Phase) -> i32 {
+    if phase == Phase::Ready {
+        EXIT_SUCCESS
+    } else {
+        EXIT_CONFIG_ERROR
+    }
+}
+
+struct PathProbe;
+
+impl Probe for PathProbe {
+    fn identity(&self) -> Result<ProbeOutput, ProbeFailure> {
+        bounded_probe(Command::new(SERVER_COMMAND).arg("--version"))
+    }
+
+    fn startup(&self, policy_root: &Path) -> Result<ProbeOutput, ProbeFailure> {
+        bounded_probe(
+            Command::new(SERVER_COMMAND)
+                .arg("--policy-root")
+                .arg(policy_root),
+        )
+    }
+}
+
+fn bounded_probe(command: &mut Command) -> Result<ProbeOutput, ProbeFailure> {
+    match run_bounded(command, PROBE_DEADLINE, PROBE_OUTPUT_CAP) {
+        Ok(output) => Ok(ProbeOutput {
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+        }),
+        Err(BoundedChildError::NotFound) => Err(ProbeFailure::NotFound),
+        Err(BoundedChildError::Timeout) => Err(ProbeFailure::Timeout),
+        Err(BoundedChildError::Spawn(kind)) => Err(ProbeFailure::OtherSpawn(kind)),
+    }
+}
+
+pub(super) fn run(args: PreflightArgs) -> anyhow::Result<i32> {
+    let report = classify(&PathProbe, &args.policy_root, env!("CARGO_PKG_VERSION"));
+    emit(&report, args.format);
+    Ok(exit_code(report.phase))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::cell::Cell;
+    use std::fs;
+    use std::io::ErrorKind;
+
+    struct FakeProbe {
+        identity: Result<ProbeOutput, ProbeFailure>,
+        startup: Result<ProbeOutput, ProbeFailure>,
+        startups: Cell<u32>,
+    }
+
+    impl FakeProbe {
+        fn identity_ok(stdout: &str) -> Self {
+            Self {
+                identity: Ok(ProbeOutput {
+                    exit_code: 0,
+                    stdout: stdout.as_bytes().to_vec(),
+                }),
+                startup: Ok(ProbeOutput {
+                    exit_code: 0,
+                    stdout: Vec::new(),
+                }),
+                startups: Cell::new(0),
+            }
+        }
+    }
+
+    impl Probe for FakeProbe {
+        fn identity(&self) -> Result<ProbeOutput, ProbeFailure> {
+            self.identity.clone()
+        }
+
+        fn startup(&self, _policy_root: &Path) -> Result<ProbeOutput, ProbeFailure> {
+            self.startups.set(self.startups.get() + 1);
+            self.startup.clone()
+        }
+    }
+
+    fn expected() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn matching_version_line() -> String {
+        format!("{SERVER_COMMAND} {}", expected())
+    }
+
+    fn dir_root() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn not_found_is_missing_other_spawn_is_unstartable() {
+        let dir = dir_root();
+        let missing = FakeProbe {
+            identity: Err(ProbeFailure::NotFound),
+            startup: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: Vec::new(),
+            }),
+            startups: Cell::new(0),
+        };
+        let report = classify(&missing, dir.path(), expected());
+        assert_eq!(report.phase, Phase::Missing);
+        assert_eq!(missing.startups.get(), 0);
+        assert_eq!(report.expected_version, expected());
+        assert!(report.next_step.contains("PATH"));
+
+        let denied = FakeProbe {
+            identity: Err(ProbeFailure::OtherSpawn(ErrorKind::PermissionDenied)),
+            startup: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: Vec::new(),
+            }),
+            startups: Cell::new(0),
+        };
+        let report = classify(&denied, dir.path(), expected());
+        assert_eq!(
+            report.phase,
+            Phase::Unstartable,
+            "folding every spawn error into missing hides PermissionDenied"
+        );
+        assert_eq!(denied.startups.get(), 0);
+    }
+
+    #[test]
+    fn parseable_mismatch_is_wrong_version() {
+        let dir = dir_root();
+        let probe = FakeProbe::identity_ok(&format!("{SERVER_COMMAND} 0.0.1"));
+        let report = classify(&probe, dir.path(), expected());
+        assert_eq!(report.phase, Phase::WrongVersion);
+        assert_eq!(report.actual_version.as_deref(), Some("0.0.1"));
+        assert_eq!(report.expected_version, expected());
+        assert_ne!(report.expected_version, "0.0.1");
+        assert!(
+            report.next_step.contains(expected()) && report.next_step.contains("--version"),
+            "WrongVersion must pin cargo install to this CLI, not latest: {}",
+            report.next_step
+        );
+        assert_eq!(probe.startups.get(), 0);
+    }
+
+    #[test]
+    fn install_matching_server_pins_expected_and_locked() {
+        let command = install_matching_server(expected());
+        assert_eq!(
+            command,
+            format!(
+                "cargo install assay-mcp-server --version {} --locked",
+                expected()
+            )
+        );
+    }
+
+    #[test]
+    fn unparsable_or_bad_prefix_is_unstartable_not_wrong_version() {
+        let dir = dir_root();
+        let trailing_junk = format!("{SERVER_COMMAND} {} junk", expected());
+        let extra_line = format!("{SERVER_COMMAND} {}\nextra", expected());
+        for stdout in [
+            "not-a-server 1.0.0",
+            "assay-mcp-server",
+            "assay-mcp-server not-a-version",
+            "LEAK_FROM_CHILD",
+            trailing_junk.as_str(),
+            extra_line.as_str(),
+        ] {
+            let probe = FakeProbe::identity_ok(stdout);
+            let report = classify(&probe, dir.path(), expected());
+            assert_eq!(
+                report.phase,
+                Phase::Unstartable,
+                "parse failure must not become wrong_version; stdout={stdout:?}"
+            );
+            assert!(report.actual_version.is_none());
+            assert_eq!(probe.startups.get(), 0);
+        }
+    }
+
+    #[test]
+    fn identity_nonzero_or_timeout_is_unstartable() {
+        let dir = dir_root();
+        let nonzero = FakeProbe {
+            identity: Ok(ProbeOutput {
+                exit_code: 3,
+                stdout: matching_version_line().into_bytes(),
+            }),
+            startup: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: Vec::new(),
+            }),
+            startups: Cell::new(0),
+        };
+        assert_eq!(
+            classify(&nonzero, dir.path(), expected()).phase,
+            Phase::Unstartable
+        );
+
+        let hung = FakeProbe {
+            identity: Err(ProbeFailure::Timeout),
+            startup: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: Vec::new(),
+            }),
+            startups: Cell::new(0),
+        };
+        assert_eq!(
+            classify(&hung, dir.path(), expected()).phase,
+            Phase::Unstartable,
+            "omitting the identity timeout folds a hang into a later phase"
+        );
+        assert_eq!(hung.startups.get(), 0);
+    }
+
+    #[test]
+    fn missing_path_and_file_root_are_invalid_root_without_startup() {
+        let probe = FakeProbe::identity_ok(&matching_version_line());
+        let missing = PathBuf::from("2195-preflight-root-does-not-exist");
+        let report = classify(&probe, &missing, expected());
+        assert_eq!(report.phase, Phase::InvalidRoot);
+        assert_eq!(probe.startups.get(), 0);
+
+        let file = tempfile::NamedTempFile::new().expect("file root");
+        let report = classify(&probe, file.path(), expected());
+        assert_eq!(
+            report.phase,
+            Phase::InvalidRoot,
+            "removing is_dir would start the server for a regular file"
+        );
+        assert_eq!(probe.startups.get(), 0);
+    }
+
+    #[test]
+    fn startup_nonzero_is_refused_and_timeout_is_startup_timeout() {
+        let dir = dir_root();
+        let refused = FakeProbe {
+            identity: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: matching_version_line().into_bytes(),
+            }),
+            startup: Ok(ProbeOutput {
+                exit_code: 1,
+                stdout: b"ignored child bytes".to_vec(),
+            }),
+            startups: Cell::new(0),
+        };
+        let report = classify(&refused, dir.path(), expected());
+        assert_eq!(report.phase, Phase::StartupRefused);
+        assert_eq!(refused.startups.get(), 1);
+
+        let hung = FakeProbe {
+            identity: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: matching_version_line().into_bytes(),
+            }),
+            startup: Err(ProbeFailure::Timeout),
+            startups: Cell::new(0),
+        };
+        let report = classify(&hung, dir.path(), expected());
+        assert_eq!(
+            report.phase,
+            Phase::StartupTimeout,
+            "omitting the startup timeout cannot distinguish a hang from ready"
+        );
+        assert_eq!(hung.startups.get(), 1);
+    }
+
+    #[test]
+    fn matching_version_and_directory_and_zero_exit_is_ready() {
+        let dir = dir_root();
+        let probe = FakeProbe::identity_ok(&matching_version_line());
+        let report = classify(&probe, dir.path(), expected());
+        assert_eq!(report.phase, Phase::Ready);
+        assert_eq!(report.actual_version.as_deref(), Some(expected()));
+        assert_eq!(report.expected_version, expected());
+        assert_eq!(probe.startups.get(), 1);
+        assert_eq!(exit_code(report.phase), 0);
+    }
+
+    #[test]
+    fn json_is_one_object_and_drops_child_bytes() {
+        let dir = dir_root();
+        let probe = FakeProbe {
+            identity: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: matching_version_line().into_bytes(),
+            }),
+            startup: Ok(ProbeOutput {
+                exit_code: 1,
+                stdout: b"LEAK_FROM_CHILD".to_vec(),
+            }),
+            startups: Cell::new(0),
+        };
+        let report = classify(&probe, dir.path(), expected());
+        let rendered = render_json(&report);
+        let document: Value = serde_json::from_str(&rendered).expect("one JSON object");
+        assert_eq!(document["schema"], SCHEMA);
+        assert_eq!(document["phase"], "startup_refused");
+        assert_eq!(document["expected_version"], expected());
+        assert!(
+            !rendered.contains("LEAK_FROM_CHILD"),
+            "child stdout must not enter the preflight document: {rendered}"
+        );
+        assert_eq!(exit_code(report.phase), 2);
+    }
+
+    #[test]
+    fn parse_identity_version_requires_exact_one_line() {
+        assert_eq!(
+            parse_identity_version(matching_version_line().as_bytes()).as_deref(),
+            Some(expected())
+        );
+        assert_eq!(
+            parse_identity_version(format!("{}\n", matching_version_line()).as_bytes()).as_deref(),
+            Some(expected())
+        );
+        assert_eq!(parse_identity_version(b"other 1.0.0"), None);
+        assert_eq!(
+            parse_identity_version(format!("{} junk", matching_version_line()).as_bytes()),
+            None,
+            "trailing junk must not parse as a version"
+        );
+        assert_eq!(
+            parse_identity_version(format!("{}\nextra\n", matching_version_line()).as_bytes()),
+            None,
+            "a second line must not parse as a version"
+        );
+    }
+
+    #[test]
+    fn file_is_not_a_directory() {
+        let file = tempfile::NamedTempFile::new().expect("file");
+        assert!(file.path().exists());
+        assert!(!file.path().is_dir());
+        let dir = dir_root();
+        assert!(dir.path().is_dir());
+        let _ = fs::metadata(dir.path());
+    }
+}

--- a/crates/assay-cli/src/cli/commands/mcp/preflight.rs
+++ b/crates/assay-cli/src/cli/commands/mcp/preflight.rs
@@ -204,12 +204,11 @@ fn parse_identity_version(stdout: &[u8]) -> Option<String> {
         return None;
     }
     let version = line.strip_prefix(SERVER_COMMAND)?.strip_prefix(' ')?;
-    if version.is_empty()
-        || version.contains([' ', '\t'])
-        || !version.as_bytes().first()?.is_ascii_digit()
-    {
+    if version.contains([' ', '\t']) {
         return None;
     }
+    semver::Version::parse(version).ok()?;
+    // Keep the wire token. Co-release compares this string to CARGO_PKG_VERSION.
     Some(version.to_string())
 }
 
@@ -418,6 +417,9 @@ mod tests {
             "not-a-server 1.0.0",
             "assay-mcp-server",
             "assay-mcp-server not-a-version",
+            "assay-mcp-server 1foo",
+            "assay-mcp-server 5.2",
+            "assay-mcp-server 5.2.0-",
             "LEAK_FROM_CHILD",
             trailing_junk.as_str(),
             extra_line.as_str(),
@@ -581,6 +583,18 @@ mod tests {
             parse_identity_version(format!("{}\nextra\n", matching_version_line()).as_bytes()),
             None,
             "a second line must not parse as a version"
+        );
+        for unparsable in ["1foo", "5.2", "5.2.0-"] {
+            assert_eq!(
+                parse_identity_version(format!("{SERVER_COMMAND} {unparsable}").as_bytes()),
+                None,
+                "digit-leading junk must stay unparsable: {unparsable}"
+            );
+        }
+        assert_eq!(
+            parse_identity_version(format!("{SERVER_COMMAND} 0.0.1").as_bytes()).as_deref(),
+            Some("0.0.1"),
+            "a different full SemVer must stay parseable so wrong_version remains reachable"
         );
     }
 

--- a/crates/assay-cli/src/cli/mod.rs
+++ b/crates/assay-cli/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub(crate) mod bounded_child;
 pub mod commands;
 pub mod helpers;
 pub mod util;

--- a/crates/assay-cli/tests/mcp_preflight_contract.rs
+++ b/crates/assay-cli/tests/mcp_preflight_contract.rs
@@ -1,0 +1,56 @@
+//! `assay mcp preflight` publishes one `assay.mcp_preflight.v0` document (#2195).
+
+#[path = "../../../tests/support/bounded_process.rs"]
+#[allow(dead_code)]
+mod bounded_process;
+
+use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
+use serde_json::Value;
+use std::process::{Command, Output};
+
+const PREFLIGHT_SCHEMA: &str = "assay.mcp_preflight.v0";
+
+fn preflight(args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    command.env("NO_COLOR", "1").env("PATH", "");
+    command.args(["mcp", "preflight"]).args(args);
+    run_bounded(command, b"", GOLDEN_PATH_LIMITS, "assay mcp preflight").expect("preflight ran")
+}
+
+fn exit_code(output: &Output) -> i32 {
+    output
+        .status
+        .code()
+        .expect("preflight exited by code rather than by signal")
+}
+
+#[test]
+fn policy_root_dot_format_json_is_one_preflight_document() {
+    let output = preflight(&["--policy-root", ".", "--format", "json"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        exit_code(&output),
+        2,
+        "empty PATH must not be ready; stderr={stderr}"
+    );
+    let document: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!("stdout is not one JSON document: {error}\nstdout={stdout}\nstderr={stderr}")
+    });
+    assert_eq!(document["schema"], PREFLIGHT_SCHEMA);
+    assert_eq!(document["phase"], "missing");
+    assert_eq!(document["expected_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(document["policy_root"], ".");
+}
+
+#[test]
+fn format_terminal_is_not_json() {
+    let output = preflight(&["--format", "terminal"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(exit_code(&output), 2);
+    assert!(
+        stdout.starts_with("missing:"),
+        "terminal format must stay human; stdout={stdout}"
+    );
+    assert!(serde_json::from_slice::<Value>(&output.stdout).is_err());
+}

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -41,7 +41,7 @@ assay --version
 | [`assay doctor`](doctor.md) | Diagnose setup and optionally auto-fix known issues |
 | [`assay watch`](watch.md) | Re-run on config/policy/trace changes |
 | [`assay monitor`](../../guides/runtime-monitor.md) | **Runtime Security** (Linux Kernel Enforcement) |
-| [`assay mcp`](mcp-server.md) | MCP runtime commands: wrap, discover, kill, config-path, and tool signing |
+| [`assay mcp`](mcp-server.md) | MCP runtime commands: wrap, preflight, discover, kill, config-path, and tool signing |
 | [CLI Command Grouping RFC](command-grouping-rfc.md) | Selective command grouping direction and compatibility contract |
 
 ---

--- a/docs/reference/cli/mcp-server.md
+++ b/docs/reference/cli/mcp-server.md
@@ -9,6 +9,7 @@ This page documents the current MCP runtime entry points in Assay.
 `assay mcp` is the canonical command family for MCP runtime work:
 
 - `assay mcp wrap`
+- `assay mcp preflight`
 - `assay mcp discover`
 - `assay mcp kill`
 - `assay mcp config-path`
@@ -56,7 +57,29 @@ assay mcp wrap --policy assay.yaml --dry-run -- <real-mcp-command> [args...]
 
 ---
 
-## 3) `assay-mcp-server` (separate binary)
+## 3) `assay mcp preflight` (CLI)
+
+Check whether `assay-mcp-server` on PATH matches this CLI and can start with a
+policy root. This command does not start an MCP session for a host.
+
+### Synopsis
+
+```bash
+assay mcp preflight [--policy-root .] [--format terminal|json]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--policy-root <PATH>` | Directory the host would pass as `--policy-root` (default: `.`). Must exist and be a directory. |
+| `--format <terminal\|json>` | Report format (default: `terminal`). JSON is one `assay.mcp_preflight.v0` object. |
+
+Exit `0` only for `ready`. Every other phase exits `2`.
+
+---
+
+## 4) `assay-mcp-server` (separate binary)
 
 Run the MCP server binary directly.
 


### PR DESCRIPTION
## Summary
- Adds `assay mcp preflight [--policy-root .] [--format terminal|json]`, a named-phase PATH classifier for `assay-mcp-server` (#2195).
- Exit `0` only for `ready`; every other phase exits `2` with command-local `assay.mcp_preflight.v0`.
- Version SoT is `env!("CARGO_PKG_VERSION")`; WrongVersion/Missing install recovery pins `cargo install assay-mcp-server --version {expected} --locked`.
- Identity tokens must be full SemVer (`semver::Version::parse`); co-release still compares the original wire string to `CARGO_PKG_VERSION`.

## Behavior
Ordered classifier: identity (`--version`) → root `exists && is_dir` → startup with closed stdin. Probe seam is injectable; production `PathProbe` uses a thin `bounded_child` helper (sim `wait_timeout` + kill/wait, concurrent cap-bounded readers, no test-support import).

## Non-Claims
- No scalar trust score or whole-action verdict
- No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- No provider-outcome, compliance, certification, partnership, or safe-agent claim
- No new `ReasonCode`, no policy verdict, no downloader/network, no host-discovery claim
- Does not start an MCP session for a host; plugin command stays `assay-mcp-server --policy-root .`
- Does not change `assay-mcp-server` startup rules (#2408 / #2409 own that tree)
- Windows PATHEXT and native Windows measurement are out of this slice

## Stack
- Base: `main` `25a0ac90d395e89a3505fe6cf23f49964b1bc7ef` (#2409)
- Head: `cursor/2195-mcp-preflight` **`9799a5d8f333ee6c51cecaf006844b0956dad4e0`**
- Worktree: `/Users/roelschuurkes/wt-2195-mcp-preflight`

## Invalidated prior heads
- `291911e93a7209c365a24306cdbf339811e62987` — pre-#2409; rewritten by rebase
- `17512afd9ad46218a9196917b7af109ed781f496` — post-rebase, pre-SemVer fix
- Any CI run or review bound to those SHAs is invalid. Review and CI must target `9799a5d8f333ee6c51cecaf006844b0956dad4e0` only. Rebase rewrote history; no review existed to carry.

## Commit Slices
- `17512afd` feat(cli): classify assay-mcp-server PATH readiness before host startup
- `9799a5d8` fix(cli): require SemVer for mcp preflight identity tokens

## Dependency
- Direct `semver = "1"` on `crates/assay-cli` (`Cargo.toml`)
- `Cargo.lock` records `assay-cli` → `semver 1.0.27` (already present in the lockfile; now a direct dep, not a new crate version)

## Test Evidence

Measurements below for head `9799a5d8f333ee6c51cecaf006844b0956dad4e0` unless noted.

### RED (classifier stub, pre-implementation)
Stub `classify` always returned `Ready`.

```text
cargo test -p assay-cli --bin assay -- classify not_found_is_missing parseable_mismatch unparseable_or_bad identity_nonzero missing_path_and_file startup_nonzero matching_version json_is_one_object -- --test-threads=1
```

8 failures, all `left: Ready`.

### RED (SemVer finding on `17512afd9`)
Digit-leading junk parsed as a version token.

```text
cargo test -p assay-cli --bin assay -- unparsable_or_bad_prefix parse_identity_version_requires_exact_one_line -- --test-threads=1
```

- `parse_identity_version_requires_exact_one_line`: `left: Some("1foo")` / `right: None`
- `unparsable_or_bad_prefix_is_unstartable_not_wrong_version`: `left: WrongVersion` / `right: Unstartable` for `assay-mcp-server 1foo` (same class as `5.2`, `5.2.0-`)

### GREEN (head `9799a5d8f`)
```text
cargo test -p assay-cli --bin assay -- unparsable_or_bad_prefix parse_identity_version_requires_exact_one_line parseable_mismatch -- --test-threads=1
# 3 passed (`0.0.1` remains a parseable other SemVer → wrong_version)
cargo test -p assay-cli --bin assay -- bounded_child preflight mcp_preflight mcp_group_accepts -- --test-threads=1
# 19 passed; 1 ignored (re-exec helper)
cargo test -p assay-cli --test mcp_preflight_contract -- --test-threads=1
# 17 passed; 1 ignored
cargo fmt --all -- --check
cargo clippy -p assay-cli --all-targets -- -D warnings
git diff --check
```

Co-release compare stays exact string equality against `CARGO_PKG_VERSION`. SemVer is only the syntactic gate.

### Mutations (discriminating tests failed, sources restored)
| Mutation | Discriminator | Observed |
|---|---|---|
| Fold `OtherSpawn` into `missing` | `not_found_is_missing_other_spawn_is_unstartable` | `left: Missing` |
| Remove version comparison | `parseable_mismatch_is_wrong_version` | `left: Ready` |
| Fold parse failure into `wrong_version` | `unparsable_or_bad_prefix_is_unstartable_not_wrong_version` | `left: WrongVersion` |
| Remove `is_dir` | `missing_path_and_file_root_are_invalid_root_without_startup` | `left: Ready` |
| Omit startup timeout arm | `startup_nonzero_is_refused_and_timeout_is_startup_timeout` | `left: StartupRefused` |
| Accept trailing junk | `parse_identity_version_requires_exact_one_line` | `left: Some("5.2.0")` |
| Unpin `cargo install` (`--locked` only) | `parseable_mismatch_is_wrong_version` | `next_step` missing `--version` |
| `kill` + `try_wait` | `kill_and_reap_reaps_before_drop` | pid left unreaped |

## Changed Files
11 files, +1115 / −3, including `Cargo.lock` and `crates/assay-cli/Cargo.toml` for the direct `semver` dep.

## Review Quorum
- [ ] One non-building agent review on **`9799a5d8f333ee6c51cecaf006844b0956dad4e0`**
- [ ] Every actionable finding is fixed or has a technical disposition
- Reviews or CI on `17512afd9` / `291911e93` do not count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `assay mcp preflight` to verify MCP server availability, compatibility, startup readiness, and policy-root validity.
  * Supports human-readable terminal output and machine-readable JSON output.
  * Provides clear readiness classifications and meaningful exit codes.

* **Bug Fixes**
  * Added bounded process execution to prevent probes from hanging and limit captured output.

* **Documentation**
  * Documented the new preflight command, options, output formats, and exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->