### PR TITLE
feat(coverage): publish legacy JSON failures on stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Legacy `assay coverage --format json` argument failures now publish the existing
+  `assay.run_summary.v1` diagnosis on stdout. Text mode stays operator-only and `--input` mode
+  keeps writing `coverage_report_v1` to its requested file (#2177).
 - `assay ci --format json` now publishes its authoritative `assay.run_summary.v1` report on stdout
   for completed gates and early pipeline failures while preserving `summary.json`; default text
   mode keeps stdout clear (#2177).

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -55,6 +55,14 @@ impl Cli {
         )
         .then_some(true)
         .or_else(|| match &self.cmd {
+            Command::Coverage(args)
+                if args.input.is_none() && args.format == Some(CoverageFormat::Json) =>
+            {
+                // Coverage has no signature-verification switch. Keep the inherited Summary
+                // convention used by classified machine-output paths; this flag selects the
+                // envelope and does not claim every internal coverage failure is classified.
+                Some(true)
+            }
             Command::Evidence(EvidenceArgs {
                 cmd: crate::cli::commands::evidence::EvidenceCmd::Show(args),
             }) if args.format == ShowFormat::Json => Some(!args.no_verify),

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -364,6 +364,33 @@ fn top_level_failure_funnel_owns_supported_machine_output_commands() {
         .expect("evidence show table parses");
     assert_eq!(evidence_table.machine_output_verify_enabled(), None);
 
+    let coverage_json = Cli::try_parse_from(["assay", "coverage", "--format", "json"])
+        .expect("legacy coverage JSON parses");
+    assert_eq!(
+        coverage_json.machine_output_verify_enabled(),
+        Some(true),
+        "legacy coverage JSON failures use the shared Summary envelope"
+    );
+
+    let coverage_input_json = Cli::try_parse_from([
+        "assay",
+        "coverage",
+        "--input",
+        "events.jsonl",
+        "--format",
+        "json",
+    ])
+    .expect("input-mode coverage JSON parses");
+    assert_eq!(
+        coverage_input_json.machine_output_verify_enabled(),
+        None,
+        "input mode writes coverage_report_v1 to a file and must not inherit the legacy envelope"
+    );
+
+    let coverage_text =
+        Cli::try_parse_from(["assay", "coverage"]).expect("legacy coverage text parses");
+    assert_eq!(coverage_text.machine_output_verify_enabled(), None);
+
     let run_json =
         Cli::try_parse_from(["assay", "run", "--config", "eval.yaml", "--format", "json"])
             .expect("run JSON parses");

--- a/crates/assay-cli/src/cli/commands/coverage/legacy.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/legacy.rs
@@ -1,6 +1,7 @@
 use super::io::{print_markdown_report, print_text_report};
 use super::LegacyOutputFormat;
 use crate::cli::args::CoverageArgs;
+use crate::cli_failure::CliFailure;
 use anyhow::{Context, Result};
 
 pub(super) async fn cmd_coverage_legacy(
@@ -10,10 +11,10 @@ pub(super) async fn cmd_coverage_legacy(
     let trace_file = match args.trace_file.as_ref() {
         Some(path) => path,
         None => {
-            eprintln!(
-                "Measurement error: --trace-file/--traces is required when --input is not used"
-            );
-            return Ok(crate::exit_codes::EXIT_CONFIG_ERROR);
+            return Err(CliFailure::coverage_invalid_args(
+                "--trace-file/--traces is required when --input is not used",
+            )
+            .into());
         }
     };
 

--- a/crates/assay-cli/src/cli/commands/coverage/mod.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/mod.rs
@@ -1,4 +1,5 @@
 use crate::cli::args::{CoverageArgs, CoverageFormat};
+use crate::cli_failure::CliFailure;
 use anyhow::Result;
 use std::path::Path;
 
@@ -107,8 +108,10 @@ pub(crate) async fn write_generated_coverage_report_with_format(
 
 pub async fn cmd_coverage(args: CoverageArgs) -> Result<i32> {
     if args.input.is_none() && args.out_md.is_some() {
-        eprintln!("Measurement error: --out-md is only supported with --input mode");
-        return Ok(crate::exit_codes::EXIT_CONFIG_ERROR);
+        return Err(CliFailure::coverage_invalid_args(
+            "--out-md is only supported with --input mode",
+        )
+        .into());
     }
 
     // Both mode rules sit here: each applies its own default and each refuses by name the spelling

--- a/crates/assay-cli/src/cli_failure.rs
+++ b/crates/assay-cli/src/cli_failure.rs
@@ -24,6 +24,15 @@ pub(crate) struct CliFailure {
 }
 
 impl CliFailure {
+    pub(crate) fn coverage_invalid_args(message: impl Into<String>) -> Self {
+        let outcome = RunOutcome::from_reason(ReasonCode::EInvalidArgs, Some(message.into()), None);
+        Self {
+            outcome,
+            source: "coverage",
+            context: serde_json::json!({}),
+        }
+    }
+
     pub(crate) fn policy_parse(path: &Path, error: impl std::fmt::Display) -> Self {
         let path = path.display().to_string();
         let message = format!("failed to parse policy {path}: {error}");

--- a/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
+++ b/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
@@ -234,3 +234,113 @@ fn the_ci_text_format_keeps_stdout_clear() {
         "ci text mode must retain its operator diagnostic"
     );
 }
+
+fn assert_coverage_failure_summary(out: std::process::Output, expected_message: &str) {
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "an invalid coverage invocation is exit 2; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("coverage stdout must be JSON: {error}\n{stdout}"));
+    assert_eq!(parsed["schema"], "assay.run_summary.v1");
+    assert_eq!(parsed["exit_code"], 2);
+    assert_eq!(parsed["reason_code"], "E_INVALID_ARGS");
+    assert!(
+        parsed["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(expected_message)),
+        "coverage diagnosis must retain the concrete argument failure, got {:?}",
+        parsed["message"]
+    );
+    assert!(
+        parsed["next_step"]
+            .as_str()
+            .is_some_and(|step| step.contains("assay")),
+        "coverage diagnosis must contain actionable recovery, got {:?}",
+        parsed["next_step"]
+    );
+}
+
+#[test]
+fn coverage_missing_trace_writes_the_diagnosis_to_stdout_under_json() {
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(["coverage", "--format", "json"])
+        .output()
+        .expect("the binary runs");
+
+    assert_coverage_failure_summary(out, "--trace-file/--traces is required");
+}
+
+#[test]
+fn coverage_rejected_legacy_out_md_writes_the_diagnosis_to_stdout_under_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let markdown = dir.path().join("coverage.md");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(["coverage", "--format", "json", "--out-md"])
+        .arg(markdown)
+        .output()
+        .expect("the binary runs");
+
+    assert_coverage_failure_summary(out, "--out-md is only supported with --input mode");
+}
+
+#[test]
+fn coverage_text_failures_keep_stdout_clear() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let markdown = dir.path().join("coverage.md");
+    let cases = [
+        vec!["coverage".to_string()],
+        vec![
+            "coverage".to_string(),
+            "--out-md".to_string(),
+            markdown.display().to_string(),
+        ],
+    ];
+
+    for args in cases {
+        let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+            .args(&args)
+            .output()
+            .expect("the binary runs");
+        assert_eq!(out.status.code(), Some(2), "args: {args:?}");
+        assert!(
+            out.stdout.is_empty(),
+            "coverage text mode must keep stdout clear; args: {args:?}"
+        );
+        assert!(
+            !out.stderr.is_empty(),
+            "coverage text mode must retain its operator diagnostic; args: {args:?}"
+        );
+    }
+}
+
+#[test]
+fn coverage_input_failure_does_not_publish_a_summary_to_stdout() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("missing.jsonl");
+    let report = dir.path().join("coverage.json");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(["coverage", "--input"])
+        .arg(missing)
+        .arg("--out")
+        .arg(report)
+        .args(["--declared-tool", "read_file", "--format", "json"])
+        .output()
+        .expect("the binary runs");
+
+    assert!(!out.status.success());
+    assert!(
+        out.stdout.is_empty(),
+        "--input mode writes its report to --out and must not inherit the legacy stdout envelope"
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "the input-mode failure must remain visible to the operator"
+    );
+}


### PR DESCRIPTION
## Summary

- publish the existing `assay.run_summary.v1` diagnosis on stdout for two legacy `assay coverage --format json` argument failures
- keep default text mode operator-only with empty stdout
- keep `--input` mode on its existing file-sink contract
- reuse the top-level `CliFailure` funnel rather than adding a coverage-specific envelope

## Scope / DoD

- [x] missing `--trace-file/--traces` under legacy JSON emits exit 2 + `E_INVALID_ARGS` Summary on stdout
- [x] legacy `--out-md` rejection under JSON emits exit 2 + `E_INVALID_ARGS` Summary on stdout
- [x] text variants retain empty stdout and a stderr diagnosis
- [x] `--input` mode does not inherit the legacy Summary envelope
- [x] success behavior and `coverage_report_v1` are unchanged

## Provenance

- base: `262f3972be2a0ee8ae7aa448667cc07ea9207513`
- head: `0395a56cfa9584e3b9d7940eef54677e2415b8d6`
- worktree: `/Users/roelschuurkes/wt-2177-coverage-json-failure`
- toolchain: `rustc 1.96.0`

## RED -> GREEN

On the base tree, the two new process tests failed because stdout was empty and JSON parsing reached EOF; the seven existing/control tests passed.

On the committed head:

```text
cargo test -p assay-cli --test json_format_reports_failures_on_stdout
9 passed, 0 failed

cargo test -p assay-cli --test coverage_format_modes
4 passed, 0 failed

cargo test -p assay-cli
passed

cargo clippy -p assay-cli --all-targets -- -D warnings
passed

cargo fmt --all -- --check
passed

git diff --check
passed
```

Pre-commit and pre-push hooks passed, including workspace clippy and the Linux cross-target compile gate.

## Mutation evidence

Each mutation was applied independently to a copy and killed by its intended guard:

1. restore the missing-trace arm to `Ok(2)` -> missing-trace JSON process test fails
2. restore the legacy `--out-md` arm to `Ok(2)` -> out-md JSON process test fails
3. remove the `input.is_none()` selector -> args allowlist test fails
4. remove the JSON-format selector -> text-mode process control fails

Production files were restored byte-exact after each mutation.

## Contract changes

- new typed failure constructor: `CliFailure::coverage_invalid_args`
- legacy coverage JSON is added to `machine_output_verify_enabled()` only when `--input` is absent
- no new schema, JSON field, reason code, or exit code

## Non-claims

- This classifies **2 of 11** known legacy early/error paths; it is not a completeness claim for coverage.
- `--input`/generate mode, clap parse failures, remaining `?`/`anyhow` paths, and post-report threshold failures are unchanged.
- The inherited Summary field `verify_mode` is not redesigned here.
- The existing difference between stdout write-failure policies in `output_write::write_stdout_json` and `CliFailure::emit` is unchanged.
- This does not close the wider generic gate-command table in #2177.

Closes part of #2177.
