### PR TITLE
fix(cli): bound YAML parse diagnostics through render_safe (#2266)

### DIFF
--- a/crates/assay-cli/src/cli/commands/doctor/implementation.rs
+++ b/crates/assay-cli/src/cli/commands/doctor/implementation.rs
@@ -48,9 +48,8 @@ const NO_CONFIG_FOUND: &str = "No config found; run inside project or use --conf
 ///
 /// The key is present in every JSON report rather than only in the skipped one, so the question
 /// "was this config read?" has an answer a consumer can key on without knowing which absences
-/// mean what. `reason` accompanies the two states that produced no diagnostics; on `failed` it
-/// restates `config_error.message` from the same value rather than deriving a second one, because
-/// the registered diagnosis stays the carrier a consumer branches on.
+/// mean what. `reason` names why a check was skipped. A failed load publishes only
+/// `status: "failed"`; the human detail lives once on `config_error.message`.
 fn config_check_skipped(reason: &str) -> serde_json::Value {
     serde_json::json!({
         "status": "skipped",
@@ -58,14 +57,11 @@ fn config_check_skipped(reason: &str) -> serde_json::Value {
     })
 }
 
-fn config_check_marker(checked: bool, error: Option<&str>) -> serde_json::Value {
-    match (checked, error) {
-        (_, Some(message)) => serde_json::json!({
-            "status": "failed",
-            "reason": message,
-        }),
-        (true, None) => serde_json::json!({ "status": "checked" }),
-        (false, None) => config_check_skipped(NO_CONFIG_FOUND),
+fn config_check_marker(checked: bool, failed: bool) -> serde_json::Value {
+    match (checked, failed) {
+        (_, true) => serde_json::json!({ "status": "failed" }),
+        (true, false) => serde_json::json!({ "status": "checked" }),
+        (false, false) => config_check_skipped(NO_CONFIG_FOUND),
     }
 }
 
@@ -172,11 +168,10 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         let mut exit = 0;
 
         if let Some(obj) = json_out.as_object_mut() {
-            let err_text = cfg_err.as_ref().map(ToString::to_string);
             obj.insert("generated_at".to_string(), serde_json::json!(timestamp));
             obj.insert(
                 "config_check".to_string(),
-                config_check_marker(cfg.is_some(), err_text.as_deref()),
+                config_check_marker(cfg.is_some(), cfg_err.is_some()),
             );
 
             if let Some(err) = &cfg_err {

--- a/crates/assay-cli/tests/doctor_config_check_contract.rs
+++ b/crates/assay-cli/tests/doctor_config_check_contract.rs
@@ -73,6 +73,49 @@ fn doctor_json<S: AsRef<OsStr>>(cwd: &Path, extra: &[S]) -> (i32, Value) {
     (code, document)
 }
 
+fn doctor_text<S: AsRef<OsStr>>(cwd: &Path, extra: &[S]) -> (i32, String, String) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+        .current_dir(cwd)
+        .env("NO_COLOR", "1")
+        .args(["doctor", "--format", "text"])
+        .args(extra);
+    let output = run_bounded(
+        command,
+        b"",
+        GOLDEN_PATH_LIMITS,
+        "assay doctor --format text",
+    )
+    .unwrap_or_else(|error| panic!("{error}"));
+    let code = output
+        .status
+        .code()
+        .expect("assay process terminated without an exit code");
+    (
+        code,
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// github-token shape from `render_safety/rules.rs` (`ghp_` + 36 alphanumerics).
+/// Space-separated padding stays outside that rule so the extra bytes survive
+/// redaction and force the visible truncation marker.
+fn long_secret_yaml() -> (String, String) {
+    let token = format!("ghp_{}", "A".repeat(36));
+    let yaml = format!("version: \"{token} {}\"\n", "x".repeat(300));
+    (token, yaml)
+}
+
 fn init_project(cwd: &Path) {
     let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
     command.current_dir(cwd).env("NO_COLOR", "1").args([
@@ -154,6 +197,117 @@ fn a_config_that_will_not_load_is_neither_checked_nor_skipped() {
         "failed",
         "a failed load is its own state; document:\n{}",
         serde_json::to_string_pretty(&document).expect("re-serialize")
+    );
+    assert!(
+        document["config_check"].get("reason").is_none(),
+        "failed config_check publishes status only; detail lives on config_error.message; document:\n{}",
+        serde_json::to_string_pretty(&document).expect("re-serialize")
+    );
+    let message = document["config_error"]["message"]
+        .as_str()
+        .unwrap_or_else(|| panic!("config_error.message must be a string: {document}"));
+    assert!(
+        message.contains("failed to parse YAML"),
+        "concise malformed YAML must stay diagnosed: {message}"
+    );
+    assert_eq!(
+        document["reason_code"], "E_CFG_PARSE",
+        "unloadable explicit config stays the parse class: {document}"
+    );
+    let next = document["next_step"]
+        .as_str()
+        .unwrap_or_else(|| panic!("next_step must be a string: {document}"));
+    assert!(
+        !next.trim().is_empty(),
+        "parse recovery must name a next step"
+    );
+}
+
+/// A parse error that quotes a long secret-shaped scalar must reach doctor
+/// redacted and bounded. This is the parse-Display fold, not a read ceiling,
+/// and not a claim that every YAML error echoes input.
+#[test]
+fn a_long_secret_parse_error_is_redacted_bounded_and_not_duplicated() {
+    let (token, yaml) = long_secret_yaml();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = dir.path().join("secret.yaml");
+    std::fs::write(&config, &yaml).expect("write long-secret config");
+    let config_arg = config.to_str().expect("UTF-8 path");
+
+    let (code, document) = doctor_json(dir.path(), &["--config", config_arg]);
+    assert_eq!(code, 2, "unloadable explicit config stays the config class");
+    assert_eq!(
+        document["config_check"]["status"],
+        "failed",
+        "a failed load is its own state; document:\n{}",
+        serde_json::to_string_pretty(&document).expect("re-serialize")
+    );
+    assert!(
+        document["config_check"].get("reason").is_none(),
+        "failed config_check must not restate config_error.message; document:\n{}",
+        serde_json::to_string_pretty(&document).expect("re-serialize")
+    );
+    assert_eq!(
+        document["reason_code"], "E_CFG_PARSE",
+        "long-secret parse stays the parse class: {document}"
+    );
+    let next = document["next_step"]
+        .as_str()
+        .unwrap_or_else(|| panic!("next_step must be a string: {document}"));
+    assert!(
+        !next.trim().is_empty(),
+        "parse recovery must name a next step"
+    );
+
+    let message = document["config_error"]["message"]
+        .as_str()
+        .unwrap_or_else(|| panic!("config_error.message must be a string: {document}"));
+    assert!(
+        message.contains("failed to parse YAML"),
+        "parse failures must stay diagnosed: {message}"
+    );
+    assert!(
+        !message.contains(&token),
+        "raw credential must not appear in config_error.message: {message}"
+    );
+    assert!(
+        message.contains("<redacted:"),
+        "redaction placeholder must be visible: {message}"
+    );
+    assert!(
+        message.contains("(truncated)"),
+        "truncation must be visible: {message}"
+    );
+    assert!(
+        message.chars().count() <= assay_core::render_safety::MAX_RENDER_FIELD + 80,
+        "config_error.message is prefix + bounded excerpt ({} chars): {message}",
+        message.chars().count()
+    );
+
+    let blob = serde_json::to_string(&document).expect("serialize doctor json");
+    assert!(
+        !blob.contains(&token),
+        "raw credential must not appear anywhere in the doctor JSON document"
+    );
+
+    let (text_code, stdout, stderr) = doctor_text(dir.path(), &["--config", config_arg]);
+    assert_eq!(text_code, 2, "text channel stays the config class");
+    let text = format!("{stdout}\n{stderr}");
+    assert!(
+        text.contains("Config Status: FAILED") || text.contains("failed to parse YAML"),
+        "text channel must stay diagnosed:\n{text}"
+    );
+    assert!(
+        !text.contains(&token),
+        "raw credential must not appear on the text channel:\n{text}"
+    );
+    assert!(
+        text.contains("<redacted:"),
+        "redaction placeholder must be visible on the text channel:\n{text}"
+    );
+    assert!(
+        text.contains("(truncated)"),
+        "truncation must be visible on the text channel:\n{text}"
     );
 }
 

--- a/crates/assay-cli/tests/doctor_config_check_contract.rs
+++ b/crates/assay-cli/tests/doctor_config_check_contract.rs
@@ -116,6 +116,15 @@ fn long_secret_yaml() -> (String, String) {
     (token, yaml)
 }
 
+fn yaml_location_mark(yaml: &str) -> String {
+    let err = serde_yaml::from_str::<assay_core::model::EvalConfig>(yaml)
+        .expect_err("fixture must fail YAML parse");
+    let loc = err
+        .location()
+        .expect("serde_yaml must report a location for this fixture");
+    format!("at line {} column {}", loc.line(), loc.column())
+}
+
 fn init_project(cwd: &Path) {
     let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
     command.current_dir(cwd).env("NO_COLOR", "1").args([
@@ -210,6 +219,16 @@ fn a_config_that_will_not_load_is_neither_checked_nor_skipped() {
         message.contains("failed to parse YAML"),
         "concise malformed YAML must stay diagnosed: {message}"
     );
+    let mark = yaml_location_mark("version: [\n");
+    assert!(
+        message.contains(&mark),
+        "short diagnosis must keep the location mark: {message}"
+    );
+    assert_eq!(
+        message.matches(&mark).count(),
+        1,
+        "short diagnosis must not duplicate the location mark: {message}"
+    );
     assert_eq!(
         document["reason_code"], "E_CFG_PARSE",
         "unloadable explicit config stays the parse class: {document}"
@@ -277,6 +296,24 @@ fn a_long_secret_parse_error_is_redacted_bounded_and_not_duplicated() {
     assert!(
         message.contains("(truncated)"),
         "truncation must be visible: {message}"
+    );
+    let mark = yaml_location_mark(&yaml);
+    assert!(
+        message.contains(&mark),
+        "location must survive the same total budget: {message}"
+    );
+    assert_eq!(
+        message.matches(&mark).count(),
+        1,
+        "location mark must appear once: {message}"
+    );
+    let trunc_at = message
+        .find("(truncated)")
+        .expect("truncation marker already asserted");
+    let mark_at = message.find(&mark).expect("location mark already asserted");
+    assert!(
+        mark_at > trunc_at,
+        "location is reserved after the bound excerpt, not swallowed by truncate: {message}"
     );
     assert!(
         message.chars().count() <= assay_core::render_safety::MAX_RENDER_FIELD + 80,

--- a/crates/assay-cli/tests/doctor_config_check_contract.rs
+++ b/crates/assay-cli/tests/doctor_config_check_contract.rs
@@ -242,6 +242,48 @@ fn a_config_that_will_not_load_is_neither_checked_nor_skipped() {
     );
 }
 
+/// Libyaml tab / unterminated-quote Displays keep context after the problem
+/// mark. Doctor must not append `location()` a second time.
+#[test]
+fn a_libyaml_context_parse_error_does_not_duplicate_the_problem_mark() {
+    for (label, yaml, context) in [
+        ("tab", "version: 1\n\tfoo: 1\n", "while scanning"),
+        (
+            "unterminated quote",
+            "version: \"hello\n",
+            "while scanning a quoted scalar",
+        ),
+    ] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dir.path().join("bad.yaml");
+        std::fs::write(&config, yaml).expect("write yaml");
+        let (code, document) = doctor_json(
+            dir.path(),
+            &["--config", config.to_str().expect("UTF-8 path")],
+        );
+        assert_eq!(code, 2, "{label} stays the config class");
+        let message = document["config_error"]["message"]
+            .as_str()
+            .unwrap_or_else(|| {
+                panic!("{label}: config_error.message must be a string: {document}")
+            });
+        let mark = yaml_location_mark(yaml);
+        assert_eq!(
+            message.matches(&mark).count(),
+            1,
+            "{label} problem-mark must appear once: {message}"
+        );
+        assert!(
+            message.contains(context),
+            "{label} context text must be kept: {message}"
+        );
+        assert!(
+            message.contains("at line 1 column 10"),
+            "{label} context-mark must be kept: {message}"
+        );
+    }
+}
+
 /// A parse error that quotes a long secret-shaped scalar must reach doctor
 /// redacted and bounded. This is the parse-Display fold, not a read ceiling,
 /// and not a claim that every YAML error echoes input.

--- a/crates/assay-core/src/config.rs
+++ b/crates/assay-core/src/config.rs
@@ -253,23 +253,27 @@ tests:
 
 /// Bound a `serde_yaml::Error` Display through `render_safe`, but keep the
 /// `location()` mark inside the same `MAX_RENDER_FIELD` budget. Truncating the
-/// whole Display would drop the trailing `at line N column M`. Short errors
-/// already carry that suffix; strip it first so the reserved mark is not
-/// duplicated. `Sink::Json` is identity today (M5); this is not a second
-/// sanitizer and does not raise the budget.
+/// whole Display would drop a trailing `at line N column M`. Reserve and
+/// reattach that mark only when it is a real suffix. Libyaml Displays put
+/// context after the problem-mark (`… at line N column M, while scanning …`);
+/// `strip_suffix` is then `None` and the full Display goes through
+/// `render_safe` once — no second append. `Sink::Json` is identity today
+/// (M5); this is not a second sanitizer and does not raise the budget.
 fn render_yaml_parse_error(err: &serde_yaml::Error) -> String {
     let display = err.to_string();
     let Some(loc) = err.location() else {
         return render_safe(Sink::Json, &display, MAX_RENDER_FIELD);
     };
     let mark = format!(" at line {} column {}", loc.line(), loc.column());
-    let diagnosis = display
-        .strip_suffix(mark.as_str())
-        .unwrap_or(display.as_str());
-    let reserved = mark.chars().count();
-    let budget = MAX_RENDER_FIELD.saturating_sub(reserved);
-    let safe = render_safe(Sink::Json, diagnosis, budget);
-    format!("{safe}{mark}")
+    match display.strip_suffix(mark.as_str()) {
+        Some(diagnosis) => {
+            let reserved = mark.chars().count();
+            let budget = MAX_RENDER_FIELD.saturating_sub(reserved);
+            let safe = render_safe(Sink::Json, diagnosis, budget);
+            format!("{safe}{mark}")
+        }
+        None => render_safe(Sink::Json, &display, MAX_RENDER_FIELD),
+    }
 }
 
 #[cfg(test)]
@@ -312,6 +316,68 @@ mod tests {
             .location()
             .expect("serde_yaml must report a location for this fixture");
         format!("at line {} column {}", loc.line(), loc.column())
+    }
+
+    fn load_parse_message(yaml: &str) -> String {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("bad.yaml");
+        std::fs::write(&path, yaml).expect("write yaml");
+        load_config_with_cause(&path, Default::default())
+            .expect_err("fixture must fail YAML parse")
+            .to_string()
+    }
+
+    /// Tab + unterminated quote are libyaml Displays: problem-mark is not a
+    /// suffix (`… at line N column M, while scanning …` and a second context
+    /// mark). The fold must not append `location()` again.
+    #[test]
+    fn yaml_parse_error_keeps_libyaml_context_without_duplicating_problem_mark() {
+        let tab = "version: 1\n\tfoo: 1\n";
+        let tab_msg = load_parse_message(tab);
+        let tab_mark = yaml_location_mark(tab);
+        assert!(
+            tab_msg.contains("failed to parse YAML"),
+            "tab input must stay diagnosed: {tab_msg}"
+        );
+        assert_eq!(
+            tab_msg.matches(&tab_mark).count(),
+            1,
+            "tab problem-mark must appear once: {tab_msg}"
+        );
+        assert!(
+            tab_msg.contains("while scanning"),
+            "tab context text must be kept: {tab_msg}"
+        );
+        assert!(
+            tab_msg.contains("at line 1 column 10"),
+            "tab context-mark must be kept: {tab_msg}"
+        );
+
+        let quote = "version: \"hello\n";
+        let quote_msg = load_parse_message(quote);
+        let quote_mark = yaml_location_mark(quote);
+        assert!(
+            quote_msg.contains("failed to parse YAML"),
+            "unterminated quote must stay diagnosed: {quote_msg}"
+        );
+        assert_eq!(
+            quote_msg.matches(&quote_mark).count(),
+            1,
+            "quote problem-mark must appear once: {quote_msg}"
+        );
+        assert!(
+            quote_msg.contains("while scanning a quoted scalar"),
+            "quote context text must be kept: {quote_msg}"
+        );
+        assert!(
+            quote_msg.contains("at line 1 column 10"),
+            "quote context-mark must be kept: {quote_msg}"
+        );
+        assert_ne!(
+            quote_mark.as_str(),
+            "at line 1 column 10",
+            "quote fixture must keep problem-mark distinct from context-mark"
+        );
     }
 
     #[test]

--- a/crates/assay-core/src/config.rs
+++ b/crates/assay-core/src/config.rs
@@ -91,7 +91,7 @@ pub fn load_config_with_cause(
     .map_err(|e| {
         ConfigLoadError::new(format!(
             "failed to parse YAML: {}",
-            render_safe(Sink::Json, &e.to_string(), MAX_RENDER_FIELD)
+            render_yaml_parse_error(&e)
         ))
     })?;
 
@@ -251,6 +251,27 @@ tests:
     Ok(())
 }
 
+/// Bound a `serde_yaml::Error` Display through `render_safe`, but keep the
+/// `location()` mark inside the same `MAX_RENDER_FIELD` budget. Truncating the
+/// whole Display would drop the trailing `at line N column M`. Short errors
+/// already carry that suffix; strip it first so the reserved mark is not
+/// duplicated. `Sink::Json` is identity today (M5); this is not a second
+/// sanitizer and does not raise the budget.
+fn render_yaml_parse_error(err: &serde_yaml::Error) -> String {
+    let display = err.to_string();
+    let Some(loc) = err.location() else {
+        return render_safe(Sink::Json, &display, MAX_RENDER_FIELD);
+    };
+    let mark = format!(" at line {} column {}", loc.line(), loc.column());
+    let diagnosis = display
+        .strip_suffix(mark.as_str())
+        .unwrap_or(display.as_str());
+    let reserved = mark.chars().count();
+    let budget = MAX_RENDER_FIELD.saturating_sub(reserved);
+    let safe = render_safe(Sink::Json, diagnosis, budget);
+    format!("{safe}{mark}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{load_config_with, load_config_with_cause};
@@ -282,6 +303,17 @@ mod tests {
         (token, yaml)
     }
 
+    /// serde_yaml Display's trailing mark, from `Error::location()`, not from
+    /// scraping the Display string (that is what truncation drops).
+    fn yaml_location_mark(yaml: &str) -> String {
+        let err = serde_yaml::from_str::<crate::model::EvalConfig>(yaml)
+            .expect_err("fixture must fail YAML parse");
+        let loc = err
+            .location()
+            .expect("serde_yaml must report a location for this fixture");
+        format!("at line {} column {}", loc.line(), loc.column())
+    }
+
     #[test]
     fn malformed_yaml_does_not_invent_not_found() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -293,9 +325,20 @@ mod tests {
             None,
             "YAML failures must not carry a read I/O kind: {err}"
         );
+        let message = err.to_string();
         assert!(
-            err.to_string().contains("failed to parse YAML"),
-            "concise malformed YAML must stay diagnosed: {err}"
+            message.contains("failed to parse YAML"),
+            "concise malformed YAML must stay diagnosed: {message}"
+        );
+        let mark = yaml_location_mark("version: [\n");
+        assert!(
+            message.contains(&mark),
+            "short diagnosis must keep the location mark: {message}"
+        );
+        assert_eq!(
+            message.matches(&mark).count(),
+            1,
+            "short diagnosis must not duplicate the location mark: {message}"
         );
         let public = load_config_with(&path, Default::default()).expect_err("malformed yaml");
         assert_eq!(err.to_string(), public.to_string());
@@ -338,6 +381,24 @@ mod tests {
         assert!(
             message.len() < yaml.len(),
             "bounded diagnostic must be shorter than the fixture that produced it"
+        );
+        let mark = yaml_location_mark(&yaml);
+        assert!(
+            message.contains(&mark),
+            "location must survive the same total budget: {message}"
+        );
+        assert_eq!(
+            message.matches(&mark).count(),
+            1,
+            "location mark must appear once: {message}"
+        );
+        let trunc_at = message
+            .find("(truncated)")
+            .expect("truncation marker already asserted");
+        let mark_at = message.find(&mark).expect("location mark already asserted");
+        assert!(
+            mark_at > trunc_at,
+            "location is reserved after the bound excerpt, not swallowed by truncate: {message}"
         );
         assert_eq!(
             err.io_kind(),

--- a/crates/assay-core/src/config.rs
+++ b/crates/assay-core/src/config.rs
@@ -1,5 +1,6 @@
 use crate::errors::{ConfigError, ConfigLoadError};
 use crate::model::EvalConfig;
+use crate::render_safety::{render_safe, Sink, MAX_RENDER_FIELD};
 use std::path::Path;
 
 pub mod otel;
@@ -84,7 +85,15 @@ pub fn load_config_with_cause(
     let mut cfg: EvalConfig = serde_ignored::deserialize(deserializer, |path| {
         ignored_keys.insert(path.to_string());
     })
-    .map_err(|e| ConfigLoadError::new(format!("failed to parse YAML: {}", e)))?;
+    // Parse Display can quote the offending scalar. Bound that excerpt through
+    // the existing render-safety pipeline (redact-before-truncate). This is not
+    // a read ceiling, and it does not claim every YAML error echoes input.
+    .map_err(|e| {
+        ConfigLoadError::new(format!(
+            "failed to parse YAML: {}",
+            render_safe(Sink::Json, &e.to_string(), MAX_RENDER_FIELD)
+        ))
+    })?;
 
     // Check strictness / significant unknown fields
     if strict && !ignored_keys.is_empty() {
@@ -264,6 +273,15 @@ mod tests {
         assert_eq!(typed.into_config_error().0, public.0);
     }
 
+    /// github-token shape from `render_safety/rules.rs` (`ghp_` + 36 alphanumerics).
+    /// A space then padding keeps the extra bytes outside that rule so redaction
+    /// cannot swallow the whole scalar (the `{36,}` quantifier is open-ended).
+    fn long_secret_yaml() -> (String, String) {
+        let token = format!("ghp_{}", "A".repeat(36));
+        let yaml = format!("version: \"{token} {}\"\n", "x".repeat(300));
+        (token, yaml)
+    }
+
     #[test]
     fn malformed_yaml_does_not_invent_not_found() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -275,7 +293,56 @@ mod tests {
             None,
             "YAML failures must not carry a read I/O kind: {err}"
         );
+        assert!(
+            err.to_string().contains("failed to parse YAML"),
+            "concise malformed YAML must stay diagnosed: {err}"
+        );
         let public = load_config_with(&path, Default::default()).expect_err("malformed yaml");
         assert_eq!(err.to_string(), public.to_string());
+    }
+
+    /// The YAML parse-Display fold is the one ceiling: prefix plus a render-safe
+    /// excerpt. Not a read ceiling, not a claim that every YAML error echoes input.
+    #[test]
+    fn yaml_parse_error_is_redacted_and_bounded() {
+        use crate::render_safety::MAX_RENDER_FIELD;
+
+        let (token, yaml) = long_secret_yaml();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("secret.yaml");
+        std::fs::write(&path, &yaml).expect("write long-secret yaml");
+        let err = load_config_with_cause(&path, Default::default())
+            .expect_err("long secret scalar must fail YAML parse");
+        let message = err.to_string();
+        assert!(
+            message.contains("failed to parse YAML"),
+            "parse failures must stay diagnosed: {message}"
+        );
+        assert!(
+            !message.contains(&token),
+            "raw credential must not survive the parse-Display fold: {message}"
+        );
+        assert!(
+            message.contains("<redacted:"),
+            "redaction placeholder must be visible: {message}"
+        );
+        assert!(
+            message.contains("(truncated)"),
+            "truncation must be visible: {message}"
+        );
+        assert!(
+            message.chars().count() <= MAX_RENDER_FIELD + 80,
+            "ConfigLoadError is prefix + bounded excerpt, not the full scalar ({} chars): {message}",
+            message.chars().count()
+        );
+        assert!(
+            message.len() < yaml.len(),
+            "bounded diagnostic must be shorter than the fixture that produced it"
+        );
+        assert_eq!(
+            err.io_kind(),
+            None,
+            "parse fold must not invent a read kind"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- one loader seam: `serde_yaml` parse Display at `config.rs` goes through existing `render_safe` + `MAX_RENDER_FIELD` (redact-before-truncate)
- `render_yaml_parse_error` takes `serde_yaml::Error::location()` and reserves ` at line N column M` **only when `strip_suffix(mark)` is `Some`**
- otherwise the full Display goes through `render_safe` once (no second append). That is the libyaml shape: `… at line N column M, while scanning …` plus an optional context-mark
- failed doctor `config_check` publishes only `status: "failed"`; `config_error.message` is the single human detail
- skipped `config_check.reason` unchanged
- no new reason code, exit class, or schema version
- `Sink::Json` in the loader is identity today (M5); no content change there

## Provenance

| item | value |
|---|---|
| base | `924599b1eeda055ec2a19ba3ce017841958a5e46` (`origin/main`, #2418 merged) |
| **final head** | `9a9baea666b017eee9adb55b555725e298f4f79c` (append `location()` only on a real suffix) |
| prior heads | `5f30e16d` (bound Display) → `9ec64f2c` (always reattach `location()`; blocked: duplicate problem-mark on tab/quote) |
| worktree | `/tmp/assay-2266-ruley` |
| branch | `ruley/2266-bounded-config-diagnostic` |
| rustc | `1.96.0 (ac68faa20 2026-05-25)` |
| target | `/tmp/assay-2266-target` only |

## RED

1. `version: "ghp_<36 A> <300 x>"` — raw credential before the seam; after `5f30e16d` redacted/truncated but trailing `at line N column M` dropped.
2. Tab `version: 1\n<tab>foo: 1\n` — Display is `… at line 2 column 1, while scanning a plain scalar at line 1 column 10`. On `9ec64f2c`, `strip_suffix(problem_mark)` is `None` and the code still appended `location()=(2,1)` → two problem-marks.
3. Unterminated quote `version: "hello\n` — problem-mark and context-mark; same false `unwrap_or` append.

Ordinary `version: [\n` (short Message path) must stay one trailing/embedded mark.

## GREEN

- `yaml_parse_error_keeps_libyaml_context_without_duplicating_problem_mark` (tab + quote: problem-mark once, context text + context-mark kept)
- `malformed_yaml_does_not_invent_not_found` (short Message path: mark exactly once)
- `yaml_parse_error_is_redacted_and_bounded` (long secret: redacted, `(truncated)`, bounded, location after truncate, once)
- doctor: `a_libyaml_context_parse_error_does_not_duplicate_the_problem_mark`, `a_config_that_will_not_load_is_neither_checked_nor_skipped`, `a_long_secret_parse_error_is_redacted_bounded_and_not_duplicated`
- skipped `reason` still required
- `cargo fmt -p assay-core -p assay-cli -- --check`; `clippy -D warnings` on affected targets; `git diff --check`
- no workspace suite

## Mutations

1. Raw `{}` of `e` at the seam → raw credential assertions died. Restored.
2. Restored failed `reason` → “no reason on failed” died. Restored.
3. Omit the reserved location mark on a suffix Display → long-YAML “location must survive” died. Restored.
4. Append `location()` when `strip_suffix` is `None` → tab/quote “problem-mark once” died. Restored.

## Non-claims

- **draft; not ready to merge;** extra evidence, not quorum
- not #2217 (read ceiling / FIFO)
- not ADR-043 hostile-ingest
- not #2264 / #2418 (`path_json`)
- not #2263
- not #2421 (non-UTF-8 `HOME` / `config-path --json`)
- not a new reason / exit / schema
- not a claim that every YAML error echoes input
- not a second sanitizer and not a higher total budget than `MAX_RENDER_FIELD`
- `Sink::Json` remains identity (M5); latent observation only
- read / unknown-field / version `ConfigLoadError` sites are not this seam
- `implementation.rs` is unchanged after `5f30e16d`
- no disk cleanup / deletions in this slice
- Ruley-builder comments are not the non-building-agent review

Closes nothing. Draft for #2266.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration diagnostics in the doctor command.
  - Failed checks now clearly report failure status while providing detailed error information separately.
  - YAML parsing errors retain useful context and location details, with sensitive values redacted and messages safely truncated.
  - JSON and text output now provide consistent recovery guidance without exposing credentials or other secrets.
  - Improved handling of long secrets, malformed locations, and duplicate error markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->