### PR TITLE
fix(summary): render failure text safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to this project will be documented in this file.
   class (#2165).
 
 ### Changed
+- `summary.json` and machine-readable early-failure summaries now apply the existing JSON
+  record-sink safety pipeline to failure `message` and `next_step` text. Secret shapes and terminal
+  controls are neutralized without truncating record content or changing Assay-owned contract
+  fields (#2168).
 - `assay doctor --format json` and `assay run --format json` return exit 3 when
   writing the machine document to stdout fails, including `BrokenPipe`. A
   partial or absent document is not a clean success. They no longer abort with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - `summary.json` and machine-readable early-failure summaries now apply the existing JSON
-  record-sink safety pipeline to failure `message` and `next_step` text. Secret shapes and terminal
-  controls are neutralized without truncating record content or changing Assay-owned contract
-  fields (#2168).
+  record-sink safety pipeline to failure `message` text. Secret shapes and terminal controls are
+  neutralized without truncating record content or changing Assay-owned contract fields, including
+  exact machine-readable recovery argv in `next_step` (#2168).
 - `assay doctor --format json` and `assay run --format json` return exit 3 when
   writing the machine document to stdout fails, including `BrokenPipe`. A
   partial or absent document is not a clean success. They no longer abort with

--- a/crates/assay-core/src/report/summary/writer.rs
+++ b/crates/assay-core/src/report/summary/writer.rs
@@ -1,18 +1,24 @@
 use std::path::Path;
 
+use crate::render_safety::{render_details_safe, render_safe, Sink};
+
 use super::types::Summary;
 
 pub const SUMMARY_SCHEMA: &str = "assay.run_summary.v1";
 
 /// Render the public summary artifact without expanding the public `Summary` Rust type.
 ///
-/// The schema identity is added at the document boundary. Existing summary fields retain their
-/// order and byte representation; render-safety for this artifact is tracked separately in #2168.
+/// The schema identity is added at the document boundary. Untrusted failure text is rendered safe
+/// for the JSON record sink while Assay-owned fields retain their order and byte representation.
 pub fn render_summary_json(summary: &Summary) -> anyhow::Result<String> {
-    let mut value = serde_json::to_value(summary)?;
+    let value = serde_json::to_value(summary)?;
+    let mut value = render_details_safe(Sink::Json, &value, usize::MAX);
     let object = value
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("summary must serialize as a JSON object"))?;
+    if let Some(serde_json::Value::String(next_step)) = object.get_mut("next_step") {
+        *next_step = render_safe(Sink::Json, next_step, usize::MAX);
+    }
     object.insert(
         "schema".to_string(),
         serde_json::Value::String(SUMMARY_SCHEMA.to_string()),
@@ -59,5 +65,42 @@ mod tests {
         let rerendered = render_summary_json(&named_summary).expect("rerender named summary");
 
         assert_eq!(named, rerendered);
+    }
+
+    #[test]
+    fn renderer_sanitizes_untrusted_failure_text_without_changing_owned_fields() {
+        let secret = format!("ghp_{}", "S".repeat(36));
+        let message = format!(
+            "provider said \u{1b}[2J{secret}\u{7} {}",
+            "payload".repeat(80)
+        );
+        let next_step = "retry with --config \u{1b}[31m/tmp/alice@example.com\u{1b}[0m";
+        let summary = Summary::failure(3, "E_PROVIDER", &message, next_step, "5.2.0", true);
+        let mut expected_owned = serde_json::to_value(&summary).expect("serialize summary");
+
+        let rendered = render_summary_json(&summary).expect("render summary");
+        let mut actual: serde_json::Value = serde_json::from_str(&rendered).expect("parse summary");
+        let rendered_message = actual["message"].as_str().expect("message string");
+        let rendered_next_step = actual["next_step"].as_str().expect("next_step string");
+
+        assert!(!rendered_message.contains(&secret), "message leaked secret");
+        assert!(rendered_message.contains("<redacted:github-token>"));
+        assert!(
+            rendered_message.len() > 500,
+            "record sink must not truncate the message"
+        );
+        assert!(!rendered_message.contains('\u{1b}'));
+        assert!(!rendered_message.contains('\u{7}'));
+        assert!(!rendered_next_step.contains('\u{1b}'));
+        assert!(!rendered_next_step.contains("alice@example.com"));
+
+        let expected_object = expected_owned.as_object_mut().expect("summary object");
+        expected_object.remove("message");
+        expected_object.remove("next_step");
+        let actual_object = actual.as_object_mut().expect("rendered summary object");
+        actual_object.remove("schema");
+        actual_object.remove("message");
+        actual_object.remove("next_step");
+        assert_eq!(actual, expected_owned, "Assay-owned fields changed");
     }
 }

--- a/crates/assay-core/src/report/summary/writer.rs
+++ b/crates/assay-core/src/report/summary/writer.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::render_safety::{render_details_safe, render_safe, Sink};
+use crate::render_safety::{render_details_safe, Sink};
 
 use super::types::Summary;
 
@@ -16,9 +16,6 @@ pub fn render_summary_json(summary: &Summary) -> anyhow::Result<String> {
     let object = value
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("summary must serialize as a JSON object"))?;
-    if let Some(serde_json::Value::String(next_step)) = object.get_mut("next_step") {
-        *next_step = render_safe(Sink::Json, next_step, usize::MAX);
-    }
     object.insert(
         "schema".to_string(),
         serde_json::Value::String(SUMMARY_SCHEMA.to_string()),
@@ -74,8 +71,12 @@ mod tests {
             "provider said \u{1b}[2J{secret}\u{7} {}",
             "payload".repeat(80)
         );
-        let next_step = "retry with --config \u{1b}[31m/tmp/alice@example.com\u{1b}[0m";
-        let summary = Summary::failure(3, "E_PROVIDER", &message, next_step, "5.2.0", true);
+        let recovery_path = "\u{1b}[31m/tmp/alice@example.com\u{1b}[0m";
+        let next_step = format!(
+            "Run argv: {}",
+            serde_json::json!(["assay", "doctor", format!("--config={recovery_path}")])
+        );
+        let summary = Summary::failure(3, "E_PROVIDER", &message, &next_step, "5.2.0", true);
         let mut expected_owned = serde_json::to_value(&summary).expect("serialize summary");
 
         let rendered = render_summary_json(&summary).expect("render summary");
@@ -91,16 +92,23 @@ mod tests {
         );
         assert!(!rendered_message.contains('\u{1b}'));
         assert!(!rendered_message.contains('\u{7}'));
-        assert!(!rendered_next_step.contains('\u{1b}'));
-        assert!(!rendered_next_step.contains("alice@example.com"));
+        assert_eq!(
+            rendered_next_step, &next_step,
+            "executable recovery contract changed"
+        );
+        let recovery: Vec<String> = serde_json::from_str(
+            rendered_next_step
+                .strip_prefix("Run argv: ")
+                .expect("recovery prefix"),
+        )
+        .expect("recovery argv remains parseable");
+        assert_eq!(recovery[2], format!("--config={recovery_path}"));
 
         let expected_object = expected_owned.as_object_mut().expect("summary object");
         expected_object.remove("message");
-        expected_object.remove("next_step");
         let actual_object = actual.as_object_mut().expect("rendered summary object");
         actual_object.remove("schema");
         actual_object.remove("message");
-        actual_object.remove("next_step");
         assert_eq!(actual, expected_owned, "Assay-owned fields changed");
     }
 }


### PR DESCRIPTION
## Summary

- apply the existing JSON record-sink safety pipeline to `Summary.message`
- preserve `next_step` byte-for-byte because it can carry executable `Run argv: [...]`
- preserve schema, reason codes, provenance, seeds, digests, ordering, and full record length

Closes #2168.

## Scope and non-claims

This changes only the authoritative summary renderer used by `summary.json` and machine-readable early-failure summaries. It does not change `run.json`, the public `Summary` Rust type, reason-code classification, output schemas, or executable recovery argv. JSON escaping already limits direct terminal-control execution; this fixes missing message redaction and cross-artifact policy inconsistency rather than claiming a reproduced secret leak.

## TDD evidence

Exact head: `103d7409d87fefc0519927389043d023b8b36753`
Base: `743ae89aaa19ea2a2b8f14d3bbb4c50aee20ce25`
Worktree: `/Users/roelschuurkes/wt-2168-summary-render-safety`
Toolchain: repository-pinned Rust 1.96.0

- RED 1: unsanitized renderer failed with `message leaked secret`
- GREEN 1: message sanitization passed
- advisory finding: `next_step` can carry an exact recovery argv and must not be sanitized
- RED 2: the initial field-local sanitizer failed with `executable recovery contract changed`
- GREEN 2: exact nested JSON argv survives and reparses with caller path bytes intact
- `cargo test -p assay-cli --test config_recovery_argv_contract` — 20 passed, 1 helper ignored
- `cargo test -p assay-core --lib` — 940 passed
- `cargo clippy -p assay-core --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- pre-push workspace clippy and Linux cross-target gate — passed

## Review focus

- only `message` is sanitized by the existing untrusted-key walk
- `next_step` remains part of the owned byte-stability comparison and its nested recovery argv is reparsed in the test
- `usize::MAX` intentionally preserves full record content after control stripping/redaction
- the test removes only `message` and additive `schema`, then pins every remaining serialized field against the original `Summary`
