### PR TITLE
docs(evidence): state the W005 encrypted recovery path as non-exhaustive

### DIFF
--- a/crates/assay-core/src/mcp/decision_next/event_types.rs
+++ b/crates/assay-core/src/mcp/decision_next/event_types.rs
@@ -45,6 +45,13 @@ pub const APPROVAL_RETAINED_VIEW_ENCRYPTED: &str = "encrypted";
 /// Reserved field beside an `encrypted` retained view: the party holding the decryption key.
 /// Opacity is reviewer-relative — without this a reviewer cannot even tell whether the record
 /// is opaque *to them*.
+///
+/// This field answers "who holds the key", which is a different question from "who can obtain
+/// the plaintext". The two coincide only when the ciphertext is closed, and that is a property
+/// of the crypto system, not of the retained record: for some ciphertext classes a third party
+/// recovers the plaintext with no key holder involved. So a named key holder bounds
+/// reviewability only — it never establishes that the retained body is confidential against
+/// others, and a record must not be treated as safe to publish because it is opaque.
 #[allow(dead_code)] // reserved vocabulary: no emitter exists by design
 pub const APPROVAL_ENCRYPTED_FIELD_KEY_HOLDER: &str = "approval_encryption_key_holder";
 /// Reserved field: SALTED commitment to the plaintext (salt disclosed together with the

--- a/crates/assay-evidence/src/lint/rules.rs
+++ b/crates/assay-evidence/src/lint/rules.rs
@@ -382,8 +382,10 @@ fn check_retained_view_readability(
                 .to_string()
         } else {
             "Approval basis declares an encrypted retained view (opaque_unbindable: no plaintext \
-             commitment) — content-review claims cap at incomplete; recoverable only by key \
-             disclosure"
+             commitment) — content-review claims cap at incomplete; recovery may run through key \
+             disclosure, but that path is not exhaustive: for some ciphertext classes plaintext is \
+             recoverable by a third party with no key holder involved, so opaque to the reviewer \
+             does not imply confidential against others"
                 .to_string()
         }
     } else {

--- a/crates/assay-evidence/tests/lint_test.rs
+++ b/crates/assay-evidence/tests/lint_test.rs
@@ -333,6 +333,17 @@ fn test_w005_flags_encrypted_retained_view_as_opaque_unbindable() {
     assert_eq!(findings.len(), 1, "expected one ASSAY-W005 finding");
     assert!(findings[0].contains("opaque_unbindable"));
     assert!(findings[0].contains("cap at incomplete"));
+    // The recovery path must stay non-exhaustive. Whether a ciphertext is closed is a property
+    // of the crypto system, not of the retained record, so the message must not tell a reviewer
+    // that key disclosure is the only way plaintext can be obtained.
+    assert!(
+        findings[0].contains("not exhaustive"),
+        "the opaque_unbindable recovery path must be stated as non-exhaustive"
+    );
+    assert!(
+        !findings[0].contains("only by key disclosure"),
+        "the message must not claim key disclosure is the sole recovery path"
+    );
 }
 
 #[test]

--- a/docs/lint/index.md
+++ b/docs/lint/index.md
@@ -128,13 +128,22 @@ structured basis. Every other value is treated as not readable, fail-closed, in 
 | declared view | reading | recovery |
 |---|---|---|
 | `encrypted` **with** `approval_plaintext_commitment` | `opaque_bindable` | a later disclosure is checkable against the commitment |
-| `encrypted` **without** the commitment | `opaque_unbindable` | key disclosure only |
+| `encrypted` **without** the commitment | `opaque_unbindable` | key disclosure, and possibly other paths — see below |
 | unknown value, empty string, or non-string | fail-closed | correct the producer |
 
 **Why it matters.** A content-review claim over an approval nobody can read is not a review. The
 rule caps such claims at *incomplete* rather than rejecting the bundle, because integrity is a
 floor and never a lift: a bundle can verify perfectly and still not support the claim being made
 over it.
+
+**Opaque to the reviewer is not confidential against others.** The recovery path for an
+`opaque_unbindable` view is not exhausted by key disclosure. Whether a ciphertext is closed is a
+property of the crypto system, not of the retained record, and for some classes a third party
+obtains the plaintext with no key holder involved. Two consequences: a named
+`approval_encryption_key_holder` bounds who can *review* the basis and says nothing about who can
+*read* it, and a bundle that lints clean may still carry third-party-recoverable content — the
+secret scan behind [`ASSAY-W001`](#assay-w001) matches plaintext patterns, so ciphertext passes it
+by construction. Treat publishability as a separate question from reviewability.
 
 **How to fix.** Emit `structured_meta_jcs` where the approval basis is structured. Where the body
 genuinely must be encrypted, emit `approval_plaintext_commitment` alongside it so a later


### PR DESCRIPTION
## What

Wording only, in four places that all repeat one claim about how an encrypted retained view can be recovered.

`W005`'s `opaque_unbindable` message told a reviewer the view was **"recoverable only by key disclosure"**, and `APPROVAL_ENCRYPTED_FIELD_KEY_HOLDER` documented the key holder as the party gating plaintext recovery. Both collapse two questions into one axis: *who holds the key* and *who can obtain the plaintext*.

Those are separable. Whether a ciphertext is closed is a property of the crypto system, not of the retained record, and for some ciphertext classes a third party recovers the plaintext with no key holder involved. So the stated recovery path was not exhaustive, and a named key holder bounds **reviewability** without establishing **confidentiality**.

## What this does not change

The verdict logic is untouched. Capping content-review claims at `incomplete` remains correct for every opaque view — that cap follows from the reviewer being unable to read the basis, and holds regardless of who else can. The W005 classification (`opaque_bindable` / `opaque_unbindable` / fail-closed) is unchanged, as is `check_retained_view_readability`'s control flow.

The `opaque_bindable` branch is also untouched: it makes a binding claim, not a recovery-exhaustiveness claim.

## Files

| File | Change |
|---|---|
| `crates/assay-evidence/src/lint/rules.rs` | the `opaque_unbindable` message: key disclosure as *a* path, explicitly not exhaustive |
| `crates/assay-core/src/mcp/decision_next/event_types.rs` | `key_holder` doc comment: holding the key ≠ gating plaintext recovery |
| `crates/assay-evidence/tests/lint_test.rs` | pin the non-exhaustive phrasing |
| `docs/lint/index.md` | the recovery table repeated the same claim verbatim |

## Why a test change was needed

The existing assertions covered `"opaque_unbindable"` and `"cap at incomplete"` — the *classification*, deliberately leaving prose free. That meant the recovery-path claim was never pinned at all, so nothing would have caught this drift. Added a positive assertion on the non-exhaustive phrasing plus a negative on the old wording.

Verified the assertion discriminates rather than passing incidentally: reverting the message to the pre-change wording makes `test_w005_flags_encrypted_retained_view_as_opaque_unbindable` fail on that line with *"the opaque_unbindable recovery path must be stated as non-exhaustive"*, then restored.

## Docs note

`docs/lint/index.md` also picks up the adjacent publish-side consequence, which the recovery-path correction makes load-bearing: `W001`'s secret scan matches plaintext patterns (`SECRET_PATTERNS`), so ciphertext passes it by construction. A bundle can therefore lint clean while carrying content a third party can recover. That is a property of any plaintext-pattern scanner rather than a defect in this one, and the page's "Reading a clean run" section already states the general form — this names the specific case. Framed as a retention/publish-gate question, not a scanner bug: reviewability and publishability are separate.

## Scope

`APPROVAL_RETAINED_VIEW_ENCRYPTED` is **reserved with no emitter** (`event_types.rs:38-44`); the only view any Assay path emits is `structured_meta_jcs`. No Assay-produced record carries this view today, so this is forward-looking and lands where the reserved value points: imported records.

## Verification

- `cargo test -p assay-evidence --test lint_test` 19/19, `--test lint_help_uri_targets` 7/7 (the new doc paragraph leaves the anchors intact)
- `cargo clippy -p assay-evidence -p assay-core --all-targets` clean, `cargo fmt --check` clean
- `scripts/ci/check-evidence-vocabulary.py` → `evidence-vocabulary=passed`
- All re-run after rebasing onto `8c8e42315`, the head this branch actually merges from

## Known limitation, not addressed here

`rules.rs:343-345` mirrors the producer's `"encrypted"` string with a keep-in-sync comment, because `assay-evidence` deliberately does not depend on `assay-core`. The *values* are mirrored; the *reading rule* they carry now lives in two prose blocks with nothing enforcing parity between them. Under one-rule-one-function that is the class of thing that drifts, but a parity test over doc comments is not really available, and the view has no emitter — worth revisiting when something emits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that encrypted approval data may still expose plaintext to third parties in some cases.
  * Distinguished encryption opacity from confidentiality and publication safety.
  * Documented that secret scanning cannot detect secrets hidden in ciphertext.

* **Bug Fixes**
  * Updated encrypted retention warnings to accurately describe plaintext recovery risks.
  * Strengthened validation to ensure warning messages do not imply key disclosure is the only recovery method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->