### PR TITLE
fix(mcp): echo Cursor 2025-06-18 instead of selecting 2025-11-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ All notable changes to this project will be documented in this file.
   class (#2165).
 
 ### Changed
+- `assay-mcp-server` now treats MCP `2025-06-18` as a supported legacy revision and echoes it
+  on `initialize`. The supported set is `2024-11-05`, `2025-06-18`, and `2025-11-25`. Unknown
+  requests still fall back to `2025-11-25`; this does not implement or advertise `2026-07-28`
+  (#2448).
 - Six machine-document stdout branches now use the shared fail-closed writer instead of raw
   `println!`: `evidence adapt-skill-scan`, `evidence attest`, `evidence capture-skill-supply-chain`,
   `evidence project-skill-bom`, and both `project-otel` projections. A requested document that

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -45,9 +45,6 @@ pub const MODERN_PROTOCOL_VERSION: &str = "2026-07-28";
 /// The reserved `_meta` key a request may use to declare its revision.
 const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
 
-/// Every legacy revision this server implements, newest last.
-const SUPPORTED_LEGACY_PROTOCOL_VERSIONS: &[&str] = &["2024-11-05", "2025-11-25"];
-
 /// `UnsupportedProtocolVersionError`, per the 2026-07-28 versioning spec.
 const ERROR_UNSUPPORTED_PROTOCOL_VERSION: i32 = -32022;
 
@@ -65,23 +62,38 @@ fn check_request_version(params: Option<&Value>) -> Result<(), Value> {
     else {
         return Ok(());
     };
-    if SUPPORTED_LEGACY_PROTOCOL_VERSIONS.contains(&requested) {
+    if LegacyProtocolVersion::parse(requested).is_some() {
         return Ok(());
     }
     Err(serde_json::json!({
         "requested": requested,
-        "supported": SUPPORTED_LEGACY_PROTOCOL_VERSIONS,
+        "supported": LegacyProtocolVersion::supported(),
     }))
 }
 
 #[derive(Clone, Copy)]
 enum LegacyProtocolVersion {
     V2024_11_05,
+    V2025_06_18,
     V2025_11_25,
 }
 
 impl LegacyProtocolVersion {
     const LATEST: Self = Self::V2025_11_25;
+
+    /// Every legacy revision this server implements, oldest to newest.
+    const ALL: &[Self] = &[Self::V2024_11_05, Self::V2025_06_18, Self::V2025_11_25];
+
+    fn parse(requested: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|version| version.as_str() == requested)
+    }
+
+    fn supported() -> Vec<&'static str> {
+        Self::ALL.iter().map(|version| version.as_str()).collect()
+    }
 
     fn negotiate(params: Option<&Value>) -> Result<Self, ()> {
         let params = params.and_then(Value::as_object).ok_or(())?;
@@ -103,16 +115,13 @@ impl LegacyProtocolVersion {
             .and_then(Value::as_str)
             .ok_or(())?;
 
-        Ok(match requested {
-            "2024-11-05" => Self::V2024_11_05,
-            "2025-11-25" => Self::V2025_11_25,
-            _ => Self::LATEST,
-        })
+        Ok(Self::parse(requested).unwrap_or(Self::LATEST))
     }
 
     const fn as_str(self) -> &'static str {
         match self {
             Self::V2024_11_05 => "2024-11-05",
+            Self::V2025_06_18 => "2025-06-18",
             Self::V2025_11_25 => "2025-11-25",
         }
     }
@@ -522,6 +531,7 @@ mod claims_boundary_tests {
     fn initialize_result_pins_every_value() {
         for (version, expected) in [
             (LegacyProtocolVersion::V2024_11_05, "2024-11-05"),
+            (LegacyProtocolVersion::V2025_06_18, "2025-06-18"),
             (LegacyProtocolVersion::V2025_11_25, "2025-11-25"),
         ] {
             let value = initialize_result(version);

--- a/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
+++ b/crates/assay-mcp-server/tests/protocol_negotiation_e2e.rs
@@ -4,6 +4,18 @@ use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 
 const LATEST_LEGACY_VERSION: &str = "2025-11-25";
+const CURSOR_INTERMEDIATE_VERSION: &str = "2025-06-18";
+
+/// Independent of the negotiation table so deleting a row fails this set comparison.
+const EXPECTED_ECHOED_REVISIONS: &[&str] = &["2024-11-05", "2025-06-18", "2025-11-25"];
+
+const PRODUCTION_TOOL_NAMES: &[&str] = &[
+    "assay_check_args",
+    "assay_check_sequence",
+    "assay_policy_decide",
+    "assay_check_coverage",
+    "assay_explain_trace",
+];
 
 /// `MODERN_PROTOCOL_VERSION` shipped public in `assay-mcp-server` 5.0.0, so removing it or
 /// narrowing it to private breaks a published API at an unchanged crate version.
@@ -84,14 +96,32 @@ fn initialize_request(protocol_version: Value, id: u64) -> Value {
     })
 }
 
+fn tools_list_request(id: u64) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/list",
+        "params": {}
+    })
+}
+
+fn tool_names(response: &Value) -> Vec<&str> {
+    response["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|tool| tool["name"].as_str().expect("tool name"))
+        .collect()
+}
+
 #[test]
 fn supported_legacy_versions_are_echoed_exactly() {
-    for version in ["2024-11-05", LATEST_LEGACY_VERSION] {
+    for version in EXPECTED_ECHOED_REVISIONS {
         let output = run_session(&[initialize_request(Value::String(version.to_string()), 1)]);
         let response = responses(&output).pop().expect("initialize response");
         assert_eq!(
             response["result"]["protocolVersion"].as_str(),
-            Some(version),
+            Some(*version),
             "supported legacy version must be echoed"
         );
     }
@@ -99,7 +129,7 @@ fn supported_legacy_versions_are_echoed_exactly() {
 
 #[test]
 fn unsupported_versions_negotiate_to_the_latest_legacy_revision() {
-    for requested in ["2025-06-18", "2026-07-28", "future-version"] {
+    for requested in ["2026-07-28", "future-version"] {
         let output = run_session(&[initialize_request(Value::String(requested.to_string()), 1)]);
         let response = responses(&output).pop().expect("initialize response");
         assert_eq!(
@@ -246,7 +276,7 @@ fn a_modern_revision_claim_is_refused_with_the_legacy_set() {
     assert_eq!(response["error"]["data"]["requested"], "2026-07-28");
     assert_eq!(
         response["error"]["data"]["supported"],
-        serde_json::json!(["2024-11-05", "2025-11-25"])
+        serde_json::json!(EXPECTED_ECHOED_REVISIONS)
     );
     assert!(response.get("result").is_none());
 }
@@ -279,7 +309,7 @@ fn an_unimplemented_revision_is_refused_with_the_supported_set() {
 
 #[test]
 fn every_supported_legacy_revision_is_accepted_in_request_metadata() {
-    for version in ["2024-11-05", LATEST_LEGACY_VERSION] {
+    for version in EXPECTED_ECHOED_REVISIONS {
         let request = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -346,4 +376,64 @@ fn latest_legacy_handshake_preserves_tools_list_and_call() {
     );
     assert!(parsed[1]["result"]["tools"].is_array());
     assert_eq!(parsed[2]["result"]["isError"].as_bool(), Some(false));
+}
+
+#[test]
+fn cursor_intermediate_revision_echoes_and_lists_production_tools() {
+    let requests = [
+        initialize_request(Value::String(CURSOR_INTERMEDIATE_VERSION.to_string()), 1),
+        tools_list_request(2),
+    ];
+    let parsed = responses(&run_session(&requests));
+    assert_eq!(parsed.len(), 2);
+    assert_eq!(
+        parsed[0]["result"]["protocolVersion"].as_str(),
+        Some(CURSOR_INTERMEDIATE_VERSION),
+        "2025-06-18 must be echoed exactly"
+    );
+    assert_eq!(tool_names(&parsed[1]), PRODUCTION_TOOL_NAMES);
+}
+
+#[test]
+fn negotiation_table_echoes_supported_set_and_falls_back_for_unknown_modern() {
+    let rows = [
+        ("2024-11-05", "2024-11-05"),
+        ("2025-06-18", "2025-06-18"),
+        ("2025-11-25", "2025-11-25"),
+        ("2026-07-28", LATEST_LEGACY_VERSION),
+    ];
+
+    let mut echoed = Vec::new();
+    for (requested, expected) in rows {
+        let output = run_session(&[initialize_request(Value::String(requested.to_string()), 1)]);
+        let response = responses(&output).pop().expect("initialize response");
+        let got = response["result"]["protocolVersion"]
+            .as_str()
+            .expect("protocolVersion");
+        assert_eq!(got, expected, "requested {requested}");
+        if got == requested {
+            echoed.push(requested);
+        }
+    }
+    assert_eq!(
+        echoed.as_slice(),
+        EXPECTED_ECHOED_REVISIONS,
+        "table rows that echo must match the independent expected set"
+    );
+
+    let refuse = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2099-01-01" } }
+    });
+    let refused = responses(&run_session(&[refuse]))
+        .pop()
+        .expect("unsupported revision response");
+    assert_eq!(refused["error"]["code"].as_i64(), Some(-32022));
+    assert_eq!(
+        refused["error"]["data"]["supported"],
+        serde_json::json!(EXPECTED_ECHOED_REVISIONS),
+        "-32022 data.supported must equal the revisions that echo"
+    );
 }

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -164,8 +164,8 @@ server entry. Codex uses project `.codex/config.toml` or user
 ## Remote servers
 
 This recipe covers local stdio servers only, because that is the transport Assay
-enforces today. `assay-mcp-server` negotiates the legacy revisions `2024-11-05` and
-`2025-11-25` over stdio; a request declaring MCP revision `2026-07-28` is refused with
+enforces today. `assay-mcp-server` negotiates the legacy revisions `2024-11-05`,
+`2025-06-18`, and `2025-11-25` over stdio; a request declaring MCP revision `2026-07-28` is refused with
 JSON-RPC error `-32022` rather than accepted, and the constant naming that revision is
 deprecated and read by no dispatch path.
 

--- a/docs/reference/tool-decision-surface.md
+++ b/docs/reference/tool-decision-surface.md
@@ -199,7 +199,7 @@ is incomplete, not weakly supported.
 `tracestate` and `baggage` are deliberately not retained: their values are free-form and may carry
 data the redaction rules above cannot reason about.
 
-Era scoping: this server still negotiates only legacy handshakes (`2024-11-05` / `2025-11-25`);
+Era scoping: this server still negotiates only legacy handshakes (`2024-11-05` / `2025-06-18` / `2025-11-25`);
 for such clients a `_meta.traceparent` is optional practice rather than SEP-414 conformance, so
 `basis: "none"` is the expected common case. The extraction does not gate on era: any client that
 does send the carrier gets it typed.


### PR DESCRIPTION
## Summary

- Echo MCP `2025-06-18` on `initialize` so Cursor Agent clients that request that intermediate legacy revision can complete `tools/list`.
- Make `LegacyProtocolVersion` the one source: `ALL` oldest→newest is exactly `2024-11-05`, `2025-06-18`, `2025-11-25`; `parse`, the `-32022` `data.supported` list, and `negotiate` all derive from it. Unknown requests still use the documented `LATEST` (`2025-11-25`) fallback.
- Public docs move from a pair to that triple. Bounded CHANGELOG only.

Closes #2448

## Pins

- Base / `origin/main`: `0927670d41508f20e97d2a8eb8f65414e41c5cb7`
- Head: `622854446480dc5974b7df17ad74237edd758f27`
- Branch: `cursor/2448-mcp-2025-06-18`
- Allowlist only: `server.rs`, `protocol_negotiation_e2e.rs`, `editor-mcp-recipe.md`, `tool-decision-surface.md`, `CHANGELOG.md`
- One-source extraction stayed on the allowlist (no `main.rs` / tool / capability / public API change)

## RED (unmodified base)

Focused `protocol_negotiation_e2e` against unmodified `0927670d41508f20e97d2a8eb8f65414e41c5cb7`:

- `cursor_intermediate_revision_echoes_and_lists_production_tools`: initialize `2025-06-18` echoed `2025-11-25`
- `negotiation_table_echoes_supported_set_and_falls_back_for_unknown_modern`: row `2025-06-18` expected echo, got `2025-11-25`

## GREEN

Same two tests pass after the one-source change. Full `protocol_negotiation_e2e`: 13 passed. Session asserts exact `2025-06-18` echo plus the five production tool names.

## Mutations (applied, RED captured, restored; none left in tree)

| Mutation | Bite |
|---|---|
| `2025-06-18` falls back instead of echo | session + table: got `2025-11-25` |
| Echo path not published (drop `2025-06-18` from `ALL`) | session + table: got `2025-11-25` |
| Unknown echoes requested instead of `LATEST` | table: `2026-07-28` echoed instead of `2025-11-25` |
| Delete a negotiation row | independent expected-set: `["2024-11-05", "2025-11-25"]` ≠ triple |
| Remove `2024-11-05` from `ALL` | echo + table: `2024-11-05` fell back to `2025-11-25` |

## Verification

| Check | Result |
|---|---|
| `cargo test -p assay-mcp-server --test protocol_negotiation_e2e` | 13 passed |
| `cargo test -p assay-mcp-server` | passed |
| `cargo fmt --all -- --check` | passed |
| `cargo clippy -p assay-mcp-server --all-targets -- -D warnings` | passed |
| `git diff --check` | passed |
| `scripts/ci/check-editor-mcp-recipe-truth.sh` | passed |
| Public wire strings | triple advertised; `2025-03-26` absent; `2026-07-28` not advertised as supported |

## Review / quorum

- Ruley is reserved as the exact-head independent reviewer.
- This writer is not quorum and is not an independent review.
- Claude authored the normative design and is non-independent.
- Draft only. Do not mark ready. Do not merge.

## Non-claims

- no MCP `2026-07-28` / server-discover
- no Cursor IDE / marketplace / auth claim
- no change to per-request refusal semantics except the supported set
- unknown clients may still disconnect

## Test plan

- [x] RED on unmodified base for the new session + table tests
- [x] GREEN focused + full `assay-mcp-server`
- [x] Five required mutations bite and restore
- [ ] Ruley exact-head independent review
