### PR TITLE
fix(conformance): make completeness an opt-in exit, not a silent $?

### DIFF
--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -7,7 +7,7 @@ does and does not establish.
 python3 conformance/run_all.py                     # stdlib suites only, no toolchain
 python3 conformance/run_all.py --with-cargo        # also the Rust-driven corpora
 python3 conformance/run_all.py --json              # machine-readable report
-python3 conformance/run_all.py --require-complete  # same report; exit 3 unless executed == declared
+python3 conformance/run_all.py --require-complete  # same report; exit 3 if incomplete after false/unproved
 ```
 
 Plain inventory mode — `python3 conformance/run_all.py`, with or without `--json` — is **not a completeness gate**. Exit 0 means no executed suite graded `false` or `unproved`. It does not mean every declared suite ran. Callers that require a complete inventory pass `--require-complete`.
@@ -54,16 +54,16 @@ Exit codes, with `false` taking precedence over `unproved`:
 
 | Code | Condition |
 |---|---|
-| `0` | no suite graded `false` and none graded `unproved` |
-| `1` | **at least one suite graded `false`**, regardless of any `unproved` |
-| `2` | no suite graded `false` and at least one graded `unproved` |
-| `3` | `--require-complete` was set and `complete` is false (`executed != declared`) |
+| `0` | no suite graded `false` and none graded `unproved` (plain mode ignores incompleteness) |
+| `1` | **at least one suite graded `false`**, regardless of any `unproved` or incompleteness |
+| `2` | no suite graded `false` and at least one graded `unproved` (incompleteness does not override) |
+| `3` | `--require-complete`, `complete` is false, and no suite graded `false` or `unproved` |
 
 A run with both a `false` and an `unproved` suite exits `1`: a checked disagreement is a
 stronger, more actionable result than a check that could not complete. `--require-complete`
-on an incomplete inventory exits `3` even when every executed suite graded `proved`; the
-inventory and executed outcomes are still printed. Without that flag, incompleteness does
-not change the exit.
+never hides that: incomplete+`false` is still `1`, incomplete+`unproved` is still `2`. Exit
+`3` is only incompleteness after those measured signals. The inventory and executed
+outcomes are still printed. Without the flag, incompleteness does not change the exit.
 
 ## Suites that do not run, and why that is not a pass
 

--- a/conformance/INDEX.md
+++ b/conformance/INDEX.md
@@ -4,10 +4,13 @@ One front door over every published corpus in this workspace, plus what each one
 does and does not establish.
 
 ```bash
-python3 conformance/run_all.py               # stdlib suites only, no toolchain
-python3 conformance/run_all.py --with-cargo  # also the Rust-driven corpora
-python3 conformance/run_all.py --json        # machine-readable report
+python3 conformance/run_all.py                     # stdlib suites only, no toolchain
+python3 conformance/run_all.py --with-cargo        # also the Rust-driven corpora
+python3 conformance/run_all.py --json              # machine-readable report
+python3 conformance/run_all.py --require-complete  # same report; exit 3 unless executed == declared
 ```
+
+Plain inventory mode — `python3 conformance/run_all.py`, with or without `--json` — is **not a completeness gate**. Exit 0 means no executed suite graded `false` or `unproved`. It does not mean every declared suite ran. Callers that require a complete inventory pass `--require-complete`.
 
 Standard library only. No Assay import, no pip install, no network.
 
@@ -54,9 +57,13 @@ Exit codes, with `false` taking precedence over `unproved`:
 | `0` | no suite graded `false` and none graded `unproved` |
 | `1` | **at least one suite graded `false`**, regardless of any `unproved` |
 | `2` | no suite graded `false` and at least one graded `unproved` |
+| `3` | `--require-complete` was set and `complete` is false (`executed != declared`) |
 
 A run with both a `false` and an `unproved` suite exits `1`: a checked disagreement is a
-stronger, more actionable result than a check that could not complete.
+stronger, more actionable result than a check that could not complete. `--require-complete`
+on an incomplete inventory exits `3` even when every executed suite graded `proved`; the
+inventory and executed outcomes are still printed. Without that flag, incompleteness does
+not change the exit.
 
 ## Suites that do not run, and why that is not a pass
 
@@ -79,7 +86,8 @@ implementations they grade, applied to the runner that grades them.
 
 A green run says every suite that **executed** reproduced its own pinned verdicts
 on this checkout. It does not say every declared suite ran: inspect `complete`
-and `executed/declared` in JSON, or `complete` in terminal output. It also says
+and `executed/declared` in JSON, or `complete` in terminal output. `worst_executed_grade`
+is the worst grade among suites that ran; it is not a completeness signal. It also says
 nothing about:
 
 - **independence** — everything here was authored in this workspace. Agreement

--- a/conformance/run_all.py
+++ b/conformance/run_all.py
@@ -56,6 +56,10 @@ PROVED, FALSE, UNPROVED = "proved", "false", "unproved"
 NEEDS_CANDIDATE, NOT_SELECTED, EXTERNAL = "needs_candidate", "not_selected", "external"
 
 RANK = {PROVED: 0, NEEDS_CANDIDATE: 0, NOT_SELECTED: 0, EXTERNAL: 0, UNPROVED: 1, FALSE: 2}
+EXECUTED_GRADES = (PROVED, FALSE, UNPROVED)
+# Distinct from grade exits 0/1/2. Plain mode never uses this.
+REQUIRE_COMPLETE_EXIT = 3
+_WORST_EXECUTED = (PROVED, UNPROVED, FALSE)
 
 
 def _stdlib_jsonrpc(suite: dict) -> tuple[str, str]:
@@ -203,11 +207,47 @@ SUITES = [
 ]
 
 
+def summarize(results: list) -> dict:
+    """Inventory counts plus the worst *executed* grade. complete is executed == declared."""
+    ran = [r for r in results if r["grade"] in EXECUTED_GRADES]
+    not_run = [r for r in results if r not in ran]
+    declared = len(results)
+    executed = len(ran)
+    if ran:
+        worst_executed_grade = _WORST_EXECUTED[max(RANK[r["grade"]] for r in ran)]
+    else:
+        worst_executed_grade = None
+    # worst_grade stays the executed-or-empty default used before this flag existed.
+    worst_grade = _WORST_EXECUTED[max((RANK[r["grade"]] for r in results), default=0)]
+    return {
+        "ran": ran,
+        "not_run": not_run,
+        "declared": declared,
+        "executed": executed,
+        "complete": executed == declared,
+        "worst_grade": worst_grade,
+        "worst_executed_grade": worst_executed_grade,
+    }
+
+
+def exit_status(results: list, require_complete: bool = False) -> int:
+    """Grade exits 0/1/2. --require-complete adds one extra nonzero when incomplete."""
+    if require_complete and not summarize(results)["complete"]:
+        return REQUIRE_COMPLETE_EXIT
+    if any(r["grade"] == FALSE for r in results):
+        return 1
+    if any(r["grade"] == UNPROVED for r in results):
+        return 2
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--with-cargo", action="store_true",
                     help="also run the Rust-driven corpora (needs a toolchain)")
     ap.add_argument("--json", action="store_true", help="emit a machine-readable report")
+    ap.add_argument("--require-complete", action="store_true",
+                    help="exit 3 unless every declared suite executed")
     args = ap.parse_args()
 
     results = []
@@ -222,39 +262,36 @@ def main() -> int:
         results.append({"id": suite["id"], "grade": grade, "detail": detail,
                         "vectors": suite["vectors"], "maturity": suite["maturity"]})
 
-    ran = [r for r in results if r["grade"] in (PROVED, FALSE, UNPROVED)]
-    not_run = [r for r in results if r not in ran]
-    declared = len(results)
-    executed = len(ran)
-    complete = executed == declared
-    worst = max((RANK[r["grade"]] for r in results), default=0)
+    summary = summarize(results)
+    ran = summary["ran"]
+    not_run = summary["not_run"]
 
     if args.json:
         print(json.dumps({
             "schema": "assay.conformance.run_all.v1",
             "suites": results,
             "ran": len(ran), "not_run": len(not_run),
-            "declared": declared, "executed": executed, "complete": complete,
-            "worst_grade": [PROVED, UNPROVED, FALSE][worst],
+            "declared": summary["declared"], "executed": summary["executed"],
+            "complete": summary["complete"],
+            "worst_grade": summary["worst_grade"],
+            "worst_executed_grade": summary["worst_executed_grade"],
+            "require_complete": args.require_complete,
         }, indent=2, sort_keys=True))
     else:
         width = max(len(r["id"]) for r in results)
         for r in results:
             print("%-*s  %-15s  %s" % (width, r["id"], r["grade"], r["detail"]))
         print()
-        print("executed: %d/%d   complete: %s   did NOT run: %d   worst grade: %s"
-              % (executed, declared, "yes" if complete else "no", len(not_run),
-                 [PROVED, UNPROVED, FALSE][worst]))
+        print("executed: %d/%d   complete: %s   did NOT run: %d   worst executed grade: %s"
+              % (summary["executed"], summary["declared"],
+                 "yes" if summary["complete"] else "no", len(not_run),
+                 summary["worst_executed_grade"] or "none"))
         if not_run:
             # State this every time. A suite that did not run is not a suite that agreed.
             print("NOT RUN (declared, not a pass): %s"
                   % ", ".join("%s=%s" % (r["id"], r["grade"]) for r in not_run))
 
-    if any(r["grade"] == FALSE for r in results):
-        return 1
-    if any(r["grade"] == UNPROVED for r in results):
-        return 2
-    return 0
+    return exit_status(results, require_complete=args.require_complete)
 
 
 if __name__ == "__main__":

--- a/conformance/run_all.py
+++ b/conformance/run_all.py
@@ -231,13 +231,13 @@ def summarize(results: list) -> dict:
 
 
 def exit_status(results: list, require_complete: bool = False) -> int:
-    """Grade exits 0/1/2. --require-complete adds one extra nonzero when incomplete."""
-    if require_complete and not summarize(results)["complete"]:
-        return REQUIRE_COMPLETE_EXIT
+    """FALSE, then UNPROVED, then incompleteness if --require-complete."""
     if any(r["grade"] == FALSE for r in results):
         return 1
     if any(r["grade"] == UNPROVED for r in results):
         return 2
+    if require_complete and not summarize(results)["complete"]:
+        return REQUIRE_COMPLETE_EXIT
     return 0
 
 
@@ -247,7 +247,7 @@ def main() -> int:
                     help="also run the Rust-driven corpora (needs a toolchain)")
     ap.add_argument("--json", action="store_true", help="emit a machine-readable report")
     ap.add_argument("--require-complete", action="store_true",
-                    help="exit 3 unless every declared suite executed")
+                    help="exit 3 when incomplete, after any false (1) or unproved (2)")
     args = ap.parse_args()
 
     results = []

--- a/conformance/tests/test_run_all.py
+++ b/conformance/tests/test_run_all.py
@@ -253,7 +253,137 @@ class EndToEnd(unittest.TestCase):
         self.assertIn("NOT RUN (declared, not a pass)", p.stdout)
 
 
+class CompletenessPolicy(unittest.TestCase):
+    """complete is executed == declared. The executed grade is a different fact."""
+
+    def test_zero_of_n_is_incomplete_and_has_no_executed_grade(self):
+        results = [
+            {"id": "a", "grade": run_all.NEEDS_CANDIDATE},
+            {"id": "b", "grade": run_all.EXTERNAL},
+        ]
+        s = run_all.summarize(results)
+        self.assertEqual(s["declared"], 2)
+        self.assertEqual(s["executed"], 0)
+        self.assertIs(s["complete"], False)
+        self.assertIs(s["worst_executed_grade"], None)
+        self.assertEqual([r["grade"] for r in s["not_run"]],
+                         [run_all.NEEDS_CANDIDATE, run_all.EXTERNAL])
+        self.assertEqual(s["ran"], [])
+        self.assertEqual(run_all.exit_status(results, require_complete=False), 0)
+
+    def test_one_of_n_is_incomplete_even_when_executed_grade_is_proved(self):
+        results = [
+            {"id": "ran", "grade": run_all.PROVED},
+            {"id": "skip", "grade": run_all.NOT_SELECTED},
+            {"id": "need", "grade": run_all.NEEDS_CANDIDATE},
+        ]
+        s = run_all.summarize(results)
+        self.assertEqual(s["declared"], 3)
+        self.assertEqual(s["executed"], 1)
+        self.assertIs(s["complete"], False)
+        self.assertEqual(s["worst_executed_grade"], run_all.PROVED)
+        self.assertEqual([r["id"] for r in s["not_run"]], ["skip", "need"])
+        self.assertEqual(run_all.exit_status(results, require_complete=False), 0)
+
+    def test_require_complete_exit_uses_complete_not_the_executed_grade(self):
+        # Mutation bite: deleting the completeness exit check. Uses NOT_SELECTED
+        # so a "count needs_candidate as executed" mutant cannot satisfy this.
+        results = [
+            {"id": "ran", "grade": run_all.PROVED},
+            {"id": "skip", "grade": run_all.NOT_SELECTED},
+        ]
+        self.assertIs(run_all.summarize(results)["complete"], False)
+        self.assertEqual(run_all.summarize(results)["worst_executed_grade"], run_all.PROVED)
+        self.assertEqual(run_all.exit_status(results, require_complete=False), 0)
+        self.assertEqual(run_all.exit_status(results, require_complete=True),
+                         run_all.REQUIRE_COMPLETE_EXIT)
+
+    def test_n_of_n_is_complete_and_require_complete_keeps_grade_exit(self):
+        proved = [
+            {"id": "a", "grade": run_all.PROVED},
+            {"id": "b", "grade": run_all.PROVED},
+        ]
+        s = run_all.summarize(proved)
+        self.assertEqual(s["executed"], s["declared"])
+        self.assertIs(s["complete"], True)
+        self.assertEqual(s["worst_executed_grade"], run_all.PROVED)
+        self.assertEqual(s["not_run"], [])
+        self.assertEqual(run_all.exit_status(proved, require_complete=True), 0)
+
+        mixed = [
+            {"id": "a", "grade": run_all.PROVED},
+            {"id": "b", "grade": run_all.FALSE},
+        ]
+        self.assertIs(run_all.summarize(mixed)["complete"], True)
+        self.assertEqual(run_all.summarize(mixed)["worst_executed_grade"], run_all.FALSE)
+        self.assertEqual(run_all.exit_status(mixed, require_complete=True), 1)
+
+    def test_not_run_states_are_not_counted_as_executed(self):
+        # Mutation bite: treating a not-run suite as executed makes 1/N look complete.
+        results = [
+            {"id": "ran", "grade": run_all.PROVED},
+            {"id": "need", "grade": run_all.NEEDS_CANDIDATE},
+        ]
+        s = run_all.summarize(results)
+        self.assertEqual(s["executed"], 1)
+        self.assertEqual(s["declared"], 2)
+        self.assertIs(s["complete"], False)
+        self.assertEqual(s["not_run"][0]["grade"], run_all.NEEDS_CANDIDATE)
+
+
+class RequireCompleteFlag(unittest.TestCase):
+    def test_plain_json_mode_is_not_a_completeness_gate(self):
+        p = subprocess.run([sys.executable, str(run_all.__file__), "--json"],
+                           capture_output=True, text=True, timeout=300)
+        d = json.loads(p.stdout)
+        self.assertIs(d["complete"], False)
+        self.assertLess(d["executed"], d["declared"])
+        self.assertIn(d["worst_executed_grade"], (run_all.PROVED, run_all.UNPROVED, run_all.FALSE))
+        self.assertIs(d["require_complete"], False)
+        if d["worst_executed_grade"] == run_all.PROVED:
+            self.assertEqual(p.returncode, 0)
+
+    def test_require_complete_exits_nonzero_on_incomplete_without_hiding_results(self):
+        # Mutation bite: deleting the completeness exit check.
+        p = subprocess.run(
+            [sys.executable, str(run_all.__file__), "--json", "--require-complete"],
+            capture_output=True, text=True, timeout=300)
+        self.assertEqual(p.returncode, run_all.REQUIRE_COMPLETE_EXIT)
+        d = json.loads(p.stdout)
+        self.assertIs(d["complete"], False)
+        self.assertEqual(d["declared"], len(d["suites"]))
+        self.assertGreater(d["not_run"], 0)
+        self.assertTrue(any(
+            s["grade"] in (run_all.NEEDS_CANDIDATE, run_all.NOT_SELECTED, run_all.EXTERNAL)
+            for s in d["suites"]))
+
+    def test_require_complete_is_applied_not_merely_parsed(self):
+        # Mutation bite: --require-complete accepted by argparse but unused.
+        p = subprocess.run(
+            [sys.executable, str(run_all.__file__), "--json", "--require-complete"],
+            capture_output=True, text=True, timeout=300)
+        d = json.loads(p.stdout)
+        self.assertIs(d["require_complete"], True)
+        plain = subprocess.run(
+            [sys.executable, str(run_all.__file__), "--json"],
+            capture_output=True, text=True, timeout=300)
+        self.assertIs(json.loads(plain.stdout)["require_complete"], False)
+
+    def test_plain_text_mode_still_prints_inventory_under_require_complete(self):
+        p = subprocess.run(
+            [sys.executable, str(run_all.__file__), "--require-complete"],
+            capture_output=True, text=True, timeout=300)
+        self.assertEqual(p.returncode, run_all.REQUIRE_COMPLETE_EXIT)
+        self.assertIn("NOT RUN (declared, not a pass)", p.stdout)
+        self.assertIn("complete: no", p.stdout)
+
+
 class DocumentationTruth(unittest.TestCase):
+    def test_index_says_plain_mode_is_not_a_completeness_gate(self):
+        index = (run_all.REPO / "conformance/INDEX.md").read_text()
+        self.assertIn("not a completeness gate", index)
+        self.assertIn("--require-complete", index)
+
     def test_acm_language_is_aligned_not_awarded_and_does_not_narrow_artifacts_to_code(self):
         documents = (
             run_all.REPO / "conformance/INDEX.md",

--- a/conformance/tests/test_run_all.py
+++ b/conformance/tests/test_run_all.py
@@ -295,8 +295,22 @@ class CompletenessPolicy(unittest.TestCase):
         self.assertIs(run_all.summarize(results)["complete"], False)
         self.assertEqual(run_all.summarize(results)["worst_executed_grade"], run_all.PROVED)
         self.assertEqual(run_all.exit_status(results, require_complete=False), 0)
-        self.assertEqual(run_all.exit_status(results, require_complete=True),
-                         run_all.REQUIRE_COMPLETE_EXIT)
+        self.assertEqual(run_all.exit_status(results, require_complete=True), 3)
+        self.assertEqual(run_all.REQUIRE_COMPLETE_EXIT, 3)
+
+    def test_mixed_false_unproved_incomplete_exits_false_first(self):
+        # FALSE + UNPROVED + a not-run suite: measured disagreement wins, not 2 or 3.
+        results = [
+            {"id": "bad", "grade": run_all.FALSE},
+            {"id": "stuck", "grade": run_all.UNPROVED},
+            {"id": "skip", "grade": run_all.NOT_SELECTED},
+        ]
+        self.assertIs(run_all.summarize(results)["complete"], False)
+        self.assertEqual(run_all.summarize(results)["worst_executed_grade"], run_all.FALSE)
+        code = run_all.exit_status(results, require_complete=True)
+        self.assertEqual(code, 1)
+        self.assertNotEqual(code, 2)
+        self.assertNotEqual(code, 3)
 
     def test_require_complete_does_not_mask_incomplete_false(self):
         results = [
@@ -366,7 +380,7 @@ class RequireCompleteFlag(unittest.TestCase):
         p = subprocess.run(
             [sys.executable, str(run_all.__file__), "--json", "--require-complete"],
             capture_output=True, text=True, timeout=300)
-        self.assertEqual(p.returncode, run_all.REQUIRE_COMPLETE_EXIT)
+        self.assertEqual(p.returncode, 3)
         d = json.loads(p.stdout)
         self.assertIs(d["complete"], False)
         self.assertEqual(d["declared"], len(d["suites"]))
@@ -374,6 +388,13 @@ class RequireCompleteFlag(unittest.TestCase):
         self.assertTrue(any(
             s["grade"] in (run_all.NEEDS_CANDIDATE, run_all.NOT_SELECTED, run_all.EXTERNAL)
             for s in d["suites"]))
+
+    def test_json_keeps_v1_worst_grade_key(self):
+        p = subprocess.run([sys.executable, str(run_all.__file__), "--json"],
+                           capture_output=True, text=True, timeout=300)
+        d = json.loads(p.stdout)
+        self.assertIn("worst_grade", d)
+        self.assertIn(d["worst_grade"], (run_all.PROVED, run_all.UNPROVED, run_all.FALSE))
 
     def test_json_reports_whether_require_complete_was_requested(self):
         # JSON echo of the flag, not proof the exit rule ran.
@@ -391,7 +412,7 @@ class RequireCompleteFlag(unittest.TestCase):
         p = subprocess.run(
             [sys.executable, str(run_all.__file__), "--require-complete"],
             capture_output=True, text=True, timeout=300)
-        self.assertEqual(p.returncode, run_all.REQUIRE_COMPLETE_EXIT)
+        self.assertEqual(p.returncode, 3)
         self.assertIn("NOT RUN (declared, not a pass)", p.stdout)
         self.assertIn("complete: no", p.stdout)
 

--- a/conformance/tests/test_run_all.py
+++ b/conformance/tests/test_run_all.py
@@ -298,6 +298,24 @@ class CompletenessPolicy(unittest.TestCase):
         self.assertEqual(run_all.exit_status(results, require_complete=True),
                          run_all.REQUIRE_COMPLETE_EXIT)
 
+    def test_require_complete_does_not_mask_incomplete_false(self):
+        results = [
+            {"id": "ran", "grade": run_all.FALSE},
+            {"id": "skip", "grade": run_all.NOT_SELECTED},
+        ]
+        self.assertIs(run_all.summarize(results)["complete"], False)
+        self.assertEqual(run_all.summarize(results)["worst_executed_grade"], run_all.FALSE)
+        self.assertEqual(run_all.exit_status(results, require_complete=True), 1)
+
+    def test_require_complete_does_not_mask_incomplete_unproved(self):
+        results = [
+            {"id": "ran", "grade": run_all.UNPROVED},
+            {"id": "skip", "grade": run_all.NOT_SELECTED},
+        ]
+        self.assertIs(run_all.summarize(results)["complete"], False)
+        self.assertEqual(run_all.summarize(results)["worst_executed_grade"], run_all.UNPROVED)
+        self.assertEqual(run_all.exit_status(results, require_complete=True), 2)
+
     def test_n_of_n_is_complete_and_require_complete_keeps_grade_exit(self):
         proved = [
             {"id": "a", "grade": run_all.PROVED},
@@ -357,8 +375,8 @@ class RequireCompleteFlag(unittest.TestCase):
             s["grade"] in (run_all.NEEDS_CANDIDATE, run_all.NOT_SELECTED, run_all.EXTERNAL)
             for s in d["suites"]))
 
-    def test_require_complete_is_applied_not_merely_parsed(self):
-        # Mutation bite: --require-complete accepted by argparse but unused.
+    def test_json_reports_whether_require_complete_was_requested(self):
+        # JSON echo of the flag, not proof the exit rule ran.
         p = subprocess.run(
             [sys.executable, str(run_all.__file__), "--json", "--require-complete"],
             capture_output=True, text=True, timeout=300)


### PR DESCRIPTION
## Summary

- Add `--require-complete` so incompleteness is an explicit exit (`3`), not a silent `$?` of `0`.
- Report `worst_executed_grade` separately from `complete`. `complete` remains `executed == declared`.
- Keep plain inventory mode as report-only: typed not-run states stay visible; default exits stay `0/1/2`.

Closes #2566.

## Contract

One flag, one rule: require `complete` or do not.

| Mode | `complete=false` (default 1/6 inventory) | Partial results |
|---|---|---|
| plain / `--json` | exit `0` if no executed `false`/`unproved` | printed |
| `--require-complete` | exit `3` only when no executed suite is `false`/`unproved` | still printed |

JSON keeps `ran` / `not_run` / `complete` / `worst_grade` and adds `worst_executed_grade` plus `require_complete`. A proved executed suite does not imply a complete inventory.

## Review

- **Ruley is reserved as the independent exact-final-head reviewer.** This writer is the builder.
- The builder's self-review does not count toward quorum.
- This PR does **not** claim READY, does not claim quorum, and does not enable auto-merge.

## Verification

Measured in worktree `/Users/roelschuurkes/wt-2566-run-all-completeness` on final-head candidate SHA `8ae7f7dfb2744b2c510488fdc90299b8367e2b10` (prior `81deeff5` and `ab2a55b2` are stale).

```bash
python3 conformance/tests/test_run_all.py CompletenessPolicy RequireCompleteFlag
python3 conformance/tests/test_run_all.py
python3 -m py_compile conformance/run_all.py conformance/tests/test_run_all.py
git diff --check
```

- focused new tests: 14 passed
- full `test_run_all.py`: 43 passed
- `py_compile`: ok
- `git diff --check`: clean

RED (tests added first, against `5f7f94daa2be34adde64bc32495def16d5460ea7` production):

- `CompletenessPolicy`: `AttributeError: module 'run_all' has no attribute 'summarize'`
- `RequireCompleteFlag`: missing `worst_executed_grade`; `--require-complete` unrecognized (empty stdout); no `REQUIRE_COMPLETE_EXIT`
- `DocumentationTruth.test_index_says_plain_mode_is_not_a_completeness_gate`: `'not a completeness gate' not found`

## Precedence repair

On the current head, measured outcomes retain priority: `false` → `1`, otherwise `unproved` → `2`, otherwise incomplete with `--require-complete` → `3`, otherwise `0`. RED on the prior head: incomplete+false returned `3 != 1`; incomplete+unproved returned `3 != 2`. Both regression tests pass on `8ae7f7df`.

## Mutation results

Each mutation restored after the run. Each had a unique failing test:

1. Reverse measured precedence so incomplete `FALSE + UNPROVED` returns `2` or `3` → `test_mixed_false_unproved_incomplete_exits_false_first`
2. Change public `REQUIRE_COMPLETE_EXIT` from `3` to `4` → literal unit and E2E assertions fail
3. Delete retained v1 JSON key `worst_grade` → `test_json_keeps_v1_worst_grade_key`

## Non-claims

- Plain inventory mode is not a completeness gate.
- This is not a general policy engine.
- GitHub Actions / required CI is not claimed; only the local commands above were run.
- Default `0/1/2` grade exits are unchanged when the flag is off.
- No candidate runner was added; not-run states stay typed.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--require-complete` option to fail runs when any declared test suite does not execute.
  - Reports now show completeness, executed suite counts, and the worst grade among executed suites.
  - JSON and text output distinguish executed suites from suites that were not run.
  - Exit statuses now clearly prioritize incomplete-run and test-result conditions.

- **Documentation**
  - Documented the new option, exit-code behavior, completeness rules, and grade reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


