### PR TITLE
test(evidence): probe the generic signature class semver-checks misses

### DIFF
--- a/crates/assay-evidence/tests/public_api_source_compat.rs
+++ b/crates/assay-evidence/tests/public_api_source_compat.rs
@@ -1,0 +1,76 @@
+//! Compile probes for public generic signatures that `cargo-semver-checks` does not cover.
+//!
+//! `cargo-semver-checks 0.50.0` reported all 223 checks passing across a change that altered an
+//! accepted generic iterator item type from `Item = Option<CodingAgentClaimCeiling>` to
+//! `Item = &CodingAgentClaimDecision`, while a direct old-call-site probe failed with `E0271`
+//! (#2356). That merge was safe — the signature had never been in a release tag — but it located
+//! the gate's reliability boundary: a green semver job is not on its own evidence of source
+//! compatibility for generic associated-type changes.
+//!
+//! This file is the missing signal, and it needs no new tooling. An integration test compiles
+//! against the crate's PUBLIC API exactly as a downstream consumer does, so a source-breaking
+//! signature change fails the build here even when the semver gate stays green.
+//!
+//! What each probe pins is the *accepted argument shape*, not the function's behaviour. Passing an
+//! owned collection is the assertion: if `Item` narrows to a reference, the owned value stops
+//! satisfying the bound and this stops compiling. Nothing here asserts on output, because output is
+//! already covered elsewhere and would make a failure ambiguous between behaviour and signature.
+//!
+//! Measured on `eb62b34d0`, seeding exactly the #2356 mutation
+//! (`Item = EvidenceEvent` -> `Item = &'a EvidenceEvent`) into `add_events`:
+//!
+//! ```text
+//! cargo semver-checks check-release -p assay-evidence --baseline-rev v5.4.0
+//!   223 checks: 223 pass, 31 skip
+//!   Summary no semver update required          <- exit 0, GREEN
+//!
+//! cargo test -p assay-evidence --test public_api_source_compat
+//!   error[E0271]: type mismatch resolving
+//!     `<Vec<EvidenceEvent> as IntoIterator>::Item == &EvidenceEvent`   <- RED
+//! ```
+//!
+//! So the two signals disagree on the same change, which is the whole reason this file exists. A
+//! green semver job means "no break this tool models", not "no break".
+//!
+//! Scope, so this is not read as more than it is: these are the generic public entry points that a
+//! caller can pass a collection to. This is not an exhaustive public-API snapshot — `cargo public-api`
+//! is the tool for that, and `optional-public-api-drift.sh` already runs it. The point here is
+//! narrower: cover the specific class the semver gate is known to miss.
+
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::EvidenceEvent;
+use serde_json::json;
+use std::io::Cursor;
+
+fn event(seq: u64) -> EvidenceEvent {
+    EvidenceEvent::new(
+        "assay.public_api.probe",
+        "urn:assay:public-api-probe",
+        "run_public_api_0001",
+        seq,
+        json!({ "seq": seq }),
+    )
+}
+
+/// `BundleWriter::add_events` accepts an iterator of OWNED events.
+///
+/// The probe is the ownership, not the call. Narrowing to `Item = &EvidenceEvent` is source
+/// breaking for every caller passing a `Vec`, and is the shape `cargo-semver-checks 0.50.0` did not
+/// report in #2356.
+#[test]
+fn add_events_accepts_an_owned_iterator_of_events() {
+    let mut writer = BundleWriter::new(Cursor::new(Vec::new()));
+
+    // A `Vec<EvidenceEvent>` by value: satisfies `Item = EvidenceEvent`, and does not satisfy
+    // `Item = &EvidenceEvent`.
+    let owned: Vec<EvidenceEvent> = (0..3).map(event).collect();
+    writer.add_events(owned);
+
+    // A non-`Vec` owned iterator too, so the bound is pinned rather than one concrete collection.
+    let mut writer = BundleWriter::new(Cursor::new(Vec::new()));
+    writer.add_events((3..5).map(event));
+
+    // `add_event` singular takes an owned event on the same terms.
+    let mut writer = BundleWriter::new(Cursor::new(Vec::new()));
+    writer.add_event(event(5));
+}

--- a/scripts/ci/cargo-plugin-versions.sh
+++ b/scripts/ci/cargo-plugin-versions.sh
@@ -15,6 +15,13 @@ export CARGO_AUDIT_VERSION="0.22.2"
 # crates.io max_stable_version and Rust 1.96 (each tool's MSRV is below that).
 export CARGO_NEXTEST_VERSION="0.9.143"
 export CARGO_HACK_VERSION="0.6.45"
+# cargo-semver-checks is ONE signal, not a source-compatibility proof. Measured on 0.50.0: a public
+# generic whose accepted iterator item type narrows from an owned value to a reference passes all
+# 223 checks and reports "no semver update required", while a caller passing a `Vec` fails to
+# compile with E0271 (#2356). The compensating signal is
+# `crates/assay-evidence/tests/public_api_source_compat.rs`, which fails to build on exactly that
+# change. Re-measure this note when the pinned version moves; it may stop being true, which would be
+# good news.
 export CARGO_SEMVER_CHECKS_VERSION="0.50.0"
 # CI-4D3 / #2224: optional public-api + mutants. Measured crates.io max_stable_version,
 # unyanked. cargo-public-api publishes no rust_version (do not claim formal MSRV; CI Rust


### PR DESCRIPTION
Closes #2356

## The two signals disagree on the same change

Reproduced on `eb62b34d0` against a **live published API**, seeding exactly the #2356 mutation into
`BundleWriter::add_events` (`Item = EvidenceEvent` -> `Item = &'a EvidenceEvent`):

| signal | result |
|---|---|
| `cargo semver-checks check-release -p assay-evidence --baseline-rev v5.4.0` | `223 checks: 223 pass, 31 skip` / `Summary no semver update required` / **exit 0** |
| `cargo test -p assay-evidence --test public_api_source_compat` | **`error[E0271]`** — build fails |

`223 checks: 223 pass` matches the issue's original measurement. The gate reports no semver update
required for a change that breaks every caller passing a `Vec`.

This matters beyond the issue: a green semver job had been read as evidence of source compatibility,
including by me earlier today when deciding whether two PRs were release-blocking. It means "no break
this tool models", not "no break".

## The compensating signal needs no new tooling

An integration test compiles against the crate's **public** API exactly as a downstream consumer
does, so the break fails the build here.

What is pinned is the accepted **argument shape**, not behaviour: passing an owned collection *is*
the assertion, because an `Item` that narrows to a reference stops accepting it. Both a `Vec` and a
`Map` are passed, so the bound is pinned rather than one concrete collection. Nothing asserts on
output — that is covered elsewhere, and including it would make a failure ambiguous between
behaviour and signature.

## Documented at the pin, not only in the test

`scripts/ci/cargo-plugin-versions.sh` now carries the limitation beside
`CARGO_SEMVER_CHECKS_VERSION`, because the pin is where someone stands when they decide to trust the
gate. The note asks for re-measurement when the version moves: 0.50.0 missing this is a fact about
0.50.0, not a permanent property, and it stopping being true would be good news.

## Not claimed

Not an exhaustive public-API snapshot. `cargo public-api` is that tool and
`optional-public-api-drift.sh` already runs it. This covers the specific class the semver gate is
known to miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for public API source compatibility when adding owned events and event collections.
  * Documented compatibility checks for iterator-based APIs.

* **Documentation**
  * Clarified that automated semantic version checks may not detect all source compatibility issues.
  * Added guidance on using targeted compatibility tests for public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->