### PR TITLE
feat(conformance): bind pack parse and digest to one read

### DIFF
--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -29,10 +29,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from capture_candidate import (  # noqa: E402
     build_capture,
     capture_observations,
-    load_pack,
+    load_pack_with_digest,
     positive_int,
     sha256,
-    sha256_file,
 )
 from capture_format import (  # noqa: E402
     STATE_CANDIDATE_ERROR,
@@ -269,8 +268,7 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory() as tmp:
         try:
-            pack = load_pack(args.pack, Path(tmp))
-            pack_digest = sha256_file(args.pack)
+            pack, pack_digest = load_pack_with_digest(args.pack, Path(tmp))
         except (
             OSError,
             EOFError,

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -942,6 +942,88 @@ class CandidateScorerTests(CandidateHarness, unittest.TestCase):
             original_pack_hash,
         )
 
+    def test_between_read_pack_swap_cannot_split_parsed_bytes_from_digest(self) -> None:
+        """Same-path replacement after parse must not bind a different digest.
+
+        The scorer used to parse one read and hash a second. Replacing the pack
+        between those reads recorded digest B for a pack object parsed from A.
+        """
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            import capture_candidate
+            import score_candidate
+        finally:
+            sys.path.pop(0)
+
+        mutable = self.root / "between-read-pack.tar.gz"
+        original = self.pack.read_bytes()
+        mutable.write_bytes(original)
+        digest_a = sha256(original)
+        digest_b = sha256(original + b"\x00")
+        self.assertNotEqual(digest_a, digest_b)
+
+        reads = {"n": 0}
+        real_read = capture_candidate.read_pack_bytes
+
+        def read_then_swap(path: Path) -> bytes:
+            data = real_read(path)
+            reads["n"] += 1
+            if reads["n"] == 1:
+                path.write_bytes(original + b"\x00")
+            return data
+
+        output = self.root / "between-read-report.json"
+        argv = [
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(mutable),
+            "--manifest",
+            str(CORPUS_DIR / "MANIFEST.json"),
+            "--entrypoint",
+            shlex.join([sys.executable, str(self.candidate("match"))]),
+            "--implementation-name",
+            "test implementation",
+            "--implementation-source",
+            "https://example.test/verifier",
+            "--implementation-commit",
+            IMPLEMENTATION_COMMIT,
+            "--reproduction-mode",
+            "blind_from_spec",
+            "--output",
+            str(output),
+        ]
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch.object(
+                capture_candidate, "read_pack_bytes", side_effect=read_then_swap
+            ),
+        ):
+            self.assertEqual(score_candidate.main(), 0)
+
+        report = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(report["summary"]["match"], 14)
+        self.assertEqual(report["pack_sha256"], digest_a)
+        self.assertEqual(reads["n"], 1)
+        self.assertEqual(sha256(mutable.read_bytes()), digest_b)
+
+    def test_scorer_uses_canonical_load_pack_with_digest(self) -> None:
+        """Parse and digest must come from the existing helper, not a second read."""
+        sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+        try:
+            import capture_candidate
+            import score_candidate
+        finally:
+            sys.path.pop(0)
+
+        source = inspect.getsource(score_candidate.main)
+        self.assertIn("load_pack_with_digest(", source)
+        self.assertNotIn("sha256_file(", source)
+        self.assertNotRegex(source, r"(?<![_\w])load_pack\(")
+        self.assertIs(
+            score_candidate.load_pack_with_digest,
+            capture_candidate.load_pack_with_digest,
+        )
+
     def test_timeout_kills_candidate_process_group(self) -> None:
         marker = self.root / "escaped-timeout-child"
         candidate = self.root / "candidate-timeout.py"


### PR DESCRIPTION
## Exact-head review packet

Review this SHA only. A later push invalidates this packet.

- **HEAD:** `156081a6caa17360bf9ed4e6a5f48f39f6ecd723`
- **Base:** `origin/main` `e66254dd4bbe4ab19c47a5a56c674d9ac3bab8a3`
- **Branch:** `cursor/207-pack-one-read`
- **Worktree:** `/Users/roelschuurkes/wt-cursor-207-pack-one-read`
- **Write-set:** `conformance/privileged-mcp-action-v0/scripts/score_candidate.py`, `conformance/privileged-mcp-action-v0/tests/test_activation_kit.py` only
- **Draft:** `isDraft=true` — not ready, not for merge

## Contract

`score_candidate.py` obtains the parsed pack and its digest from the existing `load_pack_with_digest()` helper (one bounded regular-file read). There is no second pack parser and no second digest read.

## RED

`CandidateScorerTests.test_between_read_pack_swap_cannot_split_parsed_bytes_from_digest` on the pre-change tree: same-path replacement after parse and before the old separate digest-read scored 14 matches from pack A and recorded `pack_sha256` digest B (`sha256:95caf704…` ≠ `sha256:7d02c211…`).

## GREEN

- One existing helper: `capture_candidate.load_pack_with_digest()`
- Two callsite rules: `main` must call `load_pack_with_digest(`; must not call `sha256_file(` or `load_pack(`
- One behavioral guard: between-read same-path replacement cannot bind digest B to a pack parsed from A (`read_pack_bytes` count stays 1)

## Independent human

Two focused tests green on this exact SHA (read-only review of pushed `156081a6caa17360bf9ed4e6a5f48f39f6ecd723`).

## Writer verification on this SHA

Worktree `/Users/roelschuurkes/wt-cursor-207-pack-one-read` at `156081a6caa17360bf9ed4e6a5f48f39f6ecd723`.

- Focused + no-op: `test_between_read_pack_swap_cannot_split_parsed_bytes_from_digest`, `test_scorer_uses_canonical_load_pack_with_digest`, `test_matching_candidate_scores_all_cases` — 3 passed, 2.371s
- Full activation-kit: `python3 -W error::ResourceWarning -m unittest conformance/privileged-mcp-action-v0/tests/test_activation_kit.py` — **46 tests**, 43.507s, OK
- Revert mutation (same tree, before this commit): restoring `load_pack(...)` plus `sha256_file(...)` turned both new tests red with the same A/B split
- No-op control: `test_matching_candidate_scores_all_cases` stayed green
- `cargo fmt --all -- --check` passed
- `git diff --check` passed
- Tree clean after verification; no new commit

## Non-claims

This binds the scorer's local pack parse and digest to one read. It does not authenticate the pack publisher, prove filesystem immutability, or make scoring a sandbox.