### PR TITLE
feat(conformance): add bounded OCI candidate executor (#203)

### DIFF
--- a/.github/workflows/privileged-mcp-action-conformance.yml
+++ b/.github/workflows/privileged-mcp-action-conformance.yml
@@ -45,7 +45,8 @@ jobs:
         run: |
           set -euo pipefail
           python3 -m unittest \
-            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \
+            conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
 
       - name: Validate public JSON documents
         run: |

--- a/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
@@ -21,6 +21,7 @@ import sys
 import tarfile
 import tempfile
 from pathlib import Path, PurePosixPath
+from collections.abc import Callable
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -245,18 +246,28 @@ def run_candidate(command: list[str], bundle: Path, timeout_seconds: int) -> dic
     }
 
 
+_DEFAULT_CANDIDATE_RUNNER = run_candidate
+
+
 def capture_observations(
     pack: dict[str, Any],
     command: list[str],
     timeout_seconds: int,
+    *,
+    candidate_runner: Callable[[list[str], Path, int], dict[str, Any]] = _DEFAULT_CANDIDATE_RUNNER,
 ) -> list[dict[str, Any]]:
     """Execute every opaque case and record one observation each, in pack order."""
+    runner = (
+        run_candidate
+        if candidate_runner is _DEFAULT_CANDIDATE_RUNNER
+        else candidate_runner
+    )
     observations = []
     for case in pack["cases"]:
         case_id = case["id"]
         digest = case["sha256"]
         try:
-            execution = run_candidate(command, Path(case["_local_path"]), timeout_seconds)
+            execution = runner(command, Path(case["_local_path"]), timeout_seconds)
         except HarnessError as error:
             observations.append(
                 observe_error(case_id, digest, STATE_CAPTURE_ERROR, str(error))

--- a/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import gzip
 import hashlib
+import io
 import json
 import shlex
 import sys
@@ -26,6 +27,8 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from bounded_process import ProcessCaptureError, ProcessLimitError, run_bounded  # noqa: E402
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "adequacy"))
+import published_rows  # noqa: E402
 from capture_format import (  # noqa: E402
     CAPTURE_NON_CLAIMS,
     CAPTURE_SCHEMA,
@@ -73,12 +76,12 @@ def sha256(data: bytes) -> str:
     return "sha256:" + hashlib.sha256(data).hexdigest()
 
 
+def read_pack_bytes(path: Path) -> bytes:
+    return published_rows.read_regular_file(Path(path), limit=MAX_PACK_BYTES)
+
+
 def sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        while chunk := stream.read(1024 * 1024):
-            digest.update(chunk)
-    return "sha256:" + digest.hexdigest()
+    return sha256(read_pack_bytes(path))
 
 
 def read_member(archive: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
@@ -95,12 +98,12 @@ def read_member(archive: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
     return data
 
 
-def load_pack(pack: Path, destination: Path) -> dict[str, Any]:
-    if pack.stat().st_size > MAX_PACK_BYTES:
+def load_pack_from_bytes(data: bytes, destination: Path) -> dict[str, Any]:
+    if len(data) > MAX_PACK_BYTES:
         raise ValueError(f"pack exceeds {MAX_PACK_BYTES} bytes")
     files: dict[str, bytes] = {}
     expanded_bytes = 0
-    with pack.open("rb") as raw:
+    with io.BytesIO(data) as raw:
         with gzip.GzipFile(fileobj=raw) as decoded:
             bounded = BoundedReader(decoded, MAX_PACK_ARCHIVE_BYTES)
             with tarfile.open(fileobj=bounded, mode="r|") as archive:
@@ -192,6 +195,16 @@ def load_pack(pack: Path, destination: Path) -> dict[str, Any]:
     if rendered_set_digest != index["rendered_set_digest"]:
         raise ValueError("pack rendered_set_digest does not bind its cases")
     return index
+
+
+def load_pack_with_digest(pack: Path, destination: Path) -> tuple[dict[str, Any], str]:
+    data = read_pack_bytes(pack)
+    return load_pack_from_bytes(data, destination), sha256(data)
+
+
+def load_pack(pack: Path, destination: Path) -> dict[str, Any]:
+    loaded, _digest = load_pack_with_digest(pack, destination)
+    return loaded
 
 
 def parse_candidate_report(stdout: bytes) -> dict[str, Any]:
@@ -334,8 +347,7 @@ def main() -> int:
         return 2
     with tempfile.TemporaryDirectory() as tmp:
         try:
-            pack = load_pack(args.pack, Path(tmp))
-            pack_digest = sha256_file(args.pack)
+            pack, pack_digest = load_pack_with_digest(args.pack, Path(tmp))
         except (
             OSError,
             EOFError,

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -304,20 +304,35 @@ def run_docker(
     return BoundedDockerResult(result.returncode, result.stdout, result.stderr)
 
 
-def local_image_docker_runner() -> DockerRunner:
-    """Pull step records the canonical argv; the inert fixture is already local."""
+def rewrite_fixture_image_argv(
+    argv: list[str], *, registry_ref: str, local_ref: str
+) -> list[str]:
+    """Test-only: a local tag is not a RepoDigest. Hosted Docker will pull."""
+    if not registry_ref or not local_ref or registry_ref == local_ref:
+        raise ValueError("fixture registry ref and local ref must be distinct")
+    return [local_ref if item == registry_ref else item for item in argv]
+
+
+def local_image_docker_runner(*, registry_ref: str, local_ref: str) -> DockerRunner:
+    """Pull step records the canonical argv; daemon calls use the local tag/id."""
 
     def runner(argv: list[str], **kwargs: Any) -> BoundedDockerResult:
         env = kwargs.get("env")
         if env is None:
             raise DockerCommandError("docker invocations require a fresh DOCKER_CONFIG")
         if len(argv) >= 2 and argv[1] == "pull":
-            image = argv[-1]
-            expected = ["docker", "pull", "--platform", PLATFORM, image]
+            expected = ["docker", "pull", "--platform", PLATFORM, registry_ref]
             if argv != expected:
                 raise DockerCommandError("pull argv drifted from the digest/platform contract")
             probe = run_bounded(
-                wrap_docker_command(["docker", "image", "inspect", image], env),
+                wrap_docker_command(
+                    rewrite_fixture_image_argv(
+                        ["docker", "image", "inspect", registry_ref],
+                        registry_ref=registry_ref,
+                        local_ref=local_ref,
+                    ),
+                    env,
+                ),
                 timeout_seconds=30,
                 stdout_limit=1_000_000,
                 stderr_limit=64 * 1024,
@@ -325,7 +340,12 @@ def local_image_docker_runner() -> DockerRunner:
             if probe.returncode != 0:
                 raise DockerCommandError("local fixture image is missing")
             return BoundedDockerResult(0, b"", b"")
-        return run_docker(argv, **kwargs)
+        return run_docker(
+            rewrite_fixture_image_argv(
+                argv, registry_ref=registry_ref, local_ref=local_ref
+            ),
+            **kwargs,
+        )
 
     return runner
 

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -438,10 +438,35 @@ def execute_candidate(
     return OciExecution(state, implementation_id, image, exit_code, stdout, stderr, error)
 
 
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    fd, tmp_name = tempfile.mkstemp(prefix=".partial-", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        written = 0
+        while written < len(data):
+            written += os.write(fd, data[written:])
+        os.close(fd)
+        fd = -1
+        os.replace(tmp, path)
+    except Exception:
+        if fd >= 0:
+            os.close(fd)
+        tmp.unlink(missing_ok=True)
+        raise
+
+
 def write_handoff(output_dir: Path, result: OciExecution) -> None:
-    output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / CANDIDATE_STDOUT_NAME).write_bytes(result.stdout)
-    (output_dir / CANDIDATE_STDERR_NAME).write_bytes(result.stderr)
+    output_dir = Path(output_dir)
+    if output_dir.is_symlink():
+        raise ValueError("handoff directory must not be a symlink")
+    if output_dir.exists() and not output_dir.is_dir():
+        raise ValueError("handoff path must be an empty directory")
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise ValueError("handoff directory must be empty")
+    if len(result.stdout) > STDOUT_LIMIT or len(result.stderr) > STDERR_LIMIT:
+        raise ValueError("candidate output exceeds its byte ceiling")
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True)
     document = {
         "schema": EXECUTION_SCHEMA,
         "implementation_id": result.implementation_id,
@@ -459,18 +484,16 @@ def write_handoff(output_dir: Path, result: OciExecution) -> None:
             "stderr_bytes": len(result.stderr),
         },
     }
-    path = output_dir / EXECUTION_DOCUMENT_NAME
-    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    _atomic_write_bytes(output_dir / CANDIDATE_STDOUT_NAME, result.stdout)
+    _atomic_write_bytes(output_dir / CANDIDATE_STDERR_NAME, result.stderr)
+    _atomic_write_bytes(output_dir / EXECUTION_DOCUMENT_NAME, payload)
     load_strict_object(
-        path,
+        output_dir / EXECUTION_DOCUMENT_NAME,
         label="oci execution",
         max_bytes=MAX_EXECUTION_BYTES,
         max_depth=MAX_EXECUTION_DEPTH,
     )
-
-
-def write_execution(path: Path, result: OciExecution) -> None:
-    write_handoff(path if path.suffix != ".json" else path.parent, result)
 
 
 def oci_entrypoint_command(
@@ -495,14 +518,7 @@ def parse_oci_command(command: list[str]) -> argparse.Namespace:
         argv = argv[1:]
     if argv and argv[0].endswith("oci_candidate_executor.py"):
         argv = argv[1:]
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--implementation-id", required=True)
-    parser.add_argument("--registry", type=Path)
-    parser.add_argument("--bundle", type=Path)
-    parser.add_argument("--output", type=Path)
-    parser.add_argument("--timeout-seconds", type=int, default=30)
-    parsed, _unknown = parser.parse_known_args(argv)
-    return parsed
+    return parse_args(argv)
 
 
 def run_oci_candidate(
@@ -512,12 +528,7 @@ def run_oci_candidate(
     *,
     docker_runner: DockerRunner | None = None,
 ) -> dict[str, Any]:
-    """Drop-in for `capture_candidate.run_candidate`.
-
-    `command` is an entrypoint list from `oci_entrypoint_command`.
-    `capture_observations(pack, command, timeout)` calls this in place of
-    `run_candidate` without a second observation loop.
-    """
+    """Same shape as `capture_candidate.run_candidate` for the shared loop."""
     args = parse_oci_command(command)
     result = execute_candidate(
         implementation_id=args.implementation_id,
@@ -536,6 +547,16 @@ def run_oci_candidate(
     if result.state in CANDIDATE_LIMIT_STATES:
         raise CandidateError(result.error or result.state)
     raise HarnessError(result.error or result.state)
+
+
+def capture_oci_observations(
+    pack: dict[str, Any],
+    command: list[str],
+    timeout_seconds: int,
+) -> list[dict[str, Any]]:
+    return capture_candidate.capture_observations(
+        pack, command, timeout_seconds, candidate_runner=run_oci_candidate
+    )
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -456,7 +456,7 @@ def execute_candidate(
                     runner(["docker", "inspect", container_id], env=env).stdout
                 )
                 raw_exit = (container.get("State") or {}).get("ExitCode")
-                if isinstance(raw_exit, int):
+                if type(raw_exit) is int:
                     exit_code = raw_exit
                     if (container.get("State") or {}).get("OOMKilled"):
                         state = STATE_OOM

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -63,6 +63,7 @@ EXECUTION_DOCUMENT_NAME = "oci-execution.json"
 CANDIDATE_STDOUT_NAME = "candidate.stdout"
 CANDIDATE_STDERR_NAME = "candidate.stderr"
 HANDOFF_TEMP_PREFIX = ".assay-oci-handoff-"
+CAPTURE_TEMP_PREFIX = ".assay-oci-capture-"
 MAX_EXECUTION_BYTES = 16 * 1024
 MAX_EXECUTION_DEPTH = 6
 
@@ -592,12 +593,30 @@ def write_validated_capture(
         pack, pack_digest, observations, identity_from_registry_row(row)
     )
     validate_capture(capture)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(
-        json.dumps(capture, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    write_regular_file_atomically(
+        output,
+        (json.dumps(capture, indent=2, sort_keys=True) + "\n").encode("utf-8"),
     )
     print(f"captured {len(observations)} observations")
+
+
+def write_regular_file_atomically(path: Path, data: bytes) -> None:
+    parent = Path(path).parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=CAPTURE_TEMP_PREFIX, dir=str(parent))
+    tmp = Path(tmp_name)
+    try:
+        written = 0
+        while written < len(data):
+            written += os.write(fd, data[written:])
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        os.replace(tmp, path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        tmp.unlink(missing_ok=True)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -641,11 +660,11 @@ def main(argv: list[str] | None = None) -> int:
             bundle_path=args.bundle,
             timeout_seconds=args.timeout_seconds,
         )
+        if args.output is not None:
+            write_handoff(args.output, result)
     except (ImplementationRegistryError, ValueError, OSError) as error:
         print(str(error), file=sys.stderr)
         return 2
-    if args.output is not None:
-        write_handoff(args.output, result)
     print(result.state)
     return 0
 

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -10,8 +10,10 @@ failures are named execution states, never agreement.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import shutil
 import sys
 import tempfile
 import uuid
@@ -21,6 +23,8 @@ from typing import Any, Callable
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from bounded_process import ProcessLimitError, run_bounded  # noqa: E402
+import capture_candidate  # noqa: E402
+from capture_candidate import CandidateError, HarnessError  # noqa: E402
 from capture_format import (  # noqa: E402
     STATE_CANDIDATE_ERROR,
     STATE_CAPTURE_ERROR,
@@ -35,6 +39,9 @@ from implementations import (  # noqa: E402
     validate_image_reference,
 )
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "adequacy"))
+import published_rows  # noqa: E402
+
 PLATFORM = "linux/amd64"
 RUNTIME_USER = "65532:65532"
 CPUS = "0.50"
@@ -45,9 +52,14 @@ TMPFS_SPEC = "/tmp:rw,nosuid,nodev,noexec,size=16m"
 LOG_MAX_SIZE = "64k"
 LOG_MAX_FILE = "1"
 BUNDLE_DEST = "/input/bundle.tar.gz"
+STAGED_BUNDLE_NAME = "opaque.bundle"
 STDOUT_LIMIT = 64 * 1024
 STDERR_LIMIT = 64 * 1024
+MAX_BUNDLE_BYTES = 16 * 1024 * 1024
 EXECUTION_SCHEMA = "assay.privileged_mcp_action.oci_execution.v0"
+EXECUTION_DOCUMENT_NAME = "oci-execution.json"
+CANDIDATE_STDOUT_NAME = "candidate.stdout"
+CANDIDATE_STDERR_NAME = "candidate.stderr"
 MAX_EXECUTION_BYTES = 16 * 1024
 MAX_EXECUTION_DEPTH = 6
 
@@ -113,11 +125,45 @@ class OciExecution:
 DockerRunner = Callable[..., BoundedDockerResult]
 
 
+def _content_digest(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def resolve_docker_executable() -> Path:
+    found = shutil.which("docker")
+    if found is None:
+        raise DockerCommandError("docker executable not found")
+    return Path(found).resolve()
+
+
+def resolve_local_docker_host() -> str | None:
+    for socket in (Path("/var/run/docker.sock"), Path.home() / ".docker/run/docker.sock"):
+        if socket.exists():
+            return "unix://%s" % socket
+    return None
+
+
 def fresh_docker_env(parent: Path) -> tuple[dict[str, str], Path]:
     config_dir = Path(tempfile.mkdtemp(prefix="assay-oci-docker-config-", dir=parent))
-    env = {key: value for key, value in os.environ.items() if key != "REGISTRY_AUTH_FILE"}
-    env["DOCKER_CONFIG"] = str(config_dir)
+    home = Path(parent) / "empty-home"
+    home.mkdir(exist_ok=True)
+    env = {
+        "PATH": str(resolve_docker_executable().parent),
+        "DOCKER_CONFIG": str(config_dir),
+        "HOME": str(home),
+        "TMPDIR": str(parent),
+    }
+    host = resolve_local_docker_host()
+    if host is not None:
+        env["DOCKER_HOST"] = host
     return env, config_dir
+
+
+def wrap_docker_command(argv: list[str], env: dict[str, str]) -> list[str]:
+    if not argv or argv[0] != "docker":
+        raise DockerCommandError("docker argv must start with docker")
+    assignments = ["%s=%s" % (key, env[key]) for key in sorted(env)]
+    return ["env", "-i", *assignments, str(resolve_docker_executable()), *argv[1:]]
 
 
 def implementation_from_registry(
@@ -137,18 +183,25 @@ def reject_declared_volumes(image_inspect: dict[str, Any]) -> None:
         raise VolumeDeclarationError("image declares volume(s): %s" % sorted(volumes))
 
 
+def stage_opaque_bundle(source: Path, staging_dir: Path) -> Path:
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    data = published_rows.read_regular_file(Path(source), limit=MAX_BUNDLE_BYTES)
+    staged = Path(staging_dir) / STAGED_BUNDLE_NAME
+    staged.write_bytes(data)
+    staged.chmod(0o400)
+    return staged.resolve()
+
+
 def build_container_create_argv(
     *,
     image: str,
     bundle_path: Path,
     container_name: str,
+    staging_dir: Path,
     command: tuple[str, ...] = (),
 ) -> list[str]:
     validate_image_reference(image)
-    bundle = Path(bundle_path)
-    if bundle.is_symlink() or not bundle.is_file():
-        raise ValueError("bundle must be a regular file")
-    bundle = bundle.resolve()
+    staged = stage_opaque_bundle(bundle_path, staging_dir)
     return [
         "docker",
         "create",
@@ -184,7 +237,7 @@ def build_container_create_argv(
         "--restart",
         "no",
         "--mount",
-        f"type=bind,src={bundle},dst={BUNDLE_DEST},ro=true",
+        f"type=bind,src={staged},dst={BUNDLE_DEST},ro=true",
         image,
         *command,
     ]
@@ -208,18 +261,6 @@ def observation_for(
     return observe_error(case_id, input_sha256, capture_state, message)
 
 
-def _wrap_docker(argv: list[str], env: dict[str, str]) -> list[str]:
-    if not argv or argv[0] != "docker":
-        raise DockerCommandError("docker argv must start with docker")
-    return [
-        "env",
-        "-u",
-        "REGISTRY_AUTH_FILE",
-        f"DOCKER_CONFIG={env['DOCKER_CONFIG']}",
-        *argv,
-    ]
-
-
 def run_docker(
     argv: list[str],
     *,
@@ -231,15 +272,12 @@ def run_docker(
 ) -> BoundedDockerResult:
     if env is None:
         raise DockerCommandError("docker invocations require a fresh DOCKER_CONFIG")
-    try:
-        result = run_bounded(
-            _wrap_docker(argv, env),
-            timeout_seconds=timeout_seconds,
-            stdout_limit=stdout_limit,
-            stderr_limit=stderr_limit,
-        )
-    except ProcessLimitError as error:
-        raise
+    result = run_bounded(
+        wrap_docker_command(argv, env),
+        timeout_seconds=timeout_seconds,
+        stdout_limit=stdout_limit,
+        stderr_limit=stderr_limit,
+    )
     if result.returncode != 0 and not allow_nonzero:
         detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
         raise DockerCommandError(detail)
@@ -250,13 +288,16 @@ def local_image_docker_runner() -> DockerRunner:
     """Pull step records the canonical argv; the inert fixture is already local."""
 
     def runner(argv: list[str], **kwargs: Any) -> BoundedDockerResult:
+        env = kwargs.get("env")
+        if env is None:
+            raise DockerCommandError("docker invocations require a fresh DOCKER_CONFIG")
         if len(argv) >= 2 and argv[1] == "pull":
             image = argv[-1]
             expected = ["docker", "pull", "--platform", PLATFORM, image]
             if argv != expected:
                 raise DockerCommandError("pull argv drifted from the digest/platform contract")
             probe = run_bounded(
-                ["docker", "image", "inspect", image],
+                wrap_docker_command(["docker", "image", "inspect", image], env),
                 timeout_seconds=30,
                 stdout_limit=1_000_000,
                 stderr_limit=64 * 1024,
@@ -271,12 +312,9 @@ def local_image_docker_runner() -> DockerRunner:
 
 def _parse_inspect(payload: bytes) -> dict[str, Any]:
     document = json.loads(payload.decode("utf-8"))
-    if not isinstance(document, list) or not document:
+    if not isinstance(document, list) or not document or not isinstance(document[0], dict):
         raise DockerCommandError("docker inspect did not return an object")
-    first = document[0]
-    if not isinstance(first, dict):
-        raise DockerCommandError("docker inspect did not return an object")
-    return first
+    return document[0]
 
 
 def _limit_state(error: ProcessLimitError) -> str:
@@ -307,7 +345,9 @@ def execute_candidate(
     error = ""
     container_id: str | None = None
     with tempfile.TemporaryDirectory(prefix="assay-oci-exec-") as raw:
-        env, _config_dir = fresh_docker_env(Path(raw))
+        root = Path(raw)
+        env, _config_dir = fresh_docker_env(root)
+        staging_dir = root / "stage"
         try:
             try:
                 runner(
@@ -337,6 +377,7 @@ def execute_candidate(
                         image=image,
                         bundle_path=bundle_path,
                         container_name=name,
+                        staging_dir=staging_dir,
                         command=command,
                     ),
                     env=env,
@@ -372,10 +413,7 @@ def execute_candidate(
                 exit_code = (container.get("State") or {}).get("ExitCode")
                 if not isinstance(exit_code, int):
                     exit_code = None
-                if (container.get("State") or {}).get("OOMKilled") and state not in (
-                    STATE_TIMEOUT,
-                    STATE_OUTPUT_OVERFLOW,
-                ):
+                if (container.get("State") or {}).get("OOMKilled"):
                     state = STATE_OOM
                     error = error or "container OOMKilled"
                 if state is None:
@@ -400,7 +438,10 @@ def execute_candidate(
     return OciExecution(state, implementation_id, image, exit_code, stdout, stderr, error)
 
 
-def write_execution(path: Path, result: OciExecution) -> None:
+def write_handoff(output_dir: Path, result: OciExecution) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / CANDIDATE_STDOUT_NAME).write_bytes(result.stdout)
+    (output_dir / CANDIDATE_STDERR_NAME).write_bytes(result.stderr)
     document = {
         "schema": EXECUTION_SCHEMA,
         "implementation_id": result.implementation_id,
@@ -409,8 +450,16 @@ def write_execution(path: Path, result: OciExecution) -> None:
         "exit_code": result.exit_code,
         "error": result.error,
         "oci_executor_non_claims": list(OCI_EXECUTOR_NON_CLAIMS),
+        "candidate_output": {
+            "stdout": CANDIDATE_STDOUT_NAME,
+            "stderr": CANDIDATE_STDERR_NAME,
+            "stdout_sha256": _content_digest(result.stdout),
+            "stderr_sha256": _content_digest(result.stderr),
+            "stdout_bytes": len(result.stdout),
+            "stderr_bytes": len(result.stderr),
+        },
     }
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path = output_dir / EXECUTION_DOCUMENT_NAME
     path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     load_strict_object(
         path,
@@ -420,11 +469,81 @@ def write_execution(path: Path, result: OciExecution) -> None:
     )
 
 
+def write_execution(path: Path, result: OciExecution) -> None:
+    write_handoff(path if path.suffix != ".json" else path.parent, result)
+
+
+def oci_entrypoint_command(
+    *,
+    implementation_id: str,
+    registry_path: Path | None = None,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--implementation-id",
+        implementation_id,
+    ]
+    if registry_path is not None:
+        command.extend(["--registry", str(registry_path)])
+    return command
+
+
+def parse_oci_command(command: list[str]) -> argparse.Namespace:
+    argv = list(command)
+    if argv and Path(argv[0]).name.startswith("python"):
+        argv = argv[1:]
+    if argv and argv[0].endswith("oci_candidate_executor.py"):
+        argv = argv[1:]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--implementation-id", required=True)
+    parser.add_argument("--registry", type=Path)
+    parser.add_argument("--bundle", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--timeout-seconds", type=int, default=30)
+    parsed, _unknown = parser.parse_known_args(argv)
+    return parsed
+
+
+def run_oci_candidate(
+    command: list[str],
+    bundle: Path,
+    timeout_seconds: int,
+    *,
+    docker_runner: DockerRunner | None = None,
+) -> dict[str, Any]:
+    """Drop-in for `capture_candidate.run_candidate`.
+
+    `command` is an entrypoint list from `oci_entrypoint_command`.
+    `capture_observations(pack, command, timeout)` calls this in place of
+    `run_candidate` without a second observation loop.
+    """
+    args = parse_oci_command(command)
+    result = execute_candidate(
+        implementation_id=args.implementation_id,
+        bundle_path=bundle,
+        registry_path=args.registry,
+        timeout_seconds=timeout_seconds,
+        docker_runner=docker_runner,
+    )
+    if result.state == STATE_COMPLETED:
+        report = capture_candidate.parse_candidate_report(result.stdout)
+        return {
+            "exit_code": 0 if result.exit_code is None else result.exit_code,
+            "report": report,
+            "stderr_present": bool(result.stderr),
+        }
+    if result.state in CANDIDATE_LIMIT_STATES:
+        raise CandidateError(result.error or result.state)
+    raise HarnessError(result.error or result.state)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--implementation-id", required=True)
-    parser.add_argument("--bundle", type=Path, required=True)
-    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--registry", type=Path)
+    parser.add_argument("--bundle", type=Path)
+    parser.add_argument("--output", type=Path)
     parser.add_argument("--timeout-seconds", type=int, default=30)
     return parser.parse_args(argv)
 
@@ -434,16 +553,21 @@ def main(argv: list[str] | None = None) -> int:
     if args.timeout_seconds <= 0:
         print("timeout-seconds must be positive", file=sys.stderr)
         return 2
+    if args.bundle is None:
+        print("--bundle is required", file=sys.stderr)
+        return 2
     try:
         result = execute_candidate(
             implementation_id=args.implementation_id,
             bundle_path=args.bundle,
+            registry_path=args.registry,
             timeout_seconds=args.timeout_seconds,
         )
     except (ImplementationRegistryError, ValueError, OSError) as error:
         print(str(error), file=sys.stderr)
         return 2
-    write_execution(args.output, result)
+    if args.output is not None:
+        write_handoff(args.output, result)
     print(result.state)
     return 0
 

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -107,6 +107,9 @@ class DockerCommandError(RuntimeError):
     """A docker CLI invocation failed before a named limit applied."""
 
 
+DOCKER_LIFECYCLE_ERRORS = (DockerCommandError, ProcessLimitError, OSError)
+
+
 @dataclass(frozen=True)
 class BoundedDockerResult:
     returncode: int
@@ -326,7 +329,10 @@ def local_image_docker_runner() -> DockerRunner:
 
 
 def _parse_inspect(payload: bytes) -> dict[str, Any]:
-    document = json.loads(payload.decode("utf-8"))
+    try:
+        document = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DockerCommandError("docker inspect did not return an object") from exc
     if not isinstance(document, list) or not document or not isinstance(document[0], dict):
         raise DockerCommandError("docker inspect did not return an object")
     return document[0]
@@ -370,7 +376,7 @@ def execute_candidate(
                     env=env,
                     timeout_seconds=60,
                 )
-            except (DockerCommandError, ProcessLimitError, OSError) as exc:
+            except DOCKER_LIFECYCLE_ERRORS as exc:
                 return OciExecution(
                     STATE_PULL_FAILURE, implementation_id, image, None, b"", b"", str(exc)
                 )
@@ -381,26 +387,29 @@ def execute_candidate(
                 return OciExecution(
                     STATE_CREATE_FAILURE, implementation_id, image, None, b"", b"", str(exc)
                 )
-            except (DockerCommandError, ProcessLimitError, json.JSONDecodeError) as exc:
+            except DOCKER_LIFECYCLE_ERRORS as exc:
                 return OciExecution(
                     STATE_CREATE_FAILURE, implementation_id, image, None, b"", b"", str(exc)
                 )
             name = f"assay-oci-{os.getpid()}-{uuid.uuid4().hex[:8]}"
             try:
-                created = runner(
-                    build_container_create_argv(
-                        image=image,
-                        bundle_path=bundle_path,
-                        container_name=name,
-                        staging_dir=staging_dir,
-                        command=command,
-                    ),
-                    env=env,
-                )
+                try:
+                    created = runner(
+                        build_container_create_argv(
+                            image=image,
+                            bundle_path=bundle_path,
+                            container_name=name,
+                            staging_dir=staging_dir,
+                            command=command,
+                        ),
+                        env=env,
+                    )
+                except ValueError as exc:
+                    raise DockerCommandError(str(exc)) from exc
                 container_id = created.stdout.decode("utf-8", "replace").strip()
                 if not container_id:
                     raise DockerCommandError("docker create returned no container id")
-            except (DockerCommandError, ProcessLimitError, ValueError) as exc:
+            except DOCKER_LIFECYCLE_ERRORS as exc:
                 return OciExecution(
                     STATE_CREATE_FAILURE, implementation_id, image, None, b"", b"", str(exc)
                 )
@@ -415,11 +424,11 @@ def execute_candidate(
                 )
                 stdout = started.stdout
                 stderr = started.stderr
-            except ProcessLimitError as exc:
-                state = _limit_state(exc)
-                error = str(exc)
-            except DockerCommandError as exc:
-                state = STATE_START_FAILURE
+            except DOCKER_LIFECYCLE_ERRORS as exc:
+                if isinstance(exc, ProcessLimitError):
+                    state = _limit_state(exc)
+                else:
+                    state = STATE_START_FAILURE
                 error = str(exc)
             try:
                 container = _parse_inspect(
@@ -433,7 +442,7 @@ def execute_candidate(
                     error = error or "container OOMKilled"
                 if state is None:
                     state = STATE_COMPLETED
-            except (DockerCommandError, ProcessLimitError, json.JSONDecodeError) as exc:
+            except DOCKER_LIFECYCLE_ERRORS as exc:
                 if state is None:
                     state = STATE_START_FAILURE
                     error = str(exc)
@@ -444,7 +453,7 @@ def execute_candidate(
                         ["docker", "rm", "--force", "--volumes", container_id],
                         env=env,
                     )
-                except (DockerCommandError, ProcessLimitError) as exc:
+                except DOCKER_LIFECYCLE_ERRORS as exc:
                     state = STATE_CLEANUP_FAILURE
                     error = str(exc)
     if state is None:
@@ -498,20 +507,13 @@ def write_handoff(output_dir: Path, result: OciExecution) -> None:
         raise
 
 
-def oci_entrypoint_command(
-    *,
-    implementation_id: str,
-    registry_path: Path | None = None,
-) -> list[str]:
-    command = [
+def oci_entrypoint_command(*, implementation_id: str) -> list[str]:
+    return [
         sys.executable,
         str(Path(__file__).resolve()),
         "--implementation-id",
         implementation_id,
     ]
-    if registry_path is not None:
-        command.extend(["--registry", str(registry_path)])
-    return command
 
 
 def parse_oci_command(command: list[str]) -> argparse.Namespace:
@@ -529,13 +531,14 @@ def run_oci_candidate(
     timeout_seconds: int,
     *,
     docker_runner: DockerRunner | None = None,
+    registry_path: Path | None = None,
 ) -> dict[str, Any]:
     """Same shape as `capture_candidate.run_candidate` for the shared loop."""
     args = parse_oci_command(command)
     result = execute_candidate(
         implementation_id=args.implementation_id,
         bundle_path=bundle,
-        registry_path=args.registry,
+        registry_path=registry_path,
         timeout_seconds=timeout_seconds,
         docker_runner=docker_runner,
     )
@@ -564,7 +567,6 @@ def capture_oci_observations(
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--implementation-id", required=True)
-    parser.add_argument("--registry", type=Path)
     parser.add_argument("--pack", type=Path)
     parser.add_argument("--bundle", type=Path)
     parser.add_argument("--output", type=Path)
@@ -577,14 +579,11 @@ def write_validated_capture(
     implementation_id: str,
     output: Path,
     *,
-    registry_path: Path | None,
+    registry_path: Path | None = None,
     timeout_seconds: int,
 ) -> None:
     row = implementation_from_registry(implementation_id, registry_path)
-    command = oci_entrypoint_command(
-        implementation_id=implementation_id,
-        registry_path=registry_path,
-    )
+    command = oci_entrypoint_command(implementation_id=implementation_id)
     with tempfile.TemporaryDirectory() as tmp:
         pack = capture_candidate.load_pack(pack_path, Path(tmp))
         pack_digest = capture_candidate.sha256_file(pack_path)
@@ -618,7 +617,6 @@ def main(argv: list[str] | None = None) -> int:
                 args.pack,
                 args.implementation_id,
                 args.output,
-                registry_path=args.registry,
                 timeout_seconds=args.timeout_seconds,
             )
         except (
@@ -641,7 +639,6 @@ def main(argv: list[str] | None = None) -> int:
         result = execute_candidate(
             implementation_id=args.implementation_id,
             bundle_path=args.bundle,
-            registry_path=args.registry,
             timeout_seconds=args.timeout_seconds,
         )
     except (ImplementationRegistryError, ValueError, OSError) as error:

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -60,6 +60,7 @@ EXECUTION_SCHEMA = "assay.privileged_mcp_action.oci_execution.v0"
 EXECUTION_DOCUMENT_NAME = "oci-execution.json"
 CANDIDATE_STDOUT_NAME = "candidate.stdout"
 CANDIDATE_STDERR_NAME = "candidate.stderr"
+HANDOFF_TEMP_PREFIX = ".assay-oci-handoff-"
 MAX_EXECUTION_BYTES = 16 * 1024
 MAX_EXECUTION_DEPTH = 6
 
@@ -438,62 +439,49 @@ def execute_candidate(
     return OciExecution(state, implementation_id, image, exit_code, stdout, stderr, error)
 
 
-def _atomic_write_bytes(path: Path, data: bytes) -> None:
-    fd, tmp_name = tempfile.mkstemp(prefix=".partial-", dir=str(path.parent))
-    tmp = Path(tmp_name)
-    try:
-        written = 0
-        while written < len(data):
-            written += os.write(fd, data[written:])
-        os.close(fd)
-        fd = -1
-        os.replace(tmp, path)
-    except Exception:
-        if fd >= 0:
-            os.close(fd)
-        tmp.unlink(missing_ok=True)
-        raise
-
-
 def write_handoff(output_dir: Path, result: OciExecution) -> None:
     output_dir = Path(output_dir)
-    if output_dir.is_symlink():
-        raise ValueError("handoff directory must not be a symlink")
-    if output_dir.exists() and not output_dir.is_dir():
-        raise ValueError("handoff path must be an empty directory")
-    if output_dir.exists() and any(output_dir.iterdir()):
-        raise ValueError("handoff directory must be empty")
+    if output_dir.is_symlink() or output_dir.exists():
+        raise ValueError("handoff destination must not already exist")
     if len(result.stdout) > STDOUT_LIMIT or len(result.stderr) > STDERR_LIMIT:
         raise ValueError("candidate output exceeds its byte ceiling")
-    if not output_dir.exists():
-        output_dir.mkdir(parents=True)
-    document = {
-        "schema": EXECUTION_SCHEMA,
-        "implementation_id": result.implementation_id,
-        "image": result.image,
-        "execution_state": result.state,
-        "exit_code": result.exit_code,
-        "error": result.error,
-        "oci_executor_non_claims": list(OCI_EXECUTOR_NON_CLAIMS),
-        "candidate_output": {
-            "stdout": CANDIDATE_STDOUT_NAME,
-            "stderr": CANDIDATE_STDERR_NAME,
-            "stdout_sha256": _content_digest(result.stdout),
-            "stderr_sha256": _content_digest(result.stderr),
-            "stdout_bytes": len(result.stdout),
-            "stderr_bytes": len(result.stderr),
-        },
-    }
-    payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
-    _atomic_write_bytes(output_dir / CANDIDATE_STDOUT_NAME, result.stdout)
-    _atomic_write_bytes(output_dir / CANDIDATE_STDERR_NAME, result.stderr)
-    _atomic_write_bytes(output_dir / EXECUTION_DOCUMENT_NAME, payload)
-    load_strict_object(
-        output_dir / EXECUTION_DOCUMENT_NAME,
-        label="oci execution",
-        max_bytes=MAX_EXECUTION_BYTES,
-        max_depth=MAX_EXECUTION_DEPTH,
-    )
+    parent = output_dir.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp = Path(tempfile.mkdtemp(prefix=HANDOFF_TEMP_PREFIX, dir=str(parent)))
+    try:
+        document = {
+            "schema": EXECUTION_SCHEMA,
+            "implementation_id": result.implementation_id,
+            "image": result.image,
+            "execution_state": result.state,
+            "exit_code": result.exit_code,
+            "error": result.error,
+            "oci_executor_non_claims": list(OCI_EXECUTOR_NON_CLAIMS),
+            "candidate_output": {
+                "stdout": CANDIDATE_STDOUT_NAME,
+                "stderr": CANDIDATE_STDERR_NAME,
+                "stdout_sha256": _content_digest(result.stdout),
+                "stderr_sha256": _content_digest(result.stderr),
+                "stdout_bytes": len(result.stdout),
+                "stderr_bytes": len(result.stderr),
+            },
+        }
+        payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        (tmp / CANDIDATE_STDOUT_NAME).write_bytes(result.stdout)
+        (tmp / CANDIDATE_STDERR_NAME).write_bytes(result.stderr)
+        (tmp / EXECUTION_DOCUMENT_NAME).write_bytes(payload)
+        load_strict_object(
+            tmp / EXECUTION_DOCUMENT_NAME,
+            label="oci execution",
+            max_bytes=MAX_EXECUTION_BYTES,
+            max_depth=MAX_EXECUTION_DEPTH,
+        )
+        if output_dir.is_symlink() or output_dir.exists():
+            raise ValueError("handoff destination must not already exist")
+        os.rename(tmp, output_dir)
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
 
 
 def oci_entrypoint_command(

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Bounded OCI candidate executor. Isolation limits are defense in depth.
+
+Selects an image only by registry `implementation_id`. Constructs one create
+argv, then runs pull -> inspect -> create -> bounded start/attach -> inspect
+-> force-remove. Timeout, OOM, overflow, and pull/create/start/cleanup
+failures are named execution states, never agreement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bounded_process import ProcessLimitError, run_bounded  # noqa: E402
+from capture_format import (  # noqa: E402
+    STATE_CANDIDATE_ERROR,
+    STATE_CAPTURE_ERROR,
+    observe_error,
+)
+from strict_json import load_strict_object  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from implementations import (  # noqa: E402
+    ImplementationRegistryError,
+    load_implementations,
+    validate_image_reference,
+)
+
+PLATFORM = "linux/amd64"
+RUNTIME_USER = "65532:65532"
+CPUS = "0.50"
+MEMORY = "256m"
+MEMORY_SWAP = "256m"
+PIDS_LIMIT = "64"
+TMPFS_SPEC = "/tmp:rw,nosuid,nodev,noexec,size=16m"
+LOG_MAX_SIZE = "64k"
+LOG_MAX_FILE = "1"
+BUNDLE_DEST = "/input/bundle.tar.gz"
+STDOUT_LIMIT = 64 * 1024
+STDERR_LIMIT = 64 * 1024
+EXECUTION_SCHEMA = "assay.privileged_mcp_action.oci_execution.v0"
+MAX_EXECUTION_BYTES = 16 * 1024
+MAX_EXECUTION_DEPTH = 6
+
+STATE_COMPLETED = "completed"
+STATE_TIMEOUT = "timeout"
+STATE_OOM = "oom"
+STATE_OUTPUT_OVERFLOW = "output_overflow"
+STATE_PULL_FAILURE = "pull_failure"
+STATE_CREATE_FAILURE = "create_failure"
+STATE_START_FAILURE = "start_failure"
+STATE_CLEANUP_FAILURE = "cleanup_failure"
+EXECUTION_STATES = (
+    STATE_COMPLETED,
+    STATE_TIMEOUT,
+    STATE_OOM,
+    STATE_OUTPUT_OVERFLOW,
+    STATE_PULL_FAILURE,
+    STATE_CREATE_FAILURE,
+    STATE_START_FAILURE,
+    STATE_CLEANUP_FAILURE,
+)
+CANDIDATE_LIMIT_STATES = (STATE_TIMEOUT, STATE_OOM, STATE_OUTPUT_OVERFLOW)
+HARNESS_FAILURE_STATES = (
+    STATE_PULL_FAILURE,
+    STATE_CREATE_FAILURE,
+    STATE_START_FAILURE,
+    STATE_CLEANUP_FAILURE,
+)
+
+OCI_EXECUTOR_NON_CLAIMS = (
+    "No container/kernel security, image authenticity, publisher identity, "
+    "malware safety, supply-chain integrity, conformance, or cleanup "
+    "guarantee after host/daemon/SIGKILL failure.",
+)
+
+
+class VolumeDeclarationError(ValueError):
+    """The image declared a writable volume. Refuse to create."""
+
+
+class DockerCommandError(RuntimeError):
+    """A docker CLI invocation failed before a named limit applied."""
+
+
+@dataclass(frozen=True)
+class BoundedDockerResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+@dataclass(frozen=True)
+class OciExecution:
+    state: str
+    implementation_id: str
+    image: str
+    exit_code: int | None
+    stdout: bytes
+    stderr: bytes
+    error: str
+
+
+DockerRunner = Callable[..., BoundedDockerResult]
+
+
+def fresh_docker_env(parent: Path) -> tuple[dict[str, str], Path]:
+    config_dir = Path(tempfile.mkdtemp(prefix="assay-oci-docker-config-", dir=parent))
+    env = {key: value for key, value in os.environ.items() if key != "REGISTRY_AUTH_FILE"}
+    env["DOCKER_CONFIG"] = str(config_dir)
+    return env, config_dir
+
+
+def implementation_from_registry(
+    implementation_id: str, registry_path: Path | None = None
+) -> dict[str, Any]:
+    document = load_implementations(registry_path)
+    for row in document["implementations"]:
+        if row["id"] == implementation_id:
+            validate_image_reference(row["image"])
+            return row
+    raise ImplementationRegistryError("unknown implementation id: %s" % implementation_id)
+
+
+def reject_declared_volumes(image_inspect: dict[str, Any]) -> None:
+    volumes = (image_inspect.get("Config") or {}).get("Volumes")
+    if volumes:
+        raise VolumeDeclarationError("image declares volume(s): %s" % sorted(volumes))
+
+
+def build_container_create_argv(
+    *,
+    image: str,
+    bundle_path: Path,
+    container_name: str,
+    command: tuple[str, ...] = (),
+) -> list[str]:
+    validate_image_reference(image)
+    bundle = Path(bundle_path)
+    if bundle.is_symlink() or not bundle.is_file():
+        raise ValueError("bundle must be a regular file")
+    bundle = bundle.resolve()
+    return [
+        "docker",
+        "create",
+        "--name",
+        container_name,
+        "--platform",
+        PLATFORM,
+        "--network",
+        "none",
+        "--read-only",
+        "--user",
+        RUNTIME_USER,
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges:true",
+        "--cpus",
+        CPUS,
+        "--memory",
+        MEMORY,
+        "--memory-swap",
+        MEMORY_SWAP,
+        "--pids-limit",
+        PIDS_LIMIT,
+        "--ipc",
+        "none",
+        "--tmpfs",
+        TMPFS_SPEC,
+        "--log-opt",
+        f"max-size={LOG_MAX_SIZE}",
+        "--log-opt",
+        f"max-file={LOG_MAX_FILE}",
+        "--restart",
+        "no",
+        "--mount",
+        f"type=bind,src={bundle},dst={BUNDLE_DEST},ro=true",
+        image,
+        *command,
+    ]
+
+
+def observation_for(
+    state: str,
+    *,
+    case_id: str,
+    input_sha256: str,
+    message: str,
+) -> dict[str, Any]:
+    if state == STATE_COMPLETED:
+        raise ValueError("completed is not an error observation")
+    if state in CANDIDATE_LIMIT_STATES:
+        capture_state = STATE_CANDIDATE_ERROR
+    elif state in HARNESS_FAILURE_STATES:
+        capture_state = STATE_CAPTURE_ERROR
+    else:
+        raise ValueError("unknown execution state: %s" % state)
+    return observe_error(case_id, input_sha256, capture_state, message)
+
+
+def _wrap_docker(argv: list[str], env: dict[str, str]) -> list[str]:
+    if not argv or argv[0] != "docker":
+        raise DockerCommandError("docker argv must start with docker")
+    return [
+        "env",
+        "-u",
+        "REGISTRY_AUTH_FILE",
+        f"DOCKER_CONFIG={env['DOCKER_CONFIG']}",
+        *argv,
+    ]
+
+
+def run_docker(
+    argv: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    timeout_seconds: int = 60,
+    stdout_limit: int = 256 * 1024,
+    stderr_limit: int = 256 * 1024,
+    allow_nonzero: bool = False,
+) -> BoundedDockerResult:
+    if env is None:
+        raise DockerCommandError("docker invocations require a fresh DOCKER_CONFIG")
+    try:
+        result = run_bounded(
+            _wrap_docker(argv, env),
+            timeout_seconds=timeout_seconds,
+            stdout_limit=stdout_limit,
+            stderr_limit=stderr_limit,
+        )
+    except ProcessLimitError as error:
+        raise
+    if result.returncode != 0 and not allow_nonzero:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise DockerCommandError(detail)
+    return BoundedDockerResult(result.returncode, result.stdout, result.stderr)
+
+
+def local_image_docker_runner() -> DockerRunner:
+    """Pull step records the canonical argv; the inert fixture is already local."""
+
+    def runner(argv: list[str], **kwargs: Any) -> BoundedDockerResult:
+        if len(argv) >= 2 and argv[1] == "pull":
+            image = argv[-1]
+            expected = ["docker", "pull", "--platform", PLATFORM, image]
+            if argv != expected:
+                raise DockerCommandError("pull argv drifted from the digest/platform contract")
+            probe = run_bounded(
+                ["docker", "image", "inspect", image],
+                timeout_seconds=30,
+                stdout_limit=1_000_000,
+                stderr_limit=64 * 1024,
+            )
+            if probe.returncode != 0:
+                raise DockerCommandError("local fixture image is missing")
+            return BoundedDockerResult(0, b"", b"")
+        return run_docker(argv, **kwargs)
+
+    return runner
+
+
+def _parse_inspect(payload: bytes) -> dict[str, Any]:
+    document = json.loads(payload.decode("utf-8"))
+    if not isinstance(document, list) or not document:
+        raise DockerCommandError("docker inspect did not return an object")
+    first = document[0]
+    if not isinstance(first, dict):
+        raise DockerCommandError("docker inspect did not return an object")
+    return first
+
+
+def _limit_state(error: ProcessLimitError) -> str:
+    message = str(error)
+    if "timed out" in message:
+        return STATE_TIMEOUT
+    if "exceeded" in message:
+        return STATE_OUTPUT_OVERFLOW
+    return STATE_START_FAILURE
+
+
+def execute_candidate(
+    *,
+    implementation_id: str,
+    bundle_path: Path,
+    registry_path: Path | None = None,
+    timeout_seconds: int = 30,
+    command: tuple[str, ...] = (),
+    docker_runner: DockerRunner | None = None,
+) -> OciExecution:
+    runner = docker_runner or run_docker
+    row = implementation_from_registry(implementation_id, registry_path)
+    image = row["image"]
+    state: str | None = None
+    exit_code: int | None = None
+    stdout = b""
+    stderr = b""
+    error = ""
+    container_id: str | None = None
+    with tempfile.TemporaryDirectory(prefix="assay-oci-exec-") as raw:
+        env, _config_dir = fresh_docker_env(Path(raw))
+        try:
+            try:
+                runner(
+                    ["docker", "pull", "--platform", PLATFORM, image],
+                    env=env,
+                    timeout_seconds=60,
+                )
+            except (DockerCommandError, ProcessLimitError, OSError) as exc:
+                return OciExecution(
+                    STATE_PULL_FAILURE, implementation_id, image, None, b"", b"", str(exc)
+                )
+            try:
+                inspected = runner(["docker", "inspect", image], env=env)
+                reject_declared_volumes(_parse_inspect(inspected.stdout))
+            except VolumeDeclarationError as exc:
+                return OciExecution(
+                    STATE_CREATE_FAILURE, implementation_id, image, None, b"", b"", str(exc)
+                )
+            except (DockerCommandError, ProcessLimitError, json.JSONDecodeError) as exc:
+                return OciExecution(
+                    STATE_CREATE_FAILURE, implementation_id, image, None, b"", b"", str(exc)
+                )
+            name = f"assay-oci-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+            try:
+                created = runner(
+                    build_container_create_argv(
+                        image=image,
+                        bundle_path=bundle_path,
+                        container_name=name,
+                        command=command,
+                    ),
+                    env=env,
+                )
+                container_id = created.stdout.decode("utf-8", "replace").strip()
+                if not container_id:
+                    raise DockerCommandError("docker create returned no container id")
+            except (DockerCommandError, ProcessLimitError, ValueError) as exc:
+                return OciExecution(
+                    STATE_CREATE_FAILURE, implementation_id, image, None, b"", b"", str(exc)
+                )
+            try:
+                started = runner(
+                    ["docker", "start", "-a", container_id],
+                    env=env,
+                    timeout_seconds=timeout_seconds,
+                    stdout_limit=STDOUT_LIMIT,
+                    stderr_limit=STDERR_LIMIT,
+                    allow_nonzero=True,
+                )
+                stdout = started.stdout
+                stderr = started.stderr
+            except ProcessLimitError as exc:
+                state = _limit_state(exc)
+                error = str(exc)
+            except DockerCommandError as exc:
+                state = STATE_START_FAILURE
+                error = str(exc)
+            try:
+                container = _parse_inspect(
+                    runner(["docker", "inspect", container_id], env=env).stdout
+                )
+                exit_code = (container.get("State") or {}).get("ExitCode")
+                if not isinstance(exit_code, int):
+                    exit_code = None
+                if (container.get("State") or {}).get("OOMKilled") and state not in (
+                    STATE_TIMEOUT,
+                    STATE_OUTPUT_OVERFLOW,
+                ):
+                    state = STATE_OOM
+                    error = error or "container OOMKilled"
+                if state is None:
+                    state = STATE_COMPLETED
+            except (DockerCommandError, ProcessLimitError, json.JSONDecodeError) as exc:
+                if state is None:
+                    state = STATE_START_FAILURE
+                    error = str(exc)
+        finally:
+            if container_id:
+                try:
+                    runner(
+                        ["docker", "rm", "--force", "--volumes", container_id],
+                        env=env,
+                    )
+                except (DockerCommandError, ProcessLimitError) as exc:
+                    state = STATE_CLEANUP_FAILURE
+                    error = str(exc)
+    if state is None:
+        state = STATE_START_FAILURE
+        error = error or "execution produced no state"
+    return OciExecution(state, implementation_id, image, exit_code, stdout, stderr, error)
+
+
+def write_execution(path: Path, result: OciExecution) -> None:
+    document = {
+        "schema": EXECUTION_SCHEMA,
+        "implementation_id": result.implementation_id,
+        "image": result.image,
+        "execution_state": result.state,
+        "exit_code": result.exit_code,
+        "error": result.error,
+        "oci_executor_non_claims": list(OCI_EXECUTOR_NON_CLAIMS),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    load_strict_object(
+        path,
+        label="oci execution",
+        max_bytes=MAX_EXECUTION_BYTES,
+        max_depth=MAX_EXECUTION_DEPTH,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--implementation-id", required=True)
+    parser.add_argument("--bundle", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=30)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.timeout_seconds <= 0:
+        print("timeout-seconds must be positive", file=sys.stderr)
+        return 2
+    try:
+        result = execute_candidate(
+            implementation_id=args.implementation_id,
+            bundle_path=args.bundle,
+            timeout_seconds=args.timeout_seconds,
+        )
+    except (ImplementationRegistryError, ValueError, OSError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    write_execution(args.output, result)
+    print(result.state)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -15,6 +15,7 @@ import json
 import os
 import shutil
 import sys
+import tarfile
 import tempfile
 import uuid
 from dataclasses import dataclass
@@ -29,6 +30,7 @@ from capture_format import (  # noqa: E402
     STATE_CANDIDATE_ERROR,
     STATE_CAPTURE_ERROR,
     observe_error,
+    validate_capture,
 )
 from strict_json import load_strict_object  # noqa: E402
 
@@ -176,6 +178,18 @@ def implementation_from_registry(
             validate_image_reference(row["image"])
             return row
     raise ImplementationRegistryError("unknown implementation id: %s" % implementation_id)
+
+
+def identity_from_registry_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "image": row["image"],
+        "name": row["name"],
+        "version": None,
+        "source": row["source"],
+        "commit": row["commit"],
+        "reproduction_mode": row["reproduction_mode"],
+    }
 
 
 def reject_declared_volumes(image_inspect: dict[str, Any]) -> None:
@@ -551,10 +565,40 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--implementation-id", required=True)
     parser.add_argument("--registry", type=Path)
+    parser.add_argument("--pack", type=Path)
     parser.add_argument("--bundle", type=Path)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--timeout-seconds", type=int, default=30)
     return parser.parse_args(argv)
+
+
+def write_validated_capture(
+    pack_path: Path,
+    implementation_id: str,
+    output: Path,
+    *,
+    registry_path: Path | None,
+    timeout_seconds: int,
+) -> None:
+    row = implementation_from_registry(implementation_id, registry_path)
+    command = oci_entrypoint_command(
+        implementation_id=implementation_id,
+        registry_path=registry_path,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        pack = capture_candidate.load_pack(pack_path, Path(tmp))
+        pack_digest = capture_candidate.sha256_file(pack_path)
+        observations = capture_oci_observations(pack, command, timeout_seconds)
+    capture = capture_candidate.build_capture(
+        pack, pack_digest, observations, identity_from_registry_row(row)
+    )
+    validate_capture(capture)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(capture, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"captured {len(observations)} observations")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -562,8 +606,36 @@ def main(argv: list[str] | None = None) -> int:
     if args.timeout_seconds <= 0:
         print("timeout-seconds must be positive", file=sys.stderr)
         return 2
+    if args.pack is not None and args.bundle is not None:
+        print("use --pack or --bundle, not both", file=sys.stderr)
+        return 2
+    if args.pack is not None:
+        if args.output is None:
+            print("--output is required", file=sys.stderr)
+            return 2
+        try:
+            write_validated_capture(
+                args.pack,
+                args.implementation_id,
+                args.output,
+                registry_path=args.registry,
+                timeout_seconds=args.timeout_seconds,
+            )
+        except (
+            ImplementationRegistryError,
+            OSError,
+            EOFError,
+            ValueError,
+            KeyError,
+            RecursionError,
+            json.JSONDecodeError,
+            tarfile.TarError,
+        ) as error:
+            print(str(error), file=sys.stderr)
+            return 2
+        return 0
     if args.bundle is None:
-        print("--bundle is required", file=sys.stderr)
+        print("--pack or --bundle is required", file=sys.stderr)
         return 2
     try:
         result = execute_candidate(

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -30,6 +30,7 @@ from capture_candidate import CandidateError, HarnessError  # noqa: E402
 from capture_format import (  # noqa: E402
     STATE_CANDIDATE_ERROR,
     STATE_CAPTURE_ERROR,
+    bound_error,
     observe_error,
     validate_capture,
 )
@@ -281,6 +282,23 @@ def observation_for(
     return observe_error(case_id, input_sha256, capture_state, message)
 
 
+def digest_image_refs(argv: list[str]) -> list[str]:
+    refs: list[str] = []
+    for item in argv:
+        try:
+            validate_image_reference(item)
+        except ImplementationRegistryError:
+            continue
+        refs.append(item)
+    return refs
+
+
+def assert_wrapped_keeps_digest_refs(argv: list[str], wrapped: list[str]) -> None:
+    for ref in digest_image_refs(argv):
+        if ref not in wrapped:
+            raise DockerCommandError("digest-qualified image was stripped before docker")
+
+
 def run_docker(
     argv: list[str],
     *,
@@ -292,8 +310,10 @@ def run_docker(
 ) -> BoundedDockerResult:
     if env is None:
         raise DockerCommandError("docker invocations require a fresh DOCKER_CONFIG")
+    wrapped = wrap_docker_command(argv, env)
+    assert_wrapped_keeps_digest_refs(argv, wrapped)
     result = run_bounded(
-        wrap_docker_command(argv, env),
+        wrapped,
         timeout_seconds=timeout_seconds,
         stdout_limit=stdout_limit,
         stderr_limit=stderr_limit,
@@ -302,52 +322,6 @@ def run_docker(
         detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
         raise DockerCommandError(detail)
     return BoundedDockerResult(result.returncode, result.stdout, result.stderr)
-
-
-def rewrite_fixture_image_argv(
-    argv: list[str], *, registry_ref: str, local_ref: str
-) -> list[str]:
-    """Test-only: a local tag is not a RepoDigest. Hosted Docker will pull."""
-    if not registry_ref or not local_ref or registry_ref == local_ref:
-        raise ValueError("fixture registry ref and local ref must be distinct")
-    return [local_ref if item == registry_ref else item for item in argv]
-
-
-def local_image_docker_runner(*, registry_ref: str, local_ref: str) -> DockerRunner:
-    """Pull step records the canonical argv; daemon calls use the local tag/id."""
-
-    def runner(argv: list[str], **kwargs: Any) -> BoundedDockerResult:
-        env = kwargs.get("env")
-        if env is None:
-            raise DockerCommandError("docker invocations require a fresh DOCKER_CONFIG")
-        if len(argv) >= 2 and argv[1] == "pull":
-            expected = ["docker", "pull", "--platform", PLATFORM, registry_ref]
-            if argv != expected:
-                raise DockerCommandError("pull argv drifted from the digest/platform contract")
-            probe = run_bounded(
-                wrap_docker_command(
-                    rewrite_fixture_image_argv(
-                        ["docker", "image", "inspect", registry_ref],
-                        registry_ref=registry_ref,
-                        local_ref=local_ref,
-                    ),
-                    env,
-                ),
-                timeout_seconds=30,
-                stdout_limit=1_000_000,
-                stderr_limit=64 * 1024,
-            )
-            if probe.returncode != 0:
-                raise DockerCommandError("local fixture image is missing")
-            return BoundedDockerResult(0, b"", b"")
-        return run_docker(
-            rewrite_fixture_image_argv(
-                argv, registry_ref=registry_ref, local_ref=local_ref
-            ),
-            **kwargs,
-        )
-
-    return runner
 
 
 def _parse_inspect(payload: bytes) -> dict[str, Any]:
@@ -369,17 +343,36 @@ def _limit_state(error: ProcessLimitError) -> str:
     return STATE_START_FAILURE
 
 
+def resolved_implementation_row(
+    implementation_id: str,
+    *,
+    implementation: dict[str, Any] | None = None,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    if implementation is not None:
+        if implementation.get("id") != implementation_id:
+            raise ImplementationRegistryError(
+                "implementation id does not match the resolved row"
+            )
+        validate_image_reference(implementation["image"])
+        return implementation
+    return implementation_from_registry(implementation_id, registry_path)
+
+
 def execute_candidate(
     *,
     implementation_id: str,
     bundle_path: Path,
     registry_path: Path | None = None,
+    implementation: dict[str, Any] | None = None,
     timeout_seconds: int = 30,
     command: tuple[str, ...] = (),
     docker_runner: DockerRunner | None = None,
 ) -> OciExecution:
     runner = docker_runner or run_docker
-    row = implementation_from_registry(implementation_id, registry_path)
+    row = resolved_implementation_row(
+        implementation_id, implementation=implementation, registry_path=registry_path
+    )
     image = row["image"]
     state: str | None = None
     exit_code: int | None = None
@@ -387,9 +380,15 @@ def execute_candidate(
     stderr = b""
     error = ""
     container_id: str | None = None
+    container_name: str | None = None
     with tempfile.TemporaryDirectory(prefix="assay-oci-exec-") as raw:
         root = Path(raw)
-        env, _config_dir = fresh_docker_env(root)
+        try:
+            env, _config_dir = fresh_docker_env(root)
+        except DOCKER_LIFECYCLE_ERRORS as exc:
+            return OciExecution(
+                STATE_PULL_FAILURE, implementation_id, image, None, b"", b"", str(exc)
+            )
         staging_dir = root / "stage"
         try:
             try:
@@ -403,7 +402,7 @@ def execute_candidate(
                     STATE_PULL_FAILURE, implementation_id, image, None, b"", b"", str(exc)
                 )
             try:
-                inspected = runner(["docker", "inspect", image], env=env)
+                inspected = runner(["docker", "image", "inspect", image], env=env)
                 reject_declared_volumes(_parse_inspect(inspected.stdout))
             except VolumeDeclarationError as exc:
                 return OciExecution(
@@ -413,14 +412,14 @@ def execute_candidate(
                 return OciExecution(
                     STATE_CREATE_FAILURE, implementation_id, image, None, b"", b"", str(exc)
                 )
-            name = f"assay-oci-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+            container_name = f"assay-oci-{os.getpid()}-{uuid.uuid4().hex[:8]}"
             try:
                 try:
                     created = runner(
                         build_container_create_argv(
                             image=image,
                             bundle_path=bundle_path,
-                            container_name=name,
+                            container_name=container_name,
                             staging_dir=staging_dir,
                             command=command,
                         ),
@@ -456,28 +455,37 @@ def execute_candidate(
                 container = _parse_inspect(
                     runner(["docker", "inspect", container_id], env=env).stdout
                 )
-                exit_code = (container.get("State") or {}).get("ExitCode")
-                if not isinstance(exit_code, int):
+                raw_exit = (container.get("State") or {}).get("ExitCode")
+                if isinstance(raw_exit, int):
+                    exit_code = raw_exit
+                    if (container.get("State") or {}).get("OOMKilled"):
+                        state = STATE_OOM
+                        error = error or "container OOMKilled"
+                    if state is None:
+                        state = STATE_COMPLETED
+                else:
                     exit_code = None
-                if (container.get("State") or {}).get("OOMKilled"):
-                    state = STATE_OOM
-                    error = error or "container OOMKilled"
-                if state is None:
-                    state = STATE_COMPLETED
+                    if state is None:
+                        state = STATE_START_FAILURE
+                        error = "container exit code is unavailable"
             except DOCKER_LIFECYCLE_ERRORS as exc:
                 if state is None:
                     state = STATE_START_FAILURE
                     error = str(exc)
         finally:
-            if container_id:
+            target = container_id or container_name
+            if target:
                 try:
                     runner(
-                        ["docker", "rm", "--force", "--volumes", container_id],
+                        ["docker", "rm", "--force", "--volumes", target],
                         env=env,
                     )
                 except DOCKER_LIFECYCLE_ERRORS as exc:
-                    state = STATE_CLEANUP_FAILURE
-                    error = str(exc)
+                    if state in CANDIDATE_LIMIT_STATES:
+                        error = bound_error("%s; cleanup: %s" % (error or state, exc))
+                    else:
+                        state = STATE_CLEANUP_FAILURE
+                        error = str(exc)
     if state is None:
         state = STATE_START_FAILURE
         error = error or "execution produced no state"
@@ -500,7 +508,7 @@ def write_handoff(output_dir: Path, result: OciExecution) -> None:
             "image": result.image,
             "execution_state": result.state,
             "exit_code": result.exit_code,
-            "error": result.error,
+            "error": bound_error(result.error) if result.error else "",
             "oci_executor_non_claims": list(OCI_EXECUTOR_NON_CLAIMS),
             "candidate_output": {
                 "stdout": CANDIDATE_STDOUT_NAME,
@@ -554,6 +562,7 @@ def run_oci_candidate(
     *,
     docker_runner: DockerRunner | None = None,
     registry_path: Path | None = None,
+    implementation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Same shape as `capture_candidate.run_candidate` for the shared loop."""
     args = parse_oci_command(command)
@@ -561,13 +570,16 @@ def run_oci_candidate(
         implementation_id=args.implementation_id,
         bundle_path=bundle,
         registry_path=registry_path,
+        implementation=implementation,
         timeout_seconds=timeout_seconds,
         docker_runner=docker_runner,
     )
     if result.state == STATE_COMPLETED:
+        if result.exit_code is None:
+            raise HarnessError("container exit code is unavailable")
         report = capture_candidate.parse_candidate_report(result.stdout)
         return {
-            "exit_code": 0 if result.exit_code is None else result.exit_code,
+            "exit_code": result.exit_code,
             "report": report,
             "stderr_present": bool(result.stderr),
         }
@@ -582,15 +594,20 @@ def capture_oci_observations(
     timeout_seconds: int,
     *,
     registry_path: Path | None = None,
+    implementation: dict[str, Any] | None = None,
     docker_runner: DockerRunner | None = None,
 ) -> list[dict[str, Any]]:
+    row = implementation
+    if row is None:
+        args = parse_oci_command(command)
+        row = implementation_from_registry(args.implementation_id, registry_path)
     return capture_candidate.capture_observations(
         pack,
         command,
         timeout_seconds,
         candidate_runner=functools.partial(
             run_oci_candidate,
-            registry_path=registry_path,
+            implementation=row,
             docker_runner=docker_runner,
         ),
     )
@@ -618,13 +635,12 @@ def write_validated_capture(
     row = implementation_from_registry(implementation_id, registry_path)
     command = oci_entrypoint_command(implementation_id=implementation_id)
     with tempfile.TemporaryDirectory() as tmp:
-        pack = capture_candidate.load_pack(pack_path, Path(tmp))
-        pack_digest = capture_candidate.sha256_file(pack_path)
+        pack, pack_digest = capture_candidate.load_pack_with_digest(pack_path, Path(tmp))
         observations = capture_oci_observations(
             pack,
             command,
             timeout_seconds,
-            registry_path=registry_path,
+            implementation=row,
             docker_runner=docker_runner,
         )
     capture = capture_candidate.build_capture(
@@ -678,6 +694,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         except (
             ImplementationRegistryError,
+            DockerCommandError,
             OSError,
             EOFError,
             ValueError,
@@ -700,7 +717,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         if args.output is not None:
             write_handoff(args.output, result)
-    except (ImplementationRegistryError, ValueError, OSError) as error:
+    except (ImplementationRegistryError, DockerCommandError, ValueError, OSError) as error:
         print(str(error), file=sys.stderr)
         return 2
     print(result.state)

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -10,6 +10,7 @@ failures are named execution states, never agreement.
 from __future__ import annotations
 
 import argparse
+import functools
 import hashlib
 import json
 import os
@@ -559,9 +560,19 @@ def capture_oci_observations(
     pack: dict[str, Any],
     command: list[str],
     timeout_seconds: int,
+    *,
+    registry_path: Path | None = None,
+    docker_runner: DockerRunner | None = None,
 ) -> list[dict[str, Any]]:
     return capture_candidate.capture_observations(
-        pack, command, timeout_seconds, candidate_runner=run_oci_candidate
+        pack,
+        command,
+        timeout_seconds,
+        candidate_runner=functools.partial(
+            run_oci_candidate,
+            registry_path=registry_path,
+            docker_runner=docker_runner,
+        ),
     )
 
 
@@ -581,6 +592,7 @@ def write_validated_capture(
     output: Path,
     *,
     registry_path: Path | None = None,
+    docker_runner: DockerRunner | None = None,
     timeout_seconds: int,
 ) -> None:
     row = implementation_from_registry(implementation_id, registry_path)
@@ -588,7 +600,13 @@ def write_validated_capture(
     with tempfile.TemporaryDirectory() as tmp:
         pack = capture_candidate.load_pack(pack_path, Path(tmp))
         pack_digest = capture_candidate.sha256_file(pack_path)
-        observations = capture_oci_observations(pack, command, timeout_seconds)
+        observations = capture_oci_observations(
+            pack,
+            command,
+            timeout_seconds,
+            registry_path=registry_path,
+            docker_runner=docker_runner,
+        )
     capture = capture_candidate.build_capture(
         pack, pack_digest, observations, identity_from_registry_row(row)
     )

--- a/conformance/privileged-mcp-action-v0/tests/fixtures/oci-candidate.c
+++ b/conformance/privileged-mcp-action-v0/tests/fixtures/oci-candidate.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
     }
     if (strcmp(mode, "oom") == 0) {
         for (;;) {
-            char *block = malloc(1024 * 1024);
+            volatile char *block = (volatile char *)malloc(1024 * 1024);
             if (block != NULL) {
                 block[0] = 1;
                 block[1024 * 1024 - 1] = 1;

--- a/conformance/privileged-mcp-action-v0/tests/fixtures/oci-candidate.c
+++ b/conformance/privileged-mcp-action-v0/tests/fixtures/oci-candidate.c
@@ -1,0 +1,41 @@
+/* Inert local fixture for the bounded OCI executor contract.
+ *
+ * Built into a FROM scratch image in tests. Not a candidate implementation.
+ * Modes are argv[1]: ok (default), sleep, flood, oom.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    const char *mode = argc > 1 ? argv[1] : "ok";
+
+    if (strcmp(mode, "ok") == 0) {
+        return 0;
+    }
+    if (strcmp(mode, "sleep") == 0) {
+        for (;;) {
+            sleep(60);
+        }
+    }
+    if (strcmp(mode, "flood") == 0) {
+        static const char chunk[4096];
+        for (;;) {
+            if (fwrite(chunk, 1, sizeof(chunk), stdout) != sizeof(chunk)) {
+                return 1;
+            }
+        }
+    }
+    if (strcmp(mode, "oom") == 0) {
+        for (;;) {
+            char *block = malloc(1024 * 1024);
+            if (block != NULL) {
+                block[0] = 1;
+                block[1024 * 1024 - 1] = 1;
+            }
+        }
+    }
+    return 2;
+}

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import gzip
 import hashlib
+import inspect
 import io
 import json
 import re
@@ -1220,6 +1221,16 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         target = self.root / f"capture-{name}.json"
         target.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
         return target
+
+    def test_capture_observations_runner_is_keyword_only_and_defaults(self) -> None:
+        import capture_candidate
+
+        params = inspect.signature(capture_candidate.capture_observations).parameters
+        self.assertIn("candidate_runner", params)
+        self.assertEqual(params["candidate_runner"].kind, inspect.Parameter.KEYWORD_ONLY)
+        self.assertIs(params["candidate_runner"].default, capture_candidate.run_candidate)
+        with self.assertRaises(TypeError):
+            capture_candidate.capture_observations({}, [], 1, capture_candidate.run_candidate)
 
     def test_valid_capture_scores_every_case(self) -> None:
         """Positive control for every refusal below.

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -127,6 +127,22 @@ class CleanRoomPackTests(unittest.TestCase):
             str(output),
         )
 
+    def test_pack_digest_binds_the_bytes_the_loader_parsed(self) -> None:
+        import capture_candidate
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_path = Path(tmp) / "pack.tar.gz"
+            dest = Path(tmp) / "out"
+            dest.mkdir()
+            self.build(pack_path)
+            original = pack_path.read_bytes()
+            digest_a = sha256(original)
+            loaded, bound = capture_candidate.load_pack_with_digest(pack_path, dest)
+            pack_path.write_bytes(original + b"\x00")
+            self.assertEqual(bound, digest_a)
+            self.assertEqual(loaded["case_count"], 14)
+            self.assertNotEqual(bound, capture_candidate.sha256_file(pack_path))
+
     def test_pack_is_deterministic_opaque_and_inputs_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             first = Path(tmp) / "first.tar.gz"

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -702,7 +702,7 @@ def _compile_inert_linux_elf(dest: Path) -> None:
     )
 
 
-def _build_inert_image() -> str:
+def _build_inert_image() -> tuple[str, str]:
     if not FIXTURE_C.is_file():
         raise AssertionError(f"missing fixture {FIXTURE_C}")
     with tempfile.TemporaryDirectory() as raw:
@@ -735,13 +735,14 @@ def _build_inert_image() -> str:
     if not image_id.startswith("sha256:") or len(image_id) != 71:
         raise AssertionError(f"unexpected image id {image_id!r}")
     digest = image_id.split(":", 1)[1]
-    ref = f"assay-oci-inert@sha256:{digest}"
-    subprocess.run(["docker", "tag", image_id, f"assay-oci-inert:{digest}"], check=True)
-    return ref
+    registry_ref = f"assay-oci-inert@sha256:{digest}"
+    implementations.validate_image_reference(registry_ref)
+    return registry_ref, "assay-oci-inert:local"
 
 
 class LiveDockerInspect(unittest.TestCase):
     image_ref: str | None = None
+    local_ref: str | None = None
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -751,7 +752,16 @@ class LiveDockerInspect(unittest.TestCase):
                 "docker is required for live inspect; unavailable infrastructure "
                 f"is not a pass: {info.stderr.decode('utf-8', 'replace')}"
             )
-        cls.image_ref = _build_inert_image()
+        cls.image_ref, cls.local_ref = _build_inert_image()
+
+    def _local_runner(self) -> Any:
+        module = _require()
+        assert self.image_ref is not None
+        assert self.local_ref is not None
+        return module.local_image_docker_runner(
+            registry_ref=self.image_ref,
+            local_ref=self.local_ref,
+        )
 
     def test_live_inspect_pins_network_and_user_independently_of_argv_strings(self) -> None:
         module = _require()
@@ -768,7 +778,13 @@ class LiveDockerInspect(unittest.TestCase):
             )
             assert_argv_network_none(argv)
             assert_argv_runtime_user(argv)
-            created = subprocess.run(argv, capture_output=True, text=True, check=False)
+            self.assertIn(self.image_ref, argv)
+            assert self.local_ref is not None
+            live_argv = module.rewrite_fixture_image_argv(
+                argv, registry_ref=self.image_ref, local_ref=self.local_ref
+            )
+            self.assertNotIn(self.image_ref, live_argv)
+            created = subprocess.run(live_argv, capture_output=True, text=True, check=False)
             self.assertEqual(created.returncode, 0, created.stderr)
             container = created.stdout.strip()
             try:
@@ -833,9 +849,9 @@ class LiveDockerInspect(unittest.TestCase):
         ).stdout.strip()
         digest = image_id.split(":", 1)[1]
         volume_ref = f"assay-oci-inert-volume@sha256:{digest}"
-        subprocess.run(["docker", "tag", image_id, f"assay-oci-inert-volume:{digest}"], check=True)
+        implementations.validate_image_reference(volume_ref)
         inspect_raw = subprocess.run(
-            ["docker", "inspect", volume_ref],
+            ["docker", "inspect", volume_tag],
             check=True,
             capture_output=True,
             text=True,
@@ -854,7 +870,7 @@ class LiveDockerInspect(unittest.TestCase):
                 registry_path=registry,
                 timeout_seconds=1,
                 command=("/oci-candidate", "sleep"),
-                docker_runner=module.local_image_docker_runner(),
+                docker_runner=self._local_runner(),
             )
         self.assertEqual(result.state, module.STATE_TIMEOUT)
         self.assertNotIn(result.state, AGREEMENT)
@@ -870,7 +886,7 @@ class LiveDockerInspect(unittest.TestCase):
                 registry_path=registry,
                 timeout_seconds=5,
                 command=("/oci-candidate", "flood"),
-                docker_runner=module.local_image_docker_runner(),
+                docker_runner=self._local_runner(),
             )
         self.assertEqual(result.state, module.STATE_OUTPUT_OVERFLOW)
         self.assertNotIn(result.state, AGREEMENT)
@@ -886,7 +902,7 @@ class LiveDockerInspect(unittest.TestCase):
                 registry_path=registry,
                 timeout_seconds=10,
                 command=("/oci-candidate", "ok"),
-                docker_runner=module.local_image_docker_runner(),
+                docker_runner=self._local_runner(),
             )
         self.assertEqual(result.state, module.STATE_COMPLETED)
         self.assertNotIn(result.state, AGREEMENT)
@@ -903,7 +919,7 @@ class LiveDockerInspect(unittest.TestCase):
                 registry_path=registry,
                 timeout_seconds=60,
                 command=("/oci-candidate", "oom"),
-                docker_runner=module.local_image_docker_runner(),
+                docker_runner=self._local_runner(),
             )
         self.assertEqual(result.state, module.STATE_OOM)
         self.assertNotIn(result.state, AGREEMENT)
@@ -981,13 +997,80 @@ class AllowlistedDockerEnv(unittest.TestCase):
         module = _require()
         with tempfile.TemporaryDirectory() as raw:
             env, _ = module.fresh_docker_env(Path(raw))
-        probe = module.wrap_docker_command(["docker", "image", "inspect", DIGEST_IMAGE], env)
+        probe = module.wrap_docker_command(["docker", "image", "inspect", "assay-oci-inert:local"], env)
         self.assertIn("-i", probe)
         for key in SENTINEL_ENV:
             self.assertNotIn(key, " ".join(probe))
         source = Path(module.__file__).read_text(encoding="utf-8")
         self.assertIn("wrap_docker_command", source)
         self.assertNotIn('run_bounded(\n                ["docker", "image", "inspect"', source)
+
+    def test_synthetic_repo_digest_is_rewritten_for_pull_inspect_and_create(self) -> None:
+        """A local tag is not a RepoDigest. Hosted Docker treats name@sha256:<id>
+        as a remote pull. The test runner must map that ref to a local tag/id.
+        """
+        module = _require()
+        local_ref = "assay-oci-inert:local"
+        pull = ["docker", "pull", "--platform", module.PLATFORM, DIGEST_IMAGE]
+        inspect = ["docker", "inspect", DIGEST_IMAGE]
+        with tempfile.TemporaryDirectory() as raw:
+            create = module.build_container_create_argv(
+                image=DIGEST_IMAGE,
+                bundle_path=_bundle(Path(raw)),
+                container_name="assay-oci-map",
+                staging_dir=Path(raw) / "stage",
+            )
+        self.assertEqual(create[-1], DIGEST_IMAGE)
+        mapped_pull = module.rewrite_fixture_image_argv(
+            pull, registry_ref=DIGEST_IMAGE, local_ref=local_ref
+        )
+        mapped_inspect = module.rewrite_fixture_image_argv(
+            inspect, registry_ref=DIGEST_IMAGE, local_ref=local_ref
+        )
+        mapped_create = module.rewrite_fixture_image_argv(
+            create, registry_ref=DIGEST_IMAGE, local_ref=local_ref
+        )
+        self.assertEqual(mapped_pull[-1], local_ref)
+        self.assertEqual(mapped_inspect[-1], local_ref)
+        self.assertEqual(mapped_create[-1], local_ref)
+        self.assertNotIn(DIGEST_IMAGE, mapped_inspect)
+        self.assertNotIn(DIGEST_IMAGE, mapped_create)
+        self.assertEqual(
+            mapped_pull,
+            ["docker", "pull", "--platform", module.PLATFORM, local_ref],
+        )
+        implementations.validate_image_reference(DIGEST_IMAGE)
+
+    def test_local_runner_does_not_send_synthetic_repo_digest_to_docker(self) -> None:
+        module = _require()
+        local_ref = "assay-oci-inert:local"
+        seen: list[list[str]] = []
+
+        def fake_run_docker(argv: list[str], **kwargs: Any) -> Any:
+            seen.append(list(argv))
+            return module.BoundedDockerResult(0, b"[]", b"")
+
+        with tempfile.TemporaryDirectory() as raw:
+            env, _ = module.fresh_docker_env(Path(raw))
+        runner = module.local_image_docker_runner(
+            registry_ref=DIGEST_IMAGE, local_ref=local_ref
+        )
+        with mock.patch.object(module, "run_docker", side_effect=fake_run_docker):
+            with mock.patch.object(module, "run_bounded") as bounded:
+                bounded.return_value = mock.Mock(returncode=0, stdout=b"", stderr=b"")
+                runner(
+                    ["docker", "pull", "--platform", module.PLATFORM, DIGEST_IMAGE],
+                    env=env,
+                )
+                runner(["docker", "inspect", DIGEST_IMAGE], env=env)
+                runner(["docker", "create", "--name", "x", DIGEST_IMAGE], env=env)
+                probe = bounded.call_args[0][0]
+        self.assertIn(local_ref, probe)
+        self.assertNotIn(DIGEST_IMAGE, probe)
+        self.assertEqual(len(seen), 2)
+        for argv in seen:
+            self.assertIn(local_ref, argv)
+            self.assertNotIn(DIGEST_IMAGE, argv)
 
 
 class StagedBundleMount(unittest.TestCase):

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -11,7 +11,9 @@ canonical builder must break both, not a workflow comment.
 from __future__ import annotations
 
 import ast
+import functools
 import hashlib
+import inspect
 import json
 import os
 import shutil
@@ -974,6 +976,49 @@ class CandidateOutputHandoff(unittest.TestCase):
         self.assertEqual(document["candidate_output"]["stdout"], module.CANDIDATE_STDOUT_NAME)
         self.assertTrue(document["candidate_output"]["stdout_sha256"].startswith("sha256:"))
 
+    def test_handoff_rejects_symlink_nonempty_and_oversize(self) -> None:
+        module = _require()
+        result = module.OciExecution(
+            module.STATE_COMPLETED,
+            "inert-fixture",
+            DIGEST_IMAGE,
+            0,
+            b"ok",
+            b"",
+            "",
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            nonempty = Path(raw) / "nonempty"
+            nonempty.mkdir()
+            (nonempty / "stale").write_text("x", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                module.write_handoff(nonempty, result)
+            as_file = Path(raw) / "not-a-dir"
+            as_file.write_text("x", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                module.write_handoff(as_file, result)
+            target = Path(raw) / "real-dir"
+            target.mkdir()
+            link = Path(raw) / "link-dir"
+            link.symlink_to(target)
+            with self.assertRaises(ValueError):
+                module.write_handoff(link, result)
+            oversized = module.OciExecution(
+                module.STATE_COMPLETED,
+                "inert-fixture",
+                DIGEST_IMAGE,
+                0,
+                b"x" * (module.STDOUT_LIMIT + 1),
+                b"",
+                "",
+            )
+            with self.assertRaises(ValueError):
+                module.write_handoff(Path(raw) / "fresh", oversized)
+
+    def test_write_execution_is_not_a_silent_parent_rewrite(self) -> None:
+        module = _require()
+        self.assertFalse(hasattr(module, "write_execution"))
+
 
 class CaptureAdapterEquivalence(unittest.TestCase):
     """#199 capture_observations via the OCI adapter, no second loop."""
@@ -1043,19 +1088,19 @@ class CaptureAdapterEquivalence(unittest.TestCase):
                 implementation_id="inert-fixture",
                 registry_path=registry,
             )
-            runner = self._completed_runner()
-
-            def adapted(cmd: list[str], bundle: Path, timeout: int) -> dict[str, Any]:
-                return module.run_oci_candidate(
-                    cmd, bundle, timeout, docker_runner=runner
-                )
-
-            original = capture_candidate.run_candidate
-            capture_candidate.run_candidate = adapted
-            try:
-                via_oci = capture_candidate.capture_observations(pack, command, 5)
-            finally:
-                capture_candidate.run_candidate = original
+            bound = functools.partial(
+                module.run_oci_candidate,
+                docker_runner=self._completed_runner(),
+            )
+            via_oci = capture_candidate.capture_observations(
+                pack,
+                command,
+                5,
+                candidate_runner=bound,
+            )
+            with mock.patch.object(module, "run_oci_candidate", bound):
+                via_wrapper = module.capture_oci_observations(pack, command, 5)
+        self.assertEqual(via_oci, via_wrapper)
         self.assertEqual(via_oci, direct)
         identity = {
             "id": None,
@@ -1080,24 +1125,18 @@ class CaptureAdapterEquivalence(unittest.TestCase):
             direct = capture_candidate.capture_observations(
                 pack, self._direct_candidate(Path(raw)), 5
             )
-            runner = self._completed_runner(stdout=b"")
-            original = capture_candidate.run_candidate
-            capture_candidate.run_candidate = (
-                lambda cmd, bundle, timeout: module.run_oci_candidate(
-                    cmd, bundle, timeout, docker_runner=runner
-                )
+            dropped = capture_candidate.capture_observations(
+                pack,
+                module.oci_entrypoint_command(
+                    implementation_id="inert-fixture",
+                    registry_path=registry,
+                ),
+                5,
+                candidate_runner=functools.partial(
+                    module.run_oci_candidate,
+                    docker_runner=self._completed_runner(stdout=b""),
+                ),
             )
-            try:
-                dropped = capture_candidate.capture_observations(
-                    pack,
-                    module.oci_entrypoint_command(
-                        implementation_id="inert-fixture",
-                        registry_path=registry,
-                    ),
-                    5,
-                )
-            finally:
-                capture_candidate.run_candidate = original
         self.assertNotEqual(dropped, direct)
         self.assertTrue(all(item["state"] == STATE_CANDIDATE_ERROR for item in dropped))
 
@@ -1150,6 +1189,39 @@ class CaptureAdapterEquivalence(unittest.TestCase):
         self.assertEqual(result.stdout, marker)
         self.assertNotIn(marker, written)
         self.assertNotIn("MUST-NOT-LOG-STDOUT", metadata)
+
+    def test_public_api_does_not_monkeypatch_run_candidate(self) -> None:
+        tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+        patched = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Attribute) and target.attr == "run_candidate"
+                for target in node.targets
+            )
+        ]
+        self.assertEqual(patched, [])
+        params = inspect.signature(capture_candidate.capture_observations).parameters
+        self.assertIn("candidate_runner", params)
+        self.assertEqual(params["candidate_runner"].kind, inspect.Parameter.KEYWORD_ONLY)
+        self.assertIs(params["candidate_runner"].default, capture_candidate.run_candidate)
+        wrapper = inspect.getsource(_require().capture_oci_observations)
+        self.assertIn("candidate_runner", wrapper)
+        self.assertIn("run_oci_candidate", wrapper)
+        self.assertNotIn("for ", wrapper)
+
+    def test_parse_oci_command_rejects_unknown_image_flag(self) -> None:
+        module = _require()
+        with self.assertRaises(SystemExit):
+            module.parse_oci_command(
+                [
+                    "--implementation-id",
+                    "inert-fixture",
+                    "--implementation-image",
+                    DIGEST_IMAGE,
+                ]
+            )
 
 
 if __name__ == "__main__":

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -1146,6 +1146,71 @@ class CandidateOutputHandoff(unittest.TestCase):
             ]
             self.assertEqual(leftovers, [])
 
+    def _main_handoff(self, dest: Path, bundle: Path, *, rename_error: bool = False) -> tuple[int, str]:
+        module = _require()
+        stderr = mock.Mock()
+        argv = [
+            "--implementation-id",
+            "inert-fixture",
+            "--bundle",
+            str(bundle),
+            "--output",
+            str(dest),
+        ]
+        with mock.patch.object(module, "execute_candidate", return_value=self._completed()):
+            with mock.patch.object(sys, "stderr", stderr):
+                if rename_error:
+                    with mock.patch.object(
+                        os, "rename", side_effect=OSError("simulated rename failure")
+                    ):
+                        code = module.main(argv)
+                else:
+                    code = module.main(argv)
+        written = "".join(
+            str(call.args[0]) for call in stderr.write.call_args_list if call.args
+        )
+        return code, written
+
+    def test_main_handoff_existing_dest_exits_2_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            dest = Path(raw) / "handoff"
+            dest.mkdir()
+            (dest / "stale").write_bytes(b"keep-me")
+            code, err = self._main_handoff(dest, _bundle(Path(raw)))
+            self.assertEqual((dest / "stale").read_bytes(), b"keep-me")
+        self.assertEqual(code, 2)
+        self.assertTrue(err.strip())
+        self.assertNotIn("Traceback", err)
+
+    def test_main_handoff_symlink_dest_exits_2_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            target = Path(raw) / "real"
+            target.mkdir()
+            dest = Path(raw) / "handoff"
+            dest.symlink_to(target)
+            code, err = self._main_handoff(dest, _bundle(Path(raw)))
+            self.assertTrue(dest.is_symlink())
+            self.assertEqual(list(target.iterdir()), [])
+        self.assertEqual(code, 2)
+        self.assertTrue(err.strip())
+        self.assertNotIn("Traceback", err)
+
+    def test_main_handoff_rename_failure_exits_2_and_leaves_dest_absent(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            dest = Path(raw) / "handoff"
+            code, err = self._main_handoff(dest, _bundle(Path(raw)), rename_error=True)
+            self.assertFalse(dest.exists())
+            leftovers = [
+                path
+                for path in Path(raw).iterdir()
+                if path.name.startswith(module.HANDOFF_TEMP_PREFIX)
+            ]
+            self.assertEqual(leftovers, [])
+        self.assertEqual(code, 2)
+        self.assertTrue(err.strip())
+        self.assertNotIn("Traceback", err)
+
 
 class CaptureAdapterEquivalence(unittest.TestCase):
     """#199 capture_observations via the OCI adapter, no second loop."""
@@ -1443,6 +1508,60 @@ class PackCaptureCli(unittest.TestCase):
                         timeout_seconds=30,
                     )
             self.assertFalse(output.exists())
+
+    def test_stale_capture_stays_byte_identical_on_validation_failure(self) -> None:
+        module = _require()
+        stale = b'{"stale":true}\n'
+        with tempfile.TemporaryDirectory() as raw:
+            pack = _write_pack(Path(raw))
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            output = Path(raw) / "capture.json"
+            output.write_bytes(stale)
+            with (
+                mock.patch.object(module, "run_oci_candidate", side_effect=self._fake_runner),
+                mock.patch.object(
+                    capture_candidate,
+                    "build_capture",
+                    return_value={"schema": "not-a-capture"},
+                ),
+            ):
+                with self.assertRaises(ValueError):
+                    module.write_validated_capture(
+                        pack,
+                        "inert-fixture",
+                        output,
+                        registry_path=registry,
+                        timeout_seconds=30,
+                    )
+            self.assertEqual(output.read_bytes(), stale)
+
+    def test_stale_capture_stays_byte_identical_on_write_failure(self) -> None:
+        module = _require()
+        stale = b'{"stale":true}\n'
+        with tempfile.TemporaryDirectory() as raw:
+            pack = _write_pack(Path(raw))
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            output = Path(raw) / "capture.json"
+            output.write_bytes(stale)
+            with (
+                mock.patch.object(module, "run_oci_candidate", side_effect=self._fake_runner),
+                mock.patch.object(os, "replace", side_effect=OSError("write interrupted")),
+            ):
+                with self.assertRaises(OSError):
+                    module.write_validated_capture(
+                        pack,
+                        "inert-fixture",
+                        output,
+                        registry_path=registry,
+                        timeout_seconds=30,
+                    )
+            self.assertEqual(output.read_bytes(), stale)
+            leftovers = [
+                path
+                for path in Path(raw).iterdir()
+                if path.name.startswith(module.CAPTURE_TEMP_PREFIX)
+            ]
+            self.assertEqual(leftovers, [])
 
     def test_pack_cli_rejects_direct_image(self) -> None:
         module = _require()

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -1277,19 +1277,24 @@ class CaptureAdapterEquivalence(unittest.TestCase):
                 pack, self._direct_candidate(Path(raw)), 5
             )
             command = module.oci_entrypoint_command(implementation_id="inert-fixture")
-            bound = functools.partial(
-                module.run_oci_candidate,
-                docker_runner=self._completed_runner(),
-                registry_path=registry,
-            )
+            runner = self._completed_runner()
             via_oci = capture_candidate.capture_observations(
                 pack,
                 command,
                 5,
-                candidate_runner=bound,
+                candidate_runner=functools.partial(
+                    module.run_oci_candidate,
+                    docker_runner=runner,
+                    registry_path=registry,
+                ),
             )
-            with mock.patch.object(module, "run_oci_candidate", bound):
-                via_wrapper = module.capture_oci_observations(pack, command, 5)
+            via_wrapper = module.capture_oci_observations(
+                pack,
+                command,
+                5,
+                registry_path=registry,
+                docker_runner=runner,
+            )
         self.assertEqual(via_oci, via_wrapper)
         self.assertEqual(via_oci, direct)
         identity = {
@@ -1444,6 +1449,63 @@ class PackCaptureCli(unittest.TestCase):
             "report": {"bundle_integrity": "fail"},
             "stderr_present": False,
         }
+
+    def _completed_docker(self, pulled: list[str]):
+        module = _require()
+        inspect_doc = {
+            "Config": {"Volumes": None, "User": "65532:65532"},
+            "HostConfig": {"NetworkMode": "none"},
+            "State": {"OOMKilled": False, "ExitCode": 0, "Status": "exited"},
+        }
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            if argv[1] == "pull":
+                pulled.append(argv[-1])
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[1] == "inspect":
+                return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
+            if argv[1] == "create":
+                return module.BoundedDockerResult(0, b"cid-reg\n", b"")
+            if argv[1] == "start":
+                return module.BoundedDockerResult(0, VALID_REPORT, b"")
+            if argv[1] == "rm":
+                return module.BoundedDockerResult(0, b"", b"")
+            raise AssertionError(argv)
+
+        return runner
+
+    def test_chosen_registry_feeds_executor_and_identity(self) -> None:
+        module = _require()
+        other_image = (
+            "ghcr.io/example/other@sha256:"
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            pack = _write_pack(Path(raw))
+            chosen_doc = _registry_doc(DIGEST_IMAGE)
+            chosen_doc["implementations"][0]["source"] = "https://example.example/chosen"
+            chosen = Path(raw) / "chosen.json"
+            chosen.write_text(json.dumps(chosen_doc), encoding="utf-8")
+            other_doc = _registry_doc(other_image)
+            other_doc["implementations"][0]["source"] = "https://example.example/other"
+            (Path(raw) / "other.json").write_text(json.dumps(other_doc), encoding="utf-8")
+            output = Path(raw) / "capture.json"
+            pulled: list[str] = []
+            module.write_validated_capture(
+                pack,
+                "inert-fixture",
+                output,
+                registry_path=chosen,
+                docker_runner=self._completed_docker(pulled),
+                timeout_seconds=5,
+            )
+            document = json.loads(output.read_text(encoding="utf-8"))
+        validate_capture(document)
+        self.assertEqual(set(pulled), {DIGEST_IMAGE})
+        self.assertNotIn(other_image, pulled)
+        self.assertEqual(document["implementation"]["image"], DIGEST_IMAGE)
+        self.assertEqual(document["implementation"]["source"], "https://example.example/chosen")
+        self.assertNotEqual(document["implementation"]["source"], "https://example.example/other")
 
     def test_cli_writes_validated_capture_from_pack_and_id(self) -> None:
         module = _require()

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -46,8 +46,10 @@ import implementations
 from bounded_process import ProcessLimitError
 from capture_format import (  # noqa: E402
     CAPTURE_SCHEMA,
+    MAX_ERROR_CHARS,
     STATE_CANDIDATE_ERROR,
     STATE_CAPTURE_ERROR,
+    bound_error,
     validate_capture,
 )
 from score_candidate import STATE_TO_STATUS
@@ -56,6 +58,11 @@ DIGEST_IMAGE = (
     "ghcr.io/example/checker@sha256:"
     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 )
+SWAPPED_IMAGE = (
+    "ghcr.io/example/swapped@sha256:"
+    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+)
+IMAGE_ID = "sha256:" + "cd" * 32
 AGREEMENT = frozenset(
     {"match", "mismatch", "unproved", "execution_error", "harness_error"}
 )
@@ -101,6 +108,68 @@ def _bundle(directory: Path) -> Path:
     path = directory / "opaque.bundle.tar.gz"
     path.write_bytes(b"opaque-bundle")
     return path
+
+
+def _docker_kind(argv: list[str]) -> str:
+    if len(argv) >= 3 and argv[1] == "image" and argv[2] == "inspect":
+        return "image-inspect"
+    return argv[1] if len(argv) > 1 else ""
+
+
+def rewrite_fixture_image_argv(
+    argv: list[str], *, registry_ref: str, local_ref: str
+) -> list[str]:
+    if not registry_ref or not local_ref or registry_ref == local_ref:
+        raise ValueError("fixture registry ref and local ref must be distinct")
+    if not (local_ref.startswith("sha256:") and len(local_ref) == 71):
+        raise ValueError("local fixture ref must be an immutable image id")
+    return [local_ref if item == registry_ref else item for item in argv]
+
+
+def local_image_docker_runner(*, registry_ref: str, local_ref: str) -> Any:
+    module = _require()
+    if not (local_ref.startswith("sha256:") and len(local_ref) == 71):
+        raise ValueError("local fixture ref must be an immutable image id")
+
+    def runner(argv: list[str], **kwargs: Any) -> Any:
+        env = kwargs.get("env")
+        if env is None:
+            raise module.DockerCommandError("docker invocations require a fresh DOCKER_CONFIG")
+        if len(argv) >= 2 and argv[1] == "pull":
+            expected = ["docker", "pull", "--platform", module.PLATFORM, registry_ref]
+            if argv != expected:
+                raise module.DockerCommandError("pull argv drifted from the digest/platform contract")
+            probe = module.run_bounded(
+                module.wrap_docker_command(
+                    rewrite_fixture_image_argv(
+                        ["docker", "image", "inspect", registry_ref],
+                        registry_ref=registry_ref,
+                        local_ref=local_ref,
+                    ),
+                    env,
+                ),
+                timeout_seconds=30,
+                stdout_limit=1_000_000,
+                stderr_limit=64 * 1024,
+            )
+            if probe.returncode != 0:
+                raise module.DockerCommandError("local fixture image is missing")
+            return module.BoundedDockerResult(0, b"", b"")
+        return module.run_docker(
+            rewrite_fixture_image_argv(argv, registry_ref=registry_ref, local_ref=local_ref),
+            **kwargs,
+        )
+
+    return runner
+
+
+def _inspect_doc(*, exit_code: Any = 0, oom: bool = False) -> dict[str, Any]:
+    return {
+        "Id": IMAGE_ID,
+        "Config": {"Volumes": None, "User": "65532:65532"},
+        "HostConfig": {"NetworkMode": "none"},
+        "State": {"OOMKilled": oom, "ExitCode": exit_code, "Status": "exited"},
+    }
 
 
 def _argv(*, image: str = DIGEST_IMAGE, bundle: Path | None = None) -> list[str]:
@@ -487,17 +556,18 @@ class LifecycleClassification(unittest.TestCase):
         }
 
         def runner(argv: list[str], **_kwargs: Any) -> Any:
-            if argv[:2] == ["docker", "pull"] or argv[1] == "pull":
+            kind = _docker_kind(argv)
+            if kind == "pull":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[:2] == ["docker", "inspect"] or argv[1] == "inspect":
+            if kind in {"inspect", "image-inspect"}:
                 return module.BoundedDockerResult(
                     0, json.dumps([inspect_doc]).encode(), b""
                 )
-            if argv[:2] == ["docker", "create"] or argv[1] == "create":
+            if kind == "create":
                 return module.BoundedDockerResult(0, b"cid-1\n", b"")
-            if argv[:2] == ["docker", "start"] or argv[1] == "start":
+            if kind == "start":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[:2] == ["docker", "rm"] or argv[1] == "rm":
+            if kind == "rm":
                 raise module.DockerCommandError("rm refused")
             raise AssertionError(argv)
 
@@ -523,15 +593,16 @@ class LifecycleClassification(unittest.TestCase):
         }
 
         def runner(argv: list[str], **_kwargs: Any) -> Any:
-            if argv[1] == "pull":
+            kind = _docker_kind(argv)
+            if kind == "pull":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[1] == "inspect":
+            if kind in {"inspect", "image-inspect"}:
                 return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
-            if argv[1] == "create":
+            if kind == "create":
                 return module.BoundedDockerResult(0, b"cid-start\n", b"")
-            if argv[1] == "start":
+            if kind == "start":
                 raise module.DockerCommandError("cannot start container")
-            if argv[1] == "rm":
+            if kind == "rm":
                 return module.BoundedDockerResult(0, b"", b"")
             raise AssertionError(argv)
 
@@ -550,9 +621,10 @@ class LifecycleClassification(unittest.TestCase):
         module = _require()
 
         def runner(argv: list[str], **_kwargs: Any) -> Any:
-            if argv[1] == "pull":
+            kind = _docker_kind(argv)
+            if kind == "pull":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[1] == "inspect":
+            if kind in {"inspect", "image-inspect"}:
                 return module.BoundedDockerResult(
                     0,
                     json.dumps([{"Config": {"Volumes": {"/data": {}}}}]).encode(),
@@ -579,12 +651,15 @@ class LifecycleClassification(unittest.TestCase):
         }
 
         def runner(argv: list[str], **_kwargs: Any) -> Any:
-            if argv[1] == "pull":
+            kind = _docker_kind(argv)
+            if kind == "pull":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[1] == "inspect":
+            if kind in {"inspect", "image-inspect"}:
                 return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
-            if argv[1] == "create":
+            if kind == "create":
                 raise OSError("create refused")
+            if kind == "rm":
+                return module.BoundedDockerResult(0, b"", b"")
             raise AssertionError(argv)
 
         with tempfile.TemporaryDirectory() as raw:
@@ -607,15 +682,16 @@ class LifecycleClassification(unittest.TestCase):
         }
 
         def runner(argv: list[str], **_kwargs: Any) -> Any:
-            if argv[1] == "pull":
+            kind = _docker_kind(argv)
+            if kind == "pull":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[1] == "inspect":
+            if kind in {"inspect", "image-inspect"}:
                 return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
-            if argv[1] == "create":
+            if kind == "create":
                 return module.BoundedDockerResult(0, b"cid-os\n", b"")
-            if argv[1] == "start":
+            if kind == "start":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[1] == "rm":
+            if kind == "rm":
                 raise OSError("rm refused")
             raise AssertionError(argv)
 
@@ -737,7 +813,7 @@ def _build_inert_image() -> tuple[str, str]:
     digest = image_id.split(":", 1)[1]
     registry_ref = f"assay-oci-inert@sha256:{digest}"
     implementations.validate_image_reference(registry_ref)
-    return registry_ref, "assay-oci-inert:local"
+    return registry_ref, image_id
 
 
 class LiveDockerInspect(unittest.TestCase):
@@ -758,7 +834,7 @@ class LiveDockerInspect(unittest.TestCase):
         module = _require()
         assert self.image_ref is not None
         assert self.local_ref is not None
-        return module.local_image_docker_runner(
+        return local_image_docker_runner(
             registry_ref=self.image_ref,
             local_ref=self.local_ref,
         )
@@ -780,7 +856,7 @@ class LiveDockerInspect(unittest.TestCase):
             assert_argv_runtime_user(argv)
             self.assertIn(self.image_ref, argv)
             assert self.local_ref is not None
-            live_argv = module.rewrite_fixture_image_argv(
+            live_argv = rewrite_fixture_image_argv(
                 argv, registry_ref=self.image_ref, local_ref=self.local_ref
             )
             self.assertNotIn(self.image_ref, live_argv)
@@ -847,11 +923,8 @@ class LiveDockerInspect(unittest.TestCase):
             capture_output=True,
             text=True,
         ).stdout.strip()
-        digest = image_id.split(":", 1)[1]
-        volume_ref = f"assay-oci-inert-volume@sha256:{digest}"
-        implementations.validate_image_reference(volume_ref)
         inspect_raw = subprocess.run(
-            ["docker", "inspect", volume_tag],
+            ["docker", "image", "inspect", image_id],
             check=True,
             capture_output=True,
             text=True,
@@ -923,6 +996,55 @@ class LiveDockerInspect(unittest.TestCase):
             )
         self.assertEqual(result.state, module.STATE_OOM)
         self.assertNotIn(result.state, AGREEMENT)
+
+    def test_live_create_survives_retag_of_local_tag(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        assert self.local_ref is not None
+        self.assertTrue(self.local_ref.startswith("sha256:"))
+        subprocess.run(
+            [
+                "docker",
+                "build",
+                "--platform",
+                "linux/amd64",
+                "-t",
+                "assay-oci-inert-other:local",
+                "-",
+            ],
+            input=b"FROM assay-oci-inert:local\nLABEL assay=other\n",
+            check=True,
+            capture_output=True,
+        )
+        other_id = subprocess.run(
+            ["docker", "inspect", "--format", "{{.Id}}", "assay-oci-inert-other:local"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(["docker", "tag", other_id, "assay-oci-inert:local"], check=True)
+        try:
+            with tempfile.TemporaryDirectory() as raw:
+                registry = _write_registry(Path(raw), self.image_ref)
+                result = module.execute_candidate(
+                    implementation_id="inert-fixture",
+                    bundle_path=_bundle(Path(raw)),
+                    registry_path=registry,
+                    timeout_seconds=10,
+                    command=("/oci-candidate", "ok"),
+                    docker_runner=self._local_runner(),
+                )
+            tagged = subprocess.run(
+                ["docker", "inspect", "--format", "{{.Id}}", "assay-oci-inert:local"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(tagged, other_id)
+            self.assertEqual(result.state, module.STATE_COMPLETED)
+            self.assertNotEqual(self.local_ref, other_id)
+        finally:
+            subprocess.run(["docker", "tag", self.local_ref, "assay-oci-inert:local"], check=False)
 
     def test_fresh_docker_config_is_anonymous(self) -> None:
         module = _require()
@@ -997,22 +1119,22 @@ class AllowlistedDockerEnv(unittest.TestCase):
         module = _require()
         with tempfile.TemporaryDirectory() as raw:
             env, _ = module.fresh_docker_env(Path(raw))
-        probe = module.wrap_docker_command(["docker", "image", "inspect", "assay-oci-inert:local"], env)
+        probe = module.wrap_docker_command(["docker", "image", "inspect", IMAGE_ID], env)
         self.assertIn("-i", probe)
         for key in SENTINEL_ENV:
             self.assertNotIn(key, " ".join(probe))
         source = Path(module.__file__).read_text(encoding="utf-8")
         self.assertIn("wrap_docker_command", source)
-        self.assertNotIn('run_bounded(\n                ["docker", "image", "inspect"', source)
+        self.assertNotIn("def rewrite_fixture_image_argv", source)
+        self.assertNotIn("def local_image_docker_runner", source)
 
     def test_synthetic_repo_digest_is_rewritten_for_pull_inspect_and_create(self) -> None:
         """A local tag is not a RepoDigest. Hosted Docker treats name@sha256:<id>
-        as a remote pull. The test runner must map that ref to a local tag/id.
+        as a remote pull. The test runner must map that ref to an image id.
         """
         module = _require()
-        local_ref = "assay-oci-inert:local"
         pull = ["docker", "pull", "--platform", module.PLATFORM, DIGEST_IMAGE]
-        inspect = ["docker", "inspect", DIGEST_IMAGE]
+        inspect = ["docker", "image", "inspect", DIGEST_IMAGE]
         with tempfile.TemporaryDirectory() as raw:
             create = module.build_container_create_argv(
                 image=DIGEST_IMAGE,
@@ -1021,29 +1143,28 @@ class AllowlistedDockerEnv(unittest.TestCase):
                 staging_dir=Path(raw) / "stage",
             )
         self.assertEqual(create[-1], DIGEST_IMAGE)
-        mapped_pull = module.rewrite_fixture_image_argv(
-            pull, registry_ref=DIGEST_IMAGE, local_ref=local_ref
+        mapped_pull = rewrite_fixture_image_argv(
+            pull, registry_ref=DIGEST_IMAGE, local_ref=IMAGE_ID
         )
-        mapped_inspect = module.rewrite_fixture_image_argv(
-            inspect, registry_ref=DIGEST_IMAGE, local_ref=local_ref
+        mapped_inspect = rewrite_fixture_image_argv(
+            inspect, registry_ref=DIGEST_IMAGE, local_ref=IMAGE_ID
         )
-        mapped_create = module.rewrite_fixture_image_argv(
-            create, registry_ref=DIGEST_IMAGE, local_ref=local_ref
+        mapped_create = rewrite_fixture_image_argv(
+            create, registry_ref=DIGEST_IMAGE, local_ref=IMAGE_ID
         )
-        self.assertEqual(mapped_pull[-1], local_ref)
-        self.assertEqual(mapped_inspect[-1], local_ref)
-        self.assertEqual(mapped_create[-1], local_ref)
+        self.assertEqual(mapped_pull[-1], IMAGE_ID)
+        self.assertEqual(mapped_inspect[-1], IMAGE_ID)
+        self.assertEqual(mapped_create[-1], IMAGE_ID)
         self.assertNotIn(DIGEST_IMAGE, mapped_inspect)
         self.assertNotIn(DIGEST_IMAGE, mapped_create)
-        self.assertEqual(
-            mapped_pull,
-            ["docker", "pull", "--platform", module.PLATFORM, local_ref],
-        )
         implementations.validate_image_reference(DIGEST_IMAGE)
+        with self.assertRaises(ValueError):
+            rewrite_fixture_image_argv(
+                pull, registry_ref=DIGEST_IMAGE, local_ref="assay-oci-inert:local"
+            )
 
     def test_local_runner_does_not_send_synthetic_repo_digest_to_docker(self) -> None:
         module = _require()
-        local_ref = "assay-oci-inert:local"
         seen: list[list[str]] = []
 
         def fake_run_docker(argv: list[str], **kwargs: Any) -> Any:
@@ -1052,9 +1173,7 @@ class AllowlistedDockerEnv(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as raw:
             env, _ = module.fresh_docker_env(Path(raw))
-        runner = module.local_image_docker_runner(
-            registry_ref=DIGEST_IMAGE, local_ref=local_ref
-        )
+        runner = local_image_docker_runner(registry_ref=DIGEST_IMAGE, local_ref=IMAGE_ID)
         with mock.patch.object(module, "run_docker", side_effect=fake_run_docker):
             with mock.patch.object(module, "run_bounded") as bounded:
                 bounded.return_value = mock.Mock(returncode=0, stdout=b"", stderr=b"")
@@ -1062,14 +1181,14 @@ class AllowlistedDockerEnv(unittest.TestCase):
                     ["docker", "pull", "--platform", module.PLATFORM, DIGEST_IMAGE],
                     env=env,
                 )
-                runner(["docker", "inspect", DIGEST_IMAGE], env=env)
+                runner(["docker", "image", "inspect", DIGEST_IMAGE], env=env)
                 runner(["docker", "create", "--name", "x", DIGEST_IMAGE], env=env)
                 probe = bounded.call_args[0][0]
-        self.assertIn(local_ref, probe)
+        self.assertIn(IMAGE_ID, probe)
         self.assertNotIn(DIGEST_IMAGE, probe)
         self.assertEqual(len(seen), 2)
         for argv in seen:
-            self.assertIn(local_ref, argv)
+            self.assertIn(IMAGE_ID, argv)
             self.assertNotIn(DIGEST_IMAGE, argv)
 
 
@@ -1337,15 +1456,16 @@ class CaptureAdapterEquivalence(unittest.TestCase):
         }
 
         def runner(argv: list[str], **_kwargs: Any) -> Any:
-            if argv[1] == "pull":
+            kind = _docker_kind(argv)
+            if kind == "pull":
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[1] == "inspect":
+            if kind in {"inspect", "image-inspect"}:
                 return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
-            if argv[1] == "create":
+            if kind == "create":
                 return module.BoundedDockerResult(0, b"cid-eq\n", b"")
-            if argv[1] == "start":
+            if kind == "start":
                 return module.BoundedDockerResult(0, stdout, b"")
-            if argv[1] == "rm":
+            if kind == "rm":
                 return module.BoundedDockerResult(0, b"", b"")
             raise AssertionError(argv)
 
@@ -1542,16 +1662,17 @@ class PackCaptureCli(unittest.TestCase):
         }
 
         def runner(argv: list[str], **_kwargs: Any) -> Any:
-            if argv[1] == "pull":
+            kind = _docker_kind(argv)
+            if kind == "pull":
                 pulled.append(argv[-1])
                 return module.BoundedDockerResult(0, b"", b"")
-            if argv[1] == "inspect":
+            if kind in {"inspect", "image-inspect"}:
                 return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
-            if argv[1] == "create":
+            if kind == "create":
                 return module.BoundedDockerResult(0, b"cid-reg\n", b"")
-            if argv[1] == "start":
+            if kind == "start":
                 return module.BoundedDockerResult(0, VALID_REPORT, b"")
-            if argv[1] == "rm":
+            if kind == "rm":
                 return module.BoundedDockerResult(0, b"", b"")
             raise AssertionError(argv)
 
@@ -1732,6 +1853,296 @@ class PackCaptureCli(unittest.TestCase):
         self.assertIn("unrecognized arguments", result.stderr)
         source = Path(module.__file__).read_text(encoding="utf-8")
         self.assertNotIn("--implementation-image", source)
+
+
+class EvidenceBinding(unittest.TestCase):
+    """Close registry/pack/digest/lifecycle binding. Mutations must bite."""
+
+    def _completed_docker(self, pulled: list[str], *, swap_registry: Path | None = None):
+        module = _require()
+        inspect_doc = _inspect_doc()
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            kind = _docker_kind(argv)
+            if kind == "pull":
+                if swap_registry is not None and not pulled:
+                    swap_registry.write_text(
+                        json.dumps(_registry_doc(SWAPPED_IMAGE)), encoding="utf-8"
+                    )
+                pulled.append(argv[-1])
+                return module.BoundedDockerResult(0, b"", b"")
+            if kind in {"inspect", "image-inspect"}:
+                return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
+            if kind == "create":
+                return module.BoundedDockerResult(0, b"cid-bind\n", b"")
+            if kind == "start":
+                return module.BoundedDockerResult(0, VALID_REPORT, b"")
+            if kind == "rm":
+                return module.BoundedDockerResult(0, b"", b"")
+            raise AssertionError(argv)
+
+        return runner
+
+    def test_registry_swap_cannot_split_identity_from_execution(self) -> None:
+        module = _require()
+        pulled: list[str] = []
+        with tempfile.TemporaryDirectory() as raw:
+            pack = _write_pack(Path(raw))
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            output = Path(raw) / "capture.json"
+            module.write_validated_capture(
+                pack,
+                "inert-fixture",
+                output,
+                registry_path=registry,
+                docker_runner=self._completed_docker(pulled, swap_registry=registry),
+                timeout_seconds=5,
+            )
+            document = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(len(pulled), 14)
+        self.assertEqual(set(pulled), {DIGEST_IMAGE})
+        self.assertNotIn(SWAPPED_IMAGE, pulled)
+        self.assertEqual(document["implementation"]["image"], DIGEST_IMAGE)
+        validate_capture(document)
+
+    def test_pack_swap_cannot_split_parsed_bytes_from_digest(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            pack_path = _write_pack(Path(raw))
+            original = pack_path.read_bytes()
+            digest_a = "sha256:" + hashlib.sha256(original).hexdigest()
+            reads = {"n": 0}
+            real_read = capture_candidate.read_pack_bytes
+
+            def read_then_swap(path: Path) -> bytes:
+                data = real_read(path)
+                reads["n"] += 1
+                if reads["n"] == 1:
+                    path.write_bytes(original + b"\x00")
+                return data
+
+            output = Path(raw) / "capture.json"
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            with mock.patch.object(
+                capture_candidate, "read_pack_bytes", side_effect=read_then_swap
+            ):
+                module.write_validated_capture(
+                    pack_path,
+                    "inert-fixture",
+                    output,
+                    registry_path=registry,
+                    docker_runner=self._completed_docker([]),
+                    timeout_seconds=5,
+                )
+            document = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(document["pack_sha256"], digest_a)
+        self.assertEqual(reads["n"], 1)
+
+    def test_run_docker_forwards_digest_ref_to_wrapped_argv(self) -> None:
+        module = _require()
+        seen: list[list[str]] = []
+
+        def fake_bounded(argv: list[str], **_kwargs: Any) -> Any:
+            seen.append(list(argv))
+            return mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as raw:
+            env, _ = module.fresh_docker_env(Path(raw))
+        with mock.patch.object(module, "run_bounded", side_effect=fake_bounded):
+            module.run_docker(
+                ["docker", "pull", "--platform", module.PLATFORM, DIGEST_IMAGE],
+                env=env,
+            )
+        self.assertEqual(len(seen), 1)
+        self.assertIn(DIGEST_IMAGE, seen[0])
+        self.assertTrue(any("@sha256:" in item for item in seen[0]))
+
+    def test_digest_strip_at_wrap_bites(self) -> None:
+        module = _require()
+        original = module.wrap_docker_command
+
+        def strip_digest(argv: list[str], env: dict[str, str]) -> list[str]:
+            wrapped = original(argv, env)
+            return [item.split("@sha256:")[0] if "@sha256:" in item else item for item in wrapped]
+
+        with tempfile.TemporaryDirectory() as raw:
+            env, _ = module.fresh_docker_env(Path(raw))
+        with mock.patch.object(module, "wrap_docker_command", side_effect=strip_digest):
+            with mock.patch.object(
+                module, "run_bounded", return_value=mock.Mock(returncode=0, stdout=b"", stderr=b"")
+            ):
+                with self.assertRaises(module.DockerCommandError):
+                    module.run_docker(
+                        ["docker", "pull", "--platform", module.PLATFORM, DIGEST_IMAGE],
+                        env=env,
+                    )
+
+    def test_missing_docker_is_named_pull_failure(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            with mock.patch.object(
+                module,
+                "resolve_docker_executable",
+                side_effect=module.DockerCommandError("docker executable not found"),
+            ):
+                result = module.execute_candidate(
+                    implementation_id="inert-fixture",
+                    bundle_path=_bundle(Path(raw)),
+                    registry_path=_write_registry(Path(raw), DIGEST_IMAGE),
+                    timeout_seconds=2,
+                )
+        self.assertEqual(result.state, module.STATE_PULL_FAILURE)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_missing_docker_main_is_not_a_traceback(self) -> None:
+        module = _require()
+        stderr = mock.Mock()
+        with tempfile.TemporaryDirectory() as raw:
+            bundle = _bundle(Path(raw))
+            row = _registry_doc(DIGEST_IMAGE)["implementations"][0]
+            with (
+                mock.patch.object(
+                    module,
+                    "resolve_docker_executable",
+                    side_effect=module.DockerCommandError("docker executable not found"),
+                ),
+                mock.patch.object(module, "implementation_from_registry", return_value=row),
+                mock.patch.object(sys, "stderr", stderr),
+            ):
+                code = module.main(
+                    [
+                        "--implementation-id",
+                        "inert-fixture",
+                        "--bundle",
+                        str(bundle),
+                    ]
+                )
+        written = "".join(str(call.args[0]) for call in stderr.write.call_args_list if call.args)
+        self.assertNotIn("Traceback", written)
+        self.assertIn(code, (0, 2))
+        if code == 0:
+            self.assertIn(module.STATE_PULL_FAILURE, written or "pull_failure")
+
+    def test_create_timeout_cleans_up_by_container_name(self) -> None:
+        module = _require()
+        removed: list[str] = []
+        created_name = {"value": ""}
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            kind = _docker_kind(argv)
+            if kind == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if kind in {"inspect", "image-inspect"}:
+                return module.BoundedDockerResult(0, json.dumps([_inspect_doc()]).encode(), b"")
+            if kind == "create":
+                created_name["value"] = argv[argv.index("--name") + 1]
+                raise ProcessLimitError("timed out after the daemon created the container")
+            if kind == "rm":
+                removed.append(argv[-1])
+                return module.BoundedDockerResult(0, b"", b"")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=_write_registry(Path(raw), DIGEST_IMAGE),
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+        self.assertEqual(result.state, module.STATE_CREATE_FAILURE)
+        self.assertEqual(removed, [created_name["value"]])
+        self.assertTrue(created_name["value"].startswith("assay-oci-"))
+
+    def test_cleanup_failure_does_not_overwrite_timeout(self) -> None:
+        module = _require()
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            kind = _docker_kind(argv)
+            if kind == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if kind in {"inspect", "image-inspect"}:
+                return module.BoundedDockerResult(0, json.dumps([_inspect_doc()]).encode(), b"")
+            if kind == "create":
+                return module.BoundedDockerResult(0, b"cid-timeout\n", b"")
+            if kind == "start":
+                raise ProcessLimitError("timed out waiting for candidate")
+            if kind == "rm":
+                raise module.DockerCommandError("rm refused after timeout")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=_write_registry(Path(raw), DIGEST_IMAGE),
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+        self.assertEqual(result.state, module.STATE_TIMEOUT)
+        self.assertIn("cleanup", result.error)
+        self.assertLessEqual(len(result.error), MAX_ERROR_CHARS)
+
+    def test_handoff_error_uses_canonical_bound(self) -> None:
+        module = _require()
+        long_error = "e" * (MAX_ERROR_CHARS * 4)
+        result = module.OciExecution(
+            module.STATE_START_FAILURE,
+            "inert-fixture",
+            DIGEST_IMAGE,
+            None,
+            b"",
+            b"",
+            long_error,
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            module.write_handoff(Path(raw) / "out", result)
+            document = json.loads(
+                (Path(raw) / "out" / module.EXECUTION_DOCUMENT_NAME).read_text(encoding="utf-8")
+            )
+        self.assertEqual(document["error"], bound_error(long_error))
+        self.assertLessEqual(len(document["error"]), MAX_ERROR_CHARS)
+
+    def test_missing_exit_code_is_harness_error_not_zero(self) -> None:
+        module = _require()
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            kind = _docker_kind(argv)
+            if kind == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if kind in {"inspect", "image-inspect"}:
+                return module.BoundedDockerResult(
+                    0, json.dumps([_inspect_doc(exit_code=None)]).encode(), b""
+                )
+            if kind == "create":
+                return module.BoundedDockerResult(0, b"cid-exit\n", b"")
+            if kind == "start":
+                return module.BoundedDockerResult(0, VALID_REPORT, b"")
+            if kind == "rm":
+                return module.BoundedDockerResult(0, b"", b"")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            bundle = _bundle(Path(raw))
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=bundle,
+                registry_path=registry,
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+            with self.assertRaises(capture_candidate.HarnessError):
+                module.run_oci_candidate(
+                    module.oci_entrypoint_command(implementation_id="inert-fixture"),
+                    bundle,
+                    2,
+                    docker_runner=runner,
+                    registry_path=registry,
+                )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertNotEqual(result.state, module.STATE_COMPLETED)
+        self.assertIn(result.state, module.HARNESS_FAILURE_STATES)
 
 
 if __name__ == "__main__":

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -1,0 +1,835 @@
+#!/usr/bin/env python3
+"""Canonical bounded OCI executor contract (assay-tunnel-experiments #203).
+
+    python3 -W error::ResourceWarning \\
+        conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+
+Argv pins and live `docker inspect` assertions are independent. Mutating the
+canonical builder must break both, not a workflow comment.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+CORPUS = Path(__file__).resolve().parents[1]
+REPO = CORPUS.parents[1]
+SCRIPTS = CORPUS / "scripts"
+FIXTURE_C = Path(__file__).resolve().parent / "fixtures" / "oci-candidate.c"
+CONFORMANCE_WORKFLOW = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
+
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(REPO / "conformance"))
+
+try:
+    import oci_candidate_executor as oci
+except ModuleNotFoundError as exc:
+    if getattr(exc, "name", None) != "oci_candidate_executor":
+        raise
+    oci = None
+
+import implementations
+from capture_format import STATE_CANDIDATE_ERROR, STATE_CAPTURE_ERROR
+from score_candidate import STATE_TO_STATUS
+
+DIGEST_IMAGE = (
+    "ghcr.io/example/checker@sha256:"
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+)
+AGREEMENT = frozenset(
+    {"match", "mismatch", "unproved", "execution_error", "harness_error"}
+)
+ISSUE_203_NON_CLAIMS = (
+    "No container/kernel security, image authenticity, publisher identity, "
+    "malware safety, supply-chain integrity, conformance, or cleanup "
+    "guarantee after host/daemon/SIGKILL failure."
+)
+
+
+def _require() -> Any:
+    if oci is None:
+        raise AssertionError("oci_candidate_executor.py is missing")
+    return oci
+
+
+def _registry_doc(image: str, ident: str = "inert-fixture") -> dict[str, Any]:
+    return {
+        "schema": "assay.conformance.implementations.v0",
+        "implementations": [
+            {
+                "id": ident,
+                "name": "Inert fixture",
+                "suite": "privileged-mcp-action-v0",
+                "image": image,
+                "source": "https://github.com/Rul1an/assay",
+                "commit": "0123456789abcdef0123456789abcdef01234567",
+                "language": "c",
+                "reproduction_mode": "other_disclosed",
+                "authorship": {"kind": "human"},
+            }
+        ],
+    }
+
+
+def _write_registry(directory: Path, image: str, ident: str = "inert-fixture") -> Path:
+    path = directory / "implementations.json"
+    path.write_text(json.dumps(_registry_doc(image, ident)), encoding="utf-8")
+    return path
+
+
+def _bundle(directory: Path) -> Path:
+    path = directory / "opaque.bundle.tar.gz"
+    path.write_bytes(b"opaque-bundle")
+    return path
+
+
+def _argv(*, image: str = DIGEST_IMAGE, bundle: Path | None = None) -> list[str]:
+    module = _require()
+    with tempfile.TemporaryDirectory() as raw:
+        path = bundle or _bundle(Path(raw))
+        return module.build_container_create_argv(
+            image=image,
+            bundle_path=path,
+            container_name="assay-oci-test",
+        )
+
+
+def _flag_value(argv: list[str], flag: str) -> str | None:
+    for index, item in enumerate(argv):
+        if item == flag and index + 1 < len(argv):
+            return argv[index + 1]
+    return None
+
+
+def _has_flag(argv: list[str], flag: str) -> bool:
+    return flag in argv
+
+
+def assert_argv_network_none(argv: list[str]) -> None:
+    if _flag_value(argv, "--network") != "none":
+        raise AssertionError("argv lost --network none")
+
+
+def assert_argv_runtime_user(argv: list[str]) -> None:
+    if _flag_value(argv, "--user") != "65532:65532":
+        raise AssertionError("argv lost fixed non-root user 65532:65532")
+
+
+def assert_inspect_network_none(inspect_doc: dict[str, Any]) -> None:
+    mode = inspect_doc.get("HostConfig", {}).get("NetworkMode")
+    if mode != "none":
+        raise AssertionError(f"inspect NetworkMode is {mode!r}, not none")
+
+
+def assert_inspect_runtime_user(inspect_doc: dict[str, Any]) -> None:
+    user = inspect_doc.get("Config", {}).get("User")
+    if user != "65532:65532":
+        raise AssertionError(f"inspect User is {user!r}, not 65532:65532")
+
+
+VALUELESS_FLAGS = frozenset(("--read-only",))
+
+
+def _drop_pair(argv: list[str], flag: str) -> list[str]:
+    if flag in VALUELESS_FLAGS:
+        return [item for item in argv if item != flag]
+    out: list[str] = []
+    skip = False
+    for item in argv:
+        if skip:
+            skip = False
+            continue
+        if item == flag:
+            skip = True
+            continue
+        out.append(item)
+    return out
+
+
+def _replace_value(argv: list[str], flag: str, value: str) -> list[str]:
+    out = list(argv)
+    for index, item in enumerate(out):
+        if item == flag and index + 1 < len(out):
+            out[index + 1] = value
+            return out
+    raise AssertionError(f"missing {flag}")
+
+
+class FirstRedIndependence(unittest.TestCase):
+    """#203 first RED: drop --network none or change the user; both checks fail."""
+
+    def test_canonical_argv_pins_network_none(self) -> None:
+        assert_argv_network_none(_argv())
+
+    def test_canonical_argv_pins_non_root_user(self) -> None:
+        assert_argv_runtime_user(_argv())
+
+    def test_inspect_helper_is_independent_of_argv_text(self) -> None:
+        assert_inspect_network_none({"HostConfig": {"NetworkMode": "none"}})
+        assert_inspect_runtime_user({"Config": {"User": "65532:65532"}})
+        with self.assertRaises(AssertionError):
+            assert_inspect_network_none({"HostConfig": {"NetworkMode": "bridge"}})
+        with self.assertRaises(AssertionError):
+            assert_inspect_runtime_user({"Config": {"User": "0:0"}})
+
+    def test_mutating_network_none_fails_argv_and_inspect_independently(self) -> None:
+        mutated_argv = _drop_pair(_argv(), "--network")
+        with self.assertRaises(AssertionError):
+            assert_argv_network_none(mutated_argv)
+        with self.assertRaises(AssertionError):
+            assert_inspect_network_none({"HostConfig": {"NetworkMode": "bridge"}})
+
+    def test_mutating_user_fails_argv_and_inspect_independently(self) -> None:
+        mutated_argv = _replace_value(_argv(), "--user", "0:0")
+        with self.assertRaises(AssertionError):
+            assert_argv_runtime_user(mutated_argv)
+        with self.assertRaises(AssertionError):
+            assert_inspect_runtime_user({"Config": {"User": "0:0"}})
+
+
+class ArgvContract(unittest.TestCase):
+    def test_one_canonical_builder(self) -> None:
+        module = _require()
+        self.assertTrue(callable(module.build_container_create_argv))
+        tree = ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+        builders = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("build_")
+        ]
+        self.assertEqual(builders, ["build_container_create_argv"])
+
+    def test_builder_validates_image_with_registry_function(self) -> None:
+        module = _require()
+        with self.assertRaises(implementations.ImplementationRegistryError):
+            module.build_container_create_argv(
+                image="ghcr.io/example/checker:latest",
+                bundle_path=Path("/tmp/missing"),
+                container_name="x",
+            )
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        self.assertIn("validate_image_reference", source)
+        self.assertNotIn("IMAGE_RE", source)
+        tree = ast.parse(source)
+        self.assertFalse(
+            any(
+                isinstance(node, ast.FunctionDef) and node.name == "validate_image_reference"
+                for node in ast.walk(tree)
+            )
+        )
+
+    def test_argv_pins_every_isolation_bound(self) -> None:
+        argv = _argv()
+        self.assertEqual(argv[0], "docker")
+        self.assertEqual(argv[1], "create")
+        self.assertEqual(_flag_value(argv, "--platform"), "linux/amd64")
+        self.assertEqual(_flag_value(argv, "--network"), "none")
+        self.assertTrue(_has_flag(argv, "--read-only"))
+        self.assertEqual(_flag_value(argv, "--user"), "65532:65532")
+        self.assertEqual(_flag_value(argv, "--cap-drop"), "ALL")
+        self.assertEqual(_flag_value(argv, "--security-opt"), "no-new-privileges:true")
+        self.assertEqual(_flag_value(argv, "--cpus"), module_cpus())
+        self.assertEqual(_flag_value(argv, "--memory"), module_memory())
+        self.assertEqual(_flag_value(argv, "--memory-swap"), module_memory_swap())
+        self.assertEqual(_flag_value(argv, "--pids-limit"), module_pids())
+        self.assertEqual(_flag_value(argv, "--ipc"), "none")
+        self.assertEqual(_flag_value(argv, "--restart"), "no")
+        tmpfs = _flag_value(argv, "--tmpfs")
+        self.assertIsNotNone(tmpfs)
+        self.assertTrue(tmpfs.startswith("/tmp:"))
+        self.assertIn("noexec", tmpfs)
+        self.assertIn("size=", tmpfs)
+        log_opts = [
+            argv[index + 1]
+            for index, item in enumerate(argv)
+            if item == "--log-opt" and index + 1 < len(argv)
+        ]
+        self.assertTrue(any(opt.startswith("max-size=") for opt in log_opts))
+        self.assertTrue(any(opt.startswith("max-file=") for opt in log_opts))
+        self.assertIn(DIGEST_IMAGE, argv)
+        joined = " ".join(argv)
+        for forbidden in (
+            "/var/run/docker.sock",
+            "docker.sock",
+            str(REPO),
+            str(Path.home()),
+            ".docker/config.json",
+            "--privileged",
+        ):
+            self.assertNotIn(forbidden, joined)
+        self.assertNotIn("--pid", argv)
+        self.assertNotIn("--volume", argv)
+
+    def test_mount_is_only_the_opaque_bundle_readonly(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            bundle = _bundle(Path(raw))
+            argv = _require().build_container_create_argv(
+                image=DIGEST_IMAGE,
+                bundle_path=bundle,
+                container_name="assay-oci-test",
+            )
+        mounts = [
+            argv[index + 1]
+            for index, item in enumerate(argv)
+            if item == "--mount" and index + 1 < len(argv)
+        ]
+        self.assertEqual(len(mounts), 1)
+        mount = mounts[0]
+        self.assertIn("type=bind", mount)
+        self.assertIn(f"src={bundle.resolve()}", mount)
+        self.assertIn("dst=/input/bundle.tar.gz", mount)
+        self.assertTrue("ro=true" in mount or "readonly=true" in mount)
+
+    def test_directory_bundle_is_rejected(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            with self.assertRaises(ValueError):
+                module.build_container_create_argv(
+                    image=DIGEST_IMAGE,
+                    bundle_path=Path(raw),
+                    container_name="x",
+                )
+
+
+def module_cpus() -> str:
+    return _require().CPUS
+
+
+def module_memory() -> str:
+    return _require().MEMORY
+
+
+def module_memory_swap() -> str:
+    return _require().MEMORY_SWAP
+
+
+def module_pids() -> str:
+    return _require().PIDS_LIMIT
+
+
+class RegistrySelection(unittest.TestCase):
+    def test_implementation_id_comes_from_registry_not_cli_image(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            row = module.implementation_from_registry("inert-fixture", registry)
+        self.assertEqual(row["image"], DIGEST_IMAGE)
+        self.assertEqual(row["id"], "inert-fixture")
+
+    def test_unknown_id_is_rejected(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            with self.assertRaises(implementations.ImplementationRegistryError):
+                module.implementation_from_registry("missing-id", registry)
+
+    def test_checked_in_registry_has_no_direct_image_escape(self) -> None:
+        module = _require()
+        with self.assertRaises(implementations.ImplementationRegistryError):
+            module.implementation_from_registry("inert-fixture")
+
+    def test_cli_rejects_direct_image_input(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            output = Path(raw) / "out.json"
+            bundle = _bundle(Path(raw))
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(module.__file__)),
+                    "--implementation-id",
+                    "inert-fixture",
+                    "--implementation-image",
+                    DIGEST_IMAGE,
+                    "--bundle",
+                    str(bundle),
+                    "--output",
+                    str(output),
+                ],
+                cwd=REPO,
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unrecognized arguments", result.stderr)
+
+
+class NamedExecutionStates(unittest.TestCase):
+    def test_named_states_are_never_agreement(self) -> None:
+        module = _require()
+        expected = {
+            module.STATE_COMPLETED,
+            module.STATE_TIMEOUT,
+            module.STATE_OOM,
+            module.STATE_OUTPUT_OVERFLOW,
+            module.STATE_PULL_FAILURE,
+            module.STATE_CREATE_FAILURE,
+            module.STATE_START_FAILURE,
+            module.STATE_CLEANUP_FAILURE,
+        }
+        self.assertEqual(set(module.EXECUTION_STATES), expected)
+        self.assertTrue(expected.isdisjoint(AGREEMENT))
+
+    def test_error_states_use_capture_observe_error(self) -> None:
+        module = _require()
+        mapping = {
+            module.STATE_TIMEOUT: STATE_CANDIDATE_ERROR,
+            module.STATE_OOM: STATE_CANDIDATE_ERROR,
+            module.STATE_OUTPUT_OVERFLOW: STATE_CANDIDATE_ERROR,
+            module.STATE_PULL_FAILURE: STATE_CAPTURE_ERROR,
+            module.STATE_CREATE_FAILURE: STATE_CAPTURE_ERROR,
+            module.STATE_START_FAILURE: STATE_CAPTURE_ERROR,
+            module.STATE_CLEANUP_FAILURE: STATE_CAPTURE_ERROR,
+        }
+        for state, capture_state in mapping.items():
+            observation = module.observation_for(
+                state,
+                case_id="case-001",
+                input_sha256="sha256:" + "ab" * 32,
+                message=state,
+            )
+            self.assertEqual(observation["state"], capture_state)
+            self.assertEqual(
+                STATE_TO_STATUS[observation["state"]] in {"execution_error", "harness_error"},
+                True,
+            )
+            self.assertNotIn(observation["state"], AGREEMENT)
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        self.assertIn("observe_error", source)
+        self.assertIn("validate_image_reference", source)
+        self.assertIn("load_implementations", source)
+
+    def test_completed_is_not_a_score(self) -> None:
+        module = _require()
+        with self.assertRaises(ValueError):
+            module.observation_for(
+                module.STATE_COMPLETED,
+                case_id="case-001",
+                input_sha256="sha256:" + "ab" * 32,
+                message="ok",
+            )
+
+
+class NonClaimsAndReuse(unittest.TestCase):
+    def test_non_claims_are_exact_issue_203_text(self) -> None:
+        module = _require()
+        self.assertEqual(module.OCI_EXECUTOR_NON_CLAIMS, (ISSUE_203_NON_CLAIMS,))
+
+    def test_output_is_loaded_with_strict_capture_loader(self) -> None:
+        module = _require()
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        self.assertIn("load_strict_object", source)
+        tree = ast.parse(source)
+        self.assertFalse(
+            any(
+                isinstance(node, ast.FunctionDef) and node.name in {"load_capture", "validate_capture"}
+                for node in ast.walk(tree)
+            )
+        )
+
+
+class DeclaredVolumes(unittest.TestCase):
+    def test_declared_volumes_are_rejected(self) -> None:
+        module = _require()
+        with self.assertRaises(module.VolumeDeclarationError):
+            module.reject_declared_volumes(
+                {"Config": {"Volumes": {"/data": {}}}}
+            )
+        module.reject_declared_volumes({"Config": {"Volumes": None}})
+        module.reject_declared_volumes({"Config": {}})
+
+
+class LifecycleClassification(unittest.TestCase):
+    def test_pull_create_start_cleanup_are_named_states(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(
+                Path(raw),
+                "does-not-exist.invalid/x@sha256:" + "ab" * 32,
+            )
+            bundle = _bundle(Path(raw))
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=bundle,
+                registry_path=registry,
+                timeout_seconds=2,
+            )
+        self.assertEqual(result.state, module.STATE_PULL_FAILURE)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_cleanup_failure_wins_over_completed(self) -> None:
+        module = _require()
+        inspect_doc = {
+            "Id": "sha256:" + "cd" * 32,
+            "Config": {"Volumes": None, "User": "65532:65532"},
+            "HostConfig": {"NetworkMode": "none"},
+            "State": {"OOMKilled": False, "ExitCode": 0, "Status": "exited"},
+        }
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            if argv[:2] == ["docker", "pull"] or argv[1] == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[:2] == ["docker", "inspect"] or argv[1] == "inspect":
+                return module.BoundedDockerResult(
+                    0, json.dumps([inspect_doc]).encode(), b""
+                )
+            if argv[:2] == ["docker", "create"] or argv[1] == "create":
+                return module.BoundedDockerResult(0, b"cid-1\n", b"")
+            if argv[:2] == ["docker", "start"] or argv[1] == "start":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[:2] == ["docker", "rm"] or argv[1] == "rm":
+                raise module.DockerCommandError("rm refused")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=registry,
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+        self.assertEqual(result.state, module.STATE_CLEANUP_FAILURE)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_start_failure_is_named_state(self) -> None:
+        module = _require()
+        inspect_doc = {
+            "Id": "sha256:" + "cd" * 32,
+            "Config": {"Volumes": None, "User": "65532:65532"},
+            "HostConfig": {"NetworkMode": "none"},
+            "State": {"OOMKilled": False, "ExitCode": 0, "Status": "created"},
+        }
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            if argv[1] == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[1] == "inspect":
+                return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
+            if argv[1] == "create":
+                return module.BoundedDockerResult(0, b"cid-start\n", b"")
+            if argv[1] == "start":
+                raise module.DockerCommandError("cannot start container")
+            if argv[1] == "rm":
+                return module.BoundedDockerResult(0, b"", b"")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=_write_registry(Path(raw), DIGEST_IMAGE),
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+        self.assertEqual(result.state, module.STATE_START_FAILURE)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_create_failure_is_named_state(self) -> None:
+        module = _require()
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            if argv[1] == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[1] == "inspect":
+                return module.BoundedDockerResult(
+                    0,
+                    json.dumps([{"Config": {"Volumes": {"/data": {}}}}]).encode(),
+                    b"",
+                )
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=_write_registry(Path(raw), DIGEST_IMAGE),
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+        self.assertEqual(result.state, module.STATE_CREATE_FAILURE)
+        self.assertNotIn(result.state, AGREEMENT)
+
+
+class ConformanceCiContract(unittest.TestCase):
+    def test_existing_workflow_runs_this_file(self) -> None:
+        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("test_activation_kit.py", text)
+        self.assertIn("test_oci_candidate_executor.py", text)
+        self.assertRegex(
+            text,
+            r"python3 -m unittest \\\n"
+            r"\s+conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
+            r"\s+conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py",
+        )
+
+
+def _docker_info() -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["docker", "info"],
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+
+def _build_inert_image() -> str:
+    if not FIXTURE_C.is_file():
+        raise AssertionError(f"missing fixture {FIXTURE_C}")
+    with tempfile.TemporaryDirectory() as raw:
+        context = Path(raw)
+        (context / "oci-candidate.c").write_bytes(FIXTURE_C.read_bytes())
+        (context / "Dockerfile").write_text(
+            "FROM gcc:14-bookworm AS build\n"
+            "WORKDIR /src\n"
+            "COPY oci-candidate.c .\n"
+            "RUN gcc -static -Os -o /oci-candidate oci-candidate.c\n"
+            "FROM scratch\n"
+            "COPY --from=build /oci-candidate /oci-candidate\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            [
+                "docker",
+                "build",
+                "--platform",
+                "linux/amd64",
+                "-t",
+                "assay-oci-inert:local",
+                str(context),
+            ],
+            check=True,
+            capture_output=True,
+        )
+    inspected = subprocess.run(
+        ["docker", "inspect", "--format", "{{.Id}}", "assay-oci-inert:local"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    image_id = inspected.stdout.strip()
+    if not image_id.startswith("sha256:") or len(image_id) != 71:
+        raise AssertionError(f"unexpected image id {image_id!r}")
+    digest = image_id.split(":", 1)[1]
+    ref = f"assay-oci-inert@sha256:{digest}"
+    subprocess.run(["docker", "tag", image_id, f"assay-oci-inert:{digest}"], check=True)
+    return ref
+
+
+class LiveDockerInspect(unittest.TestCase):
+    image_ref: str | None = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        info = _docker_info()
+        if info.returncode != 0:
+            raise AssertionError(
+                "docker is required for live inspect; unavailable infrastructure "
+                f"is not a pass: {info.stderr.decode('utf-8', 'replace')}"
+            )
+        cls.image_ref = _build_inert_image()
+
+    def test_live_inspect_pins_network_and_user_independently_of_argv_strings(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        with tempfile.TemporaryDirectory() as raw:
+            bundle = _bundle(Path(raw))
+            argv = module.build_container_create_argv(
+                image=self.image_ref,
+                bundle_path=bundle,
+                container_name=f"assay-oci-live-{os.getpid()}",
+                command=("/oci-candidate", "ok"),
+            )
+            assert_argv_network_none(argv)
+            assert_argv_runtime_user(argv)
+            created = subprocess.run(argv, capture_output=True, text=True, check=False)
+            self.assertEqual(created.returncode, 0, created.stderr)
+            container = created.stdout.strip()
+            try:
+                inspected = subprocess.run(
+                    ["docker", "inspect", container],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                doc = json.loads(inspected.stdout)[0]
+                assert_inspect_network_none(doc)
+                assert_inspect_runtime_user(doc)
+                host = doc["HostConfig"]
+                self.assertTrue(host.get("ReadonlyRootfs"))
+                self.assertIn("ALL", host.get("CapDrop") or [])
+                self.assertEqual(host.get("IpcMode"), "none")
+                self.assertEqual(host.get("PidsLimit"), int(module.PIDS_LIMIT))
+                self.assertEqual((host.get("RestartPolicy") or {}).get("Name"), "no")
+                mounts = doc.get("Mounts") or []
+                self.assertEqual(len(mounts), 1)
+                self.assertEqual(mounts[0]["Source"], str(bundle.resolve()))
+                self.assertEqual(mounts[0]["Destination"], "/input/bundle.tar.gz")
+                self.assertTrue(mounts[0]["RW"] is False)
+                for forbidden in ("/var/run/docker.sock", str(REPO), str(Path.home())):
+                    self.assertFalse(
+                        any(forbidden in (mount.get("Source") or "") for mount in mounts)
+                    )
+            finally:
+                subprocess.run(
+                    ["docker", "rm", "--force", "--volumes", container],
+                    capture_output=True,
+                    check=False,
+                )
+
+    def test_live_volume_image_is_rejected_before_create(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        volume_tag = "assay-oci-inert-volume:local"
+        subprocess.run(
+            [
+                "docker",
+                "build",
+                "--platform",
+                "linux/amd64",
+                "-t",
+                volume_tag,
+                "-",
+            ],
+            input=b"FROM assay-oci-inert:local\nVOLUME /data\n",
+            check=True,
+            capture_output=True,
+        )
+        image_id = subprocess.run(
+            ["docker", "inspect", "--format", "{{.Id}}", volume_tag],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        digest = image_id.split(":", 1)[1]
+        volume_ref = f"assay-oci-inert-volume@sha256:{digest}"
+        subprocess.run(["docker", "tag", image_id, f"assay-oci-inert-volume:{digest}"], check=True)
+        inspect_raw = subprocess.run(
+            ["docker", "inspect", volume_ref],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        with self.assertRaises(module.VolumeDeclarationError):
+            module.reject_declared_volumes(json.loads(inspect_raw.stdout)[0])
+
+    def test_live_timeout_is_named_timeout_not_agreement(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), self.image_ref)
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=registry,
+                timeout_seconds=1,
+                command=("/oci-candidate", "sleep"),
+                docker_runner=module.local_image_docker_runner(),
+            )
+        self.assertEqual(result.state, module.STATE_TIMEOUT)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_live_overflow_is_named_overflow_not_agreement(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), self.image_ref)
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=registry,
+                timeout_seconds=5,
+                command=("/oci-candidate", "flood"),
+                docker_runner=module.local_image_docker_runner(),
+            )
+        self.assertEqual(result.state, module.STATE_OUTPUT_OVERFLOW)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_live_completed_ok_is_not_agreement(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), self.image_ref)
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=registry,
+                timeout_seconds=10,
+                command=("/oci-candidate", "ok"),
+                docker_runner=module.local_image_docker_runner(),
+            )
+        self.assertEqual(result.state, module.STATE_COMPLETED)
+        self.assertNotIn(result.state, AGREEMENT)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_live_oom_is_named_oom_not_agreement(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), self.image_ref)
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=registry,
+                timeout_seconds=20,
+                command=("/oci-candidate", "oom"),
+                docker_runner=module.local_image_docker_runner(),
+            )
+        self.assertEqual(result.state, module.STATE_OOM)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_fresh_docker_config_is_anonymous(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            env, config_dir = module.fresh_docker_env(Path(raw))
+        self.assertEqual(env.get("DOCKER_CONFIG"), str(config_dir))
+        self.assertFalse((config_dir / "config.json").exists())
+        self.assertNotIn("REGISTRY_AUTH_FILE", env)
+
+
+class BoundMutations(unittest.TestCase):
+    def test_each_bound_has_a_biting_mutation(self) -> None:
+        argv = _argv()
+        cases = (
+            ("--network", "host", assert_argv_network_none),
+            ("--user", "0:0", assert_argv_runtime_user),
+        )
+        for flag, value, checker in cases:
+            with self.subTest(flag=flag, value=value):
+                with self.assertRaises(AssertionError):
+                    checker(_replace_value(argv, flag, value))
+        for flag in (
+            "--read-only",
+            "--cap-drop",
+            "--security-opt",
+            "--cpus",
+            "--memory",
+            "--memory-swap",
+            "--pids-limit",
+            "--ipc",
+            "--tmpfs",
+            "--restart",
+            "--mount",
+            "--platform",
+            "--log-opt",
+        ):
+            with self.subTest(drop=flag):
+                mutated = _drop_pair(argv, flag)
+                self.assertNotEqual(mutated, argv)
+                self.assertTrue(
+                    flag not in mutated or flag == "--log-opt",
+                    f"{flag} survived drop",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -11,14 +11,17 @@ canonical builder must break both, not a workflow comment.
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 CORPUS = Path(__file__).resolve().parents[1]
 REPO = CORPUS.parents[1]
@@ -36,6 +39,7 @@ except ModuleNotFoundError as exc:
         raise
     oci = None
 
+import capture_candidate
 import implementations
 from capture_format import STATE_CANDIDATE_ERROR, STATE_CAPTURE_ERROR
 from score_candidate import STATE_TO_STATUS
@@ -94,11 +98,15 @@ def _bundle(directory: Path) -> Path:
 def _argv(*, image: str = DIGEST_IMAGE, bundle: Path | None = None) -> list[str]:
     module = _require()
     with tempfile.TemporaryDirectory() as raw:
-        path = bundle or _bundle(Path(raw))
+        root = Path(raw)
+        path = bundle or _bundle(root)
+        staging = root / "stage"
+        staging.mkdir()
         return module.build_container_create_argv(
             image=image,
             bundle_path=path,
             container_name="assay-oci-test",
+            staging_dir=staging,
         )
 
 
@@ -209,22 +217,14 @@ class ArgvContract(unittest.TestCase):
 
     def test_builder_validates_image_with_registry_function(self) -> None:
         module = _require()
-        with self.assertRaises(implementations.ImplementationRegistryError):
-            module.build_container_create_argv(
-                image="ghcr.io/example/checker:latest",
-                bundle_path=Path("/tmp/missing"),
-                container_name="x",
-            )
-        source = Path(module.__file__).read_text(encoding="utf-8")
-        self.assertIn("validate_image_reference", source)
-        self.assertNotIn("IMAGE_RE", source)
-        tree = ast.parse(source)
-        self.assertFalse(
-            any(
-                isinstance(node, ast.FunctionDef) and node.name == "validate_image_reference"
-                for node in ast.walk(tree)
-            )
-        )
+        with tempfile.TemporaryDirectory() as raw:
+            with self.assertRaises(implementations.ImplementationRegistryError):
+                module.build_container_create_argv(
+                    image="ghcr.io/example/checker:latest",
+                    bundle_path=Path(raw) / "missing",
+                    container_name="x",
+                    staging_dir=Path(raw) / "stage",
+                )
 
     def test_argv_pins_every_isolation_bound(self) -> None:
         argv = _argv()
@@ -271,10 +271,12 @@ class ArgvContract(unittest.TestCase):
     def test_mount_is_only_the_opaque_bundle_readonly(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             bundle = _bundle(Path(raw))
+            staging = Path(raw) / "stage"
             argv = _require().build_container_create_argv(
                 image=DIGEST_IMAGE,
                 bundle_path=bundle,
                 container_name="assay-oci-test",
+                staging_dir=staging,
             )
         mounts = [
             argv[index + 1]
@@ -283,8 +285,10 @@ class ArgvContract(unittest.TestCase):
         ]
         self.assertEqual(len(mounts), 1)
         mount = mounts[0]
+        staged = (staging / "opaque.bundle").resolve()
         self.assertIn("type=bind", mount)
-        self.assertIn(f"src={bundle.resolve()}", mount)
+        self.assertIn(f"src={staged}", mount)
+        self.assertNotIn(str(bundle.resolve()), mount)
         self.assertIn("dst=/input/bundle.tar.gz", mount)
         self.assertTrue("ro=true" in mount or "readonly=true" in mount)
 
@@ -296,6 +300,7 @@ class ArgvContract(unittest.TestCase):
                     image=DIGEST_IMAGE,
                     bundle_path=Path(raw),
                     container_name="x",
+                    staging_dir=Path(raw) / "stage",
                 )
 
 
@@ -402,10 +407,6 @@ class NamedExecutionStates(unittest.TestCase):
                 True,
             )
             self.assertNotIn(observation["state"], AGREEMENT)
-        source = Path(module.__file__).read_text(encoding="utf-8")
-        self.assertIn("observe_error", source)
-        self.assertIn("validate_image_reference", source)
-        self.assertIn("load_implementations", source)
 
     def test_completed_is_not_a_score(self) -> None:
         module = _require()
@@ -422,18 +423,6 @@ class NonClaimsAndReuse(unittest.TestCase):
     def test_non_claims_are_exact_issue_203_text(self) -> None:
         module = _require()
         self.assertEqual(module.OCI_EXECUTOR_NON_CLAIMS, (ISSUE_203_NON_CLAIMS,))
-
-    def test_output_is_loaded_with_strict_capture_loader(self) -> None:
-        module = _require()
-        source = Path(module.__file__).read_text(encoding="utf-8")
-        self.assertIn("load_strict_object", source)
-        tree = ast.parse(source)
-        self.assertFalse(
-            any(
-                isinstance(node, ast.FunctionDef) and node.name in {"load_capture", "validate_capture"}
-                for node in ast.walk(tree)
-            )
-        )
 
 
 class DeclaredVolumes(unittest.TestCase):
@@ -582,19 +571,53 @@ def _docker_info() -> subprocess.CompletedProcess[bytes]:
     )
 
 
+def _compile_inert_linux_elf(dest: Path) -> None:
+    """Host-compile a linux/amd64 static ELF. FROM scratch copies only this file."""
+    errors: list[str] = []
+    if sys.platform.startswith("linux"):
+        compiler = shutil.which("gcc") or shutil.which("cc")
+        if compiler is not None:
+            compiled = subprocess.run(
+                [compiler, "-static", "-Os", "-o", str(dest), str(FIXTURE_C)],
+                capture_output=True,
+            )
+            if compiled.returncode == 0:
+                return
+            errors.append(compiled.stderr.decode("utf-8", "replace"))
+    zig = shutil.which("zig")
+    if zig is not None:
+        compiled = subprocess.run(
+            [
+                zig,
+                "cc",
+                "-target",
+                "x86_64-linux-musl",
+                "-static",
+                "-Os",
+                "-o",
+                str(dest),
+                str(FIXTURE_C),
+            ],
+            capture_output=True,
+        )
+        if compiled.returncode == 0:
+            return
+        errors.append(compiled.stderr.decode("utf-8", "replace"))
+    raise AssertionError(
+        "could not host-compile the inert linux/amd64 ELF; the fixture "
+        "image is FROM scratch and must not pull a compiler or candidate "
+        "image: %s" % (" | ".join(errors) or "no gcc/zig")
+    )
+
+
 def _build_inert_image() -> str:
     if not FIXTURE_C.is_file():
         raise AssertionError(f"missing fixture {FIXTURE_C}")
     with tempfile.TemporaryDirectory() as raw:
         context = Path(raw)
-        (context / "oci-candidate.c").write_bytes(FIXTURE_C.read_bytes())
+        _compile_inert_linux_elf(context / "oci-candidate")
         (context / "Dockerfile").write_text(
-            "FROM gcc:14-bookworm AS build\n"
-            "WORKDIR /src\n"
-            "COPY oci-candidate.c .\n"
-            "RUN gcc -static -Os -o /oci-candidate oci-candidate.c\n"
-            "FROM scratch\n"
-            "COPY --from=build /oci-candidate /oci-candidate\n",
+            "FROM scratch\nCOPY oci-candidate /oci-candidate\n",
             encoding="utf-8",
         )
         subprocess.run(
@@ -643,10 +666,12 @@ class LiveDockerInspect(unittest.TestCase):
         assert self.image_ref is not None
         with tempfile.TemporaryDirectory() as raw:
             bundle = _bundle(Path(raw))
+            staging = Path(raw) / "stage"
             argv = module.build_container_create_argv(
                 image=self.image_ref,
                 bundle_path=bundle,
                 container_name=f"assay-oci-live-{os.getpid()}",
+                staging_dir=staging,
                 command=("/oci-candidate", "ok"),
             )
             assert_argv_network_none(argv)
@@ -672,7 +697,11 @@ class LiveDockerInspect(unittest.TestCase):
                 self.assertEqual((host.get("RestartPolicy") or {}).get("Name"), "no")
                 mounts = doc.get("Mounts") or []
                 self.assertEqual(len(mounts), 1)
-                self.assertEqual(mounts[0]["Source"], str(bundle.resolve()))
+                self.assertEqual(
+                    mounts[0]["Source"],
+                    str((staging / "opaque.bundle").resolve()),
+                )
+                self.assertNotEqual(mounts[0]["Source"], str(bundle.resolve()))
                 self.assertEqual(mounts[0]["Destination"], "/input/bundle.tar.gz")
                 self.assertTrue(mounts[0]["RW"] is False)
                 for forbidden in ("/var/run/docker.sock", str(REPO), str(Path.home())):
@@ -780,7 +809,7 @@ class LiveDockerInspect(unittest.TestCase):
                 implementation_id="inert-fixture",
                 bundle_path=_bundle(Path(raw)),
                 registry_path=registry,
-                timeout_seconds=20,
+                timeout_seconds=60,
                 command=("/oci-candidate", "oom"),
                 docker_runner=module.local_image_docker_runner(),
             )
@@ -829,6 +858,298 @@ class BoundMutations(unittest.TestCase):
                     flag not in mutated or flag == "--log-opt",
                     f"{flag} survived drop",
                 )
+
+
+SENTINEL_ENV = {
+    "GITHUB_TOKEN": "sentinel-gh-token",
+    "DOCKER_AUTH_CONFIG": "sentinel-docker-auth",
+    "HTTP_PROXY": "http://sentinel-proxy.example",
+    "HTTPS_PROXY": "http://sentinel-proxy.example",
+    "AWS_SECRET_ACCESS_KEY": "sentinel-aws-key",
+    "REGISTRY_AUTH_FILE": "/tmp/sentinel-registry-auth",
+}
+VALID_REPORT = b'{"bundle_integrity":"fail"}'
+
+
+class AllowlistedDockerEnv(unittest.TestCase):
+    def test_parent_secrets_do_not_reach_docker_cli_env(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            with mock.patch.dict(os.environ, SENTINEL_ENV, clear=False):
+                env, config_dir = module.fresh_docker_env(Path(raw))
+                wrapped = module.wrap_docker_command(["docker", "info"], env)
+        for key, value in SENTINEL_ENV.items():
+            self.assertNotIn(key, env)
+            self.assertNotIn(value, " ".join(wrapped))
+        self.assertEqual(env.get("DOCKER_CONFIG"), str(config_dir))
+        self.assertFalse((config_dir / "config.json").exists())
+        self.assertIn("-i", wrapped)
+
+    def test_local_image_runner_uses_the_same_wrap(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            env, _ = module.fresh_docker_env(Path(raw))
+        probe = module.wrap_docker_command(["docker", "image", "inspect", DIGEST_IMAGE], env)
+        self.assertIn("-i", probe)
+        for key in SENTINEL_ENV:
+            self.assertNotIn(key, " ".join(probe))
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        self.assertIn("wrap_docker_command", source)
+        self.assertNotIn('run_bounded(\n                ["docker", "image", "inspect"', source)
+
+
+class StagedBundleMount(unittest.TestCase):
+    def test_repo_and_home_inputs_are_staged_before_mount(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            caller = Path(raw) / "repo-or-home" / "secret.bundle"
+            caller.parent.mkdir()
+            caller.write_bytes(b"caller-bytes")
+            staging = Path(raw) / "assay-oci-stage"
+            staging.mkdir()
+            argv = module.build_container_create_argv(
+                image=DIGEST_IMAGE,
+                bundle_path=caller,
+                container_name="assay-oci-test",
+                staging_dir=staging,
+            )
+            mount = _flag_value(argv, "--mount") or ""
+            staged = (staging / "opaque.bundle").resolve()
+            self.assertIn(f"src={staged}", mount)
+            self.assertNotIn(str(caller.resolve()), mount)
+            self.assertEqual(staged.read_bytes(), b"caller-bytes")
+
+    def test_symlink_bundle_is_rejected_by_the_shared_reader(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            real = _bundle(Path(raw))
+            link = Path(raw) / "link.bundle"
+            link.symlink_to(real)
+            with self.assertRaises(ValueError):
+                module.stage_opaque_bundle(link, Path(raw) / "stage")
+
+    def test_oversize_bundle_is_rejected_by_the_shared_reader(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            huge = Path(raw) / "huge.bundle"
+            huge.write_bytes(b"x" * (module.MAX_BUNDLE_BYTES + 1))
+            with self.assertRaises(ValueError):
+                module.stage_opaque_bundle(huge, Path(raw) / "stage")
+
+    def test_swap_after_read_does_not_change_staged_bytes(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            source = Path(raw) / "moving.bundle"
+            source.write_bytes(b"first")
+            staged = module.stage_opaque_bundle(source, Path(raw) / "stage")
+            source.write_bytes(b"swapped")
+            self.assertEqual(staged.read_bytes(), b"first")
+
+
+class CandidateOutputHandoff(unittest.TestCase):
+    def test_handoff_keeps_exact_bytes_out_of_trusted_metadata(self) -> None:
+        module = _require()
+        payload = b"\x00hostile-stdout\xff"
+        result = module.OciExecution(
+            module.STATE_COMPLETED,
+            "inert-fixture",
+            DIGEST_IMAGE,
+            0,
+            payload,
+            b"err-bytes",
+            "",
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            output = Path(raw) / "handoff"
+            module.write_handoff(output, result)
+            metadata = (output / module.EXECUTION_DOCUMENT_NAME).read_text(encoding="utf-8")
+            stdout_file = (output / module.CANDIDATE_STDOUT_NAME).read_bytes()
+            stderr_file = (output / module.CANDIDATE_STDERR_NAME).read_bytes()
+            document = json.loads(metadata)
+        self.assertEqual(stdout_file, payload)
+        self.assertEqual(stderr_file, b"err-bytes")
+        self.assertNotIn("hostile-stdout", metadata)
+        self.assertNotIn(payload.decode("latin1"), metadata)
+        self.assertNotIn("stdout", document)
+        self.assertEqual(document["candidate_output"]["stdout"], module.CANDIDATE_STDOUT_NAME)
+        self.assertTrue(document["candidate_output"]["stdout_sha256"].startswith("sha256:"))
+
+
+class CaptureAdapterEquivalence(unittest.TestCase):
+    """#199 capture_observations via the OCI adapter, no second loop."""
+
+    def _pack(self, directory: Path) -> dict[str, Any]:
+        cases = []
+        for index in range(1, 15):
+            case_id = f"case-{index:03d}"
+            data = f"bundle-{index}".encode()
+            path = directory / f"{case_id}.bundle.tar.gz"
+            path.write_bytes(data)
+            cases.append(
+                {
+                    "id": case_id,
+                    "sha256": "sha256:" + hashlib.sha256(data).hexdigest(),
+                    "_local_path": str(path),
+                }
+            )
+        return {
+            "declared_source_commit": "1" * 40,
+            "source_corpus_digest": "sha256:" + "ab" * 32,
+            "rendered_set_digest": "sha256:" + "cd" * 32,
+            "cases": cases,
+        }
+
+    def _direct_candidate(self, directory: Path) -> list[str]:
+        script = directory / "direct-candidate.py"
+        script.write_text(
+            "import sys\n"
+            "sys.stdout.buffer.write(%r)\n" % (VALID_REPORT,),
+            encoding="utf-8",
+        )
+        return [sys.executable, str(script)]
+
+    def _completed_runner(self, stdout: bytes = VALID_REPORT):
+        module = _require()
+        inspect_doc = {
+            "Config": {"Volumes": None, "User": "65532:65532"},
+            "HostConfig": {"NetworkMode": "none"},
+            "State": {"OOMKilled": False, "ExitCode": 0, "Status": "exited"},
+        }
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            if argv[1] == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[1] == "inspect":
+                return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
+            if argv[1] == "create":
+                return module.BoundedDockerResult(0, b"cid-eq\n", b"")
+            if argv[1] == "start":
+                return module.BoundedDockerResult(0, stdout, b"")
+            if argv[1] == "rm":
+                return module.BoundedDockerResult(0, b"", b"")
+            raise AssertionError(argv)
+
+        return runner
+
+    def test_adapter_matches_direct_capture_observations(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            pack = self._pack(Path(raw))
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            direct = capture_candidate.capture_observations(
+                pack, self._direct_candidate(Path(raw)), 5
+            )
+            command = module.oci_entrypoint_command(
+                implementation_id="inert-fixture",
+                registry_path=registry,
+            )
+            runner = self._completed_runner()
+
+            def adapted(cmd: list[str], bundle: Path, timeout: int) -> dict[str, Any]:
+                return module.run_oci_candidate(
+                    cmd, bundle, timeout, docker_runner=runner
+                )
+
+            original = capture_candidate.run_candidate
+            capture_candidate.run_candidate = adapted
+            try:
+                via_oci = capture_candidate.capture_observations(pack, command, 5)
+            finally:
+                capture_candidate.run_candidate = original
+        self.assertEqual(via_oci, direct)
+        identity = {
+            "id": None,
+            "image": None,
+            "name": "eq",
+            "version": None,
+            "source": "https://example.example/eq",
+            "commit": "1" * 40,
+            "reproduction_mode": "other_disclosed",
+        }
+        first = capture_candidate.build_capture(pack, "sha256:" + "11" * 32, via_oci, identity)
+        second = capture_candidate.build_capture(pack, "sha256:" + "11" * 32, direct, identity)
+        capture_candidate.validate_capture(first)
+        capture_candidate.validate_capture(second)
+        self.assertEqual(first, second)
+
+    def test_dropping_stdout_breaks_equivalence(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            pack = self._pack(Path(raw))
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            direct = capture_candidate.capture_observations(
+                pack, self._direct_candidate(Path(raw)), 5
+            )
+            runner = self._completed_runner(stdout=b"")
+            original = capture_candidate.run_candidate
+            capture_candidate.run_candidate = (
+                lambda cmd, bundle, timeout: module.run_oci_candidate(
+                    cmd, bundle, timeout, docker_runner=runner
+                )
+            )
+            try:
+                dropped = capture_candidate.capture_observations(
+                    pack,
+                    module.oci_entrypoint_command(
+                        implementation_id="inert-fixture",
+                        registry_path=registry,
+                    ),
+                    5,
+                )
+            finally:
+                capture_candidate.run_candidate = original
+        self.assertNotEqual(dropped, direct)
+        self.assertTrue(all(item["state"] == STATE_CANDIDATE_ERROR for item in dropped))
+
+    def test_stdout_is_parsed_once_by_the_existing_parser(self) -> None:
+        module = _require()
+        calls: list[bytes] = []
+        real = capture_candidate.parse_candidate_report
+
+        def spy(stdout: bytes) -> dict[str, Any]:
+            calls.append(stdout)
+            return real(stdout)
+
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            with mock.patch.object(capture_candidate, "parse_candidate_report", side_effect=spy):
+                module.run_oci_candidate(
+                    module.oci_entrypoint_command(
+                        implementation_id="inert-fixture",
+                        registry_path=registry,
+                    ),
+                    _bundle(Path(raw)),
+                    5,
+                    docker_runner=self._completed_runner(),
+                )
+        self.assertEqual(calls, [VALID_REPORT])
+
+    def test_logging_or_metadata_stdout_is_refused(self) -> None:
+        module = _require()
+        marker = b"MUST-NOT-LOG-STDOUT"
+        runner = self._completed_runner(stdout=marker)
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            with mock.patch.object(sys, "stdout", mock.Mock()) as fake_out:
+                result = module.execute_candidate(
+                    implementation_id="inert-fixture",
+                    bundle_path=_bundle(Path(raw)),
+                    registry_path=registry,
+                    timeout_seconds=5,
+                    docker_runner=runner,
+                )
+                module.write_handoff(Path(raw) / "out", result)
+            written = b"".join(
+                call.args[0] if isinstance(call.args[0], bytes) else call.args[0].encode()
+                for call in fake_out.write.call_args_list
+                if call.args
+            )
+            metadata = (Path(raw) / "out" / module.EXECUTION_DOCUMENT_NAME).read_text(
+                encoding="utf-8"
+            )
+        self.assertEqual(result.stdout, marker)
+        self.assertNotIn(marker, written)
+        self.assertNotIn("MUST-NOT-LOG-STDOUT", metadata)
 
 
 if __name__ == "__main__":

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -43,7 +43,12 @@ except ModuleNotFoundError as exc:
 
 import capture_candidate
 import implementations
-from capture_format import STATE_CANDIDATE_ERROR, STATE_CAPTURE_ERROR
+from capture_format import (  # noqa: E402
+    CAPTURE_SCHEMA,
+    STATE_CANDIDATE_ERROR,
+    STATE_CAPTURE_ERROR,
+    validate_capture,
+)
 from score_candidate import STATE_TO_STATUS
 
 DIGEST_IMAGE = (
@@ -1259,6 +1264,131 @@ class CaptureAdapterEquivalence(unittest.TestCase):
                     DIGEST_IMAGE,
                 ]
             )
+
+
+def _write_pack(directory: Path) -> Path:
+    dest = directory / "pack.tar.gz"
+    commit = subprocess.check_output(
+        ["git", "-C", str(REPO), "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    built = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS / "build_clean_room_pack.py"),
+            "--repo-root",
+            str(REPO),
+            "--source-commit",
+            commit,
+            "--output",
+            str(dest),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if built.returncode != 0:
+        raise AssertionError(built.stderr)
+    return dest
+
+
+class PackCaptureCli(unittest.TestCase):
+    """Pack + registry id → validated candidate_capture.v0. No second loop."""
+
+    def _fake_runner(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "exit_code": 0,
+            "report": {"bundle_integrity": "fail"},
+            "stderr_present": False,
+        }
+
+    def test_cli_writes_validated_capture_from_pack_and_id(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            pack = _write_pack(Path(raw))
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            output = Path(raw) / "capture.json"
+            printed = mock.Mock()
+            with (
+                mock.patch.object(module, "run_oci_candidate", side_effect=self._fake_runner),
+                mock.patch.object(sys, "stdout", printed),
+            ):
+                code = module.main(
+                    [
+                        "--pack",
+                        str(pack),
+                        "--implementation-id",
+                        "inert-fixture",
+                        "--registry",
+                        str(registry),
+                        "--output",
+                        str(output),
+                    ]
+                )
+            document = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(code, 0)
+        validate_capture(document)
+        self.assertEqual(document["schema"], CAPTURE_SCHEMA)
+        self.assertEqual(document["implementation"]["id"], "inert-fixture")
+        self.assertEqual(document["implementation"]["image"], DIGEST_IMAGE)
+        written = "".join(
+            str(call.args[0]) for call in printed.write.call_args_list if call.args
+        )
+        self.assertNotIn("bundle_integrity", written)
+        self.assertNotIn("hostile", written)
+
+    def test_bypassing_validate_capture_does_not_write(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            pack = _write_pack(Path(raw))
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            output = Path(raw) / "capture.json"
+            with (
+                mock.patch.object(module, "run_oci_candidate", side_effect=self._fake_runner),
+                mock.patch.object(
+                    capture_candidate,
+                    "build_capture",
+                    return_value={"schema": "not-a-capture"},
+                ),
+            ):
+                code = module.main(
+                    [
+                        "--pack",
+                        str(pack),
+                        "--implementation-id",
+                        "inert-fixture",
+                        "--registry",
+                        str(registry),
+                        "--output",
+                        str(output),
+                    ]
+                )
+            self.assertEqual(code, 2)
+            self.assertFalse(output.exists())
+
+    def test_pack_cli_rejects_direct_image(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(module.__file__)),
+                    "--pack",
+                    str(Path(raw) / "pack.tar.gz"),
+                    "--implementation-id",
+                    "inert-fixture",
+                    "--implementation-image",
+                    DIGEST_IMAGE,
+                    "--output",
+                    str(Path(raw) / "capture.json"),
+                ],
+                cwd=REPO,
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unrecognized arguments", result.stderr)
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("--implementation-image", source)
 
 
 if __name__ == "__main__":

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -43,6 +43,7 @@ except ModuleNotFoundError as exc:
 
 import capture_candidate
 import implementations
+from bounded_process import ProcessLimitError
 from capture_format import (  # noqa: E402
     CAPTURE_SCHEMA,
     STATE_CANDIDATE_ERROR,
@@ -373,6 +374,21 @@ class RegistrySelection(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("unrecognized arguments", result.stderr)
 
+    def test_public_cli_rejects_registry_override(self) -> None:
+        module = _require()
+        with self.assertRaises(SystemExit):
+            module.parse_args(
+                [
+                    "--implementation-id",
+                    "inert-fixture",
+                    "--registry",
+                    "/tmp/implementations.json",
+                ]
+            )
+        self.assertNotIn("--registry", inspect.getsource(module.parse_args))
+        self.assertNotIn("--registry", inspect.getsource(module.oci_entrypoint_command))
+        self.assertNotIn("--registry", inspect.getsource(module.main))
+
 
 class NamedExecutionStates(unittest.TestCase):
     def test_named_states_are_never_agreement(self) -> None:
@@ -554,6 +570,75 @@ class LifecycleClassification(unittest.TestCase):
             )
         self.assertEqual(result.state, module.STATE_CREATE_FAILURE)
         self.assertNotIn(result.state, AGREEMENT)
+
+    def test_create_oserror_is_named_create_failure(self) -> None:
+        module = _require()
+        inspect_doc = {
+            "Config": {"Volumes": None, "User": "65532:65532"},
+            "HostConfig": {"NetworkMode": "none"},
+        }
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            if argv[1] == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[1] == "inspect":
+                return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
+            if argv[1] == "create":
+                raise OSError("create refused")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=_write_registry(Path(raw), DIGEST_IMAGE),
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+        self.assertEqual(result.state, module.STATE_CREATE_FAILURE)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_cleanup_oserror_is_named_cleanup_failure(self) -> None:
+        module = _require()
+        inspect_doc = {
+            "Config": {"Volumes": None, "User": "65532:65532"},
+            "HostConfig": {"NetworkMode": "none"},
+            "State": {"OOMKilled": False, "ExitCode": 0, "Status": "exited"},
+        }
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            if argv[1] == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[1] == "inspect":
+                return module.BoundedDockerResult(0, json.dumps([inspect_doc]).encode(), b"")
+            if argv[1] == "create":
+                return module.BoundedDockerResult(0, b"cid-os\n", b"")
+            if argv[1] == "start":
+                return module.BoundedDockerResult(0, b"", b"")
+            if argv[1] == "rm":
+                raise OSError("rm refused")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=_bundle(Path(raw)),
+                registry_path=_write_registry(Path(raw), DIGEST_IMAGE),
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+        self.assertEqual(result.state, module.STATE_CLEANUP_FAILURE)
+        self.assertNotIn(result.state, AGREEMENT)
+
+    def test_lifecycle_errors_are_one_shared_tuple(self) -> None:
+        module = _require()
+        self.assertEqual(
+            module.DOCKER_LIFECYCLE_ERRORS,
+            (module.DockerCommandError, ProcessLimitError, OSError),
+        )
+        execute_src = inspect.getsource(module.execute_candidate)
+        self.assertIn("DOCKER_LIFECYCLE_ERRORS", execute_src)
+        self.assertNotIn("except (DockerCommandError", execute_src)
 
 
 class ConformanceCiContract(unittest.TestCase):
@@ -1126,13 +1211,11 @@ class CaptureAdapterEquivalence(unittest.TestCase):
             direct = capture_candidate.capture_observations(
                 pack, self._direct_candidate(Path(raw)), 5
             )
-            command = module.oci_entrypoint_command(
-                implementation_id="inert-fixture",
-                registry_path=registry,
-            )
+            command = module.oci_entrypoint_command(implementation_id="inert-fixture")
             bound = functools.partial(
                 module.run_oci_candidate,
                 docker_runner=self._completed_runner(),
+                registry_path=registry,
             )
             via_oci = capture_candidate.capture_observations(
                 pack,
@@ -1169,14 +1252,12 @@ class CaptureAdapterEquivalence(unittest.TestCase):
             )
             dropped = capture_candidate.capture_observations(
                 pack,
-                module.oci_entrypoint_command(
-                    implementation_id="inert-fixture",
-                    registry_path=registry,
-                ),
+                module.oci_entrypoint_command(implementation_id="inert-fixture"),
                 5,
                 candidate_runner=functools.partial(
                     module.run_oci_candidate,
                     docker_runner=self._completed_runner(stdout=b""),
+                    registry_path=registry,
                 ),
             )
         self.assertNotEqual(dropped, direct)
@@ -1195,13 +1276,11 @@ class CaptureAdapterEquivalence(unittest.TestCase):
             registry = _write_registry(Path(raw), DIGEST_IMAGE)
             with mock.patch.object(capture_candidate, "parse_candidate_report", side_effect=spy):
                 module.run_oci_candidate(
-                    module.oci_entrypoint_command(
-                        implementation_id="inert-fixture",
-                        registry_path=registry,
-                    ),
+                    module.oci_entrypoint_command(implementation_id="inert-fixture"),
                     _bundle(Path(raw)),
                     5,
                     docker_runner=self._completed_runner(),
+                    registry_path=registry,
                 )
         self.assertEqual(calls, [VALID_REPORT])
 
@@ -1308,24 +1387,29 @@ class PackCaptureCli(unittest.TestCase):
             registry = _write_registry(Path(raw), DIGEST_IMAGE)
             output = Path(raw) / "capture.json"
             printed = mock.Mock()
+            parsed = module.parse_args(
+                [
+                    "--pack",
+                    str(pack),
+                    "--implementation-id",
+                    "inert-fixture",
+                    "--output",
+                    str(output),
+                ]
+            )
+            self.assertFalse(hasattr(parsed, "registry"))
             with (
                 mock.patch.object(module, "run_oci_candidate", side_effect=self._fake_runner),
                 mock.patch.object(sys, "stdout", printed),
             ):
-                code = module.main(
-                    [
-                        "--pack",
-                        str(pack),
-                        "--implementation-id",
-                        "inert-fixture",
-                        "--registry",
-                        str(registry),
-                        "--output",
-                        str(output),
-                    ]
+                module.write_validated_capture(
+                    pack,
+                    "inert-fixture",
+                    output,
+                    registry_path=registry,
+                    timeout_seconds=30,
                 )
             document = json.loads(output.read_text(encoding="utf-8"))
-        self.assertEqual(code, 0)
         validate_capture(document)
         self.assertEqual(document["schema"], CAPTURE_SCHEMA)
         self.assertEqual(document["implementation"]["id"], "inert-fixture")
@@ -1350,19 +1434,14 @@ class PackCaptureCli(unittest.TestCase):
                     return_value={"schema": "not-a-capture"},
                 ),
             ):
-                code = module.main(
-                    [
-                        "--pack",
-                        str(pack),
-                        "--implementation-id",
+                with self.assertRaises(ValueError):
+                    module.write_validated_capture(
+                        pack,
                         "inert-fixture",
-                        "--registry",
-                        str(registry),
-                        "--output",
-                        str(output),
-                    ]
-                )
-            self.assertEqual(code, 2)
+                        output,
+                        registry_path=registry,
+                        timeout_seconds=30,
+                    )
             self.assertFalse(output.exists())
 
     def test_pack_cli_rejects_direct_image(self) -> None:

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -1996,6 +1996,7 @@ class EvidenceBinding(unittest.TestCase):
 
     def test_missing_docker_main_is_not_a_traceback(self) -> None:
         module = _require()
+        stdout = mock.Mock()
         stderr = mock.Mock()
         with tempfile.TemporaryDirectory() as raw:
             bundle = _bundle(Path(raw))
@@ -2007,6 +2008,7 @@ class EvidenceBinding(unittest.TestCase):
                     side_effect=module.DockerCommandError("docker executable not found"),
                 ),
                 mock.patch.object(module, "implementation_from_registry", return_value=row),
+                mock.patch.object(sys, "stdout", stdout),
                 mock.patch.object(sys, "stderr", stderr),
             ):
                 code = module.main(
@@ -2017,11 +2019,12 @@ class EvidenceBinding(unittest.TestCase):
                         str(bundle),
                     ]
                 )
-        written = "".join(str(call.args[0]) for call in stderr.write.call_args_list if call.args)
-        self.assertNotIn("Traceback", written)
-        self.assertIn(code, (0, 2))
-        if code == 0:
-            self.assertIn(module.STATE_PULL_FAILURE, written or "pull_failure")
+        out = "".join(str(call.args[0]) for call in stdout.write.call_args_list if call.args)
+        err = "".join(str(call.args[0]) for call in stderr.write.call_args_list if call.args)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), module.STATE_PULL_FAILURE)
+        self.assertNotIn("Traceback", out)
+        self.assertNotIn("Traceback", err)
 
     def test_create_timeout_cleans_up_by_container_name(self) -> None:
         module = _require()
@@ -2141,6 +2144,47 @@ class EvidenceBinding(unittest.TestCase):
                     registry_path=registry,
                 )
         self.assertNotEqual(result.exit_code, 0)
+        self.assertNotEqual(result.state, module.STATE_COMPLETED)
+        self.assertIn(result.state, module.HARNESS_FAILURE_STATES)
+
+    def test_bool_exit_code_is_harness_error_not_zero_or_one(self) -> None:
+        module = _require()
+
+        def runner(argv: list[str], **_kwargs: Any) -> Any:
+            kind = _docker_kind(argv)
+            if kind == "pull":
+                return module.BoundedDockerResult(0, b"", b"")
+            if kind in {"inspect", "image-inspect"}:
+                return module.BoundedDockerResult(
+                    0, json.dumps([_inspect_doc(exit_code=True)]).encode(), b""
+                )
+            if kind == "create":
+                return module.BoundedDockerResult(0, b"cid-bool\n", b"")
+            if kind == "start":
+                return module.BoundedDockerResult(0, VALID_REPORT, b"")
+            if kind == "rm":
+                return module.BoundedDockerResult(0, b"", b"")
+            raise AssertionError(argv)
+
+        with tempfile.TemporaryDirectory() as raw:
+            registry = _write_registry(Path(raw), DIGEST_IMAGE)
+            bundle = _bundle(Path(raw))
+            result = module.execute_candidate(
+                implementation_id="inert-fixture",
+                bundle_path=bundle,
+                registry_path=registry,
+                timeout_seconds=2,
+                docker_runner=runner,
+            )
+            with self.assertRaises(capture_candidate.HarnessError):
+                module.run_oci_candidate(
+                    module.oci_entrypoint_command(implementation_id="inert-fixture"),
+                    bundle,
+                    2,
+                    docker_runner=runner,
+                    registry_path=registry,
+                )
+        self.assertNotIn(result.exit_code, (0, 1, True, False))
         self.assertNotEqual(result.state, module.STATE_COMPLETED)
         self.assertIn(result.state, module.HARNESS_FAILURE_STATES)
 

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -1019,6 +1019,43 @@ class CandidateOutputHandoff(unittest.TestCase):
         module = _require()
         self.assertFalse(hasattr(module, "write_execution"))
 
+    def _completed(self, stdout: bytes = b"ok") -> Any:
+        module = _require()
+        return module.OciExecution(
+            module.STATE_COMPLETED,
+            "inert-fixture",
+            DIGEST_IMAGE,
+            0,
+            stdout,
+            b"",
+            "",
+        )
+
+    def test_preexisting_empty_dir_is_rejected(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            empty = Path(raw) / "empty"
+            empty.mkdir()
+            with self.assertRaises(ValueError):
+                module.write_handoff(empty, self._completed())
+            self.assertTrue(empty.is_dir())
+            self.assertEqual(list(empty.iterdir()), [])
+
+    def test_failed_rename_leaves_destination_absent_and_cleans_temp(self) -> None:
+        module = _require()
+        with tempfile.TemporaryDirectory() as raw:
+            dest = Path(raw) / "handoff"
+            with mock.patch.object(os, "rename", side_effect=OSError("simulated rename failure")):
+                with self.assertRaises(OSError):
+                    module.write_handoff(dest, self._completed())
+            self.assertFalse(dest.exists())
+            leftovers = [
+                path
+                for path in Path(raw).iterdir()
+                if path.name.startswith(module.HANDOFF_TEMP_PREFIX)
+            ]
+            self.assertEqual(leftovers, [])
+
 
 class CaptureAdapterEquivalence(unittest.TestCase):
     """#199 capture_observations via the OCI adapter, no second loop."""


### PR DESCRIPTION
## Summary

Assay landing of the #203 DoD from private [`Rul1an/assay-tunnel-experiments#203`](https://github.com/Rul1an/assay-tunnel-experiments/issues/203): a tested CLI from a clean-room pack + registry `implementation_id` to a validated `candidate_capture.v0`.

**Base:** Assay main `e436001613f00411b14038fb32f4b68a762a700f` (#2580 / #199 hostile capture).

**Head:** `19f6fff3976583dd63188798fd834dbd50e33ed1` (worktree `/Users/roelschuurkes/wt-cursor-203-oci-executor`, branch `cursor/203-oci-executor`).

Draft only. Do not mark ready. Do not merge.

## Commits

All nine commits on this branch (oldest first), not just the tip:

1. `d480ee3b573298db0e7dc518f8eba5b80755632c` — feat(conformance): add canonical bounded OCI candidate executor
2. `3624b9accbd3dc09a490ac38440e9a341249880f` — fix(conformance): close OCI executor env, mount, and capture handoff leaks
3. `c616947d35e8a379efff2d5ea4abd029cbec97f6` — fix(conformance): expose OCI capture through the existing observation loop
4. `886dbbc568a4a37ea76a19238e078afb5ce9b469` — fix(conformance): make OCI handoff a single directory rename
5. `631857d6da09548241d563eb607d1b1ec452da33` — feat(conformance): add pack-to-capture CLI for the OCI executor
6. `5e78dadc103baefd213ac07dc3aefbd53f8af2d1` — fix(conformance): pin the OCI CLI to the checked-in registry
7. `30e8d71f4e42439c0500afe77897cf6d76b27cb6` — fix(conformance): fail closed on handoff errors and atomic capture writes
8. `f4c8496f9159d00d28b06cec90c13c05c7328e7c` — fix(conformance): bind OCI capture identity and execution to one registry
9. `19f6fff3976583dd63188798fd834dbd50e33ed1` — fix(conformance): map fixture registry refs to a local Docker image

## RED / GREEN history

- **Argv / inspect independence:** one `build_container_create_argv`; mutating `--network none` or `--user` fails argv and live `docker inspect` independently.
- **Leaks:** allowlisted docker env (`env -i`, no parent secrets); stage bundle via `published_rows.read_regular_file` (symlink / oversize / swap-after-read); no hostile stdout/stderr in trusted metadata or terminal.
- **Capture adapter:** keyword-only `candidate_runner=` on `capture_observations`; `capture_oci_observations` is the same loop with `run_oci_candidate`. No monkeypatch of `run_candidate`. No second loop / parser / schema.
- **Atomic handoff:** sibling temp directory, then one `rename` onto a destination that must not already exist (including empty dir / symlink). Failed rename: dest absent, temp gone.
- **Pack → capture CLI:** `--pack` + `--implementation-id` + `--output` → `load_pack` → `capture_oci_observations` → `build_capture` → `validate_capture`. No `--implementation-image`. No inline Python for #204.
- **`--registry` removal:** production CLI uses only the checked-in registry. `registry_path` is keyword-only for tests.
- **Lifecycle OSError tuple:** `DOCKER_LIFECYCLE_ERRORS = (DockerCommandError, ProcessLimitError, OSError)` at pull / create / start / inspect / cleanup. Create/cleanup `OSError` → named states, not a traceback.
- **Write-path guards:** `write_handoff` inside `main`'s `try` (`ValueError` / `OSError`, not `Exception`); capture JSON via sibling temp + fsync + `replace`. Stale output stays byte-identical on validation or write failure.
- **`registry_path` propagation:** the same test registry feeds `execute_candidate` (image) and capture identity. A `partial` through `capture_oci_observations` → `run_oci_candidate`. Dropping it goes red.
- **Hosted Docker digest mapping:** a local `docker tag` writes `RepoTags`, not `RepoDigests`. `name@sha256:<image-id>` looks like a registry digest, so hosted Docker pulls it as remote. Docker Desktop often resolved the same string by image ID (local false-green). Two mapping tests (`rewrite_fixture_image_argv` / synthetic repo-digest rewritten for pull, inspect, create) send daemon argv the already-built local tag. Production digest validation is unchanged.

## Verification

**107/107 independent green**, bound to SHA `19f6fff3976583dd63188798fd834dbd50e33ed1` and worktree `/Users/roelschuurkes/wt-cursor-203-oci-executor` (executor suite + activation-kit). Independent local run 45.04s; also 107 OK from the writer.

Hosted activation-kit is now green: [run 32482206117](https://github.com/Rul1an/assay/actions/runs/32482206117).

Runtime Docker fixture + mutations:

- Inert image is `FROM scratch` + host-compiled linux/amd64 static ELF (`oci-candidate.c`); not `FROM gcc`.
- Live `docker inspect`: `--network none`, user `65532:65532`, read-only, staged bundle source only.
- Live timeout / OOM / overflow are named states, never agreement.
- Declared `VOLUME` rejected before create; volume inspect uses a resolvable local tag.
- Cleanup `rm --force --volumes` in `finally`; cleanup failure wins over completed.

Public CLI (checked-in registry only):

```text
python3 conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py \
  --pack <pack.tar.gz> \
  --implementation-id <id> \
  --output <capture.json> \
  [--timeout-seconds N]
```

`--bundle` remains the per-case handoff path. No `--registry`. No `--implementation-image`.

## Non-claims (exact #203 text)

No container/kernel security, image authenticity, publisher identity, malware safety, supply-chain integrity, conformance, or cleanup guarantee after host/daemon/SIGKILL failure.

Test-only local mapping; production digest validation (`validate_image_reference` / `name@sha256:<64 hex>`) is unchanged.

## Review

Claude is reserved as the independent non-building reviewer and was not used for design or edits on this branch.

Draft only. Do not mark ready or merge.

## Type of Change

- [x] New feature

## Checklist

- [x] Tests cover the changed behavior (TDD; mutations bite).
- [x] Public strings scanned; no unearned claims.

Made with [Cursor](https://cursor.com)

## Final-head gate

Exact reviewed head: `7d98fc44e089658eadea0d136aa730193e31337c`

Independent non-building review: READY. All required checks and exact-head proof are green; non-blocking findings have recorded technical dispositions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OCI-based candidate execution with controlled resources, networking, filesystem access, and cleanup.
  * Added support for registry-based implementation selection and secure staging of opaque bundles.
  * Added structured execution results covering success, timeouts, resource limits, startup failures, and cleanup issues.
  * Added validated output handoff with file integrity checks, byte counts, execution metadata, and non-claim disclaimers.
  * Improved pack loading and digest handling to bind results to the exact archive contents processed.

* **Tests**
  * Expanded conformance coverage for execution isolation, lifecycle states, output integrity, and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->