### PR TITLE
fix(cli): qualify evidence-diff scope as retained verified events (#2445)

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/diff.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/diff.rs
@@ -2,7 +2,33 @@ use anyhow::{Context, Result};
 use assay_evidence::diff::engine::diff_bundles;
 use assay_evidence::VerifyLimits;
 use clap::{Args, ValueEnum};
+use serde::Serialize;
 use std::fs::File;
+
+const COMPARISON_SCOPE_SENTENCE: &str =
+    "Comparison scope: retained verified events. Absence and completeness are not established.";
+
+#[derive(Debug, Serialize)]
+struct DiffComparisonScope {
+    basis: &'static str,
+    absence_completeness: &'static str,
+}
+
+impl DiffComparisonScope {
+    const fn retained_verified() -> Self {
+        Self {
+            basis: "retained_verified_events",
+            absence_completeness: "not_established",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct DiffCliDocument<'a> {
+    comparison_scope: DiffComparisonScope,
+    #[serde(flatten)]
+    report: &'a assay_evidence::diff::DiffReport,
+}
 
 /// The shapes `evidence diff` can emit. A type rather than a string, so the match over it is
 /// exhaustive and no spelling can reach it that the parser did not accept.
@@ -61,7 +87,11 @@ pub fn cmd_diff(args: DiffArgs) -> Result<i32> {
 
     match args.format {
         DiffFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&report)?);
+            let document = DiffCliDocument {
+                comparison_scope: DiffComparisonScope::retained_verified(),
+                report: &report,
+            };
+            println!("{}", serde_json::to_string_pretty(&document)?);
         }
         DiffFormat::Human => {
             eprintln!("Assay Evidence Diff");
@@ -75,6 +105,8 @@ pub fn cmd_diff(args: DiffArgs) -> Result<i32> {
                 report.candidate.run_id, report.candidate.event_count
             );
             eprintln!("Event count delta: {:+}", report.summary.event_count_delta);
+            eprintln!();
+            eprintln!("{COMPARISON_SCOPE_SENTENCE}");
             eprintln!();
 
             print_diff_set("Network", &report.network);

--- a/crates/assay-cli/tests/evidence_diff_stdout_contract.rs
+++ b/crates/assay-cli/tests/evidence_diff_stdout_contract.rs
@@ -1,0 +1,189 @@
+//! `assay evidence diff` must qualify comparison scope on the output that invites over-read (#2445).
+//!
+//! The computed set difference is over retained verified `.net` / `.fs` / `.process` subjects.
+//! Session-finding `extent` does not license those absences. This contract pins the CLI surface
+//! only: one human sentence on stderr before any sets, and one additive JSON object. It does not
+//! change `DiffReport`, the engine, verification, or exit codes.
+
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::EvidenceEvent;
+use assert_cmd::Command;
+use chrono::{TimeZone, Utc};
+use serde_json::Value;
+use std::path::Path;
+use tempfile::tempdir;
+
+const SCOPE_SENTENCE: &str =
+    "Comparison scope: retained verified events. Absence and completeness are not established.";
+
+fn write_bundle(path: &Path, run_id: &str, include_config: bool) {
+    let mut events = Vec::new();
+
+    let mut started = EvidenceEvent::new(
+        "assay.profile.started",
+        "urn:assay:test",
+        run_id,
+        0,
+        serde_json::json!({"name": "diff-scope"}),
+    );
+    started.time = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    events.push(started);
+
+    let mut net = EvidenceEvent::new(
+        "assay.net.connect",
+        "urn:assay:test",
+        run_id,
+        1,
+        serde_json::json!({"host": "api.example.com"}),
+    );
+    net.time = Utc.timestamp_opt(1_700_000_001, 0).unwrap();
+    net = net.with_subject("api.example.com:443");
+    events.push(net);
+
+    if include_config {
+        let mut fs = EvidenceEvent::new(
+            "assay.fs.access",
+            "urn:assay:test",
+            run_id,
+            2,
+            serde_json::json!({"path": "/etc/config"}),
+        );
+        fs.time = Utc.timestamp_opt(1_700_000_002, 0).unwrap();
+        fs = fs.with_subject("/etc/config");
+        events.push(fs);
+    }
+
+    let mut file = std::fs::File::create(path).expect("create bundle");
+    let mut writer = BundleWriter::new(&mut file);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer.finish().expect("finish bundle");
+}
+
+fn run_diff(baseline: &Path, candidate: &Path, format: &str) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("assay")
+        .expect("assay binary")
+        .args([
+            "evidence",
+            "diff",
+            baseline.to_str().expect("utf8 baseline"),
+            candidate.to_str().expect("utf8 candidate"),
+            "--format",
+            format,
+        ])
+        .assert()
+}
+
+fn scope_appears_before(haystack: &str, later: &str) {
+    let scope_at = haystack
+        .find(SCOPE_SENTENCE)
+        .unwrap_or_else(|| panic!("stderr must contain the exact scope sentence:\n{haystack}"));
+    let later_at = haystack
+        .find(later)
+        .unwrap_or_else(|| panic!("stderr must contain {later:?}:\n{haystack}"));
+    assert!(
+        scope_at < later_at,
+        "scope sentence must appear before {later:?}"
+    );
+}
+
+fn assert_no_extent_license(value: &Value, path: &str) {
+    match value {
+        Value::Object(map) => {
+            assert!(
+                !map.contains_key("extent"),
+                "{path} must not introduce an extent license key"
+            );
+            for (key, child) in map {
+                assert_no_extent_license(child, &format!("{path}.{key}"));
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                assert_no_extent_license(child, &format!("{path}[{index}]"));
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn empty_human_diff_prints_scope_before_no_differences_found() {
+    let dir = tempdir().expect("tempdir");
+    let baseline = dir.path().join("baseline.tar.gz");
+    let candidate = dir.path().join("candidate.tar.gz");
+    write_bundle(&baseline, "run_base", true);
+    write_bundle(&candidate, "run_cand", true);
+
+    let output = run_diff(&baseline, &candidate, "human")
+        .success()
+        .get_output()
+        .clone();
+    assert_eq!(output.status.code(), Some(0));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    scope_appears_before(&stderr, "No differences found.");
+}
+
+#[test]
+fn removed_config_human_diff_prints_scope_before_the_removed_path() {
+    let dir = tempdir().expect("tempdir");
+    let baseline = dir.path().join("baseline.tar.gz");
+    let candidate = dir.path().join("candidate.tar.gz");
+    write_bundle(&baseline, "run_base", true);
+    write_bundle(&candidate, "run_cand", false);
+
+    let output = run_diff(&baseline, &candidate, "human")
+        .success()
+        .get_output()
+        .clone();
+    assert_eq!(output.status.code(), Some(0));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("  - /etc/config"),
+        "removed path must still be reported:\n{stderr}"
+    );
+    scope_appears_before(&stderr, "  - /etc/config");
+}
+
+#[test]
+fn json_diff_publishes_comparison_scope_and_keeps_report_fields() {
+    let dir = tempdir().expect("tempdir");
+    let baseline = dir.path().join("baseline.tar.gz");
+    let candidate = dir.path().join("candidate.tar.gz");
+    write_bundle(&baseline, "run_base", true);
+    write_bundle(&candidate, "run_cand", false);
+
+    let output = run_diff(&baseline, &candidate, "json")
+        .success()
+        .get_output()
+        .clone();
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8(output.stdout.clone()).expect("stdout utf8");
+    let report: Value = serde_json::from_str(&stdout).expect("stdout is one JSON document");
+
+    assert_eq!(
+        report["comparison_scope"],
+        serde_json::json!({
+            "basis": "retained_verified_events",
+            "absence_completeness": "not_established"
+        })
+    );
+    assert!(
+        report.get("baseline").is_some(),
+        "existing baseline field must stay top-level"
+    );
+    assert!(
+        report.get("candidate").is_some(),
+        "existing candidate field must stay top-level"
+    );
+    assert!(
+        report.get("filesystem").is_some(),
+        "existing filesystem field must stay top-level"
+    );
+    assert_eq!(
+        report["comparison_scope"]["absence_completeness"],
+        "not_established"
+    );
+    assert_no_extent_license(&report, "$");
+}


### PR DESCRIPTION
## Description

Successful `assay evidence diff` comparisons invited readers to treat missing hosts, paths, or processes as established absences. This PR qualifies comparison scope on the CLI surface only: one human sentence on stderr before any sets, and one additive JSON object on stdout. Existing `DiffReport` fields stay top-level via a local serializable wrapper.

Governing measured DoD: https://github.com/Rul1an/assay/issues/2445#issuecomment-5320389989

Refs #2445. Does not close or supersede #2422.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Exact base / head

- Base (`origin/main`): `70a915cf63b213881e3f716319b5d70f6f489962`
- Head: `062b341860d70eee3e5cbd4d96a394ac9c0d45c5`
- Branch: `cursor/2445-evidence-diff-scope`
- Allowlist (2 files): `crates/assay-cli/src/cli/commands/evidence/diff.rs`, `crates/assay-cli/tests/evidence_diff_stdout_contract.rs`
- No docs. No `assay-evidence` files.

## Behavior

Human stderr on every successful comparison, before sets, exactly:

```
Comparison scope: retained verified events. Absence and completeness are not established.
```

JSON stdout adds one CLI-local object; existing report fields stay top-level:

```json
"comparison_scope": {
  "basis": "retained_verified_events",
  "absence_completeness": "not_established"
}
```

Exit 0 is unchanged.

## Non-claims

- Does not change public `DiffReport`, the diff engine, verification, session-finding vocabulary, comparison semantics, or exit codes.
- Does not emit `extent` / `complete` / `partial` as a license. Session-finding `extent` remains temporal finality of one evaluated sequence; it does not license host, path, or process absences.
- `absence_completeness` is `not_established` only. Completeness is not claimed.

## RED (unmodified product + new contract)

Command:

```
cargo test -p assay-cli --test evidence_diff_stdout_contract -- --nocapture
```

HEAD at RED: `70a915cf63b213881e3f716319b5d70f6f489962`

Result: `test result: FAILED. 0 passed; 3 failed;`

- empty human: missing exact scope sentence; still printed `No differences found.`
- removed `/etc/config` human: missing sentence; still printed `Filesystem:` / `  - /etc/config`
- JSON: `comparison_scope` was `Null`; expected `{basis:"retained_verified_events",absence_completeness:"not_established"}`

## GREEN

Same command after the smallest CLI-local wrapper.

Result: `test result: ok. 3 passed; 0 failed;`

Affected unit tests:

```
cargo test -p assay-cli --bin assay test_validate_baseline_key -- --nocapture
```

Result: `test result: ok. 6 passed; 0 failed;` (600 filtered)

## Mutations (scratch; restored; `RESTORE_OK`)

1. Delete human sentence → empty + removed human fail; JSON ok (`1 passed; 2 failed`)
2. Serialize raw `DiffReport` → JSON `comparison_scope` is `Null` (`2 passed; 1 failed`)
3. Emit `comparison_scope` as a string, not an object → left `String("retained_verified_events")`, right Object (`2 passed; 1 failed`)
4. Emit human sentence only when `!report.is_empty()` → empty human fails; removed-path still ok (`2 passed; 1 failed`)
5. `absence_completeness: "complete"` → exact-object assert fails (`2 passed; 1 failed`)

## Verification
- [x] Focused contract: `cargo test -p assay-cli --test evidence_diff_stdout_contract -- --nocapture` (3 passed)
- [x] Affected unit tests: `cargo test -p assay-cli --bin assay test_validate_baseline_key -- --nocapture` (6 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-cli --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] Public-string inspection on `diff.rs`: exact sentence 1, `retained_verified_events` 1, `not_established` 1, `extent` 0, `partial` 0. Substring `complete` is 3, all from `completeness` / `absence_completeness`, not a license field.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (intentionally none; docs are out of allowlist)
- [x] I have added tests to cover my changes.

Draft only. Do not mark ready or merge. Ruley is reserved independent reviewer.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comparison-scope details to evidence diff results in both human-readable and JSON formats.
  - Clarifies that comparisons cover retained verified events and do not confirm absence or completeness.

- **Bug Fixes**
  - Preserved existing JSON report fields while adding scope information.
  - Prevented unsupported extent licensing data from appearing in diff output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->