### PR TITLE
fix(cli): sanitize caller-derived doctor text for the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ All notable changes to this project will be documented in this file.
       - dangerous_tool
   ```
 
+### Fixed
+- `assay doctor` text output now passes caller-derived interpolations (target
+  path, parse-error detail, suite, and diagnostic message) through the existing
+  `render_safe(Sink::Stdout, …, usize::MAX)` pipeline so ESC/CSI/OSC8/BEL cannot
+  paint the terminal. Assay-owned labels stay byte-stable, and the JSON channel
+  remains serializer-owned (#2265).
+
 ## [5.2.0] - 2026-08-14
 
 This release hardens the evidence verifier and makes the Linux monitor's declared observation

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -29,6 +29,7 @@ exclude = [
     "tests/init_stdout_contract.rs",
     "tests/doctor_exit_class_contract.rs",
     "tests/doctor_argument_contract.rs",
+    "tests/doctor_text_render_contract.rs",
     "tests/stdout_json_write_contract.rs",
     "tests/mcp_preflight_contract.rs",
     "tests/recovery_argv_publisher_parity.rs",

--- a/crates/assay-cli/src/cli/commands/doctor/implementation.rs
+++ b/crates/assay-cli/src/cli/commands/doctor/implementation.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use assay_core::config::{load_config_with_cause, path_resolver::PathResolver, LoadOptions};
 use assay_core::errors::ConfigLoadError;
+use assay_core::render_safety::{render_safe, Sink};
 
 use crate::cli::args::common::OutputFormat;
 use crate::cli::args::DoctorArgs;
@@ -38,6 +39,11 @@ pub(super) fn config_failure(path: &Path, err: &ConfigLoadError) -> RunOutcome {
 /// Why no config was read when none was requested and none was found. Rendered by both channels,
 /// from here, so the machine report cannot say something different from the line a human reads.
 const NO_CONFIG_FOUND: &str = "No config found; run inside project or use --config";
+
+/// Caller-derived doctor text for the terminal. Assay-owned labels stay outside this helper.
+fn caller_text(value: impl std::fmt::Display) -> String {
+    render_safe(Sink::Stdout, &value.to_string(), usize::MAX)
+}
 
 /// Whether the config check ran, for a consumer that reads only the JSON document.
 ///
@@ -232,8 +238,8 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
 
     if let Some(e) = &cfg_err {
         println!("\nConfig Status: FAILED");
-        println!("  File:     {}", target_path.display());
-        println!("  Error:    {}\n", e);
+        println!("  File:     {}", caller_text(target_path.display()));
+        println!("  Error:    {}\n", caller_text(e));
 
         if args.fix {
             return try_fix_parse_error(&args, &target_path, e, legacy_mode);
@@ -243,8 +249,8 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
 
     if let Some(c) = cfg {
         println!("\nPolicy Check:");
-        println!("  Config:   {}", target_path.display());
-        println!("  Suite:    {}", c.suite);
+        println!("  Config:   {}", caller_text(target_path.display()));
+        println!("  Suite:    {}", caller_text(&c.suite));
 
         let resolver = PathResolver::new(&target_path);
         let opts = assay_core::doctor::DoctorOptions {
@@ -259,7 +265,12 @@ pub async fn run(args: DoctorArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         if !core_report.diagnostics.is_empty() {
             println!("  Issues:   {}", core_report.diagnostics.len());
             for d in &core_report.diagnostics {
-                println!("    - [{}] [{}] {}", d.code, d.severity, d.message);
+                println!(
+                    "    - [{}] [{}] {}",
+                    d.code,
+                    d.severity,
+                    caller_text(&d.message)
+                );
             }
         } else {
             println!("  Issues:   None (Clean)");

--- a/crates/assay-cli/tests/doctor_text_render_contract.rs
+++ b/crates/assay-cli/tests/doctor_text_render_contract.rs
@@ -1,0 +1,293 @@
+//! `assay doctor` text interpolations must not write raw terminal-control bytes (#2265).
+//!
+//! Caller-derived strings — target path, parse-error detail, suite, and diagnostic
+//! message — go through `render_safe(Sink::Stdout, …, usize::MAX)`. Assay-owned
+//! labels and codes stay outside that helper. The JSON channel stays serializer-owned:
+//! no raw `0x1b`/`0x07` on the wire, and decoded string values keep the original
+//! control bytes. `--db` is a non-claim: doctor does not echo it today.
+
+#[path = "../../../tests/support/bounded_process.rs"]
+#[allow(dead_code)]
+mod bounded_process;
+
+use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+
+/// The four caller-derived interpolations on doctor's text channel.
+/// `--db` is intentionally absent: the command does not echo it.
+const CALLER_INTERPOLATIONS: &[&str] = &[
+    "target_path",
+    "parse_error_detail",
+    "suite",
+    "diagnostic_message",
+];
+
+const OSC8: &str = "\u{1b}]8;;http://evil\u{07}click\u{1b}]8;;\u{07}";
+const CSI: &str = "\u{1b}[31m";
+const LONE_ESC: &str = "\u{1b}";
+const BEL: &str = "\u{07}";
+
+const MATCHING_TRACE: &str = r#"{"schema_version": 1, "type": "assay.trace", "request_id": "hello_1", "prompt": "hello_prompt", "response": "Hello Assay", "model": "trace", "provider": "trace"}
+"#;
+
+struct DoctorRun {
+    code: i32,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+fn all_controls() -> String {
+    format!("{OSC8}{CSI}{LONE_ESC}{BEL}")
+}
+
+/// YAML double-quoted escapes for the same payload. Raw C0 bytes are rejected by
+/// the YAML parser; these decode into `EvalConfig.suite` as the live controls.
+const YAML_ESCAPED_CONTROLS: &str =
+    r#"\u001b]8;;http://evil\u0007click\u001b]8;;\u0007\u001b[31m\u001b\u0007"#;
+
+fn eval_yaml(suite_yaml: &str) -> String {
+    format!(
+        r#"configVersion: 1
+suite: "{suite_yaml}"
+model: "trace"
+tests:
+  - id: "render_safety"
+    input:
+      prompt: "hello_prompt"
+    expected:
+      type: regex_match
+      pattern: "Hello\\s+Assay"
+      flags: ["i"]
+"#
+    )
+}
+
+fn doctor(cwd: &Path, args: &[&str]) -> DoctorRun {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+        .current_dir(cwd)
+        .env("NO_COLOR", "1")
+        .arg("doctor")
+        .args(args);
+    let output = run_bounded(command, b"", GOLDEN_PATH_LIMITS, "assay doctor")
+        .unwrap_or_else(|error| panic!("{error}"));
+    DoctorRun {
+        code: output
+            .status
+            .code()
+            .expect("doctor exited by code rather than by signal"),
+        stdout: output.stdout,
+        stderr: output.stderr,
+    }
+}
+
+fn stdout_text(run: &DoctorRun) -> String {
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+fn assert_no_raw_esc_or_bel(label: &str, bytes: &[u8]) {
+    let esc = bytes.iter().filter(|b| **b == 0x1b).count();
+    let bel = bytes.iter().filter(|b| **b == 0x07).count();
+    assert_eq!(
+        (esc, bel),
+        (0, 0),
+        "{label} still has raw ESC×{esc} BEL×{bel}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(bytes),
+        ""
+    );
+}
+
+fn write_tree(dir: &Path, suite: &str) {
+    std::fs::write(dir.join("eval.yaml"), eval_yaml(suite)).expect("wrote eval.yaml");
+    std::fs::create_dir_all(dir.join("traces")).expect("created traces/");
+    std::fs::write(dir.join("traces/present.jsonl"), MATCHING_TRACE).expect("wrote trace");
+}
+
+#[test]
+fn caller_interpolation_classes_are_inventoried() {
+    assert_eq!(
+        CALLER_INTERPOLATIONS,
+        [
+            "target_path",
+            "parse_error_detail",
+            "suite",
+            "diagnostic_message"
+        ]
+    );
+}
+
+#[test]
+fn benign_doctor_text_and_owned_labels_stay_byte_stable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_tree(dir.path(), "hello_smoke");
+    let long_trace = format!("{}missing.jsonl", "x".repeat(300));
+
+    let run = doctor(
+        dir.path(),
+        &[
+            "--format",
+            "text",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            &long_trace,
+        ],
+    );
+    let text = stdout_text(&run);
+
+    assert_eq!(
+        run.code, 2,
+        "missing long trace is still a config-class miss"
+    );
+    assert!(
+        !text.contains("(truncated)"),
+        "benign caller text must not hit the default 256-char render cap; stdout:\n{text}"
+    );
+    assert!(
+        text.contains(&long_trace),
+        "the full benign --trace-file path must survive; stdout:\n{text}"
+    );
+    for label in [
+        "Policy Check:",
+        "  Config:   eval.yaml",
+        "  Suite:    hello_smoke",
+        "    - [E_PATH_NOT_FOUND] [error] Trace file not found: ",
+    ] {
+        assert!(
+            text.contains(label),
+            "Assay-owned label {label:?} must stay byte-stable; stdout:\n{text}"
+        );
+    }
+    assert_no_raw_esc_or_bel("benign text", &run.stdout);
+}
+
+#[test]
+fn hostile_trace_and_suite_are_inert_on_text_and_escaped_on_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let hostile = all_controls();
+    write_tree(dir.path(), &format!("suite-{YAML_ESCAPED_CONTROLS}-end"));
+    let trace = format!("{hostile}.jsonl");
+
+    let text_run = doctor(
+        dir.path(),
+        &[
+            "--format",
+            "text",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            &trace,
+        ],
+    );
+    let text = stdout_text(&text_run);
+    assert_eq!(text_run.code, 2);
+    assert_no_raw_esc_or_bel("doctor text (suite + diagnostic)", &text_run.stdout);
+    assert!(
+        text.contains("  Suite:    "),
+        "suite interpolation must still render; stdout:\n{text}"
+    );
+    assert!(
+        text.contains("click") && text.contains("suite-") && text.contains("-end"),
+        "sanitized suite/path needles must remain visible; stdout:\n{text}"
+    );
+    assert!(
+        text.contains("    - [E_PATH_NOT_FOUND] [error] Trace file not found: "),
+        "owned diagnostic labels must stay byte-stable; stdout:\n{text}"
+    );
+    assert!(
+        !text.contains("http://evil"),
+        "OSC8 target must not survive on the text channel; stdout:\n{text}"
+    );
+
+    let json_run = doctor(
+        dir.path(),
+        &[
+            "--format",
+            "json",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            &trace,
+        ],
+    );
+    assert_eq!(json_run.code, 2);
+    assert_no_raw_esc_or_bel("doctor JSON wire", &json_run.stdout);
+    let wire = String::from_utf8_lossy(&json_run.stdout);
+    assert!(
+        wire.contains("\\u001b") && wire.contains("\\u0007"),
+        "JSON must keep the escaped machine shape, not a stdout-sanitized rewrite; wire:\n{wire}"
+    );
+    let document: Value = serde_json::from_slice(&json_run.stdout).unwrap_or_else(|error| {
+        panic!(
+            "doctor JSON is not one document: {error}\nstdout:\n{wire}\nstderr:\n{}",
+            String::from_utf8_lossy(&json_run.stderr)
+        )
+    });
+    let message = document["data_diagnostics"][0]["message"]
+        .as_str()
+        .unwrap_or_default();
+    assert_eq!(
+        document["data_diagnostics"][0]["code"], "E_PATH_NOT_FOUND",
+        "owned JSON code must stay byte-stable; document={document}"
+    );
+    assert_eq!(
+        document["data_diagnostics"][0]["severity"], "error",
+        "owned JSON severity must stay byte-stable; document={document}"
+    );
+    assert!(
+        message.contains('\u{1b}') && message.contains('\u{07}') && message.contains(&trace),
+        "decoded JSON message must keep the original control bytes; message={message:?}"
+    );
+}
+
+#[test]
+fn hostile_config_path_and_parse_error_are_inert_on_text() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let hostile = all_controls();
+    let missing = format!("{hostile}missing.yaml");
+    let path_run = doctor(dir.path(), &["--format", "text", "--config", &missing]);
+    let path_text = stdout_text(&path_run);
+    assert_eq!(path_run.code, 2);
+    assert_no_raw_esc_or_bel("doctor text (target_path)", &path_run.stdout);
+    assert!(
+        path_text.contains("  File:     "),
+        "target-path interpolation must still render; stdout:\n{path_text}"
+    );
+    assert!(
+        path_text.contains("Config Status: FAILED"),
+        "owned config-failure labels must stay byte-stable; stdout:\n{path_text}"
+    );
+    assert!(
+        !path_text.contains("http://evil"),
+        "OSC8 in --config must not survive on the text channel; stdout:\n{path_text}"
+    );
+
+    std::fs::write(
+        dir.path().join("broken.yaml"),
+        format!("\"{YAML_ESCAPED_CONTROLS}quoted-root\"\n"),
+    )
+    .expect("wrote broken.yaml");
+    let parse_run = doctor(dir.path(), &["--format", "text", "--config", "broken.yaml"]);
+    let parse_text = stdout_text(&parse_run);
+    assert_eq!(parse_run.code, 2);
+    assert_no_raw_esc_or_bel("doctor text (parse_error_detail)", &parse_run.stdout);
+    assert!(
+        parse_text.contains("  Error:    "),
+        "parse-error interpolation must still render; stdout:\n{parse_text}"
+    );
+    assert!(
+        parse_text.contains("quoted-root") && parse_text.contains("  File:     broken.yaml"),
+        "sanitized parse detail and owned file label must remain; stdout:\n{parse_text}"
+    );
+}


### PR DESCRIPTION
## Summary
- Sanitize only caller-derived `assay doctor` text interpolations (target path, parse-error detail, suite, and diagnostic message) through the existing `assay_core::render_safety::render_safe(Sink::Stdout, value, usize::MAX)` helper so raw ESC/CSI/OSC8/BEL cannot paint a terminal.
- Assay-owned codes, severity, and labels stay outside the helper and remain byte-stable. JSON stays serializer-owned: no raw `0x1b`/`0x07` on the wire, decoded string values keep the original control bytes.
- Closes the #2265 text-channel leak without a second sanitizer, without an `assay-evidence` dependency change, and without a doctor schema or exit-class change.
- Follow-up: exclude `tests/doctor_text_render_contract.rs` from the published `assay-cli` tarball. The contract uses shared workspace `bounded-process` support, same as the other workspace-only doctor contracts.
- This head merges `origin/main` at `323d6dadafa3a7a62319eab3c125fdd32ebdf0b8` (#2443). CHANGELOG auto-merged cleanly; no conflict resolution was invented.

## Provenance
- Base: `323d6dadafa3a7a62319eab3c125fdd32ebdf0b8` (`origin/main`, #2443)
- Head: `9d3c7d7a0f03634a3a005121ce0ac19b28ecff9a`
- Prior heads (invalidated by later pushes): `05cb3a1b9f1c8672db88630c6517a3855971da7a`, `01c6e0535949e5c0c49a16a4dfcbb654e25c2fcb`
- Worktree: `/Users/roelschuurkes/wt-2265-doctor-terminal-sanitize`
- Branch: `cursor/2265-doctor-terminal-sanitize`
- Local `target/` only; `CARGO_TARGET_DIR` unset

## Why `render_safe`, not `assay_evidence::sanitize`
The issue's older “same TUI sanitizer” wording is stale on this head. `assay-cli` already depends on the canonical `assay_core::render_safety` pipeline. Calling or adding the TUI helper would give one terminal rule two owners. This PR reuses the core stdout sink with `usize::MAX` so benign caller text is not truncated at the default 256-char field cap.

## Driven RED / GREEN
- **RED** on `2e03b3b92d65e04732d5dc874ff6ad76625d71dc` before production edits: hostile `--trace-file` + YAML-decoded suite, and hostile `--config` path / parse-error detail, wrote raw ESC×8 BEL×6 on text. Benign positive control (owned labels + 300-char path, no `(truncated)`) already passed.
- **GREEN** after the local `caller_text` helper: text has no raw `0x1b`/`0x07`; OSC8 target `http://evil` is gone from suite/path/diagnostic text; JSON wire stays `\u001b`/`\u0007` and decoded `data_diagnostics[0].message` still contains the original control bytes.

## Mutations (bit, then restored)
| Mutation | What failed | Distinguished defect |
|---|---|---|
| One of four callsites raw (`d.message`) | `hostile_trace_and_suite_*` only (ESC×4 BEL×3 on the diagnostic line; suite still sanitized) | Missed diagnostic interpolation |
| Helper replaced with identity | both hostile tests (ESC×8 BEL×6 on suite + diagnostic + `--config`) | Sanitizer not actually applied |
| JSON `data_diagnostics` sent through `render_details_safe(Sink::Stdout)` | JSON decoded message became `click��.jsonl` (lost original controls) | Machine channel rewritten by the stdout renderer |
| Owned label `Suite:` → `Suite name:` | benign label-stability test (and the suite-line assertion) | Assay-owned label drift |

Replayed on `05cb3a1b9f1c8672db88630c6517a3855971da7a`. Later commits are the publish-shape exclusion and this main merge only.

## Inventory
The four caller-derived interpolation classes are listed and driven: `target_path`, `parse_error_detail`, `suite`, `diagnostic_message`. Trace-path plus suite/diagnostic demonstrably bite. `--db` is a non-claim: doctor does not echo it today.

## Non-claims
- `--db` echo / sanitization
- JSON semantic bytes beyond “no raw ESC/BEL on the wire, decoded values keep the original controls”
- #2436 (newline / JSON-line uniqueness)
- TUI / `assay_evidence::sanitize`
- Windows path proof
- Universal output abstraction
- Doctor schema or exit-class change
- TTY-paint proof (bytes on stdout, no TTY)
- No CHANGELOG conflict resolution (auto-merge only)

## Review
- **Ruley reviews the new exact head `9d3c7d7a0f03634a3a005121ce0ac19b28ecff9a`.** Ruley is reserved as the independent non-building exact-head reviewer.
- Any prior or current Ruley review on an earlier head is invalidated by this merge and will be redone on this final head.
- The writer (Cursor builder) does not count for quorum. This self-review is not a review.
- Draft only. Do not mark ready. Do not merge.

## Test plan
- [x] Focused `cargo test -p assay-cli --test doctor_text_render_contract` (replayed after the main merge)
- [x] `scripts/ci/check_assay_cli_publish_shape.sh` (exit 0 on this head)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-cli --all-targets -- -D warnings`
- [x] `git diff --check`

Fixes #2265
