### PR TITLE
fix(conformance): expose partial execution truth

### DIFF
--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -20,6 +20,7 @@ grade `false` or `unproved` rather than pass silently.
 | Corpus | Vectors | Runner | Maturity |
 |---|---|---|---|
 | [`privileged-mcp-action-v0`](privileged-mcp-action-v0/) | 14 (5 accept, 9 reject) | **needs a candidate** | frozen, digest-pinned, open reproduction request ([#1840](https://github.com/Rul1an/assay/issues/1840)) |
+| [`privileged-mcp-action-v1`](privileged-mcp-action-v1/) | 7 (4 accept, 3 reject) | **needs a candidate** | published profile corpus; no candidate-neutral runner registered |
 | [`mcp-jsonrpc-id-conformance`](../examples/mcp-jsonrpc-id-conformance/) | 3 | stdlib, `check.py reproduce` | published pack; carries a positive control |
 | [`rfc8785` canonicalization](../crates/assay-canonical/tests/vectors/rfc8785.json) | 31 | `cargo test -p assay-canonical --test rfc8785_conformance` | prerequisite vectors; vendored byte-identical into the clean-room pack |
 | [`mcp-era-parity-v0`](../crates/assay-core/tests/fixtures/mcp-era-parity-v0/) | 18 (+2 equivalence pairs) | `cargo test -p assay-core --lib mcp::era_parity_tests` | **exploratory** — deliberately lower than the frozen corpus |
@@ -61,9 +62,11 @@ stronger, more actionable result than a check that could not complete.
 
 Three states are **declared, never inferred**, and always printed in the summary:
 
-- `needs_candidate` — `privileged-mcp-action-v0` is a clean-room gate.
-  `score_candidate.py` requires `--entrypoint`, an outside implementation. There
-  is no self-run and deliberately so: a corpus that scores itself answers a
+- `needs_candidate` — `privileged-mcp-action-v0` is a clean-room gate whose
+  `score_candidate.py` requires `--entrypoint`, an outside implementation.
+  `privileged-mcp-action-v1` likewise has no candidate-neutral runner registered;
+  invoking the shipped Assay verifier would exercise the author implementation.
+  There is no self-run for either corpus: a corpus that scores itself answers a
   question nobody asked.
 - `not_selected` — a Rust-driven corpus when `--with-cargo` was not passed.
 - `external` — the corpus lives in another repository.
@@ -74,8 +77,10 @@ implementations they grade, applied to the runner that grades them.
 
 ## What a green run does and does not establish
 
-A green run says the published corpora reproduce **their own** pinned verdicts
-on this checkout. It says nothing about:
+A green run says every suite that **executed** reproduced its own pinned verdicts
+on this checkout. It does not say every declared suite ran: inspect `complete`
+and `executed/declared` in JSON, or `complete` in terminal output. It also says
+nothing about:
 
 - **independence** — everything here was authored in this workspace. Agreement
   with yourself is not evidence.
@@ -88,10 +93,11 @@ on this checkout. It says nothing about:
 
 ## Claim vocabulary
 
-Where a reproduction is recorded, it carries an
+Where a reproduction is recorded, it uses an
 [ACM Artifact Review and Badging](https://www.acm.org/publications/policies/artifact-review-and-badging-current)
-class, because the distinction is easy to blur and ACM already drew it. Note the
-terms are the reverse of the common intuition:
+classification because the distinction is easy to blur and ACM already drew it.
+These are **ACM-aligned classifications, not ACM-awarded badges**. Note the terms
+are the reverse of the common intuition:
 
 **These one-line glosses are abbreviations, not the criteria.** The badges carry
 requirements this table does not restate: *Artifacts Available* needs an archival
@@ -108,16 +114,18 @@ before claiming a badge; the column below only says which distinction is meant.
 | **Results Reproduced** | a different team obtained the result, **using** the author's artifacts |
 | **Results Replicated** | a different team obtained the result **without** the author's artifacts |
 
-Running a published checker over its own shipped vectors is *Functional*.
+Running a published checker over its own shipped vectors is aligned with
+*Artifacts Evaluated -- Functional*; this project does not award that badge.
 
-**Where the ACM frame stops short, stated rather than glossed.** ACM assumes the
-author-supplied artifact is the author's *code*, so *Replicated* means obtaining
-the result without it. A conformance corpus inverts that: the corpus IS the
-artifact, and no reproduction can avoid using it. An outside party who writes an
-implementation from the specification text alone, imports none of the author's
-code, and recomputes every expected outcome from the inputs is therefore still
-*Results Reproduced* under a strict reading, because the vectors came from the
-author. That is the class this project claims, and it is the defensible one.
+**Where the ACM frame stops short, stated rather than glossed.** ACM artifacts
+explicitly include software, scripts, input datasets and raw data. A conformance
+corpus is therefore an author-supplied artifact, not an exception to that
+definition. An outside party who writes an implementation from the specification
+text alone, imports none of the author's code, and recomputes every expected
+outcome from the inputs is still *Results Reproduced* under a strict reading,
+because the run uses the author's vectors. *Results Replicated* would require
+obtaining the result without the author's artifacts and therefore cannot describe
+a run that scores this corpus.
 
 The fact worth reporting has no ACM badge: **independent implementation,
 author-supplied vectors, expected outcomes recomputed from inputs alone.** That

--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -218,9 +218,9 @@ correlated on the profile's ambiguous regions, which is where a corpus carries i
 report may state agreement; it may not state that agreement was reached independently unless the
 authorship methods make that a claim someone can check.
 
-### Which badge a run earns, and the one it cannot
+### Which ACM classification describes a run, and the one that cannot
 
-**No badge here is conferred by anyone.** ACM badges are awarded by a venue's artifact-evaluation committee. What follows borrows ACM's *vocabulary* to describe a claim precisely; it is a self-description under a published definition, not an ACM award.
+**No badge here is conferred by anyone.** ACM badges are awarded by a venue's artifact-evaluation committee. What follows is an **ACM-aligned classification, not ACM-awarded**; it borrows ACM's *vocabulary* to describe a claim precisely.
 
 Reports here describe themselves with an [ACM Artifact Review and Badging](https://www.acm.org/publications/policies/artifact-review-and-badging-current)
 class, because the distinction between kinds of reproduction is easy to blur and
@@ -228,16 +228,16 @@ ACM already drew it. The two terms are the reverse of the common intuition:
 *Results Reproduced* means a different team obtained the result **using** the
 author's artifacts; *Results Replicated* means **without** them.
 
-A blind from-spec run against this pack earns **Results Reproduced**. The
+A blind from-spec run against this pack is aligned with **Results Reproduced**. The
 implementation is the reproducer's own and imports nothing from Assay, but the
 opaque cases, the descriptor and the specification all come from the author.
 
-**Results Replicated is not reachable against this or any conformance corpus, and
-that is a property of corpora rather than a shortfall of any reproducer.** ACM
-assumes the author-supplied artifact is the author's *code*, so obtaining the
-result without it is meaningful. A conformance corpus inverts that: the corpus is
-the artifact, and no reproduction can avoid using it. A report claiming
-*Replicated* against this pack has either misread the badge or not used the pack.
+**Results Replicated is not reachable for a run that scores this conformance
+corpus, and that is a property of the measurement rather than a shortfall of any
+reproducer.** ACM artifacts explicitly include software, scripts, input datasets
+and raw data. This corpus is therefore an author-supplied artifact. A report
+claiming *Replicated* while scoring this pack has either misread the classification
+or not used the pack.
 
 So the fact worth stating has no ACM badge, and a report should state it in full
 rather than reach for a stronger label: **an independently written implementation,

--- a/conformance/run_all.py
+++ b/conformance/run_all.py
@@ -152,6 +152,15 @@ SUITES = [
                 "No self-run by design.",
     },
     {
+        "id": "privileged-mcp-action-v1",
+        "path": "conformance/privileged-mcp-action-v1",
+        "vectors": 7,
+        "maturity": "published profile corpus; candidate-neutral runner not registered",
+        "kind": NEEDS_CANDIDATE,
+        "note": "candidate-neutral runner is not registered. The shipped Assay verifier "
+                "would exercise the author implementation, not an outside candidate.",
+    },
+    {
         "id": "mcp-jsonrpc-id-conformance",
         "path": "examples/mcp-jsonrpc-id-conformance",
         "vectors": 3,
@@ -215,6 +224,9 @@ def main() -> int:
 
     ran = [r for r in results if r["grade"] in (PROVED, FALSE, UNPROVED)]
     not_run = [r for r in results if r not in ran]
+    declared = len(results)
+    executed = len(ran)
+    complete = executed == declared
     worst = max((RANK[r["grade"]] for r in results), default=0)
 
     if args.json:
@@ -222,6 +234,7 @@ def main() -> int:
             "schema": "assay.conformance.run_all.v1",
             "suites": results,
             "ran": len(ran), "not_run": len(not_run),
+            "declared": declared, "executed": executed, "complete": complete,
             "worst_grade": [PROVED, UNPROVED, FALSE][worst],
         }, indent=2, sort_keys=True))
     else:
@@ -229,8 +242,9 @@ def main() -> int:
         for r in results:
             print("%-*s  %-15s  %s" % (width, r["id"], r["grade"], r["detail"]))
         print()
-        print("ran: %d   did NOT run: %d   worst grade: %s"
-              % (len(ran), len(not_run), [PROVED, UNPROVED, FALSE][worst]))
+        print("executed: %d/%d   complete: %s   did NOT run: %d   worst grade: %s"
+              % (executed, declared, "yes" if complete else "no", len(not_run),
+                 [PROVED, UNPROVED, FALSE][worst]))
         if not_run:
             # State this every time. A suite that did not run is not a suite that agreed.
             print("NOT RUN (declared, not a pass): %s"

--- a/conformance/tests/test_run_all.py
+++ b/conformance/tests/test_run_all.py
@@ -240,6 +240,13 @@ class EndToEnd(unittest.TestCase):
         self.assertEqual(v1["grade"], run_all.NEEDS_CANDIDATE)
         self.assertIn("candidate", v1["detail"].lower())
 
+    def test_v1_inventory_path_and_vector_count_match_its_manifest(self):
+        suite = next(s for s in run_all.SUITES if s["id"] == "privileged-mcp-action-v1")
+        manifest_path = run_all.REPO / suite["path"] / "MANIFEST.json"
+        self.assertTrue(manifest_path.is_file(), manifest_path)
+        manifest = json.loads(manifest_path.read_text())
+        self.assertEqual(suite["vectors"], sum(manifest["counts"].values()))
+
     def test_text_mode_always_names_the_suites_that_did_not_run(self):
         p = subprocess.run([sys.executable, str(run_all.__file__)],
                            capture_output=True, text=True, timeout=300)

--- a/conformance/tests/test_run_all.py
+++ b/conformance/tests/test_run_all.py
@@ -222,10 +222,45 @@ class EndToEnd(unittest.TestCase):
         self.assertEqual(len(d["suites"]), d["ran"] + d["not_run"])
         self.assertGreater(d["not_run"], 0, "non-run suites must be counted, never omitted")
 
+    def test_json_mode_marks_partial_execution_instead_of_reporting_complete(self):
+        p = subprocess.run([sys.executable, str(run_all.__file__), "--json"],
+                           capture_output=True, text=True, timeout=300)
+        self.assertIn(p.returncode, (0, 1, 2))
+        d = json.loads(p.stdout)
+        self.assertEqual(d["declared"], len(d["suites"]))
+        self.assertEqual(d["executed"], d["ran"])
+        self.assertLess(d["executed"], d["declared"])
+        self.assertIs(d["complete"], False)
+
+    def test_v1_corpus_is_inventoried_with_an_honest_non_run_state(self):
+        p = subprocess.run([sys.executable, str(run_all.__file__), "--json"],
+                           capture_output=True, text=True, timeout=300)
+        d = json.loads(p.stdout)
+        v1 = next(s for s in d["suites"] if s["id"] == "privileged-mcp-action-v1")
+        self.assertEqual(v1["grade"], run_all.NEEDS_CANDIDATE)
+        self.assertIn("candidate", v1["detail"].lower())
+
     def test_text_mode_always_names_the_suites_that_did_not_run(self):
         p = subprocess.run([sys.executable, str(run_all.__file__)],
                            capture_output=True, text=True, timeout=300)
         self.assertIn("NOT RUN (declared, not a pass)", p.stdout)
+
+
+class DocumentationTruth(unittest.TestCase):
+    def test_acm_language_is_aligned_not_awarded_and_does_not_narrow_artifacts_to_code(self):
+        documents = (
+            run_all.REPO / "conformance/INDEX.md",
+            run_all.REPO / "conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md",
+        )
+        for path in documents:
+            text = path.read_text()
+            self.assertIn("ACM-aligned", text, path)
+            self.assertIn("not ACM-awarded", text, path)
+            self.assertNotIn("ACM assumes the author-supplied artifact is the author's *code*", text,
+                             path)
+            self.assertNotIn("badge a run earns", text, path)
+        index = documents[0].read_text()
+        self.assertNotIn("shipped vectors is *Functional*", index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- expose partial conformance execution with `declared`, `executed`, and `complete`
- inventory `privileged-mcp-action-v1` with an explicit `needs_candidate` non-run state
- replace the false ACM artifact premise with ACM-aligned, non-awarded terminology
- preserve existing `ran`/`not_run`, grade, and exit-code semantics

Closes #2564.

## Contract

Default `python3 conformance/run_all.py --json` now reports:

```json
{
  "declared": 6,
  "executed": 1,
  "complete": false,
  "ran": 1,
  "not_run": 5,
  "worst_grade": "proved"
}
```

`worst_grade` still summarizes executed outcomes. `complete` independently states whether every declared suite executed, so exit `0` no longer looks like a complete run when declared non-run suites remain.

## TDD evidence

RED on `77753cf4135064a2e78d16f71e6a348015ac48da`:

- `KeyError: 'declared'`
- no `privileged-mcp-action-v1` suite row
- public docs lacked `ACM-aligned` and retained the false code-only premise

GREEN on `fabb5c39e0583bef5c8727ae68f310825127aa48`:

- `python3 conformance/tests/test_run_all.py` - 28 passed
- `python3 conformance/tests/test_corpus_adequacy_own_corpora.py` - 9 skipped as designed without a sibling tool checkout
- `python3 conformance/tests/test_published_numbers_guard.py` - 18 passed, 2 optional tool reproductions skipped
- `python3 -m py_compile conformance/run_all.py conformance/tests/test_run_all.py`
- `pre-commit run --files ...` - passed
- full pre-push hooks, workspace clippy, and Linux cross-target compile gate - passed
- `git diff --check` - clean

## Mutation evidence

Each mutation independently made `test_run_all.py` fail:

- remove the JSON `complete` field
- rename the v1 suite ID in the production inventory
- restore `badge a run earns` in the protocol

## Non-claims

- no candidate runner was added
- no conformance verdict or exit-code semantics changed
- local classifications are ACM-aligned descriptions, not ACM-awarded badges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `privileged-mcp-action-v1` conformance corpus to the published index and validation process.
  * Conformance reports now distinguish declared suites from executed suites and show whether a run is complete.

* **Documentation**
  * Clarified that privileged MCP action corpora require an external candidate and cannot run independently.
  * Updated ACM-aligned terminology and clarified the distinction between evaluating shipped artifacts, reproducing results, and replicating results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->