### PR TITLE
fix(cli): classify startup re-resolution without erasing identity (#2195)

### DIFF
--- a/crates/assay-cli/src/cli/commands/mcp/preflight.rs
+++ b/crates/assay-cli/src/cli/commands/mcp/preflight.rs
@@ -120,7 +120,19 @@ fn classify(probe: &impl Probe, policy_root: &Path, expected_version: &str) -> R
             expected_version,
             Some(actual_version),
         ),
-        Ok(_) | Err(_) => finish(
+        Err(ProbeFailure::NotFound) => finish(
+            Phase::Missing,
+            policy_root,
+            expected_version,
+            Some(actual_version),
+        ),
+        Err(ProbeFailure::OtherSpawn(_)) => finish(
+            Phase::Unstartable,
+            policy_root,
+            expected_version,
+            Some(actual_version),
+        ),
+        Ok(_) => finish(
             Phase::StartupRefused,
             policy_root,
             expected_version,
@@ -823,5 +835,83 @@ mod tests {
                 .expect("startup_timeout json");
         assert_eq!(hung_doc["phase"], "startup_timeout");
         assert_eq!(hung_doc["actual_version"], expected());
+    }
+
+    #[test]
+    fn matching_identity_then_startup_not_found_is_missing_and_keeps_actual_version() {
+        let dir = dir_root();
+        let probe = FakeProbe {
+            identity: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: matching_version_line().into_bytes(),
+            }),
+            startup: Err(ProbeFailure::NotFound),
+            startups: Cell::new(0),
+        };
+        let report = classify(&probe, dir.path(), expected());
+        assert_eq!(
+            report.phase,
+            Phase::Missing,
+            "startup NotFound after a matching identity must not stay in the refused catch-all"
+        );
+        assert_eq!(probe.startups.get(), 1);
+        assert_eq!(
+            (report.message.as_str(), report.next_step.as_str()),
+            (
+                "assay-mcp-server was not found on PATH",
+                format!(
+                    "Install assay-mcp-server on PATH ({}), then re-run assay mcp preflight.",
+                    install_matching_server(expected())
+                )
+                .as_str(),
+            )
+        );
+        let document: Value =
+            serde_json::from_str(&render_json(&report)).expect("missing-after-identity json");
+        assert_eq!(document["phase"], "missing");
+        assert_eq!(
+            document["actual_version"],
+            expected(),
+            "dropping retained identity hides that --version already parsed: {document}"
+        );
+        assert_eq!(document["message"], report.message);
+        assert_eq!(document["next_step"], report.next_step);
+    }
+
+    #[test]
+    fn matching_identity_then_startup_permission_denied_is_unstartable_and_keeps_actual_version() {
+        let dir = dir_root();
+        let probe = FakeProbe {
+            identity: Ok(ProbeOutput {
+                exit_code: 0,
+                stdout: matching_version_line().into_bytes(),
+            }),
+            startup: Err(ProbeFailure::OtherSpawn(ErrorKind::PermissionDenied)),
+            startups: Cell::new(0),
+        };
+        let report = classify(&probe, dir.path(), expected());
+        assert_eq!(
+            report.phase,
+            Phase::Unstartable,
+            "startup OtherSpawn after a matching identity must not stay in the refused catch-all"
+        );
+        assert_eq!(probe.startups.get(), 1);
+        assert_eq!(
+            (report.message.as_str(), report.next_step.as_str()),
+            (
+                "assay-mcp-server on PATH could not be started or did not report a version",
+                "Replace the assay-mcp-server on PATH with a working binary from the same Assay release.",
+            )
+        );
+        let document: Value =
+            serde_json::from_str(&render_json(&report)).expect("unstartable-after-identity json");
+        assert_eq!(document["phase"], "unstartable");
+        assert_eq!(
+            document["actual_version"],
+            expected(),
+            "dropping retained identity hides that --version already parsed: {document}"
+        );
+        assert_eq!(document["message"], report.message);
+        assert_eq!(document["next_step"], report.next_step);
     }
 }

--- a/docs/reference/cli/mcp-server.md
+++ b/docs/reference/cli/mcp-server.md
@@ -94,9 +94,14 @@ the preflight JSON document.
 | `expected_version` | This CLI's `CARGO_PKG_VERSION`. |
 | `policy_root` | The path that was checked. |
 
-`actual_version` is present only after the identity probe parsed a version
-token: `wrong_version`, `invalid_root`, `startup_refused`, `startup_timeout`,
-and `ready`. It is omitted for `missing` and `unstartable`.
+`actual_version` is present exactly when the identity probe parsed a version
+token. Identity-time `missing` and `unstartable` omit it. The same phases
+reached after the second spawn retain it, as do `wrong_version`,
+`invalid_root`, `startup_refused`, `startup_timeout`, and `ready`.
+
+`ready` proves only a matching identity followed by an accepted startup
+attempt. It does not prove both resolutions selected one immutable
+executable.
 
 This is a command-local schema. It is not a `ReasonCode`, policy verdict, or
 host-discovery document.


### PR DESCRIPTION
## Summary

- after a matching identity, startup `NotFound` is `missing` and startup `OtherSpawn(_)` is `unstartable`
- both retain `actual_version` from the identity parse
- nonzero startup stays `startup_refused`; timeout stays `startup_timeout`
- no new phase
- docs state the provenance rule and that `ready` does not prove one immutable executable
- injected `Probe` seam only; two new tests, no duplicates of identity-omission / nonzero / timeout / ready

## Provenance

| item | value |
|---|---|
| base | `7a47afe2204f50dd46644b88b19b2afd31cd0652` (`origin/main`, #2425) |
| **final head** | `7eac983736492ea61e8a44322d22ec0bb98683fd` |
| worktree | `/tmp/assay-2195-reresolve-ruley` |
| branch | `ruley/2195-startup-reresolution` |
| rustc | `1.96.0 (ac68faa20 2026-05-25)` |
| target | `/tmp/assay-2195-target` only |
| design | https://github.com/Rul1an/assay/issues/2195#issuecomment-5309827371 |

## RED

1. matching identity + startup `NotFound` — phase was `StartupRefused`, expected `Missing`.
2. matching identity + startup `OtherSpawn(PermissionDenied)` — phase was `StartupRefused`, expected `Unstartable`.

## GREEN

- split exhaustive startup arms; `Ok(_)` remains refused
- `cargo test -p assay-cli --bin assay -- cli::commands::mcp::preflight::tests --test-threads=1` — 17 passed
- `cargo test -p assay-cli --test mcp_preflight_contract -- --test-threads=1` — passed
- `cargo fmt -p assay-cli -- --check`
- `cargo clippy -p assay-cli --bin assay --tests -- -D warnings`
- `git diff --check`

## Mutations (restored)

1. swap mappings — NotFound became `Unstartable`, OtherSpawn became `Missing`.
2. pass `None` for retained identity — rendered `actual_version` was `Null`, expected `5.2.0`.
3. restore `Ok(_) | Err(_)` catch-all — both cases became `StartupRefused`.

## Non-claims

- not item 1 (native Windows/PATHEXT)
- not item 5 (descendant / process-tree / JobObject)
- not inode, digest, fd, or one-resolution identity
- not a real-process swap incidence test
- not a new wire phase or schema version
- Claude co-designed this slice and is not the independent reviewer