### PR TITLE
docs(lint): correct W001 retained-payload boundary

### DIFF
--- a/docs/lint/index.md
+++ b/docs/lint/index.md
@@ -142,8 +142,9 @@ property of the crypto system, not of the retained record, and for some classes 
 obtains the plaintext with no key holder involved. Two consequences: a named
 `approval_encryption_key_holder` bounds who can *review* the basis and says nothing about who can
 *read* it, and a bundle that lints clean may still carry third-party-recoverable content — the
-secret scan behind [`ASSAY-W001`](#assay-w001) matches plaintext patterns, so ciphertext passes it
-by construction. Treat publishability as a separate question from reviewability.
+[`ASSAY-W001`](#assay-w001) check is a narrow subject-pattern heuristic and neither validates nor
+decrypts retained approval payloads. Treat publishability as a separate question from
+reviewability.
 
 **How to fix.** Emit `structured_meta_jcs` where the approval basis is structured. Where the body
 genuinely must be encrypted, emit `approval_plaintext_commitment` alongside it so a later


### PR DESCRIPTION
## Summary

- correct the W001 public description after PR #2426 merged an independently blocked claim
- state the implemented boundary: W001 inspects subject patterns and does not validate or decrypt retained approval payloads
- preserve the intended non-claim that clean lint is not a confidentiality or publishability proof

## Review input

- exact head: `943159b2eb19969a62d999803fc6c0433a6c2e91`
- base: `f9006934cc182bc1fe8dc367a8501aa20118250b`
- scope: `docs/lint/index.md` only
- verification: `pre-commit run --files docs/lint/index.md`, `git diff --check`
- no production behavior, wire schema, reason code, or cryptographic claim changes

## Why this is separate

PR #2426 was merged at unchanged head `0a377d4aebc6a5c415b33167b1ea5fced953c7bf` after an exact-head BLOCKED review identified this sentence. This PR resolves that outstanding finding rather than treating the merge as its disposition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the scope of the ASSAY-W001 subject-pattern check.
  * Documented that retained approval payloads are not validated or decrypted.
  * Distinguished between publishability and reviewability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->