### PR TITLE
feat(conformance): Rust adapter, and a control that proves the harness detects anything

### DIFF
--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "assay.corpus_adequacy.manifest.v0",
   "runner": "process",
-  "_about": "Mutation adequacy for privileged-mcp-action/v0, the corpus whose digest is a published contract. Mutants span BOTH crates that carry its rules: the CLI verifier and assay-evidence's denial-marker classification. Every mutant COMPILES, because a build failure means the corpus never saw the mutant and proves nothing about the rule. NOTE: bindable_denial_marker mutants were removed after grep showed the CLI verifier never calls it; declaring a mutant on an unreachable rule measures nothing. Three rules are recorded as KNOWN HOLES against the current corpus digest: they are in scope, genuinely unexercised, and acknowledged rather than fixed because adding vectors moves a published digest. The acknowledgement is pinned and expires when the corpus changes.",
+  "_about": "Mutation adequacy for privileged-mcp-action/v0. ONE genuine hole: the origin leg of the v0 marker triple is promised and unexercised. Two further rules were declared and are NOT holes -- they mutate the wrong stage and the wrong profile -- and are marked out_of_scope with that reasoning rather than dropped, so the mistake stays visible. Independently classified by Ruley against docs/profiles/privileged-mcp-action/v0.md \u00a75 and the Stage 2/3 architecture.",
   "repo_root": "../..",
   "implementation_sources": [
     "../../crates/assay-evidence/src/denial_marker.rs",
@@ -38,7 +38,9 @@
       {
         "label": "0 an unrecognised marker triple fails closed",
         "anchor": "        _ => None,\n    }\n}",
-        "replacement": "        _ => Some(DenialMarkerVersion::V1),\n    }\n}"
+        "replacement": "        _ => Some(DenialMarkerVersion::V1),\n    }\n}",
+        "scope": "out_of_scope",
+        "reason": "WRONG STAGE, not a hole. v0 does promise that an unrecognised in-namespace schema fails closed, but that promise is the Stage 2 arm (other => unknown_profile_schema) at verify_privileged_mcp_action.rs:331, which runs BEFORE the classifier. Under v0, observation_schema() admits only .v0 payloads, so classify_denial_marker never sees an unrecognised schema on this path: returning Some(V1) for a non-triple still fails == Some(V0) and is still not a marker. This mutant cannot move any of the 14 outcomes even in theory. To measure that promise, mutate the Stage 2 match instead."
       },
       {
         "label": "1 the origin must be the proxy",
@@ -48,7 +50,9 @@
       {
         "label": "2 v1 pairs with the v1 error code",
         "anchor": "(DENIED_CALL_OBSERVATION_V1, PROXY_DENIED_V1, PROXY_ORIGIN)",
-        "replacement": "(DENIED_CALL_OBSERVATION_V1, _, PROXY_ORIGIN)"
+        "replacement": "(DENIED_CALL_OBSERVATION_V1, _, PROXY_ORIGIN)",
+        "scope": "out_of_scope",
+        "reason": "WRONG PROFILE, not a hole. The v1 schema / -31999 pairing is Stage 3 of v1.md. v0's rule for a v1 schema is the opposite of pairing: unrecognised, therefore invalid. Under v0 selection a .v1 payload never enters observations, so the V1 arm of the match is unreachable here. Its survival does not mean a stranger can ignore the v1 pairing and reproduce the v0 digest; it means the v0 corpus never presents that pairing. The v1 corpus already covers it (ok-003-cross-pair-inert)."
       },
       {
         "label": "CONTROL harness reachability on the verifier path",
@@ -64,18 +68,8 @@
   "known_holes": {
     "sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342": [
       {
-        "label": "0 an unrecognised marker triple fails closed",
-        "reason": "no vector carries an observation whose schema/code/origin triple is unrecognised, so nothing distinguishes fail-closed from accept-anything. Recorded rather than fixed because adding a vector changes the corpus digest, and that digest is a published contract carried by assay#1840.",
-        "recorded": "2026-08-19"
-      },
-      {
         "label": "1 the origin must be the proxy",
-        "reason": "every observation in the corpus carries the proxy origin, so an implementation ignoring the field is indistinguishable. Same digest constraint.",
-        "recorded": "2026-08-19"
-      },
-      {
-        "label": "2 v1 pairs with the v1 error code",
-        "reason": "no vector pairs a v1 schema with a non-v1 error code, so the pairing rule is unexercised. Same digest constraint.",
+        "reason": "v0 Stage 3 promises an observation is a marker only if ALL THREE legs hold: schema, code AND origin == assay-proxy. No vector among the 14 is a well-formed v0 observation whose only defect is a wrong origin, so deleting the third leg cannot move a pinned outcome. This is a genuine, profile-promised, unexercised check. Recorded rather than fixed because adding a vector moves a digest that is a published contract carried by assay#1840.",
         "recorded": "2026-08-19"
       }
     ]

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "assay.corpus_adequacy.manifest.v0",
   "runner": "process",
-  "_about": "Mutation adequacy for privileged-mcp-action/v0, the corpus whose digest is a published contract. Mutants span BOTH crates that carry its rules: the CLI verifier and assay-evidence's denial-marker classification. Every mutant COMPILES, because a build failure means the corpus never saw the mutant and proves nothing about the rule. NOTE: bindable_denial_marker mutants were removed after grep showed the CLI verifier never calls it; declaring a mutant on an unreachable rule measures nothing.",
+  "_about": "Mutation adequacy for privileged-mcp-action/v0, the corpus whose digest is a published contract. Mutants span BOTH crates that carry its rules: the CLI verifier and assay-evidence's denial-marker classification. Every mutant COMPILES, because a build failure means the corpus never saw the mutant and proves nothing about the rule. NOTE: bindable_denial_marker mutants were removed after grep showed the CLI verifier never calls it; declaring a mutant on an unreachable rule measures nothing. Three rules are recorded as KNOWN HOLES against the current corpus digest: they are in scope, genuinely unexercised, and acknowledged rather than fixed because adding vectors moves a published digest. The acknowledgement is pinned and expires when the corpus changes.",
   "repo_root": "../..",
   "implementation_sources": [
     "../../crates/assay-evidence/src/denial_marker.rs",
@@ -58,5 +58,26 @@
       }
     ]
   },
-  "equivalent": {}
+  "equivalent": {},
+  "corpus_digest_file": "../privileged-mcp-action-v0/candidate-release.json",
+  "corpus_digest_key": "corpus_digest",
+  "known_holes": {
+    "sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342": [
+      {
+        "label": "0 an unrecognised marker triple fails closed",
+        "reason": "no vector carries an observation whose schema/code/origin triple is unrecognised, so nothing distinguishes fail-closed from accept-anything. Recorded rather than fixed because adding a vector changes the corpus digest, and that digest is a published contract carried by assay#1840.",
+        "recorded": "2026-08-19"
+      },
+      {
+        "label": "1 the origin must be the proxy",
+        "reason": "every observation in the corpus carries the proxy origin, so an implementation ignoring the field is indistinguishable. Same digest constraint.",
+        "recorded": "2026-08-19"
+      },
+      {
+        "label": "2 v1 pairs with the v1 error code",
+        "reason": "no vector pairs a v1 schema with a non-v1 error code, so the pairing rule is unexercised. Same digest constraint.",
+        "recorded": "2026-08-19"
+      }
+    ]
+  }
 }

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema": "assay.corpus_adequacy.manifest.v0",
+  "runner": "process",
+  "_about": "Mutation adequacy for privileged-mcp-action/v0, the corpus whose digest is a published contract. Mutants span BOTH crates that carry its rules: the CLI verifier and assay-evidence's denial-marker classification. Every mutant COMPILES, because a build failure means the corpus never saw the mutant and proves nothing about the rule. NOTE: bindable_denial_marker mutants were removed after grep showed the CLI verifier never calls it; declaring a mutant on an unreachable rule measures nothing.",
+  "repo_root": "../..",
+  "implementation_sources": [
+    "../../crates/assay-evidence/src/denial_marker.rs",
+    "../../crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs",
+    "../../crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs"
+  ],
+  "build": [
+    "cargo",
+    "build",
+    "-p",
+    "assay-cli",
+    "--bin",
+    "assay"
+  ],
+  "entrypoint_command": [
+    "./target/debug/assay",
+    "evidence",
+    "verify-privileged-mcp-action",
+    "{vector}",
+    "--format",
+    "json"
+  ],
+  "outcome_from": [
+    "bundle_integrity",
+    "verdict",
+    "reason_code"
+  ],
+  "vectors": "privileged-mcp-action-v0.vectors.json",
+  "id_key": "vector_id",
+  "vector_path_key": "path",
+  "default_group": "denial_marker_binding",
+  "mutants": {
+    "denial_marker_binding": [
+      {
+        "label": "0 an unrecognised marker triple fails closed",
+        "anchor": "        _ => None,\n    }\n}",
+        "replacement": "        _ => Some(DenialMarkerVersion::V1),\n    }\n}"
+      },
+      {
+        "label": "1 the origin must be the proxy",
+        "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN)",
+        "replacement": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, _)"
+      },
+      {
+        "label": "2 v1 pairs with the v1 error code",
+        "anchor": "(DENIED_CALL_OBSERVATION_V1, PROXY_DENIED_V1, PROXY_ORIGIN)",
+        "replacement": "(DENIED_CALL_OBSERVATION_V1, _, PROXY_ORIGIN)"
+      },
+      {
+        "label": "CONTROL harness reachability on the verifier path",
+        "anchor": ".filter(|obs| classify_denial_marker(obs) == Some(profile_version.marker_version()));",
+        "replacement": ".filter(|_obs| false);",
+        "control": true
+      }
+    ]
+  },
+  "equivalent": {}
+}

--- a/conformance/adequacy/privileged-mcp-action-v0.vectors.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.vectors.json
@@ -1,0 +1,60 @@
+{
+  "vectors": [
+    {
+      "vector_id": "bad-101-tampered-bundle",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-101-tampered-bundle.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-102-missing-target-digest",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-102-missing-target-digest.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-103-two-decisions",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-103-two-decisions.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-104-unknown-schema",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-104-unknown-schema.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-105-observation-binding-mismatch",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-105-observation-binding-mismatch.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-106-fail-closed-inconsistent",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-106-fail-closed-inconsistent.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-107-unknown-decision-value",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-107-unknown-decision-value.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-108-observation-without-decision",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-108-observation-without-decision.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-109-bundle-id-mismatch",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-109-bundle-id-mismatch.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-001-deny-bound-observation",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-001-deny-bound-observation.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-002-deny-observation-missing",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-002-deny-observation-missing.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-003-allow-no-outcome-observation",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-003-allow-no-outcome-observation.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-004-allow-with-diagnostic-establish",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-004-allow-with-diagnostic-establish.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-005-allow-contradicted-by-denial",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-005-allow-contradicted-by-denial.bundle.tar.gz"
+    }
+  ]
+}

--- a/conformance/bounded_run.py
+++ b/conformance/bounded_run.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""One bounded child-process runner, shared by the conformance tools.
+
+Standard library only. Extracted so the output ceiling has a single
+implementation: two copies of a resource ceiling drift, and the copy that
+drifts is the one that stops enforcing it.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+# Output ceiling per child process. Both children can emit arbitrary output and
+# a timeout does not bound memory, so the cap is applied while the process runs
+# rather than after it exits.
+OUTPUT_CAP_BYTES = 4 * 1024 * 1024
+
+
+class _OutputTooLarge(Exception):
+    """A child exceeded OUTPUT_CAP_BYTES; its output is not materialized."""
+
+
+def _run_capped(cmd: list[str], cwd: Path, timeout: int) -> subprocess.CompletedProcess:
+    """subprocess.run with a ceiling on how much output is ever held.
+
+    Streams both pipes to temporary files, polls their combined size while the
+    child runs, and kills it the moment the cap is crossed. Only the first
+    OUTPUT_CAP_BYTES are ever read into memory.
+    """
+    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
+        # A descendant that inherits stdout/stderr keeps writing after proc.kill()
+        # and walks straight through the ceiling, so the child leads its own session
+        # and the whole group is stopped and reaped.
+        proc = subprocess.Popen(cmd, cwd=str(cwd), stdout=out, stderr=err,
+                                start_new_session=True)
+
+        def _kill_tree() -> None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                proc.kill()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
+        deadline = time.monotonic() + timeout
+        try:
+            while True:
+                try:
+                    proc.wait(timeout=0.25)
+                    break
+                except subprocess.TimeoutExpired:
+                    pass
+                if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
+                    _kill_tree()
+                    raise _OutputTooLarge()
+                if time.monotonic() > deadline:
+                    _kill_tree()
+                    raise subprocess.TimeoutExpired(cmd, timeout)
+        finally:
+            # Reap the group even on the clean path: the leader can exit while a
+            # descendant it spawned is still holding the inherited handles.
+            _kill_tree()
+        if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
+            raise _OutputTooLarge()
+        out.seek(0)
+        err.seek(0)
+        return subprocess.CompletedProcess(
+            cmd, proc.returncode,
+            out.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
+            err.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
+        )

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -73,8 +73,14 @@ import argparse
 import importlib.util
 import json
 import sys
+import subprocess
 import tempfile
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bounded_run import (  # noqa: E402
+    OUTPUT_CAP_BYTES, _OutputTooLarge, _run_capped,
+)
 
 SCHEMA = "assay.corpus_adequacy.manifest.v0"
 
@@ -94,9 +100,10 @@ def load_manifest(path: Path) -> dict:
     if m.get("schema") != SCHEMA:
         raise ManifestError("schema must be %r, got %r" % (SCHEMA, m.get("schema")))
     base = path.parent
-    for key in ("implementation", "vectors"):
-        _req(m, key, "manifest")
-    m["_impl_path"] = (base / m["implementation"]).resolve()
+    _req(m, "vectors", "manifest")
+    if m.get("runner", "module") == "module":
+        _req(m, "implementation", "manifest")
+    m["_impl_path"] = (base / m["implementation"]).resolve() if m.get("implementation") else None
     m["_vectors_path"] = (base / m["vectors"]).resolve()
     m.setdefault("entrypoint", "evaluate")
     # group_key is OPTIONAL. A corpus with no axis column is one group; forcing it to invent
@@ -110,6 +117,22 @@ def load_manifest(path: Path) -> dict:
     m.setdefault("entrypoint_args",
                  [k for k in (m["group_key"], m["inputs_key"]) if k is not None])
     m.setdefault("default_group", "all")
+    m.setdefault("runner", "module")
+    if m["runner"] not in ("module", "process"):
+        raise ManifestError("runner must be module or process, got %r" % m["runner"])
+    if m["runner"] == "process":
+        for key in ("build", "entrypoint_command", "outcome_from"):
+            _req(m, key, "manifest (runner=process)")
+        srcs = m.get("implementation_sources") or [m["implementation"]]
+        m["_source_paths"] = [(base / x).resolve() for x in srcs]
+        for sp in m["_source_paths"]:
+            if not sp.is_file():
+                raise ManifestError("implementation source not found: %s" % sp)
+        m.setdefault("repo_root", ".")
+        m["_repo_root"] = (base / m["repo_root"]).resolve()
+        m.setdefault("vector_path_key", "path")
+        m.setdefault("build_timeout", 1800)
+        m.setdefault("vector_timeout", 120)
     m.setdefault("mutants", {})
     m.setdefault("equivalent", {})
     if not m["mutants"]:
@@ -119,6 +142,10 @@ def load_manifest(path: Path) -> dict:
             for key in ("label", "anchor", "replacement"):
                 _req(e, key, "mutants[%s][%d]" % (group, i))
             e.setdefault("scope", "declared")
+            e.setdefault("control", False)
+            if e["control"] and e["scope"] != "declared":
+                raise ManifestError("mutants[%s][%d] %r: a control cannot be out_of_scope"
+                                    % (group, i, e["label"]))
             if e["scope"] not in ("declared", "out_of_scope"):
                 raise ManifestError("mutants[%s][%d] %r: scope must be declared or out_of_scope"
                                     % (group, i, e["label"]))
@@ -173,8 +200,236 @@ def _outcomes(fn, vectors: list[dict], m: dict) -> tuple[dict, list[str]]:
     return outcomes, raised
 
 
+
+# ---------------------------------------------------------------------------
+# process runner: a compiled implementation behind a command line
+# ---------------------------------------------------------------------------
+
+
+class _SourceGuard:
+    """Restores every mutated source file, including on crash.
+
+    The adapter edits files in the working tree. A restore that only happens on
+    the happy path leaks a mutant into a commit, so the originals are captured
+    up front and rewritten in a finally block.
+    """
+
+    def __init__(self, paths: list[Path]) -> None:
+        self.original = {p: p.read_bytes() for p in paths}
+
+    def restore(self) -> None:
+        for path, data in self.original.items():
+            if path.read_bytes() != data:
+                path.write_bytes(data)
+
+    def verify_clean(self) -> list[str]:
+        return [str(p) for p, d in self.original.items() if p.read_bytes() != d]
+
+
+def _tree_is_dirty(repo_root: Path, paths: list[Path]) -> list[str]:
+    """Declared sources with uncommitted changes. Mutating those loses work."""
+    try:
+        out = subprocess.run(["git", "-C", str(repo_root), "status", "--porcelain", "--"]
+                             + [str(p) for p in paths],
+                             capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
+        return []          # no git: nothing to protect, and nothing to claim
+    return [ln[3:] for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def _build(m: dict) -> tuple[bool, str]:
+    try:
+        p = _run_capped(list(m["build"]), m["_repo_root"], timeout=m["build_timeout"])
+    except _OutputTooLarge:
+        return False, "build output exceeded the ceiling"
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, "build could not complete: %r" % (exc,)
+    if p.returncode != 0:
+        tail = [ln for ln in (p.stdout + p.stderr).splitlines()
+                if "error" in ln.lower()][-3:]
+        return False, " | ".join(tail)[:300] or "build exited %d" % p.returncode
+    return True, "built"
+
+
+def _process_outcomes(m: dict, vectors: list[dict]) -> tuple[dict, list[str]]:
+    """Run the built command once per vector. A vector that cannot be read is a raise."""
+    outcomes, raised = {}, []
+    for v in vectors:
+        vid = v[m["id_key"]]
+        cmd = [str(x).replace("{vector}", str((m["_repo_root"] / v[m["vector_path_key"]]).resolve()))
+               for x in m["entrypoint_command"]]
+        try:
+            p = _run_capped(cmd, m["_repo_root"], timeout=m["vector_timeout"])
+            doc = json.loads(p.stdout)
+            keys = m["outcome_from"]
+            # A single key can collapse every rejection onto one value and lose all
+            # discrimination, so a list is allowed and compared as a tuple.
+            outcomes[vid] = (tuple(doc.get(k) for k in keys) if isinstance(keys, list)
+                             else doc.get(keys))
+        except Exception:  # noqa: BLE001 - unreadable output is a behaviour change
+            raised.append(vid)
+    return outcomes, raised
+
+
+
+def _run_process(m: dict, manifest_path: Path) -> dict:
+    """Mutate declared sources, rebuild, and run the corpus against the binary."""
+    doc = json.loads(m["_vectors_path"].read_text(encoding="utf-8"))
+    all_vectors = doc[m["vectors_key"]] if isinstance(doc, dict) else doc
+    failures: list[str] = []
+
+    dirty = _tree_is_dirty(m["_repo_root"], m["_source_paths"])
+    if dirty:
+        raise ManifestError(
+            "declared sources have uncommitted changes: %s. This adapter edits them in "
+            "place, so it refuses to run rather than risk losing that work" % dirty)
+
+    groups_in_corpus = {_group_of(v, m) for v in all_vectors}
+    unmutated = sorted(groups_in_corpus - set(m["mutants"]))
+    if unmutated:
+        failures.append("groups present in the corpus with no declared mutants: %s" % unmutated)
+    stale = sorted(set(m["mutants"]) - groups_in_corpus)
+    if stale:
+        failures.append("mutants declared for groups not in the corpus: %s" % stale)
+
+    if not any(mut.get("control") for muts in m["mutants"].values() for mut in muts):
+        failures.append("no control mutant declared. Without one, a run of all-survivors "
+                        "cannot be told apart from a harness that detects nothing")
+    results, killed, survived, equivalent, out_of_scope, unproved = [], 0, 0, 0, 0, 0
+    guard = _SourceGuard(m["_source_paths"])
+    try:
+        ok, detail = _build(m)
+        if not ok:
+            raise ManifestError("the UNMUTATED tree does not build: %s" % detail)
+
+        baselines = {}
+        for group in sorted(m["mutants"]):
+            vectors = [v for v in all_vectors if _group_of(v, m) == group]
+            if not vectors:
+                failures.append("%s: no vectors, so its mutants cannot be scored" % group)
+                continue
+            base, raised = _process_outcomes(m, vectors)
+            if raised:
+                failures.append("%s: the UNMUTATED binary failed on %s" % (group, raised))
+                continue
+            baselines[group] = (vectors, base)
+
+        for group in sorted(m["mutants"]):
+            if group not in baselines:
+                continue
+            vectors, baseline = baselines[group]
+            for mut in m["mutants"][group]:
+                scope = mut.get("scope", "declared")
+                hits = [(sp, sp.read_text(encoding="utf-8").count(mut["anchor"]))
+                        for sp in m["_source_paths"]]
+                total = sum(n for _, n in hits)
+                if total == 0:
+                    failures.append("%s / %s: anchor not found in any declared source"
+                                    % (group, mut["label"]))
+                    continue
+                if total > 1:
+                    failures.append(
+                        "%s / %s: the anchor occurs %d times across the declared sources, so "
+                        "the substitution would pick one arbitrarily. Make it unique"
+                        % (group, mut["label"], total))
+                    continue
+
+                target = next(sp for sp, n in hits if n == 1)
+                original = target.read_text(encoding="utf-8")
+                target.write_text(original.replace(mut["anchor"], mut["replacement"], 1),
+                                  encoding="utf-8")
+                try:
+                    built, detail = _build(m)
+                    if not built:
+                        # Cursor's ruling on the design: rustc exit 1 yields no verdict, so
+                        # the corpus never saw this mutant. Counting it killed would let a
+                        # typo in the substitution print as "rule covered". Measure a
+                        # load-bearing arm with a variant that COMPILES, or declare it
+                        # equivalent.
+                        results.append({"group": group, "label": mut["label"],
+                                        "verdict": "unproved", "scope": scope, "moved": 0,
+                                        "how": "the mutant does not build, so the corpus was "
+                                               "never run against it: %s" % detail})
+                        unproved += 1
+                        continue
+                    out, raised = _process_outcomes(m, vectors)
+                finally:
+                    target.write_text(original, encoding="utf-8")
+
+                moved = [vid for vid, val in out.items() if baseline.get(vid) != val]
+                if mut.get("control"):
+                    # A control exists to prove the harness can detect ANYTHING. It is
+                    # never scored: counting it would inflate the very number it exists
+                    # to make trustworthy. A control that survives means the run says
+                    # nothing at all about the corpus.
+                    ok = bool(raised or moved)
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "control-killed" if ok else "control-SURVIVED",
+                                    "scope": scope, "moved": len(moved),
+                                    "how": ("harness detects a change on this path"
+                                            if ok else "THE HARNESS DETECTS NOTHING")})
+                    if not ok:
+                        failures.append(
+                            "control %r survived: the harness cannot detect a change on this "
+                            "path, so every other verdict in this run is meaningless"
+                            % mut["label"])
+                    continue
+                if raised or moved:
+                    results.append({"group": group, "label": mut["label"], "verdict": "killed",
+                                    "scope": scope, "moved": len(moved),
+                                    "how": ("raises on %d vector(s)" % len(raised)) if raised
+                                           else "%d vector(s) moved" % len(moved)})
+                    killed += 1
+                elif scope == "out_of_scope":
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "unexercised", "scope": scope, "moved": 0,
+                                    "how": "out of scope: %s" % mut["reason"]})
+                    out_of_scope += 1
+                else:
+                    results.append({"group": group, "label": mut["label"], "verdict": "survived",
+                                    "scope": scope, "moved": 0,
+                                    "how": "no vector distinguishes it. An implementation can "
+                                           "delete this rule and still reproduce the digest"})
+                    survived += 1
+
+            for eq in m["equivalent"].get(group, []):
+                results.append({"group": group, "label": eq["label"], "verdict": "equivalent",
+                                "how": eq["reason"], "moved": 0})
+                equivalent += 1
+    finally:
+        guard.restore()
+        leaked = guard.verify_clean()
+        if leaked:
+            failures.append("SOURCES NOT RESTORED: %s" % leaked)
+        _build(m)   # leave the tree with a binary built from the real source
+
+    denom = killed + survived
+    score = 100.0 if denom == 0 else round(100.0 * killed / denom, 1)
+    if unproved:
+        failures.append("%d mutant(s) never ran, so this corpus was not measured against them"
+                        % unproved)
+    if survived:
+        failures.append("%d mutant(s) survived; the required score is 100%% of non-equivalent "
+                        "mutants" % survived)
+    if denom == 0 and not failures:
+        failures.append("no non-equivalent mutants were scored, so no adequacy was measured")
+
+    return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
+            "runner": "process", "killed": killed, "survived": survived,
+            "equivalent": equivalent, "unexercised_out_of_scope": out_of_scope,
+            "unproved": unproved,
+            "declared_total": killed + survived + equivalent + out_of_scope + unproved,
+            "out_of_scope_ratio": (None if denom == 0 else round(out_of_scope / denom, 2)),
+            "score_percent": score,
+            "score_means": ("percent of author-declared in-scope rules killed; NOT percent of "
+                            "the rules the implementation actually has"),
+            "mutants": results, "failures": failures, "adequate": not failures}
+
+
 def run(manifest_path: Path) -> dict:
     m = load_manifest(manifest_path)
+    if m["runner"] == "process":
+        return _run_process(m, manifest_path)
     source = m["_impl_path"].read_text(encoding="utf-8")
     doc = json.loads(m["_vectors_path"].read_text(encoding="utf-8"))
     all_vectors = doc[m["vectors_key"]] if isinstance(doc, dict) else doc
@@ -193,6 +448,7 @@ def run(manifest_path: Path) -> dict:
         failures.append("mutants declared for groups not in the corpus: %s" % stale)
 
     results, killed, survived, equivalent, out_of_scope = [], 0, 0, 0, 0
+    unproved = 0
     with tempfile.TemporaryDirectory() as raw:
         tmp = Path(raw)
         base_mod = _load_module(source, "base", tmp)
@@ -226,18 +482,38 @@ def run(manifest_path: Path) -> dict:
                         "one arbitrarily and any breakage would be scored as a kill. Make the "
                         "anchor unique" % (group, mut["label"], occurrences, m["implementation"]))
                     continue
+                scope = mut.get("scope", "declared")
                 mutated = source.replace(mut["anchor"], mut["replacement"], 1)
                 try:
                     mod = _load_module(mutated, "%s_%d" % (group.replace("-", "_"), idx), tmp)
                     fn = getattr(mod, m["entrypoint"])
                 except Exception as exc:  # noqa: BLE001
-                    results.append({"group": group, "label": mut["label"], "verdict": "killed",
-                                    "how": "the mutant does not load: %r" % (exc,), "moved": 0})
-                    killed += 1
+                    # A mutant that never loaded was never shown to the corpus, so the
+                    # corpus said nothing about it. Counting that as a kill lets a typo
+                    # in the substitution print as "rule covered". The same argument
+                    # rules out treating a Rust build failure as a kill; measure a
+                    # load-bearing rule with a variant that RUNS, or declare it equivalent.
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "unproved", "scope": scope, "moved": 0,
+                                    "how": "the mutant does not load, so the corpus never "
+                                           "saw it and said nothing about this rule: %r" % (exc,)})
+                    unproved += 1
                     continue
-                scope = mut.get("scope", "declared")
                 out, raised = _outcomes(fn, vectors, m)
                 moved = [vid for vid, val in out.items() if baseline.get(vid) != val]
+                if mut.get("control"):
+                    ok = bool(raised or moved)
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "control-killed" if ok else "control-SURVIVED",
+                                    "scope": scope, "moved": len(moved),
+                                    "how": ("harness detects a change on this path"
+                                            if ok else "THE HARNESS DETECTS NOTHING")})
+                    if not ok:
+                        failures.append(
+                            "control %r survived: the harness cannot detect a change on this "
+                            "path, so every other verdict in this run is meaningless"
+                            % mut["label"])
+                    continue
                 if raised:
                     results.append({"group": group, "label": mut["label"], "verdict": "killed",
                                     "scope": scope, "how": "raises on %d vector(s)" % len(raised),
@@ -276,6 +552,11 @@ def run(manifest_path: Path) -> dict:
 
     denom = killed + survived
     score = 100.0 if denom == 0 else round(100.0 * killed / denom, 1)
+    if unproved:
+        # Not a soft warning: an unproved mutant means the measurement did not happen,
+        # and a score computed over the rest reports more than the run established.
+        failures.append("%d mutant(s) never ran, so this corpus was not measured against "
+                        "them. Fix the substitution or declare them equivalent" % unproved)
     if survived:
         failures.append("%d mutant(s) survived; the required score is 100%% of non-equivalent "
                         "mutants" % survived)
@@ -284,8 +565,8 @@ def run(manifest_path: Path) -> dict:
 
     return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
             "killed": killed, "survived": survived, "equivalent": equivalent,
-            "unexercised_out_of_scope": out_of_scope,
-            "declared_total": killed + survived + equivalent + out_of_scope,
+            "unexercised_out_of_scope": out_of_scope, "unproved": unproved,
+            "declared_total": killed + survived + equivalent + out_of_scope + unproved,
             "out_of_scope_ratio": (None if (killed + survived) == 0
                                    else round(out_of_scope / (killed + survived), 2)),
             "score_means": ("percent of author-declared in-scope rules killed; NOT percent of the "
@@ -317,9 +598,10 @@ def main() -> int:
         # exclusions is a percentage target wearing a different coat: an author can
         # exclude almost everything and still print 100%.
         print("%d of %d DECLARED in-scope rules killed (%.1f%%). %d declared equivalent, "
-              "%d declared out of scope. %d rules declared in total."
+              "%d declared out of scope, %d unproved. %d rules declared in total."
               % (rep["killed"], rep["killed"] + rep["survived"], rep["score_percent"],
-                 rep["equivalent"], rep["unexercised_out_of_scope"], rep["declared_total"]))
+                 rep["equivalent"], rep["unexercised_out_of_scope"], rep["unproved"],
+                 rep["declared_total"]))
         print("This is %.1f%% of what the AUTHOR DECLARED, not of the rules the implementation "
               "has. A rule nobody declared is invisible to this check." % rep["score_percent"])
         if rep["unexercised_out_of_scope"]:

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -201,11 +201,19 @@ def _load_module(source: str, tag: str, tmp: Path):
 
 
 def _acknowledged_holes(m: dict) -> dict:
-    """Holes acknowledged against the corpus digest that is actually present.
+    """Holes acknowledged against the DECLARED corpus digest.
 
-    Pinned deliberately. An acknowledgement is a statement about ONE corpus, so a
-    corpus that moves loses every acknowledgement and the holes reappear as
-    survivors. Without that, this becomes the escape hatch out_of_scope nearly was.
+    STATED PRECISELY, because the earlier wording here was false. This pins to a
+    digest STRING read from a file the manifest itself names. It is an
+    author-supplied claim about the corpus, not a measurement of it: nothing here
+    recomputes the digest from the vectors. Point the file at a stale value, or
+    leave it untouched while the corpus moves, and every acknowledgement survives
+    a corpus it no longer describes.
+
+    So the expiry is only as strong as the honesty of that file. That is the same
+    declared-versus-observed gap this tool exists to find, one level up, in its
+    own implementation. Whether the tool should recompute the digest is a contract
+    decision with a canonicalisation question attached, and it is not made here.
     """
     if not m.get("_corpus_digest"):
         return {}
@@ -447,12 +455,15 @@ def _run_process(m: dict, manifest_path: Path) -> dict:
             failures.append("SOURCES NOT RESTORED: %s" % leaked)
         _build(m)   # leave the tree with a binary built from the real source
 
-    fixed = [r["label"] for r in results
-             if r["verdict"] == "killed" and r["label"] in acknowledged]
-    if fixed:
-        failures.append("known_holes still acknowledge rules the corpus now exercises: %s. "
-                        "Remove them; a stale acknowledgement hides a real regression later"
-                        % sorted(fixed))
+    # A stale acknowledgement is not only one whose rule became killed. Any verdict
+    # other than known-hole means the acknowledgement no longer describes anything,
+    # and a leftover that points at nothing is what hides the next regression.
+    linger = {r["label"]: r["verdict"] for r in results
+              if r["label"] in acknowledged and r["verdict"] != "known-hole"}
+    if linger:
+        failures.append("known_holes acknowledge rules that are no longer holes: %s. Remove "
+                        "them; an acknowledgement pointing at nothing hides the next regression"
+                        % sorted("%s (now %s)" % kv for kv in linger.items()))
     denom = killed + survived
     # No denominator means no measurement. Printing 100% over zero is the same
     # defect as excluding everything and printing 100%.
@@ -473,6 +484,9 @@ def _run_process(m: dict, manifest_path: Path) -> dict:
     return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
             "runner": "process", "killed": killed, "survived": survived,
             "known_holes": known_holes, "corpus_digest": m.get("_corpus_digest"),
+            "acknowledged_digests": len(m.get("known_holes", {})),
+            "hole_ratio": (None if (killed + survived) == 0
+                           else round(known_holes / (killed + survived), 2)),
             "equivalent": equivalent, "unexercised_out_of_scope": out_of_scope,
             "unproved": unproved,
             "declared_total": (killed + survived + equivalent + out_of_scope + unproved
@@ -620,12 +634,12 @@ def run(manifest_path: Path) -> dict:
                                 "how": eq["reason"], "moved": 0})
                 equivalent += 1
 
-    fixed = [r["label"] for r in results
-             if r["verdict"] == "killed" and r["label"] in acknowledged]
-    if fixed:
-        failures.append("known_holes still acknowledge rules the corpus now exercises: %s. "
-                        "Remove them; a stale acknowledgement hides a real regression later"
-                        % sorted(fixed))
+    linger = {r["label"]: r["verdict"] for r in results
+              if r["label"] in acknowledged and r["verdict"] != "known-hole"}
+    if linger:
+        failures.append("known_holes acknowledge rules that are no longer holes: %s. Remove "
+                        "them; an acknowledgement pointing at nothing hides the next regression"
+                        % sorted("%s (now %s)" % kv for kv in linger.items()))
     denom = killed + survived
     score = None if denom == 0 else round(100.0 * killed / denom, 1)
     if unproved:
@@ -646,6 +660,9 @@ def run(manifest_path: Path) -> dict:
     return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
             "killed": killed, "survived": survived, "equivalent": equivalent,
             "known_holes": known_holes, "corpus_digest": m.get("_corpus_digest"),
+            "acknowledged_digests": len(m.get("known_holes", {})),
+            "hole_ratio": (None if (killed + survived) == 0
+                           else round(known_holes / (killed + survived), 2)),
             "unexercised_out_of_scope": out_of_scope, "unproved": unproved,
             "declared_total": (killed + survived + equivalent + out_of_scope + unproved
                                + known_holes),
@@ -702,10 +719,21 @@ def main() -> int:
         if rep.get("known_holes"):
             # Louder than the pass line, and pinned. An acknowledgement that outlives
             # the corpus it was made about is worse than no acknowledgement.
-            print("%d KNOWN HOLE(S) recorded against %s. These are rules the corpus DOES "
-                  "claim and does NOT exercise. The acknowledgement is pinned to that digest "
-                  "and expires the moment the corpus changes."
+            print("%d KNOWN HOLE(S) against the DECLARED digest %s. These are rules the "
+                  "corpus DOES claim and does NOT exercise."
                   % (rep["known_holes"], rep.get("corpus_digest")))
+            print("  The digest is a value READ FROM A FILE THE MANIFEST NAMES. It is not "
+                  "recomputed from the vectors, so these acknowledgements expire only if that "
+                  "file is kept honest.")
+            if rep.get("acknowledged_digests", 0) > 1:
+                print("  %d digests carry acknowledgements in this manifest. Entries for a "
+                      "digest that is not the declared one are not in force, but pre-declaring "
+                      "future digests is how this expiry gets bypassed."
+                      % rep["acknowledged_digests"])
+            if rep.get("hole_ratio") is not None and rep["hole_ratio"] > 1.0:
+                print("  more rules are acknowledged as holes than are measured (ratio %.2f). "
+                      "The score below is a statement about a minority of the declared rules."
+                      % rep["hole_ratio"])
         if rep["adequate"]:
             if rep["out_of_scope_ratio"] is not None and rep["out_of_scope_ratio"] > 1.0:
                 # The closing line is what gets quoted. It may not read as unqualified
@@ -714,7 +742,10 @@ def main() -> int:
                       "(%d of %d rules declared here were excluded from it)"
                       % (rep["unexercised_out_of_scope"], rep["declared_total"]))
             else:
-                suffix = (" -- but see the known holes above" if rep.get("known_holes") else "")
+                suffix = ""
+                if rep.get("known_holes"):
+                    suffix = (" for the rules still measured -- %d are acknowledged holes"
+                              % rep["known_holes"])
                 print("mutation-adequacy check passed: every non-equivalent mutant is killed"
                       + suffix)
 

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -717,8 +717,8 @@ def main() -> int:
         for f in rep["failures"]:
             print("FAIL: %s" % f)
         if rep.get("known_holes"):
-            # Louder than the pass line, and pinned. An acknowledgement that outlives
-            # the corpus it was made about is worse than no acknowledgement.
+            # Louder than the pass line. Not pinned to the corpus: pinned to a value
+            # another tool has to keep honest, which is what the text below says.
             print("%d KNOWN HOLE(S) against the DECLARED digest %s. These are rules the "
                   "corpus DOES claim and does NOT exercise."
                   % (rep["known_holes"], rep.get("corpus_digest")))
@@ -732,8 +732,8 @@ def main() -> int:
                       % rep["acknowledged_digests"])
             if rep.get("hole_ratio") is not None and rep["hole_ratio"] > 1.0:
                 print("  more rules are acknowledged as holes than are measured (ratio %.2f). "
-                      "The score below is a statement about a minority of the declared rules."
-                      % rep["hole_ratio"])
+                      "The score printed above is a statement about a minority of the "
+                      "declared rules." % rep["hole_ratio"])
         if rep["adequate"]:
             if rep["out_of_scope_ratio"] is not None and rep["out_of_scope_ratio"] > 1.0:
                 # The closing line is what gets quoted. It may not read as unqualified

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -117,6 +117,22 @@ def load_manifest(path: Path) -> dict:
     m.setdefault("entrypoint_args",
                  [k for k in (m["group_key"], m["inputs_key"]) if k is not None])
     m.setdefault("default_group", "all")
+    m.setdefault("known_holes", {})
+    m["_corpus_digest"] = None
+    if m["known_holes"]:
+        for key in ("corpus_digest_file", "corpus_digest_key"):
+            _req(m, key, "manifest (known_holes declared)")
+        dp = (base / m["corpus_digest_file"]).resolve()
+        if not dp.is_file():
+            raise ManifestError("corpus_digest_file not found: %s" % dp)
+        m["_corpus_digest"] = json.loads(dp.read_text(encoding="utf-8"))[m["corpus_digest_key"]]
+        for digest, entries in m["known_holes"].items():
+            for i, e in enumerate(entries):
+                for key in ("label", "reason", "recorded"):
+                    _req(e, key, "known_holes[%s][%d]" % (digest, i))
+                if not str(e["reason"]).strip():
+                    raise ManifestError("known_holes[%s][%d] %r: a hole needs a stated reason"
+                                        % (digest, i, e["label"]))
     m.setdefault("runner", "module")
     if m["runner"] not in ("module", "process"):
         raise ManifestError("runner must be module or process, got %r" % m["runner"])
@@ -182,6 +198,18 @@ def _load_module(source: str, tag: str, tmp: Path):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _acknowledged_holes(m: dict) -> dict:
+    """Holes acknowledged against the corpus digest that is actually present.
+
+    Pinned deliberately. An acknowledgement is a statement about ONE corpus, so a
+    corpus that moves loses every acknowledgement and the holes reappear as
+    survivors. Without that, this becomes the escape hatch out_of_scope nearly was.
+    """
+    if not m.get("_corpus_digest"):
+        return {}
+    return {e["label"]: e for e in m["known_holes"].get(m["_corpus_digest"], [])}
 
 
 def _group_of(v: dict, m: dict) -> str:
@@ -295,7 +323,12 @@ def _run_process(m: dict, manifest_path: Path) -> dict:
     if not any(mut.get("control") for muts in m["mutants"].values() for mut in muts):
         failures.append("no control mutant declared. Without one, a run of all-survivors "
                         "cannot be told apart from a harness that detects nothing")
+    acknowledged = _acknowledged_holes(m)
+    stale = set(acknowledged) - {mu["label"] for ms in m["mutants"].values() for mu in ms}
+    if stale:
+        failures.append("known_holes name mutants that do not exist: %s" % sorted(stale))
     results, killed, survived, equivalent, out_of_scope, unproved = [], 0, 0, 0, 0, 0
+    known_holes = 0
     guard = _SourceGuard(m["_source_paths"])
     try:
         ok, detail = _build(m)
@@ -385,6 +418,17 @@ def _run_process(m: dict, manifest_path: Path) -> dict:
                                     "verdict": "unexercised", "scope": scope, "moved": 0,
                                     "how": "out of scope: %s" % mut["reason"]})
                     out_of_scope += 1
+                elif mut["label"] in acknowledged:
+                    ack = acknowledged[mut["label"]]
+                    # A KNOWN HOLE is not a scope statement. The corpus does claim this
+                    # rule, the rule is genuinely unexercised, and that fact is recorded
+                    # against ONE digest rather than fixed today. It stays loud.
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "known-hole", "scope": scope, "moved": 0,
+                                    "how": "KNOWN HOLE against %s, recorded %s: %s"
+                                           % (m["_corpus_digest"][:19], ack["recorded"],
+                                              ack["reason"])})
+                    known_holes += 1
                 else:
                     results.append({"group": group, "label": mut["label"], "verdict": "survived",
                                     "scope": scope, "moved": 0,
@@ -403,22 +447,36 @@ def _run_process(m: dict, manifest_path: Path) -> dict:
             failures.append("SOURCES NOT RESTORED: %s" % leaked)
         _build(m)   # leave the tree with a binary built from the real source
 
+    fixed = [r["label"] for r in results
+             if r["verdict"] == "killed" and r["label"] in acknowledged]
+    if fixed:
+        failures.append("known_holes still acknowledge rules the corpus now exercises: %s. "
+                        "Remove them; a stale acknowledgement hides a real regression later"
+                        % sorted(fixed))
     denom = killed + survived
-    score = 100.0 if denom == 0 else round(100.0 * killed / denom, 1)
+    # No denominator means no measurement. Printing 100% over zero is the same
+    # defect as excluding everything and printing 100%.
+    score = None if denom == 0 else round(100.0 * killed / denom, 1)
     if unproved:
         failures.append("%d mutant(s) never ran, so this corpus was not measured against them"
                         % unproved)
     if survived:
         failures.append("%d mutant(s) survived; the required score is 100%% of non-equivalent "
                         "mutants" % survived)
-    if denom == 0 and not failures:
-        failures.append("no non-equivalent mutants were scored, so no adequacy was measured")
+    if denom == 0:
+        failures.append(
+            "nothing was measured: every declared in-scope rule is either a known hole, "
+            "declared equivalent or out of scope. There is no adequacy result here"
+            if (known_holes or equivalent or out_of_scope)
+            else "no non-equivalent mutants were scored, so no adequacy was measured")
 
     return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
             "runner": "process", "killed": killed, "survived": survived,
+            "known_holes": known_holes, "corpus_digest": m.get("_corpus_digest"),
             "equivalent": equivalent, "unexercised_out_of_scope": out_of_scope,
             "unproved": unproved,
-            "declared_total": killed + survived + equivalent + out_of_scope + unproved,
+            "declared_total": (killed + survived + equivalent + out_of_scope + unproved
+                               + known_holes),
             "out_of_scope_ratio": (None if denom == 0 else round(out_of_scope / denom, 2)),
             "score_percent": score,
             "score_means": ("percent of author-declared in-scope rules killed; NOT percent of "
@@ -447,8 +505,12 @@ def run(manifest_path: Path) -> dict:
     if stale:
         failures.append("mutants declared for groups not in the corpus: %s" % stale)
 
+    acknowledged = _acknowledged_holes(m)
+    stale = set(acknowledged) - {mu["label"] for ms in m["mutants"].values() for mu in ms}
+    if stale:
+        failures.append("known_holes name mutants that do not exist: %s" % sorted(stale))
     results, killed, survived, equivalent, out_of_scope = [], 0, 0, 0, 0
-    unproved = 0
+    unproved = known_holes = 0
     with tempfile.TemporaryDirectory() as raw:
         tmp = Path(raw)
         base_mod = _load_module(source, "base", tmp)
@@ -535,6 +597,14 @@ def run(manifest_path: Path) -> dict:
                         # "each with a stated reason" without showing one is an assertion.
                         "how": "out of scope: %s" % mut["reason"]})
                     out_of_scope += 1
+                elif mut["label"] in acknowledged:
+                    ack = acknowledged[mut["label"]]
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "known-hole", "scope": scope, "moved": 0,
+                                    "how": "KNOWN HOLE against %s, recorded %s: %s"
+                                           % (str(m["_corpus_digest"])[:19], ack["recorded"],
+                                              ack["reason"])})
+                    known_holes += 1
                 else:
                     results.append({
                         "group": group, "label": mut["label"], "verdict": "survived",
@@ -550,8 +620,14 @@ def run(manifest_path: Path) -> dict:
                                 "how": eq["reason"], "moved": 0})
                 equivalent += 1
 
+    fixed = [r["label"] for r in results
+             if r["verdict"] == "killed" and r["label"] in acknowledged]
+    if fixed:
+        failures.append("known_holes still acknowledge rules the corpus now exercises: %s. "
+                        "Remove them; a stale acknowledgement hides a real regression later"
+                        % sorted(fixed))
     denom = killed + survived
-    score = 100.0 if denom == 0 else round(100.0 * killed / denom, 1)
+    score = None if denom == 0 else round(100.0 * killed / denom, 1)
     if unproved:
         # Not a soft warning: an unproved mutant means the measurement did not happen,
         # and a score computed over the rest reports more than the run established.
@@ -560,13 +636,19 @@ def run(manifest_path: Path) -> dict:
     if survived:
         failures.append("%d mutant(s) survived; the required score is 100%% of non-equivalent "
                         "mutants" % survived)
-    if denom == 0 and not failures:
-        failures.append("no non-equivalent mutants were scored, so no adequacy was measured")
+    if denom == 0:
+        failures.append(
+            "nothing was measured: every declared in-scope rule is either a known hole, "
+            "declared equivalent or out of scope. There is no adequacy result here"
+            if (known_holes or equivalent or out_of_scope)
+            else "no non-equivalent mutants were scored, so no adequacy was measured")
 
     return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
             "killed": killed, "survived": survived, "equivalent": equivalent,
+            "known_holes": known_holes, "corpus_digest": m.get("_corpus_digest"),
             "unexercised_out_of_scope": out_of_scope, "unproved": unproved,
-            "declared_total": killed + survived + equivalent + out_of_scope + unproved,
+            "declared_total": (killed + survived + equivalent + out_of_scope + unproved
+                               + known_holes),
             "out_of_scope_ratio": (None if (killed + survived) == 0
                                    else round(out_of_scope / (killed + survived), 2)),
             "score_means": ("percent of author-declared in-scope rules killed; NOT percent of the "
@@ -597,13 +679,17 @@ def main() -> int:
         # Never a bare percentage. A score reported without its denominator and its
         # exclusions is a percentage target wearing a different coat: an author can
         # exclude almost everything and still print 100%.
-        print("%d of %d DECLARED in-scope rules killed (%.1f%%). %d declared equivalent, "
+        pct = ("no result" if rep["score_percent"] is None
+               else "%.1f%%" % rep["score_percent"])
+        print("%d of %d DECLARED in-scope rules killed (%s). %d declared equivalent, "
               "%d declared out of scope, %d unproved. %d rules declared in total."
-              % (rep["killed"], rep["killed"] + rep["survived"], rep["score_percent"],
+              % (rep["killed"], rep["killed"] + rep["survived"], pct,
                  rep["equivalent"], rep["unexercised_out_of_scope"], rep["unproved"],
                  rep["declared_total"]))
-        print("This is %.1f%% of what the AUTHOR DECLARED, not of the rules the implementation "
-              "has. A rule nobody declared is invisible to this check." % rep["score_percent"])
+        if rep["score_percent"] is not None:
+            print("This is %.1f%% of what the AUTHOR DECLARED, not of the rules the "
+                  "implementation has. A rule nobody declared is invisible to this check."
+                  % rep["score_percent"])
         if rep["unexercised_out_of_scope"]:
             print("out of scope (%d, each with a stated reason): real gaps in what the corpus "
                   "covers, not holes in what it claims" % rep["unexercised_out_of_scope"])
@@ -613,6 +699,13 @@ def main() -> int:
                   % rep["out_of_scope_ratio"])
         for f in rep["failures"]:
             print("FAIL: %s" % f)
+        if rep.get("known_holes"):
+            # Louder than the pass line, and pinned. An acknowledgement that outlives
+            # the corpus it was made about is worse than no acknowledgement.
+            print("%d KNOWN HOLE(S) recorded against %s. These are rules the corpus DOES "
+                  "claim and does NOT exercise. The acknowledgement is pinned to that digest "
+                  "and expires the moment the corpus changes."
+                  % (rep["known_holes"], rep.get("corpus_digest")))
         if rep["adequate"]:
             if rep["out_of_scope_ratio"] is not None and rep["out_of_scope_ratio"] > 1.0:
                 # The closing line is what gets quoted. It may not read as unqualified
@@ -621,7 +714,9 @@ def main() -> int:
                       "(%d of %d rules declared here were excluded from it)"
                       % (rep["unexercised_out_of_scope"], rep["declared_total"]))
             else:
-                print("mutation-adequacy check passed: every non-equivalent mutant is killed")
+                suffix = (" -- but see the known holes above" if rep.get("known_holes") else "")
+                print("mutation-adequacy check passed: every non-equivalent mutant is killed"
+                      + suffix)
 
     return 0 if rep["adequate"] else 1
 

--- a/conformance/run_all.py
+++ b/conformance/run_all.py
@@ -43,6 +43,11 @@ import time
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bounded_run import (  # noqa: E402
+    OUTPUT_CAP_BYTES, _OutputTooLarge, _run_capped,
+)
+
 REPO = Path(__file__).resolve().parent.parent
 
 # Grades a run can produce.
@@ -51,68 +56,6 @@ PROVED, FALSE, UNPROVED = "proved", "false", "unproved"
 NEEDS_CANDIDATE, NOT_SELECTED, EXTERNAL = "needs_candidate", "not_selected", "external"
 
 RANK = {PROVED: 0, NEEDS_CANDIDATE: 0, NOT_SELECTED: 0, EXTERNAL: 0, UNPROVED: 1, FALSE: 2}
-
-
-# Output ceiling per child process. Both children can emit arbitrary output and
-# a timeout does not bound memory, so the cap is applied while the process runs
-# rather than after it exits.
-OUTPUT_CAP_BYTES = 4 * 1024 * 1024
-
-
-class _OutputTooLarge(Exception):
-    """A child exceeded OUTPUT_CAP_BYTES; its output is not materialized."""
-
-
-def _run_capped(cmd: list[str], cwd: Path, timeout: int) -> subprocess.CompletedProcess:
-    """subprocess.run with a ceiling on how much output is ever held.
-
-    Streams both pipes to temporary files, polls their combined size while the
-    child runs, and kills it the moment the cap is crossed. Only the first
-    OUTPUT_CAP_BYTES are ever read into memory.
-    """
-    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
-        # A descendant that inherits stdout/stderr keeps writing after proc.kill()
-        # and walks straight through the ceiling, so the child leads its own session
-        # and the whole group is stopped and reaped.
-        proc = subprocess.Popen(cmd, cwd=str(cwd), stdout=out, stderr=err,
-                                start_new_session=True)
-
-        def _kill_tree() -> None:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError, OSError):
-                proc.kill()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                pass
-        deadline = time.monotonic() + timeout
-        try:
-            while True:
-                try:
-                    proc.wait(timeout=0.25)
-                    break
-                except subprocess.TimeoutExpired:
-                    pass
-                if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
-                    _kill_tree()
-                    raise _OutputTooLarge()
-                if time.monotonic() > deadline:
-                    _kill_tree()
-                    raise subprocess.TimeoutExpired(cmd, timeout)
-        finally:
-            # Reap the group even on the clean path: the leader can exit while a
-            # descendant it spawned is still holding the inherited handles.
-            _kill_tree()
-        if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
-            raise _OutputTooLarge()
-        out.seek(0)
-        err.seek(0)
-        return subprocess.CompletedProcess(
-            cmd, proc.returncode,
-            out.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
-            err.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
-        )
 
 
 def _stdlib_jsonrpc(suite: dict) -> tuple[str, str]:

--- a/conformance/tests/test_corpus_adequacy.py
+++ b/conformance/tests/test_corpus_adequacy.py
@@ -90,11 +90,47 @@ class Scoring(unittest.TestCase):
         self.assertEqual(rep["equivalent"], 1)
         self.assertEqual(rep["killed"] + rep["survived"], 1)
 
-    def test_a_mutant_that_crashes_the_module_counts_as_killed(self):
+    def test_a_mutant_that_never_loads_is_unproved_not_killed(self):
+        # Reversed deliberately on the Rust-adapter review: a mutant that never
+        # loaded was never shown to the corpus, so the corpus said nothing about
+        # that rule. Counting it killed lets a typo in the substitution print as
+        # "rule covered". Measure a load-bearing rule with a variant that RUNS.
         broken = {"label": "syntax", "anchor": 'return "ok"', "replacement": "return ??"}
         with tempfile.TemporaryDirectory() as d:
             rep = ca.run(_manifest(Path(d), {"a": [broken]}))
-        self.assertEqual(rep["killed"], 1)
+        self.assertEqual(rep["killed"], 0)
+        self.assertEqual(rep["unproved"], 1)
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("never ran" in f for f in rep["failures"]), rep["failures"])
+
+
+class ControlMutants(unittest.TestCase):
+    """A control proves the harness detects anything. It is never scored."""
+
+    def test_a_killed_control_does_not_inflate_the_score(self):
+        ctrl = dict(KILLABLE, label="CONTROL reachability", control=True)
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [ctrl]}))
+        self.assertEqual(rep["killed"], 0, "a control must not count as a kill")
+        self.assertIn("control-killed", [r["verdict"] for r in rep["mutants"]])
+
+    def test_a_surviving_control_invalidates_the_whole_run(self):
+        # The distinction the control exists for: all-survivors because the corpus is
+        # weak, versus all-survivors because nothing was ever measured.
+        ctrl = dict(SURVIVOR, label="CONTROL reachability", control=True)
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, ctrl]}))
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("harness cannot detect" in f for f in rep["failures"]),
+                        rep["failures"])
+
+    def test_a_control_may_not_be_declared_out_of_scope(self):
+        ctrl = dict(KILLABLE, label="c", control=True, scope="out_of_scope", reason="x")
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [ctrl]})
+            with self.assertRaises(ca.ManifestError) as cm:
+                ca.load_manifest(p)
+        self.assertIn("control cannot be out_of_scope", str(cm.exception))
 
 
 class Guards(unittest.TestCase):

--- a/conformance/tests/test_corpus_adequacy.py
+++ b/conformance/tests/test_corpus_adequacy.py
@@ -133,6 +133,67 @@ class ControlMutants(unittest.TestCase):
         self.assertIn("control cannot be out_of_scope", str(cm.exception))
 
 
+class KnownHoles(unittest.TestCase):
+    """An acknowledged hole is pinned to one digest and expires with it."""
+
+    def _mf(self, tmp: Path, digest_in_file, holes_for, extra_mutants=None):
+        (tmp / "digest.json").write_text(json.dumps({"corpus_digest": digest_in_file}))
+        muts = [dict(SURVIVOR, label="unexercised rule")] + (extra_mutants or [])
+        p = _manifest(tmp, {"a": muts}, raw={
+            "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+            "known_holes": {holes_for: [{"label": "unexercised rule",
+                                         "reason": "no vector reaches it",
+                                         "recorded": "2026-08-19"}]}})
+        return p
+
+    def test_a_hole_acknowledged_for_the_present_digest_is_not_a_survivor(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(self._mf(Path(d), "sha256:aaa", "sha256:aaa", [KILLABLE]))
+        self.assertEqual(rep["survived"], 0)
+        self.assertEqual(rep["known_holes"], 1)
+        self.assertIn("known-hole", [r["verdict"] for r in rep["mutants"]])
+
+    def test_the_acknowledgement_expires_when_the_corpus_moves(self):
+        # The rule that stops this being an escape hatch: an acknowledgement is a
+        # statement about ONE corpus, so a corpus that changes loses it.
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(self._mf(Path(d), "sha256:NEW", "sha256:OLD", [KILLABLE]))
+        self.assertEqual(rep["known_holes"], 0)
+        self.assertEqual(rep["survived"], 1, "the hole must reappear as a survivor")
+        self.assertFalse(rep["adequate"])
+
+    def test_an_acknowledgement_for_a_rule_now_exercised_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [dict(KILLABLE, label="now exercised")]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "now exercised", "reason": "x",
+                                                "recorded": "2026-08-19"}]}})
+            rep = ca.run(p)
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("now exercises" in f for f in rep["failures"]), rep["failures"])
+
+    def test_a_hole_without_a_reason_is_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "x", "reason": " ",
+                                                "recorded": "2026-08-19"}]}})
+            with self.assertRaises(ca.ManifestError) as cm:
+                ca.load_manifest(p)
+        self.assertIn("stated reason", str(cm.exception))
+
+    def test_an_all_holes_manifest_reports_no_result_rather_than_100_percent(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(self._mf(Path(d), "sha256:aaa", "sha256:aaa"))
+        self.assertIsNone(rep["score_percent"], "an empty denominator is not 100%")
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("nothing was measured" in f for f in rep["failures"]))
+
+
 class Guards(unittest.TestCase):
     def test_a_group_in_the_corpus_with_no_mutants_is_a_hard_failure(self):
         v = {"vectors": VECTORS["vectors"] + [

--- a/conformance/tests/test_corpus_adequacy.py
+++ b/conformance/tests/test_corpus_adequacy.py
@@ -172,7 +172,64 @@ class KnownHoles(unittest.TestCase):
                                                 "recorded": "2026-08-19"}]}})
             rep = ca.run(p)
         self.assertFalse(rep["adequate"])
-        self.assertTrue(any("now exercises" in f for f in rep["failures"]), rep["failures"])
+        # The message widened from "now exercises" to cover every transition away
+        # from known-hole, not only becoming killed.
+        self.assertTrue(any("no longer holes" in f and "now killed" in f
+                            for f in rep["failures"]), rep["failures"])
+
+    def test_the_report_does_not_claim_the_pin_is_to_the_corpus(self):
+        # The wording was false and the tool printed it: with a corpus that had moved
+        # it said the acknowledgement "expires the moment the corpus changes" while
+        # exiting 0 at 100%. The digest is a value read from a file the manifest
+        # names, never recomputed from the vectors, and the report must say so.
+        with tempfile.TemporaryDirectory() as d:
+            p = self._mf(Path(d), "sha256:aaa", "sha256:aaa", [KILLABLE])
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertNotIn("expires the moment the corpus changes", r.stdout)
+        self.assertIn("not recomputed from the vectors", r.stdout)
+
+    def test_pre_declared_future_digests_are_surfaced(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE, dict(SURVIVOR, label="hole")]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "hole", "reason": "x",
+                                                "recorded": "2026-08-19"}],
+                                "sha256:future1": [], "sha256:future2": []}})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertIn("digests carry acknowledgements", r.stdout)
+
+    def test_holes_outnumbering_measurements_is_stated(self):
+        holes = [dict(SURVIVOR, label=f"h{i}") for i in range(4)]
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE] + holes}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": f"h{i}", "reason": "x",
+                                                "recorded": "2026-08-19"} for i in range(4)]}})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertIn("acknowledged as holes than are measured", r.stdout)
+        self.assertIn("acknowledged holes", r.stdout.strip().splitlines()[-1])
+
+    def test_an_acknowledgement_lingers_when_its_rule_becomes_out_of_scope(self):
+        # Only one of four transitions was covered: killed. A rule that becomes
+        # out_of_scope left the acknowledgement pointing at nothing, silently.
+        oos = dict(SURVIVOR, label="hole", scope="out_of_scope", reason="marked oos later")
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE, oos]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "hole", "reason": "x",
+                                                "recorded": "2026-08-19"}]}})
+            rep = ca.run(p)
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("no longer holes" in f for f in rep["failures"]), rep["failures"])
 
     def test_a_hole_without_a_reason_is_refused(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Implements the process runner from the design review on [#192](https://github.com/Rul1an/assay-tunnel-experiments/issues/192), and uses it to measure `privileged-mcp-action-v0` for the first time — the corpus whose digest is a published contract, and the one [#1840](https://github.com/Rul1an/assay/issues/1840) invites strangers to reproduce.

## The finding: 0 of 1

**Corrected after independent review.** The first version of this PR said "0 of 3". Two of those three were not holes, and both were the exact error class the brief predicted: real code on a real path that the profile does not promise *there*, which surfaces as a survivor rather than as a failure.

**The one genuine hole** is the **origin leg** of the v0 marker triple. `docs/profiles/privileged-mcp-action/v0.md` §5 Stage 3 promises an observation is a marker only if all three legs hold — schema, code **and** `origin == "assay-proxy"`. No vector among the fourteen is a well-formed v0 observation whose only defect is a wrong origin, so deleting that check cannot move a pinned outcome. Recorded as a known hole against `sha256:cb58ce91…`.

**The two that are not holes**, verified at source:

`verify_privileged_mcp_action.rs:331` admits only payloads matching the *selected* profile's `observation_schema()`; everything else in the namespace becomes a Stage 2 `unknown_profile_schema` violation. `classify_denial_marker` at `:405` runs only on that already-filtered set.

| Declared rule | Why it is not a hole |
|---|---|
| `_ => Some(V1)` — unrecognised triple fails closed | **Wrong stage.** That promise lives in the Stage 2 arm, not the classifier default. Under v0 the classifier never sees a non-`.v0` payload, so returning `Some(V1)` still fails `== Some(V0)`. Cannot move any outcome *even in theory*. |
| `(V1, _, ORIGIN)` — v1 pairs with the v1 code | **Wrong profile.** That is Stage 3 of `v1.md`. Under v0 a `.v1` payload never enters `observations`, so the V1 arm is unreachable. Survival means the v0 corpus never presents that pairing. |

Both are marked `out_of_scope` **with the full reasoning rather than deleted**, so the mistake stays visible in the artifact instead of being tidied away.

**Consequence, stated rather than smoothed:** with one in-scope rule, and that rule a known hole, this manifest now measures nothing and says so (`no result`, exit 1). Declaring mutants for rules the corpus *does* exercise is follow-up work.

## Why the number is worth reading: control mutants

The first run said `0 of 5` and should not have been published. **All-survivors because the corpus is weak, and all-survivors because nothing was ever measured, print identically.**

So a manifest must now declare at least one **control**: a mutation on the same path that MUST be killed.

- It is **excluded from the score** — counting it would inflate the very number it exists to make trustworthy.
- If it **survives**, the run fails outright and every other verdict is declared meaningless.
- A manifest with no control fails before it starts.

Here the control is killed, so the three survivors are a finding rather than a broken harness.

## The tool caught two of my own setup errors

Both surfaced as hard failures instead of as scores, which is the outcome to want:

1. Mutants declared on `bindable_denial_marker` measured nothing — `grep` showed the CLI verifier never calls it. Removed.
2. The control's anchor was not found, because I had declared the wrong verifier file as a source. `verify_privileged_mcp_action.rs` was missing from `implementation_sources`.

## Build failure is `unproved`, never a kill

Per the review: `rustc` exit 1 yields no verdict, so the corpus never saw the mutant, and a typo in my substitution would otherwise print as a covered rule. A load-bearing arm is measured with a variant that **compiles**, or declared equivalent.

The same argument applies to the module runner, where a mutant that failed to import counted as a kill. Corrected here, and the test asserting the old behaviour is reversed with the reasoning recorded in place.

## Safety around a tool that edits the working tree

- originals captured up front, restored in a `finally`, and **verified afterwards** that nothing leaked
- **refuses to run** when a declared source has uncommitted changes
- `crates/` is clean after roughly fifteen build cycles

## Measurement

| | |
|---|---|
| mutants × vectors | 5 × 14 |
| per mutant | ~29 s |
| why | every build touches `assay-evidence`, which rebuilds **11 crates** |

That last row is the correction from the design review: my earlier "the rules sit in a leaf crate" framing was wrong, and the 7.5 s figure was the exception rather than the rule.

`conformance/bounded_run.py` is new: the bounded child-process runner now has **one** implementation instead of two that drift.

## Verification

- 28 tests here, 7 own-corpora, 25 for `run_all`
- rge-bench parity unchanged: **30 of 30**, 1 declared equivalent
- three control tests: a killed control does not inflate the score, a surviving control invalidates the run, a control may not be declared out of scope

