### PR TITLE
feat(conformance): separate hostile capture from trusted scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `capture_candidate.py` records a candidate's observations over the opaque cases and
+  writes `assay.privileged_mcp_action.candidate_capture.v0`. It takes no manifest and no
+  expectations, so a candidate that escapes its process bounds finds no answers on that
+  host. `score_candidate.py --capture` scores that artifact on a host that never ran the
+  candidate; `--entrypoint` still captures and scores in one process, and both paths call
+  the same capture builder and the same scorer, so a given candidate yields byte-identical
+  run records either way. A capture that does not bind the pack is refused before any
+  comparison, exit `2`, and no run record is written. `report.v0` gains optional
+  `implementation.id` and `implementation.image`, present only together, so an existing v0
+  record stays valid. A capture is an observation artifact, not a verdict, attestation,
+  sandbox proof, or independent reproduction; a capture host can fabricate observations, so
+  separating the phases removes the oracle from the hostile host without authenticating what
+  that host produces (Rul1an/assay-tunnel-experiments#199).
 - `conformance/implementations.json` is a static, fail-closed registry of candidate
   images addressed as `name@sha256:<64 hex>`. Authorship is a typed object (`human`,
   or agent kinds with model and prompt strategy). Required CI calls the same stdlib
@@ -31,6 +44,14 @@ All notable changes to this project will be documented in this file.
   revision (#2482).
 
 ### Changed
+- One strict bounded loader now reads every hostile JSON input in the conformance corpus.
+  `strict_json.load_strict_object` calls the existing regular-file reader and JSON parser and
+  adds the two bounds they did not carry: nesting depth, scanned before `json.loads` sees the
+  text, and the JSON number domain. `validate_run_record.py` reads through it rather than
+  keeping its own reader, which changes one diagnostic's wording and no exit status.
+  `conformance/implementations.py` exposes `validate_image_reference`, and `_validate_row`
+  calls it instead of matching the image pattern a second time.
+
 - `assay_check_sequence` answers the sequence-rule language by calling
   `assay_core::sequence_eval` and mapping the record into its published JSON.
   The MCP copy of the rule is gone (#2227, #2228).

--- a/conformance/implementations.py
+++ b/conformance/implementations.py
@@ -68,6 +68,26 @@ def _reject_unknown_fields(obj: dict, allowed: tuple[str, ...], *, what: str) ->
         )
 
 
+def validate_image_reference(value: object) -> str:
+    """Refuse anything that is not an exact `name@sha256:<64 hex>` reference.
+
+    Public because the conformance capture format binds a run to the same image
+    reference this registry stores, and two spellings of that rule are two
+    answers to what a capture is bound to. `_validate_row` calls this rather
+    than matching the pattern again.
+
+    A digest addresses bytes. It does not authenticate the publisher and it does
+    not establish that the addressed image is the one that ran.
+    """
+    if not isinstance(value, str) or not value:
+        raise ImplementationRegistryError("image must be a non-empty string")
+    if not IMAGE_RE.fullmatch(value):
+        raise ImplementationRegistryError(
+            "image must be name@sha256:<64 hex digest>, not a tag"
+        )
+    return value
+
+
 def _require_text(value: object, field: str, ident: str) -> str:
     if not isinstance(value, str) or not value:
         raise ImplementationRegistryError("%s: %s must be a non-empty string" % (ident, field))
@@ -107,11 +127,10 @@ def _validate_row(row: object, seen: set[str]) -> dict:
     suite = _require_text(row["suite"], "suite", ident)
     if suite not in ALLOWED_SUITES:
         raise ImplementationRegistryError("%s: unknown suite %r" % (ident, suite))
-    image = _require_text(row["image"], "image", ident)
-    if not IMAGE_RE.fullmatch(image):
-        raise ImplementationRegistryError(
-            "%s: image must be name@sha256:<64 hex digest>, not a tag" % ident
-        )
+    try:
+        validate_image_reference(row["image"])
+    except ImplementationRegistryError as exc:
+        raise ImplementationRegistryError("%s: %s" % (ident, exc)) from exc
     source = _require_text(row["source"], "source", ident)
     if not SOURCE_RE.fullmatch(source):
         raise ImplementationRegistryError(

--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -14,8 +14,7 @@ verifier logic, interpret the profile, or establish that an implementation is in
 3. Read `spec.md` and `descriptor.json`.
 4. Implement a command that consumes one bundle path and emits the profile report.
 5. Freeze the implementation commit and record all materials consulted.
-6. Run the scorer. It snapshots the canonical oracle into scorer-private memory for tamper resistance,
-   executes every opaque case without passing that oracle to the candidate, and only then compares.
+6. Run the scorer, in one phase or two. See "Scoring" below for which to pick.
 7. Publish the implementation source, run record, and completed implementation report.
 
 Reading Assay's verifier, `gen_vectors.py`, the canonical `MANIFEST.json`, or a prior scored report
@@ -130,7 +129,13 @@ disclosure it does not make itself is asking for deference rather than evidence.
 
 ## Scoring
 
-Run from an Assay source checkout at the pinned activation-kit revision:
+Two shapes, one comparison. Both call the same capture builder and the same
+scorer, so a given candidate produces byte-identical run records either way.
+
+### One phase, when you trust the candidate
+
+Run from an Assay source checkout at the pinned activation-kit revision. The
+canonical oracle is resident in this process while candidate code runs.
 
 ```bash
 python3 conformance/privileged-mcp-action-v0/scripts/score_candidate.py \
@@ -143,6 +148,56 @@ python3 conformance/privileged-mcp-action-v0/scripts/score_candidate.py \
   --reproduction-mode blind_from_spec \
   --output implementation-report.json
 ```
+
+### Two phases, when you do not
+
+The capture phase takes a pack and an entrypoint. It takes no manifest, no
+expectations and no canonical corpus, so a candidate that escapes its process
+bounds finds no answers on that host to read. Run it wherever you are willing to
+run the candidate; it needs no Assay checkout beyond these scripts.
+
+```bash
+python3 conformance/privileged-mcp-action-v0/scripts/capture_candidate.py \
+  --pack privileged-mcp-action-v0-clean-room.tar.gz \
+  --entrypoint "./my-verifier --format json" \
+  --implementation-name "my verifier" \
+  --implementation-source "https://github.com/example/my-verifier" \
+  --implementation-commit "<full commit>" \
+  --reproduction-mode blind_from_spec \
+  --output capture.json
+```
+
+Add `--implementation-id` and `--implementation-image` when a registered image
+produced the capture. They travel together: a capture names a registry row and
+the image bytes that row addresses, or it names neither. Omitting them is a
+disclosure that no image was declared, not a gap to be filled with a placeholder.
+
+Score the capture on a host that never ran the candidate:
+
+```bash
+python3 conformance/privileged-mcp-action-v0/scripts/score_candidate.py \
+  --pack privileged-mcp-action-v0-clean-room.tar.gz \
+  --manifest conformance/privileged-mcp-action-v0/MANIFEST.json \
+  --capture capture.json \
+  --output implementation-report.json
+```
+
+The scoring host recomputes the pack digest, the declared source commit, the
+corpus digest, the rendered-set digest and every case identifier and input digest
+from its own copy of the pack. The capture's copies of those values are compared
+against the recomputed ones and never adopted. A capture that does not bind is
+refused before any comparison, exit status `2`, and no run record is written:
+a partial record would publish agreement that was never measured.
+
+`capture.schema.json` documents the capture format. It carries no expected value,
+no match or mismatch, no count of agreement, no score and no badge.
+
+### What the split does and does not buy
+
+It removes the oracle from the host that runs candidate code. It does not
+authenticate the capture. A hostile capture host can emit a capture claiming
+whatever it likes, and this protocol has no way to tell. The two threat models
+are different, and only the first one is addressed here.
 
 Exit status is `0` for complete normative agreement, `1` for a completed run with at least one
 normative mismatch, and `2` for an execution or harness error. A mismatch is a useful result and
@@ -211,6 +266,12 @@ pinning when updating the action used by a long-lived workflow.
 A matching run demonstrates agreement on the pinned 14-case corpus. It does not establish
 implementation independence, security, compliance, complete profile determinacy, or any provider
 outcome. Those claims require separate evidence.
+
+A capture adds no claim of its own. It records what a candidate emitted; it is not a verdict, an
+attestation, a sandbox proof, or an independent reproduction. A capture host can fabricate
+observations wholesale, so a capture is an unauthenticated artifact and separating the phases does
+not change that. A declared image digest addresses bytes; it neither authenticates the publisher nor
+establishes that the addressed image is the one that ran.
 
 Nor does it establish independence of failure. Where either implementation was generatively written,
 a match is bounded further by the result cited under Authorship method: agreement is expected to be

--- a/conformance/privileged-mcp-action-v0/capture.schema.json
+++ b/conformance/privileged-mcp-action-v0/capture.schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/conformance/privileged-mcp-action-v0/capture.schema.json",
+  "title": "Privileged MCP Action v0 candidate capture",
+  "description": "What an untrusted capture host may record. It carries no expected value, no match or mismatch, no count of agreement, no score and no badge.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "capture_non_claims",
+    "implementation",
+    "observations",
+    "pack_declared_source_commit",
+    "pack_sha256",
+    "profile",
+    "rendered_set_digest",
+    "schema",
+    "source_corpus_digest",
+    "suite"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.privileged_mcp_action.candidate_capture.v0"
+    },
+    "profile": {
+      "const": "privileged-mcp-action/v0"
+    },
+    "suite": {
+      "const": "privileged-mcp-action-v0"
+    },
+    "pack_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "pack_declared_source_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "source_corpus_digest": {
+      "$ref": "#/$defs/sha256"
+    },
+    "rendered_set_digest": {
+      "$ref": "#/$defs/sha256"
+    },
+    "implementation": {
+      "$ref": "#/$defs/implementation"
+    },
+    "observations": {
+      "type": "array",
+      "minItems": 14,
+      "maxItems": 14,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/observed"
+          },
+          {
+            "$ref": "#/$defs/errored"
+          }
+        ]
+      }
+    },
+    "capture_non_claims": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "prefixItems": [
+        {
+          "const": "a capture records what a candidate emitted; it is not a verdict"
+        },
+        {
+          "const": "a capture host can fabricate observations, so a capture is not authenticated"
+        },
+        {
+          "const": "candidate process limits are operational bounds, not a sandbox"
+        },
+        {
+          "const": "a declared image digest addresses bytes; it does not prove which image ran"
+        }
+      ],
+      "items": false
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commit",
+        "id",
+        "image",
+        "name",
+        "reproduction_mode",
+        "source",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+        },
+        "image": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[^:@\\s]+(?:/[^:@\\s]+)*@sha256:[0-9a-f]{64}$",
+          "description": "Exact name@sha256:<64 hex>, or null when no image was declared. A digest addresses bytes; it does not prove which image ran."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "pattern": "^https?://[^\\s]+$"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "reproduction_mode": {
+          "enum": [
+            "blind_from_spec",
+            "commissioned_clean_room",
+            "from_spec_then_conformance",
+            "other_disclosed"
+          ]
+        }
+      }
+    },
+    "observed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "exit_code",
+        "input_sha256",
+        "observed",
+        "report_profile_matches",
+        "report_schema_matches",
+        "reviewer_reason_present",
+        "state",
+        "stderr_present"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^case-[0-9]{3}$"
+        },
+        "input_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "state": {
+          "const": "observed"
+        },
+        "observed": {
+          "$ref": "#/$defs/normativeSurface"
+        },
+        "exit_code": {
+          "type": "integer",
+          "minimum": -256,
+          "maximum": 255
+        },
+        "stderr_present": {
+          "type": "boolean"
+        },
+        "reviewer_reason_present": {
+          "type": "boolean"
+        },
+        "report_schema_matches": {
+          "type": "boolean"
+        },
+        "report_profile_matches": {
+          "type": "boolean"
+        }
+      }
+    },
+    "errored": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "error",
+        "input_sha256",
+        "state"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^case-[0-9]{3}$"
+        },
+        "input_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "state": {
+          "enum": [
+            "candidate_error",
+            "capture_error"
+          ]
+        },
+        "error": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        }
+      }
+    },
+    "normativeSurface": {
+      "description": "Identical to the run record's observed surface; see report.schema.json.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bundle_integrity"
+          ],
+          "properties": {
+            "bundle_integrity": {
+              "const": "fail"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bundle_integrity",
+            "verdict"
+          ],
+          "properties": {
+            "bundle_integrity": {
+              "const": "pass"
+            },
+            "verdict": {
+              "const": "invalid"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bundle_integrity",
+            "verdict",
+            "claims"
+          ],
+          "properties": {
+            "bundle_integrity": {
+              "const": "pass"
+            },
+            "verdict": {
+              "const": "valid"
+            },
+            "claims": {
+              "type": "object"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/conformance/privileged-mcp-action-v0/report.schema.json
+++ b/conformance/privileged-mcp-action-v0/report.schema.json
@@ -78,7 +78,25 @@
             "commissioned_clean_room",
             "other_disclosed"
           ]
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+          "description": "Optional conformance/implementations.json row id. Present only with image."
+        },
+        "image": {
+          "type": "string",
+          "pattern": "^[^:@\\s]+(?:/[^:@\\s]+)*@sha256:[0-9a-f]{64}$",
+          "description": "Optional exact name@sha256:<64 hex> declared by the capture. A digest addresses bytes; it does not prove which image ran."
         }
+      },
+      "dependentRequired": {
+        "id": [
+          "image"
+        ],
+        "image": [
+          "id"
+        ]
       }
     },
     "summary": {

--- a/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Run a candidate over the opaque cases and record what it emitted. No oracle here.
+
+This is the phase hostile code runs in. It takes a clean-room pack and an
+entrypoint; it takes no manifest, no expectations and no canonical corpus, so a
+candidate that escapes its process bounds has nothing on this host to read. The
+capture it writes is scored later, elsewhere, by `score_candidate.py --capture`.
+
+What that separation does and does not buy is stated in `CAPTURE_NON_CLAIMS`:
+the oracle is absent from this host, and the capture is still unauthenticated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import shlex
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bounded_process import ProcessCaptureError, ProcessLimitError, run_bounded  # noqa: E402
+from capture_format import (  # noqa: E402
+    CAPTURE_NON_CLAIMS,
+    CAPTURE_SCHEMA,
+    STATE_CANDIDATE_ERROR,
+    STATE_CAPTURE_ERROR,
+    SUITE,
+    add_identity_arguments,
+    identity_from_args,
+    normative_surface,
+    observe,
+    observe_error,
+    validate_capture,
+)
+from pack_format import BoundedReader, opaque_case_id  # noqa: E402
+from validate_run_record import (  # noqa: E402
+    EXPECTED_CASE_COUNT,
+    FULL_SHA,
+    PROFILE,
+    SHA256,
+    validate_normative_surface,
+)
+
+PACK_ROOT = "privileged-mcp-action-v0"
+PACK_SCHEMA = "assay.privileged_mcp_action.clean_room_pack.v0"
+MAX_PACK_BYTES = 100 * 1024 * 1024
+MAX_MEMBER_BYTES = 16 * 1024 * 1024
+# README, cases.json, descriptor.json, spec.md, plus the two canonicalization members added in
+# candidate.4 (#1990). Counted rather than derived so a pack that grew a member fails here instead
+# of being accepted because the scorer was taught to expect whatever it was handed.
+EXPECTED_PACK_MEMBERS = EXPECTED_CASE_COUNT + 6
+MAX_PACK_ARCHIVE_BYTES = 32 * 1024 * 1024
+MAX_MEMBER_NAME_BYTES = 512
+MAX_OUTPUT_BYTES = 1024 * 1024
+
+
+class CandidateError(ValueError):
+    pass
+
+
+class HarnessError(RuntimeError):
+    pass
+
+
+def sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def read_member(archive: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
+    if not member.isfile():
+        raise ValueError(f"pack member is not a regular file: {member.name}")
+    if member.size > MAX_MEMBER_BYTES:
+        raise ValueError(f"pack member exceeds {MAX_MEMBER_BYTES} bytes: {member.name}")
+    source = archive.extractfile(member)
+    if source is None:
+        raise ValueError(f"cannot read pack member: {member.name}")
+    data = source.read(MAX_MEMBER_BYTES + 1)
+    if len(data) > MAX_MEMBER_BYTES:
+        raise ValueError(f"pack member expands past {MAX_MEMBER_BYTES} bytes: {member.name}")
+    return data
+
+
+def load_pack(pack: Path, destination: Path) -> dict[str, Any]:
+    if pack.stat().st_size > MAX_PACK_BYTES:
+        raise ValueError(f"pack exceeds {MAX_PACK_BYTES} bytes")
+    files: dict[str, bytes] = {}
+    expanded_bytes = 0
+    with pack.open("rb") as raw:
+        with gzip.GzipFile(fileobj=raw) as decoded:
+            bounded = BoundedReader(decoded, MAX_PACK_ARCHIVE_BYTES)
+            with tarfile.open(fileobj=bounded, mode="r|") as archive:
+                for index_number, member in enumerate(archive):
+                    if index_number >= EXPECTED_PACK_MEMBERS:
+                        raise ValueError("pack contains surplus members")
+                    if len(member.name.encode("utf-8")) > MAX_MEMBER_NAME_BYTES:
+                        raise ValueError("pack member name is too long")
+                    if member.name in files:
+                        raise ValueError("pack contains duplicate member names")
+                    expanded_bytes += member.size
+                    if expanded_bytes > MAX_PACK_ARCHIVE_BYTES:
+                        raise ValueError(
+                            f"pack expands past {MAX_PACK_ARCHIVE_BYTES} bytes"
+                        )
+                    files[member.name] = read_member(archive, member)
+
+    if len(files) != EXPECTED_PACK_MEMBERS:
+        raise ValueError("pack member count is invalid")
+    index_name = f"{PACK_ROOT}/cases.json"
+    if index_name not in files:
+        raise ValueError("pack is missing cases.json")
+    index = json.loads(files[index_name])
+    if index.get("schema") != PACK_SCHEMA or index.get("profile") != PROFILE:
+        raise ValueError("pack schema or profile mismatch")
+    if not FULL_SHA.fullmatch(index.get("declared_source_commit", "")):
+        raise ValueError("pack declared_source_commit is not a full commit")
+    if not SHA256.fullmatch(index.get("source_corpus_digest", "")):
+        raise ValueError("pack source_corpus_digest is malformed")
+    if not SHA256.fullmatch(index.get("rendered_set_digest", "")):
+        raise ValueError("pack rendered_set_digest is malformed")
+    cases = index.get("cases")
+    if (
+        not isinstance(cases, list)
+        or len(cases) != EXPECTED_CASE_COUNT
+        or index.get("case_count") != len(cases)
+    ):
+        raise ValueError("pack case count is invalid")
+
+    expected_names = {
+        f"{PACK_ROOT}/README.md",
+        f"{PACK_ROOT}/cases.json",
+        f"{PACK_ROOT}/descriptor.json",
+        f"{PACK_ROOT}/spec.md",
+        f"{PACK_ROOT}/canonicalization/README.md",
+        f"{PACK_ROOT}/canonicalization/rfc8785-vectors.json",
+    }
+    seen_ids: set[str] = set()
+    seen_hashes: set[str] = set()
+    for index_number, case in enumerate(cases, start=1):
+        case_id = case.get("id")
+        relative = case.get("file")
+        expected_hash = case.get("sha256")
+        expected_id = opaque_case_id(index_number)
+        if case_id != expected_id or case_id in seen_ids:
+            raise ValueError("pack case ids must be ordered unique case numbers")
+        if not isinstance(relative, str):
+            raise ValueError(f"{case_id}: case path must be a string")
+        path = PurePosixPath(relative)
+        if (
+            path.is_absolute()
+            or ".." in path.parts
+            or path.as_posix() != f"cases/{case_id}.bundle.tar.gz"
+        ):
+            raise ValueError(f"{case_id}: unsafe case path")
+        if not SHA256.fullmatch(expected_hash or ""):
+            raise ValueError(f"{case_id}: malformed case digest")
+        member_name = f"{PACK_ROOT}/{path.as_posix()}"
+        expected_names.add(member_name)
+        data = files.get(member_name)
+        if data is None:
+            raise ValueError(f"{case_id}: pack member is missing")
+        digest = sha256(data)
+        if digest != expected_hash:
+            raise ValueError(f"{case_id}: case digest mismatch")
+        if digest in seen_hashes:
+            raise ValueError(f"{case_id}: duplicate case bytes")
+        seen_ids.add(case_id)
+        seen_hashes.add(digest)
+        output = destination / f"{case_id}.bundle.tar.gz"
+        output.write_bytes(data)
+        case["_local_path"] = str(output)
+
+    if set(files) != expected_names:
+        raise ValueError("pack contains missing or surplus members")
+    rendered_set_digest = sha256(
+        "".join(case["sha256"] + "\n" for case in cases).encode()
+    )
+    if rendered_set_digest != index["rendered_set_digest"]:
+        raise ValueError("pack rendered_set_digest does not bind its cases")
+    return index
+
+
+def parse_candidate_report(stdout: bytes) -> dict[str, Any]:
+    try:
+        value = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, RecursionError) as error:
+        raise CandidateError(f"stdout is not exactly one JSON document: {error}") from error
+    if not isinstance(value, dict):
+        raise CandidateError("candidate report must be a JSON object")
+    integrity = value.get("bundle_integrity")
+    if integrity not in {"pass", "fail"}:
+        raise CandidateError("bundle_integrity must be pass or fail")
+    if integrity == "fail":
+        if "verdict" in value or "claims" in value:
+            raise CandidateError("integrity-fail report must omit verdict and claims")
+        return value
+    verdict = value.get("verdict")
+    if verdict not in {"valid", "invalid"}:
+        raise CandidateError("pass report verdict must be valid or invalid")
+    if verdict == "valid" and not isinstance(value.get("claims"), dict):
+        raise CandidateError("valid report must carry a claims object")
+    if verdict == "invalid" and "claims" in value:
+        raise CandidateError("invalid report must omit claims")
+    try:
+        validate_normative_surface(normative_surface(value))
+    except (KeyError, TypeError, ValueError) as error:
+        raise CandidateError(f"candidate normative result is invalid: {error}") from error
+    return value
+
+
+def run_candidate(command: list[str], bundle: Path, timeout_seconds: int) -> dict[str, Any]:
+    try:
+        completed = run_bounded(
+            [*command, str(bundle)],
+            timeout_seconds=timeout_seconds,
+            stdout_limit=MAX_OUTPUT_BYTES,
+            stderr_limit=MAX_OUTPUT_BYTES,
+        )
+    except ProcessCaptureError as error:
+        raise HarnessError(f"candidate output capture failed: {error}") from error
+    except ProcessLimitError as error:
+        raise CandidateError(f"candidate execution limit exceeded: {error}") from error
+    except OSError as error:
+        raise CandidateError(
+            f"candidate process could not start ({type(error).__name__})"
+        ) from error
+    report = parse_candidate_report(completed.stdout)
+    return {
+        "exit_code": completed.returncode,
+        "report": report,
+        "stderr_present": bool(completed.stderr),
+    }
+
+
+def capture_observations(
+    pack: dict[str, Any],
+    command: list[str],
+    timeout_seconds: int,
+) -> list[dict[str, Any]]:
+    """Execute every opaque case and record one observation each, in pack order."""
+    observations = []
+    for case in pack["cases"]:
+        case_id = case["id"]
+        digest = case["sha256"]
+        try:
+            execution = run_candidate(command, Path(case["_local_path"]), timeout_seconds)
+        except HarnessError as error:
+            observations.append(
+                observe_error(case_id, digest, STATE_CAPTURE_ERROR, str(error))
+            )
+        except (OSError, CandidateError) as error:
+            observations.append(
+                observe_error(case_id, digest, STATE_CANDIDATE_ERROR, str(error))
+            )
+        else:
+            observations.append(
+                observe(
+                    case_id,
+                    digest,
+                    execution["report"],
+                    execution["exit_code"],
+                    execution["stderr_present"],
+                )
+            )
+    return observations
+
+
+def build_capture(
+    pack: dict[str, Any],
+    pack_digest: str,
+    observations: list[dict[str, Any]],
+    implementation: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema": CAPTURE_SCHEMA,
+        "profile": PROFILE,
+        "suite": SUITE,
+        "pack_sha256": pack_digest,
+        "pack_declared_source_commit": pack["declared_source_commit"],
+        "source_corpus_digest": pack["source_corpus_digest"],
+        "rendered_set_digest": pack["rendered_set_digest"],
+        "implementation": implementation,
+        "observations": observations,
+        "capture_non_claims": list(CAPTURE_NON_CLAIMS),
+    }
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pack", type=Path, required=True)
+    parser.add_argument("--entrypoint", required=True)
+    add_identity_arguments(parser)
+    parser.add_argument("--timeout-seconds", type=positive_int, default=30)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    command = shlex.split(args.entrypoint)
+    if not command:
+        print("--entrypoint must not be empty", file=sys.stderr)
+        return 2
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            pack = load_pack(args.pack, Path(tmp))
+            pack_digest = sha256_file(args.pack)
+        except (
+            OSError,
+            EOFError,
+            ValueError,
+            KeyError,
+            RecursionError,
+            json.JSONDecodeError,
+            tarfile.TarError,
+        ) as error:
+            print(f"invalid clean-room pack: {error}", file=sys.stderr)
+            return 2
+        observations = capture_observations(pack, command, args.timeout_seconds)
+
+    capture = build_capture(pack, pack_digest, observations, identity_from_args(args))
+    try:
+        validate_capture(capture)
+    except ValueError as error:
+        print(f"capture host produced an invalid capture: {error}", file=sys.stderr)
+        return 2
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(capture, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"captured {len(observations)} observations")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/privileged-mcp-action-v0/scripts/capture_format.py
+++ b/conformance/privileged-mcp-action-v0/scripts/capture_format.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""The candidate-capture artifact: what an untrusted host may record, and nothing else.
+
+A capture holds observations of a candidate's own output plus the bindings a
+trusted scorer needs to refuse a capture that does not belong to the pack it was
+told to score. It carries no expected value, no match or mismatch, no count of
+agreement, no score and no badge, because the host that writes it is the host
+hostile code runs on.
+
+Observation and judgement are split. The capture host records three bounded facts
+about the candidate's own report; the trusted side owns the rule that turns those
+facts into reviewer warnings. That also keeps unbounded free-form findings out of
+the artifact entirely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from strict_json import load_strict_object  # noqa: E402
+from validate_run_record import (  # noqa: E402
+    EXPECTED_CASE_COUNT,
+    FULL_SHA,
+    PROFILE,
+    SHA256,
+    validate_normative_surface,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from implementations import (  # noqa: E402
+    ID_RE,
+    ImplementationRegistryError,
+    validate_image_reference,
+)
+
+CAPTURE_SCHEMA = "assay.privileged_mcp_action.candidate_capture.v0"
+REPORT_SCHEMA = "assay.privileged_mcp_action.verify.report.v0"
+SUITE = "privileged-mcp-action-v0"
+
+# Fourteen bounded observations plus a fixed header. The ceiling is two orders
+# of magnitude of slack over the largest honest capture, and it exists so a
+# capture cannot be used to hand the trusted host an arbitrary payload.
+MAX_CAPTURE_BYTES = 64 * 1024
+MAX_CAPTURE_DEPTH = 8
+# Error text is candidate-influenced. It is bounded here rather than trusted to
+# stay short, because "the messages we emit today are short" is a property of
+# today's messages and not of the format.
+MAX_ERROR_CHARS = 512
+# POSIX exit statuses, plus the negative form subprocess reports for a signal.
+MIN_EXIT_CODE = -256
+MAX_EXIT_CODE = 255
+
+STATE_OBSERVED = "observed"
+STATE_CANDIDATE_ERROR = "candidate_error"
+STATE_CAPTURE_ERROR = "capture_error"
+OBSERVATION_STATES = (STATE_OBSERVED, STATE_CANDIDATE_ERROR, STATE_CAPTURE_ERROR)
+
+REPRODUCTION_MODES = (
+    "blind_from_spec",
+    "from_spec_then_conformance",
+    "commissioned_clean_room",
+    "other_disclosed",
+)
+
+CAPTURE_NON_CLAIMS = (
+    "a capture records what a candidate emitted; it is not a verdict",
+    "a capture host can fabricate observations, so a capture is not authenticated",
+    "candidate process limits are operational bounds, not a sandbox",
+    "a declared image digest addresses bytes; it does not prove which image ran",
+)
+
+TOP_LEVEL_KEYS = {
+    "schema",
+    "profile",
+    "suite",
+    "pack_sha256",
+    "pack_declared_source_commit",
+    "source_corpus_digest",
+    "rendered_set_digest",
+    "implementation",
+    "observations",
+    "capture_non_claims",
+}
+IMPLEMENTATION_KEYS = {
+    "id",
+    "image",
+    "name",
+    "version",
+    "source",
+    "commit",
+    "reproduction_mode",
+}
+OBSERVED_KEYS = {
+    "case_id",
+    "input_sha256",
+    "state",
+    "observed",
+    "exit_code",
+    "stderr_present",
+    "reviewer_reason_present",
+    "report_schema_matches",
+    "report_profile_matches",
+}
+ERROR_KEYS = {"case_id", "input_sha256", "state", "error"}
+
+REJECT_REASON_MISSING = "reject_reason_missing"
+REPORT_SCHEMA_WARNING = "report_schema_missing_or_unexpected"
+REPORT_PROFILE_WARNING = "report_profile_missing_or_unexpected"
+
+
+class CaptureError(ValueError):
+    """A capture does not bind. Never turned into a partial result."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise CaptureError(message)
+
+
+def normative_surface(report: dict[str, Any]) -> dict[str, Any]:
+    """The only fields a run compares. One definition, used by both phases."""
+    result = {"bundle_integrity": report["bundle_integrity"]}
+    if report["bundle_integrity"] == "pass":
+        result["verdict"] = report["verdict"]
+        if report["verdict"] == "valid":
+            result["claims"] = report["claims"]
+    return result
+
+
+def has_reviewer_reason(report: dict[str, Any]) -> bool:
+    findings = report.get("findings")
+    if not isinstance(findings, list):
+        return False
+    return any(
+        (isinstance(finding, str) and bool(finding.strip()))
+        or (
+            isinstance(finding, dict)
+            and any(
+                isinstance(value, str) and bool(value.strip())
+                for value in finding.values()
+            )
+        )
+        for finding in findings
+    )
+
+
+def bound_error(message: str) -> str:
+    text = str(message).strip() or "unspecified error"
+    if len(text) > MAX_ERROR_CHARS:
+        text = text[: MAX_ERROR_CHARS - 1] + "…"
+    return text
+
+
+def observe(
+    case_id: str,
+    input_sha256: str,
+    report: dict[str, Any],
+    exit_code: int,
+    stderr_present: bool,
+) -> dict[str, Any]:
+    """One observation of one candidate execution. Records facts, decides nothing."""
+    return {
+        "case_id": case_id,
+        "input_sha256": input_sha256,
+        "state": STATE_OBSERVED,
+        "observed": normative_surface(report),
+        "exit_code": exit_code,
+        "stderr_present": bool(stderr_present),
+        "reviewer_reason_present": has_reviewer_reason(report),
+        "report_schema_matches": report.get("schema") == REPORT_SCHEMA,
+        "report_profile_matches": report.get("profile") == PROFILE,
+    }
+
+
+def observe_error(case_id: str, input_sha256: str, state: str, message: str) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "input_sha256": input_sha256,
+        "state": state,
+        "error": bound_error(message),
+    }
+
+
+def review_warnings(observation: dict[str, Any]) -> list[str]:
+    """The reviewer-warning rule. Owned by the trusted side, from recorded facts."""
+    if observation["state"] != STATE_OBSERVED:
+        return []
+    observed = observation["observed"]
+    warnings = []
+    if (
+        observed.get("bundle_integrity") == "pass"
+        and observed.get("verdict") == "invalid"
+        and not observation["reviewer_reason_present"]
+    ):
+        warnings.append(REJECT_REASON_MISSING)
+    if not observation["report_schema_matches"]:
+        warnings.append(REPORT_SCHEMA_WARNING)
+    if not observation["report_profile_matches"]:
+        warnings.append(REPORT_PROFILE_WARNING)
+    return warnings
+
+
+def expected_case_ids() -> list[str]:
+    return [f"case-{index:03d}" for index in range(1, EXPECTED_CASE_COUNT + 1)]
+
+
+def validate_implementation(implementation: Any) -> None:
+    require(isinstance(implementation, dict), "capture implementation must be an object")
+    require(
+        set(implementation) == IMPLEMENTATION_KEYS,
+        "capture implementation has missing or surplus fields",
+    )
+    require(
+        isinstance(implementation["name"], str) and bool(implementation["name"]),
+        "capture implementation name is missing",
+    )
+    require(
+        implementation["version"] is None or isinstance(implementation["version"], str),
+        "capture implementation version is invalid",
+    )
+    source = implementation["source"]
+    require(
+        isinstance(source, str) and source.startswith(("http://", "https://")),
+        "capture implementation source must be an absolute HTTP(S) URL",
+    )
+    require(
+        isinstance(implementation["commit"], str)
+        and bool(FULL_SHA.fullmatch(implementation["commit"])),
+        "capture implementation commit is malformed",
+    )
+    require(
+        implementation["reproduction_mode"] in REPRODUCTION_MODES,
+        "capture implementation reproduction_mode is invalid",
+    )
+    identifier = implementation["id"]
+    image = implementation["image"]
+    # Either the capture names a registered image or it declares that it names
+    # none. A half-binding would read as a row reference the run record cannot
+    # honour, so the two travel together or not at all.
+    require(
+        (identifier is None) == (image is None),
+        "capture implementation id and image must both be present or both be null",
+    )
+    if identifier is None:
+        return
+    require(
+        isinstance(identifier, str) and bool(ID_RE.fullmatch(identifier)),
+        "capture implementation id is malformed",
+    )
+    try:
+        validate_image_reference(image)
+    except ImplementationRegistryError as error:
+        raise CaptureError(f"capture implementation image is invalid: {error}") from error
+
+
+def validate_observation(observation: Any, index: int, case_id: str) -> None:
+    require(isinstance(observation, dict), f"observation {index} must be an object")
+    require(
+        observation.get("case_id") == case_id,
+        "capture case ids must be complete and ordered",
+    )
+    require(
+        isinstance(observation.get("input_sha256"), str)
+        and bool(SHA256.fullmatch(observation["input_sha256"])),
+        f"{case_id}: capture input digest is malformed",
+    )
+    state = observation.get("state")
+    require(state in OBSERVATION_STATES, f"{case_id}: capture state is invalid")
+    if state != STATE_OBSERVED:
+        require(set(observation) == ERROR_KEYS, f"{case_id}: error observation has missing or surplus fields")
+        error = observation["error"]
+        require(
+            isinstance(error, str) and bool(error) and len(error) <= MAX_ERROR_CHARS,
+            f"{case_id}: capture error text is missing or exceeds {MAX_ERROR_CHARS} characters",
+        )
+        return
+    require(set(observation) == OBSERVED_KEYS, f"{case_id}: observation has missing or surplus fields")
+    try:
+        validate_normative_surface(observation["observed"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise CaptureError(f"{case_id}: observed result is invalid: {error}") from error
+    exit_code = observation["exit_code"]
+    require(type(exit_code) is int, f"{case_id}: capture exit_code must be an int")
+    require(
+        MIN_EXIT_CODE <= exit_code <= MAX_EXIT_CODE,
+        f"{case_id}: capture exit_code is outside [{MIN_EXIT_CODE}, {MAX_EXIT_CODE}]",
+    )
+    for field in ("stderr_present", "reviewer_reason_present", "report_schema_matches",
+                  "report_profile_matches"):
+        require(
+            isinstance(observation[field], bool),
+            f"{case_id}: capture {field} must be a boolean",
+        )
+
+
+def validate_capture(capture: Any) -> None:
+    """Whole-capture validation. All or nothing, before any comparison happens."""
+    require(isinstance(capture, dict), "capture must be an object")
+    require(set(capture) == TOP_LEVEL_KEYS, "capture has missing or surplus fields")
+    require(capture["schema"] == CAPTURE_SCHEMA, "capture schema mismatch")
+    require(capture["profile"] == PROFILE, "capture profile mismatch")
+    require(capture["suite"] == SUITE, "capture suite mismatch")
+    for field in ("pack_sha256", "source_corpus_digest", "rendered_set_digest"):
+        require(
+            isinstance(capture[field], str) and bool(SHA256.fullmatch(capture[field])),
+            f"capture {field} is malformed",
+        )
+    require(
+        isinstance(capture["pack_declared_source_commit"], str)
+        and bool(FULL_SHA.fullmatch(capture["pack_declared_source_commit"])),
+        "capture pack_declared_source_commit is malformed",
+    )
+    validate_implementation(capture["implementation"])
+    observations = capture["observations"]
+    require(
+        isinstance(observations, list) and len(observations) == EXPECTED_CASE_COUNT,
+        f"capture must contain {EXPECTED_CASE_COUNT} observations",
+    )
+    for index, (observation, case_id) in enumerate(zip(observations, expected_case_ids())):
+        validate_observation(observation, index, case_id)
+    require(
+        capture["capture_non_claims"] == list(CAPTURE_NON_CLAIMS),
+        "capture_non_claims must match the fixed capture claim ceiling",
+    )
+
+
+def load_capture(path: Path) -> dict:
+    """Read one capture as hostile input, then validate it whole."""
+    try:
+        document = load_strict_object(
+            Path(path),
+            label="capture",
+            max_bytes=MAX_CAPTURE_BYTES,
+            max_depth=MAX_CAPTURE_DEPTH,
+        )
+    except ValueError as error:
+        raise CaptureError(str(error)) from error
+    validate_capture(document)
+    return document
+
+
+def add_identity_arguments(parser: "argparse.ArgumentParser", *, required: bool = True) -> None:
+    """One place that states what identifies an implementation to this corpus."""
+    parser.add_argument("--implementation-name", required=required)
+    parser.add_argument("--implementation-version")
+    parser.add_argument("--implementation-source", required=required)
+    parser.add_argument("--implementation-commit", required=required)
+    parser.add_argument(
+        "--reproduction-mode", choices=REPRODUCTION_MODES, required=required
+    )
+    parser.add_argument(
+        "--implementation-id",
+        help="registry row id from conformance/implementations.json",
+    )
+    parser.add_argument(
+        "--implementation-image",
+        help="exact name@sha256:<64 hex> of the image that ran, if one did",
+    )
+
+
+def identity_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "id": args.implementation_id,
+        "image": args.implementation_image,
+        "name": args.implementation_name,
+        "version": args.implementation_version,
+        "source": args.implementation_source,
+        "commit": args.implementation_commit,
+        "reproduction_mode": args.reproduction_mode,
+    }

--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -1,253 +1,66 @@
 #!/usr/bin/env python3
-"""Run a candidate implementation against opaque cases, then score normative results."""
+"""Score a candidate's observations against the canonical oracle. Trusted phase.
+
+Two ways in, one comparison. `--capture` scores a capture written elsewhere by
+`capture_candidate.py`, so the host holding the oracle never executes candidate
+code. `--entrypoint` still captures and scores in one process, and it does so by
+calling the same capture builder and the same scorer, which is why both produce
+byte-identical run records for the same candidate.
+
+Pack, corpus and case bindings are recomputed here from this host's own copy of
+the pack. The capture's copies of those values are compared against the
+recomputed ones and never adopted; a capture that does not bind is refused
+before any comparison, and no run record is written.
+"""
 
 from __future__ import annotations
 
 import argparse
-import gzip
-import hashlib
 import json
-import re
 import shlex
 import sys
 import tarfile
 import tempfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from bounded_process import ProcessCaptureError, ProcessLimitError, run_bounded
-from pack_format import (
-    BoundedReader,
-    opaque_case_id,
-    opaque_run_id,
-    ordered_vectors,
-    rewrite_bundle_stream_identity,
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from capture_candidate import (  # noqa: E402
+    build_capture,
+    capture_observations,
+    load_pack,
+    positive_int,
+    sha256,
+    sha256_file,
 )
-from validate_run_record import (
+from capture_format import (  # noqa: E402
+    STATE_CANDIDATE_ERROR,
+    STATE_CAPTURE_ERROR,
+    STATE_OBSERVED,
+    CaptureError,
+    add_identity_arguments,
+    identity_from_args,
+    load_capture,
+    normative_surface,
+    review_warnings,
+    validate_capture,
+)
+from pack_format import ordered_vectors, rewrite_bundle_stream_identity  # noqa: E402
+from validate_run_record import (  # noqa: E402
+    FULL_SHA,
+    PROFILE,
     RUN_NON_CLAIMS,
-    validate_normative_surface,
+    RUN_SCHEMA,
     validate_run_record,
 )
 
-PACK_ROOT = "privileged-mcp-action-v0"
-PACK_SCHEMA = "assay.privileged_mcp_action.clean_room_pack.v0"
-RUN_SCHEMA = "assay.privileged_mcp_action.conformance_run.v0"
-PROFILE = "privileged-mcp-action/v0"
-REPORT_SCHEMA = "assay.privileged_mcp_action.verify.report.v0"
-REPRODUCTION_MODES = (
-    "blind_from_spec",
-    "from_spec_then_conformance",
-    "commissioned_clean_room",
-    "other_disclosed",
-)
-MAX_PACK_BYTES = 100 * 1024 * 1024
-MAX_MEMBER_BYTES = 16 * 1024 * 1024
-EXPECTED_CASE_COUNT = 14
-# spec.md, descriptor.json, cases.json, README.md. Derived rather than written out again:
-# the pack member count and the case count are one fact, and holding them as two numbers is
-# how the corpus grew to fourteen while a constant still said thirteen.
-# README, cases.json, descriptor.json, spec.md, plus the two canonicalization members added in
-# candidate.4 (#1990). Counted rather than derived so a pack that grew a member fails here instead
-# of being accepted because the scorer was taught to expect whatever it was handed.
-EXPECTED_PACK_MEMBERS = EXPECTED_CASE_COUNT + 6
-MAX_PACK_ARCHIVE_BYTES = 32 * 1024 * 1024
-MAX_MEMBER_NAME_BYTES = 512
-MAX_OUTPUT_BYTES = 1024 * 1024
-FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
-SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
-
-
-class CandidateError(ValueError):
-    pass
-
-
-class HarnessError(RuntimeError):
-    pass
-
-
-def sha256(data: bytes) -> str:
-    return "sha256:" + hashlib.sha256(data).hexdigest()
-
-
-def sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        while chunk := stream.read(1024 * 1024):
-            digest.update(chunk)
-    return "sha256:" + digest.hexdigest()
-
-
-def read_member(
-    archive: tarfile.TarFile,
-    member: tarfile.TarInfo,
-) -> bytes:
-    if not member.isfile():
-        raise ValueError(f"pack member is not a regular file: {member.name}")
-    if member.size > MAX_MEMBER_BYTES:
-        raise ValueError(f"pack member exceeds {MAX_MEMBER_BYTES} bytes: {member.name}")
-    source = archive.extractfile(member)
-    if source is None:
-        raise ValueError(f"cannot read pack member: {member.name}")
-    data = source.read(MAX_MEMBER_BYTES + 1)
-    if len(data) > MAX_MEMBER_BYTES:
-        raise ValueError(f"pack member expands past {MAX_MEMBER_BYTES} bytes: {member.name}")
-    return data
-
-
-def load_pack(pack: Path, destination: Path) -> dict[str, Any]:
-    if pack.stat().st_size > MAX_PACK_BYTES:
-        raise ValueError(f"pack exceeds {MAX_PACK_BYTES} bytes")
-    files: dict[str, bytes] = {}
-    expanded_bytes = 0
-    with pack.open("rb") as raw:
-        with gzip.GzipFile(fileobj=raw) as decoded:
-            bounded = BoundedReader(decoded, MAX_PACK_ARCHIVE_BYTES)
-            with tarfile.open(fileobj=bounded, mode="r|") as archive:
-                for index_number, member in enumerate(archive):
-                    if index_number >= EXPECTED_PACK_MEMBERS:
-                        raise ValueError("pack contains surplus members")
-                    if len(member.name.encode("utf-8")) > MAX_MEMBER_NAME_BYTES:
-                        raise ValueError("pack member name is too long")
-                    if member.name in files:
-                        raise ValueError("pack contains duplicate member names")
-                    expanded_bytes += member.size
-                    if expanded_bytes > MAX_PACK_ARCHIVE_BYTES:
-                        raise ValueError(
-                            f"pack expands past {MAX_PACK_ARCHIVE_BYTES} bytes"
-                        )
-                    files[member.name] = read_member(archive, member)
-
-    if len(files) != EXPECTED_PACK_MEMBERS:
-        raise ValueError("pack member count is invalid")
-    index_name = f"{PACK_ROOT}/cases.json"
-    if index_name not in files:
-        raise ValueError("pack is missing cases.json")
-    index = json.loads(files[index_name])
-    if index.get("schema") != PACK_SCHEMA or index.get("profile") != PROFILE:
-        raise ValueError("pack schema or profile mismatch")
-    if not FULL_SHA.fullmatch(index.get("declared_source_commit", "")):
-        raise ValueError("pack declared_source_commit is not a full commit")
-    if not SHA256.fullmatch(index.get("source_corpus_digest", "")):
-        raise ValueError("pack source_corpus_digest is malformed")
-    if not SHA256.fullmatch(index.get("rendered_set_digest", "")):
-        raise ValueError("pack rendered_set_digest is malformed")
-    cases = index.get("cases")
-    if (
-        not isinstance(cases, list)
-        or len(cases) != EXPECTED_CASE_COUNT
-        or index.get("case_count") != len(cases)
-    ):
-        raise ValueError("pack case count is invalid")
-
-    expected_names = {
-        f"{PACK_ROOT}/README.md",
-        f"{PACK_ROOT}/cases.json",
-        f"{PACK_ROOT}/descriptor.json",
-        f"{PACK_ROOT}/spec.md",
-        f"{PACK_ROOT}/canonicalization/README.md",
-        f"{PACK_ROOT}/canonicalization/rfc8785-vectors.json",
-    }
-    seen_ids: set[str] = set()
-    seen_hashes: set[str] = set()
-    for index_number, case in enumerate(cases, start=1):
-        case_id = case.get("id")
-        relative = case.get("file")
-        expected_hash = case.get("sha256")
-        expected_id = opaque_case_id(index_number)
-        if case_id != expected_id or case_id in seen_ids:
-            raise ValueError("pack case ids must be ordered unique case numbers")
-        if not isinstance(relative, str):
-            raise ValueError(f"{case_id}: case path must be a string")
-        path = PurePosixPath(relative)
-        if (
-            path.is_absolute()
-            or ".." in path.parts
-            or path.as_posix() != f"cases/{case_id}.bundle.tar.gz"
-        ):
-            raise ValueError(f"{case_id}: unsafe case path")
-        if not SHA256.fullmatch(expected_hash or ""):
-            raise ValueError(f"{case_id}: malformed case digest")
-        member_name = f"{PACK_ROOT}/{path.as_posix()}"
-        expected_names.add(member_name)
-        data = files.get(member_name)
-        if data is None:
-            raise ValueError(f"{case_id}: pack member is missing")
-        digest = sha256(data)
-        if digest != expected_hash:
-            raise ValueError(f"{case_id}: case digest mismatch")
-        if digest in seen_hashes:
-            raise ValueError(f"{case_id}: duplicate case bytes")
-        seen_ids.add(case_id)
-        seen_hashes.add(digest)
-        output = destination / f"{case_id}.bundle.tar.gz"
-        output.write_bytes(data)
-        case["_local_path"] = str(output)
-
-    if set(files) != expected_names:
-        raise ValueError("pack contains missing or surplus members")
-    rendered_set_digest = sha256(
-        "".join(case["sha256"] + "\n" for case in cases).encode()
-    )
-    if rendered_set_digest != index["rendered_set_digest"]:
-        raise ValueError("pack rendered_set_digest does not bind its cases")
-    return index
-
-
-def parse_candidate_report(stdout: bytes) -> dict[str, Any]:
-    try:
-        value = json.loads(stdout.decode("utf-8"))
-    except (UnicodeDecodeError, ValueError, RecursionError) as error:
-        raise CandidateError(f"stdout is not exactly one JSON document: {error}") from error
-    if not isinstance(value, dict):
-        raise CandidateError("candidate report must be a JSON object")
-    integrity = value.get("bundle_integrity")
-    if integrity not in {"pass", "fail"}:
-        raise CandidateError("bundle_integrity must be pass or fail")
-    if integrity == "fail":
-        if "verdict" in value or "claims" in value:
-            raise CandidateError("integrity-fail report must omit verdict and claims")
-        return value
-    verdict = value.get("verdict")
-    if verdict not in {"valid", "invalid"}:
-        raise CandidateError("pass report verdict must be valid or invalid")
-    if verdict == "valid" and not isinstance(value.get("claims"), dict):
-        raise CandidateError("valid report must carry a claims object")
-    if verdict == "invalid" and "claims" in value:
-        raise CandidateError("invalid report must omit claims")
-    try:
-        validate_normative_surface(normative_surface(value))
-    except (KeyError, TypeError, ValueError) as error:
-        raise CandidateError(f"candidate normative result is invalid: {error}") from error
-    return value
-
-
-def run_candidate(
-    command: list[str],
-    bundle: Path,
-    timeout_seconds: int,
-) -> dict[str, Any]:
-    try:
-        completed = run_bounded(
-            [*command, str(bundle)],
-            timeout_seconds=timeout_seconds,
-            stdout_limit=MAX_OUTPUT_BYTES,
-            stderr_limit=MAX_OUTPUT_BYTES,
-        )
-    except ProcessCaptureError as error:
-        raise HarnessError(f"candidate output capture failed: {error}") from error
-    except ProcessLimitError as error:
-        raise CandidateError(f"candidate execution limit exceeded: {error}") from error
-    except OSError as error:
-        raise CandidateError(
-            f"candidate process could not start ({type(error).__name__})"
-        ) from error
-    report = parse_candidate_report(completed.stdout)
-    return {
-        "exit_code": completed.returncode,
-        "report": report,
-        "stderr_present": bool(completed.stderr),
-    }
+# A capture state names what happened on the capture host; a run-record status
+# names what the run concluded. The two vocabularies are joined in one place.
+STATE_TO_STATUS = {
+    STATE_CANDIDATE_ERROR: "execution_error",
+    STATE_CAPTURE_ERROR: "harness_error",
+}
 
 
 def load_expectations(manifest_path: Path) -> tuple[dict[str, Any], str, str]:
@@ -258,10 +71,7 @@ def load_expectations(manifest_path: Path) -> tuple[dict[str, Any], str, str]:
         source = (manifest_path.parent / vector["file"]).read_bytes()
         if sha256(source) != vector["sha256"]:
             raise ValueError(f"canonical source digest mismatch for {vector['file']}")
-        transformed = rewrite_bundle_stream_identity(
-            source,
-            opaque_run_id(index),
-        )
+        transformed = rewrite_bundle_stream_identity(source, f"pmav0-case-{index:03d}")
         digest = sha256(transformed)
         if digest in expected_by_hash:
             raise ValueError(f"duplicate rendered vector digest: {digest}")
@@ -278,74 +88,184 @@ def load_expectations(manifest_path: Path) -> tuple[dict[str, Any], str, str]:
     return expected_by_hash, manifest["corpus_digest"], rendered_set_digest
 
 
-def normative_surface(report: dict[str, Any]) -> dict[str, Any]:
-    result = {"bundle_integrity": report["bundle_integrity"]}
-    if report["bundle_integrity"] == "pass":
-        result["verdict"] = report["verdict"]
-        if report["verdict"] == "valid":
-            result["claims"] = report["claims"]
-    return result
+def require_capture_binds_pack(capture: dict[str, Any], pack: dict[str, Any], pack_digest: str) -> None:
+    """Compare the capture's bindings against locally recomputed values.
 
-
-def has_reviewer_reason(report: dict[str, Any]) -> bool:
-    findings = report.get("findings")
-    if not isinstance(findings, list):
-        return False
-    return any(
-        (isinstance(finding, str) and bool(finding.strip()))
-        or (
-            isinstance(finding, dict)
-            and any(
-                isinstance(value, str) and bool(value.strip())
-                for value in finding.values()
+    Fatal, and fatal before comparison. A capture that names a different pack has
+    not observed the cases this host is about to score, and a partial run record
+    would publish agreement it did not measure.
+    """
+    for field, recomputed in (
+        ("pack_sha256", pack_digest),
+        ("pack_declared_source_commit", pack["declared_source_commit"]),
+        ("source_corpus_digest", pack["source_corpus_digest"]),
+        ("rendered_set_digest", pack["rendered_set_digest"]),
+    ):
+        if capture[field] != recomputed:
+            raise CaptureError(
+                f"capture {field} does not bind this pack"
             )
+    for observation, case in zip(capture["observations"], pack["cases"]):
+        if observation["case_id"] != case["id"]:
+            raise CaptureError("capture case ids do not bind this pack in order")
+        if observation["input_sha256"] != case["sha256"]:
+            raise CaptureError(
+                f"{case['id']}: capture input digest does not bind this pack"
+            )
+
+
+def implementation_record(declared: dict[str, Any]) -> dict[str, Any]:
+    """Carry the capture's declared identity. Shape-validated, never verified.
+
+    `id` and `image` appear only when the capture declared them, so an existing
+    v0 run record with neither stays valid and a run that named no image does
+    not grow a field implying one.
+    """
+    record = {
+        "name": declared["name"],
+        "version": declared["version"],
+        "source": declared["source"],
+        "commit": declared["commit"],
+        "reproduction_mode": declared["reproduction_mode"],
+    }
+    if declared["id"] is not None:
+        record["id"] = declared["id"]
+        record["image"] = declared["image"]
+    return record
+
+
+def score_capture(
+    capture: dict[str, Any],
+    pack: dict[str, Any],
+    pack_digest: str,
+    expected_by_hash: dict[str, Any],
+    source_corpus_digest: str,
+    rendered_set_digest: str,
+) -> dict[str, Any]:
+    """Compare recorded observations with the canonical oracle. The only oracle."""
+    harness_errors = []
+    if source_corpus_digest != pack["source_corpus_digest"]:
+        harness_errors.append("pack and canonical source corpus digests differ")
+    if rendered_set_digest != pack["rendered_set_digest"]:
+        harness_errors.append("pack and canonical rendered-set digests differ")
+    pack_hashes = {case["sha256"] for case in pack["cases"]}
+    expectation_hashes = set(expected_by_hash)
+    missing_expectations = pack_hashes - expectation_hashes
+    missing_cases = expectation_hashes - pack_hashes
+    if missing_expectations:
+        harness_errors.append(
+            f"{len(missing_expectations)} opaque case(s) lack canonical expectations"
         )
-        for finding in findings
-    )
+    if missing_cases:
+        harness_errors.append(
+            f"{len(missing_cases)} canonical expectation(s) lack opaque cases"
+        )
 
+    cases = []
+    counts = {
+        "total": len(capture["observations"]),
+        "match": 0,
+        "mismatch": 0,
+        "execution_error": 0,
+        "harness_error": 0,
+        "review_warnings": 0,
+    }
+    for observation in capture["observations"]:
+        result: dict[str, Any] = {
+            "case_id": observation["case_id"],
+            "input_sha256": observation["input_sha256"],
+        }
+        if observation["state"] != STATE_OBSERVED:
+            status = STATE_TO_STATUS[observation["state"]]
+            result.update(status=status, error=observation["error"])
+            counts[status] += 1
+            cases.append(result)
+            continue
+        observed = observation["observed"]
+        expected = expected_by_hash.get(observation["input_sha256"])
+        if expected is None:
+            result.update(
+                status="harness_error",
+                error="opaque case is absent from canonical expectations",
+            )
+            counts["harness_error"] += 1
+            cases.append(result)
+            continue
+        result.update(
+            status="match" if observed == expected else "mismatch",
+            observed=observed,
+            exit_code=observation["exit_code"],
+            stderr_present=observation["stderr_present"],
+        )
+        counts[result["status"]] += 1
+        warnings = review_warnings(observation)
+        if warnings:
+            result["review_warnings"] = warnings
+            counts["review_warnings"] += len(warnings)
+        cases.append(result)
 
-def positive_int(value: str) -> int:
-    parsed = int(value)
-    if parsed <= 0:
-        raise argparse.ArgumentTypeError("must be a positive integer")
-    return parsed
+    return {
+        "schema": RUN_SCHEMA,
+        "profile": PROFILE,
+        "source_corpus_digest": pack["source_corpus_digest"],
+        "rendered_set_digest": pack["rendered_set_digest"],
+        "pack_sha256": pack_digest,
+        "pack_declared_source_commit": pack["declared_source_commit"],
+        "pack_provenance_verification": "not_performed_by_scorer",
+        "implementation": implementation_record(capture["implementation"]),
+        "summary": counts,
+        "harness_errors": harness_errors,
+        "cases": cases,
+        "non_claims": list(RUN_NON_CLAIMS),
+    }
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--pack", type=Path, required=True)
     parser.add_argument("--manifest", type=Path, required=True)
-    parser.add_argument("--entrypoint", required=True)
-    parser.add_argument("--implementation-name", required=True)
-    parser.add_argument(
-        "--reproduction-mode",
-        choices=REPRODUCTION_MODES,
-        required=True,
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--entrypoint")
+    source.add_argument(
+        "--capture",
+        type=Path,
+        help="score a capture recorded by capture_candidate.py; runs no candidate code",
     )
-    parser.add_argument("--implementation-version")
-    parser.add_argument("--implementation-source", required=True)
-    parser.add_argument("--implementation-commit", required=True)
+    add_identity_arguments(parser, required=False)
     parser.add_argument("--timeout-seconds", type=positive_int, default=30)
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args()
 
 
+def check_entrypoint_identity(args: argparse.Namespace) -> str | None:
+    for flag, value in (
+        ("--implementation-name", args.implementation_name),
+        ("--implementation-source", args.implementation_source),
+        ("--implementation-commit", args.implementation_commit),
+        ("--reproduction-mode", args.reproduction_mode),
+    ):
+        if value is None:
+            return f"{flag} is required with --entrypoint"
+    implementation_source = urlparse(args.implementation_source)
+    if implementation_source.scheme not in {"http", "https"} or not implementation_source.netloc:
+        return "--implementation-source must be an absolute HTTP(S) URL"
+    if not FULL_SHA.fullmatch(args.implementation_commit):
+        return "--implementation-commit must be a full lowercase 40-hex commit"
+    return None
+
+
 def main() -> int:
     args = parse_args()
-    command = shlex.split(args.entrypoint)
-    if not command:
-        print("--entrypoint must not be empty", file=sys.stderr)
-        return 2
-    implementation_source = urlparse(args.implementation_source)
-    if (
-        implementation_source.scheme not in {"http", "https"}
-        or not implementation_source.netloc
-    ):
-        print("--implementation-source must be an absolute HTTP(S) URL", file=sys.stderr)
-        return 2
-    if not FULL_SHA.fullmatch(args.implementation_commit):
-        print("--implementation-commit must be a full lowercase 40-hex commit", file=sys.stderr)
-        return 2
+    command: list[str] = []
+    if args.entrypoint is not None:
+        problem = check_entrypoint_identity(args)
+        if problem is not None:
+            print(problem, file=sys.stderr)
+            return 2
+        command = shlex.split(args.entrypoint)
+        if not command:
+            print("--entrypoint must not be empty", file=sys.stderr)
+            return 2
 
     with tempfile.TemporaryDirectory() as tmp:
         try:
@@ -380,124 +300,31 @@ def main() -> int:
             print(f"cannot load canonical expectations: {error}", file=sys.stderr)
             return 2
 
-        # Snapshot the oracle before candidate code runs so it cannot rewrite the
-        # comparison inputs. The snapshot is scorer-private and is never passed to
-        # the candidate; comparisons still happen only after every opaque execution.
-        observations = []
-        for case in pack["cases"]:
-            try:
-                execution = run_candidate(
-                    command,
-                    Path(case["_local_path"]),
-                    args.timeout_seconds,
+        try:
+            if args.capture is not None:
+                capture = load_capture(args.capture)
+            else:
+                # The oracle is already resident, so this path is for candidates
+                # the operator trusts. capture_candidate.py exists for the ones
+                # they do not.
+                observations = capture_observations(pack, command, args.timeout_seconds)
+                capture = build_capture(
+                    pack, pack_digest, observations, identity_from_args(args)
                 )
-                observations.append({"case": case, "execution": execution})
-            except HarnessError as error:
-                observations.append({"case": case, "harness_error": str(error)})
-            except (OSError, CandidateError) as error:
-                observations.append({"case": case, "error": str(error)})
+                validate_capture(capture)
+            require_capture_binds_pack(capture, pack, pack_digest)
+        except (CaptureError, OSError) as error:
+            print(f"capture does not bind: {error}", file=sys.stderr)
+            return 2
 
-        harness_errors = []
-        if source_corpus_digest != pack["source_corpus_digest"]:
-            harness_errors.append("pack and canonical source corpus digests differ")
-        if rendered_set_digest != pack["rendered_set_digest"]:
-            harness_errors.append("pack and canonical rendered-set digests differ")
-        pack_hashes = {case["sha256"] for case in pack["cases"]}
-        expectation_hashes = set(expected_by_hash)
-        missing_expectations = pack_hashes - expectation_hashes
-        missing_cases = expectation_hashes - pack_hashes
-        if missing_expectations:
-            harness_errors.append(
-                f"{len(missing_expectations)} opaque case(s) lack canonical expectations"
-            )
-        if missing_cases:
-            harness_errors.append(
-                f"{len(missing_cases)} canonical expectation(s) lack opaque cases"
-            )
-
-        cases = []
-        counts = {
-            "total": len(observations),
-            "match": 0,
-            "mismatch": 0,
-            "execution_error": 0,
-            "harness_error": 0,
-            "review_warnings": 0,
-        }
-        for observation in observations:
-            case = observation["case"]
-            result: dict[str, Any] = {
-                "case_id": case["id"],
-                "input_sha256": case["sha256"],
-            }
-            if "harness_error" in observation:
-                result.update(
-                    status="harness_error",
-                    error=observation["harness_error"],
-                )
-                counts["harness_error"] += 1
-                cases.append(result)
-                continue
-            if "error" in observation:
-                result.update(status="execution_error", error=observation["error"])
-                counts["execution_error"] += 1
-                cases.append(result)
-                continue
-            execution = observation["execution"]
-            observed = normative_surface(execution["report"])
-            expected = expected_by_hash.get(case["sha256"])
-            if expected is None:
-                result.update(
-                    status="harness_error",
-                    error="opaque case is absent from canonical expectations",
-                )
-                counts["harness_error"] += 1
-                cases.append(result)
-                continue
-            matched = observed == expected
-            result.update(
-                status="match" if matched else "mismatch",
-                observed=observed,
-                exit_code=execution["exit_code"],
-                stderr_present=execution["stderr_present"],
-            )
-            counts[result["status"]] += 1
-            warnings = []
-            if (
-                observed.get("bundle_integrity") == "pass"
-                and observed.get("verdict") == "invalid"
-                and not has_reviewer_reason(execution["report"])
-            ):
-                warnings.append("reject_reason_missing")
-            if execution["report"].get("schema") != REPORT_SCHEMA:
-                warnings.append("report_schema_missing_or_unexpected")
-            if execution["report"].get("profile") != PROFILE:
-                warnings.append("report_profile_missing_or_unexpected")
-            if warnings:
-                result["review_warnings"] = warnings
-                counts["review_warnings"] += len(warnings)
-            cases.append(result)
-
-    report = {
-        "schema": RUN_SCHEMA,
-        "profile": PROFILE,
-        "source_corpus_digest": pack["source_corpus_digest"],
-        "rendered_set_digest": pack["rendered_set_digest"],
-        "pack_sha256": pack_digest,
-        "pack_declared_source_commit": pack["declared_source_commit"],
-        "pack_provenance_verification": "not_performed_by_scorer",
-        "implementation": {
-            "name": args.implementation_name,
-            "version": args.implementation_version,
-            "source": args.implementation_source,
-            "commit": args.implementation_commit,
-            "reproduction_mode": args.reproduction_mode,
-        },
-        "summary": counts,
-        "harness_errors": harness_errors,
-        "cases": cases,
-        "non_claims": list(RUN_NON_CLAIMS),
-    }
+    report = score_capture(
+        capture,
+        pack,
+        pack_digest,
+        expected_by_hash,
+        source_corpus_digest,
+        rendered_set_digest,
+    )
     try:
         validate_run_record(report)
     except (KeyError, TypeError, ValueError) as error:
@@ -508,10 +335,14 @@ def main() -> int:
         json.dumps(report, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    print(json.dumps(counts, sort_keys=True))
-    if counts["execution_error"] or counts["harness_error"] or harness_errors:
+    print(json.dumps(report["summary"], sort_keys=True))
+    if (
+        report["summary"]["execution_error"]
+        or report["summary"]["harness_error"]
+        or report["harness_errors"]
+    ):
         return 2
-    if counts["mismatch"]:
+    if report["summary"]["mismatch"]:
         return 1
     return 0
 

--- a/conformance/privileged-mcp-action-v0/scripts/strict_json.py
+++ b/conformance/privileged-mcp-action-v0/scripts/strict_json.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""One strict, bounded JSON-object loader for every hostile input in this corpus.
+
+`conformance/adequacy/published_rows.py` already refuses symlinks, non-regular
+files, oversized files, non-UTF-8 bytes, duplicate object names and non-finite
+numbers. This module calls that loader rather than restating it, and adds the
+two bounds it does not carry: nesting depth, and the JSON number domain.
+
+Depth is scanned on the raw text *before* `json.loads` sees it. That ordering is
+the point: CPython raises `RecursionError` out of the decoder on deeply nested
+input, and `RecursionError` is not a `ValueError`, so a parse-then-check design
+lets a traceback reach the user instead of a typed refusal.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "adequacy"))
+import published_rows  # noqa: E402
+
+MAX_JSON_DEPTH = 64
+# The interoperable range every JSON implementation agrees on (RFC 7493 §2.2).
+# Outside it, two readers of the same bytes can disagree about the value.
+MAX_SAFE_INTEGER = 2**53 - 1
+
+
+def scan_depth(text: str, limit: int, label: str) -> None:
+    """Refuse nesting past `limit` without materializing the document."""
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > limit:
+                raise ValueError(f"{label} nesting exceeds {limit}")
+        elif character in "]}":
+            depth -= 1
+
+
+def reject_number_domain(value: Any, label: str) -> None:
+    """Refuse floats outright and integers outside the interoperable range.
+
+    Every number this corpus carries is an exit code, a byte count or a
+    sequence: all exact integers. A float in that domain is either a precision
+    loss that already happened or a value the producer never meant to send.
+    """
+    pending = [value]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, bool):
+            continue
+        if isinstance(current, float):
+            raise ValueError(f"{label} carries a JSON number that is not an integer")
+        if isinstance(current, int) and abs(current) > MAX_SAFE_INTEGER:
+            raise ValueError(
+                f"{label} carries an integer outside the interoperable range"
+            )
+        if isinstance(current, dict):
+            pending.extend(current.values())
+        elif isinstance(current, list):
+            pending.extend(current)
+
+
+def parse_strict_object(
+    data: bytes,
+    *,
+    label: str,
+    max_depth: int = MAX_JSON_DEPTH,
+) -> dict:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{label} is not UTF-8") from error
+    scan_depth(text, max_depth, label)
+    document = published_rows.parse_json_object(data, label)
+    reject_number_domain(document, label)
+    return document
+
+
+def load_strict_object(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int,
+    max_depth: int = MAX_JSON_DEPTH,
+) -> dict:
+    data = published_rows.read_regular_file(Path(path), limit=max_bytes)
+    return parse_strict_object(data, label=label, max_depth=max_depth)

--- a/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
+++ b/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
@@ -8,8 +8,18 @@ from collections import Counter
 import json
 from pathlib import Path
 import re
+import sys
 from typing import Any
 from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from implementations import (  # noqa: E402
+    ID_RE,
+    ImplementationRegistryError,
+    validate_image_reference,
+)
+from strict_json import MAX_JSON_DEPTH, load_strict_object  # noqa: E402
 
 
 RUN_SCHEMA = "assay.privileged_mcp_action.conformance_run.v0"
@@ -37,7 +47,6 @@ SOURCE_CLASSES = {
     "unknown",
 }
 MAX_RUN_RECORD_BYTES = 4 * 1024 * 1024
-MAX_JSON_DEPTH = 64
 RUN_NON_CLAIMS = (
     "a matching run demonstrates agreement on the pinned corpus only",
     "a matching run does not establish implementation independence",
@@ -51,6 +60,14 @@ REPRODUCTION_MODES = {
     "commissioned_clean_room",
     "other_disclosed",
 }
+IMPLEMENTATION_REQUIRED_KEYS = {
+    "name",
+    "version",
+    "source",
+    "commit",
+    "reproduction_mode",
+}
+IMPLEMENTATION_BINDING_KEYS = {"id", "image"}
 TOP_LEVEL_KEYS = {
     "schema",
     "profile",
@@ -73,32 +90,18 @@ def require(condition: bool, message: str) -> None:
 
 
 def load_run_record(path: Path) -> Any:
-    with path.open("rb") as source:
-        data = source.read(MAX_RUN_RECORD_BYTES + 1)
-    require(
-        len(data) <= MAX_RUN_RECORD_BYTES,
-        f"run record exceeds {MAX_RUN_RECORD_BYTES} bytes",
+    """Read one run record through the corpus-wide strict loader.
+
+    The bounds are the same ones every hostile input in this corpus gets, which
+    is the point: a second bounded reader here would be a second answer to what
+    this project will parse.
+    """
+    return load_strict_object(
+        path,
+        label="run record",
+        max_bytes=MAX_RUN_RECORD_BYTES,
+        max_depth=MAX_JSON_DEPTH,
     )
-    text = data.decode("utf-8")
-    depth = 0
-    in_string = False
-    escaped = False
-    for character in text:
-        if in_string:
-            if escaped:
-                escaped = False
-            elif character == "\\":
-                escaped = True
-            elif character == '"':
-                in_string = False
-        elif character == '"':
-            in_string = True
-        elif character in "[{":
-            depth += 1
-            require(depth <= MAX_JSON_DEPTH, f"run record nesting exceeds {MAX_JSON_DEPTH}")
-        elif character in "]}":
-            depth -= 1
-    return json.loads(text)
 
 
 def validate_normative_surface(value: dict[str, Any]) -> None:
@@ -168,10 +171,28 @@ def validate_run_record(report: dict[str, Any]) -> None:
     implementation = report["implementation"]
     require(isinstance(implementation, dict), "implementation must be an object")
     require(
-        set(implementation)
-        == {"name", "version", "source", "commit", "reproduction_mode"},
+        set(implementation) >= IMPLEMENTATION_REQUIRED_KEYS
+        and set(implementation) <= IMPLEMENTATION_REQUIRED_KEYS | IMPLEMENTATION_BINDING_KEYS,
         "implementation has missing or surplus fields",
     )
+    # `id` and `image` are optional so a v0 record produced before this binding
+    # existed stays valid, and they travel together so a record cannot name a
+    # registry row without naming the image bytes that row addresses.
+    binding = set(implementation) & IMPLEMENTATION_BINDING_KEYS
+    require(
+        binding in (set(), IMPLEMENTATION_BINDING_KEYS),
+        "implementation id and image must both be present or both be absent",
+    )
+    if binding:
+        require(
+            isinstance(implementation["id"], str)
+            and bool(ID_RE.fullmatch(implementation["id"])),
+            "implementation id is malformed",
+        )
+        try:
+            validate_image_reference(implementation["image"])
+        except ImplementationRegistryError as error:
+            raise ValueError("implementation image is invalid: %s" % error) from error
     require(
         isinstance(implementation["name"], str) and bool(implementation["name"]),
         "implementation name is missing",

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -546,7 +546,14 @@ class CleanRoomPackTests(unittest.TestCase):
                     rewrite_bundle_stream_identity(bundle, "pmav0-case-001")
 
 
-class CandidateScorerTests(unittest.TestCase):
+class CandidateHarness:
+    """Pack build and fake-candidate factory, shared by both scoring shapes.
+
+    A plain mixin rather than a base TestCase: subclassing the combined-mode
+    suite would re-run all sixteen of its cases under the split-mode suite.
+    """
+
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.tmp = tempfile.TemporaryDirectory()
@@ -682,6 +689,8 @@ class CandidateScorerTests(unittest.TestCase):
             check=False,
         )
 
+
+class CandidateScorerTests(CandidateHarness, unittest.TestCase):
     def test_matching_candidate_scores_all_cases(self) -> None:
         output = self.root / "report.json"
         result = self.score(self.candidate("match"), output)
@@ -861,10 +870,18 @@ class CandidateScorerTests(unittest.TestCase):
         oversized.write_bytes(b'{"padding":"' + b"x" * (4 * 1024 * 1024) + b'"}')
         too_deep = self.root / "deep-run-record.json"
         too_deep.write_text("[" * 65 + "0" + "]" * 65)
+        # Past CPython's decoder recursion limit and still inside the 4 MiB
+        # ceiling: the case the depth scan exists for. Parsed first, this raises
+        # RecursionError, which is not a ValueError and reaches the user as a
+        # traceback. The capture ceiling is too small to reach here, so this is
+        # the only place the scan's purpose can be observed.
+        recursive = self.root / "recursive-run-record.json"
+        recursive.write_text("[" * 200_000 + "0" + "]" * 200_000)
 
         for path, diagnostic in (
-            (oversized, "exceeds 4194304 bytes"),
+            (oversized, "exceeds the 4194304-byte limit"),
             (too_deep, "nesting exceeds 64"),
+            (recursive, "nesting exceeds 64"),
         ):
             with self.subTest(path=path.name):
                 result = run(str(VALIDATE_SCRIPT), str(path), check=False)
@@ -932,7 +949,7 @@ class CandidateScorerTests(unittest.TestCase):
         bundle.write_bytes(b"ignored")
         sys.path.insert(0, str(CORPUS_DIR / "scripts"))
         try:
-            from score_candidate import CandidateError, run_candidate
+            from capture_candidate import CandidateError, run_candidate
         finally:
             sys.path.pop(0)
 
@@ -965,7 +982,7 @@ class CandidateScorerTests(unittest.TestCase):
         bundle.write_bytes(b"ignored")
         sys.path.insert(0, str(CORPUS_DIR / "scripts"))
         try:
-            from score_candidate import CandidateError, run_candidate
+            from capture_candidate import CandidateError, run_candidate
         finally:
             sys.path.pop(0)
 
@@ -1030,6 +1047,7 @@ class CandidateScorerTests(unittest.TestCase):
         output = self.root / "capture-harness-error.json"
         sys.path.insert(0, str(CORPUS_DIR / "scripts"))
         try:
+            import capture_candidate
             import score_candidate
         finally:
             sys.path.pop(0)
@@ -1055,10 +1073,12 @@ class CandidateScorerTests(unittest.TestCase):
         ]
         with (
             mock.patch.object(sys, "argv", argv),
+            # Patched where it is executed: capture_observations resolves
+            # run_candidate in its own module, not through score_candidate.
             mock.patch.object(
-                score_candidate,
+                capture_candidate,
                 "run_candidate",
-                side_effect=score_candidate.HarnessError("synthetic capture failure"),
+                side_effect=capture_candidate.HarnessError("synthetic capture failure"),
             ),
         ):
             self.assertEqual(score_candidate.main(), 2)
@@ -1120,6 +1140,537 @@ class CandidateScorerTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertNotIn("Traceback", result.stderr)
         self.assertFalse(output.exists())
+
+
+sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+import capture_format  # noqa: E402
+import score_candidate  # noqa: E402
+import strict_json  # noqa: E402
+
+CAPTURE_SCRIPT = CORPUS_DIR / "scripts" / "capture_candidate.py"
+CAPTURE_SCHEMA_DOC = CORPUS_DIR / "capture.schema.json"
+
+
+class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
+    """Split-phase capture and trusted scoring.
+
+    Inherits the pack build and the fake-candidate factory from the combined-mode
+    tests rather than restating them: the point of the split is that both phases
+    drive the same candidate over the same pack.
+    """
+
+    def capture(
+        self,
+        candidate: Path,
+        output: Path,
+        *,
+        pack: Path | None = None,
+        extra: tuple[str, ...] = (),
+    ) -> subprocess.CompletedProcess[str]:
+        return run(
+            str(CAPTURE_SCRIPT),
+            "--pack",
+            str(pack or self.pack),
+            "--entrypoint",
+            shlex.join([sys.executable, str(candidate)]),
+            "--implementation-name",
+            "test implementation",
+            "--implementation-source",
+            "https://example.test/verifier",
+            "--implementation-commit",
+            IMPLEMENTATION_COMMIT,
+            "--reproduction-mode",
+            "blind_from_spec",
+            *extra,
+            "--output",
+            str(output),
+            check=False,
+        )
+
+    def score_capture(
+        self,
+        capture: Path,
+        output: Path,
+        *,
+        pack: Path | None = None,
+        manifest: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return run(
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(pack or self.pack),
+            "--manifest",
+            str(manifest or CORPUS_DIR / "MANIFEST.json"),
+            "--capture",
+            str(capture),
+            "--output",
+            str(output),
+            check=False,
+        )
+
+    def valid_capture(self, name: str) -> Path:
+        capture = self.root / f"capture-{name}.json"
+        result = self.capture(self.candidate("match"), capture)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return capture
+
+    def rewrite(self, capture: Path, name: str, mutate) -> Path:
+        document = json.loads(capture.read_text())
+        mutate(document)
+        target = self.root / f"capture-{name}.json"
+        target.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
+        return target
+
+    def test_valid_capture_scores_every_case(self) -> None:
+        """Positive control for every refusal below.
+
+        Without it, a scorer that refused all captures would satisfy the negative
+        cases and prove nothing.
+        """
+        capture = self.valid_capture("control")
+        output = self.root / "capture-control-report.json"
+        result = self.score_capture(capture, output)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(output.read_text())
+        self.assertEqual(report["summary"]["match"], 14)
+        self.assertEqual(report["summary"]["total"], 14)
+
+    def test_missing_or_duplicated_observation_is_refused_without_a_record(self) -> None:
+        capture = self.valid_capture("cardinality")
+
+        def drop(document: object) -> None:
+            del document["observations"][6]
+
+        def duplicate(document: object) -> None:
+            document["observations"].append(json.loads(json.dumps(document["observations"][6])))
+
+        for name, mutate in (("thirteen", drop), ("fifteen", duplicate)):
+            with self.subTest(shape=name):
+                hostile = self.rewrite(capture, name, mutate)
+                output = self.root / f"capture-{name}-report.json"
+                result = self.score_capture(hostile, output)
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertFalse(
+                    output.exists(),
+                    "a capture that does not bind must leave no run record",
+                )
+
+    def test_direct_and_split_paths_produce_byte_identical_run_records(self) -> None:
+        """The migration guarantee, and the proof that there is one comparison.
+
+        Two records built from the same candidate through different plumbing can
+        only be byte-identical if both went through the same scorer.
+        """
+        candidate = self.candidate("match")
+        direct = self.root / "equivalence-direct.json"
+        self.assertEqual(self.score(candidate, direct).returncode, 0)
+
+        capture = self.root / "equivalence-capture.json"
+        self.assertEqual(self.capture(candidate, capture).returncode, 0)
+        split = self.root / "equivalence-split.json"
+        self.assertEqual(self.score_capture(capture, split).returncode, 0)
+
+        self.assertEqual(direct.read_bytes(), split.read_bytes())
+
+    def test_run_record_pack_digest_is_recomputed_locally(self) -> None:
+        capture = self.valid_capture("digest")
+        output = self.root / "digest-report.json"
+        self.assertEqual(self.score_capture(capture, output).returncode, 0)
+        self.assertEqual(
+            json.loads(output.read_text())["pack_sha256"],
+            sha256(self.pack.read_bytes()),
+        )
+
+    def test_scorer_recomputes_the_pack_digest_rather_than_copying_it(self) -> None:
+        """Directly on the scorer, with the CLI's binding guard out of the way.
+
+        Through the CLI a lying capture never reaches this code, so `recomputed`
+        and `capture["pack_sha256"]` are equal wherever it can be observed and
+        the difference between them is invisible. Calling the scorer with a
+        capture that lies is the only way to see which one the record carries.
+        """
+        capture = json.loads(self.valid_capture("recompute").read_text())
+        lie = "sha256:" + "d" * 64
+        capture["pack_sha256"] = lie
+        recomputed = sha256(self.pack.read_bytes())
+        self.assertNotEqual(lie, recomputed)
+
+        pack = {
+            "declared_source_commit": capture["pack_declared_source_commit"],
+            "source_corpus_digest": capture["source_corpus_digest"],
+            "rendered_set_digest": capture["rendered_set_digest"],
+            "cases": [
+                {"id": observation["case_id"], "sha256": observation["input_sha256"]}
+                for observation in capture["observations"]
+            ],
+        }
+        expected = {
+            observation["input_sha256"]: observation["observed"]
+            for observation in capture["observations"]
+        }
+        report = score_candidate.score_capture(
+            capture,
+            pack,
+            recomputed,
+            expected,
+            pack["source_corpus_digest"],
+            pack["rendered_set_digest"],
+        )
+        self.assertEqual(report["pack_sha256"], recomputed)
+        self.assertNotEqual(report["pack_sha256"], lie)
+
+    def test_capture_that_does_not_bind_the_pack_is_refused(self) -> None:
+        capture = self.valid_capture("binding")
+        other = "sha256:" + "b" * 64
+
+        def swap_order(document):
+            document["observations"][2], document["observations"][9] = (
+                document["observations"][9],
+                document["observations"][2],
+            )
+
+        def foreign_input_digest(document):
+            document["observations"][4]["input_sha256"] = other
+
+        def foreign_pack(document):
+            document["pack_sha256"] = other
+
+        def foreign_corpus(document):
+            document["source_corpus_digest"] = other
+
+        def foreign_commit(document):
+            document["pack_declared_source_commit"] = "c" * 40
+
+        for name, mutate in (
+            ("reordered", swap_order),
+            ("foreign-input-digest", foreign_input_digest),
+            ("foreign-pack", foreign_pack),
+            ("foreign-corpus", foreign_corpus),
+            ("foreign-commit", foreign_commit),
+        ):
+            with self.subTest(binding=name):
+                hostile = self.rewrite(capture, name, mutate)
+                output = self.root / f"bind-{name}.json"
+                result = self.score_capture(hostile, output)
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertFalse(output.exists())
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_hostile_capture_bytes_fail_closed_without_a_traceback(self) -> None:
+        capture = self.valid_capture("hostile")
+        valid_text = capture.read_text()
+        cases = {
+            "duplicate-key": valid_text.replace(
+                '"schema":', '"schema": "assay.privileged_mcp_action.candidate_capture.v0",\n  "schema":', 1
+            ),
+            "non-finite": valid_text.replace('"exit_code": 0', '"exit_code": NaN', 1),
+            "float-exit-code": valid_text.replace('"exit_code": 0', '"exit_code": 0.0', 1),
+            "oversized-integer": valid_text.replace(
+                '"exit_code": 0', '"exit_code": 9007199254740992', 1
+            ),
+            "out-of-range-exit-code": valid_text.replace('"exit_code": 0', '"exit_code": 4096', 1),
+            # Deep enough that json.loads would raise RecursionError, small enough
+            # that the byte ceiling cannot be what refuses it. Without both, this
+            # case proves the ceiling works and says nothing about the depth scan.
+            "deeply-nested": "[" * 30000 + "0" + "]" * 30000,
+            "not-utf8": None,
+            "not-an-object": "[]",
+        }
+        for name, text in cases.items():
+            with self.subTest(hostile=name):
+                path = self.root / f"hostile-{name}.json"
+                if text is None:
+                    path.write_bytes(b'{"schema": "\xff\xfe"}')
+                else:
+                    path.write_text(text)
+                output = self.root / f"hostile-{name}-report.json"
+                result = self.score_capture(path, output)
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertFalse(output.exists())
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_capture_over_the_byte_ceiling_is_refused_by_the_ceiling(self) -> None:
+        """Oversized but otherwise valid, so only the ceiling can be the refusal.
+
+        A padded piece of junk would also be shape-invalid, and then this case
+        would pass with the ceiling removed.
+        """
+        # A literal, not a multiple of the ceiling: a fixture sized from the
+        # constant under test grows with it, and a raised ceiling would then
+        # never be observed.
+        padding = 200_000
+        self.assertGreater(
+            padding,
+            capture_format.MAX_CAPTURE_BYTES,
+            "fixture must exceed the shipped ceiling for this test to mean anything",
+        )
+        document = json.loads(self.valid_capture("ceiling").read_text())
+        document["implementation"]["version"] = "v" * padding
+        path = self.root / "capture-over-ceiling.json"
+        path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
+        capture_format.validate_capture(document)  # valid but for its size
+
+        output = self.root / "over-ceiling-report.json"
+        result = self.score_capture(path, output)
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertFalse(output.exists())
+        self.assertIn(str(capture_format.MAX_CAPTURE_BYTES), result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_capture_validator_owns_cardinality_and_ordering(self) -> None:
+        """Directly on the validator.
+
+        Through the CLI these refusals are masked by the run-record case count
+        and by the pack-binding check, so a CLI-only test cannot tell whether the
+        capture format states its own rules.
+        """
+        valid = json.loads(self.valid_capture("validator").read_text())
+        capture_format.validate_capture(valid)
+
+        def dropped(document):
+            del document["observations"][6]
+
+        def duplicated(document):
+            document["observations"].append(document["observations"][6])
+
+        def reordered(document):
+            document["observations"][0], document["observations"][1] = (
+                document["observations"][1],
+                document["observations"][0],
+            )
+
+        def renamed(document):
+            document["observations"][3]["case_id"] = "case-999"
+
+        for name, mutate in (
+            ("thirteen", dropped),
+            ("fifteen", duplicated),
+            ("reordered", reordered),
+            ("renamed", renamed),
+        ):
+            with self.subTest(shape=name):
+                document = json.loads(json.dumps(valid))
+                mutate(document)
+                with self.assertRaises(capture_format.CaptureError):
+                    capture_format.validate_capture(document)
+
+    def test_strict_loader_owns_the_json_number_domain(self) -> None:
+        """Directly on the shared loader.
+
+        Every capture field is separately type-checked, so at capture level this
+        rule is defence in depth. It is pinned here because the same loader reads
+        run records, where a number can land in a less tightly checked position.
+        """
+        self.assertEqual(
+            strict_json.parse_strict_object(b'{"a": 1, "b": [-9]}', label="probe"),
+            {"a": 1, "b": [-9]},
+        )
+        for payload in (
+            b'{"a": 1.0}',
+            b'{"a": [1.5]}',
+            b'{"a": 9007199254740992}',
+            b'{"a": {"b": -9007199254740992}}',
+        ):
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValueError):
+                    strict_json.parse_strict_object(payload, label="probe")
+
+    def test_capture_refuses_a_symlink_and_a_missing_file(self) -> None:
+        capture = self.valid_capture("symlink-source")
+        link = self.root / "capture-symlink.json"
+        if link.exists() or link.is_symlink():
+            link.unlink()
+        link.symlink_to(capture)
+        for path in (link, self.root / "capture-absent.json"):
+            with self.subTest(path=path.name):
+                output = self.root / f"nofollow-{path.name}"
+                result = self.score_capture(path, output)
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertFalse(output.exists())
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_capture_error_text_is_bounded(self) -> None:
+        long_message = "e" * (capture_format.MAX_ERROR_CHARS * 4)
+        bounded = capture_format.bound_error(long_message)
+        self.assertLessEqual(len(bounded), capture_format.MAX_ERROR_CHARS)
+        self.assertEqual(capture_format.bound_error("  short  "), "short")
+        self.assertEqual(capture_format.bound_error("   "), "unspecified error")
+
+        capture = self.valid_capture("bounded-error")
+
+        def overlong_error(document):
+            document["observations"][0] = {
+                "case_id": document["observations"][0]["case_id"],
+                "input_sha256": document["observations"][0]["input_sha256"],
+                "state": "candidate_error",
+                "error": long_message,
+            }
+
+        hostile = self.rewrite(capture, "overlong-error", overlong_error)
+        output = self.root / "overlong-error-report.json"
+        result = self.score_capture(hostile, output)
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertFalse(output.exists())
+
+    def test_capture_image_binding_uses_the_registry_rule(self) -> None:
+        digest_image = "ghcr.io/example/verifier@sha256:" + "1" * 64
+        capture = self.root / "capture-image.json"
+        result = self.capture(
+            self.candidate("match"),
+            capture,
+            extra=("--implementation-id", "example-verifier",
+                   "--implementation-image", digest_image),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = self.root / "image-report.json"
+        self.assertEqual(self.score_capture(capture, output).returncode, 0)
+        implementation = json.loads(output.read_text())["implementation"]
+        self.assertEqual(implementation["id"], "example-verifier")
+        self.assertEqual(implementation["image"], digest_image)
+
+        def tag_only(document):
+            document["implementation"]["image"] = "ghcr.io/example/verifier:latest"
+
+        def half_binding(document):
+            document["implementation"]["image"] = None
+
+        for name, mutate in (("tag-only", tag_only), ("half-binding", half_binding)):
+            with self.subTest(image=name):
+                hostile = self.rewrite(capture, name, mutate)
+                bad = self.root / f"image-{name}.json"
+                result = self.score_capture(hostile, bad)
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertFalse(bad.exists())
+
+    def test_run_record_omits_the_binding_when_the_capture_declared_none(self) -> None:
+        capture = self.valid_capture("no-image")
+        self.assertIsNone(json.loads(capture.read_text())["implementation"]["id"])
+        output = self.root / "no-image-report.json"
+        self.assertEqual(self.score_capture(capture, output).returncode, 0)
+        implementation = json.loads(output.read_text())["implementation"]
+        self.assertNotIn("id", implementation)
+        self.assertNotIn("image", implementation)
+
+    def test_capture_carries_no_oracle_derived_field(self) -> None:
+        """Structural, not textual: every key must come from the declared vocabulary."""
+        capture = json.loads(self.valid_capture("vocabulary").read_text())
+        seen = set()
+        pending = [capture]
+        while pending:
+            current = pending.pop()
+            if isinstance(current, dict):
+                seen.update(current)
+                pending.extend(current.values())
+            elif isinstance(current, list):
+                pending.extend(current)
+        allowed = (
+            capture_format.TOP_LEVEL_KEYS
+            | capture_format.IMPLEMENTATION_KEYS
+            | capture_format.OBSERVED_KEYS
+            | capture_format.ERROR_KEYS
+            | {"bundle_integrity", "verdict", "claims", "status", "source_class"}
+            | {
+                "policy_decision_recorded",
+                "caller_visible_denial",
+                "upstream_delivery",
+                "external_side_effect",
+            }
+        )
+        self.assertEqual(seen - allowed, set())
+        for forbidden in ("expected", "match", "mismatch", "score", "badge", "summary"):
+            self.assertNotIn(forbidden, seen)
+
+    def test_capture_schema_document_matches_the_validator_vocabulary(self) -> None:
+        schema = json.loads(CAPTURE_SCHEMA_DOC.read_text())
+        self.assertEqual(schema["properties"]["schema"]["const"], capture_format.CAPTURE_SCHEMA)
+        self.assertEqual(sorted(capture_format.TOP_LEVEL_KEYS), schema["required"])
+        observations = schema["properties"]["observations"]
+        self.assertEqual(observations["minItems"], capture_format.EXPECTED_CASE_COUNT)
+        self.assertEqual(observations["maxItems"], capture_format.EXPECTED_CASE_COUNT)
+        self.assertEqual(
+            schema["properties"]["capture_non_claims"]["prefixItems"],
+            [{"const": text} for text in capture_format.CAPTURE_NON_CLAIMS],
+        )
+        observed = schema["$defs"]["observed"]["properties"]["exit_code"]
+        self.assertEqual(observed["minimum"], capture_format.MIN_EXIT_CODE)
+        self.assertEqual(observed["maximum"], capture_format.MAX_EXIT_CODE)
+        self.assertEqual(
+            schema["$defs"]["errored"]["properties"]["error"]["maxLength"],
+            capture_format.MAX_ERROR_CHARS,
+        )
+
+    def test_capture_phase_completes_with_the_oracle_absent_from_its_filesystem(self) -> None:
+        """The point of the split, measured rather than asserted.
+
+        The probe reports whether it could open the canonical MANIFEST.json by
+        the same relative path the composite action uses. The combined-mode arm
+        is the positive control: without it, a probe that always reported
+        `False` would pass this test while proving nothing.
+        """
+        probe = self.root / "oracle-probe.py"
+        marker = self.root / "oracle-probe-marker.json"
+        probe.write_text(
+            textwrap.dedent(
+                f"""\
+                import json, os
+                from pathlib import Path
+                oracle = Path("conformance/privileged-mcp-action-v0/MANIFEST.json")
+                marker = Path({str(marker)!r})
+                try:
+                    readable = len(json.loads(oracle.read_text())["vectors"]) > 0
+                except OSError:
+                    readable = False
+                seen = json.loads(marker.read_text()) if marker.exists() else []
+                seen.append({{"cwd": os.getcwd(), "oracle_readable": readable}})
+                marker.write_text(json.dumps(seen))
+                print(json.dumps({{"bundle_integrity": "fail"}}))
+                """
+            )
+        )
+
+        elsewhere = self.root / "no-oracle-here"
+        elsewhere.mkdir(exist_ok=True)
+        capture = self.root / "oracle-absent-capture.json"
+        split = subprocess.run(
+            [
+                sys.executable,
+                str(CAPTURE_SCRIPT),
+                "--pack", str(self.pack),
+                "--entrypoint", shlex.join([sys.executable, str(probe)]),
+                "--implementation-name", "oracle probe",
+                "--implementation-source", "https://example.test/verifier",
+                "--implementation-commit", IMPLEMENTATION_COMMIT,
+                "--reproduction-mode", "blind_from_spec",
+                "--output", str(capture),
+            ],
+            cwd=elsewhere,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(split.returncode, 0, split.stderr)
+        split_observations = json.loads(marker.read_text())
+        marker.unlink()
+
+        self.assertEqual(len(split_observations), 14)
+        self.assertTrue(
+            all(not seen["oracle_readable"] for seen in split_observations),
+            "the capture phase must not carry the oracle on its filesystem",
+        )
+
+        report = self.root / "oracle-absent-report.json"
+        self.assertEqual(self.score_capture(capture, report).returncode, 1)
+        self.assertEqual(json.loads(report.read_text())["summary"]["total"], 14)
+
+        combined = self.root / "oracle-present-report.json"
+        self.score(probe, combined)
+        combined_observations = json.loads(marker.read_text())
+        self.assertEqual(len(combined_observations), 14)
+        self.assertTrue(
+            all(seen["oracle_readable"] for seen in combined_observations),
+            "positive control: the probe must be able to discriminate",
+        )
+
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_implementations.py
+++ b/conformance/tests/test_implementations.py
@@ -480,5 +480,81 @@ class OneRuleNoNetwork(unittest.TestCase):
         self.assertEqual(items["properties"]["image"]["pattern"], module.IMAGE_PATTERN)
 
 
+class PublicImageValidator(unittest.TestCase):
+    """The image rule has one implementation, and the row validator calls it.
+
+    The conformance capture format binds a run to the same image reference this
+    registry stores. Two spellings of that rule would be two answers to what a
+    run is bound to, so the test is that there is one function, not that two
+    functions currently agree.
+    """
+
+    HOSTILE = (
+        "ghcr.io/example/verifier:latest",
+        "ghcr.io/example/verifier:v1@sha256:" + "a" * 64,
+        "ghcr.io/example/verifier@sha256:" + "a" * 63,
+        "ghcr.io/example/verifier@sha256:" + "A" * 64,
+        "ghcr.io/example/verifier@sha512:" + "a" * 64,
+        "ghcr.io/example/verifier",
+        "ghcr.io/exam ple/verifier@sha256:" + "a" * 64,
+        "",
+    )
+    VALID = "ghcr.io/example/verifier@sha256:" + "a" * 64
+
+    def setUp(self) -> None:
+        self.module = _require_module()
+
+    def test_public_validator_refuses_every_non_digest_reference(self) -> None:
+        self.assertEqual(self.module.validate_image_reference(self.VALID), self.VALID)
+        for reference in self.HOSTILE:
+            with self.subTest(image=reference):
+                with self.assertRaises(self.module.ImplementationRegistryError):
+                    self.module.validate_image_reference(reference)
+        for reference in (None, 42, ["x"], {"x": 1}):
+            with self.subTest(image=type(reference).__name__):
+                with self.assertRaises(self.module.ImplementationRegistryError):
+                    self.module.validate_image_reference(reference)
+
+    def _row(self, image: object) -> dict:
+        return {
+            "id": "example-verifier",
+            "name": "Example verifier",
+            "suite": "privileged-mcp-action-v0",
+            "image": image,
+            "source": "https://example.test/verifier",
+            "commit": "1" * 40,
+            "language": "rust",
+            "reproduction_mode": "blind_from_spec",
+            "authorship": {"kind": "human"},
+        }
+
+    def test_row_validation_refuses_the_same_references(self) -> None:
+        self.module._validate_row(self._row(self.VALID), set())
+        for reference in self.HOSTILE:
+            with self.subTest(image=reference):
+                with self.assertRaises(self.module.ImplementationRegistryError):
+                    self.module._validate_row(self._row(reference), set())
+
+    def test_row_validation_goes_through_the_public_validator(self) -> None:
+        """Behavioural single-source proof.
+
+        If the row validator still matched the pattern itself, neutering the
+        public function would leave a tag-only image refused and this would fail.
+        """
+        with mock.patch.object(self.module, "validate_image_reference", return_value="accepted"):
+            self.module._validate_row(self._row("ghcr.io/example/verifier:latest"), set())
+
+    def test_published_schema_states_the_same_pattern(self) -> None:
+        schema = self.module.implementation_schema()
+        pattern = schema["properties"]["implementations"]["items"]["properties"]["image"]["pattern"]
+        self.assertEqual(pattern, self.module.IMAGE_PATTERN)
+        compiled = re.compile(pattern)
+        self.assertTrue(compiled.fullmatch(self.VALID))
+        for reference in self.HOSTILE:
+            with self.subTest(image=reference):
+                self.assertIsNone(compiled.fullmatch(reference))
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Implements Rul1an/assay-tunnel-experiments#199 (slice of #191), from the measured design in [issue #199 comment 5368130745](https://github.com/Rul1an/assay-tunnel-experiments/issues/199#issuecomment-5368130745).

**Base** `bb6ef072d74630a6b71b5d79cdadbdf1451e03c2` · **Head** `c24c3d2c77d373ec0572e5306b218a0248fb3a41`

## The gap this closes

`score_candidate.py` held the canonical oracle in the same process, on the same filesystem, while it executed candidate code. The defence was ordering — snapshot expectations before the candidate runs — which covers tampering, not confidentiality, and only the tamper direction had a test (`test_candidate_cannot_rewrite_oracle_or_report_a_mutated_pack_hash`).

Measured through the exact helper `run_candidate` uses: a candidate inherits the scorer's working directory and reads the canonical `MANIFEST.json` at a relative path, with all 14 expected surfaces. Positive control — a sibling path that does not exist raised `FileNotFoundError`, so the read is real. `action.yml:57` puts that file on the same runner as the entrypoint.

## What changed

`capture_candidate.py` runs the candidate and records what it emitted as `assay.privileged_mcp_action.candidate_capture.v0`. It takes no manifest and no expectations. `score_candidate.py --capture` scores that artifact elsewhere. `--entrypoint` still does both in one process, calling the same capture builder and the same scorer.

The scoring host recomputes every pack, corpus and case binding from its own copy of the pack and compares the capture's copies rather than adopting them. A capture that does not bind is refused before any comparison: exit `2`, **no run record**, no `unproved` token.

One strict bounded loader now reads every hostile JSON input here. `published_rows` already refused symlinks, oversized files, non-UTF-8 bytes, duplicate object names and non-finite numbers, so `strict_json` calls it and adds the two bounds it lacked: nesting depth — scanned *before* `json.loads`, because `RecursionError` is not a `ValueError` and would reach the user as a traceback — and the JSON number domain. `validate_run_record` reads through the same loader.

`implementations.py` exposes `validate_image_reference`; `_validate_row` calls it. `report.v0` gains optional `implementation.id` and `implementation.image`, present only together.

## RED → GREEN

First RED was the pair from the issue: a 13-observation capture and a duplicate-to-15 capture must exit 2 and leave no record, with the 14-observation control at 14/14 exit 0. Both failed on the missing module, which is an existence red and proves nothing on its own; the discriminating red is the control going green while the cardinality cases stay at exit 2. That is now the state.

| | |
|---|---|
| `-k CandidateCapture` | **17 OK** |
| full `test_activation_kit.py` | **42 OK** (25 pre-existing + 17 new) |
| `test_implementations.py` | **36 OK** (32 pre-existing + 4 new) |
| `test_registry`, `test_run_all`, `test_published_rows`, `test_published_numbers_guard`, `test_published_numbers_provenance`, `test_completion_scope`, `test_corpus_adequacy_own_corpora` | OK |
| `python3 conformance/implementations.py`, `conformance/registry.py` | rc=0 |
| `py_compile`, `json.tool` ×3, `cargo fmt --all -- --check`, `git diff --check` | OK |
| pre-commit and pre-push hooks on `c24c3d2c7` | Passed (incl. clippy, linux compile gate) |

Byte-identity is the migration guarantee and the proof there is one comparison: `test_direct_and_split_paths_produce_byte_identical_run_records` scores one deterministic fake candidate through both paths and asserts identical bytes.

## Mutations — 13/13 killed, control green

Runner restores in a `finally` and asserts the file hash matches the pre-mutation digest; the control runs before the matrix and any red control aborts.

| # | Mutation | Named test that died |
|---|---|---|
| M1 | capture cardinality → `>= 1` | `test_capture_validator_owns_cardinality_and_ordering` |
| M2 | positional `case_id` → any string | `test_capture_validator_owns_cardinality_and_ordering` |
| M3 | positional input-digest binding off | `test_capture_that_does_not_bind_the_pack_is_refused` |
| M4 | pack binding comparison off | `test_capture_that_does_not_bind_the_pack_is_refused` |
| M5 | record copies the capture's digest | `test_scorer_recomputes_the_pack_digest_rather_than_copying_it` |
| M5b | drop `pack_sha256` from the binding tuple | `test_capture_that_does_not_bind_the_pack_is_refused` |
| M6 | capture byte ceiling → 1 GiB | `test_capture_over_the_byte_ceiling_is_refused_by_the_ceiling` |
| M7 | bypass the strict parser | `test_hostile_capture_bytes_fail_closed_without_a_traceback` |
| M8 | remove the depth scan | `test_standalone_run_record_validator_bounds_bytes_and_nesting` |
| M9 | remove the JSON number domain | `test_strict_loader_owns_the_json_number_domain` |
| M10 | unbounded error text | `test_capture_error_text_is_bounded` |
| M11 | neuter the image rule | 7 tests across both suites |
| M12 | put the oracle back on the capture host | `test_capture_phase_completes_with_the_oracle_absent_from_its_filesystem` |

### Two earlier matrices did not count, and why

**First run** timed out mid-M7 and left `strict_json.py` mutated. My cleanliness check used `git diff` — blind to an untracked new file — so the next run's control was already red and every "KILLED" was the same pre-existing breakage. Discarded.

**Second run** had a green control and reported 6 killed, 6 survived. Four survivors were defects in my tests, each confirmed by measurement rather than inspection:

- the oversized fixture was sized from `MAX_CAPTURE_BYTES` itself, so it grew with the mutant;
- the deep fixture was 400001 bytes, over the 64 KiB ceiling, so the ceiling refused it and the depth scan was never reached — and within that ceiling, recursion is unreachable (measured: depth 60000 parses fine, 200000 raises), so the scan's purpose is only observable on the run-record loader's 4 MiB ceiling;
- cardinality and ordering were masked through the CLI by the run-record case count and the pack-binding check, so only a direct call to `validate_capture` can see them;
- the number domain is redundant with the per-field type checks at capture level, so it is pinned on the shared loader instead.

**M5 was measured, not assumed.** With the binding guard disabled, the unmutated line published `sha256:b35e5e3d…` (recomputed) and the mutant published `sha256:dddddddd…` (the capture's lie). So the two expressions differ in general and are equal only at the program point the guard creates — an observability gap, not an untested rule. It was made observable by calling `score_capture` directly with a lying capture, and M5b was added as a non-equivalent mutation on the same binding. No survivor was removed from the matrix.

## Non-claims

- A capture is an observation artifact: not a verdict, attestation, sandbox proof, or independent reproduction.
- **A hostile capture host can emit a perfect capture without running anything.** This does not prevent that and does not try to. It removes the oracle from the host where candidate code runs. Authenticating a capture is a different property.
- Separation is not sandboxing; `bounded_process.py` bounds I/O and the initial POSIX process group and says so in its own comments.
- A declared image digest addresses bytes. It does not authenticate the publisher and does not establish that the addressed image is the one that ran. `image: null` is a disclosure that none was declared.
- The scoring host recomputes pack, corpus and case bindings. Implementation identity has no independent source on that host and is carried from the capture as a shape-validated declaration.
- `test_capture_phase_completes_with_the_oracle_absent_from_its_filesystem` shows the capture phase *can* run with no oracle present. It does not show any deployment separates them; that is operational.

## Deliberately out of scope

No `.github/**` (the composite action is pinned by full commit for third parties and needs no change), no container pull or run, no signing, no matrix, badge, score or tier, no v1 corpus, no network. Candidate `cwd` is not pinned — that would break the documented `./target/release/my-verifier` entrypoint form and needs its own argv[0] resolution rule.

### Findings for separate issues, not fixed here

- `published_rows.parse_json_object` lets `RecursionError` escape on deeply nested input (measured). Reached through this corpus it is now unreachable because `strict_json` scans depth first, but the underlying helper is shared and out of this allowlist.
- The authorship axis has two vocabularies: `implementations.py` uses `human`/`agent-assisted`/`agent-generated`; `CONFORMANCE-PROTOCOL.md` uses the `Authored-By:`/`Assisted-By:`/`Generated-By:` trailers.
- The case count `14` is stated in four enforcing places. This branch adds none — `capture_format` imports `EXPECTED_CASE_COUNT` — but the existing four remain.

## Writer

I authored the #199 design and this change, so I am the builder and do not count toward review quorum. Draft; not ready, not merged. Final head to be dispatched for independent review by the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added split-phase candidate capture and scoring workflows.
  - Added capture validation with pack, source, corpus, case, and input integrity checks.
  - Added optional implementation identifiers and container image references to reports.
  - Added clearer scoring modes and capture limitations documentation.

- **Bug Fixes**
  - Standardized image-reference validation.
  - Strengthened JSON handling with nesting-depth, encoding, size, and safe-number limits.
  - Improved rejection of invalid or unbound captures before scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->