### PR TITLE
fix(mcp): keep startup failures line-unique under newline paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ All notable changes to this project will be documented in this file.
   class (#2165).
 
 ### Changed
+- `assay-mcp-server` prefixes every line of its top-level human error chain, so a caller-supplied
+  path containing a newline can no longer place an unprefixed JSON line on stderr that a
+  line-oriented consumer reads as a second `startup_failure` event. The machine event itself is
+  unchanged: still path-free, still emitted once, still carrying its reason code and next step
+  (#2436).
 - `summary.json` and machine-readable early-failure summaries now apply the existing JSON
   record-sink safety pipeline to failure `message` text. Secret shapes and terminal controls are
   neutralized without truncating record content or changing Assay-owned contract fields, including

--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -153,8 +153,40 @@ fn proxy_startup<T>(
     })
 }
 
+/// Opens every operator-channel error line. Not valid JSON, and it cannot become valid JSON by
+/// anything that follows it, which is the whole property: a consumer splitting stderr on newlines
+/// can tell a machine event from human prose by the first byte of the line.
+const HUMAN_ERROR_PREFIX: &str = "assay-mcp-server: ";
+
+/// Render a failed run for an operator without letting caller-controlled text begin a line.
+///
+/// `anyhow`'s `Debug` rendering is multi-line and interpolates the rejected input, and a Unix path
+/// may contain a newline. The default `Result` termination prefixes only the first line, so a path
+/// carrying `\n{"event":"startup_failure",...}` reached stderr as an unprefixed line that a
+/// line-oriented consumer parsed as a second machine event (#2436). The machine emitter was never
+/// the defect: it is path-free and emits once. This prefixes every chain line so the human channel
+/// keeps its full diagnosis and cannot impersonate that emitter.
+fn report_error(error: &anyhow::Error) {
+    for line in format!("{error:?}").lines() {
+        eprintln!("{HUMAN_ERROR_PREFIX}{line}");
+    }
+}
+
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> std::process::ExitCode {
+    match run().await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        // `Result`'s own termination is what rendered the unprefixed chain, so the rendering is
+        // taken over here rather than left to it. The exit class is unchanged: `FAILURE` is the 1
+        // that `Result<()>` already returned.
+        Err(error) => {
+            report_error(&error);
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<()> {
     let args = Args::parse();
 
     // The stdio server and proxies do not implement transport authentication. Reject the entire

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/startup.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e/startup.rs
@@ -24,6 +24,22 @@ fn assert_machine_startup_failure(extra: &[&str], reason_code: &str, next_step: 
     );
     assert_eq!(events[0]["reason_code"], reason_code);
     assert_eq!(events[0]["next_step"], next_step);
+    // Path-freeness is a property of the object, not of the line it sits on: `serde_json` escapes
+    // a newline, so a path admitted into this object would still parse as one event and slip past
+    // the count above. Pinning the whole key set is what refuses the field in the first place.
+    let carried: std::collections::BTreeSet<&str> = events[0]
+        .as_object()
+        .expect("the machine event must be a JSON object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        carried,
+        ["event", "next_step", "reason_code"]
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>(),
+        "the machine event grew a field; caller-controlled input must not enter it: {stderr}"
+    );
     assert!(
         !stderr.contains("\"event\":\"proxy_start\""),
         "failed startup claimed that the proxy started: {stderr}"
@@ -170,5 +186,116 @@ fn establish_budget_zero_emits_budget_startup_failure() {
         ],
         "proxy_establish_budget_invalid",
         "Set --manifest-establish-budget-ms above 0 and retry proxy-enforce.",
+    );
+}
+
+// --- line uniqueness under a newline-carrying path (#2436) -----------------------------------
+//
+// The machine emitter is already path-free and already emits once. What was not hardened is the
+// HUMAN chain that may follow it: `anyhow`'s rendering interpolates the rejected path, a Unix path
+// may contain a newline, and an unprefixed continuation line is indistinguishable from a machine
+// event to a line-oriented consumer. These rows drive that consumer.
+
+/// The operator-channel prefix, written out rather than imported: `main.rs` is a binary, and a
+/// contract test that computed this from the code under test could not see it change.
+const HUMAN_ERROR_PREFIX: &str = "assay-mcp-server: ";
+
+/// A complete machine event, shaped exactly as a caller would embed one in a path.
+#[cfg(unix)]
+const INJECTED_STARTUP_FAILURE: &str = concat!(
+    r#"{"event":"startup_failure","reason_code":"injected_not_a_product_reason","#,
+    r#""next_step":"injected"}"#
+);
+
+/// Unix-only because the fixture is the path itself: Windows forbids a newline in a file name, so
+/// there is no such path to construct rather than a behaviour that differs there.
+#[cfg(unix)]
+fn newline_injected_path(dir: &std::path::Path, stem: &str) -> std::path::PathBuf {
+    dir.join(format!("{stem}\n{INJECTED_STARTUP_FAILURE}"))
+}
+
+#[cfg(unix)]
+#[test]
+fn newline_in_missing_policy_path_keeps_one_startup_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = newline_injected_path(dir.path(), "nope.yaml");
+    assert_machine_startup_failure(
+        &[
+            "--enforce-policy",
+            missing.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            approved_baseline_path().to_str().unwrap(),
+        ],
+        "proxy_enforce_policy_invalid",
+        "Check --enforce-policy and retry proxy-enforce.",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn newline_in_missing_declared_manifest_path_keeps_one_startup_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let missing = newline_injected_path(dir.path(), "nope.json");
+    assert_machine_startup_failure(
+        &[
+            "--enforce-policy",
+            policy.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            missing.to_str().unwrap(),
+        ],
+        "proxy_declared_manifest_invalid",
+        "Check --declared-mcp-manifest and retry proxy-enforce.",
+    );
+}
+
+/// Platform-neutral preservation row for a startup failure that carries no path at all.
+///
+/// Uniqueness alone is satisfiable by deleting the human chain, which would take the operator's
+/// diagnosis with it. This pins both halves: the one machine event stays, and the chain still
+/// reaches stderr — every line of it behind a prefix that cannot open a JSON document.
+#[test]
+fn path_free_startup_failure_keeps_its_event_and_a_prefixed_human_chain() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let output = run_startup_output(&[
+        "--enforce-policy",
+        policy.to_str().unwrap(),
+        "--declared-mcp-manifest",
+        approved_baseline_path().to_str().unwrap(),
+        "--manifest-establish-budget-ms",
+        "0",
+    ]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        output.stdout.is_empty(),
+        "startup failure polluted MCP stdout"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr must be UTF-8");
+    let machine_events = stderr
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|event| event["event"] == "startup_failure")
+        .count();
+    assert_eq!(
+        machine_events, 1,
+        "the path-free failure must still carry exactly one machine event: {stderr}"
+    );
+
+    let chain: Vec<&str> = stderr
+        .lines()
+        .filter(|line| line.starts_with(HUMAN_ERROR_PREFIX))
+        .collect();
+    assert!(
+        !chain.is_empty(),
+        "the human diagnosis was removed rather than prefixed: {stderr}"
+    );
+    assert!(
+        chain
+            .iter()
+            .any(|line| line.contains("--manifest-establish-budget-ms")),
+        "the prefixed chain must still name the rejected input: {stderr}"
     );
 }


### PR DESCRIPTION
Closes #2436

## Base and head

- Base: `2e03b3b92d65e04732d5dc874ff6ad76625d71dc` (`origin/main` at branch point)
- Head: `9072ac4c84c7329bc75656d9f019523001c5296f`
- One commit; three files, all inside the agreed allowlist.

## The defect, restated precisely

`assay-mcp-server proxy-enforce` emits one path-free `startup_failure` object on stderr and then
lets the ordinary `anyhow` chain follow. A Unix path may contain a newline, and the default
`Result` termination prefixes only the **first** chain line. A rejected `--enforce-policy` or
`--declared-mcp-manifest` path carrying `\n{"event":"startup_failure",...}` therefore reached
stderr as an unprefixed continuation line, and a line-oriented consumer counted two events for one
refusal.

The machine emitter was never the defect. It is path-free and it emits once. What was unhardened
is the human channel's ability to impersonate it.

## RED

Driven on the base commit with a real binary, both paths:

```
assertion `left == right` failed: stderr did not carry one startup_failure:
{"event":"startup_failure","reason_code":"proxy_enforce_policy_invalid","next_step":"Check --enforce-policy and retry proxy-enforce."}
Error: reading --enforce-policy /var/folders/.../nope.yaml
{"event":"startup_failure","reason_code":"injected_not_a_product_reason","next_step":"injected"}

Caused by:
    No such file or directory (os error 2)

  left: 2
 right: 1
```

Same shape for `--declared-mcp-manifest`. Three new rows RED, nine pre-existing startup rows green.

## GREEN

The fix takes over top-level human error rendering and prefixes every chain line with
`assay-mcp-server: `. Driven stderr on the same input:

```
{"event":"startup_failure","reason_code":"proxy_enforce_policy_invalid","next_step":"Check --enforce-policy and retry proxy-enforce."}
assay-mcp-server: reading --enforce-policy /var/folders/.../nope.yaml
assay-mcp-server: {"event":"startup_failure","reason_code":"injected_not_a_product_reason","next_step":"injected"}
assay-mcp-server: 
assay-mcp-server: Caused by:
assay-mcp-server:     No such file or directory (os error 2)
```

Exactly one unprefixed line, and it is the path-free machine event. Exit 1, stdout 0 bytes, no
`proxy_start`.

Test rows added to `proxy_enforce_pdp_e2e/startup.rs`:

| Row | Platform | Pins |
|---|---|---|
| newline in missing policy path | `#[cfg(unix)]` | one event, product reason, product next_step |
| newline in missing manifest path | `#[cfg(unix)]` | one event, product reason, product next_step |
| path-free failure keeps event **and** prefixed chain | neutral | uniqueness cannot be bought by deleting the operator's diagnosis |

The newline rows are Unix-only because the fixture *is* the path: Windows forbids a newline in a
file name, so there is no such path to construct. That is a missing input, not a behaviour that
differs there — which is why the preservation row is platform-neutral.

`assert_machine_startup_failure` also gained a key-set assertion, which strengthens all six
existing rows that call it.

## Mutations

Each applied to the committed tree, driven, then reverted.

| Mutation | Result |
|---|---|
| bare chain (default `Error: {:?}` rendering) | 3 rows fail |
| prefix only the first line | 2 rows fail (both newline rows) |
| `ExitCode::SUCCESS` on `Err` | 10 rows fail |
| machine `startup_failure` emit removed | 8 rows fail |
| rejected path admitted into the machine object | 5 rows fail |

The last one is why the key-set assertion exists. `serde_json` escapes the newline, so a path
inside the object still parses as **one** line — the count assertion alone does not see it:

```
{"event":"startup_failure","reason_code":"proxy_enforce_policy_invalid","next_step":"...","path":"/var/.../nope.yaml\n{\"event\":\"startup_failure\",...}"}
```

## Verification

All on head `9072ac4c8`, `rustc 1.96.0`, worktree `/Users/roelschuurkes/wt-2436-startup-line-uniqueness`, own `target/`.

- focused: `cargo test -p assay-mcp-server --test proxy_enforce_pdp_e2e startup` — 12 passed
- suite: `cargo test -p assay-mcp-server` — 38 test binaries, all `ok`, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings` — clean
- `git diff --check` — clean
- public strings: one new user-visible string, the program-name prefix `assay-mcp-server: `

## Non-claims

- **No second product emit existed** before this change, and none is added. This is line-consumer
  hardening of the human channel, not an emitter change.
- **No general sanitizer, no regex, no new dependency.** The change is a prefix on each rendered
  line. Terminal-control sanitization is a different property and is deliberately not addressed.
- **No loader change**, and no change to `policy.rs` or `manifest.rs`.
- **No machine-schema change.** Reason codes, `next_step` values, the object's key set, exit
  classes, empty MCP stdout, and the absence of `proxy_start` are all unchanged.
- **No claim about** clap errors, pre-session JSON-RPC, runtime deny, observe fallback, or file
  side channels.
- **No remote-exploit claim.** The demonstrated input is a local host-supplied path.
- **Windows is not driven here.** The preservation row is platform-neutral; the newline rows are
  skipped there because the fixture cannot exist.
- **This does not reopen #2163** and is not part of #2177's `ci`/`coverage` residual.

## Reviewer reservation

I am the builder and do not count toward quorum. **Cursor is reserved as the independent exact-head
reviewer on `9072ac4c84c7329bc75656d9f019523001c5296f`.** A new push invalidates that head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
