### PR TITLE
feat(ci): prove published release golden path

### DIFF
--- a/.github/workflows/published-release-golden-path.yml
+++ b/.github/workflows/published-release-golden-path.yml
@@ -1,0 +1,51 @@
+name: Published Release Golden Path
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Exact stable release tag to exercise
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Exact stable release tag to exercise (vX.Y.Z)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  linux-x86_64:
+    name: Linux x86_64 install to verified evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout the exact harness
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Exercise the attested published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RUN_ROOT: ${{ runner.temp }}/assay-published-release-golden-path
+        run: |
+          set -euo pipefail
+          bash scripts/ci/published-release-golden-path.sh \
+            --release-tag "$RELEASE_TAG" \
+            --harness-sha "$GITHUB_SHA" \
+            --run-root "$RUN_ROOT"
+
+      - name: Retain the replayable journey evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: published-release-golden-path-${{ inputs.release_tag }}-${{ github.sha }}
+          path: ${{ runner.temp }}/assay-published-release-golden-path/results/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/published-release-golden-path.yml
+++ b/.github/workflows/published-release-golden-path.yml
@@ -1,4 +1,4 @@
-name: Published Release Golden Path
+name: Published Release Verification
 
 on:
   workflow_call:
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   linux-x86_64:
-    name: Linux x86_64 install to verified evidence
+    name: Linux x86_64 post-publication journey
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -39,6 +39,8 @@ jobs:
           bash scripts/ci/published-release-golden-path.sh \
             --release-tag "$RELEASE_TAG" \
             --harness-sha "$GITHUB_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
             --run-root "$RUN_ROOT"
 
       - name: Retain the replayable journey evidence

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -755,6 +755,20 @@ jobs:
     with:
       version: ${{ needs.release-contract.outputs.version }}
 
+  # The release must exist before this job starts: the path intentionally downloads and verifies
+  # the published bytes rather than reusing build artifacts from this workflow.
+  published-release-golden-path:
+    name: Gate the published release journey
+    needs: [release-contract, release]
+    if: >-
+      (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc') && !contains(github.ref, '-beta')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.version, 'v') && !contains(github.event.inputs.version, '-rc') && !contains(github.event.inputs.version, '-beta'))
+    permissions:
+      contents: read
+    uses: ./.github/workflows/published-release-golden-path.yml
+    with:
+      release_tag: ${{ needs.release-contract.outputs.version }}
+
   record-mcp-registry-result:
     name: Record MCP Registry result
     needs: [release-contract, release, publish-mcp-registry]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -755,10 +755,10 @@ jobs:
     with:
       version: ${{ needs.release-contract.outputs.version }}
 
-  # The release must exist before this job starts: the path intentionally downloads and verifies
-  # the published bytes rather than reusing build artifacts from this workflow.
+  # This is deliberately post-publication verification: it downloads the public bytes rather than
+  # reusing build artifacts. A failure turns the release workflow red but cannot unpublish assets.
   published-release-golden-path:
-    name: Gate the published release journey
+    name: Verify the published release journey
     needs: [release-contract, release]
     if: >-
       (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc') && !contains(github.ref, '-beta')) ||

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,7 +162,7 @@ repos:
         entry: bash scripts/ci/test-published-release-golden-path-contract.sh
         language: system
         pass_filenames: false
-        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|release_attestation_enforce\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|bounded_download\.py|test_bounded_download\.py|release_attestation_enforce\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
 
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,6 +157,13 @@ repos:
         stages: [pre-push]
         files: ^(Cargo\.toml|scripts/docs/generate-agent-golden-path\.py|scripts/ci/(read-assay-release-tag\.sh|test-agent-golden-path-skill(-(optimization|hardening)\.sh|\.py)|test-golden-path-mock-bounds\.py|test-generate-agent-golden-path-check\.py|lib/(golden-path-fixture-staging\.sh|workspace_version\.py))|\.github/assay-release-tag|docs/generated/agent-golden-path\.json|docs/guides/agent-golden-path\.md|\.(agents|claude)/skills/assay-golden-path/SKILL\.md|\.claude-plugin/.*|packaging/claude-plugin/.*|packaging/agent-plugin/.*|\.github/workflows/kernel-matrix\.yml|\.gitignore|\.gitattributes|\.pre-commit-config\.yaml)$
 
+      - id: published-release-golden-path-contract
+        name: Published-release golden-path contract
+        entry: bash scripts/ci/test-published-release-golden-path-contract.sh
+        language: system
+        pass_filenames: false
+        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
+
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test
         entry: bash scripts/ci/test-claude-plugin-install.sh --self-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,7 +162,7 @@ repos:
         entry: bash scripts/ci/test-published-release-golden-path-contract.sh
         language: system
         pass_filenames: false
-        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|release_attestation_enforce\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
 
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,7 +162,7 @@ repos:
         entry: bash scripts/ci/test-published-release-golden-path-contract.sh
         language: system
         pass_filenames: false
-        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|bounded_download\.py|test_bounded_download\.py|release_attestation_enforce\.sh|release_archive_inventory\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/(published-release-golden-path\.sh|published_release_proxy_phase\.py|test_published_release_proxy_phase\.py|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|bounded_download\.py|test_bounded_download\.py|release_attestation_enforce\.sh|release_archive_inventory\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
 
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,7 +162,7 @@ repos:
         entry: bash scripts/ci/test-published-release-golden-path-contract.sh
         language: system
         pass_filenames: false
-        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|bounded_download\.py|test_bounded_download\.py|release_attestation_enforce\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
+        files: ^(scripts/ci/(published-release-golden-path\.sh|check-published-release-golden-path-contract\.py|test-published-release-golden-path-contract\.sh|safe_extract_release_archive\.py|test_safe_extract_release_archive\.py|bounded_download\.py|test_bounded_download\.py|release_attestation_enforce\.sh|release_archive_inventory\.sh|test-release-attestation-enforce\.sh|fixtures/published-release-golden-path/.*)|examples/privileged-action-gate/(mock_github_mcp\.py|baseline-approved\.json|policies/no-allowance\.yaml)|\.github/workflows/(published-release-golden-path|release)\.yml|\.pre-commit-config\.yaml)$
 
       - id: claude-plugin-install-workflow-self-test
         name: Claude plugin install workflow self-test

--- a/scripts/ci/bounded_download.py
+++ b/scripts/ci/bounded_download.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Atomically download a public artifact without exceeding a byte ceiling."""
+
+from __future__ import annotations
+
+import pathlib
+import urllib.request
+
+
+class DownloadRejected(ValueError):
+    pass
+
+
+def download(url: str, destination: pathlib.Path, *, max_bytes: int) -> None:
+    if max_bytes <= 0:
+        raise ValueError("download ceiling must be positive")
+    if destination.exists():
+        raise DownloadRejected("download destination already exists")
+    scratch = destination.with_name(f".{destination.name}.downloading")
+    if scratch.exists():
+        raise DownloadRejected("download scratch destination already exists")
+
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/octet-stream", "User-Agent": "assay-release-verifier"},
+    )
+    try:
+        # The driver validates the exact GitHub release URL before this call.
+        with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310
+            declared = response.headers.get("Content-Length")
+            if declared is not None and (not declared.isdigit() or int(declared) > max_bytes):
+                raise DownloadRejected("download content length exceeds ceiling")
+            total = 0
+            with scratch.open("xb") as output:
+                while chunk := response.read(min(65536, max_bytes - total + 1)):
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise DownloadRejected("download stream exceeds ceiling")
+                    output.write(chunk)
+            if total == 0:
+                raise DownloadRejected("download yielded no bytes")
+        scratch.replace(destination)
+    except BaseException:
+        scratch.unlink(missing_ok=True)
+        raise

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -223,6 +223,10 @@ def validate_contract(
             "external release-tag source binding drifted"
         ),
         'SOURCE_DIGEST="$source_digest" \\': "attestation source digest is not externally bound",
+        '[[ "$source_type" == "commit" && "$source_digest" =~ ^[0-9a-f]{40}$ ]] \\': (
+            "release tag must peel to a commit before attestation verification"
+        ),
+        'OUT_RAW_DIR="$results/attestation-raw" \\': "raw attestation inputs must be retained",
         'downloads="$results/release-assets"': "release inputs must be retained with the run artifact",
         'download_release_asset "$cli_asset" 67108864': "CLI compressed-size ceiling drifted",
         'download_release_asset "$mcp_asset" 33554432': "MCP compressed-size ceiling drifted",

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -98,6 +98,13 @@ def validate_manifest(
     ]
     if paths != expected:
         problems.append("harness manifest must list exactly the reviewed harness inputs")
+    executable_paths = [
+        row.get("path")
+        for row in files
+        if isinstance(row, dict) and row.get("executable") is True
+    ]
+    if executable_paths != ["scripts/ci/release_archive_inventory.sh"]:
+        problems.append("harness executable surface drifted")
 
 
 def validate_contract(

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -188,7 +188,7 @@ def validate_contract(
         "external tag source": '"$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}"',
         "reviewed attestation verifier": 'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"',
         "compressed asset ceiling": "release asset exceeds compressed-size ceiling",
-        "bounded archive extractor": '"$PYTHON_BIN" "$ROOT/scripts/ci/safe_extract_release_archive.py"',
+        "bounded archive extractor": "from safe_extract_release_archive import extract_archive",
         "retained release inputs": 'downloads="$results/release-assets"',
         "disposable HOME": 'export HOME="$run_root/home"',
         "restricted PATH": 'export PATH="$install_root/bin:/usr/bin:/bin"',
@@ -226,8 +226,8 @@ def validate_contract(
         'downloads="$results/release-assets"': "release inputs must be retained with the run artifact",
         'download_release_asset "$cli_asset" 67108864': "CLI compressed-size ceiling drifted",
         'download_release_asset "$mcp_asset" 33554432': "MCP compressed-size ceiling drifted",
-        '"$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728': "CLI safe-extraction ceiling drifted",
-        '"$downloads/$mcp_asset" "$mcp_extract" --max-decoded-bytes 67108864': "MCP safe-extraction ceiling drifted",
+        'safe_extract "$downloads/$cli_asset" "$cli_extract" 134217728': "CLI safe-extraction ceiling drifted",
+        'safe_extract "$downloads/$mcp_asset" "$mcp_extract" 67108864': "MCP safe-extraction ceiling drifted",
         '--bundle-out "$bundle" --run-id "published-release-${workflow_run_id}-${workflow_run_attempt}" \\': (
             "evidence run id is not bound to the workflow invocation"
         ),
@@ -243,8 +243,8 @@ def validate_contract(
     else:
         verifier = driver_lines.index(verifier_line)
         product_boundaries = [
-            '"$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728',
-            '"$downloads/$mcp_asset" "$mcp_extract" --max-decoded-bytes 67108864',
+            'safe_extract "$downloads/$cli_asset" "$cli_extract" 134217728',
+            'safe_extract "$downloads/$mcp_asset" "$mcp_extract" 67108864',
             'cp "${cli_candidates[0]}" "$install_root/bin/assay"',
             'cp "${mcp_candidates[0]}" "$install_root/bin/assay-mcp-server"',
             'run_capture "assay-version" 0 "$results/assay-version.txt" "$results/assay-version.stderr" assay version',

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -42,6 +42,31 @@ def mapping_block(text: str, key: str, indent: int, problems: list[str]) -> str:
     return "\n".join(lines[start:end])
 
 
+def named_step_lines(text: str, name: str, problems: list[str]) -> list[str]:
+    marker = f"      - name: {name}"
+    lines = text.splitlines()
+    starts = [index for index, line in enumerate(lines) if line == marker]
+    if len(starts) != 1:
+        problems.append(f"expected exactly one workflow step named {name!r}")
+        return []
+    start = starts[0]
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("      - name:"):
+            end = index
+            break
+    return active_lines("\n".join(lines[start:end]))
+
+
+def lines_between(text: str, start_marker: str, end_marker: str, problems: list[str]) -> list[str]:
+    if text.count(start_marker) != 1 or text.count(end_marker) != 1:
+        problems.append(f"expected unique contract block markers: {start_marker!r}, {end_marker!r}")
+        return []
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    return active_lines(text[start:end])
+
+
 def validate_manifest(
     path: Path,
     source_root: Path,
@@ -119,6 +144,9 @@ def validate_contract(
         workflow_text = workflow.read_text(encoding="utf-8")
         release_text = release_workflow.read_text(encoding="utf-8")
         driver_text = driver.read_text(encoding="utf-8")
+        attestation_text = (source_root / "scripts/ci/release_attestation_enforce.sh").read_text(
+            encoding="utf-8"
+        )
     except OSError as error:
         return [f"contract input is missing: {error}"]
 
@@ -132,6 +160,24 @@ def validate_contract(
         "workflow must execute the reviewed driver",
         problems,
     )
+    expected_exercise_step = [
+        "- name: Exercise the attested published release",
+        "shell: bash",
+        "env:",
+        "GH_TOKEN: ${{ github.token }}",
+        "RELEASE_TAG: ${{ inputs.release_tag }}",
+        "RUN_ROOT: ${{ runner.temp }}/assay-published-release-golden-path",
+        "run: |",
+        "set -euo pipefail",
+        "bash scripts/ci/published-release-golden-path.sh \\",
+        '--release-tag "$RELEASE_TAG" \\',
+        '--harness-sha "$GITHUB_SHA" \\',
+        '--workflow-run-id "$GITHUB_RUN_ID" \\',
+        '--workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \\',
+        '--run-root "$RUN_ROOT"',
+    ]
+    if named_step_lines(workflow_text, "Exercise the attested published release", problems) != expected_exercise_step:
+        problems.append("workflow must execute only the exact reviewed driver invocation")
     require(workflow_text, "--harness-sha \"$GITHUB_SHA\"", "workflow must bind the harness head", problems)
     require(workflow_text, "--workflow-run-id \"$GITHUB_RUN_ID\"", "workflow must bind its run id", problems)
     require(
@@ -207,6 +253,31 @@ def validate_contract(
         problems.append("release transaction must describe this as post-publication verification")
 
     driver_lines = active_lines(driver_text)
+    expected_attestation_block = [
+        'signer_workflow="$REPO/.github/workflows/release.yml"',
+        'if ! GH_BIN="$GH_BIN" JQ_BIN="$JQ_BIN" \\',
+        'ASSETS_DIR="$downloads" \\',
+        'OUT_SUMMARY="$results/attestation-summary.json" \\',
+        'OUT_RAW_DIR="$results/attestation-raw" \\',
+        'REPO="$REPO" \\',
+        'SIGNER_WORKFLOW="$signer_workflow" \\',
+        'SOURCE_REF="" \\',
+        'SOURCE_DIGEST="$source_digest" \\',
+        'bash "$harness_root/scripts/ci/release_attestation_enforce.sh" \\',
+        '>"$results/attestation-verify.log" 2>&1; then',
+        'cat "$results/attestation-verify.log" >&2',
+        'fail "reviewed release attestation verifier rejected the published assets"',
+        "fi",
+        'record_command "verify-release-attestations" 0 "$harness_root/scripts/ci/release_attestation_enforce.sh"',
+    ]
+    attestation_block = lines_between(
+        driver_text,
+        "# Execute reviewed harness code, not a script carried inside a mutable release asset.",
+        'cli_extract="$run_root/cli-extract"',
+        problems,
+    )
+    if attestation_block != expected_attestation_block:
+        problems.append("driver attestation execution block drifted")
     required_driver_fragments = {
         "exact stable tag": "release tag must be an exact stable vX.Y.Z tag",
         "fresh run root": "run root already exists; refusing to reuse prior evidence",
@@ -267,6 +338,34 @@ def validate_contract(
             problems.append(message)
     if driver_lines.count('PYTHONPATH="$harness_root/scripts/ci" "$PYTHON_BIN" -c \\') != 2:
         problems.append("bounded helper execution drifted")
+    semantic_driver_lines = {
+        '[[ "$(tr -d \'\\r\\n\' <"$results/mcp-version.txt")" == "assay-mcp-server $version" ]] \\': (
+            "exact MCP version comparison drifted"
+        ),
+        'record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"': (
+            "proxy command provenance no longer uses the executed argv"
+        ),
+        'for pattern, expected in (("release-assets/*.tar.gz", 2), ("attestation-raw/*.json", 2)):': (
+            "retained trust-input count enforcement drifted"
+        ),
+        '[[ "$asset_url" == "https://github.com/${REPO}/releases/download/${release_tag}/${asset_name}" ]] \\': (
+            "release asset URL binding drifted"
+        ),
+    }
+    for line, message in semantic_driver_lines.items():
+        if driver_lines.count(line) != 1:
+            problems.append(message)
+    attestation_lines = active_lines(attestation_text)
+    for line, message in {
+        '--signer-workflow "$SIGNER_WORKFLOW"': "attestation signer binding drifted",
+        '--source-digest "$SOURCE_DIGEST"': "attestation source digest binding drifted",
+        '--deny-self-hosted-runners': "attestation hosted-runner policy drifted",
+        'any(.[]; any((.verificationResult.statement.subject // [])[]?; .digest.sha256? == $digest))': (
+            "attestation local-subject digest binding drifted"
+        ),
+    }.items():
+        if attestation_lines.count(line) != 1:
+            problems.append(message)
     if any("verify-offline.sh" in line or "release-proof-kit" in line for line in driver_lines):
         problems.append("driver must not execute or trust code carried by the release proof kit")
     verifier_line = 'bash "$harness_root/scripts/ci/release_attestation_enforce.sh" \\'

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -17,6 +17,31 @@ def require(text: str, needle: str, message: str, problems: list[str]) -> None:
         problems.append(message)
 
 
+def active_lines(text: str) -> list[str]:
+    """Return executable/config lines, excluding blank and comment-only lines."""
+    return [line.strip() for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def mapping_block(text: str, key: str, indent: int, problems: list[str]) -> str:
+    marker = f"{' ' * indent}{key}:"
+    lines = text.splitlines()
+    starts = [index for index, line in enumerate(lines) if line == marker]
+    if len(starts) != 1:
+        problems.append(f"expected exactly one {key} mapping, found {len(starts)}")
+        return ""
+    start = starts[0]
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line and not line.startswith(" "):
+            end = index
+            break
+        if line.startswith(" " * indent) and not line.startswith(" " * (indent + 1)):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
 def validate_manifest(path: Path, source_root: Path, problems: list[str]) -> None:
     try:
         manifest = json.loads(path.read_text(encoding="utf-8"))
@@ -82,6 +107,13 @@ def validate_contract(
         problems,
     )
     require(workflow_text, "--harness-sha \"$GITHUB_SHA\"", "workflow must bind the harness head", problems)
+    require(workflow_text, "--workflow-run-id \"$GITHUB_RUN_ID\"", "workflow must bind its run id", problems)
+    require(
+        workflow_text,
+        "--workflow-run-attempt \"$GITHUB_RUN_ATTEMPT\"",
+        "workflow must bind its run attempt",
+        problems,
+    )
     require(workflow_text, "if: always()", "workflow must retain partial failure evidence", problems)
     require(workflow_text, "retention-days: 30", "workflow must pin artifact retention", problems)
     require(workflow_text, "if-no-files-found: error", "missing replay evidence must fail closed", problems)
@@ -105,7 +137,7 @@ def validate_contract(
     require(
         release_text,
         "uses: ./.github/workflows/published-release-golden-path.yml",
-        "release transaction must call the published-release gate",
+        "release transaction must call published-release verification",
         problems,
     )
     require(
@@ -117,23 +149,53 @@ def validate_contract(
     require(
         release_text,
         "needs: [release-contract, release]",
-        "published-release gate must wait until release publication completes",
+        "published-release verification must wait until release publication completes",
         problems,
     )
+    caller = mapping_block(release_text, "published-release-golden-path", 2, problems)
+    caller_lines = active_lines(caller)
+    reusable_call = "uses: ./.github/workflows/published-release-golden-path.yml"
+    if active_lines(release_text).count(reusable_call) != 1:
+        problems.append("release transaction must contain exactly one published-release workflow caller")
+    if reusable_call not in caller_lines:
+        problems.append("published-release job must be the reusable workflow caller")
+    if caller_lines.count("needs: [release-contract, release]") != 1:
+        problems.append("published-release job must uniquely wait for release publication")
+    if any(line.startswith("continue-on-error:") for line in caller_lines):
+        problems.append("release caller must not ignore failed published-release verification")
+    if caller_lines.count("if: >-") != 1:
+        problems.append("published-release job must have exactly one stable-release condition")
+    for condition in (
+        "startsWith(github.ref, 'refs/tags/v')",
+        "github.event_name == 'workflow_dispatch'",
+        "!contains(github.ref, '-rc')",
+        "!contains(github.ref, '-beta')",
+        "!contains(github.event.inputs.version, '-rc')",
+        "!contains(github.event.inputs.version, '-beta')",
+    ):
+        if condition not in caller:
+            problems.append(f"published-release caller condition lost: {condition}")
+    if caller_lines.count("release_tag: ${{ needs.release-contract.outputs.version }}") != 1:
+        problems.append("published-release caller must pass the validated version exactly once")
+    if caller_lines.count("name: Verify the published release journey") != 1:
+        problems.append("release transaction must describe this as post-publication verification")
 
+    driver_lines = active_lines(driver_text)
     required_driver_fragments = {
         "exact stable tag": "release tag must be an exact stable vX.Y.Z tag",
         "fresh run root": "run root already exists; refusing to reuse prior evidence",
-        "proof-kit API digest": "proof-kit digest differs from the release API",
-        "canonical attestation verifier": (
-            '"$kit_root/verify-offline.sh" --assets-dir "$downloads" '
-            '>"$results/attestation-verify.log" 2>&1'
-        ),
+        "stable published release": "release tag is still draft or prerelease",
+        "external tag source": '"$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}"',
+        "reviewed attestation verifier": 'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"',
+        "compressed asset ceiling": "release asset exceeds compressed-size ceiling",
+        "bounded archive extractor": '"$PYTHON_BIN" "$ROOT/scripts/ci/safe_extract_release_archive.py"',
+        "retained release inputs": 'downloads="$results/release-assets"',
         "disposable HOME": 'export HOME="$run_root/home"',
         "restricted PATH": 'export PATH="$install_root/bin:/usr/bin:/bin"',
         "installed CLI resolution": '"$(command -v assay)" == "$install_root/bin/assay"',
         "installed MCP resolution": '"$(command -v assay-mcp-server)" == "$install_root/bin/assay-mcp-server"',
         "harness head": '"head_sha": harness_sha',
+        "workflow run binding": '"workflow_run_id": workflow_run_id',
         "separate release provenance": '"release": {',
         "separate harness provenance": '"harness": {',
         "produced bundle": 'bundle="$results/produced.bundle.tar.gz"',
@@ -141,18 +203,67 @@ def validate_contract(
         "verify produced bundle": 'assay evidence verify-privileged-mcp-action "$bundle" --format json',
         "tamper failure code": 'reason_code == "E_EVIDENCE_INTEGRITY"',
         "artifact manifest": '"assay.published_release_golden_path.artifacts.v1"',
+        "claim ceiling": "the harness is not a shipped release asset",
     }
     for label, fragment in required_driver_fragments.items():
         require(driver_text, fragment, f"driver lost {label}", problems)
     if "|| true" in driver_text or "set +e" in driver_text:
         problems.append("driver suppresses a failure instead of recording its exact status")
-    verifier = driver_text.find(
-        '"$kit_root/verify-offline.sh" --assets-dir "$downloads" '
-        '>"$results/attestation-verify.log" 2>&1'
-    )
-    first_product_call = driver_text.find('run_capture "assay-version"')
-    if verifier < 0 or first_product_call < 0 or verifier > first_product_call:
-        problems.append("release attestations must verify before the first Assay invocation")
+    exact_active_lines = {
+        '[[ "$release_tag" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]] || fail "release tag must be an exact stable vX.Y.Z tag"': (
+            "stable release-tag validation drifted"
+        ),
+        '"$JQ_BIN" -e \'.draft == false and .prerelease == false\' "$release_api" >/dev/null \\': (
+            "published release-state validation drifted"
+        ),
+        '[[ "$actual_digest" == "$api_digest" ]] || fail "downloaded asset digest differs: $asset_name"': (
+            "downloaded asset digest comparison drifted"
+        ),
+        '"$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}" >"$tag_ref"': (
+            "external release-tag source binding drifted"
+        ),
+        'SOURCE_DIGEST="$source_digest" \\': "attestation source digest is not externally bound",
+        'downloads="$results/release-assets"': "release inputs must be retained with the run artifact",
+        'download_release_asset "$cli_asset" 67108864': "CLI compressed-size ceiling drifted",
+        'download_release_asset "$mcp_asset" 33554432': "MCP compressed-size ceiling drifted",
+        '"$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728': "CLI safe-extraction ceiling drifted",
+        '"$downloads/$mcp_asset" "$mcp_extract" --max-decoded-bytes 67108864': "MCP safe-extraction ceiling drifted",
+        '--bundle-out "$bundle" --run-id "published-release-${workflow_run_id}-${workflow_run_attempt}" \\': (
+            "evidence run id is not bound to the workflow invocation"
+        ),
+    }
+    for line, message in exact_active_lines.items():
+        if driver_lines.count(line) != 1:
+            problems.append(message)
+    if any("verify-offline.sh" in line or "release-proof-kit" in line for line in driver_lines):
+        problems.append("driver must not execute or trust code carried by the release proof kit")
+    verifier_line = 'bash "$ROOT/scripts/ci/release_attestation_enforce.sh" \\'
+    if driver_lines.count(verifier_line) != 1:
+        problems.append("driver must execute the reviewed attestation verifier exactly once")
+    else:
+        verifier = driver_lines.index(verifier_line)
+        product_boundaries = [
+            '"$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728',
+            '"$downloads/$mcp_asset" "$mcp_extract" --max-decoded-bytes 67108864',
+            'cp "${cli_candidates[0]}" "$install_root/bin/assay"',
+            'cp "${mcp_candidates[0]}" "$install_root/bin/assay-mcp-server"',
+            'run_capture "assay-version" 0 "$results/assay-version.txt" "$results/assay-version.stderr" assay version',
+        ]
+        for boundary in product_boundaries:
+            if boundary not in driver_lines or verifier > driver_lines.index(boundary):
+                problems.append(f"release attestations must precede product use: {boundary}")
+    exact_assignments = [
+        'cli_asset="assay-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"',
+        'mcp_asset="assay-mcp-server-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"',
+    ]
+    for assignment in exact_assignments:
+        if driver_lines.count(assignment) != 1:
+            problems.append(f"Linux x86_64 product asset assignment drifted: {assignment}")
+    inspect_command = 'assay evidence show --format json -- "$bundle"'
+    if driver_lines.count(inspect_command) != 1:
+        problems.append("driver must inspect the same bundle it produced exactly once")
+    if sum("assay evidence show" in line for line in driver_lines) != 1:
+        problems.append("driver contains an alternate evidence-inspection target")
     required_artifacts = [
         "run-pin.json",
         "commands.ndjson",
@@ -162,6 +273,9 @@ def validate_contract(
         "verify.json",
         "tamper-verify.json",
         "enforcement.sarif",
+        "release-api.json",
+        "tag-ref.json",
+        "attestation-summary.json",
     ]
     for name in required_artifacts:
         if f'"{name}"' not in driver_text:

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -297,18 +297,9 @@ def validate_contract(
         'call_request=\'{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}\'',
         "proxy_status=0",
         'printf \'%s\\n%s\\n\' "$init_request" "$call_request" \\',
-        '| "$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \\',
-        '--mcp-bin "$install_root/bin/assay-mcp-server" \\',
-        '--python-bin "$PYTHON_BIN" \\',
-        '--fixture "$fixture_dir/mock_github_mcp.py" \\',
-        '--policy "$fixture_dir/policies/no-allowance.yaml" \\',
-        '--declared-manifest "$fixture_dir/baseline-approved.json" \\',
-        '--decisions "$decisions" \\',
-        '--observations "$observations" \\',
-        '--commands "$commands_file" \\',
-        '--stdout "$results/proxy.jsonl" \\',
-        '--stderr "$results/proxy.stderr" \\',
-        "--timeout-seconds 60 || proxy_status=$?",
+        '| (cd "$results" && \\',
+        '"$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \\',
+        "--timeout-seconds 60) || proxy_status=$?",
     ]
     proxy_block = lines_between(
         driver_text,
@@ -330,7 +321,6 @@ def validate_contract(
         'run_capture "mcp-version" 0 "$results/mcp-version.txt" "$results/mcp-version.stderr" assay-mcp-server --version',
         '[[ "$(tr -d \'\\r\\n\' <"$results/mcp-version.txt")" == "assay-mcp-server $version" ]] \\',
         '|| fail "assay-mcp-server version differs from pinned release"',
-        '--mcp-bin "$install_root/bin/assay-mcp-server" \\',
         'assay-mcp-server enforcement-sarif --input "$decisions" --output "$results/enforcement.sarif"',
     ]
     mcp_binary_surface = [line for line in driver_lines if "assay-mcp-server" in line]

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 from pathlib import Path, PurePosixPath
 
 
@@ -65,6 +66,41 @@ def lines_between(text: str, start_marker: str, end_marker: str, problems: list[
     start = text.index(start_marker)
     end = text.index(end_marker, start)
     return active_lines(text[start:end])
+
+
+def shell_control_depth_before(text: str, marker: str, problems: list[str]) -> int:
+    """Return lexical shell control depth before a unique executable marker."""
+    if text.count(marker) != 1:
+        problems.append(f"expected unique shell control marker: {marker!r}")
+        return -1
+
+    target_line = text[: text.index(marker)].count("\n")
+    stack: list[str] = []
+    heredoc_end: str | None = None
+    for raw_line in text.splitlines()[:target_line]:
+        stripped = raw_line.strip()
+        if heredoc_end is not None:
+            if stripped == heredoc_end:
+                heredoc_end = None
+            continue
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if re.match(r"^(fi|done|esac|\})(?:\s|$)", stripped):
+            if stack:
+                stack.pop()
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\(\)\s*\{$", stripped):
+            stack.append("function")
+        elif re.match(r"^(if|for|while|until|case)\b", stripped):
+            stack.append(stripped.split(maxsplit=1)[0])
+        elif re.search(r"(?:^|\|\||&&)\s*\{\s*$", stripped):
+            stack.append("group")
+
+        heredoc = re.search(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?", stripped)
+        if heredoc:
+            heredoc_end = heredoc.group(1)
+
+    return len(stack)
 
 
 def validate_manifest(
@@ -314,6 +350,26 @@ def validate_contract(
     )
     if proxy_block != expected_proxy_block:
         problems.append("proxy execution and provenance block drifted")
+    if shell_control_depth_before(driver_text, "proxy_status=0", problems) != 0:
+        problems.append("proxy execution block must run at top level")
+    proxy_tokens = ("proxy-enforce", "proxy_argv", "proxy_status")
+    expected_proxy_surface = [
+        line
+        for line in expected_proxy_block
+        + [
+            '[[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"',
+            '[[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"',
+            '[[ -s "$observations" ]] || fail "proxy-enforce produced no denied-call observation"',
+        ]
+        if any(token in line for token in proxy_tokens)
+    ]
+    proxy_surface = [
+        line
+        for line in driver_lines
+        if any(token in line for token in proxy_tokens)
+    ]
+    if proxy_surface != expected_proxy_surface:
+        problems.append("driver has an alternate proxy execution or provenance path")
     required_driver_fragments = {
         "exact stable tag": "release tag must be an exact stable vX.Y.Z tag",
         "fresh run root": "run root already exists; refusing to reuse prior evidence",

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -278,6 +278,42 @@ def validate_contract(
     )
     if attestation_block != expected_attestation_block:
         problems.append("driver attestation execution block drifted")
+    expected_version_block = [
+        'run_capture "mcp-version" 0 "$results/mcp-version.txt" "$results/mcp-version.stderr" assay-mcp-server --version',
+        '[[ "$(tr -d \'\\r\\n\' <"$results/mcp-version.txt")" == "assay-mcp-server $version" ]] \\',
+        '|| fail "assay-mcp-server version differs from pinned release"',
+    ]
+    version_block = lines_between(
+        driver_text,
+        'run_capture "mcp-version"',
+        'pushd "$session_root"',
+        problems,
+    )
+    if version_block != expected_version_block:
+        problems.append("exact MCP version execution block drifted")
+    expected_proxy_block = [
+        "proxy_status=0",
+        "proxy_argv=(",
+        "assay-mcp-server proxy-enforce",
+        '--upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py"',
+        '--enforce-policy "$fixture_dir/policies/no-allowance.yaml"',
+        '--declared-mcp-manifest "$fixture_dir/baseline-approved.json"',
+        '--enforcement-decision-out "$decisions"',
+        '--denied-call-observation-out "$observations"',
+        ")",
+        'printf \'%s\\n%s\\n\' "$init_request" "$call_request" \\',
+        '| "${proxy_argv[@]}" \\',
+        '>"$results/proxy.jsonl" 2>"$results/proxy.stderr" || proxy_status=$?',
+        'record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"',
+    ]
+    proxy_block = lines_between(
+        driver_text,
+        "proxy_status=0",
+        '[[ "$proxy_status"',
+        problems,
+    )
+    if proxy_block != expected_proxy_block:
+        problems.append("proxy execution and provenance block drifted")
     required_driver_fragments = {
         "exact stable tag": "release tag must be an exact stable vX.Y.Z tag",
         "fresh run root": "run root already exists; refusing to reuse prior evidence",
@@ -339,12 +375,6 @@ def validate_contract(
     if driver_lines.count('PYTHONPATH="$harness_root/scripts/ci" "$PYTHON_BIN" -c \\') != 2:
         problems.append("bounded helper execution drifted")
     semantic_driver_lines = {
-        '[[ "$(tr -d \'\\r\\n\' <"$results/mcp-version.txt")" == "assay-mcp-server $version" ]] \\': (
-            "exact MCP version comparison drifted"
-        ),
-        'record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"': (
-            "proxy command provenance no longer uses the executed argv"
-        ),
         'for pattern, expected in (("release-assets/*.tar.gz", 2), ("attestation-raw/*.json", 2)):': (
             "retained trust-input count enforcement drifted"
         ),
@@ -355,17 +385,42 @@ def validate_contract(
     for line, message in semantic_driver_lines.items():
         if driver_lines.count(line) != 1:
             problems.append(message)
-    attestation_lines = active_lines(attestation_text)
-    for line, message in {
-        '--signer-workflow "$SIGNER_WORKFLOW"': "attestation signer binding drifted",
-        '--source-digest "$SOURCE_DIGEST"': "attestation source digest binding drifted",
-        '--deny-self-hosted-runners': "attestation hosted-runner policy drifted",
-        'any(.[]; any((.verificationResult.statement.subject // [])[]?; .digest.sha256? == $digest))': (
-            "attestation local-subject digest binding drifted"
-        ),
-    }.items():
-        if attestation_lines.count(line) != 1:
-            problems.append(message)
+    expected_verify_args = [
+        "verify_args=(",
+        'attestation verify "$asset"',
+        '--repo "$REPO"',
+        '--signer-workflow "$SIGNER_WORKFLOW"',
+        '--cert-oidc-issuer "$CERT_OIDC_ISSUER"',
+        '--predicate-type "$PREDICATE_TYPE"',
+        '--source-digest "$SOURCE_DIGEST"',
+        "--deny-self-hosted-runners",
+        "--format json",
+        ")",
+    ]
+    verify_args = lines_between(
+        attestation_text,
+        "  verify_args=(",
+        '  if [ -n "$SOURCE_REF" ]',
+        problems,
+    )
+    if verify_args != expected_verify_args:
+        problems.append("attestation verification argv binding drifted")
+    expected_subject_digest_block = [
+        'if ! printf \'%s\\n\' "$verify_json" | "$JQ_BIN" -e --arg digest "$asset_sha256" \'',
+        'any(.[]; any((.verificationResult.statement.subject // [])[]?; .digest.sha256? == $digest))',
+        "' >/dev/null; then",
+        'echo "Verified attestation for ${asset_name} does not match the local subject digest" >&2',
+        "exit 1",
+        "fi",
+    ]
+    subject_digest_block = lines_between(
+        attestation_text,
+        '  if ! printf \'%s\\n\' "$verify_json" | "$JQ_BIN" -e --arg digest "$asset_sha256"',
+        '  printf \'%s\\n\' "$verify_json" | "$JQ_BIN" -c',
+        problems,
+    )
+    if subject_digest_block != expected_subject_digest_block:
+        problems.append("attestation local-subject digest execution block drifted")
     if any("verify-offline.sh" in line or "release-proof-kit" in line for line in driver_lines):
         problems.append("driver must not execute or trust code carried by the release proof kit")
     verifier_line = 'bash "$harness_root/scripts/ci/release_attestation_enforce.sh" \\'

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Fail-closed structural contract for the published-release golden path."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def require(text: str, needle: str, message: str, problems: list[str]) -> None:
+    if needle not in text:
+        problems.append(message)
+
+
+def validate_manifest(path: Path, source_root: Path, problems: list[str]) -> None:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        problems.append(f"harness manifest is unreadable: {error}")
+        return
+    if manifest.get("schema") != "assay.published_release_golden_path.harness.v1":
+        problems.append("harness manifest schema drifted")
+    files = manifest.get("files")
+    if not isinstance(files, list) or not files:
+        problems.append("harness manifest has no files")
+        return
+    paths: list[str] = []
+    for row in files:
+        if not isinstance(row, dict) or not isinstance(row.get("path"), str):
+            problems.append("harness manifest row has no path")
+            continue
+        relative = PurePosixPath(row["path"])
+        paths.append(str(relative))
+        if relative.is_absolute() or "." in relative.parts or ".." in relative.parts:
+            problems.append(f"unsafe harness manifest path: {relative}")
+            continue
+        source = source_root.joinpath(*relative.parts)
+        try:
+            actual = hashlib.sha256(source.read_bytes()).hexdigest()
+        except OSError as error:
+            problems.append(f"harness file is unreadable: {relative}: {error}")
+            continue
+        if row.get("sha256") != actual:
+            problems.append(f"harness digest drifted: {relative}")
+    expected = [
+        "examples/privileged-action-gate/mock_github_mcp.py",
+        "examples/privileged-action-gate/policies/no-allowance.yaml",
+        "examples/privileged-action-gate/baseline-approved.json",
+    ]
+    if paths != expected:
+        problems.append("harness manifest must list exactly the bounded denied-call fixture")
+
+
+def validate_contract(
+    workflow: Path,
+    release_workflow: Path,
+    driver: Path,
+    manifest: Path,
+    source_root: Path,
+) -> list[str]:
+    problems: list[str] = []
+    try:
+        workflow_text = workflow.read_text(encoding="utf-8")
+        release_text = release_workflow.read_text(encoding="utf-8")
+        driver_text = driver.read_text(encoding="utf-8")
+    except OSError as error:
+        return [f"contract input is missing: {error}"]
+
+    require(workflow_text, "workflow_call:", "workflow must be reusable from release.yml", problems)
+    require(workflow_text, "workflow_dispatch:", "workflow must support an explicit replay", problems)
+    require(workflow_text, "release_tag:", "workflow must require an exact release tag input", problems)
+    require(workflow_text, "timeout-minutes: 20", "live job must have a bounded timeout", problems)
+    require(
+        workflow_text,
+        "bash scripts/ci/published-release-golden-path.sh",
+        "workflow must execute the reviewed driver",
+        problems,
+    )
+    require(workflow_text, "--harness-sha \"$GITHUB_SHA\"", "workflow must bind the harness head", problems)
+    require(workflow_text, "if: always()", "workflow must retain partial failure evidence", problems)
+    require(workflow_text, "retention-days: 30", "workflow must pin artifact retention", problems)
+    require(workflow_text, "if-no-files-found: error", "missing replay evidence must fail closed", problems)
+    require(
+        workflow_text,
+        "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09",
+        "checkout action must be SHA-pinned",
+        problems,
+    )
+    require(
+        workflow_text,
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        "artifact upload action must be SHA-pinned",
+        problems,
+    )
+    if "continue-on-error:" in workflow_text:
+        problems.append("published-release journey must not continue on error")
+    if "releases/latest" in workflow_text.lower() or "release_tag: latest" in workflow_text.lower():
+        problems.append("workflow must not resolve a moving latest release")
+
+    require(
+        release_text,
+        "uses: ./.github/workflows/published-release-golden-path.yml",
+        "release transaction must call the published-release gate",
+        problems,
+    )
+    require(
+        release_text,
+        "release_tag: ${{ needs.release-contract.outputs.version }}",
+        "release transaction must pass its validated version",
+        problems,
+    )
+    require(
+        release_text,
+        "needs: [release-contract, release]",
+        "published-release gate must wait until release publication completes",
+        problems,
+    )
+
+    required_driver_fragments = {
+        "exact stable tag": "release tag must be an exact stable vX.Y.Z tag",
+        "fresh run root": "run root already exists; refusing to reuse prior evidence",
+        "proof-kit API digest": "proof-kit digest differs from the release API",
+        "canonical attestation verifier": (
+            '"$kit_root/verify-offline.sh" --assets-dir "$downloads" '
+            '>"$results/attestation-verify.log" 2>&1'
+        ),
+        "disposable HOME": 'export HOME="$run_root/home"',
+        "restricted PATH": 'export PATH="$install_root/bin:/usr/bin:/bin"',
+        "installed CLI resolution": '"$(command -v assay)" == "$install_root/bin/assay"',
+        "installed MCP resolution": '"$(command -v assay-mcp-server)" == "$install_root/bin/assay-mcp-server"',
+        "harness head": '"head_sha": harness_sha',
+        "separate release provenance": '"release": {',
+        "separate harness provenance": '"harness": {',
+        "produced bundle": 'bundle="$results/produced.bundle.tar.gz"',
+        "inspect produced bundle": 'assay evidence show --format json -- "$bundle"',
+        "verify produced bundle": 'assay evidence verify-privileged-mcp-action "$bundle" --format json',
+        "tamper failure code": 'reason_code == "E_EVIDENCE_INTEGRITY"',
+        "artifact manifest": '"assay.published_release_golden_path.artifacts.v1"',
+    }
+    for label, fragment in required_driver_fragments.items():
+        require(driver_text, fragment, f"driver lost {label}", problems)
+    if "|| true" in driver_text or "set +e" in driver_text:
+        problems.append("driver suppresses a failure instead of recording its exact status")
+    verifier = driver_text.find(
+        '"$kit_root/verify-offline.sh" --assets-dir "$downloads" '
+        '>"$results/attestation-verify.log" 2>&1'
+    )
+    first_product_call = driver_text.find('run_capture "assay-version"')
+    if verifier < 0 or first_product_call < 0 or verifier > first_product_call:
+        problems.append("release attestations must verify before the first Assay invocation")
+    required_artifacts = [
+        "run-pin.json",
+        "commands.ndjson",
+        "produced.bundle.tar.gz",
+        "decisions.ndjson",
+        "inspect.json",
+        "verify.json",
+        "tamper-verify.json",
+        "enforcement.sarif",
+    ]
+    for name in required_artifacts:
+        if f'"{name}"' not in driver_text:
+            problems.append(f"driver no longer requires retained artifact: {name}")
+
+    validate_manifest(manifest, source_root, problems)
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workflow", type=Path, default=ROOT / ".github/workflows/published-release-golden-path.yml")
+    parser.add_argument("--release-workflow", type=Path, default=ROOT / ".github/workflows/release.yml")
+    parser.add_argument("--driver", type=Path, default=ROOT / "scripts/ci/published-release-golden-path.sh")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=ROOT / "scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json",
+    )
+    parser.add_argument("--source-root", type=Path, default=ROOT)
+    args = parser.parse_args()
+    problems = validate_contract(
+        args.workflow, args.release_workflow, args.driver, args.manifest, args.source_root
+    )
+    if problems:
+        for problem in problems:
+            print(f"FAIL: {problem}")
+        return 1
+    print("ok: published-release golden-path contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -270,7 +270,7 @@ def validate_contract(
         'fail "reviewed release attestation verifier rejected the published assets"',
         "fi",
         'record_command "verify-release-attestations" 0 "$harness_root/scripts/ci/release_attestation_enforce.sh"',
-        "unset GH_TOKEN GITHUB_TOKEN",
+        "unset GH_TOKEN GITHUB_TOKEN PYTHONPATH",
     ]
     attestation_block = lines_between(
         driver_text,
@@ -298,7 +298,7 @@ def validate_contract(
         "proxy_status=0",
         'printf \'%s\\n%s\\n\' "$init_request" "$call_request" \\',
         '| (cd "$results" && \\',
-        '"$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \\',
+        '"$PYTHON_BIN" -I "$harness_root/scripts/ci/published_release_proxy_phase.py" \\',
         "--timeout-seconds 60) || proxy_status=$?",
     ]
     proxy_block = lines_between(
@@ -338,7 +338,7 @@ def validate_contract(
         "retained release inputs": 'downloads="$results/release-assets"',
         "disposable HOME": 'export HOME="$run_root/home"',
         "restricted PATH": 'export PATH="$install_root/bin:/usr/bin:/bin"',
-        "release credential boundary": "unset GH_TOKEN GITHUB_TOKEN",
+        "release credential boundary": "unset GH_TOKEN GITHUB_TOKEN PYTHONPATH",
         "installed CLI resolution": '"$(command -v assay)" == "$install_root/bin/assay"',
         "installed MCP resolution": '"$(command -v assay-mcp-server)" == "$install_root/bin/assay-mcp-server"',
         "harness head": '"head_sha": harness_sha',
@@ -354,7 +354,7 @@ def validate_contract(
     }
     for label, fragment in required_driver_fragments.items():
         require(driver_text, fragment, f"driver lost {label}", problems)
-    if "unset GH_TOKEN GITHUB_TOKEN" not in driver_lines:
+    if "unset GH_TOKEN GITHUB_TOKEN PYTHONPATH" not in driver_lines:
         problems.append("release binaries must not inherit GitHub credentials")
     if "|| true" in driver_text or "set +e" in driver_text:
         problems.append("driver suppresses a failure instead of recording its exact status")

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -92,6 +92,7 @@ def validate_manifest(
         ".github/workflows/release.yml",
         "scripts/ci/published-release-golden-path.sh",
         "scripts/ci/release_attestation_enforce.sh",
+        "scripts/ci/release_archive_inventory.sh",
         "scripts/ci/safe_extract_release_archive.py",
         "scripts/ci/bounded_download.py",
     ]

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -42,7 +42,14 @@ def mapping_block(text: str, key: str, indent: int, problems: list[str]) -> str:
     return "\n".join(lines[start:end])
 
 
-def validate_manifest(path: Path, source_root: Path, problems: list[str]) -> None:
+def validate_manifest(
+    path: Path,
+    source_root: Path,
+    workflow: Path,
+    release_workflow: Path,
+    driver: Path,
+    problems: list[str],
+) -> None:
     try:
         manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
@@ -55,6 +62,11 @@ def validate_manifest(path: Path, source_root: Path, problems: list[str]) -> Non
         problems.append("harness manifest has no files")
         return
     paths: list[str] = []
+    input_overrides = {
+        ".github/workflows/published-release-golden-path.yml": workflow,
+        ".github/workflows/release.yml": release_workflow,
+        "scripts/ci/published-release-golden-path.sh": driver,
+    }
     for row in files:
         if not isinstance(row, dict) or not isinstance(row.get("path"), str):
             problems.append("harness manifest row has no path")
@@ -64,7 +76,7 @@ def validate_manifest(path: Path, source_root: Path, problems: list[str]) -> Non
         if relative.is_absolute() or "." in relative.parts or ".." in relative.parts:
             problems.append(f"unsafe harness manifest path: {relative}")
             continue
-        source = source_root.joinpath(*relative.parts)
+        source = input_overrides.get(str(relative), source_root.joinpath(*relative.parts))
         try:
             actual = hashlib.sha256(source.read_bytes()).hexdigest()
         except OSError as error:
@@ -76,9 +88,15 @@ def validate_manifest(path: Path, source_root: Path, problems: list[str]) -> Non
         "examples/privileged-action-gate/mock_github_mcp.py",
         "examples/privileged-action-gate/policies/no-allowance.yaml",
         "examples/privileged-action-gate/baseline-approved.json",
+        ".github/workflows/published-release-golden-path.yml",
+        ".github/workflows/release.yml",
+        "scripts/ci/published-release-golden-path.sh",
+        "scripts/ci/release_attestation_enforce.sh",
+        "scripts/ci/safe_extract_release_archive.py",
+        "scripts/ci/bounded_download.py",
     ]
     if paths != expected:
-        problems.append("harness manifest must list exactly the bounded denied-call fixture")
+        problems.append("harness manifest must list exactly the reviewed harness inputs")
 
 
 def validate_contract(
@@ -186,7 +204,7 @@ def validate_contract(
         "fresh run root": "run root already exists; refusing to reuse prior evidence",
         "stable published release": "release tag is still draft or prerelease",
         "external tag source": '"$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}"',
-        "reviewed attestation verifier": 'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"',
+        "reviewed attestation verifier": 'bash "$harness_root/scripts/ci/release_attestation_enforce.sh"',
         "compressed asset ceiling": "release asset exceeds compressed-size ceiling",
         "bounded archive extractor": "from safe_extract_release_archive import extract_archive",
         "retained release inputs": 'downloads="$results/release-assets"',
@@ -239,9 +257,11 @@ def validate_contract(
     for line, message in exact_active_lines.items():
         if driver_lines.count(line) != 1:
             problems.append(message)
+    if driver_lines.count('PYTHONPATH="$harness_root/scripts/ci" "$PYTHON_BIN" -c \\') != 2:
+        problems.append("bounded helper execution drifted")
     if any("verify-offline.sh" in line or "release-proof-kit" in line for line in driver_lines):
         problems.append("driver must not execute or trust code carried by the release proof kit")
-    verifier_line = 'bash "$ROOT/scripts/ci/release_attestation_enforce.sh" \\'
+    verifier_line = 'bash "$harness_root/scripts/ci/release_attestation_enforce.sh" \\'
     if driver_lines.count(verifier_line) != 1:
         problems.append("driver must execute the reviewed attestation verifier exactly once")
     else:
@@ -285,7 +305,7 @@ def validate_contract(
         if f'"{name}"' not in driver_text:
             problems.append(f"driver no longer requires retained artifact: {name}")
 
-    validate_manifest(manifest, source_root, problems)
+    validate_manifest(manifest, source_root, workflow, release_workflow, driver, problems)
     return problems
 
 

--- a/scripts/ci/check-published-release-golden-path-contract.py
+++ b/scripts/ci/check-published-release-golden-path-contract.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import re
 from pathlib import Path, PurePosixPath
 
 
@@ -68,41 +67,6 @@ def lines_between(text: str, start_marker: str, end_marker: str, problems: list[
     return active_lines(text[start:end])
 
 
-def shell_control_depth_before(text: str, marker: str, problems: list[str]) -> int:
-    """Return lexical shell control depth before a unique executable marker."""
-    if text.count(marker) != 1:
-        problems.append(f"expected unique shell control marker: {marker!r}")
-        return -1
-
-    target_line = text[: text.index(marker)].count("\n")
-    stack: list[str] = []
-    heredoc_end: str | None = None
-    for raw_line in text.splitlines()[:target_line]:
-        stripped = raw_line.strip()
-        if heredoc_end is not None:
-            if stripped == heredoc_end:
-                heredoc_end = None
-            continue
-        if not stripped or stripped.startswith("#"):
-            continue
-
-        if re.match(r"^(fi|done|esac|\})(?:\s|$)", stripped):
-            if stack:
-                stack.pop()
-        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\(\)\s*\{$", stripped):
-            stack.append("function")
-        elif re.match(r"^(if|for|while|until|case)\b", stripped):
-            stack.append(stripped.split(maxsplit=1)[0])
-        elif re.search(r"(?:^|\|\||&&)\s*\{\s*$", stripped):
-            stack.append("group")
-
-        heredoc = re.search(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?", stripped)
-        if heredoc:
-            heredoc_end = heredoc.group(1)
-
-    return len(stack)
-
-
 def validate_manifest(
     path: Path,
     source_root: Path,
@@ -152,6 +116,7 @@ def validate_manifest(
         ".github/workflows/published-release-golden-path.yml",
         ".github/workflows/release.yml",
         "scripts/ci/published-release-golden-path.sh",
+        "scripts/ci/published_release_proxy_phase.py",
         "scripts/ci/release_attestation_enforce.sh",
         "scripts/ci/release_archive_inventory.sh",
         "scripts/ci/safe_extract_release_archive.py",
@@ -305,6 +270,7 @@ def validate_contract(
         'fail "reviewed release attestation verifier rejected the published assets"',
         "fi",
         'record_command "verify-release-attestations" 0 "$harness_root/scripts/ci/release_attestation_enforce.sh"',
+        "unset GH_TOKEN GITHUB_TOKEN",
     ]
     attestation_block = lines_between(
         driver_text,
@@ -328,59 +294,61 @@ def validate_contract(
     if version_block != expected_version_block:
         problems.append("exact MCP version execution block drifted")
     expected_proxy_block = [
+        'call_request=\'{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}\'',
         "proxy_status=0",
-        "proxy_argv=(",
-        "assay-mcp-server proxy-enforce",
-        '--upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py"',
-        '--enforce-policy "$fixture_dir/policies/no-allowance.yaml"',
-        '--declared-mcp-manifest "$fixture_dir/baseline-approved.json"',
-        '--enforcement-decision-out "$decisions"',
-        '--denied-call-observation-out "$observations"',
-        ")",
         'printf \'%s\\n%s\\n\' "$init_request" "$call_request" \\',
-        '| "${proxy_argv[@]}" \\',
-        '>"$results/proxy.jsonl" 2>"$results/proxy.stderr" || proxy_status=$?',
-        'record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"',
+        '| "$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \\',
+        '--mcp-bin "$install_root/bin/assay-mcp-server" \\',
+        '--python-bin "$PYTHON_BIN" \\',
+        '--fixture "$fixture_dir/mock_github_mcp.py" \\',
+        '--policy "$fixture_dir/policies/no-allowance.yaml" \\',
+        '--declared-manifest "$fixture_dir/baseline-approved.json" \\',
+        '--decisions "$decisions" \\',
+        '--observations "$observations" \\',
+        '--commands "$commands_file" \\',
+        '--stdout "$results/proxy.jsonl" \\',
+        '--stderr "$results/proxy.stderr" \\',
+        "--timeout-seconds 60 || proxy_status=$?",
     ]
     proxy_block = lines_between(
         driver_text,
-        "proxy_status=0",
+        "call_request=",
         '[[ "$proxy_status"',
         problems,
     )
     if proxy_block != expected_proxy_block:
         problems.append("proxy execution and provenance block drifted")
-    if shell_control_depth_before(driver_text, "proxy_status=0", problems) != 0:
-        problems.append("proxy execution block must run at top level")
-    proxy_tokens = ("proxy-enforce", "proxy_argv", "proxy_status")
-    expected_proxy_surface = [
-        line
-        for line in expected_proxy_block
-        + [
-            '[[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"',
-            '[[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"',
-            '[[ -s "$observations" ]] || fail "proxy-enforce produced no denied-call observation"',
-        ]
-        if any(token in line for token in proxy_tokens)
+    if 'record_command "proxy-enforce"' in driver_text:
+        problems.append("driver must not record proxy provenance separately from execution")
+    expected_mcp_binary_surface = [
+        'mcp_asset="assay-mcp-server-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"',
+        'mapfile -t mcp_candidates < <(find "$mcp_extract" -type f -name assay-mcp-server -perm -u+x)',
+        '[[ "${#mcp_candidates[@]}" -eq 1 ]] || fail "MCP archive must contain exactly one executable assay-mcp-server binary"',
+        'cp "${mcp_candidates[0]}" "$install_root/bin/assay-mcp-server"',
+        'chmod 0755 "$install_root/bin/assay" "$install_root/bin/assay-mcp-server"',
+        '[[ "$(command -v assay-mcp-server)" == "$install_root/bin/assay-mcp-server" ]] || fail "assay-mcp-server did not resolve from the disposable install prefix"',
+        'run_capture "mcp-version" 0 "$results/mcp-version.txt" "$results/mcp-version.stderr" assay-mcp-server --version',
+        '[[ "$(tr -d \'\\r\\n\' <"$results/mcp-version.txt")" == "assay-mcp-server $version" ]] \\',
+        '|| fail "assay-mcp-server version differs from pinned release"',
+        '--mcp-bin "$install_root/bin/assay-mcp-server" \\',
+        'assay-mcp-server enforcement-sarif --input "$decisions" --output "$results/enforcement.sarif"',
     ]
-    proxy_surface = [
-        line
-        for line in driver_lines
-        if any(token in line for token in proxy_tokens)
-    ]
-    if proxy_surface != expected_proxy_surface:
-        problems.append("driver has an alternate proxy execution or provenance path")
+    mcp_binary_surface = [line for line in driver_lines if "assay-mcp-server" in line]
+    if mcp_binary_surface != expected_mcp_binary_surface:
+        problems.append("driver MCP binary invocation surface drifted")
     required_driver_fragments = {
         "exact stable tag": "release tag must be an exact stable vX.Y.Z tag",
         "fresh run root": "run root already exists; refusing to reuse prior evidence",
         "stable published release": "release tag is still draft or prerelease",
         "external tag source": '"$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}"',
         "reviewed attestation verifier": 'bash "$harness_root/scripts/ci/release_attestation_enforce.sh"',
+        "single-owner proxy phase": 'published_release_proxy_phase.py',
         "compressed asset ceiling": "release asset exceeds compressed-size ceiling",
         "bounded archive extractor": "from safe_extract_release_archive import extract_archive",
         "retained release inputs": 'downloads="$results/release-assets"',
         "disposable HOME": 'export HOME="$run_root/home"',
         "restricted PATH": 'export PATH="$install_root/bin:/usr/bin:/bin"',
+        "release credential boundary": "unset GH_TOKEN GITHUB_TOKEN",
         "installed CLI resolution": '"$(command -v assay)" == "$install_root/bin/assay"',
         "installed MCP resolution": '"$(command -v assay-mcp-server)" == "$install_root/bin/assay-mcp-server"',
         "harness head": '"head_sha": harness_sha',
@@ -396,6 +364,8 @@ def validate_contract(
     }
     for label, fragment in required_driver_fragments.items():
         require(driver_text, fragment, f"driver lost {label}", problems)
+    if "unset GH_TOKEN GITHUB_TOKEN" not in driver_lines:
+        problems.append("release binaries must not inherit GitHub credentials")
     if "|| true" in driver_text or "set +e" in driver_text:
         problems.append("driver suppresses a failure instead of recording its exact status")
     exact_active_lines = {

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -12,6 +12,30 @@
     {
       "path": "examples/privileged-action-gate/baseline-approved.json",
       "sha256": "db210a8f7d7e5850322eddf18ffbef268b1d19595f568e7b3b7a4ec8e50326c3"
+    },
+    {
+      "path": ".github/workflows/published-release-golden-path.yml",
+      "sha256": "807a930392bf2bfc3487d931840fcb7ae2e6f987e6db4e05c88a0a31adbf43e2"
+    },
+    {
+      "path": ".github/workflows/release.yml",
+      "sha256": "a25a1fc1e8a1f72806b8caca9747381fd6bee09a86bc6d0af94d11c6a708428a"
+    },
+    {
+      "path": "scripts/ci/published-release-golden-path.sh",
+      "sha256": "5cde9c8909df8f5b5a2c9ef4131e2aded6ded6e0d80c224bf7de8caef022afff"
+    },
+    {
+      "path": "scripts/ci/release_attestation_enforce.sh",
+      "sha256": "01bfa586b826fa74838c58e765f40982537f8ea14325b803fc9183fcf4e8277f"
+    },
+    {
+      "path": "scripts/ci/safe_extract_release_archive.py",
+      "sha256": "0d0c4462d2373cfd29fb6424ac6cba26e8218a3cdbe4cf93055362b19acdaef9"
+    },
+    {
+      "path": "scripts/ci/bounded_download.py",
+      "sha256": "08eff32101003614a9d5de93507c2d26ec087d1417179d34bea41a70ee4bafaa"
     }
   ]
 }

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -30,6 +30,10 @@
       "sha256": "01bfa586b826fa74838c58e765f40982537f8ea14325b803fc9183fcf4e8277f"
     },
     {
+      "path": "scripts/ci/release_archive_inventory.sh",
+      "sha256": "3ac3604dc26b843066751a50d9c25c8e780ac6e5e8bcf9645b672af27f161afb"
+    },
+    {
       "path": "scripts/ci/safe_extract_release_archive.py",
       "sha256": "0d0c4462d2373cfd29fb6424ac6cba26e8218a3cdbe4cf93055362b19acdaef9"
     },

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -1,0 +1,17 @@
+{
+  "schema": "assay.published_release_golden_path.harness.v1",
+  "files": [
+    {
+      "path": "examples/privileged-action-gate/mock_github_mcp.py",
+      "sha256": "4b489043fed724b332f9f216942778992270d85a89de4589c73a23fbb86aa48d"
+    },
+    {
+      "path": "examples/privileged-action-gate/policies/no-allowance.yaml",
+      "sha256": "2f7ae26b2d172b291f0d98b3724c729cccd52f7bfc1b9003df96a92c8434f1d2"
+    },
+    {
+      "path": "examples/privileged-action-gate/baseline-approved.json",
+      "sha256": "db210a8f7d7e5850322eddf18ffbef268b1d19595f568e7b3b7a4ec8e50326c3"
+    }
+  ]
+}

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -27,7 +27,7 @@
     },
     {
       "path": "scripts/ci/published_release_proxy_phase.py",
-      "sha256": "2b908d766b99ad0d5811b06c061e4d2ed25c1b8d69372e5369b21f955146d0b5"
+      "sha256": "18e4bd292027cc2a27c3baa6720dbf3593dd1ff329be8f8240ab5cc4549ddae1"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -23,11 +23,11 @@
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",
-      "sha256": "262673a18a1b881a3d026bc0bae84399e39d24612817a8e2f6d043339b88826d"
+      "sha256": "95ed52c2a068af457fcb9221fe131555f33b54dc744f37d8470a3d91046b428e"
     },
     {
       "path": "scripts/ci/published_release_proxy_phase.py",
-      "sha256": "b28017d025f71f81ce102809e9efb7c69e950e4de39415e2a0c33d450647cc97"
+      "sha256": "2b908d766b99ad0d5811b06c061e4d2ed25c1b8d69372e5369b21f955146d0b5"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",
-      "sha256": "9ab436674b998c6753e2962bbe1b6c48f8c9231075d138b1cd887be0ea8aa838"
+      "sha256": "85fa4e9ab80b3baa187772f245494ed4a957a9df8b42b7b680236cfbfc5b0912"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -27,7 +27,7 @@
     },
     {
       "path": "scripts/ci/published_release_proxy_phase.py",
-      "sha256": "18e4bd292027cc2a27c3baa6720dbf3593dd1ff329be8f8240ab5cc4549ddae1"
+      "sha256": "487e630413335a0698f5ce89ea6bbc366ab25389731f802e47c7f3d035fee352"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",
-      "sha256": "95ed52c2a068af457fcb9221fe131555f33b54dc744f37d8470a3d91046b428e"
+      "sha256": "d3a4ad56b35d27447625c18d90a18353d32499149d29ef9bc7fb23d2f242cbf3"
     },
     {
       "path": "scripts/ci/published_release_proxy_phase.py",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",
-      "sha256": "5cde9c8909df8f5b5a2c9ef4131e2aded6ded6e0d80c224bf7de8caef022afff"
+      "sha256": "9ab436674b998c6753e2962bbe1b6c48f8c9231075d138b1cd887be0ea8aa838"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",
@@ -31,7 +31,8 @@
     },
     {
       "path": "scripts/ci/release_archive_inventory.sh",
-      "sha256": "3ac3604dc26b843066751a50d9c25c8e780ac6e5e8bcf9645b672af27f161afb"
+      "sha256": "3ac3604dc26b843066751a50d9c25c8e780ac6e5e8bcf9645b672af27f161afb",
+      "executable": true
     },
     {
       "path": "scripts/ci/safe_extract_release_archive.py",

--- a/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
+++ b/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json
@@ -23,7 +23,11 @@
     },
     {
       "path": "scripts/ci/published-release-golden-path.sh",
-      "sha256": "85fa4e9ab80b3baa187772f245494ed4a957a9df8b42b7b680236cfbfc5b0912"
+      "sha256": "262673a18a1b881a3d026bc0bae84399e39d24612817a8e2f6d043339b88826d"
+    },
+    {
+      "path": "scripts/ci/published_release_proxy_phase.py",
+      "sha256": "b28017d025f71f81ce102809e9efb7c69e950e4de39415e2a0c33d450647cc97"
     },
     {
       "path": "scripts/ci/release_attestation_enforce.sh",

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -248,25 +248,15 @@ run_capture "evaluate" 0 "$results/evaluate.json" "$results/evaluate.stderr" \
 "$JQ_BIN" -e '.schema == "assay.run_report.v1"' "$results/evaluate.json" >/dev/null || fail "evaluation output identity drifted"
 popd >/dev/null
 
-fixture_dir="$harness_root/examples/privileged-action-gate"
 decisions="$results/decisions.ndjson"
 observations="$results/denied-observations.ndjson"
 init_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"published-release-gate","version":"1"}}}'
 call_request='{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}'
 proxy_status=0
 printf '%s\n%s\n' "$init_request" "$call_request" \
-  | "$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \
-      --mcp-bin "$install_root/bin/assay-mcp-server" \
-      --python-bin "$PYTHON_BIN" \
-      --fixture "$fixture_dir/mock_github_mcp.py" \
-      --policy "$fixture_dir/policies/no-allowance.yaml" \
-      --declared-manifest "$fixture_dir/baseline-approved.json" \
-      --decisions "$decisions" \
-      --observations "$observations" \
-      --commands "$commands_file" \
-      --stdout "$results/proxy.jsonl" \
-      --stderr "$results/proxy.stderr" \
-      --timeout-seconds 60 || proxy_status=$?
+  | (cd "$results" && \
+      "$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \
+        --timeout-seconds 60) || proxy_status=$?
 [[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"
 [[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"
 [[ -s "$observations" ]] || fail "proxy-enforce produced no denied-call observation"

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -197,10 +197,13 @@ record_command "verify-release-attestations" 0 "$ROOT/scripts/ci/release_attesta
 
 cli_extract="$run_root/cli-extract"
 mcp_extract="$run_root/mcp-extract"
-"$PYTHON_BIN" "$ROOT/scripts/ci/safe_extract_release_archive.py" \
-  "$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728
-"$PYTHON_BIN" "$ROOT/scripts/ci/safe_extract_release_archive.py" \
-  "$downloads/$mcp_asset" "$mcp_extract" --max-decoded-bytes 67108864
+safe_extract() {
+  PYTHONPATH="$ROOT/scripts/ci" "$PYTHON_BIN" -c \
+    'import pathlib,sys; from safe_extract_release_archive import extract_archive; extract_archive(pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), max_decoded_bytes=int(sys.argv[3]))' \
+    "$1" "$2" "$3"
+}
+safe_extract "$downloads/$cli_asset" "$cli_extract" 134217728
+safe_extract "$downloads/$mcp_asset" "$mcp_extract" 67108864
 mapfile -t cli_candidates < <(find "$cli_extract" -type f -name assay -perm -u+x)
 mapfile -t mcp_candidates < <(find "$mcp_extract" -type f -name assay-mcp-server -perm -u+x)
 [[ "${#cli_candidates[@]}" -eq 1 ]] || fail "CLI archive must contain exactly one executable assay binary"

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -251,20 +251,18 @@ observations="$results/denied-observations.ndjson"
 init_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"published-release-gate","version":"1"}}}'
 call_request='{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}'
 proxy_status=0
-printf '%s\n%s\n' "$init_request" "$call_request" \
-  | assay-mcp-server proxy-enforce \
-      --upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py" \
-      --enforce-policy "$fixture_dir/policies/no-allowance.yaml" \
-      --declared-mcp-manifest "$fixture_dir/baseline-approved.json" \
-      --enforcement-decision-out "$decisions" \
-      --denied-call-observation-out "$observations" \
-      >"$results/proxy.jsonl" 2>"$results/proxy.stderr" || proxy_status=$?
-record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce \
-  --upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py" \
-  --enforce-policy "$fixture_dir/policies/no-allowance.yaml" \
-  --declared-mcp-manifest "$fixture_dir/baseline-approved.json" \
-  --enforcement-decision-out "$decisions" \
+proxy_argv=(
+  assay-mcp-server proxy-enforce
+  --upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py"
+  --enforce-policy "$fixture_dir/policies/no-allowance.yaml"
+  --declared-mcp-manifest "$fixture_dir/baseline-approved.json"
+  --enforcement-decision-out "$decisions"
   --denied-call-observation-out "$observations"
+)
+printf '%s\n%s\n' "$init_request" "$call_request" \
+  | "${proxy_argv[@]}" \
+      >"$results/proxy.jsonl" 2>"$results/proxy.stderr" || proxy_status=$?
+record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"
 [[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"
 [[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"
 [[ -s "$observations" ]] || fail "proxy-enforce produced no denied-call observation"

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -16,13 +16,15 @@ fail() {
 }
 
 usage() {
-  echo "usage: published-release-golden-path.sh --release-tag vX.Y.Z --harness-sha <40-hex> --run-root <abs-path>" >&2
+  echo "usage: published-release-golden-path.sh --release-tag vX.Y.Z --harness-sha <40-hex> --workflow-run-id <id> --workflow-run-attempt <n> --run-root <abs-path>" >&2
   exit 2
 }
 
 release_tag=""
 harness_sha=""
 run_root=""
+workflow_run_id=""
+workflow_run_attempt=""
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --release-tag)
@@ -40,27 +42,38 @@ while [[ "$#" -gt 0 ]]; do
       run_root="$2"
       shift 2
       ;;
+    --workflow-run-id)
+      [[ "$#" -ge 2 ]] || usage
+      workflow_run_id="$2"
+      shift 2
+      ;;
+    --workflow-run-attempt)
+      [[ "$#" -ge 2 ]] || usage
+      workflow_run_attempt="$2"
+      shift 2
+      ;;
     *) usage ;;
   esac
 done
 
 [[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "release tag must be an exact stable vX.Y.Z tag"
 [[ "$harness_sha" =~ ^[0-9a-f]{40}$ ]] || fail "harness SHA must be exactly 40 lowercase hex characters"
+[[ "$workflow_run_id" =~ ^[A-Za-z0-9_.-]+$ ]] || fail "workflow run id has an unsafe shape"
+[[ "$workflow_run_attempt" =~ ^[0-9]+$ ]] || fail "workflow run attempt must be numeric"
 [[ "$run_root" = /* ]] || fail "run root must be absolute"
 [[ ! -e "$run_root" ]] || fail "run root already exists; refusing to reuse prior evidence: $run_root"
 [[ -f "$HARNESS_MANIFEST" ]] || fail "harness manifest is missing"
 
-for required in "$GH_BIN" "$JQ_BIN" "$PYTHON_BIN" sha256sum tar; do
+for required in "$GH_BIN" "$JQ_BIN" "$PYTHON_BIN" sha256sum; do
   command -v "$required" >/dev/null 2>&1 || fail "missing required command: $required"
 done
 
-downloads="$run_root/downloads"
-proof_root="$run_root/proof"
 install_root="$run_root/install"
 harness_root="$run_root/harness"
 session_root="$run_root/session"
 results="$run_root/results"
-mkdir -p "$downloads" "$proof_root" "$install_root/bin" "$harness_root" "$session_root" "$results"
+downloads="$results/release-assets"
+mkdir -p "$downloads" "$install_root/bin" "$harness_root" "$session_root" "$results/attestation-raw"
 
 commands_file="$results/commands.ndjson"
 : >"$commands_file"
@@ -121,50 +134,73 @@ report_path.write_text(
 PY
 
 version="${release_tag#v}"
-proof_asset="assay-${release_tag}-release-proof-kit.tar.gz"
 release_api="$results/release-api.json"
 "$GH_BIN" api "repos/${REPO}/releases/tags/${release_tag}" >"$release_api"
-"$GH_BIN" release download "$release_tag" --repo "$REPO" --dir "$downloads" --pattern "$proof_asset" --clobber
-
-proof_digest="$($JQ_BIN -er --arg name "$proof_asset" '.assets[] | select(.name == $name) | .digest' "$release_api")"
-[[ "$proof_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "release API omitted the proof-kit sha256 digest"
-actual_proof_digest="sha256:$(sha256sum "$downloads/$proof_asset" | cut -d' ' -f1)"
-[[ "$actual_proof_digest" == "$proof_digest" ]] || fail "proof-kit digest differs from the release API"
-
-tar -xzf "$downloads/$proof_asset" -C "$proof_root"
-kit_root="$proof_root/release-proof-kit"
-kit_manifest="$kit_root/manifest.json"
-[[ -x "$kit_root/verify-offline.sh" ]] || fail "release proof kit has no executable offline verifier"
-[[ "$($JQ_BIN -er '.tag' "$kit_manifest")" == "$release_tag" ]] || fail "proof-kit tag differs from requested release"
-[[ "$($JQ_BIN -er '.repo' "$kit_manifest")" == "$REPO" ]] || fail "proof-kit repository differs from requested repository"
-source_digest="$($JQ_BIN -er '.source_digest' "$kit_manifest")"
-[[ "$source_digest" =~ ^[0-9a-f]{40}$ ]] || fail "proof-kit source digest is not a commit SHA"
-
-while IFS= read -r asset_name; do
-  "$GH_BIN" release download "$release_tag" --repo "$REPO" --dir "$downloads" --pattern "$asset_name" --clobber
-  expected_api_digest="$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest' "$release_api")"
-  expected_kit_digest="sha256:$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .sha256' "$kit_manifest")"
-  actual_digest="sha256:$(sha256sum "$downloads/$asset_name" | cut -d' ' -f1)"
-  [[ "$expected_api_digest" == "$expected_kit_digest" ]] || fail "release API and proof kit disagree for $asset_name"
-  [[ "$actual_digest" == "$expected_kit_digest" ]] || fail "downloaded asset digest differs for $asset_name"
-done < <("$JQ_BIN" -er '.assets[].name' "$kit_manifest")
-
-# This is the release's canonical offline attestation policy. It must complete before installation.
-"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1
-record_command "verify-release-attestations" 0 "$kit_root/verify-offline.sh" --assets-dir "$downloads"
-
+"$JQ_BIN" -e '.draft == false and .prerelease == false' "$release_api" >/dev/null \
+  || fail "release tag is still draft or prerelease"
 cli_asset="assay-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"
 mcp_asset="assay-mcp-server-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"
-for asset in "$cli_asset" "$mcp_asset"; do
-  "$JQ_BIN" -e --arg name "$asset" '.assets[] | select(.name == $name)' "$kit_manifest" >/dev/null \
-    || fail "proof kit does not attest required Linux asset: $asset"
+
+tag_ref="$results/tag-ref.json"
+"$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}" >"$tag_ref"
+source_type="$($JQ_BIN -er '.object.type' "$tag_ref")"
+source_digest="$($JQ_BIN -er '.object.sha' "$tag_ref")"
+for depth in 1 2 3 4; do
+  [[ "$source_type" != "tag" ]] || {
+    tag_object="$results/tag-object-${depth}.json"
+    "$GH_BIN" api "repos/${REPO}/git/tags/${source_digest}" >"$tag_object"
+    source_type="$($JQ_BIN -er '.object.type' "$tag_object")"
+    source_digest="$($JQ_BIN -er '.object.sha' "$tag_object")"
+  }
 done
+[[ "$source_type" == "commit" && "$source_digest" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "release tag does not resolve to a commit within four tag objects"
+
+download_release_asset() {
+  local asset_name="$1" max_bytes="$2"
+  local count api_size api_digest actual_size actual_digest
+  count="$($JQ_BIN -er --arg name "$asset_name" '[.assets[] | select(.name == $name)] | length' "$release_api")"
+  [[ "$count" -eq 1 ]] || fail "release must contain exactly one asset named $asset_name"
+  api_size="$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .size' "$release_api")"
+  api_digest="$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest' "$release_api")"
+  [[ "$api_size" =~ ^[0-9]+$ && "$api_size" -gt 0 && "$api_size" -le "$max_bytes" ]] \
+    || fail "release asset exceeds compressed-size ceiling: $asset_name"
+  [[ "$api_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "release API omitted asset sha256: $asset_name"
+  "$GH_BIN" release download "$release_tag" --repo "$REPO" --dir "$downloads" --pattern "$asset_name" --clobber
+  actual_size="$(wc -c <"$downloads/$asset_name" | tr -d ' ')"
+  [[ "$actual_size" -eq "$api_size" && "$actual_size" -le "$max_bytes" ]] \
+    || fail "downloaded asset size differs or exceeds its ceiling: $asset_name"
+  actual_digest="sha256:$(sha256sum "$downloads/$asset_name" | cut -d' ' -f1)"
+  [[ "$actual_digest" == "$api_digest" ]] || fail "downloaded asset digest differs: $asset_name"
+  record_command "download-release-asset" 0 "$GH_BIN" release download "$release_tag" --pattern "$asset_name"
+}
+
+download_release_asset "$cli_asset" 67108864
+download_release_asset "$mcp_asset" 33554432
+
+# Execute reviewed harness code, not a script carried inside a mutable release asset.
+signer_workflow="$REPO/.github/workflows/release.yml"
+if ! GH_BIN="$GH_BIN" JQ_BIN="$JQ_BIN" \
+  ASSETS_DIR="$downloads" \
+  OUT_SUMMARY="$results/attestation-summary.json" \
+  OUT_RAW_DIR="$results/attestation-raw" \
+  REPO="$REPO" \
+  SIGNER_WORKFLOW="$signer_workflow" \
+  SOURCE_REF="" \
+  SOURCE_DIGEST="$source_digest" \
+  bash "$ROOT/scripts/ci/release_attestation_enforce.sh" \
+  >"$results/attestation-verify.log" 2>&1; then
+  cat "$results/attestation-verify.log" >&2
+  fail "reviewed release attestation verifier rejected the published assets"
+fi
+record_command "verify-release-attestations" 0 "$ROOT/scripts/ci/release_attestation_enforce.sh"
 
 cli_extract="$run_root/cli-extract"
 mcp_extract="$run_root/mcp-extract"
-mkdir -p "$cli_extract" "$mcp_extract"
-tar -xzf "$downloads/$cli_asset" -C "$cli_extract"
-tar -xzf "$downloads/$mcp_asset" -C "$mcp_extract"
+"$PYTHON_BIN" "$ROOT/scripts/ci/safe_extract_release_archive.py" \
+  "$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728
+"$PYTHON_BIN" "$ROOT/scripts/ci/safe_extract_release_archive.py" \
+  "$downloads/$mcp_asset" "$mcp_extract" --max-decoded-bytes 67108864
 mapfile -t cli_candidates < <(find "$cli_extract" -type f -name assay -perm -u+x)
 mapfile -t mcp_candidates < <(find "$mcp_extract" -type f -name assay-mcp-server -perm -u+x)
 [[ "${#cli_candidates[@]}" -eq 1 ]] || fail "CLI archive must contain exactly one executable assay binary"
@@ -221,7 +257,7 @@ bundle="$results/produced.bundle.tar.gz"
 run_capture "produce-bundle" 0 "$results/produce.stdout" "$results/produce.stderr" \
   assay evidence import privileged-mcp-action \
     --decisions "$decisions" --denied-observations "$observations" \
-    --bundle-out "$bundle" --run-id published-release-golden-path \
+    --bundle-out "$bundle" --run-id "published-release-${workflow_run_id}-${workflow_run_attempt}" \
     --import-time 2026-01-01T00:00:00Z
 [[ -s "$bundle" ]] || fail "bundle production yielded no bytes"
 
@@ -270,23 +306,28 @@ run_capture "verify-tampered-bundle" 2 "$results/tamper-verify.json" "$results/t
 
 driver_digest="$(sha256sum "$ROOT/scripts/ci/published-release-golden-path.sh" | cut -d' ' -f1)"
 harness_manifest_digest="$(sha256sum "$HARNESS_MANIFEST" | cut -d' ' -f1)"
-"$PYTHON_BIN" - "$release_tag" "$source_digest" "$kit_manifest" "$harness_sha" "$driver_digest" \
+"$PYTHON_BIN" - "$release_tag" "$source_digest" "$results/attestation-summary.json" \
+  "$harness_sha" "$workflow_run_id" "$workflow_run_attempt" "$driver_digest" \
   "$harness_manifest_digest" "$results/harness-files.json" "$commands_file" "$results/run-pin.json" <<'PY'
 import json, pathlib, sys
-(release_tag, source_digest, kit_manifest_path, harness_sha, driver_digest,
- harness_manifest_digest, harness_files_path, commands_path, output_path) = sys.argv[1:]
-kit = json.loads(pathlib.Path(kit_manifest_path).read_text(encoding="utf-8"))
+(release_tag, source_digest, attestation_summary_path, harness_sha, workflow_run_id,
+ workflow_run_attempt, driver_digest, harness_manifest_digest, harness_files_path,
+ commands_path, output_path) = sys.argv[1:]
+attestations = json.loads(pathlib.Path(attestation_summary_path).read_text(encoding="utf-8"))
 harness = json.loads(pathlib.Path(harness_files_path).read_text(encoding="utf-8"))
 commands = [json.loads(line) for line in pathlib.Path(commands_path).read_text(encoding="utf-8").splitlines() if line]
 document = {
     "schema": "assay.published_release_golden_path.run_pin.v1",
     "release": {
         "tag": release_tag,
+        "source_ref": f"refs/tags/{release_tag}",
         "source_digest": source_digest,
-        "assets": [{"name": row["name"], "sha256": row["sha256"]} for row in kit["assets"]],
+        "assets": [{"name": row["name"], "sha256": row["sha256"]} for row in attestations["assets"]],
     },
     "harness": {
         "head_sha": harness_sha,
+        "workflow_run_id": workflow_run_id,
+        "workflow_run_attempt": int(workflow_run_attempt),
         "driver_sha256": driver_digest,
         "manifest_sha256": harness_manifest_digest,
         "files": harness["files"],
@@ -306,15 +347,24 @@ root, output = map(pathlib.Path, sys.argv[1:])
 required = [
     "run-pin.json", "commands.ndjson", "produced.bundle.tar.gz", "decisions.ndjson",
     "inspect.json", "verify.json", "tamper-verify.json", "enforcement.sarif",
+    "release-api.json", "tag-ref.json", "attestation-summary.json",
 ]
 for name in required:
     path = root / name
     if not path.is_file() or path.stat().st_size == 0:
         raise SystemExit(f"required retained artifact is missing or empty: {name}")
+for pattern, expected in (("release-assets/*.tar.gz", 2), ("attestation-raw/*.json", 2)):
+    matches = list(root.glob(pattern))
+    if len(matches) != expected or any(path.stat().st_size == 0 for path in matches):
+        raise SystemExit(f"retained trust inputs for {pattern} are incomplete")
 files = []
-for path in sorted(root.iterdir()):
+for path in sorted(root.rglob("*")):
     if path.is_file() and path != output:
-        files.append({"path": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest(), "size": path.stat().st_size})
+        files.append({
+            "path": path.relative_to(root).as_posix(),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            "size": path.stat().st_size,
+        })
 document = {"schema": "assay.published_release_golden_path.artifacts.v1", "files": files}
 output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 PY

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -206,7 +206,7 @@ fi
 record_command "verify-release-attestations" 0 "$harness_root/scripts/ci/release_attestation_enforce.sh"
 
 # Release binaries and the mock upstream do not need repository credentials.
-unset GH_TOKEN GITHUB_TOKEN
+unset GH_TOKEN GITHUB_TOKEN PYTHONPATH
 
 cli_extract="$run_root/cli-extract"
 mcp_extract="$run_root/mcp-extract"
@@ -255,7 +255,7 @@ call_request='{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"gi
 proxy_status=0
 printf '%s\n%s\n' "$init_request" "$call_request" \
   | (cd "$results" && \
-      "$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \
+      "$PYTHON_BIN" -I "$harness_root/scripts/ci/published_release_proxy_phase.py" \
         --timeout-seconds 60) || proxy_status=$?
 [[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"
 [[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -158,21 +158,26 @@ done
 
 download_release_asset() {
   local asset_name="$1" max_bytes="$2"
-  local count api_size api_digest actual_size actual_digest
+  local count api_size api_digest asset_url actual_size actual_digest
   count="$($JQ_BIN -er --arg name "$asset_name" '[.assets[] | select(.name == $name)] | length' "$release_api")"
   [[ "$count" -eq 1 ]] || fail "release must contain exactly one asset named $asset_name"
   api_size="$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .size' "$release_api")"
   api_digest="$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest' "$release_api")"
+  asset_url="$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .browser_download_url' "$release_api")"
   [[ "$api_size" =~ ^[0-9]+$ && "$api_size" -gt 0 && "$api_size" -le "$max_bytes" ]] \
     || fail "release asset exceeds compressed-size ceiling: $asset_name"
   [[ "$api_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "release API omitted asset sha256: $asset_name"
-  "$GH_BIN" release download "$release_tag" --repo "$REPO" --dir "$downloads" --pattern "$asset_name" --clobber
+  [[ "$asset_url" == "https://github.com/${REPO}/releases/download/${release_tag}/${asset_name}" ]] \
+    || fail "release API returned an unexpected asset URL: $asset_name"
+  PYTHONPATH="$harness_root/scripts/ci" "$PYTHON_BIN" -c \
+    'import pathlib,sys; from bounded_download import download; download(sys.argv[1], pathlib.Path(sys.argv[2]), max_bytes=int(sys.argv[3]))' \
+    "$asset_url" "$downloads/$asset_name" "$max_bytes"
   actual_size="$(wc -c <"$downloads/$asset_name" | tr -d ' ')"
   [[ "$actual_size" -eq "$api_size" && "$actual_size" -le "$max_bytes" ]] \
     || fail "downloaded asset size differs or exceeds its ceiling: $asset_name"
   actual_digest="sha256:$(sha256sum "$downloads/$asset_name" | cut -d' ' -f1)"
   [[ "$actual_digest" == "$api_digest" ]] || fail "downloaded asset digest differs: $asset_name"
-  record_command "download-release-asset" 0 "$GH_BIN" release download "$release_tag" --pattern "$asset_name"
+  record_command "download-release-asset" 0 bounded_download "$asset_url" "$downloads/$asset_name" "$max_bytes"
 }
 
 download_release_asset "$cli_asset" 67108864
@@ -188,17 +193,17 @@ if ! GH_BIN="$GH_BIN" JQ_BIN="$JQ_BIN" \
   SIGNER_WORKFLOW="$signer_workflow" \
   SOURCE_REF="" \
   SOURCE_DIGEST="$source_digest" \
-  bash "$ROOT/scripts/ci/release_attestation_enforce.sh" \
+  bash "$harness_root/scripts/ci/release_attestation_enforce.sh" \
   >"$results/attestation-verify.log" 2>&1; then
   cat "$results/attestation-verify.log" >&2
   fail "reviewed release attestation verifier rejected the published assets"
 fi
-record_command "verify-release-attestations" 0 "$ROOT/scripts/ci/release_attestation_enforce.sh"
+record_command "verify-release-attestations" 0 "$harness_root/scripts/ci/release_attestation_enforce.sh"
 
 cli_extract="$run_root/cli-extract"
 mcp_extract="$run_root/mcp-extract"
 safe_extract() {
-  PYTHONPATH="$ROOT/scripts/ci" "$PYTHON_BIN" -c \
+  PYTHONPATH="$harness_root/scripts/ci" "$PYTHON_BIN" -c \
     'import pathlib,sys; from safe_extract_release_archive import extract_archive; extract_archive(pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), max_decoded_bytes=int(sys.argv[3]))' \
     "$1" "$2" "$3"
 }
@@ -221,7 +226,8 @@ export PATH="$install_root/bin:/usr/bin:/bin"
 run_capture "assay-version" 0 "$results/assay-version.txt" "$results/assay-version.stderr" assay version
 [[ "$(tr -d '\r\n' <"$results/assay-version.txt")" == "$version" ]] || fail "assay version differs from pinned release"
 run_capture "mcp-version" 0 "$results/mcp-version.txt" "$results/mcp-version.stderr" assay-mcp-server --version
-grep -Eq "(^|[[:space:]])${version}$" "$results/mcp-version.txt" || fail "assay-mcp-server version differs from pinned release"
+[[ "$(tr -d '\r\n' <"$results/mcp-version.txt")" == "assay-mcp-server $version" ]] \
+  || fail "assay-mcp-server version differs from pinned release"
 
 pushd "$session_root" >/dev/null
 run_capture "init" 0 "$results/init.json" "$results/init.stderr" assay init --preset dev --hello-trace --format json
@@ -248,7 +254,12 @@ printf '%s\n%s\n' "$init_request" "$call_request" \
       --enforcement-decision-out "$decisions" \
       --denied-call-observation-out "$observations" \
       >"$results/proxy.jsonl" 2>"$results/proxy.stderr" || proxy_status=$?
-record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce --upstream-command python3
+record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce \
+  --upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py" \
+  --enforce-policy "$fixture_dir/policies/no-allowance.yaml" \
+  --declared-mcp-manifest "$fixture_dir/baseline-approved.json" \
+  --enforcement-decision-out "$decisions" \
+  --denied-call-observation-out "$observations"
 [[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"
 [[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"
 [[ -s "$observations" ]] || fail "proxy-enforce produced no denied-call observation"

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -126,7 +126,12 @@ for item in files:
     destination = output_path.joinpath(*relative.parts)
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_bytes(data)
-    report.append({"path": str(relative), "sha256": digest})
+    executable = item.get("executable", False)
+    if not isinstance(executable, bool):
+        raise SystemExit(f"invalid executable flag: {relative}")
+    if executable:
+        destination.chmod(0o755)
+    report.append({"path": str(relative), "sha256": digest, "executable": executable})
 report_path.write_text(
     json.dumps({"schema": manifest["schema"], "files": report}, indent=2, sort_keys=True) + "\n",
     encoding="utf-8",

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -205,6 +205,9 @@ if ! GH_BIN="$GH_BIN" JQ_BIN="$JQ_BIN" \
 fi
 record_command "verify-release-attestations" 0 "$harness_root/scripts/ci/release_attestation_enforce.sh"
 
+# Release binaries and the mock upstream do not need repository credentials.
+unset GH_TOKEN GITHUB_TOKEN
+
 cli_extract="$run_root/cli-extract"
 mcp_extract="$run_root/mcp-extract"
 safe_extract() {
@@ -251,18 +254,19 @@ observations="$results/denied-observations.ndjson"
 init_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"published-release-gate","version":"1"}}}'
 call_request='{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}'
 proxy_status=0
-proxy_argv=(
-  assay-mcp-server proxy-enforce
-  --upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py"
-  --enforce-policy "$fixture_dir/policies/no-allowance.yaml"
-  --declared-mcp-manifest "$fixture_dir/baseline-approved.json"
-  --enforcement-decision-out "$decisions"
-  --denied-call-observation-out "$observations"
-)
 printf '%s\n%s\n' "$init_request" "$call_request" \
-  | "${proxy_argv[@]}" \
-      >"$results/proxy.jsonl" 2>"$results/proxy.stderr" || proxy_status=$?
-record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"
+  | "$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \
+      --mcp-bin "$install_root/bin/assay-mcp-server" \
+      --python-bin "$PYTHON_BIN" \
+      --fixture "$fixture_dir/mock_github_mcp.py" \
+      --policy "$fixture_dir/policies/no-allowance.yaml" \
+      --declared-manifest "$fixture_dir/baseline-approved.json" \
+      --decisions "$decisions" \
+      --observations "$observations" \
+      --commands "$commands_file" \
+      --stdout "$results/proxy.jsonl" \
+      --stderr "$results/proxy.stderr" \
+      --timeout-seconds 60 || proxy_status=$?
 [[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"
 [[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"
 [[ -s "$observations" ]] || fail "proxy-enforce produced no denied-call observation"

--- a/scripts/ci/published-release-golden-path.sh
+++ b/scripts/ci/published-release-golden-path.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# jq programs intentionally use single quotes so shell variables are not expanded.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO="${GITHUB_REPOSITORY:-Rul1an/assay}"
+GH_BIN="${GH_BIN:-gh}"
+JQ_BIN="${JQ_BIN:-jq}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+HARNESS_MANIFEST="${ROOT}/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+usage() {
+  echo "usage: published-release-golden-path.sh --release-tag vX.Y.Z --harness-sha <40-hex> --run-root <abs-path>" >&2
+  exit 2
+}
+
+release_tag=""
+harness_sha=""
+run_root=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --release-tag)
+      [[ "$#" -ge 2 ]] || usage
+      release_tag="$2"
+      shift 2
+      ;;
+    --harness-sha)
+      [[ "$#" -ge 2 ]] || usage
+      harness_sha="$2"
+      shift 2
+      ;;
+    --run-root)
+      [[ "$#" -ge 2 ]] || usage
+      run_root="$2"
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+
+[[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "release tag must be an exact stable vX.Y.Z tag"
+[[ "$harness_sha" =~ ^[0-9a-f]{40}$ ]] || fail "harness SHA must be exactly 40 lowercase hex characters"
+[[ "$run_root" = /* ]] || fail "run root must be absolute"
+[[ ! -e "$run_root" ]] || fail "run root already exists; refusing to reuse prior evidence: $run_root"
+[[ -f "$HARNESS_MANIFEST" ]] || fail "harness manifest is missing"
+
+for required in "$GH_BIN" "$JQ_BIN" "$PYTHON_BIN" sha256sum tar; do
+  command -v "$required" >/dev/null 2>&1 || fail "missing required command: $required"
+done
+
+downloads="$run_root/downloads"
+proof_root="$run_root/proof"
+install_root="$run_root/install"
+harness_root="$run_root/harness"
+session_root="$run_root/session"
+results="$run_root/results"
+mkdir -p "$downloads" "$proof_root" "$install_root/bin" "$harness_root" "$session_root" "$results"
+
+commands_file="$results/commands.ndjson"
+: >"$commands_file"
+
+record_command() {
+  local name="$1" status="$2"
+  shift 2
+  "$PYTHON_BIN" - "$commands_file" "$name" "$status" "$@" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+record = {"name": sys.argv[2], "exit_code": int(sys.argv[3]), "argv": sys.argv[4:]}
+with path.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+PY
+}
+
+run_capture() {
+  local name="$1" expected="$2" stdout_path="$3" stderr_path="$4"
+  shift 4
+  local status=0
+  "$@" >"$stdout_path" 2>"$stderr_path" || status=$?
+  record_command "$name" "$status" "$@"
+  [[ "$status" -eq "$expected" ]] || {
+    cat "$stderr_path" >&2
+    fail "$name exited $status, expected $expected"
+  }
+}
+
+# Stage only manifest-listed harness bytes, verify each digest first, and retain what was used.
+"$PYTHON_BIN" - "$HARNESS_MANIFEST" "$ROOT" "$harness_root" "$results/harness-files.json" <<'PY'
+import hashlib, json, pathlib, shutil, sys
+
+manifest_path, root_path, output_path, report_path = map(pathlib.Path, sys.argv[1:])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+if manifest.get("schema") != "assay.published_release_golden_path.harness.v1":
+    raise SystemExit("unexpected harness manifest schema")
+files = manifest.get("files")
+if not isinstance(files, list) or not files:
+    raise SystemExit("harness manifest contains no files")
+report = []
+for item in files:
+    relative = pathlib.PurePosixPath(item["path"])
+    if relative.is_absolute() or ".." in relative.parts or "." in relative.parts:
+        raise SystemExit(f"unsafe harness path: {relative}")
+    source = root_path.joinpath(*relative.parts)
+    data = source.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != item.get("sha256"):
+        raise SystemExit(f"harness digest mismatch: {relative}")
+    destination = output_path.joinpath(*relative.parts)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(data)
+    report.append({"path": str(relative), "sha256": digest})
+report_path.write_text(
+    json.dumps({"schema": manifest["schema"], "files": report}, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+
+version="${release_tag#v}"
+proof_asset="assay-${release_tag}-release-proof-kit.tar.gz"
+release_api="$results/release-api.json"
+"$GH_BIN" api "repos/${REPO}/releases/tags/${release_tag}" >"$release_api"
+"$GH_BIN" release download "$release_tag" --repo "$REPO" --dir "$downloads" --pattern "$proof_asset" --clobber
+
+proof_digest="$($JQ_BIN -er --arg name "$proof_asset" '.assets[] | select(.name == $name) | .digest' "$release_api")"
+[[ "$proof_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "release API omitted the proof-kit sha256 digest"
+actual_proof_digest="sha256:$(sha256sum "$downloads/$proof_asset" | cut -d' ' -f1)"
+[[ "$actual_proof_digest" == "$proof_digest" ]] || fail "proof-kit digest differs from the release API"
+
+tar -xzf "$downloads/$proof_asset" -C "$proof_root"
+kit_root="$proof_root/release-proof-kit"
+kit_manifest="$kit_root/manifest.json"
+[[ -x "$kit_root/verify-offline.sh" ]] || fail "release proof kit has no executable offline verifier"
+[[ "$($JQ_BIN -er '.tag' "$kit_manifest")" == "$release_tag" ]] || fail "proof-kit tag differs from requested release"
+[[ "$($JQ_BIN -er '.repo' "$kit_manifest")" == "$REPO" ]] || fail "proof-kit repository differs from requested repository"
+source_digest="$($JQ_BIN -er '.source_digest' "$kit_manifest")"
+[[ "$source_digest" =~ ^[0-9a-f]{40}$ ]] || fail "proof-kit source digest is not a commit SHA"
+
+while IFS= read -r asset_name; do
+  "$GH_BIN" release download "$release_tag" --repo "$REPO" --dir "$downloads" --pattern "$asset_name" --clobber
+  expected_api_digest="$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest' "$release_api")"
+  expected_kit_digest="sha256:$($JQ_BIN -er --arg name "$asset_name" '.assets[] | select(.name == $name) | .sha256' "$kit_manifest")"
+  actual_digest="sha256:$(sha256sum "$downloads/$asset_name" | cut -d' ' -f1)"
+  [[ "$expected_api_digest" == "$expected_kit_digest" ]] || fail "release API and proof kit disagree for $asset_name"
+  [[ "$actual_digest" == "$expected_kit_digest" ]] || fail "downloaded asset digest differs for $asset_name"
+done < <("$JQ_BIN" -er '.assets[].name' "$kit_manifest")
+
+# This is the release's canonical offline attestation policy. It must complete before installation.
+"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1
+record_command "verify-release-attestations" 0 "$kit_root/verify-offline.sh" --assets-dir "$downloads"
+
+cli_asset="assay-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"
+mcp_asset="assay-mcp-server-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"
+for asset in "$cli_asset" "$mcp_asset"; do
+  "$JQ_BIN" -e --arg name "$asset" '.assets[] | select(.name == $name)' "$kit_manifest" >/dev/null \
+    || fail "proof kit does not attest required Linux asset: $asset"
+done
+
+cli_extract="$run_root/cli-extract"
+mcp_extract="$run_root/mcp-extract"
+mkdir -p "$cli_extract" "$mcp_extract"
+tar -xzf "$downloads/$cli_asset" -C "$cli_extract"
+tar -xzf "$downloads/$mcp_asset" -C "$mcp_extract"
+mapfile -t cli_candidates < <(find "$cli_extract" -type f -name assay -perm -u+x)
+mapfile -t mcp_candidates < <(find "$mcp_extract" -type f -name assay-mcp-server -perm -u+x)
+[[ "${#cli_candidates[@]}" -eq 1 ]] || fail "CLI archive must contain exactly one executable assay binary"
+[[ "${#mcp_candidates[@]}" -eq 1 ]] || fail "MCP archive must contain exactly one executable assay-mcp-server binary"
+cp "${cli_candidates[0]}" "$install_root/bin/assay"
+cp "${mcp_candidates[0]}" "$install_root/bin/assay-mcp-server"
+chmod 0755 "$install_root/bin/assay" "$install_root/bin/assay-mcp-server"
+
+export HOME="$run_root/home"
+mkdir -p "$HOME"
+export PATH="$install_root/bin:/usr/bin:/bin"
+[[ "$(command -v assay)" == "$install_root/bin/assay" ]] || fail "assay did not resolve from the disposable install prefix"
+[[ "$(command -v assay-mcp-server)" == "$install_root/bin/assay-mcp-server" ]] || fail "assay-mcp-server did not resolve from the disposable install prefix"
+
+run_capture "assay-version" 0 "$results/assay-version.txt" "$results/assay-version.stderr" assay version
+[[ "$(tr -d '\r\n' <"$results/assay-version.txt")" == "$version" ]] || fail "assay version differs from pinned release"
+run_capture "mcp-version" 0 "$results/mcp-version.txt" "$results/mcp-version.stderr" assay-mcp-server --version
+grep -Eq "(^|[[:space:]])${version}$" "$results/mcp-version.txt" || fail "assay-mcp-server version differs from pinned release"
+
+pushd "$session_root" >/dev/null
+run_capture "init" 0 "$results/init.json" "$results/init.stderr" assay init --preset dev --hello-trace --format json
+"$JQ_BIN" -e '.schema == "assay.init_report.v0"' "$results/init.json" >/dev/null || fail "init output identity drifted"
+run_capture "policy-validate" 0 "$results/policy-validate.json" "$results/policy-validate.stderr" \
+  assay policy validate --input policy.yaml --format json
+"$JQ_BIN" -e '.schema == "assay.run_summary.v1"' "$results/policy-validate.json" >/dev/null || fail "policy validation output identity drifted"
+run_capture "evaluate" 0 "$results/evaluate.json" "$results/evaluate.stderr" \
+  assay run --config eval.yaml --trace-file traces/hello.jsonl --format json
+"$JQ_BIN" -e '.schema == "assay.run_report.v1"' "$results/evaluate.json" >/dev/null || fail "evaluation output identity drifted"
+popd >/dev/null
+
+fixture_dir="$harness_root/examples/privileged-action-gate"
+decisions="$results/decisions.ndjson"
+observations="$results/denied-observations.ndjson"
+init_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"published-release-gate","version":"1"}}}'
+call_request='{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}'
+proxy_status=0
+printf '%s\n%s\n' "$init_request" "$call_request" \
+  | assay-mcp-server proxy-enforce \
+      --upstream-command "$PYTHON_BIN" --upstream-arg -u --upstream-arg "$fixture_dir/mock_github_mcp.py" \
+      --enforce-policy "$fixture_dir/policies/no-allowance.yaml" \
+      --declared-mcp-manifest "$fixture_dir/baseline-approved.json" \
+      --enforcement-decision-out "$decisions" \
+      --denied-call-observation-out "$observations" \
+      >"$results/proxy.jsonl" 2>"$results/proxy.stderr" || proxy_status=$?
+record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce --upstream-command python3
+[[ "$proxy_status" -eq 0 ]] || fail "proxy-enforce exited $proxy_status, expected 0 for a policy denial"
+[[ -s "$decisions" ]] || fail "proxy-enforce produced no enforcement decision"
+[[ -s "$observations" ]] || fail "proxy-enforce produced no denied-call observation"
+"$JQ_BIN" -e 'select(.schema == "assay.enforcement_decision.v0" and .decision == "deny" and .reason == "no_declared_allowance")' "$decisions" >/dev/null \
+  || fail "enforcement decision identity or semantics drifted"
+
+bundle="$results/produced.bundle.tar.gz"
+[[ ! -e "$bundle" ]] || fail "bundle existed before production"
+run_capture "produce-bundle" 0 "$results/produce.stdout" "$results/produce.stderr" \
+  assay evidence import privileged-mcp-action \
+    --decisions "$decisions" --denied-observations "$observations" \
+    --bundle-out "$bundle" --run-id published-release-golden-path \
+    --import-time 2026-01-01T00:00:00Z
+[[ -s "$bundle" ]] || fail "bundle production yielded no bytes"
+
+run_capture "inspect-produced-bundle" 0 "$results/inspect.json" "$results/inspect.stderr" \
+  assay evidence show --format json -- "$bundle"
+"$JQ_BIN" -e '.verify_mode == "enabled" and (.manifest | type == "object") and (.events | length > 0)' "$results/inspect.json" >/dev/null \
+  || fail "inspection did not verify the produced bundle"
+run_capture "verify-produced-bundle" 0 "$results/verify.json" "$results/verify.stderr" \
+  assay evidence verify-privileged-mcp-action "$bundle" --format json
+"$JQ_BIN" -e '.schema == "assay.privileged_mcp_action.verify.report.v0" and .bundle_integrity == "pass" and .verdict == "valid"' "$results/verify.json" >/dev/null \
+  || fail "profile verification did not validate the produced bundle"
+
+run_capture "export-sarif" 0 "$results/sarif.stdout" "$results/sarif.stderr" \
+  assay-mcp-server enforcement-sarif --input "$decisions" --output "$results/enforcement.sarif"
+"$JQ_BIN" -e '.version == "2.1.0" and (.runs[0].results | length == 1)' "$results/enforcement.sarif" >/dev/null \
+  || fail "SARIF export identity or deny count drifted"
+
+tampered="$results/tampered.bundle.tar.gz"
+"$PYTHON_BIN" - "$bundle" "$tampered" <<'PY'
+import io, tarfile, sys
+source, destination = sys.argv[1:]
+with tarfile.open(source, "r:gz") as archive:
+    members = archive.getmembers()
+    payloads = {}
+    for member in members:
+        if member.isfile():
+            handle = archive.extractfile(member)
+            payloads[member.name] = handle.read() if handle else b""
+event_name = next((name for name in payloads if name.endswith("events.ndjson")), None)
+if event_name is None:
+    raise SystemExit("produced bundle has no events.ndjson")
+payloads[event_name] += b"\n"
+with tarfile.open(destination, "w:gz") as archive:
+    for member in members:
+        if member.isfile():
+            data = payloads[member.name]
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+        else:
+            archive.addfile(member)
+PY
+run_capture "verify-tampered-bundle" 2 "$results/tamper-verify.json" "$results/tamper-verify.stderr" \
+  assay evidence verify-privileged-mcp-action "$tampered" --format json
+"$JQ_BIN" -e '.schema == "assay.privileged_mcp_action.verify.report.v0" and .bundle_integrity == "fail" and .reason_code == "E_EVIDENCE_INTEGRITY"' "$results/tamper-verify.json" >/dev/null \
+  || fail "tampered produced bundle did not fail with E_EVIDENCE_INTEGRITY"
+
+driver_digest="$(sha256sum "$ROOT/scripts/ci/published-release-golden-path.sh" | cut -d' ' -f1)"
+harness_manifest_digest="$(sha256sum "$HARNESS_MANIFEST" | cut -d' ' -f1)"
+"$PYTHON_BIN" - "$release_tag" "$source_digest" "$kit_manifest" "$harness_sha" "$driver_digest" \
+  "$harness_manifest_digest" "$results/harness-files.json" "$commands_file" "$results/run-pin.json" <<'PY'
+import json, pathlib, sys
+(release_tag, source_digest, kit_manifest_path, harness_sha, driver_digest,
+ harness_manifest_digest, harness_files_path, commands_path, output_path) = sys.argv[1:]
+kit = json.loads(pathlib.Path(kit_manifest_path).read_text(encoding="utf-8"))
+harness = json.loads(pathlib.Path(harness_files_path).read_text(encoding="utf-8"))
+commands = [json.loads(line) for line in pathlib.Path(commands_path).read_text(encoding="utf-8").splitlines() if line]
+document = {
+    "schema": "assay.published_release_golden_path.run_pin.v1",
+    "release": {
+        "tag": release_tag,
+        "source_digest": source_digest,
+        "assets": [{"name": row["name"], "sha256": row["sha256"]} for row in kit["assets"]],
+    },
+    "harness": {
+        "head_sha": harness_sha,
+        "driver_sha256": driver_digest,
+        "manifest_sha256": harness_manifest_digest,
+        "files": harness["files"],
+    },
+    "commands": commands,
+    "claim_ceiling": (
+        "The attested release binaries completed the bounded Linux x86_64 journey under the "
+        "recorded harness head and fixture digests; the harness is not a shipped release asset."
+    ),
+}
+pathlib.Path(output_path).write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+"$PYTHON_BIN" - "$results" "$results/retained-artifacts.json" <<'PY'
+import hashlib, json, pathlib, sys
+root, output = map(pathlib.Path, sys.argv[1:])
+required = [
+    "run-pin.json", "commands.ndjson", "produced.bundle.tar.gz", "decisions.ndjson",
+    "inspect.json", "verify.json", "tamper-verify.json", "enforcement.sarif",
+]
+for name in required:
+    path = root / name
+    if not path.is_file() or path.stat().st_size == 0:
+        raise SystemExit(f"required retained artifact is missing or empty: {name}")
+files = []
+for path in sorted(root.iterdir()):
+    if path.is_file() and path != output:
+        files.append({"path": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest(), "size": path.stat().st_size})
+document = {"schema": "assay.published_release_golden_path.artifacts.v1", "files": files}
+output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+echo "PASS: published release ${release_tag} completed the install-to-verified-evidence journey"

--- a/scripts/ci/published_release_proxy_phase.py
+++ b/scripts/ci/published_release_proxy_phase.py
@@ -8,6 +8,7 @@ import json
 import os
 from pathlib import Path
 import resource
+import shutil
 import subprocess
 import sys
 
@@ -25,16 +26,6 @@ def bounded_seconds(value: str) -> int:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mcp-bin", required=True)
-    parser.add_argument("--python-bin", required=True)
-    parser.add_argument("--fixture", type=Path, required=True)
-    parser.add_argument("--policy", type=Path, required=True)
-    parser.add_argument("--declared-manifest", type=Path, required=True)
-    parser.add_argument("--decisions", type=Path, required=True)
-    parser.add_argument("--observations", type=Path, required=True)
-    parser.add_argument("--commands", type=Path, required=True)
-    parser.add_argument("--stdout", type=Path, required=True)
-    parser.add_argument("--stderr", type=Path, required=True)
     parser.add_argument("--timeout-seconds", type=bounded_seconds, default=60)
     return parser.parse_args()
 
@@ -58,29 +49,40 @@ def limit_child_output() -> None:
 
 def main() -> int:
     args = parse_args()
+    results = Path.cwd().resolve()
+    harness_root = Path(__file__).resolve().parents[2]
+    fixture_root = harness_root / "examples/privileged-action-gate"
+    decisions = results / "decisions.ndjson"
+    observations = results / "denied-observations.ndjson"
     request = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
     if len(request) > MAX_REQUEST_BYTES:
         raise SystemExit("proxy request exceeds 1 MiB ceiling")
 
+    mcp_bin = shutil.which("assay-mcp-server", path=child_environment().get("PATH"))
+    if mcp_bin is None:
+        raise SystemExit("assay-mcp-server is absent from the restricted PATH")
+
     argv = [
-        args.mcp_bin,
+        mcp_bin,
         "proxy-enforce",
         "--upstream-command",
-        args.python_bin,
+        sys.executable,
         "--upstream-arg",
         "-u",
         "--upstream-arg",
-        str(args.fixture),
+        str(fixture_root / "mock_github_mcp.py"),
         "--enforce-policy",
-        str(args.policy),
+        str(fixture_root / "policies/no-allowance.yaml"),
         "--declared-mcp-manifest",
-        str(args.declared_manifest),
+        str(fixture_root / "baseline-approved.json"),
         "--enforcement-decision-out",
-        str(args.decisions),
+        str(decisions),
         "--denied-call-observation-out",
-        str(args.observations),
+        str(observations),
     ]
-    with args.stdout.open("wb") as stdout_handle, args.stderr.open("wb") as stderr_handle:
+    with (results / "proxy.jsonl").open("wb") as stdout_handle, (
+        results / "proxy.stderr"
+    ).open("wb") as stderr_handle:
         try:
             completed = subprocess.run(
                 argv,
@@ -98,7 +100,7 @@ def main() -> int:
         except OSError as error:
             stderr_handle.write(f"proxy process failed to start: {error}\n".encode())
             status = 127
-    append_command_record(args.commands, status, argv)
+    append_command_record(results / "commands.ndjson", status, argv)
     return status if 0 <= status <= 255 else 125
 
 

--- a/scripts/ci/published_release_proxy_phase.py
+++ b/scripts/ci/published_release_proxy_phase.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Execute and record the published-release proxy phase from one argv value."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import resource
+import subprocess
+import sys
+
+
+MAX_REQUEST_BYTES = 1_048_576
+MAX_OUTPUT_BYTES = 16_777_216
+
+
+def bounded_seconds(value: str) -> int:
+    seconds = int(value)
+    if not 1 <= seconds <= 300:
+        raise argparse.ArgumentTypeError("timeout must be between 1 and 300 seconds")
+    return seconds
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mcp-bin", required=True)
+    parser.add_argument("--python-bin", required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--policy", type=Path, required=True)
+    parser.add_argument("--declared-manifest", type=Path, required=True)
+    parser.add_argument("--decisions", type=Path, required=True)
+    parser.add_argument("--observations", type=Path, required=True)
+    parser.add_argument("--commands", type=Path, required=True)
+    parser.add_argument("--stdout", type=Path, required=True)
+    parser.add_argument("--stderr", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=bounded_seconds, default=60)
+    return parser.parse_args()
+
+
+def append_command_record(path: Path, exit_code: int, argv: list[str]) -> None:
+    record = {"name": "proxy-enforce", "exit_code": exit_code, "argv": argv}
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def child_environment() -> dict[str, str]:
+    allowed = ("HOME", "PATH", "LANG", "LC_ALL", "TZ")
+    return {key: os.environ[key] for key in allowed if key in os.environ}
+
+
+def limit_child_output() -> None:
+    resource.setrlimit(resource.RLIMIT_FSIZE, (MAX_OUTPUT_BYTES, MAX_OUTPUT_BYTES))
+
+
+def main() -> int:
+    args = parse_args()
+    request = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(request) > MAX_REQUEST_BYTES:
+        raise SystemExit("proxy request exceeds 1 MiB ceiling")
+
+    argv = [
+        args.mcp_bin,
+        "proxy-enforce",
+        "--upstream-command",
+        args.python_bin,
+        "--upstream-arg",
+        "-u",
+        "--upstream-arg",
+        str(args.fixture),
+        "--enforce-policy",
+        str(args.policy),
+        "--declared-mcp-manifest",
+        str(args.declared_manifest),
+        "--enforcement-decision-out",
+        str(args.decisions),
+        "--denied-call-observation-out",
+        str(args.observations),
+    ]
+    with args.stdout.open("wb") as stdout_handle, args.stderr.open("wb") as stderr_handle:
+        try:
+            completed = subprocess.run(
+                argv,
+                input=request,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                check=False,
+                env=child_environment(),
+                preexec_fn=limit_child_output,
+                timeout=args.timeout_seconds,
+            )
+            status = completed.returncode
+        except subprocess.TimeoutExpired:
+            status = 124
+        except OSError as error:
+            stderr_handle.write(f"proxy process failed to start: {error}\n".encode())
+            status = 127
+    append_command_record(args.commands, status, argv)
+    return status if 0 <= status <= 255 else 125
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/published_release_proxy_phase.py
+++ b/scripts/ci/published_release_proxy_phase.py
@@ -114,8 +114,9 @@ def main() -> int:
                 process.communicate(input=request, timeout=args.timeout_seconds)
                 status = process.returncode
             except subprocess.TimeoutExpired:
-                stop_process_group(process)
                 status = 124
+            finally:
+                stop_process_group(process)
         except OSError as error:
             stderr_handle.write(f"proxy process failed to start: {error}\n".encode())
             status = 127

--- a/scripts/ci/published_release_proxy_phase.py
+++ b/scripts/ci/published_release_proxy_phase.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import resource
 import shutil
+import signal
 import subprocess
 import sys
 
@@ -45,6 +46,22 @@ def child_environment() -> dict[str, str]:
 
 def limit_child_output() -> None:
     resource.setrlimit(resource.RLIMIT_FSIZE, (MAX_OUTPUT_BYTES, MAX_OUTPUT_BYTES))
+
+
+def stop_process_group(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait()
 
 
 def main() -> int:
@@ -84,19 +101,21 @@ def main() -> int:
         results / "proxy.stderr"
     ).open("wb") as stderr_handle:
         try:
-            completed = subprocess.run(
+            process = subprocess.Popen(
                 argv,
-                input=request,
+                stdin=subprocess.PIPE,
                 stdout=stdout_handle,
                 stderr=stderr_handle,
-                check=False,
                 env=child_environment(),
                 preexec_fn=limit_child_output,
-                timeout=args.timeout_seconds,
+                start_new_session=True,
             )
-            status = completed.returncode
-        except subprocess.TimeoutExpired:
-            status = 124
+            try:
+                process.communicate(input=request, timeout=args.timeout_seconds)
+                status = process.returncode
+            except subprocess.TimeoutExpired:
+                stop_process_group(process)
+                status = 124
         except OSError as error:
             stderr_handle.write(f"proxy process failed to start: {error}\n".encode())
             status = 127

--- a/scripts/ci/release_attestation_enforce.sh
+++ b/scripts/ci/release_attestation_enforce.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# jq programs intentionally use single quotes so shell variables are not expanded.
+# shellcheck disable=SC2016
 set -euo pipefail
 
 GH_BIN="${GH_BIN:-gh}"
@@ -8,7 +10,7 @@ OUT_SUMMARY="${OUT_SUMMARY:?OUT_SUMMARY is required}"
 OUT_RAW_DIR="${OUT_RAW_DIR:?OUT_RAW_DIR is required}"
 REPO="${REPO:?REPO is required}"
 SIGNER_WORKFLOW="${SIGNER_WORKFLOW:?SIGNER_WORKFLOW is required}"
-SOURCE_REF="${SOURCE_REF:?SOURCE_REF is required}"
+SOURCE_REF="${SOURCE_REF:-}"
 SOURCE_DIGEST="${SOURCE_DIGEST:?SOURCE_DIGEST is required}"
 CERT_OIDC_ISSUER="${CERT_OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
 PREDICATE_TYPE="${PREDICATE_TYPE:-https://slsa.dev/provenance/v1}"
@@ -63,17 +65,22 @@ for asset in "${assets[@]}"; do
   verify_json=""
   attempt=1
   delay_seconds="$ATTESTATION_VERIFY_RETRY_DELAY_SECONDS"
+  verify_args=(
+    attestation verify "$asset"
+    --repo "$REPO"
+    --signer-workflow "$SIGNER_WORKFLOW"
+    --cert-oidc-issuer "$CERT_OIDC_ISSUER"
+    --predicate-type "$PREDICATE_TYPE"
+    --source-digest "$SOURCE_DIGEST"
+    --deny-self-hosted-runners
+    --format json
+  )
+  if [ -n "$SOURCE_REF" ]; then
+    verify_args+=(--source-ref "$SOURCE_REF")
+  fi
 
   while :; do
-    if verify_json="$("$GH_BIN" attestation verify "$asset" \
-      --repo "$REPO" \
-      --signer-workflow "$SIGNER_WORKFLOW" \
-      --cert-oidc-issuer "$CERT_OIDC_ISSUER" \
-      --predicate-type "$PREDICATE_TYPE" \
-      --source-digest "$SOURCE_DIGEST" \
-      --source-ref "$SOURCE_REF" \
-      --deny-self-hosted-runners \
-      --format json)"; then
+    if verify_json="$("$GH_BIN" "${verify_args[@]}")"; then
       break
     fi
 
@@ -138,7 +145,7 @@ done
       repo: $repo,
       signer_workflow: $signer_workflow,
       cert_oidc_issuer: $cert_oidc_issuer,
-      source_ref: $source_ref,
+    source_ref: (if $source_ref == "" then null else $source_ref end),
       source_digest: $source_digest,
       predicate_type: $predicate_type,
       deny_self_hosted_runners: true

--- a/scripts/ci/safe_extract_release_archive.py
+++ b/scripts/ci/safe_extract_release_archive.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Validate and atomically extract a bounded release tar archive."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import shutil
+import tarfile
+
+
+class ArchiveRejected(ValueError):
+    pass
+
+
+def extract_archive(
+    archive: pathlib.Path,
+    destination: pathlib.Path,
+    *,
+    max_decoded_bytes: int,
+    max_members: int = 32,
+) -> None:
+    if max_decoded_bytes <= 0 or max_members <= 0:
+        raise ValueError("archive ceilings must be positive")
+    if destination.exists():
+        raise ArchiveRejected("archive destination already exists")
+
+    with tarfile.open(archive, "r:gz") as handle:
+        members = handle.getmembers()
+        if not 1 <= len(members) <= max_members:
+            raise ArchiveRejected("archive member-count ceiling exceeded")
+
+        total = 0
+        seen: set[str] = set()
+        for member in members:
+            relative = pathlib.PurePosixPath(member.name)
+            if (
+                relative.is_absolute()
+                or not relative.parts
+                or "." in relative.parts
+                or ".." in relative.parts
+                or "\\" in member.name
+                or member.name in seen
+                or not (member.isdir() or member.isreg())
+            ):
+                raise ArchiveRejected(f"unsafe archive member: {member.name!r}")
+            seen.add(member.name)
+            if member.isreg():
+                if member.size < 0 or member.size > max_decoded_bytes:
+                    raise ArchiveRejected(f"archive member exceeds size ceiling: {member.name}")
+                total += member.size
+                if total > max_decoded_bytes:
+                    raise ArchiveRejected("archive decoded-size ceiling exceeded")
+
+        scratch = destination.with_name(f".{destination.name}.extracting")
+        if scratch.exists():
+            raise ArchiveRejected("archive scratch destination already exists")
+        scratch.mkdir(parents=True)
+        try:
+            for member in members:
+                target = scratch.joinpath(*pathlib.PurePosixPath(member.name).parts)
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                source = handle.extractfile(member)
+                if source is None:
+                    raise ArchiveRejected(f"archive member could not be read: {member.name}")
+                with source, target.open("wb") as output:
+                    shutil.copyfileobj(source, output, length=1024 * 1024)
+                if target.stat().st_size != member.size:
+                    raise ArchiveRejected(f"archive member size changed while extracting: {member.name}")
+                target.chmod(member.mode & 0o777)
+            scratch.replace(destination)
+        except BaseException:
+            shutil.rmtree(scratch, ignore_errors=True)
+            raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive", type=pathlib.Path)
+    parser.add_argument("destination", type=pathlib.Path)
+    parser.add_argument("--max-decoded-bytes", type=int, required=True)
+    parser.add_argument("--max-members", type=int, default=32)
+    args = parser.parse_args()
+    try:
+        extract_archive(
+            args.archive,
+            args.destination,
+            max_decoded_bytes=args.max_decoded_bytes,
+            max_members=args.max_members,
+        )
+    except (ArchiveRejected, OSError, tarfile.TarError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/safe_extract_release_archive.py
+++ b/scripts/ci/safe_extract_release_archive.py
@@ -12,6 +12,41 @@ class ArchiveRejected(ValueError):
     pass
 
 
+def _validate_members(
+    handle: tarfile.TarFile, *, max_decoded_bytes: int, max_members: int
+) -> tuple[int, int]:
+    count = 0
+    file_count = 0
+    total = 0
+    seen: set[str] = set()
+    for member in handle:
+        count += 1
+        if count > max_members:
+            raise ArchiveRejected("archive member-count ceiling exceeded")
+        relative = pathlib.PurePosixPath(member.name)
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or "." in relative.parts
+            or ".." in relative.parts
+            or "\\" in member.name
+            or member.name in seen
+            or not (member.isdir() or member.isreg())
+        ):
+            raise ArchiveRejected(f"unsafe archive member: {member.name!r}")
+        seen.add(member.name)
+        if member.isreg():
+            file_count += 1
+            if member.size < 0 or member.size > max_decoded_bytes:
+                raise ArchiveRejected(f"archive member exceeds size ceiling: {member.name}")
+            total += member.size
+            if total > max_decoded_bytes:
+                raise ArchiveRejected("archive decoded-size ceiling exceeded")
+    if count == 0:
+        raise ArchiveRejected("archive contains no members")
+    return file_count, total
+
+
 def extract_archive(
     archive: pathlib.Path,
     destination: pathlib.Path,
@@ -24,42 +59,25 @@ def extract_archive(
     if destination.exists():
         raise ArchiveRejected("archive destination already exists")
 
-    with tarfile.open(archive, "r:gz") as handle:
-        members = handle.getmembers()
-        if not 1 <= len(members) <= max_members:
-            raise ArchiveRejected("archive member-count ceiling exceeded")
-
-        total = 0
-        seen: set[str] = set()
-        for member in members:
-            relative = pathlib.PurePosixPath(member.name)
-            if (
-                relative.is_absolute()
-                or not relative.parts
-                or "." in relative.parts
-                or ".." in relative.parts
-                or "\\" in member.name
-                or member.name in seen
-                or not (member.isdir() or member.isreg())
-            ):
-                raise ArchiveRejected(f"unsafe archive member: {member.name!r}")
-            seen.add(member.name)
-            if member.isreg():
-                if member.size < 0 or member.size > max_decoded_bytes:
-                    raise ArchiveRejected(f"archive member exceeds size ceiling: {member.name}")
-                total += member.size
-                if total > max_decoded_bytes:
-                    raise ArchiveRejected("archive decoded-size ceiling exceeded")
-
+    with archive.open("rb") as raw:
+        with tarfile.open(fileobj=raw, mode="r|gz") as handle:
+            expected_count, expected_size = _validate_members(
+                handle,
+                max_decoded_bytes=max_decoded_bytes,
+                max_members=max_members,
+            )
+        raw.seek(0)
         scratch = destination.with_name(f".{destination.name}.extracting")
         if scratch.exists():
             raise ArchiveRejected("archive scratch destination already exists")
         scratch.mkdir(parents=True)
         try:
-            handle.extractall(path=scratch, members=members, filter="data")
+            with tarfile.open(fileobj=raw, mode="r|gz") as handle:
+                handle.extractall(path=scratch, members=handle, filter="data")
+            extracted_count = sum(1 for path in scratch.rglob("*") if path.is_file())
             extracted_size = sum(path.stat().st_size for path in scratch.rglob("*") if path.is_file())
-            if extracted_size != total:
-                raise ArchiveRejected("archive decoded size changed while extracting")
+            if extracted_count != expected_count or extracted_size != expected_size:
+                raise ArchiveRejected("archive contents changed while extracting")
             scratch.replace(destination)
         except BaseException:
             shutil.rmtree(scratch, ignore_errors=True)

--- a/scripts/ci/safe_extract_release_archive.py
+++ b/scripts/ci/safe_extract_release_archive.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import argparse
 import pathlib
 import shutil
 import tarfile
@@ -57,44 +56,11 @@ def extract_archive(
             raise ArchiveRejected("archive scratch destination already exists")
         scratch.mkdir(parents=True)
         try:
-            for member in members:
-                target = scratch.joinpath(*pathlib.PurePosixPath(member.name).parts)
-                if member.isdir():
-                    target.mkdir(parents=True, exist_ok=True)
-                    continue
-                target.parent.mkdir(parents=True, exist_ok=True)
-                source = handle.extractfile(member)
-                if source is None:
-                    raise ArchiveRejected(f"archive member could not be read: {member.name}")
-                with source, target.open("wb") as output:
-                    shutil.copyfileobj(source, output, length=1024 * 1024)
-                if target.stat().st_size != member.size:
-                    raise ArchiveRejected(f"archive member size changed while extracting: {member.name}")
-                target.chmod(member.mode & 0o777)
+            handle.extractall(path=scratch, members=members, filter="data")
+            extracted_size = sum(path.stat().st_size for path in scratch.rglob("*") if path.is_file())
+            if extracted_size != total:
+                raise ArchiveRejected("archive decoded size changed while extracting")
             scratch.replace(destination)
         except BaseException:
             shutil.rmtree(scratch, ignore_errors=True)
             raise
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("archive", type=pathlib.Path)
-    parser.add_argument("destination", type=pathlib.Path)
-    parser.add_argument("--max-decoded-bytes", type=int, required=True)
-    parser.add_argument("--max-members", type=int, default=32)
-    args = parser.parse_args()
-    try:
-        extract_archive(
-            args.archive,
-            args.destination,
-            max_decoded_bytes=args.max_decoded_bytes,
-            max_members=args.max_members,
-        )
-    except (ArchiveRejected, OSError, tarfile.TarError) as error:
-        parser.error(str(error))
-    return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -34,12 +34,11 @@ PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_bounded_download.py
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 verifier_call='bash "$harness_root/scripts/ci/release_attestation_enforce.sh" '"\\"
-proxy_record_call='record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce '"\\"
 workflow_driver_call='          bash scripts/ci/published-release-golden-path.sh '"\\"
 workflow_driver_decoy=$'          # bash scripts/ci/published-release-golden-path.sh\n          echo skipped-reviewed-driver '"\\"
 
 expect_mutation_failure() {
-  local name="$1" target="$2" old="$3" new="$4" expected="$5"
+  local name="$1" target="$2" old="$3" new="$4" expected="$5" refresh_path="${6:-}"
   local case_root="$scratch/$name"
   mkdir -p "$case_root"
   cp "$WORKFLOW" "$case_root/workflow.yml"
@@ -65,6 +64,19 @@ if text.count(old) != 1:
     raise SystemExit(f"mutation anchor count for {old!r}: {text.count(old)}")
 path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
+  if [[ -n "$refresh_path" ]]; then
+    python3 - "$case_root/manifest.json" "$case_root/$target" "$refresh_path" <<'PY'
+import hashlib, json, pathlib, sys
+manifest_path, changed_path = map(pathlib.Path, sys.argv[1:3])
+logical_path = sys.argv[3]
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+rows = [row for row in manifest["files"] if row["path"] == logical_path]
+if len(rows) != 1:
+    raise SystemExit(f"refresh path is not unique in manifest: {logical_path}")
+rows[0]["sha256"] = hashlib.sha256(changed_path.read_bytes()).hexdigest()
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+  fi
   if python3 "$CHECKER" \
       --workflow "$case_root/workflow.yml" \
       --release-workflow "$case_root/release.yml" \
@@ -228,37 +240,57 @@ expect_mutation_failure \
   "reviewed-driver-dead-code-decoy" "driver.sh" \
   "$verifier_call" \
   $'if false; then\n      bash "$harness_root/scripts/ci/release_attestation_enforce.sh" \\\n    fi\n    bash "$downloads/verifier.sh" \\' \
-  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
+  "driver attestation execution block drifted" \
+  "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "mcp-version-regex-loosened" "driver.sh" \
   '"assay-mcp-server $version"' \
   '"$version"' \
-  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
+  "exact MCP version comparison drifted" \
+  "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "proxy-command-provenance-truncated" "driver.sh" \
-  "$proxy_record_call" \
+  'record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"' \
   'record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce --upstream-command python3' \
-  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
+  "proxy command provenance no longer uses the executed argv" \
+  "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "workflow-driver-comment-decoy" "workflow.yml" \
   "$workflow_driver_call" \
   "$workflow_driver_decoy" \
-  "harness digest drifted: .github/workflows/published-release-golden-path.yml"
+  "workflow must execute only the exact reviewed driver invocation" \
+  ".github/workflows/published-release-golden-path.yml"
 
 expect_mutation_failure \
   "signer-binding-removed" "scripts/ci/release_attestation_enforce.sh" \
   '    --signer-workflow "$SIGNER_WORKFLOW"' \
   '    --predicate-type https://slsa.dev/provenance/v1' \
-  "harness digest drifted: scripts/ci/release_attestation_enforce.sh"
+  "attestation signer binding drifted" \
+  "scripts/ci/release_attestation_enforce.sh"
 
 expect_mutation_failure \
   "raw-attestation-count-disabled" "driver.sh" \
   '("attestation-raw/*.json", 2)' \
   '("attestation-raw/*.json", 0)' \
-  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
+  "retained trust-input count enforcement drifted" \
+  "scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "source-digest-binding-removed" "scripts/ci/release_attestation_enforce.sh" \
+  '    --source-digest "$SOURCE_DIGEST"' \
+  '    --source-ref refs/heads/main' \
+  "attestation source digest binding drifted" \
+  "scripts/ci/release_attestation_enforce.sh"
+
+expect_mutation_failure \
+  "local-subject-binding-loosened" "scripts/ci/release_attestation_enforce.sh" \
+  'any(.[]; any((.verificationResult.statement.subject // [])[]?; .digest.sha256? == $digest))' \
+  'any(.[]; (.verificationResult.statement.subject // [] | length) > 0)' \
+  "attestation local-subject digest binding drifted" \
+  "scripts/ci/release_attestation_enforce.sh"
 
 expect_mutation_failure \
   "inventory-executable-flag-removed" "manifest.json" \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Mutation anchors intentionally preserve literal shell and Actions expressions.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${WORKFLOW:-${ROOT}/.github/workflows/published-release-golden-path.yml}"
+DRIVER="${DRIVER:-${ROOT}/scripts/ci/published-release-golden-path.sh}"
+MANIFEST="${MANIFEST:-${ROOT}/scripts/ci/fixtures/published-release-golden-path/v1/harness-manifest.json}"
+RELEASE_WORKFLOW="${RELEASE_WORKFLOW:-${ROOT}/.github/workflows/release.yml}"
+CHECKER="${ROOT}/scripts/ci/check-published-release-golden-path-contract.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$WORKFLOW" ]] || fail "missing published-release golden-path workflow"
+[[ -f "$DRIVER" ]] || fail "missing published-release golden-path driver"
+[[ -f "$MANIFEST" ]] || fail "missing published-release golden-path harness manifest"
+[[ -f "$RELEASE_WORKFLOW" ]] || fail "missing release workflow"
+[[ -f "$CHECKER" ]] || fail "missing published-release golden-path checker"
+
+python3 "$CHECKER" \
+  --workflow "$WORKFLOW" \
+  --release-workflow "$RELEASE_WORKFLOW" \
+  --driver "$DRIVER" \
+  --manifest "$MANIFEST" \
+  --source-root "$ROOT"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+expect_mutation_failure() {
+  local name="$1" target="$2" old="$3" new="$4" expected="$5"
+  local case_root="$scratch/$name"
+  mkdir -p "$case_root"
+  cp "$WORKFLOW" "$case_root/workflow.yml"
+  cp "$RELEASE_WORKFLOW" "$case_root/release.yml"
+  cp "$DRIVER" "$case_root/driver.sh"
+  cp "$MANIFEST" "$case_root/manifest.json"
+  python3 - "$case_root/$target" "$old" "$new" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+old, new = sys.argv[2:]
+text = path.read_text(encoding="utf-8")
+if text.count(old) != 1:
+    raise SystemExit(f"mutation anchor count for {old!r}: {text.count(old)}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+  if python3 "$CHECKER" \
+      --workflow "$case_root/workflow.yml" \
+      --release-workflow "$case_root/release.yml" \
+      --driver "$case_root/driver.sh" \
+      --manifest "$case_root/manifest.json" \
+      --source-root "$ROOT" >"$case_root/output" 2>&1; then
+    fail "mutation stayed green: $name"
+  fi
+  grep -F "$expected" "$case_root/output" >/dev/null \
+    || fail "mutation $name missed expected guard: $expected"
+}
+
+expect_mutation_failure \
+  "attestation-removed" "driver.sh" \
+  '"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1' \
+  'echo skipped-attestation >"$results/attestation-verify.log"' \
+  "release attestations must verify before the first Assay invocation"
+
+expect_mutation_failure \
+  "attestation-suppressed" "driver.sh" \
+  '"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1' \
+  '"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1 || true' \
+  "driver suppresses a failure"
+
+expect_mutation_failure \
+  "ambient-home" "driver.sh" \
+  'export HOME="$run_root/home"' 'export HOME="${HOME}"' \
+  "driver lost disposable HOME"
+
+expect_mutation_failure \
+  "ambient-path" "driver.sh" \
+  'export PATH="$install_root/bin:/usr/bin:/bin"' 'export PATH="/usr/bin:/bin"' \
+  "driver lost restricted PATH"
+
+expect_mutation_failure \
+  "preexisting-inspection" "driver.sh" \
+  'assay evidence show --format json -- "$bundle"' \
+  'assay evidence show --format json -- conformance/privileged-mcp-action-v0/vectors/ok-001.bundle.tar.gz' \
+  "driver lost inspect produced bundle"
+
+expect_mutation_failure \
+  "provenance-collapsed" "driver.sh" \
+  '"harness": {' '"release_harness": {' \
+  "driver lost separate harness provenance"
+
+expect_mutation_failure \
+  "fixture-digest-drift" "manifest.json" \
+  '4b489043fed724b332f9f216942778992270d85a89de4589c73a23fbb86aa48d' \
+  '0b489043fed724b332f9f216942778992270d85a89de4589c73a23fbb86aa48d' \
+  "harness digest drifted"
+
+expect_mutation_failure \
+  "artifact-omitted" "driver.sh" \
+  '"tamper-verify.json", "enforcement.sarif",' \
+  '"enforcement.sarif",' \
+  "driver no longer requires retained artifact: tamper-verify.json"
+
+expect_mutation_failure \
+  "release-input-drift" "release.yml" \
+  'release_tag: ${{ needs.release-contract.outputs.version }}' \
+  'release_tag: v0.0.0' \
+  "release transaction must pass its validated version"
+
+echo "ok: published-release golden-path contract"

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -27,6 +27,8 @@ python3 "$CHECKER" \
   --driver "$DRIVER" \
   --manifest "$MANIFEST" \
   --source-root "$ROOT"
+bash "$ROOT/scripts/ci/test-release-attestation-enforce.sh"
+PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_safe_extract_release_archive.py"
 
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
@@ -62,14 +64,14 @@ PY
 
 expect_mutation_failure \
   "attestation-removed" "driver.sh" \
-  '"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1' \
-  'echo skipped-attestation >"$results/attestation-verify.log"' \
-  "release attestations must verify before the first Assay invocation"
+  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  'echo skipped-attestation' \
+  "driver must execute the reviewed attestation verifier exactly once"
 
 expect_mutation_failure \
   "attestation-suppressed" "driver.sh" \
-  '"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1' \
-  '"$kit_root/verify-offline.sh" --assets-dir "$downloads" >"$results/attestation-verify.log" 2>&1 || true' \
+  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh" || true' \
   "driver suppresses a failure"
 
 expect_mutation_failure \
@@ -110,5 +112,89 @@ expect_mutation_failure \
   'release_tag: ${{ needs.release-contract.outputs.version }}' \
   'release_tag: v0.0.0' \
   "release transaction must pass its validated version"
+
+expect_mutation_failure \
+  "publication-wait-removed" "release.yml" \
+  $'  published-release-golden-path:\n    name: Verify the published release journey\n    needs: [release-contract, release]' \
+  $'  published-release-golden-path:\n    name: Verify the published release journey\n    needs: [release-contract]' \
+  "published-release job must uniquely wait for release publication"
+
+expect_mutation_failure \
+  "caller-failure-ignored" "release.yml" \
+  $'    permissions:\n      contents: read\n    uses: ./.github/workflows/published-release-golden-path.yml' \
+  $'    permissions:\n      contents: read\n    continue-on-error: true\n    uses: ./.github/workflows/published-release-golden-path.yml' \
+  "release caller must not ignore failed published-release verification"
+
+expect_mutation_failure \
+  "caller-condition-disabled" "release.yml" \
+  $'  published-release-golden-path:\n    name: Verify the published release journey\n    needs: [release-contract, release]\n    if: >-' \
+  $'  published-release-golden-path:\n    name: Verify the published release journey\n    needs: [release-contract, release]\n    if: false' \
+  "published-release job must have exactly one stable-release condition"
+
+expect_mutation_failure \
+  "linux-asset-drift" "driver.sh" \
+  'cli_asset="assay-${release_tag}-x86_64-unknown-linux-gnu.tar.gz"' \
+  'cli_asset="assay-${release_tag}-aarch64-apple-darwin.tar.gz"' \
+  "Linux x86_64 product asset assignment drifted"
+
+expect_mutation_failure \
+  "same-bundle-command-commented" "driver.sh" \
+  'assay evidence show --format json -- "$bundle"' \
+  $'assay evidence show --format json -- conformance/privileged-mcp-action-v0/vectors/ok-001.bundle.tar.gz\n  # assay evidence show --format json -- "$bundle"' \
+  "driver must inspect the same bundle it produced exactly once"
+
+expect_mutation_failure \
+  "verifier-commented" "driver.sh" \
+  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  '# bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  "driver must execute the reviewed attestation verifier exactly once"
+
+expect_mutation_failure \
+  "claim-ceiling-overstated" "driver.sh" \
+  'the harness is not a shipped release asset' \
+  'the harness is a shipped and attested release asset' \
+  "driver lost claim ceiling"
+
+expect_mutation_failure \
+  "draft-release-accepted" "driver.sh" \
+  $'"$JQ_BIN" -e \'.draft == false and .prerelease == false\' "$release_api" >/dev/null \\\n  || fail "release tag is still draft or prerelease"' \
+  'echo accepted-unpublished-release >/dev/null' \
+  "driver lost stable published release"
+
+expect_mutation_failure \
+  "release-carried-verifier" "driver.sh" \
+  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  'bash "$downloads/release-proof-kit/verify-offline.sh"' \
+  "driver must not execute or trust code carried by the release proof kit"
+
+expect_mutation_failure \
+  "external-tag-binding-removed" "driver.sh" \
+  '"$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}" >"$tag_ref"' \
+  '# "$GH_BIN" api "repos/${REPO}/git/ref/tags/${release_tag}" >"$tag_ref"' \
+  "external release-tag source binding drifted"
+
+expect_mutation_failure \
+  "asset-digest-comparison-inverted" "driver.sh" \
+  '[[ "$actual_digest" == "$api_digest" ]] || fail "downloaded asset digest differs: $asset_name"' \
+  '[[ "$actual_digest" != "$api_digest" ]] || fail "downloaded asset digest differs: $asset_name"' \
+  "downloaded asset digest comparison drifted"
+
+expect_mutation_failure \
+  "unsafe-archive-extraction" "driver.sh" \
+  '"$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728' \
+  '"$downloads/$cli_asset" -C "$cli_extract"' \
+  "CLI safe-extraction ceiling drifted"
+
+expect_mutation_failure \
+  "release-inputs-not-retained" "driver.sh" \
+  'downloads="$results/release-assets"' \
+  'downloads="$run_root/release-assets"' \
+  "release inputs must be retained with the run artifact"
+
+expect_mutation_failure \
+  "workflow-run-unbound" "driver.sh" \
+  '--bundle-out "$bundle" --run-id "published-release-${workflow_run_id}-${workflow_run_attempt}"' \
+  '--bundle-out "$bundle" --run-id published-release-golden-path' \
+  "evidence run id is not bound to the workflow invocation"
 
 echo "ok: published-release golden-path contract"

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -260,4 +260,10 @@ expect_mutation_failure \
   '("attestation-raw/*.json", 0)' \
   "harness digest drifted: scripts/ci/published-release-golden-path.sh"
 
+expect_mutation_failure \
+  "inventory-executable-flag-removed" "manifest.json" \
+  '"executable": true' \
+  '"executable": false' \
+  "harness executable surface drifted"
+
 echo "ok: published-release golden-path contract"

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -36,6 +36,8 @@ trap 'rm -rf "$scratch"' EXIT
 verifier_call='bash "$harness_root/scripts/ci/release_attestation_enforce.sh" '"\\"
 workflow_driver_call='          bash scripts/ci/published-release-golden-path.sh '"\\"
 workflow_driver_decoy=$'          # bash scripts/ci/published-release-golden-path.sh\n          echo skipped-reviewed-driver '"\\"
+proxy_execute_call='  | "${proxy_argv[@]}" '"\\"
+proxy_execute_diverged='  | assay-mcp-server proxy-enforce --upstream-command "$PYTHON_BIN" '"\\"
 
 expect_mutation_failure() {
   local name="$1" target="$2" old="$3" new="$4" expected="$5" refresh_path="${6:-}"
@@ -247,14 +249,14 @@ expect_mutation_failure \
   "mcp-version-regex-loosened" "driver.sh" \
   '"assay-mcp-server $version"' \
   '"$version"' \
-  "exact MCP version comparison drifted" \
+  "exact MCP version execution block drifted" \
   "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "proxy-command-provenance-truncated" "driver.sh" \
   'record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"' \
   'record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce --upstream-command python3' \
-  "proxy command provenance no longer uses the executed argv" \
+  "proxy execution and provenance block drifted" \
   "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
@@ -268,7 +270,7 @@ expect_mutation_failure \
   "signer-binding-removed" "scripts/ci/release_attestation_enforce.sh" \
   '    --signer-workflow "$SIGNER_WORKFLOW"' \
   '    --predicate-type https://slsa.dev/provenance/v1' \
-  "attestation signer binding drifted" \
+  "attestation verification argv binding drifted" \
   "scripts/ci/release_attestation_enforce.sh"
 
 expect_mutation_failure \
@@ -282,15 +284,22 @@ expect_mutation_failure \
   "source-digest-binding-removed" "scripts/ci/release_attestation_enforce.sh" \
   '    --source-digest "$SOURCE_DIGEST"' \
   '    --source-ref refs/heads/main' \
-  "attestation source digest binding drifted" \
+  "attestation verification argv binding drifted" \
   "scripts/ci/release_attestation_enforce.sh"
 
 expect_mutation_failure \
   "local-subject-binding-loosened" "scripts/ci/release_attestation_enforce.sh" \
   'any(.[]; any((.verificationResult.statement.subject // [])[]?; .digest.sha256? == $digest))' \
   'any(.[]; (.verificationResult.statement.subject // [] | length) > 0)' \
-  "attestation local-subject digest binding drifted" \
+  "attestation local-subject digest execution block drifted" \
   "scripts/ci/release_attestation_enforce.sh"
+
+expect_mutation_failure \
+  "proxy-execution-diverges-from-record" "driver.sh" \
+  "$proxy_execute_call" \
+  "$proxy_execute_diverged" \
+  "proxy execution and provenance block drifted" \
+  "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "inventory-executable-flag-removed" "manifest.json" \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -29,9 +29,14 @@ python3 "$CHECKER" \
   --source-root "$ROOT"
 bash "$ROOT/scripts/ci/test-release-attestation-enforce.sh"
 PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_safe_extract_release_archive.py"
+PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_bounded_download.py"
 
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
+verifier_call='bash "$harness_root/scripts/ci/release_attestation_enforce.sh" '"\\"
+proxy_record_call='record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce '"\\"
+workflow_driver_call='          bash scripts/ci/published-release-golden-path.sh '"\\"
+workflow_driver_decoy=$'          # bash scripts/ci/published-release-golden-path.sh\n          echo skipped-reviewed-driver '"\\"
 
 expect_mutation_failure() {
   local name="$1" target="$2" old="$3" new="$4" expected="$5"
@@ -41,6 +46,16 @@ expect_mutation_failure() {
   cp "$RELEASE_WORKFLOW" "$case_root/release.yml"
   cp "$DRIVER" "$case_root/driver.sh"
   cp "$MANIFEST" "$case_root/manifest.json"
+  python3 - "$MANIFEST" "$ROOT" "$case_root" <<'PY'
+import json, pathlib, shutil, sys
+manifest_path, source_root, destination_root = map(pathlib.Path, sys.argv[1:])
+for row in json.loads(manifest_path.read_text(encoding="utf-8"))["files"]:
+    relative = pathlib.PurePosixPath(row["path"])
+    source = source_root.joinpath(*relative.parts)
+    destination = destination_root.joinpath(*relative.parts)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+PY
   python3 - "$case_root/$target" "$old" "$new" <<'PY'
 import pathlib, sys
 path = pathlib.Path(sys.argv[1])
@@ -55,7 +70,7 @@ PY
       --release-workflow "$case_root/release.yml" \
       --driver "$case_root/driver.sh" \
       --manifest "$case_root/manifest.json" \
-      --source-root "$ROOT" >"$case_root/output" 2>&1; then
+      --source-root "$case_root" >"$case_root/output" 2>&1; then
     fail "mutation stayed green: $name"
   fi
   grep -F "$expected" "$case_root/output" >/dev/null \
@@ -64,14 +79,14 @@ PY
 
 expect_mutation_failure \
   "attestation-removed" "driver.sh" \
-  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  'bash "$harness_root/scripts/ci/release_attestation_enforce.sh"' \
   'echo skipped-attestation' \
   "driver must execute the reviewed attestation verifier exactly once"
 
 expect_mutation_failure \
   "attestation-suppressed" "driver.sh" \
-  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
-  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh" || true' \
+  'bash "$harness_root/scripts/ci/release_attestation_enforce.sh"' \
+  'bash "$harness_root/scripts/ci/release_attestation_enforce.sh" || true' \
   "driver suppresses a failure"
 
 expect_mutation_failure \
@@ -145,8 +160,8 @@ expect_mutation_failure \
 
 expect_mutation_failure \
   "verifier-commented" "driver.sh" \
-  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
-  '# bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  'bash "$harness_root/scripts/ci/release_attestation_enforce.sh"' \
+  '# bash "$harness_root/scripts/ci/release_attestation_enforce.sh"' \
   "driver must execute the reviewed attestation verifier exactly once"
 
 expect_mutation_failure \
@@ -163,7 +178,7 @@ expect_mutation_failure \
 
 expect_mutation_failure \
   "release-carried-verifier" "driver.sh" \
-  'bash "$ROOT/scripts/ci/release_attestation_enforce.sh"' \
+  'bash "$harness_root/scripts/ci/release_attestation_enforce.sh"' \
   'bash "$downloads/release-proof-kit/verify-offline.sh"' \
   "driver must not execute or trust code carried by the release proof kit"
 
@@ -208,5 +223,41 @@ expect_mutation_failure \
   'OUT_RAW_DIR="$results/attestation-raw"' \
   'OUT_RAW_DIR="$run_root/attestation-raw"' \
   "raw attestation inputs must be retained"
+
+expect_mutation_failure \
+  "reviewed-driver-dead-code-decoy" "driver.sh" \
+  "$verifier_call" \
+  $'if false; then\n      bash "$harness_root/scripts/ci/release_attestation_enforce.sh" \\\n    fi\n    bash "$downloads/verifier.sh" \\' \
+  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "mcp-version-regex-loosened" "driver.sh" \
+  '"assay-mcp-server $version"' \
+  '"$version"' \
+  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "proxy-command-provenance-truncated" "driver.sh" \
+  "$proxy_record_call" \
+  'record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce --upstream-command python3' \
+  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "workflow-driver-comment-decoy" "workflow.yml" \
+  "$workflow_driver_call" \
+  "$workflow_driver_decoy" \
+  "harness digest drifted: .github/workflows/published-release-golden-path.yml"
+
+expect_mutation_failure \
+  "signer-binding-removed" "scripts/ci/release_attestation_enforce.sh" \
+  '    --signer-workflow "$SIGNER_WORKFLOW"' \
+  '    --predicate-type https://slsa.dev/provenance/v1' \
+  "harness digest drifted: scripts/ci/release_attestation_enforce.sh"
+
+expect_mutation_failure \
+  "raw-attestation-count-disabled" "driver.sh" \
+  '("attestation-raw/*.json", 2)' \
+  '("attestation-raw/*.json", 0)' \
+  "harness digest drifted: scripts/ci/published-release-golden-path.sh"
 
 echo "ok: published-release golden-path contract"

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -334,8 +334,8 @@ expect_mutation_failure \
 
 expect_proxy_helper_behavior_failure \
   "proxy-execution-diverges-from-record" \
-  $'            completed = subprocess.run(\n                argv,' \
-  $'            completed = subprocess.run(\n                argv[:-2],'
+  $'            process = subprocess.Popen(\n                argv,' \
+  $'            process = subprocess.Popen(\n                argv[:-2],'
 
 expect_proxy_helper_behavior_failure \
   "proxy-exit-status-diverges" \
@@ -344,18 +344,23 @@ expect_proxy_helper_behavior_failure \
 
 expect_proxy_helper_behavior_failure \
   "proxy-executes-twice" \
-  '            completed = subprocess.run(' \
-  $'            subprocess.run(argv, input=request, stdout=stdout_handle, stderr=stderr_handle, check=False)\n            completed = subprocess.run('
+  '            process = subprocess.Popen(' \
+  $'            subprocess.Popen(argv, env=child_environment()).wait()\n            process = subprocess.Popen('
 
 expect_proxy_helper_behavior_failure \
   "proxy-shell-interpretation-enabled" \
-  $'            completed = subprocess.run(\n                argv,' \
-  $'            completed = subprocess.run(\n                " ".join(argv),\n                shell=True,'
+  $'            process = subprocess.Popen(\n                argv,' \
+  $'            process = subprocess.Popen(\n                " ".join(argv),\n                shell=True,'
 
 expect_proxy_helper_behavior_failure \
   "github-token-added-to-child-environment" \
   '("HOME", "PATH", "LANG", "LC_ALL", "TZ")' \
   '("HOME", "PATH", "LANG", "LC_ALL", "TZ", "GITHUB_TOKEN")'
+
+expect_proxy_helper_behavior_failure \
+  "proxy-timeout-kills-only-parent" \
+  '                stop_process_group(process)' \
+  '                process.kill(); process.wait()'
 
 expect_mutation_failure \
   "proxy-block-unreachable" "driver.sh" \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -149,7 +149,7 @@ expect_mutation_failure \
 
 expect_mutation_failure \
   "github-token-reaches-release-binaries" "driver.sh" \
-  'unset GH_TOKEN GITHUB_TOKEN' ': # credentials retained' \
+  'unset GH_TOKEN GITHUB_TOKEN PYTHONPATH' ': # ambient environment retained' \
   "release binaries must not inherit GitHub credentials" \
   "scripts/ci/published-release-golden-path.sh"
 
@@ -296,6 +296,13 @@ expect_proxy_helper_behavior_failure \
   "proxy-provenance-truncated" \
   'append_command_record(results / "commands.ndjson", status, argv)' \
   'append_command_record(results / "commands.ndjson", status, argv[:-2])'
+
+expect_mutation_failure \
+  "proxy-python-isolation-removed" "driver.sh" \
+  $'"$PYTHON_BIN" -I "$harness_root/scripts/ci/published_release_proxy_phase.py" \\' \
+  $'"$PYTHON_BIN" "$harness_root/scripts/ci/published_release_proxy_phase.py" \\' \
+  "proxy execution and provenance block drifted" \
+  "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "workflow-driver-comment-decoy" "workflow.yml" \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -30,14 +30,13 @@ python3 "$CHECKER" \
 bash "$ROOT/scripts/ci/test-release-attestation-enforce.sh"
 PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_safe_extract_release_archive.py"
 PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_bounded_download.py"
+PYTHONPATH="$ROOT/scripts/ci" python3 "$ROOT/scripts/ci/test_published_release_proxy_phase.py"
 
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 verifier_call='bash "$harness_root/scripts/ci/release_attestation_enforce.sh" '"\\"
 workflow_driver_call='          bash scripts/ci/published-release-golden-path.sh '"\\"
 workflow_driver_decoy=$'          # bash scripts/ci/published-release-golden-path.sh\n          echo skipped-reviewed-driver '"\\"
-proxy_execute_call='  | "${proxy_argv[@]}" '"\\"
-proxy_execute_diverged='  | assay-mcp-server proxy-enforce --upstream-command "$PYTHON_BIN" '"\\"
 
 expect_mutation_failure() {
   local name="$1" target="$2" old="$3" new="$4" expected="$5" refresh_path="${6:-}"
@@ -103,6 +102,27 @@ PY
     || fail "mutation $name missed expected guard: $expected"
 }
 
+expect_proxy_helper_behavior_failure() {
+  local name="$1" old="$2" new="$3"
+  local case_root="$scratch/$name"
+  mkdir -p "$case_root"
+  cp "$ROOT/scripts/ci/published_release_proxy_phase.py" "$case_root/proxy-phase.py"
+  python3 - "$case_root/proxy-phase.py" "$old" "$new" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+old, new = sys.argv[2:]
+text = path.read_text(encoding="utf-8")
+if text.count(old) != 1:
+    raise SystemExit(f"proxy helper mutation anchor count for {old!r}: {text.count(old)}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+  if PUBLISHED_RELEASE_PROXY_PHASE="$case_root/proxy-phase.py" \
+      python3 "$ROOT/scripts/ci/test_published_release_proxy_phase.py" \
+      >"$case_root/output" 2>&1; then
+    fail "proxy helper mutation stayed green: $name"
+  fi
+}
+
 expect_mutation_failure \
   "attestation-removed" "driver.sh" \
   'bash "$harness_root/scripts/ci/release_attestation_enforce.sh"' \
@@ -124,6 +144,12 @@ expect_mutation_failure \
   "ambient-path" "driver.sh" \
   'export PATH="$install_root/bin:/usr/bin:/bin"' 'export PATH="/usr/bin:/bin"' \
   "driver lost restricted PATH"
+
+expect_mutation_failure \
+  "github-token-reaches-release-binaries" "driver.sh" \
+  'unset GH_TOKEN GITHUB_TOKEN' ': # credentials retained' \
+  "release binaries must not inherit GitHub credentials" \
+  "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \
   "preexisting-inspection" "driver.sh" \
@@ -264,12 +290,10 @@ expect_mutation_failure \
   "exact MCP version execution block drifted" \
   "scripts/ci/published-release-golden-path.sh"
 
-expect_mutation_failure \
-  "proxy-command-provenance-truncated" "driver.sh" \
-  'record_command "proxy-enforce" "$proxy_status" "${proxy_argv[@]}"' \
-  'record_command "proxy-enforce" "$proxy_status" assay-mcp-server proxy-enforce --upstream-command python3' \
-  "proxy execution and provenance block drifted" \
-  "scripts/ci/published-release-golden-path.sh"
+expect_proxy_helper_behavior_failure \
+  "proxy-provenance-truncated" \
+  'append_command_record(args.commands, status, argv)' \
+  'append_command_record(args.commands, status, argv[:-2])'
 
 expect_mutation_failure \
   "workflow-driver-comment-decoy" "workflow.yml" \
@@ -306,27 +330,58 @@ expect_mutation_failure \
   "attestation local-subject digest execution block drifted" \
   "scripts/ci/release_attestation_enforce.sh"
 
-expect_mutation_failure \
-  "proxy-execution-diverges-from-record" "driver.sh" \
-  "$proxy_execute_call" \
-  "$proxy_execute_diverged" \
-  "proxy execution and provenance block drifted" \
-  "scripts/ci/published-release-golden-path.sh"
+expect_proxy_helper_behavior_failure \
+  "proxy-execution-diverges-from-record" \
+  $'            completed = subprocess.run(\n                argv,' \
+  $'            completed = subprocess.run(\n                argv[:-2],'
+
+expect_proxy_helper_behavior_failure \
+  "proxy-exit-status-diverges" \
+  'append_command_record(args.commands, status, argv)' \
+  'append_command_record(args.commands, 0, argv)'
+
+expect_proxy_helper_behavior_failure \
+  "proxy-executes-twice" \
+  '            completed = subprocess.run(' \
+  $'            subprocess.run(argv, input=request, stdout=stdout_handle, stderr=stderr_handle, check=False)\n            completed = subprocess.run('
 
 expect_mutation_failure \
   "proxy-block-unreachable" "driver.sh" \
   'proxy_status=0' $'if false; then\nproxy_status=0' \
-  "proxy execution block must run at top level" \
+  "proxy execution and provenance block drifted" \
   "scripts/ci/published-release-golden-path.sh" \
   'bundle="$results/produced.bundle.tar.gz"' \
   $'fi\nbundle="$results/produced.bundle.tar.gz"'
 
 expect_mutation_failure \
+  "proxy-block-unreachable-subshell" "driver.sh" \
+  'proxy_status=0' $'false && (\nproxy_status=0' \
+  "proxy execution and provenance block drifted" \
+  "scripts/ci/published-release-golden-path.sh" \
+  'bundle="$results/produced.bundle.tar.gz"' \
+  $')\nbundle="$results/produced.bundle.tar.gz"'
+
+expect_mutation_failure \
   "alternate-proxy-path" "driver.sh" \
   'bundle="$results/produced.bundle.tar.gz"' \
   $'assay-mcp-server proxy-enforce --upstream-command "$PYTHON_BIN"\nbundle="$results/produced.bundle.tar.gz"' \
-  "driver has an alternate proxy execution or provenance path" \
+  "driver MCP binary invocation surface drifted" \
   "scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "split-token-alternate-proxy-path" "driver.sh" \
+  'bundle="$results/produced.bundle.tar.gz"' \
+  $'verb="$(printf \'%s%s\' proxy -enforce)"\n"$install_root/bin/assay-mcp-server" "$verb"\nbundle="$results/produced.bundle.tar.gz"' \
+  "driver MCP binary invocation surface drifted" \
+  "scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "combined-dead-helper-and-truncated-alternate" "driver.sh" \
+  'proxy_status=0' $'false && (\nproxy_status=0' \
+  "proxy execution and provenance block drifted" \
+  "scripts/ci/published-release-golden-path.sh" \
+  'bundle="$results/produced.bundle.tar.gz"' \
+  $')\nverb="$(printf \'%s%s\' proxy -enforce)"\n"$install_root/bin/assay-mcp-server" "$verb"\nrecord_command "proxy-enforce" 0 "$install_root/bin/assay-mcp-server"\nbundle="$results/produced.bundle.tar.gz"'
 
 expect_mutation_failure \
   "inventory-executable-flag-removed" "manifest.json" \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -197,4 +197,16 @@ expect_mutation_failure \
   '--bundle-out "$bundle" --run-id published-release-golden-path' \
   "evidence run id is not bound to the workflow invocation"
 
+expect_mutation_failure \
+  "tag-peel-type-check-removed" "driver.sh" \
+  '[[ "$source_type" == "commit" && "$source_digest" =~ ^[0-9a-f]{40}$ ]]' \
+  '[[ "$source_digest" =~ ^[0-9a-f]{40}$ ]]' \
+  "release tag must peel to a commit before attestation verification"
+
+expect_mutation_failure \
+  "raw-attestations-not-retained" "driver.sh" \
+  'OUT_RAW_DIR="$results/attestation-raw"' \
+  'OUT_RAW_DIR="$run_root/attestation-raw"' \
+  "raw attestation inputs must be retained"
+
 echo "ok: published-release golden-path contract"

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -105,9 +105,12 @@ PY
 expect_proxy_helper_behavior_failure() {
   local name="$1" old="$2" new="$3"
   local case_root="$scratch/$name"
-  mkdir -p "$case_root"
-  cp "$ROOT/scripts/ci/published_release_proxy_phase.py" "$case_root/proxy-phase.py"
-  python3 - "$case_root/proxy-phase.py" "$old" "$new" <<'PY'
+  mkdir -p "$case_root/scripts/ci"
+  cp "$ROOT/scripts/ci/published_release_proxy_phase.py" \
+    "$case_root/scripts/ci/published_release_proxy_phase.py"
+  cp "$ROOT/scripts/ci/test_published_release_proxy_phase.py" \
+    "$case_root/scripts/ci/test_published_release_proxy_phase.py"
+  python3 - "$case_root/scripts/ci/published_release_proxy_phase.py" "$old" "$new" <<'PY'
 import pathlib, sys
 path = pathlib.Path(sys.argv[1])
 old, new = sys.argv[2:]
@@ -116,8 +119,7 @@ if text.count(old) != 1:
     raise SystemExit(f"proxy helper mutation anchor count for {old!r}: {text.count(old)}")
 path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
-  if PUBLISHED_RELEASE_PROXY_PHASE="$case_root/proxy-phase.py" \
-      python3 "$ROOT/scripts/ci/test_published_release_proxy_phase.py" \
+  if python3 "$case_root/scripts/ci/test_published_release_proxy_phase.py" \
       >"$case_root/output" 2>&1; then
     fail "proxy helper mutation stayed green: $name"
   fi
@@ -292,8 +294,8 @@ expect_mutation_failure \
 
 expect_proxy_helper_behavior_failure \
   "proxy-provenance-truncated" \
-  'append_command_record(args.commands, status, argv)' \
-  'append_command_record(args.commands, status, argv[:-2])'
+  'append_command_record(results / "commands.ndjson", status, argv)' \
+  'append_command_record(results / "commands.ndjson", status, argv[:-2])'
 
 expect_mutation_failure \
   "workflow-driver-comment-decoy" "workflow.yml" \
@@ -337,8 +339,8 @@ expect_proxy_helper_behavior_failure \
 
 expect_proxy_helper_behavior_failure \
   "proxy-exit-status-diverges" \
-  'append_command_record(args.commands, status, argv)' \
-  'append_command_record(args.commands, 0, argv)'
+  'append_command_record(results / "commands.ndjson", status, argv)' \
+  'append_command_record(results / "commands.ndjson", 0, argv)'
 
 expect_proxy_helper_behavior_failure \
   "proxy-executes-twice" \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -347,6 +347,16 @@ expect_proxy_helper_behavior_failure \
   '            completed = subprocess.run(' \
   $'            subprocess.run(argv, input=request, stdout=stdout_handle, stderr=stderr_handle, check=False)\n            completed = subprocess.run('
 
+expect_proxy_helper_behavior_failure \
+  "proxy-shell-interpretation-enabled" \
+  $'            completed = subprocess.run(\n                argv,' \
+  $'            completed = subprocess.run(\n                " ".join(argv),\n                shell=True,'
+
+expect_proxy_helper_behavior_failure \
+  "github-token-added-to-child-environment" \
+  '("HOME", "PATH", "LANG", "LC_ALL", "TZ")' \
+  '("HOME", "PATH", "LANG", "LC_ALL", "TZ", "GITHUB_TOKEN")'
+
 expect_mutation_failure \
   "proxy-block-unreachable" "driver.sh" \
   'proxy_status=0' $'if false; then\nproxy_status=0' \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -181,8 +181,8 @@ expect_mutation_failure \
 
 expect_mutation_failure \
   "unsafe-archive-extraction" "driver.sh" \
-  '"$downloads/$cli_asset" "$cli_extract" --max-decoded-bytes 134217728' \
-  '"$downloads/$cli_asset" -C "$cli_extract"' \
+  'safe_extract "$downloads/$cli_asset" "$cli_extract" 134217728' \
+  'tar -xzf "$downloads/$cli_asset" -C "$cli_extract"' \
   "CLI safe-extraction ceiling drifted"
 
 expect_mutation_failure \

--- a/scripts/ci/test-published-release-golden-path-contract.sh
+++ b/scripts/ci/test-published-release-golden-path-contract.sh
@@ -41,6 +41,7 @@ proxy_execute_diverged='  | assay-mcp-server proxy-enforce --upstream-command "$
 
 expect_mutation_failure() {
   local name="$1" target="$2" old="$3" new="$4" expected="$5" refresh_path="${6:-}"
+  local second_old="${7:-}" second_new="${8:-}"
   local case_root="$scratch/$name"
   mkdir -p "$case_root"
   cp "$WORKFLOW" "$case_root/workflow.yml"
@@ -66,6 +67,17 @@ if text.count(old) != 1:
     raise SystemExit(f"mutation anchor count for {old!r}: {text.count(old)}")
 path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
+  if [[ -n "$second_old" ]]; then
+    python3 - "$case_root/$target" "$second_old" "$second_new" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+old, new = sys.argv[2:]
+text = path.read_text(encoding="utf-8")
+if text.count(old) != 1:
+    raise SystemExit(f"second mutation anchor count for {old!r}: {text.count(old)}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+  fi
   if [[ -n "$refresh_path" ]]; then
     python3 - "$case_root/manifest.json" "$case_root/$target" "$refresh_path" <<'PY'
 import hashlib, json, pathlib, sys
@@ -299,6 +311,21 @@ expect_mutation_failure \
   "$proxy_execute_call" \
   "$proxy_execute_diverged" \
   "proxy execution and provenance block drifted" \
+  "scripts/ci/published-release-golden-path.sh"
+
+expect_mutation_failure \
+  "proxy-block-unreachable" "driver.sh" \
+  'proxy_status=0' $'if false; then\nproxy_status=0' \
+  "proxy execution block must run at top level" \
+  "scripts/ci/published-release-golden-path.sh" \
+  'bundle="$results/produced.bundle.tar.gz"' \
+  $'fi\nbundle="$results/produced.bundle.tar.gz"'
+
+expect_mutation_failure \
+  "alternate-proxy-path" "driver.sh" \
+  'bundle="$results/produced.bundle.tar.gz"' \
+  $'assay-mcp-server proxy-enforce --upstream-command "$PYTHON_BIN"\nbundle="$results/produced.bundle.tar.gz"' \
+  "driver has an alternate proxy execution or provenance path" \
   "scripts/ci/published-release-golden-path.sh"
 
 expect_mutation_failure \

--- a/scripts/ci/test-release-attestation-enforce.sh
+++ b/scripts/ci/test-release-attestation-enforce.sh
@@ -208,6 +208,41 @@ run_retry_success_case() {
   jq -e '.assets[0].verified_attestations == 1' "$summary" >/dev/null
 }
 
+run_digest_only_success_case() {
+  local temp_dir="$1"
+  local assets_dir="$temp_dir/assets-digest-only"
+  local raw_dir="$temp_dir/raw-digest-only"
+  local summary="$temp_dir/summary-digest-only.json"
+  local log="$temp_dir/gh-digest-only.log"
+  local json="$temp_dir/gh-digest-only.json"
+  local fake_gh="$temp_dir/fake-gh-digest-only"
+
+  mkdir -p "$assets_dir" "$raw_dir"
+  printf 'release bytes\n' > "$assets_dir/test-asset.tar.gz"
+  local digest
+  digest="$(compute_sha256 "$assets_dir/test-asset.tar.gz")"
+  write_success_json "$json" "$digest"
+  make_fake_gh "$fake_gh"
+
+  FAKE_GH_JSON="$json" \
+  FAKE_GH_LOG="$log" \
+  GH_BIN="$fake_gh" \
+  ASSETS_DIR="$assets_dir" \
+  OUT_SUMMARY="$summary" \
+  OUT_RAW_DIR="$raw_dir" \
+  REPO="Rul1an/assay" \
+  SIGNER_WORKFLOW="Rul1an/assay/.github/workflows/release.yml" \
+  SOURCE_DIGEST="abc123" \
+  bash "$SCRIPT"
+
+  jq -e '.verification_policy.source_ref == null' "$summary" >/dev/null
+  grep -F -- '--source-digest abc123' "$log" >/dev/null
+  if grep -F -- '--source-ref' "$log" >/dev/null; then
+    echo "digest-only verification unexpectedly passed --source-ref" >&2
+    exit 1
+  fi
+}
+
 run_missing_witness_case() {
   local temp_dir="$1"
   local assets_dir="$temp_dir/assets-missing-witness"
@@ -320,6 +355,7 @@ main() {
   trap cleanup EXIT
 
   run_success_case "$TEST_TEMP_DIR"
+  run_digest_only_success_case "$TEST_TEMP_DIR"
   run_retry_success_case "$TEST_TEMP_DIR"
   run_missing_attestation_case "$TEST_TEMP_DIR"
   run_missing_witness_case "$TEST_TEMP_DIR"

--- a/scripts/ci/test-release-attestation-enforce.sh
+++ b/scripts/ci/test-release-attestation-enforce.sh
@@ -166,6 +166,7 @@ run_success_case() {
   jq -e '.assets[0].verified_timestamp_count == 1' "$summary" >/dev/null
   test -f "$raw_dir/test-asset.tar.gz.attestation.json"
   grep -F -- '--source-digest abc123' "$log" >/dev/null
+  grep -F -- '--signer-workflow Rul1an/assay/.github/workflows/release.yml' "$log" >/dev/null
   grep -F -- '--source-ref refs/tags/v9.9.9' "$log" >/dev/null
   grep -F -- '--deny-self-hosted-runners' "$log" >/dev/null
 }

--- a/scripts/ci/test_bounded_download.py
+++ b/scripts/ci/test_bounded_download.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bounded_download import DownloadRejected, download
+
+
+class FakeResponse:
+    def __init__(self, payload: bytes, content_length: str | None = None) -> None:
+        self.payload = payload
+        self.offset = 0
+        self.read_calls = 0
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = content_length
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self, size: int) -> bytes:
+        self.read_calls += 1
+        chunk = self.payload[self.offset : self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+
+class BoundedDownloadTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_rejects_oversized_content_length_before_read(self) -> None:
+        response = FakeResponse(b"payload", content_length="8")
+
+        with mock.patch("bounded_download.urllib.request.urlopen", return_value=response):
+            with self.assertRaises(DownloadRejected):
+                download("https://example.test/asset", self.root / "asset", max_bytes=7)
+
+        self.assertEqual(response.read_calls, 0)
+        self.assertFalse((self.root / "asset").exists())
+
+    def test_rejects_stream_that_exceeds_ceiling(self) -> None:
+        response = FakeResponse(b"12345678")
+
+        with mock.patch("bounded_download.urllib.request.urlopen", return_value=response):
+            with self.assertRaises(DownloadRejected):
+                download("https://example.test/asset", self.root / "asset", max_bytes=7)
+
+        self.assertFalse((self.root / "asset").exists())
+        self.assertFalse((self.root / ".asset.downloading").exists())
+
+    def test_atomically_publishes_bounded_download(self) -> None:
+        response = FakeResponse(b"1234567", content_length="7")
+
+        with mock.patch("bounded_download.urllib.request.urlopen", return_value=response):
+            download("https://example.test/asset", self.root / "asset", max_bytes=7)
+
+        self.assertEqual((self.root / "asset").read_bytes(), b"1234567")
+        self.assertFalse((self.root / ".asset.downloading").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_published_release_proxy_phase.py
+++ b/scripts/ci/test_published_release_proxy_phase.py
@@ -77,6 +77,13 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         fake.chmod(0o755)
         results = temporary / "results"
         results.mkdir()
+        poison = temporary / "pythonpath-poison"
+        poison.mkdir()
+        poison_sentinel = results / "pythonpath-imported"
+        (poison / "json.py").write_text(
+            f"open({str(poison_sentinel)!r}, 'w').write('loaded')\nraise RuntimeError('PYTHONPATH loaded')\n",
+            encoding="utf-8",
+        )
         (results / "fake-control.json").write_text(
             json.dumps(
                 {
@@ -90,6 +97,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         )
         command = [
             sys.executable,
+            "-I",
             str(HELPER),
             "--timeout-seconds",
             str(timeout_seconds),
@@ -97,7 +105,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         environment = os.environ.copy()
         environment["GH_TOKEN"] = "must-not-reach-release-code"
         environment["GITHUB_TOKEN"] = "must-not-reach-release-code"
-        environment["PYTHONPATH"] = "/must/not/reach/release/code"
+        environment["PYTHONPATH"] = str(poison)
         environment["PATH"] = f"{temporary}{os.pathsep}{environment['PATH']}"
         completed = subprocess.run(
             command,
@@ -108,6 +116,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
             env=environment,
             cwd=results,
         )
+        self.assertFalse(poison_sentinel.exists(), "helper interpreter imported from PYTHONPATH")
         return completed, results
 
     def assert_observed_equals_recorded(self, results: Path, expected_status: int) -> None:

--- a/scripts/ci/test_published_release_proxy_phase.py
+++ b/scripts/ci/test_published_release_proxy_phase.py
@@ -26,7 +26,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         fake_output_bytes: int = 0,
         timeout_seconds: int = 60,
     ) -> tuple[subprocess.CompletedProcess[bytes], Path]:
-        temporary = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        temporary = Path(self.enterContext(tempfile.TemporaryDirectory(prefix="proxy phase ")))
         fake = temporary / "assay-mcp-server"
         fake.write_text(
             textwrap.dedent(
@@ -79,6 +79,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         ]
         environment = os.environ.copy()
         environment["GH_TOKEN"] = "must-not-reach-release-code"
+        environment["GITHUB_TOKEN"] = "must-not-reach-release-code"
         environment["PYTHONPATH"] = "/must/not/reach/release/code"
         environment["PATH"] = f"{temporary}{os.pathsep}{environment['PATH']}"
         completed = subprocess.run(
@@ -114,6 +115,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
             (results / "fake-environment.json").read_text(encoding="utf-8")
         )
         self.assertNotIn("GH_TOKEN", child_environment)
+        self.assertNotIn("GITHUB_TOKEN", child_environment)
         self.assertNotIn("PYTHONPATH", child_environment)
 
     def test_success_records_the_executed_argv_once(self) -> None:

--- a/scripts/ci/test_published_release_proxy_phase.py
+++ b/scripts/ci/test_published_release_proxy_phase.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the published-release proxy phase."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = Path(
+    os.environ.get(
+        "PUBLISHED_RELEASE_PROXY_PHASE",
+        ROOT / "scripts/ci/published_release_proxy_phase.py",
+    )
+)
+
+
+class PublishedReleaseProxyPhaseTests(unittest.TestCase):
+    def run_phase(
+        self,
+        fake_exit: int,
+        request: bytes = b'{"jsonrpc":"2.0","id":1}\n',
+        fake_sleep: float = 0,
+        fake_output_bytes: int = 0,
+        timeout_seconds: int = 60,
+    ) -> tuple[subprocess.CompletedProcess[bytes], Path]:
+        temporary = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        fake = temporary / "assay-mcp-server"
+        fake.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json, os, pathlib, sys, time
+
+                def value(flag):
+                    return pathlib.Path(sys.argv[sys.argv.index(flag) + 1])
+
+                decisions = value("--enforcement-decision-out")
+                observations = value("--denied-call-observation-out")
+                invocation = decisions.parent / "fake-invocations.jsonl"
+                with invocation.open("a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(sys.argv) + "\\n")
+                (decisions.parent / "fake-environment.json").write_text(
+                    json.dumps(dict(os.environ)), encoding="utf-8"
+                )
+                control = json.loads(
+                    (decisions.parent / "fake-control.json").read_text(encoding="utf-8")
+                )
+                sys.stdin.buffer.read()
+                time.sleep(control["sleep"])
+                if control["output_bytes"]:
+                    sys.stdout.write("x" * control["output_bytes"])
+                    sys.stdout.flush()
+                decisions.write_text('{"decision":"deny"}\\n', encoding="utf-8")
+                observations.write_text('{"observed":true}\\n', encoding="utf-8")
+                print("fake proxy stdout")
+                print("fake proxy stderr", file=sys.stderr)
+                raise SystemExit(control["exit"])
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        results = temporary / "results"
+        results.mkdir()
+        (results / "fake-control.json").write_text(
+            json.dumps(
+                {"exit": fake_exit, "sleep": fake_sleep, "output_bytes": fake_output_bytes}
+            ),
+            encoding="utf-8",
+        )
+        fixture = temporary / "fixture"
+        fixture.mkdir()
+        for name in ("mock.py", "policy.yaml", "manifest.json"):
+            (fixture / name).write_text("{}\n", encoding="utf-8")
+
+        command = [
+            sys.executable,
+            str(HELPER),
+            "--mcp-bin",
+            str(fake),
+            "--python-bin",
+            sys.executable,
+            "--fixture",
+            str(fixture / "mock.py"),
+            "--policy",
+            str(fixture / "policy.yaml"),
+            "--declared-manifest",
+            str(fixture / "manifest.json"),
+            "--decisions",
+            str(results / "decisions.ndjson"),
+            "--observations",
+            str(results / "observations.ndjson"),
+            "--commands",
+            str(results / "commands.ndjson"),
+            "--stdout",
+            str(results / "proxy.jsonl"),
+            "--stderr",
+            str(results / "proxy.stderr"),
+            "--timeout-seconds",
+            str(timeout_seconds),
+        ]
+        environment = os.environ.copy()
+        environment["GH_TOKEN"] = "must-not-reach-release-code"
+        environment["PYTHONPATH"] = "/must/not/reach/release/code"
+        completed = subprocess.run(
+            command,
+            input=request,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env=environment,
+        )
+        return completed, results
+
+    def assert_observed_equals_recorded(self, results: Path, expected_status: int) -> None:
+        observed = [
+            json.loads(line)
+            for line in (results / "fake-invocations.jsonl").read_text(encoding="utf-8").splitlines()
+        ]
+        records = [
+            json.loads(line)
+            for line in (results / "commands.ndjson").read_text(encoding="utf-8").splitlines()
+        ]
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["name"], "proxy-enforce")
+        self.assertEqual(records[0]["exit_code"], expected_status)
+        self.assertEqual(records[0]["argv"], observed[0])
+        self.assertEqual((results / "proxy.jsonl").read_text(encoding="utf-8"), "fake proxy stdout\n")
+        self.assertEqual((results / "proxy.stderr").read_text(encoding="utf-8"), "fake proxy stderr\n")
+        self.assertTrue((results / "decisions.ndjson").is_file())
+        self.assertTrue((results / "observations.ndjson").is_file())
+        child_environment = json.loads(
+            (results / "fake-environment.json").read_text(encoding="utf-8")
+        )
+        self.assertNotIn("GH_TOKEN", child_environment)
+        self.assertNotIn("PYTHONPATH", child_environment)
+
+    def test_success_records_the_executed_argv_once(self) -> None:
+        completed, results = self.run_phase(0)
+        self.assertEqual(completed.returncode, 0, completed.stderr.decode())
+        self.assert_observed_equals_recorded(results, 0)
+
+    def test_failure_preserves_the_real_status_and_argv(self) -> None:
+        completed, results = self.run_phase(23)
+        self.assertEqual(completed.returncode, 23, completed.stderr.decode())
+        self.assert_observed_equals_recorded(results, 23)
+
+    def test_request_ceiling_fails_before_execution(self) -> None:
+        completed, results = self.run_phase(0, b"x" * (1_048_576 + 1))
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn(b"proxy request exceeds 1 MiB ceiling", completed.stderr)
+        self.assertFalse((results / "fake-invocations.jsonl").exists())
+        self.assertFalse((results / "commands.ndjson").exists())
+
+    def test_timeout_records_the_bounded_harness_status(self) -> None:
+        completed, results = self.run_phase(0, fake_sleep=2, timeout_seconds=1)
+        self.assertEqual(completed.returncode, 124, completed.stderr.decode())
+        records = [
+            json.loads(line)
+            for line in (results / "commands.ndjson").read_text(encoding="utf-8").splitlines()
+        ]
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["exit_code"], 124)
+        observed = [
+            json.loads(line)
+            for line in (results / "fake-invocations.jsonl").read_text(encoding="utf-8").splitlines()
+        ]
+        self.assertEqual(records[0]["argv"], observed[0])
+
+    def test_output_file_ceiling_stops_unbounded_child_output(self) -> None:
+        completed, results = self.run_phase(0, fake_output_bytes=16_777_216 + 1)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertLessEqual((results / "proxy.jsonl").stat().st_size, 16_777_216)
+        records = [
+            json.loads(line)
+            for line in (results / "commands.ndjson").read_text(encoding="utf-8").splitlines()
+        ]
+        self.assertEqual(len(records), 1)
+        self.assertNotEqual(records[0]["exit_code"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_published_release_proxy_phase.py
+++ b/scripts/ci/test_published_release_proxy_phase.py
@@ -57,8 +57,9 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
                         [
                             sys.executable,
                             "-c",
-                            "import pathlib,sys,time; time.sleep(1.5); pathlib.Path(sys.argv[1]).write_text('survived')",
+                            'import pathlib,sys,time; time.sleep(1.5); pathlib.Path(sys.argv[1]).write_text("survived"); pathlib.Path(sys.argv[2]).write_text("mutated")',
                             str(sentinel),
+                            str(decisions),
                         ]
                     )
                 time.sleep(control["sleep"])
@@ -183,6 +184,20 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 124, completed.stderr.decode())
         time.sleep(1)
         self.assertFalse((results / "grandchild-sentinel").exists())
+
+    def test_success_reaps_proxy_descendants_before_recording(self) -> None:
+        completed, results = self.run_phase(0, spawn_grandchild=True)
+        self.assertEqual(
+            completed.returncode,
+            0,
+            (results / "proxy.stderr").read_text(encoding="utf-8"),
+        )
+        time.sleep(2)
+        self.assertFalse((results / "grandchild-sentinel").exists())
+        self.assertEqual(
+            (results / "decisions.ndjson").read_text(encoding="utf-8"),
+            '{"decision":"deny"}\n',
+        )
 
     def test_output_file_ceiling_stops_unbounded_child_output(self) -> None:
         completed, results = self.run_phase(0, fake_output_bytes=16_777_216 + 1)

--- a/scripts/ci/test_published_release_proxy_phase.py
+++ b/scripts/ci/test_published_release_proxy_phase.py
@@ -14,12 +14,7 @@ import unittest
 
 
 ROOT = Path(__file__).resolve().parents[2]
-HELPER = Path(
-    os.environ.get(
-        "PUBLISHED_RELEASE_PROXY_PHASE",
-        ROOT / "scripts/ci/published_release_proxy_phase.py",
-    )
-)
+HELPER = ROOT / "scripts/ci/published_release_proxy_phase.py"
 
 
 class PublishedReleaseProxyPhaseTests(unittest.TestCase):
@@ -76,40 +71,16 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
             ),
             encoding="utf-8",
         )
-        fixture = temporary / "fixture"
-        fixture.mkdir()
-        for name in ("mock.py", "policy.yaml", "manifest.json"):
-            (fixture / name).write_text("{}\n", encoding="utf-8")
-
         command = [
             sys.executable,
             str(HELPER),
-            "--mcp-bin",
-            str(fake),
-            "--python-bin",
-            sys.executable,
-            "--fixture",
-            str(fixture / "mock.py"),
-            "--policy",
-            str(fixture / "policy.yaml"),
-            "--declared-manifest",
-            str(fixture / "manifest.json"),
-            "--decisions",
-            str(results / "decisions.ndjson"),
-            "--observations",
-            str(results / "observations.ndjson"),
-            "--commands",
-            str(results / "commands.ndjson"),
-            "--stdout",
-            str(results / "proxy.jsonl"),
-            "--stderr",
-            str(results / "proxy.stderr"),
             "--timeout-seconds",
             str(timeout_seconds),
         ]
         environment = os.environ.copy()
         environment["GH_TOKEN"] = "must-not-reach-release-code"
         environment["PYTHONPATH"] = "/must/not/reach/release/code"
+        environment["PATH"] = f"{temporary}{os.pathsep}{environment['PATH']}"
         completed = subprocess.run(
             command,
             input=request,
@@ -117,6 +88,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
             stderr=subprocess.PIPE,
             check=False,
             env=environment,
+            cwd=results,
         )
         return completed, results
 
@@ -137,7 +109,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         self.assertEqual((results / "proxy.jsonl").read_text(encoding="utf-8"), "fake proxy stdout\n")
         self.assertEqual((results / "proxy.stderr").read_text(encoding="utf-8"), "fake proxy stderr\n")
         self.assertTrue((results / "decisions.ndjson").is_file())
-        self.assertTrue((results / "observations.ndjson").is_file())
+        self.assertTrue((results / "denied-observations.ndjson").is_file())
         child_environment = json.loads(
             (results / "fake-environment.json").read_text(encoding="utf-8")
         )

--- a/scripts/ci/test_published_release_proxy_phase.py
+++ b/scripts/ci/test_published_release_proxy_phase.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import unittest
 
 
@@ -24,6 +25,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         request: bytes = b'{"jsonrpc":"2.0","id":1}\n',
         fake_sleep: float = 0,
         fake_output_bytes: int = 0,
+        spawn_grandchild: bool = False,
         timeout_seconds: int = 60,
     ) -> tuple[subprocess.CompletedProcess[bytes], Path]:
         temporary = Path(self.enterContext(tempfile.TemporaryDirectory(prefix="proxy phase ")))
@@ -32,7 +34,7 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
             textwrap.dedent(
                 """\
                 #!/usr/bin/env python3
-                import json, os, pathlib, sys, time
+                import json, os, pathlib, subprocess, sys, time
 
                 def value(flag):
                     return pathlib.Path(sys.argv[sys.argv.index(flag) + 1])
@@ -49,6 +51,16 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
                     (decisions.parent / "fake-control.json").read_text(encoding="utf-8")
                 )
                 sys.stdin.buffer.read()
+                if control["spawn_grandchild"]:
+                    sentinel = decisions.parent / "grandchild-sentinel"
+                    subprocess.Popen(
+                        [
+                            sys.executable,
+                            "-c",
+                            "import pathlib,sys,time; time.sleep(1.5); pathlib.Path(sys.argv[1]).write_text('survived')",
+                            str(sentinel),
+                        ]
+                    )
                 time.sleep(control["sleep"])
                 if control["output_bytes"]:
                     sys.stdout.write("x" * control["output_bytes"])
@@ -67,7 +79,12 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
         results.mkdir()
         (results / "fake-control.json").write_text(
             json.dumps(
-                {"exit": fake_exit, "sleep": fake_sleep, "output_bytes": fake_output_bytes}
+                {
+                    "exit": fake_exit,
+                    "sleep": fake_sleep,
+                    "output_bytes": fake_output_bytes,
+                    "spawn_grandchild": spawn_grandchild,
+                }
             ),
             encoding="utf-8",
         )
@@ -149,6 +166,14 @@ class PublishedReleaseProxyPhaseTests(unittest.TestCase):
             for line in (results / "fake-invocations.jsonl").read_text(encoding="utf-8").splitlines()
         ]
         self.assertEqual(records[0]["argv"], observed[0])
+
+    def test_timeout_reaps_proxy_descendants_before_recording(self) -> None:
+        completed, results = self.run_phase(
+            0, fake_sleep=3, spawn_grandchild=True, timeout_seconds=1
+        )
+        self.assertEqual(completed.returncode, 124, completed.stderr.decode())
+        time.sleep(1)
+        self.assertFalse((results / "grandchild-sentinel").exists())
 
     def test_output_file_ceiling_stops_unbounded_child_output(self) -> None:
         completed, results = self.run_phase(0, fake_output_bytes=16_777_216 + 1)

--- a/scripts/ci/test_safe_extract_release_archive.py
+++ b/scripts/ci/test_safe_extract_release_archive.py
@@ -82,6 +82,14 @@ class SafeExtractReleaseArchiveTests(unittest.TestCase):
         with self.assertRaises(ArchiveRejected):
             extract_archive(archive, self.root / "out", max_decoded_bytes=4, max_members=4)
 
+    def test_rejects_aggregate_decoded_size_ceiling(self) -> None:
+        archive = self.write_archive(
+            [("pkg/assay", b"123", "file"), ("pkg/README.md", b"456", "file")]
+        )
+
+        with self.assertRaises(ArchiveRejected):
+            extract_archive(archive, self.root / "out", max_decoded_bytes=4, max_members=4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_safe_extract_release_archive.py
+++ b/scripts/ci/test_safe_extract_release_archive.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from safe_extract_release_archive import ArchiveRejected, extract_archive
+
+
+class SafeExtractReleaseArchiveTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write_archive(self, rows: list[tuple[str, bytes, str]]) -> Path:
+        archive = self.root / "input.tar.gz"
+        with tarfile.open(archive, "w:gz") as handle:
+            for name, payload, kind in rows:
+                member = tarfile.TarInfo(name)
+                if kind == "file":
+                    member.size = len(payload)
+                    member.mode = 0o755
+                    handle.addfile(member, io.BytesIO(payload))
+                elif kind == "symlink":
+                    member.type = tarfile.SYMTYPE
+                    member.linkname = payload.decode()
+                    handle.addfile(member)
+                else:
+                    raise AssertionError(kind)
+        return archive
+
+    def test_extracts_bounded_regular_file(self) -> None:
+        archive = self.write_archive([("pkg/assay", b"binary", "file")])
+        destination = self.root / "out"
+
+        extract_archive(archive, destination, max_decoded_bytes=32, max_members=4)
+
+        self.assertEqual((destination / "pkg/assay").read_bytes(), b"binary")
+        self.assertTrue((destination / "pkg/assay").stat().st_mode & 0o100)
+
+    def test_rejects_traversal_before_materialization(self) -> None:
+        archive = self.write_archive([("../escape", b"bad", "file")])
+        destination = self.root / "out"
+
+        with self.assertRaises(ArchiveRejected):
+            extract_archive(archive, destination, max_decoded_bytes=32, max_members=4)
+
+        self.assertFalse(destination.exists())
+        self.assertFalse((self.root / "escape").exists())
+
+    def test_rejects_link_member(self) -> None:
+        archive = self.write_archive([("pkg/link", b"/tmp/target", "symlink")])
+
+        with self.assertRaises(ArchiveRejected):
+            extract_archive(archive, self.root / "out", max_decoded_bytes=32, max_members=4)
+
+    def test_rejects_duplicate_member(self) -> None:
+        archive = self.write_archive(
+            [("pkg/assay", b"one", "file"), ("pkg/assay", b"two", "file")]
+        )
+
+        with self.assertRaises(ArchiveRejected):
+            extract_archive(archive, self.root / "out", max_decoded_bytes=32, max_members=4)
+
+    def test_rejects_member_count_ceiling(self) -> None:
+        archive = self.write_archive(
+            [(f"pkg/{index}", b"x", "file") for index in range(5)]
+        )
+
+        with self.assertRaises(ArchiveRejected):
+            extract_archive(archive, self.root / "out", max_decoded_bytes=32, max_members=4)
+
+    def test_rejects_decoded_size_ceiling(self) -> None:
+        archive = self.write_archive([("pkg/assay", b"12345", "file")])
+
+        with self.assertRaises(ArchiveRejected):
+            extract_archive(archive, self.root / "out", max_decoded_bytes=4, max_members=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_safe_extract_release_archive.py
+++ b/scripts/ci/test_safe_extract_release_archive.py
@@ -6,6 +6,7 @@ import tarfile
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from safe_extract_release_archive import ArchiveRejected, extract_archive
 
@@ -43,6 +44,19 @@ class SafeExtractReleaseArchiveTests(unittest.TestCase):
 
         self.assertEqual((destination / "pkg/assay").read_bytes(), b"binary")
         self.assertTrue((destination / "pkg/assay").stat().st_mode & 0o100)
+
+    def test_does_not_materialize_member_table(self) -> None:
+        archive = self.write_archive([("pkg/assay", b"binary", "file")])
+        destination = self.root / "out"
+
+        with mock.patch.object(
+            tarfile.TarFile,
+            "getmembers",
+            side_effect=AssertionError("member table was materialized"),
+        ):
+            extract_archive(archive, destination, max_decoded_bytes=32, max_members=4)
+
+        self.assertEqual((destination / "pkg/assay").read_bytes(), b"binary")
 
     def test_rejects_traversal_before_materialization(self) -> None:
         archive = self.write_archive([("../escape", b"bad", "file")])


### PR DESCRIPTION
## Summary

- add reusable post-publication verification for the published Linux x86_64 CLI/MCP journey
- resolve the requested tag to an external commit anchor and verify both downloaded product archives online with reviewed exact-head attestation code before extraction or execution
- enforce compressed/decoded/member ceilings and atomically extract only regular files/directories
- exercise init, policy validation/evaluation, MCP deny enforcement, same-run evidence production, inspection, verification, SARIF export, and tamper rejection
- retain the downloaded archives, raw attestations, release/tag API inputs, commands and journey outputs with separate release/harness/workflow provenance
- guard the wiring and trust boundaries with structural checks, 40 structural mutations, seven behavioral proxy mutations, seven proxy-phase tests, eight archive tests, three bounded-download tests, and digest-only attestation tests

Progresses #2486. Capability promotion remains separate until this merges and a `main` workflow run succeeds with retained proof.

## Contract

This is **post-publication verification**, not a publication gate. A failure turns the release workflow red but cannot retract assets or stop concurrent external publishers.

Bounded claim:

> The attested v5.3.0 Linux x86_64 CLI/MCP archives completed the journey under harness head `402c750d415834d27e657f476ab482bb27a130a7`, workflow invocation identity, and recorded fixture digests.

Non-claims:

- harness files are not shipped or release-attested assets
- no proof-kit-carried script is trusted or executed
- no macOS/Windows, provider-outcome, upstream-side-effect, or registry-publication claim
- capability remains `planned` until the post-merge run is inspected

## RED / GREEN

Initial RED:

```text
FAIL: missing published-release golden-path workflow
```

Review-driven RED:

```text
SOURCE_REF: SOURCE_REF is required
```

This captured the valid `workflow_dispatch` release case where the tag and attestation bind the same commit but the attestation source ref is `refs/heads/main`.

GREEN on `402c750d415834d27e657f476ab482bb27a130a7`:

- focused contract + 40 structural and seven behavioral mutations pass
- seven proxy-phase tests pass: success/failure parity, request ceiling, timeout provenance, timeout and successful-exit descendant containment, output ceiling, and credential-free child environment
- `release_attestation_enforce` tests pass, including digest-only source binding
- eight safe-extraction tests pass: valid archive, traversal, symlink, duplicate, member-count, per-member decoded-size, aggregate decoded-size, streaming member scan
- YAML, Actionlint, ShellCheck, pre-commit, workspace Clippy and Linux cross-target compile pass

## Committed-head live proof

Ubuntu 24.04 `linux/amd64`; Docker server 29.2.1; GitHub CLI 2.83.1 (tar SHA-256 `1c5252d4ce3db07b51c01ff0b909583da6364ff3fdc06d0c2e75e62dc0380a34`):

```text
PASS: published release v5.3.0 completed the install-to-verified-evidence journey
release.tag=v5.3.0
release.source_digest=9f1f2834215847479daffe3caf14bf44c7e4d270
release.assets=2
harness.head_sha=402c750d415834d27e657f476ab482bb27a130a7
workflow_run_id=local-docker
workflow_run_attempt=1
RETAINED_COUNT=38
```

## Review disposition

The first exact-head review correctly blocked `8b485a…`. The new head:

- structurally binds the unique caller job, publication dependency, condition and failure behavior
- removes release-proof-kit execution entirely
- externally resolves tag→commit and verifies SLSA attestations against that digest
- retains exact archives and raw trust inputs
- applies bounded download plus streaming pre-materialization size/member/path/type ceilings
- pins the exact workflow, driver, verifier and helper bytes staged for the run
- independently checks exact live workflow, attestation, version and the single-owner proxy helper invocation plus retained-input counts even when manifest hashes are refreshed
- binds evidence run ID to workflow run/attempt
- renames the job and documentation to honest post-publication verification
- owns the proxy process group and reaps descendants before recording command provenance
- launches the staged Python helper in isolated mode and rejects ambient `PYTHONPATH` poisoning

Ruley’s prior asset inventory and Cursor’s design review materially improved this boundary. All prior reviews are invalidated by subsequent hardening pushes; final quorum must review `402c750d415834d27e657f476ab482bb27a130a7`.


### Scanner disposition

The first safe-extractor CLI shape triggered 11 CodeQL path-expression alerts despite prevalidation. Final head removes the unnecessary CLI taint source and uses an import-only helper plus Python's `tarfile` data filter; the same eight archive tests and three bounded-download tests still pass. The committed-head Docker replay above is from this scanner-visible final shape.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated verification for published releases, including asset integrity, attestations, command behavior, evidence bundles, and tamper detection.
  - Added safeguards for securely downloading and extracting release archives.

- **Bug Fixes**
  - Release attestation checks now support verification using a source digest without requiring a source reference.
  - Improved cleanup and failure handling during downloads and archive processing.

- **Tests**
  - Added comprehensive contract, mutation, integration, and safety tests for the release verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->









