### PR TITLE
fix(cli): preserve doctor config exit class under --fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,8 +155,9 @@ below may require CLI, MCP, evidence-input or policy-pin migration.
   the public `MODERN_PROTOCOL_VERSION` constant remains available but deprecated (#2267).
 - `assay doctor` now exits `2` for configuration-class failures. This changes JSON runs with an
   error-severity configuration diagnostic from `0` to `2`, and unloadable-config failures without
-  `--fix` from `1` to `2`; repair paths can still exit `1`, while scripts should treat `2` as
-  configuration/user error (#2247, #2209).
+  `--fix` from `1` to `2`. An unloadable config now retains that class under `--fix` when no repair
+  is available, a repair is declined or previewed, or the repair leaves it unresolved (#2247,
+  #2209).
 - MCP `tool_pins` now require 64-character lowercase hexadecimal hashes, and schema identity uses
   RFC 8785 canonical JSON bytes. A policy carrying a malformed pin now fails to load. Re-record
   otherwise valid pins created by older versions after upgrading or calls can be denied with

--- a/crates/assay-cli/src/cli/commands/doctor/implementation.rs
+++ b/crates/assay-cli/src/cli/commands/doctor/implementation.rs
@@ -236,7 +236,7 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         println!("  Error:    {}\n", e);
 
         if args.fix {
-            return try_fix_parse_error(&args, &target_path, &e.to_string(), legacy_mode);
+            return try_fix_parse_error(&args, &target_path, e, legacy_mode);
         }
         return Ok(config_failure(&target_path, e).exit_code);
     }

--- a/crates/assay-cli/src/cli/commands/doctor/parse_error.rs
+++ b/crates/assay-cli/src/cli/commands/doctor/parse_error.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::Context;
 use assay_core::config::{load_config_with_cause, LoadOptions};
 use assay_core::errors::similarity::closest_prompt;
+use assay_core::errors::ConfigLoadError;
 use dialoguer::{theme::ColorfulTheme, Confirm};
 
 use crate::cli::args::DoctorArgs;
@@ -13,16 +14,19 @@ use super::patching::{print_unified_diff, write_text_file};
 pub(super) fn try_fix_parse_error(
     args: &DoctorArgs,
     config_path: &Path,
-    err: &str,
+    err: &ConfigLoadError,
     legacy_mode: bool,
 ) -> anyhow::Result<i32> {
-    let (unknown, candidates) = parse_unknown_field_error(err)
+    // `--fix` changes what doctor attempts, not the class of the config failure it observed.
+    let unresolved_exit = config_failure(config_path, err).exit_code;
+    let err_text = err.to_string();
+    let (unknown, candidates) = parse_unknown_field_error(&err_text)
         .map(|(u, c)| (u.to_string(), c))
         .unwrap_or_else(|| (String::new(), Vec::new()));
 
     if unknown.is_empty() || candidates.is_empty() {
         println!("No auto-fixable config parse issue detected.");
-        return Ok(1);
+        return Ok(unresolved_exit);
     }
 
     let replacement = closest_prompt(&unknown, candidates.iter()).and_then(|m| {
@@ -38,7 +42,7 @@ pub(super) fn try_fix_parse_error(
             "No safe replacement found for '{}'. Try fixing the key manually.",
             unknown
         );
-        return Ok(1);
+        return Ok(unresolved_exit);
     };
 
     let do_apply = if args.yes || args.dry_run {
@@ -58,7 +62,7 @@ pub(super) fn try_fix_parse_error(
 
     if !do_apply {
         println!("No fixes applied.");
-        return Ok(1);
+        return Ok(unresolved_exit);
     }
 
     let before = std::fs::read_to_string(config_path)
@@ -69,7 +73,7 @@ pub(super) fn try_fix_parse_error(
             unknown,
             config_path.display()
         );
-        return Ok(1);
+        return Ok(unresolved_exit);
     };
 
     if args.dry_run {
@@ -80,7 +84,7 @@ pub(super) fn try_fix_parse_error(
             &after,
         );
         println!("Dry run complete. 1 fix(es) previewed.");
-        return Ok(1);
+        return Ok(unresolved_exit);
     }
 
     write_text_file(config_path, &after)
@@ -104,10 +108,7 @@ pub(super) fn try_fix_parse_error(
             Ok(0)
         }
         Err(e) => {
-            // The same question `fixes.rs` asks after applying its own repairs — this config does
-            // not load — so the same answer, from the reason code that owns an unloadable config.
-            // The five returns above are a different question: no repair was applied, so they
-            // report the outcome of an offer, and #2209 owns what those are worth.
+            // A repair changed the file, so classify the new load failure rather than the original.
             println!("Config still has issues after fix: {}", e);
             Ok(config_failure(config_path, &e).exit_code)
         }

--- a/crates/assay-cli/tests/doctor_exit_class_contract.rs
+++ b/crates/assay-cli/tests/doctor_exit_class_contract.rs
@@ -71,6 +71,9 @@ tests:
       pattern: "Hello"
 "#;
 
+/// A malformed config for which `doctor --fix` has no repair to offer.
+const UNFIXABLE_CONFIG: &str = "configVersion: [\n";
+
 /// A second entry in the legacy OpenAI shape. `analyze_trace_schema` raises `E_TRACE_INVALID` at
 /// `warn` for it, which is how this fixture gets a diagnostic that is not an error.
 const LEGACY_LINE: &str = r#"{"schema_version": 1, "type": "assay.trace", "request_id": "legacy_1", "prompt": "p2", "response": "r", "model": "trace", "provider": "trace", "function_call": {"name": "x"}}
@@ -191,6 +194,29 @@ fn the_exit_class_does_not_depend_on_whether_a_fix_was_requested() {
         "doctor returned exit {plain} and `doctor --fix --dry-run` returned exit {fixing} for one \
          tree. `--fix` says what to attempt about a diagnostic, not what class the diagnostic has, \
          so a repair flag must not reclassify it: the class comes from `decide_exit` on both paths."
+    );
+}
+
+#[test]
+fn an_unfixed_parse_failure_keeps_its_exit_class() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("eval.yaml"), UNFIXABLE_CONFIG).expect("wrote config");
+    let before = std::fs::read_to_string(dir.path().join("eval.yaml")).expect("read config");
+
+    let plain = doctor_exit_code(dir.path(), "text", "unused.jsonl");
+    let fixing = doctor_exit_code_with(dir.path(), "text", "unused.jsonl", &["--fix", "--yes"]);
+
+    let after = std::fs::read_to_string(dir.path().join("eval.yaml")).expect("read config");
+    assert_eq!(after, before, "doctor changed a config it could not repair");
+    assert_eq!(
+        plain, 2,
+        "the malformed config did not use the config-error class"
+    );
+    assert_eq!(
+        fixing, plain,
+        "doctor returned exit {plain} and `doctor --fix --yes` returned exit {fixing} for the same \
+         malformed config. Requesting a repair must not reclassify the config failure when no \
+         repair is available."
     );
 }
 

--- a/crates/assay-cli/tests/doctor_fix_e2e.rs
+++ b/crates/assay-cli/tests/doctor_fix_e2e.rs
@@ -95,7 +95,7 @@ fn doctor_fix_parse_error_dry_run_exits_nonzero_and_does_not_write() {
         .arg("--dry-run")
         .arg("--yes")
         .assert()
-        .code(1);
+        .failure();
 
     let after = fs::read_to_string(&config).expect("read after");
     assert_eq!(

--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -78,23 +78,20 @@ invocation reaches, the row says so rather than describing it as behaviour.
 | Code | Meaning |
 |------|---------|
 | `0` | No error-severity diagnostic remains, or the fixes resolved them. Measured identical on the text channel, under `--format json` and under `--fix --yes`, because all three read the class from one function. It also covers the run that checked no config at all, so read `config_check.status` before `data_diagnostics[]`; see below. |
-| `1` | A config that will not load under `--fix` when no repair was applied: nothing auto-fixable, no safe replacement found, the offer declined, or a dry-run preview. That is [#2209](https://github.com/Rul1an/assay/issues/2209). |
-| `2` | Five conditions. Argument misuse — `--fix` under `--format json`, or `--yes`/`--dry-run` without `--fix` — exits the invalid-args class. The JSON request publishes one `assay.doctor_report.v0` with `E_INVALID_ARGS`; the text request keeps the existing rejection on stderr and empty stdout. The other four come from something outside this command: an explicit `--config` that will not load with no `--fix`, or an error-severity diagnostic whose registered class is a config fault — what `assay validate` and `assay run` return for the same input; `--fix` unable to write a repair — what `assay fix` returns for a patch that fails to apply; and a repair that rewrote the config and left it still unloadable — the reason code for an unloadable config, which the parse-repair path reads too. |
+| `1` | An error-severity diagnostic whose registered class is a test failure. No input reaching this route has been measured; see below. |
+| `2` | Configuration or invocation failure. Argument misuse — `--fix` under `--format json`, or `--yes`/`--dry-run` without `--fix` — exits the invalid-args class. The JSON request publishes one `assay.doctor_report.v0` with `E_INVALID_ARGS`; the text request keeps the existing rejection on stderr and empty stdout. An explicit `--config` that will not load exits this class with or without `--fix`, including when no repair is available, a repair is declined or previewed, or a repair leaves the config unloadable. Error-severity diagnostics registered as config faults and repairs that cannot be written also exit this class. |
 
 Four things the table does not say, which a reader would otherwise have to find out:
 
-- **No `1` observed here comes from the class table.** Its route to `1` is an error-severity
+- **No `1` has been observed here.** Its route to `1` is an error-severity
   diagnostic whose registered class is not a config fault, and every code doctor names deliberately
   is registered a config fault. That leaves the bare `E_UNKNOWN` raised as a fallback for a trace
-  error the mapper does not recognise, and no input reaching it has been constructed. So `1` means
-  #2209, not a verdict about a tree. Argument misuse is the invalid-args class on `2`.
-- **One flag-dependence remains, and it is the config no repair changed.** `doctor --config nope.yaml`
-  exits `2`; the same config under `--fix --yes` exits `1`, because that return reports the outcome
-  of a repair offer rather than the state of the config. #2209 owns it. Every other pairing measured
-  the same with and without the flag: for a tree carrying one `E_PATH_NOT_FOUND`, text,
-  `--format json`, `--fix --dry-run` and `--fix --yes` all exit `2`, including when the repair itself
-  fails to write; and a repair that rewrites the config and leaves it unloadable exits `2`, the class
-  the config had before the repair ran.
+  error the mapper does not recognise, and no input reaching it has been constructed. Argument misuse
+  and unloadable configs use the classes documented on `2`.
+- **A repair request does not reclassify an unloadable config.** `doctor --config nope.yaml` and the
+  same config under `--fix --yes` both exit `2`, whether the repair is unavailable, declined,
+  previewed, or insufficient. The repair flag changes what doctor attempts, not what condition it
+  observed.
 - **A failed repair and the diagnostics behind it cannot disagree today.** A repair is offered only
   for `E_PATH_NOT_FOUND` or `E_TRACE_MISS`, both error-severity and both a config fault, so any tree
   where a write can fail already exits `2`. The two are still decided by separate functions, and


### PR DESCRIPTION
## Summary
- preserve the registered config-error exit class when `assay doctor --fix` cannot complete a repair
- pass the typed `ConfigLoadError` into the repair path instead of discarding it as prose
- align the doctor reference and changelog with the flag-independent exit contract

Closes #2209.

## Contract
- `doctor --config <malformed>` and `doctor --fix --yes --config <malformed>` both exit `2`
- an unsuccessful repair attempt does not rewrite the config
- a successful repair still exits `0`
- no JSON/envelope, reason-code, schema, or repair-selection change

## TDD evidence
- **RED** on base `b71e19f3bf0606eb58a20c93f9e0d8368e5a546e`: the new behavioral test observed plain exit `2` versus `--fix --yes` exit `1`
- **GREEN** on head `55d0246e4f1c652828d66afb98b21804d7a25961`: focused contract test passes
- **mutation**: replacing the shared unresolved exit with literal `1` made the focused test fail with `2` versus `1`; source was restored before verification

## Verification
- `cargo test -p assay-cli`
- `cargo test -p assay-cli --test doctor_exit_class_contract an_unfixed_parse_failure_keeps_its_exit_class -- --nocapture`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- path-scoped `pre-commit run --files ...`

## Risk
Low. The change reuses the existing `config_failure` classifier already used after an insufficient repair. It changes only unresolved text-mode repair exits and their documentation.
