### PR TITLE
Register opt-in pma-v0-repro image (#206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
           python3 conformance/registry.py
           python3 conformance/implementations.py
           python3 -W error::ResourceWarning conformance/tests/test_implementations.py
+          python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
           python3 -W error::ResourceWarning conformance/tests/test_registry.py
           python3 -W error::ResourceWarning conformance/tests/test_run_all.py
           python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py

--- a/conformance/implementations.json
+++ b/conformance/implementations.json
@@ -1,4 +1,20 @@
 {
   "schema": "assay.conformance.implementations.v0",
-  "implementations": []
+  "implementations": [
+    {
+      "id": "pma-v0-repro",
+      "name": "pma-v0-repro privileged-mcp-action/v0 verifier",
+      "suite": "privileged-mcp-action-v0",
+      "image": "ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493",
+      "source": "https://github.com/Rul1an/pma-v0-repro",
+      "commit": "c226a34f3cea50a114607c35f0976048ff3cab2b",
+      "language": "python",
+      "reproduction_mode": "other_disclosed",
+      "authorship": {
+        "kind": "agent-assisted",
+        "model": "Cursor Grok (RuleyRuley)",
+        "prompt_strategy": "Verifier core was written blind_from_spec and frozen at fc6cb25d5d1e18396d78815723e241425447ab7d (tree 1c66ef3b8ca35cfbff53938b791c56a39eef77a0). OCI packaging, listing consent, and a SHA-pinned GHCR publish workflow were added later by an agent without changing verifier blobs, so reproduction_mode is other_disclosed. Consent to public listing and bounded execution: https://github.com/Rul1an/pma-v0-repro/blob/c226a34f3cea50a114607c35f0976048ff3cab2b/README.md"
+      }
+    }
+  ]
 }

--- a/conformance/implementations.json
+++ b/conformance/implementations.json
@@ -12,8 +12,8 @@
       "reproduction_mode": "other_disclosed",
       "authorship": {
         "kind": "agent-assisted",
-        "model": "Cursor Grok (RuleyRuley)",
-        "prompt_strategy": "Verifier core was written blind_from_spec and frozen at fc6cb25d5d1e18396d78815723e241425447ab7d (tree 1c66ef3b8ca35cfbff53938b791c56a39eef77a0). OCI packaging, listing consent, and a SHA-pinned GHCR publish workflow were added later by an agent without changing verifier blobs, so reproduction_mode is other_disclosed. Consent to public listing and bounded execution: https://github.com/Rul1an/pma-v0-repro/blob/c226a34f3cea50a114607c35f0976048ff3cab2b/README.md"
+        "model": "Grok Bot",
+        "prompt_strategy": "Packaging and registry row authored by Grok Bot assistant RuleyRuley. Verifier core was written blind_from_spec and frozen at fc6cb25d5d1e18396d78815723e241425447ab7d (tree 1c66ef3b8ca35cfbff53938b791c56a39eef77a0). OCI packaging, listing consent, and a SHA-pinned GHCR publish workflow were added later by an agent without changing verifier blobs, so reproduction_mode is other_disclosed. Consent to public listing and bounded execution: https://github.com/Rul1an/pma-v0-repro/blob/c226a34f3cea50a114607c35f0976048ff3cab2b/README.md"
       }
     }
   ]

--- a/conformance/tests/test_pma_v0_registration.py
+++ b/conformance/tests/test_pma_v0_registration.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""#206: one opt-in pma-v0-repro registry row. Mutations are copies, not edits.
+"""#206: one opt-in pma-v0-repro registry row.
 
     python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
 
 A digest addresses bytes. This test does not pull, run, or endorse the image.
+Generic schema rejection lives in test_implementations.py.
 """
 
 from __future__ import annotations
 
-import copy
 import json
+import re
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 
@@ -33,60 +33,62 @@ CONSENT_URL = (
     + "/README.md"
 )
 ROW_ID = "pma-v0-repro"
+MODEL = "Grok Bot"
+CI_YML = REPO / ".github/workflows/ci.yml"
+CI_COMMAND = (
+    "python3 -W error::ResourceWarning "
+    "conformance/tests/test_pma_v0_registration.py"
+)
+INVENTORY_STEP_RE = re.compile(
+    r"(?ms)^      - name: Conformance inventory\n(?:        .+\n)+"
+)
+JOB_KEY_RE = re.compile(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:")
 
 
-def _load():
-    return implementations.load_implementations()
+def _inventory_step() -> str:
+    text = CI_YML.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    start = next((i for i, line in enumerate(lines) if line.startswith("  scope:")), None)
+    if start is None:
+        raise AssertionError("ci.yml missing scope job")
+    end = start + 1
+    while end < len(lines) and not JOB_KEY_RE.match(lines[end]):
+        end += 1
+    step = INVENTORY_STEP_RE.search("".join(lines[start:end]))
+    if step is None:
+        raise AssertionError("scope job missing Conformance inventory step")
+    return step.group(0)
 
 
 def _row(test: unittest.TestCase) -> dict:
-    doc = _load()
+    doc = implementations.load_implementations()
     rows = doc["implementations"]
     test.assertEqual(len(rows), 1, "exactly one implementation row is registered")
     return rows[0]
 
 
-def _write_and_load(doc: dict) -> None:
-    with tempfile.TemporaryDirectory() as raw:
-        path = Path(raw) / "implementations.json"
-        path.write_text(json.dumps(doc), encoding="utf-8")
-        implementations.load_implementations(path)
-
-
 class CheckedInRow(unittest.TestCase):
-    def test_schema_valid_pma_v0_repro_row(self) -> None:
-        doc = _load()
+    def test_row_pins_measured_facts(self) -> None:
+        doc = implementations.load_implementations()
         self.assertEqual(doc["schema"], implementations.SCHEMA)
         row = _row(self)
         self.assertEqual(row["id"], ROW_ID)
         self.assertEqual(row["suite"], "privileged-mcp-action-v0")
         self.assertEqual(row["source"], SOURCE)
         self.assertEqual(row["commit"], PACKAGING_COMMIT)
+        self.assertNotEqual(row["commit"], FREEZE_COMMIT)
         self.assertEqual(row["image"], IMAGE)
         self.assertEqual(row["language"], "python")
         self.assertEqual(row["reproduction_mode"], "other_disclosed")
-        self.assertNotEqual(row["commit"], FREEZE_COMMIT)
-
-    def test_authorship_is_agent_assisted_with_method(self) -> None:
-        row = _row(self)
         auth = row["authorship"]
         self.assertEqual(auth["kind"], "agent-assisted")
-        self.assertTrue(auth["model"].strip())
+        self.assertEqual(auth["model"], MODEL)
         strategy = auth["prompt_strategy"]
-        self.assertTrue(strategy.strip())
         self.assertIn(FREEZE_COMMIT, strategy)
         self.assertIn("other_disclosed", strategy)
         self.assertIn("blind_from_spec", strategy)
         self.assertIn(CONSENT_URL, strategy)
-
-    def test_consent_url_is_the_pinned_readme(self) -> None:
-        row = _row(self)
-        self.assertIn(CONSENT_URL, row["authorship"]["prompt_strategy"])
-        self.assertIn(PACKAGING_COMMIT, CONSENT_URL)
-
-    def test_non_claim_strings_are_not_inverted(self) -> None:
-        row = _row(self)
-        blob = json.dumps(row)
+        blob = json.dumps(row).lower()
         for forbidden in (
             "independent implementation",
             "publisher authenticated",
@@ -94,51 +96,14 @@ class CheckedInRow(unittest.TestCase):
             "docker is a sandbox",
             "certified conformant",
         ):
-            self.assertNotIn(forbidden, blob.lower())
+            self.assertNotIn(forbidden, blob)
 
 
-class Mutations(unittest.TestCase):
-    def _doc(self) -> dict:
-        return copy.deepcopy(_load())
-
-    def test_digest_swap_is_rejected(self) -> None:
-        row = _row(self)
-        swapped = "ghcr.io/rul1an/pma-v0-repro@sha256:" + "0" * 64
-        self.assertEqual(row["image"], IMAGE)
-        self.assertNotEqual(row["image"], swapped)
-        self.assertNotIn("d81847d77b5add3ae68eb1a640ee1fc9cba854911fb17161a98f4134a92a0043", row["image"])
-
-    def test_source_commit_swap_is_rejected(self) -> None:
-        row = _row(self)
-        self.assertNotEqual(row["commit"], FREEZE_COMMIT)
-        self.assertNotEqual(row["commit"], "25939fd80baf9ee7a179f3b4aeb904ed6d243b30")
-        self.assertEqual(row["commit"], PACKAGING_COMMIT)
-
-    def test_tag_only_image_is_rejected_by_validator(self) -> None:
-        doc = self._doc()
-        doc["implementations"][0]["image"] = "ghcr.io/rul1an/pma-v0-repro:c226a34f"
-        with self.assertRaises(implementations.ImplementationRegistryError) as ctx:
-            _write_and_load(doc)
-        self.assertIn("image", str(ctx.exception).lower())
-
-    def test_missing_prompt_strategy_is_rejected(self) -> None:
-        doc = self._doc()
-        del doc["implementations"][0]["authorship"]["prompt_strategy"]
-        with self.assertRaises(implementations.ImplementationRegistryError) as ctx:
-            _write_and_load(doc)
-        self.assertIn("prompt_strategy", str(ctx.exception).lower())
-
-    def test_missing_model_is_rejected(self) -> None:
-        doc = self._doc()
-        del doc["implementations"][0]["authorship"]["model"]
-        with self.assertRaises(implementations.ImplementationRegistryError) as ctx:
-            _write_and_load(doc)
-        self.assertIn("model", str(ctx.exception).lower())
-
-    def test_human_authorship_is_rejected_for_this_row(self) -> None:
-        row = _row(self)
-        self.assertEqual(row["authorship"]["kind"], "agent-assisted")
-        self.assertNotEqual(row["authorship"]["kind"], "human")
+class RequiredCi(unittest.TestCase):
+    def test_conformance_inventory_invokes_this_module(self) -> None:
+        step = _inventory_step()
+        self.assertIn(CI_COMMAND, step)
+        self.assertNotIn("continue-on-error", step)
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_pma_v0_registration.py
+++ b/conformance/tests/test_pma_v0_registration.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""#206: one opt-in pma-v0-repro registry row. Mutations are copies, not edits.
+
+    python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
+
+A digest addresses bytes. This test does not pull, run, or endorse the image.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "conformance"))
+
+import implementations
+
+PACKAGING_COMMIT = "c226a34f3cea50a114607c35f0976048ff3cab2b"
+FREEZE_COMMIT = "fc6cb25d5d1e18396d78815723e241425447ab7d"
+IMAGE = (
+    "ghcr.io/rul1an/pma-v0-repro@sha256:"
+    "88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493"
+)
+SOURCE = "https://github.com/Rul1an/pma-v0-repro"
+CONSENT_URL = (
+    "https://github.com/Rul1an/pma-v0-repro/blob/"
+    + PACKAGING_COMMIT
+    + "/README.md"
+)
+ROW_ID = "pma-v0-repro"
+
+
+def _load():
+    return implementations.load_implementations()
+
+
+def _row(test: unittest.TestCase) -> dict:
+    doc = _load()
+    rows = doc["implementations"]
+    test.assertEqual(len(rows), 1, "exactly one implementation row is registered")
+    return rows[0]
+
+
+def _write_and_load(doc: dict) -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        path = Path(raw) / "implementations.json"
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        implementations.load_implementations(path)
+
+
+class CheckedInRow(unittest.TestCase):
+    def test_schema_valid_pma_v0_repro_row(self) -> None:
+        doc = _load()
+        self.assertEqual(doc["schema"], implementations.SCHEMA)
+        row = _row(self)
+        self.assertEqual(row["id"], ROW_ID)
+        self.assertEqual(row["suite"], "privileged-mcp-action-v0")
+        self.assertEqual(row["source"], SOURCE)
+        self.assertEqual(row["commit"], PACKAGING_COMMIT)
+        self.assertEqual(row["image"], IMAGE)
+        self.assertEqual(row["language"], "python")
+        self.assertEqual(row["reproduction_mode"], "other_disclosed")
+        self.assertNotEqual(row["commit"], FREEZE_COMMIT)
+
+    def test_authorship_is_agent_assisted_with_method(self) -> None:
+        row = _row(self)
+        auth = row["authorship"]
+        self.assertEqual(auth["kind"], "agent-assisted")
+        self.assertTrue(auth["model"].strip())
+        strategy = auth["prompt_strategy"]
+        self.assertTrue(strategy.strip())
+        self.assertIn(FREEZE_COMMIT, strategy)
+        self.assertIn("other_disclosed", strategy)
+        self.assertIn("blind_from_spec", strategy)
+        self.assertIn(CONSENT_URL, strategy)
+
+    def test_consent_url_is_the_pinned_readme(self) -> None:
+        row = _row(self)
+        self.assertIn(CONSENT_URL, row["authorship"]["prompt_strategy"])
+        self.assertIn(PACKAGING_COMMIT, CONSENT_URL)
+
+    def test_non_claim_strings_are_not_inverted(self) -> None:
+        row = _row(self)
+        blob = json.dumps(row)
+        for forbidden in (
+            "independent implementation",
+            "publisher authenticated",
+            "malware safe",
+            "docker is a sandbox",
+            "certified conformant",
+        ):
+            self.assertNotIn(forbidden, blob.lower())
+
+
+class Mutations(unittest.TestCase):
+    def _doc(self) -> dict:
+        return copy.deepcopy(_load())
+
+    def test_digest_swap_is_rejected(self) -> None:
+        row = _row(self)
+        swapped = "ghcr.io/rul1an/pma-v0-repro@sha256:" + "0" * 64
+        self.assertEqual(row["image"], IMAGE)
+        self.assertNotEqual(row["image"], swapped)
+        self.assertNotIn("d81847d77b5add3ae68eb1a640ee1fc9cba854911fb17161a98f4134a92a0043", row["image"])
+
+    def test_source_commit_swap_is_rejected(self) -> None:
+        row = _row(self)
+        self.assertNotEqual(row["commit"], FREEZE_COMMIT)
+        self.assertNotEqual(row["commit"], "25939fd80baf9ee7a179f3b4aeb904ed6d243b30")
+        self.assertEqual(row["commit"], PACKAGING_COMMIT)
+
+    def test_tag_only_image_is_rejected_by_validator(self) -> None:
+        doc = self._doc()
+        doc["implementations"][0]["image"] = "ghcr.io/rul1an/pma-v0-repro:c226a34f"
+        with self.assertRaises(implementations.ImplementationRegistryError) as ctx:
+            _write_and_load(doc)
+        self.assertIn("image", str(ctx.exception).lower())
+
+    def test_missing_prompt_strategy_is_rejected(self) -> None:
+        doc = self._doc()
+        del doc["implementations"][0]["authorship"]["prompt_strategy"]
+        with self.assertRaises(implementations.ImplementationRegistryError) as ctx:
+            _write_and_load(doc)
+        self.assertIn("prompt_strategy", str(ctx.exception).lower())
+
+    def test_missing_model_is_rejected(self) -> None:
+        doc = self._doc()
+        del doc["implementations"][0]["authorship"]["model"]
+        with self.assertRaises(implementations.ImplementationRegistryError) as ctx:
+            _write_and_load(doc)
+        self.assertIn("model", str(ctx.exception).lower())
+
+    def test_human_authorship_is_rejected_for_this_row(self) -> None:
+        row = _row(self)
+        self.assertEqual(row["authorship"]["kind"], "agent-assisted")
+        self.assertNotEqual(row["authorship"]["kind"], "human")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Adds one schema-valid `implementations.json` row for `pma-v0-repro`.
- Pins `source` `https://github.com/Rul1an/pma-v0-repro`, packaging commit `c226a34f3cea50a114607c35f0976048ff3cab2b`, and image `ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493`.
- `reproduction_mode` is `other_disclosed`. Verifier core was `blind_from_spec` frozen at `fc6cb25d5d1e18396d78815723e241425447ab7d`; OCI packaging was added later without changing verifier blobs.
- Authorship is `agent-assisted`. `model` is `Grok Bot` (the runtime identity in this assistant's system prompt: "You are Grok Bot"). `RuleyRuley` is the agent name in `prompt_strategy`, not the model. The previous `Cursor Grok (RuleyRuley)` string mixed the host product with the model and was corrected.
- Consent to listing and bounded execution is the pinned README: https://github.com/Rul1an/pma-v0-repro/blob/c226a34f3cea50a114607c35f0976048ff3cab2b/README.md
- `test_pma_v0_registration.py` binds this row's identity. It does not pull, inspect, or run the image.

Depends on published packaging at `Rul1an/pma-v0-repro@c226a34f`. Does not touch `cursor/207-pack-one-read` (#2582).

## Live preflight (already executed; not re-run here)
- GHA publish run https://github.com/Rul1an/pma-v0-repro/actions/runs/32490945286 on packaging head `c226a34f3cea50a114607c35f0976048ff3cab2b` (success).
- Anonymous index pull of `ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493` returned 200; `Docker-Content-Digest` matched that index digest.
- linux/amd64 image manifest: `sha256:edab0b06fa931462c9b562f57f27a97d6845b83260a63ef3681723a95df04400` (index is that image plus an OCI attestation manifest).
- Image config: `User 65532:65532`, no `Volumes`, fixed entrypoint `python3 /app/verify.py /input/bundle.tar.gz`.
- Independent live check under #203-class limits (network-none / read-only / cap-drop / no-new-privileges / resource limits): candidate.4 case-001 twice, byte-identical 740-byte stdout, 0 stderr, `bundle_integrity=pass`, `verdict=valid`, output sha256 `6a861a7c…`.
- Platform / volume / runtime mutations live in the existing #203 OCI executor contract tests. This PR only binds the registry row to the published source commit and digest.

## Non-claims
A registry row and digest address bytes. They do not authenticate the publisher, prove reproducibility or independence, establish malware safety, certify conformance, or make Docker a sandbox. Consent is permission to list and run the declared candidate, not endorsement.

## Test plan
- [x] RED: empty `implementations.json` fails `test_pma_v0_registration.py`
- [x] GREEN: `python3 conformance/implementations.py` and `python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py` plus `test_implementations.py`
- [x] Checked-in-row mutations (copy of `implementations.json`, then the same unittest; restore after). All exit 1:
  - digest swap to `@sha256:`+64 zeros → pin tests FAIL (`88a5ef28…` expected)
  - source commit swapped to freeze `fc6cb25d…` → pin tests FAIL (`c226a34f…` expected)
  - tag-only `ghcr.io/rul1an/pma-v0-repro:c226a34f` → validator errors on load (`image must be name@sha256:<64 hex digest>, not a tag`; 10 errors)
  - missing `authorship.prompt_strategy` → validator errors on load (`authorship missing prompt_strategy`; 10 errors)

Do not ready/merge unless asked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance checks validating implementation registration, metadata, pinned references, disclosures, and CI inventory coverage.
  * Resource warnings are now treated as errors during the relevant conformance test run.

* **Chores**
  * Registered the `pma-v0-repro` implementation with its verification and source metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->