### PR TITLE
docs(release): include adapter API in publish checks

### DIFF
--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -46,6 +46,7 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - `assay-registry`
   - `assay-canonical`
   - `assay-evidence`
+  - `assay-adapter-api`
   - `assay-core`
   - `assay-metrics`
   - `assay-policy`
@@ -57,7 +58,6 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - `assay-sim`
   - `assay-cli`
 - [ ] **Non-crates.io workspace members**: Confirm these remain `publish = false` unless a dedicated distribution freeze changes the contract:
-  - `assay-adapter-api` (historical crates.io versions exist, but the current release line does not publish it)
   - `assay-adapter-acp`
   - `assay-adapter-a2a`
   - `assay-adapter-ucp`


### PR DESCRIPTION
## Summary
- move assay-adapter-api into the Trusted Publishing checklist
- remove the stale claim that the current release line does not publish it

## Why
The manifest, public-crate policy, and publish_idempotent.sh all publish this crate before assay-core. The release runbook was the only surface still classifying it as private, which could skip its crates.io OIDC preflight before an irreversible release.

## Verification
- manifest-derived checklist comparison: 15 publishable / 7 private, exact match
- bash scripts/ci/check-public-crate-policy.sh
- pre-commit run --files docs/reference/release.md
- git diff --check

## Scope
Docs-only release prerequisite. No package, workflow, pin, tag, or publication change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release checklist to include `assay-adapter-api` in the packages requiring Trusted Publishing.
  * Removed it from the list of non-crates.io workspace members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Exact head
Reviewed and verified at 1b94147d7f1c85fd2a5258ffaa5ac5972ce23d3f.