### PR TITLE
test(plugin): pin portable package LF and route inventory CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ examples/mcp-jsonrpc-id-conformance/** text eol=lf
 packaging/claude-plugin/.claude-plugin/plugin.json text eol=lf
 packaging/claude-plugin/.mcp.json text eol=lf
 packaging/claude-plugin/skills/assay-golden-path/** text eol=lf
+packaging/agent-plugin/** text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
               echo "workflow_dispatch PR must contain a non-empty docs-only file set" >&2
               exit 2
             fi
-            lightweight_only=true
+            lightweight_only="$(bash scripts/ci/classify-lightweight-changes.sh "$changed_file")"
             mcp_registry_touched=false
             ebpf_smoke_required=false
             self_hosted_ebpf_required=false
@@ -99,13 +99,7 @@ jobs:
               fi
             fi
 
-            if [[ ! -s "$changed_file" ]]; then
-              lightweight_only=false
-            elif grep -Ev '^(docs/|.*\.md$|mkdocs\.yml$|scripts/ci/review-[^/]+\.sh$|\.github/ISSUE_TEMPLATE/[^/]+\.ya?ml$|\.github/DISCUSSION_TEMPLATE/[^/]+\.ya?ml$)' "$changed_file" >/dev/null; then
-              lightweight_only=false
-            else
-              lightweight_only=true
-            fi
+            lightweight_only="$(bash scripts/ci/classify-lightweight-changes.sh "$changed_file")"
 
             if grep -E '^(crates/assay-mcp-server/|packaging/mcpb/|packaging/mcp-registry/|scripts/ci/(build_mcpb_bundle|write_sha256_sidecar)\.sh$|scripts/ci/render_registry_server_json\.sh$|scripts/publish-mcpcentral\.sh$|\.github/workflows/release\.yml$)' "$changed_file" >/dev/null; then
               mcp_registry_touched=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,10 +128,10 @@ repos:
 
       - id: agent-golden-path-skill-contract
         name: Agent golden-path skill contract
-        entry: bash -c 'python3 scripts/ci/test-agent-golden-path-skill.py && python3 scripts/ci/test-golden-path-mock-bounds.py && python3 scripts/ci/test-generate-agent-golden-path-check.py'
+        entry: bash -c 'python3 scripts/ci/test-agent-golden-path-skill.py && python3 scripts/ci/test-golden-path-mock-bounds.py && python3 scripts/ci/test-generate-agent-golden-path-check.py && bash scripts/ci/test-classify-lightweight-changes.sh'
         language: system
         pass_filenames: false
-        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|test-generate-agent-golden-path-check\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
+        files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|test-generate-agent-golden-path-check\.py|(test-)?classify-lightweight-changes\.sh|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*|\.github/workflows/(kernel-matrix|ci)\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
       - id: agent-golden-path-skill-mutations
         name: Agent golden-path skill mutations

--- a/scripts/ci/classify-lightweight-changes.sh
+++ b/scripts/ci/classify-lightweight-changes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Ordinary CI lightweight-only classifier. Empty input is not lightweight.
+# packaging/agent-plugin/** is never lightweight, including Markdown-only edits.
+set -euo pipefail
+
+list="${1:-/dev/stdin}"
+
+if [[ ! -s "$list" ]]; then
+  echo false
+  exit 0
+fi
+
+if grep -E '^packaging/agent-plugin/' "$list" >/dev/null; then
+  echo false
+  exit 0
+fi
+
+if grep -Ev '^(docs/|.*\.md$|mkdocs\.yml$|scripts/ci/review-[^/]+\.sh$|\.github/ISSUE_TEMPLATE/[^/]+\.ya?ml$|\.github/DISCUSSION_TEMPLATE/[^/]+\.ya?ml$)' "$list" >/dev/null; then
+  echo false
+  exit 0
+fi
+
+echo true

--- a/scripts/ci/test-classify-lightweight-changes.sh
+++ b/scripts/ci/test-classify-lightweight-changes.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Prove the ordinary lightweight-only classifier and that ci.yml invokes it
+# in both workflow_dispatch-with-PR and normal-event paths. Do not restate
+# the changed-file rule here; call the real classifier.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLASSIFIER="${ROOT}/scripts/ci/classify-lightweight-changes.sh"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+classify() {
+  local list
+  list="$(mktemp)"
+  if (($#)); then
+    printf '%s\n' "$@" >"$list"
+  else
+    : >"$list"
+  fi
+  bash "$CLASSIFIER" "$list"
+  rm -f "$list"
+}
+
+expect_class() {
+  local expected="$1"
+  shift
+  local got
+  got="$(classify "$@")"
+  [[ "$got" == "$expected" ]] || fail "classifier($*) => $got, expected $expected"
+}
+
+[[ -x "$CLASSIFIER" || -f "$CLASSIFIER" ]] || fail "missing $CLASSIFIER"
+
+expect_class false
+expect_class true "docs/foo.md"
+expect_class false "packaging/agent-plugin/skills/assay-golden-path/SKILL.md"
+expect_class false "docs/foo.md" "packaging/agent-plugin/skills/assay-golden-path/SKILL.md"
+expect_class true "mkdocs.yml"
+expect_class true "scripts/ci/review-example.sh"
+expect_class false "crates/assay-cli/src/lib.rs"
+
+python3 - "$WORKFLOW" <<'PY' || fail "ci.yml does not invoke the classifier in both required detect paths"
+import re
+import sys
+
+text = open(sys.argv[1]).read()
+start = text.find("      - id: detect\n")
+if start < 0:
+    raise SystemExit("could not find the detect step")
+rest = text[start:]
+run_at = rest.find("        run: |")
+if run_at < 0:
+    raise SystemExit("detect step has no run block")
+body_start = start + run_at
+lines = text[body_start:].splitlines()
+indent = len(lines[0]) - len(lines[0].lstrip())
+body = []
+for line in lines[1:]:
+    if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+        break
+    body.append(line)
+script = "\n".join(body)
+if script.count("lightweight_only=true") != 0:
+    raise SystemExit("detect step still hardcodes lightweight_only=true")
+invocations = [
+    line
+    for line in body
+    if "scripts/ci/classify-lightweight-changes.sh" in line
+]
+if len(invocations) != 2:
+    raise SystemExit(
+        f"detect step must call classify-lightweight-changes.sh twice, found {len(invocations)}"
+    )
+dispatch_pr = re.search(
+    r'GITHUB_EVENT_NAME\}" == "workflow_dispatch" &&.*?elif \[\[ "\$\{GITHUB_EVENT_NAME\}" == "workflow_dispatch"',
+    script,
+    re.S,
+)
+bare_dispatch = re.search(
+    r'elif \[\[ "\$\{GITHUB_EVENT_NAME\}" == "workflow_dispatch" \]\]; then(.*?)else',
+    script,
+    re.S,
+)
+normal = re.search(
+    r'elif \[\[ "\$\{GITHUB_EVENT_NAME\}" == "workflow_dispatch" \]\]; then.*?else\n(.*)\Z',
+    script,
+    re.S,
+)
+if dispatch_pr is None or bare_dispatch is None or normal is None:
+    raise SystemExit("could not split detect branches")
+if "classify-lightweight-changes.sh" not in dispatch_pr.group(0):
+    raise SystemExit("workflow_dispatch-with-PR path does not invoke the classifier")
+if "classify-lightweight-changes.sh" in bare_dispatch.group(1):
+    raise SystemExit("manual workflow_dispatch-without-PR must not invoke the classifier")
+if "lightweight_only=false" not in bare_dispatch.group(1):
+    raise SystemExit("manual workflow_dispatch-without-PR must stay lightweight_only=false")
+if "classify-lightweight-changes.sh" not in normal.group(1):
+    raise SystemExit("normal-event path does not invoke the classifier")
+print("ci.yml detect paths invoke the classifier")
+PY
+
+echo "ok: lightweight classifier cases and ci.yml invocations"

--- a/scripts/ci/test-generate-agent-golden-path-check.py
+++ b/scripts/ci/test-generate-agent-golden-path-check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -21,6 +22,9 @@ PORTABLE_SCHEMA = Path("packaging/agent-plugin/schemas/plugin.schema.json")
 PORTABLE_SCHEMA_LOCK = Path("packaging/agent-plugin/schemas/plugin.schema.lock.json")
 PORTABLE_SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
 PORTABLE_SCHEMA_SHA256 = "0a4aad95ce337878ad38802ebf0daa3fde76abe3f65400c86bcbb1ec0b3ab883"
+PORTABLE_SCHEMA_BYTES = 1805
+GITATTRIBUTES = Path(".gitattributes")
+PORTABLE_EOL_ATTR = "packaging/agent-plugin/** text eol=lf"
 # Closed public inventory. Do not build this from rendered_outputs().
 GENERATED_OUTPUTS = (
     Path("docs/generated/agent-golden-path.json"),
@@ -153,12 +157,82 @@ def check_portable_schema_lock(root: Path) -> None:
     expected = {
         "canonical_url": PORTABLE_SCHEMA_URL,
         "sha256": PORTABLE_SCHEMA_SHA256,
-        "bytes": len(schema),
+        "bytes": PORTABLE_SCHEMA_BYTES,
     }
     if lock != expected:
         fail("portable Agent Plugin schema lock does not match its pinned contract")
+    if len(schema) != PORTABLE_SCHEMA_BYTES:
+        fail("portable Agent Plugin schema bytes differ from the pinned contract")
     if hashlib.sha256(schema).hexdigest() != PORTABLE_SCHEMA_SHA256:
         fail("portable Agent Plugin schema bytes differ from the pinned contract")
+
+
+def _git_env() -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+    }
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_AUTHOR_NAME"] = "assay-ci"
+    env["GIT_AUTHOR_EMAIL"] = "ci@example.com"
+    env["GIT_COMMITTER_NAME"] = "assay-ci"
+    env["GIT_COMMITTER_EMAIL"] = "ci@example.com"
+    return env
+
+
+def _run_git(args: list[str], cwd: Path) -> None:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_git_env(),
+    )
+    if completed.returncode != 0:
+        fail("git " + " ".join(args) + " failed: " + (completed.stderr or completed.stdout).strip())
+
+
+def check_portable_schema_survives_autocrlf_checkout(source_root: Path) -> None:
+    attributes = (source_root / GITATTRIBUTES).read_text(encoding="utf-8")
+    schema = (source_root / PORTABLE_SCHEMA).read_bytes()
+    lock = (source_root / PORTABLE_SCHEMA_LOCK).read_bytes()
+    with tempfile.TemporaryDirectory() as raw:
+        workspace = Path(raw)
+        origin = workspace / "origin"
+        checkout = workspace / "checkout"
+        (origin / PORTABLE_SCHEMA.parent).mkdir(parents=True)
+        (origin / GITATTRIBUTES).write_text(attributes, encoding="utf-8")
+        (origin / PORTABLE_SCHEMA).write_bytes(schema)
+        (origin / PORTABLE_SCHEMA_LOCK).write_bytes(lock)
+        _run_git(["init", "--initial-branch=main"], origin)
+        _run_git(["-c", "core.autocrlf=false", "add", "-A"], origin)
+        _run_git(["-c", "core.autocrlf=false", "commit", "-m", "portable schema"], origin)
+        _run_git(
+            [
+                "-c",
+                "core.autocrlf=true",
+                "clone",
+                "--config",
+                "core.autocrlf=true",
+                origin.as_posix(),
+                checkout.as_posix(),
+            ],
+            workspace,
+        )
+        checked_out = (checkout / PORTABLE_SCHEMA).read_bytes()
+        if len(checked_out) != PORTABLE_SCHEMA_BYTES:
+            fail(
+                "portable schema checkout with core.autocrlf=true changed byte count: "
+                f"{len(checked_out)} != {PORTABLE_SCHEMA_BYTES}"
+            )
+        digest = hashlib.sha256(checked_out).hexdigest()
+        if digest != PORTABLE_SCHEMA_SHA256:
+            fail("portable schema checkout with core.autocrlf=true changed SHA-256")
+        if PORTABLE_EOL_ATTR not in attributes.splitlines():
+            fail("packaging/agent-plugin text eol=lf is missing from .gitattributes")
 
 
 def check_rejects_unknown_argument(root: Path) -> None:
@@ -305,6 +379,7 @@ def main() -> None:
     expect_schema_lock_rejects(
         "portable schema byte drift", apply_portable_schema_byte_mutation
     )
+    check_portable_schema_survives_autocrlf_checkout(ROOT)
     print("golden-path generator --check: compares bytes, names drift, rejects unknown argv")
 
 

--- a/scripts/ci/test-generate-agent-golden-path-check.py
+++ b/scripts/ci/test-generate-agent-golden-path-check.py
@@ -174,7 +174,7 @@ def _git_env() -> dict[str, str]:
         if not key.startswith("GIT_")
     }
     env["GIT_CONFIG_NOSYSTEM"] = "1"
-    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_AUTHOR_NAME"] = "assay-ci"
     env["GIT_AUTHOR_EMAIL"] = "ci@example.com"
     env["GIT_COMMITTER_NAME"] = "assay-ci"


### PR DESCRIPTION
## Summary
- Slice A of #2406 only: pin `packaging/agent-plugin/** text eol=lf` and extract the ordinary lightweight-only rule into one classifier so Markdown-only package edits still run the inventory gate.
- No generated contract bytes and no path resolver. Slice B remains.

## Provenance
- Base: `db4623564294057a7ffc8b45794869c0f6802fc9` (`origin/main`)
- Head: `7dc930573d013d88615d89da6f28ce96ec261008`
- Branch: `cursor/2406-agent-plugin-gates`
- Worktree: `/Users/roelschuurkes/wt-2406-agent-plugin-gates`

## Allowlist (six files)
- `.gitattributes`
- `.github/workflows/ci.yml`
- `.pre-commit-config.yaml`
- `scripts/ci/classify-lightweight-changes.sh`
- `scripts/ci/test-classify-lightweight-changes.sh`
- `scripts/ci/test-generate-agent-golden-path-check.py`

## RED
- Hostile `core.autocrlf=true` checkout of the portable schema: `1870 != 1805`.
- Classifier self-test: `scripts/ci/classify-lightweight-changes.sh` missing.

## GREEN
- `.gitattributes` pins `packaging/agent-plugin/** text eol=lf`.
- One classifier owner: empty → false; `docs/foo.md` → true; `packaging/agent-plugin/skills/assay-golden-path/SKILL.md` → false; mixed docs+package → false.
- `ci.yml` invokes that classifier on workflow_dispatch-with-PR and normal-event paths. Manual workflow_dispatch-without-PR stays `lightweight_only=false`.
- Cheap classifier self-test is wired into `agent-golden-path-skill-contract` and its selector.

## Mutations
| Mutation | Bite |
|---|---|
| Dispatch-with-PR invocation replaced with `true` | detect step hardcodes `lightweight_only=true` |
| Normal-event invocation replaced with `true` | same |
| Portable prefix exception removed | packaged `SKILL.md` → true |
| Docs-only made heavy | `docs/foo.md` → false |
| LF `.gitattributes` line removed | checkout `1870 != 1805` |

## Tests
- [x] `python3 scripts/ci/test-generate-agent-golden-path-check.py`
- [x] `bash scripts/ci/test-classify-lightweight-changes.sh`
- [x] `pre-commit run agent-golden-path-skill-contract`
- [x] actionlint / shellcheck
- [x] `cargo test -p assay-cli --test agent_plugin_package_contract`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Non-claims
- No generated golden-path / packaged JSON byte changes.
- No `examples/` → `assets/` path resolver.
- The 100-case golden-path mutation suite stays pre-push, not always-on CI.
- No marketplace, MCP transport, or network schema validation.

## Review
- Ruley is reserved as the independent exact-head reviewer.
- The writer does not count for quorum.
- Draft only. Do not mark ready. Do not merge.

Refs #2406

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Improved detection of documentation-only and lightweight changes across automated checks and pull request workflows.
  - Added validation to ensure lightweight-change classification remains accurate for different file types and workflow paths.

- **Reliability**
  - Enforced consistent LF line endings for agent plugin packaging files.
  - Added checks to ensure portable schemas remain byte-identical across Git checkout settings.

- **Testing**
  - Expanded automated coverage for change classification and cross-platform schema consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->