### PR TITLE
fix(cli): route six machine stdout writers through the fail-closed sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ All notable changes to this project will be documented in this file.
   class (#2165).
 
 ### Changed
+- Six machine-document stdout branches now use the shared fail-closed writer instead of raw
+  `println!`: `evidence adapt-skill-scan`, `evidence attest`, `evidence capture-skill-supply-chain`,
+  `evidence project-skill-bom`, and both `project-otel` projections. A requested document that
+  cannot be delivered returns the registered output-write exit `3` rather than aborting the process.
+  Open-reader bytes, `--out` file behaviour, and successful exits are unchanged (#2441).
 - `assay-mcp-server` prefixes every line of its top-level human error chain, so a caller-supplied
   path containing a newline can no longer place an unprefixed JSON line on stderr that a
   line-oriented consumer reads as a second `startup_failure` event. The machine event itself is

--- a/crates/assay-cli/src/cli/commands/evidence/adapt_skill_scan.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/adapt_skill_scan.rs
@@ -13,6 +13,7 @@
 
 use super::skill_supply_chain::{expected_verdict, validate_carrier};
 use crate::exit_codes;
+use crate::output_write::write_stdout_json;
 use anyhow::{bail, Context, Result};
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
@@ -67,7 +68,7 @@ pub fn cmd_adapt_skill_scan(args: AdaptSkillScanArgs) -> Result<i32> {
                 .with_context(|| format!("failed to write {}", path.display()))?;
             eprintln!("Wrote augmented carrier to {}", path.display());
         }
-        None => println!("{json}"),
+        None => return Ok(write_stdout_json(&json)),
     }
     Ok(exit_codes::OK)
 }

--- a/crates/assay-cli/src/cli/commands/evidence/attest.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/attest.rs
@@ -7,6 +7,7 @@
 //! external. Attestation binds who-said-it and the bundle content; it does not
 //! upgrade observed support.
 
+use crate::output_write::write_stdout_json;
 use anyhow::{Context, Result};
 use assay_common::limits::{LimitKind, LimitReader};
 use assay_evidence::attestation::{sign_statement, statement_for_bundle_with_limits};
@@ -50,11 +51,18 @@ fn read_bundle_bounded(path: &std::path::Path, limits: VerifyLimits) -> Result<V
 }
 
 pub fn cmd_attest(args: AttestArgs) -> Result<i32> {
-    run(args)?;
-    Ok(0)
+    run(args)
 }
 
-fn run(args: AttestArgs) -> Result<()> {
+/// Returns the process exit rather than `()`.
+///
+/// The envelope is a machine document, and whether it was delivered is an exit class, not a detail
+/// of the value produced. `Result<()>` had nowhere to put that, so a failed stdout write could only
+/// become an `Err` — which reaches the generic top-level fallback and reports the config-error exit
+/// `2` for what is an output-write failure (#2441). Returning the writer's own code keeps the
+/// registered infrastructure exit `3` intact and leaves `Err` meaning what it already meant here:
+/// the attestation itself could not be produced.
+fn run(args: AttestArgs) -> Result<i32> {
     // 1. Refuse an unusable invocation before touching anything on disk.
     //
     //    `--predicate` is rejected rather than silently ignored: every v1 field is derived from the
@@ -106,9 +114,9 @@ fn run(args: AttestArgs) -> Result<()> {
                 .with_context(|| format!("write {}", p.display()))?;
             eprintln!("Attestation: {}", p.display());
         }
-        None => println!("{json}"),
+        None => return Ok(write_stdout_json(&json)),
     }
-    Ok(())
+    Ok(crate::exit_codes::EXIT_SUCCESS)
 }
 
 #[cfg(test)]

--- a/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs
@@ -10,6 +10,7 @@
 
 use super::skill_supply_chain::CARRIER_EVENT_TYPE;
 use crate::exit_codes;
+use crate::output_write::write_stdout_json;
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::fs;
@@ -74,7 +75,7 @@ pub fn cmd_project_skill_bom(args: ProjectSkillBomArgs) -> Result<i32> {
                 .with_context(|| format!("failed to write {}", path.display()))?;
             eprintln!("Projected CycloneDX AI-BOM to {}", path.display());
         }
-        None => println!("{json}"),
+        None => return Ok(write_stdout_json(&json)),
     }
     Ok(exit_codes::OK)
 }

--- a/crates/assay-cli/src/cli/commands/evidence/skill_supply_chain_capture.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/skill_supply_chain_capture.rs
@@ -11,6 +11,7 @@
 
 use super::skill_supply_chain::{expected_verdict, validate_carrier};
 use crate::exit_codes;
+use crate::output_write::write_stdout_json;
 use anyhow::{bail, Context, Result};
 use serde_json::{json, Value};
 use std::fs;
@@ -58,7 +59,7 @@ pub fn cmd_capture_skill_supply_chain(args: CaptureSkillSupplyChainArgs) -> Resu
                 .with_context(|| format!("failed to write {}", path.display()))?;
             eprintln!("Captured skill supply-chain carrier to {}", path.display());
         }
-        None => println!("{json}"),
+        None => return Ok(write_stdout_json(&json)),
     }
     Ok(exit_codes::OK)
 }

--- a/crates/assay-cli/src/cli/commands/project_otel.rs
+++ b/crates/assay-cli/src/cli/commands/project_otel.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 
 use crate::cli::args::ProjectOtelArgs;
 use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_SUCCESS};
+use crate::output_write::write_stdout_json;
 
 fn read_json(path: &Path) -> anyhow::Result<Value> {
     let text = std::fs::read_to_string(path)
@@ -77,7 +78,7 @@ pub fn run(args: ProjectOtelArgs) -> anyhow::Result<i32> {
                 return Ok(EXIT_CONFIG_ERROR);
             }
         }
-        None => println!("{json}"),
+        None => return Ok(write_stdout_json(&json)),
     }
     Ok(EXIT_SUCCESS)
 }
@@ -129,7 +130,7 @@ fn run_tool_decision_truth(bundle: &Path, out: Option<&Path>) -> anyhow::Result<
                 return Ok(EXIT_CONFIG_ERROR);
             }
         }
-        None => println!("{json}"),
+        None => return Ok(write_stdout_json(&json)),
     }
     Ok(EXIT_SUCCESS)
 }

--- a/crates/assay-cli/tests/stdout_json_write_contract.rs
+++ b/crates/assay-cli/tests/stdout_json_write_contract.rs
@@ -586,3 +586,338 @@ fn partial_read_times_out_when_the_child_never_writes_stdout() {
         started.elapsed()
     );
 }
+
+// --- the six bounded machine-stdout writers (#2441) -------------------------------------------
+//
+// These commands render a machine document and, with no `--out`, put it on stdout. They are outside
+// the golden path #2439 repaired, so they kept a raw `println!` and a closed reader turned them into
+// a Rust panic rather than the registered output-write exit.
+//
+// Every row drives the real binary twice. The first drive writes to `--out` and must succeed: a
+// fixture that fails verification exits before the writer is ever reached, and a closed-reader row
+// over such a fixture would pass while proving nothing. The second drive removes `--out` and hands
+// the process a stdout whose reader is already gone.
+
+/// One row per stdout branch this slice owns. Two `project-otel` variants because the command has
+/// two independent write paths, not one shared seam.
+#[derive(Clone, Copy, Debug)]
+enum SinkCase {
+    AdaptSkillScan,
+    Attest,
+    CaptureSkillSupplyChain,
+    ProjectSkillBom,
+    ProjectOtelCapabilitySurface,
+    ProjectOtelToolDecisionTruth,
+}
+
+/// Written out independently of `SINK_CASES`. The equality below is what makes deleting a row fail
+/// rather than silently shrinking the contract this file claims to cover.
+const EXPECTED_SINK_COMMANDS: &[&str] = &[
+    "evidence adapt-skill-scan",
+    "evidence attest",
+    "evidence capture-skill-supply-chain",
+    "evidence project-skill-bom",
+    "project-otel --capability-surface",
+    "project-otel --tool-decision-truth",
+];
+
+const SINK_CASES: &[SinkCase] = &[
+    SinkCase::AdaptSkillScan,
+    SinkCase::Attest,
+    SinkCase::CaptureSkillSupplyChain,
+    SinkCase::ProjectSkillBom,
+    SinkCase::ProjectOtelCapabilitySurface,
+    SinkCase::ProjectOtelToolDecisionTruth,
+];
+
+impl SinkCase {
+    fn label(self) -> &'static str {
+        match self {
+            Self::AdaptSkillScan => "evidence adapt-skill-scan",
+            Self::Attest => "evidence attest",
+            Self::CaptureSkillSupplyChain => "evidence capture-skill-supply-chain",
+            Self::ProjectSkillBom => "evidence project-skill-bom",
+            Self::ProjectOtelCapabilitySurface => "project-otel --capability-surface",
+            Self::ProjectOtelToolDecisionTruth => "project-otel --tool-decision-truth",
+        }
+    }
+
+    /// Build this row's inputs under `dir` and return the argv that reaches its stdout writer.
+    fn argv(self, dir: &Path) -> Vec<std::ffi::OsString> {
+        let s = |v: &str| std::ffi::OsString::from(v);
+        let p = |v: std::path::PathBuf| v.into_os_string();
+        match self {
+            Self::AdaptSkillScan => vec![
+                s("evidence"),
+                s("adapt-skill-scan"),
+                s("--carrier"),
+                p(write_skill_carrier(dir)),
+                s("--sarif"),
+                p(write_sarif(dir)),
+            ],
+            Self::Attest => vec![
+                s("evidence"),
+                s("attest"),
+                s("--bundle"),
+                p(skill_supply_chain_bundle(dir)),
+                s("--key"),
+                p(write_ed25519_key(dir)),
+            ],
+            Self::CaptureSkillSupplyChain => vec![
+                s("evidence"),
+                s("capture-skill-supply-chain"),
+                s("--root"),
+                p(write_skill_root(dir)),
+            ],
+            Self::ProjectSkillBom => vec![
+                s("evidence"),
+                s("project-skill-bom"),
+                p(skill_supply_chain_bundle(dir)),
+            ],
+            Self::ProjectOtelCapabilitySurface => vec![
+                s("project-otel"),
+                s("--capability-surface"),
+                p(write_capability_surface(dir)),
+            ],
+            Self::ProjectOtelToolDecisionTruth => vec![
+                s("project-otel"),
+                s("--evidence-bundle"),
+                p(tool_decision_truth_bundle(dir)),
+            ],
+        }
+    }
+}
+
+fn write_skill_root(dir: &Path) -> std::path::PathBuf {
+    let root = dir.join("skill");
+    std::fs::create_dir_all(&root).expect("create skill root");
+    std::fs::write(
+        root.join("SKILL.md"),
+        "---\nname: stdout-sink-probe\n---\n\nA skill body.\n",
+    )
+    .expect("write SKILL.md");
+    root
+}
+
+fn write_skill_carrier(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("carrier.json");
+    let carrier = serde_json::json!({
+        "schema": "assay.skill_supply_chain.v0",
+        "root": {"name": "s", "path": "skills/s"},
+        "verdict": "review_complete",
+        "reason_codes": [],
+        "coverage": {
+            "front_matter": "present", "body_text": "present", "scripts": "present",
+            "lockfiles": "present", "transitive_traversal": "present"
+        },
+        "signals": [],
+        "non_claims": ["review_complete_is_not_skill_safe"]
+    });
+    std::fs::write(&path, serde_json::to_string_pretty(&carrier).unwrap()).expect("write carrier");
+    path
+}
+
+fn write_sarif(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("scan.sarif");
+    let sarif = serde_json::json!({
+        "version": "2.1.0",
+        "runs": [{"tool": {"driver": {"name": "SkillSpector"}}, "results": []}]
+    });
+    std::fs::write(&path, serde_json::to_string_pretty(&sarif).unwrap()).expect("write sarif");
+    path
+}
+
+/// A real carrier through the real producer and the real import gate, rather than a hand-written
+/// one: the import gate refuses an incoherent carrier, so a bundle that exists here is one
+/// `project-skill-bom` will actually verify.
+fn skill_supply_chain_bundle(dir: &Path) -> std::path::PathBuf {
+    let bundle = dir.join("ssc.tar.gz");
+    if bundle.is_file() {
+        return bundle;
+    }
+    let carrier = dir.join("captured-carrier.json");
+    let captured = assay(
+        dir,
+        &[
+            OsStr::new("evidence"),
+            OsStr::new("capture-skill-supply-chain"),
+            OsStr::new("--root"),
+            write_skill_root(dir).as_os_str(),
+            OsStr::new("--out"),
+            carrier.as_os_str(),
+        ],
+        LIMITS,
+        "capture carrier for bundle",
+    );
+    assert_eq!(
+        captured.status.code(),
+        Some(0),
+        "capture must produce a carrier; stderr={}",
+        String::from_utf8_lossy(&captured.stderr)
+    );
+    let imported = assay(
+        dir,
+        &[
+            OsStr::new("evidence"),
+            OsStr::new("import"),
+            OsStr::new("skill-supply-chain"),
+            OsStr::new("--carrier"),
+            carrier.as_os_str(),
+            OsStr::new("--bundle-out"),
+            bundle.as_os_str(),
+        ],
+        LIMITS,
+        "import carrier into bundle",
+    );
+    assert_eq!(
+        imported.status.code(),
+        Some(0),
+        "import must produce a bundle; stderr={}",
+        String::from_utf8_lossy(&imported.stderr)
+    );
+    bundle
+}
+
+/// Deterministic PKCS#8 PEM. The key material is a test constant, never generated, so the row does
+/// not depend on an RNG and the fixture is reproducible.
+fn write_ed25519_key(dir: &Path) -> std::path::PathBuf {
+    use ed25519_dalek::pkcs8::EncodePrivateKey;
+    let path = dir.join("attest-key.pem");
+    let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+    let pem = key
+        .to_pkcs8_pem(ed25519_dalek::pkcs8::spki::der::pem::LineEnding::LF)
+        .expect("encode PKCS#8 PEM");
+    std::fs::write(&path, pem.as_bytes()).expect("write key");
+    path
+}
+
+fn write_capability_surface(dir: &Path) -> std::path::PathBuf {
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../assay-core/tests/fixtures/otel_projection/input.json");
+    let input: Value =
+        serde_json::from_str(&std::fs::read_to_string(&source).expect("read otel input fixture"))
+            .expect("otel input fixture parses");
+    let path = dir.join("capability-surface.json");
+    std::fs::write(
+        &path,
+        serde_json::to_string(&input["capability_surface"]).unwrap(),
+    )
+    .expect("write capability surface");
+    path
+}
+
+/// A carrier plus its recipe row, built through the same producers the verifier checks, so the
+/// bundle passes `verify_and_collect` and the projection reaches the writer.
+fn tool_decision_truth_bundle(dir: &Path) -> std::path::PathBuf {
+    use assay_core::mcp::policy::McpPolicy;
+    use assay_core::mcp::tool_decision_truth::{self as tdt, DecisionEvidence};
+    use assay_evidence::bundle::BundleWriter;
+    use assay_evidence::types::EvidenceEvent;
+
+    let bundle = dir.join("tdt.tar.gz");
+    let policy: McpPolicy = serde_json::from_value(serde_json::json!({
+        "version": "1",
+        "tools": {"allow": ["deploy"], "deny": ["delete_all"]},
+        "schemas": {"deploy": {"type": "object", "required": ["env"],
+            "properties": {"env": {"enum": ["staging", "prod"]}}}},
+        "enforcement": {"unconstrained_tools": "warn"}
+    }))
+    .expect("policy parses");
+    let carrier = tdt::build_classified_record(
+        &policy,
+        "deploy",
+        &serde_json::json!({"env": "prod"}),
+        0,
+        b"stdout-sink-test-key-v0",
+        "fixture-kid-v0",
+        "authoritative_boundary",
+        "c0",
+        "ok",
+        "present",
+        &DecisionEvidence::default(),
+    )
+    .expect("build classified record");
+    let row = tdt::pack_recipe_row(
+        &carrier,
+        carrier["decision_verdict"].as_str().expect("verdict"),
+        "assay://evidence-event/run/0",
+    )
+    .expect("pack recipe row");
+
+    let file = std::fs::File::create(&bundle).expect("create tdt bundle");
+    let mut writer = BundleWriter::new(file);
+    writer.add_event(EvidenceEvent::new(
+        "assay.tool_decision_truth.v0",
+        "urn:assay:test",
+        "run",
+        0,
+        carrier,
+    ));
+    writer.add_event(EvidenceEvent::new(
+        "assay.tool_decision_truth.recipe_row.v0",
+        "urn:assay:test",
+        "run",
+        1,
+        row,
+    ));
+    writer.finish().expect("finish tdt bundle");
+    bundle
+}
+
+#[test]
+fn the_sink_case_table_covers_the_expected_command_set() {
+    let labels: Vec<&str> = SINK_CASES.iter().map(|case| case.label()).collect();
+    assert_eq!(
+        labels, EXPECTED_SINK_COMMANDS,
+        "the driven machine-stdout table must cover exactly the bounded writer set"
+    );
+}
+
+#[test]
+fn every_sink_case_fixture_reaches_its_writer() {
+    for &case in SINK_CASES {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("written.json");
+        let mut argv = case.argv(dir.path());
+        argv.push(std::ffi::OsString::from("--out"));
+        argv.push(out.clone().into_os_string());
+
+        let output = assay(dir.path(), &argv, LIMITS, case.label());
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{}: the fixture must reach the writer, otherwise the closed-reader row is vacuous; \
+             stderr={}",
+            case.label(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let written = std::fs::read_to_string(&out)
+            .unwrap_or_else(|error| panic!("{}: --out file unreadable: {error}", case.label()));
+        serde_json::from_str::<Value>(&written)
+            .unwrap_or_else(|error| panic!("{}: --out file is not JSON: {error}", case.label()));
+    }
+}
+
+#[test]
+fn every_sink_case_reader_gone_is_exit_three() {
+    // Collected rather than asserted per row: one unconverted writer should not hide the state of
+    // the other five, and the failure text is the inventory a reader needs.
+    let mut offenders = Vec::new();
+    for &case in SINK_CASES {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let argv = case.argv(dir.path());
+        let mut command = assay_command(dir.path());
+        command.args(&argv);
+        let result = run_reader_already_gone(command, case.label());
+        if result.code != Some(3) {
+            offenders.push(format!("{} => exit {:?}", case.label(), result.code));
+            continue;
+        }
+        assert_no_rust_panic(&result.stderr, case.label());
+    }
+    assert!(
+        offenders.is_empty(),
+        "an undelivered machine document must exit 3, not abort or succeed: {}",
+        offenders.join("; ")
+    );
+}


### PR DESCRIPTION
Closes #2441

## Base and head

- Base: `3817680444d8fb5c832bbbe52b70e89ed23b1824`
- Head: `a9ea7c1082f8ad90850b8aa99fc91fc9aba99830`
- One commit, seven files, all inside the agreed allowlist.

## Change

Six commands render a machine document and, with no `--out`, wrote it to stdout with a raw
`println!`. Under `panic = "abort"` a closed reader turned each into SIGABRT instead of the
registered output-write exit `3`.

All six now use the existing `output_write::write_stdout_json`. No new sink, no new abstraction.

Five sites already returned `Result<i32>` and became one line each:

```rust
None => return Ok(write_stdout_json(&json)),
```

Exit-identical on the open-reader path, because each already returned `EXIT_SUCCESS` immediately
after the write.

### `evidence attest` — the one decision

Its internal `run` returned `Result<()>`, so a failed write could only become an `Err`, and `Err`
reaches the generic top-level fallback at the **config-error exit 2** — the same defect class #2439
closed elsewhere. `run` now returns `Result<i32>`: the `--out` branch returns `EXIT_SUCCESS`, the
stdout branch returns the writer's code, and `cmd_attest` propagates it. The rationale is a doc
comment on `run`, and mutation 3 below pins it.

## RED

Driven on the unmodified base. Every row reported, not just the first:

```
an undelivered machine document must exit 3, not abort or succeed:
evidence adapt-skill-scan => exit None; evidence attest => exit None;
evidence capture-skill-supply-chain => exit None; evidence project-skill-bom => exit None;
project-otel --capability-surface => exit None; project-otel --tool-decision-truth => exit None
```

`exit None` is death by signal; stderr carried `failed printing to stdout: Broken pipe`.

**`every_sink_case_fixture_reaches_its_writer` passed on the same base.** That is the anti-vacuity
control: each row first runs with `--out` and must exit 0 with parseable JSON, so a fixture that
fails verification cannot produce a closed-reader row that passes while never reaching the writer.
The three bundle-dependent rows build real inputs through real producers — capture + import through
the CLI's own gate for the skill-supply-chain bundle, `tdt::build_classified_record` +
`pack_recipe_row` for the tool-decision-truth bundle, and a deterministic PKCS#8 key for `attest`.

## GREEN

`cargo test -p assay-cli --test stdout_json_write_contract` — 31 passed, 0 failed, 1 ignored.

## Mutations

Each applied to the committed tree, driven, reverted.

| Mutation | Result |
|---|---|
| restore one raw `println!` (`project-otel --capability-surface`) | that row only: `exit None` |
| failed write mapped to success (`adapt-skill-scan`) | that row only: `exit Some(0)` |
| `attest` maps write failure to a generic `Err` | `evidence attest => exit Some(2)` |
| delete a row from `SINK_CASES` | expected-set equality fails, both lists printed |
| invalidate the skill-supply-chain bundle | precondition **and** closed-reader rows fail for `attest` + `project-skill-bom` |
| invalidate the tool-decision-truth bundle | precondition **and** closed-reader row fail for that projection |

The last two are why the precondition test exists: with an invalid bundle the closed-reader row
reports `exit Some(2)`, which is "not 3" for the wrong reason. Only the precondition distinguishes a
genuine sink failure from a fixture that never reached the sink.

## Verification

Head `a9ea7c108`, `rustc 1.96.0`, worktree `/Users/roelschuurkes/wt-2441-machine-stdout-sinks`, own `target/`.

- focused: `cargo test -p assay-cli --test stdout_json_write_contract` — 31 passed
- suite: `cargo test -p assay-cli` — all binaries `ok`, zero `FAILED`, zero `failures:`
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p assay-cli --all-targets -- -D warnings` — clean
- `git diff --check` — clean
- public strings: **none added**; the write-failure diagnostic already ships in `output_write::map_write_result`

## Non-claims

- **No schema, reason-code, signing, projection, or `--out` change.** Open-reader bytes and
  successful exits are unchanged; the five mechanical sites are exit-identical when the write
  succeeds.
- **No claim about the ~20 differently spelled writers.** `println!("{}", serde_json::to_string_pretty(…))`
  sites and `inventory.rs`'s `stdout().write_all(…)?` keep their current behaviour by design. This
  slice is the six `println!("{json}")` branches named on #2441 and nothing else.
- **No golden-path repair.** `evidence show`, `evidence verify-privileged-mcp-action` and `init`
  remain on raw `println!`; they are outside this scope.
- **Not a workspace-wide proof** that no other machine-document writer exists.
- SIGABRT is asserted as "not exit 3" plus `assert_no_rust_panic`, never by naming a signal number.

## Reviewer reservation

I authored the read-only design and this implementation, so I am the builder and do not count
toward quorum. **Cursor is reserved as the independent exact-head reviewer on
`a9ea7c1082f8ad90850b8aa99fc91fc9aba99830`.** A new push invalidates that head.

Draft on purpose: not ready, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of machine-readable JSON output when stdout cannot be written.
  * Commands now return the appropriate output-write error code instead of terminating unexpectedly.
  * File-based output and successful command behavior remain unchanged.

* **Tests**
  * Added coverage for six machine-output command paths, including closed stdout scenarios and file output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->