### PR TITLE
feat(conformance): run the JCS adequacy control, and correct two overstatements it exposed

### DIFF
--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -136,17 +136,27 @@ rules the author declared.
 The results below include the ones that do not flatter us, because a tool that
 audits corpora is worth nothing if its author has not survived it.
 
+**"Unexercised" below always means unexercised *by the published corpus*, never
+unexercised in our tree.** The two come apart, and the difference is the whole
+point: a rule our unit tests cover but our vectors cannot discriminate is one our
+implementation gets right and our corpus cannot ask a stranger to get right. Such a
+rule is a hole in what the corpus *transmits*, not a defect in what we ship, and
+the rows below say which of the two they mean.
+
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **4 of 4** in scope. **7 rules unexercised and out of scope**, ratio 1.75 — the score is a statement about a minority of the declared rules |
-| `privileged-mcp-action-v0` | process | **1 known hole**: the origin leg of the v0 marker triple is promised by §5 and no vector discriminates it. Recorded against `sha256:cb58ce91…` rather than fixed, because adding a vector moves a published digest. Two further rules I declared turned out to mutate the wrong stage and the wrong profile; they are marked out of scope **with that reasoning rather than deleted** |
+| `privileged-mcp-action-v0` | process | **No adequacy result. Exit 1.** All three declared rules are a known hole or out of scope, so nothing was measured, and the tool refuses to report a score it did not earn. The hole: the origin leg of the v0 marker triple is promised by §5 Stage 3 and no vector discriminates it. **The gap is in the corpus, not in the implementation** — our own tree exercises the leg in `denial_marker_classifier.rs::wrong_origin_is_inert`; what the corpus cannot do is *transmit* the requirement to a stranger, who can skip the leg and still reproduce the pinned digest. Recorded against `sha256:cb58ce91…` rather than fixed, because adding a vector moves a published digest. The other two rules I declared turned out to mutate the wrong stage and the wrong profile; they are out of scope **with that reasoning rather than deleted**. Three declared, none scorable — the corpus that carries our most public reproduction request is the one this tool can say least about |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **4 of 5**. One survivor: an implementation can read the body regardless of whether the ref recomputed and still reproduce all fourteen cases |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | 30 of 30, 1 declared equivalent |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: see below |
 | `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict |
 
-**Four measured, one control-only, one not measurable.** Stated rather than
-rounded up.
+**Three measured, one with no scorable result, one control-only, one not
+measurable.** Stated rather than rounded up — and corrected on 2026-08-19, when
+this line still read *four measured* and counted `privileged-mcp-action-v0` among
+them. The tool had been printing `FAIL: nothing was measured` for that corpus the
+whole time; the summary above it had rounded up anyway.
 
 ### Why `rfc8785` has a control and no declared rules
 

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -142,10 +142,35 @@ audits corpora is worth nothing if its author has not survived it.
 | `privileged-mcp-action-v0` | process | **1 known hole**: the origin leg of the v0 marker triple is promised by §5 and no vector discriminates it. Recorded against `sha256:cb58ce91…` rather than fixed, because adding a vector moves a published digest. Two further rules I declared turned out to mutate the wrong stage and the wrong profile; they are marked out of scope **with that reasoning rather than deleted** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **4 of 5**. One survivor: an implementation can read the body regardless of whether the ref recomputed and still reproduce all fourteen cases |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | 30 of 30, 1 declared equivalent |
-| `rfc8785` · `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict, which is a fourth runner shape |
+| `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: see below |
+| `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict |
 
-**Four of six.** Stated rather than rounded up: two corpora have no adequacy
-measurement at all, and one of the four measured has an acknowledged hole.
+**Four measured, one control-only, one not measurable.** Stated rather than
+rounded up.
+
+### Why `rfc8785` has a control and no declared rules
+
+`crates/assay-canonical/src/jcs.rs` is a thin wrapper: it delegates to `serde_jcs`
+and declares almost no rules of its own. Rule-deletion mutation therefore does not
+apply the way it does to a corpus with its own logic — there is nothing of ours to
+delete. The question for a delegating wrapper is different: **does the corpus catch
+a wrong delegate?**
+
+That control was not invented for this measurement. `tests/rfc8785_conformance.rs`
+documents it in prose at the top of the file: swap `serde_jcs::to_vec` for
+`serde_json::to_vec` and at least 8 of 31 vectors must fail, with
+`keyorder_utf16_vs_codepoint` among them, because that is the only vector where
+code-unit, code-point and byte order disagree. The file says the property is
+written down "so it stays checkable rather than remembered".
+
+**It was remembered, not checked.** Run for the first time on 2026-08-19 it holds
+exactly: `8 of 31 RFC 8785 vectors diverged`, and the named vector is among them.
+That is now executable rather than a paragraph.
+
+What the control does **not** establish is coverage of RFC 8785 itself. It shows
+the corpus bites against **one** wrong implementation. Whether it bites against the
+other plausible ones is a question about RFC coverage rather than about our code,
+and it is open.
 
 Every manifest must declare at least one **control** — a mutation on the same
 path that MUST be killed. All-survivors because a corpus is weak and

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -146,17 +146,49 @@ the rows below say which of the two they mean.
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **4 of 4** in scope. **7 rules unexercised and out of scope**, ratio 1.75 — the score is a statement about a minority of the declared rules |
-| `privileged-mcp-action-v0` | process | **No adequacy result. Exit 1.** All three declared rules are a known hole or out of scope, so nothing was measured, and the tool refuses to report a score it did not earn. The hole: the origin leg of the v0 marker triple is promised by §5 Stage 3 and no vector discriminates it. **The gap is in the corpus, not in the implementation** — our own tree exercises the leg in `denial_marker_classifier.rs::wrong_origin_is_inert`; what the corpus cannot do is *transmit* the requirement to a stranger, who can skip the leg and still reproduce the pinned digest. Recorded against `sha256:cb58ce91…` rather than fixed, because adding a vector moves a published digest. The other two rules I declared turned out to mutate the wrong stage and the wrong profile; they are out of scope **with that reasoning rather than deleted**. Three declared, none scorable — the corpus that carries our most public reproduction request is the one this tool can say least about |
+| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 1 known hole.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. The survivors form **one systematic gap, not four**: wherever a rule has sibling members, the corpus discriminates exactly one and leaves the rest free. Decision cardinality is caught (`bad-103`) and observation and establish cardinality are not; the decision's `target_digest` is caught (`bad-102`) and the observation's `response_digest` is not; the binding pair is caught on its digest leg (`bad-105`) and not on its tool-name leg; the marker triple is caught on schema and code and not on origin (the known hole). One vector per failure mode, and every failure mode has siblings on the same code path that never got one. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **4 of 5**. One survivor: an implementation can read the body regardless of whether the ref recomputed and still reproduce all fourteen cases |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | 30 of 30, 1 declared equivalent |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: see below |
 | `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict |
 
-**Three measured, one with no scorable result, one control-only, one not
-measurable.** Stated rather than rounded up — and corrected on 2026-08-19, when
-this line still read *four measured* and counted `privileged-mcp-action-v0` among
-them. The tool had been printing `FAIL: nothing was measured` for that corpus the
-whole time; the summary above it had rounded up anyway.
+**Four measured, one control-only, one not measurable.** Stated rather than
+rounded up — and this line has now been wrong in both directions on the same day.
+It read *four measured* while `privileged-mcp-action-v0` was scoring nothing; it
+was corrected to *three*; and it is four again only because that corpus was then
+declared properly and finally produced a number. The number is 50%, which is the
+worst result on this page. Both corrections are left visible, because a table
+whose purpose is to publish unflattering results should show its own edits.
+
+### The v0 survivors are one gap wearing four faces
+
+Worth stating separately because it changes what closing them costs. The four
+survivors in `privileged-mcp-action-v0` are not four independent oversights; they
+are four instances of the same construction habit. Every one of them is a *sibling*
+of a rule the corpus does catch, sitting on the same code path:
+
+| the corpus discriminates | it does not discriminate | shared path |
+|---|---|---|
+| `decisions.len() != 1` (`bad-103`) | `observations.len() > 1`, `establishes.len() > 1` | Stage 2 cardinality |
+| decision `action.target_digest` (`bad-102`) | observation `caller_visible_response_digest` | `is_sha256_digest` |
+| binding on `target_digest` (`bad-105`) | binding on `tool_name` | the same `&&` chain |
+| marker `schema` + `code` | marker `origin` (the known hole) | the same triple match |
+
+The corpus was built one vector per failure *mode*. Each mode's siblings share the
+structure but never got a vector, so an implementer can drop the second member of
+any of these pairs and reproduce all fourteen outcomes.
+
+That the pattern is uniform is the useful part: it says the fix is not fourteen
+judgement calls but one rule — **for every conjunct and every sibling member, ask
+whether a vector isolates it** — and it says the same audit is worth running against
+the other corpora on this page before trusting their scores. Note that our own tree
+catches all four; this is about what the corpus can transmit, not about what we ship.
+
+Not fixed here. Every one of these needs a new vector, and a new vector moves a
+digest that [#1840](https://github.com/Rul1an/assay/issues/1840) has published as a
+reproduction target. Whether that is answered by an addendum corpus at a second
+digest, or by leaving v0 pinned and honest, is a contract decision rather than a
+tooling one.
 
 ### Why `rfc8785` has a control and no declared rules
 

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
   "runner": "process",
-  "_about": "Mutation adequacy for privileged-mcp-action/v0. ONE genuine hole: the origin leg of the v0 marker triple is promised and unexercised. Two further rules were declared and are NOT holes -- they mutate the wrong stage and the wrong profile -- and are marked out_of_scope with that reasoning rather than dropped, so the mistake stays visible. Independently classified by Ruley against docs/profiles/privileged-mcp-action/v0.md \u00a75 and the Stage 2/3 architecture.",
+  "_about": "Mutation adequacy for privileged-mcp-action/v0. First pass declared THREE rules and scored nothing: one genuine hole (the origin leg) and two that mutate the wrong stage and the wrong profile, kept out_of_scope with that reasoning rather than dropped. A corpus of 14 vectors that yields no adequacy result is a signal about the DECLARATION, not about the corpus -- so eight further rules were declared, read off the verifier path rather than off the vector names.",
   "repo_root": "../..",
   "implementation_sources": [
     "../../crates/assay-evidence/src/denial_marker.rs",
@@ -53,6 +53,46 @@
         "replacement": "(DENIED_CALL_OBSERVATION_V1, _, PROXY_ORIGIN)",
         "scope": "out_of_scope",
         "reason": "WRONG PROFILE, not a hole. The v1 schema / -31999 pairing is Stage 3 of v1.md. v0's rule for a v1 schema is the opposite of pairing: unrecognised, therefore invalid. Under v0 selection a .v1 payload never enters observations, so the V1 arm of the match is unreachable here. Its survival does not mean a stranger can ignore the v1 pairing and reproduce the v0 digest; it means the v0 corpus never presents that pairing. The v1 corpus already covers it (ok-003-cross-pair-inert)."
+      },
+      {
+        "label": "3 exactly one decision record",
+        "anchor": "if decisions.len() != 1 {",
+        "replacement": "if false {"
+      },
+      {
+        "label": "4 at most one observation record",
+        "anchor": "if observations.len() > 1 {",
+        "replacement": "if false {"
+      },
+      {
+        "label": "5 at most one establish record",
+        "anchor": "if establishes.len() > 1 {",
+        "replacement": "if false {"
+      },
+      {
+        "label": "6 the decision target digest must be a well-formed sha256",
+        "anchor": "if !digest.map(is_sha256_digest).unwrap_or(false) {\n        violations.push(finding(\n            \"target_digest_missing\",",
+        "replacement": "if false {\n        violations.push(finding(\n            \"target_digest_missing\","
+      },
+      {
+        "label": "7 the observation response digest must be a well-formed sha256",
+        "anchor": "if !digest.map(is_sha256_digest).unwrap_or(false) {\n        violations.push(finding(\n            \"observation_response_digest\",",
+        "replacement": "if false {\n        violations.push(finding(\n            \"observation_response_digest\","
+      },
+      {
+        "label": "8 fail_closed must equal (decision == deny)",
+        "anchor": "if fc != (d == \"deny\") {",
+        "replacement": "if false {"
+      },
+      {
+        "label": "9 the marker must bind on the tool-name leg",
+        "anchor": "if obs_tool.is_some() && obs_tool == dec_tool && Some(obs_digest) == dec_digest {",
+        "replacement": "if obs_tool.is_some() && Some(obs_digest) == dec_digest {"
+      },
+      {
+        "label": "10 the marker must bind on the target-digest leg",
+        "anchor": "if obs_tool.is_some() && obs_tool == dec_tool && Some(obs_digest) == dec_digest {",
+        "replacement": "if obs_tool.is_some() && obs_tool == dec_tool {"
       },
       {
         "label": "CONTROL harness reachability on the verifier path",

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -69,8 +69,10 @@
     "sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342": [
       {
         "label": "1 the origin must be the proxy",
-        "reason": "v0 Stage 3 promises an observation is a marker only if ALL THREE legs hold: schema, code AND origin == assay-proxy. No vector among the 14 is a well-formed v0 observation whose only defect is a wrong origin, so deleting the third leg cannot move a pinned outcome. This is a genuine, profile-promised, unexercised check. Recorded rather than fixed because adding a vector moves a digest that is a published contract carried by assay#1840.",
-        "recorded": "2026-08-19"
+        "reason": "v0 Stage 3 promises an observation is a marker only if ALL THREE legs hold: schema, code AND origin == assay-proxy, and it spells out the consequence -- an observation that is well-formed but fails the triple is valid and inert. No vector among the 14 is a well-formed v0 observation whose only defect is a wrong origin, so deleting the third leg cannot move a pinned outcome. THE GAP IS IN THE CORPUS, NOT IN THE IMPLEMENTATION. Our own tree does exercise this leg, in crates/assay-evidence/tests/denial_marker_classifier.rs::wrong_origin_is_inert, for v0 and v1 both. What the corpus cannot do is TRANSMIT the requirement: a stranger reimplementing from the published vectors plus v0.md gets no vector that fails if they skip the origin leg, and still reproduces the pinned digest. Recorded rather than fixed because adding a vector moves a digest that is a published contract carried by assay#1840.",
+        "recorded": "2026-08-19",
+        "exercised_outside_corpus": "crates/assay-evidence/tests/denial_marker_classifier.rs::wrong_origin_is_inert",
+        "corrected": "2026-08-19"
       }
     ]
   }

--- a/conformance/adequacy/rfc8785-canonicalization.manifest.json
+++ b/conformance/adequacy/rfc8785-canonicalization.manifest.json
@@ -1,0 +1,36 @@
+{
+  "schema": "corpus-adequacy.manifest.v0",
+  "runner": "batch",
+  "outcome_parse": "test-names",
+  "_about": "Mutation adequacy for the RFC 8785 (JCS) conformance corpus. Every content id, mandate id and bundle run root in this workspace is a sha256 over the bytes this canonicalizer emits, so a divergence makes those digests irreproducible by any other implementation. THE CONTROL IS NOT INVENTED HERE: rfc8785_conformance.rs documents it in prose at the top of the file -- swap serde_jcs::to_vec for serde_json::to_vec and at least 8 vectors must fail, keyorder_utf16_vs_codepoint among them. That property was written down so it would stay checkable rather than remembered. This runs it.",
+  "repo_root": "../..",
+  "implementation_sources": [
+    "../../crates/assay-canonical/src/jcs.rs"
+  ],
+  "build": [],
+  "entrypoint_command": [
+    "cargo",
+    "test",
+    "-p",
+    "assay-canonical",
+    "--test",
+    "rfc8785_conformance",
+    "--",
+    "--nocapture"
+  ],
+  "vectors": "../../crates/assay-canonical/tests/vectors/rfc8785.json",
+  "id_key": "vector_id",
+  "default_group": "jcs_canonicalization",
+  "vector_timeout": 900,
+  "mutants": {
+    "jcs_canonicalization": [
+      {
+        "label": "CONTROL the corpus still bites (serde_json instead of serde_jcs)",
+        "control": true,
+        "anchor": "serde_jcs::to_vec(value)",
+        "replacement": "serde_json::to_vec(value)"
+      }
+    ]
+  },
+  "equivalent": {}
+}


### PR DESCRIPTION
`crates/assay-canonical/tests/rfc8785_conformance.rs` states its own adequacy check in prose at the top of the file:

> **To confirm this corpus still bites**, swap `serde_jcs::to_vec` for `serde_json::to_vec` in `src/jcs.rs` and run this file. At least 8 vectors must fail, and `keyorder_utf16_vs_codepoint` must be among them […] A corpus that survives that substitution is measuring nothing, and the property is written here rather than left in a pull request description **so it stays checkable rather than remembered**.

**It was remembered, not checked.** Run for the first time on 2026-08-19 it holds exactly:

```
8 of 31 RFC 8785 vectors diverged:
[keyorder_utf16_vs_codepoint]
     got: "{"\u{e000}":"bmp U+E000","𐀀":"non-bmp U+10000"}"
  wanted: "{"𐀀":"non-bmp U+10000","\u{e000}":"bmp U+E000"}"
    pins: DECISIVE: sorting is by UTF-16 code unit […]
```

That paragraph is now an executable manifest rather than an instruction nobody runs.

## Why this corpus declares a control and no rules

`src/jcs.rs` is a **thin wrapper**: it delegates to `serde_jcs` and declares almost no rules of its own. Rule-deletion mutation therefore does not apply the way it does to a corpus with its own logic — there is nothing of ours to delete.

The question for a delegating wrapper is different: **does the corpus catch a wrong delegate?** That is precisely what the documented control asks, which is why the control is the corpus's own and not one I invented for the measurement.

## What this does NOT establish, stated so it is not assumed

The control shows the corpus bites against **one** wrong implementation. Whether it bites against the other plausible ones — sorting by code point, sorting by UTF-8 bytes, skipping number normalisation, escaping the solidus — is a question about **RFC 8785 coverage** rather than about our code, and it is open.

An independent crosswalk against the RFC is requested separately, deliberately derived from the RFC rather than from our implementation: declaring the rules from our own code is how I got two of three wrong on another corpus earlier today.

`conformance/INDEX.md` records the distinction so a reader does not take the control for coverage.

## Upstream

Needs `corpus-adequacy` at `ff9466f` or later, which adds a **test-names** outcome mode: a corpus whose checker is a test binary is measured by *which tests failed*. A bare pass/fail would make every mutant kill everything or nothing. The mode also refuses a run whose filter selected no tests, since that exits 0 and would read as agreement.

## Verification

```
python3 ../corpus-adequacy/corpus_adequacy.py \
  conformance/adequacy/rfc8785-canonicalization.manifest.json
```

Exit 1 — control killed, no rules scored, and the report says so rather than reporting a score it did not earn. `crates/` clean after the run; the source guard restores `jcs.rs`.

---

## Two corrections the run exposed, both mine, both published

Re-running `privileged-mcp-action-v0` while writing the section above surfaced two overstatements already sitting in `conformance/INDEX.md`. Neither was found by re-reading prose; both were found by running the tool and reading what it actually said.

**1. "Four measured" counted a corpus with no result.**

```
0 of 0 DECLARED in-scope rules killed (no result). 0 declared equivalent,
2 declared out of scope, 0 unproved. 3 rules declared in total.
FAIL: nothing was measured: every declared in-scope rule is either a known
hole, declared equivalent or out of scope. There is no adequacy result here
```

Exit 1. All three declared rules of `privileged-mcp-action-v0` are a known hole or out of scope, so nothing was measured — and the tool had been printing exactly that under a summary line that rounded up anyway. **The corpus carrying our most public reproduction request (#1840) is the one this tool can say least about.** The count is now three, and the summary line says it was wrong rather than quietly reading right.

**2. The origin-leg hole was called an "unexercised check". It is exercised.**

`crates/assay-evidence/tests/denial_marker_classifier.rs::wrong_origin_is_inert` covers it, for v0 and v1 both. The gap is in what the corpus can **transmit**: a reimplementer working from the 14 published vectors plus `v0.md` §5 Stage 3 gets no vector that fails if they skip the origin leg, and reproduces the pinned digest regardless. Our implementation is right; our corpus cannot ask a stranger to be right. That is a different fact, and the one this project exists to measure.

`"unexercised"` is now bound once above the table rather than qualified per row.

---

## And then the null result turned out to be a fact about my declaration

Writing the correction above raised the obvious question: is `privileged-mcp-action-v0` really unmeasurable, or did I declare the wrong rules? My record on that corpus was one of three. The 14 vector names — `bad-103-two-decisions`, `bad-105-observation-binding-mismatch`, `bad-106-fail-closed-inconsistent` — practically announce the rules, and the verifier had at least eight more that nothing had been declared for.

Eight were declared, read off the verifier path rather than off the vector names:

```
4 of 8 DECLARED in-scope rules killed (50.0%). 0 declared equivalent,
2 declared out of scope, 0 unproved. 11 rules declared in total.
FAIL: 4 mutant(s) survived; the required score is 100% of non-equivalent mutants
```

**50%, the worst result on the page, on the corpus carrying our live reproduction request.**

### The four survivors are one gap wearing four faces

Each is the *sibling* of a rule the corpus does catch, sitting on the same code path:

| discriminated | not discriminated | shared path |
|---|---|---|
| `decisions.len() != 1` (`bad-103`) | `observations.len() > 1`, `establishes.len() > 1` | Stage 2 cardinality |
| decision `action.target_digest` (`bad-102`) | observation `caller_visible_response_digest` | `is_sha256_digest` |
| binding on `target_digest` (`bad-105`) | binding on `tool_name` | the same `&&` chain |
| marker `schema` + `code` | marker `origin` (the known hole) | the same triple match |

That mutant 9 survives while mutant 10 dies is what pins the reading rather than leaving it a story: `bad-105` diverges on the digest, so no vector ever isolates the tool-name leg.

The corpus was built one vector per failure *mode*, and every mode has siblings on the same path that never got a vector. The uniformity is the useful part — the fix is one rule (**for every conjunct and every sibling member, ask whether a vector isolates it**) rather than four judgement calls, and the same audit is owed to the other corpora on this page before their scores are trusted.

**Not fixed here.** Each of these needs a new vector, and a new vector moves a digest that #1840 publishes as a reproduction target. Addendum corpus at a second digest, or v0 left pinned and honest, is a contract decision rather than a tooling one.

### Upstream, same session

`corpus-adequacy@75a6b93` now says what a null result licenses you to conclude, because I read my own output wrong: *"A null result is a statement about the DECLARATION before it is one about the corpus."* Both branches pinned by tests; reverting either sentence fails its test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded conformance guidance with clearer definitions for mutation adequacy and coverage.
  - Added detailed measurements for privileged action validation and RFC 8785 canonicalization.
  - Updated the overall adequacy status and documented known coverage limitations.

- **Tests**
  - Added mutation checks covering record counts, digests, fail-closed behavior, tool names, and target-digest binding.
  - Added RFC 8785 vector-based canonicalization conformance testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->