### PR TITLE
test(core): pin JSON number parsing premise

### DIFF
--- a/crates/assay-core/src/mcp/identity.rs
+++ b/crates/assay-core/src/mcp/identity.rs
@@ -108,6 +108,17 @@ mod tests {
         );
     }
 
+    /// The premise behind `compute_json_hash`'s `expect` and behind
+    /// `canonicalization_succeeds_across_the_value_domain`: a parsed `Value` cannot hold a
+    /// non-finite number, because a literal outside `f64` range does not parse.
+    /// `arbitrary_precision` would retain the literal, `serde_jcs` would reject it, and the
+    /// `expect` would abort.
+    #[test]
+    fn premise_out_of_range_number_literals_do_not_parse_in_this_build() {
+        assert!(serde_json::from_str::<Value>("1e400").is_err());
+        assert!(serde_json::from_str::<Value>("-1e400").is_err());
+    }
+
     /// The defect: two spellings of one schema must be one identity.
     #[test]
     fn reordered_schema_keys_produce_the_same_identity() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
- Add an in-repository premise test beside the existing `preserve_order` check: out-of-range JSON numeric literals must fail to parse into `serde_json::Value` in this build.
- No production behavior changed.
- Closes #2261.

The test is capable of going red: on commit `d8785060fd867862db3bc0bea8d8c5f59a52709f`, running `cargo test -p assay-core --features serde_json/arbitrary_precision --lib mcp::identity::tests::premise_out_of_range_number_literals_do_not_parse_in_this_build -- --exact` compiled with the wrong feature configuration and failed at the first `is_err()` assertion for `1e400`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Verification
- [x] `cargo check` / clippy passes
- [x] `cargo test` passes
- [ ] Ran a demo suite (e.g. `examples/rag-grounding`)
- [x] The issue-requested filter command is green. Because `--exact` matches fully qualified Rust unit-test names, it filters out the new module test; `cargo test -p assay-core --lib mcp::identity::tests::premise_out_of_range_number_literals_do_not_parse_in_this_build -- --exact` executed it successfully.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-core --all-targets -- -D warnings`

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f314e040-d4fe-497e-b5d5-138b4458a534?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f314e040-d4fe-497e-b5d5-138b4458a534&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

