### PR TITLE
docs(product): promote published release golden path

### DIFF
--- a/docs/data/product-capabilities.v0.json
+++ b/docs/data/product-capabilities.v0.json
@@ -103,9 +103,9 @@
       "id": "published-release-golden-path",
       "label": "Published release golden path",
       "summary": "Install an attested release in a disposable environment and produce verified evidence.",
-      "maturity": "planned",
-      "introduced_release": null,
-      "target_release": "5.3.0",
+      "maturity": "stable",
+      "introduced_release": "5.3.0",
+      "target_release": null,
       "protocol_versions": [
         {"protocol": "mcp", "version": "2024-11-05", "transport": "stdio"},
         {"protocol": "mcp", "version": "2025-06-18", "transport": "stdio"},
@@ -114,15 +114,23 @@
       "profile_versions": [
         {"profile": "privileged-mcp-action", "version": "v0"}
       ],
-      "platforms": ["linux-aarch64", "linux-x86_64"],
+      "platforms": ["linux-x86_64"],
       "enforcement_points": ["cli", "mcp-proxy"],
-      "limitations": ["No exact-release install-to-evidence gate has landed yet."],
-      "non_claims": ["The planned gate will not prove external side effects, policy completeness or semantic safety."],
+      "limitations": ["The retained post-publication proof currently covers only the published Linux x86_64 CLI and MCP archives."],
+      "non_claims": ["This proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety."],
       "claims": [
         {
           "id": "release-install-to-verified-evidence",
           "axis": "outcome",
-          "gap": {"issue": "2486"}
+          "proofs": [
+            {
+              "url": "https://github.com/Rul1an/assay/actions/runs/32166096190",
+              "run_id": 32166096190,
+              "commit_sha": "3c0df3cbac793854f67caad44a46fda1bcafc02f",
+              "digest": "sha256:810989f56bcfa596b4f055435b4cd4db3ebdef0eb2089b55525f6acd022a2c5e",
+              "artifact": "published-release-golden-path-v5.3.0-3c0df3cbac793854f67caad44a46fda1bcafc02f"
+            }
+          ]
         }
       ]
     }

--- a/docs/data/product-capabilities.v0.json
+++ b/docs/data/product-capabilities.v0.json
@@ -28,30 +28,35 @@
           "axis": "observation",
           "proofs": [
             {
+              "kind": "release-asset",
               "artifact": "assay-v5.3.0-aarch64-apple-darwin.tar.gz",
               "commit_sha": "9f1f2834215847479daffe3caf14bf44c7e4d270",
               "digest": "sha256:541a40eb72e387f1caf9c66586eae765fe0bcd9c702fc1eb3944d1fd098bfb68",
               "run_id": 32106898803
             },
             {
+              "kind": "release-asset",
               "artifact": "assay-v5.3.0-aarch64-unknown-linux-gnu.tar.gz",
               "commit_sha": "9f1f2834215847479daffe3caf14bf44c7e4d270",
               "digest": "sha256:15f18617505a0bc3652714ea5b1f17d87f346c5936fff3f0ac7d767a6cb8c0f4",
               "run_id": 32106898803
             },
             {
+              "kind": "release-asset",
               "artifact": "assay-v5.3.0-x86_64-apple-darwin.tar.gz",
               "commit_sha": "9f1f2834215847479daffe3caf14bf44c7e4d270",
               "digest": "sha256:11702950c0782272ef1b396fe92ac2e61ede8b67ba229eb8ed440f40efc20a84",
               "run_id": 32106898803
             },
             {
+              "kind": "release-asset",
               "artifact": "assay-v5.3.0-x86_64-pc-windows-msvc.zip",
               "commit_sha": "9f1f2834215847479daffe3caf14bf44c7e4d270",
               "digest": "sha256:4c831e6ce4897a423a4ce08b81bdeb2eed9beb88d70aa39781aa6afbab8e003f",
               "run_id": 32106898803
             },
             {
+              "kind": "release-asset",
               "artifact": "assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz",
               "commit_sha": "9f1f2834215847479daffe3caf14bf44c7e4d270",
               "digest": "sha256:c4ab77a4c3aa5f7f27afff3c80ca8cd4d7ee838d6e0524454a103620af10df34",
@@ -84,12 +89,14 @@
           "axis": "observation",
           "proofs": [
             {
+              "kind": "release-asset",
               "artifact": "assay-mcp-server-v5.3.0-aarch64-unknown-linux-gnu.tar.gz",
               "commit_sha": "9f1f2834215847479daffe3caf14bf44c7e4d270",
               "digest": "sha256:2d3e92a59475230b03155380ca3f01a43e2732958195424d0ebec73561a30dda",
               "run_id": 32106898803
             },
             {
+              "kind": "release-asset",
               "artifact": "assay-mcp-server-v5.3.0-x86_64-unknown-linux-gnu.tar.gz",
               "commit_sha": "9f1f2834215847479daffe3caf14bf44c7e4d270",
               "digest": "sha256:3bd678d9c85b881dbeb92d5f6f9194c51db9f58d826bebb8f79168b3e590b512",
@@ -117,13 +124,16 @@
       "platforms": ["linux-x86_64"],
       "enforcement_points": ["cli", "mcp-proxy"],
       "limitations": ["The retained post-publication proof currently covers only the published Linux x86_64 CLI and MCP archives."],
-      "non_claims": ["This proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety."],
+      "non_claims": [
+        "The exact-head harness, fixture, mock, policy and baseline are not shipped, release-attested or part of the v5.3.0 product archives; this proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety."
+      ],
       "claims": [
         {
           "id": "release-install-to-verified-evidence",
           "axis": "outcome",
           "proofs": [
             {
+              "kind": "github-actions-artifact",
               "url": "https://github.com/Rul1an/assay/actions/runs/32166096190",
               "run_id": 32166096190,
               "commit_sha": "3c0df3cbac793854f67caad44a46fda1bcafc02f",

--- a/docs/generated/product-claim-proof.md
+++ b/docs/generated/product-claim-proof.md
@@ -11,11 +11,11 @@ Proof identities are checked for shape offline; this generator does not fetch th
 
 <a id="claim-v5-3-cli-release-assets"></a>
 ### `v5-3-cli-release-assets` (`observation`)
-- Proof: `artifact=assay-v5.3.0-aarch64-apple-darwin.tar.gz`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`, `digest=sha256:541a40eb72e387f1caf9c66586eae765fe0bcd9c702fc1eb3944d1fd098bfb68`, `run_id=32106898803`
-- Proof: `artifact=assay-v5.3.0-aarch64-unknown-linux-gnu.tar.gz`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`, `digest=sha256:15f18617505a0bc3652714ea5b1f17d87f346c5936fff3f0ac7d767a6cb8c0f4`, `run_id=32106898803`
-- Proof: `artifact=assay-v5.3.0-x86_64-apple-darwin.tar.gz`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`, `digest=sha256:11702950c0782272ef1b396fe92ac2e61ede8b67ba229eb8ed440f40efc20a84`, `run_id=32106898803`
-- Proof: `artifact=assay-v5.3.0-x86_64-pc-windows-msvc.zip`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`, `digest=sha256:4c831e6ce4897a423a4ce08b81bdeb2eed9beb88d70aa39781aa6afbab8e003f`, `run_id=32106898803`
-- Proof: `artifact=assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`, `digest=sha256:c4ab77a4c3aa5f7f27afff3c80ca8cd4d7ee838d6e0524454a103620af10df34`, `run_id=32106898803`
+- Proof: `kind=release-asset`, `release_asset=assay-v5.3.0-aarch64-apple-darwin.tar.gz`, `release_asset_digest=sha256:541a40eb72e387f1caf9c66586eae765fe0bcd9c702fc1eb3944d1fd098bfb68`, `run_id=32106898803`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`
+- Proof: `kind=release-asset`, `release_asset=assay-v5.3.0-aarch64-unknown-linux-gnu.tar.gz`, `release_asset_digest=sha256:15f18617505a0bc3652714ea5b1f17d87f346c5936fff3f0ac7d767a6cb8c0f4`, `run_id=32106898803`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`
+- Proof: `kind=release-asset`, `release_asset=assay-v5.3.0-x86_64-apple-darwin.tar.gz`, `release_asset_digest=sha256:11702950c0782272ef1b396fe92ac2e61ede8b67ba229eb8ed440f40efc20a84`, `run_id=32106898803`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`
+- Proof: `kind=release-asset`, `release_asset=assay-v5.3.0-x86_64-pc-windows-msvc.zip`, `release_asset_digest=sha256:4c831e6ce4897a423a4ce08b81bdeb2eed9beb88d70aa39781aa6afbab8e003f`, `run_id=32106898803`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`
+- Proof: `kind=release-asset`, `release_asset=assay-v5.3.0-x86_64-unknown-linux-gnu.tar.gz`, `release_asset_digest=sha256:c4ab77a4c3aa5f7f27afff3c80ca8cd4d7ee838d6e0524454a103620af10df34`, `run_id=32106898803`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`
 
 ## `published-mcp-server`
 
@@ -25,15 +25,15 @@ Proof identities are checked for shape offline; this generator does not fetch th
 
 <a id="claim-v5-3-mcp-release-assets"></a>
 ### `v5-3-mcp-release-assets` (`observation`)
-- Proof: `artifact=assay-mcp-server-v5.3.0-aarch64-unknown-linux-gnu.tar.gz`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`, `digest=sha256:2d3e92a59475230b03155380ca3f01a43e2732958195424d0ebec73561a30dda`, `run_id=32106898803`
-- Proof: `artifact=assay-mcp-server-v5.3.0-x86_64-unknown-linux-gnu.tar.gz`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`, `digest=sha256:3bd678d9c85b881dbeb92d5f6f9194c51db9f58d826bebb8f79168b3e590b512`, `run_id=32106898803`
+- Proof: `kind=release-asset`, `release_asset=assay-mcp-server-v5.3.0-aarch64-unknown-linux-gnu.tar.gz`, `release_asset_digest=sha256:2d3e92a59475230b03155380ca3f01a43e2732958195424d0ebec73561a30dda`, `run_id=32106898803`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`
+- Proof: `kind=release-asset`, `release_asset=assay-mcp-server-v5.3.0-x86_64-unknown-linux-gnu.tar.gz`, `release_asset_digest=sha256:3bd678d9c85b881dbeb92d5f6f9194c51db9f58d826bebb8f79168b3e590b512`, `run_id=32106898803`, `commit_sha=9f1f2834215847479daffe3caf14bf44c7e4d270`
 
 ## `published-release-golden-path`
 
 - Protocol versions: mcp 2024-11-05 over stdio, mcp 2025-06-18 over stdio, mcp 2025-11-25 over stdio
 - Profile versions: privileged-mcp-action/v0
-- Non-claims: This proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety.
+- Non-claims: The exact-head harness, fixture, mock, policy and baseline are not shipped, release-attested or part of the v5.3.0 product archives; this proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety.
 
 <a id="claim-release-install-to-verified-evidence"></a>
 ### `release-install-to-verified-evidence` (`outcome`)
-- Proof: `artifact=published-release-golden-path-v5.3.0-3c0df3cbac793854f67caad44a46fda1bcafc02f`, `commit_sha=3c0df3cbac793854f67caad44a46fda1bcafc02f`, `digest=sha256:810989f56bcfa596b4f055435b4cd4db3ebdef0eb2089b55525f6acd022a2c5e`, `run_id=32166096190`
+- Proof: `kind=github-actions-artifact`, `run_artifact=published-release-golden-path-v5.3.0-3c0df3cbac793854f67caad44a46fda1bcafc02f`, `run_artifact_digest=sha256:810989f56bcfa596b4f055435b4cd4db3ebdef0eb2089b55525f6acd022a2c5e`, `run_id=32166096190`, `commit_sha=3c0df3cbac793854f67caad44a46fda1bcafc02f`

--- a/docs/generated/product-claim-proof.md
+++ b/docs/generated/product-claim-proof.md
@@ -32,8 +32,8 @@ Proof identities are checked for shape offline; this generator does not fetch th
 
 - Protocol versions: mcp 2024-11-05 over stdio, mcp 2025-06-18 over stdio, mcp 2025-11-25 over stdio
 - Profile versions: privileged-mcp-action/v0
-- Non-claims: The planned gate will not prove external side effects, policy completeness or semantic safety.
+- Non-claims: This proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety.
 
 <a id="claim-release-install-to-verified-evidence"></a>
 ### `release-install-to-verified-evidence` (`outcome`)
-- Gap issue: `#2486`
+- Proof: `artifact=published-release-golden-path-v5.3.0-3c0df3cbac793854f67caad44a46fda1bcafc02f`, `commit_sha=3c0df3cbac793854f67caad44a46fda1bcafc02f`, `digest=sha256:810989f56bcfa596b4f055435b4cd4db3ebdef0eb2089b55525f6acd022a2c5e`, `run_id=32166096190`

--- a/docs/reference/product-support.md
+++ b/docs/reference/product-support.md
@@ -49,7 +49,7 @@ Install an attested release in a disposable environment and produce verified evi
 - Profile versions: privileged-mcp-action/v0
 - Enforcement points: cli, mcp-proxy
 - Limitations: The retained post-publication proof currently covers only the published Linux x86_64 CLI and MCP archives.
-- Non-claims: This proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety.
+- Non-claims: The exact-head harness, fixture, mock, policy and baseline are not shipped, release-attested or part of the v5.3.0 product archives; this proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety.
 
 | Claim | Axis | Evidence state |
 |---|---|---|

--- a/docs/reference/product-support.md
+++ b/docs/reference/product-support.md
@@ -42,15 +42,15 @@ Attested assay-mcp-server release archives are published for the listed Linux ta
 
 Install an attested release in a disposable environment and produce verified evidence.
 
-- Maturity: `planned`
-- Target release: `5.3.0`
-- Platforms: linux-aarch64, linux-x86_64
+- Maturity: `stable`
+- Introduced: `5.3.0`
+- Platforms: linux-x86_64
 - Protocol versions: mcp 2024-11-05 over stdio, mcp 2025-06-18 over stdio, mcp 2025-11-25 over stdio
 - Profile versions: privileged-mcp-action/v0
 - Enforcement points: cli, mcp-proxy
-- Limitations: No exact-release install-to-evidence gate has landed yet.
-- Non-claims: The planned gate will not prove external side effects, policy completeness or semantic safety.
+- Limitations: The retained post-publication proof currently covers only the published Linux x86_64 CLI and MCP archives.
+- Non-claims: This proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety.
 
 | Claim | Axis | Evidence state |
 |---|---|---|
-| `release-install-to-verified-evidence` | `outcome` | [gap #2486](https://github.com/Rul1an/assay/issues/2486) |
+| `release-install-to-verified-evidence` | `outcome` | proof-backed ([identities](../generated/product-claim-proof.md#claim-release-install-to-verified-evidence)) |

--- a/scripts/ci/test-generate-product-capabilities.py
+++ b/scripts/ci/test-generate-product-capabilities.py
@@ -231,6 +231,11 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
         self.assertIsNone(capability["target_release"])
         self.assertEqual(capability["platforms"], ["linux-x86_64"])
         self.assertEqual(
+            capability["profile_versions"],
+            [{"profile": "privileged-mcp-action", "version": "v0"}],
+        )
+        self.assertEqual(capability["enforcement_points"], ["cli", "mcp-proxy"])
+        self.assertEqual(
             capability["limitations"],
             [
                 "The retained post-publication proof currently covers only the published Linux x86_64 CLI and MCP archives."

--- a/scripts/ci/test-generate-product-capabilities.py
+++ b/scripts/ci/test-generate-product-capabilities.py
@@ -185,6 +185,34 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
             capabilities["published-release-golden-path"]["protocol_versions"], expected
         )
 
+    def test_published_release_golden_path_is_bound_to_retained_linux_proof(self) -> None:
+        manifest = json.loads(
+            (REPO_ROOT / "docs/data/product-capabilities.v0.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        capabilities = {entry["id"]: entry for entry in manifest["capabilities"]}
+        capability = capabilities["published-release-golden-path"]
+        claim = capability["claims"][0]
+
+        self.assertEqual(capability["maturity"], "stable")
+        self.assertEqual(capability["introduced_release"], "5.3.0")
+        self.assertIsNone(capability["target_release"])
+        self.assertEqual(capability["platforms"], ["linux-x86_64"])
+        self.assertNotIn("gap", claim)
+        self.assertEqual(
+            claim["proofs"],
+            [
+                {
+                    "url": "https://github.com/Rul1an/assay/actions/runs/32166096190",
+                    "run_id": 32166096190,
+                    "commit_sha": "3c0df3cbac793854f67caad44a46fda1bcafc02f",
+                    "digest": "sha256:810989f56bcfa596b4f055435b4cd4db3ebdef0eb2089b55525f6acd022a2c5e",
+                    "artifact": "published-release-golden-path-v5.3.0-3c0df3cbac793854f67caad44a46fda1bcafc02f",
+                }
+            ],
+        )
+
     def test_writes_both_views_in_shared_id_order(self) -> None:
         manifest = minimal_manifest()
         first = manifest["capabilities"][0]

--- a/scripts/ci/test-generate-product-capabilities.py
+++ b/scripts/ci/test-generate-product-capabilities.py
@@ -200,6 +200,22 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
             capabilities["published-release-golden-path"]["protocol_versions"], expected
         )
 
+    def test_published_binary_proofs_are_release_assets(self) -> None:
+        manifest = json.loads(
+            (REPO_ROOT / "docs/data/product-capabilities.v0.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        capabilities = {entry["id"]: entry for entry in manifest["capabilities"]}
+
+        for capability_id in ("published-cli", "published-mcp-server"):
+            with self.subTest(capability=capability_id):
+                proofs = capabilities[capability_id]["claims"][0]["proofs"]
+                self.assertTrue(proofs)
+                self.assertTrue(
+                    all(proof["kind"] == "release-asset" for proof in proofs)
+                )
+
     def test_published_release_golden_path_is_bound_to_retained_linux_proof(self) -> None:
         manifest = json.loads(
             (REPO_ROOT / "docs/data/product-capabilities.v0.json").read_text(

--- a/scripts/ci/test-generate-product-capabilities.py
+++ b/scripts/ci/test-generate-product-capabilities.py
@@ -32,7 +32,12 @@ def minimal_manifest() -> dict:
                     {
                         "id": "published-install",
                         "axis": "observation",
-                        "proofs": [{"url": "https://example.invalid/latest"}],
+                        "proofs": [
+                            {
+                                "kind": "github-actions-artifact",
+                                "url": "https://example.invalid/latest",
+                            }
+                        ],
                     }
                 ],
             }
@@ -88,7 +93,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_rejects_duplicate_claim_ids(self) -> None:
         manifest = minimal_manifest()
         claim = manifest["capabilities"][0]["claims"][0]
-        claim["proofs"] = [{"run_id": 32122877879}]
+        claim["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 32122877879}
+        ]
         manifest["capabilities"][0]["claims"].append(dict(claim))
         with tempfile.TemporaryDirectory() as tmp:
             result = run_generator(manifest, Path(tmp))
@@ -98,7 +105,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
 
     def test_rejects_duplicate_capability_ids(self) -> None:
         manifest = minimal_manifest()
-        manifest["capabilities"][0]["claims"][0]["proofs"] = [{"run_id": 1}]
+        manifest["capabilities"][0]["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 1}
+        ]
         manifest["capabilities"].append(
             json.loads(json.dumps(manifest["capabilities"][0]))
         )
@@ -111,7 +120,7 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_rejects_unknown_proof_fields(self) -> None:
         manifest = minimal_manifest()
         manifest["capabilities"][0]["claims"][0]["proofs"] = [
-            {"run_id": 1, "status": "certified"}
+            {"kind": "github-actions-artifact", "run_id": 1, "status": "certified"}
         ]
         with tempfile.TemporaryDirectory() as tmp:
             result = run_generator(manifest, Path(tmp))
@@ -122,13 +131,15 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_rejects_unknown_fields_at_every_manifest_level(self) -> None:
         cases = []
         root_manifest = minimal_manifest()
-        root_manifest["capabilities"][0]["claims"][0]["proofs"] = [{"run_id": 1}]
+        root_manifest["capabilities"][0]["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 1}
+        ]
         root_manifest["status"] = "certified"
         cases.append((root_manifest, "manifest has unknown fields: status"))
 
         capability_manifest = minimal_manifest()
         capability_manifest["capabilities"][0]["claims"][0]["proofs"] = [
-            {"run_id": 1}
+            {"kind": "github-actions-artifact", "run_id": 1}
         ]
         capability_manifest["capabilities"][0]["certification"] = "certified"
         cases.append(
@@ -136,7 +147,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
         )
 
         claim_manifest = minimal_manifest()
-        claim_manifest["capabilities"][0]["claims"][0]["proofs"] = [{"run_id": 1}]
+        claim_manifest["capabilities"][0]["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 1}
+        ]
         claim_manifest["capabilities"][0]["claims"][0]["status"] = "certified"
         cases.append((claim_manifest, "claim has unknown fields: status"))
 
@@ -154,7 +167,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
 
     def test_rejects_duplicate_json_object_keys(self) -> None:
         manifest = minimal_manifest()
-        manifest["capabilities"][0]["claims"][0]["proofs"] = [{"run_id": 1}]
+        manifest["capabilities"][0]["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 1}
+        ]
         raw = json.dumps(manifest).replace(
             '"run_id": 1', '"run_id": 0, "run_id": 1'
         )
@@ -199,11 +214,25 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
         self.assertEqual(capability["introduced_release"], "5.3.0")
         self.assertIsNone(capability["target_release"])
         self.assertEqual(capability["platforms"], ["linux-x86_64"])
+        self.assertEqual(
+            capability["limitations"],
+            [
+                "The retained post-publication proof currently covers only the published Linux x86_64 CLI and MCP archives."
+            ],
+        )
+        self.assertEqual(
+            capability["non_claims"],
+            [
+                "The exact-head harness, fixture, mock, policy and baseline are not shipped, release-attested or part of the v5.3.0 product archives; this proof does not cover macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness or semantic safety."
+            ],
+        )
+        self.assertEqual(claim["axis"], "outcome")
         self.assertNotIn("gap", claim)
         self.assertEqual(
             claim["proofs"],
             [
                 {
+                    "kind": "github-actions-artifact",
                     "url": "https://github.com/Rul1an/assay/actions/runs/32166096190",
                     "run_id": 32166096190,
                     "commit_sha": "3c0df3cbac793854f67caad44a46fda1bcafc02f",
@@ -213,15 +242,66 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
             ],
         )
 
+    def test_rejects_proof_without_kind(self) -> None:
+        manifest = minimal_manifest()
+        manifest["capabilities"][0]["claims"][0]["proofs"] = [{"run_id": 1}]
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_generator(manifest, Path(tmp))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("proof is missing fields: kind", result.stderr)
+
+    def test_rejects_unknown_proof_kind(self) -> None:
+        manifest = minimal_manifest()
+        manifest["capabilities"][0]["claims"][0]["proofs"] = [
+            {"kind": "generic-digest", "run_id": 1}
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_generator(manifest, Path(tmp))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("proof has unknown kind", result.stderr)
+
+    def test_renders_digest_subject_by_proof_kind(self) -> None:
+        manifest = minimal_manifest()
+        claim = manifest["capabilities"][0]["claims"][0]
+        claim["proofs"] = [
+            {
+                "kind": "release-asset",
+                "artifact": "assay.tar.gz",
+                "digest": "sha256:" + "a" * 64,
+            },
+            {
+                "kind": "github-actions-artifact",
+                "artifact": "journey-proof",
+                "digest": "sha256:" + "b" * 64,
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = run_generator(manifest, root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            proof = (root / "proof.md").read_text(encoding="utf-8")
+
+        self.assertIn("release_asset=assay.tar.gz", proof)
+        self.assertIn("release_asset_digest=sha256:" + "a" * 64, proof)
+        self.assertIn("run_artifact=journey-proof", proof)
+        self.assertIn("run_artifact_digest=sha256:" + "b" * 64, proof)
+
     def test_writes_both_views_in_shared_id_order(self) -> None:
         manifest = minimal_manifest()
         first = manifest["capabilities"][0]
         first["id"] = "z-capability"
         first["claims"][0]["id"] = "z-claim"
-        first["claims"][0]["proofs"] = [{"commit_sha": "a" * 40}]
+        first["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "commit_sha": "a" * 40}
+        ]
         earlier_claim = json.loads(json.dumps(first["claims"][0]))
         earlier_claim["id"] = "b-claim"
-        earlier_claim["proofs"] = [{"run_id": 2}]
+        earlier_claim["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 2}
+        ]
         first["claims"].append(earlier_claim)
         second = json.loads(json.dumps(first))
         second["id"] = "a-capability"
@@ -230,7 +310,12 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
             {
                 "id": "a-claim",
                 "axis": "observation",
-                "proofs": [{"digest": "sha256:" + "b" * 64}],
+                "proofs": [
+                    {
+                        "kind": "github-actions-artifact",
+                        "digest": "sha256:" + "b" * 64,
+                    }
+                ],
             }
         ]
         manifest["capabilities"].append(second)
@@ -251,7 +336,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
 
     def test_rejects_boolean_run_id(self) -> None:
         manifest = minimal_manifest()
-        manifest["capabilities"][0]["claims"][0]["proofs"] = [{"run_id": True}]
+        manifest["capabilities"][0]["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": True}
+        ]
         with tempfile.TemporaryDirectory() as tmp:
             result = run_generator(manifest, Path(tmp))
 
@@ -261,7 +348,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_rejects_markdown_unsafe_identifier(self) -> None:
         manifest = minimal_manifest()
         manifest["capabilities"][0]["id"] = "bad|identifier"
-        manifest["capabilities"][0]["claims"][0]["proofs"] = [{"run_id": 1}]
+        manifest["capabilities"][0]["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 1}
+        ]
         with tempfile.TemporaryDirectory() as tmp:
             result = run_generator(manifest, Path(tmp))
 
@@ -271,7 +360,7 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_rejects_mutable_commit_ref(self) -> None:
         manifest = minimal_manifest()
         manifest["capabilities"][0]["claims"][0]["proofs"] = [
-            {"commit_sha": "main"}
+            {"kind": "github-actions-artifact", "commit_sha": "main"}
         ]
         with tempfile.TemporaryDirectory() as tmp:
             result = run_generator(manifest, Path(tmp))
@@ -282,7 +371,7 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_rejects_artifact_without_digest(self) -> None:
         manifest = minimal_manifest()
         manifest["capabilities"][0]["claims"][0]["proofs"] = [
-            {"artifact": "assay.tar.gz", "run_id": 1}
+            {"kind": "release-asset", "artifact": "assay.tar.gz", "run_id": 1}
         ]
         with tempfile.TemporaryDirectory() as tmp:
             result = run_generator(manifest, Path(tmp))
@@ -293,7 +382,12 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_rejects_invalid_digest_even_with_valid_run_id(self) -> None:
         manifest = minimal_manifest()
         manifest["capabilities"][0]["claims"][0]["proofs"] = [
-            {"artifact": "assay.tar.gz", "digest": "latest", "run_id": 1}
+            {
+                "kind": "release-asset",
+                "artifact": "assay.tar.gz",
+                "digest": "latest",
+                "run_id": 1,
+            }
         ]
         with tempfile.TemporaryDirectory() as tmp:
             result = run_generator(manifest, Path(tmp))
@@ -315,7 +409,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
     def test_public_view_links_proofs_and_gaps_and_states_verification_boundary(self) -> None:
         manifest = minimal_manifest()
         proof_claim = manifest["capabilities"][0]["claims"][0]
-        proof_claim["proofs"] = [{"run_id": 1}]
+        proof_claim["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 1}
+        ]
         gap_claim = {"id": "tracked-gap", "axis": "outcome", "gap": {"issue": "2486"}}
         manifest["capabilities"][0]["claims"].append(gap_claim)
 
@@ -338,7 +434,9 @@ class ProductCapabilityGeneratorTests(unittest.TestCase):
         capability["profile_versions"] = [
             {"profile": "privileged-mcp-action", "version": "v0"}
         ]
-        capability["claims"][0]["proofs"] = [{"run_id": 1}]
+        capability["claims"][0]["proofs"] = [
+            {"kind": "github-actions-artifact", "run_id": 1}
+        ]
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/scripts/docs/generate-product-capabilities.py
+++ b/scripts/docs/generate-product-capabilities.py
@@ -27,7 +27,8 @@ CAPABILITY_FIELDS = {
 }
 CLAIM_FIELDS = {"id", "axis", "proofs", "gap"}
 GAP_FIELDS = {"issue"}
-PROOF_FIELDS = {"url", "run_id", "commit_sha", "digest", "artifact"}
+PROOF_FIELDS = {"kind", "url", "run_id", "commit_sha", "digest", "artifact"}
+PROOF_KIND_VALUES = {"release-asset", "github-actions-artifact"}
 ID_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
 COMMIT_SHA_PATTERN = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
 DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}\Z")
@@ -146,7 +147,11 @@ def proof_has_immutable_identity(proof: dict) -> bool:
 
 
 def validate_proof(proof: object, claim_id: str) -> dict:
-    proof = require_object_fields(proof, PROOF_FIELDS, set(), f"claim {claim_id} proof")
+    proof = require_object_fields(
+        proof, PROOF_FIELDS, {"kind"}, f"claim {claim_id} proof"
+    )
+    if proof["kind"] not in PROOF_KIND_VALUES:
+        raise ValueError(f"claim {claim_id} proof has unknown kind")
     if "run_id" in proof:
         run_id = proof["run_id"]
         if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id <= 0:
@@ -339,8 +344,21 @@ def render_proof(manifest: dict) -> str:
                 lines.append(f"- Gap issue: `#{claim['gap']['issue']}`")
             else:
                 for proof in claim["proofs"]:
+                    field_names = {
+                        "release-asset": {
+                            "artifact": "release_asset",
+                            "digest": "release_asset_digest",
+                        },
+                        "github-actions-artifact": {
+                            "artifact": "run_artifact",
+                            "digest": "run_artifact_digest",
+                        },
+                    }[proof["kind"]]
+                    field_order = ("kind", "artifact", "digest", "run_id", "commit_sha")
                     rendered = ", ".join(
-                        f"`{key}={proof[key]}`" for key in sorted(proof) if key != "url"
+                        f"`{field_names.get(key, key)}={proof[key]}`"
+                        for key in field_order
+                        if key in proof
                     )
                     lines.append(f"- Proof: {rendered}")
             lines.append("")


### PR DESCRIPTION
## Summary

- promote `published-release-golden-path` from planned to stable after the post-publication v5.3.0 proof succeeded
- bind the capability claim to the retained GitHub Actions artifact, run, digest, and exact main SHA
- narrow platform support to the measured `linux-x86_64` path and state explicit non-claims for unmeasured hosts and outcomes
- type proof subjects so release-asset digests cannot be confused with GitHub Actions artifact digests
- add a source-contract test that pins scope, claim axis, non-claims, and the complete immutable proof tuple

Closes #2486

## Proof

- workflow run: https://github.com/Rul1an/assay/actions/runs/32166096190
- proof head: `3c0df3cbac793854f67caad44a46fda1bcafc02f`
- artifact: `published-release-golden-path-v5.3.0-3c0df3cbac793854f67caad44a46fda1bcafc02f`
- artifact digest: `sha256:810989f56bcfa596b4f055435b4cd4db3ebdef0eb2089b55525f6acd022a2c5e`
- measured scope: published v5.3.0 Linux x86_64 CLI and MCP archives

## Verification

- RED: new promotion contract failed on `planned != stable`
- `python3 -m unittest scripts/ci/test-generate-product-capabilities.py`
- `bash scripts/ci/check-docs-generated-drift.sh`
- `pre-commit run product-capability-generator-self-test --files ...`
- `pre-commit run docs-generated-drift --files ...`
- commit-time pre-commit suite
- `git diff --check`

## Non-claims

This promotion does not claim macOS, Windows, Linux aarch64, editor discovery, remote transports, external side effects, policy completeness, or semantic safety.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Marked the published release installation path as stable for v5.3.0.
  - Clarified that verified release evidence currently covers Linux x86_64 CLI and MCP archives.
  - Updated limitations and non-claims to distinguish available, unshipped, and unverified capabilities.
  - Added clearer release evidence details, including artifact and digest identifiers, to improve verification of published downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->