### PR TITLE
feat(conformance): vendor-neutral mutation adequacy for a published corpus

### DIFF
--- a/conformance/adequacy/mcp-jsonrpc-id.manifest.json
+++ b/conformance/adequacy/mcp-jsonrpc-id.manifest.json
@@ -1,0 +1,83 @@
+{
+  "schema": "assay.corpus_adequacy.manifest.v0",
+  "_about": "Mutation adequacy for the mcp-jsonrpc-id pack. The pack's README declares a NARROW scope: the error-response id contradiction, two incompatibility arms plus one positive control. The four id rules are in scope. The envelope-shape rules are real rules the pack depends on but never claimed to exercise, so they are declared out_of_scope and reported rather than scored. Lives OUTSIDE the pack on purpose: the pack checksums its own public files, so adding a manifest to it would break its integrity guard. The vectors file here is derived from the pack's vectors/*.json and conformance/tests/test_corpus_adequacy_own_corpora.py asserts it has not drifted.",
+  "implementation": "../../examples/mcp-jsonrpc-id-conformance/check.py",
+  "entrypoint": "evaluate_message",
+  "entrypoint_args": [
+    "message"
+  ],
+  "vectors": "mcp-jsonrpc-id.vectors.json",
+  "id_key": "vector_id",
+  "default_group": "error_response_id",
+  "mutants": {
+    "error_response_id": [
+      {
+        "label": "0 envelope must declare jsonrpc 2.0",
+        "anchor": "        message.get(\"jsonrpc\") == \"2.0\"\n        and \"result\" not in message",
+        "replacement": "        True\n        and \"result\" not in message",
+        "scope": "out_of_scope"
+      },
+      {
+        "label": "1 an error response must not carry result",
+        "anchor": "        and \"result\" not in message\n        and isinstance(error, dict)",
+        "replacement": "        and isinstance(error, dict)",
+        "scope": "out_of_scope"
+      },
+      {
+        "label": "2 error must be an object",
+        "anchor": "        and isinstance(error, dict)\n        and isinstance(error.get(\"code\"), int)",
+        "replacement": "        and isinstance(error.get(\"code\"), int)",
+        "scope": "out_of_scope"
+      },
+      {
+        "label": "3 error code must be an int",
+        "anchor": "        and isinstance(error.get(\"code\"), int)\n",
+        "replacement": "        and True\n",
+        "scope": "out_of_scope"
+      },
+      {
+        "label": "4 a bool is not an int code",
+        "anchor": "        and not isinstance(error.get(\"code\"), bool)\n",
+        "replacement": "        and True\n",
+        "scope": "out_of_scope"
+      },
+      {
+        "label": "5 error message must be a string",
+        "anchor": "        and isinstance(error.get(\"message\"), str)\n",
+        "replacement": "        and True\n",
+        "scope": "out_of_scope"
+      },
+      {
+        "label": "6 MCP tolerates an omitted id",
+        "anchor": "    mcp_id_valid = not has_id or (",
+        "replacement": "    mcp_id_valid = False or (",
+        "scope": "declared"
+      },
+      {
+        "label": "7 MCP RequestId excludes null",
+        "anchor": "        isinstance(identifier, str)\n        or (isinstance(identifier, int) and not isinstance(identifier, bool))\n    )",
+        "replacement": "        identifier is None\n        or isinstance(identifier, str)\n        or (isinstance(identifier, int) and not isinstance(identifier, bool))\n    )",
+        "scope": "declared"
+      },
+      {
+        "label": "8 JSON-RPC requires id to be present",
+        "anchor": "    jsonrpc_id_valid = has_id and (",
+        "replacement": "    jsonrpc_id_valid = True and (",
+        "scope": "declared"
+      },
+      {
+        "label": "9 JSON-RPC permits a null id",
+        "anchor": "        identifier is None or isinstance(identifier, str) or _is_number(identifier)",
+        "replacement": "        isinstance(identifier, str) or _is_number(identifier)",
+        "scope": "declared"
+      },
+      {
+        "label": "10 a non-object message is rejected outright",
+        "anchor": "    if not isinstance(message, dict) or not _error_shape_is_valid(message):",
+        "replacement": "    if not _error_shape_is_valid(message):",
+        "scope": "out_of_scope"
+      }
+    ]
+  },
+  "equivalent": {}
+}

--- a/conformance/adequacy/mcp-jsonrpc-id.manifest.json
+++ b/conformance/adequacy/mcp-jsonrpc-id.manifest.json
@@ -15,37 +15,43 @@
         "label": "0 envelope must declare jsonrpc 2.0",
         "anchor": "        message.get(\"jsonrpc\") == \"2.0\"\n        and \"result\" not in message",
         "replacement": "        True\n        and \"result\" not in message",
-        "scope": "out_of_scope"
+        "scope": "out_of_scope",
+        "reason": "envelope shape; the pack tests the id contradiction, and every vector is already a well-formed 2.0 error response"
       },
       {
         "label": "1 an error response must not carry result",
         "anchor": "        and \"result\" not in message\n        and isinstance(error, dict)",
         "replacement": "        and isinstance(error, dict)",
-        "scope": "out_of_scope"
+        "scope": "out_of_scope",
+        "reason": "envelope shape; no vector carries both result and error because the contradiction under test is about id alone"
       },
       {
         "label": "2 error must be an object",
         "anchor": "        and isinstance(error, dict)\n        and isinstance(error.get(\"code\"), int)",
         "replacement": "        and isinstance(error.get(\"code\"), int)",
-        "scope": "out_of_scope"
+        "scope": "out_of_scope",
+        "reason": "envelope shape; all three vectors carry a well-formed error object by construction"
       },
       {
         "label": "3 error code must be an int",
         "anchor": "        and isinstance(error.get(\"code\"), int)\n",
         "replacement": "        and True\n",
-        "scope": "out_of_scope"
+        "scope": "out_of_scope",
+        "reason": "envelope shape; code type is not part of the MCP-vs-JSON-RPC id disagreement"
       },
       {
         "label": "4 a bool is not an int code",
         "anchor": "        and not isinstance(error.get(\"code\"), bool)\n",
         "replacement": "        and True\n",
-        "scope": "out_of_scope"
+        "scope": "out_of_scope",
+        "reason": "envelope shape; the bool-is-not-int edge belongs to a code-type corpus, not this one"
       },
       {
         "label": "5 error message must be a string",
         "anchor": "        and isinstance(error.get(\"message\"), str)\n",
         "replacement": "        and True\n",
-        "scope": "out_of_scope"
+        "scope": "out_of_scope",
+        "reason": "envelope shape; message type is not part of the id disagreement"
       },
       {
         "label": "6 MCP tolerates an omitted id",
@@ -75,7 +81,8 @@
         "label": "10 a non-object message is rejected outright",
         "anchor": "    if not isinstance(message, dict) or not _error_shape_is_valid(message):",
         "replacement": "    if not _error_shape_is_valid(message):",
-        "scope": "out_of_scope"
+        "scope": "out_of_scope",
+        "reason": "input-domain guard; the pack's three vectors are all objects, so nothing exercises the non-object branch"
       }
     ]
   },

--- a/conformance/adequacy/mcp-jsonrpc-id.vectors.json
+++ b/conformance/adequacy/mcp-jsonrpc-id.vectors.json
@@ -1,0 +1,36 @@
+{
+  "vectors": [
+    {
+      "vector_id": "jsonrpc-error-with-null-id",
+      "message": {
+        "jsonrpc": "2.0",
+        "id": null,
+        "error": {
+          "code": -32700,
+          "message": "Parse error"
+        }
+      }
+    },
+    {
+      "vector_id": "mcp-error-with-omitted-id",
+      "message": {
+        "jsonrpc": "2.0",
+        "error": {
+          "code": -32700,
+          "message": "Parse error"
+        }
+      }
+    },
+    {
+      "vector_id": "shared-string-id-control",
+      "message": {
+        "jsonrpc": "2.0",
+        "id": "call-1",
+        "error": {
+          "code": -32603,
+          "message": "Internal error"
+        }
+      }
+    }
+  ]
+}

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -255,8 +255,9 @@ def run(manifest_path: Path) -> dict:
                     results.append({
                         "group": group, "label": mut["label"], "verdict": "unexercised",
                         "scope": scope, "moved": 0,
-                        "how": "no vector distinguishes it, and the corpus does not claim to "
-                               "cover this rule. Not a contract hole; a scope statement"})
+                        # Print the stated reason, exactly as a declared equivalent does.
+                        # "each with a stated reason" without showing one is an assertion.
+                        "how": "out of scope: %s" % mut["reason"]})
                     out_of_scope += 1
                 else:
                     results.append({
@@ -331,7 +332,14 @@ def main() -> int:
         for f in rep["failures"]:
             print("FAIL: %s" % f)
         if rep["adequate"]:
-            print("mutation-adequacy check passed: every non-equivalent mutant is killed")
+            if rep["out_of_scope_ratio"] is not None and rep["out_of_scope_ratio"] > 1.0:
+                # The closing line is what gets quoted. It may not read as unqualified
+                # success when most declared rules were excluded from the measurement.
+                print("mutation-adequacy check passed for the DECLARED IN-SCOPE rules only "
+                      "(%d of %d rules declared here were excluded from it)"
+                      % (rep["unexercised_out_of_scope"], rep["declared_total"]))
+            else:
+                print("mutation-adequacy check passed: every non-equivalent mutant is killed")
 
     return 0 if rep["adequate"] else 1
 

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -43,6 +43,23 @@ declares its own mutants in a manifest:
   - a crash is a KILL, reported separately, because "raises without this rule"
     says more about the rule than "returns something else".
 
+WHAT THE PERCENTAGE IS A PERCENTAGE OF
+---------------------------------------
+100% here means 100% of the rules THE AUTHOR DECLARED. It does not mean 100% of
+the rules the implementation has. A rule nobody declared is invisible to this
+check, and there is no honest mechanical fix for that inside a manifest-driven
+design: the manifest is written by the same hand as the corpus.
+
+That is why the report never prints a bare percentage. It prints the numerator,
+the denominator, the count declared equivalent, the count declared out of scope,
+and the ratio between excluded and measured. A score reported without those is a
+percentage target wearing a different coat, because an author can exclude almost
+everything and still print 100%.
+
+For the same reason an out_of_scope mutant must carry a stated reason. It leaves
+the denominator exactly as a declared-equivalent one does, so it carries the same
+obligation.
+
 SELF-COVERAGE, APPLIED TO THIS CHECK
 -------------------------------------
 A group present in the corpus that declares no mutant is the same defect one
@@ -105,6 +122,17 @@ def load_manifest(path: Path) -> dict:
             if e["scope"] not in ("declared", "out_of_scope"):
                 raise ManifestError("mutants[%s][%d] %r: scope must be declared or out_of_scope"
                                     % (group, i, e["label"]))
+            # An out-of-scope mutant leaves the denominator exactly as an equivalent one does,
+            # so it carries the same obligation: a stated reason, never a bare exclusion.
+            if e["scope"] == "out_of_scope" and not str(e.get("reason", "")).strip():
+                raise ManifestError(
+                    "mutants[%s][%d] %r: an out_of_scope mutant needs a stated reason. It leaves "
+                    "the denominator like an equivalent one, so it carries the same obligation"
+                    % (group, i, e["label"]))
+            if not e["anchor"]:
+                raise ManifestError(
+                    "mutants[%s][%d] %r: the anchor is empty. An empty anchor matches everywhere, "
+                    "corrupts the source and is then counted as a kill" % (group, i, e["label"]))
             if e["anchor"] == e["replacement"]:
                 raise ManifestError(
                     "mutants[%s][%d] %r: anchor and replacement are identical, so it mutates nothing"
@@ -184,10 +212,19 @@ def run(manifest_path: Path) -> dict:
                 continue
 
             for idx, mut in enumerate(m["mutants"][group]):
-                if mut["anchor"] not in source:
+                occurrences = source.count(mut["anchor"])
+                if occurrences == 0:
                     failures.append(
                         "%s / %s: anchor not found in %s. The rule was renamed or removed and the "
                         "mutant is measuring nothing" % (group, mut["label"], m["implementation"]))
+                    continue
+                if occurrences > 1:
+                    # Substituting the first of several is a coin flip about which rule is being
+                    # measured, and a mangled substitution is then scored as a kill.
+                    failures.append(
+                        "%s / %s: the anchor occurs %d times in %s, so the substitution would pick "
+                        "one arbitrarily and any breakage would be scored as a kill. Make the "
+                        "anchor unique" % (group, mut["label"], occurrences, m["implementation"]))
                     continue
                 mutated = source.replace(mut["anchor"], mut["replacement"], 1)
                 try:
@@ -247,6 +284,11 @@ def run(manifest_path: Path) -> dict:
     return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
             "killed": killed, "survived": survived, "equivalent": equivalent,
             "unexercised_out_of_scope": out_of_scope,
+            "declared_total": killed + survived + equivalent + out_of_scope,
+            "out_of_scope_ratio": (None if (killed + survived) == 0
+                                   else round(out_of_scope / (killed + survived), 2)),
+            "score_means": ("percent of author-declared in-scope rules killed; NOT percent of the "
+                            "rules the implementation actually has"),
             "score_percent": score, "mutants": results, "failures": failures,
             "adequate": not failures}
 
@@ -270,14 +312,22 @@ def main() -> int:
             if r["verdict"] != "killed":
                 print("    %s" % r["how"])
         print()
-        print("score %.1f%% over %d in-scope non-equivalent mutants (%d killed, %d survived, "
-              "%d declared equivalent and excluded)"
-              % (rep["score_percent"], rep["killed"] + rep["survived"], rep["killed"],
-                 rep["survived"], rep["equivalent"]))
+        # Never a bare percentage. A score reported without its denominator and its
+        # exclusions is a percentage target wearing a different coat: an author can
+        # exclude almost everything and still print 100%.
+        print("%d of %d DECLARED in-scope rules killed (%.1f%%). %d declared equivalent, "
+              "%d declared out of scope. %d rules declared in total."
+              % (rep["killed"], rep["killed"] + rep["survived"], rep["score_percent"],
+                 rep["equivalent"], rep["unexercised_out_of_scope"], rep["declared_total"]))
+        print("This is %.1f%% of what the AUTHOR DECLARED, not of the rules the implementation "
+              "has. A rule nobody declared is invisible to this check." % rep["score_percent"])
         if rep["unexercised_out_of_scope"]:
-            # Always stated. A scope exclusion that is not printed reads as coverage.
-            print("%d rule(s) unexercised and declared OUT OF SCOPE: real gaps in what the corpus "
+            print("out of scope (%d, each with a stated reason): real gaps in what the corpus "
                   "covers, not holes in what it claims" % rep["unexercised_out_of_scope"])
+        if rep["out_of_scope_ratio"] is not None and rep["out_of_scope_ratio"] > 1.0:
+            print("NOTE: more rules are excluded than measured (ratio %.2f). The score is real "
+                  "but it is a statement about a minority of the declared rules."
+                  % rep["out_of_scope_ratio"])
         for f in rep["failures"]:
             print("FAIL: %s" % f)
         if rep["adequate"]:

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Mutation adequacy for a published conformance corpus, driven by a manifest.
+
+Standard library only. No Assay import, no pip install, no network.
+
+    python3 conformance/corpus_adequacy.py <manifest.json>
+    python3 conformance/corpus_adequacy.py <manifest.json> --json
+
+WHY A CORPUS NEEDS THIS AND A TEST SUITE DOES NOT
+-------------------------------------------------
+Outcome coverage is not rule coverage. A corpus can reach every declared
+outcome while some rule never decides anything, because another rule reaches
+the same outcome first on every vector it would have caught. Mutation adequacy
+is the criterion that finds that, and it outperforms structural criteria such
+as line and branch coverage for exactly this question.
+
+The bar here is higher than the usual one. In ordinary mutation testing the
+artifact under test is a test suite, a surviving mutant is a gap in confidence,
+and a score near 80% is a working target. Here the artifact under test is a
+*published corpus whose digest is the contract*. A surviving mutant means an
+implementer can delete that rule, reproduce the pinned digest, and be
+indistinguishable from a conforming implementation. That is not a confidence
+gap, it is a hole in the contract. So the required score is 100% of
+non-equivalent mutants.
+
+WHAT THIS TOOL CAN AND CANNOT GENERALIZE, STATED PLAINLY
+---------------------------------------------------------
+It cannot infer a corpus's rules from arbitrary source. That would be a static
+analysis project, and a tool that guessed would report a score it had not
+earned. What is portable is the *method*, so a corpus that wants to be measured
+declares its own mutants in a manifest:
+
+  - one mutant per DECLARED RULE, not per line. A surviving mutant then names
+    the rule an implementation could omit, instead of naming a line number.
+    Generic operators would produce mostly-equivalent noise over rules this
+    small.
+  - ordinal axes are PERMUTED, not deleted. Deletion is the wrong operator for
+    a ladder: the ordering lives in a table a comparison reads, not in a branch
+    a mutant can cut. Declare flatten-to-top, flatten-to-bottom and invert.
+  - equivalent mutants are DECLARED WITH A REASON, never inferred. Deciding
+    mutant equivalence is undecidable in general, so a tool that claimed to
+    detect it would be lying.
+  - a crash is a KILL, reported separately, because "raises without this rule"
+    says more about the rule than "returns something else".
+
+SELF-COVERAGE, APPLIED TO THIS CHECK
+-------------------------------------
+A group present in the corpus that declares no mutant is the same defect one
+level up: the check would silently cover less than its name claims. That is a
+hard failure here, not a warning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+SCHEMA = "assay.corpus_adequacy.manifest.v0"
+
+
+class ManifestError(Exception):
+    """The manifest does not describe a measurable corpus."""
+
+
+def _req(obj: dict, key: str, where: str):
+    if key not in obj:
+        raise ManifestError("%s: missing required key %r" % (where, key))
+    return obj[key]
+
+
+def load_manifest(path: Path) -> dict:
+    m = json.loads(path.read_text(encoding="utf-8"))
+    if m.get("schema") != SCHEMA:
+        raise ManifestError("schema must be %r, got %r" % (SCHEMA, m.get("schema")))
+    base = path.parent
+    for key in ("implementation", "vectors"):
+        _req(m, key, "manifest")
+    m["_impl_path"] = (base / m["implementation"]).resolve()
+    m["_vectors_path"] = (base / m["vectors"]).resolve()
+    m.setdefault("entrypoint", "evaluate")
+    # group_key is OPTIONAL. A corpus with no axis column is one group; forcing it to invent
+    # an axis would be the tool bending the corpus to fit itself.
+    m.setdefault("group_key", None)
+    m.setdefault("id_key", "vector_id")
+    m.setdefault("inputs_key", "inputs")
+    m.setdefault("vectors_key", "vectors")
+    # Which vector fields are passed positionally to the entrypoint. Signatures differ between
+    # corpora and a fixed arity would exclude every corpus that did not guess the same one.
+    m.setdefault("entrypoint_args",
+                 [k for k in (m["group_key"], m["inputs_key"]) if k is not None])
+    m.setdefault("default_group", "all")
+    m.setdefault("mutants", {})
+    m.setdefault("equivalent", {})
+    if not m["mutants"]:
+        raise ManifestError("manifest declares no mutants; there is nothing to measure")
+    for group, entries in m["mutants"].items():
+        for i, e in enumerate(entries):
+            for key in ("label", "anchor", "replacement"):
+                _req(e, key, "mutants[%s][%d]" % (group, i))
+            e.setdefault("scope", "declared")
+            if e["scope"] not in ("declared", "out_of_scope"):
+                raise ManifestError("mutants[%s][%d] %r: scope must be declared or out_of_scope"
+                                    % (group, i, e["label"]))
+            if e["anchor"] == e["replacement"]:
+                raise ManifestError(
+                    "mutants[%s][%d] %r: anchor and replacement are identical, so it mutates nothing"
+                    % (group, i, e["label"]))
+    for group, entries in m["equivalent"].items():
+        for i, e in enumerate(entries):
+            for key in ("label", "reason"):
+                _req(e, key, "equivalent[%s][%d]" % (group, i))
+            if not str(e["reason"]).strip():
+                raise ManifestError(
+                    "equivalent[%s][%d] %r: an equivalence needs a stated reason, never a bare claim"
+                    % (group, i, e["label"]))
+    return m
+
+
+def _load_module(source: str, tag: str, tmp: Path):
+    path = tmp / ("impl_%s.py" % tag)
+    path.write_text(source, encoding="utf-8")
+    spec = importlib.util.spec_from_file_location("adequacy_%s" % tag, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _group_of(v: dict, m: dict) -> str:
+    return v[m["group_key"]] if m["group_key"] else m["default_group"]
+
+
+def _outcomes(fn, vectors: list[dict], m: dict) -> tuple[dict, list[str]]:
+    """(outcome per vector id, ids that raised). A raise is a behaviour change."""
+    outcomes, raised = {}, []
+    for v in vectors:
+        vid = v[m["id_key"]]
+        try:
+            outcomes[vid] = fn(*[v[k] for k in m["entrypoint_args"]])
+        except Exception:  # noqa: BLE001 - any raise is the signal, not an error
+            raised.append(vid)
+    return outcomes, raised
+
+
+def run(manifest_path: Path) -> dict:
+    m = load_manifest(manifest_path)
+    source = m["_impl_path"].read_text(encoding="utf-8")
+    doc = json.loads(m["_vectors_path"].read_text(encoding="utf-8"))
+    all_vectors = doc[m["vectors_key"]] if isinstance(doc, dict) else doc
+
+    failures: list[str] = []
+    groups_in_corpus = {_group_of(v, m) for v in all_vectors}
+
+    # Self-coverage: the reach of this check must not narrow silently.
+    unmutated = sorted(groups_in_corpus - set(m["mutants"]))
+    if unmutated:
+        failures.append(
+            "groups present in the corpus with no declared mutants: %s. Declare a mutant per "
+            "rule, or this check covers less than its name claims" % unmutated)
+    stale = sorted(set(m["mutants"]) - groups_in_corpus)
+    if stale:
+        failures.append("mutants declared for groups not in the corpus: %s" % stale)
+
+    results, killed, survived, equivalent, out_of_scope = [], 0, 0, 0, 0
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        base_mod = _load_module(source, "base", tmp)
+        base_fn = getattr(base_mod, m["entrypoint"], None)
+        if base_fn is None:
+            raise ManifestError("implementation has no entrypoint %r" % m["entrypoint"])
+
+        for group in sorted(m["mutants"]):
+            vectors = [v for v in all_vectors if _group_of(v, m) == group]
+            if not vectors:
+                failures.append("%s: no vectors, so its mutants cannot be scored" % group)
+                continue
+            baseline, base_raised = _outcomes(base_fn, vectors, m)
+            if base_raised:
+                failures.append("%s: the UNMUTATED implementation raised on %s"
+                                % (group, base_raised))
+                continue
+
+            for idx, mut in enumerate(m["mutants"][group]):
+                if mut["anchor"] not in source:
+                    failures.append(
+                        "%s / %s: anchor not found in %s. The rule was renamed or removed and the "
+                        "mutant is measuring nothing" % (group, mut["label"], m["implementation"]))
+                    continue
+                mutated = source.replace(mut["anchor"], mut["replacement"], 1)
+                try:
+                    mod = _load_module(mutated, "%s_%d" % (group.replace("-", "_"), idx), tmp)
+                    fn = getattr(mod, m["entrypoint"])
+                except Exception as exc:  # noqa: BLE001
+                    results.append({"group": group, "label": mut["label"], "verdict": "killed",
+                                    "how": "the mutant does not load: %r" % (exc,), "moved": 0})
+                    killed += 1
+                    continue
+                scope = mut.get("scope", "declared")
+                out, raised = _outcomes(fn, vectors, m)
+                moved = [vid for vid, val in out.items() if baseline.get(vid) != val]
+                if raised:
+                    results.append({"group": group, "label": mut["label"], "verdict": "killed",
+                                    "scope": scope, "how": "raises on %d vector(s)" % len(raised),
+                                    "moved": len(moved), "raised": raised})
+                    killed += 1
+                elif moved:
+                    results.append({"group": group, "label": mut["label"], "verdict": "killed",
+                                    "scope": scope, "how": "%d vector(s) moved" % len(moved),
+                                    "moved": len(moved)})
+                    killed += 1
+                elif scope == "out_of_scope":
+                    # Declared by the manifest as a rule this corpus does not claim to cover.
+                    # Reported every run, never scored: adequacy is relative to declared scope,
+                    # and scoring a rule nobody claimed manufactures a hole that is not one.
+                    results.append({
+                        "group": group, "label": mut["label"], "verdict": "unexercised",
+                        "scope": scope, "moved": 0,
+                        "how": "no vector distinguishes it, and the corpus does not claim to "
+                               "cover this rule. Not a contract hole; a scope statement"})
+                    out_of_scope += 1
+                else:
+                    results.append({
+                        "group": group, "label": mut["label"], "verdict": "survived",
+                        "scope": scope, "moved": 0,
+                        "how": "no vector distinguishes it. An implementation can delete this rule, "
+                               "reproduce the pinned digest, and be indistinguishable from a "
+                               "conforming one. The corpus needs a vector where this rule, and only "
+                               "this rule, decides the outcome"})
+                    survived += 1
+
+            for eq in m["equivalent"].get(group, []):
+                results.append({"group": group, "label": eq["label"], "verdict": "equivalent",
+                                "how": eq["reason"], "moved": 0})
+                equivalent += 1
+
+    denom = killed + survived
+    score = 100.0 if denom == 0 else round(100.0 * killed / denom, 1)
+    if survived:
+        failures.append("%d mutant(s) survived; the required score is 100%% of non-equivalent "
+                        "mutants" % survived)
+    if denom == 0 and not failures:
+        failures.append("no non-equivalent mutants were scored, so no adequacy was measured")
+
+    return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
+            "killed": killed, "survived": survived, "equivalent": equivalent,
+            "unexercised_out_of_scope": out_of_scope,
+            "score_percent": score, "mutants": results, "failures": failures,
+            "adequate": not failures}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("manifest", type=Path)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+    try:
+        rep = run(args.manifest)
+    except (ManifestError, OSError, json.JSONDecodeError) as exc:
+        print("could not measure: %s" % exc, file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(rep, indent=2, sort_keys=True))
+    else:
+        for r in rep["mutants"]:
+            print("%-22s %-9s %s" % (r["group"], r["verdict"], r["label"]))
+            if r["verdict"] != "killed":
+                print("    %s" % r["how"])
+        print()
+        print("score %.1f%% over %d in-scope non-equivalent mutants (%d killed, %d survived, "
+              "%d declared equivalent and excluded)"
+              % (rep["score_percent"], rep["killed"] + rep["survived"], rep["killed"],
+                 rep["survived"], rep["equivalent"]))
+        if rep["unexercised_out_of_scope"]:
+            # Always stated. A scope exclusion that is not printed reads as coverage.
+            print("%d rule(s) unexercised and declared OUT OF SCOPE: real gaps in what the corpus "
+                  "covers, not holes in what it claims" % rep["unexercised_out_of_scope"])
+        for f in rep["failures"]:
+            print("FAIL: %s" % f)
+        if rep["adequate"]:
+            print("mutation-adequacy check passed: every non-equivalent mutant is killed")
+
+    return 0 if rep["adequate"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/tests/test_corpus_adequacy.py
+++ b/conformance/tests/test_corpus_adequacy.py
@@ -187,6 +187,39 @@ class RuleyFindings(unittest.TestCase):
         self.assertEqual(rep["out_of_scope_ratio"], 1.0)
         self.assertIn("author-declared", rep["score_means"])
 
+    def test_the_out_of_scope_reason_is_printed_on_its_own_line(self):
+        # Follow-up on the #2538 review: "each with a stated reason" without showing
+        # one is an assertion. A declared equivalent already prints its reason.
+        oos = dict(SURVIVOR, scope="out_of_scope", reason="UNIQUEMARKER not claimed here")
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [KILLABLE, oos]})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertIn("UNIQUEMARKER", r.stdout)
+
+    def test_the_closing_line_is_qualified_when_most_rules_were_excluded(self):
+        # Follow-up: the last line is what gets quoted, so at ratio > 1 it may not
+        # read as unqualified success.
+        oos = [dict(SURVIVOR, label=f"o{i}", anchor='return "ok"',
+                    replacement=f'return "ok"  # {i}', scope="out_of_scope",
+                    reason="not claimed") for i in range(3)]
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [KILLABLE] + oos})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertEqual(r.returncode, 0)
+        last = [l for l in r.stdout.strip().splitlines() if l.strip()][-1]
+        self.assertIn("DECLARED IN-SCOPE rules only", last)
+        self.assertNotEqual(
+            last.strip(), "mutation-adequacy check passed: every non-equivalent mutant is killed")
+
+    def test_the_closing_line_is_unqualified_when_nothing_was_excluded(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [KILLABLE]})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertIn("every non-equivalent mutant is killed", r.stdout)
+
     def test_a_majority_excluded_corpus_says_so(self):
         oos = [dict(SURVIVOR, label=f"o{i}", anchor=f'return "ok"',
                     replacement=f'return "ok"  # {i}', scope="out_of_scope",

--- a/conformance/tests/test_corpus_adequacy.py
+++ b/conformance/tests/test_corpus_adequacy.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Behavioural tests for conformance/corpus_adequacy.py. Standard library only.
+
+    python3 conformance/tests/test_corpus_adequacy.py
+
+Built against a synthetic two-rule corpus rather than a real one, so every
+verdict boundary is reachable on purpose: a rule some vector discriminates, a
+rule none does, a rule declared out of scope, and a rule declared equivalent.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import corpus_adequacy as ca  # noqa: E402
+
+IMPL = '''
+def evaluate(group, inputs):
+    if inputs.get("bad"):
+        return "rejected"
+    if inputs.get("n", 0) > 10:
+        return "big"
+    return "ok"
+'''
+
+VECTORS = {"vectors": [
+    {"vector_id": "v1", "axis": "a", "inputs": {"bad": True}},
+    {"vector_id": "v2", "axis": "a", "inputs": {"n": 1}},
+]}
+
+KILLABLE = {"label": "rejects bad input",
+            "anchor": 'if inputs.get("bad"):\n        return "rejected"',
+            "replacement": 'if False:\n        return "rejected"'}
+# No vector carries n > 10, so nothing can distinguish this rule.
+SURVIVOR = {"label": "big branch",
+            "anchor": 'if inputs.get("n", 0) > 10:',
+            "replacement": 'if inputs.get("n", 0) > 999999:'}
+
+
+def _manifest(tmp: Path, mutants, equivalent=None, vectors=None, raw=None) -> Path:
+    (tmp / "impl.py").write_text(IMPL)
+    (tmp / "vectors.json").write_text(json.dumps(vectors or VECTORS))
+    m = {"schema": ca.SCHEMA, "implementation": "impl.py", "entrypoint": "evaluate",
+         "vectors": "vectors.json", "group_key": "axis", "id_key": "vector_id",
+         "inputs_key": "inputs", "mutants": mutants, "equivalent": equivalent or {}}
+    if raw:
+        m.update(raw)
+    p = tmp / "m.json"
+    p.write_text(json.dumps(m))
+    return p
+
+
+class Scoring(unittest.TestCase):
+    def test_a_discriminated_rule_is_killed_and_scores_100(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE]}))
+        self.assertEqual((rep["killed"], rep["survived"]), (1, 0))
+        self.assertEqual(rep["score_percent"], 100.0)
+        self.assertTrue(rep["adequate"])
+
+    def test_an_undistinguished_rule_survives_and_fails_the_run(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, SURVIVOR]}))
+        self.assertEqual((rep["killed"], rep["survived"]), (1, 1))
+        self.assertEqual(rep["score_percent"], 50.0)
+        self.assertFalse(rep["adequate"])
+
+    def test_out_of_scope_is_reported_but_never_scored(self):
+        # The distinction the tool exists to keep: a rule nobody claimed is a
+        # scope statement, not a hole, and must not manufacture a failure.
+        oos = dict(SURVIVOR, scope="out_of_scope")
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, oos]}))
+        self.assertEqual(rep["survived"], 0)
+        self.assertEqual(rep["unexercised_out_of_scope"], 1)
+        self.assertEqual(rep["score_percent"], 100.0)
+        self.assertTrue(rep["adequate"])
+        self.assertIn("unexercised", [r["verdict"] for r in rep["mutants"]])
+
+    def test_declared_equivalents_are_excluded_from_the_denominator(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE]},
+                                   {"a": [{"label": "eq", "reason": "both branches return ok"}]}))
+        self.assertEqual(rep["equivalent"], 1)
+        self.assertEqual(rep["killed"] + rep["survived"], 1)
+
+    def test_a_mutant_that_crashes_the_module_counts_as_killed(self):
+        broken = {"label": "syntax", "anchor": 'return "ok"', "replacement": "return ??"}
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [broken]}))
+        self.assertEqual(rep["killed"], 1)
+
+
+class Guards(unittest.TestCase):
+    def test_a_group_in_the_corpus_with_no_mutants_is_a_hard_failure(self):
+        v = {"vectors": VECTORS["vectors"] + [
+            {"vector_id": "v3", "axis": "b", "inputs": {"n": 1}}]}
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE]}, vectors=v))
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("no declared mutants" in f for f in rep["failures"]))
+
+    def test_a_stale_anchor_fails_rather_than_scoring_nothing(self):
+        stale = {"label": "gone", "anchor": "this text is not in the impl",
+                 "replacement": "nor is this"}
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, stale]}))
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("anchor not found" in f for f in rep["failures"]))
+
+    def test_mutants_declared_for_absent_groups_fail(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE], "zz": [KILLABLE]}))
+        self.assertTrue(any("not in the corpus" in f for f in rep["failures"]))
+
+
+class ManifestValidation(unittest.TestCase):
+    def _err(self, raw):
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [KILLABLE]}, raw=raw)
+            with self.assertRaises(ca.ManifestError) as cm:
+                ca.load_manifest(p)
+            return str(cm.exception)
+
+    def test_wrong_schema_is_refused(self):
+        self.assertIn("schema", self._err({"schema": "something.else"}))
+
+    def test_no_mutants_is_refused_rather_than_scored_as_perfect(self):
+        self.assertIn("no mutants", self._err({"mutants": {}}))
+
+    def test_an_equivalence_without_a_reason_is_refused(self):
+        self.assertIn("stated reason",
+                      self._err({"equivalent": {"a": [{"label": "x", "reason": "  "}]}}))
+
+    def test_a_mutant_that_changes_nothing_is_refused(self):
+        self.assertIn("mutates nothing",
+                      self._err({"mutants": {"a": [{"label": "noop", "anchor": "x",
+                                                    "replacement": "x"}]}}))
+
+
+class Portability(unittest.TestCase):
+    def test_a_single_argument_entrypoint_is_supported(self):
+        # Found by running the tool on a second corpus: signatures differ, and a
+        # fixed arity would exclude every corpus that guessed differently.
+        impl = 'def check(msg):\n    return "ok" if msg.get("k") else "no"\n'
+        with tempfile.TemporaryDirectory() as raw:
+            d = Path(raw)
+            (d / "impl.py").write_text(impl)
+            (d / "vectors.json").write_text(json.dumps({"vectors": [
+                {"vector_id": "v1", "msg": {"k": 1}}, {"vector_id": "v2", "msg": {}}]}))
+            m = {"schema": ca.SCHEMA, "implementation": "impl.py", "entrypoint": "check",
+                 "entrypoint_args": ["msg"], "vectors": "vectors.json", "id_key": "vector_id",
+                 "default_group": "only",
+                 "mutants": {"only": [{"label": "truthy branch",
+                                       "anchor": 'if msg.get("k")', "replacement": "if False"}]}}
+            p = d / "m.json"
+            p.write_text(json.dumps(m))
+            rep = ca.run(p)
+        self.assertEqual(rep["killed"], 1)
+        self.assertTrue(rep["adequate"])
+
+
+class Cli(unittest.TestCase):
+    def _cli(self, mutants, *args):
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), mutants)
+            return subprocess.run([sys.executable, str(ca.__file__), str(p), *args],
+                                  capture_output=True, text=True, timeout=120)
+
+    def test_exit_0_when_adequate(self):
+        self.assertEqual(self._cli({"a": [KILLABLE]}).returncode, 0)
+
+    def test_exit_1_when_a_mutant_survives(self):
+        self.assertEqual(self._cli({"a": [KILLABLE, SURVIVOR]}).returncode, 1)
+
+    def test_exit_2_when_the_manifest_cannot_be_read(self):
+        r = subprocess.run([sys.executable, str(ca.__file__), "/nope/missing.json"],
+                           capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 2)
+
+    def test_json_mode_is_wellformed(self):
+        d = json.loads(self._cli({"a": [KILLABLE]}, "--json").stdout)
+        self.assertEqual(d["schema"], "assay.corpus_adequacy.report.v0")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/conformance/tests/test_corpus_adequacy.py
+++ b/conformance/tests/test_corpus_adequacy.py
@@ -74,7 +74,7 @@ class Scoring(unittest.TestCase):
     def test_out_of_scope_is_reported_but_never_scored(self):
         # The distinction the tool exists to keep: a rule nobody claimed is a
         # scope statement, not a hole, and must not manufacture a failure.
-        oos = dict(SURVIVOR, scope="out_of_scope")
+        oos = dict(SURVIVOR, scope="out_of_scope", reason="the corpus does not claim this rule")
         with tempfile.TemporaryDirectory() as d:
             rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, oos]}))
         self.assertEqual(rep["survived"], 0)
@@ -142,6 +142,60 @@ class ManifestValidation(unittest.TestCase):
         self.assertIn("mutates nothing",
                       self._err({"mutants": {"a": [{"label": "noop", "anchor": "x",
                                                     "replacement": "x"}]}}))
+
+
+class RuleyFindings(unittest.TestCase):
+    """Regressions for the blocking review on #2538. Each one scored 100% before."""
+
+    def test_out_of_scope_without_a_reason_is_refused(self):
+        # Finding 1: 1 killable + 5 unreasoned out_of_scope printed 100% and exited 0.
+        # An out_of_scope mutant leaves the denominator exactly as an equivalent one
+        # does, so it carries the same obligation.
+        oos = dict(SURVIVOR, scope="out_of_scope")
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [KILLABLE, oos]})
+            with self.assertRaises(ca.ManifestError) as cm:
+                ca.load_manifest(p)
+        self.assertIn("stated reason", str(cm.exception))
+
+    def test_an_empty_anchor_is_refused(self):
+        # Finding 2a: "" matches everywhere, corrupts the source, and the resulting
+        # import failure was then counted as a kill.
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [{"label": "empty", "anchor": "",
+                                           "replacement": "# x"}]})
+            with self.assertRaises(ca.ManifestError) as cm:
+                ca.load_manifest(p)
+        self.assertIn("anchor is empty", str(cm.exception))
+
+    def test_an_anchor_occurring_more_than_once_fails_the_run(self):
+        # Finding 2b: a substring anchor mangled the source; the breakage scored as a kill.
+        dup = {"label": "substring", "anchor": "inputs", "replacement": "broken"}
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, dup]}))
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("occurs" in f and "unique" in f for f in rep["failures"]),
+                        rep["failures"])
+
+    def test_the_report_states_what_the_percentage_is_a_percentage_of(self):
+        # Finding 3: the fix is the published sentence, not code. 100% is 100% of what
+        # the author declared, never of the rules the implementation has.
+        oos = dict(SURVIVOR, scope="out_of_scope", reason="not claimed")
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, oos]}))
+        self.assertEqual(rep["declared_total"], 2)
+        self.assertEqual(rep["out_of_scope_ratio"], 1.0)
+        self.assertIn("author-declared", rep["score_means"])
+
+    def test_a_majority_excluded_corpus_says_so(self):
+        oos = [dict(SURVIVOR, label=f"o{i}", anchor=f'return "ok"',
+                    replacement=f'return "ok"  # {i}', scope="out_of_scope",
+                    reason="not claimed") for i in range(3)]
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [KILLABLE] + oos})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertIn("more rules are excluded than measured", r.stdout)
 
 
 class Portability(unittest.TestCase):

--- a/conformance/tests/test_corpus_adequacy_own_corpora.py
+++ b/conformance/tests/test_corpus_adequacy_own_corpora.py
@@ -52,6 +52,21 @@ class OwnCorpusAdequacy(unittest.TestCase):
         self.assertEqual(rep["killed"], 4)
         self.assertEqual(rep["survived"], 0)
 
+    def test_every_out_of_scope_declaration_carries_a_reason(self):
+        # Blocking review on #2538: an unreasoned exclusion is a percentage target
+        # wearing a different coat.
+        import json as _json
+        m = _json.loads(MANIFEST.read_text())
+        for mut in m["mutants"]["error_response_id"]:
+            if mut.get("scope") == "out_of_scope":
+                self.assertTrue(str(mut.get("reason", "")).strip(), mut["label"])
+
+    def test_the_report_names_the_denominator_and_the_ratio(self):
+        rep = ca.run(MANIFEST)
+        self.assertEqual(rep["declared_total"], 11)
+        self.assertEqual(rep["out_of_scope_ratio"], 1.75)
+        self.assertIn("author-declared", rep["score_means"])
+
     def test_the_out_of_scope_count_is_stated_rather_than_hidden(self):
         # The honest half of the result: seven envelope rules no vector exercises.
         # If this number silently drops to zero, someone removed the disclosure

--- a/conformance/tests/test_corpus_adequacy_own_corpora.py
+++ b/conformance/tests/test_corpus_adequacy_own_corpora.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Adequacy of THIS repository's own corpora, plus the drift guards behind it.
+
+    python3 conformance/tests/test_corpus_adequacy_own_corpora.py
+
+#192's first obligation is to run the tool on ourselves and publish the result
+whether or not it flatters us, because offering a corpus audit we have not
+survived is a claim without cover.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import corpus_adequacy as ca  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST = REPO / "conformance/adequacy/mcp-jsonrpc-id.manifest.json"
+PACK = REPO / "examples/mcp-jsonrpc-id-conformance"
+
+
+class DerivedVectorsDoNotDrift(unittest.TestCase):
+    """The adequacy vectors are a projection of the pack; keep them one thing."""
+
+    def test_the_derived_vectors_still_match_the_pack(self):
+        derived = json.loads((REPO / "conformance/adequacy/mcp-jsonrpc-id.vectors.json")
+                             .read_text())["vectors"]
+        fresh = []
+        for f in sorted(glob.glob(str(PACK / "vectors" / "*.json"))):
+            d = json.loads(Path(f).read_text())
+            fresh.append({"vector_id": d["id"], "message": d["message"]})
+        self.assertEqual(derived, fresh,
+                         "the pack's vectors moved; regenerate mcp-jsonrpc-id.vectors.json")
+
+    def test_the_manifest_lives_outside_the_pack(self):
+        # Adding files inside the pack breaks its own SHA256SUMS guard. Verified by
+        # trying it: check.py reproduce returned PackError until they were moved out.
+        for p in PACK.rglob("adequacy*"):
+            self.fail("adequacy artifact inside the checksummed pack: %s" % p)
+
+
+class OwnCorpusAdequacy(unittest.TestCase):
+    def test_mcp_jsonrpc_id_is_adequate_within_its_declared_scope(self):
+        rep = ca.run(MANIFEST)
+        self.assertTrue(rep["adequate"], rep["failures"])
+        self.assertEqual(rep["score_percent"], 100.0)
+        self.assertEqual(rep["killed"], 4)
+        self.assertEqual(rep["survived"], 0)
+
+    def test_the_out_of_scope_count_is_stated_rather_than_hidden(self):
+        # The honest half of the result: seven envelope rules no vector exercises.
+        # If this number silently drops to zero, someone removed the disclosure
+        # rather than adding vectors.
+        rep = ca.run(MANIFEST)
+        self.assertEqual(rep["unexercised_out_of_scope"], 7)
+
+    def test_every_in_scope_mutant_is_an_id_rule(self):
+        # Guards the scope split itself: in-scope must mean the id contradiction
+        # the pack's README declares, not whatever happens to be killable.
+        m = json.loads(MANIFEST.read_text())
+        in_scope = {x["label"] for x in m["mutants"]["error_response_id"]
+                    if x.get("scope", "declared") == "declared"}
+        self.assertEqual(in_scope, {
+            "6 MCP tolerates an omitted id",
+            "7 MCP RequestId excludes null",
+            "8 JSON-RPC requires id to be present",
+            "9 JSON-RPC permits a null id",
+        }, "the in-scope set must be exactly the four id rules the README declares")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Generalizes rge-bench's `check_rule_liveness.py` into a manifest-driven tool that measures **mutation adequacy of a published conformance corpus** — any corpus, not just ours. Standard library only, no Assay import, no network.

```
python3 conformance/corpus_adequacy.py conformance/adequacy/mcp-jsonrpc-id.manifest.json
```

## Why a corpus needs this and a test suite does not

Outcome coverage is not rule coverage. A corpus can reach every declared outcome while some rule never decides anything, because another rule reaches the same outcome first on every vector it would have caught.

A surviving mutant is therefore not a confidence gap. It means **an implementer can delete that rule, reproduce the pinned digest, and be indistinguishable from a conforming implementation.** That is a hole in the contract, which is why the bar is 100% of non-equivalent mutants rather than the ~80% usual in mutation testing.

## Parity is the reason to trust it

Against rge-bench's corpus the general tool reproduces the specialised checker **exactly**: 100% over 30 non-equivalent mutants, 1 declared equivalent. The manifest for that run was generated from the existing `MUTANTS`/`EQUIVALENT` dicts rather than retyped, so the parity tests the runner and not a transcription.

If the two ever diverge, one of them is wrong, and that is now detectable.

## What is portable, stated plainly

The tool **cannot** infer a corpus's rules from arbitrary source. That would be a static-analysis project, and a tool that guessed would report a score it had not earned. What is portable is the method, so a corpus declares its own mutants:

- one mutant per **declared rule**, not per line, so a survivor names the rule an implementation could omit
- ordinal axes are **permuted**, not deleted — the ordering lives in a table a comparison reads, not in a branch a mutant can cut
- equivalence is **declared with a reason**, never inferred, because deciding it is undecidable
- a crash is a **kill**, reported separately

## Two things found by running it on our own corpus

Neither was designed. Both came from use, which is why "run it on yourself first" was the first obligation.

**Entrypoint signatures differ.** rge-bench has `evaluate(axis, inputs)`; our jsonrpc pack has `evaluate_message(message)`. A fixed arity would have excluded every corpus that guessed differently, so `entrypoint_args` and an optional `group_key` now come from the manifest.

**Adequacy is relative to declared scope, and this is the important one.** `mcp-jsonrpc-id` scored **36.4%** at first. That number was wrong — not the measurement, but my denominator: I had declared mutants for envelope rules the pack never claimed to cover. Its README says *"a narrow interoperability contradiction"*, two arms plus one positive control.

With scope declared: **100% over the four id rules it does claim, and seven rules reported unexercised and out of scope.** Out-of-scope mutants are printed every run and never scored, because an exclusion that is not printed reads as coverage.

That field is a precondition for offering this to anyone else. Without it the tool manufactures alarming numbers about other people's corpora, which makes it an attack rather than a contribution.

## Honest about our own coverage

| Corpus | Measurable | Result |
|---|---|---|
| `mcp-jsonrpc-id-conformance` | yes | **100%** in scope (4/4); **7 rules unexercised, out of scope** |
| rge-bench (external) | yes | 100% over 30 |
| `privileged-mcp-action-v0` | **no** | reference implementation is the Rust verifier, no module entrypoint |
| `mcp-era-parity-v0` | **no** | Rust-driven |
| `rfc8785` | **no** | Rust-driven |

Three of five are not measurable today, including the frozen gate whose digest is a contract. A Rust adapter is the next real work; this PR does not claim otherwise.

## Verification

- Parity against rge-bench: identical to the specialised checker
- **Positive controls, both run before commit:** an inert mutant is reported `survived` (96.8%, exit 1); a corpus group with no declared mutants is a hard failure
- 22 stdlib tests over two files: every verdict boundary, the self-coverage guard, stale anchors, manifest validation, exit codes
- A drift test asserts the derived vectors still match the pack, and that no adequacy artifact has crept back inside it

## One guard that caught me

The manifest first lived **inside** the jsonrpc pack. That broke `check.py reproduce` with `PackError`, because the pack checksums its own public files. The pack was right; the manifest now sits in `conformance/adequacy/` and the pack is byte-for-byte untouched.
