### PR TITLE
feat(runner-schema): state kernel capture origin

### DIFF
--- a/crates/assay-runner-schema/src/health.rs
+++ b/crates/assay-runner-schema/src/health.rs
@@ -75,6 +75,26 @@ pub enum KernelLayerStatus {
     Absent,
 }
 
+/// Where the kernel-layer capture was observed.
+///
+/// `Own` is the historic meaning of an omitted field. `Unsupported` preserves an unrecognised
+/// wire value as not-own rather than silently upgrading it to local runner vantage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureOrigin {
+    #[default]
+    Own,
+    ThirdParty,
+    #[serde(other)]
+    Unsupported,
+}
+
+impl CaptureOrigin {
+    fn is_own(&self) -> bool {
+        matches!(self, Self::Own)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PolicyLayerStatus {
@@ -125,6 +145,8 @@ pub struct ObservationHealth {
     pub run_id: String,
     pub platform: String,
     pub kernel_layer: KernelLayerStatus,
+    #[serde(default, skip_serializing_if = "CaptureOrigin::is_own")]
+    pub capture_origin: CaptureOrigin,
     pub ringbuf_drops: u64,
     pub policy_layer: PolicyLayerStatus,
     pub sdk_layer: SdkLayerStatus,
@@ -160,6 +182,7 @@ impl ObservationHealth {
             run_id: run_id.into(),
             platform: platform.into(),
             kernel_layer: KernelLayerStatus::Absent,
+            capture_origin: CaptureOrigin::Own,
             ringbuf_drops: 0,
             policy_layer: PolicyLayerStatus::Absent,
             sdk_layer: SdkLayerStatus::Absent,
@@ -361,5 +384,40 @@ mod tests {
             health.validate(),
             Err(ObservationHealthError::NonLinuxRequiresAbsentKernelLayer)
         );
+    }
+
+    #[test]
+    fn third_party_complete_kernel_capture_survives_json_roundtrip() {
+        let mut value = serde_json::to_value(ObservationHealth::new("run_001", "linux")).unwrap();
+        value["kernel_layer"] = serde_json::json!("complete");
+        value["capture_origin"] = serde_json::json!("third_party");
+
+        let health: ObservationHealth = serde_json::from_value(value).unwrap();
+        assert_eq!(health.capture_origin, CaptureOrigin::ThirdParty);
+        let serialized = serde_json::to_value(health).unwrap();
+
+        assert_eq!(serialized["capture_origin"], "third_party");
+    }
+
+    #[test]
+    fn missing_capture_origin_deserializes_as_own_without_emitting_a_key() {
+        let legacy = serde_json::to_value(ObservationHealth::new("run_001", "linux")).unwrap();
+
+        let health: ObservationHealth = serde_json::from_value(legacy).unwrap();
+        assert_eq!(health.capture_origin, CaptureOrigin::Own);
+
+        let serialized = serde_json::to_value(health).unwrap();
+        assert!(serialized.get("capture_origin").is_none());
+    }
+
+    #[test]
+    fn unknown_capture_origin_is_not_treated_as_own() {
+        let mut value = serde_json::to_value(ObservationHealth::new("run_001", "linux")).unwrap();
+        value["capture_origin"] = serde_json::json!("unreviewed_future_origin");
+
+        let health: ObservationHealth = serde_json::from_value(value).unwrap();
+
+        assert_eq!(health.capture_origin, CaptureOrigin::Unsupported);
+        assert_ne!(health.capture_origin, CaptureOrigin::Own);
     }
 }

--- a/crates/assay-runner-schema/src/lib.rs
+++ b/crates/assay-runner-schema/src/lib.rs
@@ -54,7 +54,7 @@ pub use fidelity::{
     RUNNER_FIDELITY_VERDICT_SCHEMA,
 };
 pub use health::{
-    CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
+    CaptureOrigin, CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
     NetworkProtocolCoverageStatus, ObservationHealth, ObservationHealthError, PolicyLayerStatus,
     Redaction, RedactionReceipt, RedactionReceiptStatus, SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
     REDACTION_RECEIPT_SCHEMA,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Closes #2446.

Adds the vocabulary-only `capture_origin` statement to `ObservationHealth`.

### Why option 1
Option 1 is the smallest faithful encoding. `KernelLayerStatus` remains exactly `Complete | PartialRingbufDrops | Absent`; adding a public enum variant would be semver-major and old JSON readers would reject it. A `capture_origin: third_party` field lets `kernel_layer: complete` mean complete as captured without claiming that the local runner had the observing vantage. No smaller Rust-minor encoding lets a reader of `ObservationHealth` itself distinguish that record from a locally observed complete capture.

The field is JSON-additive: missing `capture_origin` deserializes as `own`, and `own` is skipped while serializing, so records emitted by existing producers keep their existing JSON keys. Unknown wire values deserialize to `CaptureOrigin::Unsupported`, never `own`.

### Semver measurement
Measured on commit `0b9e0c1087ed98309119ec14f717140d827ee299` in worktree `/tmp/assay-capture-origin-f891` with `cargo-semver-checks 0.50.0` and `rustc 1.96.0`:

```text
cargo semver-checks check-release -p assay-runner-schema --baseline-rev v5.4.0
exit 100
```

Baseline tag: `v5.4.0` (resolved via `git tag --list 'v[0-9]*' --sort=-v:refname | head -n1`).

- JSON compatibility: yes — additive field, absent reads as `own`, and `own` is not emitted.
- Rust API compatibility: no — `ObservationHealth` is a public exhaustively constructible struct and this adds its public `capture_origin` field.
- Gate finding: `constructible_struct_adds_field` for `ObservationHealth.capture_origin`.

No version bump, lint suppression, dummy private field, or `#[non_exhaustive]` change is used to hide that measured Rust API break.

### Discriminating test
The test was added before the field. It constructs the ambiguous record `kernel_layer: complete` + `capture_origin: third_party`, deserializes then reserializes it, and checks that the third-party statement survives.

```text
cargo test -p assay-runner-schema third_party_complete_kernel_capture_survives_json_roundtrip
main-equivalent (test-only state before the field): exit 101
after the field: exit 0
```

The red failure was `left: Null`, `right: "third_party"`: Serde ignored the unknown field, which would have made the record appear locally observed after reserialization. Coverage also verifies legacy JSON defaults to `own` without emitting the key, and unknown origin values are not treated as `own`.

### Shared non-upgrade rule
#2446, #2170 (sim report `bypassed=0` without the tier's unattempted denominator), and #2422 (session finding `extent: complete` is temporal, not fidelity) share one underlying question: a status vocabulary that reports what happened but cannot state what was never observed.

They are not one field:

> A status answers one question. The unasked question needs its own statement. Absence of that statement must not silently upgrade.

Defaults differ by history:
- #2446: absence = `own` (today's records already mean that).
- #2422: absence should be the restrictive reading (do not treat `complete` as "the trace is whole").
- #2170: current absence of `skipped_phases` overclaims (empty looks like "nothing was out of scope").

### Verification
- `cargo test -p assay-runner-schema` — pass (28 unit, 9 claim-parity integration, 15 coverage-descriptor integration tests)
- `cargo fmt --all -- --check` — pass
- `cargo clippy -p assay-runner-schema --all-targets -- -D warnings` — pass
- `git diff --check` — pass

### Explicit non-claims
- No adapter.
- No ingestion change.
- No producer change.
- No `KernelLayerStatus` variant.
- No support claim for any particular external capture format.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da338d9a-c0c8-417c-b50a-f61161dbf891?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da338d9a-c0c8-417c-b50a-f61161dbf891&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

