### PR TITLE
fix(mcp): keep ServerConfig semver-compatible without dropping the policy ceiling (#2453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,12 @@ All notable changes to this project will be documented in this file.
   events no longer copy caller-controlled tool or policy strings. The separate
   `tool_decision` evidence event retains its existing redaction contract.
 - The five advertised MCP policy tools now read local policy files through one
-  inclusive byte ceiling (`ServerConfig.max_policy_bytes`, default 1,000,000,
-  override `ASSAY_MCP_MAX_POLICY_BYTES`) before parse or cache insertion.
-  Exactly the limit is accepted; one extra byte returns `E_LIMIT_EXCEEDED`.
-  The ceiling is independent of the JSON-RPC `ASSAY_MCP_MAX_BYTES` message
-  limit. Operators with previously accepted larger local policy files must
+  inclusive byte ceiling (default 1,000,000, override
+  `ASSAY_MCP_MAX_POLICY_BYTES`) before parse or cache insertion. Exactly the
+  limit is accepted; one extra byte returns `E_LIMIT_EXCEEDED`. The ceiling is
+  independent of the JSON-RPC `ASSAY_MCP_MAX_BYTES` message limit and is not a
+  `ServerConfig` field, so the v5.2.0 public struct shape stays minor-compatible
+  (#2453). Operators with previously accepted larger local policy files must
   shrink the file or set an explicit bounded override. This does not bound
   parser nesting, YAML aliases, proxy startup policy, manifests, trust
   policy, or CLI readers (#2389).

--- a/crates/assay-mcp-server/src/config.rs
+++ b/crates/assay-mcp-server/src/config.rs
@@ -26,11 +26,27 @@ pub fn reject_unsupported_stdio_auth_env() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Inclusive local-policy ingest ceiling. Invalid or absent
+/// `ASSAY_MCP_MAX_POLICY_BYTES` keeps this default. Independent of
+/// `ASSAY_MCP_MAX_BYTES`.
+pub(crate) const DEFAULT_POLICY_BYTE_LIMIT: usize = 1_000_000;
+
+/// Resolve the policy-file byte ceiling from the process environment.
+///
+/// One parser for startup logging and every production policy read. Not stored
+/// on `ServerConfig`: that public struct must keep the v5.2.0 field set.
+/// Visible to the stdio binary (`src/main.rs`), which is a separate crate.
+pub fn policy_byte_limit_from_env() -> usize {
+    match env::var("ASSAY_MCP_MAX_POLICY_BYTES") {
+        Ok(value) => value.parse().unwrap_or(DEFAULT_POLICY_BYTE_LIMIT),
+        Err(_) => DEFAULT_POLICY_BYTE_LIMIT,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ServerConfig {
     pub timeout_ms: u64,
     pub max_msg_bytes: usize,
-    pub max_policy_bytes: usize,
     pub max_tool_calls: usize,
     pub max_field_bytes: usize,
     pub cache_entries: u64,
@@ -50,7 +66,6 @@ impl Default for ServerConfig {
         Self {
             timeout_ms: 2000,
             max_msg_bytes: 1_000_000,
-            max_policy_bytes: 1_000_000,
             max_tool_calls: 2000,
             max_field_bytes: 64_000,
             cache_entries: 128,
@@ -71,11 +86,6 @@ impl ServerConfig {
         if let Ok(v) = env::var("ASSAY_MCP_MAX_BYTES") {
             if let Ok(n) = v.parse() {
                 cfg.max_msg_bytes = n;
-            }
-        }
-        if let Ok(v) = env::var("ASSAY_MCP_MAX_POLICY_BYTES") {
-            if let Ok(n) = v.parse() {
-                cfg.max_policy_bytes = n;
             }
         }
         if let Ok(v) = env::var("ASSAY_MCP_MAX_FIELD_BYTES") {
@@ -152,9 +162,8 @@ mod tests {
             ("ASSAY_MCP_MAX_POLICY_BYTES", None),
             ("ASSAY_MCP_MAX_BYTES", None),
         ]);
-        let cfg = ServerConfig::from_env();
-        assert_eq!(cfg.max_policy_bytes, 1_000_000);
-        assert_eq!(cfg.max_msg_bytes, 1_000_000);
+        assert_eq!(policy_byte_limit_from_env(), DEFAULT_POLICY_BYTE_LIMIT);
+        assert_eq!(ServerConfig::from_env().max_msg_bytes, 1_000_000);
     }
 
     #[test]
@@ -163,22 +172,22 @@ mod tests {
             ("ASSAY_MCP_MAX_POLICY_BYTES", Some("1234")),
             ("ASSAY_MCP_MAX_BYTES", Some("4321")),
         ]);
-        let cfg = ServerConfig::from_env();
-        assert_eq!(cfg.max_policy_bytes, 1234);
-        assert_eq!(cfg.max_msg_bytes, 4321);
+        assert_eq!(policy_byte_limit_from_env(), 1234);
+        assert_eq!(ServerConfig::from_env().max_msg_bytes, 4321);
 
         drop(_env);
         let _env = EnvRestore::apply(&[
             ("ASSAY_MCP_MAX_POLICY_BYTES", Some("4321")),
             ("ASSAY_MCP_MAX_BYTES", Some("1234")),
         ]);
-        let cfg = ServerConfig::from_env();
         assert_eq!(
-            cfg.max_policy_bytes, 4321,
+            policy_byte_limit_from_env(),
+            4321,
             "policy override must not follow ASSAY_MCP_MAX_BYTES"
         );
         assert_eq!(
-            cfg.max_msg_bytes, 1234,
+            ServerConfig::from_env().max_msg_bytes,
+            1234,
             "message override must not follow ASSAY_MCP_MAX_POLICY_BYTES"
         );
     }
@@ -189,18 +198,16 @@ mod tests {
             ("ASSAY_MCP_MAX_POLICY_BYTES", Some("1234")),
             ("ASSAY_MCP_MAX_BYTES", None),
         ]);
-        let cfg = ServerConfig::from_env();
-        assert_eq!(cfg.max_policy_bytes, 1234);
-        assert_eq!(cfg.max_msg_bytes, 1_000_000);
+        assert_eq!(policy_byte_limit_from_env(), 1234);
+        assert_eq!(ServerConfig::from_env().max_msg_bytes, 1_000_000);
 
         drop(_env);
         let _env = EnvRestore::apply(&[
             ("ASSAY_MCP_MAX_POLICY_BYTES", None),
             ("ASSAY_MCP_MAX_BYTES", Some("4321")),
         ]);
-        let cfg = ServerConfig::from_env();
-        assert_eq!(cfg.max_policy_bytes, 1_000_000);
-        assert_eq!(cfg.max_msg_bytes, 4321);
+        assert_eq!(policy_byte_limit_from_env(), DEFAULT_POLICY_BYTE_LIMIT);
+        assert_eq!(ServerConfig::from_env().max_msg_bytes, 4321);
     }
 
     #[test]
@@ -209,8 +216,7 @@ mod tests {
             ("ASSAY_MCP_MAX_POLICY_BYTES", Some("not-a-number")),
             ("ASSAY_MCP_MAX_BYTES", Some("4321")),
         ]);
-        let cfg = ServerConfig::from_env();
-        assert_eq!(cfg.max_policy_bytes, 1_000_000);
-        assert_eq!(cfg.max_msg_bytes, 4321);
+        assert_eq!(policy_byte_limit_from_env(), DEFAULT_POLICY_BYTE_LIMIT);
+        assert_eq!(ServerConfig::from_env().max_msg_bytes, 4321);
     }
 }

--- a/crates/assay-mcp-server/src/config.rs
+++ b/crates/assay-mcp-server/src/config.rs
@@ -3,6 +3,10 @@
 use crate::auth::config::AuthConfig;
 use std::env;
 
+#[path = "policy_byte_limit.rs"]
+mod policy_byte_limit;
+pub(crate) use policy_byte_limit::policy_byte_limit_from_env;
+
 fn configured_server_auth_variables() -> Vec<String> {
     let mut names: Vec<String> = env::vars_os()
         .map(|(name, _)| name.to_string_lossy().into_owned())
@@ -24,23 +28,6 @@ pub fn reject_unsupported_stdio_auth_env() -> anyhow::Result<()> {
         );
     }
     Ok(())
-}
-
-/// Inclusive local-policy ingest ceiling. Invalid or absent
-/// `ASSAY_MCP_MAX_POLICY_BYTES` keeps this default. Independent of
-/// `ASSAY_MCP_MAX_BYTES`.
-pub(crate) const DEFAULT_POLICY_BYTE_LIMIT: usize = 1_000_000;
-
-/// Resolve the policy-file byte ceiling from the process environment.
-///
-/// One parser for startup logging and every production policy read. Not stored
-/// on `ServerConfig`: that public struct must keep the v5.2.0 field set.
-/// Visible to the stdio binary (`src/main.rs`), which is a separate crate.
-pub fn policy_byte_limit_from_env() -> usize {
-    match env::var("ASSAY_MCP_MAX_POLICY_BYTES") {
-        Ok(value) => value.parse().unwrap_or(DEFAULT_POLICY_BYTE_LIMIT),
-        Err(_) => DEFAULT_POLICY_BYTE_LIMIT,
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -113,6 +100,7 @@ impl ServerConfig {
 #[cfg(test)]
 #[allow(unsafe_code)]
 mod tests {
+    use super::policy_byte_limit::DEFAULT_POLICY_BYTE_LIMIT;
     use super::*;
     use std::sync::{Mutex, MutexGuard};
 

--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -335,7 +335,7 @@ async fn run() -> Result<()> {
                 policy_root = ?args.policy_root,
                 timeout_ms = cfg.timeout_ms,
                 max_msg_bytes = cfg.max_msg_bytes,
-                max_policy_bytes = cfg.max_policy_bytes,
+                max_policy_bytes = config::policy_byte_limit_from_env(),
                 max_tool_calls = cfg.max_tool_calls,
                 max_field_bytes = cfg.max_field_bytes,
                 cache_entries = cfg.cache_entries,

--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -9,6 +9,9 @@ use std::path::PathBuf;
 // because it is invoked solely from here. See docs/reference/mcp-upstream-proxy-mode.md.
 mod proxy;
 
+#[path = "policy_byte_limit.rs"]
+mod policy_byte_limit;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -335,7 +338,7 @@ async fn run() -> Result<()> {
                 policy_root = ?args.policy_root,
                 timeout_ms = cfg.timeout_ms,
                 max_msg_bytes = cfg.max_msg_bytes,
-                max_policy_bytes = config::policy_byte_limit_from_env(),
+                max_policy_bytes = policy_byte_limit::policy_byte_limit_from_env(),
                 max_tool_calls = cfg.max_tool_calls,
                 max_field_bytes = cfg.max_field_bytes,
                 cache_entries = cfg.cache_entries,

--- a/crates/assay-mcp-server/src/policy_byte_limit.rs
+++ b/crates/assay-mcp-server/src/policy_byte_limit.rs
@@ -1,0 +1,23 @@
+//! Shared policy-byte ceiling parser for the library crate and the stdio binary.
+//!
+//! Both crates compile this file as a private module (`#[path]`). The function
+//! stays `pub(crate)` so it is never part of the published `assay-mcp-server`
+//! public API.
+
+use std::env;
+
+/// Inclusive local-policy ingest ceiling. Invalid or absent
+/// `ASSAY_MCP_MAX_POLICY_BYTES` keeps this default. Independent of
+/// `ASSAY_MCP_MAX_BYTES`.
+pub(crate) const DEFAULT_POLICY_BYTE_LIMIT: usize = 1_000_000;
+
+/// Resolve the policy-file byte ceiling from the process environment.
+///
+/// One parser for startup logging and every production policy read. Not stored
+/// on `ServerConfig`: that public struct must keep the v5.2.0 field set.
+pub(crate) fn policy_byte_limit_from_env() -> usize {
+    match env::var("ASSAY_MCP_MAX_POLICY_BYTES") {
+        Ok(value) => value.parse().unwrap_or(DEFAULT_POLICY_BYTE_LIMIT),
+        Err(_) => DEFAULT_POLICY_BYTE_LIMIT,
+    }
+}

--- a/crates/assay-mcp-server/src/tools/policy_read.rs
+++ b/crates/assay-mcp-server/src/tools/policy_read.rs
@@ -35,8 +35,17 @@ impl ToolContext {
     /// Resolve `user_path`, then read the file through `read_bounded` on a
     /// blocking thread. The `File` is opened inside `spawn_blocking`.
     pub async fn read_policy_bounded(&self, user_path: &str) -> Result<Vec<u8>, ToolError> {
+        self.read_policy_bounded_with_limit(user_path, crate::config::policy_byte_limit_from_env())
+            .await
+    }
+
+    /// Same ingest path as production, with an explicit ceiling for focused tests.
+    pub(crate) async fn read_policy_bounded_with_limit(
+        &self,
+        user_path: &str,
+        limit: usize,
+    ) -> Result<Vec<u8>, ToolError> {
         let path = self.resolve_policy_path(user_path).await?;
-        let limit = self.cfg.max_policy_bytes;
         let rel_path = user_path.to_string();
         match tokio::task::spawn_blocking(move || {
             let file = File::open(&path)?;
@@ -157,16 +166,12 @@ mod tests {
         assert!(err.to_string().contains("injected read failure"));
     }
 
-    async fn context_with_limit(root: PathBuf, limit: usize) -> ToolContext {
-        let cfg = ServerConfig {
-            max_policy_bytes: limit,
-            ..ServerConfig::default()
-        };
+    async fn context_at(root: PathBuf) -> ToolContext {
         let canon = tokio::fs::canonicalize(&root).await.unwrap();
         ToolContext {
             policy_root: root,
             policy_root_canon: canon,
-            cfg,
+            cfg: ServerConfig::default(),
             caches: PolicyCaches::new(8),
         }
     }
@@ -174,9 +179,9 @@ mod tests {
     #[tokio::test]
     async fn async_entry_maps_missing_file() {
         let tmp = TempDir::new().unwrap();
-        let ctx = context_with_limit(tmp.path().to_path_buf(), 32).await;
+        let ctx = context_at(tmp.path().to_path_buf()).await;
         let err = ctx
-            .read_policy_bounded("missing.yaml")
+            .read_policy_bounded_with_limit("missing.yaml", 32)
             .await
             .expect_err("missing");
         assert_eq!(err.code, "E_POLICY_NOT_FOUND");
@@ -191,9 +196,9 @@ mod tests {
     async fn async_entry_maps_directory_read_as_other_io() {
         let tmp = TempDir::new().unwrap();
         std::fs::create_dir(tmp.path().join("not-a-file")).unwrap();
-        let ctx = context_with_limit(tmp.path().to_path_buf(), 32).await;
+        let ctx = context_at(tmp.path().to_path_buf()).await;
         let err = ctx
-            .read_policy_bounded("not-a-file")
+            .read_policy_bounded_with_limit("not-a-file", 32)
             .await
             .expect_err("directory");
         assert_eq!(err.code, "E_POLICY_READ");
@@ -207,9 +212,9 @@ mod tests {
     async fn async_entry_accepts_exact_limit_file() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join("exact.yaml"), vec![b'e'; 16]).unwrap();
-        let ctx = context_with_limit(tmp.path().to_path_buf(), 16).await;
+        let ctx = context_at(tmp.path().to_path_buf()).await;
         let bytes = ctx
-            .read_policy_bounded("exact.yaml")
+            .read_policy_bounded_with_limit("exact.yaml", 16)
             .await
             .unwrap_or_else(|err| {
                 panic!("exact file must be accepted: {} {}", err.code, err.message)
@@ -227,9 +232,9 @@ mod tests {
         file.sync_all().unwrap();
         drop(file);
 
-        let ctx = context_with_limit(tmp.path().to_path_buf(), 16).await;
+        let ctx = context_at(tmp.path().to_path_buf()).await;
         let err = ctx
-            .read_policy_bounded("sparse.yaml")
+            .read_policy_bounded_with_limit("sparse.yaml", 16)
             .await
             .expect_err("sparse limit+1");
         assert_eq!(err.code, "E_LIMIT_EXCEEDED");

--- a/scripts/ci/check-mcp-policy-reader-routing.py
+++ b/scripts/ci/check-mcp-policy-reader-routing.py
@@ -13,8 +13,14 @@ import sys
 from pathlib import Path
 
 
-SERVER_TOOLS = Path("crates/assay-mcp-server/src/tools")
+SERVER_SRC = Path("crates/assay-mcp-server/src")
+SERVER_TOOLS = SERVER_SRC / "tools"
 READER = SERVER_TOOLS / "policy_read.rs"
+PARSER = SERVER_SRC / "policy_byte_limit.rs"
+CONFIG = SERVER_SRC / "config.rs"
+MAIN = SERVER_SRC / "main.rs"
+PUBLIC_PARSER_FN = re.compile(r"\bpub\s+fn\s+policy_byte_limit_from_env\b")
+PUBLIC_PARSER_USE = re.compile(r"\bpub\s+use\b[^;]*\bpolicy_byte_limit_from_env\b")
 TOOL_FILES = [
     SERVER_TOOLS / "policy_decide.rs",
     SERVER_TOOLS / "check_sequence.rs",
@@ -117,8 +123,43 @@ def function_body(source: str, signature: str) -> str | None:
     return None
 
 
+def rust_sources() -> list[Path]:
+    if not SERVER_SRC.is_dir():
+        return []
+    return sorted(path for path in SERVER_SRC.rglob("*.rs") if path.is_file())
+
+
 def check() -> bool:
     errors: list[str] = []
+    if not PARSER.is_file():
+        errors.append("policy_byte_limit.rs is missing")
+    else:
+        parser = PARSER.read_text()
+        body = compact(parser)
+        if "pub(crate)fnpolicy_byte_limit_from_env(" not in body:
+            errors.append("policy_byte_limit.rs must define pub(crate) fn policy_byte_limit_from_env")
+        if "ASSAY_MCP_MAX_POLICY_BYTES" not in parser:
+            errors.append("policy_byte_limit.rs must parse ASSAY_MCP_MAX_POLICY_BYTES")
+    if CONFIG.is_file():
+        config_src = CONFIG.read_text()
+        config = compact(config_src)
+        if '#[path = "policy_byte_limit.rs"]' not in config_src:
+            errors.append("config.rs must compile policy_byte_limit.rs as a private path module")
+        if "pub(crate)usepolicy_byte_limit::" not in config or "policy_byte_limit_from_env" not in config:
+            errors.append("config.rs must pub(crate) re-export policy_byte_limit_from_env")
+    if MAIN.is_file():
+        main_src = MAIN.read_text()
+        main = compact(main_src)
+        if '#[path = "policy_byte_limit.rs"]' not in main_src:
+            errors.append("main.rs must compile policy_byte_limit.rs as a private path module")
+        if "policy_byte_limit::policy_byte_limit_from_env(" not in main:
+            errors.append("main.rs must log the ceiling via the shared private parser")
+    for path in rust_sources():
+        source = path.read_text()
+        if PUBLIC_PARSER_FN.search(source):
+            errors.append(f"{path}: pub fn policy_byte_limit_from_env expands the public API")
+        if PUBLIC_PARSER_USE.search(source):
+            errors.append(f"{path}: pub use of policy_byte_limit_from_env expands the public API")
     if not READER.is_file():
         print("FAIL: policy reader module not found", file=sys.stderr)
         return False

--- a/scripts/ci/check-mcp-policy-reader-routing.py
+++ b/scripts/ci/check-mcp-policy-reader-routing.py
@@ -124,7 +124,8 @@ def check() -> bool:
         return False
     reader = READER.read_text()
     bounded = function_body(reader, "fn read_bounded")
-    async_entry = function_body(reader, "async fn read_policy_bounded")
+    async_entry = function_body(reader, "async fn read_policy_bounded(")
+    explicit = function_body(reader, "async fn read_policy_bounded_with_limit(")
     if bounded is None:
         errors.append("read_bounded is missing")
     else:
@@ -139,16 +140,30 @@ def check() -> bool:
         errors.append("read_policy_bounded is missing")
     else:
         body = compact(async_entry)
-        if "spawn_blocking" not in body:
-            errors.append("read_policy_bounded must read inside spawn_blocking")
-        if "File::open(" not in body:
-            errors.append("read_policy_bounded must open std::fs::File")
-        if "read_bounded(" not in body:
-            errors.append("read_policy_bounded must call read_bounded")
+        if "policy_byte_limit_from_env(" not in body:
+            errors.append("read_policy_bounded must resolve the ceiling via policy_byte_limit_from_env")
+        if "read_policy_bounded_with_limit(" not in body:
+            errors.append("read_policy_bounded must delegate to read_policy_bounded_with_limit")
+        if "tokio::fs::read" in body:
+            errors.append("read_policy_bounded must not bypass via tokio::fs::read")
         if "metadata(" in body:
             errors.append("read_policy_bounded must not consult metadata")
         if "read_to_end" in body:
             errors.append("read_policy_bounded must not duplicate the read")
+    if explicit is None:
+        errors.append("read_policy_bounded_with_limit is missing")
+    else:
+        body = compact(explicit)
+        if "spawn_blocking" not in body:
+            errors.append("read_policy_bounded_with_limit must read inside spawn_blocking")
+        if "File::open(" not in body:
+            errors.append("read_policy_bounded_with_limit must open std::fs::File")
+        if "read_bounded(" not in body:
+            errors.append("read_policy_bounded_with_limit must call read_bounded")
+        if "metadata(" in body:
+            errors.append("read_policy_bounded_with_limit must not consult metadata")
+        if "read_to_end" in body:
+            errors.append("read_policy_bounded_with_limit must not duplicate the read")
 
     for rel in TOOL_FILES:
         if not rel.is_file():

--- a/scripts/ci/test-check-mcp-policy-reader-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-reader-routing.sh
@@ -124,9 +124,22 @@ p.write_text(s.replace(old, new, 1))
 PY
 }
 
+mutate_hardcode_policy_limit() {
+  python3 - "$1/crates/assay-mcp-server/src/tools/policy_read.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "crate::config::policy_byte_limit_from_env()"
+new = "1_000_000"
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
 mutant "metadata-only accept then unbounded read" mutate_metadata_accept
 mutant "direct tokio::fs::read bypass" mutate_direct_tokio
 mutant "check_args from_file bypass" mutate_check_args_from_file
 mutant "async entry skips read_bounded" mutate_skip_helper
+mutant "production read hard-codes the policy ceiling" mutate_hardcode_policy_limit
 
 echo "All MCP policy reader routing mutations caught."

--- a/scripts/ci/test-check-mcp-policy-reader-routing.sh
+++ b/scripts/ci/test-check-mcp-policy-reader-routing.sh
@@ -5,6 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUARD="$SCRIPT_DIR/check-mcp-policy-reader-routing.py"
 FILES=(
   crates/assay-mcp-server/src/tools
+  crates/assay-mcp-server/src/config.rs
+  crates/assay-mcp-server/src/main.rs
+  crates/assay-mcp-server/src/policy_byte_limit.rs
 )
 
 if ! python3 "$GUARD"; then
@@ -34,7 +37,9 @@ echo "PASS: reader guard rejects a positional path"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 mkdir -p "$TMPDIR/base/crates/assay-mcp-server/src"
-cp -R "${FILES[0]}" "$TMPDIR/base/crates/assay-mcp-server/src/"
+for src in "${FILES[@]}"; do
+  cp -R "$src" "$TMPDIR/base/$src"
+done
 
 if ! (
   cd "$TMPDIR/base"
@@ -136,10 +141,23 @@ p.write_text(s.replace(old, new, 1))
 PY
 }
 
+mutate_public_parser() {
+  python3 - "$1/crates/assay-mcp-server/src/policy_byte_limit.rs" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]); s = p.read_text()
+old = "pub(crate) fn policy_byte_limit_from_env"
+new = "pub fn policy_byte_limit_from_env"
+assert old in s
+p.write_text(s.replace(old, new, 1))
+PY
+}
+
 mutant "metadata-only accept then unbounded read" mutate_metadata_accept
 mutant "direct tokio::fs::read bypass" mutate_direct_tokio
 mutant "check_args from_file bypass" mutate_check_args_from_file
 mutant "async entry skips read_bounded" mutate_skip_helper
 mutant "production read hard-codes the policy ceiling" mutate_hardcode_policy_limit
+mutant "pub fn policy_byte_limit_from_env" mutate_public_parser
 
 echo "All MCP policy reader routing mutations caught."


### PR DESCRIPTION
## Summary
- Restore the published v5.2.0 public `ServerConfig` shape so a v5.3.0 minor can ship: `max_policy_bytes` is no longer a public field (`constructible_struct_adds_field` against crates.io `5.2.0`).
- Keep the inclusive local-policy ceiling (`ASSAY_MCP_MAX_POLICY_BYTES`, default 1_000_000, invalid → default, independent of `ASSAY_MCP_MAX_BYTES`) via one `pub(crate)` parser in a private shared source module (`policy_byte_limit.rs`) compiled by both the library (`config.rs`) and the stdio binary (`main.rs`) through `#[path]`. Production `read_policy_bounded` delegates to `read_policy_bounded_with_limit`; startup `server_start` logs the same parser. No public function or `pub use`.
- Correct the Unreleased CHANGELOG claim that advertised `ServerConfig.max_policy_bytes`. Routing guard now pins production → parser + helper, rejects `pub fn policy_byte_limit_from_env`, and the helper body still owns `spawn_blocking` / `File::open` / `read_bounded`.

Refs #2453

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Base / head
- Base (exact `origin/main`): `dc66c244ebb4408f3493204318cb69c4e6660405`
- Head (this PR): `3a638990397623b6d621e134d2176f14bf8608d7`

## RED (unmodified product on the base)
```
cargo semver-checks check-release -p assay-mcp-server --release-type minor --baseline-version 5.2.0
```
- cargo-semver-checks 0.50.0
- 196 checks: 195 pass, 1 fail
- `constructible_struct_adds_field`: field `ServerConfig.max_policy_bytes`
- Summary: semver requires new major version
- Exit 100

## GREEN
```
cargo semver-checks check-release -p assay-mcp-server --release-type minor --baseline-version 5.2.0
```
- 196 checks: 196 pass, 58 skip
- Summary: no semver update required

Focused + crate:
- `cargo test -p assay-mcp-server --lib` → 102 passed
- `cargo test -p assay-mcp-server --test policy_ingest_limits` → 3 passed (five-tool stdio; startup log showed `max_policy_bytes:128` under `ASSAY_MCP_MAX_POLICY_BYTES=128`)
- `python3 scripts/ci/check-mcp-policy-reader-routing.py` → OK
- `bash scripts/ci/test-check-mcp-policy-reader-routing.sh` → all mutations caught, including `pub fn policy_byte_limit_from_env`
- `cargo fmt --all -- --check` → pass
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings` → pass
- `git diff --check` → pass

## Required mutations (each restored; `RESTORE_OK`)
1. Re-add public `ServerConfig.max_policy_bytes` → `cargo-semver-checks` fails again (`constructible_struct_adds_field`, exit 100).
2. Couple `policy_byte_limit_from_env` to `ASSAY_MCP_MAX_BYTES` → `policy_and_message_ceilings_diverge_in_both_directions` fails (`left: 4321 right: 1234`).
3. Hard-code the parser to `DEFAULT_POLICY_BYTE_LIMIT` → same override test fails (`left: 1000000 right: 1234`).
4. Replace `assay_policy_decide` `read_policy_bounded` with `tokio::fs::read` → routing guard fails (`must call read_policy_bounded` + `direct tokio::fs::read bypass`).
5. Change `pub(crate) fn policy_byte_limit_from_env` to `pub fn` → routing guard fails (`pub fn policy_byte_limit_from_env expands the public API`).

## Non-claims
- Not a 6.0.0 / workspace major.
- No `#[non_exhaustive]`, no new `ServerConfig` field, no new public function, no new `ToolContext` / `handle_call` / `Server::run` signatures.
- No global registry / `OnceLock` / side map. Env lookup at policy-read time is intentional.
- Does not close #2359 and is not the release-prep version bump.
- Does not bound parser nesting, YAML aliases, proxy startup policy, manifests, trust policy, or CLI readers.

## Allowlist
- `crates/assay-mcp-server/src/config.rs`
- `crates/assay-mcp-server/src/policy_byte_limit.rs` (private shared source; compiled by lib and bin)
- `crates/assay-mcp-server/src/tools/policy_read.rs`
- `crates/assay-mcp-server/src/main.rs`
- `scripts/ci/check-mcp-policy-reader-routing.py`
- `scripts/ci/test-check-mcp-policy-reader-routing.sh`
- `CHANGELOG.md`

## Test plan
- [x] `cargo-semver-checks` minor vs published `5.2.0` is green
- [x] Config parser tests prove independence from `ASSAY_MCP_MAX_BYTES` and invalid → default
- [x] Policy-read helper tests: exact accept, limit+1 refuse, missing/directory mapping
- [x] Five-tool stdio `policy_ingest_limits`
- [x] Routing guard + self-test, including public-parser mutation
- [x] Required mutations bite and restore
- [ ] Independent review (not the writer)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an environment-based policy-file size limit, defaulting to 1,000,000 bytes.
  * Policy files at the exact byte limit are accepted; files exceeding it are rejected.
  * Message-size and policy-file limits are now configured independently.

* **Bug Fixes**
  * Invalid policy-limit settings now safely fall back to the default.
  * Startup reporting now displays the active policy-file limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->