### PR TITLE
fix(cli): stop mcp config-path --json aborting on a non-UTF-8 HOME

### DIFF
--- a/crates/assay-cli/src/cli/commands/config_path.rs
+++ b/crates/assay-cli/src/cli/commands/config_path.rs
@@ -3,6 +3,7 @@
 //! Detects MCP client config locations and generates ready-to-use configurations.
 //! Supports: Claude Desktop, Cursor, and generic MCP clients.
 
+use assay_core::errors::diagnostic::path_json;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::env;
@@ -344,7 +345,11 @@ pub fn run(args: crate::cli::args::ConfigPathArgs) {
 
         let output = json!({
             "client": client.display_name(),
-            "config_path": detection.as_ref().map(|d| d.config_path.clone()),
+            // `path_json`, not the `PathBuf` itself: serde's `Path` impl returns an
+            // `Error` on non-UTF-8 bytes, `json!` unwraps it, and this workspace builds with
+            // `panic = "abort"`, so reporting an unusable path killed the process (#2421).
+            // Same defect and same fix as #2264; this site was missed by that sweep.
+            "config_path": detection.as_ref().map(|d| path_json(&d.config_path)),
             "config_exists": detection.as_ref().map(|d| d.exists).unwrap_or(false),
             "generated_server": config
         });

--- a/crates/assay-cli/tests/doctor_exit_class_contract.rs
+++ b/crates/assay-cli/tests/doctor_exit_class_contract.rs
@@ -616,3 +616,79 @@ fn a_non_utf8_baseline_and_config_exit_by_code_without_abort() {
          stdout:\n{validate_config_out}"
     );
 }
+
+/// `assay mcp config-path --json` must exit by a defined code with a non-UTF-8 `HOME` (#2421).
+///
+/// Same causal class as the `--trace-file` case above and the same fix (`path_json`), reached
+/// through a different ingress: the environment rather than argv. #2264's sweep closed the argv
+/// sites and missed this one, which is why the ingress is named in the test rather than left to
+/// the reader.
+///
+/// The measured abort was `json!({ "config_path": PathBuf })` in
+/// `crates/assay-cli/src/cli/commands/config_path.rs`: serde's `Path` impl returns `Error` on
+/// non-UTF-8 bytes, `json!` unwraps it, and `panic = "abort"` turns that into SIGABRT with an
+/// empty stdout. The directory need not exist; the drive is env bytes, not a filesystem create,
+/// which also keeps the test runnable on APFS where such a name cannot be created at all.
+///
+/// The text channel already exited 0 via `Path::display()`, so it is asserted here too: the fix
+/// must bring JSON up to the text channel's behaviour, not bring text down to JSON's.
+#[cfg(unix)]
+#[test]
+fn a_non_utf8_home_leaves_mcp_config_path_json_on_a_defined_exit() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bad_home = non_utf8_os(b"/tmp/assay-home-", b"");
+
+    let run = |format_json: bool| {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay"));
+        for (name, _) in std::env::vars_os() {
+            if name
+                .to_string_lossy()
+                .to_ascii_uppercase()
+                .starts_with("ASSAY_")
+            {
+                cmd.env_remove(name);
+            }
+        }
+        cmd.current_dir(dir.path())
+            .env("NO_COLOR", "1")
+            .env("HOME", &bad_home)
+            .env_remove("XDG_CONFIG_HOME")
+            .args(["mcp", "config-path"]);
+        if format_json {
+            cmd.arg("--json");
+        }
+        cmd.arg("cursor");
+        run_bounded(cmd, b"", GOLDEN_PATH_LIMITS, "mcp config-path")
+            .unwrap_or_else(|error| panic!("{error}"))
+    };
+
+    let json = run(true);
+    let text = run(false);
+
+    let json_code = defined_exit("mcp config-path --json", &json);
+    let text_code = defined_exit("mcp config-path", &text);
+
+    assert_eq!(
+        json_code,
+        0,
+        "a non-UTF-8 HOME must not change the exit class of a successful path report; \
+         stdout was {} byte(s), stderr: {}",
+        json.stdout.len(),
+        String::from_utf8_lossy(&json.stderr)
+    );
+    assert_eq!(
+        text_code, 0,
+        "the text channel already exited 0 and must stay there"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap_or_else(|error| {
+        panic!(
+            "--json must still emit parseable JSON, got {} byte(s): {error}",
+            json.stdout.len()
+        )
+    });
+    assert!(
+        parsed.get("config_path").is_some_and(|v| v.is_string()),
+        "config_path must be a lossy JSON string rather than a serde error: {parsed}"
+    );
+}


### PR DESCRIPTION
Closes #2421

## Reproduced first

On `817c1b143`, `HOME=/tmp/assay-home-\xff` (env bytes, no filesystem create — the directory need
not exist, which also keeps this runnable on APFS where such a name cannot be created at all):

| channel | before | after |
|---|---|---|
| `--json` | **returncode −6 (SIGABRT)**, stdout 0 B, `panicked "path contains invalid UTF-8 characters"` | exit 0, 603 B, parseable JSON |
| text | exit 0, 887 B | exit 0, 887 B (unchanged) |
| UTF-8 `HOME` control | exit 0 | exit 0 (unchanged) |

## Cause, and why this is a missed site rather than a new defect

Same causal class as #2264: serde's `Path` impl returns `Error` on non-UTF-8 bytes, `json!` unwraps
it, and this workspace builds `panic = "abort"` — so a command whose job is to *report* an unusable
path killed the process instead.

#2264's sweep created `assay_core::errors::diagnostic::path_json` and closed the argv sites. This one
is reached through the **environment** rather than argv, so it survived. The fix uses that existing
helper rather than a second conversion: two constructions of "a path as JSON" would be two answers to
what the field means.

One line in `crates/assay-cli/src/cli/commands/config_path.rs`:

```rust
"config_path": detection.as_ref().map(|d| path_json(&d.config_path)),
```

## Control

The pin lives beside #2264's in `doctor_exit_class_contract.rs` and reuses its `non_utf8_os` helper,
because the two differ only in ingress and a reader should see that.

Reverting the one line makes it fail with the real diagnosis rather than a generic assertion:

```
mcp config-path --json died by signal ExitStatus(unix_wait_status(6)) (not a defined exit class).
This is the #2264 abort: serde Path error -> json! unwrap -> panic=abort. stdout=0B stderr=285B
```

It also asserts the **text** channel stays at exit 0, so the fix cannot be satisfied by bringing text
down to JSON's behaviour instead of bringing JSON up to text's. And it asserts `config_path` parses
as a JSON string, so emitting nothing at all would not pass either.

## Verification

`cargo test -p assay-cli --test doctor_exit_class_contract` — 26 passed, 0 failed.
`cargo clippy -p assay-cli --all-targets` clean, `cargo fmt` clean.

## Non-claims

Windows is out of scope: `PathBuf` is WTF-16 there and the `from_vec(0xff)` construction is Unix-only,
which is why the pin is `#[cfg(unix)]` — same boundary #2264's test states.

This does not audit for further `PathBuf`-through-`json!` sites beyond this file. #2264 claimed that
sweep and this issue is the evidence a sweep can miss one; a structural guard would be the durable
answer and belongs in its own change.