### PR TITLE
fix(conformance): rescore every corpus over its real denominator, and withdraw a refuted claim

### DIFF
--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -146,7 +146,7 @@ the rows below say which of the two they mean.
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
-| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of a declared twenty-four in scope, where eight had been declared before. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
+| `privileged-mcp-action-v0` | process | **6 of 25 in scope (24.0%), 19 survivors, 2 known holes.** Declared three times before it said anything true. First three rules and *no result*; then eight read off the verifier path, scoring 50%, published with a pattern claim. **The denominator was the finding, not the score.** An adversarial re-measurement deleted a further set of promised rules in one build and reproduced every outcome and every claim matrix, so the declaration grew from eight in-scope rules to twenty-five and the score fell to 24.0%. All six rules the corpus does isolate are now declared, and all six are killed. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
@@ -156,9 +156,10 @@ the rows below say which of the two they mean.
 rounded up — and this line has now been wrong in both directions on the same day.
 It read *four measured* while `privileged-mcp-action-v0` was scoring nothing; it
 was corrected to *three*; and it is four again only because that corpus was then
-declared properly and finally produced a number. The number is 50%, the worst on
-this page, and it is still too kind: it is 50% of eight declared rules where the
-implementation has roughly twenty-nine, which the section below measures. Both
+declared properly and finally produced a number. That number was 50% of eight
+declared rules; over the twenty-five now declared it is **24.0%**, the worst on
+this page by a wide margin. It fell because the denominator became honest, not
+because the corpus changed. Both
 corrections are left visible, because a table whose purpose is to publish
 unflattering results should show its own edits.
 
@@ -169,8 +170,13 @@ over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
 hand-written table that ADMISSION.md already warned was unchecked against
 `ref_example.py`. Those three rows now score the larger denominator and the
 numbers went down, which is the point. `privileged-mcp-action-v0` took the same
-treatment last and hardest: sixteen further in-scope rules are now declared
-individually, taking its denominator from eight to twenty-four.
+treatment last and hardest: eighteen further in-scope rules are now declared
+individually, taking its denominator from eight to twenty-five. Two of those
+eighteen were added last and are the only correction today that moved a number
+**up**: an independent count named six isolated rules where this manifest
+declared four, and the two missing ones — the Stage 2 unknown-schema arm and the
+decision vocabulary — are both killed. One of them is the measurement this
+manifest's own out-of-scope note had asked for and never ran.
 
 ### The v0 corpus isolates six rules and leaves most of the rest free
 
@@ -195,6 +201,16 @@ and all three legs of the marker triple.
 **All fourteen outcomes and all five claim matrices reproduced exactly.** The
 only difference anywhere in the corpus was one finding string, and findings are
 not on the comparison surface the corpus declares.
+
+Reproduced here independently, and the reproduction is narrower than the sentence
+above so it is stated as it ran: **nineteen** of the twenty-three applied
+simultaneously, and all fourteen vectors were byte-identical on
+`[bundle_integrity, verdict, claims]`. The other four could not join the composite
+because they share an anchor with a rule already in it — `31/32/33` are three
+replacements over one line, as are `44/45/46`. Each of those four is scored a
+survivor on its own in the per-mutant run below, so the twenty-three-way
+conclusion holds; the nineteen-way deletion is simply what was actually executed
+in one build.
 
 So an implementer can delete twenty-three rules the profile promises, reproduce
 the pinned digest, and be indistinguishable from a conforming implementation.

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -145,11 +145,11 @@ the rows below say which of the two they mean.
 
 | Corpus | Runner | Result |
 |---|---|---|
-| `mcp-jsonrpc-id-conformance` | module | **4 of 4** in scope. **7 rules unexercised and out of scope**, ratio 1.75 — the score is a statement about a minority of the declared rules |
+| `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
 | `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 1 known hole.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. The survivors form **one systematic gap, not four**: wherever a rule has sibling members, the corpus discriminates exactly one and leaves the rest free. Decision cardinality is caught (`bad-103`) and observation and establish cardinality are not; the decision's `target_digest` is caught (`bad-102`) and the observation's `response_digest` is not; the binding pair is caught on its digest leg (`bad-105`) and not on its tool-name leg; the marker triple is caught on schema and code and not on origin (the known hole). One vector per failure mode, and every failure mode has siblings on the same code path that never got one. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
-| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **4 of 5**. One survivor: an implementation can read the body regardless of whether the ref recomputed and still reproduce all fourteen cases |
-| [rge-bench](https://github.com/rge-bench/rge-bench) | module | 30 of 30, 1 declared equivalent |
-| `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: see below |
+| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
+| [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
+| `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
 | `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict |
 
 **Four measured, one control-only, one not measurable.** Stated rather than
@@ -159,6 +159,14 @@ was corrected to *three*; and it is four again only because that corpus was then
 declared properly and finally produced a number. The number is 50%, which is the
 worst result on this page. Both corrections are left visible, because a table
 whose purpose is to publish unflattering results should show its own edits.
+
+The same under-declaration then showed up on the other three scored rows. Each
+first score was a number about the rules the author happened to list, not about
+the rules the implementation has: 4 of 4 over four of ten id-field arms; 4 of 5
+over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
+hand-written table that ADMISSION.md already warned was unchecked against
+`ref_example.py`. The rows above now score the larger denominator. The numbers
+went down. That is the point.
 
 ### The v0 survivors are one gap wearing four faces
 
@@ -180,9 +188,14 @@ any of these pairs and reproduce all fourteen outcomes.
 
 That the pattern is uniform is the useful part: it says the fix is not fourteen
 judgement calls but one rule — **for every conjunct and every sibling member, ask
-whether a vector isolates it** — and it says the same audit is worth running against
-the other corpora on this page before trusting their scores. Note that our own tree
-catches all four; this is about what the corpus can transmit, not about what we ship.
+whether a vector isolates it**. That audit was then run against the other scored
+rows on this page, independently of what each manifest declared. The same habit
+showed up: mcp-jsonrpc-id isolated presence and null and left number and bool
+free; the drift consumer isolated digest-mismatch and left malformed / unresolved
+/ redacted free; rge-bench isolated the origin-ceiling ladder and left the
+strength ladder undeclared until this measurement. Note that our own tree
+catches the v0 four; this is about what the corpus can transmit, not about what
+we ship.
 
 Not fixed here. Every one of these needs a new vector, and a new vector moves a
 digest that [#1840](https://github.com/Rul1an/assay/issues/1840) has published as a

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -146,7 +146,7 @@ the rows below say which of the two they mean.
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
-| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 1 known hole.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. The survivors form **one systematic gap, not four**: wherever a rule has sibling members, the corpus discriminates exactly one and leaves the rest free. Decision cardinality is caught (`bad-103`) and observation and establish cardinality are not; the decision's `target_digest` is caught (`bad-102`) and the observation's `response_digest` is not; the binding pair is caught on its digest leg (`bad-105`) and not on its tool-name leg; the marker triple is caught on schema and code and not on origin (the known hole). One vector per failure mode, and every failure mode has siblings on the same code path that never got one. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
+| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of roughly twenty-nine. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
@@ -156,52 +156,110 @@ the rows below say which of the two they mean.
 rounded up — and this line has now been wrong in both directions on the same day.
 It read *four measured* while `privileged-mcp-action-v0` was scoring nothing; it
 was corrected to *three*; and it is four again only because that corpus was then
-declared properly and finally produced a number. The number is 50%, which is the
-worst result on this page. Both corrections are left visible, because a table
-whose purpose is to publish unflattering results should show its own edits.
+declared properly and finally produced a number. The number is 50%, the worst on
+this page, and it is still too kind: it is 50% of eight declared rules where the
+implementation has roughly twenty-nine, which the section below measures. Both
+corrections are left visible, because a table whose purpose is to publish
+unflattering results should show its own edits.
 
 The same under-declaration then showed up on the other three scored rows. Each
 first score was a number about the rules the author happened to list, not about
 the rules the implementation has: 4 of 4 over four of ten id-field arms; 4 of 5
 over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
 hand-written table that ADMISSION.md already warned was unchecked against
-`ref_example.py`. The rows above now score the larger denominator. The numbers
-went down. That is the point.
+`ref_example.py`. Those three rows now score the larger denominator and the
+numbers went down, which is the point. `privileged-mcp-action-v0` is the
+exception and is marked as one: its twenty-three further rules are identified
+and measured collectively but not yet declared individually, so its score is
+still over the small denominator.
 
-### The v0 survivors are one gap wearing four faces
+### The v0 corpus isolates six rules and leaves twenty-three free
 
-Worth stating separately because it changes what closing them costs. The four
-survivors in `privileged-mcp-action-v0` are not four independent oversights; they
-are four instances of the same construction habit. Every one of them is a *sibling*
-of a rule the corpus does catch, sitting on the same code path:
+A section here previously claimed the survivors were **"one gap wearing four
+faces"** — that wherever a v0 rule has sibling members the corpus discriminates
+exactly one and leaves the rest free. It was a tidy claim built on four data
+points, it was published, and an adversarial re-measurement refuted it. The
+replacement is below rather than an edit, because the shape of the error matters
+as much as the number: a pattern that explains four observations and flatters the
+author is not a finding, it is a hypothesis that was never attacked.
 
-| the corpus discriminates | it does not discriminate | shared path |
-|---|---|---|
-| `decisions.len() != 1` (`bad-103`) | `observations.len() > 1`, `establishes.len() > 1` | Stage 2 cardinality |
-| decision `action.target_digest` (`bad-102`) | observation `caller_visible_response_digest` | `is_sha256_digest` |
-| binding on `target_digest` (`bad-105`) | binding on `tool_name` | the same `&&` chain |
-| marker `schema` + `code` | marker `origin` (the known hole) | the same triple match |
+**The decisive experiment.** Rule deletion here is monotone — every one of these
+mutants only makes the verifier more permissive — so the rules can be deleted
+together. Twenty-three were: both cardinality siblings, the `reason` and
+`drift_state` vocabularies, both non-empty tool-name checks, the observation
+response digest, all three `caller_visible_error` member-presence rules, both
+`non_claims` checks, both establish checks, `marker_not_backed`,
+`marker_digest_unbindable`, `event_type_schema_mismatch`, the
+in-namespace-type arm, the binding tool-name leg, the establish contradiction,
+and all three legs of the marker triple.
 
-The corpus was built one vector per failure *mode*. Each mode's siblings share the
-structure but never got a vector, so an implementer can drop the second member of
-any of these pairs and reproduce all fourteen outcomes.
+**All fourteen outcomes and all five claim matrices reproduced exactly.** The
+only difference anywhere in the corpus was one finding string, and findings are
+not on the comparison surface the corpus declares.
 
-That the pattern is uniform is the useful part: it says the fix is not fourteen
-judgement calls but one rule — **for every conjunct and every sibling member, ask
-whether a vector isolates it**. That audit was then run against the other scored
-rows on this page, independently of what each manifest declared. The same habit
-showed up: mcp-jsonrpc-id isolated presence and null and left number and bool
-free; the drift consumer isolated digest-mismatch and left malformed / unresolved
-/ redacted free; rge-bench isolated the origin-ceiling ladder and left the
-strength ladder undeclared until this measurement. Note that our own tree
-catches the v0 four; this is about what the corpus can transmit, not about what
-we ship.
+So an implementer can delete twenty-three rules the profile promises, reproduce
+the pinned digest, and be indistinguishable from a conforming implementation.
+The corpus isolates six: decision cardinality, the decision vocabulary,
+unknown-schema-fails-closed, the decision `target_digest`, the `fail_closed`
+derivation, and the binding pair's digest leg.
 
-Not fixed here. Every one of these needs a new vector, and a new vector moves a
-digest that [#1840](https://github.com/Rul1an/assay/issues/1840) has published as a
+**What survived of the old claim, and what did not.** Three of its four table
+rows hold: cardinality, the `is_sha256_digest` call sites, and the `&&` chain of
+the binding pair each do discriminate one sibling and leave the others free. The
+fourth row was wrong on its *caught* side. Of the marker triple's three legs the
+corpus discriminates **none**:
+
+| leg | why no vector reaches it |
+|---|---|
+| `origin` | `gen_vectors.py:103` hard-codes `assay-proxy`; it is the only marker construction site |
+| `code` | the same line hard-codes `-32042`, with no generator parameter |
+| `schema` | decided earlier, at Stage 2 — under v0 selection only `.v0` payloads ever enter `observations` |
+
+The schema leg was credited to the corpus in the same document that, two entries
+away, used precisely this wrong-stage argument to rule a different mutant out of
+scope. The argument was available and was not applied where it was inconvenient.
+
+The generalisation that does survive is weaker and duller: **at most one member
+per family, and often zero.** Five families discriminate none — the triple legs,
+the two `check_non_claims` call sites, the two non-empty tool-name checks, the
+two `check_establish` rules, and the three `caller_visible_error` member-presence
+rules. "One vector per failure mode" is also false as counted: `bundle_integrity`
+carries two vectors, and `bad-108` fires two rules while being the only input for
+one of them, which is why `marker_not_backed` is masked and survives deletion.
+
+One rule is undiscriminable **in principle** by this corpus rather than in
+practice: `establish_journey_contradiction`. The profile calls the contradiction
+set normative and requires a finding, and a finding is the rule's only output —
+so no vector could isolate it without changing what the corpus compares.
+
+**Two method errors found in the same pass, both ours.**
+
+The manifest scored on `[bundle_integrity, verdict, reason_code]` while the
+corpus states its own surface in `MANIFEST.json`: *"expected.bundle_integrity,
+expected.verdict and expected.claims are the normative comparison surface;
+first_failure_informative is this generator's own vocabulary and is informative
+only."* So the measurement read the member declared informative and omitted the
+member declared normative. It was simultaneously weaker (a mutant flipping
+`ok-005`'s claim cell from refuted to confirmed survived the harness while the
+corpus kills it) and wider (`reason_code` separates `bad-101` from `bad-109`
+where the corpus does not). Corrected, and re-measured on the declared surface.
+
+Two adequacy runs then contaminated each other on one working tree, each finding
+the other's mutant applied to a file it had not touched, and one produced a
+believable `6 of 8 (75.0%)` where clean re-runs give `4 of 8`. `corpus-adequacy`
+now takes an exclusive lock before the dirty check and compares every captured
+original against `git show HEAD:<path>` at capture time, because the lock alone
+still left the window open. Every number on this page was re-measured after that
+landed.
+
+**Not fixed here.** Closing any of this needs new vectors, and a new vector moves
+a digest that [#1840](https://github.com/Rul1an/assay/issues/1840) publishes as a
 reproduction target. Whether that is answered by an addendum corpus at a second
-digest, or by leaving v0 pinned and honest, is a contract decision rather than a
-tooling one.
+digest or by leaving v0 pinned and honest is a contract decision rather than a
+tooling one. The twenty-three are identified but not yet declared individually in
+the manifest, so the score in the table above is still over the eight rules that
+are — which is exactly the over-generous denominator this section is about, now
+stated instead of hidden.
 
 ### Why `rfc8785` has a control and no declared rules
 

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -146,7 +146,7 @@ the rows below say which of the two they mean.
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
-| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of roughly twenty-nine. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
+| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of a declared twenty-four in scope, where eight had been declared before. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
@@ -168,12 +168,11 @@ the rules the implementation has: 4 of 4 over four of ten id-field arms; 4 of 5
 over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
 hand-written table that ADMISSION.md already warned was unchecked against
 `ref_example.py`. Those three rows now score the larger denominator and the
-numbers went down, which is the point. `privileged-mcp-action-v0` is the
-exception and is marked as one: its twenty-three further rules are identified
-and measured collectively but not yet declared individually, so its score is
-still over the small denominator.
+numbers went down, which is the point. `privileged-mcp-action-v0` took the same
+treatment last and hardest: sixteen further in-scope rules are now declared
+individually, taking its denominator from eight to twenty-four.
 
-### The v0 corpus isolates six rules and leaves twenty-three free
+### The v0 corpus isolates six rules and leaves most of the rest free
 
 A section here previously claimed the survivors were **"one gap wearing four
 faces"** — that wherever a v0 rule has sibling members the corpus discriminates
@@ -202,6 +201,13 @@ the pinned digest, and be indistinguishable from a conforming implementation.
 The corpus isolates six: decision cardinality, the decision vocabulary,
 unknown-schema-fails-closed, the decision `target_digest`, the `fail_closed`
 derivation, and the binding pair's digest leg.
+
+**Twenty-three deleted is not twenty-three new.** Five of them restate rules this
+manifest already declared, and two are out of scope — one wrong-stage, one
+undiscriminable in principle. Sixteen were new, in scope and undeclared, which
+puts the honest in-scope denominator at twenty-four rather than the eight it had
+been. The distinction is recorded because the larger number was the one that
+flattered the finding, and this page has spent the day leaning the other way.
 
 **What survived of the old claim, and what did not.** Three of its four table
 rows hold: cardinality, the `is_sha256_digest` call sites, and the `&&` chain of
@@ -252,14 +258,22 @@ original against `git show HEAD:<path>` at capture time, because the lock alone
 still left the window open. Every number on this page was re-measured after that
 landed.
 
+**The monotonicity argument, so it can be attacked rather than trusted.** Each of
+the twenty-three is a pure deletion that can only remove findings, and the outcome
+tuple depends only on whether the finding set is empty. So for rule sets `S ⊆ T`,
+`F(T) ⊆ F(S)`: if deleting all twenty-three reproduces every outcome, each single
+deletion must too. The condition a reader should push on is a deletion that *adds*
+findings — widening the marker triple makes more observations classify as markers,
+which can newly reach the binding check. That is why the three triple-leg mutants
+were not rested on the argument; each was built and run on its own, and each
+survived on its own. The argument also requires `claims` on the comparison
+surface, which is the second reason the surface error above mattered.
+
 **Not fixed here.** Closing any of this needs new vectors, and a new vector moves
 a digest that [#1840](https://github.com/Rul1an/assay/issues/1840) publishes as a
 reproduction target. Whether that is answered by an addendum corpus at a second
 digest or by leaving v0 pinned and honest is a contract decision rather than a
-tooling one. The twenty-three are identified but not yet declared individually in
-the manifest, so the score in the table above is still over the eight rules that
-are — which is exactly the over-generous denominator this section is about, now
-stated instead of hidden.
+tooling one.
 
 ### Why `rfc8785` has a control and no declared rules
 

--- a/conformance/adequacy/mcp-jsonrpc-id.manifest.json
+++ b/conformance/adequacy/mcp-jsonrpc-id.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
-  "_about": "Mutation adequacy for the mcp-jsonrpc-id pack. The pack's README declares a NARROW scope: the error-response id contradiction, two incompatibility arms plus one positive control. The four id rules are in scope. The envelope-shape rules are real rules the pack depends on but never claimed to exercise, so they are declared out_of_scope and reported rather than scored. Lives OUTSIDE the pack on purpose: the pack checksums its own public files, so adding a manifest to it would break its integrity guard. The vectors file here is derived from the pack's vectors/*.json and conformance/tests/test_corpus_adequacy_own_corpora.py asserts it has not drifted.",
+  "_about": "Mutation adequacy for the mcp-jsonrpc-id pack. The pack's README declares a NARROW scope: the error-response id contradiction, two incompatibility arms plus one positive control. Envelope-shape rules are real rules the pack depends on but never claimed to exercise, so they are out_of_scope and reported rather than scored. The first declaration scored only the four presence/null arms and called that 4 of 4. The positive control is a string id, and RequestId is string | number, so the type arms belong in the denominator: two of them (string) are isolated by that control, and the number/bool siblings are not. Lives OUTSIDE the pack on purpose: the pack checksums its own public files, so adding a manifest to it would break its integrity guard. The vectors file here is derived from the pack's vectors/*.json and conformance/tests/test_corpus_adequacy_own_corpora.py asserts it has not drifted.",
   "implementation": "../../examples/mcp-jsonrpc-id-conformance/check.py",
   "entrypoint": "evaluate_message",
   "entrypoint_args": [
@@ -76,6 +76,36 @@
         "anchor": "        identifier is None or isinstance(identifier, str) or _is_number(identifier)",
         "replacement": "        isinstance(identifier, str) or _is_number(identifier)",
         "scope": "declared"
+      },
+      {
+        "label": "11 MCP RequestId includes string",
+        "anchor": "    mcp_id_valid = not has_id or (\n        isinstance(identifier, str)\n        or (isinstance(identifier, int) and not isinstance(identifier, bool))",
+        "replacement": "    mcp_id_valid = not has_id or (\n        False\n        or (isinstance(identifier, int) and not isinstance(identifier, bool))"
+      },
+      {
+        "label": "12 JSON-RPC accepts a string id",
+        "anchor": "    jsonrpc_id_valid = has_id and (\n        identifier is None or isinstance(identifier, str) or _is_number(identifier)\n    )",
+        "replacement": "    jsonrpc_id_valid = has_id and (\n        identifier is None or False or _is_number(identifier)\n    )"
+      },
+      {
+        "label": "13 MCP RequestId includes number",
+        "anchor": "        or (isinstance(identifier, int) and not isinstance(identifier, bool))\n    )",
+        "replacement": "        or False\n    )"
+      },
+      {
+        "label": "14 a bool is not an MCP RequestId",
+        "anchor": "isinstance(identifier, int) and not isinstance(identifier, bool)",
+        "replacement": "isinstance(identifier, int)"
+      },
+      {
+        "label": "15 JSON-RPC accepts a number id",
+        "anchor": "    jsonrpc_id_valid = has_id and (\n        identifier is None or isinstance(identifier, str) or _is_number(identifier)\n    )",
+        "replacement": "    jsonrpc_id_valid = has_id and (\n        identifier is None or isinstance(identifier, str)\n    )"
+      },
+      {
+        "label": "16 a bool is not a JSON-RPC number id",
+        "anchor": "    return isinstance(value, (int, float)) and not isinstance(value, bool)",
+        "replacement": "    return isinstance(value, (int, float))"
       },
       {
         "label": "10 a non-object message is rejected outright",

--- a/conformance/adequacy/observed-effect-drift-consumer.manifest.json
+++ b/conformance/adequacy/observed-effect-drift-consumer.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
   "runner": "batch",
-  "_about": "Mutation adequacy for the observed-effect-v0 drift consumer. BATCH runner: the checker takes the whole vector file and reports a summary, so the corpus is exercised as a unit and the summary IS the outcome. Its failures list names the case ids, which is what makes it discriminate; a checker reporting only a boolean would make every mutant kill everything or nothing. The command is relative on purpose -- the consumer REFUSES an absolute vectors path, which is its own hardening and not something to work around. Requires Rul1an/observed-effect-v0 cloned as a sibling of this repository; without it the run fails with a missing source rather than silently measuring nothing.",
+  "_about": "Mutation adequacy for the observed-effect-v0 drift consumer. BATCH runner: the checker takes the whole vector file and reports a summary, so the corpus is exercised as a unit and the summary IS the outcome. Its failures list names the case ids, which is what makes it discriminate; a checker reporting only a boolean would make every mutant kill everything or nothing. The first declaration scored five merge-policy rules (4 of 5). The 14 case names announce the recompute, advisory, and profile rules as well; those belong in the denominator. The command is relative on purpose -- the consumer REFUSES an absolute vectors path, which is its own hardening and not something to work around. Requires Rul1an/observed-effect-v0 cloned as a sibling of this repository; without it the run fails with a missing source rather than silently measuring nothing.",
   "repo_root": "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06",
   "implementation_sources": [
     "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06/independent_consumer.py"
@@ -44,6 +44,96 @@
         "label": "4 the body is only read when the ref recomputed",
         "anchor": "body = store.get(ref.get(\"ref\")) if rv == \"recomputed\" else None",
         "replacement": "body = store.get(ref.get(\"ref\"))"
+      },
+      {
+        "label": "5 agreement falls through to allow",
+        "anchor": "    else:\n        decision = \"allow\"",
+        "replacement": "    else:\n        decision = \"review_required\""
+      },
+      {
+        "label": "6 surface remains the authority",
+        "anchor": "\"surface_is_authority\": True,",
+        "replacement": "\"surface_is_authority\": False,"
+      },
+      {
+        "label": "7 observed divergence drives the decision",
+        "anchor": "    elif adv == \"divergence_observed\":\n        decision = \"quarantine\" if opt_in else \"review_required\"",
+        "replacement": "    elif False:\n        decision = \"quarantine\" if opt_in else \"review_required\""
+      },
+      {
+        "label": "8 not_observed or unknown basis is insufficient coverage",
+        "anchor": "    if b not in BASIS_OK or b in (\"not_observed\", \"unknown\"):",
+        "replacement": "    if b not in BASIS_OK:"
+      },
+      {
+        "label": "9 an unexpected basis is insufficient coverage",
+        "anchor": "    if b not in BASIS_OK or b in (\"not_observed\", \"unknown\"):",
+        "replacement": "    if b in (\"not_observed\", \"unknown\"):"
+      },
+      {
+        "label": "10 nonempty divergence is observed",
+        "anchor": "    return \"divergence_observed\" if (body.get(\"divergence\") or []) else \"none\"",
+        "replacement": "    return \"none\""
+      },
+      {
+        "label": "11 an unknown profile is unsupported",
+        "anchor": "    if not isinstance(canon, str) or canon not in PROFILES:\n        return \"unsupported_canonicalization\"",
+        "replacement": "    if False:\n        return \"unsupported_canonicalization\""
+      },
+      {
+        "label": "12 the digest must match the recomputed address",
+        "anchor": "    if addr(body, canon) != ref[\"digest\"]:",
+        "replacement": "    if False:"
+      },
+      {
+        "label": "13 required fields must be present and unredacted",
+        "anchor": "    if any(f not in body or redacted(body[f]) for f in spec[\"required_fields\"]):\n        return \"incomplete_projection\"",
+        "replacement": "    if False:\n        return \"incomplete_projection\""
+      },
+      {
+        "label": "14 a redacted required field is incomplete",
+        "anchor": "    if any(f not in body or redacted(body[f]) for f in spec[\"required_fields\"]):",
+        "replacement": "    if any(f not in body for f in spec[\"required_fields\"]):"
+      },
+      {
+        "label": "15 jcs-json-v1 is a live profile",
+        "anchor": "    if profile == \"jcs-json-v1\":\n        return \"sha256:\" + hashlib.sha256(canon_jcs(body)).hexdigest()",
+        "replacement": "    if False:\n        return \"sha256:\" + hashlib.sha256(canon_jcs(body)).hexdigest()"
+      },
+      {
+        "label": "16 cbor-deterministic-v1 is a live profile",
+        "anchor": "    if profile == \"cbor-deterministic-v1\":\n        return \"sha256:\" + hashlib.sha256(canon_cbor(body)).hexdigest()",
+        "replacement": "    if False:\n        return \"sha256:\" + hashlib.sha256(canon_cbor(body)).hexdigest()"
+      },
+      {
+        "label": "17 JCS object keys are ordered by UTF-16 code unit",
+        "anchor": "        items = sorted(o.items(), key=lambda kv: kv[0].encode(\"utf-16-be\"))",
+        "replacement": "        items = sorted(o.items(), key=lambda kv: kv[0])"
+      },
+      {
+        "label": "18 a missing digest or profile is malformed",
+        "anchor": "    if not ref.get(\"digest\") or not ref.get(\"canonicalization\"):\n        return \"malformed_ref\"",
+        "replacement": "    if False:\n        return \"malformed_ref\""
+      },
+      {
+        "label": "19 a digest without a location is unresolvable",
+        "anchor": "    if loc is None:\n        return \"unresolvable_digest_only\"",
+        "replacement": "    if False:\n        return \"unresolvable_digest_only\""
+      },
+      {
+        "label": "20 a location absent from the store is unresolved",
+        "anchor": "    if loc not in store:\n        return \"unresolved_ref\"",
+        "replacement": "    if False:\n        return \"unresolved_ref\""
+      },
+      {
+        "label": "21 an unknown schema fails closed",
+        "anchor": "    if spec is None:\n        return \"schema_mismatch\"",
+        "replacement": "    if False:\n        return \"schema_mismatch\""
+      },
+      {
+        "label": "22 a digest that matches the other profile is a canonicalization mismatch",
+        "anchor": "        for alt in PROFILES:\n            if alt != canon and addr(body, alt) == ref[\"digest\"]:\n                return \"canonicalization_mismatch\"\n        return \"digest_mismatch\"",
+        "replacement": "        return \"digest_mismatch\""
       },
       {
         "label": "CONTROL harness reachability",

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -204,6 +204,18 @@
         "reason": "WRONG STAGE, same argument as declared mutant 0. Under v0 selection only payloads whose schema member is assay.denied_call_observation.v0 are collected into `observations`, so the classifier's schema leg cannot decide anything on this path: it is an equivalent mutant here, not a hole. Measured SURVIVED, as the reasoning predicts. Recorded because the published table credits this leg to the corpus."
       },
       {
+        "label": "47 an unrecognised in-namespace payload schema fails closed (Stage 2)",
+        "anchor": "                    other => violations.push(finding(\n                        \"unknown_profile_schema\",\n                        format!(\n                            \"payload schema {other:?} is inside the profile namespace but is not a recognized {} record; unknown fails closed\",\n                            profile_version.as_profile_id()\n                        ),\n                    )),",
+        "replacement": "                    other => { let _ = other; }",
+        "reason": "v0 Stage 2. Declared mutant 0 mutates the Stage 3 classifier and is out of scope for exactly this reason -- 'to measure that promise, mutate the Stage 2 match instead'. This is that mutant. bad-104 should kill it."
+      },
+      {
+        "label": "48 the decision value must be in the closed vocabulary",
+        "anchor": "check_vocab(dec, \"decision\", DECISION_VOCAB, violations);",
+        "replacement": "let _ = DECISION_VOCAB;",
+        "reason": "v0 Stage 2 closed vocabulary. Declared as its own call site rather than by mutating check_vocab, which would delete four rules at once. bad-107 should kill it."
+      },
+      {
         "label": "CONTROL harness reachability on the verifier path",
         "anchor": ".filter(|obs| classify_denial_marker(obs) == Some(profile_version.marker_version()));",
         "replacement": ".filter(|_obs| false);",

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
   "runner": "process",
-  "_about": "Mutation adequacy for privileged-mcp-action/v0. First pass declared THREE rules and scored nothing: one genuine hole (the origin leg) and two that mutate the wrong stage and the wrong profile, kept out_of_scope with that reasoning rather than dropped. A corpus of 14 vectors that yields no adequacy result is a signal about the DECLARATION, not about the corpus -- so eight further rules were declared, read off the verifier path rather than off the vector names.",
+  "_about": "Mutation adequacy for privileged-mcp-action/v0, third declaration. The first declared THREE rules and scored nothing. The second declared eight read off the verifier path and scored 4 of 8, which was published with a pattern claim that an adversarial re-measurement then refuted: deleting 23 further promised rules AT ONCE reproduced all fourteen outcomes and all five claim matrices. This declaration folds those in, deduplicated by (anchor, replacement) rather than by label -- five of the 23 turned out to restate rules already declared here, and counting them again would have inflated the denominator in the direction that flatters. outcome_from now reads the surface MANIFEST.json declares normative rather than the one it calls informative.",
   "repo_root": "../..",
   "implementation_sources": [
     "../../crates/assay-evidence/src/denial_marker.rs",
@@ -98,6 +98,110 @@
         "label": "11 the code must be the v0 deny code",
         "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
         "replacement": "(DENIED_CALL_OBSERVATION_V0, _, PROXY_ORIGIN) => {"
+      },
+      {
+        "label": "26 the decision reason must be in the closed producer set",
+        "anchor": "check_vocab(dec, \"reason\", REASON_VOCAB, violations);",
+        "replacement": "let _ = (dec, REASON_VOCAB, &violations);",
+        "reason": "v0 Section 5 Stage 2: `reason` in the closed producer set unclassified_tool_call | classification_incomplete | no_declared_allowance | credential_scope_unknown | credential_scope_insufficient | manifest_baseline_missing | manifest_observation_ambiguous | manifest_current_observation_incomplete | manifest_drifted_since_approval | allow."
+      },
+      {
+        "label": "27 the decision drift_state must be in the closed set",
+        "anchor": "check_vocab(dec, \"drift_state\", DRIFT_STATE_VOCAB, violations);",
+        "replacement": "let _ = (dec, DRIFT_STATE_VOCAB, &violations);",
+        "reason": "v0 Section 5 Stage 2: `drift_state` in satisfied | baseline_missing | current_observation_incomplete | observation_ambiguous | drifted | not_evaluated."
+      },
+      {
+        "label": "28 the decision tool.name must be a non-empty string",
+        "anchor": "if tool_name.map(str::is_empty).unwrap_or(true) {\n        violations.push(finding(\n            \"decision_tool_name\",",
+        "replacement": "if false {\n        violations.push(finding(\n            \"decision_tool_name\",",
+        "reason": "v0 Section 5 Stage 2: `tool.name` a non-empty string."
+      },
+      {
+        "label": "29 the observation call.tool_name must be a non-empty string",
+        "anchor": "if tool_name.map(str::is_empty).unwrap_or(true) {\n        violations.push(finding(\n            \"observation_tool_name\",",
+        "replacement": "if false {\n        violations.push(finding(\n            \"observation_tool_name\",",
+        "reason": "v0 Section 5 Stage 2: observation record constraints, `call.tool_name` non-empty."
+      },
+      {
+        "label": "31 the observation caller_visible_error.code must be present and non-null",
+        "anchor": "for member in [\"code\", \"origin\", \"reason\"] {",
+        "replacement": "for member in [\"origin\", \"reason\"] {",
+        "reason": "v0 Section 5 Stage 2: caller_visible_error.code, caller_visible_error.origin, caller_visible_error.reason present and non-null. Stage 2 checks presence only; stage 3 compares typed values."
+      },
+      {
+        "label": "32 the observation caller_visible_error.origin must be present and non-null",
+        "anchor": "for member in [\"code\", \"origin\", \"reason\"] {",
+        "replacement": "for member in [\"code\", \"reason\"] {",
+        "reason": "v0 Section 5 Stage 2: caller_visible_error.code, caller_visible_error.origin, caller_visible_error.reason present and non-null. Stage 2 checks presence only; stage 3 compares typed values."
+      },
+      {
+        "label": "33 the observation caller_visible_error.reason must be present and non-null",
+        "anchor": "for member in [\"code\", \"origin\", \"reason\"] {",
+        "replacement": "for member in [\"code\", \"origin\"] {",
+        "reason": "v0 Section 5 Stage 2: caller_visible_error.code, caller_visible_error.origin, caller_visible_error.reason present and non-null. Stage 2 checks presence only; stage 3 compares typed values."
+      },
+      {
+        "label": "34 the decision must carry the five producer non-claims verbatim",
+        "anchor": "    check_non_claims(\n        dec,\n        DECISION_PRODUCER_NON_CLAIMS,\n        \"decision_non_claims\",\n        violations,\n    );",
+        "replacement": "    let _ = (\n        dec,\n        DECISION_PRODUCER_NON_CLAIMS,\n        \"decision_non_claims\",\n        &violations,\n    );",
+        "reason": "v0 Section 5 Stage 2: `non_claims` MUST be an array containing at least the five producer strings verbatim."
+      },
+      {
+        "label": "35 the observation must carry the four producer non-claims verbatim",
+        "anchor": "    check_non_claims(\n        obs,\n        OBSERVATION_PRODUCER_NON_CLAIMS,\n        \"observation_non_claims\",\n        violations,\n    );",
+        "replacement": "    let _ = (\n        obs,\n        OBSERVATION_PRODUCER_NON_CLAIMS,\n        \"observation_non_claims\",\n        &violations,\n    );",
+        "reason": "v0 Section 5 Stage 2: observation `non_claims` containing the four producer strings."
+      },
+      {
+        "label": "36 the establish_path must be in the closed set",
+        "anchor": "check_vocab(est, \"establish_path\", ESTABLISH_PATH_VOCAB, violations);",
+        "replacement": "let _ = (est, ESTABLISH_PATH_VOCAB, &violations);",
+        "reason": "v0 Section 5 Stage 2: `establish_path` in no_establish_needed | established_then_allowed | established_then_denied | immediate_deny."
+      },
+      {
+        "label": "37 establish_attempted must equal (run_outcome != not_performed)",
+        "anchor": "if attempted != (outcome != \"not_performed\") {",
+        "replacement": "if false {",
+        "reason": "v0 Section 5 Stage 2: establish_attempted MUST equal (run_outcome != \"not_performed\"). Note: the sibling promise in the same bullet -- that a missing or wrongly typed member is itself invalid, since the equality must be checkable -- is NOT declared here and is a further undeclared rule."
+      },
+      {
+        "label": "38 the event type must equal the payload schema it declares",
+        "anchor": "if ev.type_ != s {",
+        "replacement": "if false {",
+        "reason": "v0 Section 2: events are selected by the exact `schema` member of their payload; the event's `type` MUST equal that schema string."
+      },
+      {
+        "label": "39 an in-namespace event type over a payload that declares no in-namespace schema fails closed",
+        "anchor": "_ if in_namespace(&ev.type_) => violations.push(finding(",
+        "replacement": "_ if in_namespace(&ev.type_) => drop(finding(",
+        "reason": "v0 Section 2: a mismatch in either direction within the profile's namespaces -- including an in-namespace type over a payload that declares no in-namespace schema -- is invalid, fail closed."
+      },
+      {
+        "label": "40 a caller-visible denial marker must be backed by a decision record",
+        "anchor": "(None, _) => violations.push(finding(\n                \"marker_not_backed\",",
+        "replacement": "(None, _) => drop(finding(\n                \"marker_not_backed\",",
+        "reason": "v0 Section 5 Stage 3: a marker present with no decision record at all is invalid. Undiscriminated by masking rather than by absence: bad-108 does present this input, but the same bundle also trips decision_cardinality, which reaches the same outcome, so deleting this rule alone moves nothing."
+      },
+      {
+        "label": "41 a marker with a null or empty call.target_digest is unbindable and invalid",
+        "anchor": "(Some(_), None) => violations.push(finding(\n                \"marker_digest_unbindable\",",
+        "replacement": "(Some(_), None) => drop(finding(\n                \"marker_digest_unbindable\",",
+        "reason": "v0 Section 5 Stage 3: a marker with a null or empty call.target_digest is unbindable and invalid for the same reason."
+      },
+      {
+        "label": "43 a contradicting establish journey must be reported as a finding",
+        "anchor": "if contradiction {",
+        "replacement": "if false {",
+        "scope": "out_of_scope",
+        "reason": "OUT OF SCOPE ON THE COMPARISON SURFACE, and separately a corpus gap. v0 Section 5 Stage 4 makes the contradiction set normative and requires the verifier to emit a finding and not alter the matrix. Deleting the rule can only remove a finding, and findings are not part of the corpus's normative comparison surface (Section 8: bundle_integrity, verdict, and for accepts the claim matrix). No vector could discriminate it under that surface however it were written. Independently, the corpus also presents no contradicting journey at all: ok-004 is an allow beside established_then_allowed, which never contradicts. If findings are ever admitted to the comparison surface this becomes an in-scope hole needing a vector, so it is recorded rather than dropped."
+      },
+      {
+        "label": "44 the marker triple must match on the schema leg",
+        "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
+        "replacement": "(_, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
+        "scope": "out_of_scope",
+        "reason": "WRONG STAGE, same argument as declared mutant 0. Under v0 selection only payloads whose schema member is assay.denied_call_observation.v0 are collected into `observations`, so the classifier's schema leg cannot decide anything on this path: it is an equivalent mutant here, not a hole. Measured SURVIVED, as the reasoning predicts. Recorded because the published table credits this leg to the corpus."
       },
       {
         "label": "CONTROL harness reachability on the verifier path",

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -27,7 +27,7 @@
   "outcome_from": [
     "bundle_integrity",
     "verdict",
-    "reason_code"
+    "claims"
   ],
   "vectors": "privileged-mcp-action-v0.vectors.json",
   "id_key": "vector_id",
@@ -95,6 +95,11 @@
         "replacement": "if obs_tool.is_some() && obs_tool == dec_tool {"
       },
       {
+        "label": "11 the code must be the v0 deny code",
+        "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
+        "replacement": "(DENIED_CALL_OBSERVATION_V0, _, PROXY_ORIGIN) => {"
+      },
+      {
         "label": "CONTROL harness reachability on the verifier path",
         "anchor": ".filter(|obs| classify_denial_marker(obs) == Some(profile_version.marker_version()));",
         "replacement": ".filter(|_obs| false);",
@@ -113,7 +118,14 @@
         "recorded": "2026-08-19",
         "exercised_outside_corpus": "crates/assay-evidence/tests/denial_marker_classifier.rs::wrong_origin_is_inert",
         "corrected": "2026-08-19"
+      },
+      {
+        "label": "11 the code must be the v0 deny code",
+        "reason": "The SECOND leg of the same triple, found only because the first was published as a hole and someone asked what the other two do. v0 Stage 3 promises all three legs. Deleting the code conjunct leaves the 14-vector corpus test at 10 of 10 green, so no vector discriminates it. Cause is structural rather than an oversight in any one vector: gen_vectors.py:103 hard-codes the single marker shape {code: -32042, origin: assay-proxy} and is the only marker construction site, so no vector CAN vary either member. Corpus-only, like the origin leg: our tree does catch it -- deleting the conjunct fails crates/assay-evidence/tests/denial_marker_classifier.rs::cross_pair_v0_schema_v1_code_is_inert. Note the schema leg is not caught by the triple match either; bad-104 is decided earlier at Stage 2. Of the three legs the corpus discriminates NONE.",
+        "exercised_outside_corpus": "crates/assay-evidence/tests/denial_marker_classifier.rs::cross_pair_v0_schema_v1_code_is_inert",
+        "recorded": "2026-08-19"
       }
     ]
-  }
+  },
+  "_outcome_from_why": "The corpus declares its own comparison surface in MANIFEST.json: 'expected.bundle_integrity, expected.verdict and expected.claims are the normative comparison surface; first_failure_informative is this generator's own vocabulary and is informative only.' The first version of this manifest read [bundle_integrity, verdict, reason_code] -- the informative vocabulary, with the normative member omitted. That is weaker AND wider than the corpus at once. Measured consequence: a mutant flipping the Stage 4 (allow, bound) arm from refuted to confirmed moves ok-005's claim cell, so the CORPUS kills it, while the old surface did not see it and scored it a survivor. Wider, because reason_code separates bad-101 from bad-109 where the corpus does not."
 }

--- a/conformance/adequacy/rge-bench.manifest.json
+++ b/conformance/adequacy/rge-bench.manifest.json
@@ -1,0 +1,336 @@
+{
+  "schema": "corpus-adequacy.manifest.v0",
+  "_about": "Mutation adequacy for rge-bench's ref_example.py, measured from this workspace against the sibling checkout. The first published score was 30 of 30 over the hand-written mutant table in scripts/check_rule_liveness.py. ADMISSION.md already says that table is not checked against the rules the implementation contains. The missing rules were read off ref_example.py and the 95 vectors: the strength ladder (the ceiling ladder's sibling, already known to need permutations), the AND conjuncts scored as one mutant, the soft-digest and replay-equality fallthroughs, and the semantic-equality helpers the contract-edge prose claims. A 30 of 30 over half the discriminable rules is a number about half a corpus.",
+  "implementation": "../../../rge-bench/ref_example.py",
+  "entrypoint": "evaluate",
+  "entrypoint_args": [
+    "axis",
+    "inputs"
+  ],
+  "vectors": "../../../rge-bench/vectors.json",
+  "id_key": "vector_id",
+  "group_key": "axis",
+  "mutants": {
+    "claim_support": [
+      {
+        "label": "0 unknown vocabulary fails closed",
+        "anchor": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE or kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "0a unknown observer class fails closed",
+        "anchor": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE or kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\"",
+        "replacement": "if kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\""
+      },
+      {
+        "label": "0b unknown claim kind fails closed",
+        "anchor": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE or kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\"",
+        "replacement": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE:\n        return \"invalid\""
+      },
+      {
+        "label": "1 undeclared probe set is invalid",
+        "anchor": "if declared is None:\n        if is_absence:\n            return \"invalid\"",
+        "replacement": "if declared is None:\n        if False:\n            return \"invalid\""
+      },
+      {
+        "label": "2 surface outside the declared set",
+        "anchor": "elif claim.get(\"surface\") not in declared:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "elif False:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "3 reported gap removes absence support",
+        "anchor": "if observation.get(\"observation_gap\") and is_absence:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if False:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "3a a gap without absence still fires",
+        "anchor": "if observation.get(\"observation_gap\") and is_absence:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if observation.get(\"observation_gap\"):\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "3b absence without a gap still fires",
+        "anchor": "if observation.get(\"observation_gap\") and is_absence:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if is_absence:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "4 occurrence branch",
+        "anchor": "    if not is_absence:\n        return \"supported\" if observation.get(\"saw_event\") else \"unsupported\"",
+        "replacement": "    if False:\n        return \"supported\" if observation.get(\"saw_event\") else \"unsupported\""
+      },
+      {
+        "label": "4a occurrence requires a seen event",
+        "anchor": "        return \"supported\" if observation.get(\"saw_event\") else \"unsupported\"",
+        "replacement": "        return \"supported\""
+      },
+      {
+        "label": "5 a seen event contradicts absence",
+        "anchor": "if observation.get(\"saw_event\"):\n        return \"contradicted\"",
+        "replacement": "if False:\n        return \"contradicted\""
+      },
+      {
+        "label": "6 blinding cost bounds silence",
+        "anchor": "if _SUBJECT_CONTROLLABLE[observer[\"class\"]] and not observer.get(\"routing_enforced_by\"):\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if False:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "6b independently enforced routing escape",
+        "anchor": "if _SUBJECT_CONTROLLABLE[observer[\"class\"]] and not observer.get(\"routing_enforced_by\"):",
+        "replacement": "if _SUBJECT_CONTROLLABLE[observer[\"class\"]]:"
+      },
+      {
+        "label": "7 silence from an unblindable observer is supported",
+        "anchor": "    # 7. silence from an observer the subject cannot blind, within its declared probe set\n    return \"supported\"",
+        "replacement": "    # 7. silence from an observer the subject cannot blind, within its declared probe set\n    return \"inconclusive_no_coverage\""
+      }
+    ],
+    "coverage_honesty": [
+      {
+        "label": "declared set must be a non-empty list and results a dict",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "declared_cases must be a list",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if not declared or not isinstance(results, dict):\n        return \"invalid\""
+      },
+      {
+        "label": "declared_cases must be non-empty",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if not isinstance(declared, list) or not isinstance(results, dict):\n        return \"invalid\""
+      },
+      {
+        "label": "case_results must be a dict",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if not isinstance(declared, list) or not declared:\n        return \"invalid\""
+      },
+      {
+        "label": "a missing result reads not_run rather than passing",
+        "anchor": "states = [results.get(case_id, \"not_run\") for case_id in declared]",
+        "replacement": "states = [results.get(case_id, \"passed\") for case_id in declared]"
+      },
+      {
+        "label": "an explicit failure refutes, ahead of confirmation",
+        "anchor": "if any(state == \"failed\" for state in states):\n        return \"refuted\"",
+        "replacement": "if False:\n        return \"refuted\""
+      },
+      {
+        "label": "confirmation requires every declared case to pass",
+        "anchor": "if all(state == \"passed\" for state in states):\n        return \"confirmed\"",
+        "replacement": "if any(state == \"passed\" for state in states):\n        return \"confirmed\""
+      }
+    ],
+    "hard_soft_digest": [
+      {
+        "label": "a missing or mismatched hard digest fails closed",
+        "anchor": "if not _present_string(hs) or not _present_string(hr) or hs != hr:\n        return \"rejected_hard\"",
+        "replacement": "if False:\n        return \"rejected_hard\""
+      },
+      {
+        "label": "an empty hard digest counts as missing",
+        "anchor": "if not _present_string(hs) or not _present_string(hr) or hs != hr:",
+        "replacement": "if hs is None or hr is None or hs != hr:"
+      },
+      {
+        "label": "soft compares only after hard accepts",
+        "anchor": "    return \"soft_equivalent\" if inp.get(\"soft_a\") == inp.get(\"soft_b\") else \"soft_divergent\"",
+        "replacement": "    return \"soft_equivalent\" if True else \"soft_divergent\""
+      }
+    ],
+    "retained_replay": [
+      {
+        "label": "carrier validity is a precondition",
+        "anchor": "if not inp.get(\"carrier_valid\"):\n        return \"rejected_carrier\"",
+        "replacement": "if False:\n        return \"rejected_carrier\""
+      },
+      {
+        "label": "a valid carrier over absent records is incomplete",
+        "anchor": "if not inp.get(\"records_retained\"):\n        return \"incomplete\"",
+        "replacement": "if False:\n        return \"incomplete\""
+      },
+      {
+        "label": "replayed must equal recorded",
+        "anchor": "    return \"replayed_match\" if set(inp.get(\"replayed\", [])) == set(inp.get(\"recorded\", [])) else \"replayed_mismatch\"",
+        "replacement": "    return \"replayed_match\" if True else \"replayed_mismatch\""
+      }
+    ],
+    "delegated_scope": [
+      {
+        "label": "granted and used must both be lists",
+        "anchor": "if not isinstance(granted, list) or not isinstance(used, list):\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "granted must be a list",
+        "anchor": "if not isinstance(granted, list) or not isinstance(used, list):\n        return \"invalid\"",
+        "replacement": "if not isinstance(used, list):\n        return \"invalid\""
+      },
+      {
+        "label": "used must be a list",
+        "anchor": "if not isinstance(granted, list) or not isinstance(used, list):\n        return \"invalid\"",
+        "replacement": "if not isinstance(granted, list):\n        return \"invalid\""
+      },
+      {
+        "label": "used must stay within granted",
+        "anchor": "return \"within_grant\" if set(used) <= set(granted) else \"exceeds_grant\"",
+        "replacement": "return \"within_grant\" if True else \"exceeds_grant\""
+      }
+    ],
+    "mcp_description_code": [
+      {
+        "label": "undeclared effect takes precedence over over-declaration",
+        "anchor": "if code - declared:\n        return \"undeclared_effect\"",
+        "replacement": "if False:\n        return \"undeclared_effect\""
+      },
+      {
+        "label": "an interface declaring unexercised effects is over_declared",
+        "anchor": "if declared - code:\n        return \"over_declared\"",
+        "replacement": "if False:\n        return \"over_declared\""
+      },
+      {
+        "label": "matching declared and code is consistent",
+        "anchor": "    return \"consistent\"",
+        "replacement": "    return \"over_declared\""
+      }
+    ],
+    "tamper_fail_closed": [
+      {
+        "label": "a missing digest fails closed",
+        "anchor": "return \"accepted\" if _present_string(stored) and _present_string(recomputed) and stored == recomputed else \"rejected\"",
+        "replacement": "return \"accepted\" if stored == recomputed else \"rejected\""
+      },
+      {
+        "label": "stored and recomputed digests must be equal",
+        "anchor": "return \"accepted\" if _present_string(stored) and _present_string(recomputed) and stored == recomputed else \"rejected\"",
+        "replacement": "return \"accepted\" if _present_string(stored) and _present_string(recomputed) else \"rejected\""
+      },
+      {
+        "label": "an empty digest string counts as missing",
+        "anchor": "    return isinstance(value, str) and value != \"\"",
+        "replacement": "    return isinstance(value, str)"
+      }
+    ],
+    "sufficiency": [
+      {
+        "label": "sufficiency requires a valid record AND complete coverage",
+        "anchor": "        if inp.get(\"record_valid\") and inp.get(\"coverage\") == \"complete\"",
+        "replacement": "        if inp.get(\"record_valid\")"
+      },
+      {
+        "label": "sufficiency requires a valid record",
+        "anchor": "        if inp.get(\"record_valid\") and inp.get(\"coverage\") == \"complete\"",
+        "replacement": "        if inp.get(\"coverage\") == \"complete\""
+      },
+      {
+        "label": "coverage must be the token complete",
+        "anchor": "        if inp.get(\"record_valid\") and inp.get(\"coverage\") == \"complete\"",
+        "replacement": "        if inp.get(\"record_valid\") and inp.get(\"coverage\")"
+      }
+    ],
+    "incomplete_visibility": [
+      {
+        "label": "only a present observation is observed",
+        "anchor": "return \"observed\" if inp.get(\"observation\") == \"present\" else \"incomplete\"",
+        "replacement": "return \"observed\" if inp.get(\"observation\") != \"not_checked\" else \"incomplete\""
+      }
+    ],
+    "source_class_ceiling": [
+      {
+        "label": "an unknown class or strength is invalid, not a pass",
+        "anchor": "if ceiling is None or strength is None:\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "claim strength must not exceed the origin ceiling",
+        "anchor": "return \"within_ceiling\" if strength <= ceiling else \"exceeds_ceiling\"",
+        "replacement": "return \"within_ceiling\" if True else \"exceeds_ceiling\""
+      },
+      {
+        "label": "the ceiling ladder ranks origin classes, flattened to the highest",
+        "anchor": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 3,\n}",
+        "replacement": "_CEILING = {\n    \"producer_reported\": 3,\n    \"issuer_attested\": 3,\n    \"receiver_receipt\": 3,\n}"
+      },
+      {
+        "label": "the ceiling ladder ranks origin classes, flattened to the lowest",
+        "anchor": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 3,\n}",
+        "replacement": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 1,\n    \"receiver_receipt\": 1,\n}"
+      },
+      {
+        "label": "the ceiling ladder is ordered, not merely three-valued: inverted",
+        "anchor": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 3,\n}",
+        "replacement": "_CEILING = {\n    \"producer_reported\": 3,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 1,\n}"
+      },
+      {
+        "label": "the strength ladder ranks claims, flattened to the highest",
+        "anchor": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 2,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 4,\n    \"independently_confirmed\": 5,\n}",
+        "replacement": "_STRENGTH = {\n    \"asserted\": 5,\n    \"asserted_signed\": 5,\n    \"observed_at_receiver\": 5,\n    \"observed_in_path\": 5,\n    \"independently_confirmed\": 5,\n}"
+      },
+      {
+        "label": "the strength ladder ranks claims, flattened to the lowest",
+        "anchor": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 2,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 4,\n    \"independently_confirmed\": 5,\n}",
+        "replacement": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 1,\n    \"observed_at_receiver\": 1,\n    \"observed_in_path\": 1,\n    \"independently_confirmed\": 1,\n}"
+      },
+      {
+        "label": "the strength ladder is ordered, not merely five-valued: inverted",
+        "anchor": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 2,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 4,\n    \"independently_confirmed\": 5,\n}",
+        "replacement": "_STRENGTH = {\n    \"asserted\": 5,\n    \"asserted_signed\": 4,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 2,\n    \"independently_confirmed\": 1,\n}"
+      }
+    ],
+    "format_equivalence": [
+      {
+        "label": "equivalence is over semantic fields, not the envelope shape",
+        "anchor": "        if _json_semantic_equal(inp.get(\"a\", {}).get(\"semantic\"), inp.get(\"b\", {}).get(\"semantic\"))",
+        "replacement": "        if inp.get(\"a\", {}).get(\"shape\") == inp.get(\"b\", {}).get(\"shape\")"
+      },
+      {
+        "label": "semantic equality preserves array order",
+        "anchor": "        return len(left) == len(right) and all(_json_semantic_equal(a, b) for a, b in zip(left, right))",
+        "replacement": "        return sorted(left) == sorted(right)"
+      },
+      {
+        "label": "semantic equality is over object key sets",
+        "anchor": "        return set(left) == set(right) and all(_json_semantic_equal(left[key], right[key]) for key in left)",
+        "replacement": "        return True"
+      },
+      {
+        "label": "a bool is not equal to the number one",
+        "anchor": "    if isinstance(left, bool) or isinstance(right, bool):\n        return left is right",
+        "replacement": "    if False:\n        return left is right"
+      }
+    ],
+    "recompute": [
+      {
+        "label": "observed must be a subset of declared",
+        "anchor": "return \"match\" if set(inp.get(\"observed\", [])) <= set(inp.get(\"declared\", [])) else \"mismatch\"",
+        "replacement": "return \"match\" if True else \"mismatch\""
+      },
+      {
+        "label": "CONTROL harness reachability",
+        "control": true,
+        "anchor": "    return fn(inputs) if fn else \"unsupported\"",
+        "replacement": "    return \"unsupported\""
+      },
+      {
+        "label": "an unknown axis is unsupported",
+        "scope": "out_of_scope",
+        "reason": "input-domain guard; the published corpus only presents the twelve named axes, so evaluate's unsupported fallback never runs",
+        "anchor": "    return fn(inputs) if fn else \"unsupported\"",
+        "replacement": "    return fn(inputs) if fn else \"sufficient\""
+      }
+    ]
+  },
+  "equivalent": {
+    "claim_support": [
+      {
+        "label": "order of rules 2 and 3",
+        "reason": "both return inconclusive_no_coverage, so no vector can distinguish which one fired; stated in the README as a deliberate boundary rather than found as a gap"
+      }
+    ],
+    "format_equivalence": [
+      {
+        "label": "JSON numbers compare by numeric value",
+        "reason": "Python == already treats 1 and 1.0 as equal, so deleting the Number branch cannot move a vector in this implementation. The rule exists for language-neutral implementers (JM-Lab's JVM drift) and is equivalent here, not unexercised."
+      }
+    ]
+  }
+}

--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -1,0 +1,117 @@
+# Errata for privileged-mcp-action/v0
+
+**Applies to corpus digest `sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342`**, and to
+nothing else. If the digest changes, this file is void until it is re-measured against the new one.
+
+Recorded 2026-08-19. **No vector, expectation or digest is changed by this file.** A published
+corpus whose digest is its identity does not get edited; it gets an erratum, and a later corpus
+gets the fix.
+
+## What reproducing this corpus does and does not establish
+
+An independent implementation that reproduces all fourteen outcomes has demonstrated agreement on
+**six** of the profile's rules. It has not demonstrated agreement on the profile.
+
+This is not a defect in the vectors as written, nor a claim that the reference implementation is
+wrong. It is a statement about **what fourteen vectors can transmit**. Where the profile promises a
+rule that no vector isolates, an implementation can omit that rule, reproduce this digest, and be
+indistinguishable here from one that honours it.
+
+Measured with [`corpus-adequacy`](https://github.com/corpus-adequacy/corpus-adequacy) over the
+normative comparison surface this corpus declares in `MANIFEST.json`
+(`bundle_integrity`, `verdict`, `claims`):
+
+```
+6 of 25 DECLARED in-scope rules killed (24.0%). 4 declared out of scope, 31 rules declared.
+control-killed. 19 mutant(s) survived. 2 KNOWN HOLES.
+```
+
+Reproduce with:
+
+```
+python3 ../../../corpus-adequacy/corpus_adequacy.py \
+  ../adequacy/privileged-mcp-action-v0.manifest.json
+```
+
+## The six rules reproduction does establish
+
+| rule | isolated by |
+|---|---|
+| exactly one decision record | `bad-103` |
+| the decision value is in the closed vocabulary | `bad-107` |
+| an unrecognised in-namespace payload schema fails closed (Stage 2) | `bad-104` |
+| the decision `action.target_digest` is a well-formed sha256 | `bad-102` |
+| `fail_closed` equals (`decision` == `"deny"`) | `bad-106` |
+| a marker binds on the `target_digest` leg | `bad-105` |
+
+## The nineteen it does not
+
+Each is promised by [v0.md](../../docs/profiles/privileged-mcp-action/v0.md) and is not
+discriminated by any of the fourteen vectors.
+
+**Cardinality and shape**
+- at most one observation record; at most one establish record
+- the observation `caller_visible_response_digest` is a well-formed sha256
+- the decision `tool.name` is a non-empty string; the observation `call.tool_name` is a non-empty string
+- the event type equals the payload schema it declares
+- an in-namespace event type over a payload declaring no in-namespace schema fails closed
+
+**Closed vocabularies**
+- the decision `reason` is in the closed producer set
+- the decision `drift_state` is in the closed set
+- the `establish_path` is in the closed set
+- `establish_attempted` equals (`run_outcome` != `not_performed`)
+
+**Marker binding**
+- a marker binds on the `tool_name` leg
+- a caller-visible denial marker is backed by a decision record
+- a marker with a null or empty `call.target_digest` is unbindable and invalid
+
+**Marker payload members**
+- `caller_visible_error.code`, `.origin` and `.reason` are each present and non-null
+
+**Producer non-claims**
+- the decision carries the five producer non-claims verbatim
+- the observation carries the four producer non-claims verbatim
+
+## Two known holes, and why they are structural
+
+`caller_visible_error.origin` must be `"assay-proxy"` and `caller_visible_error.code` must be
+`-32042` — both legs of the Stage 3 marker triple, both promised, neither discriminated.
+
+The cause is not an omission in any one vector. [`gen_vectors.py:103`](gen_vectors.py) hard-codes the
+single marker shape and is the only marker construction site, so **no vector in this corpus can vary
+either member**. Closing them requires a generator parameter, which is a new corpus.
+
+The triple's third leg, `schema`, is decided earlier at Stage 2 and so is not discriminated by the
+triple match either. Of the triple's three legs this corpus isolates none.
+
+## Rules out of scope for this corpus
+
+Four declared rules are excluded with stated reasons in
+[`../adequacy/privileged-mcp-action-v0.manifest.json`](../adequacy/privileged-mcp-action-v0.manifest.json):
+two mutate a v1 arm or an earlier stage and cannot move an outcome here even in principle, and one —
+the establish-journey contradiction — emits only a *finding*, and findings are not on this corpus's
+normative comparison surface. That last one is undiscriminable in principle rather than in practice,
+and becomes an in-scope hole the moment findings join the surface.
+
+## What this changes for an implementer
+
+Nothing about the exercise. Reproducing the fourteen outcomes remains the task, the expectations are
+unchanged, and a reproduction is still worth having: it is the only independent evidence that the
+specification text is sufficient to build against.
+
+What changes is the claim you can make afterwards, and the claim we can make about you. A successful
+reproduction establishes agreement on the six rules above. Anyone stating more than that — including
+us — is overstating what fourteen vectors measured.
+
+## How this was found
+
+Not by inspection. By mutation adequacy: delete one declared rule from the implementation, rebuild,
+and see whether the corpus notices. A rule the corpus cannot notice is a rule it cannot ask a third
+party to implement.
+
+The first three declarations of that measurement were themselves wrong — the first declared three
+rules and scored nothing, the second declared eight and published a pattern claim that an
+adversarial re-measurement refuted. `../INDEX.md` carries that sequence, including the run whose
+control survived and which therefore said nothing at all.

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -16,6 +16,18 @@ Vectors for the [Privileged MCP Action Evidence Profile v0](../../docs/profiles/
 - The corpus digest is a **candidate** until an independent, non-author implementation reproduces
   the expected outcomes from the specification text alone.
 
+## What a reproduction establishes: read [ERRATA.md](ERRATA.md) first
+
+Reproducing all fourteen outcomes demonstrates agreement on **six** of the profile's rules, not on
+the profile. Nineteen further rules that v0.md promises are not discriminated by any vector here, so
+an implementation can omit them and still reproduce this digest. Two of those — the `origin` and
+`code` legs of the Stage 3 marker triple — cannot be discriminated by any vector this generator can
+produce, because `gen_vectors.py` hard-codes the single marker shape.
+
+That does not change the exercise, the expectations, or the value of doing it. It changes the claim
+that can be made afterwards, by the implementer and by us. [ERRATA.md](ERRATA.md) names all
+twenty-five measured rules and is pinned to the current corpus digest.
+
 ## Attempting the independent reproduction
 
 The corpus digest stays a **candidate** until a non-author implementation reproduces the expected

--- a/conformance/tests/test_corpus_adequacy_own_corpora.py
+++ b/conformance/tests/test_corpus_adequacy_own_corpora.py
@@ -31,6 +31,10 @@ except ImportError:  # pragma: no cover - environment without the sibling checko
 REPO = Path(__file__).resolve().parents[2]
 MANIFEST = REPO / "conformance/adequacy/mcp-jsonrpc-id.manifest.json"
 PACK = REPO / "examples/mcp-jsonrpc-id-conformance"
+OBS_MANIFEST = REPO / "conformance/adequacy/observed-effect-drift-consumer.manifest.json"
+OBS_CONSUMER = REPO.parent / "observed-effect-v0/observed-effect-drift-consumer-2026-06/independent_consumer.py"
+RGE_MANIFEST = REPO / "conformance/adequacy/rge-bench.manifest.json"
+RGE_IMPL = REPO.parent / "rge-bench/ref_example.py"
 
 
 @unittest.skipIf(ca is None,
@@ -58,12 +62,15 @@ class DerivedVectorsDoNotDrift(unittest.TestCase):
 
 @unittest.skipIf(ca is None, "corpus-adequacy not found as a sibling checkout")
 class OwnCorpusAdequacy(unittest.TestCase):
-    def test_mcp_jsonrpc_id_is_adequate_within_its_declared_scope(self):
+    def test_mcp_jsonrpc_id_scores_the_id_type_arms_not_only_presence(self):
+        # 4 of 4 was a score over the presence/null arms alone. The positive
+        # control is a string id and RequestId is string | number, so the type
+        # arms belong in the denominator. Two of them are isolated; four are not.
         rep = ca.run(MANIFEST)
-        self.assertTrue(rep["adequate"], rep["failures"])
-        self.assertEqual(rep["score_percent"], 100.0)
-        self.assertEqual(rep["killed"], 4)
-        self.assertEqual(rep["survived"], 0)
+        self.assertEqual(rep["killed"], 6)
+        self.assertEqual(rep["survived"], 4)
+        self.assertEqual(rep["score_percent"], 60.0)
+        self.assertFalse(rep["adequate"])
 
     def test_every_out_of_scope_declaration_carries_a_reason(self):
         # Blocking review on #2538: an unreasoned exclusion is a percentage target
@@ -76,14 +83,15 @@ class OwnCorpusAdequacy(unittest.TestCase):
 
     def test_the_report_names_the_denominator_and_the_ratio(self):
         rep = ca.run(MANIFEST)
-        self.assertEqual(rep["declared_total"], 11)
-        self.assertEqual(rep["out_of_scope_ratio"], 1.75)
+        self.assertEqual(rep["declared_total"], 17)
+        self.assertEqual(rep["out_of_scope_ratio"], 0.7)
         self.assertIn("author-declared", rep["score_means"])
 
     def test_the_out_of_scope_count_is_stated_rather_than_hidden(self):
         # The honest half of the result: seven envelope rules no vector exercises.
         # If this number silently drops to zero, someone removed the disclosure
-        # rather than adding vectors.
+        # rather than adding vectors. Re-checked by applying each envelope mutant
+        # to the three published messages: none of them moves an outcome.
         rep = ca.run(MANIFEST)
         self.assertEqual(rep["unexercised_out_of_scope"], 7)
 
@@ -98,7 +106,40 @@ class OwnCorpusAdequacy(unittest.TestCase):
             "7 MCP RequestId excludes null",
             "8 JSON-RPC requires id to be present",
             "9 JSON-RPC permits a null id",
-        }, "the in-scope set must be exactly the four id rules the README declares")
+            "11 MCP RequestId includes string",
+            "12 JSON-RPC accepts a string id",
+            "13 MCP RequestId includes number",
+            "14 a bool is not an MCP RequestId",
+            "15 JSON-RPC accepts a number id",
+            "16 a bool is not a JSON-RPC number id",
+        }, "in-scope is the id-field rules, including the type arms the control exists for")
+
+
+@unittest.skipIf(ca is None, "corpus-adequacy not found as a sibling checkout")
+@unittest.skipUnless(OBS_CONSUMER.is_file(),
+                     "observed-effect-v0 not found as a sibling checkout")
+class ObservedEffectDeclarationIsTheConsumer(unittest.TestCase):
+    def test_the_score_is_over_recompute_and_profile_not_only_merge(self):
+        # 4 of 5 was merge-policy only. The 14 case names announce the rest.
+        # This number is supposed to be the lower, true one; do not tune it up.
+        rep = ca.run(OBS_MANIFEST)
+        self.assertEqual(rep["killed"], 14)
+        self.assertEqual(rep["survived"], 9)
+        self.assertEqual(rep["score_percent"], 60.9)
+        self.assertFalse(rep["adequate"])
+
+
+@unittest.skipIf(ca is None, "corpus-adequacy not found as a sibling checkout")
+@unittest.skipUnless(RGE_IMPL.is_file(), "rge-bench not found as a sibling checkout")
+class RgeBenchDeclarationMatchesTheImplementation(unittest.TestCase):
+    def test_the_score_is_over_the_rules_ref_example_has(self):
+        # 30 of 30 was the hand-written table. The strength ladder, the
+        # conjuncts, and the fallthroughs were discriminable and undeclared.
+        rep = ca.run(RGE_MANIFEST)
+        self.assertEqual(rep["killed"], 51)
+        self.assertEqual(rep["survived"], 3)
+        self.assertEqual(rep["score_percent"], 94.4)
+        self.assertFalse(rep["adequate"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three corpora rescored over their real denominators, one published claim withdrawn after it was refuted, and the tool hardened where this work found it wrong.

## What started it

`conformance/INDEX.md` published a section claiming the `privileged-mcp-action-v0` survivors were **"one gap wearing four faces"** — that wherever a rule has sibling members, the corpus discriminates exactly one and leaves the rest free. Tidy, built on four data points, and published before anything attacked it.

An adversarial re-measurement deleted **23 promised rules at once** — rule deletion here is monotone, so they compose — and **reproduced all fourteen outcomes and all five claim matrices exactly**. The only difference anywhere was one finding string, and findings are not on the surface the corpus declares.

The corpus isolates **six** rules. The claim undercounted by roughly a factor of six, and its crisp form is false; what survives is *"at most one member per family, and often zero"*, with five families discriminating none.

Three of its four table rows hold. The fourth was wrong on its **caught** side: of the marker triple's three legs the corpus discriminates none. `gen_vectors.py:103` hard-codes both code and origin and is the only marker construction site, and the schema leg is decided earlier at Stage 2 — *the same wrong-stage argument this manifest already used, two entries away, to rule a different mutant out of scope*. The argument was available and was not applied where it was inconvenient.

## The same habit on every other row

| corpus | first score | over the real denominator |
|---|---|---|
| `mcp-jsonrpc-id` | 4 of 4 — 100% | **6 of 10 — 60%**, 4 survivors |
| `observed-effect-v0` | 4 of 5 — 80% | **14 of 23 — 60.9%**, 9 survivors |
| rge-bench | 30 of 30 — 100% | **51 of 54 — 94.4%**, 3 survivors |
| `privileged-mcp-action-v0` | no result, then 4 of 8 | denominator 8 → **24** |
| `rfc8785` | control killed | unchanged — the one row not wearing a coat |

`mcp-jsonrpc-id` scored the presence and null arms only; `RequestId` is string or number, so the type arms belong in the denominator. rge-bench scored a hand-written table its own `ADMISSION.md` already warned was unchecked against `ref_example.py`.

The own-corpora test pinned `killed == 4` and `declared_total == 11`, which made the declaration a thing to preserve rather than a thing to test — adding rules broke it, and the change that kept it green was not adding them. It now pins the larger denominators.

## Two method errors, both ours

**The manifest read the wrong comparison surface.** It scored `[bundle_integrity, verdict, reason_code]`. `MANIFEST.json` states: *"expected.bundle_integrity, expected.verdict and expected.claims are the normative comparison surface; first_failure_informative is this generator's own vocabulary and is informative only."* So the measurement read the member declared informative and omitted the one declared normative — weaker **and** wider than the corpus at once. Measured consequence: a mutant flipping `ok-005`'s claim cell from refuted to confirmed survived the harness while the corpus kills it.

**Two adequacy runs contaminated one working tree.** Each reviewer found the other's mutant applied to a file it had not touched, and one run produced a believable `6 of 8 (75.0%)` where clean re-runs give `4 of 8`.

## Upstream, in `corpus-adequacy`

- `d686540` — a non-blocking POSIX lock, taken **before** the dirty check. A tree observed clean outside the lock can be mutated before the originals are captured, which is the same bug one step earlier.
- `5401922` — captured originals are compared against `git show HEAD:<path>` at capture time. The lock excludes another instance of the tool; it cannot exclude a hand edit or an instance that started before the lock existed.
- `6c41920` — an `outcome_from` member the implementation never emits is now refused. `doc.get(k)` returned `None` silently, so such a member compared `None` to `None` on every mutant and every score over it was over-generous by whatever it would have caught.

Each is pinned by tests at the artefact level rather than on the helper, and each positive control was run.

## Twenty-three deleted is not twenty-three new

Five of the 23 restate rules already declared; two are out of scope. **Sixteen** were new. Deduplicated by `(anchor, replacement)` rather than by label, because one pair is the same rule differing only by a trailing `=> {`. The larger number was the flattering one for a finding about under-declaration, so the smaller one is taken and the difference is recorded.

The monotonicity argument that licenses reading 23 individual survivals off one composite experiment is published with the condition that would break it — a deletion that *adds* findings. Widening the marker triple does exactly that in principle, so the three triple-leg mutants were built and run individually rather than inferred.

## Still open

Closing any of this needs new vectors, and a new vector moves a digest that #1840 publishes as a reproduction target. Addendum corpus at a second digest, or v0 left pinned and honest, is a contract decision rather than a tooling one and is not settled here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded mutation-adequacy results with updated measurements, survivor analysis, control results, and documented safeguards.
  * Clarified scoring scope, out-of-scope rules, known corpus gaps, and outcome-surface analysis across existing adequacy declarations.

* **Tests**
  * Added adequacy coverage for observed-effect and RGE benchmark corpora.
  * Updated JSON-RPC identifier expectations to distinguish supported type-specific rules.
  * Added checks for manifest alignment and inadequate-score outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->