### PR TITLE
feat(sim): state the phases a tier never attempts

### DIFF
--- a/crates/assay-cli/src/cli/commands/sim.rs
+++ b/crates/assay-cli/src/cli/commands/sim.rs
@@ -155,7 +155,16 @@ fn cmd_run(args: SimRunArgs) -> Result<i32> {
         return Ok(2);
     }
 
-    println!("\n✅ All attacks blocked.");
+    if report.phases_not_attempted.is_empty() {
+        println!("\n✅ All attacks blocked.");
+    } else {
+        // "All attacks blocked" over a tier that skips a phase invites the reading
+        // that everything was tried. Name the untried phases in the same breath.
+        println!(
+            "\n✅ All attempted attacks blocked. Not attempted by this tier: {}.",
+            report.phases_not_attempted.join(", ")
+        );
+    }
     Ok(0)
 }
 

--- a/crates/assay-sim/src/report.rs
+++ b/crates/assay-sim/src/report.rs
@@ -14,6 +14,15 @@ pub struct SimReport {
     /// Phases skipped when time budget exceeded
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub skipped_phases: Vec<String>,
+    /// Phases this tier does not run at all, named so a clean summary cannot be
+    /// read as "everything was tried".
+    ///
+    /// Deliberately not merged with `skipped_phases`: a phase absent because the
+    /// tier never includes it is a programme statement, and a phase dropped
+    /// because the budget ran out is a degradation. A reader deciding whether a
+    /// `bypassed=0` run is reassuring needs to tell those apart.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub phases_not_attempted: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Clone, Default)]
@@ -54,7 +63,16 @@ impl SimReport {
             results: Vec::new(),
             time_budget_exceeded: false,
             skipped_phases: Vec::new(),
+            phases_not_attempted: Vec::new(),
         }
+    }
+
+    /// Record the phases this tier never runs.
+    ///
+    /// `total` counts what ran, so without this a tier that omits a whole phase
+    /// and a tier that ran everything produce the same shape of clean report.
+    pub fn set_phases_not_attempted(&mut self, not_attempted: Vec<String>) {
+        self.phases_not_attempted = not_attempted;
     }
 
     pub fn set_time_budget_exceeded(&mut self, skipped: Vec<String>) {

--- a/crates/assay-sim/src/suite.rs
+++ b/crates/assay-sim/src/suite.rs
@@ -73,8 +73,25 @@ impl TimeBudget {
     }
 }
 
+/// The phases a tier never runs.
+///
+/// Kept beside `run_suite`'s phase gates rather than derived from them, because the
+/// gates are `if` statements over a tier and cannot be enumerated. The pairing is
+/// pinned by `chaos_phase_gate_matches_the_declared_omission`, so a new gate that
+/// forgets this list fails a test instead of quietly overstating the run.
+fn phases_not_attempted_for(tier: &SuiteTier) -> Vec<String> {
+    match tier {
+        SuiteTier::Chaos => Vec::new(),
+        SuiteTier::Quick | SuiteTier::Nightly | SuiteTier::Stress => vec!["chaos".to_string()],
+    }
+}
+
 pub fn run_suite(cfg: SuiteConfig) -> Result<SimReport> {
     let mut report = SimReport::new(&format!("{:?}", cfg.tier), cfg.seed);
+    // The chaos phase is gated on the Chaos tier below. Naming it here keeps the
+    // statement next to the gate that causes it, so a new gate that forgets to
+    // update this list is a visible omission rather than a silent one.
+    report.set_phases_not_attempted(phases_not_attempted_for(&cfg.tier));
     let budget = TimeBudget::new(Duration::from_secs(cfg.time_budget_secs));
     let limits = cfg
         .verify_limits
@@ -258,5 +275,52 @@ fn run_chaos_phase(report: &mut SimReport, seed: u64, budget: &TimeBudget) {
                 duration_ms: 0,
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod not_attempted_tests {
+    use super::*;
+
+    /// The tiers that skip the chaos phase must say so, and the tier that runs it must not.
+    ///
+    /// This is the control for #2170: before it, a Quick run reported `bypassed=0` over a
+    /// programme that never attempted a whole phase, and a reader could not tell that from a
+    /// run that attempted everything.
+    #[test]
+    fn tiers_that_skip_chaos_declare_it() {
+        for tier in [SuiteTier::Quick, SuiteTier::Nightly, SuiteTier::Stress] {
+            assert_eq!(
+                phases_not_attempted_for(&tier),
+                vec!["chaos".to_string()],
+                "{tier:?} does not run the chaos phase and must declare it"
+            );
+        }
+        assert!(
+            phases_not_attempted_for(&SuiteTier::Chaos).is_empty(),
+            "the Chaos tier runs every phase, so it declares no omission"
+        );
+    }
+
+    /// Pins the declaration to the gate that causes it.
+    ///
+    /// `run_suite` gates the chaos phase on `matches!(cfg.tier, SuiteTier::Chaos)`. If that gate
+    /// moves, this reads the source and fails, rather than leaving the declaration describing a
+    /// programme the code no longer runs.
+    ///
+    /// Only the code above `#[cfg(test)]` is searched. This test lives in the file it reads, so a
+    /// whole-file search would be satisfied by this test's own literal — the assertion would hold
+    /// even after the real gate moved, which is precisely the failure it exists to prevent.
+    #[test]
+    fn chaos_phase_gate_matches_the_declared_omission() {
+        let source = include_str!("suite.rs");
+        let production = source
+            .split_once("#[cfg(test)]")
+            .expect("suite.rs keeps its test module")
+            .0;
+        assert!(
+            production.contains("if matches!(cfg.tier, SuiteTier::Chaos) {"),
+            "the chaos gate moved; phases_not_attempted_for must be updated with it"
+        );
     }
 }


### PR DESCRIPTION
Closes #2170

## Measured defect

`SimSummary.total` counts what **ran**, so a tier that omits a whole phase and a tier that ran
everything produce the same shape of clean report. The quick suite prints `bypassed=0` and
`All attacks blocked` while never attempting the chaos phase, which `run_suite` gates on
`matches!(cfg.tier, SuiteTier::Chaos)`.

Measured on `8e8a7645e`, quick suite against `tests/fixtures/evidence/test-bundle.tar.gz`:

| | before | after |
|---|---|---|
| console | `✅ All attacks blocked.` | `✅ All attempted attacks blocked. Not attempted by this tier: chaos.` |
| JSON | *(no such field)* | `"phases_not_attempted": ["chaos"]` |

Counts are unchanged in both: `blocked=8 passed=1 bypassed=0`, `total=9`.

## Deliberately not merged with `skipped_phases`

A phase absent because the tier never includes it is a **programme** statement. A phase dropped
because the time budget ran out is a **degradation**. A reader deciding whether a `bypassed=0` run
is reassuring needs to tell those apart, and one list would destroy the distinction. `skipped_phases`
keeps its existing meaning and stays paired with `time_budget_exceeded`.

## Controls

- `tiers_that_skip_chaos_declare_it` pins both directions, including that the Chaos tier declares
  no omission — otherwise the field could be filled unconditionally and still "pass".
- `chaos_phase_gate_matches_the_declared_omission` pins the declaration to the gate that causes it.
  Widening the gate to `SuiteTier::Chaos | SuiteTier::Stress` while leaving the declaration stale
  **fails** it.

That second control searches only the source **above** `#[cfg(test)]`. It lives in the file it
reads, and my first version searched the whole file — which its own literal satisfied, so the
assertion held even with the real gate mutated. That is exactly the failure it exists to prevent,
and it is worth stating plainly rather than quietly fixing: a guard that reads a file containing
itself must exclude itself, or it is asserting about its own copy.

## Verification

`cargo test -p assay-sim` green (39 lib tests), `cargo clippy --all-targets` clean, `cargo fmt` clean.

## Related

One of three issues sharing a single question — a status vocabulary that reports what happened but
cannot state what was never observed. #2422 (session-finding fidelity) and #2446 (`KernelLayerStatus`
cannot say a capture was third-party) are the other two, in flight as #2534 and #2533.