### PR TITLE
fix(deps): update h2 past RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4887,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1615,7 +1615,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3105,7 +3105,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4410,7 +4410,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4468,7 +4468,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4882,7 +4882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5057,7 +5057,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5070,7 +5070,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5841,7 +5841,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -641,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1819,7 +1819,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2135,7 +2135,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2193,7 +2193,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2624,7 +2624,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3056,7 +3056,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

- update root `h2` from 0.4.13 to 0.4.16
- update fuzz `h2` from 0.4.15 to 0.4.16
- replace yanked transitive `spin` 0.10.0 with compatible 0.10.1
- retain Cargo 1.89's generated compatible `windows-sys` edge selections rather than manually rewriting the lockfiles

Closes #2505.

## Why

`RUSTSEC-2026-0258` blocks the required dependency-security job for every PR. The patched `h2` release is 0.4.16.

## Cargo resolver note

The lockfiles were produced from base `489ce78ad5850c67a08d8762dda8fee8f0196f61` with Cargo 1.89.0:

```bash
cargo +1.89.0 update -p h2@0.4.13 --precise 0.4.16
cargo +1.89.0 update -p spin@0.10.0 --precise 0.10.1
cargo +1.89.0 update --manifest-path fuzz/Cargo.toml \
  -p h2@0.4.15 --precise 0.4.16
```

Cargo also reselected semver-compatible `windows-sys` dependency edges without changing the parent package versions. That generated collateral is retained and verified cross-platform. It is not presented as an `h2` dependency change.

A prior head tried to remove this collateral via repeated no-op `--precise` updates. Independent review proved that the open Cargo resolver behavior tracked by rust-lang/cargo#5529 and #16802 alternates those edge selections rather than reaching a byte-stable fixed point. This head therefore keeps the reproducible one-pass Cargo output and does not manually edit either lockfile.

## Scope

- `Cargo.lock`
- `fuzz/Cargo.lock`

No manifest constraint, feature, source, public contract, or workflow changes.

## Verification

Measured on `d0f9c4e5a97a36298b1ace890dcb9bac8e1b3f0d` in `/tmp/assay-2505-h2` with Cargo 1.89.0/1.96.0:

- RED: `cargo-deny check advisories bans licenses sources` -> exit 1, `RUSTSEC-2026-0258`
- RED: isolated root and fuzz `cargo-audit` -> exit 1, `RUSTSEC-2026-0258`
- GREEN: `cargo-deny check advisories bans licenses sources`
- GREEN: `scripts/ci/cargo-audit-with-isolated-db.sh`
- GREEN: `scripts/ci/cargo-audit-with-isolated-db.sh --file fuzz/Cargo.lock`
- GREEN: root and fuzz `cargo metadata --locked`
- GREEN: `cargo check --locked --workspace --exclude assay-ebpf --exclude assay-it --exclude assay-monitor`
- GREEN: `cargo fmt --all -- --check`
- GREEN: `git diff --check`
- pre-commit and pre-push hooks pass, including workspace clippy and Linux cross-target compile

Mutation proof:

- root `h2` restored to 0.4.13 in a temporary lock copy -> exit 1, `RUSTSEC-2026-0258`
- fuzz `h2` restored to 0.4.15 in a temporary lock copy -> exit 1, `RUSTSEC-2026-0258`

## Non-claims

- no broad package-version refresh
- no claim that `windows-sys` edge reselection is required by `h2`
- no claim that allowed RustSec warnings are fixed
- no source-level runtime behavior change
