### PR TITLE
fix(conformance): fail closed on unavailable measurement provenance

### DIFF
--- a/.github/workflows/adequacy-drift.yml
+++ b/.github/workflows/adequacy-drift.yml
@@ -112,7 +112,9 @@ jobs:
       # derivation that has silently stopped refusing would gate this lane open.
       - name: Self-test the lane helpers
         # sys.path[0] is the script's own directory, so the two helpers import from repo root too.
-        run: python3 scripts/ci/test_adequacy_lane.py
+        run: |
+          python3 scripts/ci/test_adequacy_lane.py
+          python3 conformance/tests/test_published_numbers_provenance.py
 
       - name: Derive relevance
         id: plan
@@ -332,6 +334,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,15 @@ jobs:
           python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py
           python3 conformance/run_all.py --require-complete --completion-scope required
 
+      # Stdlib-only. Required CI cannot go green if these tests are deleted;
+      # adequacy-drift is not a required context. No if:/continue-on-error.
+      # After setup-python so this uses the pinned 3.12, not the runner default.
+      - name: Published-numbers provenance contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 conformance/tests/test_published_numbers_provenance.py
+
       - name: Evidence vocabulary guard
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           python3 conformance/run_all.py --require-complete --completion-scope required
 
       # Stdlib-only. Required CI cannot go green if these tests are deleted;
-      # adequacy-drift is not a required context. No if:/continue-on-error.
+      # adequacy-drift is not a required context. No conditional or soft-failure settings.
       # After setup-python so this uses the pinned 3.12, not the runner default.
       - name: Published-numbers provenance contract
         shell: bash

--- a/conformance/adequacy/check_published_numbers.py
+++ b/conformance/adequacy/check_published_numbers.py
@@ -76,6 +76,9 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
+# Object database for freshness. File reads use REPO; a sandbox may point
+# those at a copy, but git must still see the real commits.
+GIT_REPO = REPO
 ADEQUACY = REPO / "conformance/adequacy"
 RESULTS = ADEQUACY / "results.json"
 
@@ -114,6 +117,52 @@ _WORD_RE = re.compile(r"\b(%s)\b" % "|".join(sorted(_WORDS, key=len, reverse=Tru
 # An expression is arithmetic over the measured row. Anything else is refused
 # rather than evaluated: this file runs in CI over repository content.
 _EXPR_OK = re.compile(r"^[A-Za-z0-9_+\-*/(). ,]+$")
+
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+MALFORMED = "malformed"
+UNREACHABLE = "unreachable"
+DIRTY = "dirty"
+CLEAN = "clean"
+_GIT_TIMEOUT = 30
+
+
+def classify_measured_commit(commit, depends_on, repo: Path) -> tuple[str, list[str]]:
+    """Classify one recorded measurement commit. Unresolved is never clean.
+
+    Only a lowercase 40-hex string is offered to git. Everything else is
+    malformed, including names git would resolve (HEAD, origin/main) and
+    strings that look like flags (-n).
+    """
+    if not isinstance(commit, str) or not COMMIT_RE.fullmatch(commit):
+        return MALFORMED, []
+    repo_s = str(repo)
+    try:
+        probe = subprocess.run(
+            ["git", "-C", repo_s, "cat-file", "-e", commit + "^{commit}"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return UNREACHABLE, []
+    if probe.returncode != 0:
+        return UNREACHABLE, []
+    paths = [p for p in (depends_on or []) if isinstance(p, str)]
+    try:
+        moved = subprocess.run(
+            ["git", "-C", repo_s, "diff", "--name-only", commit, "HEAD", "--", *paths],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return UNREACHABLE, []
+    if moved.returncode != 0:
+        return UNREACHABLE, []
+    changed = [ln for ln in moved.stdout.splitlines() if ln.strip()]
+    if changed:
+        return DIRTY, changed
+    return CLEAN, []
 
 
 def normalise(text: str) -> str:
@@ -251,18 +300,24 @@ def check() -> list[str]:
             findings.append("%s records no measured_at commit, so nothing can say whether its "
                             "number is still current for this code" % name)
             continue
-        moved = subprocess.run(
-            ["git", "-C", str(REPO), "diff", "--name-only", taken["commit"], "HEAD", "--",
-             *taken.get("depends_on", [])],
-            capture_output=True, text=True)
-        if moved.returncode != 0:
-            continue          # shallow clone or unknown commit: not a claim either way
-        changed = [ln for ln in moved.stdout.splitlines() if ln.strip()]
-        if changed:
+        kind, extra = classify_measured_commit(
+            taken["commit"], taken.get("depends_on", []), GIT_REPO)
+        if kind == MALFORMED:
+            findings.append(
+                "%s records a malformed measured_at.commit; a freshness claim "
+                "cannot be made from %r" % (name, taken["commit"]))
+        elif kind == UNREACHABLE:
+            shown = taken["commit"]
+            if isinstance(shown, str) and COMMIT_RE.fullmatch(shown):
+                shown = shown[:9]
+            findings.append(
+                "%s was measured at %s which cannot be resolved in this checkout, "
+                "so freshness is unavailable rather than clean" % (name, shown))
+        elif kind == DIRTY:
             findings.append(
                 "%s was measured at %s and %s changed since, so the published number describes "
                 "code this revision no longer has. Re-run measure_all.py --only %s"
-                % (name, taken["commit"][:9], ", ".join(sorted(changed)[:3]), name))
+                % (name, taken["commit"][:9], ", ".join(sorted(extra)[:3]), name))
 
     # ---- 2. tool pin ------------------------------------------------------
     for name, path in sorted(on_disk.items()):

--- a/conformance/adequacy/check_published_numbers.py
+++ b/conformance/adequacy/check_published_numbers.py
@@ -130,15 +130,17 @@ def is_canonical_dependency(path) -> bool:
     """True iff path is a canonical non-empty repository-relative path.
 
     Rejects git pathspec magic (a leading colon), absolute paths, ``..``,
-    empty segments, and backslashes. This is intentionally lexical: resolving
-    through the working tree would let a symlink answer a different question
-    than the literal path later passed to Git.
+    empty segments, control characters, and backslashes. This is intentionally
+    lexical: resolving through the working tree would let a symlink answer a
+    different question than the literal path later passed to Git.
     """
     if not isinstance(path, str) or path == "":
         return False
     if path.startswith(":"):
         return False
     if "\\" in path:
+        return False
+    if any(ord(char) < 32 or ord(char) == 127 for char in path):
         return False
     if path.startswith("/") or Path(path).is_absolute():
         return False

--- a/conformance/adequacy/check_published_numbers.py
+++ b/conformance/adequacy/check_published_numbers.py
@@ -126,12 +126,13 @@ CLEAN = "clean"
 _GIT_TIMEOUT = 30
 
 
-def is_canonical_dependency(path, repo: Path) -> bool:
+def is_canonical_dependency(path) -> bool:
     """True iff path is a canonical non-empty repository-relative path.
 
     Rejects git pathspec magic (a leading colon), absolute paths, ``..``,
-    empty segments, and anything that resolves outside the repo root.
-    A malformed dependency is a typed finding, never filtered away.
+    empty segments, and backslashes. This is intentionally lexical: resolving
+    through the working tree would let a symlink answer a different question
+    than the literal path later passed to Git.
     """
     if not isinstance(path, str) or path == "":
         return False
@@ -144,13 +145,45 @@ def is_canonical_dependency(path, repo: Path) -> bool:
     parts = path.split("/")
     if any(part == "" or part == "." or part == ".." for part in parts):
         return False
-    try:
-        root = repo.resolve()
-        resolved = (root / path).resolve()
-        resolved.relative_to(root)
-    except (ValueError, OSError):
-        return False
     return True
+
+
+def git_tree_entry_kind(repo: Path, revision: str, path: str) -> str | None:
+    """Classify one literal path in one Git tree without materializing it.
+
+    ``None`` means the tree could not be inspected. ``absent`` is distinct from
+    an inspection failure so a regular add/delete can be accepted while a name
+    absent at both endpoints cannot become a false-clean empty diff.
+    """
+    try:
+        entry = subprocess.run(
+            ["git", "-C", str(repo), "--literal-pathspecs", "ls-tree", "-z",
+             revision, "--", path],
+            capture_output=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if entry.returncode != 0:
+        return None
+    records = [record for record in entry.stdout.split(b"\0") if record]
+    if not records:
+        return "absent"
+    if len(records) != 1:
+        return "nonregular"
+    meta, separator, raw_name = records[0].partition(b"\t")
+    if not separator:
+        return "nonregular"
+    try:
+        mode, object_type, _object_id = meta.decode("ascii").split()
+        name = raw_name.decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        return "nonregular"
+    if name != path:
+        return "nonregular"
+    if object_type == "blob" and mode in ("100644", "100755"):
+        return "regular"
+    return "nonregular"
 
 
 def classify_measured_commit(commit, depends_on, repo: Path) -> tuple[str, list[str]]:
@@ -168,10 +201,10 @@ def classify_measured_commit(commit, depends_on, repo: Path) -> tuple[str, list[
     elif isinstance(depends_on, (list, tuple)):
         paths_in = list(depends_on)
     else:
-        return MALFORMED, []
+        return MALFORMED, [depends_on]
     paths = []
     for raw in paths_in:
-        if not is_canonical_dependency(raw, repo):
+        if not is_canonical_dependency(raw):
             return MALFORMED, [raw] if isinstance(raw, str) else []
         paths.append(raw)
     repo_s = str(repo)
@@ -186,6 +219,15 @@ def classify_measured_commit(commit, depends_on, repo: Path) -> tuple[str, list[
         return UNREACHABLE, []
     if probe.returncode != 0:
         return UNREACHABLE, []
+    for path in paths:
+        measured_kind = git_tree_entry_kind(repo, commit, path)
+        head_kind = git_tree_entry_kind(repo, "HEAD", path)
+        if measured_kind is None or head_kind is None:
+            return UNREACHABLE, []
+        if "nonregular" in (measured_kind, head_kind):
+            return MALFORMED, [path]
+        if measured_kind == "absent" and head_kind == "absent":
+            return MALFORMED, [path]
     try:
         moved = subprocess.run(
             ["git", "-C", repo_s, "--literal-pathspecs",

--- a/conformance/adequacy/check_published_numbers.py
+++ b/conformance/adequacy/check_published_numbers.py
@@ -126,15 +126,54 @@ CLEAN = "clean"
 _GIT_TIMEOUT = 30
 
 
+def is_canonical_dependency(path, repo: Path) -> bool:
+    """True iff path is a canonical non-empty repository-relative path.
+
+    Rejects git pathspec magic (a leading colon), absolute paths, ``..``,
+    empty segments, and anything that resolves outside the repo root.
+    A malformed dependency is a typed finding, never filtered away.
+    """
+    if not isinstance(path, str) or path == "":
+        return False
+    if path.startswith(":"):
+        return False
+    if "\\" in path:
+        return False
+    if path.startswith("/") or Path(path).is_absolute():
+        return False
+    parts = path.split("/")
+    if any(part == "" or part == "." or part == ".." for part in parts):
+        return False
+    try:
+        root = repo.resolve()
+        resolved = (root / path).resolve()
+        resolved.relative_to(root)
+    except (ValueError, OSError):
+        return False
+    return True
+
+
 def classify_measured_commit(commit, depends_on, repo: Path) -> tuple[str, list[str]]:
     """Classify one recorded measurement commit. Unresolved is never clean.
 
     Only a lowercase 40-hex string is offered to git. Everything else is
     malformed, including names git would resolve (HEAD, origin/main) and
-    strings that look like flags (-n).
+    strings that look like flags (-n). Each depends_on entry must be a
+    canonical repository-relative path; pathspec magic is malformed.
     """
     if not isinstance(commit, str) or not COMMIT_RE.fullmatch(commit):
         return MALFORMED, []
+    if depends_on is None:
+        paths_in = []
+    elif isinstance(depends_on, (list, tuple)):
+        paths_in = list(depends_on)
+    else:
+        return MALFORMED, []
+    paths = []
+    for raw in paths_in:
+        if not is_canonical_dependency(raw, repo):
+            return MALFORMED, [raw] if isinstance(raw, str) else []
+        paths.append(raw)
     repo_s = str(repo)
     try:
         probe = subprocess.run(
@@ -147,10 +186,10 @@ def classify_measured_commit(commit, depends_on, repo: Path) -> tuple[str, list[
         return UNREACHABLE, []
     if probe.returncode != 0:
         return UNREACHABLE, []
-    paths = [p for p in (depends_on or []) if isinstance(p, str)]
     try:
         moved = subprocess.run(
-            ["git", "-C", repo_s, "diff", "--name-only", commit, "HEAD", "--", *paths],
+            ["git", "-C", repo_s, "--literal-pathspecs",
+             "diff", "--name-only", commit, "HEAD", "--", *paths],
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
@@ -303,9 +342,14 @@ def check() -> list[str]:
         kind, extra = classify_measured_commit(
             taken["commit"], taken.get("depends_on", []), GIT_REPO)
         if kind == MALFORMED:
-            findings.append(
-                "%s records a malformed measured_at.commit; a freshness claim "
-                "cannot be made from %r" % (name, taken["commit"]))
+            if extra:
+                findings.append(
+                    "%s records a malformed depends_on path; a freshness claim "
+                    "cannot be made from %r" % (name, extra[0]))
+            else:
+                findings.append(
+                    "%s records a malformed measured_at.commit; a freshness claim "
+                    "cannot be made from %r" % (name, taken["commit"]))
         elif kind == UNREACHABLE:
             shown = taken["commit"]
             if isinstance(shown, str) and COMMIT_RE.fullmatch(shown):

--- a/conformance/tests/test_published_numbers_guard.py
+++ b/conformance/tests/test_published_numbers_guard.py
@@ -56,7 +56,7 @@ def sandbox():
         for manifest in (REPO / "conformance/adequacy").glob("*.manifest.json"):
             shutil.copy2(manifest, adequacy / manifest.name)
 
-        saved = (chk.REPO, chk.ADEQUACY, chk.RESULTS, chk.DOCUMENTS)
+        saved = (chk.REPO, chk.ADEQUACY, chk.RESULTS, chk.DOCUMENTS, chk.GIT_REPO)
         chk.REPO = root
         chk.ADEQUACY = adequacy
         chk.RESULTS = adequacy / "results.json"
@@ -65,7 +65,7 @@ def sandbox():
         try:
             yield root
         finally:
-            chk.REPO, chk.ADEQUACY, chk.RESULTS, chk.DOCUMENTS = saved
+            chk.REPO, chk.ADEQUACY, chk.RESULTS, chk.DOCUMENTS, chk.GIT_REPO = saved
 
 
 def edit(path: Path, old: str, new: str) -> None:

--- a/conformance/tests/test_published_numbers_provenance.py
+++ b/conformance/tests/test_published_numbers_provenance.py
@@ -152,6 +152,7 @@ class ClassifyMeasuredCommit(unittest.TestCase):
         "",
         "tracked.txt/",
         ":tracked.txt",
+        "bad\0path",
     )
 
     def test_hostile_depends_on_is_malformed_not_clean(self):

--- a/conformance/tests/test_published_numbers_provenance.py
+++ b/conformance/tests/test_published_numbers_provenance.py
@@ -141,6 +141,66 @@ class ClassifyMeasuredCommit(unittest.TestCase):
             self.assertEqual(kind, chk.CLEAN)
             self.assertEqual(extra, [])
 
+    HOSTILE_DEPENDS = (
+        ":(exclude)tracked.txt",
+        ":!tracked.txt",
+        ":(glob,exclude)**",
+        "/tracked.txt",
+        "../tracked.txt",
+        "foo/../tracked.txt",
+        "foo//tracked.txt",
+        "",
+        "tracked.txt/",
+        ":tracked.txt",
+    )
+
+    def test_hostile_depends_on_is_malformed_not_clean(self):
+        """CONTROL: pathspec magic / non-canonical paths are typed findings.
+
+        Accepting :(exclude)tracked.txt as a path would hide a dirty file and
+        report CLEAN. Validation removed must make this test RED.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(
+                repo, {"tracked.txt": "a\n"}, later={"tracked.txt": "b\n"}
+            )
+            dirty_kind, dirty_extra = chk.classify_measured_commit(
+                first, ["tracked.txt"], repo
+            )
+            self.assertEqual(dirty_kind, chk.DIRTY)
+            self.assertIn("tracked.txt", dirty_extra)
+            for pathspec in self.HOSTILE_DEPENDS:
+                with self.subTest(pathspec=pathspec):
+                    kind, extra = chk.classify_measured_commit(first, [pathspec], repo)
+                    self.assertEqual(kind, chk.MALFORMED)
+                    self.assertNotEqual(kind, chk.CLEAN)
+                    if pathspec:
+                        self.assertIn(pathspec, extra)
+
+    def test_true_no_drift_on_tracked_path_is_clean(self):
+        """CONTROL: a genuine no-drift path is still GREEN after path validation."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(repo, {"tracked.txt": "a\n"})
+            kind, extra = chk.classify_measured_commit(first, ["tracked.txt"], repo)
+            self.assertEqual(kind, chk.CLEAN)
+            self.assertEqual(extra, [])
+
+    def test_one_malformed_dependency_is_not_filtered_away(self):
+        """A valid dirty path next to pathspec magic is still a typed finding."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(
+                repo, {"tracked.txt": "a\n"}, later={"tracked.txt": "b\n"}
+            )
+            kind, extra = chk.classify_measured_commit(
+                first, ["tracked.txt", ":(exclude)tracked.txt"], repo
+            )
+            self.assertEqual(kind, chk.MALFORMED)
+            self.assertNotEqual(kind, chk.CLEAN)
+            self.assertNotEqual(kind, chk.DIRTY)
+
 
 class CheckerFailsClosedOnUnresolved(unittest.TestCase):
     """The caller's findings and exit must not stay clean when resolution fails.
@@ -201,11 +261,22 @@ class CheckerFailsClosedOnUnresolved(unittest.TestCase):
             self.assertFalse(payload["ok"])
             self.assertTrue(payload["findings"])
 
-
     def test_checker_does_no_network(self):
         src = Path(chk.__file__).read_text(encoding="utf-8")
         self.assertNotIn("git fetch", src)
         self.assertNotIn("shell=True", src)
+        self.assertIn("--literal-pathspecs", src)
+
+    def test_a_hostile_depends_on_makes_the_checker_red(self):
+        """CONTROL: :(exclude) in results.json is a typed finding, not no-drift."""
+        with sandbox() as root:
+            self.assertEqual(chk.check(), [])
+            res = root / "conformance/adequacy/results.json"
+            doc = json.loads(res.read_text())
+            doc["corpora"][0]["measured_at"]["depends_on"] = [":(exclude)tracked.txt"]
+            res.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+            self.assert_red("malformed")
+            self.assertEqual(chk.main(["--json"]), 1)
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_published_numbers_provenance.py
+++ b/conformance/tests/test_published_numbers_provenance.py
@@ -187,6 +187,49 @@ class ClassifyMeasuredCommit(unittest.TestCase):
             self.assertEqual(kind, chk.CLEAN)
             self.assertEqual(extra, [])
 
+    def test_dependency_absent_from_both_git_trees_is_malformed(self):
+        """An untracked name cannot establish freshness by producing an empty diff."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(repo, {"tracked.txt": "a\n"})
+            kind, extra = chk.classify_measured_commit(first, ["missing.txt"], repo)
+            self.assertEqual(kind, chk.MALFORMED)
+            self.assertEqual(extra, ["missing.txt"])
+
+    def test_git_symlink_dependency_is_malformed_even_if_worktree_file_is_regular(self):
+        """Git-tree mode, not the current filesystem target, defines the dependency."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            self._tiny_repo(repo, {"target.txt": "a\n"})
+            link = repo / "link.txt"
+            link.write_text("target.txt", encoding="utf-8")
+            blob = self._git(repo, "hash-object", "-w", "--", "link.txt").stdout.strip()
+            self._git(repo, "update-index", "--add", "--cacheinfo", "120000,%s,link.txt" % blob)
+            self._git(repo, "commit", "-m", "git symlink entry")
+            measured = self._git(repo, "rev-parse", "HEAD").stdout.strip()
+
+            kind, extra = chk.classify_measured_commit(measured, ["link.txt"], repo)
+            self.assertEqual(kind, chk.MALFORMED)
+            self.assertEqual(extra, ["link.txt"])
+
+    def test_regular_file_added_after_measurement_is_dirty(self):
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(repo, {"keep.txt": "a\n"}, later={"added.txt": "b\n"})
+            kind, extra = chk.classify_measured_commit(first, ["added.txt"], repo)
+            self.assertEqual(kind, chk.DIRTY)
+            self.assertEqual(extra, ["added.txt"])
+
+    def test_regular_file_deleted_after_measurement_is_dirty(self):
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(repo, {"deleted.txt": "a\n"})
+            self._git(repo, "rm", "--", "deleted.txt")
+            self._git(repo, "commit", "-m", "delete regular dependency")
+            kind, extra = chk.classify_measured_commit(first, ["deleted.txt"], repo)
+            self.assertEqual(kind, chk.DIRTY)
+            self.assertEqual(extra, ["deleted.txt"])
+
     def test_one_malformed_dependency_is_not_filtered_away(self):
         """A valid dirty path next to pathspec magic is still a typed finding."""
         with tempfile.TemporaryDirectory() as raw:
@@ -200,6 +243,14 @@ class ClassifyMeasuredCommit(unittest.TestCase):
             self.assertEqual(kind, chk.MALFORMED)
             self.assertNotEqual(kind, chk.CLEAN)
             self.assertNotEqual(kind, chk.DIRTY)
+
+    def test_wrongly_typed_depends_on_is_reported_as_a_dependency_problem(self):
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(repo, {"tracked.txt": "a\n"})
+            kind, extra = chk.classify_measured_commit(first, "tracked.txt", repo)
+            self.assertEqual(kind, chk.MALFORMED)
+            self.assertEqual(extra, ["tracked.txt"])
 
 
 class CheckerFailsClosedOnUnresolved(unittest.TestCase):

--- a/conformance/tests/test_published_numbers_provenance.py
+++ b/conformance/tests/test_published_numbers_provenance.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Fail-closed classification of published-number measurement commits.
+
+    python3 conformance/tests/test_published_numbers_provenance.py
+
+The hole is check_published_numbers.py:248-259 on edc9df0c085ad51724ed29d9eee7d905568b49b9:
+`git diff <measured-at> HEAD` then `continue` on nonzero, so an unavailable commit
+produced no finding. These controls fire each classification on purpose.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "conformance/adequacy"))
+
+import check_published_numbers as chk  # noqa: E402
+
+# Reuse the existing sandbox so file reads stay off the working tree.
+from test_published_numbers_guard import sandbox  # noqa: E402
+
+
+class ClassifyMeasuredCommit(unittest.TestCase):
+    """One function, four outcomes. Hostile strings never become git revisions."""
+
+    HOSTILE = (
+        "'; rm -rf /'",
+        "-n",
+        "HEAD",
+        "origin/main",
+        "EDC9DF0C085AD51724ED29D9EEE7D905568B49B9",
+        "a" * 39,
+        "a" * 41,
+        "\u00e9" + "a" * 39,
+        "",
+        "../" + "a" * 37,
+        "deadbeef\n" + "a" * 31,
+    )
+    UNREACHABLE = "deadbeef" * 5
+
+    def _git(self, repo: Path, *args: str) -> subprocess.CompletedProcess:
+        env = {
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t.example",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t.example",
+        }
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+            env=env,
+        )
+
+    def _tiny_repo(self, root: Path, files: dict, later: dict | None = None) -> str:
+        self._git(root, "init", "-b", "main")
+        for rel, body in files.items():
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+            self._git(root, "add", "--", rel)
+        self._git(
+            root,
+            "-c",
+            "user.email=t@t.example",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            "one",
+        )
+        first = self._git(root, "rev-parse", "HEAD").stdout.strip()
+        self.assertRegex(first, r"^[0-9a-f]{40}$")
+        if later:
+            for rel, body in later.items():
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(body, encoding="utf-8")
+                self._git(root, "add", "--", rel)
+            self._git(
+                root,
+                "-c",
+                "user.email=t@t.example",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-m",
+                "two",
+            )
+        return first
+
+    def test_malformed_commits_are_not_offered_to_git(self):
+        """CONTROL: hostile / wrong-shape strings are malformed, never resolved."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            self._tiny_repo(repo, {"keep.txt": "a\n"})
+            for commit in self.HOSTILE:
+                with self.subTest(commit=commit):
+                    kind, extra = chk.classify_measured_commit(commit, ["keep.txt"], repo)
+                    self.assertEqual(kind, chk.MALFORMED)
+                    self.assertEqual(extra, [])
+
+    def test_a_valid_looking_but_unreachable_commit_is_not_clean(self):
+        """CONTROL: 40-hex that git cannot resolve is unreachable, not no-drift."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            self._tiny_repo(repo, {"keep.txt": "a\n"})
+            kind, extra = chk.classify_measured_commit(self.UNREACHABLE, ["keep.txt"], repo)
+            self.assertEqual(kind, chk.UNREACHABLE)
+            self.assertEqual(extra, [])
+
+    def test_a_dirty_generated_result_is_dirty(self):
+        """CONTROL: depends_on that moved since the measurement is dirty."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(repo, {"keep.txt": "a\n"}, later={"keep.txt": "b\n"})
+            kind, extra = chk.classify_measured_commit(first, ["keep.txt"], repo)
+            self.assertEqual(kind, chk.DIRTY)
+            self.assertIn("keep.txt", extra)
+
+    def test_true_no_drift_is_clean(self):
+        """CONTROL: a reachable commit whose depends_on did not move is clean."""
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            first = self._tiny_repo(repo, {"keep.txt": "a\n"})
+            kind, extra = chk.classify_measured_commit(first, ["keep.txt"], repo)
+            self.assertEqual(kind, chk.CLEAN)
+            self.assertEqual(extra, [])
+
+
+class CheckerFailsClosedOnUnresolved(unittest.TestCase):
+    """The caller's findings and exit must not stay clean when resolution fails.
+
+    Restoring `if moved.returncode != 0: continue` makes
+    test_an_unreachable_measured_commit_makes_the_checker_red stay green.
+    """
+
+    UNREACHABLE = "deadbeef" * 5
+
+    def assert_red(self, needle: str):
+        findings = chk.check()
+        self.assertTrue(findings, "the checker stayed green; this guard is wired to nothing")
+        self.assertTrue(
+            any(needle in f for f in findings),
+            "went red for the wrong reason: %s" % findings,
+        )
+
+    def test_an_unreachable_measured_commit_makes_the_checker_red(self):
+        """CONTROL: results.json names a 40-hex commit this checkout does not have."""
+        with sandbox() as root:
+            self.assertEqual(chk.check(), [])
+            res = root / "conformance/adequacy/results.json"
+            doc = json.loads(res.read_text())
+            doc["corpora"][0]["measured_at"]["commit"] = self.UNREACHABLE
+            res.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+            self.assert_red("cannot be resolved")
+            self.assertEqual(chk.main(["--json"]), 1)
+            # restore so the next assertion is about this control, not leftover state
+            res.write_text(
+                (REPO / "conformance/adequacy/results.json").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            self.assertEqual(chk.check(), [])
+
+    def test_a_malformed_measured_commit_makes_the_checker_red(self):
+        """CONTROL: origin/main is malformed, not a git revision."""
+        with sandbox() as root:
+            res = root / "conformance/adequacy/results.json"
+            doc = json.loads(res.read_text())
+            doc["corpora"][0]["measured_at"]["commit"] = "origin/main"
+            res.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+            self.assert_red("malformed")
+            self.assertEqual(chk.main(["--json"]), 1)
+
+    def test_required_context_is_not_clean_when_resolution_is_skipped(self):
+        """JSON ok must be false when a commit is unresolved."""
+        with sandbox() as root:
+            res = root / "conformance/adequacy/results.json"
+            doc = json.loads(res.read_text())
+            doc["corpora"][0]["measured_at"]["commit"] = self.UNREACHABLE
+            res.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                code = chk.main(["--json"])
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(code, 1)
+            self.assertFalse(payload["ok"])
+            self.assertTrue(payload["findings"])
+
+
+    def test_checker_does_no_network(self):
+        src = Path(chk.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("git fetch", src)
+        self.assertNotIn("shell=True", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -690,14 +690,9 @@ required = (
     "set -euo pipefail",
     "python3 conformance/tests/test_published_numbers_provenance.py",
 )
-for cmd in required:
-    if cmd not in active:
-        sys.exit("active command missing or not live: " + cmd)
-    for line in active:
-        if line == cmd:
-            continue
-        if line == ": " + cmd or line.startswith(": " + cmd):
-            sys.exit("active command neutralized with ':': " + cmd)
+if active != list(required):
+    sys.exit("active provenance step body must be exactly %r, got %r" %
+             (list(required), active))
 sys.exit(0)
 PY
 then

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -650,6 +650,62 @@ else
   fail "ci.yml does not actively invoke evidence-vocabulary in the scope job"
 fi
 
+echo "== required CI workflow actively runs published-numbers provenance contract =="
+# Adequacy-drift is not a required context. Without this always-run scope-job
+# caller, required CI can go green after the provenance tests are deleted.
+# This is the only callsite guard: comment-out, ':' neutralization, or deletion
+# of either live command must make this contract red.
+if python3 - "${CI_WF}" <<'PY'
+import re
+import sys
+
+text = open(sys.argv[1]).read()
+match = re.search(r"(?ms)^  scope:\n(.*?)(?=^  [a-zA-Z][\w-]*:|\Z)", text)
+if not match:
+    sys.exit("scope job missing from ci.yml")
+section = match.group(1)
+setup_at = section.find("uses: actions/setup-python")
+step_at = section.find("- name: Published-numbers provenance contract")
+if setup_at < 0 or step_at < 0 or step_at < setup_at:
+    sys.exit("provenance-contract step must follow actions/setup-python")
+step = re.search(
+    r"(?m)^      - name: Published-numbers provenance contract\n(?P<body>(?:        .+\n)+)(?:\n*)(?=^      - |\Z)",
+    section,
+)
+if not step:
+    sys.exit("scope job missing 'Published-numbers provenance contract' step")
+body = step.group("body")
+for forbidden in ("if:", "continue-on-error:"):
+    if re.search(rf"(?m)^        {re.escape(forbidden)}", body):
+        sys.exit(f"provenance-contract step must not use {forbidden}")
+active = []
+for line in body.splitlines():
+    if not line.startswith("          "):
+        continue
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        continue
+    active.append(stripped)
+required = (
+    "set -euo pipefail",
+    "python3 conformance/tests/test_published_numbers_provenance.py",
+)
+for cmd in required:
+    if cmd not in active:
+        sys.exit("active command missing or not live: " + cmd)
+    for line in active:
+        if line == cmd:
+            continue
+        if line == ": " + cmd or line.startswith(": " + cmd):
+            sys.exit("active command neutralized with ':': " + cmd)
+sys.exit(0)
+PY
+then
+  ok "ci.yml scope job actively runs the published-numbers provenance contract"
+else
+  fail "ci.yml does not actively invoke the provenance contract in the scope job"
+fi
+
 if [[ "${failures}" -ne 0 ]]; then
   echo "ci-hardening-b1 contract: ${failures} failure(s)" >&2
   exit 1

--- a/scripts/ci/test_adequacy_lane.py
+++ b/scripts/ci/test_adequacy_lane.py
@@ -343,5 +343,41 @@ class LiveTree(unittest.TestCase):
         )
 
 
+
+class CheckDriftProvenanceTransport(unittest.TestCase):
+    """The check-drift job must fetch history or the exact commit, never a branch."""
+
+    WORKFLOW = REPO_ROOT / ".github/workflows/adequacy-drift.yml"
+
+    def _check_drift_job(self) -> str:
+        text = self.WORKFLOW.read_text(encoding="utf-8")
+        marker = "name: Adequacy drift gate"
+        start = text.index(marker)
+        return text[start:]
+
+    def test_check_drift_checkout_is_not_shallow(self):
+        """The gate's checkout used to be depth-1; a missing measured_at then skipped."""
+        job = self._check_drift_job()
+        checkout = job.split("uses: actions/checkout", 1)[1]
+        # First checkout block in this job.
+        self.assertIn("fetch-depth: 0", checkout.split("\n- ")[0])
+
+    def test_check_drift_does_not_substitute_a_branch_for_the_commit(self):
+        job = self._check_drift_job()
+        self.assertNotIn("origin/main", job)
+        self.assertNotIn("git fetch origin main", job)
+        self.assertNotIn("refs/heads/main", job)
+
+    def test_checker_step_has_no_continue_on_error(self):
+        job = self._check_drift_job()
+        self.assertIn("python3 conformance/adequacy/check_published_numbers.py", job)
+        self.assertNotIn("continue-on-error:", job)
+
+    def test_check_drift_does_not_fetch_commits_from_results_json(self):
+        job = self._check_drift_job()
+        self.assertNotIn("Fetch recorded measurement commits", job)
+        self.assertNotIn("git fetch", job)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- fail closed when a recorded `measured_at.commit` is malformed or unavailable;
- validate `depends_on` lexically, including control-byte rejection, and inspect the same literal path in both Git trees;
- accept only regular tracked blobs at one or both endpoints, rejecting symlinks, non-regular entries, and paths absent from both trees;
- keep regular add/delete/change as dirty and unchanged regular paths as clean;
- run the provenance contract in the always-run required `CI` scope after pinned Python 3.12;
- make the workflow witness require an exact two-line active body, so `if false`, `|| true`, comments, or extra shell cannot neutralize it.

Closes #2570.

## Why

The previous checker continued when Git could not resolve or diff the recorded commit. It could therefore report freshness as clean when provenance was unavailable. A later candidate also trusted `Path.resolve()` while passing the original path to Git, which let a symlink or an absent-both dependency produce a false-clean empty diff.

## Verification

Candidate head: `8a0347b3c93bc50b008816d4341f6213df13afeb`

- `python3 conformance/tests/test_published_numbers_provenance.py -v` — 17/17 pass;
- `python3 scripts/ci/test_adequacy_lane.py` — 30/30 pass;
- `bash scripts/ci/test-ci-hardening-b1.sh` — pass;
- canonical registry/completion chain — 29 + 46 + 21 tests pass; required scope exits clean;
- `python3 -m py_compile ...` — pass;
- `git diff --check` — pass;
- commit hooks — all applicable hooks pass.

RED reproduced before the repair:

- absent-both dependency returned `clean` instead of `malformed`;
- a Git symlink entry returned `clean` even when its worktree path looked regular;
- wrongly typed `depends_on` was reported as a commit problem;
- a `depends_on` containing JSON `\u0000` reached `subprocess` and raised `ValueError` instead of returning a typed finding;
- wrapping the required-CI command in `if false` left B1 green.

Must-bite mutations after the repair:

- removing Git-tree entry checks makes both absent/symlink tests fail;
- `if false` around the provenance invocation makes B1 fail;
- appending `|| true` makes B1 fail;
- existing mutations continue to cover unreachable-commit `continue`, pathspec acceptance, comment-out/colon neutralization, and required callsite deletion.

## Integration note

The non-required `adequacy-drift` remeasurement is intentionally not claimed green here. corpus-adequacy PR #24 changed the common producer `report.v0` shape; Assay's stored projection predates that contract and is being rebuilt under #2572 after corpus-adequacy #25. Mechanically rewriting those rows in this provenance slice would hide that dependency rather than fix it. Required `CI`, `host-capability-check`, and `lane-check/proof` remain the merge gates.

## Non-claims

- Resolving and comparing a commit proves attribution/freshness availability, not semantic correctness of the measurement.
- SHA/path checks do not validate author-declared mutants, known-hole reasons, or report completeness.
- This change performs no network fetch and does not substitute branch names for exact commits.
- No published-number, report schema, scoring, release, trust, safety, compliance, or certification claim changes here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of published measurement provenance, including malformed, unreachable, modified, or missing source revisions.
  * Added safer handling for dependency paths, file types, symlinks, additions, and deletions.
  * Prevented unresolved provenance data from being treated as valid.

* **Tests**
  * Added comprehensive provenance and CI hardening checks.
  * Added workflow checks for complete repository history and safe commit validation.

* **Chores**
  * Updated automated checks to run the expanded provenance test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->