### PR TITLE
ci: add a repository-wide continue-on-error policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -346,6 +346,15 @@ repos:
         # no `target/` build it still verifies source and published-release truth independently.
         files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
 
+      - id: workflow-continue-on-error-policy
+        name: Workflow continue-on-error policy
+        entry: bash scripts/ci/test-check-workflow-continue-on-error.sh
+        language: system
+        pass_filenames: false
+        # Every workflow, plus the checker and its battery. A new workflow must reach this hook,
+        # which is the case the battery's unauthorized-new-workflow mutation covers.
+        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check|test-check)-workflow-continue-on-error\.(py|sh)|\.pre-commit-config\.yaml)$
+
       - id: verify-release-oracle-self-test
         name: Release oracle offline contract tests
         entry: bash scripts/ci/test-verify-release.sh

--- a/scripts/ci/check-workflow-continue-on-error.py
+++ b/scripts/ci/check-workflow-continue-on-error.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Repository-wide policy for `continue-on-error` in GitHub workflows.
+
+`continue-on-error: true` makes a failure not fail its job. That is legitimate for advisory work
+and for a step whose failure is not the thing under test, and it is a fail-open route everywhere
+else. Nothing checked it outside `ci.yml` (#2348).
+
+This is deliberately NOT an extension of `check-ci-gate-coverage.py`. That checker answers a
+different question -- does every gating job in `ci.yml` reach the required `CI` rollup and get
+judged fail-closed -- and it needs that rollup's topology to do it. The other workflows have no such
+aggregator, so broadening it by swapping a constant would silently change what it means. One rule,
+one checker.
+
+The rule:
+
+* A **job-level** `continue-on-error: true` is refused unless the workflow is declared advisory in
+  ALLOWED_JOB_LEVEL, with a reason. A whole job that cannot fail is a job whose result nobody reads.
+* A **step-level** `continue-on-error: true` is refused unless that step is in ALLOWED_STEP_LEVEL,
+  with a reason. Step-level use is ordinarily fine -- an artifact upload should not fail a run whose
+  real work already passed -- but "ordinarily fine" is not a thing a checker can assert, so each one
+  is named.
+
+Both lists carry a reason per entry rather than a bare path. An allowlist without reasons is a
+grandfather clause: it records that something was permitted, not why, so nobody can later tell an
+intentional exemption from one that was pasted in to make a red go away.
+
+Fails closed. An unreadable file, a `continue-on-error` this parser cannot attribute to a job or a
+step, an allowlist entry naming something that no longer exists, and any spelling other than a bare
+`true`/`false` are all errors rather than passes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOW_DIR = Path(".github/workflows")
+
+# workflow -> reason. Every job in these workflows may carry `continue-on-error: true`.
+ALLOWED_JOB_LEVEL: dict[str, str] = {
+    "adr025-nightly-evidence.yml": (
+        "Nightly informational evidence. The jobs are named '(informational)' and publish a "
+        "readiness signal; a red one is a datum, not a gate."
+    ),
+    "perf_pr.yml": (
+        "Criterion compare is advisory on a PR: benchmark noise must not block a merge. The "
+        "enforcing perf signal is Bencher's threshold on main, not this job."
+    ),
+    "split-wave0-gates.yml": (
+        "The Wave 0.1 nightly safety job is an explicit non-blocking stub; its own name says so."
+    ),
+    "wave6-nightly-safety.yml": (
+        "Nightly Miri and property smoke. Both are long-running exploratory checks whose failures "
+        "are investigated rather than merge-blocking."
+    ),
+}
+
+# (workflow, step name) -> reason.
+ALLOWED_STEP_LEVEL: dict[tuple[str, str], str] = {
+    ("action-v2-test.yml", "Run action with missing pack (expected failure)"): (
+        "The step failing IS the assertion; the following step checks the outcome."
+    ),
+    ("action-v2-test.yml", "Run action with invalid pack (expected failure)"): (
+        "The step failing IS the assertion; the following step checks the outcome."
+    ),
+    ("adr025-nightly-evidence.yml", "Download current soak artifact"): (
+        "A first run has no prior artifact to download; absence is expected, not a failure."
+    ),
+    ("adr025-nightly-evidence.yml", "Download current readiness artifact"): (
+        "A first run has no prior artifact to download; absence is expected, not a failure."
+    ),
+    ("assay-security.yml", "Validate (SARIF)"): (
+        "SARIF upload is reporting, not gating. The security verdict is the scan's own exit code."
+    ),
+    ("ci.yml", "Upload verification logs"): (
+        "Diagnostics for a run that has already reached its verdict. Losing the upload must not "
+        "change that verdict."
+    ),
+    ("fuzz-smoke.yml", "Upload crash artifacts"): (
+        "Runs only when a crash was found; the fuzz step has already failed the job by then."
+    ),
+    ("osv-scanner-scheduled.yml", "Run OSV scanner"): (
+        "Scheduled advisory scan. A scanner outage must not page anyone; findings are read from "
+        "the uploaded report."
+    ),
+    ("smoke-install.yml", "Publish test report"): (
+        "Reporting step after the smoke assertions have already decided the job."
+    ),
+}
+
+BOOL_RE = re.compile(r"^(?P<indent>\s*)continue-on-error:\s*(?P<value>\S+)\s*(?:#.*)?$")
+NAME_RE = re.compile(r"^\s*-?\s*name:\s*(?P<name>.+?)\s*$")
+JOB_INDENT = 4
+STEP_MIN_INDENT = 8
+
+
+class PolicyError(Exception):
+    """The policy could not be evaluated, or was violated."""
+
+
+def _step_name(lines: list[str], index: int) -> str | None:
+    """The `name:` of the step or job the flag at `index` belongs to.
+
+    Walks backwards to the nearest `name:`. A `continue-on-error` with no name above it in the file
+    cannot be attributed, and is an error rather than a pass.
+    """
+    for j in range(index, -1, -1):
+        match = NAME_RE.match(lines[j])
+        if match:
+            return match.group("name").strip("\"'")
+    return None
+
+
+def scan(path: Path) -> list[tuple[str, str, str]]:
+    """(kind, name, raw-value) for every `continue-on-error` in one workflow."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as error:
+        raise PolicyError(f"{path}: unreadable, so the policy cannot be evaluated: {error}") from None
+
+    found = []
+    for index, line in enumerate(lines):
+        # A commented flag sets nothing. Stripping comments first would also swallow a real flag
+        # whose value carries a trailing comment, so the comment case is matched, not removed.
+        if line.lstrip().startswith("#"):
+            continue
+        match = BOOL_RE.match(line)
+        if not match:
+            continue
+        value = match.group("value")
+        if value not in {"true", "false"}:
+            raise PolicyError(
+                f"{path}:{index + 1}: `continue-on-error: {value}` is not a bare true/false. "
+                "GitHub accepts other spellings and expressions; this policy does not read them, "
+                "so it refuses rather than guessing."
+            )
+        if value == "false":
+            continue
+        indent = len(match.group("indent"))
+        name = _step_name(lines, index)
+        if name is None:
+            raise PolicyError(
+                f"{path}:{index + 1}: `continue-on-error: true` has no `name:` above it, so it "
+                "cannot be attributed to a job or step."
+            )
+        kind = "step" if indent >= STEP_MIN_INDENT else "job"
+        found.append((kind, name, value))
+    return found
+
+
+def main() -> int:
+    if not WORKFLOW_DIR.is_dir():
+        print(f"FAIL: {WORKFLOW_DIR} is not a directory", file=sys.stderr)
+        return 2
+
+    violations: list[str] = []
+    seen_jobs: set[str] = set()
+    seen_steps: set[tuple[str, str]] = set()
+
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        try:
+            entries = scan(path)
+        except PolicyError as error:
+            print(f"FAIL: {error}", file=sys.stderr)
+            return 2
+        for kind, name, _ in entries:
+            if kind == "job":
+                if path.name not in ALLOWED_JOB_LEVEL:
+                    violations.append(
+                        f"{path.name}: job '{name}' sets continue-on-error: true. A job that "
+                        "cannot fail is a job whose result nobody reads. Add the workflow to "
+                        "ALLOWED_JOB_LEVEL with a reason, or remove the flag."
+                    )
+                seen_jobs.add(path.name)
+            else:
+                key = (path.name, name)
+                if key not in ALLOWED_STEP_LEVEL:
+                    violations.append(
+                        f"{path.name}: step '{name}' sets continue-on-error: true and is not in "
+                        "ALLOWED_STEP_LEVEL. Add it with a reason, or remove the flag."
+                    )
+                seen_steps.add(key)
+
+    # An allowlist entry for something that no longer exists is a stale permission. It reads as
+    # review having happened when it has not, and it hides the entry that replaced it.
+    for workflow in sorted(set(ALLOWED_JOB_LEVEL) - seen_jobs):
+        violations.append(
+            f"{workflow}: allowlisted for job-level continue-on-error but has none. Remove the "
+            "stale entry."
+        )
+    for workflow, step in sorted(set(ALLOWED_STEP_LEVEL) - seen_steps):
+        violations.append(
+            f"{workflow}: step '{step}' is allowlisted but not present. Remove the stale entry."
+        )
+
+    if violations:
+        for violation in violations:
+            print(f"FAIL: {violation}", file=sys.stderr)
+        return 1
+
+    print(
+        f"workflow continue-on-error policy: {len(seen_jobs)} advisory workflow(s), "
+        f"{len(seen_steps)} named step(s), each with a stated reason."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test-check-workflow-continue-on-error.sh
+++ b/scripts/ci/test-check-workflow-continue-on-error.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Mutation battery for check-workflow-continue-on-error.py.
+#
+# The checker is a policy, so the only thing worth testing is what it REFUSES. Each case below is a
+# mutation that must bite; a case that passes here means the policy has a hole of that shape.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="scripts/ci/check-workflow-continue-on-error.py"
+[[ -f "${ROOT}/${CHECKER}" ]] || { echo "FAIL: checker missing" >&2; exit 1; }
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# A tree the checker can run in: the real checker, a minimal workflow set.
+seed() {
+  local case_root="$1"
+  mkdir -p "$case_root/.github/workflows" "$case_root/scripts/ci"
+  # The sandbox carries one synthetic workflow, so the real allowlists would all read as stale --
+  # correctly, since none of those workflows are here. Blanking them keeps each case about the one
+  # mutation it seeds, and case 6 puts an entry back to exercise the stale rule itself.
+  python3 - "${ROOT}/${CHECKER}" "$case_root/scripts/ci/$(basename "${CHECKER}")" <<'PY'
+import pathlib, re, sys
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+t = src.read_text()
+t = re.sub(r"ALLOWED_JOB_LEVEL: dict\[str, str\] = \{.*?\n\}",
+           "ALLOWED_JOB_LEVEL: dict[str, str] = {}", t, count=1, flags=re.S)
+t = re.sub(r"ALLOWED_STEP_LEVEL: dict\[tuple\[str, str\], str\] = \{.*?\n\}",
+           "ALLOWED_STEP_LEVEL: dict[tuple[str, str], str] = {}", t, count=1, flags=re.S)
+dst.write_text(t)
+PY
+  cat > "$case_root/.github/workflows/clean.yml" <<'YAML'
+name: Clean
+on: [push]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compile
+        run: cargo build
+YAML
+}
+
+run_case() {
+  local name="$1" case_root="$2" expected="$3"
+  local status=0
+  ( cd "$case_root" && python3 "$CHECKER" ) >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+# 0. The clean tree passes, or every case below proves nothing.
+c="$scratch/clean"; seed "$c"
+run_case "a-clean-tree-passes" "$c" 0
+
+# 1. Job-level on an un-allowlisted workflow.
+c="$scratch/job-level"; seed "$c"
+cat >> "$c/.github/workflows/clean.yml" <<'YAML'
+  advisory:
+    name: Advisory
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Thing
+        run: true
+YAML
+run_case "job-level-is-refused" "$c" 1
+
+# 2. Step-level not on the allowlist.
+c="$scratch/step-level"; seed "$c"
+cat >> "$c/.github/workflows/clean.yml" <<'YAML'
+      - name: Upload something
+        run: true
+        continue-on-error: true
+YAML
+run_case "unlisted-step-is-refused" "$c" 1
+
+# 3. An alternate YAML boolean. GitHub accepts spellings this parser does not read, so it must
+#    refuse rather than silently treat `yes` as absent and pass.
+c="$scratch/alt-bool"; seed "$c"
+cat >> "$c/.github/workflows/clean.yml" <<'YAML'
+      - name: Sneaky
+        run: true
+        continue-on-error: yes
+YAML
+run_case "alternate-boolean-is-refused-not-ignored" "$c" 2
+
+# 4. A commented decoy sets nothing and must not be reported.
+c="$scratch/decoy"; seed "$c"
+cat >> "$c/.github/workflows/clean.yml" <<'YAML'
+      - name: Honest
+        run: true
+        # continue-on-error: true
+YAML
+run_case "commented-decoy-is-not-a-violation" "$c" 0
+
+# 5. A brand-new workflow cannot bring its own exemption.
+c="$scratch/new-workflow"; seed "$c"
+cat > "$c/.github/workflows/rogue.yml" <<'YAML'
+name: Rogue
+on: [push]
+jobs:
+  rogue:
+    name: Rogue
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Thing
+        run: true
+YAML
+run_case "unauthorized-new-workflow-is-refused" "$c" 1
+
+# 6. A stale allowlist entry is a permission for something that no longer exists.
+c="$scratch/stale"; seed "$c"
+python3 - "$c/scripts/ci/$(basename "$CHECKER")" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+t = t.replace('ALLOWED_JOB_LEVEL: dict[str, str] = {}',
+              'ALLOWED_JOB_LEVEL: dict[str, str] = {"gone.yml": "workflow deleted long ago"}', 1)
+p.write_text(t)
+PY
+run_case "stale-allowlist-entry-is-refused" "$c" 1
+
+# 7. An unattributable flag: present, but no name to bind it to.
+c="$scratch/orphan"; seed "$c"
+cat > "$c/.github/workflows/orphan.yml" <<'YAML'
+continue-on-error: true
+YAML
+run_case "unattributable-flag-fails-closed" "$c" 2
+
+printf 'PASS: workflow continue-on-error policy mutation battery (8 cases)\n'


### PR DESCRIPTION
Closes #2348

## Measured, and growing

On `20b9c40c8`: **18 sites across 10 workflows** — 8 job-level, 10 step-level. The issue counted 17
on 2026-08-13. The surface grew while it sat open, which is the argument for a policy rather than a
one-time cleanup.

## A separate checker, deliberately

`check-ci-gate-coverage.py` hardcodes `.github/workflows/ci.yml`, and that is correct for its
contract: it needs the required `CI` rollup's topology to judge whether a gating job is fail-closed.
The other workflows have no such aggregator, so broadening it by swapping a constant would silently
change what it means. One rule, one checker. The sibling is untouched and
`test-ci-gate-expectations.sh` stays green.

## The rule

- **Job-level refused** unless the workflow is declared advisory. A job that cannot fail is a job
  whose result nobody reads.
- **Step-level refused** unless that step is named. "An upload should not fail a run that already
  reached its verdict" is true, and is not something a checker can assert.

**Every entry carries a reason.** An allowlist without reasons is a grandfather clause: it records
that something was permitted, not why, so nobody can later separate a deliberate exemption from one
pasted in to clear a red. All 18 existing sites are dispositioned individually — nightly
informational jobs, advisory benchmark compares, artifact uploads after a verdict, and two steps
whose failure *is* the assertion.

A **stale** allowlist entry is refused too. An entry for something that no longer exists reads as
review having happened when it has not.

## Fails closed

- a value other than bare `true`/`false` — GitHub accepts spellings and expressions this parser does
  not read, so it refuses rather than treating `yes` as absent
- a flag with no `name:` above it to attribute it to a job or step

## Battery: 8 mutations, each shown to bite

| case | exit |
|---|---|
| clean tree passes | 0 |
| job-level refused | 1 |
| unlisted step refused | 1 |
| alternate boolean refused, not ignored | 2 |
| commented decoy is **not** a violation | 0 |
| unauthorized new workflow refused | 1 |
| stale allowlist entry refused | 1 |
| unattributable flag fails closed | 2 |

The clean-tree case is there so the other seven prove something.

Worth recording: my first battery run failed correctly. The sandbox held only a synthetic workflow,
so every real allowlist entry read as stale — the checker was right and my harness was wrong. The
sandbox now blanks the allowlists so each case is about the one mutation it seeds.

## Stdlib only

No PyYAML in this repo and the sibling checker is stdlib regex parsing, so this follows that rather
than introducing a dependency for a policy check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for workflow error-handling settings.
  * Pre-commit checks now flag unsupported, unapproved, or unexplained workflow exceptions before changes are submitted.
* **Tests**
  * Added comprehensive checks covering authorized and unauthorized configurations, syntax variations, comments, new workflows, and outdated approvals.
  * Validation now reports clear failures and confirms successful policy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->