### PR TITLE
feat(conformance): batch runner, and publish the adequacy results we have

### DIFF
--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -23,7 +23,7 @@ grade `false` or `unproved` rather than pass silently.
 | [`mcp-jsonrpc-id-conformance`](../examples/mcp-jsonrpc-id-conformance/) | 3 | stdlib, `check.py reproduce` | published pack; carries a positive control |
 | [`rfc8785` canonicalization](../crates/assay-canonical/tests/vectors/rfc8785.json) | 31 | `cargo test -p assay-canonical --test rfc8785_conformance` | prerequisite vectors; vendored byte-identical into the clean-room pack |
 | [`mcp-era-parity-v0`](../crates/assay-core/tests/fixtures/mcp-era-parity-v0/) | 18 (+2 equivalence pairs) | `cargo test -p assay-core --lib mcp::era_parity_tests` | **exploratory** — deliberately lower than the frozen corpus |
-| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) | — | its own repository | published separately; stdlib recompute + `corpusDigest` |
+| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) | 14 cases | its own repository | published separately; stdlib recompute + `corpusDigest`. Adequacy measured — see below |
 
 Related but not a corpus in this table: [RGE-Bench](https://github.com/rge-bench/rge-bench)
 is maintained in its own repository under its own machine-checked neutrality guard,
@@ -123,3 +123,32 @@ The fact worth reporting has no ACM badge: **independent implementation,
 author-supplied vectors, expected outcomes recomputed from inputs alone.** That
 is what [#1840](https://github.com/Rul1an/assay/issues/1840) asks for, and it is
 more informative than either badge on its own.
+
+## Mutation adequacy, measured on ourselves
+
+`conformance/corpus_adequacy.py` asks a different question from the runner above:
+not *do these corpora reproduce their own verdicts*, but **can an implementer
+delete a declared rule, still reproduce the pinned outcomes, and be
+indistinguishable from a conforming implementation?** A surviving mutant is a
+hole in the contract rather than a gap in confidence, so the bar is 100% of the
+rules the author declared.
+
+The results below include the ones that do not flatter us, because a tool that
+audits corpora is worth nothing if its author has not survived it.
+
+| Corpus | Runner | Result |
+|---|---|---|
+| `mcp-jsonrpc-id-conformance` | module | **4 of 4** in scope. **7 rules unexercised and out of scope**, ratio 1.75 — the score is a statement about a minority of the declared rules |
+| `privileged-mcp-action-v0` | process | **1 known hole**: the origin leg of the v0 marker triple is promised by §5 and no vector discriminates it. Recorded against `sha256:cb58ce91…` rather than fixed, because adding a vector moves a published digest. Two further rules I declared turned out to mutate the wrong stage and the wrong profile; they are marked out of scope **with that reasoning rather than deleted** |
+| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **4 of 5**. One survivor: an implementation can read the body regardless of whether the ref recomputed and still reproduce all fourteen cases |
+| [rge-bench](https://github.com/rge-bench/rge-bench) | module | 30 of 30, 1 declared equivalent |
+| `rfc8785` · `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict, which is a fourth runner shape |
+
+**Four of six.** Stated rather than rounded up: two corpora have no adequacy
+measurement at all, and one of the four measured has an acknowledged hole.
+
+Every manifest must declare at least one **control** — a mutation on the same
+path that MUST be killed. All-survivors because a corpus is weak and
+all-survivors because nothing was ever measured print identically, so without a
+control a zero says nothing. Controls are excluded from the score, and a control
+that survives fails the run with every other verdict declared meaningless.

--- a/conformance/adequacy/observed-effect-drift-consumer.manifest.json
+++ b/conformance/adequacy/observed-effect-drift-consumer.manifest.json
@@ -1,0 +1,57 @@
+{
+  "schema": "assay.corpus_adequacy.manifest.v0",
+  "runner": "batch",
+  "_about": "Mutation adequacy for the observed-effect-v0 drift consumer. BATCH runner: the checker takes the whole vector file and reports a summary, so the corpus is exercised as a unit and the summary IS the outcome. Its failures list names the case ids, which is what makes it discriminate; a checker reporting only a boolean would make every mutant kill everything or nothing. The command is relative on purpose -- the consumer REFUSES an absolute vectors path, which is its own hardening and not something to work around. Requires Rul1an/observed-effect-v0 cloned as a sibling of this repository; without it the run fails with a missing source rather than silently measuring nothing.",
+  "repo_root": "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06",
+  "implementation_sources": [
+    "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06/independent_consumer.py"
+  ],
+  "entrypoint_command": [
+    "python3",
+    "independent_consumer.py",
+    "vectors.json"
+  ],
+  "outcome_from": [
+    "all_reproduced",
+    "failures"
+  ],
+  "vectors": "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06/vectors.json",
+  "id_key": "vector_id",
+  "default_group": "drift_consumer",
+  "mutants": {
+    "drift_consumer": [
+      {
+        "label": "0 a surface drift block overrides everything",
+        "anchor": "    if surface == \"surface_drift_block\":\n        decision = \"block\"",
+        "replacement": "    if False:\n        decision = \"block\""
+      },
+      {
+        "label": "1 observed divergence without opt-in is review, not quarantine",
+        "anchor": "decision = \"quarantine\" if opt_in else \"review_required\"",
+        "replacement": "decision = \"quarantine\""
+      },
+      {
+        "label": "2 insufficient coverage requires review",
+        "anchor": "    elif adv == \"insufficient_coverage\":\n        decision = \"review_required\"",
+        "replacement": "    elif False:\n        decision = \"review_required\""
+      },
+      {
+        "label": "3 hard-block capability follows operator opt-in",
+        "anchor": "\"effect_can_hard_block\": bool(opt_in),",
+        "replacement": "\"effect_can_hard_block\": True,"
+      },
+      {
+        "label": "4 the body is only read when the ref recomputed",
+        "anchor": "body = store.get(ref.get(\"ref\")) if rv == \"recomputed\" else None",
+        "replacement": "body = store.get(ref.get(\"ref\"))"
+      },
+      {
+        "label": "CONTROL harness reachability",
+        "control": true,
+        "anchor": "if merge(c, registry) != c[\"expected\"]",
+        "replacement": "if True"
+      }
+    ]
+  },
+  "equivalent": {}
+}

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,0 +1,77 @@
+{
+  "schema": "assay.corpus_adequacy.manifest.v0",
+  "runner": "process",
+  "_about": "Mutation adequacy for privileged-mcp-action/v0. ONE genuine hole: the origin leg of the v0 marker triple is promised and unexercised. Two further rules were declared and are NOT holes -- they mutate the wrong stage and the wrong profile -- and are marked out_of_scope with that reasoning rather than dropped, so the mistake stays visible. Independently classified by Ruley against docs/profiles/privileged-mcp-action/v0.md \u00a75 and the Stage 2/3 architecture.",
+  "repo_root": "../..",
+  "implementation_sources": [
+    "../../crates/assay-evidence/src/denial_marker.rs",
+    "../../crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs",
+    "../../crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs"
+  ],
+  "build": [
+    "cargo",
+    "build",
+    "-p",
+    "assay-cli",
+    "--bin",
+    "assay"
+  ],
+  "entrypoint_command": [
+    "./target/debug/assay",
+    "evidence",
+    "verify-privileged-mcp-action",
+    "{vector}",
+    "--format",
+    "json"
+  ],
+  "outcome_from": [
+    "bundle_integrity",
+    "verdict",
+    "reason_code"
+  ],
+  "vectors": "privileged-mcp-action-v0.vectors.json",
+  "id_key": "vector_id",
+  "vector_path_key": "path",
+  "default_group": "denial_marker_binding",
+  "mutants": {
+    "denial_marker_binding": [
+      {
+        "label": "0 an unrecognised marker triple fails closed",
+        "anchor": "        _ => None,\n    }\n}",
+        "replacement": "        _ => Some(DenialMarkerVersion::V1),\n    }\n}",
+        "scope": "out_of_scope",
+        "reason": "WRONG STAGE, not a hole. v0 does promise that an unrecognised in-namespace schema fails closed, but that promise is the Stage 2 arm (other => unknown_profile_schema) at verify_privileged_mcp_action.rs:331, which runs BEFORE the classifier. Under v0, observation_schema() admits only .v0 payloads, so classify_denial_marker never sees an unrecognised schema on this path: returning Some(V1) for a non-triple still fails == Some(V0) and is still not a marker. This mutant cannot move any of the 14 outcomes even in theory. To measure that promise, mutate the Stage 2 match instead."
+      },
+      {
+        "label": "1 the origin must be the proxy",
+        "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN)",
+        "replacement": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, _)"
+      },
+      {
+        "label": "2 v1 pairs with the v1 error code",
+        "anchor": "(DENIED_CALL_OBSERVATION_V1, PROXY_DENIED_V1, PROXY_ORIGIN)",
+        "replacement": "(DENIED_CALL_OBSERVATION_V1, _, PROXY_ORIGIN)",
+        "scope": "out_of_scope",
+        "reason": "WRONG PROFILE, not a hole. The v1 schema / -31999 pairing is Stage 3 of v1.md. v0's rule for a v1 schema is the opposite of pairing: unrecognised, therefore invalid. Under v0 selection a .v1 payload never enters observations, so the V1 arm of the match is unreachable here. Its survival does not mean a stranger can ignore the v1 pairing and reproduce the v0 digest; it means the v0 corpus never presents that pairing. The v1 corpus already covers it (ok-003-cross-pair-inert)."
+      },
+      {
+        "label": "CONTROL harness reachability on the verifier path",
+        "anchor": ".filter(|obs| classify_denial_marker(obs) == Some(profile_version.marker_version()));",
+        "replacement": ".filter(|_obs| false);",
+        "control": true
+      }
+    ]
+  },
+  "equivalent": {},
+  "corpus_digest_file": "../privileged-mcp-action-v0/candidate-release.json",
+  "corpus_digest_key": "corpus_digest",
+  "known_holes": {
+    "sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342": [
+      {
+        "label": "1 the origin must be the proxy",
+        "reason": "v0 Stage 3 promises an observation is a marker only if ALL THREE legs hold: schema, code AND origin == assay-proxy. No vector among the 14 is a well-formed v0 observation whose only defect is a wrong origin, so deleting the third leg cannot move a pinned outcome. This is a genuine, profile-promised, unexercised check. Recorded rather than fixed because adding a vector moves a digest that is a published contract carried by assay#1840.",
+        "recorded": "2026-08-19"
+      }
+    ]
+  }
+}

--- a/conformance/adequacy/privileged-mcp-action-v0.vectors.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.vectors.json
@@ -1,0 +1,60 @@
+{
+  "vectors": [
+    {
+      "vector_id": "bad-101-tampered-bundle",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-101-tampered-bundle.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-102-missing-target-digest",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-102-missing-target-digest.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-103-two-decisions",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-103-two-decisions.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-104-unknown-schema",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-104-unknown-schema.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-105-observation-binding-mismatch",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-105-observation-binding-mismatch.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-106-fail-closed-inconsistent",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-106-fail-closed-inconsistent.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-107-unknown-decision-value",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-107-unknown-decision-value.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-108-observation-without-decision",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-108-observation-without-decision.bundle.tar.gz"
+    },
+    {
+      "vector_id": "bad-109-bundle-id-mismatch",
+      "path": "conformance/privileged-mcp-action-v0/vectors/bad-109-bundle-id-mismatch.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-001-deny-bound-observation",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-001-deny-bound-observation.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-002-deny-observation-missing",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-002-deny-observation-missing.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-003-allow-no-outcome-observation",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-003-allow-no-outcome-observation.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-004-allow-with-diagnostic-establish",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-004-allow-with-diagnostic-establish.bundle.tar.gz"
+    },
+    {
+      "vector_id": "ok-005-allow-contradicted-by-denial",
+      "path": "conformance/privileged-mcp-action-v0/vectors/ok-005-allow-contradicted-by-denial.bundle.tar.gz"
+    }
+  ]
+}

--- a/conformance/bounded_run.py
+++ b/conformance/bounded_run.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""One bounded child-process runner, shared by the conformance tools.
+
+Standard library only. Extracted so the output ceiling has a single
+implementation: two copies of a resource ceiling drift, and the copy that
+drifts is the one that stops enforcing it.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+# Output ceiling per child process. Both children can emit arbitrary output and
+# a timeout does not bound memory, so the cap is applied while the process runs
+# rather than after it exits.
+OUTPUT_CAP_BYTES = 4 * 1024 * 1024
+
+
+class _OutputTooLarge(Exception):
+    """A child exceeded OUTPUT_CAP_BYTES; its output is not materialized."""
+
+
+def _run_capped(cmd: list[str], cwd: Path, timeout: int) -> subprocess.CompletedProcess:
+    """subprocess.run with a ceiling on how much output is ever held.
+
+    Streams both pipes to temporary files, polls their combined size while the
+    child runs, and kills it the moment the cap is crossed. Only the first
+    OUTPUT_CAP_BYTES are ever read into memory.
+    """
+    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
+        # A descendant that inherits stdout/stderr keeps writing after proc.kill()
+        # and walks straight through the ceiling, so the child leads its own session
+        # and the whole group is stopped and reaped.
+        proc = subprocess.Popen(cmd, cwd=str(cwd), stdout=out, stderr=err,
+                                start_new_session=True)
+
+        def _kill_tree() -> None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                proc.kill()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
+        deadline = time.monotonic() + timeout
+        try:
+            while True:
+                try:
+                    proc.wait(timeout=0.25)
+                    break
+                except subprocess.TimeoutExpired:
+                    pass
+                if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
+                    _kill_tree()
+                    raise _OutputTooLarge()
+                if time.monotonic() > deadline:
+                    _kill_tree()
+                    raise subprocess.TimeoutExpired(cmd, timeout)
+        finally:
+            # Reap the group even on the clean path: the leader can exit while a
+            # descendant it spawned is still holding the inherited handles.
+            _kill_tree()
+        if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
+            raise _OutputTooLarge()
+        out.seek(0)
+        err.seek(0)
+        return subprocess.CompletedProcess(
+            cmd, proc.returncode,
+            out.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
+            err.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
+        )

--- a/conformance/corpus_adequacy.py
+++ b/conformance/corpus_adequacy.py
@@ -73,8 +73,14 @@ import argparse
 import importlib.util
 import json
 import sys
+import subprocess
 import tempfile
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bounded_run import (  # noqa: E402
+    OUTPUT_CAP_BYTES, _OutputTooLarge, _run_capped,
+)
 
 SCHEMA = "assay.corpus_adequacy.manifest.v0"
 
@@ -94,9 +100,10 @@ def load_manifest(path: Path) -> dict:
     if m.get("schema") != SCHEMA:
         raise ManifestError("schema must be %r, got %r" % (SCHEMA, m.get("schema")))
     base = path.parent
-    for key in ("implementation", "vectors"):
-        _req(m, key, "manifest")
-    m["_impl_path"] = (base / m["implementation"]).resolve()
+    _req(m, "vectors", "manifest")
+    if m.get("runner", "module") == "module":
+        _req(m, "implementation", "manifest")
+    m["_impl_path"] = (base / m["implementation"]).resolve() if m.get("implementation") else None
     m["_vectors_path"] = (base / m["vectors"]).resolve()
     m.setdefault("entrypoint", "evaluate")
     # group_key is OPTIONAL. A corpus with no axis column is one group; forcing it to invent
@@ -110,6 +117,43 @@ def load_manifest(path: Path) -> dict:
     m.setdefault("entrypoint_args",
                  [k for k in (m["group_key"], m["inputs_key"]) if k is not None])
     m.setdefault("default_group", "all")
+    m.setdefault("known_holes", {})
+    m["_corpus_digest"] = None
+    if m["known_holes"]:
+        for key in ("corpus_digest_file", "corpus_digest_key"):
+            _req(m, key, "manifest (known_holes declared)")
+        dp = (base / m["corpus_digest_file"]).resolve()
+        if not dp.is_file():
+            raise ManifestError("corpus_digest_file not found: %s" % dp)
+        m["_corpus_digest"] = json.loads(dp.read_text(encoding="utf-8"))[m["corpus_digest_key"]]
+        for digest, entries in m["known_holes"].items():
+            for i, e in enumerate(entries):
+                for key in ("label", "reason", "recorded"):
+                    _req(e, key, "known_holes[%s][%d]" % (digest, i))
+                if not str(e["reason"]).strip():
+                    raise ManifestError("known_holes[%s][%d] %r: a hole needs a stated reason"
+                                        % (digest, i, e["label"]))
+    m.setdefault("runner", "module")
+    if m["runner"] not in ("module", "process", "batch"):
+        raise ManifestError("runner must be module, process or batch, got %r" % m["runner"])
+    if m["runner"] in ("process", "batch"):
+        for key in ("entrypoint_command", "outcome_from"):
+            _req(m, key, "manifest (runner=%s)" % m["runner"])
+        # A batch corpus is exercised as a unit, so there is nothing to build and no
+        # per-vector path. Anything else must declare its build.
+        if m["runner"] == "process":
+            _req(m, "build", "manifest (runner=process)")
+        m.setdefault("build", [])
+        srcs = m.get("implementation_sources") or [m["implementation"]]
+        m["_source_paths"] = [(base / x).resolve() for x in srcs]
+        for sp in m["_source_paths"]:
+            if not sp.is_file():
+                raise ManifestError("implementation source not found: %s" % sp)
+        m.setdefault("repo_root", ".")
+        m["_repo_root"] = (base / m["repo_root"]).resolve()
+        m.setdefault("vector_path_key", "path")
+        m.setdefault("build_timeout", 1800)
+        m.setdefault("vector_timeout", 120)
     m.setdefault("mutants", {})
     m.setdefault("equivalent", {})
     if not m["mutants"]:
@@ -119,6 +163,10 @@ def load_manifest(path: Path) -> dict:
             for key in ("label", "anchor", "replacement"):
                 _req(e, key, "mutants[%s][%d]" % (group, i))
             e.setdefault("scope", "declared")
+            e.setdefault("control", False)
+            if e["control"] and e["scope"] != "declared":
+                raise ManifestError("mutants[%s][%d] %r: a control cannot be out_of_scope"
+                                    % (group, i, e["label"]))
             if e["scope"] not in ("declared", "out_of_scope"):
                 raise ManifestError("mutants[%s][%d] %r: scope must be declared or out_of_scope"
                                     % (group, i, e["label"]))
@@ -157,6 +205,26 @@ def _load_module(source: str, tag: str, tmp: Path):
     return module
 
 
+def _acknowledged_holes(m: dict) -> dict:
+    """Holes acknowledged against the DECLARED corpus digest.
+
+    STATED PRECISELY, because the earlier wording here was false. This pins to a
+    digest STRING read from a file the manifest itself names. It is an
+    author-supplied claim about the corpus, not a measurement of it: nothing here
+    recomputes the digest from the vectors. Point the file at a stale value, or
+    leave it untouched while the corpus moves, and every acknowledgement survives
+    a corpus it no longer describes.
+
+    So the expiry is only as strong as the honesty of that file. That is the same
+    declared-versus-observed gap this tool exists to find, one level up, in its
+    own implementation. Whether the tool should recompute the digest is a contract
+    decision with a canonicalisation question attached, and it is not made here.
+    """
+    if not m.get("_corpus_digest"):
+        return {}
+    return {e["label"]: e for e in m["known_holes"].get(m["_corpus_digest"], [])}
+
+
 def _group_of(v: dict, m: dict) -> str:
     return v[m["group_key"]] if m["group_key"] else m["default_group"]
 
@@ -173,8 +241,308 @@ def _outcomes(fn, vectors: list[dict], m: dict) -> tuple[dict, list[str]]:
     return outcomes, raised
 
 
+
+# ---------------------------------------------------------------------------
+# process runner: a compiled implementation behind a command line
+# ---------------------------------------------------------------------------
+
+
+class _SourceGuard:
+    """Restores every mutated source file, including on crash.
+
+    The adapter edits files in the working tree. A restore that only happens on
+    the happy path leaks a mutant into a commit, so the originals are captured
+    up front and rewritten in a finally block.
+    """
+
+    def __init__(self, paths: list[Path]) -> None:
+        self.original = {p: p.read_bytes() for p in paths}
+
+    def restore(self) -> None:
+        for path, data in self.original.items():
+            if path.read_bytes() != data:
+                path.write_bytes(data)
+
+    def verify_clean(self) -> list[str]:
+        return [str(p) for p, d in self.original.items() if p.read_bytes() != d]
+
+
+def _tree_is_dirty(repo_root: Path, paths: list[Path]) -> list[str]:
+    """Declared sources with uncommitted changes. Mutating those loses work."""
+    try:
+        out = subprocess.run(["git", "-C", str(repo_root), "status", "--porcelain", "--"]
+                             + [str(p) for p in paths],
+                             capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
+        return []          # no git: nothing to protect, and nothing to claim
+    return [ln[3:] for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def _build(m: dict) -> tuple[bool, str]:
+    if not m.get("build"):
+        return True, "nothing to build"      # an interpreted corpus has no build step
+    try:
+        p = _run_capped(list(m["build"]), m["_repo_root"], timeout=m["build_timeout"])
+    except _OutputTooLarge:
+        return False, "build output exceeded the ceiling"
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, "build could not complete: %r" % (exc,)
+    if p.returncode != 0:
+        tail = [ln for ln in (p.stdout + p.stderr).splitlines()
+                if "error" in ln.lower()][-3:]
+        return False, " | ".join(tail)[:300] or "build exited %d" % p.returncode
+    return True, "built"
+
+
+def _batch_outcome(m: dict) -> tuple[dict, list[str]]:
+    """Run the command ONCE over the whole corpus.
+
+    Some corpora are consumed as a unit: the checker takes the vector file and
+    reports a summary. Per-vector invocation is not available there, so the unit
+    IS the outcome. Discrimination then depends entirely on the summary naming
+    which cases moved -- a checker reporting only a boolean would make every
+    mutant either kill everything or nothing, and this runner would be measuring
+    almost nothing. That limitation belongs to the corpus, and it is stated in the
+    report rather than hidden by a per-vector shape this corpus does not have.
+    """
+    cmd = [str(x) for x in m["entrypoint_command"]]
+    try:
+        p = _run_capped(cmd, m["_repo_root"], timeout=m["vector_timeout"])
+        doc = json.loads(p.stdout)
+    except Exception:  # noqa: BLE001
+        return {}, ["<batch>"]
+    keys = m["outcome_from"]
+    vals = [doc.get(k) for k in (keys if isinstance(keys, list) else [keys])]
+    # lists are compared as tuples so a failures list discriminates per case
+    norm = tuple(tuple(v) if isinstance(v, list) else v for v in vals)
+    return {"<batch>": norm}, []
+
+
+def _process_outcomes(m: dict, vectors: list[dict]) -> tuple[dict, list[str]]:
+    """Run the built command once per vector. A vector that cannot be read is a raise."""
+    if m["runner"] == "batch":
+        return _batch_outcome(m)
+    outcomes, raised = {}, []
+    for v in vectors:
+        vid = v[m["id_key"]]
+        cmd = [str(x).replace("{vector}", str((m["_repo_root"] / v[m["vector_path_key"]]).resolve()))
+               for x in m["entrypoint_command"]]
+        try:
+            p = _run_capped(cmd, m["_repo_root"], timeout=m["vector_timeout"])
+            doc = json.loads(p.stdout)
+            keys = m["outcome_from"]
+            # A single key can collapse every rejection onto one value and lose all
+            # discrimination, so a list is allowed and compared as a tuple.
+            outcomes[vid] = (tuple(doc.get(k) for k in keys) if isinstance(keys, list)
+                             else doc.get(keys))
+        except Exception:  # noqa: BLE001 - unreadable output is a behaviour change
+            raised.append(vid)
+    return outcomes, raised
+
+
+
+def _run_process(m: dict, manifest_path: Path) -> dict:
+    """Mutate declared sources, rebuild, and run the corpus against the binary."""
+    doc = json.loads(m["_vectors_path"].read_text(encoding="utf-8"))
+    if m["runner"] == "batch":
+        # One synthetic unit. The corpus's real cases live inside the file the
+        # command reads; the group exists so the self-coverage guard still applies.
+        all_vectors = [{m["id_key"]: "<batch>",
+                        (m["group_key"] or "_g"): m["default_group"]}]
+        if m["group_key"] is None:
+            m["group_key"] = "_g"
+    else:
+        all_vectors = doc[m["vectors_key"]] if isinstance(doc, dict) else doc
+    failures: list[str] = []
+
+    dirty = _tree_is_dirty(m["_repo_root"], m["_source_paths"])
+    if dirty:
+        raise ManifestError(
+            "declared sources have uncommitted changes: %s. This adapter edits them in "
+            "place, so it refuses to run rather than risk losing that work" % dirty)
+
+    groups_in_corpus = {_group_of(v, m) for v in all_vectors}
+    unmutated = sorted(groups_in_corpus - set(m["mutants"]))
+    if unmutated:
+        failures.append("groups present in the corpus with no declared mutants: %s" % unmutated)
+    stale = sorted(set(m["mutants"]) - groups_in_corpus)
+    if stale:
+        failures.append("mutants declared for groups not in the corpus: %s" % stale)
+
+    if not any(mut.get("control") for muts in m["mutants"].values() for mut in muts):
+        failures.append("no control mutant declared. Without one, a run of all-survivors "
+                        "cannot be told apart from a harness that detects nothing")
+    acknowledged = _acknowledged_holes(m)
+    stale = set(acknowledged) - {mu["label"] for ms in m["mutants"].values() for mu in ms}
+    if stale:
+        failures.append("known_holes name mutants that do not exist: %s" % sorted(stale))
+    results, killed, survived, equivalent, out_of_scope, unproved = [], 0, 0, 0, 0, 0
+    known_holes = 0
+    guard = _SourceGuard(m["_source_paths"])
+    try:
+        ok, detail = _build(m)
+        if not ok:
+            raise ManifestError("the UNMUTATED tree does not build: %s" % detail)
+
+        baselines = {}
+        for group in sorted(m["mutants"]):
+            vectors = [v for v in all_vectors if _group_of(v, m) == group]
+            if not vectors:
+                failures.append("%s: no vectors, so its mutants cannot be scored" % group)
+                continue
+            base, raised = _process_outcomes(m, vectors)
+            if raised:
+                failures.append("%s: the UNMUTATED binary failed on %s" % (group, raised))
+                continue
+            baselines[group] = (vectors, base)
+
+        for group in sorted(m["mutants"]):
+            if group not in baselines:
+                continue
+            vectors, baseline = baselines[group]
+            for mut in m["mutants"][group]:
+                scope = mut.get("scope", "declared")
+                hits = [(sp, sp.read_text(encoding="utf-8").count(mut["anchor"]))
+                        for sp in m["_source_paths"]]
+                total = sum(n for _, n in hits)
+                if total == 0:
+                    failures.append("%s / %s: anchor not found in any declared source"
+                                    % (group, mut["label"]))
+                    continue
+                if total > 1:
+                    failures.append(
+                        "%s / %s: the anchor occurs %d times across the declared sources, so "
+                        "the substitution would pick one arbitrarily. Make it unique"
+                        % (group, mut["label"], total))
+                    continue
+
+                target = next(sp for sp, n in hits if n == 1)
+                original = target.read_text(encoding="utf-8")
+                target.write_text(original.replace(mut["anchor"], mut["replacement"], 1),
+                                  encoding="utf-8")
+                try:
+                    built, detail = _build(m)
+                    if not built:
+                        # Cursor's ruling on the design: rustc exit 1 yields no verdict, so
+                        # the corpus never saw this mutant. Counting it killed would let a
+                        # typo in the substitution print as "rule covered". Measure a
+                        # load-bearing arm with a variant that COMPILES, or declare it
+                        # equivalent.
+                        results.append({"group": group, "label": mut["label"],
+                                        "verdict": "unproved", "scope": scope, "moved": 0,
+                                        "how": "the mutant does not build, so the corpus was "
+                                               "never run against it: %s" % detail})
+                        unproved += 1
+                        continue
+                    out, raised = _process_outcomes(m, vectors)
+                finally:
+                    target.write_text(original, encoding="utf-8")
+
+                moved = [vid for vid, val in out.items() if baseline.get(vid) != val]
+                if mut.get("control"):
+                    # A control exists to prove the harness can detect ANYTHING. It is
+                    # never scored: counting it would inflate the very number it exists
+                    # to make trustworthy. A control that survives means the run says
+                    # nothing at all about the corpus.
+                    ok = bool(raised or moved)
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "control-killed" if ok else "control-SURVIVED",
+                                    "scope": scope, "moved": len(moved),
+                                    "how": ("harness detects a change on this path"
+                                            if ok else "THE HARNESS DETECTS NOTHING")})
+                    if not ok:
+                        failures.append(
+                            "control %r survived: the harness cannot detect a change on this "
+                            "path, so every other verdict in this run is meaningless"
+                            % mut["label"])
+                    continue
+                if raised or moved:
+                    results.append({"group": group, "label": mut["label"], "verdict": "killed",
+                                    "scope": scope, "moved": len(moved),
+                                    "how": ("raises on %d vector(s)" % len(raised)) if raised
+                                           else "%d vector(s) moved" % len(moved)})
+                    killed += 1
+                elif scope == "out_of_scope":
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "unexercised", "scope": scope, "moved": 0,
+                                    "how": "out of scope: %s" % mut["reason"]})
+                    out_of_scope += 1
+                elif mut["label"] in acknowledged:
+                    ack = acknowledged[mut["label"]]
+                    # A KNOWN HOLE is not a scope statement. The corpus does claim this
+                    # rule, the rule is genuinely unexercised, and that fact is recorded
+                    # against ONE digest rather than fixed today. It stays loud.
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "known-hole", "scope": scope, "moved": 0,
+                                    "how": "KNOWN HOLE against %s, recorded %s: %s"
+                                           % (m["_corpus_digest"][:19], ack["recorded"],
+                                              ack["reason"])})
+                    known_holes += 1
+                else:
+                    results.append({"group": group, "label": mut["label"], "verdict": "survived",
+                                    "scope": scope, "moved": 0,
+                                    "how": "no vector distinguishes it. An implementation can "
+                                           "delete this rule and still reproduce the digest"})
+                    survived += 1
+
+            for eq in m["equivalent"].get(group, []):
+                results.append({"group": group, "label": eq["label"], "verdict": "equivalent",
+                                "how": eq["reason"], "moved": 0})
+                equivalent += 1
+    finally:
+        guard.restore()
+        leaked = guard.verify_clean()
+        if leaked:
+            failures.append("SOURCES NOT RESTORED: %s" % leaked)
+        _build(m)   # leave the tree with a binary built from the real source
+
+    # A stale acknowledgement is not only one whose rule became killed. Any verdict
+    # other than known-hole means the acknowledgement no longer describes anything,
+    # and a leftover that points at nothing is what hides the next regression.
+    linger = {r["label"]: r["verdict"] for r in results
+              if r["label"] in acknowledged and r["verdict"] != "known-hole"}
+    if linger:
+        failures.append("known_holes acknowledge rules that are no longer holes: %s. Remove "
+                        "them; an acknowledgement pointing at nothing hides the next regression"
+                        % sorted("%s (now %s)" % kv for kv in linger.items()))
+    denom = killed + survived
+    # No denominator means no measurement. Printing 100% over zero is the same
+    # defect as excluding everything and printing 100%.
+    score = None if denom == 0 else round(100.0 * killed / denom, 1)
+    if unproved:
+        failures.append("%d mutant(s) never ran, so this corpus was not measured against them"
+                        % unproved)
+    if survived:
+        failures.append("%d mutant(s) survived; the required score is 100%% of non-equivalent "
+                        "mutants" % survived)
+    if denom == 0:
+        failures.append(
+            "nothing was measured: every declared in-scope rule is either a known hole, "
+            "declared equivalent or out of scope. There is no adequacy result here"
+            if (known_holes or equivalent or out_of_scope)
+            else "no non-equivalent mutants were scored, so no adequacy was measured")
+
+    return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
+            "runner": m["runner"], "killed": killed, "survived": survived,
+            "known_holes": known_holes, "corpus_digest": m.get("_corpus_digest"),
+            "acknowledged_digests": len(m.get("known_holes", {})),
+            "hole_ratio": (None if (killed + survived) == 0
+                           else round(known_holes / (killed + survived), 2)),
+            "equivalent": equivalent, "unexercised_out_of_scope": out_of_scope,
+            "unproved": unproved,
+            "declared_total": (killed + survived + equivalent + out_of_scope + unproved
+                               + known_holes),
+            "out_of_scope_ratio": (None if denom == 0 else round(out_of_scope / denom, 2)),
+            "score_percent": score,
+            "score_means": ("percent of author-declared in-scope rules killed; NOT percent of "
+                            "the rules the implementation actually has"),
+            "mutants": results, "failures": failures, "adequate": not failures}
+
+
 def run(manifest_path: Path) -> dict:
     m = load_manifest(manifest_path)
+    if m["runner"] in ("process", "batch"):
+        return _run_process(m, manifest_path)
     source = m["_impl_path"].read_text(encoding="utf-8")
     doc = json.loads(m["_vectors_path"].read_text(encoding="utf-8"))
     all_vectors = doc[m["vectors_key"]] if isinstance(doc, dict) else doc
@@ -192,7 +560,12 @@ def run(manifest_path: Path) -> dict:
     if stale:
         failures.append("mutants declared for groups not in the corpus: %s" % stale)
 
+    acknowledged = _acknowledged_holes(m)
+    stale = set(acknowledged) - {mu["label"] for ms in m["mutants"].values() for mu in ms}
+    if stale:
+        failures.append("known_holes name mutants that do not exist: %s" % sorted(stale))
     results, killed, survived, equivalent, out_of_scope = [], 0, 0, 0, 0
+    unproved = known_holes = 0
     with tempfile.TemporaryDirectory() as raw:
         tmp = Path(raw)
         base_mod = _load_module(source, "base", tmp)
@@ -226,18 +599,38 @@ def run(manifest_path: Path) -> dict:
                         "one arbitrarily and any breakage would be scored as a kill. Make the "
                         "anchor unique" % (group, mut["label"], occurrences, m["implementation"]))
                     continue
+                scope = mut.get("scope", "declared")
                 mutated = source.replace(mut["anchor"], mut["replacement"], 1)
                 try:
                     mod = _load_module(mutated, "%s_%d" % (group.replace("-", "_"), idx), tmp)
                     fn = getattr(mod, m["entrypoint"])
                 except Exception as exc:  # noqa: BLE001
-                    results.append({"group": group, "label": mut["label"], "verdict": "killed",
-                                    "how": "the mutant does not load: %r" % (exc,), "moved": 0})
-                    killed += 1
+                    # A mutant that never loaded was never shown to the corpus, so the
+                    # corpus said nothing about it. Counting that as a kill lets a typo
+                    # in the substitution print as "rule covered". The same argument
+                    # rules out treating a Rust build failure as a kill; measure a
+                    # load-bearing rule with a variant that RUNS, or declare it equivalent.
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "unproved", "scope": scope, "moved": 0,
+                                    "how": "the mutant does not load, so the corpus never "
+                                           "saw it and said nothing about this rule: %r" % (exc,)})
+                    unproved += 1
                     continue
-                scope = mut.get("scope", "declared")
                 out, raised = _outcomes(fn, vectors, m)
                 moved = [vid for vid, val in out.items() if baseline.get(vid) != val]
+                if mut.get("control"):
+                    ok = bool(raised or moved)
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "control-killed" if ok else "control-SURVIVED",
+                                    "scope": scope, "moved": len(moved),
+                                    "how": ("harness detects a change on this path"
+                                            if ok else "THE HARNESS DETECTS NOTHING")})
+                    if not ok:
+                        failures.append(
+                            "control %r survived: the harness cannot detect a change on this "
+                            "path, so every other verdict in this run is meaningless"
+                            % mut["label"])
+                    continue
                 if raised:
                     results.append({"group": group, "label": mut["label"], "verdict": "killed",
                                     "scope": scope, "how": "raises on %d vector(s)" % len(raised),
@@ -259,6 +652,14 @@ def run(manifest_path: Path) -> dict:
                         # "each with a stated reason" without showing one is an assertion.
                         "how": "out of scope: %s" % mut["reason"]})
                     out_of_scope += 1
+                elif mut["label"] in acknowledged:
+                    ack = acknowledged[mut["label"]]
+                    results.append({"group": group, "label": mut["label"],
+                                    "verdict": "known-hole", "scope": scope, "moved": 0,
+                                    "how": "KNOWN HOLE against %s, recorded %s: %s"
+                                           % (str(m["_corpus_digest"])[:19], ack["recorded"],
+                                              ack["reason"])})
+                    known_holes += 1
                 else:
                     results.append({
                         "group": group, "label": mut["label"], "verdict": "survived",
@@ -274,18 +675,38 @@ def run(manifest_path: Path) -> dict:
                                 "how": eq["reason"], "moved": 0})
                 equivalent += 1
 
+    linger = {r["label"]: r["verdict"] for r in results
+              if r["label"] in acknowledged and r["verdict"] != "known-hole"}
+    if linger:
+        failures.append("known_holes acknowledge rules that are no longer holes: %s. Remove "
+                        "them; an acknowledgement pointing at nothing hides the next regression"
+                        % sorted("%s (now %s)" % kv for kv in linger.items()))
     denom = killed + survived
-    score = 100.0 if denom == 0 else round(100.0 * killed / denom, 1)
+    score = None if denom == 0 else round(100.0 * killed / denom, 1)
+    if unproved:
+        # Not a soft warning: an unproved mutant means the measurement did not happen,
+        # and a score computed over the rest reports more than the run established.
+        failures.append("%d mutant(s) never ran, so this corpus was not measured against "
+                        "them. Fix the substitution or declare them equivalent" % unproved)
     if survived:
         failures.append("%d mutant(s) survived; the required score is 100%% of non-equivalent "
                         "mutants" % survived)
-    if denom == 0 and not failures:
-        failures.append("no non-equivalent mutants were scored, so no adequacy was measured")
+    if denom == 0:
+        failures.append(
+            "nothing was measured: every declared in-scope rule is either a known hole, "
+            "declared equivalent or out of scope. There is no adequacy result here"
+            if (known_holes or equivalent or out_of_scope)
+            else "no non-equivalent mutants were scored, so no adequacy was measured")
 
     return {"schema": "assay.corpus_adequacy.report.v0", "manifest": str(manifest_path),
             "killed": killed, "survived": survived, "equivalent": equivalent,
-            "unexercised_out_of_scope": out_of_scope,
-            "declared_total": killed + survived + equivalent + out_of_scope,
+            "known_holes": known_holes, "corpus_digest": m.get("_corpus_digest"),
+            "acknowledged_digests": len(m.get("known_holes", {})),
+            "hole_ratio": (None if (killed + survived) == 0
+                           else round(known_holes / (killed + survived), 2)),
+            "unexercised_out_of_scope": out_of_scope, "unproved": unproved,
+            "declared_total": (killed + survived + equivalent + out_of_scope + unproved
+                               + known_holes),
             "out_of_scope_ratio": (None if (killed + survived) == 0
                                    else round(out_of_scope / (killed + survived), 2)),
             "score_means": ("percent of author-declared in-scope rules killed; NOT percent of the "
@@ -316,12 +737,17 @@ def main() -> int:
         # Never a bare percentage. A score reported without its denominator and its
         # exclusions is a percentage target wearing a different coat: an author can
         # exclude almost everything and still print 100%.
-        print("%d of %d DECLARED in-scope rules killed (%.1f%%). %d declared equivalent, "
-              "%d declared out of scope. %d rules declared in total."
-              % (rep["killed"], rep["killed"] + rep["survived"], rep["score_percent"],
-                 rep["equivalent"], rep["unexercised_out_of_scope"], rep["declared_total"]))
-        print("This is %.1f%% of what the AUTHOR DECLARED, not of the rules the implementation "
-              "has. A rule nobody declared is invisible to this check." % rep["score_percent"])
+        pct = ("no result" if rep["score_percent"] is None
+               else "%.1f%%" % rep["score_percent"])
+        print("%d of %d DECLARED in-scope rules killed (%s). %d declared equivalent, "
+              "%d declared out of scope, %d unproved. %d rules declared in total."
+              % (rep["killed"], rep["killed"] + rep["survived"], pct,
+                 rep["equivalent"], rep["unexercised_out_of_scope"], rep["unproved"],
+                 rep["declared_total"]))
+        if rep["score_percent"] is not None:
+            print("This is %.1f%% of what the AUTHOR DECLARED, not of the rules the "
+                  "implementation has. A rule nobody declared is invisible to this check."
+                  % rep["score_percent"])
         if rep["unexercised_out_of_scope"]:
             print("out of scope (%d, each with a stated reason): real gaps in what the corpus "
                   "covers, not holes in what it claims" % rep["unexercised_out_of_scope"])
@@ -331,6 +757,24 @@ def main() -> int:
                   % rep["out_of_scope_ratio"])
         for f in rep["failures"]:
             print("FAIL: %s" % f)
+        if rep.get("known_holes"):
+            # Louder than the pass line. Not pinned to the corpus: pinned to a value
+            # another tool has to keep honest, which is what the text below says.
+            print("%d KNOWN HOLE(S) against the DECLARED digest %s. These are rules the "
+                  "corpus DOES claim and does NOT exercise."
+                  % (rep["known_holes"], rep.get("corpus_digest")))
+            print("  The digest is a value READ FROM A FILE THE MANIFEST NAMES. It is not "
+                  "recomputed from the vectors, so these acknowledgements expire only if that "
+                  "file is kept honest.")
+            if rep.get("acknowledged_digests", 0) > 1:
+                print("  %d digests carry acknowledgements in this manifest. Entries for a "
+                      "digest that is not the declared one are not in force, but pre-declaring "
+                      "future digests is how this expiry gets bypassed."
+                      % rep["acknowledged_digests"])
+            if rep.get("hole_ratio") is not None and rep["hole_ratio"] > 1.0:
+                print("  more rules are acknowledged as holes than are measured (ratio %.2f). "
+                      "The score printed above is a statement about a minority of the "
+                      "declared rules." % rep["hole_ratio"])
         if rep["adequate"]:
             if rep["out_of_scope_ratio"] is not None and rep["out_of_scope_ratio"] > 1.0:
                 # The closing line is what gets quoted. It may not read as unqualified
@@ -339,7 +783,12 @@ def main() -> int:
                       "(%d of %d rules declared here were excluded from it)"
                       % (rep["unexercised_out_of_scope"], rep["declared_total"]))
             else:
-                print("mutation-adequacy check passed: every non-equivalent mutant is killed")
+                suffix = ""
+                if rep.get("known_holes"):
+                    suffix = (" for the rules still measured -- %d are acknowledged holes"
+                              % rep["known_holes"])
+                print("mutation-adequacy check passed: every non-equivalent mutant is killed"
+                      + suffix)
 
     return 0 if rep["adequate"] else 1
 

--- a/conformance/run_all.py
+++ b/conformance/run_all.py
@@ -43,6 +43,11 @@ import time
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bounded_run import (  # noqa: E402
+    OUTPUT_CAP_BYTES, _OutputTooLarge, _run_capped,
+)
+
 REPO = Path(__file__).resolve().parent.parent
 
 # Grades a run can produce.
@@ -51,68 +56,6 @@ PROVED, FALSE, UNPROVED = "proved", "false", "unproved"
 NEEDS_CANDIDATE, NOT_SELECTED, EXTERNAL = "needs_candidate", "not_selected", "external"
 
 RANK = {PROVED: 0, NEEDS_CANDIDATE: 0, NOT_SELECTED: 0, EXTERNAL: 0, UNPROVED: 1, FALSE: 2}
-
-
-# Output ceiling per child process. Both children can emit arbitrary output and
-# a timeout does not bound memory, so the cap is applied while the process runs
-# rather than after it exits.
-OUTPUT_CAP_BYTES = 4 * 1024 * 1024
-
-
-class _OutputTooLarge(Exception):
-    """A child exceeded OUTPUT_CAP_BYTES; its output is not materialized."""
-
-
-def _run_capped(cmd: list[str], cwd: Path, timeout: int) -> subprocess.CompletedProcess:
-    """subprocess.run with a ceiling on how much output is ever held.
-
-    Streams both pipes to temporary files, polls their combined size while the
-    child runs, and kills it the moment the cap is crossed. Only the first
-    OUTPUT_CAP_BYTES are ever read into memory.
-    """
-    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
-        # A descendant that inherits stdout/stderr keeps writing after proc.kill()
-        # and walks straight through the ceiling, so the child leads its own session
-        # and the whole group is stopped and reaped.
-        proc = subprocess.Popen(cmd, cwd=str(cwd), stdout=out, stderr=err,
-                                start_new_session=True)
-
-        def _kill_tree() -> None:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError, OSError):
-                proc.kill()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                pass
-        deadline = time.monotonic() + timeout
-        try:
-            while True:
-                try:
-                    proc.wait(timeout=0.25)
-                    break
-                except subprocess.TimeoutExpired:
-                    pass
-                if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
-                    _kill_tree()
-                    raise _OutputTooLarge()
-                if time.monotonic() > deadline:
-                    _kill_tree()
-                    raise subprocess.TimeoutExpired(cmd, timeout)
-        finally:
-            # Reap the group even on the clean path: the leader can exit while a
-            # descendant it spawned is still holding the inherited handles.
-            _kill_tree()
-        if out.tell() + err.tell() > OUTPUT_CAP_BYTES:
-            raise _OutputTooLarge()
-        out.seek(0)
-        err.seek(0)
-        return subprocess.CompletedProcess(
-            cmd, proc.returncode,
-            out.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
-            err.read(OUTPUT_CAP_BYTES).decode("utf-8", "replace"),
-        )
 
 
 def _stdlib_jsonrpc(suite: dict) -> tuple[str, str]:

--- a/conformance/tests/test_corpus_adequacy.py
+++ b/conformance/tests/test_corpus_adequacy.py
@@ -90,11 +90,223 @@ class Scoring(unittest.TestCase):
         self.assertEqual(rep["equivalent"], 1)
         self.assertEqual(rep["killed"] + rep["survived"], 1)
 
-    def test_a_mutant_that_crashes_the_module_counts_as_killed(self):
+    def test_a_mutant_that_never_loads_is_unproved_not_killed(self):
+        # Reversed deliberately on the Rust-adapter review: a mutant that never
+        # loaded was never shown to the corpus, so the corpus said nothing about
+        # that rule. Counting it killed lets a typo in the substitution print as
+        # "rule covered". Measure a load-bearing rule with a variant that RUNS.
         broken = {"label": "syntax", "anchor": 'return "ok"', "replacement": "return ??"}
         with tempfile.TemporaryDirectory() as d:
             rep = ca.run(_manifest(Path(d), {"a": [broken]}))
+        self.assertEqual(rep["killed"], 0)
+        self.assertEqual(rep["unproved"], 1)
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("never ran" in f for f in rep["failures"]), rep["failures"])
+
+
+class ControlMutants(unittest.TestCase):
+    """A control proves the harness detects anything. It is never scored."""
+
+    def test_a_killed_control_does_not_inflate_the_score(self):
+        ctrl = dict(KILLABLE, label="CONTROL reachability", control=True)
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [ctrl]}))
+        self.assertEqual(rep["killed"], 0, "a control must not count as a kill")
+        self.assertIn("control-killed", [r["verdict"] for r in rep["mutants"]])
+
+    def test_a_surviving_control_invalidates_the_whole_run(self):
+        # The distinction the control exists for: all-survivors because the corpus is
+        # weak, versus all-survivors because nothing was ever measured.
+        ctrl = dict(SURVIVOR, label="CONTROL reachability", control=True)
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(_manifest(Path(d), {"a": [KILLABLE, ctrl]}))
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("harness cannot detect" in f for f in rep["failures"]),
+                        rep["failures"])
+
+    def test_a_control_may_not_be_declared_out_of_scope(self):
+        ctrl = dict(KILLABLE, label="c", control=True, scope="out_of_scope", reason="x")
+        with tempfile.TemporaryDirectory() as d:
+            p = _manifest(Path(d), {"a": [ctrl]})
+            with self.assertRaises(ca.ManifestError) as cm:
+                ca.load_manifest(p)
+        self.assertIn("control cannot be out_of_scope", str(cm.exception))
+
+
+class KnownHoles(unittest.TestCase):
+    """An acknowledged hole is pinned to one digest and expires with it."""
+
+    def _mf(self, tmp: Path, digest_in_file, holes_for, extra_mutants=None):
+        (tmp / "digest.json").write_text(json.dumps({"corpus_digest": digest_in_file}))
+        muts = [dict(SURVIVOR, label="unexercised rule")] + (extra_mutants or [])
+        p = _manifest(tmp, {"a": muts}, raw={
+            "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+            "known_holes": {holes_for: [{"label": "unexercised rule",
+                                         "reason": "no vector reaches it",
+                                         "recorded": "2026-08-19"}]}})
+        return p
+
+    def test_a_hole_acknowledged_for_the_present_digest_is_not_a_survivor(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(self._mf(Path(d), "sha256:aaa", "sha256:aaa", [KILLABLE]))
+        self.assertEqual(rep["survived"], 0)
+        self.assertEqual(rep["known_holes"], 1)
+        self.assertIn("known-hole", [r["verdict"] for r in rep["mutants"]])
+
+    def test_the_acknowledgement_expires_when_the_corpus_moves(self):
+        # The rule that stops this being an escape hatch: an acknowledgement is a
+        # statement about ONE corpus, so a corpus that changes loses it.
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(self._mf(Path(d), "sha256:NEW", "sha256:OLD", [KILLABLE]))
+        self.assertEqual(rep["known_holes"], 0)
+        self.assertEqual(rep["survived"], 1, "the hole must reappear as a survivor")
+        self.assertFalse(rep["adequate"])
+
+    def test_an_acknowledgement_for_a_rule_now_exercised_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [dict(KILLABLE, label="now exercised")]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "now exercised", "reason": "x",
+                                                "recorded": "2026-08-19"}]}})
+            rep = ca.run(p)
+        self.assertFalse(rep["adequate"])
+        # The message widened from "now exercises" to cover every transition away
+        # from known-hole, not only becoming killed.
+        self.assertTrue(any("no longer holes" in f and "now killed" in f
+                            for f in rep["failures"]), rep["failures"])
+
+    def test_the_report_does_not_claim_the_pin_is_to_the_corpus(self):
+        # The wording was false and the tool printed it: with a corpus that had moved
+        # it said the acknowledgement "expires the moment the corpus changes" while
+        # exiting 0 at 100%. The digest is a value read from a file the manifest
+        # names, never recomputed from the vectors, and the report must say so.
+        with tempfile.TemporaryDirectory() as d:
+            p = self._mf(Path(d), "sha256:aaa", "sha256:aaa", [KILLABLE])
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertNotIn("expires the moment the corpus changes", r.stdout)
+        self.assertIn("not recomputed from the vectors", r.stdout)
+
+    def test_pre_declared_future_digests_are_surfaced(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE, dict(SURVIVOR, label="hole")]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "hole", "reason": "x",
+                                                "recorded": "2026-08-19"}],
+                                "sha256:future1": [], "sha256:future2": []}})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertIn("digests carry acknowledgements", r.stdout)
+
+    def test_holes_outnumbering_measurements_is_stated(self):
+        holes = [dict(SURVIVOR, label=f"h{i}") for i in range(4)]
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE] + holes}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": f"h{i}", "reason": "x",
+                                                "recorded": "2026-08-19"} for i in range(4)]}})
+            r = subprocess.run([sys.executable, str(ca.__file__), str(p)],
+                               capture_output=True, text=True, timeout=120)
+        self.assertIn("acknowledged as holes than are measured", r.stdout)
+        self.assertIn("acknowledged holes", r.stdout.strip().splitlines()[-1])
+
+    def test_an_acknowledgement_lingers_when_its_rule_becomes_out_of_scope(self):
+        # Only one of four transitions was covered: killed. A rule that becomes
+        # out_of_scope left the acknowledgement pointing at nothing, silently.
+        oos = dict(SURVIVOR, label="hole", scope="out_of_scope", reason="marked oos later")
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE, oos]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "hole", "reason": "x",
+                                                "recorded": "2026-08-19"}]}})
+            rep = ca.run(p)
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("no longer holes" in f for f in rep["failures"]), rep["failures"])
+
+    def test_a_hole_without_a_reason_is_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / "digest.json").write_text(json.dumps({"corpus_digest": "sha256:aaa"}))
+            p = _manifest(tmp, {"a": [KILLABLE]}, raw={
+                "corpus_digest_file": "digest.json", "corpus_digest_key": "corpus_digest",
+                "known_holes": {"sha256:aaa": [{"label": "x", "reason": " ",
+                                                "recorded": "2026-08-19"}]}})
+            with self.assertRaises(ca.ManifestError) as cm:
+                ca.load_manifest(p)
+        self.assertIn("stated reason", str(cm.exception))
+
+    def test_an_all_holes_manifest_reports_no_result_rather_than_100_percent(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(self._mf(Path(d), "sha256:aaa", "sha256:aaa"))
+        self.assertIsNone(rep["score_percent"], "an empty denominator is not 100%")
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("nothing was measured" in f for f in rep["failures"]))
+
+
+class BatchRunner(unittest.TestCase):
+    """A corpus consumed as a unit: one invocation, the summary is the outcome."""
+
+    def _corpus(self, tmp: Path):
+        (tmp / "check.py").write_text(
+            "import json, sys\n"
+            "doc = json.load(open(sys.argv[1]))\n"
+            "fails = [c['id'] for c in doc['cases'] if c['n'] > 10]\n"
+            "print(json.dumps({'ok': not fails, 'failures': fails}))\n")
+        (tmp / "vectors.json").write_text(json.dumps({"cases": [
+            {"id": "c1", "n": 1}, {"id": "c2", "n": 2}]}))
+        m = {"schema": ca.SCHEMA, "runner": "batch", "repo_root": ".",
+             "implementation_sources": ["check.py"],
+             "entrypoint_command": ["python3", "check.py", "vectors.json"],
+             "outcome_from": ["ok", "failures"], "vectors": "vectors.json",
+             "id_key": "vector_id", "default_group": "g",
+             "mutants": {"g": [
+                 {"label": "threshold", "anchor": "c['n'] > 10", "replacement": "c['n'] > 1"},
+                 # must actually move the summary: emptying the case list leaves
+                 # `failures` empty exactly as the baseline does, and the control
+                 # guard correctly refused that when it was tried.
+                 {"label": "CONTROL", "control": True,
+                  "anchor": "'ok': not fails", "replacement": "'ok': 'MOVED'"}]}}
+        p = tmp / "m.json"
+        p.write_text(json.dumps(m))
+        return p
+
+    def test_one_invocation_still_discriminates_via_the_summary(self):
+        with tempfile.TemporaryDirectory() as d:
+            rep = ca.run(self._corpus(Path(d)))
+        self.assertEqual(rep["runner"], "batch")
         self.assertEqual(rep["killed"], 1)
+        self.assertTrue(rep["adequate"], rep["failures"])
+
+    def test_the_source_is_restored_after_a_batch_run(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            p = self._corpus(tmp)
+            before = (tmp / "check.py").read_bytes()
+            ca.run(p)
+            self.assertEqual((tmp / "check.py").read_bytes(), before)
+
+    def test_a_batch_manifest_needs_no_build(self):
+        # An interpreted corpus has no build step; requiring one would exclude it.
+        with tempfile.TemporaryDirectory() as d:
+            m = ca.load_manifest(self._corpus(Path(d)))
+        self.assertEqual(m["build"], [])
+
+    def test_an_unreadable_summary_is_a_raise_not_a_silent_pass(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            p = self._corpus(tmp)
+            (tmp / "check.py").write_text("print('not json')\n")
+            rep = ca.run(p)
+        self.assertFalse(rep["adequate"])
+        self.assertTrue(any("UNMUTATED" in f for f in rep["failures"]), rep["failures"])
 
 
 class Guards(unittest.TestCase):


### PR DESCRIPTION
Closes the third of four runner shapes, and takes **step 2 of the [#194](https://github.com/Rul1an/assay-tunnel-experiments/issues/194) gate**: publish the adequacy results including the parts that do not flatter us.

> **Stacked on [#2543](https://github.com/Rul1an/assay/pull/2543).** This branch carries that PR's commit as well, so the diff below is currently ~988 lines. Once #2543 merges, a rebase shrinks this to the batch runner and the `INDEX.md` table alone. Review the last commit (`78c792f57`) rather than the range.

## The batch runner

Some corpora are consumed **as a unit**. `observed-effect-v0`'s drift consumer takes the whole vector file and prints a summary, so per-vector invocation is not available and the summary *is* the outcome.

That only discriminates because its `failures` list **names the case ids**. A checker reporting a bare boolean would make every mutant kill everything or nothing, and this runner would be measuring almost nothing. That limitation belongs to the corpus, and the docstring says so rather than hiding it behind a per-vector shape the corpus does not have.

**Measured: 4 of 5.** One survivor — an implementation can read the body regardless of whether the ref recomputed and still reproduce all fourteen cases.

## Two details the corpus itself forced, both of them right

- `independent_consumer.py` **refuses an absolute vectors path**. The command is therefore relative and runs with the corpus as its working directory. That is its hardening, not an obstacle to route around.
- An interpreted corpus has **no build step**, so requiring one would have excluded it. `build` is now optional and empty means nothing to build.

## The results, published as one table

`conformance/INDEX.md` now carries them in one place instead of scattered across commit messages:

| Corpus | Runner | Result |
|---|---|---|
| `mcp-jsonrpc-id-conformance` | module | 4 of 4 in scope; **7 rules unexercised and out of scope**, ratio 1.75 |
| `privileged-mcp-action-v0` | process | **1 known hole** (origin leg), plus two rules I declared that turned out to mutate the wrong stage and the wrong profile |
| `observed-effect-v0` drift consumer | **batch** | **4 of 5**, one survivor |
| rge-bench | module | 30 of 30, 1 equivalent |
| `rfc8785` · `mcp-era-parity-v0` | — | **not measurable** — Rust *tests* without a per-vector verdict, a fourth shape |

**Four of six**, written that way rather than rounded up. Two corpora have no measurement at all and one of the four measured carries an acknowledged hole.

The reason this matters beyond bookkeeping: #194 proposes offering corpus audits to peers, and *"it is in a commit message somewhere"* is the same thin cover we mark in other people's claims. A tool that audits corpora is worth nothing if its author has not survived it, visibly.

## Verification

- 41 tests here, 7 own-corpora, 25 for `run_all`
- rge-bench parity unchanged: 30 of 30, 1 declared equivalent
- source restored after every batch run; a test asserts it

The control requirement caught **my own test fixture** while writing this: a control that emptied the case list left `failures` empty exactly as the baseline did, so it was inert and the run correctly refused it.
