### PR TITLE
fix(ci): reconcile programme and Wave 0 truth

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -37,6 +37,12 @@ on:
       # under Lint (pre-commit) here. `scripts/**` covers a guard change; a recipe-only drift
       # touches no script, so the recipe needs its own entry or the guard never executes in CI.
       - "docs/guides/editor-mcp-recipe.md"
+      # Programme-truth hook runs under Lint (pre-commit) here. scripts/** covers
+      # the tests; these docs/ruleset paths are the remaining truth inputs.
+      - "AGENTS.md"
+      - "docs/contributing/WAVE0-GATES.md"
+      - "docs/contributing/REFACTOR-WAVE-STATUS.md"
+      - ".github/rulesets/main-required-ci-contexts.json"
       - ".github/workflows/kernel-matrix.yml"
       # S1b coverage-gate hook runs under Lint (pre-commit) in this workflow.
       - ".github/workflows/monitor-attach-smoke.yml"

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -353,35 +353,6 @@ jobs:
       - name: Clippy (deny placeholder paths)
         run: cargo clippy --workspace --all-targets -- -D warnings -D clippy::todo -D clippy::unimplemented
 
-      - name: Unsafe boundary preview (warn-only)
-        shell: bash
-        run: |
-          set -euo pipefail
-          all_unsafe="$(rg -n '\bunsafe\b' crates/assay-cli/src/cli/commands -g '*.rs' || true)"
-          outside_target="$(printf '%s\n' "$all_unsafe" | rg -v 'crates/assay-cli/src/cli/commands/monitor.rs' || true)"
-          {
-            echo "## Unsafe preview (warn-only)"
-            if [[ -z "$all_unsafe" ]]; then
-              echo "- No unsafe usage found under commands/"
-            else
-              echo "- Unsafe usage found under commands/:"
-              echo '```text'
-              printf '%s\n' "$all_unsafe"
-              echo '```'
-            fi
-            if [[ -n "$outside_target" ]]; then
-              echo "- Warning: unsafe outside monitor.rs detected (non-blocking in Wave 0):"
-              echo '```text'
-              printf '%s\n' "$outside_target"
-              echo '```'
-            else
-              echo "- Unsafe outside monitor.rs: none"
-            fi
-            echo ""
-            echo "### Wave 3 TODO"
-            echo "- Promote this preview to a blocking boundary gate: unsafe allowed only in the monitor syscall boundary module."
-          } >> "$GITHUB_STEP_SUMMARY"
-
   semver-public:
     name: Wave 0 semver checks (public crates)
     needs: detect-changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -570,6 +570,13 @@ repos:
         stages: [pre-push]
         pass_filenames: false
 
+      - id: ci-programme-truth
+        name: CI programme-truth contract
+        entry: bash -c 'bash scripts/ci/test-ci-programme-truth.sh && bash scripts/ci/test-review-split-wave.sh'
+        language: system
+        pass_filenames: false
+        files: ^(AGENTS\.md|docs/contributing/(WAVE0-GATES|REFACTOR-WAVE-STATUS)\.md|\.github/(workflows/split-wave0-gates\.yml|rulesets/main-required-ci-contexts\.json)|scripts/ci/(review-split-wave|test-ci-programme-truth|test-review-split-wave)\.sh|\.pre-commit-config\.yaml)$
+
       - id: semver-gate-self-test
         name: Semver gate self-test
         entry: bash scripts/ci/test-semver-gate.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -575,7 +575,7 @@ repos:
         entry: bash -c 'bash scripts/ci/test-ci-programme-truth.sh && bash scripts/ci/test-review-split-wave.sh'
         language: system
         pass_filenames: false
-        files: ^(AGENTS\.md|docs/contributing/(WAVE0-GATES|REFACTOR-WAVE-STATUS)\.md|\.github/(workflows/split-wave0-gates\.yml|rulesets/main-required-ci-contexts\.json)|scripts/ci/(review-split-wave|test-ci-programme-truth|test-review-split-wave)\.sh|\.pre-commit-config\.yaml)$
+        files: ^(AGENTS\.md|docs/contributing/(WAVE0-GATES|REFACTOR-WAVE-STATUS)\.md|\.github/(workflows/(split-wave0-gates|kernel-matrix)\.yml|rulesets/main-required-ci-contexts\.json)|scripts/ci/(review-split-wave|test-ci-programme-truth|test-review-split-wave)\.sh|\.pre-commit-config\.yaml)$
 
       - id: semver-gate-self-test
         name: Semver gate self-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -575,7 +575,8 @@ repos:
         entry: bash -c 'bash scripts/ci/test-ci-programme-truth.sh && bash scripts/ci/test-review-split-wave.sh'
         language: system
         pass_filenames: false
-        files: ^(AGENTS\.md|docs/contributing/(WAVE0-GATES|REFACTOR-WAVE-STATUS)\.md|\.github/(workflows/(split-wave0-gates|kernel-matrix)\.yml|rulesets/main-required-ci-contexts\.json)|scripts/ci/(review-split-wave|test-ci-programme-truth|test-review-split-wave)\.sh|\.pre-commit-config\.yaml)$
+        stages: [pre-commit, pre-push]
+        files: ^(AGENTS\.md|docs/contributing/(WAVE0-GATES|REFACTOR-WAVE-STATUS)\.md|\.github/(workflows/(split-wave0-gates|kernel-matrix)\.yml|rulesets/main-required-ci-contexts\.json)|scripts/ci/(review-split-wave|test-ci-programme-truth|test-review-split-wave)\.sh|scripts/ci/lib/resource_ceilings\.py|\.pre-commit-config\.yaml)$
 
       - id: semver-gate-self-test
         name: Semver gate self-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@ this contract.
 ## Canonical State
 
 - Repository truth is the checked-in code and documentation.
-- The public execution ledger for the active programme is named on this line: [issue #2388](https://github.com/Rul1an/assay/issues/2388).
-  Name the new ledger here when one opens, and
-  say so plainly here when none is active. Keep
+- The public execution ledger for the active programme is named on this line. **No programme is
+  active.** The previous one, [issue #2388](https://github.com/Rul1an/assay/issues/2388), closed on
+  2026-08-15; name the new ledger here when one opens, and say so plainly here when none is. Keep
   the number to this one line; everywhere else the contract names the role, so the next programme
   costs one edit here rather than one in every section. Nothing enforces that, so it is an
   instruction and not a guarantee — and the way it fails is quiet: the line kept pointing at a

--- a/docs/contributing/REFACTOR-WAVE-STATUS.md
+++ b/docs/contributing/REFACTOR-WAVE-STATUS.md
@@ -32,7 +32,7 @@ It answers four questions:
 | Wave68 | Metrics args_valid | `#1535` | Closed-loop | split args_valid metric into facade + `args_valid_next/{matcher,policy,evaluator,tests}.rs`; kept `ArgsValidMetric` public surface stable |
 | Wave69 | Policy tiers | `#1538` | Closed-loop | split policy tier compiler into facade + `tiers_next/{types,compiler,classifier,maps,tests}.rs`; kept `assay_policy::tiers::*` public surface stable |
 | Wave70 | Evidence mandate core types | `#1540` | Closed-loop | split mandate core data model into facade + `core_next/*`; added serde contract guard for `MandateContent` JSON shape |
-| Wave71 | Hotspot LOC under 600 | in progress | Active | current handwritten `>=600` LOC files are being reduced by subsystem waves with `review-hotspot-loc-under-600.sh` as the final closure gate |
+| Wave71 | Hotspot LOC under 600 | incomplete | Dormant | handwritten `>=600` LOC files remain; `review-hotspot-loc-under-600.sh` is a measurement/selection tool, not an active execution ledger |
 | Housekeeping | Refactor artifacts | `#1527` | Closed-loop | removed historical per-wave `SPLIT-*` docs and `review-wave*.sh` scripts after the durable generic gate landed |
 | Housekeeping | Stale review scripts | `#1529` | Closed-loop | removed non-wave review scripts that still referenced deleted `SPLIT-*` docs |
 

--- a/docs/contributing/WAVE0-GATES.md
+++ b/docs/contributing/WAVE0-GATES.md
@@ -81,12 +81,10 @@ fires before tag, not at release time.
 
 ## Required checks
 
-Live `main` branch protection requires the contexts in
-`.github/rulesets/main-required-ci-contexts.json`:
-
-- `CI`
-- `host-capability-check`
-- `lane-check/proof`
+The live required contexts are named once in `CI-CONTRACT.md` at
+`Currently required live branch-protection contexts`, and
+`scripts/ci/check-required-contexts.py` pins that list to
+`.github/rulesets/main-required-ci-contexts.json`. Do not copy the names here.
 
 Wave 0 job names (`Wave 0 feature matrix`, `Wave 0 quality gates`,
 `Wave 0 semver checks (public crates)`) are workflow jobs, not current

--- a/docs/contributing/WAVE0-GATES.md
+++ b/docs/contributing/WAVE0-GATES.md
@@ -9,14 +9,13 @@ Wave 0 gates are the pre-refactor guardrails for:
 - feature drift
 - semver drift for public crates
 - placeholder/temporary panic regressions
-- unsafe-boundary creep (warn-only in first iteration)
 
-## Baseline SHA policy (semver checks)
+## Baseline policy (semver checks)
 
-- Source of truth: workflow env `WAVE0_SEMVER_BASELINE_SHA`.
-- Current pinned baseline: `9cc23b4c684be7cfd81f170c4f66d59903dd76eb`.
-- Reset cadence: update once at the start of a refactor sprint, not during a sprint.
-- Update rule: change SHA + mention the reset in PR description with reason.
+- Source of truth: the newest `v[0-9]*` release tag, resolved at job time
+  (`git tag --list 'v[0-9]*' --sort=-v:refname`).
+- There is no pinned baseline SHA. A missing tag fails the job.
+- The contract is `scripts/ci/test-semver-gate.sh`.
 
 ## Runtime budget targets
 
@@ -80,13 +79,18 @@ fires before tag, not at release time.
   - parser/crypto fuzz smoke with fixed runtime budget
   - optional Kani lane (opt-in)
 
-## Required checks recommendation
+## Required checks
 
-Configure branch protection to require:
+Live `main` branch protection requires the contexts in
+`.github/rulesets/main-required-ci-contexts.json`:
 
-- `Wave 0 feature matrix`
-- `Wave 0 quality gates`
-- `Wave 0 semver checks (public crates)`
+- `CI`
+- `host-capability-check`
+- `lane-check/proof`
+
+Wave 0 job names (`Wave 0 feature matrix`, `Wave 0 quality gates`,
+`Wave 0 semver checks (public crates)`) are workflow jobs, not current
+required contexts.
 
 Wave 0 workflow always triggers on `pull_request`; heavy jobs are conditional to avoid docs-only blocking.
 
@@ -96,4 +100,3 @@ Before declaring Wave 0 stable:
 
 1. No new semver false-positive failures across 3 non-refactor PRs.
 2. Runtime stays within budget targets above.
-3. Unsafe preview remains non-blocking until monitor split isolates unsafe code.

--- a/scripts/ci/lib/resource_ceilings.py
+++ b/scripts/ci/lib/resource_ceilings.py
@@ -5,11 +5,15 @@ Measured live max among programme-truth inputs: 26008 bytes
 (``.github/workflows/kernel-matrix.yml``). The document ceiling is 65536
 bytes (64 KiB). Inventories are bounded before unique-sort materialization.
 Exceeding a ceiling is an error; nothing is silently truncated.
+
+Callers may lower inventory caps via the environment. They cannot raise
+them above the canonical 8192 / 524288 values.
 """
 
 from __future__ import annotations
 
 import os
+import stat
 import sys
 
 MAX_DOC_BYTES = 65536
@@ -26,16 +30,35 @@ def require_bounded_bytes(
     return data
 
 
-def require_bounded_file(
+def read_bounded_file(
     path: str, label: str | None = None, limit: int = MAX_DOC_BYTES
-) -> None:
+) -> bytes:
+    """Read at most ``limit`` bytes from a regular file via one descriptor.
+
+    Non-regular inputs fail closed. At most ``limit + 1`` bytes are read
+    from the opened fd so an oversize file never reaches a consumer.
+    """
     label = label or path
     try:
-        n = os.path.getsize(path)
+        fd = os.open(path, os.O_RDONLY)
     except OSError as exc:
-        raise SystemExit(f"{label} could not be sized: {exc}") from exc
-    if n > limit:
-        raise SystemExit(f"{label} exceeds {limit}-byte ceiling ({n} bytes)")
+        raise SystemExit(f"{label} could not be opened: {exc}") from exc
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise SystemExit(f"{label} is not a regular file")
+        buf = bytearray()
+        want = limit + 1
+        while len(buf) < want:
+            chunk = os.read(fd, want - len(buf))
+            if not chunk:
+                break
+            buf.extend(chunk)
+    finally:
+        os.close(fd)
+    if len(buf) > limit:
+        raise SystemExit(f"{label} exceeds {limit}-byte ceiling ({len(buf)} bytes)")
+    return bytes(buf)
 
 
 def read_bounded_stream(
@@ -50,6 +73,21 @@ def read_bounded_stream(
             raise SystemExit(f"{label} exceeds {limit}-byte ceiling")
         buf.extend(chunk)
     return bytes(buf)
+
+
+def caller_cap(env_name: str, canonical: int) -> int:
+    raw = os.environ.get(env_name)
+    if raw is None or raw == "":
+        return canonical
+    try:
+        value = int(raw, 10)
+    except ValueError:
+        raise SystemExit(f"{env_name} is not a positive integer") from None
+    if value <= 0:
+        raise SystemExit(f"{env_name} must be a positive integer")
+    if value > canonical:
+        raise SystemExit(f"{env_name} cannot exceed canonical {canonical}")
+    return value
 
 
 def bound_inventory(
@@ -83,26 +121,29 @@ def main(argv: list[str]) -> None:
     if not argv:
         raise SystemExit(
             "usage: resource_ceilings.py "
-            "check-file|check-stdin|inventory|max-doc-bytes [path]"
+            "check-file|read-file|check-stdin|inventory|"
+            "max-doc-bytes|canonical-inventory-limits [path]"
         )
     cmd = argv[0]
     if cmd == "max-doc-bytes":
         print(MAX_DOC_BYTES)
         return
+    if cmd == "canonical-inventory-limits":
+        print(f"{MAX_INVENTORY_PATHS} {MAX_INVENTORY_BYTES}")
+        return
     if cmd == "check-file":
-        require_bounded_file(argv[1])
+        read_bounded_file(argv[1])
+        return
+    if cmd == "read-file":
+        sys.stdout.buffer.write(read_bounded_file(argv[1]))
         return
     if cmd == "check-stdin":
         label = argv[1] if len(argv) > 1 else "input"
         read_bounded_stream(sys.stdin.buffer, label)
         return
     if cmd == "inventory":
-        max_paths = int(
-            os.environ.get("BOUNDED_INVENTORY_MAX_PATHS", MAX_INVENTORY_PATHS)
-        )
-        max_bytes = int(
-            os.environ.get("BOUNDED_INVENTORY_MAX_BYTES", MAX_INVENTORY_BYTES)
-        )
+        max_paths = caller_cap("BOUNDED_INVENTORY_MAX_PATHS", MAX_INVENTORY_PATHS)
+        max_bytes = caller_cap("BOUNDED_INVENTORY_MAX_BYTES", MAX_INVENTORY_BYTES)
         for path in bound_inventory(
             sys.stdin, max_paths=max_paths, max_bytes=max_bytes
         ):

--- a/scripts/ci/lib/resource_ceilings.py
+++ b/scripts/ci/lib/resource_ceilings.py
@@ -36,6 +36,39 @@ def reject_programme_overrides(env: dict[str, str] | None = None) -> None:
             raise SystemExit(f"{name} cannot replace the script worktree")
 
 
+REJECT_OVERRIDES_CALLER = "python3 " + '"$_TRUTH_LIB"' + " reject-overrides"
+
+
+def reject_overrides_caller_count(text: str) -> int:
+    count = 0
+    for line in text.splitlines():
+        if line.split("#", 1)[0].strip() == REJECT_OVERRIDES_CALLER:
+            count += 1
+    return count
+
+
+def assert_reject_overrides_caller(path: str) -> None:
+    count = reject_overrides_caller_count(read_bounded_file(path).decode("utf-8"))
+    if count != 1:
+        raise SystemExit(f"reject-overrides caller count is {count}, want 1")
+
+
+def drop_reject_overrides_caller(src: str, dst: str) -> None:
+    text = read_bounded_file(src).decode("utf-8")
+    count = reject_overrides_caller_count(text)
+    if count != 1:
+        raise SystemExit(f"reject-overrides caller count is {count}, want 1")
+    kept = [
+        line
+        for line in text.splitlines(keepends=True)
+        if line.split("#", 1)[0].strip() != REJECT_OVERRIDES_CALLER
+    ]
+    out = "".join(kept).encode("utf-8")
+    require_bounded_bytes(out, dst)
+    with open(dst, "wb") as fh:
+        fh.write(out)
+
+
 def require_bounded_bytes(
     data: bytes, label: str, limit: int = MAX_DOC_BYTES
 ) -> bytes:
@@ -144,7 +177,8 @@ def main(argv: list[str]) -> None:
             "usage: resource_ceilings.py "
             "check-file|read-file|check-stdin|inventory|"
             "max-doc-bytes|canonical-inventory-limits|"
-            "reject-overrides|forbidden-overrides [path]"
+            "reject-overrides|forbidden-overrides|"
+            "assert-reject-caller|drop-reject-caller [path]"
         )
     cmd = argv[0]
     if cmd == "max-doc-bytes":
@@ -159,6 +193,12 @@ def main(argv: list[str]) -> None:
         return
     if cmd == "reject-overrides":
         reject_programme_overrides()
+        return
+    if cmd == "assert-reject-caller":
+        assert_reject_overrides_caller(argv[1])
+        return
+    if cmd == "drop-reject-caller":
+        drop_reject_overrides_caller(argv[1], argv[2])
         return
     if cmd == "check-file":
         read_bounded_file(argv[1])

--- a/scripts/ci/lib/resource_ceilings.py
+++ b/scripts/ci/lib/resource_ceilings.py
@@ -7,7 +7,8 @@ bytes (64 KiB). Inventories are bounded before unique-sort materialization.
 Exceeding a ceiling is an error; nothing is silently truncated.
 
 Callers may lower inventory caps via the environment. They cannot raise
-them above the canonical 8192 / 524288 values.
+them above the canonical 8192 / 524288 values. An absent variable uses
+the default; an explicit empty override is invalid.
 """
 
 from __future__ import annotations
@@ -30,6 +31,13 @@ def require_bounded_bytes(
     return data
 
 
+def _readonly_open_flags() -> int:
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
+    return flags
+
+
 def read_bounded_file(
     path: str, label: str | None = None, limit: int = MAX_DOC_BYTES
 ) -> bytes:
@@ -40,7 +48,7 @@ def read_bounded_file(
     """
     label = label or path
     try:
-        fd = os.open(path, os.O_RDONLY)
+        fd = os.open(path, _readonly_open_flags())
     except OSError as exc:
         raise SystemExit(f"{label} could not be opened: {exc}") from exc
     try:
@@ -76,15 +84,14 @@ def read_bounded_stream(
 
 
 def caller_cap(env_name: str, canonical: int) -> int:
-    raw = os.environ.get(env_name)
-    if raw is None or raw == "":
+    if env_name not in os.environ:
         return canonical
-    try:
-        value = int(raw, 10)
-    except ValueError:
-        raise SystemExit(f"{env_name} is not a positive integer") from None
-    if value <= 0:
+    raw = os.environ[env_name]
+    if raw == "0" or (raw.startswith("-") and raw[1:].isascii() and raw[1:].isdigit()):
         raise SystemExit(f"{env_name} must be a positive integer")
+    if not raw.isascii() or not raw.isdigit() or raw.startswith("0"):
+        raise SystemExit(f"{env_name} is not a positive integer")
+    value = int(raw, 10)
     if value > canonical:
         raise SystemExit(f"{env_name} cannot exceed canonical {canonical}")
     return value

--- a/scripts/ci/lib/resource_ceilings.py
+++ b/scripts/ci/lib/resource_ceilings.py
@@ -20,6 +20,20 @@ import sys
 MAX_DOC_BYTES = 65536
 MAX_INVENTORY_PATHS = 8192
 MAX_INVENTORY_BYTES = 524288
+FORBIDDEN_PROGRAMME_OVERRIDES = (
+    "PROGRAMME_TRUTH_ROOT",
+    "PROGRAMME_TRUTH_AGENTS",
+    "PROGRAMME_TRUTH_SELFHOST",
+    "PROGRAMME_TRUTH_CEILING_CHILD",
+    "PROGRAMME_TRUTH_PREVIEW_MUTANT",
+)
+
+
+def reject_programme_overrides(env: dict[str, str] | None = None) -> None:
+    source = os.environ if env is None else env
+    for name in FORBIDDEN_PROGRAMME_OVERRIDES:
+        if name in source:
+            raise SystemExit(f"{name} cannot replace the script worktree")
 
 
 def require_bounded_bytes(
@@ -129,7 +143,8 @@ def main(argv: list[str]) -> None:
         raise SystemExit(
             "usage: resource_ceilings.py "
             "check-file|read-file|check-stdin|inventory|"
-            "max-doc-bytes|canonical-inventory-limits [path]"
+            "max-doc-bytes|canonical-inventory-limits|"
+            "reject-overrides|forbidden-overrides [path]"
         )
     cmd = argv[0]
     if cmd == "max-doc-bytes":
@@ -137,6 +152,13 @@ def main(argv: list[str]) -> None:
         return
     if cmd == "canonical-inventory-limits":
         print(f"{MAX_INVENTORY_PATHS} {MAX_INVENTORY_BYTES}")
+        return
+    if cmd == "forbidden-overrides":
+        for name in FORBIDDEN_PROGRAMME_OVERRIDES:
+            print(name)
+        return
+    if cmd == "reject-overrides":
+        reject_programme_overrides()
         return
     if cmd == "check-file":
         read_bounded_file(argv[1])

--- a/scripts/ci/lib/resource_ceilings.py
+++ b/scripts/ci/lib/resource_ceilings.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fail-closed resource ceilings for CI inventories and programme-truth docs.
+
+Measured live max among programme-truth inputs: 26008 bytes
+(``.github/workflows/kernel-matrix.yml``). The document ceiling is 65536
+bytes (64 KiB). Inventories are bounded before unique-sort materialization.
+Exceeding a ceiling is an error; nothing is silently truncated.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+MAX_DOC_BYTES = 65536
+MAX_INVENTORY_PATHS = 8192
+MAX_INVENTORY_BYTES = 524288
+
+
+def require_bounded_bytes(
+    data: bytes, label: str, limit: int = MAX_DOC_BYTES
+) -> bytes:
+    n = len(data)
+    if n > limit:
+        raise SystemExit(f"{label} exceeds {limit}-byte ceiling ({n} bytes)")
+    return data
+
+
+def require_bounded_file(
+    path: str, label: str | None = None, limit: int = MAX_DOC_BYTES
+) -> None:
+    label = label or path
+    try:
+        n = os.path.getsize(path)
+    except OSError as exc:
+        raise SystemExit(f"{label} could not be sized: {exc}") from exc
+    if n > limit:
+        raise SystemExit(f"{label} exceeds {limit}-byte ceiling ({n} bytes)")
+
+
+def read_bounded_stream(
+    fp, label: str, limit: int = MAX_DOC_BYTES
+) -> bytes:
+    buf = bytearray()
+    while True:
+        chunk = fp.read(8192)
+        if not chunk:
+            break
+        if len(buf) + len(chunk) > limit:
+            raise SystemExit(f"{label} exceeds {limit}-byte ceiling")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def bound_inventory(
+    lines,
+    max_paths: int = MAX_INVENTORY_PATHS,
+    max_bytes: int = MAX_INVENTORY_BYTES,
+) -> list[str]:
+    kept: list[str] = []
+    total = 0
+    count = 0
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line:
+            continue
+        encoded = (line + "\n").encode("utf-8")
+        count += 1
+        total += len(encoded)
+        if count > max_paths:
+            raise SystemExit(
+                f"inventory exceeds max path count {max_paths} ({count} paths)"
+            )
+        if total > max_bytes:
+            raise SystemExit(
+                f"inventory exceeds max byte budget {max_bytes} ({total} bytes)"
+            )
+        kept.append(line)
+    return sorted(set(kept))
+
+
+def main(argv: list[str]) -> None:
+    if not argv:
+        raise SystemExit(
+            "usage: resource_ceilings.py "
+            "check-file|check-stdin|inventory|max-doc-bytes [path]"
+        )
+    cmd = argv[0]
+    if cmd == "max-doc-bytes":
+        print(MAX_DOC_BYTES)
+        return
+    if cmd == "check-file":
+        require_bounded_file(argv[1])
+        return
+    if cmd == "check-stdin":
+        label = argv[1] if len(argv) > 1 else "input"
+        read_bounded_stream(sys.stdin.buffer, label)
+        return
+    if cmd == "inventory":
+        max_paths = int(
+            os.environ.get("BOUNDED_INVENTORY_MAX_PATHS", MAX_INVENTORY_PATHS)
+        )
+        max_bytes = int(
+            os.environ.get("BOUNDED_INVENTORY_MAX_BYTES", MAX_INVENTORY_BYTES)
+        )
+        for path in bound_inventory(
+            sys.stdin, max_paths=max_paths, max_bytes=max_bytes
+        ):
+            print(path)
+        return
+    raise SystemExit(f"unknown command: {cmd}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/ci/lib/resource_ceilings.py
+++ b/scripts/ci/lib/resource_ceilings.py
@@ -39,12 +39,18 @@ def reject_programme_overrides(env: dict[str, str] | None = None) -> None:
 REJECT_OVERRIDES_CALLER = "python3 " + '"$_TRUTH_LIB"' + " reject-overrides"
 
 
+def reject_overrides_caller_marks(text: str) -> list[tuple[str, bool]]:
+    marks: list[tuple[str, bool]] = []
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        marks.append(
+            (line, body.split("#", 1)[0].strip() == REJECT_OVERRIDES_CALLER)
+        )
+    return marks
+
+
 def reject_overrides_caller_count(text: str) -> int:
-    count = 0
-    for line in text.splitlines():
-        if line.split("#", 1)[0].strip() == REJECT_OVERRIDES_CALLER:
-            count += 1
-    return count
+    return sum(1 for _line, is_caller in reject_overrides_caller_marks(text) if is_caller)
 
 
 def assert_reject_overrides_caller(path: str) -> None:
@@ -55,15 +61,11 @@ def assert_reject_overrides_caller(path: str) -> None:
 
 def drop_reject_overrides_caller(src: str, dst: str) -> None:
     text = read_bounded_file(src).decode("utf-8")
-    count = reject_overrides_caller_count(text)
+    marks = reject_overrides_caller_marks(text)
+    count = sum(1 for _line, is_caller in marks if is_caller)
     if count != 1:
         raise SystemExit(f"reject-overrides caller count is {count}, want 1")
-    kept = [
-        line
-        for line in text.splitlines(keepends=True)
-        if line.split("#", 1)[0].strip() != REJECT_OVERRIDES_CALLER
-    ]
-    out = "".join(kept).encode("utf-8")
+    out = "".join(line for line, is_caller in marks if not is_caller).encode("utf-8")
     require_bounded_bytes(out, dst)
     with open(dst, "wb") as fh:
         fh.write(out)

--- a/scripts/ci/review-split-wave.sh
+++ b/scripts/ci/review-split-wave.sh
@@ -28,7 +28,16 @@ fi
 # One inventory: committed-vs-base, staged, unstaged, and untracked. Omitting
 # dirty paths is how an out-of-scope file used to pass this gate silently.
 # Bound path count and UTF-8 bytes before unique-sort materialization.
-_REVIEW_SPLIT_CEILINGS="${REVIEW_SPLIT_CEILINGS:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource_ceilings.py}"
+# The helper path is the sibling module only. Callers cannot replace it.
+if [[ -n "${REVIEW_SPLIT_CEILINGS+x}" ]]; then
+  echo "FAIL: REVIEW_SPLIT_CEILINGS cannot replace the canonical inventory helper" >&2
+  exit 1
+fi
+_REVIEW_SPLIT_CEILINGS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource_ceilings.py"
+if [[ ! -f "${_REVIEW_SPLIT_CEILINGS}" ]]; then
+  echo "FAIL: canonical inventory helper missing: ${_REVIEW_SPLIT_CEILINGS}" >&2
+  exit 1
+fi
 
 split_wave_changed_files() {
   local inventory_base="$1"

--- a/scripts/ci/review-split-wave.sh
+++ b/scripts/ci/review-split-wave.sh
@@ -27,6 +27,9 @@ fi
 
 # One inventory: committed-vs-base, staged, unstaged, and untracked. Omitting
 # dirty paths is how an out-of-scope file used to pass this gate silently.
+# Bound path count and UTF-8 bytes before unique-sort materialization.
+_REVIEW_SPLIT_CEILINGS="${REVIEW_SPLIT_CEILINGS:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource_ceilings.py}"
+
 split_wave_changed_files() {
   local inventory_base="$1"
   {
@@ -34,7 +37,7 @@ split_wave_changed_files() {
     git diff --cached --name-only
     git diff --name-only
     git ls-files --others --exclude-standard
-  } | sed '/^$/d' | sort -u
+  } | sed '/^$/d' | python3 "${_REVIEW_SPLIT_CEILINGS}" inventory
 }
 
 changed_files="$(split_wave_changed_files "${base_ref}")"

--- a/scripts/ci/review-split-wave.sh
+++ b/scripts/ci/review-split-wave.sh
@@ -25,15 +25,22 @@ if ! git rev-parse --verify "${base_ref}" >/dev/null 2>&1; then
   exit 1
 fi
 
-changed_files="$(
+# One inventory: committed-vs-base, staged, unstaged, and untracked. Omitting
+# dirty paths is how an out-of-scope file used to pass this gate silently.
+split_wave_changed_files() {
+  local inventory_base="$1"
   {
-    git diff --name-only "${base_ref}"...HEAD
+    git diff --name-only "${inventory_base}...HEAD"
     git diff --cached --name-only
-  } | sort -u
-)"
+    git diff --name-only
+    git ls-files --others --exclude-standard
+  } | sed '/^$/d' | sort -u
+}
+
+changed_files="$(split_wave_changed_files "${base_ref}")"
 
 if [[ -z "${changed_files}" ]]; then
-  echo "FAIL: no tracked changes found against ${base_ref}" >&2
+  echo "FAIL: no changes found against ${base_ref}" >&2
   exit 1
 fi
 

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -90,6 +90,7 @@ EXPECTED_LEDGER_BULLET='- The public execution ledger for the active programme i
   instruction and not a guarantee — and the way it fails is quiet: the line kept pointing at a
   finished programme, which reads as an active ledger and sends handoffs to a closed issue.'
 
+# shellcheck disable=SC2016 # Markdown backticks in this exact-section fixture are literal.
 EXPECTED_REQUIRED_CHECKS='## Required checks
 
 The live required contexts are named once in `CI-CONTRACT.md` at

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -25,6 +25,32 @@ fi
 CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
 export PYTHONPATH="$ROOT/scripts/ci/lib${PYTHONPATH:+:$PYTHONPATH}"
 python3 "$CEILINGS" assert-reject-caller "$ROOT/scripts/ci/test-review-split-wave.sh"
+
+FORBIDDEN_SPEC=(
+  PROGRAMME_TRUTH_ROOT
+  PROGRAMME_TRUTH_AGENTS
+  PROGRAMME_TRUTH_SELFHOST
+  PROGRAMME_TRUTH_CEILING_CHILD
+  PROGRAMME_TRUTH_PREVIEW_MUTANT
+)
+
+assert_forbidden_override_set() {
+  python3 - "$1" "${FORBIDDEN_SPEC[@]}" <<'PY'
+import runpy
+import sys
+
+required = tuple(sys.argv[2:])
+got = tuple(runpy.run_path(sys.argv[1])["FORBIDDEN_PROGRAMME_OVERRIDES"])
+if got != required:
+    raise SystemExit(f"forbidden override set mismatch: {got!r}")
+PY
+}
+
+if ! _parity_err="$(assert_forbidden_override_set "$CEILINGS" 2>&1)"; then
+  echo "FAIL: forbidden programme overrides are the canonical five: ${_parity_err}" >&2
+  exit 1
+fi
+
 AGENTS="$ROOT/AGENTS.md"
 WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
 STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
@@ -686,26 +712,6 @@ PY
 expect_ok "ROOT is the script worktree and not caller-overridable" \
   assert_root_is_script_worktree "${BASH_SOURCE[0]}"
 
-FORBIDDEN_SPEC=(
-  PROGRAMME_TRUTH_ROOT
-  PROGRAMME_TRUTH_AGENTS
-  PROGRAMME_TRUTH_SELFHOST
-  PROGRAMME_TRUTH_CEILING_CHILD
-  PROGRAMME_TRUTH_PREVIEW_MUTANT
-)
-
-assert_forbidden_override_set() {
-  python3 - "$1" "${FORBIDDEN_SPEC[@]}" <<'PY'
-import runpy
-import sys
-
-required = tuple(sys.argv[2:])
-got = tuple(runpy.run_path(sys.argv[1])["FORBIDDEN_PROGRAMME_OVERRIDES"])
-if got != required:
-    raise SystemExit(f"forbidden override set mismatch: {got!r}")
-PY
-}
-
 expect_ok "forbidden programme overrides are the canonical five" \
   assert_forbidden_override_set "$CEILINGS"
 
@@ -732,6 +738,28 @@ do
     "reject-overrides caller count is 0, want 1" \
     python3 "$CEILINGS" assert-reject-caller "$dest"
 done
+
+expect_ok "reject-overrides count and drop share one parser" python3 - "$CEILINGS" <<'PY'
+import runpy
+import sys
+
+mod = runpy.run_path(sys.argv[1])
+sample = (
+    "keep\n"
+    + "python3 "
+    + '"$_TRUTH_LIB"'
+    + " reject-overrides  # note\n"
+    + "keep\n"
+)
+marks = mod["reject_overrides_caller_marks"](sample)
+if sum(1 for _line, is_caller in marks if is_caller) != 1:
+    raise SystemExit("commented caller was not marked once")
+dropped = "".join(line for line, is_caller in marks if not is_caller)
+if dropped != "keep\nkeep\n":
+    raise SystemExit(f"drop diverged from marks: {dropped!r}")
+if mod["reject_overrides_caller_count"](dropped) != 0:
+    raise SystemExit("dropped text still counts a caller")
+PY
 
 for override_name in "${FORBIDDEN_SPEC[@]}"; do
   install_hermetic_programme_truth "$TRUTH_TMP/drop-${override_name}"
@@ -762,6 +790,39 @@ PY
   expect_red "forbidden set without ${override_name}" "forbidden override set mismatch" \
     assert_forbidden_override_set \
     "$TRUTH_TMP/drop-${override_name}/scripts/ci/lib/resource_ceilings.py"
+  expect_red "dropped ${override_name} suite fail-fast" \
+    "forbidden override set mismatch" \
+    python3 - \
+      "$TRUTH_TMP/drop-${override_name}/scripts/ci/test-ci-programme-truth.sh" \
+      "$CEILINGS" <<'PY'
+import os
+import subprocess
+import sys
+
+script = sys.argv[1]
+helper = sys.argv[2]
+env = os.environ.copy()
+for name in subprocess.check_output(
+    [sys.executable, helper, "forbidden-overrides"],
+    text=True,
+).split():
+    env.pop(name, None)
+try:
+    proc = subprocess.run(
+        ["/bin/bash", script],
+        env=env,
+        timeout=5,
+        capture_output=True,
+        text=True,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit("dropped-override suite timed out")
+err = (proc.stderr or "") + (proc.stdout or "")
+if proc.returncode == 0:
+    raise SystemExit("dropped-override suite left the contract green")
+sys.stderr.write(err)
+raise SystemExit(proc.returncode)
+PY
 done
 
 stale_semver=$'Source of truth: workflow env WAVE0_SEMVER_BASELINE_SHA.\n'

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -13,7 +13,7 @@
 # would break a later legitimate boundary split.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT="${PROGRAMME_TRUTH_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
 export PYTHONPATH="$ROOT/scripts/ci/lib${PYTHONPATH:+:$PYTHONPATH}"
 AGENTS="${PROGRAMME_TRUTH_AGENTS:-$ROOT/AGENTS.md}"
@@ -410,36 +410,15 @@ assert_monitor_rs_still_exists() {
   return 0
 }
 
+# Shared unsafe-preview checker (one implementation).
 assert_no_generic_unsafe_preview() {
-  local workflow="$1" docs="$2"
-  if grep -Fq 'deleted' <<<"$workflow$docs" && grep -Fq 'monitor.rs' <<<"$workflow$docs"; then
-    echo "preview removal must not claim monitor.rs was deleted"
-    return 1
-  fi
-  if grep -Fq 'Unsafe boundary preview' <<<"$workflow"; then
-    echo "workflow still has the generic warn-only unsafe preview"
-    return 1
-  fi
-  if grep -Fq 'unsafe allowed only in the monitor syscall boundary' <<<"$workflow$docs"; then
-    echo "single-boundary Wave 3 TODO is still present"
-    return 1
-  fi
-  if grep -Fq 'unsafe outside monitor.rs' <<<"$workflow"; then
-    echo "workflow still treats paths outside monitor.rs as the deviation"
-    return 1
-  fi
-  return 0
-}
-
-assert_no_generic_unsafe_preview_files() {
-  local workflow_path="$1" docs_path="$2"
-  PROGRAMME_TRUTH_WORKFLOW="$workflow_path" PROGRAMME_TRUTH_DOCS="$docs_path" python3 - <<'PY'
-import os
+  python3 - "$1" "$2" <<'PY'
+import sys
 
 from resource_ceilings import read_bounded_file
 
-workflow = read_bounded_file(os.environ["PROGRAMME_TRUTH_WORKFLOW"]).decode("utf-8")
-docs = read_bounded_file(os.environ["PROGRAMME_TRUTH_DOCS"]).decode("utf-8")
+workflow = read_bounded_file(sys.argv[1]).decode("utf-8")
+docs = read_bounded_file(sys.argv[2]).decode("utf-8")
 combined = workflow + docs
 if "deleted" in combined and "monitor.rs" in combined:
     raise SystemExit("preview removal must not claim monitor.rs was deleted")
@@ -573,7 +552,7 @@ done
 
 expect_ok "monitor.rs still exists" assert_monitor_rs_still_exists
 expect_ok "generic unsafe preview and single-boundary TODO are gone" \
-  assert_no_generic_unsafe_preview_files "$WORKFLOW" "$WAVE0"
+  assert_no_generic_unsafe_preview "$WORKFLOW" "$WAVE0"
 expect_ok "AGENTS.md ledger bullet is structurally valid" assert_agents_ledger "$AGENTS"
 expect_ok "WAVE0-GATES.md describes dynamic latest-release baseline" assert_wave0_semver_file "$WAVE0"
 expect_ok "WAVE0-GATES.md points at the canonical required-context contract" \
@@ -730,12 +709,19 @@ stale_wave71=$'| Wave71 | Hotspot LOC under 600 | in progress | Active | still r
 expect_red "Wave71 Active" "claims Active" assert_wave71_not_active "$stale_wave71"
 
 stale_preview=$'      - name: Unsafe boundary preview (warn-only)\n        run: echo unsafe outside monitor.rs\n# unsafe allowed only in the monitor syscall boundary module.\n'
+printf '%s' "$stale_preview" >"$TRUTH_TMP/restored-preview.yml"
+: >"$TRUTH_TMP/restored-preview-docs.md"
 expect_red "restored generic preview" "generic warn-only unsafe preview" \
-  assert_no_generic_unsafe_preview "$stale_preview" ""
+  assert_no_generic_unsafe_preview "$TRUTH_TMP/restored-preview.yml" "$TRUTH_TMP/restored-preview-docs.md"
+: >"$TRUTH_TMP/todo-preview.yml"
+printf '%s' 'unsafe allowed only in the monitor syscall boundary module.' \
+  >"$TRUTH_TMP/todo-preview-docs.md"
 expect_red "restored single-boundary TODO" "single-boundary Wave 3 TODO" \
-  assert_no_generic_unsafe_preview "" "unsafe allowed only in the monitor syscall boundary module."
+  assert_no_generic_unsafe_preview "$TRUTH_TMP/todo-preview.yml" "$TRUTH_TMP/todo-preview-docs.md"
+printf '%s' 'monitor.rs was deleted' >"$TRUTH_TMP/deleted-preview.yml"
+: >"$TRUTH_TMP/deleted-preview-docs.md"
 expect_red "deleted-monitor.rs claim" "must not claim monitor.rs was deleted" \
-  assert_no_generic_unsafe_preview "monitor.rs was deleted" ""
+  assert_no_generic_unsafe_preview "$TRUTH_TMP/deleted-preview.yml" "$TRUTH_TMP/deleted-preview-docs.md"
 
 python3 - "$AGENTS" "$TRUTH_TMP/nul-agents.md" <<'PY'
 import sys
@@ -788,7 +774,7 @@ expect_red "oversized real document" "exceeds 65536-byte ceiling" \
 expect_red "oversized document never reaches a ledger consumer" "exceeds 65536-byte ceiling" \
   assert_agents_ledger "$TRUTH_TMP/oversized.md"
 
-if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" && -z "${PROGRAMME_TRUTH_CEILING_CHILD:-}" ]]; then
+if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" && -z "${PROGRAMME_TRUTH_CEILING_CHILD:-}" && -z "${PROGRAMME_TRUTH_PREVIEW_MUTANT:-}" ]]; then
   active_agents="$TRUTH_TMP/selfhost-agents.md"
   selfhost_log="$TRUTH_TMP/selfhost.log"
   replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$ROOT/AGENTS.md" "$active_agents"
@@ -811,6 +797,41 @@ if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" && -z "${PROGRAMME_TRUTH_CEILING_CHILD:
     ok "oversized AGENTS stops before consumers"
   else
     bad "oversized AGENTS red without ceiling: $child_out"
+  fi
+
+  python3 - "${BASH_SOURCE[0]}" "$TRUTH_TMP/truth-neutralized.sh" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+src = read_bounded_file(sys.argv[1]).decode("utf-8")
+start = src.find("# Shared unsafe-preview checker (one implementation).")
+if start < 0:
+    raise SystemExit("shared unsafe-preview checker marker missing")
+end = src.find("\nassert_prepush_covers_ceilings()", start)
+if end < 0:
+    raise SystemExit("shared unsafe-preview checker end missing")
+out = (
+    src[:start]
+    + "assert_no_generic_unsafe_preview() { return 0; }\n"
+    + src[end:]
+)
+require_bounded_bytes(out.encode("utf-8"), "neutralized preview checker")
+Path(sys.argv[2]).write_text(out, encoding="utf-8")
+PY
+  if mutant_out="$(
+    PROGRAMME_TRUTH_ROOT="$ROOT" \
+    PROGRAMME_TRUTH_PREVIEW_MUTANT=1 \
+    PROGRAMME_TRUTH_SELFHOST=1 \
+    PROGRAMME_TRUTH_CEILING_CHILD=1 \
+    bash "$TRUTH_TMP/truth-neutralized.sh" 2>&1
+  )"; then
+    bad "neutralized preview checker left the suite green"
+  elif grep -Fq 'restored generic preview left the contract green' <<<"$mutant_out"; then
+    ok "neutralized preview checker turns the suite red"
+  else
+    bad "neutralized preview checker red without fixture miss: $mutant_out"
   fi
 fi
 

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -512,8 +512,12 @@ entry = re.search(
 if entry is None:
     raise SystemExit("ci-programme-truth hook entry is missing")
 hook = entry.group(1)
-if "test-ci-programme-truth.sh" not in hook or "test-review-split-wave.sh" not in hook:
-    raise SystemExit("ci-programme-truth hook does not run both focused suites")
+expected_entry = (
+    "bash -c 'bash scripts/ci/test-ci-programme-truth.sh && "
+    "bash scripts/ci/test-review-split-wave.sh'"
+)
+if hook != expected_entry:
+    raise SystemExit(f"ci-programme-truth hook entry mismatch: {hook!r}")
 raw = match.group(1).strip()
 if raw[0] in "'\"" and raw[-1] == raw[0]:
     raw = raw[1:-1]
@@ -630,6 +634,27 @@ expect_ok "kernel-matrix.yml pull_request.paths owns programme-truth inputs" \
   assert_ci_trigger_owns_truth_inputs "$KERNEL_MATRIX"
 expect_ok "pre-push files regex covers resource_ceilings.py" \
   assert_prepush_covers_ceilings "$PRECOMMIT"
+
+python3 - "$PRECOMMIT" "$TRUTH_TMP/precommit-echo.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+text = read_bounded_file(str(src)).decode("utf-8")
+old = "&& bash " + "scripts/ci/test-review-split-wave.sh"
+new = "&& echo " + "scripts/ci/test-review-split-wave.sh"
+if old not in text:
+    raise SystemExit("hook entry does not execute test-review-split-wave.sh")
+out = text.replace(old, new, 1)
+require_bounded_bytes(out.encode("utf-8"), "neutralized hook entry")
+dst.write_text(out, encoding="utf-8")
+PY
+expect_red "neutralized review-split hook execution" \
+  "ci-programme-truth hook entry mismatch" \
+  assert_prepush_covers_ceilings "$TRUTH_TMP/precommit-echo.yaml"
 
 assert_root_is_script_worktree() {
   python3 - "$1" <<'PY'

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# #2515: programme ledger, Wave 0 docs, and Wave71 status match live repository truth.
+#
+# Refuted issue premises, pinned so they cannot drive the patch:
+# - crates/assay-cli/src/cli/commands/monitor.rs still exists; the preview is not
+#   removed because that file was deleted.
+# - the review-split-wave Assay Sim example path still exists (pinned in
+#   test-review-split-wave.sh); do not replace it.
+#
+# The generic warn-only unsafe preview still goes: its Wave 3
+# single-boundary TODO is false. This test does not freeze a catalogue of
+# intentional unsafe sites; no such allowlist exists, and inventing one
+# would break a later legitimate boundary split.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AGENTS="$ROOT/AGENTS.md"
+WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
+STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
+RULESET="$ROOT/.github/rulesets/main-required-ci-contexts.json"
+WORKFLOW="$ROOT/.github/workflows/split-wave0-gates.yml"
+MONITOR="$ROOT/crates/assay-cli/src/cli/commands/monitor.rs"
+
+FAILURES=0
+ok()  { echo "ok    $1"; }
+bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
+
+live_required_contexts() {
+  python3 - "$RULESET" <<'PY'
+import json, sys
+from pathlib import Path
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+seen = []
+for rule in data.get("rules", []):
+    if rule.get("type") != "required_status_checks":
+        continue
+    for check in rule.get("parameters", {}).get("required_status_checks", []):
+        ctx = check.get("context")
+        if ctx and ctx not in seen:
+            seen.append(ctx)
+if not seen:
+    raise SystemExit("ruleset has no required_status_checks contexts")
+print("\n".join(seen))
+PY
+}
+
+assert_agents_ledger() {
+  local text="$1"
+  local collapsed
+  collapsed="$(printf '%s' "$text" | tr '\n' ' ' | tr -s ' ')"
+  if ! grep -q 'public execution ledger' <<<"$collapsed"; then
+    echo "AGENTS.md has no public execution ledger line"
+    return 1
+  fi
+  if grep -Eq 'named on this line:[[:space:]]*\[issue #' <<<"$collapsed"; then
+    echo "ledger line still names a GitHub issue as the active programme"
+    return 1
+  fi
+  if ! grep -Eq 'No programme is active' <<<"$collapsed"; then
+    echo "ledger line does not say no programme is active"
+    return 1
+  fi
+  return 0
+}
+
+assert_wave0_semver_doc() {
+  local text="$1"
+  if grep -q 'WAVE0_SEMVER_BASELINE_SHA' <<<"$text"; then
+    echo "WAVE0-GATES.md still documents WAVE0_SEMVER_BASELINE_SHA"
+    return 1
+  fi
+  if ! grep -Eqi 'newest|latest' <<<"$text" || ! grep -Eq 'release tag' <<<"$text"; then
+    echo "WAVE0-GATES.md does not describe the dynamic latest-release baseline"
+    return 1
+  fi
+  if ! grep -q 'test-semver-gate.sh' <<<"$text"; then
+    echo "WAVE0-GATES.md does not point at scripts/ci/test-semver-gate.sh"
+    return 1
+  fi
+  return 0
+}
+
+assert_wave0_required_contexts() {
+  local text="$1"
+  local ctx
+  while IFS= read -r ctx; do
+    if ! grep -Fq -- "$ctx" <<<"$text"; then
+      echo "WAVE0-GATES.md does not name live required context ${ctx}"
+      return 1
+    fi
+  done < <(live_required_contexts)
+  if grep -q 'Configure branch protection to require:' <<<"$text"; then
+    echo "WAVE0-GATES.md still presents Wave 0 jobs as the branch-protection recommendation"
+    return 1
+  fi
+  return 0
+}
+
+assert_monitor_rs_still_exists() {
+  if [[ ! -f "$MONITOR" ]]; then
+    echo "monitor.rs missing; do not treat that as the reason to drop the preview"
+    return 1
+  fi
+  return 0
+}
+
+assert_no_generic_unsafe_preview() {
+  local workflow="$1" docs="$2"
+  if grep -Fq 'deleted' <<<"$workflow$docs" && grep -Fq 'monitor.rs' <<<"$workflow$docs"; then
+    echo "preview removal must not claim monitor.rs was deleted"
+    return 1
+  fi
+  if grep -Fq 'Unsafe boundary preview' <<<"$workflow"; then
+    echo "workflow still has the generic warn-only unsafe preview"
+    return 1
+  fi
+  if grep -Fq 'unsafe allowed only in the monitor syscall boundary' <<<"$workflow$docs"; then
+    echo "single-boundary Wave 3 TODO is still present"
+    return 1
+  fi
+  if grep -Fq 'unsafe outside monitor.rs' <<<"$workflow"; then
+    echo "workflow still treats paths outside monitor.rs as the deviation"
+    return 1
+  fi
+  return 0
+}
+
+assert_wave71_not_active() {
+  local text="$1"
+  local row
+  row="$(printf '%s\n' "$text" | grep -E '^\| Wave71 \|' || true)"
+  if [[ -z "$row" ]]; then
+    echo "REFACTOR-WAVE-STATUS.md has no Wave71 row"
+    return 1
+  fi
+  if grep -Fq '| Active |' <<<"$row"; then
+    echo "Wave71 row still claims Active without a current execution ledger"
+    return 1
+  fi
+  if ! grep -Eqi 'Dormant|Incomplete' <<<"$row"; then
+    echo "Wave71 row is not marked Dormant or Incomplete"
+    return 1
+  fi
+  return 0
+}
+
+expect_ok() {
+  local label="$1"
+  shift
+  local err
+  if err="$("$@" 2>&1)"; then
+    ok "$label"
+  else
+    bad "$label: $err"
+  fi
+}
+
+expect_red() {
+  local label="$1" needle="$2"
+  shift 2
+  local err
+  if err="$("$@" 2>&1)"; then
+    bad "$label left the contract green"
+  elif grep -Fq -- "$needle" <<<"$err"; then
+    ok "$label turns red ($err)"
+  else
+    bad "$label red without ${needle}: ${err}"
+  fi
+}
+
+expect_ok "monitor.rs still exists" assert_monitor_rs_still_exists
+expect_ok "generic unsafe preview and single-boundary TODO are gone" \
+  assert_no_generic_unsafe_preview "$(<"$WORKFLOW")" "$(<"$WAVE0")"
+expect_ok "AGENTS.md ledger says no programme is active" assert_agents_ledger "$(<"$AGENTS")"
+expect_ok "WAVE0-GATES.md describes dynamic latest-release baseline" assert_wave0_semver_doc "$(<"$WAVE0")"
+expect_ok "WAVE0-GATES.md names live required contexts" assert_wave0_required_contexts "$(<"$WAVE0")"
+expect_ok "Wave71 is dormant or incomplete" assert_wave71_not_active "$(<"$STATUS")"
+
+stale_ledger=$'The public execution ledger for the active programme is named on this line: [issue #2388](https://github.com/Rul1an/assay/issues/2388).\n'
+expect_red "active-issue ledger pointer" "names a GitHub issue" assert_agents_ledger "$stale_ledger"
+
+stale_semver=$'Source of truth: workflow env WAVE0_SEMVER_BASELINE_SHA.\n'
+expect_red "pinned baseline SHA" "WAVE0_SEMVER_BASELINE_SHA" assert_wave0_semver_doc "$stale_semver"
+
+stale_required="$(live_required_contexts)
+Configure branch protection to require:
+- Wave 0 feature matrix
+"
+expect_red "Wave 0 jobs as required checks" "branch-protection recommendation" assert_wave0_required_contexts "$stale_required"
+
+stale_wave71=$'| Wave71 | Hotspot LOC under 600 | in progress | Active | still reducing |\n'
+expect_red "Wave71 Active" "claims Active" assert_wave71_not_active "$stale_wave71"
+
+stale_preview=$'      - name: Unsafe boundary preview (warn-only)\n        run: echo unsafe outside monitor.rs\n# unsafe allowed only in the monitor syscall boundary module.\n'
+expect_red "restored generic preview" "generic warn-only unsafe preview" \
+  assert_no_generic_unsafe_preview "$stale_preview" ""
+expect_red "restored single-boundary TODO" "single-boundary Wave 3 TODO" \
+  assert_no_generic_unsafe_preview "" "unsafe allowed only in the monitor syscall boundary module."
+expect_red "deleted-monitor.rs claim" "must not claim monitor.rs was deleted" \
+  assert_no_generic_unsafe_preview "monitor.rs was deleted" ""
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES programme-truth case(s) failed"
+  exit 1
+fi
+echo "PASS: ci programme truth"

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -34,6 +34,26 @@ assert_extracted_block() {
   PROGRAMME_TRUTH_DOC="$text" \
   PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" python3 - <<'PY'
 import os
+import re
+
+INACTIVE_DECL = "**No programme is active.**"
+LEDGER_PHRASES = (
+    "active programme ledger",
+    "public execution ledger",
+    "No programme is active",
+)
+ISSUE_LINK = re.compile(
+    r"\[issue #(\d+)\]\((https://github\.com/[^)\s]+/issues/(\d+))\)"
+)
+# Spaced prose, or a list item whose token contains required-context(s)/check(s).
+# Do not match arbitrary hyphen tokens (crate names) or the checker filename.
+REQUIRED_OUTSIDE = re.compile(
+    r"\brequired contexts?\b|\brequired checks?\b|"
+    r"^\s*-\s+\S*required-contexts?\b|"
+    r"^\s*-\s+\S*required-checks?\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 def normalize(text: str) -> str:
     lines = [line.rstrip() for line in text.splitlines()]
@@ -43,7 +63,8 @@ def normalize(text: str) -> str:
         lines.pop()
     return "\n".join(lines)
 
-def extract_heading_section(text: str, heading: str) -> str:
+
+def heading_bounds(text: str, heading: str) -> tuple[int, int]:
     lines = text.splitlines()
     start = next((i for i, line in enumerate(lines) if line.strip() == heading), None)
     if start is None:
@@ -52,13 +73,22 @@ def extract_heading_section(text: str, heading: str) -> str:
         (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
         len(lines),
     )
-    return normalize("\n".join(lines[start:end]))
+    return start, end
 
-def extract_top_level_bullet(text: str, prefix: str) -> str:
+
+def extract_heading_section(text: str, heading: str) -> str:
+    start, end = heading_bounds(text, heading)
+    return normalize("\n".join(text.splitlines()[start:end]))
+
+
+def split_top_level_bullet(text: str, prefix: str) -> tuple[str, str]:
     lines = text.splitlines()
-    start = next((i for i, line in enumerate(lines) if line.startswith(prefix)), None)
-    if start is None:
+    starts = [i for i, line in enumerate(lines) if line.startswith(prefix)]
+    if not starts:
         raise SystemExit("missing ledger bullet")
+    if len(starts) != 1:
+        raise SystemExit("duplicate ledger bullet")
+    start = starts[0]
     end = next(
         (
             i
@@ -67,28 +97,61 @@ def extract_top_level_bullet(text: str, prefix: str) -> str:
         ),
         len(lines),
     )
-    return normalize("\n".join(lines[start:end]))
+    bullet = normalize("\n".join(lines[start:end]))
+    remainder = "\n".join(lines[:start] + lines[end:])
+    return bullet, remainder
+
+
+def collapsed(text: str) -> str:
+    return re.sub(r"\s+", " ", text)
+
+
+def validate_ledger(text: str, prefix: str) -> None:
+    bullet, remainder = split_top_level_bullet(text, prefix)
+    bullet_c = collapsed(bullet)
+    remainder_c = collapsed(remainder)
+    outside = [phrase for phrase in LEDGER_PHRASES if phrase in remainder_c]
+    if outside:
+        raise SystemExit(
+            "contradictory ledger declaration outside the ledger bullet: "
+            + ", ".join(outside)
+        )
+    inactive_count = bullet_c.count(INACTIVE_DECL)
+    links = ISSUE_LINK.findall(bullet)
+    if inactive_count > 1:
+        raise SystemExit("ledger bullet has multiple inactive declarations")
+    if inactive_count == 1:
+        if "active programme ledger" in bullet_c:
+            raise SystemExit("contradictory ledger claims in the ledger bullet")
+        return
+    if len(links) != 1:
+        raise SystemExit(
+            "ledger bullet is neither a valid inactive nor a valid active state"
+        )
+    visible, _url, url_id = links[0]
+    if visible != url_id:
+        raise SystemExit("visible issue-ID != URL-ID")
+
+
+def validate_required(text: str, expected: str) -> None:
+    heading = "## Required checks"
+    actual = extract_heading_section(text, heading)
+    if actual != normalize(expected):
+        raise SystemExit("## Required checks section mismatch")
+    start, end = heading_bounds(text, heading)
+    remainder = "\n".join(text.splitlines()[:start] + text.splitlines()[end:])
+    if REQUIRED_OUTSIDE.search(remainder):
+        raise SystemExit("required-context declaration outside ## Required checks")
+
 
 kind = os.environ["PROGRAMME_TRUTH_KIND"]
 text = os.environ["PROGRAMME_TRUTH_DOC"]
 if kind == "ledger":
-    actual = extract_top_level_bullet(text, os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"])
-    label = "ledger bullet mismatch"
+    validate_ledger(text, os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"])
 else:
-    actual = extract_heading_section(text, "## Required checks")
-    label = "## Required checks section mismatch"
-if actual != normalize(os.environ["PROGRAMME_TRUTH_EXPECTED"]):
-    raise SystemExit(label)
+    validate_required(text, os.environ["PROGRAMME_TRUTH_EXPECTED"])
 PY
 }
-
-EXPECTED_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line. **No programme is
-  active.** The previous one, [issue #2388](https://github.com/Rul1an/assay/issues/2388), closed on
-  2026-08-15; name the new ledger here when one opens, and say so plainly here when none is. Keep
-  the number to this one line; everywhere else the contract names the role, so the next programme
-  costs one edit here rather than one in every section. Nothing enforces that, so it is an
-  instruction and not a guarantee — and the way it fails is quiet: the line kept pointing at a
-  finished programme, which reads as an active ledger and sends handoffs to a closed issue.'
 
 # shellcheck disable=SC2016 # Markdown backticks in this exact-section fixture are literal.
 EXPECTED_REQUIRED_CHECKS='## Required checks
@@ -105,7 +168,7 @@ required contexts.
 Wave 0 workflow always triggers on `pull_request`; heavy jobs are conditional to avoid docs-only blocking.'
 
 assert_agents_ledger() {
-  assert_extracted_block ledger "$EXPECTED_LEDGER_BULLET" "$1"
+  assert_extracted_block ledger "" "$1"
 }
 
 assert_wave0_required_contexts() {
@@ -150,6 +213,7 @@ PY
 # Insert inside the ledger bullet, immediately before the next top-level "- ".
 insert_into_ledger_bullet() {
   local extra="$1" text="$2"
+  PROGRAMME_TRUTH_MODE="${PROGRAMME_TRUTH_MODE:-insert}" \
   PROGRAMME_TRUTH_EXTRA="$extra" PROGRAMME_TRUTH_DOC="$text" \
   PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" python3 - <<'PY'
 import os
@@ -169,9 +233,17 @@ end = next(
     ),
     len(lines),
 )
-lines.insert(end, extra if extra.endswith("\n") else extra + "\n")
+payload = extra if extra.endswith("\n") else extra + "\n"
+if os.environ["PROGRAMME_TRUTH_MODE"] == "replace":
+    lines[start:end] = [payload]
+else:
+    lines.insert(end, payload)
 print("".join(lines), end="")
 PY
+}
+
+replace_ledger_bullet() {
+  PROGRAMME_TRUTH_MODE=replace insert_into_ledger_bullet "$1" "$2"
 }
 
 # Docs/ruleset surfaces the hook reads that `scripts/**` does not cover.
@@ -278,7 +350,7 @@ expect_red() {
 expect_ok "monitor.rs still exists" assert_monitor_rs_still_exists
 expect_ok "generic unsafe preview and single-boundary TODO are gone" \
   assert_no_generic_unsafe_preview "$(<"$WORKFLOW")" "$(<"$WAVE0")"
-expect_ok "AGENTS.md ledger says no programme is active" assert_agents_ledger "$(<"$AGENTS")"
+expect_ok "AGENTS.md ledger bullet is structurally valid" assert_agents_ledger "$(<"$AGENTS")"
 expect_ok "WAVE0-GATES.md describes dynamic latest-release baseline" assert_wave0_semver_doc "$(<"$WAVE0")"
 expect_ok "WAVE0-GATES.md points at the canonical required-context contract" \
   assert_wave0_required_contexts "$(<"$WAVE0")"
@@ -286,20 +358,33 @@ expect_ok "Wave71 is dormant or incomplete" assert_wave71_not_active "$(<"$STATU
 expect_ok "kernel-matrix.yml pull_request.paths owns programme-truth inputs" \
   assert_ci_trigger_owns_truth_inputs "$(<"$KERNEL_MATRIX")"
 
-stale_ledger="$(insert_into_ledger_bullet \
-  '  named on this line: [issue #2388](https://example.invalid).' \
-  "$(<"$AGENTS")")"
-expect_red "active-issue ledger pointer" "ledger bullet mismatch" \
-  assert_agents_ledger "$stale_ledger"
-
 stale_semver=$'Source of truth: workflow env WAVE0_SEMVER_BASELINE_SHA.\n'
 expect_red "pinned baseline SHA" "WAVE0_SEMVER_BASELINE_SHA" assert_wave0_semver_doc "$stale_semver"
 
 contradictory_ledger="$(insert_into_ledger_bullet \
   'The active programme ledger is issue #9999.' \
   "$(<"$AGENTS")")"
-expect_red "additive active-issue ledger" "ledger bullet mismatch" \
+expect_red "additive active-issue ledger in the bullet" "contradictory ledger claims in the ledger bullet" \
   assert_agents_ledger "$contradictory_ledger"
+
+elsewhere_ledger="$(printf '%s\n%s\n' "$(<"$AGENTS")" 'The active programme ledger is issue #9999.')"
+expect_red "inactive plus active sentence elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$elsewhere_ledger"
+
+ACTIVE_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4242).'
+active_ledger="$(replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
+expect_ok "structurally active ledger fixture" assert_agents_ledger "$active_ledger"
+
+mismatch_ledger="$(replace_ledger_bullet \
+  '- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4243).' \
+  "$(<"$AGENTS")")"
+expect_red "active fixture with text/link issue mismatch" "visible issue-ID != URL-ID" \
+  assert_agents_ledger "$mismatch_ledger"
+
+duplicate_ledger="$(insert_into_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
+expect_red "duplicate ledger bullet" "duplicate ledger bullet" \
+  assert_agents_ledger "$duplicate_ledger"
 
 stale_required="$(insert_before_next_heading "## Required checks" \
   'Configure branch protection to require:' \
@@ -312,6 +397,11 @@ extra_context="$(insert_before_next_heading "## Required checks" \
   "$(<"$WAVE0")")"
 expect_red "additive extra required context" "## Required checks section mismatch" \
   assert_wave0_required_contexts "$extra_context"
+
+elsewhere_required="$(printf '%s\n%s\n' "$(<"$WAVE0")" '- stale-required-context')"
+expect_red "pointer-only required section plus stale-required-context elsewhere" \
+  "required-context declaration outside ## Required checks" \
+  assert_wave0_required_contexts "$elsewhere_required"
 
 narrowed_trigger="$(printf '%s\n' "$(<"$KERNEL_MATRIX")" | grep -v '"AGENTS.md"')"
 expect_red "AGENTS.md dropped from CI trigger" "omits AGENTS.md" \

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -17,50 +17,98 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 AGENTS="$ROOT/AGENTS.md"
 WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
 STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
-RULESET="$ROOT/.github/rulesets/main-required-ci-contexts.json"
 WORKFLOW="$ROOT/.github/workflows/split-wave0-gates.yml"
+KERNEL_MATRIX="$ROOT/.github/workflows/kernel-matrix.yml"
 MONITOR="$ROOT/crates/assay-cli/src/cli/commands/monitor.rs"
 
 FAILURES=0
 ok()  { echo "ok    $1"; }
 bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
 
-live_required_contexts() {
-  python3 - "$RULESET" <<'PY'
-import json, sys
-from pathlib import Path
-data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-seen = []
-for rule in data.get("rules", []):
-    if rule.get("type") != "required_status_checks":
-        continue
-    for check in rule.get("parameters", {}).get("required_status_checks", []):
-        ctx = check.get("context")
-        if ctx and ctx not in seen:
-            seen.append(ctx)
-if not seen:
-    raise SystemExit("ruleset has no required_status_checks contexts")
-print("\n".join(seen))
+LEDGER_PREFIX='- The public execution ledger'
+
+assert_extracted_block() {
+  local kind="$1" expected="$2" text="$3"
+  PROGRAMME_TRUTH_KIND="$kind" \
+  PROGRAMME_TRUTH_EXPECTED="$expected" \
+  PROGRAMME_TRUTH_DOC="$text" \
+  PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" python3 - <<'PY'
+import os
+
+def normalize(text: str) -> str:
+    lines = [line.rstrip() for line in text.splitlines()]
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(lines)
+
+def extract_heading_section(text: str, heading: str) -> str:
+    lines = text.splitlines()
+    start = next((i for i, line in enumerate(lines) if line.strip() == heading), None)
+    if start is None:
+        raise SystemExit(f"missing {heading} section")
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
+        len(lines),
+    )
+    return normalize("\n".join(lines[start:end]))
+
+def extract_top_level_bullet(text: str, prefix: str) -> str:
+    lines = text.splitlines()
+    start = next((i for i, line in enumerate(lines) if line.startswith(prefix)), None)
+    if start is None:
+        raise SystemExit("missing ledger bullet")
+    end = next(
+        (
+            i
+            for i in range(start + 1, len(lines))
+            if lines[i].startswith("- ") or lines[i].startswith("## ")
+        ),
+        len(lines),
+    )
+    return normalize("\n".join(lines[start:end]))
+
+kind = os.environ["PROGRAMME_TRUTH_KIND"]
+text = os.environ["PROGRAMME_TRUTH_DOC"]
+if kind == "ledger":
+    actual = extract_top_level_bullet(text, os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"])
+    label = "ledger bullet mismatch"
+else:
+    actual = extract_heading_section(text, "## Required checks")
+    label = "## Required checks section mismatch"
+if actual != normalize(os.environ["PROGRAMME_TRUTH_EXPECTED"]):
+    raise SystemExit(label)
 PY
 }
 
+EXPECTED_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line. **No programme is
+  active.** The previous one, [issue #2388](https://github.com/Rul1an/assay/issues/2388), closed on
+  2026-08-15; name the new ledger here when one opens, and say so plainly here when none is. Keep
+  the number to this one line; everywhere else the contract names the role, so the next programme
+  costs one edit here rather than one in every section. Nothing enforces that, so it is an
+  instruction and not a guarantee — and the way it fails is quiet: the line kept pointing at a
+  finished programme, which reads as an active ledger and sends handoffs to a closed issue.'
+
+EXPECTED_REQUIRED_CHECKS='## Required checks
+
+The live required contexts are named once in `CI-CONTRACT.md` at
+`Currently required live branch-protection contexts`, and
+`scripts/ci/check-required-contexts.py` pins that list to
+`.github/rulesets/main-required-ci-contexts.json`. Do not copy the names here.
+
+Wave 0 job names (`Wave 0 feature matrix`, `Wave 0 quality gates`,
+`Wave 0 semver checks (public crates)`) are workflow jobs, not current
+required contexts.
+
+Wave 0 workflow always triggers on `pull_request`; heavy jobs are conditional to avoid docs-only blocking.'
+
 assert_agents_ledger() {
-  local text="$1"
-  local collapsed
-  collapsed="$(printf '%s' "$text" | tr '\n' ' ' | tr -s ' ')"
-  if ! grep -q 'public execution ledger' <<<"$collapsed"; then
-    echo "AGENTS.md has no public execution ledger line"
-    return 1
-  fi
-  if grep -Eq 'named on this line:[[:space:]]*\[issue #' <<<"$collapsed"; then
-    echo "ledger line still names a GitHub issue as the active programme"
-    return 1
-  fi
-  if ! grep -Eq 'No programme is active' <<<"$collapsed"; then
-    echo "ledger line does not say no programme is active"
-    return 1
-  fi
-  return 0
+  assert_extracted_block ledger "$EXPECTED_LEDGER_BULLET" "$1"
+}
+
+assert_wave0_required_contexts() {
+  assert_extracted_block required "$EXPECTED_REQUIRED_CHECKS" "$1"
 }
 
 assert_wave0_semver_doc() {
@@ -80,20 +128,78 @@ assert_wave0_semver_doc() {
   return 0
 }
 
-assert_wave0_required_contexts() {
-  local text="$1"
-  local ctx
-  while IFS= read -r ctx; do
-    if ! grep -Fq -- "$ctx" <<<"$text"; then
-      echo "WAVE0-GATES.md does not name live required context ${ctx}"
-      return 1
-    fi
-  done < <(live_required_contexts)
-  if grep -q 'Configure branch protection to require:' <<<"$text"; then
-    echo "WAVE0-GATES.md still presents Wave 0 jobs as the branch-protection recommendation"
-    return 1
-  fi
-  return 0
+insert_before_next_heading() {
+  local heading="$1" extra="$2" text="$3"
+  PROGRAMME_TRUTH_HEADING="$heading" PROGRAMME_TRUTH_EXTRA="$extra" PROGRAMME_TRUTH_DOC="$text" python3 - <<'PY'
+import os
+
+heading = os.environ["PROGRAMME_TRUTH_HEADING"]
+extra = os.environ["PROGRAMME_TRUTH_EXTRA"]
+text = os.environ["PROGRAMME_TRUTH_DOC"]
+lines = text.splitlines(keepends=True)
+start = next((i for i, line in enumerate(lines) if line.strip() == heading), None)
+if start is None:
+    raise SystemExit(f"missing {heading} section")
+end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
+lines.insert(end, extra if extra.endswith("\n") else extra + "\n")
+print("".join(lines), end="")
+PY
+}
+
+# Insert inside the ledger bullet, immediately before the next top-level "- ".
+insert_into_ledger_bullet() {
+  local extra="$1" text="$2"
+  PROGRAMME_TRUTH_EXTRA="$extra" PROGRAMME_TRUTH_DOC="$text" \
+  PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" python3 - <<'PY'
+import os
+
+prefix = os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"]
+extra = os.environ["PROGRAMME_TRUTH_EXTRA"]
+text = os.environ["PROGRAMME_TRUTH_DOC"]
+lines = text.splitlines(keepends=True)
+start = next((i for i, line in enumerate(lines) if line.startswith(prefix)), None)
+if start is None:
+    raise SystemExit("missing ledger bullet")
+end = next(
+    (
+        i
+        for i in range(start + 1, len(lines))
+        if lines[i].startswith("- ") or lines[i].startswith("## ")
+    ),
+    len(lines),
+)
+lines.insert(end, extra if extra.endswith("\n") else extra + "\n")
+print("".join(lines), end="")
+PY
+}
+
+# Docs/ruleset surfaces the hook reads that `scripts/**` does not cover.
+TRUTH_TRIGGER_INPUTS="$(printf '%s\n' \
+  AGENTS.md \
+  docs/contributing/WAVE0-GATES.md \
+  docs/contributing/REFACTOR-WAVE-STATUS.md \
+  .github/rulesets/main-required-ci-contexts.json)"
+
+assert_ci_trigger_owns_truth_inputs() {
+  local workflow_text="$1"
+  PROGRAMME_TRUTH_WORKFLOW="$workflow_text" \
+  PROGRAMME_TRUTH_INPUTS="$TRUTH_TRIGGER_INPUTS" python3 - <<'PY'
+import os, re
+
+text = os.environ["PROGRAMME_TRUTH_WORKFLOW"]
+inputs = [line for line in os.environ["PROGRAMME_TRUTH_INPUTS"].splitlines() if line]
+block = re.search(r"(?ms)^  pull_request:\n((?:    .+\n|\n)*)", text)
+if not block:
+    raise SystemExit("kernel-matrix.yml has no pull_request trigger block")
+listed = re.findall(r'^\s*-\s*"([^"]+)"', block.group(1), re.M)
+missing = [path for path in inputs if path not in listed]
+if missing:
+    raise SystemExit(
+        "kernel-matrix.yml pull_request.paths omits "
+        + ", ".join(missing)
+        + "; docs-only truth drift would skip CI"
+    )
+PY
 }
 
 assert_monitor_rs_still_exists() {
@@ -173,20 +279,42 @@ expect_ok "generic unsafe preview and single-boundary TODO are gone" \
   assert_no_generic_unsafe_preview "$(<"$WORKFLOW")" "$(<"$WAVE0")"
 expect_ok "AGENTS.md ledger says no programme is active" assert_agents_ledger "$(<"$AGENTS")"
 expect_ok "WAVE0-GATES.md describes dynamic latest-release baseline" assert_wave0_semver_doc "$(<"$WAVE0")"
-expect_ok "WAVE0-GATES.md names live required contexts" assert_wave0_required_contexts "$(<"$WAVE0")"
+expect_ok "WAVE0-GATES.md points at the canonical required-context contract" \
+  assert_wave0_required_contexts "$(<"$WAVE0")"
 expect_ok "Wave71 is dormant or incomplete" assert_wave71_not_active "$(<"$STATUS")"
+expect_ok "kernel-matrix.yml pull_request.paths owns programme-truth inputs" \
+  assert_ci_trigger_owns_truth_inputs "$(<"$KERNEL_MATRIX")"
 
-stale_ledger=$'The public execution ledger for the active programme is named on this line: [issue #2388](https://github.com/Rul1an/assay/issues/2388).\n'
-expect_red "active-issue ledger pointer" "names a GitHub issue" assert_agents_ledger "$stale_ledger"
+stale_ledger="$(insert_into_ledger_bullet \
+  '  named on this line: [issue #2388](https://example.invalid).' \
+  "$(<"$AGENTS")")"
+expect_red "active-issue ledger pointer" "ledger bullet mismatch" \
+  assert_agents_ledger "$stale_ledger"
 
 stale_semver=$'Source of truth: workflow env WAVE0_SEMVER_BASELINE_SHA.\n'
 expect_red "pinned baseline SHA" "WAVE0_SEMVER_BASELINE_SHA" assert_wave0_semver_doc "$stale_semver"
 
-stale_required="$(live_required_contexts)
-Configure branch protection to require:
-- Wave 0 feature matrix
-"
-expect_red "Wave 0 jobs as required checks" "branch-protection recommendation" assert_wave0_required_contexts "$stale_required"
+contradictory_ledger="$(insert_into_ledger_bullet \
+  'The active programme ledger is issue #9999.' \
+  "$(<"$AGENTS")")"
+expect_red "additive active-issue ledger" "ledger bullet mismatch" \
+  assert_agents_ledger "$contradictory_ledger"
+
+stale_required="$(insert_before_next_heading "## Required checks" \
+  'Configure branch protection to require:' \
+  "$(<"$WAVE0")")"
+expect_red "Wave 0 jobs as required checks" "## Required checks section mismatch" \
+  assert_wave0_required_contexts "$stale_required"
+
+extra_context="$(insert_before_next_heading "## Required checks" \
+  'stale-required-context' \
+  "$(<"$WAVE0")")"
+expect_red "additive extra required context" "## Required checks section mismatch" \
+  assert_wave0_required_contexts "$extra_context"
+
+narrowed_trigger="$(printf '%s\n' "$(<"$KERNEL_MATRIX")" | grep -v '"AGENTS.md"')"
+expect_red "AGENTS.md dropped from CI trigger" "omits AGENTS.md" \
+  assert_ci_trigger_owns_truth_inputs "$narrowed_trigger"
 
 stale_wave71=$'| Wave71 | Hotspot LOC under 600 | in progress | Active | still reducing |\n'
 expect_red "Wave71 Active" "claims Active" assert_wave71_not_active "$stale_wave71"

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -41,13 +41,13 @@ ISSUE_LINK = re.compile(
     r"\[issue #(\d+)\]\((https://github\.com/[^)\s]+/issues/(\d+))\)"
 )
 VISIBLE_ISSUE = re.compile(r"(?i)issue #(\d+)")
-# Declaration-shaped only: a sentence/line that names the active ledger, or a
-# standalone inactive declaration. Raw "public execution ledger" prose is not.
+# Optional list marker and strong prefix before a declaration-shaped start.
+DECL_PREFIX = r"(?:^|[.!?]\s+)(?:-\s+)?(?:\*{1,2})?"
 OUTSIDE_ACTIVE_DECL = re.compile(
-    r"(?im)(?:^|[.!?]\s+)The active programme ledger is\b"
+    rf"(?im){DECL_PREFIX}The active programme ledger is\b"
 )
 OUTSIDE_INACTIVE_DECL = re.compile(
-    r"(?im)(?:^|[.!?]\s+)\*{0,2}No programme is active\."
+    rf"(?im){DECL_PREFIX}No programme is active\."
 )
 # List-item declarations only. Ordinary prose such as "ensure required checks
 # pass" is not a required-context declaration.
@@ -134,8 +134,8 @@ def validate_ledger(text: str, prefix: str) -> None:
     for visible, _url, url_id in links:
         if visible != url_id:
             raise SystemExit("visible issue-ID != URL-ID")
-    linked_ids = {visible for visible, _url, _url_id in links}
-    unlinked = [num for num in VISIBLE_ISSUE.findall(bullet) if num not in linked_ids]
+    stripped = ISSUE_LINK.sub("", bullet)
+    unlinked = VISIBLE_ISSUE.findall(stripped)
     if unlinked:
         raise SystemExit(
             "unlinked issue # reference in the ledger bullet: "
@@ -344,6 +344,33 @@ assert_wave71_not_active() {
   return 0
 }
 
+assert_selfhost_temp_contract() {
+  PROGRAMME_TRUTH_SCRIPT="${BASH_SOURCE[0]}" python3 - <<'PY'
+import os
+import re
+from pathlib import Path
+
+text = Path(os.environ["PROGRAMME_TRUTH_SCRIPT"]).read_text(encoding="utf-8")
+marker = 'if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then'
+idx = text.rfind(marker)
+if idx < 0:
+    raise SystemExit("missing selfhost runner")
+block = text[idx:]
+if block.count("mktemp -d") != 1:
+    raise SystemExit(
+        "selfhost runner must allocate exactly one temp directory"
+    )
+if re.search(r"\$\(mktemp\)(?! -d)", block):
+    raise SystemExit("selfhost still allocates a second mktemp file")
+alloc_at = block.find("mktemp -d")
+trap_m = re.search(r"trap\b[^\n]*\bEXIT\b", block[alloc_at:])
+if trap_m is None:
+    raise SystemExit("selfhost does not register an EXIT trap after allocation")
+if "${selfhost_dir:?}" not in block:
+    raise SystemExit("selfhost cleanup must refuse an empty directory via :?")
+PY
+}
+
 expect_ok() {
   local label="$1"
   shift
@@ -398,6 +425,18 @@ ordinary_ledger_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
 expect_ok "ordinary public-ledger prose outside the bullet" \
   assert_agents_ledger "$ordinary_ledger_prose"
 
+list_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '- The active programme ledger is issue #7777.')"
+expect_red "list-item active ledger declaration elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$list_active_elsewhere"
+
+list_inactive_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '- **No programme is active.**')"
+expect_red "list-item inactive declaration elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$list_inactive_elsewhere"
+
 ACTIVE_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4242).'
 active_ledger="$(replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
 expect_ok "structurally active ledger fixture" assert_agents_ledger "$active_ledger"
@@ -414,6 +453,12 @@ inactive_mismatch="$(replace_ledger_bullet \
   "$(<"$AGENTS")")"
 expect_red "inactive previous-link text/URL mismatch" "visible issue-ID != URL-ID" \
   assert_agents_ledger "$inactive_mismatch"
+
+linked_plus_plain="$(replace_ledger_bullet \
+  '- The public execution ledger for the active programme is named on this line: [issue #7777](https://github.com/Rul1an/assay/issues/7777). Also issue #7777.' \
+  "$(<"$AGENTS")")"
+expect_red "valid link plus extra plain issue # of the same ID" "unlinked issue #" \
+  assert_agents_ledger "$linked_plus_plain"
 
 duplicate_ledger="$(insert_into_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
 expect_red "duplicate ledger bullet" "duplicate ledger bullet" \
@@ -455,9 +500,14 @@ expect_red "restored single-boundary TODO" "single-boundary Wave 3 TODO" \
 expect_red "deleted-monitor.rs claim" "must not claim monitor.rs was deleted" \
   assert_no_generic_unsafe_preview "monitor.rs was deleted" ""
 
+expect_ok "selfhost uses one tempdir and an EXIT trap" assert_selfhost_temp_contract
+
 if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then
-  active_agents="$(mktemp)"
-  selfhost_log="$(mktemp)"
+  cleanup_selfhost() { rm -rf -- "${selfhost_dir:?}"; }
+  selfhost_dir="$(mktemp -d)"
+  trap cleanup_selfhost EXIT
+  active_agents="$selfhost_dir/agents.md"
+  selfhost_log="$selfhost_dir/selfhost.log"
   replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$ROOT/AGENTS.md")" >"$active_agents"
   if PROGRAMME_TRUTH_AGENTS="$active_agents" PROGRAMME_TRUTH_SELFHOST=1 \
     bash "${BASH_SOURCE[0]}" >"$selfhost_log" 2>&1; then
@@ -465,7 +515,8 @@ if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then
   else
     bad "full contract on active canonical AGENTS ledger: $(tail -n 20 "$selfhost_log")"
   fi
-  rm -f "$active_agents" "$selfhost_log"
+  trap - EXIT
+  cleanup_selfhost
 fi
 
 if [[ "$FAILURES" -ne 0 ]]; then

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-AGENTS="$ROOT/AGENTS.md"
+AGENTS="${PROGRAMME_TRUTH_AGENTS:-$ROOT/AGENTS.md}"
 WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
 STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
 WORKFLOW="$ROOT/.github/workflows/split-wave0-gates.yml"
@@ -37,13 +37,17 @@ import os
 import re
 
 INACTIVE_DECL = "**No programme is active.**"
-LEDGER_PHRASES = (
-    "active programme ledger",
-    "public execution ledger",
-    "No programme is active",
-)
 ISSUE_LINK = re.compile(
     r"\[issue #(\d+)\]\((https://github\.com/[^)\s]+/issues/(\d+))\)"
+)
+VISIBLE_ISSUE = re.compile(r"(?i)issue #(\d+)")
+# Declaration-shaped only: a sentence/line that names the active ledger, or a
+# standalone inactive declaration. Raw "public execution ledger" prose is not.
+OUTSIDE_ACTIVE_DECL = re.compile(
+    r"(?im)(?:^|[.!?]\s+)The active programme ledger is\b"
+)
+OUTSIDE_INACTIVE_DECL = re.compile(
+    r"(?im)(?:^|[.!?]\s+)\*{0,2}No programme is active\."
 )
 # List-item declarations only. Ordinary prose such as "ensure required checks
 # pass" is not a required-context declaration.
@@ -105,21 +109,39 @@ def collapsed(text: str) -> str:
     return re.sub(r"\s+", " ", text)
 
 
+def outside_ledger_declarations(remainder: str) -> list[str]:
+    found: list[str] = []
+    if OUTSIDE_ACTIVE_DECL.search(remainder):
+        found.append("The active programme ledger is")
+    if OUTSIDE_INACTIVE_DECL.search(remainder):
+        found.append("No programme is active")
+    return found
+
+
 def validate_ledger(text: str, prefix: str) -> None:
     # Non-claim: this offline structural check verifies issue-link form and
     # visible-text/URL-ID parity only. It does not query live GitHub OPEN or
     # CLOSED state. The current inactive AGENTS.md bullet satisfies #2515.
     bullet, remainder = split_top_level_bullet(text, prefix)
     bullet_c = collapsed(bullet)
-    remainder_c = collapsed(remainder)
-    outside = [phrase for phrase in LEDGER_PHRASES if phrase in remainder_c]
+    outside = outside_ledger_declarations(remainder)
     if outside:
         raise SystemExit(
             "contradictory ledger declaration outside the ledger bullet: "
             + ", ".join(outside)
         )
-    inactive_count = bullet_c.count(INACTIVE_DECL)
     links = ISSUE_LINK.findall(bullet)
+    for visible, _url, url_id in links:
+        if visible != url_id:
+            raise SystemExit("visible issue-ID != URL-ID")
+    linked_ids = {visible for visible, _url, _url_id in links}
+    unlinked = [num for num in VISIBLE_ISSUE.findall(bullet) if num not in linked_ids]
+    if unlinked:
+        raise SystemExit(
+            "unlinked issue # reference in the ledger bullet: "
+            + ", ".join(unlinked)
+        )
+    inactive_count = bullet_c.count(INACTIVE_DECL)
     if inactive_count > 1:
         raise SystemExit("ledger bullet has multiple inactive declarations")
     if inactive_count == 1:
@@ -130,9 +152,6 @@ def validate_ledger(text: str, prefix: str) -> None:
         raise SystemExit(
             "ledger bullet is neither a valid inactive nor a valid active state"
         )
-    visible, _url, url_id = links[0]
-    if visible != url_id:
-        raise SystemExit("visible issue-ID != URL-ID")
 
 
 def validate_required(text: str, expected: str) -> None:
@@ -366,13 +385,18 @@ expect_red "pinned baseline SHA" "WAVE0_SEMVER_BASELINE_SHA" assert_wave0_semver
 contradictory_ledger="$(insert_into_ledger_bullet \
   'The active programme ledger is issue #9999.' \
   "$(<"$AGENTS")")"
-expect_red "additive active-issue ledger in the bullet" "contradictory ledger claims in the ledger bullet" \
+expect_red "additive unlinked issue # in the ledger bullet" "unlinked issue #" \
   assert_agents_ledger "$contradictory_ledger"
 
 elsewhere_ledger="$(printf '%s\n%s\n' "$(<"$AGENTS")" 'The active programme ledger is issue #9999.')"
-expect_red "inactive plus active sentence elsewhere" \
+expect_red "active ledger declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
   assert_agents_ledger "$elsewhere_ledger"
+
+ordinary_ledger_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  'Reviewers should consult the public execution ledger before handoff.')"
+expect_ok "ordinary public-ledger prose outside the bullet" \
+  assert_agents_ledger "$ordinary_ledger_prose"
 
 ACTIVE_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4242).'
 active_ledger="$(replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
@@ -383,6 +407,13 @@ mismatch_ledger="$(replace_ledger_bullet \
   "$(<"$AGENTS")")"
 expect_red "active fixture with text/link issue mismatch" "visible issue-ID != URL-ID" \
   assert_agents_ledger "$mismatch_ledger"
+
+# Synthetic inactive: previous-link mismatch without freezing a live issue number.
+inactive_mismatch="$(replace_ledger_bullet \
+  '- The public execution ledger for the active programme is named on this line. **No programme is active.** The previous one, [issue #4242](https://github.com/Rul1an/assay/issues/9999).' \
+  "$(<"$AGENTS")")"
+expect_red "inactive previous-link text/URL mismatch" "visible issue-ID != URL-ID" \
+  assert_agents_ledger "$inactive_mismatch"
 
 duplicate_ledger="$(insert_into_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
 expect_red "duplicate ledger bullet" "duplicate ledger bullet" \
@@ -423,6 +454,19 @@ expect_red "restored single-boundary TODO" "single-boundary Wave 3 TODO" \
   assert_no_generic_unsafe_preview "" "unsafe allowed only in the monitor syscall boundary module."
 expect_red "deleted-monitor.rs claim" "must not claim monitor.rs was deleted" \
   assert_no_generic_unsafe_preview "monitor.rs was deleted" ""
+
+if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then
+  active_agents="$(mktemp)"
+  selfhost_log="$(mktemp)"
+  replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$ROOT/AGENTS.md")" >"$active_agents"
+  if PROGRAMME_TRUTH_AGENTS="$active_agents" PROGRAMME_TRUTH_SELFHOST=1 \
+    bash "${BASH_SOURCE[0]}" >"$selfhost_log" 2>&1; then
+    ok "full contract on active canonical AGENTS ledger"
+  else
+    bad "full contract on active canonical AGENTS ledger: $(tail -n 20 "$selfhost_log")"
+  fi
+  rm -f "$active_agents" "$selfhost_log"
+fi
 
 if [[ "$FAILURES" -ne 0 ]]; then
   echo "$FAILURES programme-truth case(s) failed"

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -14,6 +14,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
 AGENTS="${PROGRAMME_TRUTH_AGENTS:-$ROOT/AGENTS.md}"
 WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
 STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
@@ -27,12 +28,21 @@ bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
 
 LEDGER_PREFIX='- The public execution ledger'
 
+require_truth_file() {
+  python3 "$CEILINGS" check-file "$1"
+}
+
+require_truth_text() {
+  printf '%s' "$1" | python3 "$CEILINGS" check-stdin "${2:-programme-truth document}"
+}
+
 assert_extracted_block() {
   local kind="$1" expected="$2" text="$3"
+  require_truth_text "$text" "programme-truth document" || return 1
   PROGRAMME_TRUTH_KIND="$kind" \
   PROGRAMME_TRUTH_EXPECTED="$expected" \
-  PROGRAMME_TRUTH_DOC="$text" \
-  PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" python3 - <<'PY'
+  PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" \
+  python3 - <<'PY' 3< <(printf '%s' "$text")
 import os
 import re
 
@@ -199,6 +209,15 @@ def validate_ledger(text: str, prefix: str) -> None:
         raise SystemExit(
             "ledger bullet is neither a valid inactive nor a valid active state"
         )
+    canonical_active = (
+        "- The public execution ledger for the active programme is named on this line:"
+    )
+    if not bullet_c.startswith(canonical_active):
+        raise SystemExit("ledger bullet is not the canonical active form")
+    after = bullet_c[len(canonical_active) :].strip().rstrip(".").strip()
+    link = ISSUE_LINK.fullmatch(after)
+    if link is None or link.group(1) != link.group(3):
+        raise SystemExit("ledger bullet is not the canonical active form")
 
 
 def validate_required(text: str, expected: str) -> None:
@@ -213,7 +232,7 @@ def validate_required(text: str, expected: str) -> None:
 
 
 kind = os.environ["PROGRAMME_TRUTH_KIND"]
-text = os.environ["PROGRAMME_TRUTH_DOC"]
+text = os.fdopen(3).read()
 if kind == "ledger":
     validate_ledger(text, os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"])
 else:
@@ -262,12 +281,14 @@ assert_wave0_semver_doc() {
 
 insert_before_next_heading() {
   local heading="$1" extra="$2" text="$3"
-  PROGRAMME_TRUTH_HEADING="$heading" PROGRAMME_TRUTH_EXTRA="$extra" PROGRAMME_TRUTH_DOC="$text" python3 - <<'PY'
+  require_truth_text "$text" "programme-truth mutation input" || return 1
+  PROGRAMME_TRUTH_HEADING="$heading" PROGRAMME_TRUTH_EXTRA="$extra" \
+  python3 - <<'PY' 3< <(printf '%s' "$text")
 import os
 
 heading = os.environ["PROGRAMME_TRUTH_HEADING"]
 extra = os.environ["PROGRAMME_TRUTH_EXTRA"]
-text = os.environ["PROGRAMME_TRUTH_DOC"]
+text = os.fdopen(3).read()
 lines = text.splitlines(keepends=True)
 start = next((i for i, line in enumerate(lines) if line.strip() == heading), None)
 if start is None:
@@ -281,14 +302,16 @@ PY
 # Insert inside the ledger bullet, immediately before the next top-level "- ".
 insert_into_ledger_bullet() {
   local extra="$1" text="$2"
+  require_truth_text "$text" "programme-truth mutation input" || return 1
   PROGRAMME_TRUTH_MODE="${PROGRAMME_TRUTH_MODE:-insert}" \
-  PROGRAMME_TRUTH_EXTRA="$extra" PROGRAMME_TRUTH_DOC="$text" \
-  PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" python3 - <<'PY'
+  PROGRAMME_TRUTH_EXTRA="$extra" \
+  PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" \
+  python3 - <<'PY' 3< <(printf '%s' "$text")
 import os
 
 prefix = os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"]
 extra = os.environ["PROGRAMME_TRUTH_EXTRA"]
-text = os.environ["PROGRAMME_TRUTH_DOC"]
+text = os.fdopen(3).read()
 lines = text.splitlines(keepends=True)
 start = next((i for i, line in enumerate(lines) if line.startswith(prefix)), None)
 if start is None:
@@ -323,11 +346,12 @@ TRUTH_TRIGGER_INPUTS="$(printf '%s\n' \
 
 assert_ci_trigger_owns_truth_inputs() {
   local workflow_text="$1"
-  PROGRAMME_TRUTH_WORKFLOW="$workflow_text" \
-  PROGRAMME_TRUTH_INPUTS="$TRUTH_TRIGGER_INPUTS" python3 - <<'PY'
+  require_truth_text "$workflow_text" "kernel-matrix.yml" || return 1
+  PROGRAMME_TRUTH_INPUTS="$TRUTH_TRIGGER_INPUTS" \
+  python3 - <<'PY' 3< <(printf '%s' "$workflow_text")
 import os, re
 
-text = os.environ["PROGRAMME_TRUTH_WORKFLOW"]
+text = os.fdopen(3).read()
 inputs = [line for line in os.environ["PROGRAMME_TRUTH_INPUTS"].splitlines() if line]
 block = re.search(r"(?ms)^  pull_request:\n((?:    .+\n|\n)*)", text)
 if not block:
@@ -415,6 +439,11 @@ expect_red() {
   fi
 }
 
+for truth_file in "$AGENTS" "$WAVE0" "$STATUS" "$WORKFLOW" "$KERNEL_MATRIX"; do
+  expect_ok "${truth_file#"$ROOT"/} is within the programme-truth byte ceiling" \
+    require_truth_file "$truth_file"
+done
+
 expect_ok "monitor.rs still exists" assert_monitor_rs_still_exists
 expect_ok "generic unsafe preview and single-boundary TODO are gone" \
   assert_no_generic_unsafe_preview "$(<"$WORKFLOW")" "$(<"$WAVE0")"
@@ -501,6 +530,12 @@ ACTIVE_LEDGER_BULLET='- The public execution ledger for the active programme is 
 active_ledger="$(replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
 expect_ok "structurally active ledger fixture" assert_agents_ledger "$active_ledger"
 
+retired_ledger="$(replace_ledger_bullet \
+  '- The public execution ledger historically recorded [issue #4242](https://github.com/Rul1an/assay/issues/4242).' \
+  "$(<"$AGENTS")")"
+expect_red "retired historical wording with a valid issue-link" "canonical active form" \
+  assert_agents_ledger "$retired_ledger"
+
 mismatch_ledger="$(replace_ledger_bullet \
   '- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4243).' \
   "$(<"$AGENTS")")"
@@ -559,6 +594,16 @@ expect_red "restored single-boundary TODO" "single-boundary Wave 3 TODO" \
   assert_no_generic_unsafe_preview "" "unsafe allowed only in the monitor syscall boundary module."
 expect_red "deleted-monitor.rs claim" "must not claim monitor.rs was deleted" \
   assert_no_generic_unsafe_preview "monitor.rs was deleted" ""
+
+oversized_real="$(mktemp)"
+python3 -c "import sys; sys.stdout.buffer.write(b'x' * 65537)" >"$oversized_real"
+expect_red "oversized real document" "exceeds 65536-byte ceiling" \
+  require_truth_file "$oversized_real"
+rm -f "$oversized_real"
+
+oversized_synth="$(python3 -c "print('x' * 65537, end='')")"
+expect_red "oversized synthetic document" "exceeds 65536-byte ceiling" \
+  assert_agents_ledger "$oversized_synth"
 
 if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then
   cleanup_selfhost() { rm -rf -- "${selfhost_dir:?}"; }

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -13,26 +13,8 @@
 # would break a later legitimate boundary split.
 set -euo pipefail
 
-if [[ -n "${PROGRAMME_TRUTH_ROOT+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_ROOT cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_AGENTS+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_AGENTS cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_SELFHOST+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_SELFHOST cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_CEILING_CHILD+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_CEILING_CHILD cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_PREVIEW_MUTANT+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_PREVIEW_MUTANT cannot replace the script worktree" >&2
-  exit 1
-fi
+_TRUTH_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource_ceilings.py"
+python3 "$_TRUTH_LIB" reject-overrides
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 if [[ -e "$ROOT/.git" && -e "$ROOT/.programme-truth-hermetic" ]]; then
@@ -92,12 +74,17 @@ PY
 }
 
 run_hermetic_programme_truth() {
-  env -u PROGRAMME_TRUTH_ROOT \
-    -u PROGRAMME_TRUTH_AGENTS \
-    -u PROGRAMME_TRUTH_SELFHOST \
-    -u PROGRAMME_TRUTH_CEILING_CHILD \
-    -u PROGRAMME_TRUTH_PREVIEW_MUTANT \
-    bash "$1"
+  local -a env_args
+  local name
+  env_args=()
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    env_args[${#env_args[@]}]="-u"
+    env_args[${#env_args[@]}]="$name"
+  done <<EOF
+$(python3 "$CEILINGS" forbidden-overrides)
+EOF
+  env "${env_args[@]}" bash "$1"
 }
 
 assert_extracted_block() {
@@ -645,6 +632,11 @@ if root_override in text:
     raise SystemExit("PROGRAMME_TRUTH_ROOT is still a caller override")
 if agents_override in text:
     raise SystemExit("PROGRAMME_TRUTH_AGENTS is still a caller override")
+if "reject-overrides" not in text:
+    raise SystemExit("script does not invoke reject-overrides")
+inline_reject = "if [[ -n \"${" + "PROGRAMME_TRUTH_AGENTS+x}\" ]]"
+if inline_reject in text:
+    raise SystemExit("script still inlines programme override rejects")
 if 'ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"' not in text:
     raise SystemExit("ROOT is not derived from BASH_SOURCE")
 if 'AGENTS="$ROOT/AGENTS.md"' not in text:
@@ -659,24 +651,72 @@ PY
 expect_ok "ROOT is the script worktree and not caller-overridable" \
   assert_root_is_script_worktree "${BASH_SOURCE[0]}"
 
+FORBIDDEN_SPEC=(
+  PROGRAMME_TRUTH_ROOT
+  PROGRAMME_TRUTH_AGENTS
+  PROGRAMME_TRUTH_SELFHOST
+  PROGRAMME_TRUTH_CEILING_CHILD
+  PROGRAMME_TRUTH_PREVIEW_MUTANT
+)
+
+assert_forbidden_override_set() {
+  python3 - "$1" "${FORBIDDEN_SPEC[@]}" <<'PY'
+import runpy
+import sys
+
+required = tuple(sys.argv[2:])
+got = tuple(runpy.run_path(sys.argv[1])["FORBIDDEN_PROGRAMME_OVERRIDES"])
+if got != required:
+    raise SystemExit(f"forbidden override set mismatch: {got!r}")
+PY
+}
+
+expect_ok "forbidden programme overrides are the canonical five" \
+  assert_forbidden_override_set "$CEILINGS"
+
+for override_name in "${FORBIDDEN_SPEC[@]}"; do
+  expect_red "${override_name} override" \
+    "${override_name} cannot replace the script worktree" \
+    env "${override_name}=1" python3 "$CEILINGS" reject-overrides
+done
+
 expect_red "PROGRAMME_TRUTH_ROOT empty override" \
   "PROGRAMME_TRUTH_ROOT cannot replace the script worktree" \
   env PROGRAMME_TRUTH_ROOT= bash "${BASH_SOURCE[0]}"
 expect_red "PROGRAMME_TRUTH_ROOT nonexistent tree" \
   "PROGRAMME_TRUTH_ROOT cannot replace the script worktree" \
   env PROGRAMME_TRUTH_ROOT=/no/such/programme-truth-root bash "${BASH_SOURCE[0]}"
-expect_red "PROGRAMME_TRUTH_AGENTS override" \
-  "PROGRAMME_TRUTH_AGENTS cannot replace the script worktree" \
-  env PROGRAMME_TRUTH_AGENTS="$ROOT/AGENTS.md" bash "${BASH_SOURCE[0]}"
-expect_red "PROGRAMME_TRUTH_PREVIEW_MUTANT override" \
-  "PROGRAMME_TRUTH_PREVIEW_MUTANT cannot replace the script worktree" \
-  env PROGRAMME_TRUTH_PREVIEW_MUTANT=1 bash "${BASH_SOURCE[0]}"
-expect_red "combined AGENTS+SELFHOST+CEILING_CHILD bypass" \
-  "cannot replace the script worktree" \
-  env PROGRAMME_TRUTH_AGENTS="$ROOT/AGENTS.md" \
-  PROGRAMME_TRUTH_SELFHOST=1 \
-  PROGRAMME_TRUTH_CEILING_CHILD=1 \
-  bash "${BASH_SOURCE[0]}"
+
+for override_name in "${FORBIDDEN_SPEC[@]}"; do
+  install_hermetic_programme_truth "$TRUTH_TMP/drop-${override_name}"
+  python3 - "$TRUTH_TMP/drop-${override_name}/scripts/ci/lib/resource_ceilings.py" \
+    "$override_name" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+path = Path(sys.argv[1])
+name = sys.argv[2]
+text = read_bounded_file(str(path)).decode("utf-8")
+needle = f'    "{name}",\n'
+if needle not in text:
+    raise SystemExit(f"forbidden set does not name {name}")
+out = text.replace(needle, "", 1)
+require_bounded_bytes(out.encode("utf-8"), "dropped override set")
+path.write_text(out, encoding="utf-8")
+PY
+  if env "${override_name}=1" python3 \
+    "$TRUTH_TMP/drop-${override_name}/scripts/ci/lib/resource_ceilings.py" \
+    reject-overrides >/dev/null 2>&1; then
+    ok "dropping ${override_name} from the set leaves that override green"
+  else
+    bad "dropping ${override_name} still rejected"
+  fi
+  expect_red "forbidden set without ${override_name}" "forbidden override set mismatch" \
+    assert_forbidden_override_set \
+    "$TRUTH_TMP/drop-${override_name}/scripts/ci/lib/resource_ceilings.py"
+done
 
 stale_semver=$'Source of truth: workflow env WAVE0_SEMVER_BASELINE_SHA.\n'
 expect_red "pinned baseline SHA" "WAVE0_SEMVER_BASELINE_SHA" assert_wave0_semver_doc "$stale_semver"

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -41,10 +41,11 @@ ISSUE_LINK = re.compile(
     r"\[issue #(\d+)\]\((https://github\.com/[^)\s]+/issues/(\d+))\)"
 )
 VISIBLE_ISSUE = re.compile(r"(?i)issue #(\d+)")
-# Optional list marker and strong prefix before a declaration-shaped start.
-DECL_PREFIX = r"(?:^|[.!?]\s+)(?:-\s+)?(?:\*{1,2})?"
+# Unordered marker [-*+] and strong prefix are independent.
+DECL_PREFIX = r"(?:^|[.!?]\s+)(?:[-*+]\s+)?(?:\*{1,2})?"
+# Declaration predicates only: "is issue #N" or "is named ...", not any "is ...".
 OUTSIDE_ACTIVE_DECL = re.compile(
-    rf"(?im){DECL_PREFIX}The active programme ledger is\b"
+    rf"(?im){DECL_PREFIX}The active programme ledger is(?: issue #\d+| named\b)"
 )
 OUTSIDE_INACTIVE_DECL = re.compile(
     rf"(?im){DECL_PREFIX}No programme is active\."
@@ -344,33 +345,6 @@ assert_wave71_not_active() {
   return 0
 }
 
-assert_selfhost_temp_contract() {
-  PROGRAMME_TRUTH_SCRIPT="${BASH_SOURCE[0]}" python3 - <<'PY'
-import os
-import re
-from pathlib import Path
-
-text = Path(os.environ["PROGRAMME_TRUTH_SCRIPT"]).read_text(encoding="utf-8")
-marker = 'if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then'
-idx = text.rfind(marker)
-if idx < 0:
-    raise SystemExit("missing selfhost runner")
-block = text[idx:]
-if block.count("mktemp -d") != 1:
-    raise SystemExit(
-        "selfhost runner must allocate exactly one temp directory"
-    )
-if re.search(r"\$\(mktemp\)(?! -d)", block):
-    raise SystemExit("selfhost still allocates a second mktemp file")
-alloc_at = block.find("mktemp -d")
-trap_m = re.search(r"trap\b[^\n]*\bEXIT\b", block[alloc_at:])
-if trap_m is None:
-    raise SystemExit("selfhost does not register an EXIT trap after allocation")
-if "${selfhost_dir:?}" not in block:
-    raise SystemExit("selfhost cleanup must refuse an empty directory via :?")
-PY
-}
-
 expect_ok() {
   local label="$1"
   shift
@@ -437,6 +411,23 @@ expect_red "list-item inactive declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
   assert_agents_ledger "$list_inactive_elsewhere"
 
+star_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '* The active programme ledger is issue #7777.')"
+expect_red "star list-item active ledger declaration elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$star_active_elsewhere"
+
+plus_inactive_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '+ **No programme is active.**')"
+expect_red "plus list-item inactive declaration elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$plus_inactive_elsewhere"
+
+documented_ledger_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '- **The active programme ledger is documented in the canonical bullet above.**')"
+expect_ok "documented-in-bullet prose is not a ledger declaration" \
+  assert_agents_ledger "$documented_ledger_prose"
+
 ACTIVE_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4242).'
 active_ledger="$(replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
 expect_ok "structurally active ledger fixture" assert_agents_ledger "$active_ledger"
@@ -499,8 +490,6 @@ expect_red "restored single-boundary TODO" "single-boundary Wave 3 TODO" \
   assert_no_generic_unsafe_preview "" "unsafe allowed only in the monitor syscall boundary module."
 expect_red "deleted-monitor.rs claim" "must not claim monitor.rs was deleted" \
   assert_no_generic_unsafe_preview "monitor.rs was deleted" ""
-
-expect_ok "selfhost uses one tempdir and an EXIT trap" assert_selfhost_temp_contract
 
 if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then
   cleanup_selfhost() { rm -rf -- "${selfhost_dir:?}"; }

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 _TRUTH_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource_ceilings.py"
 python3 "$_TRUTH_LIB" reject-overrides
+python3 "$_TRUTH_LIB" assert-reject-caller "${BASH_SOURCE[0]}"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 if [[ -e "$ROOT/.git" && -e "$ROOT/.programme-truth-hermetic" ]]; then
@@ -23,6 +24,7 @@ if [[ -e "$ROOT/.git" && -e "$ROOT/.programme-truth-hermetic" ]]; then
 fi
 CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
 export PYTHONPATH="$ROOT/scripts/ci/lib${PYTHONPATH:+:$PYTHONPATH}"
+python3 "$CEILINGS" assert-reject-caller "$ROOT/scripts/ci/test-review-split-wave.sh"
 AGENTS="$ROOT/AGENTS.md"
 WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
 STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
@@ -47,6 +49,7 @@ HERMETIC_TRUTH_FILES="$(printf '%s\n' \
   .pre-commit-config.yaml \
   scripts/ci/lib/resource_ceilings.py \
   scripts/ci/test-ci-programme-truth.sh \
+  scripts/ci/test-review-split-wave.sh \
   crates/assay-cli/src/cli/commands/monitor.rs)"
 
 install_hermetic_programme_truth() {
@@ -502,6 +505,15 @@ match = re.search(
 )
 if match is None:
     raise SystemExit("ci-programme-truth files regex is missing")
+entry = re.search(
+    r"- id: ci-programme-truth\n(?:.*\n)*?        entry: (.+)\n",
+    text,
+)
+if entry is None:
+    raise SystemExit("ci-programme-truth hook entry is missing")
+hook = entry.group(1)
+if "test-ci-programme-truth.sh" not in hook or "test-review-split-wave.sh" not in hook:
+    raise SystemExit("ci-programme-truth hook does not run both focused suites")
 raw = match.group(1).strip()
 if raw[0] in "'\"" and raw[-1] == raw[0]:
     raw = raw[1:-1]
@@ -632,8 +644,6 @@ if root_override in text:
     raise SystemExit("PROGRAMME_TRUTH_ROOT is still a caller override")
 if agents_override in text:
     raise SystemExit("PROGRAMME_TRUTH_AGENTS is still a caller override")
-if "reject-overrides" not in text:
-    raise SystemExit("script does not invoke reject-overrides")
 inline_reject = "if [[ -n \"${" + "PROGRAMME_TRUTH_AGENTS+x}\" ]]"
 if inline_reject in text:
     raise SystemExit("script still inlines programme override rejects")
@@ -686,6 +696,17 @@ expect_red "PROGRAMME_TRUTH_ROOT empty override" \
 expect_red "PROGRAMME_TRUTH_ROOT nonexistent tree" \
   "PROGRAMME_TRUTH_ROOT cannot replace the script worktree" \
   env PROGRAMME_TRUTH_ROOT=/no/such/programme-truth-root bash "${BASH_SOURCE[0]}"
+
+for suite in \
+  "${BASH_SOURCE[0]}" \
+  "$ROOT/scripts/ci/test-review-split-wave.sh"
+do
+  dest="$TRUTH_TMP/no-reject-caller-$(basename -- "$suite")"
+  python3 "$CEILINGS" drop-reject-caller "$suite" "$dest"
+  expect_red "deleted reject-overrides caller in $(basename -- "$suite")" \
+    "reject-overrides caller count is 0, want 1" \
+    python3 "$CEILINGS" assert-reject-caller "$dest"
+done
 
 for override_name in "${FORBIDDEN_SPEC[@]}"; do
   install_hermetic_programme_truth "$TRUTH_TMP/drop-${override_name}"

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -260,38 +260,25 @@ assert_wave0_required_contexts() {
 }
 
 assert_wave0_semver_file() {
-  local path="$1"
-  python3 "$CEILINGS" check-file "$path" || return 1
-  if grep -q 'WAVE0_SEMVER_BASELINE_SHA' "$path"; then
-    echo "WAVE0-GATES.md still documents WAVE0_SEMVER_BASELINE_SHA"
-    return 1
-  fi
-  if ! grep -Eqi 'newest|latest' "$path" || ! grep -Eq 'release tag' "$path"; then
-    echo "WAVE0-GATES.md does not describe the dynamic latest-release baseline"
-    return 1
-  fi
-  if ! grep -q 'test-semver-gate.sh' "$path"; then
-    echo "WAVE0-GATES.md does not point at scripts/ci/test-semver-gate.sh"
-    return 1
-  fi
-  return 0
+  python3 - "$1" <<'PY'
+import sys
+
+from resource_ceilings import read_bounded_file
+
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
+if "WAVE0_SEMVER_BASELINE_SHA" in text:
+    raise SystemExit("WAVE0-GATES.md still documents WAVE0_SEMVER_BASELINE_SHA")
+lower = text.lower()
+if ("newest" not in lower and "latest" not in lower) or "release tag" not in text:
+    raise SystemExit("WAVE0-GATES.md does not describe the dynamic latest-release baseline")
+if "test-semver-gate.sh" not in text:
+    raise SystemExit("WAVE0-GATES.md does not point at scripts/ci/test-semver-gate.sh")
+PY
 }
 
 assert_wave0_semver_doc() {
-  local text="$1"
-  if grep -q 'WAVE0_SEMVER_BASELINE_SHA' <<<"$text"; then
-    echo "WAVE0-GATES.md still documents WAVE0_SEMVER_BASELINE_SHA"
-    return 1
-  fi
-  if ! grep -Eqi 'newest|latest' <<<"$text" || ! grep -Eq 'release tag' <<<"$text"; then
-    echo "WAVE0-GATES.md does not describe the dynamic latest-release baseline"
-    return 1
-  fi
-  if ! grep -q 'test-semver-gate.sh' <<<"$text"; then
-    echo "WAVE0-GATES.md does not point at scripts/ci/test-semver-gate.sh"
-    return 1
-  fi
-  return 0
+  printf '%s' "$1" >"$TRUTH_TMP/wave0-semver-fixture.md"
+  assert_wave0_semver_file "$TRUTH_TMP/wave0-semver-fixture.md"
 }
 
 insert_before_next_heading() {
@@ -496,30 +483,59 @@ PY
 }
 
 assert_wave71_file() {
-  local path="$1"
-  python3 "$CEILINGS" check-file "$path" || return 1
-  local row
-  row="$(grep -E '^\| Wave71 \|' "$path" || true)"
-  assert_wave71_not_active "$row"
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+from resource_ceilings import read_bounded_file
+
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
+rows = [line for line in text.splitlines() if re.match(r"^\| Wave71 \|", line)]
+if not rows:
+    raise SystemExit("REFACTOR-WAVE-STATUS.md has no Wave71 row")
+row = rows[0]
+if "| Active |" in row:
+    raise SystemExit("Wave71 row still claims Active without a current execution ledger")
+if re.search(r"Dormant|Incomplete", row, re.I) is None:
+    raise SystemExit("Wave71 row is not marked Dormant or Incomplete")
+PY
 }
 
 assert_wave71_not_active() {
-  local text="$1"
-  local row
-  row="$(printf '%s\n' "$text" | grep -E '^\| Wave71 \|' || true)"
-  if [[ -z "$row" ]]; then
-    echo "REFACTOR-WAVE-STATUS.md has no Wave71 row"
-    return 1
-  fi
-  if grep -Fq '| Active |' <<<"$row"; then
-    echo "Wave71 row still claims Active without a current execution ledger"
-    return 1
-  fi
-  if ! grep -Eqi 'Dormant|Incomplete' <<<"$row"; then
-    echo "Wave71 row is not marked Dormant or Incomplete"
-    return 1
-  fi
-  return 0
+  printf '%s' "$1" >"$TRUTH_TMP/wave71-fixture.md"
+  assert_wave71_file "$TRUTH_TMP/wave71-fixture.md"
+}
+
+assert_hostile_path_fails_quickly() {
+  local path="$1"
+  shift
+  PROGRAMME_TRUTH_HOSTILE_PATH="$path" PROGRAMME_TRUTH_HOSTILE_NEEDLES="$*" python3 - <<'PY'
+import os
+import signal
+
+from resource_ceilings import read_bounded_file
+
+needles = [item for item in os.environ["PROGRAMME_TRUTH_HOSTILE_NEEDLES"].split("\n") if item]
+path = os.environ["PROGRAMME_TRUTH_HOSTILE_PATH"]
+
+
+def _timeout(_signum, _frame):
+    raise SystemExit("bounded open hung")
+
+
+signal.signal(signal.SIGALRM, _timeout)
+signal.alarm(2)
+try:
+    read_bounded_file(path)
+    raise SystemExit("hostile path left the reader green")
+except SystemExit as exc:
+    signal.alarm(0)
+    msg = str(exc)
+    if msg in {"bounded open hung", "hostile path left the reader green"}:
+        raise
+    if not any(needle in msg for needle in needles):
+        raise SystemExit(f"hostile path red without {needles}: {msg}") from exc
+PY
 }
 
 expect_ok() {
@@ -749,6 +765,22 @@ expect_ok "appended NUL still validates the ledger" assert_agents_ledger "$TRUTH
 
 expect_red "non-regular programme-truth input" "not a regular file" \
   python3 "$CEILINGS" check-file /dev/null
+expect_ok "open flags refuse follow and do not block" python3 - "$CEILINGS" <<'PY'
+import sys
+
+from resource_ceilings import read_bounded_file
+
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
+if "O_NOFOLLOW" not in text or "O_NONBLOCK" not in text:
+    raise SystemExit("bounded open is missing O_NOFOLLOW or O_NONBLOCK")
+PY
+
+mkfifo "$TRUTH_TMP/fifo"
+ln -s "$AGENTS" "$TRUTH_TMP/agents.link"
+expect_ok "FIFO fails closed without hanging" \
+  assert_hostile_path_fails_quickly "$TRUTH_TMP/fifo" $'not a regular file\ncould not be opened'
+expect_ok "symlink fails closed without following" \
+  assert_hostile_path_fails_quickly "$TRUTH_TMP/agents.link" "could not be opened"
 
 python3 -c "import sys; sys.stdout.buffer.write(b'x' * 65537)" >"$TRUTH_TMP/oversized.md"
 expect_red "oversized real document" "exceeds 65536-byte ceiling" \

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -13,10 +13,35 @@
 # would break a later legitimate boundary split.
 set -euo pipefail
 
-ROOT="${PROGRAMME_TRUTH_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+if [[ -n "${PROGRAMME_TRUTH_ROOT+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_ROOT cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_AGENTS+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_AGENTS cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_SELFHOST+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_SELFHOST cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_CEILING_CHILD+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_CEILING_CHILD cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_PREVIEW_MUTANT+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_PREVIEW_MUTANT cannot replace the script worktree" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [[ -e "$ROOT/.git" && -e "$ROOT/.programme-truth-hermetic" ]]; then
+  echo "FAIL: hermetic marker must not exist in the script worktree" >&2
+  exit 1
+fi
 CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
 export PYTHONPATH="$ROOT/scripts/ci/lib${PYTHONPATH:+:$PYTHONPATH}"
-AGENTS="${PROGRAMME_TRUTH_AGENTS:-$ROOT/AGENTS.md}"
+AGENTS="$ROOT/AGENTS.md"
 WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
 STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
 WORKFLOW="$ROOT/.github/workflows/split-wave0-gates.yml"
@@ -30,6 +55,50 @@ ok()  { echo "ok    $1"; }
 bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
 
 LEDGER_PREFIX='- The public execution ledger'
+
+HERMETIC_TRUTH_FILES="$(printf '%s\n' \
+  AGENTS.md \
+  docs/contributing/WAVE0-GATES.md \
+  docs/contributing/REFACTOR-WAVE-STATUS.md \
+  .github/workflows/split-wave0-gates.yml \
+  .github/workflows/kernel-matrix.yml \
+  .pre-commit-config.yaml \
+  scripts/ci/lib/resource_ceilings.py \
+  scripts/ci/test-ci-programme-truth.sh \
+  crates/assay-cli/src/cli/commands/monitor.rs)"
+
+install_hermetic_programme_truth() {
+  local dest="$1"
+  PROGRAMME_TRUTH_HERMETIC_FILES="$HERMETIC_TRUTH_FILES" \
+  python3 - "$ROOT" "$dest" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+src_root = Path(sys.argv[1])
+dest_root = Path(sys.argv[2])
+for rel in os.environ["PROGRAMME_TRUTH_HERMETIC_FILES"].splitlines():
+    if not rel:
+        continue
+    data = read_bounded_file(str(src_root / rel))
+    require_bounded_bytes(data, rel)
+    dest = dest_root / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+PY
+  printf 'hermetic\n' >"$dest/.programme-truth-hermetic"
+}
+
+run_hermetic_programme_truth() {
+  env -u PROGRAMME_TRUTH_ROOT \
+    -u PROGRAMME_TRUTH_AGENTS \
+    -u PROGRAMME_TRUTH_SELFHOST \
+    -u PROGRAMME_TRUTH_CEILING_CHILD \
+    -u PROGRAMME_TRUTH_PREVIEW_MUTANT \
+    bash "$1"
+}
 
 assert_extracted_block() {
   local kind="$1" expected="$2" path="$3"
@@ -563,6 +632,52 @@ expect_ok "kernel-matrix.yml pull_request.paths owns programme-truth inputs" \
 expect_ok "pre-push files regex covers resource_ceilings.py" \
   assert_prepush_covers_ceilings "$PRECOMMIT"
 
+assert_root_is_script_worktree() {
+  python3 - "$1" <<'PY'
+import sys
+
+from resource_ceilings import read_bounded_file
+
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
+root_override = "ROOT=\"${" + "PROGRAMME_TRUTH_ROOT:-"
+agents_override = "AGENTS=\"${" + "PROGRAMME_TRUTH_AGENTS:-"
+if root_override in text:
+    raise SystemExit("PROGRAMME_TRUTH_ROOT is still a caller override")
+if agents_override in text:
+    raise SystemExit("PROGRAMME_TRUTH_AGENTS is still a caller override")
+if 'ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"' not in text:
+    raise SystemExit("ROOT is not derived from BASH_SOURCE")
+if 'AGENTS="$ROOT/AGENTS.md"' not in text:
+    raise SystemExit("AGENTS is not the worktree AGENTS.md")
+if '[[ ! -e "$ROOT/.programme-truth-hermetic" ]]' not in text:
+    raise SystemExit("recursion guard is not a hermetic layout marker")
+for flag in ("SELFHOST", "CEILING_CHILD", "PREVIEW_MUTANT"):
+    if "${PROGRAMME_TRUTH_" + flag + ":-" in text:
+        raise SystemExit("child flags are still a caller-controlled skip lock")
+PY
+}
+expect_ok "ROOT is the script worktree and not caller-overridable" \
+  assert_root_is_script_worktree "${BASH_SOURCE[0]}"
+
+expect_red "PROGRAMME_TRUTH_ROOT empty override" \
+  "PROGRAMME_TRUTH_ROOT cannot replace the script worktree" \
+  env PROGRAMME_TRUTH_ROOT= bash "${BASH_SOURCE[0]}"
+expect_red "PROGRAMME_TRUTH_ROOT nonexistent tree" \
+  "PROGRAMME_TRUTH_ROOT cannot replace the script worktree" \
+  env PROGRAMME_TRUTH_ROOT=/no/such/programme-truth-root bash "${BASH_SOURCE[0]}"
+expect_red "PROGRAMME_TRUTH_AGENTS override" \
+  "PROGRAMME_TRUTH_AGENTS cannot replace the script worktree" \
+  env PROGRAMME_TRUTH_AGENTS="$ROOT/AGENTS.md" bash "${BASH_SOURCE[0]}"
+expect_red "PROGRAMME_TRUTH_PREVIEW_MUTANT override" \
+  "PROGRAMME_TRUTH_PREVIEW_MUTANT cannot replace the script worktree" \
+  env PROGRAMME_TRUTH_PREVIEW_MUTANT=1 bash "${BASH_SOURCE[0]}"
+expect_red "combined AGENTS+SELFHOST+CEILING_CHILD bypass" \
+  "cannot replace the script worktree" \
+  env PROGRAMME_TRUTH_AGENTS="$ROOT/AGENTS.md" \
+  PROGRAMME_TRUTH_SELFHOST=1 \
+  PROGRAMME_TRUTH_CEILING_CHILD=1 \
+  bash "${BASH_SOURCE[0]}"
+
 stale_semver=$'Source of truth: workflow env WAVE0_SEMVER_BASELINE_SHA.\n'
 expect_red "pinned baseline SHA" "WAVE0_SEMVER_BASELINE_SHA" assert_wave0_semver_doc "$stale_semver"
 
@@ -774,21 +889,25 @@ expect_red "oversized real document" "exceeds 65536-byte ceiling" \
 expect_red "oversized document never reaches a ledger consumer" "exceeds 65536-byte ceiling" \
   assert_agents_ledger "$TRUTH_TMP/oversized.md"
 
-if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" && -z "${PROGRAMME_TRUTH_CEILING_CHILD:-}" && -z "${PROGRAMME_TRUTH_PREVIEW_MUTANT:-}" ]]; then
-  active_agents="$TRUTH_TMP/selfhost-agents.md"
+if [[ ! -e "$ROOT/.programme-truth-hermetic" ]]; then
+  install_hermetic_programme_truth "$TRUTH_TMP/selfhost-layout"
+  replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$ROOT/AGENTS.md" \
+    "$TRUTH_TMP/selfhost-layout/AGENTS.md"
   selfhost_log="$TRUTH_TMP/selfhost.log"
-  replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$ROOT/AGENTS.md" "$active_agents"
-  if PROGRAMME_TRUTH_AGENTS="$active_agents" PROGRAMME_TRUTH_SELFHOST=1 \
-    bash "${BASH_SOURCE[0]}" >"$selfhost_log" 2>&1; then
+  if run_hermetic_programme_truth \
+    "$TRUTH_TMP/selfhost-layout/scripts/ci/test-ci-programme-truth.sh" \
+    >"$selfhost_log" 2>&1; then
     ok "full contract on active canonical AGENTS ledger"
   else
     bad "full contract on active canonical AGENTS ledger: $(tail -n 20 "$selfhost_log")"
   fi
 
+  install_hermetic_programme_truth "$TRUTH_TMP/oversize-layout"
+  python3 -c "import sys; sys.stdout.buffer.write(b'x' * 65537)" \
+    >"$TRUTH_TMP/oversize-layout/AGENTS.md"
   if child_out="$(
-    PROGRAMME_TRUTH_AGENTS="$TRUTH_TMP/oversized.md" \
-    PROGRAMME_TRUTH_CEILING_CHILD=1 \
-    bash "${BASH_SOURCE[0]}" 2>&1
+    run_hermetic_programme_truth \
+      "$TRUTH_TMP/oversize-layout/scripts/ci/test-ci-programme-truth.sh" 2>&1
   )"; then
     bad "oversized AGENTS left the suite green"
   elif grep -Fq 'monitor.rs still exists' <<<"$child_out"; then
@@ -799,13 +918,15 @@ if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" && -z "${PROGRAMME_TRUTH_CEILING_CHILD:
     bad "oversized AGENTS red without ceiling: $child_out"
   fi
 
-  python3 - "${BASH_SOURCE[0]}" "$TRUTH_TMP/truth-neutralized.sh" <<'PY'
+  install_hermetic_programme_truth "$TRUTH_TMP/neutralized-layout"
+  python3 - "$TRUTH_TMP/neutralized-layout/scripts/ci/test-ci-programme-truth.sh" <<'PY'
 import sys
 from pathlib import Path
 
 from resource_ceilings import read_bounded_file, require_bounded_bytes
 
-src = read_bounded_file(sys.argv[1]).decode("utf-8")
+path = Path(sys.argv[1])
+src = read_bounded_file(str(path)).decode("utf-8")
 start = src.find("# Shared unsafe-preview checker (one implementation).")
 if start < 0:
     raise SystemExit("shared unsafe-preview checker marker missing")
@@ -818,20 +939,49 @@ out = (
     + src[end:]
 )
 require_bounded_bytes(out.encode("utf-8"), "neutralized preview checker")
-Path(sys.argv[2]).write_text(out, encoding="utf-8")
+path.write_text(out, encoding="utf-8")
 PY
   if mutant_out="$(
-    PROGRAMME_TRUTH_ROOT="$ROOT" \
-    PROGRAMME_TRUTH_PREVIEW_MUTANT=1 \
-    PROGRAMME_TRUTH_SELFHOST=1 \
-    PROGRAMME_TRUTH_CEILING_CHILD=1 \
-    bash "$TRUTH_TMP/truth-neutralized.sh" 2>&1
+    run_hermetic_programme_truth \
+      "$TRUTH_TMP/neutralized-layout/scripts/ci/test-ci-programme-truth.sh" 2>&1
   )"; then
     bad "neutralized preview checker left the suite green"
   elif grep -Fq 'restored generic preview left the contract green' <<<"$mutant_out"; then
     ok "neutralized preview checker turns the suite red"
   else
     bad "neutralized preview checker red without fixture miss: $mutant_out"
+  fi
+
+  install_hermetic_programme_truth "$TRUTH_TMP/dirty-preview-layout"
+  install_hermetic_programme_truth "$TRUTH_TMP/clean-preview-layout"
+  python3 - "$TRUTH_TMP/dirty-preview-layout/.github/workflows/split-wave0-gates.yml" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+path = Path(sys.argv[1])
+data = read_bounded_file(str(path)) + b"\n      - name: Unsafe boundary preview (warn-only)\n"
+require_bounded_bytes(data, "dirty preview workflow")
+path.write_bytes(data)
+PY
+  dirty_script="$TRUTH_TMP/dirty-preview-layout/scripts/ci/test-ci-programme-truth.sh"
+  if dirty_out="$(run_hermetic_programme_truth "$dirty_script" 2>&1)"; then
+    bad "planted unsafe preview left the hermetic suite green"
+  elif grep -Fq 'generic warn-only unsafe preview' <<<"$dirty_out"; then
+    ok "planted unsafe preview turns the hermetic suite red"
+  else
+    bad "planted unsafe preview red without preview miss: $dirty_out"
+  fi
+  if override_out="$(
+    PROGRAMME_TRUTH_ROOT="$TRUTH_TMP/clean-preview-layout" \
+    bash "$dirty_script" 2>&1
+  )"; then
+    bad "stale preview plus PROGRAMME_TRUTH_ROOT to a clean tree left the suite green"
+  elif grep -Fq 'PROGRAMME_TRUTH_ROOT cannot replace the script worktree' <<<"$override_out"; then
+    ok "stale preview cannot hide behind PROGRAMME_TRUTH_ROOT"
+  else
+    bad "stale preview plus clean-tree root red without refuse: $override_out"
   fi
 fi
 

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -41,15 +41,23 @@ ISSUE_LINK = re.compile(
     r"\[issue #(\d+)\]\((https://github\.com/[^)\s]+/issues/(\d+))\)"
 )
 VISIBLE_ISSUE = re.compile(r"(?i)issue #(\d+)")
-# Unordered marker [-*+] and strong prefix are independent.
-DECL_PREFIX = r"(?:^|[.!?]\s+)(?:[-*+]\s+)?(?:\*{1,2})?"
-# Declaration predicates only: "is issue #N" or "is named ...", not any "is ...".
-OUTSIDE_ACTIVE_DECL = re.compile(
-    rf"(?im){DECL_PREFIX}The active programme ledger is(?: issue #\d+| named\b)"
-)
-OUTSIDE_INACTIVE_DECL = re.compile(
-    rf"(?im){DECL_PREFIX}No programme is active\."
-)
+# Outside the canonical ledger bullet we recognize only checkable
+# declaration forms. This is not semantic NLP.
+#
+# At line or sentence start, strip: leading whitespace, repeated `>`,
+# one unordered marker [-*+], then an optional strong prefix.
+# Active subject (exact): "The active programme ledger is"
+# Active predicates (only):
+#   a) issue #N
+#   b) GitHub issue #N
+#   c) [issue #N](.../issues/N) with matching N
+#   d) named on this line
+# Inactive (exact): "No programme is active."
+ACTIVE_SUBJECT = "The active programme ledger is"
+INACTIVE_OUTSIDE = "No programme is active."
+ISSUE_PRED = re.compile(r"issue #\d+")
+GITHUB_ISSUE_PRED = re.compile(r"GitHub issue #\d+")
+NAMED_PRED = "named on this line"
 # List-item declarations only. Ordinary prose such as "ensure required checks
 # pass" is not a required-context declaration.
 REQUIRED_OUTSIDE = re.compile(
@@ -110,12 +118,50 @@ def collapsed(text: str) -> str:
     return re.sub(r"\s+", " ", text)
 
 
+def strip_decl_wrappers(text: str) -> str:
+    s = text.lstrip()
+    while s.startswith(">"):
+        s = s[1:].lstrip()
+    if len(s) >= 2 and s[0] in "-*+" and s[1].isspace():
+        s = s[2:].lstrip()
+    if s.startswith("**"):
+        s = s[2:]
+    return s
+
+
+def declaration_candidates(remainder: str) -> list[str]:
+    found: list[str] = []
+    for line in remainder.splitlines():
+        for piece in re.split(r"(?<=[.!?])\s+", line):
+            stripped = strip_decl_wrappers(piece)
+            if stripped:
+                found.append(stripped)
+    return found
+
+
+def is_active_declaration(text: str) -> bool:
+    if not text.startswith(ACTIVE_SUBJECT):
+        return False
+    pred = text[len(ACTIVE_SUBJECT) :].lstrip()
+    if ISSUE_PRED.match(pred) or GITHUB_ISSUE_PRED.match(pred):
+        return True
+    link = ISSUE_LINK.match(pred)
+    if link is not None and link.group(1) == link.group(3):
+        return True
+    return pred.startswith(NAMED_PRED)
+
+
+def is_inactive_declaration(text: str) -> bool:
+    return text.startswith(INACTIVE_OUTSIDE)
+
+
 def outside_ledger_declarations(remainder: str) -> list[str]:
     found: list[str] = []
-    if OUTSIDE_ACTIVE_DECL.search(remainder):
-        found.append("The active programme ledger is")
-    if OUTSIDE_INACTIVE_DECL.search(remainder):
-        found.append("No programme is active")
+    for candidate in declaration_candidates(remainder):
+        if is_active_declaration(candidate):
+            found.append("The active programme ledger is")
+        if is_inactive_declaration(candidate):
+            found.append("No programme is active")
     return found
 
 
@@ -427,6 +473,29 @@ documented_ledger_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
   '- **The active programme ledger is documented in the canonical bullet above.**')"
 expect_ok "documented-in-bullet prose is not a ledger declaration" \
   assert_agents_ledger "$documented_ledger_prose"
+
+link_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '- The active programme ledger is [issue #7777](https://github.com/Rul1an/assay/issues/7777).')"
+expect_red "markdown-link active ledger declaration elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$link_active_elsewhere"
+
+github_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  'The active programme ledger is GitHub issue #7777.')"
+expect_red "GitHub issue active ledger declaration elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$github_active_elsewhere"
+
+blockquote_inactive_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '> **No programme is active.**')"
+expect_red "blockquote inactive declaration elsewhere" \
+  "contradictory ledger declaration outside the ledger bullet" \
+  assert_agents_ledger "$blockquote_inactive_elsewhere"
+
+named_after_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
+  '- The active programme ledger is named after the team that maintains it.')"
+expect_ok "named-after prose is not a ledger declaration" \
+  assert_agents_ledger "$named_after_prose"
 
 ACTIVE_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4242).'
 active_ledger="$(replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -15,12 +15,15 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
+export PYTHONPATH="$ROOT/scripts/ci/lib${PYTHONPATH:+:$PYTHONPATH}"
 AGENTS="${PROGRAMME_TRUTH_AGENTS:-$ROOT/AGENTS.md}"
 WAVE0="$ROOT/docs/contributing/WAVE0-GATES.md"
 STATUS="$ROOT/docs/contributing/REFACTOR-WAVE-STATUS.md"
 WORKFLOW="$ROOT/.github/workflows/split-wave0-gates.yml"
 KERNEL_MATRIX="$ROOT/.github/workflows/kernel-matrix.yml"
 MONITOR="$ROOT/crates/assay-cli/src/cli/commands/monitor.rs"
+TRUTH_TMP="$(mktemp -d)"
+trap 'rm -rf -- "${TRUTH_TMP:?}"' EXIT
 
 FAILURES=0
 ok()  { echo "ok    $1"; }
@@ -28,23 +31,17 @@ bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
 
 LEDGER_PREFIX='- The public execution ledger'
 
-require_truth_file() {
-  python3 "$CEILINGS" check-file "$1"
-}
-
-require_truth_text() {
-  printf '%s' "$1" | python3 "$CEILINGS" check-stdin "${2:-programme-truth document}"
-}
-
 assert_extracted_block() {
-  local kind="$1" expected="$2" text="$3"
-  require_truth_text "$text" "programme-truth document" || return 1
+  local kind="$1" expected="$2" path="$3"
   PROGRAMME_TRUTH_KIND="$kind" \
   PROGRAMME_TRUTH_EXPECTED="$expected" \
   PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" \
-  python3 - <<'PY' 3< <(printf '%s' "$text")
+  PROGRAMME_TRUTH_DOC_PATH="$path" \
+  python3 - <<'PY'
 import os
 import re
+
+from resource_ceilings import read_bounded_file
 
 INACTIVE_DECL = "**No programme is active.**"
 ISSUE_LINK = re.compile(
@@ -232,7 +229,7 @@ def validate_required(text: str, expected: str) -> None:
 
 
 kind = os.environ["PROGRAMME_TRUTH_KIND"]
-text = os.fdopen(3).read()
+text = read_bounded_file(os.environ["PROGRAMME_TRUTH_DOC_PATH"]).decode("utf-8")
 if kind == "ledger":
     validate_ledger(text, os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"])
 else:
@@ -262,6 +259,24 @@ assert_wave0_required_contexts() {
   assert_extracted_block required "$EXPECTED_REQUIRED_CHECKS" "$1"
 }
 
+assert_wave0_semver_file() {
+  local path="$1"
+  python3 "$CEILINGS" check-file "$path" || return 1
+  if grep -q 'WAVE0_SEMVER_BASELINE_SHA' "$path"; then
+    echo "WAVE0-GATES.md still documents WAVE0_SEMVER_BASELINE_SHA"
+    return 1
+  fi
+  if ! grep -Eqi 'newest|latest' "$path" || ! grep -Eq 'release tag' "$path"; then
+    echo "WAVE0-GATES.md does not describe the dynamic latest-release baseline"
+    return 1
+  fi
+  if ! grep -q 'test-semver-gate.sh' "$path"; then
+    echo "WAVE0-GATES.md does not point at scripts/ci/test-semver-gate.sh"
+    return 1
+  fi
+  return 0
+}
+
 assert_wave0_semver_doc() {
   local text="$1"
   if grep -q 'WAVE0_SEMVER_BASELINE_SHA' <<<"$text"; then
@@ -280,38 +295,46 @@ assert_wave0_semver_doc() {
 }
 
 insert_before_next_heading() {
-  local heading="$1" extra="$2" text="$3"
-  require_truth_text "$text" "programme-truth mutation input" || return 1
+  local heading="$1" extra="$2" src="$3" dest="$4"
   PROGRAMME_TRUTH_HEADING="$heading" PROGRAMME_TRUTH_EXTRA="$extra" \
-  python3 - <<'PY' 3< <(printf '%s' "$text")
+  python3 - "$src" "$dest" <<'PY'
 import os
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
 
 heading = os.environ["PROGRAMME_TRUTH_HEADING"]
 extra = os.environ["PROGRAMME_TRUTH_EXTRA"]
-text = os.fdopen(3).read()
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
 lines = text.splitlines(keepends=True)
 start = next((i for i, line in enumerate(lines) if line.strip() == heading), None)
 if start is None:
     raise SystemExit(f"missing {heading} section")
 end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
 lines.insert(end, extra if extra.endswith("\n") else extra + "\n")
-print("".join(lines), end="")
+data = "".join(lines).encode("utf-8")
+require_bounded_bytes(data, "programme-truth mutation output")
+Path(sys.argv[2]).write_bytes(data)
 PY
 }
 
 # Insert inside the ledger bullet, immediately before the next top-level "- ".
 insert_into_ledger_bullet() {
-  local extra="$1" text="$2"
-  require_truth_text "$text" "programme-truth mutation input" || return 1
+  local extra="$1" src="$2" dest="$3"
   PROGRAMME_TRUTH_MODE="${PROGRAMME_TRUTH_MODE:-insert}" \
   PROGRAMME_TRUTH_EXTRA="$extra" \
   PROGRAMME_TRUTH_LEDGER_PREFIX="$LEDGER_PREFIX" \
-  python3 - <<'PY' 3< <(printf '%s' "$text")
+  python3 - "$src" "$dest" <<'PY'
 import os
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
 
 prefix = os.environ["PROGRAMME_TRUTH_LEDGER_PREFIX"]
 extra = os.environ["PROGRAMME_TRUTH_EXTRA"]
-text = os.fdopen(3).read()
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
 lines = text.splitlines(keepends=True)
 start = next((i for i, line in enumerate(lines) if line.startswith(prefix)), None)
 if start is None:
@@ -329,12 +352,35 @@ if os.environ["PROGRAMME_TRUTH_MODE"] == "replace":
     lines[start:end] = [payload]
 else:
     lines.insert(end, payload)
-print("".join(lines), end="")
+data = "".join(lines).encode("utf-8")
+require_bounded_bytes(data, "programme-truth mutation output")
+Path(sys.argv[2]).write_bytes(data)
 PY
 }
 
 replace_ledger_bullet() {
-  PROGRAMME_TRUTH_MODE=replace insert_into_ledger_bullet "$1" "$2"
+  PROGRAMME_TRUTH_MODE=replace insert_into_ledger_bullet "$1" "$2" "$3"
+}
+
+append_doc_line() {
+  local extra="$1" src="$2" dest="$3"
+  PROGRAMME_TRUTH_EXTRA="$extra" python3 - "$src" "$dest" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+data = read_bounded_file(sys.argv[1])
+if data and not data.endswith(b"\n"):
+    data += b"\n"
+extra = os.environ["PROGRAMME_TRUTH_EXTRA"].encode("utf-8")
+if not extra.endswith(b"\n"):
+    extra += b"\n"
+out = data + extra
+require_bounded_bytes(out, "programme-truth mutation output")
+Path(sys.argv[2]).write_bytes(out)
+PY
 }
 
 # Docs/ruleset surfaces the hook reads that `scripts/**` does not cover.
@@ -345,13 +391,15 @@ TRUTH_TRIGGER_INPUTS="$(printf '%s\n' \
   .github/rulesets/main-required-ci-contexts.json)"
 
 assert_ci_trigger_owns_truth_inputs() {
-  local workflow_text="$1"
-  require_truth_text "$workflow_text" "kernel-matrix.yml" || return 1
+  local path="$1"
   PROGRAMME_TRUTH_INPUTS="$TRUTH_TRIGGER_INPUTS" \
-  python3 - <<'PY' 3< <(printf '%s' "$workflow_text")
+  PROGRAMME_TRUTH_DOC_PATH="$path" \
+  python3 - <<'PY'
 import os, re
 
-text = os.fdopen(3).read()
+from resource_ceilings import read_bounded_file
+
+text = read_bounded_file(os.environ["PROGRAMME_TRUTH_DOC_PATH"]).decode("utf-8")
 inputs = [line for line in os.environ["PROGRAMME_TRUTH_INPUTS"].splitlines() if line]
 block = re.search(r"(?ms)^  pull_request:\n((?:    .+\n|\n)*)", text)
 if not block:
@@ -394,6 +442,65 @@ assert_no_generic_unsafe_preview() {
     return 1
   fi
   return 0
+}
+
+assert_no_generic_unsafe_preview_files() {
+  local workflow_path="$1" docs_path="$2"
+  PROGRAMME_TRUTH_WORKFLOW="$workflow_path" PROGRAMME_TRUTH_DOCS="$docs_path" python3 - <<'PY'
+import os
+
+from resource_ceilings import read_bounded_file
+
+workflow = read_bounded_file(os.environ["PROGRAMME_TRUTH_WORKFLOW"]).decode("utf-8")
+docs = read_bounded_file(os.environ["PROGRAMME_TRUTH_DOCS"]).decode("utf-8")
+combined = workflow + docs
+if "deleted" in combined and "monitor.rs" in combined:
+    raise SystemExit("preview removal must not claim monitor.rs was deleted")
+if "Unsafe boundary preview" in workflow:
+    raise SystemExit("workflow still has the generic warn-only unsafe preview")
+if "unsafe allowed only in the monitor syscall boundary" in combined:
+    raise SystemExit("single-boundary Wave 3 TODO is still present")
+if "unsafe outside monitor.rs" in workflow:
+    raise SystemExit("workflow still treats paths outside monitor.rs as the deviation")
+PY
+}
+
+assert_prepush_covers_ceilings() {
+  local config="$1"
+  PROGRAMME_TRUTH_DOC_PATH="$config" python3 - <<'PY'
+import os
+import re
+
+from resource_ceilings import read_bounded_file
+
+text = read_bounded_file(os.environ["PROGRAMME_TRUTH_DOC_PATH"]).decode("utf-8")
+match = re.search(
+    r"- id: ci-programme-truth\n(?:.*\n)*?        files: (.+)\n",
+    text,
+)
+if match is None:
+    raise SystemExit("ci-programme-truth files regex is missing")
+raw = match.group(1).strip()
+if raw[0] in "'\"" and raw[-1] == raw[0]:
+    raw = raw[1:-1]
+helper = "scripts/ci/lib/resource_ceilings.py"
+token = r"scripts/ci/lib/resource_ceilings\.py"
+if token not in raw:
+    raise SystemExit("files regex does not name resource_ceilings.py")
+if re.search(raw, helper) is None:
+    raise SystemExit("files regex does not match resource_ceilings.py")
+stripped = raw.replace(f"|{token}", "").replace(f"{token}|", "")
+if re.search(stripped, helper) is not None:
+    raise SystemExit("stripped files regex still matches resource_ceilings.py")
+PY
+}
+
+assert_wave71_file() {
+  local path="$1"
+  python3 "$CEILINGS" check-file "$path" || return 1
+  local row
+  row="$(grep -E '^\| Wave71 \|' "$path" || true)"
+  assert_wave71_not_active "$row"
 }
 
 assert_wave71_not_active() {
@@ -439,150 +546,169 @@ expect_red() {
   fi
 }
 
+PRECOMMIT="$ROOT/.pre-commit-config.yaml"
+
 for truth_file in "$AGENTS" "$WAVE0" "$STATUS" "$WORKFLOW" "$KERNEL_MATRIX"; do
-  expect_ok "${truth_file#"$ROOT"/} is within the programme-truth byte ceiling" \
-    require_truth_file "$truth_file"
+  if ! python3 "$CEILINGS" check-file "$truth_file"; then
+    echo "FAIL: canonical programme-truth input exceeds ceiling: $truth_file" >&2
+    exit 1
+  fi
 done
 
 expect_ok "monitor.rs still exists" assert_monitor_rs_still_exists
 expect_ok "generic unsafe preview and single-boundary TODO are gone" \
-  assert_no_generic_unsafe_preview "$(<"$WORKFLOW")" "$(<"$WAVE0")"
-expect_ok "AGENTS.md ledger bullet is structurally valid" assert_agents_ledger "$(<"$AGENTS")"
-expect_ok "WAVE0-GATES.md describes dynamic latest-release baseline" assert_wave0_semver_doc "$(<"$WAVE0")"
+  assert_no_generic_unsafe_preview_files "$WORKFLOW" "$WAVE0"
+expect_ok "AGENTS.md ledger bullet is structurally valid" assert_agents_ledger "$AGENTS"
+expect_ok "WAVE0-GATES.md describes dynamic latest-release baseline" assert_wave0_semver_file "$WAVE0"
 expect_ok "WAVE0-GATES.md points at the canonical required-context contract" \
-  assert_wave0_required_contexts "$(<"$WAVE0")"
-expect_ok "Wave71 is dormant or incomplete" assert_wave71_not_active "$(<"$STATUS")"
+  assert_wave0_required_contexts "$WAVE0"
+expect_ok "Wave71 is dormant or incomplete" assert_wave71_file "$STATUS"
 expect_ok "kernel-matrix.yml pull_request.paths owns programme-truth inputs" \
-  assert_ci_trigger_owns_truth_inputs "$(<"$KERNEL_MATRIX")"
+  assert_ci_trigger_owns_truth_inputs "$KERNEL_MATRIX"
+expect_ok "pre-push files regex covers resource_ceilings.py" \
+  assert_prepush_covers_ceilings "$PRECOMMIT"
 
 stale_semver=$'Source of truth: workflow env WAVE0_SEMVER_BASELINE_SHA.\n'
 expect_red "pinned baseline SHA" "WAVE0_SEMVER_BASELINE_SHA" assert_wave0_semver_doc "$stale_semver"
 
-contradictory_ledger="$(insert_into_ledger_bullet \
+insert_into_ledger_bullet \
   'The active programme ledger is issue #9999.' \
-  "$(<"$AGENTS")")"
+  "$AGENTS" "$TRUTH_TMP/contradictory.md"
 expect_red "additive unlinked issue # in the ledger bullet" "unlinked issue #" \
-  assert_agents_ledger "$contradictory_ledger"
+  assert_agents_ledger "$TRUTH_TMP/contradictory.md"
 
-elsewhere_ledger="$(printf '%s\n%s\n' "$(<"$AGENTS")" 'The active programme ledger is issue #9999.')"
+append_doc_line 'The active programme ledger is issue #9999.' \
+  "$AGENTS" "$TRUTH_TMP/elsewhere.md"
 expect_red "active ledger declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$elsewhere_ledger"
+  assert_agents_ledger "$TRUTH_TMP/elsewhere.md"
 
-ordinary_ledger_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  'Reviewers should consult the public execution ledger before handoff.')"
+append_doc_line 'Reviewers should consult the public execution ledger before handoff.' \
+  "$AGENTS" "$TRUTH_TMP/ordinary-ledger.md"
 expect_ok "ordinary public-ledger prose outside the bullet" \
-  assert_agents_ledger "$ordinary_ledger_prose"
+  assert_agents_ledger "$TRUTH_TMP/ordinary-ledger.md"
 
-list_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '- The active programme ledger is issue #7777.')"
+append_doc_line '- The active programme ledger is issue #7777.' \
+  "$AGENTS" "$TRUTH_TMP/list-active.md"
 expect_red "list-item active ledger declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$list_active_elsewhere"
+  assert_agents_ledger "$TRUTH_TMP/list-active.md"
 
-list_inactive_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '- **No programme is active.**')"
+append_doc_line '- **No programme is active.**' \
+  "$AGENTS" "$TRUTH_TMP/list-inactive.md"
 expect_red "list-item inactive declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$list_inactive_elsewhere"
+  assert_agents_ledger "$TRUTH_TMP/list-inactive.md"
 
-star_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '* The active programme ledger is issue #7777.')"
+append_doc_line '* The active programme ledger is issue #7777.' \
+  "$AGENTS" "$TRUTH_TMP/star-active.md"
 expect_red "star list-item active ledger declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$star_active_elsewhere"
+  assert_agents_ledger "$TRUTH_TMP/star-active.md"
 
-plus_inactive_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '+ **No programme is active.**')"
+append_doc_line '+ **No programme is active.**' \
+  "$AGENTS" "$TRUTH_TMP/plus-inactive.md"
 expect_red "plus list-item inactive declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$plus_inactive_elsewhere"
+  assert_agents_ledger "$TRUTH_TMP/plus-inactive.md"
 
-documented_ledger_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '- **The active programme ledger is documented in the canonical bullet above.**')"
+append_doc_line '- **The active programme ledger is documented in the canonical bullet above.**' \
+  "$AGENTS" "$TRUTH_TMP/documented.md"
 expect_ok "documented-in-bullet prose is not a ledger declaration" \
-  assert_agents_ledger "$documented_ledger_prose"
+  assert_agents_ledger "$TRUTH_TMP/documented.md"
 
-link_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '- The active programme ledger is [issue #7777](https://github.com/Rul1an/assay/issues/7777).')"
+append_doc_line '- The active programme ledger is [issue #7777](https://github.com/Rul1an/assay/issues/7777).' \
+  "$AGENTS" "$TRUTH_TMP/link-active.md"
 expect_red "markdown-link active ledger declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$link_active_elsewhere"
+  assert_agents_ledger "$TRUTH_TMP/link-active.md"
 
-github_active_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  'The active programme ledger is GitHub issue #7777.')"
+append_doc_line 'The active programme ledger is GitHub issue #7777.' \
+  "$AGENTS" "$TRUTH_TMP/github-active.md"
 expect_red "GitHub issue active ledger declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$github_active_elsewhere"
+  assert_agents_ledger "$TRUTH_TMP/github-active.md"
 
-blockquote_inactive_elsewhere="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '> **No programme is active.**')"
+append_doc_line '> **No programme is active.**' \
+  "$AGENTS" "$TRUTH_TMP/blockquote.md"
 expect_red "blockquote inactive declaration elsewhere" \
   "contradictory ledger declaration outside the ledger bullet" \
-  assert_agents_ledger "$blockquote_inactive_elsewhere"
+  assert_agents_ledger "$TRUTH_TMP/blockquote.md"
 
-named_after_prose="$(printf '%s\n%s\n' "$(<"$AGENTS")" \
-  '- The active programme ledger is named after the team that maintains it.')"
+append_doc_line '- The active programme ledger is named after the team that maintains it.' \
+  "$AGENTS" "$TRUTH_TMP/named-after.md"
 expect_ok "named-after prose is not a ledger declaration" \
-  assert_agents_ledger "$named_after_prose"
+  assert_agents_ledger "$TRUTH_TMP/named-after.md"
 
 ACTIVE_LEDGER_BULLET='- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4242).'
-active_ledger="$(replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
-expect_ok "structurally active ledger fixture" assert_agents_ledger "$active_ledger"
+replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$AGENTS" "$TRUTH_TMP/active.md"
+expect_ok "structurally active ledger fixture" assert_agents_ledger "$TRUTH_TMP/active.md"
 
-retired_ledger="$(replace_ledger_bullet \
+replace_ledger_bullet \
   '- The public execution ledger historically recorded [issue #4242](https://github.com/Rul1an/assay/issues/4242).' \
-  "$(<"$AGENTS")")"
+  "$AGENTS" "$TRUTH_TMP/retired.md"
 expect_red "retired historical wording with a valid issue-link" "canonical active form" \
-  assert_agents_ledger "$retired_ledger"
+  assert_agents_ledger "$TRUTH_TMP/retired.md"
 
-mismatch_ledger="$(replace_ledger_bullet \
+replace_ledger_bullet \
   '- The public execution ledger for the active programme is named on this line: [issue #4242](https://github.com/Rul1an/assay/issues/4243).' \
-  "$(<"$AGENTS")")"
+  "$AGENTS" "$TRUTH_TMP/mismatch.md"
 expect_red "active fixture with text/link issue mismatch" "visible issue-ID != URL-ID" \
-  assert_agents_ledger "$mismatch_ledger"
+  assert_agents_ledger "$TRUTH_TMP/mismatch.md"
 
 # Synthetic inactive: previous-link mismatch without freezing a live issue number.
-inactive_mismatch="$(replace_ledger_bullet \
+replace_ledger_bullet \
   '- The public execution ledger for the active programme is named on this line. **No programme is active.** The previous one, [issue #4242](https://github.com/Rul1an/assay/issues/9999).' \
-  "$(<"$AGENTS")")"
+  "$AGENTS" "$TRUTH_TMP/inactive-mismatch.md"
 expect_red "inactive previous-link text/URL mismatch" "visible issue-ID != URL-ID" \
-  assert_agents_ledger "$inactive_mismatch"
+  assert_agents_ledger "$TRUTH_TMP/inactive-mismatch.md"
 
-linked_plus_plain="$(replace_ledger_bullet \
+replace_ledger_bullet \
   '- The public execution ledger for the active programme is named on this line: [issue #7777](https://github.com/Rul1an/assay/issues/7777). Also issue #7777.' \
-  "$(<"$AGENTS")")"
+  "$AGENTS" "$TRUTH_TMP/linked-plus-plain.md"
 expect_red "valid link plus extra plain issue # of the same ID" "unlinked issue #" \
-  assert_agents_ledger "$linked_plus_plain"
+  assert_agents_ledger "$TRUTH_TMP/linked-plus-plain.md"
 
-duplicate_ledger="$(insert_into_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$AGENTS")")"
+insert_into_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$AGENTS" "$TRUTH_TMP/duplicate.md"
 expect_red "duplicate ledger bullet" "duplicate ledger bullet" \
-  assert_agents_ledger "$duplicate_ledger"
+  assert_agents_ledger "$TRUTH_TMP/duplicate.md"
 
-stale_required="$(insert_before_next_heading "## Required checks" \
+insert_before_next_heading "## Required checks" \
   'Configure branch protection to require:' \
-  "$(<"$WAVE0")")"
+  "$WAVE0" "$TRUTH_TMP/stale-required.md"
 expect_red "Wave 0 jobs as required checks" "## Required checks section mismatch" \
-  assert_wave0_required_contexts "$stale_required"
+  assert_wave0_required_contexts "$TRUTH_TMP/stale-required.md"
 
-extra_context="$(insert_before_next_heading "## Required checks" \
+insert_before_next_heading "## Required checks" \
   'stale-required-context' \
-  "$(<"$WAVE0")")"
+  "$WAVE0" "$TRUTH_TMP/extra-context.md"
 expect_red "additive extra required context" "## Required checks section mismatch" \
-  assert_wave0_required_contexts "$extra_context"
+  assert_wave0_required_contexts "$TRUTH_TMP/extra-context.md"
 
-elsewhere_required="$(printf '%s\n%s\n' "$(<"$WAVE0")" '- stale-required-context')"
+append_doc_line '- stale-required-context' \
+  "$WAVE0" "$TRUTH_TMP/elsewhere-required.md"
 expect_red "pointer-only required section plus stale-required-context elsewhere" \
   "required-context declaration outside ## Required checks" \
-  assert_wave0_required_contexts "$elsewhere_required"
+  assert_wave0_required_contexts "$TRUTH_TMP/elsewhere-required.md"
 
-ordinary_required_prose="$(printf '%s\n%s\n' "$(<"$WAVE0")" 'Before merging, ensure required checks pass.')"
+append_doc_line 'Before merging, ensure required checks pass.' \
+  "$WAVE0" "$TRUTH_TMP/ordinary-required.md"
 expect_ok "ordinary required-checks prose outside the section" \
-  assert_wave0_required_contexts "$ordinary_required_prose"
+  assert_wave0_required_contexts "$TRUTH_TMP/ordinary-required.md"
 
-narrowed_trigger="$(printf '%s\n' "$(<"$KERNEL_MATRIX")" | grep -v '"AGENTS.md"')"
+python3 - "$KERNEL_MATRIX" "$TRUTH_TMP/narrowed.yml" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
+out = "".join(line for line in text.splitlines(keepends=True) if '"AGENTS.md"' not in line)
+require_bounded_bytes(out.encode("utf-8"), "narrowed kernel-matrix")
+Path(sys.argv[2]).write_text(out, encoding="utf-8")
+PY
 expect_red "AGENTS.md dropped from CI trigger" "omits AGENTS.md" \
-  assert_ci_trigger_owns_truth_inputs "$narrowed_trigger"
+  assert_ci_trigger_owns_truth_inputs "$TRUTH_TMP/narrowed.yml"
 
 stale_wave71=$'| Wave71 | Hotspot LOC under 600 | in progress | Active | still reducing |\n'
 expect_red "Wave71 Active" "claims Active" assert_wave71_not_active "$stale_wave71"
@@ -595,31 +721,65 @@ expect_red "restored single-boundary TODO" "single-boundary Wave 3 TODO" \
 expect_red "deleted-monitor.rs claim" "must not claim monitor.rs was deleted" \
   assert_no_generic_unsafe_preview "monitor.rs was deleted" ""
 
-oversized_real="$(mktemp)"
-python3 -c "import sys; sys.stdout.buffer.write(b'x' * 65537)" >"$oversized_real"
+python3 - "$AGENTS" "$TRUTH_TMP/nul-agents.md" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file
+
+Path(sys.argv[2]).write_bytes(read_bounded_file(sys.argv[1]) + b"\x00")
+PY
+assert_nul_preserved() {
+  python3 - "$1" <<'PY'
+import sys
+
+from resource_ceilings import read_bounded_file
+
+data = read_bounded_file(sys.argv[1])
+if b"\x00" not in data:
+    raise SystemExit("bounded reader dropped appended NUL")
+if data.decode("utf-8").count("\x00") != 1:
+    raise SystemExit("bounded reader did not keep exactly one appended NUL")
+PY
+}
+
+expect_ok "appended NUL is preserved by the bounded reader" \
+  assert_nul_preserved "$TRUTH_TMP/nul-agents.md"
+expect_ok "appended NUL still validates the ledger" assert_agents_ledger "$TRUTH_TMP/nul-agents.md"
+
+expect_red "non-regular programme-truth input" "not a regular file" \
+  python3 "$CEILINGS" check-file /dev/null
+
+python3 -c "import sys; sys.stdout.buffer.write(b'x' * 65537)" >"$TRUTH_TMP/oversized.md"
 expect_red "oversized real document" "exceeds 65536-byte ceiling" \
-  require_truth_file "$oversized_real"
-rm -f "$oversized_real"
+  python3 "$CEILINGS" check-file "$TRUTH_TMP/oversized.md"
+expect_red "oversized document never reaches a ledger consumer" "exceeds 65536-byte ceiling" \
+  assert_agents_ledger "$TRUTH_TMP/oversized.md"
 
-oversized_synth="$(python3 -c "print('x' * 65537, end='')")"
-expect_red "oversized synthetic document" "exceeds 65536-byte ceiling" \
-  assert_agents_ledger "$oversized_synth"
-
-if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" ]]; then
-  cleanup_selfhost() { rm -rf -- "${selfhost_dir:?}"; }
-  selfhost_dir="$(mktemp -d)"
-  trap cleanup_selfhost EXIT
-  active_agents="$selfhost_dir/agents.md"
-  selfhost_log="$selfhost_dir/selfhost.log"
-  replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$(<"$ROOT/AGENTS.md")" >"$active_agents"
+if [[ -z "${PROGRAMME_TRUTH_SELFHOST:-}" && -z "${PROGRAMME_TRUTH_CEILING_CHILD:-}" ]]; then
+  active_agents="$TRUTH_TMP/selfhost-agents.md"
+  selfhost_log="$TRUTH_TMP/selfhost.log"
+  replace_ledger_bullet "$ACTIVE_LEDGER_BULLET" "$ROOT/AGENTS.md" "$active_agents"
   if PROGRAMME_TRUTH_AGENTS="$active_agents" PROGRAMME_TRUTH_SELFHOST=1 \
     bash "${BASH_SOURCE[0]}" >"$selfhost_log" 2>&1; then
     ok "full contract on active canonical AGENTS ledger"
   else
     bad "full contract on active canonical AGENTS ledger: $(tail -n 20 "$selfhost_log")"
   fi
-  trap - EXIT
-  cleanup_selfhost
+
+  if child_out="$(
+    PROGRAMME_TRUTH_AGENTS="$TRUTH_TMP/oversized.md" \
+    PROGRAMME_TRUTH_CEILING_CHILD=1 \
+    bash "${BASH_SOURCE[0]}" 2>&1
+  )"; then
+    bad "oversized AGENTS left the suite green"
+  elif grep -Fq 'monitor.rs still exists' <<<"$child_out"; then
+    bad "consumers ran after ceiling failure"
+  elif grep -Fq 'exceeds 65536-byte ceiling' <<<"$child_out"; then
+    ok "oversized AGENTS stops before consumers"
+  else
+    bad "oversized AGENTS red without ceiling: $child_out"
+  fi
 fi
 
 if [[ "$FAILURES" -ne 0 ]]; then

--- a/scripts/ci/test-ci-programme-truth.sh
+++ b/scripts/ci/test-ci-programme-truth.sh
@@ -45,10 +45,9 @@ LEDGER_PHRASES = (
 ISSUE_LINK = re.compile(
     r"\[issue #(\d+)\]\((https://github\.com/[^)\s]+/issues/(\d+))\)"
 )
-# Spaced prose, or a list item whose token contains required-context(s)/check(s).
-# Do not match arbitrary hyphen tokens (crate names) or the checker filename.
+# List-item declarations only. Ordinary prose such as "ensure required checks
+# pass" is not a required-context declaration.
 REQUIRED_OUTSIDE = re.compile(
-    r"\brequired contexts?\b|\brequired checks?\b|"
     r"^\s*-\s+\S*required-contexts?\b|"
     r"^\s*-\s+\S*required-checks?\b",
     re.IGNORECASE | re.MULTILINE,
@@ -107,6 +106,9 @@ def collapsed(text: str) -> str:
 
 
 def validate_ledger(text: str, prefix: str) -> None:
+    # Non-claim: this offline structural check verifies issue-link form and
+    # visible-text/URL-ID parity only. It does not query live GitHub OPEN or
+    # CLOSED state. The current inactive AGENTS.md bullet satisfies #2515.
     bullet, remainder = split_top_level_bullet(text, prefix)
     bullet_c = collapsed(bullet)
     remainder_c = collapsed(remainder)
@@ -402,6 +404,10 @@ elsewhere_required="$(printf '%s\n%s\n' "$(<"$WAVE0")" '- stale-required-context
 expect_red "pointer-only required section plus stale-required-context elsewhere" \
   "required-context declaration outside ## Required checks" \
   assert_wave0_required_contexts "$elsewhere_required"
+
+ordinary_required_prose="$(printf '%s\n%s\n' "$(<"$WAVE0")" 'Before merging, ensure required checks pass.')"
+expect_ok "ordinary required-checks prose outside the section" \
+  assert_wave0_required_contexts "$ordinary_required_prose"
 
 narrowed_trigger="$(printf '%s\n' "$(<"$KERNEL_MATRIX")" | grep -v '"AGENTS.md"')"
 expect_red "AGENTS.md dropped from CI trigger" "omits AGENTS.md" \

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -8,26 +8,8 @@ set -euo pipefail
 # shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
 
-if [[ -n "${PROGRAMME_TRUTH_ROOT+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_ROOT cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_AGENTS+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_AGENTS cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_SELFHOST+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_SELFHOST cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_CEILING_CHILD+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_CEILING_CHILD cannot replace the script worktree" >&2
-  exit 1
-fi
-if [[ -n "${PROGRAMME_TRUTH_PREVIEW_MUTANT+x}" ]]; then
-  echo "FAIL: PROGRAMME_TRUTH_PREVIEW_MUTANT cannot replace the script worktree" >&2
-  exit 1
-fi
+_TRUTH_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource_ceilings.py"
+python3 "$_TRUTH_LIB" reject-overrides
 if [[ -n "${REVIEW_SPLIT_ROOT+x}" ]]; then
   echo "FAIL: REVIEW_SPLIT_ROOT cannot replace the script worktree" >&2
   exit 1
@@ -329,8 +311,10 @@ if "${REVIEW_SPLIT_CEILINGS:-" in text or 'python3 "${REVIEW_SPLIT_CEILINGS}"' i
 suite = read_bounded_file(sys.argv[2]).decode("utf-8")
 if "${" + "PROGRAMME_TRUTH_ROOT:-" in suite or "${" + "REVIEW_SPLIT_ROOT:-" in suite:
     raise SystemExit("review-split-wave tests still accept a caller root override")
-if "PROGRAMME_TRUTH_ROOT cannot replace the script worktree" not in suite:
-    raise SystemExit("review-split-wave tests do not refuse PROGRAMME_TRUTH_ROOT")
+if "reject-overrides" not in suite:
+    raise SystemExit("review-split-wave tests do not invoke reject-overrides")
+if "if [[ -n \"${" + "PROGRAMME_TRUTH_AGENTS+x}\" ]]" in suite:
+    raise SystemExit("review-split-wave tests still inlined programme override rejects")
 PY
 then
   ok "review-split-wave inventories through the bounded helper"

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -10,6 +10,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-e
 
 _TRUTH_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/resource_ceilings.py"
 python3 "$_TRUTH_LIB" reject-overrides
+python3 "$_TRUTH_LIB" assert-reject-caller "${BASH_SOURCE[0]}"
 if [[ -n "${REVIEW_SPLIT_ROOT+x}" ]]; then
   echo "FAIL: REVIEW_SPLIT_ROOT cannot replace the script worktree" >&2
   exit 1
@@ -311,8 +312,6 @@ if "${REVIEW_SPLIT_CEILINGS:-" in text or 'python3 "${REVIEW_SPLIT_CEILINGS}"' i
 suite = read_bounded_file(sys.argv[2]).decode("utf-8")
 if "${" + "PROGRAMME_TRUTH_ROOT:-" in suite or "${" + "REVIEW_SPLIT_ROOT:-" in suite:
     raise SystemExit("review-split-wave tests still accept a caller root override")
-if "reject-overrides" not in suite:
-    raise SystemExit("review-split-wave tests do not invoke reject-overrides")
 if "if [[ -n \"${" + "PROGRAMME_TRUTH_AGENTS+x}\" ]]" in suite:
     raise SystemExit("review-split-wave tests still inlined programme override rejects")
 PY

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -133,11 +133,13 @@ fi
 
 # Mutation: restore the two-source inventory and require the leak to go silent.
 mutant="$TMP/review-split-wave.mutant.sh"
-python3 "$CEILINGS" check-file "$SCRIPT"
 python3 - "$SCRIPT" "$mutant" <<'PY'
 from pathlib import Path
 import sys
-src = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+src = read_bounded_file(sys.argv[1]).decode("utf-8")
 old = """changed_files="$(
   {
     git diff --name-only "${base_ref}"...HEAD
@@ -151,6 +153,7 @@ if old not in src:
     mutated = mutated.replace("git ls-files --others --exclude-standard\n", "")
 else:
     mutated = src
+require_bounded_bytes(mutated.encode("utf-8"), "review-split-wave inventory mutant")
 Path(sys.argv[2]).write_text(mutated, encoding="utf-8")
 PY
 chmod +x "$mutant"
@@ -223,8 +226,62 @@ else
   bad "invalid path cap red without positive integer: $out"
 fi
 
-# shellcheck disable=SC2016 # Literal production helper invocation, not an expansion.
-if grep -Fq 'python3 "${_REVIEW_SPLIT_CEILINGS}" inventory' "$SCRIPT"; then
+if out="$(BOUNDED_INVENTORY_MAX_PATHS='' python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "empty path cap left the inventory green"
+elif grep -Fq 'is not a positive integer' <<<"$out"; then
+  ok "empty path cap turns red ($out)"
+else
+  bad "empty path cap red without positive integer: $out"
+fi
+
+if out="$(BOUNDED_INVENTORY_MAX_PATHS=+2 python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "plus-prefixed path cap left the inventory green"
+elif grep -Fq 'is not a positive integer' <<<"$out"; then
+  ok "plus-prefixed path cap turns red ($out)"
+else
+  bad "plus-prefixed path cap red without positive integer: $out"
+fi
+
+if out="$(BOUNDED_INVENTORY_MAX_PATHS=' 2' python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "spaced path cap left the inventory green"
+elif grep -Fq 'is not a positive integer' <<<"$out"; then
+  ok "spaced path cap turns red ($out)"
+else
+  bad "spaced path cap red without positive integer: $out"
+fi
+
+if out="$(BOUNDED_INVENTORY_MAX_PATHS=2.0 python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "float path cap left the inventory green"
+elif grep -Fq 'is not a positive integer' <<<"$out"; then
+  ok "float path cap turns red ($out)"
+else
+  bad "float path cap red without positive integer: $out"
+fi
+
+if out="$(BOUNDED_INVENTORY_MAX_PATHS=-1 python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "negative path cap left the inventory green"
+elif grep -Fq 'must be a positive integer' <<<"$out"; then
+  ok "negative path cap turns red ($out)"
+else
+  bad "negative path cap red without positive integer: $out"
+fi
+
+if out="$(printf 'a\n' | BOUNDED_INVENTORY_MAX_PATHS="$CANON_PATHS" python3 "$CEILINGS" inventory 2>&1)"; then
+  ok "equal path cap is allowed"
+else
+  bad "equal path cap turned red: $out"
+fi
+
+if python3 - "$SCRIPT" <<'PY'
+import sys
+
+from resource_ceilings import read_bounded_file
+
+text = read_bounded_file(sys.argv[1]).decode("utf-8")
+if 'python3 "${_REVIEW_SPLIT_CEILINGS}" inventory' not in text:
+    raise SystemExit("review-split-wave does not invoke resource_ceilings inventory")
+PY
+then
   ok "review-split-wave inventories through the bounded helper"
 else
   bad "review-split-wave does not invoke resource_ceilings inventory"

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -11,6 +11,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-e
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/scripts/ci/review-split-wave.sh"
 CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
+export PYTHONPATH="$ROOT/scripts/ci/lib${PYTHONPATH:+:$PYTHONPATH}"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -20,15 +21,16 @@ bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
 
 assert_usage_examples_exist() {
   local script="$1"
-  python3 "$CEILINGS" check-file "$script"
   python3 - "$script" "$ROOT" "$CEILINGS" <<'PY'
 import re, subprocess, sys
 from pathlib import Path
 
+from resource_ceilings import read_bounded_file
+
 script = Path(sys.argv[1])
 root = Path(sys.argv[2])
 ceilings = Path(sys.argv[3])
-text = script.read_text(encoding="utf-8")
+text = read_bounded_file(str(script)).decode("utf-8")
 examples = re.findall(
     r"review-split-wave\.sh\s+\S+\s+'([^']+)'",
     text,
@@ -183,6 +185,93 @@ elif grep -Fq '65536-byte ceiling' <<<"$out"; then
   ok "source-script byte ceiling turns red ($out)"
 else
   bad "source-script byte ceiling red without 65536-byte ceiling: $out"
+fi
+
+read -r CANON_PATHS CANON_BYTES < <(python3 "$CEILINGS" canonical-inventory-limits)
+raise_paths=$((CANON_PATHS + 1))
+raise_bytes=$((CANON_BYTES + 1))
+
+if out="$(BOUNDED_INVENTORY_MAX_PATHS="$raise_paths" python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "caller-raised path cap left the inventory green"
+elif grep -Fq "cannot exceed canonical ${CANON_PATHS}" <<<"$out"; then
+  ok "caller cannot raise the path cap ($out)"
+else
+  bad "raised path cap red without canonical ${CANON_PATHS}: $out"
+fi
+
+if out="$(BOUNDED_INVENTORY_MAX_BYTES="$raise_bytes" python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "caller-raised byte cap left the inventory green"
+elif grep -Fq "cannot exceed canonical ${CANON_BYTES}" <<<"$out"; then
+  ok "caller cannot raise the byte cap ($out)"
+else
+  bad "raised byte cap red without canonical ${CANON_BYTES}: $out"
+fi
+
+if out="$(BOUNDED_INVENTORY_MAX_PATHS=0 python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "nonpositive path cap left the inventory green"
+elif grep -Fq 'must be a positive integer' <<<"$out"; then
+  ok "nonpositive path cap turns red ($out)"
+else
+  bad "nonpositive path cap red without positive integer: $out"
+fi
+
+if out="$(BOUNDED_INVENTORY_MAX_PATHS=abc python3 "$CEILINGS" inventory </dev/null 2>&1)"; then
+  bad "invalid path cap left the inventory green"
+elif grep -Fq 'is not a positive integer' <<<"$out"; then
+  ok "invalid path cap turns red ($out)"
+else
+  bad "invalid path cap red without positive integer: $out"
+fi
+
+# shellcheck disable=SC2016 # Literal production helper invocation, not an expansion.
+if grep -Fq 'python3 "${_REVIEW_SPLIT_CEILINGS}" inventory' "$SCRIPT"; then
+  ok "review-split-wave inventories through the bounded helper"
+else
+  bad "review-split-wave does not invoke resource_ceilings inventory"
+fi
+
+init_fixture "$TMP/overflow"
+python3 - "$TMP/overflow/allowed" "$CEILINGS" <<'PY'
+import sys
+from pathlib import Path
+
+import runpy
+
+limits = runpy.run_path(sys.argv[2])
+root = Path(sys.argv[1])
+# keep.rs is already in the committed-vs-base inventory; add the canonical
+# max so the production gate sees one path too many.
+for i in range(limits["MAX_INVENTORY_PATHS"]):
+    (root / f"overflow-{i}.rs").write_text("x\n", encoding="utf-8")
+PY
+if out="$(run_review "$TMP/overflow" "$SCRIPT" 2>&1)"; then
+  bad "production inventory overflow left the gate green"
+elif grep -Fq 'max path count' <<<"$out"; then
+  ok "production gate rejects inventory overflow"
+else
+  bad "production overflow red without max path count: $out"
+fi
+
+bypass="$TMP/review-split-wave.sort-u.sh"
+python3 - "$SCRIPT" "$bypass" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+src = read_bounded_file(sys.argv[1]).decode("utf-8")
+old = 'python3 "${_REVIEW_SPLIT_CEILINGS}" inventory'
+if old not in src:
+    raise SystemExit("production inventory helper invocation missing")
+out = src.replace(old, "sort -u")
+require_bounded_bytes(out.encode("utf-8"), "review-split-wave sort -u mutant")
+Path(sys.argv[2]).write_text(out, encoding="utf-8")
+PY
+chmod +x "$bypass"
+if out="$(run_review "$TMP/overflow" "$bypass" 2>&1)"; then
+  ok "sort -u mutant leaks overflow past the helper"
+else
+  bad "sort -u mutant still enforced a ceiling: $out"
 fi
 
 if [[ "$FAILURES" -ne 0 ]]; then

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -14,6 +14,7 @@ CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
 export PYTHONPATH="$ROOT/scripts/ci/lib${PYTHONPATH:+:$PYTHONPATH}"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+unset REVIEW_SPLIT_CEILINGS
 
 FAILURES=0
 ok()  { echo "ok    $1"; }
@@ -82,6 +83,25 @@ init_fixture() {
   git -C "$repo" commit -q -m change
 }
 
+install_hermetic_review() {
+  local dest="$1"
+  python3 - "$SCRIPT" "$CEILINGS" "$dest" <<'PY'
+import sys
+from pathlib import Path
+
+from resource_ceilings import read_bounded_file, require_bounded_bytes
+
+dest = Path(sys.argv[3])
+(dest / "lib").mkdir(parents=True, exist_ok=True)
+script = read_bounded_file(sys.argv[1])
+helper = read_bounded_file(sys.argv[2])
+require_bounded_bytes(script, "hermetic review-split-wave")
+require_bounded_bytes(helper, "hermetic resource_ceilings")
+(dest / "review-split-wave.sh").write_bytes(script)
+(dest / "lib" / "resource_ceilings.py").write_bytes(helper)
+PY
+}
+
 run_review() {
   local repo="$1"
   local script="$2"
@@ -91,8 +111,6 @@ run_review() {
   (
     cd "$repo"
     PATH="$bin:$PATH"
-    REVIEW_SPLIT_CEILINGS="$CEILINGS"
-    export REVIEW_SPLIT_CEILINGS
     bash "$script" demo '^allowed/' HEAD~1 "$@"
   )
 }
@@ -132,8 +150,9 @@ else
 fi
 
 # Mutation: restore the two-source inventory and require the leak to go silent.
-mutant="$TMP/review-split-wave.mutant.sh"
-python3 - "$SCRIPT" "$mutant" <<'PY'
+install_hermetic_review "$TMP/narrowed-layout"
+mutant="$TMP/narrowed-layout/review-split-wave.sh"
+python3 - "$mutant" "$mutant" <<'PY'
 from pathlib import Path
 import sys
 
@@ -280,6 +299,8 @@ from resource_ceilings import read_bounded_file
 text = read_bounded_file(sys.argv[1]).decode("utf-8")
 if 'python3 "${_REVIEW_SPLIT_CEILINGS}" inventory' not in text:
     raise SystemExit("review-split-wave does not invoke resource_ceilings inventory")
+if "${REVIEW_SPLIT_CEILINGS:-" in text or 'python3 "${REVIEW_SPLIT_CEILINGS}"' in text:
+    raise SystemExit("review-split-wave still accepts a caller helper override")
 PY
 then
   ok "review-split-wave inventories through the bounded helper"
@@ -309,8 +330,34 @@ else
   bad "production overflow red without max path count: $out"
 fi
 
-bypass="$TMP/review-split-wave.sort-u.sh"
-python3 - "$SCRIPT" "$bypass" <<'PY'
+printf '%s\n' 'import sys' 'for line in sys.stdin:' '    sys.stdout.write(line)' \
+  >"$TMP/unbounded_ceilings.py"
+if out="$(
+  REVIEW_SPLIT_CEILINGS="$TMP/unbounded_ceilings.py" \
+  run_review "$TMP/overflow" "$SCRIPT" 2>&1
+)"; then
+  bad "unbounded REVIEW_SPLIT_CEILINGS left the overflow green"
+elif grep -Fq 'cannot replace the canonical inventory helper' <<<"$out"; then
+  ok "caller cannot replace the production inventory helper"
+elif grep -Fq 'max path count' <<<"$out"; then
+  ok "caller helper override is ignored and overflow still fails"
+else
+  bad "unbounded helper override red without reject/overflow: $out"
+fi
+
+install_hermetic_review "$TMP/missing-helper"
+rm -f "$TMP/missing-helper/lib/resource_ceilings.py"
+if out="$(run_review "$TMP/overflow" "$TMP/missing-helper/review-split-wave.sh" 2>&1)"; then
+  bad "missing canonical helper left the gate green"
+elif grep -Fq 'canonical inventory helper missing' <<<"$out"; then
+  ok "missing canonical helper fails closed"
+else
+  bad "missing helper red without fail-closed: $out"
+fi
+
+install_hermetic_review "$TMP/sort-u-layout"
+bypass="$TMP/sort-u-layout/review-split-wave.sh"
+python3 - "$bypass" "$bypass" <<'PY'
 import sys
 from pathlib import Path
 

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -10,6 +10,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-e
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/scripts/ci/review-split-wave.sh"
+CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -19,21 +20,33 @@ bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
 
 assert_usage_examples_exist() {
   local script="$1"
-  python3 - "$script" "$ROOT" <<'PY'
+  python3 "$CEILINGS" check-file "$script"
+  python3 - "$script" "$ROOT" "$CEILINGS" <<'PY'
 import re, subprocess, sys
 from pathlib import Path
-text = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+script = Path(sys.argv[1])
 root = Path(sys.argv[2])
+ceilings = Path(sys.argv[3])
+text = script.read_text(encoding="utf-8")
 examples = re.findall(
     r"review-split-wave\.sh\s+\S+\s+'([^']+)'",
     text,
 )
 if not examples:
     raise SystemExit("no usage examples with an allowed-path regex")
-tracked = subprocess.check_output(
+git = subprocess.Popen(
     ["git", "-C", str(root), "ls-files"],
+    stdout=subprocess.PIPE,
+)
+assert git.stdout is not None
+tracked = subprocess.check_output(
+    [sys.executable, str(ceilings), "inventory"],
+    stdin=git.stdout,
     text=True,
 ).splitlines()
+if git.wait() != 0:
+    raise SystemExit("git ls-files failed")
 for regex in examples:
     rx = re.compile(regex)
     if not any(rx.search(path) for path in tracked):
@@ -76,6 +89,8 @@ run_review() {
   (
     cd "$repo"
     PATH="$bin:$PATH"
+    REVIEW_SPLIT_CEILINGS="$CEILINGS"
+    export REVIEW_SPLIT_CEILINGS
     bash "$script" demo '^allowed/' HEAD~1 "$@"
   )
 }
@@ -116,6 +131,7 @@ fi
 
 # Mutation: restore the two-source inventory and require the leak to go silent.
 mutant="$TMP/review-split-wave.mutant.sh"
+python3 "$CEILINGS" check-file "$SCRIPT"
 python3 - "$SCRIPT" "$mutant" <<'PY'
 from pathlib import Path
 import sys
@@ -142,6 +158,31 @@ if out="$(run_review "$TMP/mutant" "$mutant" 2>&1)"; then
   ok "narrowed inventory mutation stays silent on untracked leak"
 else
   bad "narrowed inventory mutation still caught the leak: $out"
+fi
+
+if out="$(printf 'a\nb\nc\n' | BOUNDED_INVENTORY_MAX_PATHS=2 python3 "$CEILINGS" inventory 2>&1)"; then
+  bad "path-count ceiling left the inventory green"
+elif grep -Fq 'max path count' <<<"$out"; then
+  ok "path-count ceiling turns red ($out)"
+else
+  bad "path-count ceiling red without max path count: $out"
+fi
+
+if out="$(printf 'xxxxxxxxxxxxxxxxxxxx\nyyyyyyyyyyyyyyyyyyyy\n' | BOUNDED_INVENTORY_MAX_BYTES=30 python3 "$CEILINGS" inventory 2>&1)"; then
+  bad "inventory byte ceiling left the inventory green"
+elif grep -Fq 'max byte budget' <<<"$out"; then
+  ok "inventory byte ceiling turns red ($out)"
+else
+  bad "inventory byte ceiling red without max byte budget: $out"
+fi
+
+python3 -c "import sys; sys.stdout.buffer.write(b'x' * 65537)" >"$TMP/oversized.sh"
+if out="$(python3 "$CEILINGS" check-file "$TMP/oversized.sh" 2>&1)"; then
+  bad "source-script byte ceiling left green"
+elif grep -Fq '65536-byte ceiling' <<<"$out"; then
+  ok "source-script byte ceiling turns red ($out)"
+else
+  bad "source-script byte ceiling red without 65536-byte ceiling: $out"
 fi
 
 if [[ "$FAILURES" -ne 0 ]]; then

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -8,6 +8,31 @@ set -euo pipefail
 # shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
 
+if [[ -n "${PROGRAMME_TRUTH_ROOT+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_ROOT cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_AGENTS+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_AGENTS cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_SELFHOST+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_SELFHOST cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_CEILING_CHILD+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_CEILING_CHILD cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${PROGRAMME_TRUTH_PREVIEW_MUTANT+x}" ]]; then
+  echo "FAIL: PROGRAMME_TRUTH_PREVIEW_MUTANT cannot replace the script worktree" >&2
+  exit 1
+fi
+if [[ -n "${REVIEW_SPLIT_ROOT+x}" ]]; then
+  echo "FAIL: REVIEW_SPLIT_ROOT cannot replace the script worktree" >&2
+  exit 1
+fi
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT/scripts/ci/review-split-wave.sh"
 CEILINGS="$ROOT/scripts/ci/lib/resource_ceilings.py"
@@ -291,7 +316,7 @@ else
   bad "equal path cap turned red: $out"
 fi
 
-if python3 - "$SCRIPT" <<'PY'
+if python3 - "$SCRIPT" "$ROOT/scripts/ci/test-review-split-wave.sh" <<'PY'
 import sys
 
 from resource_ceilings import read_bounded_file
@@ -301,6 +326,11 @@ if 'python3 "${_REVIEW_SPLIT_CEILINGS}" inventory' not in text:
     raise SystemExit("review-split-wave does not invoke resource_ceilings inventory")
 if "${REVIEW_SPLIT_CEILINGS:-" in text or 'python3 "${REVIEW_SPLIT_CEILINGS}"' in text:
     raise SystemExit("review-split-wave still accepts a caller helper override")
+suite = read_bounded_file(sys.argv[2]).decode("utf-8")
+if "${" + "PROGRAMME_TRUTH_ROOT:-" in suite or "${" + "REVIEW_SPLIT_ROOT:-" in suite:
+    raise SystemExit("review-split-wave tests still accept a caller root override")
+if "PROGRAMME_TRUTH_ROOT cannot replace the script worktree" not in suite:
+    raise SystemExit("review-split-wave tests do not refuse PROGRAMME_TRUTH_ROOT")
 PY
 then
   ok "review-split-wave inventories through the bounded helper"

--- a/scripts/ci/test-review-split-wave.sh
+++ b/scripts/ci/test-review-split-wave.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# #2515: review-split-wave.sh must inventory dirty unstaged/untracked files.
+#
+# The Assay Sim usage example is proven to exist on this pin; this test pins that
+# fact and does not demand a replacement path.
+set -euo pipefail
+
+# shellcheck source=scripts/ci/lib/clear-git-repository-env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/clear-git-repository-env.sh"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/ci/review-split-wave.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILURES=0
+ok()  { echo "ok    $1"; }
+bad() { echo "FAIL  $1"; FAILURES=$((FAILURES + 1)); }
+
+assert_usage_examples_exist() {
+  local script="$1"
+  python3 - "$script" "$ROOT" <<'PY'
+import re, subprocess, sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+root = Path(sys.argv[2])
+examples = re.findall(
+    r"review-split-wave\.sh\s+\S+\s+'([^']+)'",
+    text,
+)
+if not examples:
+    raise SystemExit("no usage examples with an allowed-path regex")
+tracked = subprocess.check_output(
+    ["git", "-C", str(root), "ls-files"],
+    text=True,
+).splitlines()
+for regex in examples:
+    rx = re.compile(regex)
+    if not any(rx.search(path) for path in tracked):
+        raise SystemExit(f"usage example regex matches no tracked file: {regex}")
+print(f"{len(examples)} usage example regexes match tracked files")
+PY
+}
+
+make_stub_cargo() {
+  local bin="$1"
+  mkdir -p "$bin"
+  cat >"$bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$bin/cargo"
+}
+
+init_fixture() {
+  local repo="$1"
+  mkdir -p "$repo/allowed"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email "ci@example.com"
+  git -C "$repo" config user.name "CI"
+  printf 'base\n' >"$repo/README"
+  printf 'ok\n' >"$repo/allowed/keep.rs"
+  git -C "$repo" add README allowed/keep.rs
+  git -C "$repo" commit -q -m base
+  printf 'changed\n' >"$repo/allowed/keep.rs"
+  git -C "$repo" add allowed/keep.rs
+  git -C "$repo" commit -q -m change
+}
+
+run_review() {
+  local repo="$1"
+  local script="$2"
+  shift 2
+  local bin="$TMP/bin"
+  make_stub_cargo "$bin"
+  (
+    cd "$repo"
+    PATH="$bin:$PATH"
+    bash "$script" demo '^allowed/' HEAD~1 "$@"
+  )
+}
+
+if examples_out="$(assert_usage_examples_exist "$SCRIPT")"; then
+  ok "usage examples resolve on the current tree ($examples_out)"
+else
+  bad "usage examples: $examples_out"
+fi
+
+# Untracked leak must not be silent.
+init_fixture "$TMP/untracked"
+printf 'leak\n' >"$TMP/untracked/surprise.txt"
+if out="$(run_review "$TMP/untracked" "$SCRIPT" 2>&1)"; then
+  bad "untracked leak left the gate green"
+  printf '%s\n' "$out"
+else
+  if grep -Fq 'surprise.txt' <<<"$out"; then
+    ok "untracked leak is inventoried ($out)"
+  else
+    bad "untracked leak failed without naming surprise.txt: $out"
+  fi
+fi
+
+# Unstaged out-of-scope edit must not be silent.
+init_fixture "$TMP/unstaged"
+printf 'dirty\n' >>"$TMP/unstaged/README"
+if out="$(run_review "$TMP/unstaged" "$SCRIPT" 2>&1)"; then
+  bad "unstaged leak left the gate green"
+  printf '%s\n' "$out"
+else
+  if grep -Fq 'README' <<<"$out"; then
+    ok "unstaged leak is inventoried ($out)"
+  else
+    bad "unstaged leak failed without naming README: $out"
+  fi
+fi
+
+# Mutation: restore the two-source inventory and require the leak to go silent.
+mutant="$TMP/review-split-wave.mutant.sh"
+python3 - "$SCRIPT" "$mutant" <<'PY'
+from pathlib import Path
+import sys
+src = Path(sys.argv[1]).read_text(encoding="utf-8")
+old = """changed_files="$(
+  {
+    git diff --name-only "${base_ref}"...HEAD
+    git diff --cached --name-only
+  } | sort -u
+)\""""
+if old not in src:
+    # After the one-function extract, strip unstaged/untracked collection.
+    mutated = src
+    mutated = mutated.replace("git diff --name-only\n", "")
+    mutated = mutated.replace("git ls-files --others --exclude-standard\n", "")
+else:
+    mutated = src
+Path(sys.argv[2]).write_text(mutated, encoding="utf-8")
+PY
+chmod +x "$mutant"
+init_fixture "$TMP/mutant"
+printf 'leak\n' >"$TMP/mutant/surprise.txt"
+if out="$(run_review "$TMP/mutant" "$mutant" 2>&1)"; then
+  ok "narrowed inventory mutation stays silent on untracked leak"
+else
+  bad "narrowed inventory mutation still caught the leak: $out"
+fi
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES review-split-wave case(s) failed"
+  exit 1
+fi
+echo "PASS: review-split-wave dirty-tree contract"


### PR DESCRIPTION
## Summary

- reset the public programme ledger to an explicit no-active-programme state
- align Wave 0 docs with the dynamic release baseline and canonical required-context source
- remove the unsupported generic single-unsafe-boundary preview
- inventory committed, staged, unstaged, and untracked split-wave changes through one shared function
- mark Wave71 dormant/incomplete without claiming the hotspot threshold is complete
- add focused mutation-sensitive contracts and ensure their documentation inputs trigger CI

## Why

The durable CI/refactor surfaces had drifted from repository and live branch-protection state. This keeps the useful Wave 0 gates while removing stale claims and making dirty worktree scope visible.

## Contract boundaries

- no repository-wide single-unsafe-boundary rule is introduced
- the ledger guard supports explicit inactive and structurally active states
- the offline ledger guard verifies link form and visible/URL issue-ID parity, not live GitHub OPEN/CLOSED state
- required contexts remain canonical in `CI-CONTRACT.md` and `.github/rulesets/main-required-ci-contexts.json`; Wave 0 docs point there rather than duplicating names
- current hotspot measurement remains above the target, so Wave71 is dormant/incomplete, not closed

## Verification

Exact head: `83138cbc34a5274b4539170ff43ae0d06ef4f457`

- `bash scripts/ci/test-ci-programme-truth.sh`
- `bash scripts/ci/test-review-split-wave.sh`
- `python3 scripts/ci/check-required-contexts.py`
- `python3 scripts/ci/check-required-contexts.py --self-test`
- live required-context reconciliation through `--live-response`
- `shellcheck -x scripts/ci/review-split-wave.sh scripts/ci/test-ci-programme-truth.sh scripts/ci/test-review-split-wave.sh`
- `actionlint .github/workflows/kernel-matrix.yml .github/workflows/split-wave0-gates.yml`
- `pre-commit validate-config`
- `cargo fmt --all -- --check`
- `git diff --check 974336892ce7721dcf32e8ad5d2160ea4ec11408..83138cbc34a5274b4539170ff43ae0d06ef4f457`
- full pre-push hook, including workspace clippy and CI programme-truth contract

All passed.

## Review quorum

Independent non-building Codex subagent reviewed exact head `83138cbc34a5274b4539170ff43ae0d06ef4f457`: **READY**, no actionable findings. It independently exercised active/inactive ledger transitions, mismatch/duplicate/contradiction mutations, benign prose, dirty-tree inventory, trigger removals, cleanup fault paths, exact hook-command execution, all five forbidden-override tuple deletions, and shared caller parsing. All three findings from the prior head were closed with targeted RED mutations.

Closes #2515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI & Quality**
  * CI checks now run when programme-truth documentation, workflows, rulesets, or related configuration changes.
  * Added fail-closed validation for file sizes, inventory limits, overrides, workflow triggers, and review-split behavior.
  * Review checks now include committed, staged, unstaged, and untracked files.
  * Programme-truth checks run during both pre-commit and pre-push.

* **Documentation**
  * Updated programme status, Wave 0 gate guidance, and refactor-wave documentation.
  * Removed the unsafe boundary preview requirement and related quality-gate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
