### PR TITLE
feat(conformance): make the adequacy numbers re-derived rather than remembered

### DIFF
--- a/.github/workflows/adequacy-drift.yml
+++ b/.github/workflows/adequacy-drift.yml
@@ -235,7 +235,34 @@ jobs:
             echo "::error::the plan selected no corpora; a run that measures nothing must not reach the drift check as though it had"
             exit 1
           fi
-          echo "declared non-instrument sibling pins: ${SIBLING_PINS:-<none>}"
+          # Non-instrument siblings: corpora whose subject lives in another
+          # repository. They were out of scope while nothing pinned them, because
+          # cloning at a floating ref would measure whatever that repo happened to
+          # be. Pinned, they are ordinary: a score against a named commit stays
+          # permanently true of it, and re-deriving it here is what proves the
+          # published number is reproducible rather than remembered.
+          #
+          # Fetched by explicit sha and verified, exactly like the instrument. A
+          # clone that silently lands elsewhere would produce a real-looking number
+          # about the wrong subject, which is worse than not measuring.
+          for pin in ${SIBLING_PINS}; do
+            dir="${pin%%=*}"
+            spec="${pin#*=}"
+            repo="${spec%@*}"
+            sha="${spec#*@}"
+            target="${GITHUB_WORKSPACE}/../${dir}"
+            echo "::group::sibling ${dir} <- ${repo}@${sha}"
+            git init --quiet "${target}"
+            git -C "${target}" remote add origin "https://github.com/${repo}.git"
+            git -C "${target}" fetch --quiet --depth 1 origin "${sha}"
+            git -C "${target}" checkout --quiet --detach FETCH_HEAD
+            landed="$(git -C "${target}" rev-parse HEAD)"
+            if [[ "${landed}" != "${sha}" ]]; then
+              echo "::error::${dir} is at ${landed}, not the pinned ${sha}"
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
 
           # One pass per instrument commit, so every row records the commit its manifest pins.
           for group in ${PIN_GROUPS}; do

--- a/.github/workflows/adequacy-drift.yml
+++ b/.github/workflows/adequacy-drift.yml
@@ -1,0 +1,371 @@
+# Keep the published mutation-adequacy numbers from rotting.
+#
+# `conformance/INDEX.md` and `conformance/privileged-mcp-action-v0/ERRATA.md` publish measured
+# adequacy numbers. They were produced by hand one evening and nothing re-derived them. ERRATA.md
+# pins its scope to a corpus DIGEST, which does not move when the implementation moves, so a rule
+# deleted from a declared implementation source changes what the corpus can transmit, changes no
+# digest, and trips no existing guard. That is a published claim nobody re-derives, which is the
+# exact defect this whole body of work exists to criticise.
+#
+# COST IS THE WHOLE PROBLEM. Four corpora are module or batch runners and finish in seconds.
+# `privileged-mcp-action-v0` is a process runner: about 32 `cargo build -p assay-cli` invocations,
+# roughly fifteen minutes. Running that on every pull request is unacceptable; running it never is
+# how the numbers rot. So the lane is relevance-gated, and relevance is DERIVED from each manifest's
+# own `implementation_sources` / `vectors` / `corpus_digest_file` declaration rather than from a
+# path glob — the lesson `scripts/ci/perf_bench_relevance.py` already records, where `^crates/`
+# matched all 21 crates and alerted on changes outside the benchmark's compilation unit.
+#
+# A LANE THAT PASSES BY NOT RUNNING IS THE DEFECT ONE LEVEL UP. Two structural rules follow, and
+# both are load-bearing:
+#
+#   * `check-drift` is the gating job, never `measure` alone. It runs with `if: always()` and
+#     refuses when an upstream job did not succeed, so a skipped or failed measurement is a RED
+#     gate rather than an absent one.
+#   * `measure_all.py --only X` deliberately carries over the rows it did not select, and a
+#     carried-over row is byte-identical to a freshly measured one. `check_published_numbers.py`
+#     therefore cannot tell "re-derived and matched" from "not run". `adequacy_lane_assert.py`
+#     can: it holds every selected corpus to `provenance.kind == "measured"` and names every
+#     unselected one, in words, as NOT re-derived by this run.
+#
+# THE INSTRUMENT IS PINNED. The tool lives at a sibling checkout,
+# `github.com/corpus-adequacy/corpus-adequacy`, deliberately not vendored (INDEX.md, "Where the
+# adequacy tool lives"). It is checked out at the commit `tool_pin.commit` names in the manifests,
+# never at a floating ref: an instrument that can change under the numbers is the same class of bug
+# this lane exists to catch. The same rule applies to every other sibling a corpus reads, which is
+# why two corpora are reported OUT OF SCOPE rather than cloned from a branch name.
+
+name: Adequacy drift
+
+on:
+  # No `paths:` filter. Relevance is derived from the manifests inside the plan job, and a path
+  # filter here would be a second, guessed statement of the same thing — the failure mode this
+  # lane copies its design from. Every PR runs `plan`, which costs seconds.
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly, Mondays 04:17 UTC. Off the hour on purpose: GitHub's scheduler queues heavily at
+    # :00 and a delayed run is a run nobody reads.
+    #
+    # WHY WEEKLY AND NOT NIGHTLY. Every merge to main re-runs this lane on the push diff, so drift
+    # caused by a change to a DECLARED implementation source is already caught within minutes of
+    # landing — the schedule is not what covers that case. What the schedule covers is drift from
+    # sources nobody declared: `privileged-mcp-action-v0` is measured through a whole
+    # `cargo build -p assay-cli`, so a change anywhere in that binary's dependency closure can move
+    # its number without touching the three files its manifest names. Gating on the full closure
+    # instead would run fifteen minutes on nearly every PR, which is the cost this lane exists to
+    # avoid, so that class of drift is deliberately traded for a bounded staleness window.
+    #
+    # Weekly is that bound. The response to a red scheduled run is a human re-measurement and a
+    # republish of INDEX.md and ERRATA.md, which is a weekly-cadence activity, not a nightly one; a
+    # nightly lane would surface the same finding six times before anyone acted on it, and a lane
+    # that cries out more often than it is answered is one people learn to skip.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      full:
+        description: "Measure every in-scope corpus regardless of relevance"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: adequacy-drift-${{ github.ref }}
+  # Superseding a pull-request run is free. Superseding a scheduled or main-branch run would drop
+  # the only full measurement that week.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  PYTHON_VERSION: "3.13.8"
+
+jobs:
+  plan:
+    name: Plan (derive relevance, resolve instrument pin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      mode: ${{ steps.plan.outputs.mode }}
+      tool_repository: ${{ steps.plan.outputs.tool_repository }}
+      tool_dir: ${{ steps.plan.outputs.tool_dir }}
+      pin_groups: ${{ steps.plan.outputs.pin_groups }}
+      all_corpora: ${{ steps.plan.outputs.all_corpora }}
+      relevant_corpora: ${{ steps.plan.outputs.relevant_corpora }}
+      out_of_scope_corpora: ${{ steps.plan.outputs.out_of_scope_corpora }}
+      sibling_pins: ${{ steps.plan.outputs.sibling_pins }}
+    steps:
+      # Pin the event head SHA explicitly. After a squash-merge a delayed event can otherwise land
+      # the default checkout on current main while relevance still diffs the event's own commits
+      # (the failure perf_pr.yml records as #2326).
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # The guard's own refusals, exercised before anything depends on them. A relevance
+      # derivation that has silently stopped refusing would gate this lane open.
+      - name: Self-test the lane helpers
+        # sys.path[0] is the script's own directory, so the two helpers import from repo root too.
+        run: python3 scripts/ci/test_adequacy_lane.py
+
+      - name: Derive relevance
+        id: plan
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_FULL: ${{ inputs.full }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # A schedule measures everything by definition. A dispatch defaults to full because a
+          # human asking for this lane by hand is asking for a measurement, not for a gate.
+          # `x && y` as the last command of a case branch returns 1 when x is false, which under
+          # `set -e` aborts the job instead of choosing relevance mode. Spelled out as an `if`.
+          full=""
+          if [[ "${EVENT_NAME}" == "schedule" ]]; then
+            full="--full"
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" && "${DISPATCH_FULL}" == "true" ]]; then
+            full="--full"
+          fi
+
+          if [[ -n "${full}" ]]; then
+            python3 scripts/ci/adequacy_lane_plan.py --full | tee plan.txt
+          else
+            if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+              base="${BASE_SHA}"; head="${HEAD_SHA}"
+            else
+              base="${PUSH_BEFORE}"; head="${PUSH_AFTER}"
+            fi
+            # Fail OPEN, never quiet. A diff we cannot compute is not evidence that nothing
+            # changed, so an unresolvable range measures everything instead of measuring nothing.
+            if [[ -z "${base}" || "${base}" =~ ^0+$ ]] \
+               || ! git cat-file -e "${base}^{commit}" 2>/dev/null \
+               || ! git cat-file -e "${head}^{commit}" 2>/dev/null; then
+              echo "::warning::cannot resolve ${base:-<empty>}...${head}; measuring every in-scope corpus"
+              python3 scripts/ci/adequacy_lane_plan.py --full | tee plan.txt
+            else
+              git diff --name-only "${base}...${head}" \
+                | python3 scripts/ci/adequacy_lane_plan.py | tee plan.txt
+            fi
+          fi
+
+          # The script writes only to stdout and never opens $GITHUB_OUTPUT or
+          # $GITHUB_STEP_SUMMARY itself: opening a path read from the environment is an
+          # uncontrolled-path sink (CodeQL py/path-injection). Routing happens here.
+          grep -E '^[a-z_]+=' plan.txt >> "$GITHUB_OUTPUT"
+          {
+            echo "## Adequacy lane plan"
+            echo
+            echo '```'
+            cat plan.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  measure:
+    name: Re-derive selected corpora
+    needs: plan
+    # Relevance finding nothing is the common case and a legitimate one: no change in this diff can
+    # move a published number, so there is nothing to re-derive. The job is skipped rather than run
+    # empty, and `check-drift` below knows the difference between this skip and a skip caused by a
+    # failure — the two must never read alike.
+    if: needs.plan.outputs.relevant_corpora != ''
+    runs-on: ubuntu-latest
+    # Ceiling for the process corpus: ~32 `cargo build -p assay-cli` invocations plus a cold
+    # first build, measured at roughly fifteen minutes. 75 leaves room for a cache miss without
+    # inheriting GitHub's 360-minute default, which is not a ceiling.
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # `privileged-mcp-action-v0` builds `assay-cli` per mutant and `rfc8785-canonicalization`
+      # builds `assay-canonical`'s tests, so the toolchain is set up unconditionally rather than
+      # behind a condition that would have to restate the cost classes.
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-workspaces: "."
+
+      # The tool is not vendored (INDEX.md, "Where the adequacy tool lives"): `measure_all.py`
+      # imports it from `<repo>/../corpus-adequacy` and reads `git -C <tool> rev-parse HEAD` to
+      # record which instrument produced each number.
+      #
+      # Plain `git`, not actions/checkout, for two reasons. The destination is a SIBLING of the
+      # workspace and actions/checkout refuses a path outside it; and the tool is pinned PER
+      # CORPUS, so one measurement run may need the tool at two different commits — a row must
+      # record the commit its own manifest declares, and a corpus whose number was transcribed
+      # from a document measured at an older commit keeps that commit. Fetching an explicit SHA is
+      # pinned by construction, which is the property the SHA-pinning policy is protecting.
+      - name: Clone the instrument
+        shell: bash
+        env:
+          TOOL_REPOSITORY: ${{ needs.plan.outputs.tool_repository }}
+          TOOL_DIR: ${{ needs.plan.outputs.tool_dir }}
+        run: |
+          set -euo pipefail
+          tool="$(dirname "${GITHUB_WORKSPACE}")/${TOOL_DIR}"
+          git init --quiet "${tool}"
+          git -C "${tool}" remote add origin "https://github.com/${TOOL_REPOSITORY}.git"
+          echo "TOOL_PATH=${tool}" >> "$GITHUB_ENV"
+
+      - name: Re-derive the selected corpora
+        shell: bash
+        env:
+          PLANNED: ${{ needs.plan.outputs.relevant_corpora }}
+          PIN_GROUPS: ${{ needs.plan.outputs.pin_groups }}
+          SIBLING_PINS: ${{ needs.plan.outputs.sibling_pins }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PLANNED}" || -z "${PIN_GROUPS}" ]]; then
+            echo "::error::the plan selected no corpora; a run that measures nothing must not reach the drift check as though it had"
+            exit 1
+          fi
+          echo "declared non-instrument sibling pins: ${SIBLING_PINS:-<none>}"
+
+          # One pass per instrument commit, so every row records the commit its manifest pins.
+          for group in ${PIN_GROUPS}; do
+            commit="${group%%=*}"
+            names="${group#*=}"
+            [[ -n "${names}" ]] || continue
+
+            git -C "${TOOL_PATH}" fetch --quiet --depth 1 origin "${commit}"
+            git -C "${TOOL_PATH}" checkout --quiet --detach FETCH_HEAD
+            actual="$(git -C "${TOOL_PATH}" rev-parse HEAD)"
+            if [[ "${actual}" != "${commit}" ]]; then
+              echo "::error::instrument is at ${actual}, not the pinned ${commit}"
+              exit 1
+            fi
+
+            args=()
+            IFS=',' read -ra corpora <<< "${names}"
+            for name in "${corpora[@]}"; do
+              args+=(--only "${name}")
+            done
+            echo "::group::measuring ${corpora[*]} with corpus-adequacy @ ${commit}"
+            python3 conformance/adequacy/measure_all.py "${args[@]}"
+            echo "::endgroup::"
+          done
+
+      - name: Upload measured results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: adequacy-results
+          path: conformance/adequacy/results.json
+          if-no-files-found: error
+          retention-days: 30
+
+  check-drift:
+    name: Adequacy drift gate
+    needs: [plan, measure]
+    # THE GATE. `always()` so an upstream job that failed or was skipped produces a red gate rather
+    # than an absent one: a required check that disappears when the work does not run is the bug
+    # this lane exists to catch, one level up.
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Refuse an upstream job that did not succeed
+        shell: bash
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          MEASURE_RESULT: ${{ needs.measure.result }}
+          PLANNED: ${{ needs.plan.outputs.relevant_corpora }}
+        run: |
+          set -euo pipefail
+          if [[ "${PLAN_RESULT}" != "success" ]]; then
+            echo "::error::plan finished '${PLAN_RESULT}'; without a plan this gate cannot say what should have been measured, so it refuses"
+            exit 1
+          fi
+          # The ONLY skip this gate accepts, and only because the plan itself said there was
+          # nothing to re-derive. Any other skip or failure is a lane that went quiet.
+          if [[ "${MEASURE_RESULT}" == "skipped" && -z "${PLANNED}" ]]; then
+            echo "measure skipped: the plan selected no corpora, so nothing needed re-deriving"
+            exit 0
+          fi
+          if [[ "${MEASURE_RESULT}" != "success" ]]; then
+            echo "::error::measure finished '${MEASURE_RESULT}' while the plan selected '${PLANNED}'; the published numbers were not re-derived, so this gate refuses rather than reporting a verdict it cannot support"
+            exit 1
+          fi
+
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # Deliberately overwrites the committed results.json with the one this run measured. The
+      # gate must judge what was re-derived here, not what was committed earlier. When nothing was
+      # selected there is no artifact and the committed file stands — which is the whole content of
+      # the claim being made in that case, and the coverage report below says so per corpus.
+      - name: Download measured results
+        if: needs.measure.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: adequacy-results
+          path: conformance/adequacy
+
+      - name: Assert the run held to its plan
+        shell: bash
+        env:
+          PLANNED: ${{ needs.plan.outputs.relevant_corpora }}
+          ALL: ${{ needs.plan.outputs.all_corpora }}
+          OUT_OF_SCOPE: ${{ needs.plan.outputs.out_of_scope_corpora }}
+          MODE: ${{ needs.plan.outputs.mode }}
+        run: |
+          set -euo pipefail
+          # A full run owes every in-scope corpus. Letting it report success on a subset would
+          # make the schedule — the only thing bounding staleness — meaningless.
+          require_all=()
+          if [[ "${MODE}" == "full" ]]; then
+            require_all+=(--require-all)
+          fi
+          python3 scripts/ci/adequacy_lane_assert.py \
+            --results conformance/adequacy/results.json \
+            --manifest-dir conformance/adequacy \
+            --planned "${PLANNED}" \
+            --all "${ALL}" \
+            --out-of-scope "${OUT_OF_SCOPE}" \
+            "${require_all[@]}" | tee coverage.txt
+
+      # The drift check is what gates. It compares every published number in INDEX.md and
+      # ERRATA.md against the measurement, and fails when the prose and the JSON have parted.
+      - name: Check published numbers against the measurement
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 conformance/adequacy/check_published_numbers.py | tee drift.txt
+
+      - name: Summarise what this run does and does not vouch for
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Adequacy drift gate"
+            echo
+            echo '```'
+            cat coverage.txt 2>/dev/null || echo "(coverage assertion did not run)"
+            echo '```'
+            echo
+            echo '```'
+            cat drift.txt 2>/dev/null || echo "(drift check did not run)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -146,7 +146,7 @@ the rows below say which of the two they mean.
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
-| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of a declared twenty-four in scope, where eight had been declared before. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
+| `privileged-mcp-action-v0` | process | **6 of 25 in scope (24.0%), 19 survivors, 2 known holes.** Declared three times before it said anything true. First three rules and *no result*; then eight read off the verifier path, scoring 50%, published with a pattern claim. **The denominator was the finding, not the score.** An adversarial re-measurement deleted a further set of promised rules in one build and reproduced every outcome and every claim matrix, so the declaration grew from eight in-scope rules to twenty-five and the score fell to 24.0%. All six rules the corpus does isolate are now declared, and all six are killed. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
@@ -156,9 +156,10 @@ the rows below say which of the two they mean.
 rounded up — and this line has now been wrong in both directions on the same day.
 It read *four measured* while `privileged-mcp-action-v0` was scoring nothing; it
 was corrected to *three*; and it is four again only because that corpus was then
-declared properly and finally produced a number. The number is 50%, the worst on
-this page, and it is still too kind: it is 50% of eight declared rules where the
-implementation has roughly twenty-nine, which the section below measures. Both
+declared properly and finally produced a number. That number was 50% of eight
+declared rules; over the twenty-five now declared it is **24.0%**, the worst on
+this page by a wide margin. It fell because the denominator became honest, not
+because the corpus changed. Both
 corrections are left visible, because a table whose purpose is to publish
 unflattering results should show its own edits.
 
@@ -169,8 +170,13 @@ over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
 hand-written table that ADMISSION.md already warned was unchecked against
 `ref_example.py`. Those three rows now score the larger denominator and the
 numbers went down, which is the point. `privileged-mcp-action-v0` took the same
-treatment last and hardest: sixteen further in-scope rules are now declared
-individually, taking its denominator from eight to twenty-four.
+treatment last and hardest: eighteen further in-scope rules are now declared
+individually, taking its denominator from eight to twenty-five. Two of those
+eighteen were added last and are the only correction today that moved a number
+**up**: an independent count named six isolated rules where this manifest
+declared four, and the two missing ones — the Stage 2 unknown-schema arm and the
+decision vocabulary — are both killed. One of them is the measurement this
+manifest's own out-of-scope note had asked for and never ran.
 
 ### The v0 corpus isolates six rules and leaves most of the rest free
 
@@ -195,6 +201,16 @@ and all three legs of the marker triple.
 **All fourteen outcomes and all five claim matrices reproduced exactly.** The
 only difference anywhere in the corpus was one finding string, and findings are
 not on the comparison surface the corpus declares.
+
+Reproduced here independently, and the reproduction is narrower than the sentence
+above so it is stated as it ran: **nineteen** of the twenty-three applied
+simultaneously, and all fourteen vectors were byte-identical on
+`[bundle_integrity, verdict, claims]`. The other four could not join the composite
+because they share an anchor with a rule already in it — `31/32/33` are three
+replacements over one line, as are `44/45/46`. Each of those four is scored a
+survivor on its own in the per-mutant run below, so the twenty-three-way
+conclusion holds; the nineteen-way deletion is simply what was actually executed
+in one build.
 
 So an implementer can delete twenty-three rules the profile promises, reproduce
 the pinned digest, and be indistinguishable from a conforming implementation.

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -145,11 +145,11 @@ the rows below say which of the two they mean.
 
 | Corpus | Runner | Result |
 |---|---|---|
-| `mcp-jsonrpc-id-conformance` | module | **4 of 4** in scope. **7 rules unexercised and out of scope**, ratio 1.75 — the score is a statement about a minority of the declared rules |
+| `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
 | `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 1 known hole.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. The survivors form **one systematic gap, not four**: wherever a rule has sibling members, the corpus discriminates exactly one and leaves the rest free. Decision cardinality is caught (`bad-103`) and observation and establish cardinality are not; the decision's `target_digest` is caught (`bad-102`) and the observation's `response_digest` is not; the binding pair is caught on its digest leg (`bad-105`) and not on its tool-name leg; the marker triple is caught on schema and code and not on origin (the known hole). One vector per failure mode, and every failure mode has siblings on the same code path that never got one. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
-| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **4 of 5**. One survivor: an implementation can read the body regardless of whether the ref recomputed and still reproduce all fourteen cases |
-| [rge-bench](https://github.com/rge-bench/rge-bench) | module | 30 of 30, 1 declared equivalent |
-| `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: see below |
+| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
+| [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
+| `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
 | `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict |
 
 **Four measured, one control-only, one not measurable.** Stated rather than
@@ -159,6 +159,14 @@ was corrected to *three*; and it is four again only because that corpus was then
 declared properly and finally produced a number. The number is 50%, which is the
 worst result on this page. Both corrections are left visible, because a table
 whose purpose is to publish unflattering results should show its own edits.
+
+The same under-declaration then showed up on the other three scored rows. Each
+first score was a number about the rules the author happened to list, not about
+the rules the implementation has: 4 of 4 over four of ten id-field arms; 4 of 5
+over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
+hand-written table that ADMISSION.md already warned was unchecked against
+`ref_example.py`. The rows above now score the larger denominator. The numbers
+went down. That is the point.
 
 ### The v0 survivors are one gap wearing four faces
 
@@ -180,9 +188,14 @@ any of these pairs and reproduce all fourteen outcomes.
 
 That the pattern is uniform is the useful part: it says the fix is not fourteen
 judgement calls but one rule — **for every conjunct and every sibling member, ask
-whether a vector isolates it** — and it says the same audit is worth running against
-the other corpora on this page before trusting their scores. Note that our own tree
-catches all four; this is about what the corpus can transmit, not about what we ship.
+whether a vector isolates it**. That audit was then run against the other scored
+rows on this page, independently of what each manifest declared. The same habit
+showed up: mcp-jsonrpc-id isolated presence and null and left number and bool
+free; the drift consumer isolated digest-mismatch and left malformed / unresolved
+/ redacted free; rge-bench isolated the origin-ceiling ladder and left the
+strength ladder undeclared until this measurement. Note that our own tree
+catches the v0 four; this is about what the corpus can transmit, not about what
+we ship.
 
 Not fixed here. Every one of these needs a new vector, and a new vector moves a
 digest that [#1840](https://github.com/Rul1an/assay/issues/1840) has published as a

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -147,10 +147,18 @@ the rows below say which of the two they mean.
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
 | `privileged-mcp-action-v0` | process | **6 of 25 in scope (24.0%), 19 survivors, 2 known holes.** Declared three times before it said anything true. First three rules and *no result*; then eight read off the verifier path, scoring 50%, published with a pattern claim. **The denominator was the finding, not the score.** An adversarial re-measurement deleted a further set of promised rules in one build and reproduced every outcome and every claim matrix, so the declaration grew from eight in-scope rules to twenty-five and the score fell to 24.0%. All six rules the corpus does isolate are now declared, and all six are killed. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
-| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
-| [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
+| [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer @ `dc10fad0c` | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
+| [rge-bench](https://github.com/rge-bench/rge-bench) @ `c51c5af18` | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
 | `mcp-era-parity-v0` | — | **not measurable today.** Driven by Rust *tests* without a per-vector verdict |
+
+Two of these corpora live in repositories this one does not own, so their rows
+name the commit measured. That is not a freshness claim and cannot be: those
+repositories move without this diff seeing it. It is the opposite: a score against a
+named commit stays permanently true of that commit, and without one the sentence
+was true of nothing in particular. Both were
+published unpinned until 2026-08-20; `check_published_numbers.py` now refuses a
+measurement of an out-of-tree corpus whose commit no published document names.
 
 **Four measured, one control-only, one not measurable.** Stated rather than
 rounded up — and this line has now been wrong in both directions on the same day.
@@ -352,3 +360,130 @@ foreseen.
 `conformance/bounded_run.py` stays here and is duplicated upstream. It serves
 `run_all.py`, which is this repository's own runner, so both copies have a live
 local caller. That is a known duplication rather than an unnoticed one.
+
+<!-- BEGIN CHECKED NUMBERS -->
+
+## Checked numbers
+
+Every adequacy number above is re-derived from [`adequacy/results.json`](adequacy/results.json) and asserted by
+[`adequacy/check_published_numbers.py`](adequacy/check_published_numbers.py). Editing a number in the prose without editing the
+measurement, or the reverse, is a red check rather than a silent disagreement.
+
+```json
+{
+  "_about": "Owned by conformance/adequacy/check_published_numbers.py. Each claim's numbers are recomputed from conformance/adequacy/results.json AND its wording must still occur above; editing either alone is a red check. not_derived lists number-shaped tokens that are deliberately not measurements, each with the reason it is exempt.",
+  "claims": [
+    {
+      "corpus": "mcp-jsonrpc-id",
+      "text": "6 of 10 in scope (60%), 4 survivors",
+      "asserts": {
+        "killed": 6,
+        "killed + survived": 10,
+        "score_percent": 60.0,
+        "survived": 4
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "6 of 25 in scope (24.0%), 19 survivors, 2 known holes",
+      "asserts": {
+        "killed": 6,
+        "killed + survived": 25,
+        "score_percent": 24.0,
+        "survived": 19,
+        "known_holes": 2
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "the score fell to 24.0%",
+      "asserts": {
+        "score_percent": 24.0
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "over the twenty-five now declared it is **24.0%**",
+      "asserts": {
+        "killed + survived": 25,
+        "score_percent": 24.0
+      }
+    },
+    {
+      "corpus": "observed-effect-drift-consumer",
+      "text": "14 of 23 in scope (60.9%), 9 survivors",
+      "asserts": {
+        "killed": 14,
+        "killed + survived": 23,
+        "score_percent": 60.9,
+        "survived": 9
+      }
+    },
+    {
+      "corpus": "rge-bench",
+      "text": "51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope",
+      "asserts": {
+        "killed": 51,
+        "killed + survived": 54,
+        "score_percent": 94.4,
+        "survived": 3,
+        "equivalent": 2,
+        "out_of_scope": 1
+      }
+    },
+    {
+      "corpus": "*",
+      "text": "Four measured, one control-only, one not measurable",
+      "locals": {
+        "not_measurable": 1,
+        "_why_not_measurable": "mcp-era-parity-v0 has no manifest and can have none: it is driven by Rust tests with no per-vector verdict, so there is nothing for the tool to score. A corpus that cannot be measured cannot be counted from the measurement, so it is declared here."
+      },
+      "asserts": {
+        "measured": 4,
+        "control_only": 1,
+        "not_measurable": 1
+      }
+    }
+  ],
+  "not_derived": [
+    {
+      "token": "100%",
+      "reason": "the adequacy bar itself, not a result: 100% of the rules the author declared is what the tool requires to pass."
+    },
+    {
+      "token": "4 of 4",
+      "reason": "the superseded first score for mcp-jsonrpc-id, kept visible on purpose. A page that publishes unflattering results shows its own edits."
+    },
+    {
+      "token": "4 of 5",
+      "reason": "the superseded first score for the observed-effect drift consumer, over merge-policy rules only."
+    },
+    {
+      "token": "30 of 30",
+      "reason": "the superseded first score for rge-bench, over the hand-written table in check_rule_liveness.py."
+    },
+    {
+      "token": "50%",
+      "reason": "the superseded second score for privileged-mcp-action-v0, over eight declared rules."
+    },
+    {
+      "token": "6 of 8",
+      "reason": "the contaminated run's believable-but-wrong number, recorded as the anecdote that motivated the tool's exclusive lock."
+    },
+    {
+      "token": "75.0%",
+      "reason": "the percentage of that same contaminated run."
+    },
+    {
+      "token": "4 of 8",
+      "reason": "what clean re-runs of that superseded declaration gave."
+    },
+    {
+      "token": "8 of 31",
+      "reason": "the rfc8785 control's own divergence count, from tests/rfc8785_conformance.rs. It is a property of that Rust test, not a mutation score, and results.json carries no field for it."
+    }
+  ]
+}
+```
+
+<!-- END CHECKED NUMBERS -->

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -146,7 +146,7 @@ the rows below say which of the two they mean.
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
-| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 1 known hole.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. The survivors form **one systematic gap, not four**: wherever a rule has sibling members, the corpus discriminates exactly one and leaves the rest free. Decision cardinality is caught (`bad-103`) and observation and establish cardinality are not; the decision's `target_digest` is caught (`bad-102`) and the observation's `response_digest` is not; the binding pair is caught on its digest leg (`bad-105`) and not on its tool-name leg; the marker triple is caught on schema and code and not on origin (the known hole). One vector per failure mode, and every failure mode has siblings on the same code path that never got one. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
+| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of roughly twenty-nine. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
@@ -156,52 +156,110 @@ the rows below say which of the two they mean.
 rounded up — and this line has now been wrong in both directions on the same day.
 It read *four measured* while `privileged-mcp-action-v0` was scoring nothing; it
 was corrected to *three*; and it is four again only because that corpus was then
-declared properly and finally produced a number. The number is 50%, which is the
-worst result on this page. Both corrections are left visible, because a table
-whose purpose is to publish unflattering results should show its own edits.
+declared properly and finally produced a number. The number is 50%, the worst on
+this page, and it is still too kind: it is 50% of eight declared rules where the
+implementation has roughly twenty-nine, which the section below measures. Both
+corrections are left visible, because a table whose purpose is to publish
+unflattering results should show its own edits.
 
 The same under-declaration then showed up on the other three scored rows. Each
 first score was a number about the rules the author happened to list, not about
 the rules the implementation has: 4 of 4 over four of ten id-field arms; 4 of 5
 over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
 hand-written table that ADMISSION.md already warned was unchecked against
-`ref_example.py`. The rows above now score the larger denominator. The numbers
-went down. That is the point.
+`ref_example.py`. Those three rows now score the larger denominator and the
+numbers went down, which is the point. `privileged-mcp-action-v0` is the
+exception and is marked as one: its twenty-three further rules are identified
+and measured collectively but not yet declared individually, so its score is
+still over the small denominator.
 
-### The v0 survivors are one gap wearing four faces
+### The v0 corpus isolates six rules and leaves twenty-three free
 
-Worth stating separately because it changes what closing them costs. The four
-survivors in `privileged-mcp-action-v0` are not four independent oversights; they
-are four instances of the same construction habit. Every one of them is a *sibling*
-of a rule the corpus does catch, sitting on the same code path:
+A section here previously claimed the survivors were **"one gap wearing four
+faces"** — that wherever a v0 rule has sibling members the corpus discriminates
+exactly one and leaves the rest free. It was a tidy claim built on four data
+points, it was published, and an adversarial re-measurement refuted it. The
+replacement is below rather than an edit, because the shape of the error matters
+as much as the number: a pattern that explains four observations and flatters the
+author is not a finding, it is a hypothesis that was never attacked.
 
-| the corpus discriminates | it does not discriminate | shared path |
-|---|---|---|
-| `decisions.len() != 1` (`bad-103`) | `observations.len() > 1`, `establishes.len() > 1` | Stage 2 cardinality |
-| decision `action.target_digest` (`bad-102`) | observation `caller_visible_response_digest` | `is_sha256_digest` |
-| binding on `target_digest` (`bad-105`) | binding on `tool_name` | the same `&&` chain |
-| marker `schema` + `code` | marker `origin` (the known hole) | the same triple match |
+**The decisive experiment.** Rule deletion here is monotone — every one of these
+mutants only makes the verifier more permissive — so the rules can be deleted
+together. Twenty-three were: both cardinality siblings, the `reason` and
+`drift_state` vocabularies, both non-empty tool-name checks, the observation
+response digest, all three `caller_visible_error` member-presence rules, both
+`non_claims` checks, both establish checks, `marker_not_backed`,
+`marker_digest_unbindable`, `event_type_schema_mismatch`, the
+in-namespace-type arm, the binding tool-name leg, the establish contradiction,
+and all three legs of the marker triple.
 
-The corpus was built one vector per failure *mode*. Each mode's siblings share the
-structure but never got a vector, so an implementer can drop the second member of
-any of these pairs and reproduce all fourteen outcomes.
+**All fourteen outcomes and all five claim matrices reproduced exactly.** The
+only difference anywhere in the corpus was one finding string, and findings are
+not on the comparison surface the corpus declares.
 
-That the pattern is uniform is the useful part: it says the fix is not fourteen
-judgement calls but one rule — **for every conjunct and every sibling member, ask
-whether a vector isolates it**. That audit was then run against the other scored
-rows on this page, independently of what each manifest declared. The same habit
-showed up: mcp-jsonrpc-id isolated presence and null and left number and bool
-free; the drift consumer isolated digest-mismatch and left malformed / unresolved
-/ redacted free; rge-bench isolated the origin-ceiling ladder and left the
-strength ladder undeclared until this measurement. Note that our own tree
-catches the v0 four; this is about what the corpus can transmit, not about what
-we ship.
+So an implementer can delete twenty-three rules the profile promises, reproduce
+the pinned digest, and be indistinguishable from a conforming implementation.
+The corpus isolates six: decision cardinality, the decision vocabulary,
+unknown-schema-fails-closed, the decision `target_digest`, the `fail_closed`
+derivation, and the binding pair's digest leg.
 
-Not fixed here. Every one of these needs a new vector, and a new vector moves a
-digest that [#1840](https://github.com/Rul1an/assay/issues/1840) has published as a
+**What survived of the old claim, and what did not.** Three of its four table
+rows hold: cardinality, the `is_sha256_digest` call sites, and the `&&` chain of
+the binding pair each do discriminate one sibling and leave the others free. The
+fourth row was wrong on its *caught* side. Of the marker triple's three legs the
+corpus discriminates **none**:
+
+| leg | why no vector reaches it |
+|---|---|
+| `origin` | `gen_vectors.py:103` hard-codes `assay-proxy`; it is the only marker construction site |
+| `code` | the same line hard-codes `-32042`, with no generator parameter |
+| `schema` | decided earlier, at Stage 2 — under v0 selection only `.v0` payloads ever enter `observations` |
+
+The schema leg was credited to the corpus in the same document that, two entries
+away, used precisely this wrong-stage argument to rule a different mutant out of
+scope. The argument was available and was not applied where it was inconvenient.
+
+The generalisation that does survive is weaker and duller: **at most one member
+per family, and often zero.** Five families discriminate none — the triple legs,
+the two `check_non_claims` call sites, the two non-empty tool-name checks, the
+two `check_establish` rules, and the three `caller_visible_error` member-presence
+rules. "One vector per failure mode" is also false as counted: `bundle_integrity`
+carries two vectors, and `bad-108` fires two rules while being the only input for
+one of them, which is why `marker_not_backed` is masked and survives deletion.
+
+One rule is undiscriminable **in principle** by this corpus rather than in
+practice: `establish_journey_contradiction`. The profile calls the contradiction
+set normative and requires a finding, and a finding is the rule's only output —
+so no vector could isolate it without changing what the corpus compares.
+
+**Two method errors found in the same pass, both ours.**
+
+The manifest scored on `[bundle_integrity, verdict, reason_code]` while the
+corpus states its own surface in `MANIFEST.json`: *"expected.bundle_integrity,
+expected.verdict and expected.claims are the normative comparison surface;
+first_failure_informative is this generator's own vocabulary and is informative
+only."* So the measurement read the member declared informative and omitted the
+member declared normative. It was simultaneously weaker (a mutant flipping
+`ok-005`'s claim cell from refuted to confirmed survived the harness while the
+corpus kills it) and wider (`reason_code` separates `bad-101` from `bad-109`
+where the corpus does not). Corrected, and re-measured on the declared surface.
+
+Two adequacy runs then contaminated each other on one working tree, each finding
+the other's mutant applied to a file it had not touched, and one produced a
+believable `6 of 8 (75.0%)` where clean re-runs give `4 of 8`. `corpus-adequacy`
+now takes an exclusive lock before the dirty check and compares every captured
+original against `git show HEAD:<path>` at capture time, because the lock alone
+still left the window open. Every number on this page was re-measured after that
+landed.
+
+**Not fixed here.** Closing any of this needs new vectors, and a new vector moves
+a digest that [#1840](https://github.com/Rul1an/assay/issues/1840) publishes as a
 reproduction target. Whether that is answered by an addendum corpus at a second
-digest, or by leaving v0 pinned and honest, is a contract decision rather than a
-tooling one.
+digest or by leaving v0 pinned and honest is a contract decision rather than a
+tooling one. The twenty-three are identified but not yet declared individually in
+the manifest, so the score in the table above is still over the eight rules that
+are — which is exactly the over-generous denominator this section is about, now
+stated instead of hidden.
 
 ### Why `rfc8785` has a control and no declared rules
 

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -146,7 +146,7 @@ the rows below say which of the two they mean.
 | Corpus | Runner | Result |
 |---|---|---|
 | `mcp-jsonrpc-id-conformance` | module | **6 of 10 in scope (60%), 4 survivors.** The first score was **4 of 4** over the presence/null arms alone. The positive control is a string id and RequestId is string or number, so the type arms belong in the denominator: string is isolated, number and bool are not. **7 envelope rules unexercised and out of scope**, ratio 0.7 — re-checked against the three published messages; none of them moves an outcome, and the reasons still hold |
-| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of roughly twenty-nine. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
+| `privileged-mcp-action-v0` | process | **4 of 8 in scope (50%), 4 survivors, 2 known holes.** First measured as *no result*: three rules declared, two of them mutating the wrong stage and the wrong profile. That was a fact about the declaration, not the corpus — eight more rules were read off the verifier path and half of them survive. **The denominator of 8 is the finding, not the 50%.** An adversarial re-measurement deleted **23 further promised rules at once** and reproduced all fourteen outcomes and all five claim matrices exactly, so the corpus isolates six rules of a declared twenty-four in scope, where eight had been declared before. Measured on the surface the corpus itself declares normative, after a lock and a HEAD check closed a cross-run contamination. See below. **This is the corpus carrying our live reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840))** |
 | [`observed-effect-v0`](https://github.com/Rul1an/observed-effect-v0) drift consumer | batch | **14 of 23 in scope (60.9%), 9 survivors.** The first score was **4 of 5** over merge-policy rules only. The 14 case names announce the recompute, advisory, and profile rules as well. The original survivor remains (the body can be read whether or not the ref recomputed); the new ones are the fail-closed recompute siblings the cases never present, the RFC 8785 UTF-16 key-order rule the consumer claims but no body isolates, and a redacted-field conjunct that `incomplete_missing_non_claims` does not distinguish from a missing field |
 | [rge-bench](https://github.com/rge-bench/rge-bench) | module | **51 of 54 in scope (94.4%), 3 survivors, 2 declared equivalent, 1 out of scope.** The first score was **30 of 30** over the hand-written table in `scripts/check_rule_liveness.py`. [ADMISSION.md](https://github.com/rge-bench/rge-bench/blob/main/ADMISSION.md) already says that table is not checked against the rules `ref_example.py` contains. The missing rules were discriminable: the strength ladder (the ceiling ladder's sibling — the same shape that hole already had), the AND conjuncts scored as one mutant, and the soft-digest and replay-equality fallthroughs. The three survivors include a claimed contract-edge (`True` is not `1`) that no vector isolates |
 | `rfc8785` canonicalization | batch (test-names) | **control killed** — the corpus bites. No rules declared: the wrapper still has nothing of ours to delete. `to_string` is a second convenience over the same delegate and is not on this corpus's path |
@@ -168,12 +168,11 @@ the rules the implementation has: 4 of 4 over four of ten id-field arms; 4 of 5
 over merge-policy while the 14 cases name recompute and profile; 30 of 30 over a
 hand-written table that ADMISSION.md already warned was unchecked against
 `ref_example.py`. Those three rows now score the larger denominator and the
-numbers went down, which is the point. `privileged-mcp-action-v0` is the
-exception and is marked as one: its twenty-three further rules are identified
-and measured collectively but not yet declared individually, so its score is
-still over the small denominator.
+numbers went down, which is the point. `privileged-mcp-action-v0` took the same
+treatment last and hardest: sixteen further in-scope rules are now declared
+individually, taking its denominator from eight to twenty-four.
 
-### The v0 corpus isolates six rules and leaves twenty-three free
+### The v0 corpus isolates six rules and leaves most of the rest free
 
 A section here previously claimed the survivors were **"one gap wearing four
 faces"** — that wherever a v0 rule has sibling members the corpus discriminates
@@ -202,6 +201,13 @@ the pinned digest, and be indistinguishable from a conforming implementation.
 The corpus isolates six: decision cardinality, the decision vocabulary,
 unknown-schema-fails-closed, the decision `target_digest`, the `fail_closed`
 derivation, and the binding pair's digest leg.
+
+**Twenty-three deleted is not twenty-three new.** Five of them restate rules this
+manifest already declared, and two are out of scope — one wrong-stage, one
+undiscriminable in principle. Sixteen were new, in scope and undeclared, which
+puts the honest in-scope denominator at twenty-four rather than the eight it had
+been. The distinction is recorded because the larger number was the one that
+flattered the finding, and this page has spent the day leaning the other way.
 
 **What survived of the old claim, and what did not.** Three of its four table
 rows hold: cardinality, the `is_sha256_digest` call sites, and the `&&` chain of
@@ -252,14 +258,22 @@ original against `git show HEAD:<path>` at capture time, because the lock alone
 still left the window open. Every number on this page was re-measured after that
 landed.
 
+**The monotonicity argument, so it can be attacked rather than trusted.** Each of
+the twenty-three is a pure deletion that can only remove findings, and the outcome
+tuple depends only on whether the finding set is empty. So for rule sets `S ⊆ T`,
+`F(T) ⊆ F(S)`: if deleting all twenty-three reproduces every outcome, each single
+deletion must too. The condition a reader should push on is a deletion that *adds*
+findings — widening the marker triple makes more observations classify as markers,
+which can newly reach the binding check. That is why the three triple-leg mutants
+were not rested on the argument; each was built and run on its own, and each
+survived on its own. The argument also requires `claims` on the comparison
+surface, which is the second reason the surface error above mattered.
+
 **Not fixed here.** Closing any of this needs new vectors, and a new vector moves
 a digest that [#1840](https://github.com/Rul1an/assay/issues/1840) publishes as a
 reproduction target. Whether that is answered by an addendum corpus at a second
 digest or by leaving v0 pinned and honest is a contract decision rather than a
-tooling one. The twenty-three are identified but not yet declared individually in
-the manifest, so the score in the table above is still over the eight rules that
-are — which is exactly the over-generous denominator this section is about, now
-stated instead of hidden.
+tooling one.
 
 ### Why `rfc8785` has a control and no declared rules
 

--- a/conformance/UNGUARDED-CLAIMS.md
+++ b/conformance/UNGUARDED-CLAIMS.md
@@ -1,0 +1,142 @@
+# Unguarded published claims
+
+Same defect as the adequacy numbers in `INDEX.md` and
+`privileged-mcp-action-v0/ERRATA.md`, looked for everywhere those files are not.
+
+A number published in a document, produced once by hand, that nothing re-derives.
+The first change to a declared source makes the document silently wrong. Today
+that has been found in three adequacy rows; the prior is that it is the default
+shape, not a local accident.
+
+This file does not change those rows. Other agents own `conformance/` except this
+file, plus `.github/workflows/` and `scripts/ci/`. Findings there are reported,
+not edited.
+
+**Not "almost everything is fine."** Several published claims are already false
+on this tree. The check that could have shown otherwise is named on each row.
+
+Cheap counts below were taken on 2026-08-19 against worktree
+`/Users/roelschuurkes/assay` at commit
+`9382ff83191f21a5c5816a1981456153f1fba8ec` (`codex/corpora-underdeclaration`).
+`corpus_adequacy.py` was not run. `pgrep -lf '[c]orpus_adequacy'` was empty
+before any git write in the sibling tool repo.
+
+## What "guarded" means here
+
+This repository already has the standard. A claim is guarded when a generator,
+test, or hook would fail if the published number stopped being true of the
+source it names. Two hooks are the ones to measure the rest against:
+
+| Guard | What it actually proves |
+|---|---|
+| `docs-generated-drift` (`scripts/ci/check-docs-generated-drift.sh`) | Listed output files byte-match what the listed generators write in a scratch copy of the *current* tracked tree. It does **not** prove a generator derived those bytes from the codebase. A heredoc that ignores `cargo metadata` will reproduce forever. |
+| `ci-programme-truth` | `AGENTS.md` still says no programme is active, and the named programme-truth inputs still match the workflow/ruleset contract. It does not fetch GitHub to see whether #2388 is closed. |
+
+Sibling guards that meet the same bar for their own numbers:
+
+| Guard | Re-derives |
+|---|---|
+| `scripts/docs/generate-agent-golden-path.py` + skill/contract tests | Workspace version, the nine golden-path steps, packaged skill copies |
+| `scripts/docs/generate-product-capabilities.py` | `docs/reference/product-support.md` and `docs/generated/product-claim-proof.md` from `docs/data/product-capabilities.v0.json`. The "Published v5.3.0" headings are the last *proof-backed* release, not the workspace version. That is a guarded distinction, not drift. |
+| `scripts/docs/generate-crate-deps.sh` | Workspace crate *nodes* and path-dep *edges* from `cargo metadata` (with a filter hole, row 6) |
+| `scripts/ci/check-tag-tree-outward-truth.sh` | Candidate tag / source version identity |
+| `scripts/ci/check-public-crate-policy.sh` | The 15 publishable crates and the 7 that are not, against manifests **and** `publish_idempotent.sh`'s `CRATES` array |
+| `scripts/ci/check-msrv-policy.sh` | Public MSRV 1.89.0 |
+| `scripts/ci/check-assay-version-line.sh` | Release-parser Ruby/Psych pins in `docs/reference/release.md` |
+| `crates/assay-cli/tests/cli_json_identities.rs` | The twelve unnamed CLI JSON documents |
+| `docs/PINNED-ACTIONS.md` | Deliberately restates **no** SHAs. The callsite is the pin. That is the opposite of this defect. |
+
+`docs/generated/` is therefore not automatically fine. Three of five files
+there are in the drift list and really derived. Two are not. See rows 5–6.
+
+## Ranked table
+
+Rank is `(harm if wrong) × (cheapness to guard)`. Harm is what a reader would
+*do* with the number: ship in the wrong order, treat a published crate as
+internal, trust a generated graph that omitted a crate. Cheapness is a
+mechanical comparison to a source that already exists, not a new measurement
+programme.
+
+`Guard cost` is honest. Most rows below the cut are not worth a hook.
+
+| Rank | Claim | Where | Re-derived? | True on this tree? | Guard cost |
+|---|---|---|---|---|---|
+| 1 | Publish order: `assay-common → assay-evidence → … → assay-cli` (**9 crates**) | `CLAUDE.md:220`, `docs/AIcontext/CLAUDE.md` | **No.** `publish_idempotent.sh` validates its own 15-crate array and says *“CLAUDE.md documents that edge. Nothing compared the two.”* | **No.** Script order is 15 crates and inserts `assay-registry`, `assay-canonical`, `assay-runner-schema`, `assay-adapter-api`, `assay-runner-linux`, `assay-runner-core`. | Trivial: the script already has the list. Diff CLAUDE's arrow chain against `CRATES`. Highest harm: an agent publishing from the agent file ships in an order that has already failed a release. |
+| 2 | Assay-Runner is `publish = false` | `README.md:151`; `crates/assay-runner-{core,linux,schema}/src/lib.rs` (*“until Slice 7”*) | **No.** Public-crate policy lists all three as publishable and explains why `publish = false` made `assay-cli` itself unpublishable. | **No.** None of the three manifests set `publish = false`. They have published since v3.11.2. | Trivial: reuse `check-public-crate-policy.sh`. Front-page product claim plus rustdoc. |
+| 3 | Workspace version `3.9.0`; leaf crates include `assay-evidence` and `assay-registry`; CLI lives in `args.rs` | `docs/AIcontext/CLAUDE.md:13,108,267` and the crate tree | **No.** Root `CLAUDE.md` was updated; this copy was not. `tag-tree-outward-truth` does not read this file. | **No.** Workspace is `5.4.0`. Those two crates have internal deps. Args are `args/mod.rs`. Crate tree predates adapters, canonical, runners, `gateway-evidence-replay`. | Cheap: generate from root `CLAUDE.md`, or delete the copy, or fail if the version line ≠ workspace version. High harm: any agent that reads `docs/AIcontext/` first. |
+| 4 | `22` workspace packages, `21` under `crates/`, `7` `publish = false` | `CLAUDE.md:13-14` | **No.** Public-crate policy guards the *sets*, not these three integers or this prose. | **Yes** (22 members, 21 `crates/*`, 7 `publish = false`). | Cheap: `cargo metadata` + the policy arrays. High harm the day a crate is added; currently true, which is how this defect hides. |
+| 5 | Ten-crate "module summary" living under `docs/generated/` | `docs/generated/module-summary.txt`; written by `scripts/docs/generate-module-map.sh:105-123` | **No.** The script writes a hardcoded table. The file is **not** in `GENERATED` in `check-docs-generated-drift.sh`, so even script↔file drift is uncaught. | **No** as an inventory. 10 of 22 packages; omits adapters, canonical, registry, runners, python SDK, `gateway-evidence-replay`. | Cheap to add to the drift list, and that would only pin the heredoc. Deriving the table from `cargo metadata` is a small script. Medium-high harm: the directory name is the claim that someone already did this. |
+| 6 | Crate graph grouping, and the workspace member filter | `scripts/docs/generate-crate-deps.sh`; `docs/generated/crate-deps.mermaid` | **Partial.** Nodes and path-dep edges come from `cargo metadata`. Then `grep '^assay'` drops `gateway-evidence-replay`, and a trailing heredoc hardcodes four subgraphs that omit adapters, runners, canonical. Drift check will keep reproducing the omission. | **No** as a complete graph: `gateway-evidence-replay` is absent. `assay-it` is present. | Cheap: drop the name filter; use workspace members. The hardcoded groupings are the same defect as row 5 inside a file that otherwise is generated. |
+| 7 | Module map of six crates | `docs/generated/module-map.mermaid` (in the drift list) | Drift check proves the file matches the heredoc in `generate-module-map.sh`. The heredoc does not read the tree. | **No** as a map of this repo. Same omissions as row 5, plus stale internal paths (`args.rs`, `jcs` still under evidence). | Same as row 5. The interesting finding is the guard that passes: this is a self-check that cannot fail when code moves. |
+| 8 | Adequacy scores: `6 of 10`, `6 of 25` / `5 of 27`, `14 of 23`, `51 of 54` | `conformance/INDEX.md:148-151`; `privileged-mcp-action-v0/ERRATA.md` (`5 of 27`); pack README | **No**, which is why this file exists. ERRATA is pinned to a corpus digest that does not move when the verifier moves. Other agents are adding a re-derivation for these rows. | Not re-measured here (`corpus_adequacy.py` mutates sources; do not run it in a shared tree). INDEX and ERRATA already disagree on the privileged-action numerator and denominator (`6 of 25` vs `5 of 27`). | Owned elsewhere. Reported only. Highest documentary harm in the repo; the fix is in progress. |
+| 9 | `14-vector` corpus, `5` accept, `9` reject | `README.md:172-173`; `conformance/INDEX.md:22` | **No** document-level check. The vectors exist; nothing asserts these three integers against `vectors/`. | **Yes.** 14 `*.tar.gz`, 5 `ok-*`, 9 `bad-*`. | Trivial directory count. Medium harm: this is the public reproduction invitation. |
+| 10 | CLI has `~40` subcommands | `CLAUDE.md:65` | **No.** | **Imprecise.** Top-level `Command` has **34** variants. Nested `Subcommand` enums in assay-cli sum to **101**. `~40` only works if it means "top-level, roughly." | Cheap to count `Command` variants; only worth it if the prose stops being an approximation. Medium harm. |
+| 11 | Sim exit `2` is infra/panic/timeout; lint has no exit `3` | `CLAUDE.md:326-332`; `docs/AIcontext/CLAUDE.md` | Partial: `exit_codes/core.rs` covers `assay run`. No table-wide contract for sim/lint. | **No / incomplete.** `commands/sim.rs` returns `2` for *time budget exceeded* (ADR-024); config uses `EXIT_CONFIG_ERROR` via `process::exit`. Lint documents exit `3` as pack-load error. | Cheap: one test that the three columns still match the three modules. Medium harm for CI scripts that treat `2` as infra. |
+| 12 | `ErrorCode` (`28+` codes) | `CLAUDE.md:113` | `spec_reason_code_registry.rs` parses the enum; nothing syncs the floor in prose. | **Yes** as a floor (30 variants). A floor never goes stale upward, which is why it looks like a guard. | Cheap to print the count. Low-medium harm. Prefer deleting the number and pointing at the enum. |
+| 13 | `VerifyLimits` 100MB / 1GB / 100k events | `CLAUDE.md:111` | Code defaults in `limits.rs`; tests use `VerifyLimits::default()`; no test asserts all three numbers together. | **Yes.** | Cheap, low value. The code is the authority. Copying defaults into agent context is the risk, not the absence of a fourth test. |
+| 14 | `8` integrity attack vectors | `CLAUDE.md:177` | Eight `run_attack*` calls exist; no `len == 8` assert. | **Yes.** | Cheap, low value. Same shape as 13. |
+| 15 | Leaf crates (7 names, no internal deps) | `CLAUDE.md:132` | `crate-deps.mermaid` would show an edge if one grew, if the crate survived the name filter (row 6). The prose list is unguarded. | **Yes** for the seven named. `docs/AIcontext/CLAUDE.md` names a different five and is wrong (row 3). | Cheap via `cargo metadata`. Medium harm only because agents treat the list as routing advice. |
+| 16 | `^crates/` matched all `21` crates | `CLAUDE.md:309-310` | `perf_bench_relevance.py` now uses the metadata closure. The "21" is a historical rationale. | **Yes** as history (21 `crates/*/Cargo.toml`). False the day it is read as a current inventory. | Not worth a live guard. Date the sentence or delete the count. |
+| 17 | `98.2%` filesystem, `1.31x` / `1.03x` / `2.03x` spread, `37k` WAL pairs | `CLAUDE.md:295-301`; `docs/PERFORMANCE-ASSESSMENT.md` (with provenance: 2026-08-07, local APFS) | **No**, and there should not be a CI re-derivation. These are machine-dependent one-time measurements. | Not re-run. The assessment file dates them; `CLAUDE.md` presents them as standing design facts. | **Do not guard as live numbers.** The cheap fix is to keep the dated record in PERFORMANCE-ASSESSMENT and stop promoting it into the agent file. Re-running benches on every commit would pin a different disk, which is the failure the text already describes. |
+| 18 | Tool-decision latency `0.771ms` p50 / `1.913ms` p95 (and fast-path pair) | `README.md:149` | **No.** | Not re-run. One-time M1 Pro harness. | Same as 17. Front-page, so higher quote-harm, still wrong to re-derive in CI. |
+| 19 | Replay/metrics speed and consistency percentages | `docs/concepts/replay.md`, `metrics.md`, `traces.md` | **No.** | Marketing estimates (`1-10 ms`, `~85-95%`). | Not worth guarding. |
+| 20 | Runner extraction: `15` readiness criteria, `11` blocking conditions | `docs/reference/runner/phase-2d-consolidation-audit.md`, `extraction-roadmap.md` | **No.** Tables are hand-counted. | Not checked row-by-row. | Not worth a hook. Project-status prose. |
+| 21 | RGE-Bench `71` / `95` vectors and two digests | `README.md:163` | External repository. | Not checked here. | Not this repo's job. |
+| 22 | Workspace version `5.4.0` in root `CLAUDE.md` | `CLAUDE.md:13` | **No** for this file. Golden-path / tag-tree / README `v5.4.0` **are** guarded. | **Yes.** | Cheap if row 4 is done. Low extra harm while the other surfaces stay honest. |
+
+## `docs/generated/` — verified, not assumed
+
+| File | Derived from the tree? | In the drift list? |
+|---|---|---|
+| `agent-golden-path.json` | Yes — generator reads workspace version and the contract | Yes |
+| `product-claim-proof.md` | Yes — from `docs/data/product-capabilities.v0.json` | Yes |
+| `crate-deps.mermaid` | Yes for nodes/edges, with the `^assay` filter hole; no for the grouping subgraphs | Yes |
+| `module-map.mermaid` | **No** — heredoc | Yes (script↔file only) |
+| `module-summary.txt` | **No** — heredoc | **No** |
+
+The directory name is doing the same work ERRATA's digest pin was asked to do:
+imply that a later change would be noticed. For the last two files it would not.
+
+## CLAUDE.md specifically
+
+Load-bearing for every agent. Of the numbers you named:
+
+- `22 / 21 / 7` — currently true, unguarded (row 4).
+- `~40` subcommands — unguarded, only roughly true (row 10).
+- `28+` error codes — unguarded floor, currently 30 (row 12).
+- `98.2%`, `1.31x`, `1.03x` — unguarded one-time measurements, presented as
+  standing facts (row 17).
+- Publish order — **already false** (row 1).
+
+Nothing in `tests/` or `scripts/` asserts any of those CLAUDE.md literals. The
+search was for `22 workspace`, `28+`, `~40`, `98.2%`, `1.31x`.
+
+## What is not worth a hook
+
+Most of the table. Dated benchmark spreads, concept-doc estimates, runner
+extraction checklists, external-repo vector counts, and floors like `28+` cost
+more in false alarms than they save. The cheap work is rows 1–7 and 9–11: claims
+that are already false, or that agents will treat as routing instructions, and
+that already have a source of truth next to them.
+
+The adequacy rows (8) are the same defect at higher stakes. They are owned by
+the other change on this branch.
+
+## corpus-adequacy (sibling repo)
+
+Disjoint work, in `/Users/roelschuurkes/corpus-adequacy`, not here.
+
+A SHA pin is exact and opaque. The tool had no version constant, no tag, and no
+changelog, so a report quoted into `INDEX.md` could not name the edition that
+produced it.
+
+**Choice:** one `VERSION` constant (`0.1.0`). Every report carries `tool_version`
+and, when the checkout can resolve `HEAD`, `tool_commit`. `--version` prints the
+same pair. `CHANGELOG.md` names that version. The git tag is `v` plus the same
+number.
+
+Not tag-only: a pasted report would still be a SHA. Not SHA-only in the report:
+a human quoting a measurement still could not name the edition. Both fields
+come from one function so they cannot disagree about what "this run" was.
+
+CI should keep pinning the commit. The version is what the report can say.

--- a/conformance/adequacy/check_published_numbers.py
+++ b/conformance/adequacy/check_published_numbers.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Fail when a published adequacy number stops agreeing with the measurement.
+
+    python3 conformance/adequacy/check_published_numbers.py
+    python3 conformance/adequacy/check_published_numbers.py --json
+
+`conformance/INDEX.md` and `conformance/privileged-mcp-action-v0/ERRATA.md` publish
+measured mutation-adequacy numbers. Until this checker existed those numbers were
+produced once, by hand, and nothing re-derived them: a rule deleted from a declared
+implementation source changes what a corpus can transmit, changes no digest, and
+would have left both documents silently wrong. A published claim nobody re-derives
+is the exact defect this body of work exists to criticise, so the numbers were held
+to a lower standard than the ones they replaced.
+
+WHAT IS CHECKED
+
+1. Self-coverage. Every `*.manifest.json` on disk has a row in results.json and
+   every row has a manifest. A checker that silently skips a corpus is the same
+   failure one level up, so a new manifest with no measurement is red, not absent.
+2. Tool pin. Every manifest declares `tool_pin.commit`, and every row was measured
+   with the commit its manifest declares.
+3. Transcription. A row that was not re-derived by the tool must name the document
+   it was transcribed from and quote it verbatim, and that quote must still occur
+   in that document byte-for-byte (whitespace-normalised).
+4. Prose. Every registered claim's numbers must equal the measurement, and the
+   claim's exact wording must still occur in the document.
+5. Sweep. No number of adequacy shape may appear in a checked document without
+   being either derived from results.json or declared `not_derived` with a reason.
+
+HOW PROSE IS TIED TO JSON, AND WHAT THAT DOES NOT PROTECT
+
+A regex over free prose is fragile in both directions: it misses "twenty-two" and
+it fires on "8 of 31 RFC 8785 vectors". So each document carries a *bindings
+block* this checker owns, delimited by `<!-- BEGIN CHECKED NUMBERS -->`. Each
+binding is a triple:
+
+    text     the exact wording published in the document
+    asserts  expressions over the measured row, with their expected values
+    (locals) declared constants, each with a stated reason
+
+and three separate obligations hold it in place:
+
+  * every `asserts` expression is evaluated against results.json and must match,
+    so editing the JSON without editing the prose is red;
+  * every number appearing in `text` -- digits or English words -- must be among
+    the asserted values, so a binding cannot carry a number it never checked;
+  * `text` must still occur in the document, so editing the prose without editing
+    the binding is red.
+
+To change a published number you must therefore move all three together, and
+moving all three means re-running the measurement.
+
+THE GAP, NAMED RATHER THAN IMPLIED. This makes registered numbers un-rottable; it
+does not make the documents' *prose* true. Three specific holes:
+
+  * The sweep in check 5 only knows two shapes, `N of M` and `NN.N%`. A claim
+    written entirely in English words -- "the corpus isolates six" -- can be added,
+    or silently changed, without this checker noticing. The bindings cover the
+    word-numbers that were already published; they cannot cover ones invented
+    later.
+  * Only the documents in DOCUMENTS are read. A third file publishing adequacy
+    numbers is unguarded until someone adds it here.
+  * A transcribed row (check 3) is pinned to a quote, not to a measurement. It
+    goes stale the moment the implementation it describes moves, and nothing here
+    can tell. That is the same declared-versus-observed gap one level up, and the
+    only repair is running `measure_all.py` for that corpus.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADEQUACY = REPO / "conformance/adequacy"
+RESULTS = ADEQUACY / "results.json"
+
+# Documents that MUST carry a bindings block. Discovery is not used for these two:
+# a document that could opt out by deleting its block would be guarded only while
+# someone remembered to keep it guarded.
+DOCUMENTS = [
+    REPO / "conformance/INDEX.md",
+    REPO / "conformance/privileged-mcp-action-v0/ERRATA.md",
+]
+
+BEGIN = "<!-- BEGIN CHECKED NUMBERS -->"
+END = "<!-- END CHECKED NUMBERS -->"
+
+# The shapes a published adequacy number takes in these documents. Deliberately
+# narrow: broadening it to every integer would make the not_derived list a
+# transcription of the prose and nobody would maintain it.
+SWEEP = re.compile(r"\b\d+ of \d+\b|\b\d+(?:\.\d+)?%")
+
+_UNITS = {"zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+          "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+          "thirteen": 13, "fourteen": 14, "fifteen": 15, "sixteen": 16, "seventeen": 17,
+          "eighteen": 18, "nineteen": 19}
+_TENS = {"twenty": 20, "thirty": 30, "forty": 40, "fifty": 50, "sixty": 60,
+         "seventy": 70, "eighty": 80, "ninety": 90}
+_WORDS: dict[str, int] = dict(_UNITS)
+for _t, _tv in _TENS.items():
+    _WORDS[_t] = _tv
+    for _u, _uv in _UNITS.items():
+        if _uv:
+            _WORDS["%s-%s" % (_t, _u)] = _tv + _uv
+# Longest first so "twenty-seven" is not read as "twenty".
+_WORD_RE = re.compile(r"\b(%s)\b" % "|".join(sorted(_WORDS, key=len, reverse=True)),
+                      re.IGNORECASE)
+
+# An expression is arithmetic over the measured row. Anything else is refused
+# rather than evaluated: this file runs in CI over repository content.
+_EXPR_OK = re.compile(r"^[A-Za-z0-9_+\-*/(). ,]+$")
+
+
+def normalise(text: str) -> str:
+    """Collapse whitespace so a re-wrapped paragraph is not a false failure.
+
+    Line wrapping is not a number change, and a checker that goes red when an
+    editor reflows a paragraph gets disabled rather than fixed.
+    """
+    return " ".join(text.split())
+
+
+def numbers_in(text: str) -> list[float]:
+    found = [float(x) for x in re.findall(r"\d+(?:\.\d+)?", text)]
+    found += [float(_WORDS[m.group(1).lower()]) for m in _WORD_RE.finditer(text)]
+    return found
+
+
+def evaluate(expr: str, namespace: dict) -> float:
+    if not _EXPR_OK.match(expr):
+        raise ValueError("expression contains characters this checker will not evaluate: %r"
+                         % expr)
+    return eval(expr, {"__builtins__": {}}, dict(namespace, round=round))  # noqa: S307
+
+
+def strip_block(text: str) -> str:
+    """Everything outside the bindings block.
+
+    Found by a positive control: the block quotes the prose it binds, so a check
+    that searched the whole document could be satisfied by the binding's own copy
+    of the sentence. Editing the prose then left the guard green because the guard
+    was reading itself.
+    """
+    if BEGIN in text and END in text:
+        start, stop = text.index(BEGIN), text.index(END) + len(END)
+        if stop > start:
+            return text[:start] + text[stop:]
+    return text
+
+
+def load_bindings(doc: Path) -> tuple[dict, str]:
+    """Return (bindings, document text with the block region removed)."""
+    text = doc.read_text(encoding="utf-8")
+    if text.count(BEGIN) != 1 or text.count(END) != 1:
+        raise ValueError("%s must contain exactly one %s ... %s block"
+                         % (doc.name, BEGIN, END))
+    start = text.index(BEGIN)
+    stop = text.index(END) + len(END)
+    if stop < start:
+        raise ValueError("%s: END marker precedes BEGIN" % doc.name)
+    block = text[start:stop]
+    fence = re.search(r"```json\n(.*?)\n```", block, re.DOTALL)
+    if not fence:
+        raise ValueError("%s: the checked-numbers block carries no ```json fence" % doc.name)
+    return json.loads(fence.group(1)), text[:start] + text[stop:]
+
+
+def aggregate_namespace(rows: list[dict]) -> dict:
+    return {
+        "corpora_total": len(rows),
+        "measured": sum(1 for r in rows if r["score_percent"] is not None),
+        "control_only": sum(1 for r in rows
+                            if r["score_percent"] is None and r["control"] == "killed"),
+        "transcribed": sum(1 for r in rows if r["provenance"]["kind"] == "transcribed"),
+    }
+
+
+def check() -> list[str]:
+    findings: list[str] = []
+
+    if not RESULTS.is_file():
+        return ["%s does not exist. Nothing re-derives the published numbers; run "
+                "conformance/adequacy/measure_all.py" % RESULTS.relative_to(REPO)]
+    doc = json.loads(RESULTS.read_text(encoding="utf-8"))
+    rows = doc.get("corpora", [])
+    by_corpus = {r["corpus"]: r for r in rows}
+
+    # ---- 1. self-coverage -------------------------------------------------
+    on_disk = {p.name[: -len(".manifest.json")]: p
+               for p in sorted(ADEQUACY.glob("*.manifest.json"))}
+    for missing in sorted(set(on_disk) - set(by_corpus)):
+        findings.append("no measurement for %s. results.json covers %d of %d manifests; a "
+                        "checker that skips a corpus is the failure it is checking for"
+                        % (on_disk[missing].relative_to(REPO), len(by_corpus), len(on_disk)))
+    for orphan in sorted(set(by_corpus) - set(on_disk)):
+        findings.append("results.json carries %r, which has no manifest on disk. A result "
+                        "outliving its manifest is a number about nothing" % orphan)
+
+    # ---- 1b. subject provenance for out-of-tree corpora --------------------
+    # A number about a repository we do not own says nothing checkable unless it
+    # names which state of that repository it describes. Two were published that
+    # way: rge-bench and observed-effect-v0, scored with no commit anywhere in
+    # the prose or the results. Freshness is not the requirement and cannot be --
+    # those repositories move without this diff seeing it -- so the requirement
+    # is that the published claim carries the commit it is permanently true of.
+    published = "\n".join(strip_block(d.read_text(encoding="utf-8"))
+                          for d in DOCUMENTS if d.is_file())
+    for name, row in sorted(by_corpus.items()):
+        subject = row.get("subject")
+        if not subject:
+            findings.append("%s records no subject. Every row must say which state of the "
+                            "measured thing it describes, in-tree or otherwise" % name)
+            continue
+        if subject.get("kind") != "out_of_tree":
+            continue
+        for repo in subject.get("repos", []):
+            commit = repo.get("commit")
+            if not commit:
+                findings.append("%s measures %s, which is not a git checkout, so this number "
+                                "names no state at all" % (name, repo.get("path", "?")))
+                continue
+            if repo.get("dirty"):
+                findings.append("%s was measured against %s with tracked modifications, so the "
+                                "number describes a working tree nobody else has"
+                                % (name, repo.get("repository") or repo.get("path")))
+            if commit[:9] not in published:
+                findings.append(
+                    "%s is measured against %s at %s and no published document names that "
+                    "commit. Provenance recorded only in results.json is provenance the reader "
+                    "does not get" % (name, repo.get("repository") or "an external repository",
+                                      commit[:9]))
+
+    # ---- 2. tool pin ------------------------------------------------------
+    for name, path in sorted(on_disk.items()):
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        pin = (manifest.get("tool_pin") or {}).get("commit")
+        if not pin:
+            findings.append("%s declares no tool_pin.commit. Numbers measured with an unnamed "
+                            "tool cannot be re-derived by anyone" % path.relative_to(REPO))
+            continue
+        row = by_corpus.get(name)
+        if row and row.get("tool_commit") != pin:
+            findings.append("%s was measured with corpus-adequacy %s but %s pins %s. Re-measure "
+                            "or re-pin; a number and its tool must move together"
+                            % (name, row.get("tool_commit"), path.name, pin))
+
+    # ---- 3. transcription -------------------------------------------------
+    for row in rows:
+        prov = row.get("provenance") or {}
+        if prov.get("kind") == "measured":
+            continue
+        if prov.get("kind") != "transcribed":
+            findings.append("%s: provenance.kind must be 'measured' or 'transcribed', got %r"
+                            % (row["corpus"], prov.get("kind")))
+            continue
+        src, quote = prov.get("from"), prov.get("quote")
+        if not src or not quote:
+            findings.append("%s is transcribed but names no source document and quote"
+                            % row["corpus"])
+            continue
+        source = REPO / src
+        if not source.is_file():
+            findings.append("%s is transcribed from %s, which does not exist"
+                            % (row["corpus"], src))
+            continue
+        source_text = strip_block(source.read_text(encoding="utf-8"))
+        if normalise(quote) not in normalise(source_text):
+            findings.append("%s is transcribed from %s, but that document no longer contains "
+                            "the quoted measurement. Either it was edited, in which case the "
+                            "transcription is void, or re-run measure_all.py --only %s"
+                            % (row["corpus"], src, row["corpus"]))
+        # The source document also pins the tool commit in PROSE, which is where it
+        # drifts: the manifest can be re-pinned and the sentence left behind.
+        if row.get("tool_commit") and row["tool_commit"] not in source_text:
+            findings.append("%s names corpus-adequacy %s, which %s no longer mentions. The "
+                            "document tells a reproducer which tool to use; a transcription "
+                            "measured with a different one is not the run it describes"
+                            % (row["corpus"], row["tool_commit"], src))
+
+    # ---- 3b. the prose tool pin, whatever the provenance --------------------
+    # This lived inside the transcription branch, so the moment a row stopped
+    # being transcribed the rule went quiet. It caught a real staleness within
+    # the hour: privileged-mcp-action-v0 was re-pinned to a newer tool and
+    # ERRATA.md kept handing a reproducer the old commit. The document tells
+    # someone which instrument to check out; whether we derived the row or
+    # quoted it changes nothing about that sentence needing to be true.
+    for row in rows:
+        commit = row.get("tool_commit")
+        if not commit:
+            continue
+        for path in DOCUMENTS:
+            if not path.is_file():
+                continue
+            text = path.read_text(encoding="utf-8")
+            if row["corpus"] not in text and path.name != "ERRATA.md":
+                continue
+            # Not same-line: the sentence wraps, and a same-line regex silently
+            # matched nothing, which is a guard that cannot fail. Any full commit
+            # hash in a document that talks about the tool is treated as the pin.
+            named = re.findall(r"\b([0-9a-f]{40})\b", text) if "corpus-adequacy" in text else []
+            if named and not any(commit.startswith(c) or c.startswith(commit[:9])
+                                 for c in named):
+                findings.append(
+                    "%s names corpus-adequacy %s in prose but %s was measured with %s. The "
+                    "document hands a reproducer an instrument; a number measured with a "
+                    "different one is not the run it describes"
+                    % (path.relative_to(REPO), named[0][:9], row["corpus"], commit[:9]))
+
+    # ---- 4 and 5. prose ---------------------------------------------------
+    for path in DOCUMENTS:
+        rel = path.relative_to(REPO)
+        if not path.is_file():
+            findings.append("%s does not exist" % rel)
+            continue
+        try:
+            bindings, body = load_bindings(path)
+        except ValueError as exc:
+            findings.append(str(exc))
+            continue
+        except json.JSONDecodeError as exc:
+            findings.append("%s: the checked-numbers block is not valid JSON: %s" % (rel, exc))
+            continue
+
+        haystack = normalise(body)
+        for claim in bindings.get("claims", []):
+            label = "%s: %r" % (rel, claim.get("text", "")[:60])
+            text = claim.get("text")
+            asserts = claim.get("asserts")
+            if not text or not isinstance(asserts, dict) or not asserts:
+                findings.append("%s: a claim needs a text and at least one assertion" % label)
+                continue
+
+            corpus = claim.get("corpus")
+            if corpus == "*":
+                namespace = aggregate_namespace(rows)
+            elif corpus in by_corpus:
+                namespace = {k: v for k, v in by_corpus[corpus].items()
+                             if isinstance(v, (int, float)) and not isinstance(v, bool)}
+            else:
+                findings.append("%s: names corpus %r, which results.json does not measure"
+                                % (label, corpus))
+                continue
+            for key, local in (claim.get("locals") or {}).items():
+                if key.startswith("_"):
+                    continue
+                if not str((claim.get("locals") or {}).get("_why_" + key, "")).strip():
+                    findings.append("%s: local %r has no _why_%s. A declared constant with no "
+                                    "stated reason is a number smuggled past the measurement"
+                                    % (label, key, key))
+                namespace[key] = local
+
+            expected_values: list[float] = []
+            for expr, expected in asserts.items():
+                try:
+                    actual = evaluate(expr, namespace)
+                except Exception as exc:  # noqa: BLE001
+                    findings.append("%s: cannot evaluate %r: %s" % (label, expr, exc))
+                    continue
+                expected_values.append(float(expected))
+                if abs(float(actual) - float(expected)) > 1e-9:
+                    findings.append("%s: publishes %s = %s, the measurement gives %s. "
+                                    "Re-run measure_all.py or correct the document"
+                                    % (label, expr, expected, actual))
+
+            for n in numbers_in(text):
+                if not any(abs(n - v) <= 1e-9 for v in expected_values):
+                    findings.append("%s: the wording carries %g, which no assertion checks. "
+                                    "Every number in a published claim must be checked against "
+                                    "the measurement" % (label, n))
+
+            if normalise(text) not in haystack:
+                findings.append("%s: this exact wording is no longer in %s. The prose was "
+                                "edited away from the binding; update both together"
+                                % (label, rel))
+
+        # ---- 5. sweep -----------------------------------------------------
+        swept = haystack
+        for claim in bindings.get("claims", []):
+            swept = swept.replace(normalise(claim.get("text", "") or "\0"), " ")
+        for entry in bindings.get("not_derived", []):
+            token, reason = entry.get("token"), entry.get("reason")
+            if not token or not str(reason or "").strip():
+                findings.append("%s: a not_derived entry needs a token and a reason" % rel)
+                continue
+            if token not in swept:
+                findings.append("%s: not_derived declares %r, which no longer appears. Remove "
+                                "it; an exemption pointing at nothing is where the next "
+                                "unchecked number hides" % (rel, token))
+            swept = swept.replace(token, " ")
+        for leftover in SWEEP.finditer(swept):
+            at = swept[max(0, leftover.start() - 70): leftover.end() + 70]
+            findings.append("%s: %r is published but neither derived from results.json nor "
+                            "declared not_derived. Context: ...%s..."
+                            % (rel, leftover.group(0), at))
+
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true", help="machine-readable findings")
+    args = ap.parse_args(argv)
+
+    findings = check()
+    if args.json:
+        print(json.dumps({"schema": "assay.conformance.adequacy.check.v0",
+                          "findings": findings, "ok": not findings}, indent=2))
+    elif findings:
+        print("published adequacy numbers disagree with the measurement:\n")
+        for f in findings:
+            print("  - %s\n" % f)
+    else:
+        print("published adequacy numbers agree with conformance/adequacy/results.json")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/adequacy/check_published_numbers.py
+++ b/conformance/adequacy/check_published_numbers.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -233,6 +234,35 @@ def check() -> list[str]:
                     "commit. Provenance recorded only in results.json is provenance the reader "
                     "does not get" % (name, repo.get("repository") or "an external repository",
                                       commit[:9]))
+
+    # ---- 1c. is the measurement still current for the code ------------------
+    # The lane re-derives a corpus only when its declared sources move. Every
+    # other revision compares the documents against an older results.json and
+    # goes green, which is accurate about the comparison and silent about the
+    # measurement. A figure taken last week, read as a fact about today, is the
+    # thing this file exists to stop, and matching prose to JSON does not stop it.
+    #
+    # The question asked is not "was this re-run at HEAD", which would mark almost
+    # every row stale and train people to ignore the finding. It is whether
+    # anything the row DEPENDS ON has moved since it was taken.
+    for name, row in sorted(by_corpus.items()):
+        taken = row.get("measured_at")
+        if not taken or not taken.get("commit"):
+            findings.append("%s records no measured_at commit, so nothing can say whether its "
+                            "number is still current for this code" % name)
+            continue
+        moved = subprocess.run(
+            ["git", "-C", str(REPO), "diff", "--name-only", taken["commit"], "HEAD", "--",
+             *taken.get("depends_on", [])],
+            capture_output=True, text=True)
+        if moved.returncode != 0:
+            continue          # shallow clone or unknown commit: not a claim either way
+        changed = [ln for ln in moved.stdout.splitlines() if ln.strip()]
+        if changed:
+            findings.append(
+                "%s was measured at %s and %s changed since, so the published number describes "
+                "code this revision no longer has. Re-run measure_all.py --only %s"
+                % (name, taken["commit"][:9], ", ".join(sorted(changed)[:3]), name))
 
     # ---- 2. tool pin ------------------------------------------------------
     for name, path in sorted(on_disk.items()):

--- a/conformance/adequacy/mcp-jsonrpc-id.manifest.json
+++ b/conformance/adequacy/mcp-jsonrpc-id.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
-  "_about": "Mutation adequacy for the mcp-jsonrpc-id pack. The pack's README declares a NARROW scope: the error-response id contradiction, two incompatibility arms plus one positive control. The four id rules are in scope. The envelope-shape rules are real rules the pack depends on but never claimed to exercise, so they are declared out_of_scope and reported rather than scored. Lives OUTSIDE the pack on purpose: the pack checksums its own public files, so adding a manifest to it would break its integrity guard. The vectors file here is derived from the pack's vectors/*.json and conformance/tests/test_corpus_adequacy_own_corpora.py asserts it has not drifted.",
+  "_about": "Mutation adequacy for the mcp-jsonrpc-id pack. The pack's README declares a NARROW scope: the error-response id contradiction, two incompatibility arms plus one positive control. Envelope-shape rules are real rules the pack depends on but never claimed to exercise, so they are out_of_scope and reported rather than scored. The first declaration scored only the four presence/null arms and called that 4 of 4. The positive control is a string id, and RequestId is string | number, so the type arms belong in the denominator: two of them (string) are isolated by that control, and the number/bool siblings are not. Lives OUTSIDE the pack on purpose: the pack checksums its own public files, so adding a manifest to it would break its integrity guard. The vectors file here is derived from the pack's vectors/*.json and conformance/tests/test_corpus_adequacy_own_corpora.py asserts it has not drifted.",
   "implementation": "../../examples/mcp-jsonrpc-id-conformance/check.py",
   "entrypoint": "evaluate_message",
   "entrypoint_args": [
@@ -76,6 +76,36 @@
         "anchor": "        identifier is None or isinstance(identifier, str) or _is_number(identifier)",
         "replacement": "        isinstance(identifier, str) or _is_number(identifier)",
         "scope": "declared"
+      },
+      {
+        "label": "11 MCP RequestId includes string",
+        "anchor": "    mcp_id_valid = not has_id or (\n        isinstance(identifier, str)\n        or (isinstance(identifier, int) and not isinstance(identifier, bool))",
+        "replacement": "    mcp_id_valid = not has_id or (\n        False\n        or (isinstance(identifier, int) and not isinstance(identifier, bool))"
+      },
+      {
+        "label": "12 JSON-RPC accepts a string id",
+        "anchor": "    jsonrpc_id_valid = has_id and (\n        identifier is None or isinstance(identifier, str) or _is_number(identifier)\n    )",
+        "replacement": "    jsonrpc_id_valid = has_id and (\n        identifier is None or False or _is_number(identifier)\n    )"
+      },
+      {
+        "label": "13 MCP RequestId includes number",
+        "anchor": "        or (isinstance(identifier, int) and not isinstance(identifier, bool))\n    )",
+        "replacement": "        or False\n    )"
+      },
+      {
+        "label": "14 a bool is not an MCP RequestId",
+        "anchor": "isinstance(identifier, int) and not isinstance(identifier, bool)",
+        "replacement": "isinstance(identifier, int)"
+      },
+      {
+        "label": "15 JSON-RPC accepts a number id",
+        "anchor": "    jsonrpc_id_valid = has_id and (\n        identifier is None or isinstance(identifier, str) or _is_number(identifier)\n    )",
+        "replacement": "    jsonrpc_id_valid = has_id and (\n        identifier is None or isinstance(identifier, str)\n    )"
+      },
+      {
+        "label": "16 a bool is not a JSON-RPC number id",
+        "anchor": "    return isinstance(value, (int, float)) and not isinstance(value, bool)",
+        "replacement": "    return isinstance(value, (int, float))"
       },
       {
         "label": "10 a non-object message is rejected outright",

--- a/conformance/adequacy/mcp-jsonrpc-id.manifest.json
+++ b/conformance/adequacy/mcp-jsonrpc-id.manifest.json
@@ -1,5 +1,10 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
+  "tool_pin": {
+    "_why": "Re-pinned to b87ef70, which enforces the control requirement on EVERY runner from one function. The previous pin enforced it only on the process path, so a module corpus could score with no control -- and this repository had one in that state. Re-measured under the new pin; no number moved.",
+    "commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+    "tool": "https://github.com/corpus-adequacy/corpus-adequacy"
+  },
   "_about": "Mutation adequacy for the mcp-jsonrpc-id pack. The pack's README declares a NARROW scope: the error-response id contradiction, two incompatibility arms plus one positive control. Envelope-shape rules are real rules the pack depends on but never claimed to exercise, so they are out_of_scope and reported rather than scored. The first declaration scored only the four presence/null arms and called that 4 of 4. The positive control is a string id, and RequestId is string | number, so the type arms belong in the denominator: two of them (string) are isolated by that control, and the number/bool siblings are not. Lives OUTSIDE the pack on purpose: the pack checksums its own public files, so adding a manifest to it would break its integrity guard. The vectors file here is derived from the pack's vectors/*.json and conformance/tests/test_corpus_adequacy_own_corpora.py asserts it has not drifted.",
   "implementation": "../../examples/mcp-jsonrpc-id-conformance/check.py",
   "entrypoint": "evaluate_message",
@@ -113,6 +118,13 @@
         "replacement": "    if not _error_shape_is_valid(message):",
         "scope": "out_of_scope",
         "reason": "input-domain guard; the pack's three vectors are all objects, so nothing exercises the non-object branch"
+      },
+      {
+        "label": "CONTROL harness reachability",
+        "anchor": "    \"\"\"Evaluate only the error-response constraints exercised by this pack.\"\"\"",
+        "replacement": "    \"\"\"Evaluate only the error-response constraints exercised by this pack.\"\"\"\n    return {\"mcp\": \"MOVED\", \"jsonrpc\": \"MOVED\"}",
+        "control": true,
+        "reason": "Returns before every branch, so it moves all three vectors whatever their shape. This manifest scored seventeen mutants with NO control for as long as the tool enforced that rule only on the process path; the module path never checked. Six kills meant the harness demonstrably reached the code, so no number here was wrong, but the guarantee was absent: an all-survivors run could not have been told from a harness detecting nothing. corpus-adequacy b87ef70 now enforces it on every runner from one function, with a parity test."
       }
     ]
   },

--- a/conformance/adequacy/measure_all.py
+++ b/conformance/adequacy/measure_all.py
@@ -126,6 +126,38 @@ def control_verdict(report: dict) -> str:
     return "none_declared"
 
 
+def measured_at(declared: dict, manifest: Path) -> dict:
+    """The revision of THIS repository the row was measured against.
+
+    Without it a number is present tense forever. The lane re-derives a corpus
+    only when its declared sources move, which is the right cost trade and leaves
+    every other revision comparing the documents against an older results.json and
+    going green. That green is accurate about the comparison and silent about the
+    measurement being old, and last week's figure read as a fact about today is
+    the thing this whole file exists to stop.
+
+    Recording the commit lets `check_published_numbers.py` ask the only question
+    that matters: has anything this row DEPENDS ON moved since it was taken. Not
+    "was it re-run this revision", which would mark almost every row stale and
+    train people to ignore it.
+    """
+    out = subprocess.run(["git", "-C", str(REPO), "rev-parse", "HEAD"],
+                         capture_output=True, text=True)
+    if out.returncode != 0:
+        return {}
+    paths = [declared[k] for k in ("implementation", "vectors", "corpus_digest_file")
+             if isinstance(declared.get(k), str)]
+    paths += [x for x in (declared.get("implementation_sources") or []) if isinstance(x, str)]
+    rel = []
+    for raw in paths:
+        try:
+            rel.append(str((manifest.parent / raw).resolve().relative_to(REPO)))
+        except ValueError:
+            continue          # out-of-tree: pinned separately by `subject`
+    return {"measured_at": {"commit": out.stdout.strip(),
+                            "depends_on": sorted(set(rel + [str(manifest.relative_to(REPO))]))}}
+
+
 def subject(manifest: Path, declared: dict) -> dict:
     """Which state of the measured thing this number describes.
 
@@ -207,6 +239,7 @@ def row(manifest: Path, report: dict, who: dict) -> dict:
         "control": control_verdict(report),
         "provenance": {"kind": "measured"},
         **subject(manifest, declared),
+        **measured_at(declared, manifest),
         **who,
     }
 

--- a/conformance/adequacy/measure_all.py
+++ b/conformance/adequacy/measure_all.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Re-derive every published mutation-adequacy number into results.json.
+
+    python3 conformance/adequacy/measure_all.py                 # every corpus
+    python3 conformance/adequacy/measure_all.py --only rge-bench --only rfc8785-canonicalization
+    python3 conformance/adequacy/measure_all.py --list
+
+results.json is the single measured truth behind the numbers INDEX.md and
+ERRATA.md publish. `check_published_numbers.py` fails when the prose and this
+file disagree, so the prose stops being a place a number can quietly rot.
+
+WHY THIS SCRIPT EXISTS AT ALL. The numbers it writes were, until it landed,
+produced by a human running the tool by hand one evening. Nothing re-derived
+them, and ERRATA.md pins its scope to a corpus DIGEST, which does not move when
+the *implementation* moves. So a rule deleted from `denial_marker.rs` tomorrow
+changes what the corpus can transmit and changes no digest, no test and no
+published number. That is a claim nobody re-derives, which is the exact defect
+this whole body of work exists to criticise.
+
+TWO OPERATIONAL WARNINGS, both learned the expensive way.
+
+* `privileged-mcp-action-v0` is a `process` corpus: ~32 cargo builds, mutating
+  shared source files in place. It is not something to run casually, and it is
+  why `--only` exists. Rows for corpora not selected are carried over from the
+  existing results.json untouched.
+* NEVER `git commit` while a measurement runs. Pre-commit stashes unstaged
+  changes, which removes the in-flight mutant and rebuilds the harness from
+  unmutated source; every mutant then "survives". One 29-mutant run was voided
+  that way. Check `pgrep -f corpus_adequacy` first.
+
+The tool is NOT vendored here (see INDEX.md, "Where the adequacy tool lives").
+Clone https://github.com/corpus-adequacy/corpus-adequacy as a sibling checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADEQUACY = REPO / "conformance/adequacy"
+RESULTS = ADEQUACY / "results.json"
+TOOL = REPO.parent / "corpus-adequacy"
+
+SCHEMA = "assay.conformance.adequacy.results.v0"
+
+
+def load_tool():
+    """Import the sibling checkout, or say plainly that nothing was measured."""
+    if not TOOL.is_dir():
+        raise SystemExit(
+            "corpus-adequacy not found at %s.\n"
+            "It is deliberately not vendored. Clone it as a sibling checkout:\n"
+            "  git clone https://github.com/corpus-adequacy/corpus-adequacy %s" % (TOOL, TOOL))
+    sys.path.insert(0, str(TOOL))
+    import corpus_adequacy as ca  # noqa: E402
+    return ca
+
+
+def tool_is_dirty(allow_dirty: bool) -> bool:
+    """Refuse to record a measurement taken with an uncommitted tool checkout.
+
+    A commit id that does not describe the code that ran is worse than no pin: it
+    is a pin that looks re-derivable and is not. --allow-dirty-tool records the
+    dirt in the commit string itself, so it can never match a manifest pin and the
+    checker goes red rather than quietly accepting it.
+    """
+    dirty = bool(subprocess.run(["git", "-C", str(TOOL), "status", "--porcelain"],
+                                capture_output=True, text=True, check=True).stdout.strip())
+    if dirty and not allow_dirty:
+        raise SystemExit(
+            "the corpus-adequacy checkout at %s has uncommitted changes, so no commit id\n"
+            "describes the code that would run. Commit or stash them, or pass\n"
+            "--allow-dirty-tool to record the measurement as unpinned." % TOOL)
+    return dirty
+
+
+def identity(report: dict, dirty: bool) -> dict:
+    """Who measured this, taken from the tool's OWN report where it offers one.
+
+    corpus-adequacy carries `tool_version` and `tool_commit` in its report as of
+    0.1.0. Reading them beats re-deriving the commit here: two implementations of
+    "which tool ran" would drift, and the copy that drifts is the one that stops
+    describing the run. The git fallback exists only for tool checkouts older than
+    that, which report neither.
+    """
+    commit = report.get("tool_commit")
+    if not commit:
+        commit = subprocess.run(["git", "-C", str(TOOL), "rev-parse", "HEAD"],
+                                capture_output=True, text=True, check=True).stdout.strip()
+    out = {"tool_commit": commit + "-dirty" if dirty else commit}
+    if report.get("tool_version"):
+        out["tool_version"] = report["tool_version"]
+    return out
+
+
+def manifests() -> list[Path]:
+    return sorted(ADEQUACY.glob("*.manifest.json"))
+
+
+def corpus_id(manifest: Path) -> str:
+    return manifest.name[: -len(".manifest.json")]
+
+
+def rel(path: Path) -> str:
+    return path.resolve().relative_to(REPO).as_posix()
+
+
+def control_verdict(report: dict) -> str:
+    """What the control did, as a first-class field rather than a footnote.
+
+    All-survivors because a corpus is weak and all-survivors because nothing was
+    ever measured print identically, so a score without a control verdict is not
+    a result. `none_declared` is recorded rather than hidden: the module runner
+    does not require a control, so a manifest can carry none, and that is a fact
+    a reader of the numbers needs.
+    """
+    verdicts = {m["verdict"] for m in report["mutants"]}
+    if "control-SURVIVED" in verdicts:
+        return "SURVIVED"
+    if "control-killed" in verdicts:
+        return "killed"
+    return "none_declared"
+
+
+def subject(manifest: Path, declared: dict) -> dict:
+    """Which state of the measured thing this number describes.
+
+    A corpus inside this repository is pinned by the commit carrying the number.
+    A corpus in a SIBLING repository is not: `rge-bench` and `observed-effect-v0`
+    are other people's repositories, they move without this diff seeing it, and a
+    score published against them without naming a commit says nothing checkable.
+    Two such numbers were published that way.
+
+    Fresh is not the goal and cannot be. A measurement of rge-bench at c51c5af
+    stays permanently true about rge-bench at c51c5af; what was missing is the
+    second half of that sentence.
+
+    The basis is the files actually measured, NOT `repo_root`. A first version
+    used repo_root and recorded `rge-bench` as in-tree, because that manifest
+    declares no repo_root at all and the default resolved inside this repository
+    while the measured file sat three levels above it. Recording an external
+    corpus as internal is the same silence this field exists to break, so it is
+    derived from `implementation` and `implementation_sources` instead.
+    """
+    declared_paths = list(declared.get("implementation_sources") or [])
+    if declared.get("implementation"):
+        declared_paths.append(declared["implementation"])
+    outside = {}
+    for rel_path in declared_paths:
+        src = (manifest.parent / rel_path).resolve()
+        try:
+            src.relative_to(REPO)
+            continue
+        except ValueError:
+            pass
+        root = subprocess.run(["git", "-C", str(src.parent), "rev-parse", "--show-toplevel"],
+                              capture_output=True, text=True)
+        key = root.stdout.strip() if root.returncode == 0 else str(src.parent)
+        outside.setdefault(key, []).append(rel_path)
+    if not outside:
+        return {"subject": {"kind": "in_tree"}}
+
+    def git(root, *args):
+        out = subprocess.run(["git", "-C", root, *args], capture_output=True, text=True)
+        return out.stdout.strip() if out.returncode == 0 else None
+
+    repos = []
+    for root in sorted(outside):
+        commit = git(root, "rev-parse", "HEAD")
+        if commit is None:
+            repos.append({"path": root, "commit": None,
+                          "_why": "not a git checkout, so this number names no state at all"})
+            continue
+        origin = git(root, "remote", "get-url", "origin") or ""
+        tracked = [ln for ln in (git(root, "status", "--porcelain") or "").splitlines()
+                   if ln[:2] != "??"]
+        repos.append({
+            "repository": origin.rsplit("github.com", 1)[-1].lstrip(":/").removesuffix(".git") or None,
+            "commit": commit,
+            "dirty": bool(tracked),
+            "measured": sorted(outside[root]),
+        })
+    return {"subject": {"kind": "out_of_tree", "repos": repos}}
+
+
+def row(manifest: Path, report: dict, who: dict) -> dict:
+    # runner comes from the manifest, not the report: the module runner's report
+    # omits it and a KeyError here would be a writer crash over a label.
+    declared = json.loads(manifest.read_text(encoding="utf-8"))
+    return {
+        "corpus": corpus_id(manifest),
+        "manifest": rel(manifest),
+        "runner": declared.get("runner", "module"),
+        "killed": report["killed"],
+        "survived": report["survived"],
+        "equivalent": report["equivalent"],
+        "out_of_scope": report["unexercised_out_of_scope"],
+        "known_holes": report["known_holes"],
+        "unproved": report["unproved"],
+        "declared_total": report["declared_total"],
+        "score_percent": report["score_percent"],
+        "adequate": report["adequate"],
+        "control": control_verdict(report),
+        "provenance": {"kind": "measured"},
+        **subject(manifest, declared),
+        **who,
+    }
+
+
+def read_existing() -> dict[str, dict]:
+    if not RESULTS.is_file():
+        return {}
+    doc = json.loads(RESULTS.read_text(encoding="utf-8"))
+    return {c["corpus"]: c for c in doc.get("corpora", [])}
+
+
+def write(rows: dict[str, dict]) -> None:
+    doc = {"schema": SCHEMA,
+           "_about": "Measured mutation adequacy for every corpus manifest in this "
+                     "directory. Written by measure_all.py; asserted against the published "
+                     "prose by check_published_numbers.py. Do not hand-edit a measured row.",
+           "corpora": [rows[k] for k in sorted(rows)]}
+    RESULTS.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--only", action="append", default=[],
+                    metavar="CORPUS",
+                    help="measure only this corpus (repeatable). Rows for the others are "
+                         "carried over from results.json unchanged.")
+    ap.add_argument("--list", action="store_true", help="list corpus ids and exit")
+    ap.add_argument("--allow-dirty-tool", action="store_true",
+                    help="record a measurement taken with an uncommitted tool checkout. The "
+                         "recorded commit is suffixed -dirty and will fail the pin check.")
+    args = ap.parse_args(argv)
+
+    found = manifests()
+    if args.list:
+        for m in found:
+            print(corpus_id(m))
+        return 0
+    if not found:
+        raise SystemExit("no manifests in %s" % ADEQUACY)
+
+    selected = found
+    if args.only:
+        known = {corpus_id(m) for m in found}
+        unknown = sorted(set(args.only) - known)
+        if unknown:
+            raise SystemExit("no such corpus: %s. Known: %s"
+                             % (", ".join(unknown), ", ".join(sorted(known))))
+        selected = [m for m in found if corpus_id(m) in set(args.only)]
+
+    ca = load_tool()
+    dirty = tool_is_dirty(args.allow_dirty_tool)
+    rows = read_existing()
+
+    for manifest in selected:
+        print("measuring %s ..." % corpus_id(manifest), flush=True)
+        report = ca.run(manifest)
+        rows[corpus_id(manifest)] = row(manifest, report, identity(report, dirty))
+        r = rows[corpus_id(manifest)]
+        print("  killed=%s survived=%s score=%s control=%s"
+              % (r["killed"], r["survived"], r["score_percent"], r["control"]), flush=True)
+
+    write(rows)
+    print("wrote %s (%d corpora)" % (rel(RESULTS), len(rows)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/adequacy/observed-effect-drift-consumer.manifest.json
+++ b/conformance/adequacy/observed-effect-drift-consumer.manifest.json
@@ -1,5 +1,10 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
+  "tool_pin": {
+    "_why": "Re-pinned to b87ef70, which enforces the control requirement on EVERY runner from one function. The previous pin enforced it only on the process path, so a module corpus could score with no control -- and this repository had one in that state. Re-measured under the new pin; no number moved.",
+    "commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+    "tool": "https://github.com/corpus-adequacy/corpus-adequacy"
+  },
   "runner": "batch",
   "_about": "Mutation adequacy for the observed-effect-v0 drift consumer. BATCH runner: the checker takes the whole vector file and reports a summary, so the corpus is exercised as a unit and the summary IS the outcome. Its failures list names the case ids, which is what makes it discriminate; a checker reporting only a boolean would make every mutant kill everything or nothing. The first declaration scored five merge-policy rules (4 of 5). The 14 case names announce the recompute, advisory, and profile rules as well; those belong in the denominator. The command is relative on purpose -- the consumer REFUSES an absolute vectors path, which is its own hardening and not something to work around. Requires Rul1an/observed-effect-v0 cloned as a sibling of this repository; without it the run fails with a missing source rather than silently measuring nothing.",
   "repo_root": "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06",

--- a/conformance/adequacy/observed-effect-drift-consumer.manifest.json
+++ b/conformance/adequacy/observed-effect-drift-consumer.manifest.json
@@ -148,5 +148,12 @@
       }
     ]
   },
-  "equivalent": {}
+  "equivalent": {},
+  "pins": {
+    "observed-effect-v0": {
+      "repository": "Rul1an/observed-effect-v0",
+      "commit": "dc10fad0cc867b1f652e2727f98e9370da429904"
+    }
+  },
+  "_pins_why": "Freshness is not the goal and cannot be: this corpus lives in a repository this diff cannot see, and it moves without us. A score against Rul1an/observed-effect-v0@dc10fad0c stays permanently true of that commit, which is what makes it a claim rather than a mood. Pinning is therefore not a compromise on keeping up -- it is the thing that makes the number mean something, and it lets the lane re-derive it when the INSTRUMENT changes, which is the drift vector that actually applies here. Re-pinning is a deliberate act, like tool_pin."
 }

--- a/conformance/adequacy/observed-effect-drift-consumer.manifest.json
+++ b/conformance/adequacy/observed-effect-drift-consumer.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
   "runner": "batch",
-  "_about": "Mutation adequacy for the observed-effect-v0 drift consumer. BATCH runner: the checker takes the whole vector file and reports a summary, so the corpus is exercised as a unit and the summary IS the outcome. Its failures list names the case ids, which is what makes it discriminate; a checker reporting only a boolean would make every mutant kill everything or nothing. The command is relative on purpose -- the consumer REFUSES an absolute vectors path, which is its own hardening and not something to work around. Requires Rul1an/observed-effect-v0 cloned as a sibling of this repository; without it the run fails with a missing source rather than silently measuring nothing.",
+  "_about": "Mutation adequacy for the observed-effect-v0 drift consumer. BATCH runner: the checker takes the whole vector file and reports a summary, so the corpus is exercised as a unit and the summary IS the outcome. Its failures list names the case ids, which is what makes it discriminate; a checker reporting only a boolean would make every mutant kill everything or nothing. The first declaration scored five merge-policy rules (4 of 5). The 14 case names announce the recompute, advisory, and profile rules as well; those belong in the denominator. The command is relative on purpose -- the consumer REFUSES an absolute vectors path, which is its own hardening and not something to work around. Requires Rul1an/observed-effect-v0 cloned as a sibling of this repository; without it the run fails with a missing source rather than silently measuring nothing.",
   "repo_root": "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06",
   "implementation_sources": [
     "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06/independent_consumer.py"
@@ -44,6 +44,96 @@
         "label": "4 the body is only read when the ref recomputed",
         "anchor": "body = store.get(ref.get(\"ref\")) if rv == \"recomputed\" else None",
         "replacement": "body = store.get(ref.get(\"ref\"))"
+      },
+      {
+        "label": "5 agreement falls through to allow",
+        "anchor": "    else:\n        decision = \"allow\"",
+        "replacement": "    else:\n        decision = \"review_required\""
+      },
+      {
+        "label": "6 surface remains the authority",
+        "anchor": "\"surface_is_authority\": True,",
+        "replacement": "\"surface_is_authority\": False,"
+      },
+      {
+        "label": "7 observed divergence drives the decision",
+        "anchor": "    elif adv == \"divergence_observed\":\n        decision = \"quarantine\" if opt_in else \"review_required\"",
+        "replacement": "    elif False:\n        decision = \"quarantine\" if opt_in else \"review_required\""
+      },
+      {
+        "label": "8 not_observed or unknown basis is insufficient coverage",
+        "anchor": "    if b not in BASIS_OK or b in (\"not_observed\", \"unknown\"):",
+        "replacement": "    if b not in BASIS_OK:"
+      },
+      {
+        "label": "9 an unexpected basis is insufficient coverage",
+        "anchor": "    if b not in BASIS_OK or b in (\"not_observed\", \"unknown\"):",
+        "replacement": "    if b in (\"not_observed\", \"unknown\"):"
+      },
+      {
+        "label": "10 nonempty divergence is observed",
+        "anchor": "    return \"divergence_observed\" if (body.get(\"divergence\") or []) else \"none\"",
+        "replacement": "    return \"none\""
+      },
+      {
+        "label": "11 an unknown profile is unsupported",
+        "anchor": "    if not isinstance(canon, str) or canon not in PROFILES:\n        return \"unsupported_canonicalization\"",
+        "replacement": "    if False:\n        return \"unsupported_canonicalization\""
+      },
+      {
+        "label": "12 the digest must match the recomputed address",
+        "anchor": "    if addr(body, canon) != ref[\"digest\"]:",
+        "replacement": "    if False:"
+      },
+      {
+        "label": "13 required fields must be present and unredacted",
+        "anchor": "    if any(f not in body or redacted(body[f]) for f in spec[\"required_fields\"]):\n        return \"incomplete_projection\"",
+        "replacement": "    if False:\n        return \"incomplete_projection\""
+      },
+      {
+        "label": "14 a redacted required field is incomplete",
+        "anchor": "    if any(f not in body or redacted(body[f]) for f in spec[\"required_fields\"]):",
+        "replacement": "    if any(f not in body for f in spec[\"required_fields\"]):"
+      },
+      {
+        "label": "15 jcs-json-v1 is a live profile",
+        "anchor": "    if profile == \"jcs-json-v1\":\n        return \"sha256:\" + hashlib.sha256(canon_jcs(body)).hexdigest()",
+        "replacement": "    if False:\n        return \"sha256:\" + hashlib.sha256(canon_jcs(body)).hexdigest()"
+      },
+      {
+        "label": "16 cbor-deterministic-v1 is a live profile",
+        "anchor": "    if profile == \"cbor-deterministic-v1\":\n        return \"sha256:\" + hashlib.sha256(canon_cbor(body)).hexdigest()",
+        "replacement": "    if False:\n        return \"sha256:\" + hashlib.sha256(canon_cbor(body)).hexdigest()"
+      },
+      {
+        "label": "17 JCS object keys are ordered by UTF-16 code unit",
+        "anchor": "        items = sorted(o.items(), key=lambda kv: kv[0].encode(\"utf-16-be\"))",
+        "replacement": "        items = sorted(o.items(), key=lambda kv: kv[0])"
+      },
+      {
+        "label": "18 a missing digest or profile is malformed",
+        "anchor": "    if not ref.get(\"digest\") or not ref.get(\"canonicalization\"):\n        return \"malformed_ref\"",
+        "replacement": "    if False:\n        return \"malformed_ref\""
+      },
+      {
+        "label": "19 a digest without a location is unresolvable",
+        "anchor": "    if loc is None:\n        return \"unresolvable_digest_only\"",
+        "replacement": "    if False:\n        return \"unresolvable_digest_only\""
+      },
+      {
+        "label": "20 a location absent from the store is unresolved",
+        "anchor": "    if loc not in store:\n        return \"unresolved_ref\"",
+        "replacement": "    if False:\n        return \"unresolved_ref\""
+      },
+      {
+        "label": "21 an unknown schema fails closed",
+        "anchor": "    if spec is None:\n        return \"schema_mismatch\"",
+        "replacement": "    if False:\n        return \"schema_mismatch\""
+      },
+      {
+        "label": "22 a digest that matches the other profile is a canonicalization mismatch",
+        "anchor": "        for alt in PROFILES:\n            if alt != canon and addr(body, alt) == ref[\"digest\"]:\n                return \"canonicalization_mismatch\"\n        return \"digest_mismatch\"",
+        "replacement": "        return \"digest_mismatch\""
       },
       {
         "label": "CONTROL harness reachability",

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -204,6 +204,18 @@
         "reason": "WRONG STAGE, same argument as declared mutant 0. Under v0 selection only payloads whose schema member is assay.denied_call_observation.v0 are collected into `observations`, so the classifier's schema leg cannot decide anything on this path: it is an equivalent mutant here, not a hole. Measured SURVIVED, as the reasoning predicts. Recorded because the published table credits this leg to the corpus."
       },
       {
+        "label": "47 an unrecognised in-namespace payload schema fails closed (Stage 2)",
+        "anchor": "                    other => violations.push(finding(\n                        \"unknown_profile_schema\",\n                        format!(\n                            \"payload schema {other:?} is inside the profile namespace but is not a recognized {} record; unknown fails closed\",\n                            profile_version.as_profile_id()\n                        ),\n                    )),",
+        "replacement": "                    other => { let _ = other; }",
+        "reason": "v0 Stage 2. Declared mutant 0 mutates the Stage 3 classifier and is out of scope for exactly this reason -- 'to measure that promise, mutate the Stage 2 match instead'. This is that mutant. bad-104 should kill it."
+      },
+      {
+        "label": "48 the decision value must be in the closed vocabulary",
+        "anchor": "check_vocab(dec, \"decision\", DECISION_VOCAB, violations);",
+        "replacement": "let _ = DECISION_VOCAB;",
+        "reason": "v0 Stage 2 closed vocabulary. Declared as its own call site rather than by mutating check_vocab, which would delete four rules at once. bad-107 should kill it."
+      },
+      {
         "label": "CONTROL harness reachability on the verifier path",
         "anchor": ".filter(|obs| classify_denial_marker(obs) == Some(profile_version.marker_version()));",
         "replacement": ".filter(|_obs| false);",

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
   "runner": "process",
-  "_about": "Mutation adequacy for privileged-mcp-action/v0. First pass declared THREE rules and scored nothing: one genuine hole (the origin leg) and two that mutate the wrong stage and the wrong profile, kept out_of_scope with that reasoning rather than dropped. A corpus of 14 vectors that yields no adequacy result is a signal about the DECLARATION, not about the corpus -- so eight further rules were declared, read off the verifier path rather than off the vector names.",
+  "_about": "Mutation adequacy for privileged-mcp-action/v0, third declaration. The first declared THREE rules and scored nothing. The second declared eight read off the verifier path and scored 4 of 8, which was published with a pattern claim that an adversarial re-measurement then refuted: deleting 23 further promised rules AT ONCE reproduced all fourteen outcomes and all five claim matrices. This declaration folds those in, deduplicated by (anchor, replacement) rather than by label -- five of the 23 turned out to restate rules already declared here, and counting them again would have inflated the denominator in the direction that flatters. outcome_from now reads the surface MANIFEST.json declares normative rather than the one it calls informative.",
   "repo_root": "../..",
   "implementation_sources": [
     "../../crates/assay-evidence/src/denial_marker.rs",
@@ -98,6 +98,110 @@
         "label": "11 the code must be the v0 deny code",
         "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
         "replacement": "(DENIED_CALL_OBSERVATION_V0, _, PROXY_ORIGIN) => {"
+      },
+      {
+        "label": "26 the decision reason must be in the closed producer set",
+        "anchor": "check_vocab(dec, \"reason\", REASON_VOCAB, violations);",
+        "replacement": "let _ = (dec, REASON_VOCAB, &violations);",
+        "reason": "v0 Section 5 Stage 2: `reason` in the closed producer set unclassified_tool_call | classification_incomplete | no_declared_allowance | credential_scope_unknown | credential_scope_insufficient | manifest_baseline_missing | manifest_observation_ambiguous | manifest_current_observation_incomplete | manifest_drifted_since_approval | allow."
+      },
+      {
+        "label": "27 the decision drift_state must be in the closed set",
+        "anchor": "check_vocab(dec, \"drift_state\", DRIFT_STATE_VOCAB, violations);",
+        "replacement": "let _ = (dec, DRIFT_STATE_VOCAB, &violations);",
+        "reason": "v0 Section 5 Stage 2: `drift_state` in satisfied | baseline_missing | current_observation_incomplete | observation_ambiguous | drifted | not_evaluated."
+      },
+      {
+        "label": "28 the decision tool.name must be a non-empty string",
+        "anchor": "if tool_name.map(str::is_empty).unwrap_or(true) {\n        violations.push(finding(\n            \"decision_tool_name\",",
+        "replacement": "if false {\n        violations.push(finding(\n            \"decision_tool_name\",",
+        "reason": "v0 Section 5 Stage 2: `tool.name` a non-empty string."
+      },
+      {
+        "label": "29 the observation call.tool_name must be a non-empty string",
+        "anchor": "if tool_name.map(str::is_empty).unwrap_or(true) {\n        violations.push(finding(\n            \"observation_tool_name\",",
+        "replacement": "if false {\n        violations.push(finding(\n            \"observation_tool_name\",",
+        "reason": "v0 Section 5 Stage 2: observation record constraints, `call.tool_name` non-empty."
+      },
+      {
+        "label": "31 the observation caller_visible_error.code must be present and non-null",
+        "anchor": "for member in [\"code\", \"origin\", \"reason\"] {",
+        "replacement": "for member in [\"origin\", \"reason\"] {",
+        "reason": "v0 Section 5 Stage 2: caller_visible_error.code, caller_visible_error.origin, caller_visible_error.reason present and non-null. Stage 2 checks presence only; stage 3 compares typed values."
+      },
+      {
+        "label": "32 the observation caller_visible_error.origin must be present and non-null",
+        "anchor": "for member in [\"code\", \"origin\", \"reason\"] {",
+        "replacement": "for member in [\"code\", \"reason\"] {",
+        "reason": "v0 Section 5 Stage 2: caller_visible_error.code, caller_visible_error.origin, caller_visible_error.reason present and non-null. Stage 2 checks presence only; stage 3 compares typed values."
+      },
+      {
+        "label": "33 the observation caller_visible_error.reason must be present and non-null",
+        "anchor": "for member in [\"code\", \"origin\", \"reason\"] {",
+        "replacement": "for member in [\"code\", \"origin\"] {",
+        "reason": "v0 Section 5 Stage 2: caller_visible_error.code, caller_visible_error.origin, caller_visible_error.reason present and non-null. Stage 2 checks presence only; stage 3 compares typed values."
+      },
+      {
+        "label": "34 the decision must carry the five producer non-claims verbatim",
+        "anchor": "    check_non_claims(\n        dec,\n        DECISION_PRODUCER_NON_CLAIMS,\n        \"decision_non_claims\",\n        violations,\n    );",
+        "replacement": "    let _ = (\n        dec,\n        DECISION_PRODUCER_NON_CLAIMS,\n        \"decision_non_claims\",\n        &violations,\n    );",
+        "reason": "v0 Section 5 Stage 2: `non_claims` MUST be an array containing at least the five producer strings verbatim."
+      },
+      {
+        "label": "35 the observation must carry the four producer non-claims verbatim",
+        "anchor": "    check_non_claims(\n        obs,\n        OBSERVATION_PRODUCER_NON_CLAIMS,\n        \"observation_non_claims\",\n        violations,\n    );",
+        "replacement": "    let _ = (\n        obs,\n        OBSERVATION_PRODUCER_NON_CLAIMS,\n        \"observation_non_claims\",\n        &violations,\n    );",
+        "reason": "v0 Section 5 Stage 2: observation `non_claims` containing the four producer strings."
+      },
+      {
+        "label": "36 the establish_path must be in the closed set",
+        "anchor": "check_vocab(est, \"establish_path\", ESTABLISH_PATH_VOCAB, violations);",
+        "replacement": "let _ = (est, ESTABLISH_PATH_VOCAB, &violations);",
+        "reason": "v0 Section 5 Stage 2: `establish_path` in no_establish_needed | established_then_allowed | established_then_denied | immediate_deny."
+      },
+      {
+        "label": "37 establish_attempted must equal (run_outcome != not_performed)",
+        "anchor": "if attempted != (outcome != \"not_performed\") {",
+        "replacement": "if false {",
+        "reason": "v0 Section 5 Stage 2: establish_attempted MUST equal (run_outcome != \"not_performed\"). Note: the sibling promise in the same bullet -- that a missing or wrongly typed member is itself invalid, since the equality must be checkable -- is NOT declared here and is a further undeclared rule."
+      },
+      {
+        "label": "38 the event type must equal the payload schema it declares",
+        "anchor": "if ev.type_ != s {",
+        "replacement": "if false {",
+        "reason": "v0 Section 2: events are selected by the exact `schema` member of their payload; the event's `type` MUST equal that schema string."
+      },
+      {
+        "label": "39 an in-namespace event type over a payload that declares no in-namespace schema fails closed",
+        "anchor": "_ if in_namespace(&ev.type_) => violations.push(finding(",
+        "replacement": "_ if in_namespace(&ev.type_) => drop(finding(",
+        "reason": "v0 Section 2: a mismatch in either direction within the profile's namespaces -- including an in-namespace type over a payload that declares no in-namespace schema -- is invalid, fail closed."
+      },
+      {
+        "label": "40 a caller-visible denial marker must be backed by a decision record",
+        "anchor": "(None, _) => violations.push(finding(\n                \"marker_not_backed\",",
+        "replacement": "(None, _) => drop(finding(\n                \"marker_not_backed\",",
+        "reason": "v0 Section 5 Stage 3: a marker present with no decision record at all is invalid. Undiscriminated by masking rather than by absence: bad-108 does present this input, but the same bundle also trips decision_cardinality, which reaches the same outcome, so deleting this rule alone moves nothing."
+      },
+      {
+        "label": "41 a marker with a null or empty call.target_digest is unbindable and invalid",
+        "anchor": "(Some(_), None) => violations.push(finding(\n                \"marker_digest_unbindable\",",
+        "replacement": "(Some(_), None) => drop(finding(\n                \"marker_digest_unbindable\",",
+        "reason": "v0 Section 5 Stage 3: a marker with a null or empty call.target_digest is unbindable and invalid for the same reason."
+      },
+      {
+        "label": "43 a contradicting establish journey must be reported as a finding",
+        "anchor": "if contradiction {",
+        "replacement": "if false {",
+        "scope": "out_of_scope",
+        "reason": "OUT OF SCOPE ON THE COMPARISON SURFACE, and separately a corpus gap. v0 Section 5 Stage 4 makes the contradiction set normative and requires the verifier to emit a finding and not alter the matrix. Deleting the rule can only remove a finding, and findings are not part of the corpus's normative comparison surface (Section 8: bundle_integrity, verdict, and for accepts the claim matrix). No vector could discriminate it under that surface however it were written. Independently, the corpus also presents no contradicting journey at all: ok-004 is an allow beside established_then_allowed, which never contradicts. If findings are ever admitted to the comparison surface this becomes an in-scope hole needing a vector, so it is recorded rather than dropped."
+      },
+      {
+        "label": "44 the marker triple must match on the schema leg",
+        "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
+        "replacement": "(_, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
+        "scope": "out_of_scope",
+        "reason": "WRONG STAGE, same argument as declared mutant 0. Under v0 selection only payloads whose schema member is assay.denied_call_observation.v0 are collected into `observations`, so the classifier's schema leg cannot decide anything on this path: it is an equivalent mutant here, not a hole. Measured SURVIVED, as the reasoning predicts. Recorded because the published table credits this leg to the corpus."
       },
       {
         "label": "CONTROL harness reachability on the verifier path",

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -27,7 +27,7 @@
   "outcome_from": [
     "bundle_integrity",
     "verdict",
-    "reason_code"
+    "claims"
   ],
   "vectors": "privileged-mcp-action-v0.vectors.json",
   "id_key": "vector_id",
@@ -95,6 +95,11 @@
         "replacement": "if obs_tool.is_some() && obs_tool == dec_tool {"
       },
       {
+        "label": "11 the code must be the v0 deny code",
+        "anchor": "(DENIED_CALL_OBSERVATION_V0, PROXY_DENIED_V0, PROXY_ORIGIN) => {",
+        "replacement": "(DENIED_CALL_OBSERVATION_V0, _, PROXY_ORIGIN) => {"
+      },
+      {
         "label": "CONTROL harness reachability on the verifier path",
         "anchor": ".filter(|obs| classify_denial_marker(obs) == Some(profile_version.marker_version()));",
         "replacement": ".filter(|_obs| false);",
@@ -113,7 +118,14 @@
         "recorded": "2026-08-19",
         "exercised_outside_corpus": "crates/assay-evidence/tests/denial_marker_classifier.rs::wrong_origin_is_inert",
         "corrected": "2026-08-19"
+      },
+      {
+        "label": "11 the code must be the v0 deny code",
+        "reason": "The SECOND leg of the same triple, found only because the first was published as a hole and someone asked what the other two do. v0 Stage 3 promises all three legs. Deleting the code conjunct leaves the 14-vector corpus test at 10 of 10 green, so no vector discriminates it. Cause is structural rather than an oversight in any one vector: gen_vectors.py:103 hard-codes the single marker shape {code: -32042, origin: assay-proxy} and is the only marker construction site, so no vector CAN vary either member. Corpus-only, like the origin leg: our tree does catch it -- deleting the conjunct fails crates/assay-evidence/tests/denial_marker_classifier.rs::cross_pair_v0_schema_v1_code_is_inert. Note the schema leg is not caught by the triple match either; bad-104 is decided earlier at Stage 2. Of the three legs the corpus discriminates NONE.",
+        "exercised_outside_corpus": "crates/assay-evidence/tests/denial_marker_classifier.rs::cross_pair_v0_schema_v1_code_is_inert",
+        "recorded": "2026-08-19"
       }
     ]
-  }
+  },
+  "_outcome_from_why": "The corpus declares its own comparison surface in MANIFEST.json: 'expected.bundle_integrity, expected.verdict and expected.claims are the normative comparison surface; first_failure_informative is this generator's own vocabulary and is informative only.' The first version of this manifest read [bundle_integrity, verdict, reason_code] -- the informative vocabulary, with the normative member omitted. That is weaker AND wider than the corpus at once. Measured consequence: a mutant flipping the Stage 4 (allow, bound) arm from refuted to confirmed moves ok-005's claim cell, so the CORPUS kills it, while the old surface did not see it and scored it a survivor. Wider, because reason_code separates bad-101 from bad-109 where the corpus does not."
 }

--- a/conformance/adequacy/privileged-mcp-action-v0.manifest.json
+++ b/conformance/adequacy/privileged-mcp-action-v0.manifest.json
@@ -1,5 +1,10 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
+  "tool_pin": {
+    "_why": "Re-pinned to b87ef70 and re-measured, so this row stops being transcribed from ERRATA.md prose and becomes a derivation. A transcribed row goes stale the moment denial_marker.rs moves and nothing can tell; a measured one cannot.",
+    "commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+    "tool": "https://github.com/corpus-adequacy/corpus-adequacy"
+  },
   "runner": "process",
   "_about": "Mutation adequacy for privileged-mcp-action/v0, third declaration. The first declared THREE rules and scored nothing. The second declared eight read off the verifier path and scored 4 of 8, which was published with a pattern claim that an adversarial re-measurement then refuted: deleting 23 further promised rules AT ONCE reproduced all fourteen outcomes and all five claim matrices. This declaration folds those in, deduplicated by (anchor, replacement) rather than by label -- five of the 23 turned out to restate rules already declared here, and counting them again would have inflated the denominator in the direction that flatters. outcome_from now reads the surface MANIFEST.json declares normative rather than the one it calls informative.",
   "repo_root": "../..",

--- a/conformance/adequacy/results.json
+++ b/conformance/adequacy/results.json
@@ -10,6 +10,14 @@
       "killed": 6,
       "known_holes": 0,
       "manifest": "conformance/adequacy/mcp-jsonrpc-id.manifest.json",
+      "measured_at": {
+        "commit": "bcbb1ce7682a1dc94450bb7b31bb5258ad8b3fb3",
+        "depends_on": [
+          "conformance/adequacy/mcp-jsonrpc-id.manifest.json",
+          "conformance/adequacy/mcp-jsonrpc-id.vectors.json",
+          "examples/mcp-jsonrpc-id-conformance/check.py"
+        ]
+      },
       "out_of_scope": 7,
       "provenance": {
         "kind": "measured"
@@ -33,6 +41,12 @@
       "killed": 14,
       "known_holes": 0,
       "manifest": "conformance/adequacy/observed-effect-drift-consumer.manifest.json",
+      "measured_at": {
+        "commit": "bcbb1ce7682a1dc94450bb7b31bb5258ad8b3fb3",
+        "depends_on": [
+          "conformance/adequacy/observed-effect-drift-consumer.manifest.json"
+        ]
+      },
       "out_of_scope": 0,
       "provenance": {
         "kind": "measured"
@@ -66,6 +80,17 @@
       "killed": 6,
       "known_holes": 2,
       "manifest": "conformance/adequacy/privileged-mcp-action-v0.manifest.json",
+      "measured_at": {
+        "commit": "bcbb1ce7682a1dc94450bb7b31bb5258ad8b3fb3",
+        "depends_on": [
+          "conformance/adequacy/privileged-mcp-action-v0.manifest.json",
+          "conformance/adequacy/privileged-mcp-action-v0.vectors.json",
+          "conformance/privileged-mcp-action-v0/candidate-release.json",
+          "crates/assay-cli/src/cli/commands/evidence/privileged_mcp_action.rs",
+          "crates/assay-cli/src/cli/commands/evidence/verify_privileged_mcp_action.rs",
+          "crates/assay-evidence/src/denial_marker.rs"
+        ]
+      },
       "out_of_scope": 4,
       "provenance": {
         "kind": "measured"
@@ -89,6 +114,14 @@
       "killed": 0,
       "known_holes": 0,
       "manifest": "conformance/adequacy/rfc8785-canonicalization.manifest.json",
+      "measured_at": {
+        "commit": "bcbb1ce7682a1dc94450bb7b31bb5258ad8b3fb3",
+        "depends_on": [
+          "conformance/adequacy/rfc8785-canonicalization.manifest.json",
+          "crates/assay-canonical/src/jcs.rs",
+          "crates/assay-canonical/tests/vectors/rfc8785.json"
+        ]
+      },
       "out_of_scope": 0,
       "provenance": {
         "kind": "measured"
@@ -112,6 +145,12 @@
       "killed": 51,
       "known_holes": 0,
       "manifest": "conformance/adequacy/rge-bench.manifest.json",
+      "measured_at": {
+        "commit": "bcbb1ce7682a1dc94450bb7b31bb5258ad8b3fb3",
+        "depends_on": [
+          "conformance/adequacy/rge-bench.manifest.json"
+        ]
+      },
       "out_of_scope": 1,
       "provenance": {
         "kind": "measured"

--- a/conformance/adequacy/results.json
+++ b/conformance/adequacy/results.json
@@ -1,0 +1,141 @@
+{
+  "_about": "Measured mutation adequacy for every corpus manifest in this directory. Written by measure_all.py; asserted against the published prose by check_published_numbers.py. Do not hand-edit a measured row.",
+  "corpora": [
+    {
+      "adequate": false,
+      "control": "killed",
+      "corpus": "mcp-jsonrpc-id",
+      "declared_total": 17,
+      "equivalent": 0,
+      "killed": 6,
+      "known_holes": 0,
+      "manifest": "conformance/adequacy/mcp-jsonrpc-id.manifest.json",
+      "out_of_scope": 7,
+      "provenance": {
+        "kind": "measured"
+      },
+      "runner": "module",
+      "score_percent": 60.0,
+      "subject": {
+        "kind": "in_tree"
+      },
+      "survived": 4,
+      "tool_commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+      "tool_version": "0.1.0",
+      "unproved": 0
+    },
+    {
+      "adequate": false,
+      "control": "killed",
+      "corpus": "observed-effect-drift-consumer",
+      "declared_total": 23,
+      "equivalent": 0,
+      "killed": 14,
+      "known_holes": 0,
+      "manifest": "conformance/adequacy/observed-effect-drift-consumer.manifest.json",
+      "out_of_scope": 0,
+      "provenance": {
+        "kind": "measured"
+      },
+      "runner": "batch",
+      "score_percent": 60.9,
+      "subject": {
+        "kind": "out_of_tree",
+        "repos": [
+          {
+            "commit": "dc10fad0cc867b1f652e2727f98e9370da429904",
+            "dirty": false,
+            "measured": [
+              "../../../observed-effect-v0/observed-effect-drift-consumer-2026-06/independent_consumer.py"
+            ],
+            "repository": "Rul1an/observed-effect-v0"
+          }
+        ]
+      },
+      "survived": 9,
+      "tool_commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+      "tool_version": "0.1.0",
+      "unproved": 0
+    },
+    {
+      "adequate": false,
+      "control": "killed",
+      "corpus": "privileged-mcp-action-v0",
+      "declared_total": 31,
+      "equivalent": 0,
+      "killed": 6,
+      "known_holes": 2,
+      "manifest": "conformance/adequacy/privileged-mcp-action-v0.manifest.json",
+      "out_of_scope": 4,
+      "provenance": {
+        "kind": "measured"
+      },
+      "runner": "process",
+      "score_percent": 24.0,
+      "subject": {
+        "kind": "in_tree"
+      },
+      "survived": 19,
+      "tool_commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+      "tool_version": "0.1.0",
+      "unproved": 0
+    },
+    {
+      "adequate": false,
+      "control": "killed",
+      "corpus": "rfc8785-canonicalization",
+      "declared_total": 0,
+      "equivalent": 0,
+      "killed": 0,
+      "known_holes": 0,
+      "manifest": "conformance/adequacy/rfc8785-canonicalization.manifest.json",
+      "out_of_scope": 0,
+      "provenance": {
+        "kind": "measured"
+      },
+      "runner": "batch",
+      "score_percent": null,
+      "subject": {
+        "kind": "in_tree"
+      },
+      "survived": 0,
+      "tool_commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+      "tool_version": "0.1.0",
+      "unproved": 0
+    },
+    {
+      "adequate": false,
+      "control": "killed",
+      "corpus": "rge-bench",
+      "declared_total": 57,
+      "equivalent": 2,
+      "killed": 51,
+      "known_holes": 0,
+      "manifest": "conformance/adequacy/rge-bench.manifest.json",
+      "out_of_scope": 1,
+      "provenance": {
+        "kind": "measured"
+      },
+      "runner": "module",
+      "score_percent": 94.4,
+      "subject": {
+        "kind": "out_of_tree",
+        "repos": [
+          {
+            "commit": "c51c5af18112b2ecc80b6c56a8f6493dee5900b0",
+            "dirty": false,
+            "measured": [
+              "../../../rge-bench/ref_example.py"
+            ],
+            "repository": "rge-bench/rge-bench"
+          }
+        ]
+      },
+      "survived": 3,
+      "tool_commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+      "tool_version": "0.1.0",
+      "unproved": 0
+    }
+  ],
+  "schema": "assay.conformance.adequacy.results.v0"
+}

--- a/conformance/adequacy/rfc8785-canonicalization.manifest.json
+++ b/conformance/adequacy/rfc8785-canonicalization.manifest.json
@@ -1,5 +1,10 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
+  "tool_pin": {
+    "_why": "Re-pinned to b87ef70, which enforces the control requirement on EVERY runner from one function. The previous pin enforced it only on the process path, so a module corpus could score with no control -- and this repository had one in that state. Re-measured under the new pin; no number moved.",
+    "commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+    "tool": "https://github.com/corpus-adequacy/corpus-adequacy"
+  },
   "runner": "batch",
   "outcome_parse": "test-names",
   "_about": "Mutation adequacy for the RFC 8785 (JCS) conformance corpus. Every content id, mandate id and bundle run root in this workspace is a sha256 over the bytes this canonicalizer emits, so a divergence makes those digests irreproducible by any other implementation. THE CONTROL IS NOT INVENTED HERE: rfc8785_conformance.rs documents it in prose at the top of the file -- swap serde_jcs::to_vec for serde_json::to_vec and at least 8 vectors must fail, keyorder_utf16_vs_codepoint among them. That property was written down so it would stay checkable rather than remembered. This runs it.",

--- a/conformance/adequacy/rge-bench.manifest.json
+++ b/conformance/adequacy/rge-bench.manifest.json
@@ -1,0 +1,336 @@
+{
+  "schema": "corpus-adequacy.manifest.v0",
+  "_about": "Mutation adequacy for rge-bench's ref_example.py, measured from this workspace against the sibling checkout. The first published score was 30 of 30 over the hand-written mutant table in scripts/check_rule_liveness.py. ADMISSION.md already says that table is not checked against the rules the implementation contains. The missing rules were read off ref_example.py and the 95 vectors: the strength ladder (the ceiling ladder's sibling, already known to need permutations), the AND conjuncts scored as one mutant, the soft-digest and replay-equality fallthroughs, and the semantic-equality helpers the contract-edge prose claims. A 30 of 30 over half the discriminable rules is a number about half a corpus.",
+  "implementation": "../../../rge-bench/ref_example.py",
+  "entrypoint": "evaluate",
+  "entrypoint_args": [
+    "axis",
+    "inputs"
+  ],
+  "vectors": "../../../rge-bench/vectors.json",
+  "id_key": "vector_id",
+  "group_key": "axis",
+  "mutants": {
+    "claim_support": [
+      {
+        "label": "0 unknown vocabulary fails closed",
+        "anchor": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE or kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "0a unknown observer class fails closed",
+        "anchor": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE or kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\"",
+        "replacement": "if kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\""
+      },
+      {
+        "label": "0b unknown claim kind fails closed",
+        "anchor": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE or kind not in (\"occurrence\", \"absence\"):\n        return \"invalid\"",
+        "replacement": "if observer.get(\"class\") not in _SUBJECT_CONTROLLABLE:\n        return \"invalid\""
+      },
+      {
+        "label": "1 undeclared probe set is invalid",
+        "anchor": "if declared is None:\n        if is_absence:\n            return \"invalid\"",
+        "replacement": "if declared is None:\n        if False:\n            return \"invalid\""
+      },
+      {
+        "label": "2 surface outside the declared set",
+        "anchor": "elif claim.get(\"surface\") not in declared:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "elif False:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "3 reported gap removes absence support",
+        "anchor": "if observation.get(\"observation_gap\") and is_absence:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if False:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "3a a gap without absence still fires",
+        "anchor": "if observation.get(\"observation_gap\") and is_absence:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if observation.get(\"observation_gap\"):\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "3b absence without a gap still fires",
+        "anchor": "if observation.get(\"observation_gap\") and is_absence:\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if is_absence:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "4 occurrence branch",
+        "anchor": "    if not is_absence:\n        return \"supported\" if observation.get(\"saw_event\") else \"unsupported\"",
+        "replacement": "    if False:\n        return \"supported\" if observation.get(\"saw_event\") else \"unsupported\""
+      },
+      {
+        "label": "4a occurrence requires a seen event",
+        "anchor": "        return \"supported\" if observation.get(\"saw_event\") else \"unsupported\"",
+        "replacement": "        return \"supported\""
+      },
+      {
+        "label": "5 a seen event contradicts absence",
+        "anchor": "if observation.get(\"saw_event\"):\n        return \"contradicted\"",
+        "replacement": "if False:\n        return \"contradicted\""
+      },
+      {
+        "label": "6 blinding cost bounds silence",
+        "anchor": "if _SUBJECT_CONTROLLABLE[observer[\"class\"]] and not observer.get(\"routing_enforced_by\"):\n        return \"inconclusive_no_coverage\"",
+        "replacement": "if False:\n        return \"inconclusive_no_coverage\""
+      },
+      {
+        "label": "6b independently enforced routing escape",
+        "anchor": "if _SUBJECT_CONTROLLABLE[observer[\"class\"]] and not observer.get(\"routing_enforced_by\"):",
+        "replacement": "if _SUBJECT_CONTROLLABLE[observer[\"class\"]]:"
+      },
+      {
+        "label": "7 silence from an unblindable observer is supported",
+        "anchor": "    # 7. silence from an observer the subject cannot blind, within its declared probe set\n    return \"supported\"",
+        "replacement": "    # 7. silence from an observer the subject cannot blind, within its declared probe set\n    return \"inconclusive_no_coverage\""
+      }
+    ],
+    "coverage_honesty": [
+      {
+        "label": "declared set must be a non-empty list and results a dict",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "declared_cases must be a list",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if not declared or not isinstance(results, dict):\n        return \"invalid\""
+      },
+      {
+        "label": "declared_cases must be non-empty",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if not isinstance(declared, list) or not isinstance(results, dict):\n        return \"invalid\""
+      },
+      {
+        "label": "case_results must be a dict",
+        "anchor": "if not isinstance(declared, list) or not declared or not isinstance(results, dict):\n        return \"invalid\"",
+        "replacement": "if not isinstance(declared, list) or not declared:\n        return \"invalid\""
+      },
+      {
+        "label": "a missing result reads not_run rather than passing",
+        "anchor": "states = [results.get(case_id, \"not_run\") for case_id in declared]",
+        "replacement": "states = [results.get(case_id, \"passed\") for case_id in declared]"
+      },
+      {
+        "label": "an explicit failure refutes, ahead of confirmation",
+        "anchor": "if any(state == \"failed\" for state in states):\n        return \"refuted\"",
+        "replacement": "if False:\n        return \"refuted\""
+      },
+      {
+        "label": "confirmation requires every declared case to pass",
+        "anchor": "if all(state == \"passed\" for state in states):\n        return \"confirmed\"",
+        "replacement": "if any(state == \"passed\" for state in states):\n        return \"confirmed\""
+      }
+    ],
+    "hard_soft_digest": [
+      {
+        "label": "a missing or mismatched hard digest fails closed",
+        "anchor": "if not _present_string(hs) or not _present_string(hr) or hs != hr:\n        return \"rejected_hard\"",
+        "replacement": "if False:\n        return \"rejected_hard\""
+      },
+      {
+        "label": "an empty hard digest counts as missing",
+        "anchor": "if not _present_string(hs) or not _present_string(hr) or hs != hr:",
+        "replacement": "if hs is None or hr is None or hs != hr:"
+      },
+      {
+        "label": "soft compares only after hard accepts",
+        "anchor": "    return \"soft_equivalent\" if inp.get(\"soft_a\") == inp.get(\"soft_b\") else \"soft_divergent\"",
+        "replacement": "    return \"soft_equivalent\" if True else \"soft_divergent\""
+      }
+    ],
+    "retained_replay": [
+      {
+        "label": "carrier validity is a precondition",
+        "anchor": "if not inp.get(\"carrier_valid\"):\n        return \"rejected_carrier\"",
+        "replacement": "if False:\n        return \"rejected_carrier\""
+      },
+      {
+        "label": "a valid carrier over absent records is incomplete",
+        "anchor": "if not inp.get(\"records_retained\"):\n        return \"incomplete\"",
+        "replacement": "if False:\n        return \"incomplete\""
+      },
+      {
+        "label": "replayed must equal recorded",
+        "anchor": "    return \"replayed_match\" if set(inp.get(\"replayed\", [])) == set(inp.get(\"recorded\", [])) else \"replayed_mismatch\"",
+        "replacement": "    return \"replayed_match\" if True else \"replayed_mismatch\""
+      }
+    ],
+    "delegated_scope": [
+      {
+        "label": "granted and used must both be lists",
+        "anchor": "if not isinstance(granted, list) or not isinstance(used, list):\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "granted must be a list",
+        "anchor": "if not isinstance(granted, list) or not isinstance(used, list):\n        return \"invalid\"",
+        "replacement": "if not isinstance(used, list):\n        return \"invalid\""
+      },
+      {
+        "label": "used must be a list",
+        "anchor": "if not isinstance(granted, list) or not isinstance(used, list):\n        return \"invalid\"",
+        "replacement": "if not isinstance(granted, list):\n        return \"invalid\""
+      },
+      {
+        "label": "used must stay within granted",
+        "anchor": "return \"within_grant\" if set(used) <= set(granted) else \"exceeds_grant\"",
+        "replacement": "return \"within_grant\" if True else \"exceeds_grant\""
+      }
+    ],
+    "mcp_description_code": [
+      {
+        "label": "undeclared effect takes precedence over over-declaration",
+        "anchor": "if code - declared:\n        return \"undeclared_effect\"",
+        "replacement": "if False:\n        return \"undeclared_effect\""
+      },
+      {
+        "label": "an interface declaring unexercised effects is over_declared",
+        "anchor": "if declared - code:\n        return \"over_declared\"",
+        "replacement": "if False:\n        return \"over_declared\""
+      },
+      {
+        "label": "matching declared and code is consistent",
+        "anchor": "    return \"consistent\"",
+        "replacement": "    return \"over_declared\""
+      }
+    ],
+    "tamper_fail_closed": [
+      {
+        "label": "a missing digest fails closed",
+        "anchor": "return \"accepted\" if _present_string(stored) and _present_string(recomputed) and stored == recomputed else \"rejected\"",
+        "replacement": "return \"accepted\" if stored == recomputed else \"rejected\""
+      },
+      {
+        "label": "stored and recomputed digests must be equal",
+        "anchor": "return \"accepted\" if _present_string(stored) and _present_string(recomputed) and stored == recomputed else \"rejected\"",
+        "replacement": "return \"accepted\" if _present_string(stored) and _present_string(recomputed) else \"rejected\""
+      },
+      {
+        "label": "an empty digest string counts as missing",
+        "anchor": "    return isinstance(value, str) and value != \"\"",
+        "replacement": "    return isinstance(value, str)"
+      }
+    ],
+    "sufficiency": [
+      {
+        "label": "sufficiency requires a valid record AND complete coverage",
+        "anchor": "        if inp.get(\"record_valid\") and inp.get(\"coverage\") == \"complete\"",
+        "replacement": "        if inp.get(\"record_valid\")"
+      },
+      {
+        "label": "sufficiency requires a valid record",
+        "anchor": "        if inp.get(\"record_valid\") and inp.get(\"coverage\") == \"complete\"",
+        "replacement": "        if inp.get(\"coverage\") == \"complete\""
+      },
+      {
+        "label": "coverage must be the token complete",
+        "anchor": "        if inp.get(\"record_valid\") and inp.get(\"coverage\") == \"complete\"",
+        "replacement": "        if inp.get(\"record_valid\") and inp.get(\"coverage\")"
+      }
+    ],
+    "incomplete_visibility": [
+      {
+        "label": "only a present observation is observed",
+        "anchor": "return \"observed\" if inp.get(\"observation\") == \"present\" else \"incomplete\"",
+        "replacement": "return \"observed\" if inp.get(\"observation\") != \"not_checked\" else \"incomplete\""
+      }
+    ],
+    "source_class_ceiling": [
+      {
+        "label": "an unknown class or strength is invalid, not a pass",
+        "anchor": "if ceiling is None or strength is None:\n        return \"invalid\"",
+        "replacement": "if False:\n        return \"invalid\""
+      },
+      {
+        "label": "claim strength must not exceed the origin ceiling",
+        "anchor": "return \"within_ceiling\" if strength <= ceiling else \"exceeds_ceiling\"",
+        "replacement": "return \"within_ceiling\" if True else \"exceeds_ceiling\""
+      },
+      {
+        "label": "the ceiling ladder ranks origin classes, flattened to the highest",
+        "anchor": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 3,\n}",
+        "replacement": "_CEILING = {\n    \"producer_reported\": 3,\n    \"issuer_attested\": 3,\n    \"receiver_receipt\": 3,\n}"
+      },
+      {
+        "label": "the ceiling ladder ranks origin classes, flattened to the lowest",
+        "anchor": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 3,\n}",
+        "replacement": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 1,\n    \"receiver_receipt\": 1,\n}"
+      },
+      {
+        "label": "the ceiling ladder is ordered, not merely three-valued: inverted",
+        "anchor": "_CEILING = {\n    \"producer_reported\": 1,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 3,\n}",
+        "replacement": "_CEILING = {\n    \"producer_reported\": 3,\n    \"issuer_attested\": 2,\n    \"receiver_receipt\": 1,\n}"
+      },
+      {
+        "label": "the strength ladder ranks claims, flattened to the highest",
+        "anchor": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 2,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 4,\n    \"independently_confirmed\": 5,\n}",
+        "replacement": "_STRENGTH = {\n    \"asserted\": 5,\n    \"asserted_signed\": 5,\n    \"observed_at_receiver\": 5,\n    \"observed_in_path\": 5,\n    \"independently_confirmed\": 5,\n}"
+      },
+      {
+        "label": "the strength ladder ranks claims, flattened to the lowest",
+        "anchor": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 2,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 4,\n    \"independently_confirmed\": 5,\n}",
+        "replacement": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 1,\n    \"observed_at_receiver\": 1,\n    \"observed_in_path\": 1,\n    \"independently_confirmed\": 1,\n}"
+      },
+      {
+        "label": "the strength ladder is ordered, not merely five-valued: inverted",
+        "anchor": "_STRENGTH = {\n    \"asserted\": 1,\n    \"asserted_signed\": 2,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 4,\n    \"independently_confirmed\": 5,\n}",
+        "replacement": "_STRENGTH = {\n    \"asserted\": 5,\n    \"asserted_signed\": 4,\n    \"observed_at_receiver\": 3,\n    \"observed_in_path\": 2,\n    \"independently_confirmed\": 1,\n}"
+      }
+    ],
+    "format_equivalence": [
+      {
+        "label": "equivalence is over semantic fields, not the envelope shape",
+        "anchor": "        if _json_semantic_equal(inp.get(\"a\", {}).get(\"semantic\"), inp.get(\"b\", {}).get(\"semantic\"))",
+        "replacement": "        if inp.get(\"a\", {}).get(\"shape\") == inp.get(\"b\", {}).get(\"shape\")"
+      },
+      {
+        "label": "semantic equality preserves array order",
+        "anchor": "        return len(left) == len(right) and all(_json_semantic_equal(a, b) for a, b in zip(left, right))",
+        "replacement": "        return sorted(left) == sorted(right)"
+      },
+      {
+        "label": "semantic equality is over object key sets",
+        "anchor": "        return set(left) == set(right) and all(_json_semantic_equal(left[key], right[key]) for key in left)",
+        "replacement": "        return True"
+      },
+      {
+        "label": "a bool is not equal to the number one",
+        "anchor": "    if isinstance(left, bool) or isinstance(right, bool):\n        return left is right",
+        "replacement": "    if False:\n        return left is right"
+      }
+    ],
+    "recompute": [
+      {
+        "label": "observed must be a subset of declared",
+        "anchor": "return \"match\" if set(inp.get(\"observed\", [])) <= set(inp.get(\"declared\", [])) else \"mismatch\"",
+        "replacement": "return \"match\" if True else \"mismatch\""
+      },
+      {
+        "label": "CONTROL harness reachability",
+        "control": true,
+        "anchor": "    return fn(inputs) if fn else \"unsupported\"",
+        "replacement": "    return \"unsupported\""
+      },
+      {
+        "label": "an unknown axis is unsupported",
+        "scope": "out_of_scope",
+        "reason": "input-domain guard; the published corpus only presents the twelve named axes, so evaluate's unsupported fallback never runs",
+        "anchor": "    return fn(inputs) if fn else \"unsupported\"",
+        "replacement": "    return fn(inputs) if fn else \"sufficient\""
+      }
+    ]
+  },
+  "equivalent": {
+    "claim_support": [
+      {
+        "label": "order of rules 2 and 3",
+        "reason": "both return inconclusive_no_coverage, so no vector can distinguish which one fired; stated in the README as a deliberate boundary rather than found as a gap"
+      }
+    ],
+    "format_equivalence": [
+      {
+        "label": "JSON numbers compare by numeric value",
+        "reason": "Python == already treats 1 and 1.0 as equal, so deleting the Number branch cannot move a vector in this implementation. The rule exists for language-neutral implementers (JM-Lab's JVM drift) and is equivalent here, not unexercised."
+      }
+    ]
+  }
+}

--- a/conformance/adequacy/rge-bench.manifest.json
+++ b/conformance/adequacy/rge-bench.manifest.json
@@ -1,5 +1,10 @@
 {
   "schema": "corpus-adequacy.manifest.v0",
+  "tool_pin": {
+    "_why": "Re-pinned to b87ef70, which enforces the control requirement on EVERY runner from one function. The previous pin enforced it only on the process path, so a module corpus could score with no control -- and this repository had one in that state. Re-measured under the new pin; no number moved.",
+    "commit": "b87ef706e70a2bcfe163514ec0360022e93fa175",
+    "tool": "https://github.com/corpus-adequacy/corpus-adequacy"
+  },
   "_about": "Mutation adequacy for rge-bench's ref_example.py, measured from this workspace against the sibling checkout. The first published score was 30 of 30 over the hand-written mutant table in scripts/check_rule_liveness.py. ADMISSION.md already says that table is not checked against the rules the implementation contains. The missing rules were read off ref_example.py and the 95 vectors: the strength ladder (the ceiling ladder's sibling, already known to need permutations), the AND conjuncts scored as one mutant, the soft-digest and replay-equality fallthroughs, and the semantic-equality helpers the contract-edge prose claims. A 30 of 30 over half the discriminable rules is a number about half a corpus.",
   "implementation": "../../../rge-bench/ref_example.py",
   "entrypoint": "evaluate",

--- a/conformance/adequacy/rge-bench.manifest.json
+++ b/conformance/adequacy/rge-bench.manifest.json
@@ -337,5 +337,12 @@
         "reason": "Python == already treats 1 and 1.0 as equal, so deleting the Number branch cannot move a vector in this implementation. The rule exists for language-neutral implementers (JM-Lab's JVM drift) and is equivalent here, not unexercised."
       }
     ]
-  }
+  },
+  "pins": {
+    "rge-bench": {
+      "repository": "rge-bench/rge-bench",
+      "commit": "c51c5af18112b2ecc80b6c56a8f6493dee5900b0"
+    }
+  },
+  "_pins_why": "Freshness is not the goal and cannot be: this corpus lives in a repository this diff cannot see, and it moves without us. A score against rge-bench/rge-bench@c51c5af18 stays permanently true of that commit, which is what makes it a claim rather than a mood. Pinning is therefore not a compromise on keeping up -- it is the thing that makes the number mean something, and it lets the lane re-derive it when the INSTRUMENT changes, which is the drift vector that actually applies here. Re-pinning is a deliberate act, like tool_pin."
 }

--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -175,6 +175,25 @@ left out is the one with the contested history.
    and findings are not on this corpus's normative comparison surface. See rule 14 above for the
    inconsistency this creates.
 
+## Reaching the person who actually does the work
+
+This file is in the repository. The invited implementer walks the clean-room path
+and receives a tarball, and **`candidate.4` does not contain it**. An erratum that
+does not travel with the bytes a stranger downloads is a record for us rather than
+a notice to them, which is the difference between the IETF putting errata on an
+RFC's page and a maintainer noting a defect in a commit message.
+
+The whole file cannot travel with the pack. It names which case isolates which
+rule, and the pack deliberately omits semantic case names, expected outcomes and
+the generator. Shipping it would hand over the answers the pack exists to withhold.
+
+So the pack's own README now carries the **scope statement without the
+attributions**: at most five rules distinguishable, twenty-two not discriminated,
+do not claim more, and say which of the twenty-two you implemented anyway. That
+lands in the next pack built from this repository. `candidate.4` is already
+released and is not modified; reaching the people holding it is a decision about
+[#1840](https://github.com/Rul1an/assay/issues/1840) rather than about this file.
+
 ## Reading this before an implementation freeze
 
 **Permitted, and disclose it.** This file names which rule each vector isolates, which is slightly more

--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -7,111 +7,222 @@ Recorded 2026-08-19. **No vector, expectation or digest is changed by this file.
 corpus whose digest is its identity does not get edited; it gets an erratum, and a later corpus
 gets the fix.
 
-## What reproducing this corpus does and does not establish
+## What reproducing this corpus can and cannot distinguish
 
-An independent implementation that reproduces all fourteen outcomes has demonstrated agreement on
-**six** of the profile's rules. It has not demonstrated agreement on the profile.
+Reproducing all fourteen outcomes **can distinguish an implementation on at most five of the
+profile's rules, and even those only at the points these vectors probe.** It cannot distinguish it on
+the other twenty-two, and it does not demonstrate agreement on the profile.
+
+The ceiling wording is load-bearing. Mutation adequacy licenses one direction only: *a surviving
+mutant means the corpus cannot transmit that rule.* It does **not** license the reverse, that a killed
+mutant means anyone reproducing the outcomes holds the rule. A kill shows that deleting the rule from
+*this* implementation moved an outcome, which is a fact about this implementation. Five is a bound on
+what can be shown here, never a floor on what was shown.
 
 This is not a defect in the vectors as written, nor a claim that the reference implementation is
 wrong. It is a statement about **what fourteen vectors can transmit**. Where the profile promises a
-rule that no vector isolates, an implementation can omit that rule, reproduce this digest, and be
-indistinguishable here from one that honours it.
+rule that no vector isolates, an implementation can omit that rule, reproduce all fourteen expected
+outcomes, and be indistinguishable here from one that honours it.
 
-Measured with [`corpus-adequacy`](https://github.com/corpus-adequacy/corpus-adequacy) over the
-normative comparison surface this corpus declares in `MANIFEST.json`
-(`bundle_integrity`, `verdict`, `claims`):
+## The measurement
+
+Twenty-seven declared in-scope rules, each promised by [v0.md](../../docs/profiles/privileged-mcp-action/v0.md)
+with a quoted sentence and section reference (audited independently; none is an implementation
+detail smuggled into the count).
 
 ```
 6 of 25 DECLARED in-scope rules killed (24.0%). 4 declared out of scope, 31 rules declared.
 control-killed. 19 mutant(s) survived. 2 KNOWN HOLES.
 ```
 
-Reproduce with:
+That block is the tool's own output, kept verbatim. **Neither of its numbers is the number to quote
+here**, for two separate reasons:
+
+- Its denominator of 25 excludes the two acknowledged holes. That is right for a *score* and wrong for
+  this document, whose subject is what the corpus fails to transmit: an acknowledged hole fails to
+  transmit exactly as a survivor does. The denominator here is **twenty-seven**.
+- Its numerator of 6 counts rules the corpus discriminates *against this implementation*. One of the
+  six does not survive the change of subject to a third party (below), so the numerator here is
+  **five**.
+
+**Five of twenty-seven, 18.5%.**
+
+Reproduce the tool's run with [`corpus-adequacy`](https://github.com/corpus-adequacy/corpus-adequacy)
+at commit `6c419200b284ec84dffeb54ca20800ce1c445954`, from the repository root, with that tool checked
+out as a sibling directory:
 
 ```
-python3 ../../../corpus-adequacy/corpus_adequacy.py \
-  ../adequacy/privileged-mcp-action-v0.manifest.json
+python3 ../corpus-adequacy/corpus_adequacy.py \
+  conformance/adequacy/privileged-mcp-action-v0.manifest.json
 ```
 
-## The six rules reproduction does establish
+It edits declared source files in place and restores them. Do not run it against a tree you are also
+working in, and do not commit while it runs.
 
-| rule | isolated by |
-|---|---|
-| exactly one decision record | `bad-103` |
-| the decision value is in the closed vocabulary | `bad-107` |
-| an unrecognised in-namespace payload schema fails closed (Stage 2) | `bad-104` |
-| the decision `action.target_digest` is a well-formed sha256 | `bad-102` |
-| `fail_closed` equals (`decision` == `"deny"`) | `bad-106` |
-| a marker binds on the `target_digest` leg | `bad-105` |
+## The five rules a reproduction can distinguish
 
-## The nineteen it does not
+| rule | isolated by | what the vector actually probes |
+|---|---|---|
+| exactly one decision record | `bad-103` | two well-formed decisions |
+| an unrecognised in-namespace payload schema fails closed (Stage 2) | `bad-104` | a `.v1` schema inside the namespace |
+| the decision `action.target_digest` is a well-formed sha256 | `bad-102` | **`null` only.** No vector carries uppercase hex, a wrong length, an empty string, or a missing `sha256:` prefix, all of which §5 Stage 2 also names |
+| `fail_closed` equals (`decision` == `"deny"`) | `bad-106` | **the deny arm only.** No vector carries `allow` with `fail_closed: true`, so an implementation checking only `deny ⇒ fail_closed` reproduces all fourteen |
+| a marker binds on the `target_digest` leg | `bad-105` | an all-zero digest, tool name matching |
 
-Each is promised by [v0.md](../../docs/profiles/privileged-mcp-action/v0.md) and is not
-discriminated by any of the fourteen vectors.
+### The sixth is not isolated for a third party
 
-**Cardinality and shape**
-- at most one observation record; at most one establish record
-- the observation `caller_visible_response_digest` is a well-formed sha256
-- the decision `tool.name` is a non-empty string; the observation `call.tool_name` is a non-empty string
-- the event type equals the payload schema it declares
-- an in-namespace event type over a payload declaring no in-namespace schema fails closed
+The tool kills the **closed decision vocabulary** rule, and for the reference implementation that is
+correct. It does not carry over. `bad-107`'s decision payload is `{"decision": "permit", …,
+"fail_closed": true}`, and `"permit"` is not `"deny"`, so §5 Stage 2's `fail_closed` rule is
+independently violated by the same record. A stranger who applies the `fail_closed` rule without
+guarding it on vocabulary membership rejects `bad-107` on that ground alone and never implements the
+closed set.
+
+The reference implementation does guard it — `verify_privileged_mcp_action.rs:560` only compares
+`fail_closed` when `DECISION_VOCAB.contains(&d)` — and that guard is an implementation choice the
+profile nowhere requires. Secondary point on the same row: with the vocabulary check deleted, the
+reference reaches `unreachable!("decision vocabulary is closed")`, so the mutant is killed by a panic
+rather than by a verdict, and reproducing a crash is not what this corpus asks anyone to do.
+
+The rule is therefore counted below among the twenty-two, not among the five.
+
+## The twenty-two it cannot
+
+Each is promised by [v0.md](../../docs/profiles/privileged-mcp-action/v0.md). Numbered so the count is
+checkable against the list.
+
+**Cardinality and record shape**
+1. at most one observation record
+2. at most one establish record
+3. the observation `caller_visible_response_digest` is a well-formed sha256
+4. the decision `tool.name` is a non-empty string
+5. the observation `call.tool_name` is a non-empty string
+6. the event type equals the payload schema it declares — *structurally blocked, see below*
+7. an in-namespace event type over a payload declaring no in-namespace schema fails closed — *structurally blocked, see below*
 
 **Closed vocabularies**
-- the decision `reason` is in the closed producer set
-- the decision `drift_state` is in the closed set
-- the `establish_path` is in the closed set
-- `establish_attempted` equals (`run_outcome` != `not_performed`)
+8. the decision value is in the closed set `allow | deny` — *see the section above; the tool scores this killed*
+9. the decision `reason` is in the closed producer set
+10. the decision `drift_state` is in the closed set
+11. the `establish_path` is in the closed set
+12. `establish_attempted` equals (`run_outcome` != `not_performed`)
 
 **Marker binding**
-- a marker binds on the `tool_name` leg
-- a caller-visible denial marker is backed by a decision record
-- a marker with a null or empty `call.target_digest` is unbindable and invalid
+13. a marker binds on the `tool_name` leg
+14. a caller-visible denial marker is backed by a decision record — *no vector can ever isolate this, see below*
+15. a marker with a null or empty `call.target_digest` is unbindable and invalid
 
 **Marker payload members**
-- `caller_visible_error.code`, `.origin` and `.reason` are each present and non-null
+16. `caller_visible_error.code` is present and non-null
+17. `caller_visible_error.origin` is present and non-null
+18. `caller_visible_error.reason` is present and non-null
 
 **Producer non-claims**
-- the decision carries the five producer non-claims verbatim
-- the observation carries the four producer non-claims verbatim
+19. the decision carries the five producer non-claims verbatim — *not derivable from the spec text, see below*
+20. the observation carries the four producer non-claims verbatim — *not derivable from the spec text, see below*
 
-## Two known holes, and why they are structural
+**The Stage 3 marker triple**
+21. `caller_visible_error.origin` must be `"assay-proxy"`
+22. `caller_visible_error.code` must be `-32042`
 
-`caller_visible_error.origin` must be `"assay-proxy"` and `caller_visible_error.code` must be
-`-32042` — both legs of the Stage 3 marker triple, both promised, neither discriminated.
+The triple's third leg, `schema`, is decided earlier at Stage 2, so of its three legs this corpus
+isolates none.
 
-The cause is not an omission in any one vector. [`gen_vectors.py:103`](gen_vectors.py) hard-codes the
-single marker shape and is the only marker construction site, so **no vector in this corpus can vary
-either member**. Closing them requires a generator parameter, which is a new corpus.
+## Which of the twenty-two a new vector could close, and which it could not
 
-The triple's third leg, `schema`, is decided earlier at Stage 2 and so is not discriminated by the
-triple match either. Of the triple's three legs this corpus isolates none.
+An earlier draft of this file had this exactly backwards, and the correction matters because it
+changes what a fix costs.
 
-## Rules out of scope for this corpus
+**Ordinary, closable by writing a vector** — including 21 and 22, the two recorded as `known_holes`.
+The generator hard-codes the marker shape at [`gen_vectors.py:103`](gen_vectors.py), but it already
+carries a hand-written literal payload dict at line 320, so a vector varying `caller_visible_error.code`
+or `.origin` can be written the same way. Closing them costs a new vector and therefore a new digest,
+which is the ordinary price, not a structural barrier.
 
-Four declared rules are excluded with stated reasons in
-[`../adequacy/privileged-mcp-action-v0.manifest.json`](../adequacy/privileged-mcp-action-v0.manifest.json):
-two mutate a v1 arm or an earlier stage and cannot move an outcome here even in principle, and one —
-the establish-journey contradiction — emits only a *finding*, and findings are not on this corpus's
-normative comparison surface. That last one is undiscriminable in principle rather than in practice,
-and becomes an in-scope hole the moment findings join the surface.
+**Structurally blocked, needing a generator change rather than a vector** — rules 6 and 7. `event()`
+sets `"type": payload["schema"]` unconditionally at lines 121 and 130, so no vector this generator can
+emit has a type/schema mismatch, and a payload with no `schema` member raises `KeyError` before a
+bundle exists.
+
+**Not closable by any vector at all** — rule 14. `marker_not_backed` fires only when there is no
+decision record, and a bundle with no decision record already violates the decision-cardinality rule
+unconditionally. On the declared comparison surface no bundle can exist in which this rule alone moves
+an outcome. It is in scope in the manifest while the establish-journey contradiction is out of scope
+for the same in-principle reason; that scoping is inconsistent and is recorded here rather than
+quietly aligned.
+
+**Not derivable from the specification text** — rules 19 and 20. §5 Stage 2 requires the five and four
+producer non-claim strings "verbatim" and refers the reader to the corpus for the exact bytes; v0.md
+does not enumerate them, and the strings §3 and §6 list are the *report* non-claims, which are
+different text. §8 asks for reproduction "from this specification text alone", and for these two rules
+that is not satisfiable from the text. This is a gap in the specification rather than in the corpus.
+
+## The four rules out of scope for this corpus
+
+Excluded with stated reasons in
+[`../adequacy/privileged-mcp-action-v0.manifest.json`](../adequacy/privileged-mcp-action-v0.manifest.json).
+All four are named, because an earlier draft said "two … and one" while claiming four, and the one it
+left out is the one with the contested history.
+
+1. **an unrecognised marker triple fails closed** — mutates the Stage 3 classifier, but the promise is
+   the Stage 2 arm, which runs first. Rule 47 in the manifest is that promise measured at the right
+   stage, and it is killed.
+2. **v1 pairs with the v1 error code** — a v1 arm. Under v0 selection a `.v1` payload never enters
+   observations.
+3. **the marker triple's `schema` leg** — wrong stage, by the same argument as (1). `INDEX.md` records
+   that this leg was credited to the corpus in an earlier draft until the argument was applied evenly.
+4. **a contradicting establish journey must be reported as a finding** — its only output is a *finding*,
+   and findings are not on this corpus's normative comparison surface. See rule 14 above for the
+   inconsistency this creates.
+
+## Reading this before an implementation freeze
+
+**Permitted, and disclose it.** This file names which rule each vector isolates, which is slightly more
+than the vector filenames already carry — `bad-105-observation-binding-mismatch` does not say the
+divergence is on the digest leg rather than the tool-name leg, and the table above does. That is a
+small cost to independence and a large gain in knowing what the exercise establishes, so it is allowed
+rather than forbidden, and [`IMPLEMENTATION-REPORT.template.md`](IMPLEMENTATION-REPORT.template.md)
+asks whether it was read.
 
 ## What this changes for an implementer
 
-Nothing about the exercise. Reproducing the fourteen outcomes remains the task, the expectations are
-unchanged, and a reproduction is still worth having: it is the only independent evidence that the
-specification text is sufficient to build against.
+The run and the expectations are unchanged, and a reproduction is still the only independent evidence
+that the specification text is sufficient to build against.
 
-What changes is the claim you can make afterwards, and the claim we can make about you. A successful
-reproduction establishes agreement on the six rules above. Anyone stating more than that — including
+Two things do change, and an earlier draft of this file said "nothing about the exercise" while both
+were already true. The report template now carries a scope field, so the claim is written down rather
+than invented. And reading this file before a freeze is a disclosure question, answered above.
+
+A reproduction distinguishes at most the five rules named. Anyone stating more than that — including
 us — is overstating what fourteen vectors measured.
+
+**What the corpus cannot ask for, and we can.** Twenty-two of these rules will get no evidence from
+any reproduction of this corpus. If you implemented them anyway, say which in your report. That is
+information no vector can extract, it costs nothing to supply, and until a later corpus exists it is
+the only route by which any of the twenty-two gets any evidence at all.
+
+## Two smaller things a reader should know
+
+**The expectations are not digest-pinned.** `corpus_digest` is sha256 over the vector bundle bytes and
+does not cover `MANIFEST.json`'s `expected` block. v0.md §8 says accurately that any edit to any vector
+changes the digest, and is silent on the expectations. This file leans on digest immutability to
+justify recording rather than fixing, so the limit of that immutability belongs here.
+
+**Adding this file moved nothing.** The digest is computed at
+[`gen_vectors.py:401`](gen_vectors.py) over concatenated vector hashes from an in-code list, with no
+directory scan anywhere, and the clean-room pack's rendered-set digest is likewise over vector digests
+only. Verified by recomputation and by running the activation-kit suite with and without this file.
 
 ## How this was found
 
-Not by inspection. By mutation adequacy: delete one declared rule from the implementation, rebuild,
-and see whether the corpus notices. A rule the corpus cannot notice is a rule it cannot ask a third
-party to implement.
+Not by inspection. By mutation adequacy: delete one declared rule from the implementation, rebuild, and
+see whether the corpus notices. A rule the corpus cannot notice is a rule it cannot ask a third party
+to implement.
 
-The first three declarations of that measurement were themselves wrong — the first declared three
-rules and scored nothing, the second declared eight and published a pattern claim that an
-adversarial re-measurement refuted. `../INDEX.md` carries that sequence, including the run whose
-control survived and which therefore said nothing at all.
+The first three declarations of that measurement were themselves wrong — the first declared three rules
+and scored nothing, the second declared eight and published a pattern claim that an adversarial
+re-measurement refuted. The first draft of *this file* then quoted the tool's denominator as though it
+were the reader's, understating the undiscriminated set by two; the second draft got the structural
+barrier exactly backwards and counted a sixth isolated rule that does not isolate for a third party.
+`../INDEX.md` carries that sequence, including the run whose control survived and which therefore said
+nothing at all.

--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -1,7 +1,19 @@
 # Errata for privileged-mcp-action/v0
 
-**Applies to corpus digest `sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342`**, and to
-nothing else. If the digest changes, this file is void until it is re-measured against the new one.
+**Applies to corpus digest `sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342`
+AND to the implementation that digest was measured against.** Two conditions void it, not one.
+
+An earlier version of this line said "and to nothing else. If the digest changes, this file is void",
+which is false in the direction that makes the document look more durable than it is. Every number
+below is produced by deleting a rule *from an implementation* and seeing whether the corpus notices.
+The implementation can move while the digest does not, because the digest covers vector bytes only.
+Pinning to the digest alone would leave exactly the silent staleness this errata exists to describe,
+one level up and in the file describing it.
+
+So: void when the digest changes, and void when a declared implementation source changes without a
+re-measurement. The second is not left to good intentions — `conformance/adequacy/results.json` is
+re-derived by [`adequacy-drift.yml`](../../.github/workflows/adequacy-drift.yml) and the numbers here
+are checked against it, so the two coming apart is a red check rather than a quiet disagreement.
 
 Recorded 2026-08-19. **No vector, expectation or digest is changed by this file.** A published
 corpus whose digest is its identity does not get edited; it gets an erratum, and a later corpus

--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -1,0 +1,117 @@
+# Errata for privileged-mcp-action/v0
+
+**Applies to corpus digest `sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342`**, and to
+nothing else. If the digest changes, this file is void until it is re-measured against the new one.
+
+Recorded 2026-08-19. **No vector, expectation or digest is changed by this file.** A published
+corpus whose digest is its identity does not get edited; it gets an erratum, and a later corpus
+gets the fix.
+
+## What reproducing this corpus does and does not establish
+
+An independent implementation that reproduces all fourteen outcomes has demonstrated agreement on
+**six** of the profile's rules. It has not demonstrated agreement on the profile.
+
+This is not a defect in the vectors as written, nor a claim that the reference implementation is
+wrong. It is a statement about **what fourteen vectors can transmit**. Where the profile promises a
+rule that no vector isolates, an implementation can omit that rule, reproduce this digest, and be
+indistinguishable here from one that honours it.
+
+Measured with [`corpus-adequacy`](https://github.com/corpus-adequacy/corpus-adequacy) over the
+normative comparison surface this corpus declares in `MANIFEST.json`
+(`bundle_integrity`, `verdict`, `claims`):
+
+```
+6 of 25 DECLARED in-scope rules killed (24.0%). 4 declared out of scope, 31 rules declared.
+control-killed. 19 mutant(s) survived. 2 KNOWN HOLES.
+```
+
+Reproduce with:
+
+```
+python3 ../../../corpus-adequacy/corpus_adequacy.py \
+  ../adequacy/privileged-mcp-action-v0.manifest.json
+```
+
+## The six rules reproduction does establish
+
+| rule | isolated by |
+|---|---|
+| exactly one decision record | `bad-103` |
+| the decision value is in the closed vocabulary | `bad-107` |
+| an unrecognised in-namespace payload schema fails closed (Stage 2) | `bad-104` |
+| the decision `action.target_digest` is a well-formed sha256 | `bad-102` |
+| `fail_closed` equals (`decision` == `"deny"`) | `bad-106` |
+| a marker binds on the `target_digest` leg | `bad-105` |
+
+## The nineteen it does not
+
+Each is promised by [v0.md](../../docs/profiles/privileged-mcp-action/v0.md) and is not
+discriminated by any of the fourteen vectors.
+
+**Cardinality and shape**
+- at most one observation record; at most one establish record
+- the observation `caller_visible_response_digest` is a well-formed sha256
+- the decision `tool.name` is a non-empty string; the observation `call.tool_name` is a non-empty string
+- the event type equals the payload schema it declares
+- an in-namespace event type over a payload declaring no in-namespace schema fails closed
+
+**Closed vocabularies**
+- the decision `reason` is in the closed producer set
+- the decision `drift_state` is in the closed set
+- the `establish_path` is in the closed set
+- `establish_attempted` equals (`run_outcome` != `not_performed`)
+
+**Marker binding**
+- a marker binds on the `tool_name` leg
+- a caller-visible denial marker is backed by a decision record
+- a marker with a null or empty `call.target_digest` is unbindable and invalid
+
+**Marker payload members**
+- `caller_visible_error.code`, `.origin` and `.reason` are each present and non-null
+
+**Producer non-claims**
+- the decision carries the five producer non-claims verbatim
+- the observation carries the four producer non-claims verbatim
+
+## Two known holes, and why they are structural
+
+`caller_visible_error.origin` must be `"assay-proxy"` and `caller_visible_error.code` must be
+`-32042` — both legs of the Stage 3 marker triple, both promised, neither discriminated.
+
+The cause is not an omission in any one vector. [`gen_vectors.py:103`](gen_vectors.py) hard-codes the
+single marker shape and is the only marker construction site, so **no vector in this corpus can vary
+either member**. Closing them requires a generator parameter, which is a new corpus.
+
+The triple's third leg, `schema`, is decided earlier at Stage 2 and so is not discriminated by the
+triple match either. Of the triple's three legs this corpus isolates none.
+
+## Rules out of scope for this corpus
+
+Four declared rules are excluded with stated reasons in
+[`../adequacy/privileged-mcp-action-v0.manifest.json`](../adequacy/privileged-mcp-action-v0.manifest.json):
+two mutate a v1 arm or an earlier stage and cannot move an outcome here even in principle, and one —
+the establish-journey contradiction — emits only a *finding*, and findings are not on this corpus's
+normative comparison surface. That last one is undiscriminable in principle rather than in practice,
+and becomes an in-scope hole the moment findings join the surface.
+
+## What this changes for an implementer
+
+Nothing about the exercise. Reproducing the fourteen outcomes remains the task, the expectations are
+unchanged, and a reproduction is still worth having: it is the only independent evidence that the
+specification text is sufficient to build against.
+
+What changes is the claim you can make afterwards, and the claim we can make about you. A successful
+reproduction establishes agreement on the six rules above. Anyone stating more than that — including
+us — is overstating what fourteen vectors measured.
+
+## How this was found
+
+Not by inspection. By mutation adequacy: delete one declared rule from the implementation, rebuild,
+and see whether the corpus notices. A rule the corpus cannot notice is a rule it cannot ask a third
+party to implement.
+
+The first three declarations of that measurement were themselves wrong — the first declared three
+rules and scored nothing, the second declared eight and published a pattern claim that an
+adversarial re-measurement refuted. `../INDEX.md` carries that sequence, including the run whose
+control survived and which therefore said nothing at all.

--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -48,7 +48,7 @@ here**, for two separate reasons:
 **Five of twenty-seven, 18.5%.**
 
 Reproduce the tool's run with [`corpus-adequacy`](https://github.com/corpus-adequacy/corpus-adequacy)
-at commit `6c419200b284ec84dffeb54ca20800ce1c445954`, from the repository root, with that tool checked
+at commit `b87ef706e70a2bcfe163514ec0360022e93fa175`, from the repository root, with that tool checked
 out as a sibling directory:
 
 ```
@@ -245,3 +245,84 @@ were the reader's, understating the undiscriminated set by two; the second draft
 barrier exactly backwards and counted a sixth isolated rule that does not isolate for a third party.
 `../INDEX.md` carries that sequence, including the run whose control survived and which therefore said
 nothing at all.
+
+<!-- BEGIN CHECKED NUMBERS -->
+
+## Checked numbers
+
+Every adequacy number above is re-derived from [`adequacy/results.json`](../adequacy/results.json) and asserted by
+[`adequacy/check_published_numbers.py`](../adequacy/check_published_numbers.py). Editing a number in the prose without editing the
+measurement, or the reverse, is a red check rather than a silent disagreement.
+
+```json
+{
+  "_about": "Owned by conformance/adequacy/check_published_numbers.py. This file's numbers are recomputed from conformance/adequacy/results.json, whose privileged-mcp-action-v0 row is TRANSCRIBED from the verbatim tool output above rather than re-derived on every run; the checker holds the transcription to that block and cannot hold the block to the implementation. See measure_all.py.",
+  "claims": [
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "6 of 25 DECLARED in-scope rules killed (24.0%). 4 declared out of scope, 31 rules declared. control-killed. 19 mutant(s) survived. 2 KNOWN HOLES.",
+      "asserts": {
+        "killed": 6,
+        "killed + survived": 25,
+        "score_percent": 24.0,
+        "out_of_scope": 4,
+        "declared_total": 31,
+        "survived": 19,
+        "known_holes": 2
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "Twenty-seven declared in-scope rules",
+      "asserts": {
+        "killed + survived + known_holes": 27
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "The denominator here is **twenty-seven**",
+      "asserts": {
+        "killed + survived + known_holes": 27
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "**Five of twenty-seven, 18.5%.**",
+      "locals": {
+        "not_isolated_for_a_third_party": 1,
+        "_why_not_isolated_for_a_third_party": "ERRATA.md's numerator is the tool's minus one: the closed decision vocabulary is killed for the reference implementation but not for a third party, because bad-107's payload violates the fail_closed rule independently. That subtraction is an editorial judgement about a stranger's implementation, not something the tool measures, so it is declared here rather than derived."
+      },
+      "asserts": {
+        "killed - not_isolated_for_a_third_party": 5,
+        "killed + survived + known_holes": 27,
+        "round(100.0 * (killed - not_isolated_for_a_third_party) / (killed + survived + known_holes), 1)": 18.5
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "on at most five of the profile's rules",
+      "locals": {
+        "not_isolated_for_a_third_party": 1,
+        "_why_not_isolated_for_a_third_party": "ERRATA.md's numerator is the tool's minus one: the closed decision vocabulary is killed for the reference implementation but not for a third party, because bad-107's payload violates the fail_closed rule independently. That subtraction is an editorial judgement about a stranger's implementation, not something the tool measures, so it is declared here rather than derived."
+      },
+      "asserts": {
+        "killed - not_isolated_for_a_third_party": 5
+      }
+    },
+    {
+      "corpus": "privileged-mcp-action-v0",
+      "text": "the other twenty-two",
+      "locals": {
+        "not_isolated_for_a_third_party": 1,
+        "_why_not_isolated_for_a_third_party": "ERRATA.md's numerator is the tool's minus one: the closed decision vocabulary is killed for the reference implementation but not for a third party, because bad-107's payload violates the fail_closed rule independently. That subtraction is an editorial judgement about a stranger's implementation, not something the tool measures, so it is declared here rather than derived."
+      },
+      "asserts": {
+        "survived + known_holes + not_isolated_for_a_third_party": 22
+      }
+    }
+  ],
+  "not_derived": []
+}
+```
+
+<!-- END CHECKED NUMBERS -->

--- a/conformance/privileged-mcp-action-v0/IMPLEMENTATION-REPORT.template.md
+++ b/conformance/privileged-mcp-action-v0/IMPLEMENTATION-REPORT.template.md
@@ -51,6 +51,18 @@ canonical expectation. Do not replace the original implementation commit or firs
 - Operating system:
 - Re-run result:
 
+## Scope of what this establishes
+
+Pre-filled from [ERRATA.md](ERRATA.md), pinned to corpus digest `sha256:cb58ce91…`. Do not widen it.
+
+- This reproduction can distinguish this implementation on **at most five** of the profile's rules,
+  and even those only at the points these vectors probe. It does not establish agreement on the
+  profile. Twenty-two promised rules are not discriminated by any vector in this corpus.
+- Was `ERRATA.md` read before the implementation was frozen? (yes/no; reading it is permitted and
+  disclosed, not disqualifying):
+- Which of the twenty-two undiscriminated rules did you implement anyway? List them. No vector can
+  extract this and it is the only evidence those rules can get before a later corpus exists:
+
 ## Non-claims
 
 This report records one implementation's result against the pinned corpus. It does not by itself

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -18,15 +18,17 @@ Vectors for the [Privileged MCP Action Evidence Profile v0](../../docs/profiles/
 
 ## What a reproduction establishes: read [ERRATA.md](ERRATA.md) first
 
-Reproducing all fourteen outcomes demonstrates agreement on **six** of the profile's rules, not on
-the profile. Nineteen further rules that v0.md promises are not discriminated by any vector here, so
-an implementation can omit them and still reproduce this digest. Two of those — the `origin` and
-`code` legs of the Stage 3 marker triple — cannot be discriminated by any vector this generator can
-produce, because `gen_vectors.py` hard-codes the single marker shape.
+Reproducing all fourteen outcomes **can distinguish an implementation on at most five** of the
+profile's rules, and even those only at the points these vectors probe. **Twenty-two further rules
+that v0.md promises are not discriminated by any vector here**, so an implementation can omit them and
+still reproduce all fourteen expected outcomes. Two of the twenty-two cannot be closed by writing a
+better vector at all, and one cannot be isolated by any bundle that could exist.
 
-That does not change the exercise, the expectations, or the value of doing it. It changes the claim
-that can be made afterwards, by the implementer and by us. [ERRATA.md](ERRATA.md) names all
-twenty-five measured rules and is pinned to the current corpus digest.
+Five of twenty-seven is 18.5%. The run and the expectations are unchanged and the exercise is still
+worth doing. What changes is the claim that can be made afterwards, by the implementer and by us, and
+the report template now carries a field for it. [ERRATA.md](ERRATA.md) names all twenty-seven measured
+rules with the profile sentence promising each, says which a new vector could close and which it could
+not, rules on whether it may be read before a freeze, and is pinned to the current corpus digest.
 
 ## Attempting the independent reproduction
 

--- a/conformance/privileged-mcp-action-v0/README.md
+++ b/conformance/privileged-mcp-action-v0/README.md
@@ -16,6 +16,18 @@ Vectors for the [Privileged MCP Action Evidence Profile v0](../../docs/profiles/
 - The corpus digest is a **candidate** until an independent, non-author implementation reproduces
   the expected outcomes from the specification text alone.
 
+## What a reproduction establishes: read [ERRATA.md](ERRATA.md) first
+
+Reproducing all fourteen outcomes demonstrates agreement on **six** of the profile's rules, not on
+the profile. Nineteen further rules that v0.md promises are not discriminated by any vector here, so
+an implementation can omit them and still reproduce this digest. Two of those — the `origin` and
+`code` legs of the Stage 3 marker triple — cannot be discriminated by any vector this generator can
+produce, because `gen_vectors.py` hard-codes the single marker shape.
+
+That does not change the exercise, the expectations, or the value of doing it. It changes the claim
+that can be made afterwards, by the implementer and by us. [ERRATA.md](ERRATA.md) names all
+twenty-five measured rules and is pinned to the current corpus digest.
+
 ## Attempting the independent reproduction
 
 The corpus digest stays a **candidate** until a non-author implementation reproduces the expected

--- a/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
+++ b/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
@@ -57,6 +57,27 @@ results. Verify the release attestation separately before relying on pack proven
 Start with `canonicalization/`. A canonicalizer that is wrong makes every later
 result uninterpretable, and it is the first thing a cross-language attempt has
 been observed to fail on. Read `canonicalization/README.md` before the spec.
+
+## What matching all fourteen cases establishes
+
+Less than the profile, and you should know the size of it before you start.
+
+These fourteen cases can distinguish an implementation on **at most five** of the
+profile's rules, and even those only at the points the cases probe. **Twenty-two
+rules that `spec.md` promises are not discriminated by any case in this pack**, so
+an implementation that omits them matches all fourteen expected outcomes anyway.
+That was measured by deleting each rule from a reference implementation and
+checking whether these cases noticed; most do not.
+
+Nothing here says which case probes which rule, because that would hand you the
+answers this pack exists to withhold. The full measurement, including the
+per-case attributions, is published as `ERRATA.md` in the source repository and
+is safe to read only after your implementation is frozen.
+
+Two consequences for your report. A match establishes agreement on at most those
+five rules and not on the profile, so do not write more than that and neither
+will we. And if you implemented any of the twenty-two anyway, say which: no case
+here can extract that, and it is the only evidence those rules can get.
 """
 
 

--- a/conformance/tests/test_corpus_adequacy_own_corpora.py
+++ b/conformance/tests/test_corpus_adequacy_own_corpora.py
@@ -100,7 +100,7 @@ class OwnCorpusAdequacy(unittest.TestCase):
         # the pack's README declares, not whatever happens to be killable.
         m = json.loads(MANIFEST.read_text())
         in_scope = {x["label"] for x in m["mutants"]["error_response_id"]
-                    if x.get("scope", "declared") == "declared"}
+                    if x.get("scope", "declared") == "declared" and not x.get("control")}
         self.assertEqual(in_scope, {
             "6 MCP tolerates an omitted id",
             "7 MCP RequestId excludes null",

--- a/conformance/tests/test_corpus_adequacy_own_corpora.py
+++ b/conformance/tests/test_corpus_adequacy_own_corpora.py
@@ -31,6 +31,10 @@ except ImportError:  # pragma: no cover - environment without the sibling checko
 REPO = Path(__file__).resolve().parents[2]
 MANIFEST = REPO / "conformance/adequacy/mcp-jsonrpc-id.manifest.json"
 PACK = REPO / "examples/mcp-jsonrpc-id-conformance"
+OBS_MANIFEST = REPO / "conformance/adequacy/observed-effect-drift-consumer.manifest.json"
+OBS_CONSUMER = REPO.parent / "observed-effect-v0/observed-effect-drift-consumer-2026-06/independent_consumer.py"
+RGE_MANIFEST = REPO / "conformance/adequacy/rge-bench.manifest.json"
+RGE_IMPL = REPO.parent / "rge-bench/ref_example.py"
 
 
 @unittest.skipIf(ca is None,
@@ -58,12 +62,15 @@ class DerivedVectorsDoNotDrift(unittest.TestCase):
 
 @unittest.skipIf(ca is None, "corpus-adequacy not found as a sibling checkout")
 class OwnCorpusAdequacy(unittest.TestCase):
-    def test_mcp_jsonrpc_id_is_adequate_within_its_declared_scope(self):
+    def test_mcp_jsonrpc_id_scores_the_id_type_arms_not_only_presence(self):
+        # 4 of 4 was a score over the presence/null arms alone. The positive
+        # control is a string id and RequestId is string | number, so the type
+        # arms belong in the denominator. Two of them are isolated; four are not.
         rep = ca.run(MANIFEST)
-        self.assertTrue(rep["adequate"], rep["failures"])
-        self.assertEqual(rep["score_percent"], 100.0)
-        self.assertEqual(rep["killed"], 4)
-        self.assertEqual(rep["survived"], 0)
+        self.assertEqual(rep["killed"], 6)
+        self.assertEqual(rep["survived"], 4)
+        self.assertEqual(rep["score_percent"], 60.0)
+        self.assertFalse(rep["adequate"])
 
     def test_every_out_of_scope_declaration_carries_a_reason(self):
         # Blocking review on #2538: an unreasoned exclusion is a percentage target
@@ -76,14 +83,15 @@ class OwnCorpusAdequacy(unittest.TestCase):
 
     def test_the_report_names_the_denominator_and_the_ratio(self):
         rep = ca.run(MANIFEST)
-        self.assertEqual(rep["declared_total"], 11)
-        self.assertEqual(rep["out_of_scope_ratio"], 1.75)
+        self.assertEqual(rep["declared_total"], 17)
+        self.assertEqual(rep["out_of_scope_ratio"], 0.7)
         self.assertIn("author-declared", rep["score_means"])
 
     def test_the_out_of_scope_count_is_stated_rather_than_hidden(self):
         # The honest half of the result: seven envelope rules no vector exercises.
         # If this number silently drops to zero, someone removed the disclosure
-        # rather than adding vectors.
+        # rather than adding vectors. Re-checked by applying each envelope mutant
+        # to the three published messages: none of them moves an outcome.
         rep = ca.run(MANIFEST)
         self.assertEqual(rep["unexercised_out_of_scope"], 7)
 
@@ -98,7 +106,40 @@ class OwnCorpusAdequacy(unittest.TestCase):
             "7 MCP RequestId excludes null",
             "8 JSON-RPC requires id to be present",
             "9 JSON-RPC permits a null id",
-        }, "the in-scope set must be exactly the four id rules the README declares")
+            "11 MCP RequestId includes string",
+            "12 JSON-RPC accepts a string id",
+            "13 MCP RequestId includes number",
+            "14 a bool is not an MCP RequestId",
+            "15 JSON-RPC accepts a number id",
+            "16 a bool is not a JSON-RPC number id",
+        }, "in-scope is the id-field rules, including the type arms the control exists for")
+
+
+@unittest.skipIf(ca is None, "corpus-adequacy not found as a sibling checkout")
+@unittest.skipUnless(OBS_CONSUMER.is_file(),
+                     "observed-effect-v0 not found as a sibling checkout")
+class ObservedEffectDeclarationIsTheConsumer(unittest.TestCase):
+    def test_the_score_is_over_recompute_and_profile_not_only_merge(self):
+        # 4 of 5 was merge-policy only. The 14 case names announce the rest.
+        # This number is supposed to be the lower, true one; do not tune it up.
+        rep = ca.run(OBS_MANIFEST)
+        self.assertEqual(rep["killed"], 14)
+        self.assertEqual(rep["survived"], 9)
+        self.assertEqual(rep["score_percent"], 60.9)
+        self.assertFalse(rep["adequate"])
+
+
+@unittest.skipIf(ca is None, "corpus-adequacy not found as a sibling checkout")
+@unittest.skipUnless(RGE_IMPL.is_file(), "rge-bench not found as a sibling checkout")
+class RgeBenchDeclarationMatchesTheImplementation(unittest.TestCase):
+    def test_the_score_is_over_the_rules_ref_example_has(self):
+        # 30 of 30 was the hand-written table. The strength ladder, the
+        # conjuncts, and the fallthroughs were discriminable and undeclared.
+        rep = ca.run(RGE_MANIFEST)
+        self.assertEqual(rep["killed"], 51)
+        self.assertEqual(rep["survived"], 3)
+        self.assertEqual(rep["score_percent"], 94.4)
+        self.assertFalse(rep["adequate"])
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_published_numbers_guard.py
+++ b/conformance/tests/test_published_numbers_guard.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""The drift guard over published adequacy numbers, each control fired on purpose.
+
+    python3 conformance/tests/test_published_numbers_guard.py
+
+Every guard here is tested by BREAKING the thing it guards and asserting the
+checker goes red, then restoring and asserting it goes green again. A guard whose
+test has never seen it fail is not a guard; it is a green light wired to nothing,
+which is the same defect the corpora themselves exist to find.
+
+Each control runs against a byte-identical COPY of the real documents, manifests
+and results, with the checker's own path constants pointed at the copy. The
+corruption is therefore applied to the real content and evaluated by the real
+code, while the working tree is never mutated -- important here because the
+measurement this file is about takes an exclusive lock on the tree and a test
+that edits it in place would collide with a run.
+
+`test_the_real_tree_is_green` is the wiring test: unpatched constants, real repo.
+Without it every other test could pass against a sandbox the checker never reads.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "conformance/adequacy"))
+
+import check_published_numbers as chk  # noqa: E402
+import measure_all  # noqa: E402
+
+COPIED = [
+    "conformance/adequacy/results.json",
+    "conformance/INDEX.md",
+    "conformance/privileged-mcp-action-v0/ERRATA.md",
+]
+
+
+@contextlib.contextmanager
+def sandbox():
+    """A byte-identical copy of everything the checker reads, with it pointed there."""
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        for rel in COPIED:
+            dst = root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO / rel, dst)
+        adequacy = root / "conformance/adequacy"
+        for manifest in (REPO / "conformance/adequacy").glob("*.manifest.json"):
+            shutil.copy2(manifest, adequacy / manifest.name)
+
+        saved = (chk.REPO, chk.ADEQUACY, chk.RESULTS, chk.DOCUMENTS)
+        chk.REPO = root
+        chk.ADEQUACY = adequacy
+        chk.RESULTS = adequacy / "results.json"
+        chk.DOCUMENTS = [root / "conformance/INDEX.md",
+                         root / "conformance/privileged-mcp-action-v0/ERRATA.md"]
+        try:
+            yield root
+        finally:
+            chk.REPO, chk.ADEQUACY, chk.RESULTS, chk.DOCUMENTS = saved
+
+
+def edit(path: Path, old: str, new: str) -> None:
+    """Replace the FIRST occurrence only.
+
+    Replacing every occurrence would edit the prose and the bindings block
+    together, which is the one edit a careful author makes and therefore the one
+    a control must not simulate. The controls here break exactly one side.
+    """
+    text = path.read_text(encoding="utf-8")
+    assert text.count(old) >= 1, "control anchor not found, so it would break nothing: %r" % old
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+class TheGuardIsWiredToTheRealTree(unittest.TestCase):
+    def test_the_real_tree_is_green(self):
+        """Wiring, not a control: the checker's own constants over the real repository.
+
+        Every other test in this file patches those constants. If none of them ran
+        against the real paths, the suite could be green while the checker read
+        nothing that ships.
+        """
+        self.assertEqual(chk.check(), [])
+
+    def test_every_manifest_on_disk_is_measured(self):
+        """Self-coverage, stated as its own assertion rather than left to the checker."""
+        results = json.loads((REPO / "conformance/adequacy/results.json").read_text())
+        measured = {c["corpus"] for c in results["corpora"]}
+        on_disk = {p.name[: -len(".manifest.json")]
+                   for p in (REPO / "conformance/adequacy").glob("*.manifest.json")}
+        self.assertEqual(measured, on_disk)
+
+    def test_results_json_is_deterministic_and_sorted(self):
+        """A file rewritten on every run in a new order makes its own diff unreadable."""
+        text = (REPO / "conformance/adequacy/results.json").read_text()
+        doc = json.loads(text)
+        names = [c["corpus"] for c in doc["corpora"]]
+        self.assertEqual(names, sorted(names))
+        self.assertEqual(text, json.dumps(doc, indent=2, sort_keys=True) + "\n")
+        self.assertEqual(doc["schema"], measure_all.SCHEMA)
+
+
+class ControlsOnTheProseBinding(unittest.TestCase):
+    def assert_red(self, needle: str):
+        findings = chk.check()
+        self.assertTrue(findings, "the checker stayed green; this guard is wired to nothing")
+        self.assertTrue(any(needle in f for f in findings),
+                        "went red for the wrong reason: %s" % findings)
+
+    def assert_green(self):
+        """The other half of a control: the setup itself must not already be red.
+
+        Without it a control can pass because the sandbox was broken before the
+        mutation, which proves the guard fires and not that it fires at the thing
+        the test names.
+        """
+        findings = chk.check()
+        self.assertFalse(findings, "expected a clean baseline, got: %s" % findings)
+
+    def test_a_measurement_that_moves_without_the_prose_is_red(self):
+        """CONTROL: change killed 51 -> 50 in results.json for rge-bench.
+
+        INDEX.md still says 51 of 54. Red on the assertion, green again on restore.
+        """
+        with sandbox() as root:
+            self.assertEqual(chk.check(), [])
+            res = root / "conformance/adequacy/results.json"
+            doc = json.loads(res.read_text())
+            for c in doc["corpora"]:
+                if c["corpus"] == "rge-bench":
+                    c["killed"] = 50
+            res.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+            self.assert_red("the measurement gives")
+            shutil.copy2(REPO / "conformance/adequacy/results.json", res)
+            self.assertEqual(chk.check(), [])
+
+    def test_prose_edited_away_from_the_binding_is_red(self):
+        """CONTROL: rewrite INDEX.md's rge-bench row to '51 of 55'.
+
+        The registered wording no longer occurs, so the binding is orphaned.
+        """
+        with sandbox() as root:
+            idx = root / "conformance/INDEX.md"
+            edit(idx, "51 of 54 in scope (94.4%)", "51 of 55 in scope (94.4%)")
+            self.assert_red("this exact wording is no longer in")
+            shutil.copy2(REPO / "conformance/INDEX.md", idx)
+            self.assertEqual(chk.check(), [])
+
+    def test_an_unregistered_number_added_to_the_prose_is_red(self):
+        """CONTROL: append a plausible new score to INDEX.md that no binding covers.
+
+        This is the failure mode the sweep exists for: a number that reads like a
+        measurement, was never measured, and would otherwise pass silently.
+        """
+        with sandbox() as root:
+            idx = root / "conformance/INDEX.md"
+            edit(idx, "## Claim vocabulary",
+                 "A later re-measurement gave 12 of 13 in scope (92.3%).\n\n## Claim vocabulary")
+            self.assert_red("neither derived from results.json nor")
+            shutil.copy2(REPO / "conformance/INDEX.md", idx)
+            self.assertEqual(chk.check(), [])
+
+    def test_a_stale_not_derived_exemption_is_red(self):
+        """CONTROL: delete the '6 of 8' anecdote from INDEX.md, leaving its exemption.
+
+        An exemption pointing at nothing is where the next unchecked number hides,
+        so the checker refuses to carry it.
+        """
+        with sandbox() as root:
+            idx = root / "conformance/INDEX.md"
+            edit(idx, "`6 of 8 (75.0%)`", "`(75.0%)`")
+            self.assert_red("not_derived declares '6 of 8'")
+            shutil.copy2(REPO / "conformance/INDEX.md", idx)
+            self.assertEqual(chk.check(), [])
+
+    def test_a_binding_that_checks_fewer_numbers_than_it_publishes_is_red(self):
+        """CONTROL: drop the survivors assertion from the mcp-jsonrpc-id binding.
+
+        The wording still says '4 survivors'. Without this rule a binding could
+        register a sentence and check only the flattering half of it.
+        """
+        with sandbox() as root:
+            idx = root / "conformance/INDEX.md"
+            edit(idx, '"score_percent": 60.0,\n        "survived": 4',
+                 '"score_percent": 60.0')
+            self.assert_red("which no assertion checks")
+            shutil.copy2(REPO / "conformance/INDEX.md", idx)
+            self.assertEqual(chk.check(), [])
+
+    def test_a_declared_constant_without_a_reason_is_red(self):
+        """CONTROL: strip the _why from INDEX.md's not_measurable local.
+
+        A constant with no stated reason is a number smuggled past the measurement,
+        which is precisely how the out_of_scope discipline was breached upstream.
+        """
+        with sandbox() as root:
+            idx = root / "conformance/INDEX.md"
+            edit(idx, '"_why_not_measurable"', '"_note_not_measurable"')
+            self.assert_red("has no _why_")
+            shutil.copy2(REPO / "conformance/INDEX.md", idx)
+            self.assertEqual(chk.check(), [])
+
+    def test_deleting_the_block_is_red(self):
+        """CONTROL: remove the BEGIN marker from ERRATA.md.
+
+        A document must not be able to opt out of the guard by dropping its block.
+        """
+        with sandbox() as root:
+            err = root / "conformance/privileged-mcp-action-v0/ERRATA.md"
+            edit(err, chk.BEGIN, "<!-- gone -->")
+            self.assert_red("must contain exactly one")
+            shutil.copy2(REPO / "conformance/privileged-mcp-action-v0/ERRATA.md", err)
+            self.assertEqual(chk.check(), [])
+
+
+class ControlsOnCoverageAndPinning(unittest.TestCase):
+    def assert_red(self, needle: str):
+        findings = chk.check()
+        self.assertTrue(findings, "the checker stayed green; this guard is wired to nothing")
+        self.assertTrue(any(needle in f for f in findings),
+                        "went red for the wrong reason: %s" % findings)
+
+    def assert_green(self):
+        """The other half of a control: the setup itself must not already be red.
+
+        Without it a control can pass because the sandbox was broken before the
+        mutation, which proves the guard fires and not that it fires at the thing
+        the test names.
+        """
+        findings = chk.check()
+        self.assertFalse(findings, "expected a clean baseline, got: %s" % findings)
+
+    def test_a_manifest_with_no_measurement_is_red(self):
+        """CONTROL: add a sixth manifest to the directory and measure nothing.
+
+        The checker must not pass by reporting on the five it happens to know.
+        A checker that silently skips a corpus is the exact failure one level up.
+        """
+        with sandbox() as root:
+            new = root / "conformance/adequacy/newly-added.manifest.json"
+            shutil.copy2(root / "conformance/adequacy/rge-bench.manifest.json", new)
+            self.assert_red("no measurement for")
+            new.unlink()
+            self.assertEqual(chk.check(), [])
+
+    def test_a_result_outliving_its_manifest_is_red(self):
+        """CONTROL: delete the rge-bench manifest, leaving its row behind."""
+        with sandbox() as root:
+            manifest = root / "conformance/adequacy/rge-bench.manifest.json"
+            keep = manifest.read_bytes()
+            manifest.unlink()
+            self.assert_red("has no manifest on disk")
+            manifest.write_bytes(keep)
+            self.assertEqual(chk.check(), [])
+
+    def test_a_manifest_with_no_tool_pin_is_red(self):
+        """CONTROL: strip tool_pin from the observed-effect manifest.
+
+        Numbers measured with an unnamed tool cannot be re-derived by anyone, which
+        is the state every manifest was in before this layer existed.
+        """
+        with sandbox() as root:
+            path = root / "conformance/adequacy/observed-effect-drift-consumer.manifest.json"
+            doc = json.loads(path.read_text())
+            saved = doc.pop("tool_pin")
+            path.write_text(json.dumps(doc, indent=2))
+            self.assert_red("declares no tool_pin.commit")
+            doc["tool_pin"] = saved
+            path.write_text(json.dumps(doc, indent=2))
+            self.assertEqual(chk.check(), [])
+
+    def test_a_row_measured_with_another_commit_is_red(self):
+        """CONTROL: re-pin the mcp-jsonrpc-id manifest to a different commit.
+
+        The row still records the commit it was measured with. A number and the
+        tool that produced it must move together.
+        """
+        with sandbox() as root:
+            path = root / "conformance/adequacy/mcp-jsonrpc-id.manifest.json"
+            # Read the pin rather than hard-coding it: a control that carries its
+            # own copy of the value stops firing the day the real pin moves, which
+            # is precisely when it is needed.
+            edit(path, json.loads(path.read_text())["tool_pin"]["commit"], "0" * 40)
+            self.assert_red("but mcp-jsonrpc-id.manifest.json pins")
+            shutil.copy2(REPO / "conformance/adequacy/mcp-jsonrpc-id.manifest.json", path)
+            self.assertEqual(chk.check(), [])
+
+    def test_the_transcription_rule_has_no_live_subject_and_says_so(self):
+        """Its control was retired with the last transcribed row, deliberately.
+
+        privileged-mcp-action-v0 was the only row nobody re-derived; it is now
+        measured like the rest, which closed the weakest link on the page. The
+        transcription rule still exists and still matters, because the next
+        expensive corpus will arrive transcribed before it arrives measured. But
+        there is nothing live for a control to break, and a synthetic transcribed
+        row did not reproduce the rule's own baseline in this harness.
+
+        Shipping a control that passes without proving the rule fires would be
+        worse than recording that the guard is currently unexercised, so this
+        records it. Restore a real control the moment a transcribed row returns:
+        a rule whose control is retired is a rule on the way to being unenforced,
+        which is the defect this whole file exists to prevent.
+        """
+        doc = json.loads((REPO / "conformance/adequacy/results.json").read_text())
+        kinds = {c["provenance"]["kind"] for c in doc["corpora"]}
+        self.assertEqual(kinds, {"measured"},
+                         "a transcribed row is back; restore the quote control with it")
+        self.assertIn("transcribed", Path(chk.__file__).read_text(),
+                      "the rule itself must still be present for the day one returns")
+
+    def test_the_prose_commit_pin_drifting_from_the_manifest_is_red(self):
+        """CONTROL: change the commit ERRATA.md names in prose.
+
+        The document hands a reproducer a commit to check out. That sentence is the
+        original hand-maintained pin and the reason tool_pin exists; it must not be
+        able to part from the manifest quietly.
+        """
+        with sandbox() as root:
+            err = root / "conformance/privileged-mcp-action-v0/ERRATA.md"
+            rows = {c["corpus"]: c for c in json.loads(
+                (root / "conformance/adequacy/results.json").read_text())["corpora"]}
+            edit(err, rows["privileged-mcp-action-v0"]["tool_commit"], "f" * 40)
+            # Reworded when the rule was ungated: it used to live inside the
+            # transcription branch and went quiet the moment the row became
+            # measured, which is a guard that disappears exactly when the thing
+            # it guards stops being obviously fragile.
+            self.assert_red("hands a reproducer an instrument")
+            shutil.copy2(REPO / "conformance/privileged-mcp-action-v0/ERRATA.md", err)
+            self.assertEqual(chk.check(), [])
+
+    def test_a_missing_results_file_is_red(self):
+        """CONTROL: delete results.json.
+
+        No measurement must never read as agreement.
+        """
+        with sandbox() as root:
+            res = root / "conformance/adequacy/results.json"
+            keep = res.read_bytes()
+            res.unlink()
+            self.assert_red("Nothing re-derives the published numbers")
+            res.write_bytes(keep)
+            self.assertEqual(chk.check(), [])
+
+
+# The tool is not vendored (INDEX.md, "Where the adequacy tool lives"). Expect it as
+# a sibling checkout and skip LOUDLY rather than pretending results.json was checked.
+_TOOL = REPO.parent / "corpus-adequacy"
+if _TOOL.is_dir():
+    sys.path.insert(0, str(_TOOL))
+try:
+    import corpus_adequacy as ca  # noqa: E402
+except ImportError:  # pragma: no cover - environment without the sibling checkout
+    ca = None
+
+# Corpora cheap enough to re-derive in a test. privileged-mcp-action-v0 is excluded on
+# purpose: ~32 cargo builds mutating shared source in place is not something a test
+# suite may do to a working tree, which is exactly why its row is transcribed.
+CHEAP = {
+    "mcp-jsonrpc-id": REPO / "conformance/adequacy/mcp-jsonrpc-id.manifest.json",
+    "observed-effect-drift-consumer":
+        REPO / "conformance/adequacy/observed-effect-drift-consumer.manifest.json",
+    "rge-bench": REPO / "conformance/adequacy/rge-bench.manifest.json",
+}
+SIBLINGS = {
+    "observed-effect-drift-consumer": REPO.parent / "observed-effect-v0",
+    "rge-bench": REPO.parent / "rge-bench",
+}
+
+
+@unittest.skipIf(ca is None,
+                 "corpus-adequacy not found as a sibling checkout; clone "
+                 "https://github.com/corpus-adequacy/corpus-adequacy next to this repository")
+class ResultsAreStillWhatTheToolProduces(unittest.TestCase):
+    """results.json is a measurement, and a measurement nobody repeats is a memory.
+
+    Not a control: the standing check that the file has not gone stale. The
+    published prose is held to results.json by the checker; this holds results.json
+    to the tool. Without it the whole layer would guarantee only that two documents
+    agree with a third that nothing re-derives.
+    """
+
+    def stored(self) -> dict:
+        return {c["corpus"]: c for c in json.loads(
+            (REPO / "conformance/adequacy/results.json").read_text())["corpora"]}
+
+    def drifted(self, stored: dict) -> list[str]:
+        """Corpora whose recorded row differs from a fresh run of the tool.
+
+        Rows are built through measure_all.row, so this comparison cannot drift
+        from the shape the writer actually records. tool_version is provenance
+        rather than measurement, and older tool checkouts report none.
+        """
+        out = []
+        for corpus, manifest in sorted(CHEAP.items()):
+            sibling = SIBLINGS.get(corpus)
+            if sibling is not None and not sibling.is_dir():
+                self.skipTest("%s not found as a sibling checkout" % sibling.name)
+            fresh = measure_all.row(manifest, ca.run(manifest),
+                                    {"tool_commit": stored[corpus]["tool_commit"]})
+            trim = lambda r: {k: v for k, v in r.items() if k != "tool_version"}  # noqa: E731
+            if trim(fresh) != trim(stored[corpus]):
+                out.append(corpus)
+        return out
+
+    def test_the_cheap_corpora_still_measure_what_results_json_records(self):
+        self.assertEqual(self.drifted(self.stored()), [],
+                         "results.json has gone stale; re-run measure_all.py")
+
+    def test_a_doctored_result_is_caught(self):
+        """CONTROL: hand-edit rge-bench's killed count and confirm the drift check bites.
+
+        Without it this comparison could be structurally unable to fail -- comparing
+        a value with itself, or skipping every corpus -- and would still print green.
+        """
+        stored = self.stored()
+        stored["rge-bench"] = dict(stored["rge-bench"], killed=stored["rge-bench"]["killed"] + 1)
+        self.assertEqual(self.drifted(stored), ["rge-bench"])
+
+
+class TheTranscribedRowSaysSoOutLoud(unittest.TestCase):
+    def test_a_row_nobody_re_derives_must_say_so(self):
+        """Every row is derived today; the rule holds for the day one is not.
+
+        privileged-mcp-action-v0 was the exception and was re-measured, so the
+        assertion is now over all rows rather than naming the weak one: any row
+        that is not measured must be labelled transcribed and must carry the
+        command that re-derives it. Naming the specific corpus would have made
+        this test go stale the moment the weak link moved, which it did.
+        """
+        doc = json.loads((REPO / "conformance/adequacy/results.json").read_text())
+        rows = {c["corpus"]: c for c in doc["corpora"]}
+        self.assertIn("--only", measure_all.__doc__)
+        for name, r in sorted(rows.items()):
+            kind = r["provenance"]["kind"]
+            if kind == "measured":
+                continue
+            self.assertEqual(kind, "transcribed", name)
+            self.assertIn("measure_all.py --only %s" % name, r["provenance"]["_why"],
+                          "a row nobody re-derives must name how to")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/BRANCH-PROTECTION-SETUP.md
+++ b/docs/BRANCH-PROTECTION-SETUP.md
@@ -84,6 +84,26 @@ Use **`CI`** (not `CIExpected` or any other variant). No workflow in this repo r
 | **assay-action-contract-tests** | Tests GitHub Action in `assay-action/` | Not needed — Cargo.toml/Cargo.lock don't touch the action. | **Essential** if PR touches `assay-action/` or workflows. |
 | **MCP Security (Assay)** | Install assay, run validate with demo config | Redundant with CI for deps-only (CI validates the binary). | Useful — sanity check for security workflow. |
 | **Kernel Matrix CI** | eBPF tests on self-hosted runner | Not needed — kernel-matrix `paths` exclude Cargo.toml/Cargo.lock. | **Essential** if PR touches eBPF/Monitor/evidence. |
+| **Adequacy drift gate** | Re-derives every published mutation-adequacy number and fails when a document and the measurement disagree | Not needed — relevance is derived from each manifest's own declared sources, which a deps bump does not touch. | Load-bearing when a PR touches a declared corpus source, its vectors, its manifest, or `conformance/INDEX.md` / `ERRATA.md`. **Deliberately not required — see below.** |
+
+### Why the adequacy drift gate is not required, and what would change that
+
+It fits the criterion the other three meet: universal, quick when irrelevant,
+load-bearing when relevant. It is kept out for a property none of them has —
+**it clones an external repository**. `corpus-adequacy` is a sibling checkout,
+deliberately not vendored, and the lane fetches it at the commit each manifest
+pins. Making the gate required would couple `main` to a third party's
+availability, and no current required check does that.
+
+That is a property of the instrument, not of the measurement, so it is fixable.
+**Promote this gate to required once the tool no longer needs a network fetch at
+gate time** — a pinned local copy verified against `tool_pin`. That is a cache,
+not a second implementation, so it does not conflict with the reason the tool is
+unvendored, which is drift between two implementations rather than storage.
+
+Until then the gate runs, reports on every PR, and is a review obligation like
+Smoke Install and MCP Security: if a PR moves a published number, its green tick
+is the thing to look for before merging.
 
 **Current recommendation:** Keep **`CI`, `lane-check/proof`, and
 `host-capability-check`** required. `CI` is the universal build/security gate;

--- a/scripts/ci/adequacy_lane_assert.py
+++ b/scripts/ci/adequacy_lane_assert.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Assert that the adequacy lane actually re-derived what it planned to re-derive.
+
+`conformance/adequacy/check_published_numbers.py` answers "do the published numbers agree with
+results.json". It cannot answer "was results.json produced by running anything", and it is not
+supposed to: `measure_all.py --only X` deliberately **carries over** every row it did not select,
+unchanged. That is the right behaviour for a tool a human drives, and it is exactly the shape that
+lets a relevance-gated CI lane go green having measured nothing — a carried-over row and a
+freshly-measured one are byte-identical.
+
+So this checker sits between the plan and the drift check and holds the run to its own plan:
+
+* every corpus the plan selected must carry `provenance.kind == "measured"` — a row still marked
+  transcribed, or carried from an earlier run's prose, is a corpus that was not re-derived;
+* every selected row must record the `tool_commit` its manifest pins, so a measurement taken with a
+  dirty or floating instrument (which `measure_all.py` records as `<sha>-dirty`) is refused;
+* a `control` that SURVIVED voids its run: the tool's own rule is that every other verdict in a
+  control-survived run is meaningless, so a score is not a result;
+* every corpus the plan did **not** select is named, in words, as NOT re-derived by this run, with
+  the reason the plan gave. Silence there is how "skipped" comes to read as "verified".
+
+Usage:
+    adequacy_lane_assert.py --results conformance/adequacy/results.json \
+        --manifest-dir conformance/adequacy \
+        --planned a,b --all a,b,c,d,e [--out-of-scope c,d] [--require-all]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+class AssertError(Exception):
+    """The lane cannot show that it re-derived what it planned to."""
+
+
+def rows_by_corpus(document: object) -> dict[str, dict]:
+    """corpus id -> its row, from the `assay.conformance.adequacy.results.v0` shape."""
+    if not isinstance(document, dict):
+        raise AssertError("results file is not a JSON object")
+    corpora = document.get("corpora")
+    if not isinstance(corpora, list):
+        raise AssertError("results file has no `corpora` list")
+    rows: dict[str, dict] = {}
+    for item in corpora:
+        if not isinstance(item, dict):
+            raise AssertError("`corpora` holds a non-object element")
+        name = item.get("corpus")
+        if not isinstance(name, str):
+            raise AssertError("a `corpora` row has no string `corpus` id")
+        rows[name] = item
+    if not rows:
+        raise AssertError("`corpora` is empty; nothing was measured and nothing can be asserted")
+    return rows
+
+
+def manifest_pins(manifest_dir: Path) -> dict[str, str]:
+    """corpus id -> the instrument commit its manifest pins."""
+    pins: dict[str, str] = {}
+    for path in sorted(manifest_dir.glob("*.manifest.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        pin = data.get("tool_pin")
+        commit = pin.get("commit") if isinstance(pin, dict) else None
+        if isinstance(commit, str):
+            pins[path.name[: -len(".manifest.json")]] = commit
+    return pins
+
+
+def check(
+    document: object,
+    pins: dict[str, str],
+    planned: list[str],
+    every: list[str],
+    out_of_scope: list[str],
+    *,
+    require_all: bool,
+) -> list[str]:
+    """Report lines for a run that held to its plan; raise on the first thing it cannot show."""
+    if require_all:
+        owed = [n for n in every if n not in planned and n not in out_of_scope]
+        if owed:
+            raise AssertError(
+                "this run was required to re-derive every in-scope corpus, but the plan omitted "
+                f"{', '.join(owed)}"
+            )
+
+    if not every:
+        raise AssertError(
+            "no corpora are known at all. Either the manifests are gone or the plan failed to "
+            "read them; a run that cannot name what it should measure must not report a verdict."
+        )
+
+    # An empty plan is a legitimate outcome and the common one: relevance found nothing that could
+    # move a number. It is NOT the same as a run that measured nothing while something did change,
+    # which is why every corpus is then listed by name below rather than passing in silence. What
+    # licenses the pass is the relevance derivation, and it is stated in the plan step's summary.
+    rows = rows_by_corpus(document)
+    failures: list[str] = []
+    lines: list[str] = []
+
+    for name in planned:
+        row = rows.get(name)
+        if row is None:
+            failures.append(f"{name}: planned for measurement but absent from results.json")
+            continue
+
+        provenance = row.get("provenance")
+        kind = provenance.get("kind") if isinstance(provenance, dict) else None
+        if kind != "measured":
+            failures.append(
+                f"{name}: planned for measurement but its row says provenance.kind={kind!r}. "
+                "A carried-over or transcribed row is not a re-derivation."
+            )
+            continue
+
+        expected = pins.get(name)
+        recorded = row.get("tool_commit")
+        if expected is None:
+            failures.append(f"{name}: no `tool_pin.commit` in its manifest to check against")
+        elif recorded != expected:
+            failures.append(
+                f"{name}: measured with tool_commit={recorded!r} but its manifest pins "
+                f"{expected!r}. The instrument that produced this number is not the pinned one."
+            )
+            continue
+
+        control = row.get("control")
+        if control == "SURVIVED":
+            failures.append(
+                f"{name}: its control mutant SURVIVED, which voids every other verdict in the "
+                "run. A score from a control-survived run is not a result."
+            )
+            continue
+        if control == "none_declared":
+            lines.append(
+                f"re-derived: {name} (no control declared; a zero from this corpus cannot be "
+                "distinguished from nothing having been measured)"
+            )
+        else:
+            lines.append(f"re-derived: {name} (control {control})")
+
+    for name in every:
+        if name in planned:
+            continue
+        if name in out_of_scope:
+            lines.append(
+                f"OUT OF SCOPE: {name} — this lane cannot keep its number fresh; see the plan step"
+            )
+        else:
+            lines.append(
+                f"NOT re-derived by this run: {name} — relevance gating found no change to its "
+                "declared inputs. Its row is carried over, and the scheduled full run is what "
+                "bounds how long that can stay true."
+            )
+
+    unknown = sorted(set(rows) - set(every))
+    if unknown:
+        # Not a failure on its own: a new manifest can land before the plan is re-run. It is
+        # reported because a silently-extra row is how a rename hides a corpus going dark.
+        lines.append(f"results carry corpora the plan does not know: {', '.join(unknown)}")
+
+    if failures:
+        raise AssertError("; ".join(failures))
+    return lines
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results", required=True, help="Path to results.json (explicit argv).")
+    parser.add_argument("--manifest-dir", required=True, help="Directory holding the manifests.")
+    parser.add_argument("--planned", default="", help="Comma-separated corpora this run selected.")
+    parser.add_argument("--all", dest="every", default="", help="Comma-separated known corpora.")
+    parser.add_argument("--out-of-scope", default="", help="Comma-separated unmeasurable corpora.")
+    parser.add_argument(
+        "--require-all",
+        action="store_true",
+        help="Refuse unless the plan covered every in-scope corpus (scheduled full run).",
+    )
+    args = parser.parse_args(argv)
+
+    planned = [s for s in args.planned.split(",") if s]
+    every = [s for s in args.every.split(",") if s] or list(planned)
+    out_of_scope = [s for s in args.out_of_scope.split(",") if s]
+
+    try:
+        document = json.loads(Path(args.results).read_text(encoding="utf-8"))
+        pins = manifest_pins(Path(args.manifest_dir))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        print(
+            f"::error::adequacy inputs unreadable ({exc}); the lane cannot show that anything was "
+            "re-derived, so it fails rather than passing",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        lines = check(document, pins, planned, every, out_of_scope, require_all=args.require_all)
+    except AssertError as exc:
+        print(f"::error::adequacy coverage assertion failed: {exc}", file=sys.stderr)
+        return 1
+
+    for line in lines:
+        print(line)
+    in_scope = [n for n in every if n not in out_of_scope]
+    print(
+        f"adequacy coverage: {len(planned)} of {len(in_scope)} in-scope corpora re-derived this "
+        f"run ({len(out_of_scope)} out of scope, {len(every)} declared)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/adequacy_lane_plan.py
+++ b/scripts/ci/adequacy_lane_plan.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Decide which mutation-adequacy corpora a changed-file set can affect, and pin the instrument.
+
+`conformance/INDEX.md` and `conformance/privileged-mcp-action-v0/ERRATA.md` publish measured
+adequacy numbers. They were produced by hand, nothing re-derives them, and ERRATA.md is pinned to a
+corpus *digest* — which does not move when the implementation moves. So the first change to a
+declared implementation source makes a published number silently wrong and no existing guard fires.
+
+Cost is what makes this a gating problem rather than a "just run it" problem. Four corpora are
+module or batch runners and finish in seconds. `privileged-mcp-action-v0` is a process runner: about
+32 `cargo build -p assay-cli` invocations, roughly fifteen minutes. On every pull request that is
+unacceptable; never is how the numbers rot.
+
+This applies the lesson `scripts/ci/perf_bench_relevance.py` already records for benchmarks: a path
+pattern like `^crates/` matched all 21 crates and alerted on changes outside the benchmark's
+compilation unit, so relevance is derived from the artifact's own declaration instead of from a glob
+someone guessed. Here the declaration is the manifest: `implementation_sources`, `vectors`,
+`corpus_digest_file`, and the manifest file itself. A hand-written path list would be a second
+statement of what the manifest already says, and the two would drift.
+
+Two different failure directions, two different postures:
+
+* **Relevance fails open.** If the manifests cannot be read, or a declared source does not exist, or
+  anything else goes wrong, every corpus is reported relevant. A gate that silently stops measuring
+  is worse than one that measures too much.
+* **The instrument pin fails closed.** The tool lives at a sibling checkout
+  (`github.com/corpus-adequacy/corpus-adequacy`) and is deliberately not vendored. Measuring with a
+  floating ref means the numbers are produced by an instrument that can change under them, which is
+  the same class of bug this lane exists to catch. A manifest with no `tool_pin.commit`, or one
+  that is not a 40-hex commit, exits non-zero rather than measuring. Manifests pinning *different*
+  commits is not an error but a fact: a number transcribed from a document measured at an older
+  commit keeps that commit, so the corpora are grouped by pin and measured one group per checkout.
+
+Usage:
+    git diff --name-only BASE...HEAD | scripts/ci/adequacy_lane_plan.py
+    scripts/ci/adequacy_lane_plan.py --full        # schedule / dispatch: measure everything
+
+Writes `key=value` lines to stdout, plus `#`-prefixed commentary. The caller routes them; this
+script never opens a path taken from the environment (an uncontrolled-path sink, CodeQL
+py/path-injection). `--repo-root` is an explicit argv path so the self-tests can point it at a
+fixture tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ADEQUACY_DIR = "conformance/adequacy"
+
+# Changed paths outside any single manifest's declaration that still change what the lane measures
+# or what it is measured against. The two documents are here because they ARE the published numbers:
+# editing a number without re-deriving it is precisely the rot this lane exists to prevent, so an
+# edit to either forces a full measurement rather than trusting the edit.
+GLOBAL_TRIGGERS = (
+    ".github/workflows/adequacy-drift.yml",
+    "scripts/ci/adequacy_lane_plan.py",
+    "scripts/ci/adequacy_lane_assert.py",
+    "conformance/adequacy/measure_all.py",
+    "conformance/adequacy/check_published_numbers.py",
+    "conformance/INDEX.md",
+    "conformance/privileged-mcp-action-v0/ERRATA.md",
+)
+
+TOOL_REPOSITORY = "corpus-adequacy/corpus-adequacy"
+
+# One spelling, matching `conformance/adequacy/check_published_numbers.py`, which requires
+# `tool_pin.commit` on every manifest and compares it against the `tool_commit` each measured row
+# records. A second accepted spelling here would be a second definition of where the pin lives.
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# The directory name the tool is expected to occupy beside this checkout. `INDEX.md` and
+# `ERRATA.md` both document the reproduction as `python3 ../corpus-adequacy/corpus_adequacy.py`,
+# so the sibling directory name is part of the published instructions, not an implementation choice.
+TOOL_DIR = "corpus-adequacy"
+
+
+class PinError(Exception):
+    """The instrument pin could not be resolved. Fail closed."""
+
+
+def _rel(path: Path, root: Path) -> str | None:
+    """Repo-relative POSIX path, or None when `path` escapes the repository."""
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
+def _sibling(path: Path, root: Path) -> str | None:
+    """First path component of `path` under the repository's parent, or None when it is not there."""
+    try:
+        return path.relative_to(root.parent).parts[0]
+    except (ValueError, IndexError):
+        return None
+
+
+def _declared_paths(manifest: dict) -> list[str]:
+    """Every filesystem path a manifest declares, as written (manifest-dir relative)."""
+    out: list[str] = []
+    for key in ("implementation", "vectors", "corpus_digest_file"):
+        value = manifest.get(key)
+        if isinstance(value, str):
+            out.append(value)
+    sources = manifest.get("implementation_sources")
+    if isinstance(sources, list):
+        out.extend(s for s in sources if isinstance(s, str))
+    return out
+
+
+def _extract_pin(manifest: dict) -> str | None:
+    """The instrument commit this manifest declares, if any: `tool_pin.commit`."""
+    pin = manifest.get("tool_pin")
+    if isinstance(pin, dict):
+        commit = pin.get("commit")
+        if isinstance(commit, str) and COMMIT_RE.match(commit.strip()):
+            return commit.strip()
+    return None
+
+
+class Corpus:
+    """One manifest, read for what it declares about itself."""
+
+    def __init__(self, path: Path, root: Path) -> None:
+        self.manifest_path = _rel(path, root) or path.as_posix()
+        self.name = path.name[: -len(".manifest.json")]
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"{self.manifest_path}: manifest is not a JSON object")
+        self.data = data
+
+        # A process runner rebuilds the subject binary per mutant; that is the fifteen-minute
+        # corpus. Cost class is read off `runner` rather than off a name, so a second process
+        # corpus is classified correctly the day it lands instead of being quietly treated as cheap.
+        self.heavy = data.get("runner") == "process"
+
+        self.triggers: set[str] = {self.manifest_path}
+        self.siblings: set[str] = set()
+        self.missing: list[str] = []
+        base = path.parent
+        for declared in _declared_paths(data):
+            resolved = (base / declared).resolve()
+            inside = _rel(resolved, root)
+            if inside is not None:
+                self.triggers.add(inside)
+                if not resolved.exists():
+                    self.missing.append(inside)
+                continue
+            sibling = _sibling(resolved, root)
+            if sibling is None:
+                # A declared path that is neither in the repository nor beside it cannot be
+                # attributed, so it cannot be watched. Fail open on this corpus.
+                self.missing.append(declared)
+            else:
+                self.siblings.add(sibling)
+
+        self.declares_pin = _extract_pin(data) is not None
+
+        # A corpus whose declared sources live beside this repository rather than inside it cannot
+        # be relevance-gated from this repository's diff: the change that would invalidate its
+        # number happens in a repository this diff cannot see. Saying so is the point — the
+        # alternative is a corpus that looks gated and is in fact unwatched.
+        self.external = bool(self.siblings)
+
+    def sibling_pins(self) -> dict[str, str]:
+        """Non-instrument sibling directory -> `owner/repo@commit`, as this manifest declares it.
+
+        The instrument is deliberately absent: it is pinned per corpus (see `pin_groups`), because
+        a number transcribed from a document measured at an older commit keeps that commit. One
+        map holding both would have to pretend there is a single tool commit, and there is not.
+        """
+        pins: dict[str, str] = {}
+        declared = self.data.get("pins")
+        if isinstance(declared, dict):
+            for directory, spec in declared.items():
+                if not isinstance(spec, dict):
+                    continue
+                repository = spec.get("repository")
+                commit = spec.get("commit") or spec.get("sha")
+                if isinstance(repository, str) and isinstance(commit, str) and COMMIT_RE.match(commit):
+                    pins[directory] = f"{repository}@{commit}"
+        return pins
+
+
+def load(root: Path) -> list[Corpus]:
+    directory = root / ADEQUACY_DIR
+    return [Corpus(p, root) for p in sorted(directory.glob("*.manifest.json"))]
+
+
+def pin_groups(corpora: list[Corpus]) -> dict[str, list[str]]:
+    """instrument commit -> the corpora whose published numbers were measured with it.
+
+    NOT one global pin. `conformance/adequacy/check_published_numbers.py` requires each row to
+    record the commit **its own manifest** declares, and the manifests legitimately disagree: a row
+    transcribed from a document measured at an older tool commit keeps that commit, while corpora
+    re-measured since carry the newer one. Collapsing them to one value would make the lane
+    re-measure a corpus with an instrument its manifest does not pin, and the drift check would
+    then fail on a difference the lane itself introduced.
+
+    A manifest with no pin is refused rather than defaulted: measuring with a floating ref means
+    the numbers are produced by an instrument that can change under them, which is the same class
+    of bug this lane exists to catch.
+    """
+    groups: dict[str, list[str]] = {}
+    unpinned: list[str] = []
+    for corpus in corpora:
+        pin = _extract_pin(corpus.data)
+        if pin is None:
+            unpinned.append(corpus.name)
+        else:
+            groups.setdefault(pin, []).append(corpus.name)
+    if unpinned:
+        raise PinError(
+            f"{', '.join(sorted(unpinned))}: no `tool_pin.commit` declared. Refusing to measure "
+            "with a floating ref."
+        )
+    return {commit: sorted(names) for commit, names in sorted(groups.items())}
+
+
+def resolve_sibling_pins(corpora: list[Corpus]) -> dict[str, str]:
+    """`sibling directory -> owner/repo@commit`, for every sibling checkout any manifest pins.
+
+    Same rule as the instrument, applied to every checkout a measurement reads: a sibling at a
+    floating ref can change under the number, so an unpinned sibling is never checked out. What
+    happens to a corpus that needs one is a scope decision, made in `plan()`; this function only
+    reports what is pinned.
+    """
+    merged: dict[str, set[str]] = {}
+    for corpus in corpora:
+        for directory, spec in corpus.sibling_pins().items():
+            merged.setdefault(directory, set()).add(spec)
+
+    conflicting = sorted(d for d, specs in merged.items() if len(specs) > 1)
+    if conflicting:
+        detail = "; ".join(f"{d}: {', '.join(sorted(merged[d]))}" for d in conflicting)
+        raise PinError(f"manifests disagree on a sibling checkout pin: {detail}")
+
+    return {d: next(iter(specs)) for d, specs in sorted(merged.items())}
+
+
+def plan(
+    corpora: list[Corpus],
+    changed: list[str],
+    *,
+    full: bool,
+    pinned_siblings: set[str],
+) -> dict:
+    """Which corpora this run must measure, and why.
+
+    A corpus whose subject lives in a sibling repository that nothing pins is **out of this lane's
+    scope**, not skipped. The distinction is the point: this repository cannot keep such a number
+    fresh by any CI design, because the change that invalidates it happens in a repository this
+    lane may not check out at a floating ref. Saying so, per corpus, with the exact declaration
+    that would bring it in scope, is a scope statement. Leaving it in the planned set would make
+    the lane red forever, which teaches people to ignore it — the same defect as a green that
+    measured nothing, arrived at from the other side.
+    """
+    detail: dict[str, str] = {}
+
+    def unpinned(corpus: Corpus) -> list[str]:
+        return sorted(s for s in corpus.siblings if s not in pinned_siblings)
+
+    out_of_scope = {c.name: unpinned(c) for c in corpora if unpinned(c)}
+    for name, missing in out_of_scope.items():
+        detail[name] = (
+            "OUT OF SCOPE for this lane: its subject lives in sibling checkout(s) "
+            f"{', '.join(missing)}, which no manifest pins. This lane will not clone at a floating "
+            'ref. Declare `"pins": {"<dir>": {"repository": "owner/name", "commit": "<40-hex>"}}` '
+            "in the manifest and it joins the scheduled run with no change here."
+        )
+
+    if full:
+        relevant = [c.name for c in corpora if c.name not in out_of_scope]
+        for name in relevant:
+            detail[name] = "full run requested (schedule or dispatch)"
+        reason = "full"
+    else:
+        changed_set = set(changed)
+        global_hits = sorted(changed_set & set(GLOBAL_TRIGGERS))
+        # A manifest that declares the instrument pin governs every corpus, not only its own: the
+        # pin moving means every number on the page was produced by a different instrument.
+        pin_hits = sorted(
+            c.manifest_path for c in corpora if c.declares_pin and c.manifest_path in changed_set
+        )
+        relevant = []
+        for corpus in corpora:
+            hits = sorted(changed_set & corpus.triggers)
+            if corpus.name in out_of_scope:
+                continue  # detail already states why, and no trigger can make it measurable
+            if global_hits:
+                relevant.append(corpus.name)
+                detail[corpus.name] = f"lane-wide change: {', '.join(global_hits)}"
+            elif pin_hits:
+                relevant.append(corpus.name)
+                detail[corpus.name] = f"instrument pin may have moved: {', '.join(pin_hits)}"
+            elif corpus.missing:
+                relevant.append(corpus.name)
+                detail[corpus.name] = (
+                    "declared path could not be resolved in this tree "
+                    f"({', '.join(corpus.missing)}); failing open"
+                )
+            elif hits:
+                relevant.append(corpus.name)
+                detail[corpus.name] = f"declared inputs changed: {', '.join(hits)}"
+            elif corpus.external:
+                detail[corpus.name] = (
+                    "declared sources live outside this repository "
+                    f"({', '.join(sorted(corpus.siblings))}); a change there is invisible to this "
+                    "diff, so relevance computed here would be a false negative. Measured by the "
+                    "scheduled full run, which checks those siblings out at their declared pins"
+                )
+            else:
+                detail[corpus.name] = (
+                    f"no changed path is declared by this corpus "
+                    f"({len(corpus.triggers)} declared: {', '.join(sorted(corpus.triggers))})"
+                )
+        reason = "relevance"
+
+    relevant_set = set(relevant)
+    return {
+        "mode": reason,
+        "all": [c.name for c in corpora],
+        "relevant": relevant,
+        "heavy": [c.name for c in corpora if c.heavy],
+        "heavy_relevant": any(c.heavy and c.name in relevant_set for c in corpora),
+        "external": [c.name for c in corpora if c.external],
+        "out_of_scope": sorted(out_of_scope),
+        "siblings": sorted({s for c in corpora if c.name in relevant_set for s in c.siblings}),
+        "detail": detail,
+    }
+
+
+def emit(
+    result: dict,
+    changed: list[str],
+    *,
+    groups: dict[str, list[str]],
+    sibling_pins: dict[str, str],
+    notes: list[str],
+) -> None:
+    """Write everything to stdout; the caller routes it.
+
+    Machine-readable lines match `^[a-z_]+=`; everything else is commentary prefixed with `#`.
+    """
+    for note in notes:
+        print(f"# {note}")
+    print(f"# mode: {result['mode']}")
+    for name in result["all"]:
+        if name in result["relevant"]:
+            mark = "MEASURE   "
+        elif name in result["out_of_scope"]:
+            mark = "OUT-OF-SCOPE"
+        else:
+            mark = "skip      "
+        print(f"# {mark} {name}: {result['detail'].get(name, '')}")
+    for path in changed:
+        print(f"#   changed: {path}")
+    print(f"mode={result['mode']}")
+    print(f"tool_repository={TOOL_REPOSITORY}")
+    print(f"tool_dir={TOOL_DIR}")
+    # `<commit>=<corpus>,<corpus>` per group, space-separated, restricted to the selected corpora.
+    # The measurement runs once per group with the tool checked out at that group's commit, because
+    # a row must record the commit its own manifest pins.
+    selected = set(result["relevant"])
+    print(
+        "pin_groups="
+        + " ".join(
+            f"{commit}={','.join(n for n in names if n in selected)}"
+            for commit, names in groups.items()
+            if any(n in selected for n in names)
+        )
+    )
+    print(f"all_corpora={','.join(result['all'])}")
+    print(f"relevant_corpora={','.join(result['relevant'])}")
+    print(f"heavy_corpora={','.join(result['heavy'])}")
+    print(f"heavy_relevant={str(result['heavy_relevant']).lower()}")
+    print(f"external_corpora={','.join(result['external'])}")
+    print(f"out_of_scope_corpora={','.join(result['out_of_scope'])}")
+    # `<dir>=<owner/repo>@<commit>` per sibling, space-separated: the workflow reads it with a
+    # `read` loop, so no value may contain a space.
+    print("sibling_pins=" + " ".join(f"{d}={spec}" for d, spec in sorted(sibling_pins.items())))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Measure every corpus regardless of the changed-file set (schedule, dispatch).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parents[2]),
+        help="Repository root. Explicit argv, never read from the environment.",
+    )
+    args = parser.parse_args(argv)
+    root = Path(args.repo_root).resolve()
+
+    changed = [] if args.full else [line.strip() for line in sys.stdin if line.strip()]
+
+    notes: list[str] = []
+    try:
+        corpora = load(root)
+        if not corpora:
+            raise ValueError(f"no manifests found under {root / ADEQUACY_DIR}")
+    except Exception as exc:  # noqa: BLE001 - relevance fails open, loudly
+        print(
+            f"::error::adequacy manifests unreadable ({exc}); relevance cannot be derived and the "
+            "instrument pin cannot be resolved, so this lane refuses rather than measuring nothing"
+        )
+        return 2
+
+    try:
+        groups = pin_groups(corpora)
+    except PinError as exc:
+        print(f"::error::{exc}")
+        return 2
+
+    try:
+        sibling_pins = resolve_sibling_pins(corpora)
+    except PinError as exc:
+        print(f"::error::{exc}")
+        return 2
+
+    try:
+        result = plan(
+            corpora, changed, full=args.full, pinned_siblings=set(sibling_pins)
+        )
+    except Exception as exc:  # noqa: BLE001 - fail open, loudly
+        notes.append(f"relevance derivation failed ({exc}); treating every corpus as relevant")
+        print(f"::warning::adequacy relevance failed ({exc}); measuring every corpus")
+        result = {
+            "mode": "fail-open",
+            "all": [c.name for c in corpora],
+            "relevant": [c.name for c in corpora],
+            "heavy": [c.name for c in corpora if c.heavy],
+            "heavy_relevant": any(c.heavy for c in corpora),
+            "external": [c.name for c in corpora if c.external],
+            "out_of_scope": [],
+            "siblings": sorted({s for c in corpora for s in c.siblings}),
+            "detail": {c.name: "fail-open" for c in corpora},
+        }
+
+    emit(result, changed, groups=groups, sibling_pins=sibling_pins, notes=notes)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/adequacy_lane_plan.py
+++ b/scripts/ci/adequacy_lane_plan.py
@@ -14,8 +14,16 @@ unacceptable; never is how the numbers rot.
 This applies the lesson `scripts/ci/perf_bench_relevance.py` already records for benchmarks: a path
 pattern like `^crates/` matched all 21 crates and alerted on changes outside the benchmark's
 compilation unit, so relevance is derived from the artifact's own declaration instead of from a glob
-someone guessed. Here the declaration is the manifest: `implementation_sources`, `vectors`,
-`corpus_digest_file`, and the manifest file itself. A hand-written path list would be a second
+someone guessed. Here the declaration is the manifest: `implementation`,
+`implementation_sources`, `vectors`, `corpus_digest_file`, and the manifest file itself.
+
+`implementation` is named FIRST and deliberately. A reader who saw only
+`implementation_sources` in this list concluded that `mcp-jsonrpc-id` and
+`rge-bench` -- which declare `implementation` and no `implementation_sources` --
+could never be selected, so an empty list would read as "never changed" and they
+would freeze on first commit. That reading is wrong about the code and was right
+about this sentence, which listed one field of the two that `_declared_paths`
+actually reads. A hand-written path list would be a second
 statement of what the manifest already says, and the two would drift.
 
 Two different failure directions, two different postures:

--- a/scripts/ci/test_adequacy_lane.py
+++ b/scripts/ci/test_adequacy_lane.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Contract tests for the adequacy drift lane's two helpers.
+
+    python3 scripts/ci/test_adequacy_lane.py
+
+A demonstrated red is not a pinned red: these exist so the lane's refusals stay refusals. Each test
+names the way the lane could otherwise go green having measured nothing.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import contextlib
+import tempfile
+import unittest
+from pathlib import Path
+
+import adequacy_lane_assert as la
+import adequacy_lane_plan as lp
+
+TOOL_PIN = "a" * 40
+OTHER_PIN = "b" * 40
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def manifest(**overrides) -> dict:
+    base = {
+        "schema": "corpus-adequacy.manifest.v0",
+        "tool_pin": {"commit": TOOL_PIN},
+        "vectors": "vectors.json",
+        "mutants": {},
+    }
+    base.update(overrides)
+    return base
+
+
+class FixtureTree:
+    """A throwaway repository with an adequacy directory, plus a parent for siblings."""
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        # Resolved: on macOS the temp dir is /var/... which is a symlink to /private/var/...,
+        # and the plan resolves declared paths. An unresolved root would make every declared
+        # source look like it escapes the repository.
+        parent = Path(self._tmp.name).resolve()
+        self.root = parent / "subject"
+        (self.root / lp.ADEQUACY_DIR).mkdir(parents=True)
+        (self.root / "crates" / "thing" / "src").mkdir(parents=True)
+        (self.root / "crates" / "thing" / "src" / "lib.rs").write_text("", encoding="utf-8")
+        (self.root / "crates" / "other").mkdir(parents=True)
+        (self.root / "crates" / "other" / "lib.rs").write_text("", encoding="utf-8")
+        (self.root / lp.ADEQUACY_DIR / "vectors.json").write_text("[]", encoding="utf-8")
+
+    def write(self, name: str, data: dict) -> None:
+        path = self.root / lp.ADEQUACY_DIR / f"{name}.manifest.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def plan(self, changed: list[str], *, full: bool = False) -> dict:
+        corpora = lp.load(self.root)
+        lp.pin_groups(corpora)  # every fixture manifest must be pinned, same as the real tree
+        pins = lp.resolve_sibling_pins(corpora)
+        return lp.plan(corpora, changed, full=full, pinned_siblings=set(pins))
+
+    def close(self) -> None:
+        self._tmp.cleanup()
+
+
+class RelevanceDerivation(unittest.TestCase):
+    """Relevance comes from what the manifest declares, not from a guessed path glob."""
+
+    def setUp(self) -> None:
+        self.tree = FixtureTree()
+        self.addCleanup(self.tree.close)
+        self.tree.write(
+            "heavy",
+            manifest(runner="process", implementation_sources=["../../crates/thing/src/lib.rs"]),
+        )
+        self.tree.write("cheap", manifest(implementation="../../crates/other/lib.rs"))
+
+    def test_declared_source_selects_only_its_own_corpus(self) -> None:
+        result = self.tree.plan(["crates/thing/src/lib.rs"])
+        self.assertEqual(result["relevant"], ["heavy"])
+        self.assertTrue(result["heavy_relevant"])
+
+    def test_unrelated_change_selects_nothing(self) -> None:
+        # The whole point of the gate: a change no corpus declares must not cost fifteen minutes.
+        result = self.tree.plan(["crates/unrelated/src/main.rs", "README.md"])
+        self.assertEqual(result["relevant"], [])
+        self.assertFalse(result["heavy_relevant"])
+
+    def test_manifest_change_selects_its_corpus(self) -> None:
+        result = self.tree.plan([f"{lp.ADEQUACY_DIR}/cheap.manifest.json"])
+        # `cheap` declares the pin like every manifest, so a pin move selects everything. That is
+        # the intended reading: the instrument changing invalidates every number on the page.
+        self.assertEqual(result["relevant"], ["cheap", "heavy"])
+
+    def test_editing_a_published_document_forces_a_full_measurement(self) -> None:
+        # Editing a number without re-deriving it is the rot this lane exists to prevent, so the
+        # edit itself is the trigger.
+        for document in (
+            "conformance/INDEX.md",
+            "conformance/privileged-mcp-action-v0/ERRATA.md",
+        ):
+            with self.subTest(document=document):
+                self.assertEqual(sorted(self.tree.plan([document])["relevant"]), ["cheap", "heavy"])
+
+    def test_a_declared_source_missing_from_the_tree_fails_open(self) -> None:
+        self.tree.write("gone", manifest(implementation="../../crates/thing/src/vanished.rs"))
+        result = self.tree.plan(["README.md"])
+        self.assertIn("gone", result["relevant"])
+        self.assertIn("failing open", result["detail"]["gone"])
+
+
+class OutOfScope(unittest.TestCase):
+    """A corpus whose subject is in an unpinned sibling is declared out of scope, never 'skipped'."""
+
+    def setUp(self) -> None:
+        self.tree = FixtureTree()
+        self.addCleanup(self.tree.close)
+        self.tree.write("local", manifest(implementation="../../crates/other/lib.rs"))
+        self.tree.write("remote", manifest(implementation="../../../elsewhere/ref.py"))
+
+    def test_unpinned_sibling_is_never_selected_even_by_a_global_trigger(self) -> None:
+        for changed, full in (
+            (["conformance/INDEX.md"], False),
+            ([], True),
+        ):
+            with self.subTest(full=full):
+                result = self.tree.plan(changed, full=full)
+                self.assertNotIn("remote", result["relevant"])
+                self.assertEqual(result["out_of_scope"], ["remote"])
+                self.assertIn("OUT OF SCOPE", result["detail"]["remote"])
+
+    def test_a_declared_pin_brings_it_into_the_scheduled_run(self) -> None:
+        self.tree.write(
+            "remote",
+            manifest(
+                implementation="../../../elsewhere/ref.py",
+                pins={"elsewhere": {"repository": "owner/elsewhere", "commit": OTHER_PIN}},
+            ),
+        )
+        result = self.tree.plan([], full=True)
+        self.assertIn("remote", result["relevant"])
+        self.assertEqual(result["out_of_scope"], [])
+
+
+class InstrumentPin(unittest.TestCase):
+    """The instrument fails closed: measuring with a floating ref is the bug the lane catches."""
+
+    def setUp(self) -> None:
+        self.tree = FixtureTree()
+        self.addCleanup(self.tree.close)
+
+    def test_missing_pin_refuses(self) -> None:
+        self.tree.write("one", manifest(tool_pin=None))
+        with self.assertRaises(lp.PinError):
+            lp.pin_groups(lp.load(self.tree.root))
+
+    def test_non_commit_pin_refuses(self) -> None:
+        self.tree.write("one", manifest(tool_pin={"commit": "main"}))
+        with self.assertRaises(lp.PinError):
+            lp.pin_groups(lp.load(self.tree.root))
+
+    def test_manifests_may_pin_different_commits(self) -> None:
+        # Not a conflict. A corpus whose number was transcribed from a document measured at an
+        # older tool commit keeps that commit; collapsing the two would make the lane re-measure
+        # with an instrument the manifest does not pin, and the drift check would then fail on a
+        # difference the lane itself introduced.
+        self.tree.write("one", manifest())
+        self.tree.write("two", manifest(tool_pin={"commit": OTHER_PIN}))
+        groups = lp.pin_groups(lp.load(self.tree.root))
+        self.assertEqual(groups, {TOOL_PIN: ["one"], OTHER_PIN: ["two"]})
+
+    def test_conflicting_sibling_pins_refuse(self) -> None:
+        self.tree.write(
+            "one",
+            manifest(pins={"e": {"repository": "a/e", "commit": OTHER_PIN}}),
+        )
+        self.tree.write(
+            "two",
+            manifest(pins={"e": {"repository": "z/e", "commit": OTHER_PIN}}),
+        )
+        with self.assertRaises(lp.PinError):
+            lp.resolve_sibling_pins(lp.load(self.tree.root))
+
+
+def results(**rows) -> dict:
+    return {"schema": "assay.conformance.adequacy.results.v0", "corpora": list(rows.values())}
+
+
+def row(name: str, *, kind: str = "measured", commit: str = TOOL_PIN, control: str = "killed"):
+    return {
+        "corpus": name,
+        "killed": 6,
+        "survived": 4,
+        "score_percent": 60.0,
+        "control": control,
+        "tool_commit": commit,
+        "provenance": {"kind": kind},
+    }
+
+
+class CoverageAssertion(unittest.TestCase):
+    """Every way the lane could report a verdict it did not earn."""
+
+    PINS = {"a": TOOL_PIN, "b": TOOL_PIN}
+
+    def check(self, document, planned, every, out_of_scope=(), require_all=False):
+        return la.check(
+            document, self.PINS, planned, every, list(out_of_scope), require_all=require_all
+        )
+
+    def test_a_carried_over_row_is_not_a_re_derivation(self) -> None:
+        # `measure_all.py --only b` leaves a's row untouched and byte-identical. Claiming a was
+        # measured must be refused, or relevance gating silently becomes "trust the old number".
+        document = results(a=row("a", kind="transcribed"), b=row("b"))
+        with self.assertRaises(la.AssertError) as caught:
+            self.check(document, ["a", "b"], ["a", "b"])
+        self.assertIn("not a re-derivation", str(caught.exception))
+
+    def test_an_absent_row_is_refused(self) -> None:
+        with self.assertRaises(la.AssertError):
+            self.check(results(b=row("b")), ["a", "b"], ["a", "b"])
+
+    def test_an_unpinned_instrument_is_refused(self) -> None:
+        document = results(a=row("a", commit=f"{TOOL_PIN}-dirty"))
+        with self.assertRaises(la.AssertError) as caught:
+            self.check(document, ["a"], ["a"])
+        self.assertIn("not the pinned one", str(caught.exception))
+
+    def test_a_survived_control_voids_the_run(self) -> None:
+        document = results(a=row("a", control="SURVIVED"))
+        with self.assertRaises(la.AssertError) as caught:
+            self.check(document, ["a"], ["a"])
+        self.assertIn("voids", str(caught.exception))
+
+    def test_an_empty_plan_names_every_corpus_as_unmeasured(self) -> None:
+        # Relevance finding nothing is legitimate and common. What is not legitimate is passing in
+        # silence, so the pass must still say, per corpus, that nothing was re-derived.
+        lines = self.check(results(a=row("a"), b=row("b")), [], ["a", "b"])
+        for name in ("a", "b"):
+            self.assertTrue(any(f"NOT re-derived by this run: {name}" in line for line in lines))
+
+    def test_knowing_no_corpora_at_all_is_refused(self) -> None:
+        with self.assertRaises(la.AssertError):
+            self.check(results(a=row("a")), [], [])
+
+    def test_require_all_refuses_a_partial_scheduled_run(self) -> None:
+        # The schedule is the only thing bounding staleness. A full run that quietly measured a
+        # subset would remove that bound while still reporting success.
+        with self.assertRaises(la.AssertError):
+            self.check(results(a=row("a")), ["a"], ["a", "b"], require_all=True)
+
+    def test_require_all_tolerates_declared_out_of_scope(self) -> None:
+        lines = self.check(
+            results(a=row("a")), ["a"], ["a", "b"], out_of_scope=["b"], require_all=True
+        )
+        self.assertTrue(any("OUT OF SCOPE: b" in line for line in lines))
+
+    def test_unmeasured_corpora_are_named_in_words(self) -> None:
+        lines = self.check(results(a=row("a"), b=row("b")), ["a"], ["a", "b"])
+        self.assertTrue(any("NOT re-derived by this run: b" in line for line in lines))
+
+    def test_an_empty_corpora_list_is_refused(self) -> None:
+        with self.assertRaises(la.AssertError):
+            self.check({"corpora": []}, ["a"], ["a"])
+
+
+class LiveTree(unittest.TestCase):
+    """The rules above, applied to this repository's actual manifests."""
+
+    def setUp(self) -> None:
+        self.corpora = lp.load(REPO_ROOT)
+        self.pins = set(lp.resolve_sibling_pins(self.corpora))
+
+    def test_every_manifest_pins_an_instrument_commit(self) -> None:
+        groups = lp.pin_groups(self.corpora)
+        self.assertEqual(
+            sorted(n for names in groups.values() for n in names),
+            sorted(c.name for c in self.corpora),
+        )
+        for commit in groups:
+            self.assertRegex(commit, lp.COMMIT_RE)
+
+    def test_the_heavy_corpus_is_the_process_runner(self) -> None:
+        heavy = [c.name for c in self.corpora if c.heavy]
+        self.assertEqual(heavy, ["privileged-mcp-action-v0"])
+
+    def test_touching_a_declared_source_selects_the_heavy_corpus(self) -> None:
+        # Regression fixture. `denial_marker.rs` is one of the three files the manifest declares;
+        # a change to it moves what the corpus can transmit and moves no digest.
+        result = lp.plan(
+            self.corpora,
+            ["crates/assay-evidence/src/denial_marker.rs"],
+            full=False,
+            pinned_siblings=self.pins,
+        )
+        self.assertEqual(result["relevant"], ["privileged-mcp-action-v0"])
+
+    def test_an_unrelated_crate_does_not_select_the_heavy_corpus(self) -> None:
+        result = lp.plan(
+            self.corpora,
+            ["crates/assay-runner-schema/src/lib.rs"],
+            full=False,
+            pinned_siblings=self.pins,
+        )
+        self.assertFalse(result["heavy_relevant"])
+
+    def test_emit_lines_are_routable_key_values(self) -> None:
+        result = lp.plan(self.corpora, [], full=True, pinned_siblings=self.pins)
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            lp.emit(
+                result,
+                [],
+                groups=lp.pin_groups(self.corpora),
+                sibling_pins={},
+                notes=[],
+            )
+        keys = {
+            line.split("=", 1)[0]
+            for line in buffer.getvalue().splitlines()
+            if not line.startswith("#")
+        }
+        # The workflow reads exactly these; a rename here silently empties a job input.
+        self.assertEqual(
+            keys,
+            {
+                "mode",
+                "tool_repository",
+                "tool_dir",
+                "pin_groups",
+                "all_corpora",
+                "relevant_corpora",
+                "heavy_corpora",
+                "heavy_relevant",
+                "external_corpora",
+                "out_of_scope_corpora",
+                "sibling_pins",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #2556, which published measured adequacy numbers. This makes them re-derived rather than remembered.

## The problem

Every number in `INDEX.md` and `ERRATA.md` existed because someone ran the tool by hand one evening. Nothing re-derived them, and `ERRATA.md` is pinned to a corpus **digest**, which does not move when code moves, so no existing guard fires. They had the epistemics of the numbers they replaced.

## The mechanism

| | |
|---|---|
| `conformance/adequacy/results.json` | the measured truth |
| `measure_all.py` | writes it; `--only` carries unselected rows over byte-identically |
| `check_published_numbers.py` | documents are checked against it, never authored |
| `.github/workflows/adequacy-drift.yml` | relevance derived from each manifest's own declarations, not a path glob |
| `tool_pin` | every manifest names the instrument commit |

Prose binds to JSON through marked blocks covering digits **and** English words, plus a sweep requiring every `N of M` token to be registered or exempted with a reason. Superseded numbers (`4 of 4`, `30 of 30`, the contaminated `6 of 8`) are declared exemptions rather than silent ones.

## Four defects the build found

**1. A corpus was scoring with no control.** `mcp-jsonrpc-id` declared seventeen mutants and none, while `INDEX.md` says every manifest must declare one. `corpus-adequacy` enforced that only in `_run_process`; the module path never checked. Not a wrong number — six kills meant the harness reached the code — but the guarantee was absent: an all-survivors run could not have been told from a harness detecting nothing. Fixed upstream in one shared function with a parity test asserting the rule is stated exactly once. Seven of the tool's own fixtures went red immediately, which is the guard working; they were given controls rather than exemptions. Score unchanged at 6 of 10.

**2. Two scores were published about repositories we do not own, with no commit.** `rge-bench` and `observed-effect-v0`. `results.json` now derives which state was measured, the rows name it, and the checker refuses an out-of-tree corpus whose commit no published document carries. Freshness is not the requirement and cannot be — those repositories move without this diff seeing it. A score against `rge-bench@c51c5af18` stays permanently true of `rge-bench@c51c5af18`, and that was the missing half of the sentence.

**3. The last transcribed row is gone.** `privileged-mcp-action-v0` was copied from `ERRATA.md` prose. Re-measured: **6 of 25, 24.0%, control killed.** Every row is now derived by the same code path. Its quote control is retired with it, and the test says so out loud rather than shipping a synthetic control that proves nothing.

**4. Re-pinning left the prose behind.** `ERRATA.md` kept handing a reproducer the old tool commit. The prose-pin rule caught it, and only because the rule was ungated first: it had lived inside the transcription branch and went quiet the moment the row became measured — a guard that disappears exactly when its subject stops looking fragile.

## Two of my own guards failed their positive control before they worked

The subject recorder first derived from `repo_root` and called `rge-bench` **in-tree**, because that manifest declares no `repo_root` and the default landed inside this repository while the measured file sat three levels above. Recording an external corpus as internal is the silence the field exists to break. It now derives from the files actually measured.

And the out-of-tree rule was satisfied by the note explaining it — the guard read itself. The note no longer carries a literal commit.

## Beyond adequacy

`conformance/UNGUARDED-CLAIMS.md` asks the same question of the rest of the repository. Its sharpest finding is an existing drift check that compares a generated file against a heredoc which never reads the tree: a self-check that cannot fail when the code moves.

## Two decisions deliberately not taken

- **Required check.** The lane fits the repo's stated criterion — universal, quick when irrelevant, load-bearing when relevant — but it clones an external repository, which no current required check does. Making it required couples `main` to a third party's availability. The trigger for promotion is a pinned local copy verified against the pin, which is a cache rather than a second implementation.
- **The two sibling corpora joining the scheduled run.** Adding a `pins` block to their manifests brings them in with no workflow change; inventing commits for repositories I do not own is not mine to do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated adequacy-drift checks that selectively remeasure affected corpora and compare results with published claims.
  - Added validation for measurement coverage, provenance, pinned tool versions, control outcomes, and reported values.
  - Added canonical adequacy results for five corpora.

- **Documentation**
  - Clarified corpus pinning, measurement scope, adequacy limitations, checked figures, and disclosure requirements.
  - Documented published claims that are not yet automatically guarded.

- **Tests**
  - Added comprehensive checks for stale, incomplete, inconsistent, or altered adequacy data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->