### PR TITLE
fix(cli): map JSON stdout write failure to exit 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable changes to this project will be documented in this file.
   class (#2165).
 
 ### Changed
+- `assay doctor --format json` and `assay run --format json` return exit 3 when
+  writing the machine document to stdout fails, including `BrokenPipe`. A
+  partial or absent document is not a clean success. They no longer abort with
+  SIGABRT (134). The mapping is the existing output-write policy used by
+  `supply-chain-conformance` (#2263).
 - `assay evidence show --format json` now emits `assay.run_summary.v1` with
   `E_EVIDENCE_CONTRACT` for a typed `Contract*` format-contract failure. Classification
   comes from the shared `reason_code_for_evidence_error` classifier. The command still

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -29,6 +29,7 @@ exclude = [
     "tests/init_stdout_contract.rs",
     "tests/doctor_exit_class_contract.rs",
     "tests/doctor_argument_contract.rs",
+    "tests/stdout_json_write_contract.rs",
     "tests/mcp_preflight_contract.rs",
     "tests/recovery_argv_publisher_parity.rs",
 ]

--- a/crates/assay-cli/src/cli/commands/doctor/implementation.rs
+++ b/crates/assay-cli/src/cli/commands/doctor/implementation.rs
@@ -8,7 +8,10 @@ use crate::cli::args::DoctorArgs;
 use crate::cli::helpers::decide_exit;
 use crate::diagnostics;
 use crate::diagnostics::format::format_text;
-use crate::exit_codes::{reason_for_unloadable_explicit_config, ReasonCode, RunOutcome};
+use crate::exit_codes::{
+    reason_for_unloadable_explicit_config, ReasonCode, RunOutcome, EXIT_SUCCESS,
+};
+use crate::output_write::write_stdout_json;
 
 use super::fixes::run_doctor_fix;
 use super::parse_error::try_fix_parse_error;
@@ -120,7 +123,10 @@ fn reject_invalid_args(format: OutputFormat, outcome: RunOutcome) -> anyhow::Res
                 obj.insert("message".to_string(), serde_json::json!(message));
             }
         }
-        println!("{}", serde_json::to_string_pretty(&json_out)?);
+        let write_code = write_stdout_json(&serde_json::to_string_pretty(&json_out)?);
+        if write_code != EXIT_SUCCESS {
+            return Ok(write_code);
+        }
         return Ok(outcome.exit_code);
     }
     if let Some(message) = &outcome.message {
@@ -184,7 +190,10 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
                         "code": outcome.reason_code,
                     }),
                 );
-                println!("{}", serde_json::to_string_pretty(&json_out)?);
+                let write_code = write_stdout_json(&serde_json::to_string_pretty(&json_out)?);
+                if write_code != EXIT_SUCCESS {
+                    return Ok(write_code);
+                }
                 return Ok(outcome.exit_code);
             }
 
@@ -210,7 +219,10 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
             }
         }
 
-        println!("{}", serde_json::to_string_pretty(&json_out)?);
+        let write_code = write_stdout_json(&serde_json::to_string_pretty(&json_out)?);
+        if write_code != EXIT_SUCCESS {
+            return Ok(write_code);
+        }
         return Ok(exit);
     }
 

--- a/crates/assay-cli/src/cli/commands/run.rs
+++ b/crates/assay-cli/src/cli/commands/run.rs
@@ -5,6 +5,8 @@ use super::reporting::{
     build_summary_from_artifacts, maybe_export_baseline, print_pipeline_summary,
 };
 use super::run_output::write_extended_run_json;
+use crate::exit_codes::EXIT_SUCCESS;
+use crate::output_write::write_stdout_json;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -51,7 +53,10 @@ pub(crate) async fn run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32>
             print_pipeline_summary(&artifacts, args.explain_skip, &summary);
         }
         super::super::args::OutputFormat::Json => {
-            println!("{}", assay_core::report::json::render_json(&artifacts)?);
+            let write_code = write_stdout_json(&assay_core::report::json::render_json(&artifacts)?);
+            if write_code != EXIT_SUCCESS {
+                return Ok(write_code);
+            }
         }
     }
 

--- a/crates/assay-cli/src/cli/commands/run.rs
+++ b/crates/assay-cli/src/cli/commands/run.rs
@@ -46,8 +46,9 @@ pub(crate) async fn run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32>
     // - text: human-readable summary on stderr (default; unchanged behavior).
     // - json: machine-readable report on stdout, so `assay run --format json
     //   > results.json` composes with CI pipelines.
-    // The run.json / summary.json artifacts are written regardless, so the
-    // exit-code contract is unaffected by the chosen display format.
+    // run.json is written before this display step. A JSON stdout write
+    // failure returns exit 3 without writing summary.json or exporting a
+    // baseline.
     match args.format {
         super::super::args::OutputFormat::Text => {
             print_pipeline_summary(&artifacts, args.explain_skip, &summary);

--- a/crates/assay-cli/src/cli/commands/supply_chain_conformance.rs
+++ b/crates/assay-cli/src/cli/commands/supply_chain_conformance.rs
@@ -13,11 +13,12 @@
 //! safe descriptor-relative file resolution. The keyless `sigstore_bundle` path is modeled in the descriptor
 //! but explicitly DEFERRED: it is rejected with a clear non-zero, never silently ignored.
 
-use std::io::Write;
+use std::fs::File;
 use std::path::Path;
 
 use crate::cli::args::SupplyChainConformanceArgs;
-use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR, EXIT_SUCCESS};
+use crate::exit_codes::EXIT_CONFIG_ERROR;
+use crate::output_write::{map_write_result, write_document, write_stdout_json};
 
 mod descriptor;
 
@@ -56,32 +57,14 @@ pub async fn run(args: SupplyChainConformanceArgs) -> anyhow::Result<i32> {
         }
     };
 
-    let rendered = format!("{}\n", serde_json::to_string_pretty(&carrier)?);
+    let rendered = serde_json::to_string_pretty(&carrier)?;
     // Output-write failures are an infra/output problem regardless of the target: stdout and file
     // writes route through the same mapping, so a broken pipe on stdout is EXIT_INFRA_ERROR just like
     // an unwritable file path (never the generic `?` bubble).
-    let write_result = if args.out == "-" {
-        std::io::stdout().write_all(rendered.as_bytes())
-    } else {
-        std::fs::write(&args.out, &rendered)
-    };
-    let target = if args.out == "-" {
-        "stdout"
-    } else {
-        args.out.as_str()
-    };
-    Ok(map_write_result(target, write_result))
-}
-
-/// Map an output-write result to an exit code. A write failure is an infra/output problem
-/// (`EXIT_INFRA_ERROR`), applied uniformly to stdout and file targets so the exit-code contract is
-/// the same whatever `--out` points at.
-fn map_write_result(target: &str, result: std::io::Result<()>) -> i32 {
-    match result {
-        Ok(()) => EXIT_SUCCESS,
-        Err(e) => {
-            eprintln!("[infra_error] cannot write output ({target}): {e}");
-            EXIT_INFRA_ERROR
-        }
+    if args.out == "-" {
+        return Ok(write_stdout_json(&rendered));
     }
+    let write_result =
+        File::create(&args.out).and_then(|mut file| write_document(&mut file, &rendered));
+    Ok(map_write_result(args.out.as_str(), write_result))
 }

--- a/crates/assay-cli/src/cli/commands/supply_chain_conformance/tests.rs
+++ b/crates/assay-cli/src/cli/commands/supply_chain_conformance/tests.rs
@@ -4,8 +4,7 @@ use assay_registry::supply_chain::{SupplyChainConformance, SCHEMA};
 use serde_json::{json, Value};
 
 use super::descriptor::{build_carrier, EmitErr, DSSE_IN_TOTO_PAYLOAD_TYPE, INPUT_SCHEMA};
-use super::map_write_result;
-use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR, EXIT_SUCCESS};
+use crate::exit_codes::EXIT_CONFIG_ERROR;
 
 fn descriptor(provenance: Value) -> String {
     json!({
@@ -107,28 +106,6 @@ fn dsse_without_required_fields_is_rejected() {
 #[test]
 fn deferred_sigstore_bundle_is_rejected_not_ignored() {
     assert!(bc(&descriptor(json!({ "kind": "sigstore_bundle" }))).is_err());
-}
-
-#[test]
-fn write_failure_maps_to_infra_error_for_any_target() {
-    use std::io::{Error, ErrorKind};
-
-    // A write failure is EXIT_INFRA_ERROR uniformly - stdout (broken pipe) and file alike.
-    assert_eq!(
-        map_write_result(
-            "stdout",
-            Err(Error::new(ErrorKind::BrokenPipe, "pipe closed"))
-        ),
-        EXIT_INFRA_ERROR
-    );
-    assert_eq!(
-        map_write_result(
-            "/tmp/x.json",
-            Err(Error::new(ErrorKind::PermissionDenied, "nope"))
-        ),
-        EXIT_INFRA_ERROR
-    );
-    assert_eq!(map_write_result("stdout", Ok(())), EXIT_SUCCESS);
 }
 
 #[test]

--- a/crates/assay-cli/src/exit_codes.rs
+++ b/crates/assay-cli/src/exit_codes.rs
@@ -32,7 +32,8 @@ pub const EXIT_TEST_FAILURE: i32 = 1;
 /// Configuration or user error (config parse, trace not found, etc.)
 pub const EXIT_CONFIG_ERROR: i32 = 2;
 
-/// Infrastructure or judge unavailable (rate limit, provider 5xx, timeout)
+/// Infrastructure or judge unavailable (rate limit, provider 5xx, timeout),
+/// including a machine-document stdout or file write failure.
 pub const EXIT_INFRA_ERROR: i32 = 3;
 
 /// Would block (dry-run mode) - sandbox-specific

--- a/crates/assay-cli/src/main.rs
+++ b/crates/assay-cli/src/main.rs
@@ -21,6 +21,7 @@ pub mod fs;
 pub mod landlock_check;
 pub mod landlock_net;
 pub mod metrics;
+mod output_write;
 pub mod packs;
 pub mod policy;
 pub mod profile;

--- a/crates/assay-cli/src/output_write.rs
+++ b/crates/assay-cli/src/output_write.rs
@@ -1,0 +1,97 @@
+//! One write/flush policy for machine documents on stdout (and other output targets).
+//!
+//! A partial or absent document is not a clean success. Any write or flush failure,
+//! including `ErrorKind::BrokenPipe`, is `EXIT_INFRA_ERROR`. Callers render first,
+//! then hand the finished bytes to this module; they do not map the error themselves.
+
+use std::io::{self, Write};
+
+use crate::exit_codes::{EXIT_INFRA_ERROR, EXIT_SUCCESS};
+
+/// Write a fully rendered machine document plus a trailing newline, then flush.
+pub(crate) fn write_document(writer: &mut impl Write, rendered: &str) -> io::Result<()> {
+    writer.write_all(rendered.as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+/// Map an output-write result to an exit code. A write failure is an infra/output
+/// problem (`EXIT_INFRA_ERROR`) for every target, including stdout BrokenPipe.
+pub(crate) fn map_write_result(target: &str, result: io::Result<()>) -> i32 {
+    match result {
+        Ok(()) => EXIT_SUCCESS,
+        Err(error) => {
+            eprintln!("[infra_error] cannot write output ({target}): {error}");
+            EXIT_INFRA_ERROR
+        }
+    }
+}
+
+/// Write a rendered JSON document to stdout. Returns `EXIT_SUCCESS` only when the
+/// write and flush both succeed; callers then apply their own command exit.
+pub(crate) fn write_stdout_json(rendered: &str) -> i32 {
+    map_write_result("stdout", write_document(&mut io::stdout(), rendered))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{map_write_result, write_document};
+    use crate::exit_codes::{EXIT_INFRA_ERROR, EXIT_SUCCESS};
+    use std::io::{self, Error, ErrorKind, Write};
+
+    struct FailWrite(ErrorKind);
+
+    impl Write for FailWrite {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(Error::new(self.0, "injected write failure"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_failure_maps_to_infra_error_for_any_target() {
+        assert_eq!(
+            map_write_result(
+                "stdout",
+                Err(Error::new(ErrorKind::BrokenPipe, "pipe closed"))
+            ),
+            EXIT_INFRA_ERROR
+        );
+        assert_eq!(
+            map_write_result(
+                "/tmp/x.json",
+                Err(Error::new(ErrorKind::PermissionDenied, "nope"))
+            ),
+            EXIT_INFRA_ERROR
+        );
+        assert_eq!(map_write_result("stdout", Ok(())), EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn write_document_failures_share_the_one_mapping() {
+        for kind in [
+            ErrorKind::BrokenPipe,
+            ErrorKind::PermissionDenied,
+            ErrorKind::Other,
+        ] {
+            let mut writer = FailWrite(kind);
+            let result = write_document(&mut writer, r#"{"ok":true}"#);
+            assert_eq!(
+                map_write_result("stdout", result),
+                EXIT_INFRA_ERROR,
+                "{kind:?} must not be swallowed or remapped"
+            );
+        }
+    }
+
+    #[test]
+    fn write_document_appends_newline_and_maps_success() {
+        let mut buf = Vec::new();
+        let result = write_document(&mut buf, r#"{"ok":true}"#);
+        assert_eq!(map_write_result("stdout", result), EXIT_SUCCESS);
+        assert_eq!(buf, b"{\"ok\":true}\n");
+    }
+}

--- a/crates/assay-cli/src/output_write.rs
+++ b/crates/assay-cli/src/output_write.rs
@@ -17,11 +17,18 @@ pub(crate) fn write_document(writer: &mut impl Write, rendered: &str) -> io::Res
 
 /// Map an output-write result to an exit code. A write failure is an infra/output
 /// problem (`EXIT_INFRA_ERROR`) for every target, including stdout BrokenPipe.
+///
+/// The diagnostic line uses a fallible stderr write whose `Result` is ignored so
+/// a closed stderr cannot panic and replace the defined exit 3.
 pub(crate) fn map_write_result(target: &str, result: io::Result<()>) -> i32 {
     match result {
         Ok(()) => EXIT_SUCCESS,
         Err(error) => {
-            eprintln!("[infra_error] cannot write output ({target}): {error}");
+            let mut stderr = io::stderr().lock();
+            let _ = writeln!(
+                stderr,
+                "[infra_error] cannot write output ({target}): {error}"
+            );
             EXIT_INFRA_ERROR
         }
     }
@@ -48,6 +55,18 @@ mod tests {
 
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
+        }
+    }
+
+    struct FailFlush;
+
+    impl Write for FailFlush {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(Error::new(ErrorKind::BrokenPipe, "injected flush failure"))
         }
     }
 
@@ -85,6 +104,33 @@ mod tests {
                 "{kind:?} must not be swallowed or remapped"
             );
         }
+    }
+
+    #[test]
+    fn write_document_flush_failure_maps_to_infra_error() {
+        let mut writer = FailFlush;
+        let result = write_document(&mut writer, r#"{"ok":true}"#);
+        assert_eq!(
+            map_write_result("stdout", result),
+            EXIT_INFRA_ERROR,
+            "a successful write that fails on flush is still exit 3"
+        );
+    }
+
+    #[test]
+    fn map_write_result_uses_a_fallible_stderr_write() {
+        let prod = include_str!("output_write.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source precedes the test module");
+        assert!(
+            !prod.contains("eprintln!"),
+            "diagnostic write must not use eprintln!, which panics on a closed stderr"
+        );
+        assert!(
+            prod.contains("writeln!") && prod.contains("let _ ="),
+            "the diagnostic must writeln! to locked stderr and ignore that Result"
+        );
     }
 
     #[test]

--- a/crates/assay-cli/tests/stdout_json_write_contract.rs
+++ b/crates/assay-cli/tests/stdout_json_write_contract.rs
@@ -14,6 +14,7 @@ use std::ffi::OsStr;
 use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -28,9 +29,8 @@ const LIMITS: ProcessLimits =
 const LARGE_RUN_LIMITS: ProcessLimits =
     ProcessLimits::new(Duration::from_secs(45), 4 * 1024 * 1024, 64 * 1024);
 const PIPE_CAPACITY: usize = 64 * 1024;
-/// POSIX minimum `PIPE_BUF`. Linux is typically 4096; either is far below the fixture.
-const PIPE_BUF: usize = 512;
 const PARTIAL_READ: usize = 200;
+const REAP_GRACE: Duration = Duration::from_secs(1);
 
 const MATCHING_TRACE: &str = r#"{"schema_version": 1, "type": "assay.trace", "request_id": "hello_1", "prompt": "hello_prompt", "response": "Hello Assay", "model": "trace", "provider": "trace"}
 "#;
@@ -154,6 +154,42 @@ fn join_bounded_reader(
         .unwrap_or_else(|error| panic!("{context}: read stderr: {error}"))
 }
 
+#[cfg(unix)]
+fn kill_already_gone(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(libc::ESRCH)
+}
+
+#[cfg(windows)]
+fn kill_already_gone(_error: &std::io::Error) -> bool {
+    false
+}
+
+fn start_kill_named(child: &mut dyn ChildWrapper, context: &str) -> Result<(), String> {
+    match child.start_kill() {
+        Ok(()) => Ok(()),
+        Err(error) if kill_already_gone(&error) => Ok(()),
+        Err(error) => Err(format!("{context}: start_kill failed: {error}")),
+    }
+}
+
+fn reap_after_kill(child: &mut dyn ChildWrapper, context: &str) -> Result<(), String> {
+    let reap_deadline = Instant::now() + REAP_GRACE;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return Ok(()),
+            Ok(None) if Instant::now() < reap_deadline => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                return Err(format!(
+                    "{context}: child did not exit within the wait deadline; reap grace expired"
+                ));
+            }
+            Err(error) => return Err(format!("{context}: reap after kill failed: {error}")),
+        }
+    }
+}
+
 fn wait_or_kill(
     child: &mut dyn ChildWrapper,
     timeout: Duration,
@@ -167,31 +203,16 @@ fn wait_or_kill(
                 thread::sleep(Duration::from_millis(10));
             }
             Ok(None) => {
-                let _ = child.start_kill();
-                let reap_deadline = Instant::now() + Duration::from_secs(1);
-                while Instant::now() < reap_deadline {
-                    match child.try_wait() {
-                        Ok(Some(_)) => {
-                            return Err(format!(
-                                "{context}: child did not exit within {timeout:?}"
-                            ));
-                        }
-                        Ok(None) => thread::sleep(Duration::from_millis(10)),
-                        Err(error) => {
-                            return Err(format!("{context}: reap after kill failed: {error}"))
-                        }
-                    }
-                }
-                return Err(format!(
-                    "{context}: child did not exit within {timeout:?}; reap grace expired"
-                ));
+                start_kill_named(child, context)?;
+                reap_after_kill(child, context)?;
+                return Err(format!("{context}: child did not exit within {timeout:?}"));
             }
             Err(error) => return Err(format!("{context}: wait failed: {error}")),
         }
     }
 }
 
-/// Wait/kill owns the deadline. The stderr reader is joined only after that.
+/// Wait/kill owns the deadline. Stderr is joined only after a child-chosen exit.
 fn collect_closed_stdout(
     child: &mut dyn ChildWrapper,
     stderr_reader: Option<thread::JoinHandle<std::io::Result<Vec<u8>>>>,
@@ -199,18 +220,49 @@ fn collect_closed_stdout(
     stdout_prefix: Vec<u8>,
     context: &str,
 ) -> Result<ClosedStdout, String> {
-    let wait = wait_or_kill(child, timeout, context);
+    let code = wait_or_kill(child, timeout, context)?;
     let stderr = join_bounded_reader(stderr_reader, context);
-    match wait {
-        Ok(code) => Ok(ClosedStdout {
-            code,
-            stdout_prefix,
-            stderr,
-        }),
-        Err(error) => Err(format!(
-            "{error}; stderr={}",
-            String::from_utf8_lossy(&stderr)
-        )),
+    Ok(ClosedStdout {
+        code,
+        stdout_prefix,
+        stderr,
+    })
+}
+
+fn read_prefix_bounded(
+    mut reader: impl Read + Send + 'static,
+    child: &mut dyn ChildWrapper,
+    timeout: Duration,
+    context: &str,
+) -> Result<Vec<u8>, String> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut buf = vec![0_u8; PARTIAL_READ];
+        let result = reader.read(&mut buf).map(|n| {
+            buf.truncate(n);
+            buf
+        });
+        let _ = tx.send(result);
+    });
+    let deadline = Instant::now() + timeout;
+    loop {
+        match rx.try_recv() {
+            Ok(Ok(buf)) => return Ok(buf),
+            Ok(Err(error)) => return Err(format!("{context}: partial read: {error}")),
+            Err(mpsc::TryRecvError::Disconnected) => {
+                return Err(format!("{context}: partial-read worker disconnected"));
+            }
+            Err(mpsc::TryRecvError::Empty) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(mpsc::TryRecvError::Empty) => {
+                start_kill_named(child, context)?;
+                reap_after_kill(child, context)?;
+                return Err(format!(
+                    "{context}: partial read did not complete within {timeout:?}"
+                ));
+            }
+        }
     }
 }
 
@@ -240,33 +292,36 @@ fn run_reader_already_gone(command: Command, context: &str) -> ClosedStdout {
         .unwrap_or_else(|error| panic!("{error}"))
 }
 
-fn run_partial_then_close(mut command: Command, context: &str) -> ClosedStdout {
-    let (mut reader, writer) = std::io::pipe().expect("pipe");
+fn run_partial_then_close_with(
+    mut command: Command,
+    timeout: Duration,
+    context: &str,
+) -> Result<ClosedStdout, String> {
+    let (reader, writer) = std::io::pipe().expect("pipe");
     command
         .stdin(Stdio::null())
         .stdout(Stdio::from(writer))
         .stderr(Stdio::piped());
     let mut child = wrap_command(command)
         .spawn()
-        .unwrap_or_else(|error| panic!("{context}: spawn: {error}"));
+        .map_err(|error| format!("{context}: spawn: {error}"))?;
     let stderr_reader = child
         .stderr()
         .take()
         .map(|pipe| spawn_bounded_reader(pipe, LARGE_RUN_LIMITS.max_stderr_bytes));
-    let mut stdout_prefix = vec![0_u8; PARTIAL_READ];
-    let read = reader
-        .read(&mut stdout_prefix)
-        .unwrap_or_else(|error| panic!("{context}: partial read: {error}"));
-    stdout_prefix.truncate(read);
-    drop(reader);
+    let stdout_prefix = read_prefix_bounded(reader, child.as_mut(), timeout, context)?;
     collect_closed_stdout(
         child.as_mut(),
         stderr_reader,
-        LARGE_RUN_LIMITS.timeout,
+        timeout,
         stdout_prefix,
         context,
     )
-    .unwrap_or_else(|error| panic!("{error}"))
+}
+
+fn run_partial_then_close(command: Command, context: &str) -> ClosedStdout {
+    run_partial_then_close_with(command, LARGE_RUN_LIMITS.timeout, context)
+        .unwrap_or_else(|error| panic!("{error}"))
 }
 
 fn assert_infra_write_failure(result: &ClosedStdout, context: &str) {
@@ -277,6 +332,26 @@ fn assert_infra_write_failure(result: &ClosedStdout, context: &str) {
         String::from_utf8_lossy(&result.stderr)
     );
     assert_no_rust_panic(&result.stderr, context);
+}
+
+#[test]
+fn closed_stdout_harness_does_not_join_stderr_on_wait_error() {
+    let harness = include_str!("stdout_json_write_contract.rs")
+        .split("#[test]")
+        .next()
+        .expect("harness helpers precede the tests");
+    assert!(
+        harness.contains("let code = wait_or_kill(child, timeout, context)?;"),
+        "wait Err must return before joining stderr"
+    );
+    assert!(
+        !harness.contains(concat!("let _ = child.", "start_kill()")),
+        "start_kill failures must be surfaced"
+    );
+    assert!(
+        harness.contains("read_prefix_bounded"),
+        "the prefix read must be deadline-bounded"
+    );
 }
 
 #[test]
@@ -388,11 +463,6 @@ fn run_json_partial_read_then_close_is_exit_three() {
         "partial-read fixture must exceed the pipe buffer, got {} bytes",
         drained.stdout.len()
     );
-    assert!(
-        drained.stdout.len() > PIPE_BUF,
-        "partial-read fixture must exceed PIPE_BUF ({PIPE_BUF}), got {} bytes",
-        drained.stdout.len()
-    );
 
     let mut command = assay_command(dir.path());
     command.args([
@@ -414,15 +484,21 @@ fn run_json_partial_read_then_close_is_exit_three() {
 
 #[cfg(unix)]
 fn hanging_stderr_command() -> Command {
-    let mut command = Command::new("sh");
-    command.args(["-c", "while :; do :; done"]);
+    let mut command = Command::new("sleep");
+    command.arg("60");
     command
 }
 
 #[cfg(windows)]
 fn hanging_stderr_command() -> Command {
-    let mut command = Command::new("ping");
-    command.args(["-t", "127.0.0.1"]);
+    let mut command = Command::new("powershell.exe");
+    command.args([
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Start-Sleep -Seconds 60",
+    ]);
     command
 }
 
@@ -442,6 +518,26 @@ fn closed_stdout_harness_times_out_when_child_keeps_stderr_open() {
     assert!(
         started.elapsed() < Duration::from_secs(2),
         "harness hung in stderr drain instead of timing out: {:?}",
+        started.elapsed()
+    );
+}
+
+#[test]
+fn partial_read_times_out_when_the_child_never_writes_stdout() {
+    let started = Instant::now();
+    let error = run_partial_then_close_with(
+        hanging_stderr_command(),
+        Duration::from_millis(250),
+        "partial-read hang probe",
+    )
+    .expect_err("a silent child must not block forever on the prefix read");
+    assert!(
+        error.contains("partial read did not complete within"),
+        "prefix read must name its deadline after kill/reap: {error}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "prefix read hung instead of timing out: {:?}",
         started.elapsed()
     );
 }

--- a/crates/assay-cli/tests/stdout_json_write_contract.rs
+++ b/crates/assay-cli/tests/stdout_json_write_contract.rs
@@ -1,0 +1,447 @@
+//! Closed or partially-closed stdout is infrastructure failure, not success or abort (#2263).
+//!
+//! `println!` panics on a stdout write failure. With `panic = "abort"` that becomes SIGABRT
+//! (exit 134), which the exit contract does not define. A partial or absent machine document
+//! is not a clean success: the write/flush error maps to `EXIT_INFRA_ERROR` (3).
+
+#[path = "../../../tests/support/bounded_process.rs"]
+#[allow(dead_code)]
+mod bounded_process;
+
+use bounded_process::{run_bounded, ProcessLimits};
+use serde_json::Value;
+use std::ffi::OsStr;
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(windows)]
+use process_wrap::std::JobObject;
+#[cfg(unix)]
+use process_wrap::std::ProcessGroup;
+use process_wrap::std::{ChildWrapper, CommandWrap};
+
+const LIMITS: ProcessLimits =
+    ProcessLimits::new(Duration::from_secs(15), 2 * 1024 * 1024, 64 * 1024);
+const LARGE_RUN_LIMITS: ProcessLimits =
+    ProcessLimits::new(Duration::from_secs(45), 4 * 1024 * 1024, 64 * 1024);
+const PIPE_CAPACITY: usize = 64 * 1024;
+/// POSIX minimum `PIPE_BUF`. Linux is typically 4096; either is far below the fixture.
+const PIPE_BUF: usize = 512;
+const PARTIAL_READ: usize = 200;
+
+const MATCHING_TRACE: &str = r#"{"schema_version": 1, "type": "assay.trace", "request_id": "hello_1", "prompt": "hello_prompt", "response": "Hello Assay", "model": "trace", "provider": "trace"}
+"#;
+
+const EVAL_ONE: &str = r#"configVersion: 1
+suite: "stdout-write"
+model: "trace"
+tests:
+  - id: "stdout_write_regex"
+    input:
+      prompt: "hello_prompt"
+    expected:
+      type: regex_match
+      pattern: "Hello\\s+Assay"
+      flags: ["i"]
+"#;
+
+fn assay_command(cwd: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command.current_dir(cwd).env("NO_COLOR", "1");
+    command
+}
+
+fn assay<T: AsRef<OsStr>>(cwd: &Path, args: &[T], limits: ProcessLimits, context: &str) -> Output {
+    let mut command = assay_command(cwd);
+    command.args(args);
+    run_bounded(command, b"", limits, context).unwrap_or_else(|error| panic!("{error}"))
+}
+
+fn exit_code(output: &Output, context: &str) -> i32 {
+    output.status.code().unwrap_or_else(|| {
+        panic!("{context}: process died by signal instead of a defined exit; {output:?}")
+    })
+}
+
+fn sole_json(output: &Output, context: &str) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{context}: stdout is not one JSON document: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn assert_no_rust_panic(stderr: &[u8], context: &str) {
+    let text = String::from_utf8_lossy(stderr);
+    assert!(
+        !text.contains("panicked at") && !text.contains("failed printing to stdout"),
+        "{context}: stderr still shows a Rust stdout panic:\n{text}"
+    );
+}
+
+fn tree_with_eval(dir: &Path, eval: &str) {
+    std::fs::write(dir.join("eval.yaml"), eval).expect("wrote eval.yaml");
+    std::fs::create_dir_all(dir.join("traces")).expect("created traces/");
+    std::fs::write(dir.join("traces/hello.jsonl"), MATCHING_TRACE).expect("wrote trace");
+}
+
+fn large_eval_yaml() -> String {
+    let pad = "x".repeat(2048);
+    let mut body =
+        String::from("configVersion: 1\nsuite: \"stdout-write-large\"\nmodel: \"trace\"\ntests:\n");
+    for i in 0..48 {
+        body.push_str(&format!(
+            "  - id: \"t{i:03}-{pad}\"\n    input:\n      prompt: \"hello_prompt\"\n    expected:\n      type: regex_match\n      pattern: \"Hello\\\\s+Assay\"\n      flags: [\"i\"]\n"
+        ));
+    }
+    body
+}
+
+#[derive(Debug)]
+struct ClosedStdout {
+    code: Option<i32>,
+    stdout_prefix: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+fn wrap_command(command: Command) -> CommandWrap {
+    let mut command = CommandWrap::from(command);
+    #[cfg(unix)]
+    command.wrap(ProcessGroup::leader());
+    #[cfg(windows)]
+    command.wrap(JobObject);
+    command
+}
+
+/// Same shape as `bounded_process::spawn_reader`: cap the stream, then `read_to_end`.
+fn spawn_bounded_reader<R: Read + Send + 'static>(
+    reader: R,
+    limit: usize,
+) -> thread::JoinHandle<std::io::Result<Vec<u8>>> {
+    thread::spawn(move || {
+        let mut bytes = Vec::with_capacity(limit.saturating_add(1));
+        reader
+            .take(limit.saturating_add(1) as u64)
+            .read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+}
+
+fn join_bounded_reader(
+    reader: Option<thread::JoinHandle<std::io::Result<Vec<u8>>>>,
+    context: &str,
+) -> Vec<u8> {
+    let Some(handle) = reader else {
+        return Vec::new();
+    };
+    handle
+        .join()
+        .unwrap_or_else(|_| panic!("{context}: stderr reader panicked"))
+        .unwrap_or_else(|error| panic!("{context}: read stderr: {error}"))
+}
+
+fn wait_or_kill(
+    child: &mut dyn ChildWrapper,
+    timeout: Duration,
+    context: &str,
+) -> Result<Option<i32>, String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status.code()),
+            Ok(None) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                let _ = child.start_kill();
+                let reap_deadline = Instant::now() + Duration::from_secs(1);
+                while Instant::now() < reap_deadline {
+                    match child.try_wait() {
+                        Ok(Some(_)) => {
+                            return Err(format!(
+                                "{context}: child did not exit within {timeout:?}"
+                            ));
+                        }
+                        Ok(None) => thread::sleep(Duration::from_millis(10)),
+                        Err(error) => {
+                            return Err(format!("{context}: reap after kill failed: {error}"))
+                        }
+                    }
+                }
+                return Err(format!(
+                    "{context}: child did not exit within {timeout:?}; reap grace expired"
+                ));
+            }
+            Err(error) => return Err(format!("{context}: wait failed: {error}")),
+        }
+    }
+}
+
+/// Wait/kill owns the deadline. The stderr reader is joined only after that.
+fn collect_closed_stdout(
+    child: &mut dyn ChildWrapper,
+    stderr_reader: Option<thread::JoinHandle<std::io::Result<Vec<u8>>>>,
+    timeout: Duration,
+    stdout_prefix: Vec<u8>,
+    context: &str,
+) -> Result<ClosedStdout, String> {
+    let wait = wait_or_kill(child, timeout, context);
+    let stderr = join_bounded_reader(stderr_reader, context);
+    match wait {
+        Ok(code) => Ok(ClosedStdout {
+            code,
+            stdout_prefix,
+            stderr,
+        }),
+        Err(error) => Err(format!(
+            "{error}; stderr={}",
+            String::from_utf8_lossy(&stderr)
+        )),
+    }
+}
+
+fn run_reader_already_gone_with(
+    mut command: Command,
+    timeout: Duration,
+    context: &str,
+) -> Result<ClosedStdout, String> {
+    let (reader, writer) = std::io::pipe().expect("pipe");
+    drop(reader);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped());
+    let mut child = wrap_command(command)
+        .spawn()
+        .map_err(|error| format!("{context}: spawn: {error}"))?;
+    let stderr_reader = child
+        .stderr()
+        .take()
+        .map(|pipe| spawn_bounded_reader(pipe, LIMITS.max_stderr_bytes));
+    collect_closed_stdout(child.as_mut(), stderr_reader, timeout, Vec::new(), context)
+}
+
+fn run_reader_already_gone(command: Command, context: &str) -> ClosedStdout {
+    run_reader_already_gone_with(command, LIMITS.timeout, context)
+        .unwrap_or_else(|error| panic!("{error}"))
+}
+
+fn run_partial_then_close(mut command: Command, context: &str) -> ClosedStdout {
+    let (mut reader, writer) = std::io::pipe().expect("pipe");
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped());
+    let mut child = wrap_command(command)
+        .spawn()
+        .unwrap_or_else(|error| panic!("{context}: spawn: {error}"));
+    let stderr_reader = child
+        .stderr()
+        .take()
+        .map(|pipe| spawn_bounded_reader(pipe, LARGE_RUN_LIMITS.max_stderr_bytes));
+    let mut stdout_prefix = vec![0_u8; PARTIAL_READ];
+    let read = reader
+        .read(&mut stdout_prefix)
+        .unwrap_or_else(|error| panic!("{context}: partial read: {error}"));
+    stdout_prefix.truncate(read);
+    drop(reader);
+    collect_closed_stdout(
+        child.as_mut(),
+        stderr_reader,
+        LARGE_RUN_LIMITS.timeout,
+        stdout_prefix,
+        context,
+    )
+    .unwrap_or_else(|error| panic!("{error}"))
+}
+
+fn assert_infra_write_failure(result: &ClosedStdout, context: &str) {
+    assert_eq!(
+        result.code,
+        Some(3),
+        "{context}: write failure must be exit 3, not 0 and not a signal; stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_no_rust_panic(&result.stderr, context);
+}
+
+#[test]
+fn golden_path_json_seams_do_not_println() {
+    let doctor = include_str!("../src/cli/commands/doctor/implementation.rs");
+    let run = include_str!("../src/cli/commands/run.rs");
+    let doctor_hits = doctor
+        .matches("println!(\"{}\", serde_json::to_string_pretty")
+        .count();
+    let run_hits = run
+        .matches("println!(\"{}\", assay_core::report::json::render_json")
+        .count();
+    assert_eq!(
+        doctor_hits, 0,
+        "doctor JSON seams must call the shared writer, not println!"
+    );
+    assert_eq!(
+        run_hits, 0,
+        "run JSON seam must call the shared writer, not println!"
+    );
+}
+
+#[test]
+fn doctor_json_success_is_one_document_and_exit_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output = assay(
+        dir.path(),
+        &["doctor", "--format", "json"],
+        LIMITS,
+        "doctor json success",
+    );
+    assert_eq!(exit_code(&output, "doctor json success"), 0);
+    let document = sole_json(&output, "doctor json success");
+    assert_eq!(document["schema"], "assay.doctor_report.v0");
+}
+
+#[test]
+fn doctor_json_reader_gone_before_first_write_is_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut command = assay_command(dir.path());
+    command.args(["doctor", "--format", "json"]);
+    let result = run_reader_already_gone(command, "doctor json reader gone");
+    assert_infra_write_failure(&result, "doctor json reader gone");
+}
+
+#[test]
+fn doctor_json_invalid_args_reader_gone_is_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut command = assay_command(dir.path());
+    command.args(["doctor", "--fix", "--format", "json"]);
+    let result = run_reader_already_gone(command, "doctor invalid-args reader gone");
+    assert_infra_write_failure(&result, "doctor invalid-args reader gone");
+}
+
+#[test]
+fn doctor_json_config_load_fail_reader_gone_is_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("eval.yaml"), "version: [\n").expect("wrote broken config");
+    let mut command = assay_command(dir.path());
+    command.args(["doctor", "--format", "json", "--config", "eval.yaml"]);
+    let result = run_reader_already_gone(command, "doctor config-fail reader gone");
+    assert_infra_write_failure(&result, "doctor config-fail reader gone");
+}
+
+#[test]
+fn run_json_success_is_one_document_and_exit_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    tree_with_eval(dir.path(), EVAL_ONE);
+    let output = assay(
+        dir.path(),
+        &[
+            "run",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            "traces/hello.jsonl",
+            "--format",
+            "json",
+        ],
+        LIMITS,
+        "run json success",
+    );
+    assert_eq!(exit_code(&output, "run json success"), 0);
+    let document = sole_json(&output, "run json success");
+    assert_eq!(document["schema"], "assay.run_report.v1");
+}
+
+#[test]
+fn run_json_partial_read_then_close_is_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    tree_with_eval(dir.path(), &large_eval_yaml());
+    let drained = assay(
+        dir.path(),
+        &[
+            "run",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            "traces/hello.jsonl",
+            "--format",
+            "json",
+        ],
+        LARGE_RUN_LIMITS,
+        "run json size probe",
+    );
+    assert_eq!(exit_code(&drained, "run json size probe"), 0);
+    assert!(
+        drained.stdout.len() > PIPE_CAPACITY,
+        "partial-read fixture must exceed the pipe buffer, got {} bytes",
+        drained.stdout.len()
+    );
+    assert!(
+        drained.stdout.len() > PIPE_BUF,
+        "partial-read fixture must exceed PIPE_BUF ({PIPE_BUF}), got {} bytes",
+        drained.stdout.len()
+    );
+
+    let mut command = assay_command(dir.path());
+    command.args([
+        "run",
+        "--config",
+        "eval.yaml",
+        "--trace-file",
+        "traces/hello.jsonl",
+        "--format",
+        "json",
+    ]);
+    let result = run_partial_then_close(command, "run json partial read");
+    assert_infra_write_failure(&result, "run json partial read");
+    assert!(
+        !result.stdout_prefix.is_empty(),
+        "partial-read case must deliver a nonempty truncated prefix"
+    );
+}
+
+#[cfg(unix)]
+fn hanging_stderr_command() -> Command {
+    let mut command = Command::new("sh");
+    command.args(["-c", "while :; do :; done"]);
+    command
+}
+
+#[cfg(windows)]
+fn hanging_stderr_command() -> Command {
+    let mut command = Command::new("ping");
+    command.args(["-t", "127.0.0.1"]);
+    command
+}
+
+#[test]
+fn closed_stdout_harness_times_out_when_child_keeps_stderr_open() {
+    let started = Instant::now();
+    let error = run_reader_already_gone_with(
+        hanging_stderr_command(),
+        Duration::from_millis(250),
+        "stderr-open hang probe",
+    )
+    .expect_err("a child that stays alive with stderr open must hit the wait deadline");
+    assert!(
+        error.contains("did not exit within"),
+        "wait/kill must own the deadline: {error}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "harness hung in stderr drain instead of timing out: {:?}",
+        started.elapsed()
+    );
+}


### PR DESCRIPTION
## Summary

- Base: `6a1f3cd78f4aad668ec0f1578fdbc71aa00486ac`
- Head: `c438ecd4d7ab62911ad5411a0c543dfa5e52f237`
- Worktree: `/Users/roelschuurkes/wt-2263`
- Branch: `cursor/2263-broken-pipe-contract`

Upstream-only merge of `origin/main` (`6a1f3cd78f4aad668ec0f1578fdbc71aa00486ac`) is an ancestor. **This commit is the only review head.** No review on `891edfb531a4452aa3066b2743e2567f75263e29` or `28a2b288f6f3872e2ac325989c8d1862c60509d0` counts.

Independent Claude review on `28a2b288f6f3872e2ac325989c8d1862c60509d0` was **BLOCKED**. Those items are addressed on this head:
1. `map_write_result` reports through locked stderr + `writeln!` and ignores that `Result` (no `eprintln!` panic). Exit remains 3. Flush-failure unit test added.
2. `run_partial_then_close` prefix read is deadline-bounded; timeout kill/reaps before a named error.
3. `collect_closed_stdout` does not join stderr after `wait_or_kill` `Err`. `start_kill` failures are surfaced. Grace-expired is not an unbounded join.
4. Hang probe uses `sleep` / Windows `Start-Sleep` (lifetime does not depend on closed stdout). Exact-head Windows probe retained.
5. `run.rs` no longer claims summary/baseline after output failure. Dead `PIPE_BUF` assertion removed.

Required CI/host/lane pending-platform finding on the prior head is resolved. Windows also proved the probe bites.

**One shared rule:** a partial or absent machine document is not a clean success. Any stdout/file write or flush failure, including `ErrorKind::BrokenPipe`, maps to infrastructure exit 3 via one function (`output_write::map_write_result`). Callers render first, then write; they do not copy the mapping.

**Four seams:** doctor JSON invalid-arg, doctor JSON config-load fail, doctor JSON success/skipped, run JSON. `supply_chain_conformance` delegates to the same helper (no second implementation).

## Test plan

- [x] RED: `doctor --format json` with reader gone before first write died by signal (`None`) with `failed printing to stdout: Broken pipe`; three doctor `println!` JSON sites; `run --format json` partial-read-then-close also signal/panic
- [x] GREEN: those cases now exit 3 with no Rust panic; ordinary success remains valid JSON and exit 0; shared writer unit tests map BrokenPipe, PermissionDenied, Other, and flush failure to 3
- [x] Mutations that bit, then restored: return 0 on BrokenPipe; leave run JSON on `println!`; map only BrokenPipe and swallow other write errors
- [x] Hang-probe mutation bit: joining stderr before wait blocked on a live child with stderr open (3s wall-clock kill); restored concurrent bounded drain; harness times out in <2s
- [x] Follow-up mutations that bit, then restored: drop `flush()`; restore `eprintln!`; unbounded prefix `read`; unconditional stderr join on wait Err

## Non-claims

- Not all 781 / 399 stdout print sites
- No generic panic hook
- No SIGPIPE policy
- Not #2217 / #2423 config read
- Not #2420 evidence show
- Not #2423 `config.rs` (Ruley-owned; no overlap)


## Independent-review follow-up (`c438ecd4d`)

Claude's review of the prior head found proof-harness and diagnostic-write gaps. This head:

- writes the infra diagnostic through a fallible locked-stderr `writeln!` and ignores only that diagnostic write result, preserving exit 3 even when stderr is closed;
- pins flush failure to exit 3;
- bounds the partial-prefix read before wait/kill and kills + reaps on deadline;
- surfaces `start_kill`/reap errors and never joins stderr after a wait error;
- uses output-independent `sleep` / PowerShell `Start-Sleep` probes;
- corrects the `run.rs` artifact comment and removes the redundant `PIPE_BUF` assertion.

Focused tests, affected tests, formatting, clippy, and diff checks passed locally. Mutations restoring panicking stderr, unbounded prefix read, and wait-error stream join each bit before restoration. The prior review is publicly recorded on the PR and is invalidated by this push; a fresh exact-head review is running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - JSON output commands now report exit code 3 when stdout cannot be written, including broken-pipe and flush failures.
  - Prevented incomplete JSON output from being treated as successful.
  - Eliminated abnormal termination during machine-readable output failures.
  - Ensured follow-up report and export generation does not occur after a failed output write.
  - Standardized JSON and file output error handling across supported commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->