### PR TITLE
fix(cli): fail closed when summary stdout is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,6 +762,23 @@ jobs:
           grep -F -- 'test native_windows_bare_command_uses_exe_not_pathext_scripts ... ok' \
             "$RUNNER_TEMP/mcp-preflight-windows.log"
 
+      - name: Test machine stdout sink contract (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test --locked -p assay-cli --test stdout_json_write_contract -- \
+            --test-threads=1 --nocapture \
+            2>&1 | tee "$RUNNER_TEMP/stdout-json-write-windows.log"
+          for test_name in \
+            run_json_early_failure_reader_gone_is_exit_three \
+            typed_cli_failure_reader_gone_is_exit_three \
+            policy_validate_json_success_reader_gone_is_exit_three
+          do
+            grep -F -- "test ${test_name} ... ok" \
+              "$RUNNER_TEMP/stdout-json-write-windows.log"
+          done
+
       # Non-Linux: Exclude OS-specific crates (assay-monitor, assay-cli)
       # Windows/macOS automatically use bundled sqlite via cfg() in Cargo.toml
       - name: Test Workspace (Cross-Platform)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ pinning without changing the CLI or evidence wire schemas.
   claimed (#2351).
 
 ### Fixed
+- Machine-summary stdout failures now share one fail-closed policy across early `run`/`ci`
+  failures, typed CLI failures, and `policy validate`: an undelivered JSON document returns the
+  registered infrastructure exit `3` without panicking or becoming a config exit (#2439).
 - The Linux monitor no longer aliases the `dedup_open_paths` setting with another CONFIG-map key,
   renders raw connect destinations as `ip:port`, and fails closed when the loaded eBPF program set
   drifts from the declared inventory (#2337, #2338, #2341).

--- a/crates/assay-cli/src/cli/commands/policy/validate.rs
+++ b/crates/assay-cli/src/cli/commands/policy/validate.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::cli::args::PolicyValidateArgs;
-use crate::cli_failure::{emit_summary_stdout, summary_from_outcome, CliFailure};
+use crate::cli_failure::{summary_from_outcome, write_summary_stdout, CliFailure};
 use crate::exit_codes;
 use crate::exit_codes::RunOutcome;
 use anyhow::Result;
@@ -24,7 +24,7 @@ pub async fn run(args: PolicyValidateArgs) -> Result<i32> {
     if args.is_json() {
         let mut summary = summary_from_outcome(&RunOutcome::success(), true);
         summary.message = None;
-        emit_summary_stdout(&summary)?;
+        return Ok(write_summary_stdout(&summary));
     }
     Ok(exit_codes::OK)
 }

--- a/crates/assay-cli/src/cli/commands/reporting.rs
+++ b/crates/assay-cli/src/cli/commands/reporting.rs
@@ -1,6 +1,7 @@
 use super::pipeline::PipelineTimings;
 use super::run_output::{export_baseline, summary_from_outcome, write_run_json_minimal};
-use crate::exit_codes::{ExitCodeVersion, ReasonCode, RunOutcome};
+use crate::cli_failure::write_summary_stdout;
+use crate::exit_codes::{ExitCodeVersion, ReasonCode, RunOutcome, EXIT_SUCCESS};
 use std::path::{Path, PathBuf};
 
 /// Write the early-exit artifacts, and put the diagnosis on stdout when the caller asked for
@@ -39,11 +40,9 @@ pub(crate) fn write_error_artifacts(
         eprintln!("WARNING: failed to write summary.json: {}", e);
     }
     if json_stdout {
-        match assay_core::report::summary::render_summary_json(&summary) {
-            Ok(rendered) => println!("{rendered}"),
-            // A failure to render is reported and does not change the exit code: the code is the
-            // classification of the run, not of our ability to describe it.
-            Err(e) => eprintln!("WARNING: failed to render summary for stdout: {e}"),
+        let write_code = write_summary_stdout(&summary);
+        if write_code != EXIT_SUCCESS {
+            return Ok(write_code);
         }
     }
     Ok(o.exit_code)

--- a/crates/assay-cli/src/cli_failure.rs
+++ b/crates/assay-cli/src/cli_failure.rs
@@ -1,11 +1,12 @@
-use std::io::Write;
+use std::io;
 use std::path::Path;
 
 use assay_core::errors::Diagnostic;
 use assay_core::report::summary::Summary;
 
 use crate::cli::commands::pipeline_error::emit_operator_diagnostic;
-use crate::exit_codes::{ReasonCode, RunOutcome};
+use crate::exit_codes::{ReasonCode, RunOutcome, EXIT_SUCCESS};
+use crate::output_write::{map_write_result, write_stdout_json};
 
 fn evidence_reason(error: &anyhow::Error) -> Option<ReasonCode> {
     crate::evidence_verify_reason::reason_code_for_evidence_error(error)
@@ -126,11 +127,9 @@ impl CliFailure {
         emit_operator_diagnostic(&self.diagnostic());
         if let Some(verify_enabled) = machine_output_verify_enabled {
             let summary = summary_from_outcome(&self.outcome, verify_enabled);
-            if let Err(error) = emit_summary_stdout(&summary) {
-                let _ = writeln!(
-                    std::io::stderr().lock(),
-                    "WARNING: failed to render CLI failure on stdout: {error}"
-                );
+            let write_code = write_summary_stdout(&summary);
+            if write_code != EXIT_SUCCESS {
+                return write_code;
             }
         }
         self.outcome.exit_code
@@ -175,10 +174,23 @@ pub(crate) fn summary_from_outcome(outcome: &RunOutcome, verify_enabled: bool) -
     }
 }
 
-pub(crate) fn emit_summary_stdout(summary: &Summary) -> anyhow::Result<()> {
-    let rendered = assay_core::report::summary::render_summary_json(summary)?;
-    writeln!(std::io::stdout().lock(), "{rendered}")?;
-    Ok(())
+/// Render and deliver the one machine-summary shape used by command failures and policy validation.
+/// A render, write, or flush failure means the requested document was not delivered, so the shared
+/// output policy returns `EXIT_INFRA_ERROR` rather than preserving the semantic command result.
+pub(crate) fn write_summary_stdout(summary: &Summary) -> i32 {
+    let rendered = match assay_core::report::summary::render_summary_json(summary) {
+        Ok(rendered) => rendered,
+        Err(error) => {
+            return map_write_result(
+                "stdout",
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("failed to render machine summary: {error}"),
+                )),
+            )
+        }
+    };
+    write_stdout_json(&rendered)
 }
 
 #[cfg(test)]

--- a/crates/assay-cli/tests/stdout_json_write_contract.rs
+++ b/crates/assay-cli/tests/stdout_json_write_contract.rs
@@ -48,6 +48,13 @@ tests:
       flags: ["i"]
 "#;
 
+const MCP_POLICY: &str = r#"version: "2.0"
+name: stdout-write
+tools:
+  allow:
+    - read_file
+"#;
+
 fn assay_command(cwd: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
     for (name, _) in std::env::vars_os() {
@@ -480,6 +487,44 @@ fn run_json_partial_read_then_close_is_exit_three() {
         !result.stdout_prefix.is_empty(),
         "partial-read case must deliver a nonempty truncated prefix"
     );
+}
+
+#[test]
+fn run_json_early_failure_reader_gone_is_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut command = assay_command(dir.path());
+    command.args(["run", "--config", "missing.yaml", "--format", "json"]);
+
+    let result = run_reader_already_gone(command, "run early failure reader gone");
+    assert_infra_write_failure(&result, "run early failure reader gone");
+}
+
+#[test]
+fn typed_cli_failure_reader_gone_is_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut command = assay_command(dir.path());
+    command.args(["coverage", "--format", "json"]);
+
+    let result = run_reader_already_gone(command, "typed CLI failure reader gone");
+    assert_infra_write_failure(&result, "typed CLI failure reader gone");
+}
+
+#[test]
+fn policy_validate_json_success_reader_gone_is_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("policy.yaml"), MCP_POLICY).expect("wrote policy");
+    let mut command = assay_command(dir.path());
+    command.args([
+        "policy",
+        "validate",
+        "--input",
+        "policy.yaml",
+        "--format",
+        "json",
+    ]);
+
+    let result = run_reader_already_gone(command, "policy validate reader gone");
+    assert_infra_write_failure(&result, "policy validate reader gone");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- route machine-summary stdout through the existing fail-closed output sink
- return registered infrastructure exit `3` when JSON summary rendering, writing, or flushing fails
- preserve existing semantic exits and bytes when stdout remains available
- add closed-reader contracts for early `run`, typed CLI failures, and successful `policy validate`

Closes #2439

## Scope
This MVP slice covers the shared `Summary` publishers used by golden-path command failures and policy validation. Six remaining experimental/projector machine writers are explicitly tracked in #2441 and are not claimed here.

## TDD evidence
RED on base `efe0aa3c6c9774ba87f1fec6a513921fba7db382`:
- early `run --format json` died by signal after a broken-pipe panic
- typed `CliFailure` preserved semantic exit `2` after delivery failed
- successful `policy validate --format json` printed `Policy OK`, then returned config exit `2` after broken pipe

GREEN on `2492a625edbf8ca501ec8fa6728f772a3c0a3dc8`:
- `cargo test -p assay-cli --test stdout_json_write_contract` (28 passed, 1 ignored)
- `cargo test -p assay-cli --test policy_validate_machine_contract` (18 passed, 1 ignored)
- `cargo test -p assay-cli --test json_format_reports_failures_on_stdout` (5 passed)
- `cargo test -p assay-cli` (all passed)
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- path-scoped pre-commit and pre-push hooks
- `git diff --check`

## Mutation evidence
Each mutation was applied to a scratch copy and killed by its dedicated row:
- restore raw `println!` in early reporting
- discard the policy writer's returned exit
- preserve a typed failure's semantic exit after sink failure

## Non-claims
- no JSON schema, reason-code, or successful-output-byte change
- no claim that every machine writer in the CLI is covered; #2441 owns the residual inventory
- no evidence-boundary or authorization change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Machine-readable JSON output failures now fail safely with infrastructure exit code `3`.
  - Applies to early command failures, typed CLI errors, and policy validation.
  - Prevents stdout write problems from being misclassified as configuration errors.
  - Eliminates Rust stdout panics when summary output cannot be written.

- **Tests**
  - Added coverage for JSON output write failures across supported command outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Windows integration
- the `Build + Test (windows-latest)` leg now runs `stdout_json_write_contract` explicitly because the general non-Linux workspace command excludes `assay-cli`
- the step greps all three new test result lines, so a zero-match or ignored contract cannot pass silently

## Final reviewed head
`f78876520fa6419ba4d8ab4fbc3370edc5374703`
