### PR TITLE
test(cli): pin the CLI JSON document inventory and fail the build on drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `docs/architecture/CLI-JSON-IDENTITIES.md` records which `assay.<segments>.vN` identities
+  ship and which of them are CLI JSON documents. `cli_json_identities.rs` fails the build when
+  source and record disagree, including for the nine documents that carry no identity at all
+  and which no source scan can see; three of those twelve were found only by an independent
+  read, after two separately written inventories missed them (#2484, #2167).
 - `assay describe [path...]` walks the clap command tree so a caller can ask
   for the top-level surface and descend. Node identities are the existing
   shipping constants, not a second registry. Global `--quiet` /

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -32,6 +32,31 @@ const INVENTORY: &str = "docs/architecture/CLI-JSON-IDENTITIES.md";
 /// class of mistake this file exists to catch.
 const SCANNED: &[&str] = &["crates/assay-cli/src", "crates/assay-core/src"];
 
+/// Crates `assay-cli` depends on. Their `pub const` identities must be classified too.
+///
+/// Following each write by hand does not notice the next one. `trust-basis.diff` was found that
+/// way, and then `runner.observation_health` shipped unrecorded anyway: its string appears in
+/// `assay-cli` only inside a `//!` comment and a `#[cfg(test)]` assertion, so nothing here could
+/// see it. Requiring every published identity in the import graph to be classified turns the next
+/// such crate into a red instead of a review comment.
+///
+/// Only `pub const` in these crates, never every literal: scanning their full source would flood
+/// the partition with kernel events and mandate events that no command has any relationship to.
+const DEPENDENCY_CRATES: &[&str] = &[
+    "crates/assay-canonical/src",
+    "crates/assay-common/src",
+    "crates/assay-evidence/src",
+    "crates/assay-mcp-server/src",
+    "crates/assay-metrics/src",
+    "crates/assay-monitor/src",
+    "crates/assay-policy/src",
+    "crates/assay-registry/src",
+    "crates/assay-runner-core/src",
+    "crates/assay-runner-linux/src",
+    "crates/assay-runner-schema/src",
+    "crates/assay-sim/src",
+];
+
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
@@ -98,12 +123,12 @@ fn non_document_rows() -> BTreeMap<String, String> {
 /// rather than by a path or filename rule, because `supply_chain_conformance/tests.rs` is a file
 /// named `tests.rs` that sits in `src/`: any name-based rule has to decide it, and deciding it
 /// wrongly is silent in both directions.
-fn strip_test_modules(src: &str) -> String {
+fn strip_test_modules_at(src: &str, whose: &str) -> String {
     let mut out = String::with_capacity(src.len());
     let mut rest = src;
     while let Some((attr, body)) = find_test_mod(rest) {
         out.push_str(&rest[..attr]);
-        rest = &rest[skip_balanced(rest, body)..];
+        rest = &rest[skip_balanced(rest, body, whose)..];
     }
     out.push_str(rest);
     out
@@ -140,7 +165,7 @@ fn find_test_mod(src: &str) -> Option<(usize, usize)> {
 /// Braces inside string literals, char literals and comments are not braces. Counting them was
 /// this function's first bug: a production file containing `"{"` made the depth never reach zero,
 /// and the failure surfaced as an assertion about unbalanced source rather than as a wrong answer.
-fn skip_balanced(src: &str, from: usize) -> usize {
+fn skip_balanced(src: &str, from: usize, whose: &str) -> usize {
     let bytes = src.as_bytes();
     let mut i = from;
     let mut depth = 1usize;
@@ -166,7 +191,10 @@ fn skip_balanced(src: &str, from: usize) -> usize {
         }
         i += 1;
     }
-    assert_eq!(depth, 0, "a `#[cfg(test)] mod` block is never closed");
+    assert_eq!(
+        depth, 0,
+        "a `#[cfg(test)] mod` block is never closed in {whose}"
+    );
     i
 }
 
@@ -179,7 +207,12 @@ fn skip_string(bytes: &[u8], open: usize) -> usize {
         hashes += 1;
         back -= 1;
     }
-    let raw = hashes > 0 && back > 0 && bytes[back - 1] == b'r';
+    // `r"…"` with zero hashes is raw too. Treating it as escaped was this scanner's second bug:
+    // `assay-evidence`'s glob tests contain `r"test\\"`, a raw string ending in a backslash, and
+    // reading that backslash as an escape ran the scan past the closing quote and off the end of
+    // the module. It surfaced as "a `#[cfg(test)] mod` block is never closed", which is at least a
+    // loud failure rather than a wrong answer — the same luck as the first brace bug.
+    let raw = back > 0 && bytes[back - 1] == b'r';
     let mut i = open + 1;
     if raw {
         while i < bytes.len() {
@@ -335,9 +368,14 @@ fn identities_in_source() -> BTreeMap<String, String> {
                     }
                     let src = std::fs::read_to_string(&p)
                         .unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
-                    let src = strip_test_modules(&src);
+                    let src = strip_test_modules_at(&src, &p.display().to_string());
                     for (lineno, line) in src.lines().enumerate() {
-                        if line.trim_start().starts_with("//") {
+                        // Trailing comments too, not only whole-line ones. `let x = 1; //
+                        // "assay.foo.v0"` would otherwise be collected as a producer. No instance
+                        // exists on this head; the hole was pointed out before one did, which is
+                        // the only time it is cheap to close.
+                        let line = code_before_comment(line);
+                        if line.trim().is_empty() {
                             continue;
                         }
                         for ident in identities_in_line(line) {
@@ -351,11 +389,73 @@ fn identities_in_source() -> BTreeMap<String, String> {
             }
         }
     }
+    for (identity, site) in published_identities_in_dependencies() {
+        found.entry(identity).or_insert(site);
+    }
     assert!(
         !found.is_empty(),
         "collected no identities; the scan shape moved"
     );
     found
+}
+
+/// `pub const NAME: &str = "assay.…vN"` in every crate `assay-cli` depends on.
+fn published_identities_in_dependencies() -> BTreeMap<String, String> {
+    let root = workspace_root();
+    let mut found = BTreeMap::new();
+    for dir in DEPENDENCY_CRATES {
+        let base = root.join(dir);
+        if !base.exists() {
+            continue;
+        }
+        let mut stack = vec![base];
+        while let Some(path) = stack.pop() {
+            for entry in std::fs::read_dir(&path).expect("read_dir") {
+                let p = entry.expect("dir entry").path();
+                if p.is_dir() {
+                    stack.push(p);
+                    continue;
+                }
+                if p.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let src = strip_test_modules_at(
+                    &std::fs::read_to_string(&p).expect("read"),
+                    &p.display().to_string(),
+                );
+                for (lineno, line) in src.lines().enumerate() {
+                    let line = code_before_comment(line);
+                    if !line.trim_start().starts_with("pub const ") {
+                        continue;
+                    }
+                    for identity in identities_in_line(line) {
+                        let rel = p.strip_prefix(&root).unwrap_or(&p).display();
+                        found
+                            .entry(identity)
+                            .or_insert_with(|| format!("{rel}:{}", lineno + 1));
+                    }
+                }
+            }
+        }
+    }
+    found
+}
+
+/// The part of a line before a `//` that is not inside a string literal.
+fn code_before_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut i = 0usize;
+    let mut in_string = false;
+    while i + 1 < bytes.len() {
+        match bytes[i] {
+            b'\\' if in_string => i += 1,
+            b'"' => in_string = !in_string,
+            b'/' if !in_string && bytes[i + 1] == b'/' => return &line[..i],
+            _ => {}
+        }
+        i += 1;
+    }
+    line
 }
 
 /// `"assay.…vN"` literals on one line.
@@ -412,6 +512,9 @@ const WRITERS: &[&str] = &[
     "std::fs::write",
     "tokio::fs::write",
     "fs::write",
+    "write_document",
+    "write_all",
+    "writeln!",
     "println!",
 ];
 

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -773,3 +773,56 @@ fn constant_names_for(identity: &str) -> Vec<String> {
     }
     names
 }
+
+/// `DEPENDENCY_CRATES` is the `assay-*` dependency list of `assay-cli`, not a list someone typed.
+///
+/// The const-in-dependencies rule is only as tight as this array. Adding `assay-new` to the
+/// manifest and forgetting it here is the sixth crate, invisible again, with every other test
+/// green — the same hole the rule was written to close, one level up. A review pointed that out
+/// before it happened, which is the only time it costs one function.
+#[test]
+fn dependency_crates_match_the_manifest() {
+    let manifest = read("crates/assay-cli/Cargo.toml");
+    let deps = manifest
+        .split_once("\n[dependencies]")
+        .expect("assay-cli manifest has no [dependencies] section")
+        .1;
+    let deps = deps.split_once("\n[").map(|(head, _)| head).unwrap_or(deps);
+
+    let mut declared = BTreeSet::new();
+    for line in deps.lines() {
+        // `assay-core.workspace = true` and `assay-policy = { … }` are both dependency lines, and
+        // a crate name never contains a dot, so the key ends at the first `.`, `=` or space.
+        let name = line.split(['.', '=', ' ']).next().unwrap_or("").trim();
+        if name.starts_with("assay-") {
+            declared.insert(name.to_string());
+        }
+    }
+    assert!(
+        !declared.is_empty(),
+        "parsed no assay-* dependencies; the manifest shape moved"
+    );
+
+    // `assay-core` is scanned in full by SCANNED, so it is not in the pub-const-only list.
+    let separately_scanned: BTreeSet<String> = SCANNED
+        .iter()
+        .filter_map(|dir| dir.strip_prefix("crates/"))
+        .filter_map(|rest| rest.strip_suffix("/src"))
+        .map(str::to_string)
+        .collect();
+
+    let listed: BTreeSet<String> = DEPENDENCY_CRATES
+        .iter()
+        .filter_map(|dir| dir.strip_prefix("crates/"))
+        .filter_map(|rest| rest.strip_suffix("/src"))
+        .map(str::to_string)
+        .collect();
+
+    let expected: BTreeSet<String> = declared.difference(&separately_scanned).cloned().collect();
+    assert_eq!(
+        listed, expected,
+        "DEPENDENCY_CRATES has drifted from assay-cli/Cargo.toml. Every assay-* dependency is \
+         either scanned in full (SCANNED) or scanned for pub const identities (DEPENDENCY_CRATES); \
+         a dependency in neither is a crate whose published identities nothing classifies"
+    );
+}

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -1,0 +1,456 @@
+//! The CLI JSON identity inventory in `docs/architecture/CLI-JSON-IDENTITIES.md` is checked here.
+//!
+//! #2167 settled one convention for public CLI JSON documents: the discriminator is `schema`,
+//! carrying `assay.<segments>.vN`. Nothing held the *set* of those identities together — an
+//! emitter could arrive and no record would notice, which is how two counts of that set were
+//! published and withdrawn before this guard existed.
+//!
+//! Three properties, and the third is the one that matters:
+//!
+//! 1. Every identity string in production source is recorded, in the block that says what it is.
+//!    The two blocks are a partition, so "in neither" is a failure rather than a silence.
+//! 2. An identity written as an inline literal counts. Seven shipping verify-report documents are
+//!    declared that way, so a `const`-only collector would be satisfied by a coding convention
+//!    this codebase does not follow.
+//! 3. Documents that carry *no* identity are required rows. Measured: coverage, session-state
+//!    window, soak, `Baseline`, `HygieneReport`, both `run.json` writers, the sim-run report and
+//!    SARIF have zero identity constants between them. A pin built from a source scan alone
+//!    satisfies (1) and (2) while omitting every document #2485 has to migrate, and stays green.
+//!
+//! The inventory is never generated — not in CI and not locally-then-committed. This test reads it
+//! and never writes it.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+const INVENTORY: &str = "docs/architecture/CLI-JSON-IDENTITIES.md";
+
+/// Crates whose production sources are scanned.
+///
+/// Both crates entirely, not a subdirectory of either. Scoping to `assay-core/src/report` hid
+/// `assay.run_report.v1`'s siblings under `mcp/`, `otel/` and `discovery/`, which is the same
+/// class of mistake this file exists to catch.
+const SCANNED: &[&str] = &["crates/assay-cli/src", "crates/assay-core/src"];
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn read(rel: &str) -> String {
+    let path = workspace_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// The lines recorded under a `<!-- machine-checked: NAME -->` marker.
+///
+/// Anchored on an HTML comment rather than a heading, so the prose can be rewritten without
+/// silently changing what is checked.
+fn recorded(marker: &str) -> Vec<String> {
+    let doc = read(INVENTORY);
+    let needle = format!("<!-- machine-checked: {marker} -->");
+    let after = doc
+        .split_once(&needle)
+        .unwrap_or_else(|| panic!("{INVENTORY} has no `{needle}` marker"))
+        .1;
+    let block = after
+        .split_once("```text\n")
+        .unwrap_or_else(|| panic!("marker `{marker}` is not followed by a ```text block"))
+        .1;
+    let block = block
+        .split_once("\n```")
+        .unwrap_or_else(|| panic!("marker `{marker}` block is unterminated"))
+        .0;
+    block
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn recorded_set(marker: &str) -> BTreeSet<String> {
+    let mut set = BTreeSet::new();
+    for line in recorded(marker) {
+        assert!(
+            set.insert(line.clone()),
+            "{INVENTORY}: `{marker}` records {line:?} twice"
+        );
+    }
+    set
+}
+
+/// Source with `#[cfg(test)] mod … { … }` bodies removed.
+///
+/// A test module inside a production file is not a producer. It is removed by brace matching
+/// rather than by a path or filename rule, because `supply_chain_conformance/tests.rs` is a file
+/// named `tests.rs` that sits in `src/`: any name-based rule has to decide it, and deciding it
+/// wrongly is silent in both directions.
+fn strip_test_modules(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut rest = src;
+    while let Some((attr, body)) = find_test_mod(rest) {
+        out.push_str(&rest[..attr]);
+        rest = &rest[skip_balanced(rest, body)..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// `(offset of `#[cfg(test)]`, offset just past its `mod … {`)`, if the attribute introduces a
+/// module. An attribute on anything else — a `fn`, a `use` — is left alone.
+fn find_test_mod(src: &str) -> Option<(usize, usize)> {
+    const ATTR: &str = "#[cfg(test)]";
+    let mut from = 0usize;
+    while let Some(rel) = src[from..].find(ATTR) {
+        let attr = from + rel;
+        let after = &src[attr + ATTR.len()..];
+        let trimmed = after.trim_start();
+        if let Some(tail) = trimmed.strip_prefix("mod ") {
+            if let Some(brace) = tail.find('{') {
+                if tail[..brace]
+                    .trim()
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_')
+                {
+                    let consumed = after.len() - trimmed.len() + "mod ".len() + brace + 1;
+                    return Some((attr, attr + ATTR.len() + consumed));
+                }
+            }
+        }
+        from = attr + ATTR.len();
+    }
+    None
+}
+
+/// Offset just past the `}` that closes the block whose body starts at `from`.
+///
+/// Braces inside string literals, char literals and comments are not braces. Counting them was
+/// this function's first bug: a production file containing `"{"` made the depth never reach zero,
+/// and the failure surfaced as an assertion about unbalanced source rather than as a wrong answer.
+fn skip_balanced(src: &str, from: usize) -> usize {
+    let bytes = src.as_bytes();
+    let mut i = from;
+    let mut depth = 1usize;
+    while i < bytes.len() && depth > 0 {
+        match bytes[i] {
+            b'{' => depth += 1,
+            b'}' => depth -= 1,
+            b'"' => i = skip_string(bytes, i),
+            b'\'' => i = skip_char(bytes, i),
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i += 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    assert_eq!(depth, 0, "a `#[cfg(test)] mod` block is never closed");
+    i
+}
+
+/// Offset of the closing quote of the string literal opening at `open`. Raw strings included:
+/// `r#"…"#` bodies may contain unescaped quotes and braces.
+fn skip_string(bytes: &[u8], open: usize) -> usize {
+    let mut hashes = 0usize;
+    let mut back = open;
+    while back > 0 && bytes[back - 1] == b'#' {
+        hashes += 1;
+        back -= 1;
+    }
+    let raw = hashes > 0 && back > 0 && bytes[back - 1] == b'r';
+    let mut i = open + 1;
+    if raw {
+        while i < bytes.len() {
+            if bytes[i] == b'"' && bytes[i + 1..].iter().take(hashes).all(|b| *b == b'#') {
+                return i + hashes;
+            }
+            i += 1;
+        }
+        return bytes.len();
+    }
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 1,
+            b'"' => return i,
+            _ => {}
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+/// Offset of the closing quote of a char literal, or `open` itself when the quote is a lifetime.
+fn skip_char(bytes: &[u8], open: usize) -> usize {
+    let mut i = open + 1;
+    if bytes.get(i) == Some(&b'\\') {
+        i += 1;
+    }
+    match bytes.get(i + 1) {
+        Some(b'\'') => i + 1,
+        _ => open,
+    }
+}
+
+/// Every `"assay.<segments>.vN"` string literal in production source, with one citing site.
+///
+/// Both `const NAME: &str = "…"` and inline literals, because the codebase writes both and the
+/// difference is a style choice rather than a property of the document.
+fn identities_in_source() -> BTreeMap<String, String> {
+    let root = workspace_root();
+    let mut found: BTreeMap<String, String> = BTreeMap::new();
+    for dir in SCANNED {
+        let base = root.join(dir);
+        let mut stack = vec![base.clone()];
+        while let Some(path) = stack.pop() {
+            let entries = std::fs::read_dir(&path)
+                .unwrap_or_else(|e| panic!("read_dir {}: {e}", path.display()));
+            for entry in entries {
+                let entry = entry.expect("dir entry");
+                let p = entry.path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    let src = std::fs::read_to_string(&p)
+                        .unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+                    let src = strip_test_modules(&src);
+                    for (lineno, line) in src.lines().enumerate() {
+                        if line.trim_start().starts_with("//") {
+                            continue;
+                        }
+                        for ident in identities_in_line(line) {
+                            let rel = p.strip_prefix(&root).unwrap_or(&p).display();
+                            found
+                                .entry(ident)
+                                .or_insert_with(|| format!("{rel}:{}", lineno + 1));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        !found.is_empty(),
+        "collected no identities; the scan shape moved"
+    );
+    found
+}
+
+/// `"assay.…vN"` literals on one line.
+///
+/// A trailing `.v<digits>` segment is required, so a prefix constant such as `"assay.receipt."`
+/// is not mistaken for an identity.
+fn identities_in_line(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = line.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] != b'"' {
+            i += 1;
+            continue;
+        }
+        let start = i + 1;
+        let Some(rel_end) = line[start..].find('"') else {
+            break;
+        };
+        let literal = &line[start..start + rel_end];
+        i = start + rel_end + 1;
+        if !literal.starts_with("assay.") {
+            continue;
+        }
+        let Some(last) = literal.rsplit('.').next() else {
+            continue;
+        };
+        let is_generation = last.len() > 1
+            && last.starts_with('v')
+            && last[1..].chars().all(|c| c.is_ascii_digit());
+        if !is_generation {
+            continue;
+        }
+        if literal
+            .chars()
+            .any(|c| !(c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-'))
+        {
+            continue;
+        }
+        out.push(literal.to_string());
+    }
+    out
+}
+
+/// Every identity in source is recorded as a document or as not-a-document, and nothing else is.
+#[test]
+fn every_production_identity_is_classified() {
+    let documents = recorded_set("cli-documents");
+    let others = recorded_set("not-cli-documents");
+
+    let overlap: Vec<_> = documents.intersection(&others).cloned().collect();
+    assert!(
+        overlap.is_empty(),
+        "{INVENTORY}: these are recorded as both a document and not a document: {overlap:?}"
+    );
+
+    let in_source = identities_in_source();
+    let recorded: BTreeSet<String> = documents.union(&others).cloned().collect();
+    let collected: BTreeSet<String> = in_source.keys().cloned().collect();
+
+    let unrecorded: Vec<String> = collected
+        .difference(&recorded)
+        .map(|id| format!("{id} ({})", in_source[id]))
+        .collect();
+    assert!(
+        unrecorded.is_empty(),
+        "these identities ship but are in neither block of {INVENTORY}. Add each one to the block \
+         that says what it is — a document a CLI command emits, or an event / nested object / \
+         input / digest domain:\n  {}",
+        unrecorded.join("\n  ")
+    );
+
+    let stale: Vec<_> = recorded.difference(&collected).cloned().collect();
+    assert!(
+        stale.is_empty(),
+        "{INVENTORY} records identities that no longer appear in production source: {stale:?}"
+    );
+}
+
+/// Documents with no identity string are required rows, and each row still names something real.
+///
+/// Without this, the guard is satisfied by a source scan — and a source scan cannot see any of the
+/// documents #2485 migrates, because not one of them has an identity constant.
+#[test]
+fn documents_without_an_identity_are_recorded_and_still_exist() {
+    const REQUIRED: &[&str] = &[
+        "baseline",
+        "baseline_diff",
+        "coverage_report",
+        "discover_inventory",
+        "hygiene_report",
+        "run_json_extended",
+        "run_json_minimal",
+        "sarif",
+        "session_state_window",
+        "sim_run_report",
+        "soak_report",
+        "trust_basis_generate",
+    ];
+
+    let mut rows: BTreeMap<String, (String, String)> = BTreeMap::new();
+    for line in recorded("unnamed-documents") {
+        let parts: Vec<&str> = line.split('|').map(str::trim).collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "{INVENTORY}: `unnamed-documents` row is not `key | producer | token`: {line:?}"
+        );
+        assert!(
+            rows.insert(
+                parts[0].to_string(),
+                (parts[1].to_string(), parts[2].to_string())
+            )
+            .is_none(),
+            "{INVENTORY}: duplicate `unnamed-documents` key {:?}",
+            parts[0]
+        );
+    }
+
+    let recorded_keys: BTreeSet<&str> = rows.keys().map(String::as_str).collect();
+    let required: BTreeSet<&str> = REQUIRED.iter().copied().collect();
+
+    let missing: Vec<_> = required.difference(&recorded_keys).collect();
+    assert!(
+        missing.is_empty(),
+        "{INVENTORY} is missing required rows for documents that carry no identity: {missing:?}. \
+         These cannot be collected from source, so dropping the row would leave no trace."
+    );
+    let unexpected: Vec<_> = recorded_keys.difference(&required).collect();
+    assert!(
+        unexpected.is_empty(),
+        "{INVENTORY} records unnamed documents this test does not require: {unexpected:?}. Add \
+         them to REQUIRED in the same commit, so the row cannot be dropped later without failing."
+    );
+
+    for (key, (producer, token)) in &rows {
+        let path = workspace_root().join(producer);
+        let src = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            panic!(
+                "{INVENTORY}: row `{key}` names a producer that cannot be read: {producer} ({e})"
+            )
+        });
+        assert!(
+            src.contains(token.as_str()),
+            "{INVENTORY}: row `{key}` says {producer} carries {token:?}, and it does not. The \
+             producer moved; move the row with it."
+        );
+    }
+}
+
+/// `assay describe` may only bind identities the inventory records as documents.
+///
+/// One direction on purpose. `BINDING_ROWS` is a projection of seven clap paths, not the
+/// inventory, and it omits the run report and run summary. That gap is recorded in the inventory
+/// prose rather than enforced here, because forcing `describe` to grow is a product decision and
+/// this test is a bookkeeping guard.
+#[test]
+fn describe_binds_only_recorded_documents() {
+    let documents = recorded_set("cli-documents");
+    let src = read("crates/assay-cli/src/cli/commands/describe/bindings.rs");
+
+    let mut constants = BTreeSet::new();
+    for line in src.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("identity: ") {
+            constants.insert(rest.trim_end_matches(',').to_string());
+        }
+    }
+    assert!(
+        !constants.is_empty(),
+        "parsed no `identity:` bindings; the BINDING_ROWS shape moved"
+    );
+
+    // Resolve each binding constant to its value through the whole scanned source.
+    let mut values = BTreeSet::new();
+    for dir in SCANNED {
+        let base = workspace_root().join(dir);
+        let mut stack = vec![base];
+        while let Some(path) = stack.pop() {
+            for entry in std::fs::read_dir(&path).expect("read_dir") {
+                let p = entry.expect("dir entry").path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    let text = std::fs::read_to_string(&p).expect("read");
+                    for name in &constants {
+                        for line in text.lines() {
+                            if line.contains(&format!("const {name}:")) {
+                                if let Some(v) = identities_in_line(line).into_iter().next() {
+                                    values.insert(v);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        values.len(),
+        constants.len(),
+        "could not resolve every `BINDING_ROWS` identity constant to a literal: {constants:?} \
+         resolved to {values:?}"
+    );
+    let unrecorded: Vec<_> = values.difference(&documents).cloned().collect();
+    assert!(
+        unrecorded.is_empty(),
+        "`assay describe` binds identities the inventory does not record as documents: \
+         {unrecorded:?}"
+    );
+}

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -405,8 +405,13 @@ fn identities_in_line(line: &str) -> Vec<String> {
 const WRITERS: &[&str] = &[
     "write_stdout_json",
     "to_string_pretty",
+    "to_vec_pretty",
     "to_writer",
+    "serde_json::to_string(",
+    "serde_json::to_vec(",
     "std::fs::write",
+    "tokio::fs::write",
+    "fs::write",
     "println!",
 ];
 

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -79,6 +79,30 @@ fn recorded_set(marker: &str) -> BTreeSet<String> {
     set
 }
 
+/// The `not-cli-documents` block, as `identity -> reason`.
+///
+/// The reason is mandatory. A static check cannot tell a document from an event when the naming and
+/// the writing sit in different files, which is true of several of these. What it can do is make a
+/// misclassification require someone to write a false sentence instead of deleting a line.
+fn non_document_rows() -> BTreeMap<String, String> {
+    let mut rows = BTreeMap::new();
+    for line in recorded("not-cli-documents") {
+        let (ident, reason) = line.split_once('|').unwrap_or_else(|| {
+            panic!("{INVENTORY}: `not-cli-documents` row is not `identity | reason`: {line:?}")
+        });
+        let (ident, reason) = (ident.trim(), reason.trim());
+        assert!(
+            !reason.is_empty(),
+            "{INVENTORY}: {ident:?} is recorded as a non-document with no reason"
+        );
+        assert!(
+            rows.insert(ident.to_string(), reason.to_string()).is_none(),
+            "{INVENTORY}: `not-cli-documents` records {ident:?} twice"
+        );
+    }
+    rows
+}
+
 /// Source with `#[cfg(test)] mod … { … }` bodies removed.
 ///
 /// A test module inside a production file is not a producer. It is removed by brace matching
@@ -200,12 +224,110 @@ fn skip_char(bytes: &[u8], open: usize) -> usize {
     }
 }
 
+/// Files that are test-only because a `#[cfg(test)] mod name;` declaration brings them in.
+///
+/// The brace-matching stripper only removes `#[cfg(test)] mod name { … }` written inline. Thirty
+/// modules in these two crates are declared as a bare `#[cfg(test)] mod name;` instead, and their
+/// files sit in `src/` looking exactly like production. Scanning them collected identities that no
+/// shipping code writes — which is the failure this whole file exists to stop, found inside the
+/// guard itself.
+fn test_only_files() -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    let mut queue: Vec<PathBuf> = Vec::new();
+    for dir in SCANNED {
+        let base = workspace_root().join(dir);
+        let mut stack = vec![base];
+        while let Some(path) = stack.pop() {
+            for entry in std::fs::read_dir(&path).expect("read_dir") {
+                let p = entry.expect("dir entry").path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    for name in test_mod_declarations(&std::fs::read_to_string(&p).expect("read")) {
+                        queue.extend(module_files(&p, &name));
+                    }
+                }
+            }
+        }
+    }
+    // A test-only module's own submodules are test-only too.
+    while let Some(file) = queue.pop() {
+        if !out.insert(file.clone()) {
+            continue;
+        }
+        let Ok(src) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        for name in declared_modules(&src) {
+            queue.extend(module_files(&file, &name));
+        }
+    }
+    out
+}
+
+/// `name` for each `#[cfg(test)] mod name;` in this source.
+fn test_mod_declarations(src: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut lines = src.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.trim() != "#[cfg(test)]" {
+            continue;
+        }
+        let Some(next) = lines.peek() else { continue };
+        if let Some(name) = bare_mod_name(next) {
+            names.push(name);
+        }
+    }
+    names
+}
+
+/// `name` for every `mod name;` in this source, cfg-gated or not.
+fn declared_modules(src: &str) -> Vec<String> {
+    src.lines().filter_map(bare_mod_name).collect()
+}
+
+fn bare_mod_name(line: &str) -> Option<String> {
+    let line = line.trim();
+    let rest = line
+        .strip_prefix("mod ")
+        .or_else(|| line.strip_prefix("pub mod "))
+        .or_else(|| line.strip_prefix("pub(crate) mod "))
+        .or_else(|| line.strip_prefix("pub(super) mod "))?;
+    let name = rest.strip_suffix(';')?;
+    name.chars()
+        .all(|c| c.is_alphanumeric() || c == '_')
+        .then(|| name.to_string())
+}
+
+/// The candidate files a `mod name;` inside `declaring` resolves to.
+fn module_files(declaring: &std::path::Path, name: &str) -> Vec<PathBuf> {
+    let dir = if declaring.file_name().and_then(|f| f.to_str()) == Some("mod.rs")
+        || declaring.file_name().and_then(|f| f.to_str()) == Some("main.rs")
+        || declaring.file_name().and_then(|f| f.to_str()) == Some("lib.rs")
+    {
+        declaring.parent().map(|p| p.to_path_buf())
+    } else {
+        declaring
+            .parent()
+            .map(|p| p.join(declaring.file_stem().and_then(|s| s.to_str()).unwrap_or("")))
+    };
+    let Some(dir) = dir else { return Vec::new() };
+    [
+        dir.join(format!("{name}.rs")),
+        dir.join(name).join("mod.rs"),
+    ]
+    .into_iter()
+    .filter(|p| p.exists())
+    .collect()
+}
+
 /// Every `"assay.<segments>.vN"` string literal in production source, with one citing site.
 ///
 /// Both `const NAME: &str = "…"` and inline literals, because the codebase writes both and the
 /// difference is a style choice rather than a property of the document.
 fn identities_in_source() -> BTreeMap<String, String> {
     let root = workspace_root();
+    let test_only = test_only_files();
     let mut found: BTreeMap<String, String> = BTreeMap::new();
     for dir in SCANNED {
         let base = root.join(dir);
@@ -219,6 +341,9 @@ fn identities_in_source() -> BTreeMap<String, String> {
                 if p.is_dir() {
                     stack.push(p);
                 } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    if test_only.contains(&p) {
+                        continue;
+                    }
                     let src = std::fs::read_to_string(&p)
                         .unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
                     let src = strip_test_modules(&src);
@@ -286,11 +411,45 @@ fn identities_in_line(line: &str) -> Vec<String> {
     out
 }
 
+/// Writer idioms. A file that contains none of these does not emit anything, so a row naming it as
+/// the writer of a document is wrong.
+const WRITERS: &[&str] = &[
+    "write_stdout_json",
+    "to_string_pretty",
+    "to_writer",
+    "std::fs::write",
+    "println!",
+];
+
+/// `identity -> writing command file`, from the `cli-documents` block.
+fn document_rows() -> BTreeMap<String, (String, String)> {
+    let mut rows = BTreeMap::new();
+    for line in recorded("cli-documents") {
+        let parts: Vec<&str> = line.split('|').map(str::trim).collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "{INVENTORY}: `cli-documents` row is not `identity | writer | namer`: {line:?}"
+        );
+        let namer = if parts[2] == "-" { parts[1] } else { parts[2] };
+        assert!(
+            rows.insert(
+                parts[0].to_string(),
+                (parts[1].to_string(), namer.to_string())
+            )
+            .is_none(),
+            "{INVENTORY}: `cli-documents` records {:?} twice",
+            parts[0]
+        );
+    }
+    rows
+}
+
 /// Every identity in source is recorded as a document or as not-a-document, and nothing else is.
 #[test]
 fn every_production_identity_is_classified() {
-    let documents = recorded_set("cli-documents");
-    let others = recorded_set("not-cli-documents");
+    let documents: BTreeSet<String> = document_rows().keys().cloned().collect();
+    let others: BTreeSet<String> = non_document_rows().keys().cloned().collect();
 
     let overlap: Vec<_> = documents.intersection(&others).cloned().collect();
     assert!(
@@ -314,11 +473,16 @@ fn every_production_identity_is_classified() {
         unrecorded.join("\n  ")
     );
 
-    let stale: Vec<_> = recorded.difference(&collected).cloned().collect();
+    // A document row may name an identity declared outside the scanned crates — `assay-evidence`
+    // declares one that the CLI writes. Following the write rather than the crate is deliberate,
+    // and `documents_are_bound_to_a_writer` is what keeps such a row honest. Non-document rows have
+    // no write to bind to, so a stale one there is simply stale.
+    let stale: Vec<_> = others.difference(&collected).cloned().collect();
     assert!(
         stale.is_empty(),
-        "{INVENTORY} records identities that no longer appear in production source: {stale:?}"
+        "{INVENTORY} records non-documents that no longer appear in production source: {stale:?}"
     );
+    let _ = &recorded;
 }
 
 /// Documents with no identity string are required rows, and each row still names something real.
@@ -400,7 +564,7 @@ fn documents_without_an_identity_are_recorded_and_still_exist() {
 /// this test is a bookkeeping guard.
 #[test]
 fn describe_binds_only_recorded_documents() {
-    let documents = recorded_set("cli-documents");
+    let documents: BTreeSet<String> = document_rows().keys().cloned().collect();
     let src = read("crates/assay-cli/src/cli/commands/describe/bindings.rs");
 
     let mut constants = BTreeSet::new();
@@ -453,4 +617,62 @@ fn describe_binds_only_recorded_documents() {
         "`assay describe` binds identities the inventory does not record as documents: \
          {unrecorded:?}"
     );
+}
+
+/// Every recorded document names a file that both knows the identity and writes something.
+///
+/// Membership alone let six identities sit in the wrong block because a word in their name —
+/// "carrier", "projection", "health artifact" — read as not-a-document. The partition stayed green,
+/// since it only asked whether each identity appeared *somewhere*. Binding the row to a write is
+/// what makes that class of mistake fail.
+#[test]
+fn documents_are_bound_to_a_writer() {
+    for (identity, (writer, namer)) in document_rows() {
+        let naming = read(&namer);
+        let names_it = naming.contains(&format!("\"{identity}\""))
+            || constant_names_for(&identity)
+                .iter()
+                .any(|name| naming.contains(name.as_str()));
+        assert!(
+            names_it,
+            "{INVENTORY}: {identity} is recorded as named in {namer}, and that file neither \
+             contains the literal nor mentions a constant holding it"
+        );
+        let writing = read(&writer);
+        assert!(
+            WRITERS.iter().any(|w| writing.contains(w)),
+            "{INVENTORY}: {identity} is recorded as written by {writer}, and that file calls no \
+             writer ({WRITERS:?}). Either it is not the writer, or it is not a document"
+        );
+    }
+}
+
+/// Constant names anywhere in the scanned source whose value is this identity.
+fn constant_names_for(identity: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for dir in SCANNED {
+        let base = workspace_root().join(dir);
+        let mut stack = vec![base];
+        while let Some(path) = stack.pop() {
+            for entry in std::fs::read_dir(&path).expect("read_dir") {
+                let p = entry.expect("dir entry").path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    let text = std::fs::read_to_string(&p).expect("read");
+                    for line in text.lines() {
+                        if !line.contains(&format!("\"{identity}\"")) {
+                            continue;
+                        }
+                        if let Some(rest) = line.trim().split("const ").nth(1) {
+                            if let Some(name) = rest.split(':').next() {
+                                names.push(name.trim().to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    names
 }

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -27,78 +27,102 @@ what it is. Removing one from the source fails until the row goes. See #2167 for
 
 ## Machine-checked: identities that ARE CLI JSON documents
 
-A top-level JSON document written to stdout or to a `--report` / artifact path, carrying this string
-as its `schema`.
+A top-level JSON document a command writes to stdout or to a caller-named path, carrying this
+string as its `schema`.
+
+Each row is `identity | writing file | naming file`, where `-` means the writing file also names the
+identity. The test asserts the writing file calls a writer and the naming file carries the identity.
+The third column exists because some documents split the two: `assay doctor` sets its `schema` in
+`diagnostics/probes.rs` and writes in `doctor/implementation.rs`, and the three `evidence schema`
+reports are declared in `schema/reports.rs` and written in `schema/write.rs`. Recording the split is
+better than loosening the check until it fits. Membership alone was not enough: an earlier
+revision of this file classified six of these as non-documents on the strength of a word in their
+name — "carrier", "projection", "health artifact" — and the partition stayed green, because it only
+checked that every identity appeared somewhere. Two independent reviews found all six. Binding the
+row to a write is what turns that class of mistake into a failure.
 
 <!-- machine-checked: cli-documents -->
 ```text
-assay.cli.describe.v0
-assay.doctor_report.v0
-assay.evidence.schema.list.v1
-assay.evidence.schema.show.v1
-assay.evidence.schema.validation.v1
-assay.experiment.runner_phase_timing.v0
-assay.init_report.v0
-assay.mcp.execution-record-pairing.report.v0
-assay.mcp.execution-record-supersession.report.v0
-assay.mcp.tunnel-observed.report.v0
-assay.mcp_preflight.v0
-assay.monitor.observed_peers.v0
-assay.privileged_mcp_action.verify.report.v0
-assay.run_report.v1
-assay.run_summary.v1
-assay.side_effect_verification.v0
-assay.skill_supply_chain.verify_report.v0
-assay.supply_chain_conformance.v0
-assay.tool_decision_truth.verify.report.v0
-assay.trust-basis.assert.v1
-assay.validate_report.v1
+assay.cli.describe.v0 | crates/assay-cli/src/cli/commands/describe.rs | -
+assay.doctor_report.v0 | crates/assay-cli/src/cli/commands/doctor/implementation.rs | crates/assay-cli/src/diagnostics/probes.rs
+assay.enforcement_health.v0 | crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs | -
+assay.enforcement_health.v1 | crates/assay-cli/src/enforcement_health_v1.rs | -
+assay.evidence.schema.list.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
+assay.evidence.schema.show.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
+assay.evidence.schema.validation.v1 | crates/assay-cli/src/cli/commands/evidence/schema/write.rs | crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
+assay.experiment.runner_phase_timing.v0 | crates/assay-cli/src/cli/commands/runner_spike/phases.rs | -
+assay.init_report.v0 | crates/assay-cli/src/cli/commands/init_report.rs | -
+assay.mcp.execution-record-pairing.report.v0 | crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs | -
+assay.mcp.execution-record-supersession.report.v0 | crates/assay-cli/src/cli/commands/evidence/mcp_supersession.rs | -
+assay.mcp.tunnel-observed.report.v0 | crates/assay-cli/src/cli/commands/evidence/mcp_tunnel_observed.rs | -
+assay.mcp_preflight.v0 | crates/assay-cli/src/cli/commands/mcp/preflight.rs | -
+assay.mcp_server_inventory.v0 | crates/assay-cli/src/cli/commands/inventory.rs | crates/assay-core/src/discovery/inventory_carrier.rs
+assay.monitor.observed_peers.v0 | crates/assay-cli/src/cli/commands/monitor_next/observed_peers.rs | -
+assay.otel_projection.v0 | crates/assay-cli/src/cli/commands/project_otel.rs | crates/assay-core/src/otel/projection.rs
+assay.privileged_mcp_action.verify.report.v0 | crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs | -
+assay.run_report.v1 | crates/assay-core/src/report/json.rs | -
+assay.run_summary.v1 | crates/assay-core/src/report/summary/writer.rs | -
+assay.side_effect_verification.v0 | crates/assay-cli/src/cli/commands/evidence/verify_side_effects.rs | -
+assay.skill_supply_chain.v0 | crates/assay-cli/src/cli/commands/evidence/skill_supply_chain_capture.rs | -
+assay.skill_supply_chain.verify_report.v0 | crates/assay-cli/src/cli/commands/evidence/verify_skill_supply_chain.rs | -
+assay.supply_chain_conformance.v0 | crates/assay-cli/src/cli/commands/supply_chain_conformance.rs | crates/assay-registry/src/supply_chain.rs
+assay.tool_decision_truth.otel_projection.v0 | crates/assay-cli/src/cli/commands/project_otel.rs | crates/assay-core/src/otel/projection.rs
+assay.tool_decision_truth.verify.report.v0 | crates/assay-cli/src/cli/commands/evidence/verify_tool_decision_truth.rs | -
+assay.trust-basis.assert.v1 | crates/assay-cli/src/cli/commands/trust_basis.rs | -
+assay.trust-basis.diff.v1 | crates/assay-cli/src/cli/commands/trust_basis.rs | crates/assay-evidence/src/trust_basis/types.rs
+assay.validate_report.v1 | crates/assay-cli/src/cli/commands/validate.rs | -
 ```
+
+`assay.trust-basis.diff.v1` is declared in `assay-evidence`, outside the scanned crates. An earlier
+revision recorded that as a known hole. It is not a hole: the CLI writes the document
+(`write_diff_json`), and following the write rather than the crate puts it here with everything else.
 
 ## Machine-checked: identities that are NOT CLI JSON documents
 
-Evidence events inside a bundle, nested objects, read-only inputs, projections, and one digest
-domain. They are recorded so that the partition is total: an identity that is in neither block is a
-failed build, which is what stops a new emitter from arriving unnoticed.
+Evidence events inside a bundle, nested objects, read-only inputs, and one digest domain. Each row is
+`identity | reason`, and the reason is required.
+
+The partition is total, so an identity in neither block fails the build. That stops a new emitter
+arriving unnoticed. It does not stop a *misclassification*, and no static check can: naming and
+writing live in different files for several of these, so nothing can decide from source alone that
+`assay.otel_projection.v0` is the document `assay project-otel` writes. Requiring a reason is what
+this file can do about it — moving a real document into this block now means writing a sentence that
+is false, rather than deleting a line. Two independent reviews caught six such moves in the previous
+revision, when this block was a bare list.
 
 <!-- machine-checked: not-cli-documents -->
 ```text
-assay.aee_run_context.v0
-assay.aee_seal_key.v0
-assay.aee_trust_set.v0
-assay.approval_artifact.structured_meta_jcs.v0
-assay.denied_call_observation.v0
-assay.denied_call_observation.v1
-assay.enforcement_decision.v0
-assay.enforcement_health.v0
-assay.enforcement_health.v1
-assay.fallback_projection.v0
-assay.mandate.revoked.v1
-assay.mandate.used.v1
-assay.manifest_establish.v0
-assay.mcp.policy.snapshot.v1
-assay.mcp.tool-definition.snapshot.v1
-assay.mcp.tunnel_observed.v0
-assay.mcp_server_inventory.v0
-assay.otel_projection.v0
-assay.receipt.cyclonedx.mlbom-model-component.v1
-assay.receipt.cyclonedx.mlbom_model_component.v1
-assay.receipt.livekit.tool-action.v1
-assay.receipt.livekit.tool_action.v1
-assay.receipt.mastra.score_event.v1
-assay.receipt.openfeature.evaluation_details.v1
-assay.receipt.promptfoo.assertion-component.v1
-assay.receipt.promptfoo.assertion_component.v1
-assay.receipt.pydantic.case_result.v1
-assay.render_safety_conformance.v0
-assay.skill_supply_chain.v0
-assay.supply_chain_conformance.input.v0
-assay.tool_args.v0
-assay.tool_decision_surface.v0
-assay.tool_decision_truth.otel_projection.v0
-assay.tool_decision_truth.recipe_row.v0
-assay.tool_decision_truth.v0
+assay.aee_run_context.v0 | input the sandbox reads; exact key set enforced on read
+assay.aee_seal_key.v0 | input the sandbox reads; exact key set enforced on read
+assay.aee_trust_set.v0 | input the sandbox reads; exact key set enforced on read
+assay.approval_artifact.structured_meta_jcs.v0 | a canonicalization domain for approval metadata, not a document
+assay.denied_call_observation.v0 | nested inside the privileged-mcp-action verify report
+assay.denied_call_observation.v1 | nested inside the privileged-mcp-action verify report
+assay.enforcement_decision.v0 | evidence event read from a bundle; the command writes a verify report about it
+assay.fallback_projection.v0 | an input mode name for mcp-execution-records, not a schema it emits
+assay.mandate.revoked.v1 | MCP lifecycle event type inside a bundle
+assay.mandate.used.v1 | MCP lifecycle event type inside a bundle
+assay.manifest_establish.v0 | nested inside the privileged-mcp-action verify report
+assay.mcp.policy.snapshot.v1 | policy snapshot event carried in evidence, not written by a command
+assay.mcp.tool-definition.snapshot.v1 | tool-definition snapshot event carried in evidence
+assay.mcp.tunnel_observed.v0 | the carrier event; the command writes assay.mcp.tunnel-observed.report.v0
+assay.receipt.cyclonedx.mlbom-model-component.v1 | receipt written into an evidence bundle by BundleWriter, never to stdout
+assay.receipt.cyclonedx.mlbom_model_component.v1 | event type beside that receipt schema, same bundle write
+assay.receipt.livekit.tool-action.v1 | receipt written into an evidence bundle by BundleWriter, never to stdout
+assay.receipt.livekit.tool_action.v1 | event type beside that receipt schema, same bundle write
+assay.receipt.mastra.score_event.v1 | receipt written into an evidence bundle by BundleWriter, never to stdout
+assay.receipt.openfeature.evaluation_details.v1 | receipt written into an evidence bundle by BundleWriter, never to stdout
+assay.receipt.promptfoo.assertion-component.v1 | receipt written into an evidence bundle by BundleWriter, never to stdout
+assay.receipt.promptfoo.assertion_component.v1 | event type beside that receipt schema, same bundle write
+assay.receipt.pydantic.case_result.v1 | receipt written into an evidence bundle by BundleWriter, never to stdout
+assay.render_safety_conformance.v0 | a golden corpus identity compared against, not a document a command mints
+assay.supply_chain_conformance.input.v0 | the input descriptor the command reads; it writes assay.supply_chain_conformance.v0
+assay.tool_args.v0 | a digest domain string; nothing serializes it as a document
+assay.tool_decision_surface.v0 | event type read from a bundle by verify-side-effects
+assay.tool_decision_truth.recipe_row.v0 | a row inside the projection, not the projection
+assay.tool_decision_truth.v0 | the carrier read as input by project-otel; the projection is the document
 ```
+
 
 ## Machine-checked: documents with no identity at all
 
@@ -147,21 +171,31 @@ missed them. That is the argument for the required-rows check stated as evidence
 principle: the documents a scan cannot see are also the ones a single careful reader does not think
 of, and there is no instrument that fixes that.
 
-## Confidence
+## What this guard cannot do, stated plainly
 
-Rows I opened the producer for: every entry in *documents with no identity*, plus `run_report`,
-`run_summary`, `validate_report`, `doctor_report`, `describe`, `skill_supply_chain.verify_report`,
-`fallback_projection`, and the six receipt families.
+- **It cannot verify a classification.** For several identities the naming and the writing live in
+  different files — `assay project-otel` calls into `assay-core`, which sets the schema — so nothing
+  in source connects them. A reclassification is caught only because every non-document row must
+  carry a reason: moving a document here means writing a false sentence, not deleting a line. That
+  is a weaker guarantee than the rest of this file and it is the honest ceiling.
+- **The writer list is a fixed set of idioms.** A file emitting through some other route would not be
+  seen by `documents_are_bound_to_a_writer`. `serde_json::to_writer` was missing from the first
+  version and `assay describe` exposed it.
+- **Four crates now declare identities the CLI writes** — `assay-cli`, `assay-core`,
+  `assay-evidence` (`trust-basis.diff`) and `assay-registry` (`supply_chain_conformance`). The
+  collector scans the first two; the other two are reached only through a document row's naming
+  column. An identity minted in a fifth crate and written by the CLI would be invisible.
+- **`describe ⊆ pin` is one-directional.** `BINDING_ROWS` is seven clap paths and omits the run
+  report and run summary. Forcing `describe` to grow is a product decision, not bookkeeping.
 
-Rows classified from the declaration site without following the emit path: the remaining
-`not-cli-documents` entries, and `assay.experiment.runner_phase_timing.v0`,
-`assay.supply_chain_conformance.v0`, `assay.side_effect_verification.v0`,
-`assay.mcp.execution-record-*.report.v0` and `assay.trust-basis.assert.v1` under documents. Those are
-the rows most likely to be wrong, and they are named here rather than left for a reader to discover.
+## Provenance of this file
 
-`assay.trust-basis.diff.v1` is declared in `assay-evidence` and printed by the CLI. It is out of the
-collector's crates and therefore **not** covered by this guard today. That is a known hole, recorded
-rather than silently omitted.
+The identity strings were located by searching source; the classification, the writer bindings and
+every reason are hand-made judgements, and they are the content. Three rows — `baseline_diff`,
+`discover_inventory`, `trust_basis_generate` — came from an independent read after two separately
+written inventories missed them. Six identities were misclassified as non-documents in the first
+revision on the strength of a word in their name ("carrier", "projection", "health artifact"); two
+independent reviews found all six, which is why the reason column exists.
 
 ## What is not here
 

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -195,11 +195,13 @@ of, and there is no instrument that fixes that.
 
 ## What this guard cannot do, stated plainly
 
-- **It cannot verify a classification.** For several identities the naming and the writing live in
-  different files — `assay project-otel` calls into `assay-core`, which sets the schema — so nothing
-  in source connects them. A reclassification is caught only because every non-document row must
-  carry a reason: moving a document here means writing a false sentence, not deleting a line. That
-  is a weaker guarantee than the rest of this file and it is the honest ceiling.
+- **It cannot verify a classification, and the reason column is a speed bump, not a gate.** The test
+  checks that a row has a `|` and a non-empty right-hand side. It does not read the sentence: `a
+  banana` passes. A misclassification costs writing a false sentence instead of deleting a line,
+  which is why two independent reviews caught six of them — but the build stays green either way.
+  The theory that produced those six ("a projection, not a document") writes a perfectly non-empty
+  reason. **#2485 must not read these sentences as evidence that a row is right.** Three of them have
+  been wrong today, and the third was written after conceding the first two.
 - **The writer list is a fixed set of idioms**, and it has been wrong twice. `serde_json::to_writer`
   was missing until `assay describe` exposed it; `to_vec_pretty`, `tokio::fs::write`,
   `serde_json::to_string` and a bare `fs::write` were missing until a review opened the emit paths.
@@ -223,8 +225,11 @@ of, and there is no instrument that fixes that.
   (`trust-basis.diff`), `assay-registry` (`supply_chain_conformance`) and `assay-runner-schema`
   (`runner.observation_health`). The collector scans the first two; the rest are reached only through
   a document row's naming column, which is why `runner.observation_health` was missing from the first
-  revision of this file and the guard was green without it. The converse-writer rule below is what
-  turns "invisible" into "must be answered"; until it lands, a sixth crate would be invisible too.
+  revision of this file and the guard was green without it. A **sixth** crate is now caught:
+  `every_production_identity_is_classified` also collects `pub const` identities from every crate
+  `assay-cli` depends on, and `DEPENDENCY_CRATES` is pinned against `assay-cli/Cargo.toml` so the
+  list cannot drift away from the manifest. What that rule does *not* catch is a new command file in
+  a crate already scanned — `evidence lint` and `evidence diff` are that class, and it is #2555.
 - **`describe ⊆ pin` is one-directional.** `BINDING_ROWS` is seven clap paths and omits the run
   report and run summary. Forcing `describe` to grow is a product decision, not bookkeeping.
 

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -1,0 +1,169 @@
+# CLI JSON document identities
+
+This file is the **record** of which `assay.<segments>.vN` identities exist in production source,
+and which of them are top-level JSON documents a CLI command emits.
+
+It is **hand-edited**. Nothing generates it — not CI, not a committed script, not a local
+"generate once and check in". A pin derived from its producer is not a record of that producer; it
+is the producer restating itself, and it cannot fail. `crates/assay-cli/tests/cli_json_identities.rs`
+reads this file and never writes it.
+
+A scan can tell you that an identity string exists. It cannot tell you whether that string names a
+document, an evidence event, a nested object, an input, or a digest domain. **That judgement is what
+this file stores**, and it is why the two blocks below are a partition rather than a list.
+
+Adding an identity to the source fails the test until it is recorded here, in the block that says
+what it is. Removing one from the source fails until the row goes. See #2167 for the convention and
+#2484 for this guard.
+
+## Convention (decided in #2167)
+
+- The discriminator is `schema`, carrying `assay.<segments>.vN`. `.vN` is the breaking generation.
+- A closed schema stays closed; a compatible addition keeps the identity and edits the schema in the
+  same commit. Our CI stays green; a third party holding a vendored copy of that schema goes red
+  later, unsignalled. That is the accepted cost.
+- An unknown identity is fail-closed everywhere. Unknown *fields* are rejected on emit validators,
+  AEE readers, receipt validators and fail-closed inputs; third-party stdout readers field-pick.
+
+## Machine-checked: identities that ARE CLI JSON documents
+
+A top-level JSON document written to stdout or to a `--report` / artifact path, carrying this string
+as its `schema`.
+
+<!-- machine-checked: cli-documents -->
+```text
+assay.cli.describe.v0
+assay.doctor_report.v0
+assay.evidence.schema.list.v1
+assay.evidence.schema.show.v1
+assay.evidence.schema.validation.v1
+assay.experiment.runner_phase_timing.v0
+assay.init_report.v0
+assay.mcp.execution-record-pairing.report.v0
+assay.mcp.execution-record-supersession.report.v0
+assay.mcp.tunnel-observed.report.v0
+assay.mcp_preflight.v0
+assay.monitor.observed_peers.v0
+assay.privileged_mcp_action.verify.report.v0
+assay.run_report.v1
+assay.run_summary.v1
+assay.side_effect_verification.v0
+assay.skill_supply_chain.verify_report.v0
+assay.supply_chain_conformance.v0
+assay.tool_decision_truth.verify.report.v0
+assay.trust-basis.assert.v1
+assay.validate_report.v1
+```
+
+## Machine-checked: identities that are NOT CLI JSON documents
+
+Evidence events inside a bundle, nested objects, read-only inputs, projections, and one digest
+domain. They are recorded so that the partition is total: an identity that is in neither block is a
+failed build, which is what stops a new emitter from arriving unnoticed.
+
+<!-- machine-checked: not-cli-documents -->
+```text
+assay.aee_run_context.v0
+assay.aee_seal_key.v0
+assay.aee_trust_set.v0
+assay.approval_artifact.structured_meta_jcs.v0
+assay.denied_call_observation.v0
+assay.denied_call_observation.v1
+assay.enforcement_decision.v0
+assay.enforcement_health.v0
+assay.enforcement_health.v1
+assay.fallback_projection.v0
+assay.mandate.revoked.v1
+assay.mandate.used.v1
+assay.manifest_establish.v0
+assay.mcp.policy.snapshot.v1
+assay.mcp.tool-definition.snapshot.v1
+assay.mcp.tunnel_observed.v0
+assay.mcp_server_inventory.v0
+assay.otel_projection.v0
+assay.receipt.cyclonedx.mlbom-model-component.v1
+assay.receipt.cyclonedx.mlbom_model_component.v1
+assay.receipt.livekit.tool-action.v1
+assay.receipt.livekit.tool_action.v1
+assay.receipt.mastra.score_event.v1
+assay.receipt.openfeature.evaluation_details.v1
+assay.receipt.promptfoo.assertion-component.v1
+assay.receipt.promptfoo.assertion_component.v1
+assay.receipt.pydantic.case_result.v1
+assay.render_safety_conformance.v0
+assay.skill_supply_chain.v0
+assay.supply_chain_conformance.input.v0
+assay.tool_args.v0
+assay.tool_decision_surface.v0
+assay.tool_decision_truth.otel_projection.v0
+assay.tool_decision_truth.recipe_row.v0
+assay.tool_decision_truth.v0
+```
+
+## Machine-checked: documents with no identity at all
+
+These are the rows a source scan structurally cannot produce, because **none of them has a dotted
+identity constant** — measured, all twelve. A pin built only from identity strings would satisfy every
+other check in the guard while omitting every document #2485 has to migrate. They are therefore
+*required* rows: a missing one fails the build even though there is nothing in the source to collect.
+
+Each row is `key | producer path | token`, and the test asserts the producer file exists and still
+contains the token, so a row cannot outlive the thing it names.
+
+<!-- machine-checked: unnamed-documents -->
+```text
+baseline | crates/assay-core/src/baseline/mod.rs | schema_version
+baseline_diff | crates/assay-cli/src/cli/commands/baseline.rs | baseline.diff(&candidate)
+coverage_report | crates/assay-cli/src/cli/commands/coverage/report.rs | coverage_report_v1
+discover_inventory | crates/assay-cli/src/cli/commands/discover.rs | DiscoverFormat::Json
+hygiene_report | crates/assay-core/src/baseline/report.rs | schema_version
+run_json_extended | crates/assay-cli/src/cli/commands/run_output.rs | write_extended_run_json
+run_json_minimal | crates/assay-cli/src/cli/commands/run_output.rs | write_run_json_minimal
+sarif | crates/assay-core/src/report/sarif.rs | 2.1.0
+session_state_window | crates/assay-cli/src/cli/commands/session_state_window.rs | session_state_window_v1
+sim_run_report | crates/assay-cli/src/cli/commands/sim.rs | to_string_pretty
+soak_report | crates/assay-cli/src/cli/commands/sim/soak/report.rs | soak-report-v1
+trust_basis_generate | crates/assay-cli/src/cli/commands/trust_basis.rs | generate_trust_basis
+```
+
+| key | version field | class | note |
+|---|---|---|---|
+| `baseline` | integer, `load` fails on `!= 1` | (c) | live gate; minting an identity is a #2485 review, not a rename |
+| `coverage_report` | string `coverage_report_v1` + `report_version` | (b) | closed schema, validated on emit |
+| `hygiene_report` | integer | (c) | second document, not `baseline` |
+| `run_json_extended` | none | (d) | **not** `assay.run_report.v1`; may be consumed by `bundle create --from` |
+| `run_json_minimal` | none | (d) | early-exit shape; same-or-split identity is a #2485 review |
+| `sarif` | SARIF `2.1.0` | (g) | foreign identity (OASIS); do not mint an `assay.*` name |
+| `session_state_window` | string `session_state_window_v1` + `report_version` | (b) | closed schema, validated on emit |
+| `sim_run_report` | none | (d) | `assay sim run --report`; **not** the soak report |
+| `baseline_diff` | none | (d) | `assay baseline check --format json` prints `BaselineDiff` |
+| `discover_inventory` | none | (d) | `assay mcp discover --format json`; **not** `assay.mcp_server_inventory.v0` |
+| `trust_basis_generate` | none | (d) | `assay trust-basis generate` writes canonical JSON; the `assert` report is a separate, named document |
+| `soak_report` | string `soak-report-v1` + `report_version` | (b) | closed schema, validated on emit |
+
+Three of these rows — `baseline_diff`, `discover_inventory` and `trust_basis_generate` — came from
+an independent read, not from the author of this file. Two separately written inventories both
+missed them. That is the argument for the required-rows check stated as evidence rather than as
+principle: the documents a scan cannot see are also the ones a single careful reader does not think
+of, and there is no instrument that fixes that.
+
+## Confidence
+
+Rows I opened the producer for: every entry in *documents with no identity*, plus `run_report`,
+`run_summary`, `validate_report`, `doctor_report`, `describe`, `skill_supply_chain.verify_report`,
+`fallback_projection`, and the six receipt families.
+
+Rows classified from the declaration site without following the emit path: the remaining
+`not-cli-documents` entries, and `assay.experiment.runner_phase_timing.v0`,
+`assay.supply_chain_conformance.v0`, `assay.side_effect_verification.v0`,
+`assay.mcp.execution-record-*.report.v0` and `assay.trust-basis.assert.v1` under documents. Those are
+the rows most likely to be wrong, and they are named here rather than left for a reader to discover.
+
+`assay.trust-basis.diff.v1` is declared in `assay-evidence` and printed by the CLI. It is out of the
+collector's crates and therefore **not** covered by this guard today. That is a known hole, recorded
+rather than silently omitted.
+
+## What is not here
+
+Bundle manifests, trust cards, attestation and lint packs keep their own integers under #2552. The
+CLI field-name rule does not cross that crate boundary by implication.

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -59,6 +59,7 @@ assay.mcp_preflight.v0 | crates/assay-cli/src/cli/commands/mcp/preflight.rs | -
 assay.mcp_server_inventory.v0 | crates/assay-cli/src/cli/commands/inventory.rs | crates/assay-core/src/discovery/inventory_carrier.rs
 assay.monitor.observed_peers.v0 | crates/assay-cli/src/cli/commands/monitor_next/observed_peers.rs | -
 assay.otel_projection.v0 | crates/assay-cli/src/cli/commands/project_otel.rs | crates/assay-core/src/otel/projection.rs
+assay.runner.observation_health.v0 | crates/assay-cli/src/cli/commands/monitor_next/observation_health.rs | crates/assay-runner-schema/src/health.rs
 assay.privileged_mcp_action.verify.report.v0 | crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs | -
 assay.run_report.v1 | crates/assay-core/src/report/json.rs | -
 assay.run_summary.v1 | crates/assay-core/src/report/summary/writer.rs | -
@@ -178,13 +179,27 @@ of, and there is no instrument that fixes that.
   in source connects them. A reclassification is caught only because every non-document row must
   carry a reason: moving a document here means writing a false sentence, not deleting a line. That
   is a weaker guarantee than the rest of this file and it is the honest ceiling.
-- **The writer list is a fixed set of idioms.** A file emitting through some other route would not be
-  seen by `documents_are_bound_to_a_writer`. `serde_json::to_writer` was missing from the first
-  version and `assay describe` exposed it.
-- **Four crates now declare identities the CLI writes** — `assay-cli`, `assay-core`,
-  `assay-evidence` (`trust-basis.diff`) and `assay-registry` (`supply_chain_conformance`). The
-  collector scans the first two; the other two are reached only through a document row's naming
-  column. An identity minted in a fifth crate and written by the CLI would be invisible.
+- **The writer list is a fixed set of idioms**, and it has been wrong twice. `serde_json::to_writer`
+  was missing until `assay describe` exposed it; `to_vec_pretty`, `tokio::fs::write`,
+  `serde_json::to_string` and a bare `fs::write` were missing until a review opened the emit paths.
+  A file emitting through some route still not on the list is invisible to
+  `documents_are_bound_to_a_writer`.
+
+- **The guard follows rows to writers, never writers to rows.** A document row must name a file that
+  writes; a file that writes need not be named by any row. That is the hole
+  `assay.runner.observation_health.v0` fell through. Measured on this head: **31 production files
+  under `cli/commands` serialize JSON and are named by no row.** Some of them almost certainly emit
+  documents — `evidence lint`, `evidence diff`, `evidence list`, `store-status`, `explain`, `import`,
+  `trace`. Closing this means requiring every JSON-serializing command file to be named by a row or
+  to carry an explicit opt-out, and triaging those 31. It is tracked separately rather than answered
+  here, because thirty-one classifications written in one sitting is the failure this file exists to
+  record.
+- **Five crates declare identities the CLI writes** — `assay-cli`, `assay-core`, `assay-evidence`
+  (`trust-basis.diff`), `assay-registry` (`supply_chain_conformance`) and `assay-runner-schema`
+  (`runner.observation_health`). The collector scans the first two; the rest are reached only through
+  a document row's naming column, which is why `runner.observation_health` was missing from the first
+  revision of this file and the guard was green without it. The converse-writer rule below is what
+  turns "invisible" into "must be answered"; until it lands, a sixth crate would be invisible too.
 - **`describe ⊆ pin` is one-directional.** `BINDING_ROWS` is seven clap paths and omits the run
   report and run summary. Forcing `describe` to grow is a product decision, not bookkeeping.
 

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -93,6 +93,27 @@ revision, when this block was a bare list.
 
 <!-- machine-checked: not-cli-documents -->
 ```text
+assay.coding_agent.evidence_pack.v0 | declared in assay-evidence as a bundle pack schema; no CLI write opened
+assay.mandate.v1 | mandate event carried in evidence, not written by a command
+assay.mcp_manifest_observed.v0 | assay-mcp-server observation event inside a bundle
+assay.mcp_manifest_projection.v0 | assay-mcp-server projection event inside a bundle
+assay.mcp_tool_field.v0 | a field-level record nested in the manifest observation
+assay.provider_audit_record.v0 | assay-mcp-server audit record written to the audit log, not a command document
+assay.redaction_receipt.v0 | runner receipt inside an archive
+assay.runner.archive_manifest.v0 | runner archive manifest; #2552 owns archive integers and identities
+assay.runner.capability_surface.v0 | runner capability surface read by project-otel as input
+assay.runner.claim_support_parity.v0 | runner parity artifact inside an archive
+assay.runner.correlation_report.v0 | runner correlation artifact inside an archive
+assay.runner.coverage_descriptor.v0 | runner coverage descriptor inside an archive
+assay.runner.event.v0 | runner event stream entry
+assay.runner.fidelity_verdict.v0 | runner verdict inside an archive
+assay.runner.kernel_event.v0 | kernel event stream entry
+assay.runner.path_projection.v0 | runner path projection inside an archive
+assay.runner.policy_event.v0 | policy event stream entry
+assay.runner.sdk_event.v0 | SDK event stream entry
+assay.semantic-digest.jcs-rfc8785.v1 | a canonicalization profile name, not a document
+assay.token_passthrough_conformance.v0 | assay-mcp-server conformance carrier inside a bundle
+assay.tool_annotation_conformance.v0 | assay-mcp-server conformance carrier inside a bundle
 assay.aee_run_context.v0 | input the sandbox reads; exact key set enforced on read
 assay.aee_seal_key.v0 | input the sandbox reads; exact key set enforced on read
 assay.aee_trust_set.v0 | input the sandbox reads; exact key set enforced on read
@@ -121,7 +142,7 @@ assay.supply_chain_conformance.input.v0 | the input descriptor the command reads
 assay.tool_args.v0 | a digest domain string; nothing serializes it as a document
 assay.tool_decision_surface.v0 | event type read from a bundle by verify-side-effects
 assay.tool_decision_truth.recipe_row.v0 | a row inside the projection, not the projection
-assay.tool_decision_truth.v0 | the carrier read as input by project-otel; the projection is the document
+assay.tool_decision_truth.v0 | `assay mcp --tool-decision-truth-out` DOES append these to a caller-named path, one JSON object per line; the file is NDJSON and no line is the top-level document. An earlier reason here said "read as input", which was the same keyword error as "projection"
 ```
 
 
@@ -194,6 +215,10 @@ of, and there is no instrument that fixes that.
   to carry an explicit opt-out, and triaging those 31. It is tracked separately rather than answered
   here, because thirty-one classifications written in one sitting is the failure this file exists to
   record.
+- **Twenty-one of the non-document rows are declared in dependency crates and their emit paths were
+  not opened.** They are classified from the declaring module. That is a weaker basis than the rows
+  whose producer I read, and three such judgements have already been wrong today.
+
 - **Five crates declare identities the CLI writes** — `assay-cli`, `assay-core`, `assay-evidence`
   (`trust-basis.diff`), `assay-registry` (`supply_chain_conformance`) and `assay-runner-schema`
   (`runner.observation_health`). The collector scans the first two; the rest are reached only through


### PR DESCRIPTION
Closes #2484 when the reviews land. Convention: #2167.

## What this is

The record of which `assay.<segments>.vN` identities ship, which of them are CLI JSON documents, and a test that fails the build when source and record disagree.

Two counts of this set were published and withdrawn in one day. Both times the instrument answered a neighbouring question — a character class that could not see hyphens, then a path scope that could not contain `assay-core`. This makes the set a record instead of a measurement.

**The record is hand-edited. Nothing generates it**, in CI or locally-then-committed: a pin derived from its producer is the producer restating itself, and cannot fail. The test reads it and never writes it.

## Why a source scan is not enough

A scan can tell you an identity string exists. It cannot tell you whether that string names a document, an evidence event, a nested object, an input, or a digest domain. Of the 56 identities found, **21 are documents and 35 are not** (`assay.tool_args.v0` is a digest domain). That judgement is the record's content, which is why the two blocks are a partition — "in neither" is a failure, not a silence.

Two measured facts drive the other checks:

- **Seven shipping verify-report documents are declared as inline literals, not consts.** A `const`-only collector is satisfied by a coding convention this codebase does not follow.
- **Twelve CLI JSON documents carry no identity at all** — coverage, session-state-window, soak, `Baseline`, `HygieneReport`, `BaselineDiff`, both `run.json` writers, sim-run, discover inventory, trust-basis generate, SARIF. Not one has an identity constant. A guard built from a source scan passes every other check while omitting **every document #2485 has to migrate**, and stays green. Hence required rows, which also name a producer and a token the test asserts still exist.

## What the blind diff produced

Cursor and Ruley each wrote an inventory without seeing the other's or mine. `baseline_diff`, `discover_inventory` and `trust_basis_generate` appear in **one** of the three. Two separately written lists missed them.

That is the required-rows argument as evidence rather than principle: the documents a scan cannot see are also the ones a single careful reader does not think of, and no instrument fixes that. It is recorded in the file.

## Mutations, each demonstrated

| | mutation | result |
|---|---|---|
| M1 | new emitter added as an inline literal | red |
| M2 | required row for an identity-less document deleted | red |
| M3 | a row's producer moves so its token is gone | red |
| M4 | identity removed from source, row left behind | red |
| M5 | **control**: identity inside `#[cfg(test)]` | green |

M5 is the one that matters as much as the reds: it proves the test-module stripper is not over-broad. A guard that reddens on everything is as useless as one that never does.

## Known limits, stated rather than discovered

- The partition checks **membership, not classification**. Moving an identity from `cli-documents` to `not-cli-documents` stays green. Deliberate — classification is a judgement — but a wrong classification is silent.
- `assay.trust-basis.diff.v1` is declared in `assay-evidence`, outside the collector's two crates. Known hole, recorded in the file rather than omitted.
- `REQUIRED` lives in the test, so dropping a row takes two edits. Same shape as the pin itself, and the assertion message says so.
- `describe ⊆ pin` is one-directional on purpose: `BINDING_ROWS` is a projection of seven clap paths and omits the run report and run summary. Forcing `describe` to grow is a product decision, not bookkeeping.

## Review

Blocking review wanted from both agents, on the limits above first — three of today's four findings against my work were in exactly the places I had not thought to name.
