### PR TITLE
feat(ci): publish summary JSON on stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `assay ci --format json` now publishes its authoritative `assay.run_summary.v1` report on stdout
+  for completed gates and early pipeline failures while preserving `summary.json`; default text
+  mode keeps stdout clear (#2177).
 - A stable JSON `startup_failure` diagnosis is emitted on stderr for enforcing-proxy policy,
   manifest, and establish-budget startup failures while MCP stdout stays empty and recovery stays
   independent of log level (#2163).

--- a/crates/assay-cli/src/cli/args/run.rs
+++ b/crates/assay-cli/src/cli/args/run.rs
@@ -219,6 +219,10 @@ pub struct CiArgs {
     #[arg(long)]
     pub no_verify: bool,
 
+    /// Output format: text prints the human report to stderr; json prints the summary to stdout.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+
     /// Write PR comment body (markdown) to file for GitHub Actions
     #[arg(long)]
     pub pr_comment: Option<PathBuf>,

--- a/crates/assay-cli/src/cli/commands/ci.rs
+++ b/crates/assay-cli/src/cli/commands/ci.rs
@@ -1,10 +1,12 @@
-use super::super::args::CiArgs;
+use super::super::args::{CiArgs, OutputFormat};
 use super::pipeline::{execute_pipeline, PipelineInput};
 use super::pipeline_error::elapsed_ms;
 use super::reporting::{
     build_summary_from_artifacts, maybe_export_baseline, print_pipeline_summary,
 };
 use super::run_output::write_extended_run_json;
+use crate::exit_codes::EXIT_SUCCESS;
+use crate::output_write::write_stdout_json;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -13,9 +15,10 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
     let run_json_path = PathBuf::from("run.json");
 
     let input = PipelineInput::from_ci(&args);
+    let json_output = matches!(args.format, OutputFormat::Json);
     let execution = match execute_pipeline(&input, legacy_mode).await {
         Ok(ok) => ok,
-        Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path, false),
+        Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path, json_output),
     };
 
     if execution.cfg.version > 0 {
@@ -68,7 +71,9 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
         build_summary_from_artifacts(&outcome, !args.no_verify, &artifacts, Some(&timings), None);
     summary = summary.with_sarif_omitted(sarif_omitted);
 
-    print_pipeline_summary(&artifacts, args.explain_skip, &summary);
+    if !json_output {
+        print_pipeline_summary(&artifacts, args.explain_skip, &summary);
+    }
 
     let otel_cfg = assay_core::otel::OTelConfig {
         jsonl_path: args.otel_jsonl.clone(),
@@ -99,6 +104,14 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
     );
     final_summary = final_summary.with_sarif_omitted(sarif_omitted);
     assay_core::report::summary::write_summary(&final_summary, &summary_path)?;
+
+    if json_output {
+        let rendered = assay_core::report::summary::render_summary_json(&final_summary)?;
+        let write_code = write_stdout_json(&rendered);
+        if write_code != EXIT_SUCCESS {
+            return Ok(write_code);
+        }
+    }
 
     Ok(outcome.exit_code)
 }

--- a/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
+++ b/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
@@ -121,3 +121,116 @@ fn the_text_format_keeps_stdout_clear() {
         "and stderr must still carry the human report"
     );
 }
+
+#[test]
+fn a_failing_ci_writes_the_diagnosis_to_stdout_under_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("missing.yaml");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .current_dir(dir.path())
+        .args(["ci", "--format", "json", "--config"])
+        .arg(&missing)
+        .output()
+        .expect("the binary runs");
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a missing config is exit 2; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+    assert!(
+        !stdout.trim().is_empty(),
+        "ci --format json must publish its early-failure diagnosis; stderr was: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout must parse as JSON: {e}\n{stdout}"));
+
+    assert_eq!(parsed["schema"], "assay.run_summary.v1");
+    assert_eq!(parsed["exit_code"], 2);
+    assert_eq!(parsed["reason_code"], "E_MISSING_CONFIG");
+    assert!(
+        parsed["next_step"]
+            .as_str()
+            .is_some_and(|step| step.contains("assay")),
+        "the diagnosis must contain actionable recovery, got {:?}",
+        parsed["next_step"]
+    );
+
+    let summary = dir.path().join("summary.json");
+    assert!(summary.is_file(), "summary.json must remain the artifact");
+    let from_disk: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&summary).expect("read summary"))
+            .expect("summary.json parses");
+    assert_eq!(
+        from_disk["reason_code"], parsed["reason_code"],
+        "the artifact and stdout must carry one diagnosis"
+    );
+}
+
+#[test]
+fn a_completed_ci_writes_its_summary_to_stdout_under_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let suite = vacuous_suite(dir.path());
+
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .current_dir(dir.path())
+        .args([
+            "ci",
+            "--format",
+            "json",
+            "--allow-ineffective-assertions",
+            "--config",
+        ])
+        .arg(&suite)
+        .output()
+        .expect("the binary runs");
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "the trace-free probe completes with a failed test; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("completed ci stdout must be JSON: {e}\n{stdout}"));
+    assert_eq!(parsed["schema"], "assay.run_summary.v1");
+    assert_eq!(parsed["exit_code"], 1);
+
+    let from_disk: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.path().join("summary.json")).expect("read summary"),
+    )
+    .expect("summary.json parses");
+    assert_eq!(
+        parsed, from_disk,
+        "stdout and summary.json must be the same authoritative report"
+    );
+}
+
+#[test]
+fn the_ci_text_format_keeps_stdout_clear() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("missing.yaml");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .current_dir(dir.path())
+        .args(["ci", "--config"])
+        .arg(&missing)
+        .output()
+        .expect("the binary runs");
+
+    assert_eq!(out.status.code(), Some(2));
+    assert!(
+        out.stdout.is_empty(),
+        "ci text mode must not leak the machine report to stdout"
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "ci text mode must retain its operator diagnostic"
+    );
+}

--- a/docs/AIcontext/run-output.md
+++ b/docs/AIcontext/run-output.md
@@ -15,6 +15,11 @@ After a run, Assay writes:
 
 Consumers should branch on **`(reason_code_version, reason_code)`** for semantics; exit code is coarse transport only.
 
+`assay ci --format json` writes the same `assay.run_summary.v1` document as `summary.json` to
+stdout after a completed gate, and writes the same early-failure diagnosis there when the pipeline
+cannot start. The default `text` format keeps stdout empty and retains the operator report on
+stderr. `summary.json` remains the authoritative artifact in both modes.
+
 ## run.json
 
 | Field | Type | Description |
@@ -92,6 +97,7 @@ On config error, missing trace, or similar early-exit:
 - **run.json** (minimal): exit_code, reason_code, reason_code_version, seed_version present; **order_seed** and **judge_seed** may be **null**.
 - **summary.json**: Uses `schema: "assay.run_summary.v1"`; seeds object present with seed_version; order_seed/judge_seed null when unknown.
 - **`assay run --format json` stdout**: uses `assay.run_report.v1` after a completed run, but emits the same `assay.run_summary.v1` diagnosis as `summary.json` when the run fails before results exist.
+- **`assay ci --format json` stdout**: uses `assay.run_summary.v1` for both completed gates and early failures; `summary.json` remains present with the same document.
 
 Replay-specific note (E9d hardening): for replay early-exit paths (missing dependency, verify fail, parse/open fail), seeds are intentionally written as `null` to indicate that no new deterministic replay execution occurred.
 


### PR DESCRIPTION
## Summary

- add `--format text|json` to `assay ci`
- publish the authoritative `assay.run_summary.v1` document on stdout for completed gates
- publish the same summary diagnosis for early pipeline failures
- preserve `summary.json`, exit mappings, and default text-mode channels

Part of #2177. Coverage failure output remains a separate follow-up slice.

## Contract

| Mode | stdout | stderr | artifact |
|---|---|---|---|
| `ci --format json`, completed | `assay.run_summary.v1` | operational diagnostics | same `summary.json` |
| `ci --format json`, early failure | actionable `assay.run_summary.v1` | operator diagnostic | same `summary.json` |
| `ci` / `--format text` | empty | existing human report | unchanged |

No new schema, reason code, emitter, or exit mapping is introduced. Stdout uses the existing summary renderer and shared write/flush policy; a write failure remains exit 3.

## TDD evidence

Exact head: `4b14996096f89e98ec0afd3d790f5d18ad4ced77`
Base: `a1d24d68b77621ad5992cee3dabc8e24e7debefa`
Worktree: `/Users/roelschuurkes/wt-2177-ci-json-failure`
Toolchain: rustc/cargo 1.96.0

RED:
- early failure: clap rejected `ci --format json`; stdout was 0 bytes
- completed gate: command ran and wrote `summary.json`; stdout was 0 bytes / JSON parse EOF

GREEN:
- `cargo test -p assay-cli --test json_format_reports_failures_on_stdout` — 5 passed
- `cargo test -p assay-cli` — all tests passed
- `cargo clippy -p assay-cli --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- pre-commit and pre-push hooks — passed
- `git diff --check` — passed

Mutations:
- forcing early-failure `json_stdout=false` makes only the early-CI contract fail
- suppressing completed-summary stdout makes only the completed-CI contract fail

## Non-claims

- no `assay coverage` behavior change
- no table-driven command-wide migration in this slice
- no change to `assay run` report identity
- no generic conversion of untyped errors into clean diagnoses
- no MCP stdio change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `assay ci --format json` to emit structured `assay.run_summary.v1` results to stdout for completed runs and early failures.
  * JSON output includes exit status, failure reasons, and actionable next steps.

* **Bug Fixes**
  * Preserved `summary.json` generation when using JSON output.
  * Ensured text mode keeps stdout clear while reporting diagnostics on stderr.

* **Documentation**
  * Documented CI output formats and early-failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->