### PR TITLE
mcp: reconcile outer-fallback contract truth (#2402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Telemetry follow-up for the #2391 outer-fallback surface: `tool_call_crash`
+  was removed; outer dispatch failures emit `tool_execution_error`. Remaining
+  `tool_call_start` / `tool_call_done` / `tool_call_timeout` events stay
+  value-free (no caller tool or policy strings). `tool_decision` is unchanged
+  and still out of this note's scope (#2402).
+
 ## [5.3.0] - 2026-08-18
 
 This release collects the post-`v5.2.0` main line: fail-closed machine stdout,

--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -487,6 +487,13 @@ mod claims_boundary_tests {
                 serde_json::json!({"allowed": false, "error": {"code": "E_INTERNAL"}}),
                 (false, true),
             ),
+            // Defence: an error object without `allowed` is still an MCP error. Production
+            // `ToolError::result` always sets both, so this row is the only independent
+            // witness for the `has_error` arm.
+            (
+                serde_json::json!({"error": {"code": "E_INTERNAL"}}),
+                (false, true),
+            ),
             // Report tools return data rather than a policy decision. Preserve the existing
             // decision telemetry while keeping their successful MCP result non-error.
             (serde_json::json!({"report": {}}), (false, false)),

--- a/crates/assay-mcp-server/tests/outer_fallback_contract.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_contract.rs
@@ -2,7 +2,8 @@
 
 use serde_json::Value;
 use std::fs;
-use std::process::{Command, Stdio};
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
 
 mod jsonrpc_conn;
 use jsonrpc_conn::Conn;
@@ -10,6 +11,7 @@ use jsonrpc_conn::Conn;
 const HEAD: &str = "HEAD_SENTINEL";
 const MID: &str = "MID_SENTINEL";
 const TAIL: &str = "TAIL_SENTINEL";
+const NOT_JSON: &str = "NOT_JSON_SENTINEL";
 
 fn spawn_server(timeout_ms: Option<&str>) -> (Conn, tempfile::TempDir) {
     let policy_root = tempfile::tempdir().expect("temporary policy root");
@@ -163,4 +165,76 @@ fn caller_cannot_fail_open_timeouts() {
 
     assert_fixed_failure(&response, "E_TIMEOUT", "Tool execution timed out");
     assert!(conn.shutdown().success());
+}
+
+/// Batch stdin with piped stderr. `Conn::send` only accepts JSON `Value`, so a
+/// non-JSON line has to go through this local spawn, not the shared harness.
+fn run_raw_session(lines: &[&str]) -> Output {
+    let policy_root = tempfile::tempdir().expect("temporary policy root");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(["--policy-root", policy_root.path().to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn assay-mcp-server");
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        for line in lines {
+            writeln!(stdin, "{line}").expect("write stdin line");
+        }
+    }
+    let output = child.wait_with_output().expect("wait for server");
+    drop(policy_root);
+    output
+}
+
+#[test]
+fn invalid_json_line_is_ignored_and_session_continues() {
+    let initialize = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "outer-fallback-contract", "version": "1"}
+        }
+    });
+    let output = run_raw_session(&[NOT_JSON, &initialize.to_string()]);
+    assert!(
+        output.status.success(),
+        "server failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains(NOT_JSON), "stdout reflected {NOT_JSON}");
+    let responses: Vec<Value> = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_str(line).expect("JSON-RPC response"))
+        .collect();
+    assert_eq!(responses.len(), 1, "stdout: {stdout}");
+    assert_eq!(responses[0]["id"], 1);
+    assert!(
+        responses[0].get("result").is_some(),
+        "initialize: {}",
+        responses[0]
+    );
+    assert!(
+        responses[0].get("error").is_none(),
+        "unexpected protocol error: {}",
+        responses[0]
+    );
+    for response in &responses {
+        assert_ne!(
+            response.pointer("/error/code"),
+            Some(&serde_json::json!(-32700)),
+            "parse error leaked: {response}"
+        );
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains(NOT_JSON), "stderr reflected {NOT_JSON}");
 }

--- a/crates/assay-mcp-server/tests/outer_fallback_docs.rs
+++ b/crates/assay-mcp-server/tests/outer_fallback_docs.rs
@@ -1,0 +1,43 @@
+//! Docs must describe the shipped outer-fallback contracts, not the former ones.
+
+#[test]
+fn mcp_api_states_invalid_json_lines_are_ignored() {
+    let doc = include_str!("../../../docs/reference/mcp-api.md");
+    assert!(
+        !doc.contains("Protocol-level errors (invalid JSON) return a JSON-RPC `error`."),
+        "mcp-api.md still claims a JSON-RPC error for invalid JSON"
+    );
+    assert!(
+        doc.contains("invalid JSON lines are ignored") && doc.contains("no JSON-RPC response"),
+        "mcp-api.md must state the ignore-and-continue contract"
+    );
+}
+
+#[test]
+fn mcp_api_states_malformed_arguments_are_fixed_e_internal() {
+    let doc = include_str!("../../../docs/reference/mcp-api.md");
+    assert!(doc.contains("E_INTERNAL"));
+    assert!(doc.contains("missing or malformed tool arguments"));
+}
+
+#[test]
+fn fail_safe_does_not_imply_a_configured_mcp_failure_policy() {
+    let doc = include_str!("../../../docs/concepts/fail-safe.md");
+    assert!(
+        !doc.contains("Verify that the configured failure policy was applied"),
+        "audit-trail still points at a removed MCP failure policy"
+    );
+    let mcp = doc
+        .split("### In the stdio MCP server")
+        .nth(1)
+        .expect("MCP subsection");
+    assert!(mcp.contains("Caller-supplied `arguments.on_error` has no authority"));
+}
+
+#[test]
+fn changelog_names_the_tool_execution_error_rename() {
+    let log = include_str!("../../../CHANGELOG.md");
+    let unreleased = log.split("## [5.3.0]").next().expect("Unreleased preface");
+    assert!(unreleased.contains("tool_call_crash"));
+    assert!(unreleased.contains("tool_execution_error"));
+}

--- a/docs/concepts/fail-safe.md
+++ b/docs/concepts/fail-safe.md
@@ -162,11 +162,15 @@ or raw internal errors. For example, a timeout result contains:
 Use structured results and logs to:
 1. Monitor error rates
 2. Debug configuration issues
-3. Verify that the configured failure policy was applied
+3. Verify that the fixed MCP fail-closed payload (`allowed: false`, `isError: true`) was published
 
 ---
 
 ## Decision Framework
+
+This tree applies only to `assay run` suite `settings.on_error`.
+It is not an MCP server setting. The stdio MCP server always fail-closes with
+a fixed payload; see [In the stdio MCP server](#in-the-stdio-mcp-server-assay-mcp-server).
 
 ```
 Is this a regulated/compliance environment?

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -4,7 +4,13 @@ The Assay MCP Server exposes tools for agent self-verification.
 
 ## Error Handling
 All tools return a standardized error structure if the operation cannot be performed (e.g., policy missing).
-Note: This is an **Application-Level Error**, returned within the JSON-RPC `result`. Protocol-level errors (invalid JSON) return a JSON-RPC `error`.
+Note: This is an **Application-Level Error**, returned within the JSON-RPC `result`.
+Stdio invalid JSON lines are ignored and produce no JSON-RPC response; the
+server continues to the next line. On a valid `tools/call`, missing or malformed tool arguments
+are not a distinct client error: they are published as the
+fixed outer-dispatch payload `E_INTERNAL` / `Tool execution failed` with
+`allowed: false` and `isError: true`. Unknown JSON-RPC methods remain protocol
+error `-32601`.
 
 ### Error Shape
 


### PR DESCRIPTION
## Summary
- Pin `classify_tool_result`'s `has_error` defence with an `error`-without-`allowed` row. The named surviving mutation was `is_error = explicit_allowed == Some(false)`.
- Document the shipped contracts: stdio invalid JSON is ignore-and-continue (no JSON-RPC `-32700`); missing or malformed tool arguments stay the fixed `E_INTERNAL` / `Tool execution failed` payload already proven by `caller_cannot_fail_open_handler_errors`.
- Narrow fail-safe corrections to Audit Trail item 3 and the Decision Framework (`assay run` `settings.on_error` only). The MCP subsection is unchanged. Unreleased names the `tool_call_crash` → `tool_execution_error` rename; 5.3.0 is not rewritten.

Fixes #2402.

## Type of Change
- [x] Documentation update
- [x] Tests (characterization + mutation-kill)

## Behavior
No production wire change. Invalid JSON on stdio remains ignore-and-continue. Malformed tool arguments remain fixed `E_INTERNAL`. `has_error` stays as defence.

## Non-Claims
- No MCP 2026-07-28 / `server/discover` / `LegacyProtocolVersion` change.
- No `tool_decision` redaction or length bound.
- No invalid-JSON wire change to `-32700`.
- No typed malformed-argument codes (would change the #2391 `E_INTERNAL` contract).
- No runner / #2478 files.
- Pretty-vs-compact inner `text` is not a public contract.
- stderr `json_parse_error` wording / `rid` values are not a stable contract.

## Test plan
Measured on worktree `/Users/roelschuurkes/wt-2402-mcp-contract-truth`, head `8a25b4b3f95562be25f11d2b8cbda9ca28d86c2e`, rustc `1.96.0 (ac68faa20 2026-05-25)`, original measured base `489ce78ad5850c67a08d8762dda8fee8f0196f61`; branch advanced conflict-free to current base `ae1ddb2fdfcf4666109217597d744c8c1937328b`.

- [x] `cargo test -p assay-mcp-server --lib claims_boundary_tests::tool_result_classification_separates_decision_from_mcp_error`
- [x] Mutation: drop `has_error ||` → new row `(false, false) != (false, true)`
- [x] `cargo test -p assay-mcp-server --test outer_fallback_docs` (RED on stale wording, then GREEN)
- [x] Docs mutations: restore old `mcp-api` Note, restore “configured failure policy”, delete Unreleased rename sentence → each fails its guard
- [x] `cargo test -p assay-mcp-server --test outer_fallback_contract` (GREEN characterization; `-32700` mutation adds a second stdout line)
- [x] `cargo test -p assay-mcp-server --test protocol_negotiation_e2e` (untouched; drift alarm)
- [x] `cargo test -p assay-mcp-server`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`
- [x] `git diff --check`

Allowlist is six files. `tool_decision.rs`, `jsonrpc_conn`, `protocol_negotiation_e2e.rs`, and runner paths are untouched.

Made with [Cursor](https://cursor.com)
