### PR TITLE
test(mcp): pin native Windows preflight resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -747,6 +747,21 @@ jobs:
               ;;
           esac
 
+      - name: Test native Windows MCP preflight resolution
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf 'sha=%s\nrunner_os=%s\nimage_os=%s\nimage_version=%s\n' \
+            "$GITHUB_SHA" "$RUNNER_OS" "${ImageOS:-unset}" "${ImageVersion:-unset}"
+          rustc -vV
+          cargo test --locked -p assay-cli --test mcp_preflight_contract -- \
+            native_windows_bare_command_uses_exe_not_pathext_scripts \
+            --exact --test-threads=1 --nocapture \
+            2>&1 | tee "$RUNNER_TEMP/mcp-preflight-windows.log"
+          grep -F -- 'test native_windows_bare_command_uses_exe_not_pathext_scripts ... ok' \
+            "$RUNNER_TEMP/mcp-preflight-windows.log"
+
       # Non-Linux: Exclude OS-specific crates (assay-monitor, assay-cli)
       # Windows/macOS automatically use bundled sqlite via cfg() in Cargo.toml
       - name: Test Workspace (Cross-Platform)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -359,6 +359,13 @@ repos:
         # 360-minute default; this hook rejects that, wrong classes, and eBPF drift.
         files: ^(scripts/ci/test-ci-job-timeouts-contract\.sh|\.github/workflows/ci\.yml|\.pre-commit-config\.yaml)$
 
+      - id: mcp-preflight-windows-contract-self-test
+        name: Native Windows MCP preflight workflow contract
+        entry: bash scripts/ci/test-mcp-preflight-windows-contract.sh --self-test
+        language: system
+        pass_filenames: false
+        files: ^(crates/assay-cli/tests/mcp_preflight_contract\.rs|scripts/ci/test-mcp-preflight-windows-contract\.sh|\.github/workflows/ci\.yml|docs/reference/cli/mcp-server\.md|\.pre-commit-config\.yaml)$
+
       - id: ci-gate-coverage
         name: Required CI gate waits on every gating job
         entry: bash -c 'python3 scripts/ci/check-ci-gate-coverage.py --self-test && python3 scripts/ci/check-ci-gate-coverage.py'

--- a/crates/assay-cli/tests/mcp_preflight_contract.rs
+++ b/crates/assay-cli/tests/mcp_preflight_contract.rs
@@ -224,7 +224,12 @@ fn native_windows_bare_command_uses_exe_not_pathext_scripts() {
             String::from_utf8_lossy(&where_output.stderr)
         );
         let where_stdout = String::from_utf8_lossy(&where_output.stdout).to_ascii_lowercase();
-        let expected_script = script.to_string_lossy().to_ascii_lowercase();
+        // tempfile may expose a verbatim `\\?\` path while where.exe prints
+        // the equivalent DOS path. Compare the same Windows representation.
+        let expected_script = script
+            .to_string_lossy()
+            .trim_start_matches(r"\\?\")
+            .to_ascii_lowercase();
         assert!(
             where_stdout.contains(expected_script.as_str()),
             "where.exe output must name the .{extension} fixture: {}",

--- a/crates/assay-cli/tests/mcp_preflight_contract.rs
+++ b/crates/assay-cli/tests/mcp_preflight_contract.rs
@@ -8,6 +8,13 @@ use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
 use serde_json::Value;
 use std::process::{Command, Output};
 
+#[cfg(windows)]
+use std::ffi::OsString;
+#[cfg(windows)]
+use std::fs;
+#[cfg(windows)]
+use std::path::{Path, PathBuf};
+
 const PREFLIGHT_SCHEMA: &str = "assay.mcp_preflight.v0";
 
 fn preflight(args: &[&str]) -> Output {
@@ -86,4 +93,159 @@ fn format_terminal_is_not_json() {
         "terminal format must stay human; stdout={stdout}"
     );
     assert!(serde_json::from_slice::<Value>(&output.stdout).is_err());
+}
+
+#[cfg(windows)]
+fn compile_windows_server(executable: &Path) {
+    let source = executable.with_extension("rs");
+    let helper = format!(
+        r#"use std::env;
+
+fn main() {{
+    let mut args = env::args();
+    let _program = args.next();
+    match args.next().as_deref() {{
+        Some("--version") if args.next().is_none() => {{
+            println!("assay-mcp-server {}");
+        }}
+        Some("--policy-root") if args.next().is_some() && args.next().is_none() => {{}}
+        _ => std::process::exit(64),
+    }}
+}}
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    fs::write(&source, helper).expect("write Windows server helper source");
+
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+    let output = Command::new(rustc)
+        .arg(&source)
+        .arg("-o")
+        .arg(executable)
+        .output()
+        .expect("run rustc for Windows server helper");
+    assert!(
+        output.status.success(),
+        "Windows server helper failed to compile: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(windows)]
+fn native_windows_preflight(
+    assay: &Path,
+    path: &Path,
+    pathext: &str,
+    policy_root: &Path,
+) -> Output {
+    let mut command = Command::new(assay);
+    command
+        .env("NO_COLOR", "1")
+        .env("PATH", path)
+        .env("PATHEXT", pathext)
+        .args(["mcp", "preflight", "--policy-root"])
+        .arg(policy_root)
+        .args(["--format", "json"]);
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("ASSAY_AUTH_") {
+            command.env_remove(key);
+        }
+    }
+    run_bounded(command, b"", GOLDEN_PATH_LIMITS, "native Windows preflight")
+        .expect("native Windows preflight ran")
+}
+
+#[cfg(windows)]
+fn preflight_document(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is not one JSON document: {error}\nstdout={}\nstderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[cfg(windows)]
+#[test]
+fn native_windows_bare_command_uses_exe_not_pathext_scripts() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let launcher_dir = root.path().join("launcher");
+    let exe_dir = root.path().join("exe-only");
+    fs::create_dir_all(&launcher_dir).expect("create isolated launcher directory");
+    fs::create_dir_all(&exe_dir).expect("create exe fixture directory");
+
+    let assay = launcher_dir.join("assay.exe");
+    fs::copy(env!("CARGO_BIN_EXE_assay"), &assay).expect("copy assay into isolated directory");
+
+    let server = exe_dir.join("assay-mcp-server.exe");
+    compile_windows_server(&server);
+    let exe_output = native_windows_preflight(&assay, &exe_dir, ".CMD;.BAT", root.path());
+    let exe_document = preflight_document(&exe_output);
+    assert_eq!(
+        exit_code(&exe_output),
+        0,
+        "bare command must resolve .exe without .EXE in PATHEXT: {exe_document}"
+    );
+    assert_eq!(exe_document["schema"], PREFLIGHT_SCHEMA);
+    assert_eq!(exe_document["phase"], "ready");
+    assert_eq!(exe_document["expected_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(exe_document["actual_version"], env!("CARGO_PKG_VERSION"));
+
+    let system_root = std::env::var_os("SystemRoot").expect("SystemRoot is set on Windows");
+    let where_exe = PathBuf::from(system_root).join("System32/where.exe");
+    for extension in ["cmd", "bat"] {
+        let script_dir = root.path().join(format!("{extension}-only"));
+        fs::create_dir_all(&script_dir).expect("create PATHEXT fixture directory");
+        let script = script_dir.join(format!("assay-mcp-server.{extension}"));
+        let marker = script_dir.join("invoked.txt");
+        fs::write(
+            &script,
+            format!(
+                "@echo off\r\necho invoked>\"%~dp0invoked.txt\"\r\nif \"%~1\"==\"--version\" echo assay-mcp-server {}\r\nexit /b 0\r\n",
+                env!("CARGO_PKG_VERSION")
+            ),
+        )
+        .expect("write PATHEXT script fixture");
+
+        let pathext = format!(".{}", extension.to_ascii_uppercase());
+        let where_output = Command::new(&where_exe)
+            .arg("assay-mcp-server")
+            .current_dir(&launcher_dir)
+            .env("PATH", &script_dir)
+            .env("PATHEXT", &pathext)
+            .output()
+            .expect("run where.exe");
+        assert!(
+            where_output.status.success(),
+            "where.exe must resolve the .{extension} fixture through PATHEXT: stdout={} stderr={}",
+            String::from_utf8_lossy(&where_output.stdout),
+            String::from_utf8_lossy(&where_output.stderr)
+        );
+        let where_stdout = String::from_utf8_lossy(&where_output.stdout).to_ascii_lowercase();
+        let expected_script = script.to_string_lossy().to_ascii_lowercase();
+        assert!(
+            where_stdout.contains(expected_script.as_str()),
+            "where.exe output must name the .{extension} fixture: {}",
+            String::from_utf8_lossy(&where_output.stdout)
+        );
+
+        let output = native_windows_preflight(&assay, &script_dir, &pathext, root.path());
+        let document = preflight_document(&output);
+        assert_eq!(
+            exit_code(&output),
+            2,
+            ".{extension} alone must not satisfy the bare Command lookup: {document}"
+        );
+        assert_eq!(document["phase"], "missing");
+        assert!(
+            document.get("actual_version").is_none(),
+            ".{extension} missing phase must omit actual_version: {document}"
+        );
+        assert!(
+            !marker.exists(),
+            ".{extension} fixture must not be executed by the bare Command lookup"
+        );
+    }
 }

--- a/crates/assay-cli/tests/mcp_preflight_contract.rs
+++ b/crates/assay-cli/tests/mcp_preflight_contract.rs
@@ -223,15 +223,14 @@ fn native_windows_bare_command_uses_exe_not_pathext_scripts() {
             String::from_utf8_lossy(&where_output.stdout),
             String::from_utf8_lossy(&where_output.stderr)
         );
-        let where_stdout = String::from_utf8_lossy(&where_output.stdout).to_ascii_lowercase();
-        // tempfile may expose a verbatim `\\?\` path while where.exe prints
-        // the equivalent DOS path. Compare the same Windows representation.
-        let expected_script = script
-            .to_string_lossy()
-            .trim_start_matches(r"\\?\")
+        let where_stdout = String::from_utf8_lossy(&where_output.stdout)
+            .replace('\\', "/")
             .to_ascii_lowercase();
+        let expected_suffix = format!("/{extension}-only/assay-mcp-server.{extension}");
         assert!(
-            where_stdout.contains(expected_script.as_str()),
+            where_stdout
+                .lines()
+                .any(|line| line.ends_with(&expected_suffix)),
             "where.exe output must name the .{extension} fixture: {}",
             String::from_utf8_lossy(&where_output.stdout)
         );

--- a/docs/reference/cli/mcp-server.md
+++ b/docs/reference/cli/mcp-server.md
@@ -105,6 +105,16 @@ reached after the second spawn retain it, as do `wrong_version`,
 attempt. It does not prove both resolutions selected one immutable
 executable.
 
+On Windows, the bare `assay-mcp-server` command resolves an
+`assay-mcp-server.exe` on `PATH` even when `.EXE` is absent from `PATHEXT`.
+The preflight does not expand `PATHEXT` to run `.cmd` or `.bat` shims; a
+directory containing only one of those shell-discoverable shims is reported as
+`missing`.
+
+This is process-level behavior for the preflight's environment. It does not
+establish that an editor or other GUI host sees the same `PATH`, add a published
+Windows MCP-server asset, or define an explicit-script invocation contract.
+
 This is a command-local schema. It is not a `ReasonCode`, policy verdict, or
 host-discovery document.
 

--- a/scripts/ci/test-mcp-preflight-windows-contract.sh
+++ b/scripts/ci/test-mcp-preflight-windows-contract.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+SELF_TEST=""
+
+case "${1:-}" in
+  --self-test)
+    SELF_TEST="--self-test"
+    WORKFLOW="${2:-$WORKFLOW}"
+    ;;
+  "")
+    ;;
+  *)
+    WORKFLOW="$1"
+    ;;
+esac
+
+fail() {
+  echo "FAIL: $*" >&2
+  return 1
+}
+
+check_contract() {
+  local workflow="$1"
+
+  python3 - "$workflow" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+workflow = Path(sys.argv[1])
+text = workflow.read_text(encoding="utf-8")
+
+job_match = re.search(r"(?ms)^  test:\s*$\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\s*$|\Z)", text)
+if job_match is None:
+    raise SystemExit("FAIL: ci.yml has no test job")
+job = job_match.group(0)
+
+step_name = "Test native Windows MCP preflight resolution"
+step_matches = list(
+    re.finditer(
+        rf"(?ms)^      - name: {re.escape(step_name)}\s*$\n(?P<body>.*?)(?=^      - (?:name:|uses:)|\Z)",
+        job,
+    )
+)
+if len(step_matches) != 1:
+    raise SystemExit(
+        f"FAIL: test job must contain exactly one {step_name!r} step; found {len(step_matches)}"
+    )
+step = step_matches[0].group(0)
+
+required_lines = (
+    "        if: runner.os == 'Windows'",
+    "        shell: bash",
+)
+for line in required_lines:
+    if line not in step.splitlines():
+        raise SystemExit(f"FAIL: Windows preflight step is missing exact line: {line.strip()}")
+
+run_match = re.search(r"(?ms)^        run: \|\s*$\n(?P<body>(?:^          .*\n?)*)", step)
+if run_match is None:
+    raise SystemExit("FAIL: Windows preflight step has no block run script")
+run = run_match.group("body")
+active = "\n".join(
+    line.strip() for line in run.splitlines() if line.strip() and not line.lstrip().startswith("#")
+)
+joined = " ".join(line.removesuffix("\\").strip() for line in active.splitlines())
+
+invocation = (
+    "cargo test --locked -p assay-cli --test mcp_preflight_contract -- "
+    "native_windows_bare_command_uses_exe_not_pathext_scripts "
+    "--exact --test-threads=1 --nocapture 2>&1 | "
+    'tee "$RUNNER_TEMP/mcp-preflight-windows.log"'
+)
+if invocation not in joined:
+    raise SystemExit("FAIL: Windows preflight step is missing the exact native test invocation")
+
+success_guard = (
+    "grep -F -- "
+    "'test native_windows_bare_command_uses_exe_not_pathext_scripts ... ok' "
+    '"$RUNNER_TEMP/mcp-preflight-windows.log"'
+)
+if success_guard not in joined:
+    raise SystemExit("FAIL: Windows preflight step is missing the exact test-success guard")
+
+for token in ("GITHUB_SHA", "RUNNER_OS", "ImageOS", "ImageVersion", "rustc -vV"):
+    if token not in active:
+        raise SystemExit(f"FAIL: Windows preflight step is missing provenance token {token}")
+
+print("PASS: native Windows MCP preflight workflow contract")
+PY
+}
+
+expect_red() {
+  local label="$1"
+  local workflow="$2"
+
+  if check_contract "$workflow" >/dev/null 2>&1; then
+    fail "mutation stayed green: ${label}"
+  fi
+  echo "PASS: mutation turns contract red: ${label}"
+}
+
+case "$SELF_TEST" in
+  "")
+    check_contract "$WORKFLOW"
+    ;;
+  --self-test)
+    check_contract "$WORKFLOW"
+    scratch="$(mktemp -d "${TMPDIR:-/tmp}/assay-mcp-preflight-windows-contract.XXXXXX")"
+    trap 'rm -rf "$scratch"' EXIT
+
+    python3 - "$WORKFLOW" "$scratch" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+scratch = Path(sys.argv[2])
+
+mutations = {
+    "renamed-step.yml": (
+        "- name: Test native Windows MCP preflight resolution",
+        "- name: Test Windows MCP preflight",
+    ),
+    "renamed-test.yml": (
+        "native_windows_bare_command_uses_exe_not_pathext_scripts \\",
+        "native_windows_pathext_smoke \\",
+    ),
+    "removed-success-guard.yml": (
+        "grep -F -- 'test native_windows_bare_command_uses_exe_not_pathext_scripts ... ok' \\",
+        "printf '%s\\n' 'native Windows test command completed' \\",
+    ),
+}
+
+for name, (old, new) in mutations.items():
+    if source.count(old) != 1:
+        raise SystemExit(f"mutation anchor {old!r} occurs {source.count(old)} times, expected once")
+    (scratch / name).write_text(source.replace(old, new, 1), encoding="utf-8")
+PY
+
+    expect_red "renamed Windows step" "$scratch/renamed-step.yml"
+    expect_red "renamed native test invocation" "$scratch/renamed-test.yml"
+    expect_red "removed exact-success guard" "$scratch/removed-success-guard.yml"
+    ;;
+  *)
+    fail "usage: $0 [workflow-path] | $0 --self-test [workflow-path]"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- characterize native Windows resolution used by `assay mcp preflight`
- prove bare `assay-mcp-server.exe` resolution is independent of `PATHEXT`
- prove `.cmd` and `.bat` PATHEXT shims are not silently executed
- run the exact characterization in the existing required Windows test matrix
- pin the CI invocation and success witness with a mutation-tested local contract

## Scope

This closes the sole remaining item in #2195. It changes tests, CI wiring, and documentation only.
The production preflight classifier and resolver are unchanged.

## Review Packet

- Base: `0e934b718f44db3554d9e5cf79d73f5d7180d351`
- Head: `67d00a5b232a63e29f03e4ee41f43a2b0c622e40`
- Hot files: `crates/assay-cli/tests/mcp_preflight_contract.rs`, `.github/workflows/ci.yml`
- Contract change: documented Windows lookup boundary; no wire/schema/exit-code change
- Security: script fixtures write marker files if unexpectedly executed
- Performance: one focused Windows integration test in the existing required matrix

## TDD And Mutations

RED on the base:

```text
FAIL: test job must contain exactly one 'Test native Windows MCP preflight resolution' step; found 0
```

GREEN:

- workflow contract + self-test pass
- focused integration target: 17 passed, 1 ignored on macOS; Windows-only case awaits CI
- mutations for renamed step, renamed test invocation, and removed success guard all turn RED
- pre-commit, shellcheck, actionlint, fmt, clippy, Linux compile gate, and `git diff --check` pass

First `windows-latest` run on `d3acbd60613a71ba73489cb1c185ae42ca2a6fa8` reached the intended
test and failed because `tempfile` exposed a verbatim `\\?\` path while `where.exe` printed the
equivalent DOS path. The follow-up normalizes only that comparison representation. The native
behavior remains unclaimed until CI passes on the current head.

## Native Windows Proof Required

The Windows behavior remains a non-claim until `windows-latest` runs
`native_windows_bare_command_uses_exe_not_pathext_scripts` on this exact head. The workflow logs
the SHA, runner image values, and `rustc -vV`, then requires the exact libtest success line.

## Non-Claims

- no `.COM`, PowerShell, or explicit-script invocation contract
- no editor/GUI PATH equivalence
- no published Windows MCP-server asset
- no immutable identity across the two preflight spawns
- no process-tree or Windows Job Object behavior
- no downloader, updater, shell invocation, or manifest change

## Verification

```bash
bash scripts/ci/test-mcp-preflight-windows-contract.sh --self-test
cargo test --locked -p assay-cli --test mcp_preflight_contract
cargo fmt --all -- --check
shellcheck scripts/ci/test-mcp-preflight-windows-contract.sh
actionlint .github/workflows/ci.yml
pre-commit run mcp-preflight-windows-contract-self-test --all-files
git diff --check
```

Closes #2195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Windows MCP server preflight behavior.
  - Bare `assay-mcp-server` commands can resolve `.exe` files through `PATH`, even when `.EXE` is absent from `PATHEXT`.
  - `.cmd` and `.bat` shims are not expanded or accepted during preflight.

- **Tests**
  - Added Windows coverage to verify executable discovery and prevent unsupported command shims from being used.
  - Added automated checks to keep the Windows preflight workflow contract consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Native follow-up

The second `windows-latest` run on `6a14be7f05302d884549b50599ec894190144177` showed that
normalizing only the verbatim prefix was still too coupled to the full temporary path representation.
The current head instead checks the unique extension-specific fixture suffix while `PATH` contains
only that fixture directory. This preserves the `where.exe` positive control without making absolute
path rendering part of the contract. Native Windows remains a non-claim until this head passes.
