### PR TITLE
test(cli): tie a recorded writer to the identity it writes

### DIFF
--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -725,6 +725,7 @@ fn describe_binds_only_recorded_documents() {
 #[test]
 fn documents_are_bound_to_a_writer() {
     for (identity, (writer, namer)) in document_rows() {
+        assert_writer_is_about_this_identity(&identity, &writer, &namer);
         let naming = read(&namer);
         let names_it = naming.contains(&format!("\"{identity}\""))
             || constant_names_for(&identity)
@@ -825,4 +826,113 @@ fn dependency_crates_match_the_manifest() {
          either scanned in full (SCANNED) or scanned for pub const identities (DEPENDENCY_CRATES); \
          a dependency in neither is a crate whose published identities nothing classifies"
     );
+}
+
+/// The writer file must be about *this* identity, not merely about writing.
+///
+/// `documents_are_bound_to_a_writer` asks whether the named file contains any writer idiom. That
+/// leaves `assay.foo.v0` bindable to a file that writes `assay.bar.v0` and happens to `println!`.
+/// A review measured the gap: six rows do not contain their identity in the writer at all, and all
+/// six are the write/name splits.
+///
+/// Two cases, no dataflow:
+///
+/// - the writer also names the identity (`namer` is `-`): it must contain the literal, or a
+///   constant whose value is the literal. Almost every row.
+/// - the naming file is separate: the writer must mention a symbol that file publishes. A writer
+///   that touches none of the namer's types is not the writer of its document.
+fn assert_writer_is_about_this_identity(identity: &str, writer: &str, namer: &str) {
+    let writing = read(writer);
+    if writer == namer {
+        let named = writing.contains(&format!("\"{identity}\""))
+            || constant_names_for(identity)
+                .iter()
+                .any(|name| mentions_token(&writing, name));
+        assert!(
+            named,
+            "{INVENTORY}: {identity} names {writer} as both writer and namer, and that file does \
+             not mention the identity. Either it is not the writer, or the naming column should \
+             point at the file that sets the schema"
+        );
+        return;
+    }
+    let published = published_symbols(namer);
+    assert!(
+        !published.is_empty(),
+        "{INVENTORY}: {identity} names {namer} as its naming file and that file publishes no \
+         symbols, so nothing can tie the writer to it"
+    );
+    let touched: Vec<&String> = published
+        .iter()
+        .filter(|symbol| mentions_token(&writing, symbol))
+        .collect();
+    assert!(
+        !touched.is_empty(),
+        "{INVENTORY}: {identity} is recorded as written by {writer} and named in {namer}, and the \
+         writer mentions none of that file's public symbols ({published:?}). A file that writes \
+         some other document and happens to call a writer would look identical"
+    );
+}
+
+/// Whether `src` uses `token` as a whole identifier rather than as a substring of a longer one.
+///
+/// `contains` was wrong here and a mutation caught it: `mcp/preflight.rs` declares its identity as
+/// `const SCHEMA`, and `init_report.rs` contains `INIT_REPORT_SCHEMA`, so binding the preflight
+/// document to the init writer passed. A substring match knows nothing about identifiers — the same
+/// defect that made a `git grep` for a constant look empty earlier in this file's history.
+fn mentions_token(src: &str, token: &str) -> bool {
+    let mut from = 0usize;
+    while let Some(rel) = src[from..].find(token) {
+        let start = from + rel;
+        let end = start + token.len();
+        let before_ok = start == 0
+            || !src.as_bytes()[start - 1].is_ascii_alphanumeric()
+                && src.as_bytes()[start - 1] != b'_';
+        let after_ok = end >= src.len()
+            || !src.as_bytes()[end].is_ascii_alphanumeric() && src.as_bytes()[end] != b'_';
+        if before_ok && after_ok {
+            return true;
+        }
+        from = start + token.len();
+    }
+    false
+}
+
+/// `pub` item names declared in a file: consts, structs, enums, type aliases and functions.
+fn published_symbols(path: &str) -> BTreeSet<String> {
+    let src = read(path);
+    let mut names = BTreeSet::new();
+    for line in src.lines() {
+        let line = code_before_comment(line).trim();
+        // `pub(crate)` and `pub(super)` publish to the writer just as well as bare `pub`; the
+        // schema-report constants are `pub(crate)` and this parser saw none of them at first.
+        let Some(rest) = line.strip_prefix("pub") else {
+            continue;
+        };
+        let rest = match rest.strip_prefix('(') {
+            Some(restricted) => match restricted.split_once(')') {
+                Some((_, after)) => after,
+                None => continue,
+            },
+            None => rest,
+        };
+        let Some(rest) = rest.strip_prefix(' ') else {
+            continue;
+        };
+        let rest = rest
+            .strip_prefix("const ")
+            .or_else(|| rest.strip_prefix("struct "))
+            .or_else(|| rest.strip_prefix("enum "))
+            .or_else(|| rest.strip_prefix("type "))
+            .or_else(|| rest.strip_prefix("fn "));
+        let Some(rest) = rest else { continue };
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if !name.is_empty() {
+            names.insert(name);
+        }
+    }
+    names
 }

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -31,7 +31,10 @@ A top-level JSON document a command writes to stdout or to a caller-named path, 
 string as its `schema`.
 
 Each row is `identity | writing file | naming file`, where `-` means the writing file also names the
-identity. The test asserts the writing file calls a writer and the naming file carries the identity.
+identity. The test asserts three things: the writing file calls a writer, the naming file carries the
+identity, and **the writing file is about this identity** — it names the identity itself, or, when
+the two files differ, mentions a symbol the naming file publishes. Without the third, a row could be
+bound to a file that writes some other document and happens to call a writer.
 The third column exists because some documents split the two: `assay doctor` sets its `schema` in
 `diagnostics/probes.rs` and writes in `doctor/implementation.rs`, and the three `evidence schema`
 reports are declared in `schema/reports.rs` and written in `schema/write.rs`. Recording the split is
@@ -202,6 +205,10 @@ of, and there is no instrument that fixes that.
   The theory that produced those six ("a projection, not a document") writes a perfectly non-empty
   reason. **#2485 must not read these sentences as evidence that a row is right.** Three of them have
   been wrong today, and the third was written after conceding the first two.
+- **The writer-to-identity tie is a token check, not dataflow.** A writer that mentions the right
+  constant while serializing something else would pass. Closing that means following the value into
+  the `schema` field, which nothing here does.
+
 - **The writer list is a fixed set of idioms**, and it has been wrong twice. `serde_json::to_writer`
   was missing until `assay describe` exposed it; `to_vec_pretty`, `tokio::fs::write`,
   `serde_json::to_string` and a bare `fs::write` were missing until a review opened the emit paths.


### PR DESCRIPTION
Closes the `V` finding from #2554's round-four review. Related: #2555, #2484, convention in #2167.

## What was wrong

`documents_are_bound_to_a_writer` asked whether the named file contains **any** writer idiom. So `assay.foo.v0` could be bound to a file that writes `assay.bar.v0` and happens to `println!`, and the guard stayed green.

The reviewer measured the gap rather than asserting it: six document rows do not contain their identity in the writer at all, and all six are the write/name splits.

## The check, without dataflow

- **Writer also names the identity** (`namer` is `-`): the file must contain the literal, or a constant whose value is that literal.
- **Naming file is separate**: the writer must mention a symbol the naming file publishes. A writer touching none of the namer's types is not the writer of its document.

## The part worth reading

**The first version passed the mutation it exists to catch.**

`mcp/preflight.rs` declares its identity as `const SCHEMA`. `init_report.rs` contains `INIT_REPORT_SCHEMA`. `contains` matched the shorter name *inside* the longer one, so binding the preflight document to the init writer was green.

Matching is now on identifier boundaries. A substring knows nothing about identifiers — the same defect that made an earlier search for `BINDING_ROWS`' identities look empty, because they are held in constants rather than written as literals.

`published_symbols` also missed `pub(crate)` and `pub(super)` on the first pass, so the three evidence-schema constants published nothing a writer could be tied to.

Neither of those came from reading the code. Both came from running a mutation that the property itself implied.

## Mutations

| | mutation | result |
|---|---|---|
| M16 | row pointed at a file writing a **different** document | red |
| M17 | split row whose writer touches none of the namer's symbols | red |
| M18 | **control**: unchanged tree | green |

## Limit, recorded in the file

The tie is a token check, not dataflow. A writer that mentions the right constant while serializing something else would pass. Closing that means following the value into the `schema` field, which nothing here does.

## What this does not close

`#2555` is still open and is a different class: a **new command file** in a crate already scanned. Const-in-dependencies catches a new crate; this catches a mis-bound row; #2555 catches `evidence lint` and `evidence diff`.
