### PR TITLE
fix(ci): let the privileged-action-gate example say why it failed

### DIFF
--- a/examples/privileged-action-gate/run.sh
+++ b/examples/privileged-action-gate/run.sh
@@ -118,17 +118,53 @@ capture() {
 }
 
 # matrix <label> <bundle> [verify-args...]: verify one bundle and print a compact claim-matrix line.
+# The verifier carries "claims" only behind a valid verdict: a stage-1 integrity failure or a
+# rejected statement omits the member and exits 2, because a matrix it could not recompute is not
+# a matrix it will print. The report is read from a file rather than piped, so neither the exit
+# code (pipefail) nor the absent member (KeyError) can end the demo without saying why.
 matrix() {
   local label="$1" bundle="$2"
   shift 2
+  local report="$WORK/verify-report.json" status=0
   "$ASSAY_CLI" evidence verify-privileged-mcp-action "$bundle" --format json "$@" \
-    | "$PY" -c '
+    >"$report" || status=$?
+  "$PY" - "$label" "$report" "$status" <<'PYEOF'
 import json, sys
-label = sys.argv[1]
-report = json.load(sys.stdin)
-cells = " ".join("{}={}".format(name, cell["status"]) for name, cell in report["claims"].items())
+
+label, path, status = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(path) as handle:
+        report = json.load(handle)
+except (OSError, ValueError):
+    print(f"  {label}: the verifier produced no JSON report (exit {status})", file=sys.stderr)
+    raise SystemExit(1)
+
+claims = report.get("claims")
+if claims is None:
+    # Absent by design, never by omission. Print the verifier's own diagnosis: which stage refused,
+    # under which reason code, and every finding it recorded.
+    print(
+        "  {}: NO CLAIM MATRIX  bundle_integrity={}  verdict={}  reason_code={}  (verifier exit {})".format(
+            label,
+            report.get("bundle_integrity", "?"),
+            report.get("verdict", "absent"),
+            report.get("reason_code", "?"),
+            status,
+        ),
+        file=sys.stderr,
+    )
+    for finding in report.get("findings", []):
+        print("    {}: {}".format(finding.get("id", "?"), finding.get("detail", "")), file=sys.stderr)
+    print(
+        "    The claim matrix is recomputed only behind a valid verdict. A profile mismatch is the"
+        " usual cause: pass the --profile-version matching the records this demo produced.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+cells = " ".join("{}={}".format(name, cell["status"]) for name, cell in claims.items())
 print("  {}: verdict={}  {}".format(label, report["verdict"], cells))
-' "$label"
+PYEOF
 }
 
 echo

--- a/examples/privileged-action-gate/verify.sh
+++ b/examples/privileged-action-gate/verify.sh
@@ -4,7 +4,22 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-actual="$(./run.sh 2>/dev/null | "${PYTHON:-python3}" -c '
+# run.sh writes build progress and any diagnosis to stderr. It is captured rather than discarded:
+# discarding it (and letting pipefail abort the pipeline) is why a failing example used to reach CI
+# as a bare "Process completed with exit code 1" with nothing to read. Its exit code is also read
+# here directly, not through a pipe, so a failure is reported before any output is parsed.
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+status=0
+raw="$(./run.sh 2>"$log")" || status=$?
+if [ "$status" -ne 0 ]; then
+  echo "FAIL: run.sh exited ${status}. Its stderr follows:" >&2
+  cat "$log" >&2
+  exit 1
+fi
+
+actual="$(printf '%s\n' "$raw" | "${PYTHON:-python3}" -c '
 import sys, re
 for line in sys.stdin:
     m = re.search(r"(DENY|ALLOW).*reason=([a-z_]+)", line)


### PR DESCRIPTION
The "Demo smoke (privileged-action-gate)" check reached CI as a bare `Process completed with exit code 1` with **nothing else in the log**. Two independent maskings produced that, and both are fixed here.

## Why this is worth a PR even though the red is gone

[#2528](https://github.com/Rul1an/assay/pull/2528) (merged 09:38 today) already cleared the specific failure by adding `--profile-version v1` to the denied-bundle `matrix` call. That fixed **one pairing, not the class**. The maskings below are still on `main`, so the next example that reaches a non-valid verdict produces the same silent exit-1 with no diagnosis, and the next person spends the same twenty minutes finding out why.

## The two maskings

**`verify.sh` discarded the evidence.** It ran `./run.sh 2>/dev/null | python3 ...` under `set -euo pipefail`. When `run.sh` failed, `pipefail` plus `set -e` aborted before anything printed, and `run.sh`'s stderr had already gone to `/dev/null`. It now reads the exit code directly instead of through the pipe, captures stderr to a temp file, and replays it on failure.

**`run.sh`'s `matrix()` assumed a conditional field.** `Report.claims` is `Option<Claims>` behind `skip_serializing_if`, doc-commented *"Present only when `verdict` is `valid`"*. The verifier refuses to print a claim matrix it could not recompute — that is the profile's fail-closed posture, so the example is the side that was wrong, and the absence assertions in `verify_privileged_mcp_action.rs` (lines 992, 1023, 1053) are deliberate.

There was a **second trap underneath the first**: `cmd_verify_privileged_mcp_action` returns exit 2 on an invalid verdict, and `matrix()` ran the CLI in a pipeline under `set -o pipefail`. Teaching the parser to tolerate a missing key would therefore not have been enough — the CLI's own exit 2 would still have killed `run.sh`. `matrix()` now reads the report from a file rather than a pipe, which is what lets `|| status=$?` observe the code instead of having `pipefail` eat the script.

## What it prints now

Instead of silence:

```
denied path bundle : NO CLAIM MATRIX  bundle_integrity=pass  verdict=invalid  reason_code=E_EVIDENCE_PROFILE_INVALID  (verifier exit 2)
  unknown_profile_schema: payload schema "assay.denied_call_observation.v1" is inside the profile namespace but is not a recognized privileged-mcp-action/v0 record; unknown fails closed
```

## Verification

- `bash examples/privileged-action-gate/verify.sh` → exit 0
- **Control on the mutated line:** reintroducing the #2528 defect (dropping `--profile-version v1`) now yields the diagnosis above instead of silence. That is the exact input that produced the bare "exit code 1" in CI.
- Two further absence paths exercised: a stage-1 integrity failure (`verdict=absent`, `E_EVIDENCE_UNREADABLE`), and a report that is not JSON at all.
- `shellcheck` clean; `pre-commit` on both files exits 0; `check-published-release-golden-path-contract.py` OK — it parses `run.sh` and asserts `matrix()` still forwards `"$@"`, and the rewrite keeps that on one line so the guard still binds.
- **CI:** "Demo smoke (privileged-action-gate)" dispatched on this branch → success, [run 32241737989](https://github.com/Rul1an/assay/actions/runs/32241737989), step output `OK: privileged-action-gate verdicts match expected-output.txt`.

One thing stated rather than hidden: `scripts/ci/test_published_release_proxy_phase.py` failed once mid-session with `proxy process failed to start: [Errno 1] Operation not permitted`. That was a transient local sandbox spawn failure, not this change — it passes 4/4 on the patched tree.
