### PR TITLE
docs(cli): state MCP preflight direct-child reap non-claim (#2195)

### DIFF
--- a/docs/reference/cli/mcp-server.md
+++ b/docs/reference/cli/mcp-server.md
@@ -79,7 +79,9 @@ Exit `0` only for `ready`. Every other phase exits `2`.
 
 Both child probes use a 2-second wall-clock deadline and cap each of stdout
 and stderr at 8 KiB before materialization. Child output is never copied into
-the preflight JSON document.
+the preflight JSON document. On timeout, cleanup kills and reaps only the
+direct probe child. Descendant or process-tree termination via Unix process
+groups or Windows Job Objects is not promised.
 
 ### JSON document (`assay.mcp_preflight.v0`)
 


### PR DESCRIPTION
## Summary

- one public non-claim next to the preflight 2s / 8 KiB resource bounds
- timeout cleanup kills and reaps only the direct probe child
- descendant or process-tree termination via Unix process groups or Windows Job Objects is not promised
- does not claim descendants survive
- no production, test, classifier, or 2s/8 KiB contract change

## Provenance

| item | value |
|---|---|
| base | `fd913f5da6daf1c879a607a90e6dfb299109c8a4` (`origin/main`, #2430) |
| **final head** | `189e3f769a8da1b1847f598ad9f6dd6c39fbe1fa` |
| worktree | `/tmp/assay-2195-nonclaim-ruley` |
| branch | `ruley/2195-direct-child-nonclaim` |
| file | `docs/reference/cli/mcp-server.md` only |
| design | https://github.com/Rul1an/assay/issues/2195#issuecomment-5313068212 |

## Verification

- `pre-commit run --files docs/reference/cli/mcp-server.md` — markdown-applicable hooks passed (merge-conflict, EOF, trailing whitespace, typos, evidence vocabulary, MCP token hygiene). `cargo-fmt` was skipped here: this machine has no `rustfmt` and this slice touches no Rust.
- local-links check on this file — all local markdown links resolve
- `git diff --check`
- wording inspect: no survival claim, no PATHEXT, no host-discovery expansion

## Non-claims

- not item 1 (native Windows/PATHEXT)
- not host discovery (#2359)
- not a Unix descendant-liveness test
- not a production process-tree / Job Object / process-group change
- not a change to the 2-second / 8 KiB contract
- not a close of #2195 (item 1 remains)