### PR TITLE
fix(metrics): canonicalize tool schema hash bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - `TraceExtent` and session-finding notes state that extent makes no fidelity claim:
   `complete` must not be read as "nothing is missing" (#2422). A producer-declared
   `coverage` field on the finding waits for a planned major.
+- `tool_description_integrity` hashes `input_schema` over canonical RFC 8785 bytes through
+  `assay_core::mcp::jcs`. Pins recorded against the prior compact-JSON preimage may need
+  regeneration even where a schema is unchanged; key reordering no longer reads as a mutation
+  (#2245).
 
 ### Fixed
 - Published-release golden path and `examples/privileged-action-gate/run.sh` verify the

--- a/crates/assay-metrics/src/tool_description_integrity.rs
+++ b/crates/assay-metrics/src/tool_description_integrity.rs
@@ -1,5 +1,5 @@
-use assay_core::metrics_api::{Metric, MetricResult};
 use assay_core::mcp::jcs;
+use assay_core::metrics_api::{Metric, MetricResult};
 use assay_core::model::{Expected, LlmResponse, TestCase};
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};

--- a/crates/assay-metrics/src/tool_description_integrity.rs
+++ b/crates/assay-metrics/src/tool_description_integrity.rs
@@ -1,4 +1,5 @@
 use assay_core::metrics_api::{Metric, MetricResult};
+use assay_core::mcp::jcs;
 use assay_core::model::{Expected, LlmResponse, TestCase};
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
@@ -10,9 +11,11 @@ fn sha256_str(s: &str) -> String {
     hex::encode(Sha256::digest(s.as_bytes()))
 }
 
-/// Stable hash over a JSON value: serialise to compact JSON then SHA-256.
+/// Hash a JSON value over the RFC 8785 canonical bytes used by tool identity.
 fn sha256_value(v: &serde_json::Value) -> String {
-    sha256_str(&serde_json::to_string(v).unwrap_or_default())
+    hex::encode(Sha256::digest(
+        jcs::to_vec(v).expect("a serde_json::Value is always JCS-serializable"),
+    ))
 }
 
 /// Extract `meta["tool_definitions"]` as a flat list of tool objects.
@@ -317,6 +320,61 @@ mod tests {
                 .unwrap()
                 .contains("E_TOOL_DESCRIPTION_MUTATED"),
             "details={}",
+            result.details
+        );
+    }
+
+    #[test]
+    fn schema_hash_ignores_object_key_order() {
+        let first: serde_json::Value =
+            serde_json::from_str(r#"{"type":"object","properties":{"path":{"type":"string"}}}"#)
+                .expect("first schema parses");
+        let reordered: serde_json::Value =
+            serde_json::from_str(r#"{"properties":{"path":{"type":"string"}},"type":"object"}"#)
+                .expect("reordered schema parses");
+
+        assert_eq!(sha256_value(&first), sha256_value(&reordered));
+    }
+
+    #[tokio::test]
+    async fn snapshot_mode_ignores_input_schema_key_order() {
+        let metric = ToolDescriptionIntegrityMetric;
+        let tc = test_case();
+        let expected = Expected::ToolDescriptionIntegrity {
+            pinned_tools: vec![],
+        };
+        let resp = LlmResponse {
+            meta: serde_json::from_str(
+                r#"{
+                    "tool_definition_snapshots": [
+                        [{
+                            "name": "exec",
+                            "description": "Runs a command",
+                            "input_schema": {
+                                "type": "object",
+                                "properties": {"command": {"type": "string"}}
+                            }
+                        }],
+                        [{
+                            "name": "exec",
+                            "description": "Runs a command",
+                            "input_schema": {
+                                "properties": {"command": {"type": "string"}},
+                                "type": "object"
+                            }
+                        }]
+                    ]
+                }"#,
+            )
+            .expect("tool snapshots parse"),
+            ..Default::default()
+        };
+
+        let result = metric.evaluate(&tc, &expected, &resp).await.unwrap();
+
+        assert!(
+            result.passed,
+            "key order alone must not emit E_TOOL_SCHEMA_MUTATED: {}",
             result.details
         );
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Fixes #2245 by hashing `input_schema` over RFC 8785 bytes through the existing `assay_core::mcp::jcs` export. The metric keeps its existing comparison sites and violation codes; only the hash preimage changes. A CHANGELOG entry under **Unreleased → Changed** makes the existing-pin migration visible outside the PR body.

`assay-metrics` already depends on `assay-core`. `mcp::jcs::to_vec` directly wraps the workspace-pinned `serde_jcs = "=0.2.0"`, the same serializer/version used by `assay-canonical`; this avoids a new published-crate graph edge. This meets the CLAUDE.md bar for shared mechanisms: "a mechanism whose second implementation would silently mean something different." No local serializer or second canonicalization wrapper was added.

This intentionally changes the byte basis for operator-authored `schema_sha256` pins. Existing recorded pins may need regeneration because their preimage is now canonical JSON, even where a schema's meaning is unchanged.

Does not change `compute_json_hash`, does not add the #2261 premise test, and does not close #2261.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Refactor

## Verification
Implementation verification ran on `e3c6d167898aac77f8c58beaa05d086fb3d90f14` in `/workspace` with the Cloud Rust/Cargo toolchain:

- Key-order control was red before the production change: `cargo test -p assay-metrics tool_description_integrity::tests::schema_hash_ignores_object_key_order -- --exact` exited 101; it was green after the change (exit 0).
- Snapshot reorder control was red with `E_TOOL_SCHEMA_MUTATED` (exit 101), then green after the change (exit 0).
- `cargo test -p assay-metrics`: 65 unit tests and doc tests passed.
- `cargo fmt --all -- --check`, `cargo clippy -p assay-metrics --all-targets -- -D warnings`, and `git diff --check` passed.

Follow-up documentation head: `3f84abdb8028dd3dfc0df8957a5bf36f8b9b76b3`.

- `git diff --check HEAD^ HEAD`: passed.
- The review recorded on the preceding implementation head does not apply to this new head. A final-head automated review was unavailable because CodeRabbit requires browser authentication; no verdict is claimed.

- [x] `cargo check` passes (via clippy on implementation head)
- [x] `cargo test` passes (on implementation head)
- [ ] Ran a demo suite (e.g. `examples/rag-grounding`)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover the production change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c6fe17a-13dc-497f-803a-1f89f8372fb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c6fe17a-13dc-497f-803a-1f89f8372fb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

