### PR TITLE
test(cli): pin gate-command JSON failure set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- The JSON failure process contract now pins the explicit gate-command set (`run`, `ci`,
+  `coverage`, and `validate`) and drives both machine and default output modes (#2177).
 - Legacy `assay coverage --format json` argument failures now publish the existing
   `assay.run_summary.v1` diagnosis on stdout. Text mode stays operator-only and `--input` mode
   keeps writing `coverage_report_v1` to its requested file (#2177).

--- a/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
+++ b/crates/assay-cli/tests/json_format_reports_failures_on_stdout.rs
@@ -10,6 +10,9 @@
 //! already correct. `summary.json` carried `reason_code` and `next_step`, the exit code was right,
 //! and the only wrong thing was which stream the bytes reached. A test over constants cannot see
 //! that, which is why this one runs the binary and reads its actual stdout.
+//!
+//! The explicit gate-command set below is intentionally separate from the driven rows: deleting a
+//! row must fail rather than silently narrowing the contract the suite claims to cover (#2177).
 
 use std::io::Write;
 use std::process::Command;
@@ -36,140 +39,220 @@ tests:
     path
 }
 
+#[derive(Clone, Copy, Debug)]
+enum GateFailureCase {
+    Ci,
+    Coverage,
+    Run,
+    Validate,
+}
+
+impl GateFailureCase {
+    fn command(self) -> &'static str {
+        match self {
+            Self::Ci => "ci",
+            Self::Coverage => "coverage",
+            Self::Run => "run",
+            Self::Validate => "validate",
+        }
+    }
+
+    fn drive(self, dir: &std::path::Path, json: bool) -> std::process::Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+        command.current_dir(dir).env("NO_COLOR", "1");
+        for (name, _) in std::env::vars_os() {
+            if name
+                .to_string_lossy()
+                .to_ascii_uppercase()
+                .starts_with("ASSAY_")
+            {
+                command.env_remove(name);
+            }
+        }
+
+        match self {
+            Self::Ci => {
+                command.arg("ci");
+                if json {
+                    command.args(["--format", "json"]);
+                }
+                command.arg("--config");
+                command.arg(dir.join("missing.yaml"));
+            }
+            Self::Coverage => {
+                command.arg("coverage");
+                if json {
+                    command.args(["--format", "json"]);
+                }
+            }
+            Self::Run => {
+                command.arg("run");
+                if json {
+                    command.args(["--format", "json"]);
+                }
+                command.arg("--config");
+                command.arg(vacuous_suite(dir));
+            }
+            Self::Validate => {
+                command.arg("validate");
+                if json {
+                    command.args(["--format", "json"]);
+                }
+                command.arg("--config");
+                command.arg(dir.join("missing.yaml"));
+            }
+        }
+
+        command.output().expect("the binary runs")
+    }
+
+    fn expected_schema(self) -> &'static str {
+        match self {
+            Self::Validate => "assay.validate_report.v1",
+            Self::Ci | Self::Coverage | Self::Run => "assay.run_summary.v1",
+        }
+    }
+}
+
+const EXPECTED_GATE_COMMANDS: &[&str] = &["ci", "coverage", "run", "validate"];
+const GATE_FAILURE_CASES: &[GateFailureCase] = &[
+    GateFailureCase::Ci,
+    GateFailureCase::Coverage,
+    GateFailureCase::Run,
+    GateFailureCase::Validate,
+];
+
 #[test]
-fn a_failing_run_writes_the_diagnosis_to_stdout_under_json() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let suite = vacuous_suite(dir.path());
-
-    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
-        .current_dir(dir.path())
-        .args(["run", "--format", "json", "--config"])
-        .arg(&suite)
-        .output()
-        .expect("the binary runs");
+fn every_gate_command_has_a_driven_json_failure_contract() {
+    // Keep this list independent from EXPECTED_GATE_COMMANDS. The equality is what makes deleting
+    // a process row fail instead of silently shrinking the claimed gate surface.
+    let commands: Vec<&str> = GATE_FAILURE_CASES
+        .iter()
+        .map(|case| case.command())
+        .collect();
 
     assert_eq!(
-        out.status.code(),
-        Some(2),
-        "a config that cannot load is exit 2; stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
+        commands, EXPECTED_GATE_COMMANDS,
+        "the driven JSON-failure table must cover the explicit gate-command set"
     );
 
-    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
-    assert!(
-        !stdout.trim().is_empty(),
-        "--format json documents a machine-readable report on stdout, and the failure path wrote \
-         nothing there. stderr was: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    for &case in GATE_FAILURE_CASES {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = case.drive(dir.path(), true);
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "{} failure must retain exit 2; stderr: {}",
+            case.command(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !out.stdout.is_empty(),
+            "{} advertised JSON but wrote zero bytes; stderr: {}",
+            case.command(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let document: serde_json::Value =
+            serde_json::from_slice(&out.stdout).unwrap_or_else(|error| {
+                panic!(
+                    "{} failure stdout must be JSON: {error}\n{}",
+                    case.command(),
+                    String::from_utf8_lossy(&out.stdout)
+                )
+            });
+        assert_eq!(
+            document["schema"],
+            case.expected_schema(),
+            "{} machine-document identity",
+            case.command()
+        );
+        assert_eq!(
+            document["schema_version"],
+            1,
+            "{} schema version",
+            case.command()
+        );
+        assert_eq!(document["exit_code"], 2, "{} document exit", case.command());
 
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("stdout must parse as JSON: {e}\n{stdout}"));
-
-    // The three fields a caller needs to act without reading a file or the human channel. Asserted
-    // by name rather than by shape, because a consumer branches on `reason_code` and follows
-    // `next_step`, and an object that merely parses gives it neither.
-    assert_eq!(parsed["exit_code"], 2, "stdout must carry the exit code");
-    assert_eq!(
-        parsed["reason_code"], "E_CFG_PARSE",
-        "stdout must carry the machine-readable reason"
-    );
-    assert!(
-        parsed["next_step"]
-            .as_str()
-            .is_some_and(|s| s.contains("assay")),
-        "a non-zero exit must suggest a concrete next command, got {:?}",
-        parsed["next_step"]
-    );
-
-    // `summary.json` is unchanged and still the artifact. Consumers depend on it, and this fix adds
-    // a stream rather than moving one.
-    let summary = dir.path().join("summary.json");
-    assert!(summary.is_file(), "summary.json must still be written");
-    let from_disk: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&summary).expect("read summary"))
-            .expect("summary.json parses");
-    assert_eq!(
-        from_disk["reason_code"], parsed["reason_code"],
-        "the artifact and stdout must be one diagnosis, not two renderings"
-    );
+        match case {
+            GateFailureCase::Ci => assert_summary_failure(
+                &document,
+                "E_MISSING_CONFIG",
+                "ci",
+                Some(dir.path().join("summary.json")),
+            ),
+            GateFailureCase::Coverage => {
+                assert_summary_failure(&document, "E_INVALID_ARGS", "coverage", None)
+            }
+            GateFailureCase::Run => assert_summary_failure(
+                &document,
+                "E_CFG_PARSE",
+                "run",
+                Some(dir.path().join("summary.json")),
+            ),
+            GateFailureCase::Validate => {
+                assert_eq!(document["ok"], false);
+                assert_eq!(document["diagnostics"][0]["code"], "E_CFG_PARSE");
+                assert!(
+                    document["suggested_actions"]
+                        .as_array()
+                        .is_some_and(|actions| !actions.is_empty()),
+                    "validate failure must publish actionable remediation: {document}"
+                );
+            }
+        }
+    }
 }
 
 #[test]
-fn the_text_format_keeps_stdout_clear() {
-    // The other half of the contract: `--format text` says the human report goes to stderr, so a
-    // caller redirecting stdout under the default gets nothing to misparse. Without this, "put it
-    // on stdout" could be satisfied by putting it there always, which would break every existing
-    // pipeline that treats stdout as the machine channel only when asked.
-    let dir = tempfile::tempdir().expect("tempdir");
-    let suite = vacuous_suite(dir.path());
-
-    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
-        .current_dir(dir.path())
-        .args(["run", "--config"])
-        .arg(&suite)
-        .output()
-        .expect("the binary runs");
-
-    assert_eq!(out.status.code(), Some(2));
-    assert!(
-        String::from_utf8_lossy(&out.stdout).trim().is_empty(),
-        "under the default format the diagnosis belongs on stderr"
-    );
-    assert!(
-        !out.stderr.is_empty(),
-        "and stderr must still carry the human report"
-    );
+fn every_gate_command_default_failure_keeps_stdout_clear() {
+    for &case in GATE_FAILURE_CASES {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = case.drive(dir.path(), false);
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "{} default exit",
+            case.command()
+        );
+        assert!(
+            out.stdout.is_empty(),
+            "{} default mode must keep stdout clear",
+            case.command()
+        );
+        assert!(
+            !out.stderr.is_empty(),
+            "{} default mode must retain an operator diagnostic",
+            case.command()
+        );
+    }
 }
 
-#[test]
-fn a_failing_ci_writes_the_diagnosis_to_stdout_under_json() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let missing = dir.path().join("missing.yaml");
-
-    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
-        .current_dir(dir.path())
-        .args(["ci", "--format", "json", "--config"])
-        .arg(&missing)
-        .output()
-        .expect("the binary runs");
-
-    assert_eq!(
-        out.status.code(),
-        Some(2),
-        "a missing config is exit 2; stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-
-    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+fn assert_summary_failure(
+    document: &serde_json::Value,
+    expected_reason: &str,
+    command: &str,
+    artifact: Option<std::path::PathBuf>,
+) {
+    assert_eq!(document["reason_code"], expected_reason, "{command} reason");
     assert!(
-        !stdout.trim().is_empty(),
-        "ci --format json must publish its early-failure diagnosis; stderr was: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("stdout must parse as JSON: {e}\n{stdout}"));
-
-    assert_eq!(parsed["schema"], "assay.run_summary.v1");
-    assert_eq!(parsed["exit_code"], 2);
-    assert_eq!(parsed["reason_code"], "E_MISSING_CONFIG");
-    assert!(
-        parsed["next_step"]
+        document["next_step"]
             .as_str()
             .is_some_and(|step| step.contains("assay")),
-        "the diagnosis must contain actionable recovery, got {:?}",
-        parsed["next_step"]
+        "{command} failure must publish actionable recovery: {document}"
     );
 
-    let summary = dir.path().join("summary.json");
-    assert!(summary.is_file(), "summary.json must remain the artifact");
-    let from_disk: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&summary).expect("read summary"))
-            .expect("summary.json parses");
-    assert_eq!(
-        from_disk["reason_code"], parsed["reason_code"],
-        "the artifact and stdout must carry one diagnosis"
-    );
+    if let Some(path) = artifact {
+        let from_disk: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("read {}: {error}", path.display())),
+        )
+        .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()));
+        assert_eq!(
+            from_disk, *document,
+            "{command} stdout and summary.json must be one authoritative report"
+        );
+    }
 }
 
 #[test]
@@ -212,29 +295,6 @@ fn a_completed_ci_writes_its_summary_to_stdout_under_json() {
     );
 }
 
-#[test]
-fn the_ci_text_format_keeps_stdout_clear() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let missing = dir.path().join("missing.yaml");
-
-    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
-        .current_dir(dir.path())
-        .args(["ci", "--config"])
-        .arg(&missing)
-        .output()
-        .expect("the binary runs");
-
-    assert_eq!(out.status.code(), Some(2));
-    assert!(
-        out.stdout.is_empty(),
-        "ci text mode must not leak the machine report to stdout"
-    );
-    assert!(
-        !out.stderr.is_empty(),
-        "ci text mode must retain its operator diagnostic"
-    );
-}
-
 fn assert_coverage_failure_summary(out: std::process::Output, expected_message: &str) {
     assert_eq!(
         out.status.code(),
@@ -266,57 +326,32 @@ fn assert_coverage_failure_summary(out: std::process::Output, expected_message: 
 }
 
 #[test]
-fn coverage_missing_trace_writes_the_diagnosis_to_stdout_under_json() {
-    let out = Command::new(env!("CARGO_BIN_EXE_assay"))
-        .args(["coverage", "--format", "json"])
-        .output()
-        .expect("the binary runs");
-
-    assert_coverage_failure_summary(out, "--trace-file/--traces is required");
-}
-
-#[test]
 fn coverage_rejected_legacy_out_md_writes_the_diagnosis_to_stdout_under_json() {
     let dir = tempfile::tempdir().expect("tempdir");
     let markdown = dir.path().join("coverage.md");
 
     let out = Command::new(env!("CARGO_BIN_EXE_assay"))
         .args(["coverage", "--format", "json", "--out-md"])
-        .arg(markdown)
+        .arg(&markdown)
         .output()
         .expect("the binary runs");
 
     assert_coverage_failure_summary(out, "--out-md is only supported with --input mode");
-}
 
-#[test]
-fn coverage_text_failures_keep_stdout_clear() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let markdown = dir.path().join("coverage.md");
-    let cases = [
-        vec!["coverage".to_string()],
-        vec![
-            "coverage".to_string(),
-            "--out-md".to_string(),
-            markdown.display().to_string(),
-        ],
-    ];
-
-    for args in cases {
-        let out = Command::new(env!("CARGO_BIN_EXE_assay"))
-            .args(&args)
-            .output()
-            .expect("the binary runs");
-        assert_eq!(out.status.code(), Some(2), "args: {args:?}");
-        assert!(
-            out.stdout.is_empty(),
-            "coverage text mode must keep stdout clear; args: {args:?}"
-        );
-        assert!(
-            !out.stderr.is_empty(),
-            "coverage text mode must retain its operator diagnostic; args: {args:?}"
-        );
-    }
+    let text = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .args(["coverage", "--out-md"])
+        .arg(&markdown)
+        .output()
+        .expect("the binary runs");
+    assert_eq!(text.status.code(), Some(2));
+    assert!(
+        text.stdout.is_empty(),
+        "coverage text mode stays stdout-clean"
+    );
+    assert!(
+        !text.stderr.is_empty(),
+        "the operator diagnosis stays visible"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace separate `run` / `ci` / coverage failure tests with one explicit, table-driven gate-command contract
- pin the intended set as `run`, `ci`, `coverage`, and `validate`
- drive each command's advertised JSON failure plus its default/text stdout control
- retain completed-CI, second coverage-argument, and coverage `--input` controls

## Why `validate` is included

The three Summary publishers (`run`, `ci`, `coverage`) were already separate rows in this file. #2177's remaining DoD also requires a command-specific gate report. `validate` is the bounded fit: its failure publishes `assay.validate_report.v1`, `diagnostics[].code`, and `suggested_actions`, while default mode keeps stdout clear. `doctor`, `init`, evidence commands, and `policy validate` remain outside this gate set because their channel/schema contracts or current behavior differ and are guarded elsewhere.

## Provenance

- base: `f2a558d1ce16cc31d565ef6ed6a7773e81002339`
- head: `0534f7fbde89127f60c50aaf1cc3d7d423b6ee0e`
- worktree: `/Users/roelschuurkes/wt-2177-gate-command-table`
- toolchain: `rustc 1.96.0`

## RED -> GREEN

RED deliberately omitted the `validate` process row while keeping it in `EXPECTED_GATE_COMMANDS`:

```text
left:  ["ci", "coverage", "run"]
right: ["ci", "coverage", "run", "validate"]
```

GREEN on the committed head:

```text
cargo test -p assay-cli --test json_format_reports_failures_on_stdout
5 passed, 0 failed

cargo test -p assay-cli
passed

cargo clippy -p assay-cli --all-targets -- -D warnings
passed

cargo fmt --all -- --check
passed

git diff --check
passed
```

Pre-commit and pre-push hooks passed, including workspace clippy and the Linux cross-target compile gate.

## Mutation evidence

Each mutation was applied independently and restored before commit:

1. remove `validate` from the driven rows -> expected-set assertion fails
2. restore coverage's zero-stdout `Ok(2)` return -> only coverage reports zero bytes
3. change `assay.validate_report.v1` to `.v0` -> only validate schema identity fails
4. change coverage `E_INVALID_ARGS` to `E_POLICY_PARSE` -> only coverage reason identity fails

## Contract table

| Command | Failure document | Actionable identity |
|---|---|---|
| `run` | `assay.run_summary.v1` | `E_CFG_PARSE` + `next_step`; stdout equals `summary.json` |
| `ci` | `assay.run_summary.v1` | `E_MISSING_CONFIG` + `next_step`; stdout equals `summary.json` |
| `coverage` | `assay.run_summary.v1` | `E_INVALID_ARGS` + `next_step` |
| `validate` | `assay.validate_report.v1` | `diagnostics[0].code=E_CFG_PARSE` + non-empty `suggested_actions` |

All four default/text failures retain exit 2, empty stdout, and non-empty stderr.

## Non-claims

- test-only change; no production behavior, schema, reason code, or exit mapping changes
- not an inventory of every JSON-capable CLI command
- no sink-write policy change; #2439 owns exit 3 when stdout itself cannot be written
- `doctor`, `init`, evidence, `policy validate`, coverage `--input`, and remaining legacy coverage `Err`/`?` paths are not added to this set

Closes #2177.
