### PR TITLE
test(cli): read the writer's module, and stop tying rows through comments

### DIFF
--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -842,7 +842,12 @@ fn dependency_crates_match_the_manifest() {
 /// - the naming file is separate: the writer must mention a symbol that file publishes. A writer
 ///   that touches none of the namer's types is not the writer of its document.
 fn assert_writer_is_about_this_identity(identity: &str, writer: &str, namer: &str) {
-    let writing = read(writer);
+    // Comments are stripped on both sides. `published_symbols` already ignored them and the writer
+    // side did not, so the two halves of the tie spoke different languages: at one point
+    // `supply_chain_conformance.rs` was tied to its namer by a single `//!` line naming
+    // `verify_supply_chain`, and rewriting that sentence would have dissolved the tie without
+    // touching a line of code.
+    let writing = strip_comments(&writer_module_source(writer));
     if writer == namer {
         let named = writing.contains(&format!("\"{identity}\""))
             || constant_names_for(identity)
@@ -873,6 +878,68 @@ fn assert_writer_is_about_this_identity(identity: &str, writer: &str, namer: &st
          some other document and happens to call a writer would look identical"
     );
 }
+
+/// A writer file plus the non-test modules it declares.
+///
+/// A command is its module tree, not one file. `assay registry supply-chain-conformance` writes in
+/// `supply_chain_conformance.rs` and builds the carrier in its own `descriptor` module, so the
+/// registry symbols that prove the tie live one file down. Reading only the named file made that
+/// row green on a single `//!` line and red as soon as comments were stripped from both sides —
+/// the row was never wrong, the reading was.
+fn writer_module_source(writer: &str) -> String {
+    let root = workspace_root();
+    let path = root.join(writer);
+    let mut out = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {writer}: {e}"));
+    let head = strip_comments(&out);
+    let test_only: BTreeSet<String> = test_mod_declarations(&head).into_iter().collect();
+    for name in declared_modules(&head) {
+        if test_only.contains(&name) {
+            continue;
+        }
+        for file in module_files(&path, &name) {
+            if let Ok(src) = std::fs::read_to_string(&file) {
+                out.push('\n');
+                out.push_str(&src);
+            }
+        }
+    }
+    out
+}
+
+/// Source with every `//` comment removed, line by line.
+fn strip_comments(src: &str) -> String {
+    src.lines()
+        .map(code_before_comment)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Published names too generic to tie a writer to a document.
+///
+/// Identifier boundaries stop `SCHEMA` matching `INIT_REPORT_SCHEMA`. They do not stop `new`
+/// matching `Sha256::new()`: `assay-runner-schema`'s health module publishes `pub fn new`, and the
+/// observation-health writer calls `Sha256::new()`, so that row would stay tied with every
+/// meaningful symbol removed.
+const TOO_GENERIC: &[&str] = &[
+    "new",
+    "default",
+    "from",
+    "try_from",
+    "into",
+    "parse",
+    "fmt",
+    "next",
+    "len",
+    "is_empty",
+    "build",
+    "builder",
+    "as_str",
+    "to_string",
+    "get",
+    "insert",
+    "push",
+    "run",
+];
 
 /// Whether `src` uses `token` as a whole identifier rather than as a substring of a longer one.
 ///
@@ -930,7 +997,7 @@ fn published_symbols(path: &str) -> BTreeSet<String> {
             .chars()
             .take_while(|c| c.is_alphanumeric() || *c == '_')
             .collect();
-        if !name.is_empty() {
+        if !name.is_empty() && !TOO_GENERIC.contains(&name.as_str()) {
             names.insert(name);
         }
     }

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -207,7 +207,20 @@ of, and there is no instrument that fixes that.
   been wrong today, and the third was written after conceding the first two.
 - **The writer-to-identity tie is a token check, not dataflow.** A writer that mentions the right
   constant while serializing something else would pass. Closing that means following the value into
-  the `schema` field, which nothing here does.
+  the `schema` field, which nothing here does. Both sides now ignore comments and generic published
+  names (`new`, `from`, `parse`, …); one row was briefly tied by a single `//!` line, and another
+  would have stayed tied through `Sha256::new()` alone.
+
+- **The split-row tie has no demonstrated source-mutation red, and cannot have one.** Severing it in
+  source — removing the writer's use of the naming file's symbol — does not compile
+  (`unresolved import`). That is a stronger guarantee than a red test and it is why the mutations for
+  this property are edits to *this file* rather than to code. Stated because a guard whose reds are
+  all document edits has not been shown to notice a source change, and here the reason is structural
+  rather than an omission.
+
+- **A shared naming file is one bit for several rows.** `evidence/schema/write.rs` and
+  `schema/reports.rs` serve three identities, and the tie for all three is the same `use`. Requiring
+  a symbol unique to each identity would need a fourth column naming it; that is not done here.
 
 - **The writer list is a fixed set of idioms**, and it has been wrong twice. `serde_json::to_writer`
   was missing until `assay describe` exposed it; `to_vec_pretty`, `tokio::fs::write`,


### PR DESCRIPTION
Closes the three `Z` findings from #2557's post-merge review. Related: #2555, #2484, #2167.

## Three ways the tie held without meaning anything

The reviewer gave a live instance of each, and all three reproduce.

**Comments counted on the writer side and not on the namer side.** `published_symbols` stripped comments; the writer match did not. So the two halves of the tie spoke different languages — and `assay.supply_chain_conformance.v0` was tied to its naming file by **exactly one line**:

```rust
//! carrier by running the existing `assay_registry::supply_chain::verify_supply_chain` producer over a
```

Rewriting that sentence would have dissolved the tie without touching a line of code.

**Generic published names tied rows on nothing.** Identifier boundaries stop `SCHEMA` matching `INIT_REPORT_SCHEMA`. They do not stop `new` matching `Sha256::new()` — and `assay-runner-schema`'s health module publishes `pub fn new`, so the observation-health row would have stayed tied with every meaningful symbol removed.

## The fix that was not the obvious one

Stripping comments from both sides reddened the supply-chain row — correctly, and **for the wrong reason**. The row was never wrong; the reading was. That command writes in `supply_chain_conformance.rs` and builds its carrier in its own `descriptor` module, which is where the registry call lives.

A command is its module tree, not one file. The tie now reads the writer plus the non-test modules it declares, and lands on `verify_supply_chain` in production code rather than in a doc comment.

## On demonstrating this one

There is **no source mutation that severs this tie and still compiles**. Removing the writer's use of the naming file's symbol is an `unresolved import`:

```
error[E0432]: unresolved import `assay_registry::supply_chain::GONE_SYMBOL`
```

That is a stronger guarantee than a red test, and it is why this property's mutations edit the inventory rather than the source. It answers the `AB` objection structurally instead of by omission.

My first attempt aliased the import instead — which leaves the token on the `use` line, so the mutation did not test what it claimed. That is the criticism made of my controls twice tonight, made once more by my own hand.

## Recorded, not closed

A shared naming file is **one bit for several rows**. `evidence/schema/write.rs` and `schema/reports.rs` serve three identities through the same `use`. Requiring a symbol unique to each identity needs a fourth column naming it, and that is not done here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of writer-to-identity associations by ignoring comments and generic identifiers.
  - Reduced ambiguous symbol matches when linking naming and writer files.
  - Validation now focuses on code-bearing, non-test modules to prevent comment-only associations.

- **Documentation**
  - Clarified guard limitations, including split-row ties and shared naming files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->