### PR TITLE
feat(cli): let a caller walk the contract at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
           export PATH="${HOME}/.local/bin:${PATH}"
           bash scripts/ci/test-evidence-vocabulary.sh
           python3 scripts/ci/check-evidence-vocabulary.py
+          bash scripts/ci/test-cli-describe-contract.sh
 
   # --- Dependency security (advisories, licenses, sources) ---
   deps-security:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `assay describe [path...]` walks the clap command tree so a caller can ask
+  for the top-level surface and descend. Node identities are the existing
+  shipping constants, not a second registry. Global `--quiet` /
+  `--non-interactive` stay absent: `NO_COLOR` is already honoured and `watch`
+  is the only interactive command (#2178).
+
 ### Changed
 - `assay_check_sequence` answers the sequence-rule language by calling
   `assay_core::sequence_eval` and mapping the record into its published JSON.

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -32,6 +32,7 @@ exclude = [
     "tests/doctor_exit_class_contract.rs",
     "tests/doctor_argument_contract.rs",
     "tests/doctor_text_render_contract.rs",
+    "tests/cli_describe_contract.rs",
     "tests/stdout_json_write_contract.rs",
     "tests/mcp_preflight_contract.rs",
     "tests/recovery_argv_publisher_parity.rs",

--- a/crates/assay-cli/src/cli/args/describe.rs
+++ b/crates/assay-cli/src/cli/args/describe.rs
@@ -1,0 +1,8 @@
+use clap::Args;
+
+/// Ask for one node of the CLI contract. Empty path is the top level.
+#[derive(Args, Debug, Clone)]
+pub struct DescribeArgs {
+    /// Command path to descend into. Omit to list the top-level surface.
+    pub path: Vec<String>,
+}

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -4,6 +4,7 @@ pub mod baseline;
 pub mod bundle;
 pub mod common;
 pub mod coverage;
+pub mod describe;
 pub mod evidence;
 pub mod import;
 pub mod mcp;
@@ -21,6 +22,7 @@ pub use baseline::*;
 pub use bundle::*;
 pub use common::*;
 pub use coverage::*;
+pub use describe::*;
 pub use evidence::*;
 pub use import::*;
 pub use mcp::*;
@@ -115,6 +117,8 @@ pub enum Command {
     Registry(RegistryArgs),
     /// Print Assay version information
     Version,
+    /// Enumerate the CLI contract at a command path
+    Describe(DescribeArgs),
     /// Validate, format, and migrate policies
     Policy(PolicyArgs),
     /// Runtime eBPF Monitor (Linux only)

--- a/crates/assay-cli/src/cli/commands/describe.rs
+++ b/crates/assay-cli/src/cli/commands/describe.rs
@@ -1,0 +1,100 @@
+mod bindings;
+
+use crate::cli::args::{Cli, DescribeArgs};
+use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_SUCCESS};
+use anyhow::Result;
+use clap::{Command, CommandFactory};
+use serde::Serialize;
+use std::io::{self, Write};
+
+/// Document identity for the machine describe channel.
+pub(crate) const DESCRIBE_REPORT_SCHEMA: &str = "assay.cli.describe.v0";
+
+#[derive(Serialize)]
+struct DescribeReport {
+    schema: &'static str,
+    path: Vec<String>,
+    commands: Vec<CommandEntry>,
+    identities: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct CommandEntry {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    about: Option<String>,
+    has_children: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    format: Vec<String>,
+}
+
+pub fn run(args: DescribeArgs) -> Result<i32> {
+    let root = Cli::command();
+    let Some(node) = resolve_node(&root, &args.path) else {
+        return Ok(EXIT_CONFIG_ERROR);
+    };
+    let report = DescribeReport {
+        schema: DESCRIBE_REPORT_SCHEMA,
+        path: args.path.clone(),
+        commands: visible_subcommands(node).map(command_entry).collect(),
+        identities: bindings::identities_for(&args.path),
+    };
+    let mut stdout = io::stdout().lock();
+    serde_json::to_writer(&mut stdout, &report)?;
+    writeln!(stdout)?;
+    Ok(EXIT_SUCCESS)
+}
+
+fn resolve_node<'a>(root: &'a Command, path: &[String]) -> Option<&'a Command> {
+    let mut current = root;
+    for (index, segment) in path.iter().enumerate() {
+        match visible_subcommands(current).find(|child| child.get_name() == segment) {
+            Some(child) => current = child,
+            None => {
+                let parent = if index == 0 {
+                    "assay".to_string()
+                } else {
+                    format!("assay {}", path[..index].join(" "))
+                };
+                let children: Vec<&str> = visible_subcommands(current)
+                    .map(Command::get_name)
+                    .collect();
+                let mut stderr = io::stderr().lock();
+                let _ = writeln!(
+                    stderr,
+                    "error: unknown command path segment {segment:?} under {parent}"
+                );
+                if !children.is_empty() {
+                    let _ = writeln!(stderr, "visible children: {}", children.join(", "));
+                }
+                return None;
+            }
+        }
+    }
+    Some(current)
+}
+
+fn visible_subcommands(cmd: &Command) -> impl Iterator<Item = &Command> {
+    cmd.get_subcommands().filter(|child| !child.is_hide_set())
+}
+
+fn command_entry(cmd: &Command) -> CommandEntry {
+    CommandEntry {
+        name: cmd.get_name().to_string(),
+        about: cmd.get_about().map(ToString::to_string),
+        has_children: visible_subcommands(cmd).next().is_some(),
+        format: format_values(cmd),
+    }
+}
+
+fn format_values(cmd: &Command) -> Vec<String> {
+    cmd.get_arguments()
+        .find(|arg| arg.get_long() == Some("format"))
+        .map(|arg| {
+            arg.get_possible_values()
+                .into_iter()
+                .map(|value| value.get_name().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/crates/assay-cli/src/cli/commands/describe/bindings.rs
+++ b/crates/assay-cli/src/cli/commands/describe/bindings.rs
@@ -1,0 +1,93 @@
+use super::DESCRIBE_REPORT_SCHEMA;
+use crate::cli::commands::evidence::schema::{
+    SCHEMA_LIST_REPORT, SCHEMA_SHOW_REPORT, SCHEMA_VALIDATION_REPORT,
+};
+use crate::cli::commands::init_report::INIT_REPORT_SCHEMA;
+use crate::cli::commands::validate::VALIDATE_REPORT_SCHEMA;
+use crate::diagnostics::report::DOCTOR_REPORT_SCHEMA;
+
+/// One shipping identity owned by a clap path. The identity field is the
+/// existing constant, not a second string.
+pub(super) struct IdentityBinding {
+    pub path: &'static str,
+    pub identity: &'static str,
+}
+
+/// Leaf paths only. A parent listing includes exact matches and immediate children.
+pub(super) const BINDING_ROWS: &[IdentityBinding] = &[
+    IdentityBinding {
+        path: "describe",
+        identity: DESCRIBE_REPORT_SCHEMA,
+    },
+    IdentityBinding {
+        path: "doctor",
+        identity: DOCTOR_REPORT_SCHEMA,
+    },
+    IdentityBinding {
+        path: "init",
+        identity: INIT_REPORT_SCHEMA,
+    },
+    IdentityBinding {
+        path: "validate",
+        identity: VALIDATE_REPORT_SCHEMA,
+    },
+    IdentityBinding {
+        path: "evidence/schema/list",
+        identity: SCHEMA_LIST_REPORT,
+    },
+    IdentityBinding {
+        path: "evidence/schema/show",
+        identity: SCHEMA_SHOW_REPORT,
+    },
+    IdentityBinding {
+        path: "evidence/schema/validate",
+        identity: SCHEMA_VALIDATION_REPORT,
+    },
+];
+
+pub(super) fn identities_for(path: &[String]) -> Vec<&'static str> {
+    if path.is_empty() {
+        return Vec::new();
+    }
+    let joined = path.join("/");
+    BINDING_ROWS
+        .iter()
+        .filter(|binding| belongs_on_node(binding.path, &joined))
+        .map(|binding| binding.identity)
+        .collect()
+}
+
+fn belongs_on_node(binding_path: &str, node_path: &str) -> bool {
+    if binding_path == node_path {
+        return true;
+    }
+    binding_path
+        .strip_prefix(node_path)
+        .is_some_and(|rest| rest.starts_with('/') && !rest[1..].contains('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{identities_for, BINDING_ROWS};
+    use crate::diagnostics::report::DOCTOR_REPORT_SCHEMA;
+
+    #[test]
+    fn root_lists_no_leaf_identities() {
+        assert!(identities_for(&[]).is_empty());
+    }
+
+    #[test]
+    fn doctor_node_lists_the_shipping_doctor_identity() {
+        assert!(identities_for(&["doctor".into()]).contains(&DOCTOR_REPORT_SCHEMA));
+    }
+
+    #[test]
+    fn every_binding_identity_is_a_row_constant_not_a_literal_copy() {
+        assert!(
+            BINDING_ROWS
+                .iter()
+                .any(|binding| binding.identity == DOCTOR_REPORT_SCHEMA),
+            "doctor report must stay wired through its shipping constant"
+        );
+    }
+}

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -51,5 +51,6 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
             println!("{}", env!("CARGO_PKG_VERSION"));
             Ok(EXIT_SUCCESS)
         }
+        Command::Describe(args) => super::describe::run(args),
     }
 }

--- a/crates/assay-cli/src/cli/commands/evidence/schema.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema.rs
@@ -3,6 +3,8 @@ mod reports;
 mod validate;
 mod write;
 
+pub(crate) use reports::{SCHEMA_LIST_REPORT, SCHEMA_SHOW_REPORT, SCHEMA_VALIDATION_REPORT};
+
 use crate::cli::args::OutputFormat;
 use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_SUCCESS, EXIT_TEST_FAILURE};
 use anyhow::{Context, Result};

--- a/crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
@@ -1,9 +1,9 @@
 use serde::Serialize;
 use std::fmt;
 
-pub(super) const SCHEMA_LIST_REPORT: &str = "assay.evidence.schema.list.v1";
-pub(super) const SCHEMA_SHOW_REPORT: &str = "assay.evidence.schema.show.v1";
-pub(super) const SCHEMA_VALIDATION_REPORT: &str = "assay.evidence.schema.validation.v1";
+pub(crate) const SCHEMA_LIST_REPORT: &str = "assay.evidence.schema.list.v1";
+pub(crate) const SCHEMA_SHOW_REPORT: &str = "assay.evidence.schema.show.v1";
+pub(crate) const SCHEMA_VALIDATION_REPORT: &str = "assay.evidence.schema.validation.v1";
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod ci;
 pub mod config_path;
 pub mod coverage;
 pub mod demo;
+pub mod describe;
 pub mod discover;
 pub mod doctor;
 pub mod events;

--- a/crates/assay-cli/src/cli/commands/validate.rs
+++ b/crates/assay-cli/src/cli/commands/validate.rs
@@ -7,7 +7,7 @@ use crate::cli::args::{ValidateArgs, ValidateOutputFormat};
 use crate::cli::util::{decide_exit, infer_policy_path, normalize_severity};
 use crate::exit_codes;
 
-const VALIDATE_REPORT_SCHEMA: &str = "assay.validate_report.v1";
+pub(crate) const VALIDATE_REPORT_SCHEMA: &str = "assay.validate_report.v1";
 
 pub async fn run(args: ValidateArgs, legacy_mode: bool) -> anyhow::Result<i32> {
     if args.deny_deprecations {

--- a/crates/assay-cli/tests/cli_describe_contract.rs
+++ b/crates/assay-cli/tests/cli_describe_contract.rs
@@ -1,0 +1,185 @@
+//! Runtime CLI contract traversal (#2178).
+//!
+//! The product claim is that contracts are machine-checkable. This test is the
+//! first place a caller can ask for the surface and descend it. Identities are
+//! asserted from the shipping constants that emit them, not from copies here.
+
+#[path = "../../../tests/support/bounded_process.rs"]
+#[allow(dead_code)]
+mod bounded_process;
+
+use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn assay_src(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(relative)
+}
+
+/// Read a `&str` shipping constant from assay-cli source. The value lives in one
+/// place; copying it into this test would be a second definition that can drift.
+fn shipping_str_const(relative: &str, name: &str) -> String {
+    let source = fs::read_to_string(assay_src(relative)).unwrap_or_else(|error| {
+        panic!("failed to read shipping constant source {relative}: {error}")
+    });
+    let needle = format!("const {name}: &str = \"");
+    let start = source
+        .find(&needle)
+        .unwrap_or_else(|| panic!("{relative} must define {name} as a &str constant"));
+    let rest = &source[start + needle.len()..];
+    let end = rest
+        .find('"')
+        .unwrap_or_else(|| panic!("{name} in {relative} is not a closed string literal"));
+    rest[..end].to_string()
+}
+
+fn describe(path: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_assay"));
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("ASSAY_")
+        {
+            command.env_remove(name);
+        }
+    }
+    command.env("NO_COLOR", "1").arg("describe").args(path);
+    run_bounded(command, b"", GOLDEN_PATH_LIMITS, "assay describe").expect("describe ran")
+}
+
+fn exit_code(output: &Output) -> i32 {
+    output
+        .status
+        .code()
+        .expect("describe exited by code rather than by signal")
+}
+
+fn sole_report(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "describe stdout is not one JSON document: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn command_names(document: &Value) -> Vec<&str> {
+    document["commands"]
+        .as_array()
+        .expect("describe document must list commands")
+        .iter()
+        .map(|command| {
+            command["name"]
+                .as_str()
+                .expect("each command entry must have a name")
+        })
+        .collect()
+}
+
+fn identities(document: &Value) -> Vec<&str> {
+    document["identities"]
+        .as_array()
+        .expect("describe document must list identities")
+        .iter()
+        .map(|identity| identity.as_str().expect("identities are strings"))
+        .collect()
+}
+
+#[test]
+fn describe_lists_top_level_commands_without_dumping_identities() {
+    let output = describe(&[]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        exit_code(&output),
+        0,
+        "assay describe must be a runtime entry point; stderr={stderr}"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "machine describe must not also write a human line; stderr={stderr}"
+    );
+
+    let document = sole_report(&output);
+    let describe_schema = shipping_str_const("cli/commands/describe.rs", "DESCRIBE_REPORT_SCHEMA");
+    assert_eq!(document["schema"], describe_schema);
+    assert_eq!(document["path"], Value::Array(vec![]));
+
+    let names = command_names(&document);
+    assert!(
+        names.contains(&"doctor"),
+        "top-level listing must include doctor so a caller can descend; names={names:?}"
+    );
+    assert!(
+        names.contains(&"evidence"),
+        "top-level listing must include evidence so a caller can descend; names={names:?}"
+    );
+    assert!(
+        names.contains(&"describe"),
+        "the introspection command is itself part of the surface; names={names:?}"
+    );
+    assert!(
+        names.iter().all(|name| *name != "runner-spike"),
+        "hidden commands stay hidden; names={names:?}"
+    );
+
+    let top_identities = identities(&document);
+    let doctor_schema = shipping_str_const("diagnostics/report.rs", "DOCTOR_REPORT_SCHEMA");
+    assert!(
+        !top_identities.contains(&doctor_schema.as_str()),
+        "root must not dump leaf identities; identities={top_identities:?}"
+    );
+}
+
+#[test]
+fn describe_descends_to_a_leaf_and_lists_its_shipping_identity() {
+    let doctor_schema = shipping_str_const("diagnostics/report.rs", "DOCTOR_REPORT_SCHEMA");
+    let output = describe(&["doctor"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        exit_code(&output),
+        0,
+        "assay describe doctor must descend; stderr={stderr}"
+    );
+
+    let document = sole_report(&output);
+    assert_eq!(document["path"], Value::Array(vec!["doctor".into()]));
+    let listed = identities(&document);
+    assert!(
+        listed.contains(&doctor_schema.as_str()),
+        "doctor listing must publish the shipping doctor report identity; identities={listed:?}"
+    );
+}
+
+#[test]
+fn describe_parent_listing_includes_child_identities() {
+    let list_schema = shipping_str_const(
+        "cli/commands/evidence/schema/reports.rs",
+        "SCHEMA_LIST_REPORT",
+    );
+    let output = describe(&["evidence", "schema"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        exit_code(&output),
+        0,
+        "assay describe evidence schema must descend; stderr={stderr}"
+    );
+
+    let document = sole_report(&output);
+    let names = command_names(&document);
+    assert!(
+        names.contains(&"list"),
+        "parent listing must name the list child; names={names:?}"
+    );
+
+    let listed = identities(&document);
+    assert!(
+        listed.contains(&list_schema.as_str()),
+        "parent listing must include a child identity that exists in code; identities={listed:?}"
+    );
+}

--- a/scripts/ci/cli_describe_contract.py
+++ b/scripts/ci/cli_describe_contract.py
@@ -1,0 +1,118 @@
+"""Guard for the runtime CLI describe tree (#2178).
+
+The old guard only checks that a listing is a describe document. The new guard
+requires every shipping identity that belongs on that node to appear in the
+listing, and forbids identities the bindings do not own. Values come from the
+existing Rust constants, not from copies in this file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+CONST_RE = re.compile(r"const\s+([A-Z][A-Z0-9_]*)\s*:\s*&str\s*=\s*\"([^\"]+)\"")
+BINDING_RE = re.compile(
+    r'path:\s*"(?P<path>[^"]+)",\s*\n\s*identity:\s*(?P<const>[A-Z][A-Z0-9_]*)',
+    re.MULTILINE,
+)
+BINDINGS_REL = Path("crates/assay-cli/src/cli/commands/describe/bindings.rs")
+CLI_SRC_REL = Path("crates/assay-cli/src")
+
+
+def shipping_constants(src_root: Path) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for path in src_root.rglob("*.rs"):
+        text = path.read_text(encoding="utf-8")
+        for match in CONST_RE.finditer(text):
+            found[match.group(1)] = match.group(2)
+    return found
+
+
+def binding_rows(repo: Path, constants: dict[str, str]) -> list[tuple[str, str]]:
+    text = (repo / BINDINGS_REL).read_text(encoding="utf-8")
+    rows: list[tuple[str, str]] = []
+    for match in BINDING_RE.finditer(text):
+        name = match.group("const")
+        if name not in constants:
+            raise SystemExit(f"binding {name} is not a shipping &str constant")
+        rows.append((match.group("path"), constants[name]))
+    if not rows:
+        raise SystemExit("describe bindings table is empty")
+    return rows
+
+
+def belongs_on_node(binding_path: str, node_path: str) -> bool:
+    if not node_path:
+        return False
+    if binding_path == node_path:
+        return True
+    rest = binding_path[len(node_path) :] if binding_path.startswith(node_path) else ""
+    return rest.startswith("/") and "/" not in rest[1:]
+
+
+def node_path(listing: dict) -> str:
+    path = listing.get("path")
+    if not isinstance(path, list) or not all(isinstance(part, str) for part in path):
+        raise SystemExit("listing path must be an array of strings")
+    return "/".join(path)
+
+
+def old_guard(listing: dict) -> list[str]:
+    problems: list[str] = []
+    if not isinstance(listing.get("schema"), str) or not listing["schema"]:
+        problems.append("describe listing is missing a schema field")
+    if not isinstance(listing.get("commands"), list):
+        problems.append("describe listing is missing a commands array")
+    return problems
+
+
+def new_guard(listing: dict, rows: list[tuple[str, str]]) -> list[str]:
+    problems = old_guard(listing)
+    identities = listing.get("identities")
+    if not isinstance(identities, list) or not all(isinstance(item, str) for item in identities):
+        problems.append("describe listing is missing an identities array")
+        return problems
+    node = node_path(listing)
+    expected = {identity for path, identity in rows if belongs_on_node(path, node)}
+    listed = set(identities)
+    for identity in sorted(expected - listed):
+        problems.append(f"parent listing omitted shipping identity {identity}")
+    for identity in sorted(listed - expected):
+        problems.append(f"parent listing leaked identity {identity}")
+    return problems
+
+
+def seed_identity_omission(listing: dict, identity: str) -> dict:
+    mutated = json.loads(json.dumps(listing))
+    identities = mutated.get("identities")
+    if not isinstance(identities, list) or identity not in identities:
+        raise SystemExit("cannot seed omission: listing does not carry the shipping identity")
+    mutated["identities"] = [item for item in identities if item != identity]
+    return mutated
+
+
+def load_listing(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--listing", type=Path, required=True)
+    parser.add_argument("--guard", choices=("old", "new"), required=True)
+    args = parser.parse_args(argv)
+    constants = shipping_constants(args.repo / CLI_SRC_REL)
+    rows = binding_rows(args.repo, constants)
+    listing = load_listing(args.listing)
+    problems = old_guard(listing) if args.guard == "old" else new_guard(listing, rows)
+    for problem in problems:
+        print(problem, file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test-cli-describe-contract.sh
+++ b/scripts/ci/test-cli-describe-contract.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Discriminating control for assay describe (#2178).
+# The mutant is a parent listing that drops a shipping identity still present
+# in code. Same fixture, old guard then new guard; both exit codes are recorded.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="${ROOT}/scripts/ci/cli_describe_contract.py"
+BINDINGS="${ROOT}/crates/assay-cli/src/cli/commands/describe/bindings.rs"
+DOCTOR_SRC="${ROOT}/crates/assay-cli/src/diagnostics/report.rs"
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$CHECKER" ]] || fail "checker missing: $CHECKER"
+[[ -f "$BINDINGS" ]] || fail "bindings missing: $BINDINGS"
+
+DOCTOR_SCHEMA="$(
+  python3 - "$DOCTOR_SRC" <<'PY'
+import re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+match = re.search(r'const DOCTOR_REPORT_SCHEMA: &str = "([^"]+)"', text)
+if not match:
+    raise SystemExit("DOCTOR_REPORT_SCHEMA is not a shipping &str constant")
+print(match.group(1))
+PY
+)" || fail "could not read DOCTOR_REPORT_SCHEMA from its defining file"
+
+grep -q 'identity: DOCTOR_REPORT_SCHEMA' "$BINDINGS" \
+  || fail "bindings must reference DOCTOR_REPORT_SCHEMA, not a copied literal"
+
+LISTING="${SCRATCH}/doctor.json"
+python3 - "$LISTING" "$DOCTOR_SCHEMA" <<'PY'
+import json, sys
+path, identity = sys.argv[1], sys.argv[2]
+json.dump(
+    {
+        "schema": "assay.cli.describe.v0",
+        "path": ["doctor"],
+        "commands": [],
+        "identities": [identity],
+    },
+    open(path, "w", encoding="utf-8"),
+)
+PY
+
+MUTANT="${SCRATCH}/doctor-omit-shipping-identity.json"
+python3 - "$CHECKER" "$LISTING" "$MUTANT" "$DOCTOR_SCHEMA" <<'PY' || fail "could not seed the shipping-identity omission from the doctor constant"
+import importlib.util, json, pathlib, sys
+spec = importlib.util.spec_from_file_location("cli_describe_contract", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+listing = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+mutated = mod.seed_identity_omission(listing, sys.argv[4])
+pathlib.Path(sys.argv[3]).write_text(json.dumps(mutated), encoding="utf-8")
+PY
+
+old_exit=0
+python3 "$CHECKER" --repo "$ROOT" --listing "$MUTANT" --guard old >/dev/null 2>"$SCRATCH/old.err" \
+  || old_exit=$?
+[[ "$old_exit" -eq 0 ]] || fail "old guard rejected the identity-omission mutant (exit $old_exit): $(cat "$SCRATCH/old.err")"
+
+new_exit=0
+python3 "$CHECKER" --repo "$ROOT" --listing "$MUTANT" --guard new >/dev/null 2>"$SCRATCH/new.err" \
+  || new_exit=$?
+[[ "$new_exit" -ne 0 ]] || fail "new guard stayed green on the identity-omission mutant"
+grep -F "parent listing omitted shipping identity ${DOCTOR_SCHEMA}" "$SCRATCH/new.err" >/dev/null \
+  || fail "new guard missed the shipping doctor identity: $(cat "$SCRATCH/new.err")"
+
+echo "identity omission old_guard_exit=${old_exit} new_guard_exit=${new_exit}"
+echo "ok: cli describe contract"


### PR DESCRIPTION
For a tool whose product claim is that contracts should be machine-checkable, the contract itself is the one thing a machine cannot ask for.

## Summary
- Adds `assay describe [path...]`: one introspection entry point that walks the clap command tree. Ask for the top level, then descend. This is not a dump of all 83 commands.
- Node identities are the existing shipping constants (`DOCTOR_REPORT_SCHEMA`, evidence schema reports, and a few siblings). No second identity vocabulary, and #2167 is not decided.
- Global `--quiet` / `--non-interactive` are intentionally not added. `NO_COLOR` is already honoured; `watch` is the only genuinely interactive command. The gap is predictability, not a blocked journey.

Refs #2178. The issue should stay open: this slice makes the command tree traversable and proves identity attachment at a descended node. It does not enumerate all ~81 `assay.*.vN` identities, unify `--format` spellings, or add global posture flags.

## Test plan
- [x] RED: `cargo test -p assay-cli --test cli_describe_contract` failed with `unrecognized subcommand 'describe'` (exit 2) before the command existed
- [x] GREEN: the same three tests pass after the implementation
- [x] Mutant: same doctor listing with `DOCTOR_REPORT_SCHEMA` omitted — old guard exit 0, new guard exit 1 (`bash scripts/ci/test-cli-describe-contract.sh`)
- [x] `cargo clippy -p assay-cli --all-targets -- -D warnings`
- [ ] `assay describe` lists top-level commands and does not dump leaf identities
- [ ] `assay describe doctor` lists the shipping doctor report identity
- [ ] `assay describe evidence schema` lists `list` and the child list-report identity


Made with [Cursor](https://cursor.com)