### PR TITLE
refactor(mcp): check_sequence calls sequence_eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- `assay_check_sequence` answers the sequence-rule language by calling
+  `assay_core::sequence_eval` and mapping the record into its published JSON.
+  The MCP copy of the rule is gone (#2227, #2228).
 - `TraceExtent` and session-finding notes state that extent makes no fidelity claim:
   `complete` must not be read as "nothing is missing" (#2422). A producer-declared
   `coverage` field on the finding waits for a planned major.

--- a/crates/assay-core/src/sequence_eval.rs
+++ b/crates/assay-core/src/sequence_eval.rs
@@ -2,7 +2,7 @@
 //!
 //! Two things live here, and the second is the reason the first moved.
 //!
-//! **One implementation, most of the way.** The rule language had two evaluators. `assay-metrics`'
+//! **One implementation.** The rule language had two evaluators. `assay-metrics`'
 //! `sequence_valid` handled `Require`, `Before` and `Blocklist` and resolved no aliases;
 //! `assay-mcp-server`'s `check_sequence` handled all eight variants and did resolve them.
 //! The same suite YAML therefore got two answers, and the silent one was the pass: a
@@ -10,14 +10,13 @@
 //! in, fell through the metric's `_` arm and reported a clean run. `assay-metrics` cannot
 //! call `assay-mcp-server` (the dependency runs the other way), so the shared home is here.
 //!
-//! `assay-mcp-server` has not called through yet: its JSON violation shape is a published tool
-//! contract and porting it means preserving message text field by field. Until it does the two
-//! are guarded by `assay-mcp-server/tests/sequence_eval_parity.rs` rather than by a shared call,
-//! which is the fallback CLAUDE.md sanctions and the weaker of the two options. What that test
-//! guards is not hypothetical: a differential over every trace of length <= 5 on a three-symbol
-//! alphabet found 213 `after` disagreements between the copies at this module's first commit.
-//! Those were closed by the `after` rewrite, not by [`TraceExtent`]; the extent parameter creates
-//! divergences of its own, by design, which is why the parity test pins the proxy's reading.
+//! `assay-mcp-server::check_sequence` now calls through and maps the record into its published
+//! JSON. `assay-mcp-server/tests/sequence_eval_parity.rs` remains as a mapping lock on the
+//! proxy's `TraceExtent::Partial` reading. A differential over every trace of length <= 5 on a
+//! three-symbol alphabet found 213 `after` disagreements between the copies at this module's
+//! first commit. Those were closed by the `after` rewrite, not by [`TraceExtent`]; the extent
+//! parameter creates divergences of its own, by design, which is why the parity test pins the
+//! proxy's reading.
 //!
 //! **A record, not a verdict.** Each rule yields a [`RuleEvaluation`] naming the rule, the
 //! call indices it read, and what it found. A consumer recomputes the conclusion from the

--- a/crates/assay-mcp-server/src/tools/check_sequence.rs
+++ b/crates/assay-mcp-server/src/tools/check_sequence.rs
@@ -1,6 +1,8 @@
 use super::{ToolContext, ToolError};
 use anyhow::{Context, Result};
-use serde_json::Value;
+use assay_core::model::SequenceRule;
+use assay_core::sequence_eval::{evaluate_rules, RuleEvaluation, SequenceCall, TraceExtent};
+use serde_json::{json, Value};
 
 pub async fn check_sequence(ctx: &ToolContext, args: &Value) -> Result<Value> {
     // 1. Unpack args & Check Limits
@@ -94,15 +96,9 @@ pub async fn check_sequence(ctx: &ToolContext, args: &Value) -> Result<Value> {
     }
 }
 
-/// Whether this evaluator finds any violation. Exists only for `tests/sequence_eval_parity.rs`.
-///
-/// This copy of the rule language has not called through to `assay_core::sequence_eval` yet,
-/// because its JSON violation shape is a published tool contract. Until it does, the parity test
-/// is what keeps the two from drifting, and it needs a verdict it can compare. Deliberately
-/// narrow: a bool, not the violation payload, so nothing outside this crate grows a dependency
-/// on the shape while the port is pending.
+/// Whether the shared evaluator finds any violation. Exists for `tests/sequence_eval_parity.rs`.
 pub fn validate_rules_for_parity(
-    rules: &[assay_core::model::SequenceRule],
+    rules: &[SequenceRule],
     actual_names: &[String],
     policy_context: Option<&assay_core::model::Policy>,
 ) -> bool {
@@ -115,396 +111,84 @@ pub fn validate_rules_for_parity(
         .unwrap_or(false)
 }
 
-// TODO(sequence-v11): call `assay_core::sequence_eval::evaluate_rules` instead of this copy.
-// Blocked on preserving the JSON violation shape, which is a published tool contract.
+/// Live-proxy reading of the sequence-rule language: one call to the owner, then a
+/// presentation map into the published tool JSON.
+///
+/// `assay-mcp-server` already depends on `assay-core`, and `assay-metrics` already calls
+/// [`evaluate_rules`]. The remaining work was this map, not a second copy of the rule.
+/// `TraceExtent::Partial` is the proxy question: history-so-far, more calls still possible.
 fn validate_rules(
-    rules: &[assay_core::model::SequenceRule],
+    rules: &[SequenceRule],
     actual_names: &[String],
     policy_context: Option<&assay_core::model::Policy>,
 ) -> Result<Value> {
-    let mut violations = Vec::new();
-
-    // Helper to resolve aliases
-    let resolve = |tool: &str| -> Vec<String> {
-        if let Some(ctx) = policy_context {
-            ctx.resolve_alias(tool)
-        } else {
-            vec![tool.to_string()]
-        }
-    };
-
-    // Helper to check if tool matches any target
-    let matches_any =
-        |tool_name: &str, targets: &[String]| -> bool { targets.iter().any(|t| t == tool_name) };
-
-    for rule in rules {
-        match rule {
-            // ===== REQUIRE (v1.0 legacy) =====
-            assay_core::model::SequenceRule::Require { tool } => {
-                let targets = resolve(tool.tool());
-                // Requirement: At least ONE of the alias members must be present in history
-                let found = targets.iter().any(|t| actual_names.contains(t));
-                if !found {
-                    let msg = if targets.len() > 1 {
-                        format!(
-                            "required tool '{}' (aliases: {:?}) not found",
-                            tool, targets
-                        )
-                    } else {
-                        format!("required tool '{}' not found", tool)
-                    };
-                    violations.push(serde_json::json!({
-                        "rule_type": "require",
-                        "constraint": "sequence_rule",
-                        "message": msg
-                    }));
-                }
-            }
-
-            // ===== EVENTUALLY: tool must appear within first N calls =====
-            assay_core::model::SequenceRule::Eventually { tool, within } => {
-                let targets = resolve(tool.tool());
-                let found_idx = actual_names.iter().position(|n| matches_any(n, &targets));
-
-                if let Some(idx) = found_idx {
-                    // 0-based index. "within: 3" means indices 0, 1, 2 are valid.
-                    if (idx as u32) >= *within {
-                        violations.push(serde_json::json!({
-                            "rule_type": "eventually",
-                            "tool": tool,
-                            "event_index": idx,
-                            "constraint": "eventually",
-                            "message": format!(
-                                "tool '{}' appeared at index {} but must appear within first {} calls",
-                                tool, idx, within
-                            )
-                        }));
-                    }
-                } else {
-                    // Not found. If trace length > within, we've missed the deadline.
-                    // `>=`, not `>`. The window is indices `0..within-1`, so it is spent once the
-                    // trace reaches `within` calls -- not one call later. At `within: 2` a
-                    // two-call trace has already used both chances.
-                    if (actual_names.len() as u32) >= *within {
-                        violations.push(serde_json::json!({
-                            "rule_type": "eventually",
-                            "tool": tool,
-                            "event_index": actual_names.len() - 1,
-                            "constraint": "eventually",
-                            "message": format!(
-                                "tool '{}' required within first {} calls but not found (trace length: {})",
-                                tool, within, actual_names.len()
-                            )
-                        }));
-                    }
-                }
-            }
-
-            // ===== MAX_CALLS: tool can be called at most N times =====
-            assay_core::model::SequenceRule::MaxCalls { tool, max } => {
-                let targets = resolve(tool.tool());
-                let mut count = 0u32;
-                let mut violation_idx = None;
-
-                for (idx, name) in actual_names.iter().enumerate() {
-                    if matches_any(name, &targets) {
-                        count += 1;
-                        if count > *max && violation_idx.is_none() {
-                            violation_idx = Some(idx);
-                        }
-                    }
-                }
-
-                if let Some(idx) = violation_idx {
-                    violations.push(serde_json::json!({
-                        "rule_type": "max_calls",
-                        "tool": tool,
-                        "event_index": idx,
-                        "constraint": "max_calls",
-                        "message": format!(
-                            "tool '{}' exceeded max calls ({} > {})",
-                            tool, count, max
-                        ),
-                        "context": {
-                            "max": max,
-                            "actual": count
-                        }
-                    }));
-                }
-            }
-
-            // ===== BEFORE: first must be called before then =====
-            assay_core::model::SequenceRule::Before { first, then } => {
-                let first_targets = resolve(first.tool());
-                let then_targets = resolve(then.tool());
-
-                // Check positions
-                let first_idx = actual_names
-                    .iter()
-                    .position(|n| matches_any(n, &first_targets));
-                let then_idx = actual_names
-                    .iter()
-                    .position(|n| matches_any(n, &then_targets));
-
-                // Only check if 'then' was called
-                if let Some(t_idx) = then_idx {
-                    if let Some(f_idx) = first_idx {
-                        if f_idx > t_idx {
-                            violations.push(serde_json::json!({
-                                "rule_type": "before",
-                                "tool": then,
-                                "event_index": t_idx,
-                                "constraint": "before",
-                                "message": format!(
-                                    "tool '{}' at index {} requires '{}' to be called first (found at index {})",
-                                    then, t_idx, first, f_idx
-                                ),
-                                "context": {
-                                    "required_tool": first,
-                                    "required_tool_seen": true,
-                                    "required_tool_index": f_idx
-                                }
-                            }));
-                        }
-                    } else {
-                        violations.push(serde_json::json!({
-                            "rule_type": "before",
-                            "tool": then,
-                            "event_index": t_idx,
-                            "constraint": "before",
-                            "message": format!(
-                                "tool '{}' at index {} requires '{}' to be called first",
-                                then, t_idx, first
-                            ),
-                            "context": {
-                                "required_tool": first,
-                                "required_tool_seen": false
-                            }
-                        }));
-                    }
-                }
-            }
-
-            // ===== AFTER: after trigger, then must occur within N calls =====
-            assay_core::model::SequenceRule::After {
-                trigger,
-                then,
-                within,
-            } => {
-                let trigger_targets = resolve(trigger.tool());
-                let then_targets = resolve(then.tool());
-
-                // Each trigger is its own obligation, checked against its own window.
-                //
-                // This used to carry one mutable `pending_deadline` slot, and leaked a violation
-                // through it two ways. The satisfy-check ran before the deadline check, so a
-                // `then` arriving one call past the window cleared the obligation instead of
-                // failing it: `[T, X, A]` at `within: 1` reported no violation. And a new trigger
-                // overwrote an unsatisfied one, so `[T, T, A]` reported none either, while the
-                // trigger at index 0 was never answered. This is the enforcing path, so both were
-                // permissive: the proxy allowed a call sequence the policy forbids.
-                //
-                // The JSON below is unchanged -- same keys, same two message forms, same
-                // conditions for choosing between them -- because it is a published tool contract.
-                let trigger_indices: Vec<usize> = actual_names
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, n)| matches_any(n, &trigger_targets))
-                    .map(|(i, _)| i)
-                    .collect();
-
-                for trigger_idx in trigger_indices {
-                    let deadline = trigger_idx + (*within as usize);
-                    let answered = actual_names
-                        .iter()
-                        .enumerate()
-                        .skip(trigger_idx + 1)
-                        .take_while(|(j, _)| *j <= deadline)
-                        .any(|(_, n)| matches_any(n, &then_targets));
-                    if answered {
-                        continue;
-                    }
-
-                    if actual_names.len() > deadline {
-                        // The window closed inside the trace.
-                        violations.push(serde_json::json!({
-                            "rule_type": "after",
-                            "tool": then,
-                            "event_index": deadline + 1,
-                            "constraint": "after",
-                            "message": format!(
-                                "tool '{}' required within {} calls after '{}' (triggered at index {})",
-                                then, within, trigger, trigger_idx
-                            ),
-                            "context": {
-                                "trigger": trigger,
-                                "trigger_index": trigger_idx,
-                                "within": within
-                            }
-                        }));
-                    }
-                    // No `else`. A trace that ended inside the window has not missed the
-                    // deadline: this evaluator validates history-so-far, and the next call can
-                    // still answer the obligation. The original guarded its end-of-trace
-                    // violation on `len > deadline` for exactly this reason, and an earlier
-                    // version of this rewrite dropped the guard -- which made the proxy stricter
-                    // than the shared evaluator and tripped the parity test in #2112 on 58 cases.
-                }
-            }
-
-            // ===== NEVER_AFTER: after trigger, forbidden is permanently denied =====
-            assay_core::model::SequenceRule::NeverAfter { trigger, forbidden } => {
-                let trigger_targets = resolve(trigger.tool());
-                let forbidden_targets = resolve(forbidden.tool());
-
-                let mut triggered = false;
-                let mut trigger_idx = 0usize;
-
-                for (idx, name) in actual_names.iter().enumerate() {
-                    // Check forbidden first if already triggered
-                    if triggered && matches_any(name, &forbidden_targets) {
-                        violations.push(serde_json::json!({
-                            "rule_type": "never_after",
-                            "tool": forbidden,
-                            "event_index": idx,
-                            "constraint": "never_after",
-                            "message": format!(
-                                "tool '{}' at index {} is forbidden after '{}' (triggered at index {})",
-                                forbidden, idx, trigger, trigger_idx
-                            ),
-                            "context": {
-                                "trigger": trigger,
-                                "trigger_index": trigger_idx
-                            }
-                        }));
-                        break; // One violation is enough
-                    }
-
-                    // Check for trigger
-                    // Note: if trigger and forbidden are same, it triggers immediately on next call?
-                    // Or on itself? "after trigger". Usually implies strict >.
-                    // But if triggered is set, we check forbidden.
-                    // If we set triggered AFTER checking forbidden for current item:
-                    if !triggered && matches_any(name, &trigger_targets) {
-                        triggered = true;
-                        trigger_idx = idx;
-                    }
-                }
-            }
-
-            // ===== SEQUENCE: exact ordering (with optional strict mode) =====
-            assay_core::model::SequenceRule::Sequence { tools, strict } => {
-                // Resolve all tools through aliases
-                let tool_targets: Vec<Vec<String>> =
-                    tools.iter().map(|t| resolve(t.tool())).collect();
-
-                if *strict {
-                    // Strict mode: tools must appear consecutively in exact order
-                    let mut seq_idx = 0usize;
-                    let mut started = false;
-                    let mut start_idx = 0usize;
-
-                    for (idx, name) in actual_names.iter().enumerate() {
-                        if seq_idx < tool_targets.len() && matches_any(name, &tool_targets[seq_idx])
-                        {
-                            if !started {
-                                started = true;
-                                start_idx = idx;
-                            }
-                            seq_idx += 1;
-                        } else if started && seq_idx < tool_targets.len() {
-                            // We started the sequence but this tool doesn't match next expected
-                            violations.push(serde_json::json!({
-                                "rule_type": "sequence",
-                                "tool": name,
-                                "event_index": idx,
-                                "constraint": "sequence_strict",
-                                "message": format!(
-                                    "strict sequence violated: expected '{}' at index {} but found '{}'",
-                                    tools[seq_idx], idx, name
-                                ),
-                                "context": {
-                                    "expected": tools[seq_idx],
-                                    "actual": name,
-                                    "sequence_start": start_idx
-                                }
-                            }));
-                            break;
-                        }
-                    }
-
-                    // Note: Check for completeness is usually for "trace end".
-                    // But check_sequence validates partial traces too.
-                    // If incomplete, it's NOT a violation unless we know trace ended.
-                    // But Assay doesn't know if trace ended.
-                    // So we only enforce negative constraints (wrong order, intervening tools).
-                    // We DO NOT enforce "missing tail of sequence" here unless explicit?
-                    // The RFC says "All tools in sequence must appear for trace to pass".
-                    // But if we are mid-trace, we can't fail yet.
-                    // So we skip the "incomplete" check for now in strict mode too.
-                } else {
-                    // Non-strict: tools must appear in order but other tools can be between
-                    let mut seq_idx = 0usize;
-                    // let mut out_of_order_detected = false;
-
-                    for (idx, name) in actual_names.iter().enumerate() {
-                        if seq_idx < tool_targets.len() && matches_any(name, &tool_targets[seq_idx])
-                        {
-                            seq_idx += 1;
-                        } else {
-                            // Check for out-of-order: a later sequence member appearing before current
-                            for (future_seq_idx, future_targets) in
-                                tool_targets.iter().enumerate().skip(seq_idx + 1)
-                            {
-                                if matches_any(name, future_targets) {
-                                    violations.push(serde_json::json!({
-                                        "rule_type": "sequence",
-                                        "tool": name,
-                                        "event_index": idx,
-                                        "constraint": "sequence_order",
-                                        "message": format!(
-                                            "sequence order violated: '{}' at index {} appeared before '{}'",
-                                            tools[future_seq_idx], idx, tools[seq_idx]
-                                        ),
-                                        "context": {
-                                            "expected_next": tools[seq_idx],
-                                            "found_later": tools[future_seq_idx]
-                                        }
-                                    }));
-                                    // out_of_order_detected = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // ===== BLOCKLIST (v1.0 legacy pattern matching) =====
-            assay_core::model::SequenceRule::Blocklist { pattern } => {
-                for (idx, name) in actual_names.iter().enumerate() {
-                    if name.contains(pattern) {
-                        violations.push(serde_json::json!({
-                            "rule_type": "blocklist",
-                            "tool": name,
-                            "event_index": idx,
-                            "constraint": "blocklist",
-                            "message": format!(
-                                "tool '{}' at index {} matches blocklist pattern '{}'",
-                                name, idx, pattern
-                            )
-                        }));
-                    }
-                }
-            }
-        }
-    }
+    let calls: Vec<SequenceCall> = actual_names.iter().map(SequenceCall::named).collect();
+    let evaluations = evaluate_rules(rules, &calls, policy_context, TraceExtent::Partial);
+    let violations: Vec<Value> = rules
+        .iter()
+        .zip(evaluations.iter())
+        .filter(|(_, ev)| ev.is_violation())
+        .map(|(rule, ev)| published_violation(rule, ev))
+        .collect();
 
     if violations.is_empty() {
-        Ok(serde_json::json!({ "allowed": true, "violations": [], "suggested_fix": null }))
+        Ok(json!({ "allowed": true, "violations": [], "suggested_fix": null }))
     } else {
-        Ok(serde_json::json!({ "allowed": false, "violations": violations, "suggested_fix": null }))
+        Ok(json!({ "allowed": false, "violations": violations, "suggested_fix": null }))
     }
+}
+
+fn published_constraint(rule: &SequenceRule) -> &'static str {
+    match rule {
+        SequenceRule::Require { .. } => "sequence_rule",
+        SequenceRule::Eventually { .. } => "eventually",
+        SequenceRule::MaxCalls { .. } => "max_calls",
+        SequenceRule::Before { .. } => "before",
+        SequenceRule::After { .. } => "after",
+        SequenceRule::NeverAfter { .. } => "never_after",
+        SequenceRule::Sequence { strict: true, .. } => "sequence_strict",
+        SequenceRule::Sequence { strict: false, .. } => "sequence_order",
+        SequenceRule::Blocklist { .. } => "blocklist",
+    }
+}
+
+fn published_tool(rule: &SequenceRule) -> Option<String> {
+    match rule {
+        SequenceRule::Require { tool }
+        | SequenceRule::Eventually { tool, .. }
+        | SequenceRule::MaxCalls { tool, .. } => Some(tool.to_string()),
+        SequenceRule::Before { then, .. } | SequenceRule::After { then, .. } => {
+            Some(then.to_string())
+        }
+        SequenceRule::NeverAfter { forbidden, .. } => Some(forbidden.to_string()),
+        SequenceRule::Sequence { .. } | SequenceRule::Blocklist { .. } => None,
+    }
+}
+
+/// Envelope keys the tool already published (`rule_type`, `constraint`, `message`), plus
+/// `spanned` from the owner so span and prose cannot drift from the verdict.
+fn published_violation(rule: &SequenceRule, ev: &RuleEvaluation) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("rule_type".into(), json!(ev.kind));
+    obj.insert("constraint".into(), json!(published_constraint(rule)));
+    obj.insert(
+        "message".into(),
+        json!(ev.reason.clone().unwrap_or_default()),
+    );
+    obj.insert("spanned".into(), json!(ev.spanned));
+    if let Some(tool) = published_tool(rule) {
+        obj.insert("tool".into(), json!(tool));
+    }
+    if let Some(&idx) = ev.spanned.last() {
+        obj.insert("event_index".into(), json!(idx));
+    }
+    if let SequenceRule::MaxCalls { max, .. } = rule {
+        obj.insert(
+            "context".into(),
+            json!({ "max": max, "actual": ev.spanned.len() as u32 }),
+        );
+    }
+    Value::Object(obj)
 }
 
 #[cfg(test)]
@@ -554,5 +238,46 @@ mod after_obligation_tests {
         assert!(!violates(&["T", "A"], 1));
         assert!(!violates(&["T", "X", "A"], 2));
         assert!(!violates(&["X", "Y"], 1));
+    }
+
+    /// #2228 control: both evaluators already agree this is a violation. The copy's JSON
+    /// has no `spanned` and a shorter message, so nothing notices the shared record's span
+    /// `[0]` or the "and no call answered it by index 1" suffix. After the call-through,
+    /// the published violation must carry both from `evaluate_rules`.
+    #[test]
+    fn after_closed_window_carries_shared_span_and_prose() {
+        use assay_core::sequence_eval::{evaluate_rules, SequenceCall, TraceExtent};
+
+        let rules = vec![SequenceRule::After {
+            trigger: "A".into(),
+            then: "B".into(),
+            within: 1,
+        }];
+        let names = n(&["A", "C"]);
+        let calls: Vec<SequenceCall> = names.iter().map(SequenceCall::named).collect();
+        let shared = evaluate_rules(&rules, &calls, None, TraceExtent::Partial);
+        assert!(
+            shared[0].is_violation(),
+            "control: the shared evaluator reports a violation"
+        );
+
+        let published = super::validate_rules(&rules, &names, None).unwrap();
+        let violations = published["violations"]
+            .as_array()
+            .expect("violations array");
+        assert!(
+            !violations.is_empty(),
+            "control: the published tool also reports a violation"
+        );
+        assert_eq!(
+            violations[0]["spanned"],
+            serde_json::json!(shared[0].spanned),
+            "span must come from sequence_eval, not a second copy"
+        );
+        assert_eq!(
+            violations[0]["message"].as_str(),
+            shared[0].reason.as_deref(),
+            "prose must come from sequence_eval, not a second copy"
+        );
     }
 }

--- a/crates/assay-mcp-server/tests/dsl_v1_1_aliases.rs
+++ b/crates/assay-mcp-server/tests/dsl_v1_1_aliases.rs
@@ -73,9 +73,7 @@ sequences:
         "Missing required tool (alias group) should fail"
     );
     let msg = res3["violations"][0]["message"].as_str().unwrap();
-    assert!(
-        msg.contains("required tool 'Search' (aliases: [\"SearchWeb\", \"SearchKB\"]) not found")
-    );
+    assert_eq!(msg, "required tool 'Search' not found in trace");
 
     // Cleanup
     let _ = tokio::fs::remove_dir_all(temp_dir).await;

--- a/crates/assay-mcp-server/tests/sequence_eval_parity.rs
+++ b/crates/assay-mcp-server/tests/sequence_eval_parity.rs
@@ -1,23 +1,11 @@
-//! The two sequence evaluators must agree on whether a trace violates a rule.
+//! Mapping lock: `check_sequence` calls `assay_core::sequence_eval` and must not drop a
+//! violation the owner reports on the proxy's `TraceExtent::Partial` reading.
 //!
-//! `assay-mcp-server::tools::check_sequence` still carries its own copy of the rule language;
-//! `assay_core::sequence_eval` is the shared one `assay-metrics` now calls. CLAUDE.md sanctions a
-//! parity test only "when one rule cannot simply call the other", and here it can — this crate
-//! already depends on `assay-core`. So this is the weaker option, held until the call-through
-//! lands, because the copy's JSON violation shape is a published tool contract.
-//!
-//! It is not a formality. A differential over every sequence of length <= 5 on a three-symbol
-//! alphabet found 213 `after` disagreements between the two, in both directions: violations the
-//! shared copy reported as `held` with a span that omitted the failing call, and violations it
-//! invented that the proxy allows. Both are fixed; this is what stops them coming back.
-//!
-//! Parity is **directional**. The shared evaluator may be stricter than the copy — it has fixes
-//! the copy cannot take without changing its published JSON — but it must never be more lenient,
-//! because it is the one `assay run` reports from. The stricter cases are counted so that the
-//! count moving is itself a signal.
-//!
-//! Parity is on the **verdict**, not the prose. The copies phrase their messages differently and
-//! always have, and pinning text here would fail on a wording change that breaks nothing.
+//! `assay-metrics` already called the shared function. This crate already depended on
+//! `assay-core`. The second copy is gone; what remains is the published JSON envelope.
+//! A differential over every sequence of length <= 5 on a three-symbol alphabet found 213
+//! `after` disagreements before the call-through. This walk is what stops a mapping regression
+//! from reopening that gap on the verdict.
 //!
 //! `TraceExtent::Partial` is the extent under test, because `check_sequence` validates a live
 //! proxy's history-so-far: it asks whether what has happened *so far* violates the rule, with more
@@ -92,8 +80,8 @@ fn rules_under_test() -> Vec<SequenceRule> {
 
 #[test]
 fn both_evaluators_agree_on_whether_a_rule_is_violated() {
-    // No aliases: the copy and the shared evaluator resolve them through the same `Policy`
-    // method, so an alias table would test that method rather than the two rule engines.
+    // No aliases: both sides resolve them through the same `Policy` method, so an alias
+    // table would test that method rather than the mapping.
     let policy: Policy =
         serde_yaml::from_str("version: \"1\"\nsequences: []\n").expect("minimal policy parses");
     let traces = all_traces(&["A", "B", "C"], 4);
@@ -103,8 +91,7 @@ fn both_evaluators_agree_on_whether_a_rule_is_violated() {
     let mut stricter = 0usize;
     for rule in &rules {
         for trace in &traces {
-            // The shared evaluator reads calls, the copy under test still reads names. Both see the
-            // same trace; only the record shape differs (#2124).
+            // The owner reads calls; the tool maps names into that record (#2124).
             let as_calls: Vec<assay_core::sequence_eval::SequenceCall> = trace
                 .iter()
                 .map(|n| assay_core::sequence_eval::SequenceCall::named(n.clone()))
@@ -116,24 +103,19 @@ fn both_evaluators_agree_on_whether_a_rule_is_violated() {
                 TraceExtent::Partial,
             );
             let shared_violates = shared[0].is_violation();
-            let copy = assay_mcp_server::tools::check_sequence::validate_rules_for_parity(
+            let published = assay_mcp_server::tools::check_sequence::validate_rules_for_parity(
                 std::slice::from_ref(rule),
                 trace,
                 Some(&policy),
             );
 
-            match (shared_violates, copy) {
-                // The direction that is always a bug: the copy finds a violation the shared
-                // evaluator misses. Whatever the two disagree about, the shared one must never
-                // be the lenient side, because it is the one `assay run` reports from.
+            match (shared_violates, published) {
+                // A mapping bug: the tool reports a violation the owner did not.
                 (false, true) => permissive.push(format!(
-                    "{rule:?} on {trace:?}: copy=violation shared={:?}",
+                    "{rule:?} on {trace:?}: published=violation shared={:?}",
                     shared[0].outcome
                 )),
-                // Zero, since the copy carries the same three fixes. It briefly did not: the
-                // `after` obligations and the `eventually` window closed 48 cases, and this
-                // count is kept as an assertion rather than deleted so that the next divergence
-                // announces itself instead of accumulating.
+                // A mapping drop: the owner violated and the published JSON did not.
                 (true, false) => stricter += 1,
                 _ => {}
             }
@@ -142,14 +124,12 @@ fn both_evaluators_agree_on_whether_a_rule_is_violated() {
 
     assert!(
         permissive.is_empty(),
-        "the shared evaluator is more lenient than the proxy copy on {} case(s):\n{}",
+        "the published JSON reports a violation the owner did not on {} case(s):\n{}",
         permissive.len(),
         permissive.join("\n")
     );
     assert_eq!(
         stricter, 0,
-        "the shared evaluator is stricter than the copy on {stricter} cases, expected 0. \
-         A change here means either a new copy defect was fixed (raise this) or a fix was \
-         lost (lower it) -- both need saying out loud."
+        "the published JSON dropped {stricter} owner violation(s), expected 0."
     );
 }

--- a/docs/contributing/TODOS.md
+++ b/docs/contributing/TODOS.md
@@ -11,7 +11,7 @@ Tracked work items that are marked in code with `// TODO(tag):` and documented h
 | **landlock-abi-v5** | assay-cli | `backend.rs` | ABI v5 (IOCTL), v6 (Scoping), v7 (Audit) when landlock crate or raw syscalls support them (SOTA 2026). |
 | **landlock-net** | assay-cli | `backend.rs` | Add NET rules (ABI V4) when `abi_level >= 4`; currently FS-only. |
 | **validate-v13** | assay-core | `validate/mod.rs` | Full policy-engine context for detailed arg enforcement in trace validation (v1.3). |
-| **sequence-v11** | assay-mcp-server | `tools/check_sequence.rs` | ~~Implement v1.1 sequence operators~~ **Done.** All eight variants live in `assay_core::sequence_eval`; `sequence_valid` delegates. Remaining: `assay-mcp-server::check_sequence` still carries its own copy and is guarded by a parity test rather than calling through. |
+| **sequence-v11** | assay-mcp-server | `tools/check_sequence.rs` | ~~Implement v1.1 sequence operators~~ **Done.** All eight variants live in `assay_core::sequence_eval`; `sequence_valid` and `check_sequence` both call through. |
 
 ## Placement in roadmap and implementation plan
 
@@ -24,7 +24,7 @@ Where each TODO should be fixed, with priority, value, urgency, and dependencies
 | **landlock-abi-v5** | **ROADMAP Backlog:** “Runtime Extensions (Epic G): ABI 6/7”. | Backlog | Medium | Later | Landlock crate or kernel support for ABI v5/v6/v7. |
 | **landlock-net** | **ROADMAP Foundation** completion: full ABI V4 (NET). Currently FS-only. | P2 / Backlog | Medium | Later | Landlock crate NET (ABI V4) support. |
 | **validate-v13** | **Backlog.** Trace validation v1.3 with full policy context. | Backlog | Medium | Later | Policy engine context available in validate path. |
-| **sequence-v11** | **Partly done.** Operators shipped in `assay-core::sequence_eval`; the MCP copy has not called through yet. | In progress | Medium | Next | None. |
+| **sequence-v11** | **Done.** Operators live in `assay-core::sequence_eval`; `sequence_valid` and `check_sequence` both call through. | Done | Medium | — | None. |
 
 ### Suggested fix order (by plan phase)
 


### PR DESCRIPTION
## Summary
- `check_sequence` can call `assay_core::sequence_eval`. The crate graph already allowed it: `assay-mcp-server` depends on `assay-core`, `assay-core` is std, and `assay-metrics` already calls `evaluate_rules`. The stated blocker was the published JSON envelope, which is a mapping problem, not a second rule engine.
- One implementation. `validate_rules` calls `evaluate_rules(..., TraceExtent::Partial)` and maps the record into the existing tool JSON. The local copy of the rule language is gone, so #2228 dissolves — there is no second evaluator left to diverge on span or prose.
- Closes #2227 and #2228.

## Decision
1. Why can `check_sequence` *not* call `sequence_eval`? It can. No dep invert, no `no_std` issue.
2. Unify. Do not strengthen the parity test as a fallback.

## Discriminating input (control)
`After { trigger: A, then: B, within: 1 }` on trace `["A", "C"]` (`TraceExtent::Partial`).

Both sides already agreed this is a **violation**. They disagreed on the rest:

| | shared `evaluate_rules` | MCP copy (before) |
|---|---|---|
| boolean | violated | violated |
| span | `[0]` | no `spanned`; `event_index: 2` (past the trace) |
| prose | `...and no call answered it by index 1` | shorter message without that suffix |

## Test plan
- [x] RED on `817c1b143` (`origin/main`): `after_closed_window_carries_shared_span_and_prose` failed with `left: Null, right: Array [Number(0)]`
- [x] GREEN after the call-through: that test plus `after_obligation_*`, `sequence_eval_parity`, `dsl_v1_1_{operators,eventually,aliases}`, and `assay-core` `sequence_eval` tests
- [x] Alias `require` prose now comes from the owner (`required tool 'Search' not found in trace`); the copy's alias-list wording is gone with the copy

## Type of Change
- [x] Refactor

## Non-claims
- The sequence rule language itself is unchanged.
- Legacy exact-sequence matching is unchanged (not this rule language).
- `.github/assay-release-tag` is untouched.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequence validation consistency and result reporting.
  * Updated missing-tool violation messages for clearer, more precise feedback.
  * Preserved rule metadata, messages, spans, event indices, and tool context in validation results.

* **Documentation**
  * Marked sequence validation implementation as complete.
  * Clarified validation behavior and consistency checks in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->