### PR TITLE
feat(conformance): share deterministic artifact I/O (#209)

### DIFF
--- a/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
+++ b/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Shared byte rendering and atomic replacement for JSON artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ARTIFACT_TEMP_PREFIX = ".assay-artifact-"
+
+
+def content_sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def render_deterministic_json_bytes(value: Any) -> bytes:
+    """Render the programme's stable pretty-JSON form, including one trailing LF."""
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def write_regular_file_atomically(path: Path, data: bytes) -> None:
+    """Replace a regular-file artifact without exposing a partial destination."""
+    destination = Path(path)
+    parent = destination.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=ARTIFACT_TEMP_PREFIX, dir=str(parent))
+    tmp = Path(tmp_name)
+    try:
+        written = 0
+        while written < len(data):
+            count = os.write(fd, data[written:])
+            if count <= 0:
+                raise OSError("artifact write made no progress")
+            written += count
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        os.replace(tmp, destination)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        tmp.unlink(missing_ok=True)

--- a/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
+++ b/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
@@ -23,17 +23,18 @@ def render_deterministic_json_bytes(value: Any) -> bytes:
 
 
 def write_regular_file_atomically(path: Path, data: bytes) -> None:
-    """Replace a regular-file artifact without exposing a partial destination."""
+    """Replace an artifact without exposing a partial destination.
+
+    The caller must keep the parent path stable while this function runs. Repointing a symlinked
+    parent concurrently can make replacement fail and can prevent best-effort temp-file cleanup.
+    """
     destination = Path(path)
     parent = destination.parent
     # The destination is the caller's explicit output path. This helper writes no data read from
     # that path and executes nothing from it; selecting any writable destination is the API.
-    # codeql[py/path-injection]
     parent.mkdir(parents=True, exist_ok=True)
     # The temporary file stays beside that explicit destination so replacement is atomic.
-    fd, tmp_name = tempfile.mkstemp(  # codeql[py/path-injection]
-        prefix=ARTIFACT_TEMP_PREFIX, dir=str(parent)
-    )
+    fd, tmp_name = tempfile.mkstemp(prefix=ARTIFACT_TEMP_PREFIX, dir=str(parent))
     tmp = Path(tmp_name)
     try:
         written = 0
@@ -46,10 +47,9 @@ def write_regular_file_atomically(path: Path, data: bytes) -> None:
         os.close(fd)
         fd = -1
         # Replacing the caller-selected destination is the intended output capability.
-        # codeql[py/path-injection]
         os.replace(tmp, destination)
     finally:
         if fd >= 0:
             os.close(fd)
         # `tmp` is the exact path returned by mkstemp above, never caller-provided.
-        tmp.unlink(missing_ok=True)  # codeql[py/path-injection]
+        tmp.unlink(missing_ok=True)

--- a/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
+++ b/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
@@ -26,7 +26,12 @@ def write_regular_file_atomically(path: Path, data: bytes) -> None:
     """Replace a regular-file artifact without exposing a partial destination."""
     destination = Path(path)
     parent = destination.parent
+    # The destination is the caller's explicit output path. This helper writes no data read from
+    # that path and executes nothing from it; selecting any writable destination is the API.
+    # codeql[py/path-injection]
     parent.mkdir(parents=True, exist_ok=True)
+    # The temporary file stays beside that explicit destination so replacement is atomic.
+    # codeql[py/path-injection]
     fd, tmp_name = tempfile.mkstemp(prefix=ARTIFACT_TEMP_PREFIX, dir=str(parent))
     tmp = Path(tmp_name)
     try:
@@ -39,8 +44,12 @@ def write_regular_file_atomically(path: Path, data: bytes) -> None:
         os.fsync(fd)
         os.close(fd)
         fd = -1
+        # Replacing the caller-selected destination is the intended output capability.
+        # codeql[py/path-injection]
         os.replace(tmp, destination)
     finally:
         if fd >= 0:
             os.close(fd)
+        # `tmp` is the exact path returned by mkstemp above, never caller-provided.
+        # codeql[py/path-injection]
         tmp.unlink(missing_ok=True)

--- a/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
+++ b/conformance/privileged-mcp-action-v0/scripts/artifact_io.py
@@ -31,8 +31,9 @@ def write_regular_file_atomically(path: Path, data: bytes) -> None:
     # codeql[py/path-injection]
     parent.mkdir(parents=True, exist_ok=True)
     # The temporary file stays beside that explicit destination so replacement is atomic.
-    # codeql[py/path-injection]
-    fd, tmp_name = tempfile.mkstemp(prefix=ARTIFACT_TEMP_PREFIX, dir=str(parent))
+    fd, tmp_name = tempfile.mkstemp(  # codeql[py/path-injection]
+        prefix=ARTIFACT_TEMP_PREFIX, dir=str(parent)
+    )
     tmp = Path(tmp_name)
     try:
         written = 0
@@ -51,5 +52,4 @@ def write_regular_file_atomically(path: Path, data: bytes) -> None:
         if fd >= 0:
             os.close(fd)
         # `tmp` is the exact path returned by mkstemp above, never caller-provided.
-        # codeql[py/path-injection]
-        tmp.unlink(missing_ok=True)
+        tmp.unlink(missing_ok=True)  # codeql[py/path-injection]

--- a/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
+++ b/conformance/privileged-mcp-action-v0/scripts/build_clean_room_pack.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import re
 
 from bounded_process import ProcessLimitError, run_bounded
+from artifact_io import render_deterministic_json_bytes
 from pack_format import (
     clean_room_descriptor,
     clean_room_spec,
@@ -205,9 +206,7 @@ def build_pack(repo_root: Path, source_commit: str) -> bytes:
         "README.md": README.encode(),
         "canonicalization/README.md": JCS_README.encode(),
         "canonicalization/rfc8785-vectors.json": jcs_vectors,
-        "cases.json": (
-            json.dumps(case_index, indent=2, sort_keys=True) + "\n"
-        ).encode(),
+        "cases.json": render_deterministic_json_bytes(case_index),
         "descriptor.json": descriptor,
         "spec.md": spec,
     }

--- a/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/capture_candidate.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import gzip
-import hashlib
 import io
 import json
 import shlex
@@ -27,6 +26,11 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from bounded_process import ProcessCaptureError, ProcessLimitError, run_bounded  # noqa: E402
+from artifact_io import (  # noqa: E402
+    content_sha256 as sha256,
+    render_deterministic_json_bytes,
+    write_regular_file_atomically,
+)
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "adequacy"))
 import published_rows  # noqa: E402
 from capture_format import (  # noqa: E402
@@ -70,10 +74,6 @@ class CandidateError(ValueError):
 
 class HarnessError(RuntimeError):
     pass
-
-
-def sha256(data: bytes) -> str:
-    return "sha256:" + hashlib.sha256(data).hexdigest()
 
 
 def read_pack_bytes(path: Path) -> bytes:
@@ -368,10 +368,7 @@ def main() -> int:
         print(f"capture host produced an invalid capture: {error}", file=sys.stderr)
         return 2
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(
-        json.dumps(capture, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    write_regular_file_atomically(args.output, render_deterministic_json_bytes(capture))
     print(f"captured {len(observations)} observations")
     return 0
 

--- a/conformance/privileged-mcp-action-v0/scripts/capture_format.py
+++ b/conformance/privileged-mcp-action-v0/scripts/capture_format.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from strict_json import load_strict_object  # noqa: E402
+from artifact_io import content_sha256  # noqa: E402
+from strict_json import parse_strict_object  # noqa: E402
 from validate_run_record import (  # noqa: E402
     EXPECTED_CASE_COUNT,
     FULL_SHA,
@@ -36,6 +37,9 @@ from implementations import (  # noqa: E402
     ImplementationRegistryError,
     validate_image_reference,
 )
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "adequacy"))
+import published_rows  # noqa: E402
 
 CAPTURE_SCHEMA = "assay.privileged_mcp_action.candidate_capture.v0"
 REPORT_SCHEMA = "assay.privileged_mcp_action.verify.report.v0"
@@ -328,19 +332,24 @@ def validate_capture(capture: Any) -> None:
     )
 
 
-def load_capture(path: Path) -> dict:
-    """Read one capture as hostile input, then validate it whole."""
+def load_capture_with_digest(path: Path) -> tuple[dict, str]:
+    """Read hostile capture bytes once, bind their digest, then validate them whole."""
     try:
-        document = load_strict_object(
-            Path(path),
+        data = published_rows.read_regular_file(Path(path), limit=MAX_CAPTURE_BYTES)
+        document = parse_strict_object(
+            data,
             label="capture",
-            max_bytes=MAX_CAPTURE_BYTES,
             max_depth=MAX_CAPTURE_DEPTH,
         )
     except ValueError as error:
         raise CaptureError(str(error)) from error
     validate_capture(document)
-    return document
+    return document, content_sha256(data)
+
+
+def load_capture(path: Path) -> dict:
+    """Read one capture as hostile input, then validate it whole."""
+    return load_capture_with_digest(path)[0]
 
 
 def add_identity_arguments(parser: "argparse.ArgumentParser", *, required: bool = True) -> None:

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -25,6 +25,11 @@ from typing import Any, Callable
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from bounded_process import ProcessLimitError, run_bounded  # noqa: E402
+from artifact_io import (  # noqa: E402
+    ARTIFACT_TEMP_PREFIX as CAPTURE_TEMP_PREFIX,
+    render_deterministic_json_bytes,
+    write_regular_file_atomically,
+)
 import capture_candidate  # noqa: E402
 from capture_candidate import CandidateError, HarnessError  # noqa: E402
 from capture_format import (  # noqa: E402
@@ -65,7 +70,6 @@ EXECUTION_DOCUMENT_NAME = "oci-execution.json"
 CANDIDATE_STDOUT_NAME = "candidate.stdout"
 CANDIDATE_STDERR_NAME = "candidate.stderr"
 HANDOFF_TEMP_PREFIX = ".assay-oci-handoff-"
-CAPTURE_TEMP_PREFIX = ".assay-oci-capture-"
 MAX_EXECUTION_BYTES = 16 * 1024
 MAX_EXECUTION_DEPTH = 6
 
@@ -519,7 +523,7 @@ def write_handoff(output_dir: Path, result: OciExecution) -> None:
                 "stderr_bytes": len(result.stderr),
             },
         }
-        payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        payload = render_deterministic_json_bytes(document)
         (tmp / CANDIDATE_STDOUT_NAME).write_bytes(result.stdout)
         (tmp / CANDIDATE_STDERR_NAME).write_bytes(result.stderr)
         (tmp / EXECUTION_DOCUMENT_NAME).write_bytes(payload)
@@ -649,28 +653,9 @@ def write_validated_capture(
     validate_capture(capture)
     write_regular_file_atomically(
         output,
-        (json.dumps(capture, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+        render_deterministic_json_bytes(capture),
     )
     print(f"captured {len(observations)} observations")
-
-
-def write_regular_file_atomically(path: Path, data: bytes) -> None:
-    parent = Path(path).parent
-    parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=CAPTURE_TEMP_PREFIX, dir=str(parent))
-    tmp = Path(tmp_name)
-    try:
-        written = 0
-        while written < len(data):
-            written += os.write(fd, data[written:])
-        os.fsync(fd)
-        os.close(fd)
-        fd = -1
-        os.replace(tmp, path)
-    finally:
-        if fd >= 0:
-            os.close(fd)
-        tmp.unlink(missing_ok=True)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/conformance/privileged-mcp-action-v0/scripts/pack_format.py
+++ b/conformance/privileged-mcp-action-v0/scripts/pack_format.py
@@ -10,6 +10,8 @@ import json
 import tarfile
 from typing import Any, BinaryIO, Iterable
 
+from artifact_io import render_deterministic_json_bytes
+
 MAX_SOURCE_BUNDLE_BYTES = 16 * 1024 * 1024
 MAX_MANIFEST_BYTES = 1024 * 1024
 MAX_EVENTS_BYTES = 8 * 1024 * 1024
@@ -219,4 +221,4 @@ omitted from this pack because they name answer-bearing corpus surfaces. Normati
 def clean_room_descriptor(descriptor: bytes) -> bytes:
     value = json.loads(descriptor)
     value.pop("corpus", None)
-    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+    return render_deterministic_json_bytes(value)

--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -33,6 +33,10 @@ from capture_candidate import (  # noqa: E402
     positive_int,
     sha256,
 )
+from artifact_io import (  # noqa: E402
+    render_deterministic_json_bytes,
+    write_regular_file_atomically,
+)
 from capture_format import (  # noqa: E402
     STATE_CANDIDATE_ERROR,
     STATE_CAPTURE_ERROR,
@@ -329,10 +333,7 @@ def main() -> int:
         print(f"scorer produced an invalid run record: {error}", file=sys.stderr)
         return 2
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    write_regular_file_atomically(args.output, render_deterministic_json_bytes(report))
     print(json.dumps(report["summary"], sort_keys=True))
     if (
         report["summary"]["execution_error"]

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -1244,6 +1244,7 @@ class CandidateScorerTests(CandidateHarness, unittest.TestCase):
 
 
 sys.path.insert(0, str(CORPUS_DIR / "scripts"))
+import artifact_io  # noqa: E402
 import capture_format  # noqa: E402
 import score_candidate  # noqa: E402
 import strict_json  # noqa: E402
@@ -1493,7 +1494,10 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         )
         capture = self.valid_capture("one-read-digest")
         original = capture.read_bytes()
-        swapped = original + b" "
+        original_document = json.loads(original)
+        swapped_document = json.loads(original)
+        swapped_document["implementation"]["name"] = "swapped implementation"
+        swapped = artifact_io.render_deterministic_json_bytes(swapped_document)
         reads = {"count": 0}
         real_read = capture_format.published_rows.read_regular_file
 
@@ -1511,6 +1515,8 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             document, digest = capture_format.load_capture_with_digest(capture)
 
         capture_format.validate_capture(document)
+        self.assertEqual(document, original_document)
+        self.assertNotEqual(document, swapped_document)
         self.assertEqual(digest, sha256(original))
         self.assertEqual(reads["count"], 1)
         self.assertEqual(capture.read_bytes(), swapped)

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import ast
 import gzip
 import hashlib
+import importlib
 import inspect
 import io
 import json
@@ -1248,6 +1250,142 @@ import strict_json  # noqa: E402
 
 CAPTURE_SCRIPT = CORPUS_DIR / "scripts" / "capture_candidate.py"
 CAPTURE_SCHEMA_DOC = CORPUS_DIR / "capture.schema.json"
+ARTIFACT_IO_PATH = CORPUS_DIR / "scripts" / "artifact_io.py"
+
+
+class SharedArtifactIoContractTests(unittest.TestCase):
+    """The byte-I/O rule is shared, not restated by each producer."""
+
+    def artifact_io(self):
+        self.assertTrue(ARTIFACT_IO_PATH.is_file(), "shared artifact_io.py is missing")
+        importlib.invalidate_caches()
+        sys.modules.pop("artifact_io", None)
+        return importlib.import_module("artifact_io")
+
+    def test_deterministic_json_bytes_pin_key_order_indent_and_one_lf(self) -> None:
+        artifact_io = self.artifact_io()
+        self.assertEqual(
+            artifact_io.render_deterministic_json_bytes(
+                {"z": 3, "a": {"second": 2, "first": 1}}
+            ),
+            b'{\n  "a": {\n    "first": 1,\n    "second": 2\n  },\n  "z": 3\n}\n',
+        )
+
+    def test_every_pretty_json_producer_calls_the_shared_renderer(self) -> None:
+        scripts = CORPUS_DIR / "scripts"
+        paths = tuple(
+            scripts / name
+            for name in (
+                "pack_format.py",
+                "build_clean_room_pack.py",
+                "capture_candidate.py",
+                "score_candidate.py",
+                "oci_candidate_executor.py",
+            )
+        )
+        shared_calls = 0
+        inline_pretty_calls = []
+        for path in paths:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if isinstance(node.func, ast.Name) and node.func.id == "render_deterministic_json_bytes":
+                    shared_calls += 1
+                if not (
+                    isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "json"
+                    and node.func.attr == "dumps"
+                ):
+                    continue
+                keywords = {item.arg: item.value for item in node.keywords if item.arg}
+                indent = keywords.get("indent")
+                sort_keys = keywords.get("sort_keys")
+                if (
+                    isinstance(indent, ast.Constant)
+                    and indent.value == 2
+                    and isinstance(sort_keys, ast.Constant)
+                    and sort_keys.value is True
+                ):
+                    inline_pretty_calls.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(inline_pretty_calls, [], "inline deterministic renderers drift")
+        self.assertEqual(shared_calls, 6, "the six shipped pretty-JSON sites must delegate")
+
+    def test_capture_and_record_outputs_use_one_atomic_writer(self) -> None:
+        scripts = CORPUS_DIR / "scripts"
+        paths = tuple(
+            scripts / name
+            for name in (
+                "capture_candidate.py",
+                "score_candidate.py",
+                "oci_candidate_executor.py",
+            )
+        )
+        atomic_calls = 0
+        direct_writes = []
+        for path in paths:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if isinstance(node.func, ast.Name) and node.func.id == "write_regular_file_atomically":
+                    atomic_calls += 1
+                if isinstance(node.func, ast.Attribute) and node.func.attr == "write_text":
+                    direct_writes.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(direct_writes, [], "capture/scoring output must not truncate in place")
+        self.assertEqual(atomic_calls, 3, "capture, scorer and OCI capture must share the writer")
+
+    def test_failed_atomic_replace_preserves_old_bytes_and_cleans_temp(self) -> None:
+        artifact_io = self.artifact_io()
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            output = root / "record.json"
+            stale = b'{"stale":true}\n'
+            output.write_bytes(stale)
+            with mock.patch.object(
+                artifact_io.os, "replace", side_effect=OSError("rename interrupted")
+            ):
+                with self.assertRaisesRegex(OSError, "rename interrupted"):
+                    artifact_io.write_regular_file_atomically(output, b'{"new":true}\n')
+            self.assertEqual(output.read_bytes(), stale)
+            self.assertEqual(
+                [p for p in root.iterdir() if p.name.startswith(artifact_io.ARTIFACT_TEMP_PREFIX)],
+                [],
+            )
+
+    def test_atomic_writer_completes_short_writes(self) -> None:
+        artifact_io = self.artifact_io()
+        with tempfile.TemporaryDirectory() as raw:
+            output = Path(raw) / "record.json"
+            expected = b'{"long":"enough to require several writes"}\n'
+            real_write = artifact_io.os.write
+
+            def short_write(fd: int, data: bytes) -> int:
+                return real_write(fd, data[:3])
+
+            with mock.patch.object(artifact_io.os, "write", side_effect=short_write):
+                artifact_io.write_regular_file_atomically(output, expected)
+
+            self.assertEqual(output.read_bytes(), expected)
+
+    def test_zero_progress_write_preserves_old_bytes_and_cleans_temp(self) -> None:
+        artifact_io = self.artifact_io()
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            output = root / "record.json"
+            stale = b'{"stale":true}\n'
+            output.write_bytes(stale)
+
+            with mock.patch.object(artifact_io.os, "write", return_value=0):
+                with self.assertRaisesRegex(OSError, "made no progress"):
+                    artifact_io.write_regular_file_atomically(output, b'{"new":true}\n')
+
+            self.assertEqual(output.read_bytes(), stale)
+            self.assertEqual(
+                [p for p in root.iterdir() if p.name.startswith(artifact_io.ARTIFACT_TEMP_PREFIX)],
+                [],
+            )
 
 
 class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
@@ -1343,6 +1481,66 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         report = json.loads(output.read_text())
         self.assertEqual(report["summary"]["match"], 14)
         self.assertEqual(report["summary"]["total"], 14)
+
+    def test_capture_digest_binds_the_single_bounded_read(self) -> None:
+        self.assertTrue(
+            hasattr(capture_format, "published_rows"),
+            "capture loading must delegate its bounded read to published_rows",
+        )
+        self.assertTrue(
+            hasattr(capture_format, "load_capture_with_digest"),
+            "capture loading must return the document and digest from one read",
+        )
+        capture = self.valid_capture("one-read-digest")
+        original = capture.read_bytes()
+        swapped = original + b" "
+        reads = {"count": 0}
+        real_read = capture_format.published_rows.read_regular_file
+
+        def read_then_swap(path: Path, *, limit: int) -> bytes:
+            data = real_read(path, limit=limit)
+            reads["count"] += 1
+            Path(path).write_bytes(swapped)
+            return data
+
+        with mock.patch.object(
+            capture_format.published_rows,
+            "read_regular_file",
+            side_effect=read_then_swap,
+        ):
+            document, digest = capture_format.load_capture_with_digest(capture)
+
+        capture_format.validate_capture(document)
+        self.assertEqual(digest, sha256(original))
+        self.assertEqual(reads["count"], 1)
+        self.assertEqual(capture.read_bytes(), swapped)
+        self.assertNotEqual(digest, sha256(swapped))
+
+    def test_capture_digest_hashes_input_bytes_not_a_reserialization(self) -> None:
+        self.assertTrue(
+            hasattr(capture_format, "load_capture_with_digest"),
+            "capture loading must expose the digest of the exact input bytes",
+        )
+        capture = self.valid_capture("input-byte-digest")
+        document = json.loads(capture.read_text(encoding="utf-8"))
+        compact = json.dumps(document, separators=(",", ":")).encode("utf-8")
+        capture.write_bytes(compact)
+
+        loaded, digest = capture_format.load_capture_with_digest(capture)
+
+        self.assertEqual(loaded, document)
+        self.assertEqual(digest, sha256(compact))
+        self.assertNotEqual(digest, sha256(json.dumps(document, sort_keys=True).encode()))
+        self.assertEqual(capture_format.load_capture(capture), loaded)
+
+    def test_capture_digest_path_still_rejects_semantically_invalid_input(self) -> None:
+        capture = self.valid_capture("digest-validation")
+        document = json.loads(capture.read_text(encoding="utf-8"))
+        document["schema"] = "unknown.capture.v0"
+        capture.write_text(json.dumps(document), encoding="utf-8")
+
+        with self.assertRaisesRegex(ValueError, "capture schema mismatch"):
+            capture_format.load_capture_with_digest(capture)
 
     def test_missing_or_duplicated_observation_is_refused_without_a_record(self) -> None:
         capture = self.valid_capture("cardinality")


### PR DESCRIPTION
## Summary

- add one shared deterministic JSON byte renderer and atomic artifact writer
- bind capture parsing and digesting to one bounded regular-file read
- route the six shipped pretty-JSON sites and all three capture/run-record output paths through the shared rules
- preserve existing schemas, workflows, byte limits and public claims

Closes private programme issue `assay-tunnel-experiments#209` after merge.

## Contract

- sorted keys, two-space indentation, UTF-8, exactly one trailing LF
- capture digest addresses the exact bytes parsed and validated
- capture ceiling remains 64 KiB; run-record ceiling remains 4 MiB
- atomic replacement never exposes a partial destination and cleans temporary files on failure

## RED -> GREEN

Before production changes, the activation-kit suite ran 52 tests with six intended failures:

- missing shared renderer/writer
- six inline pretty-JSON implementations
- direct capture/scorer `write_text`
- missing one-read capture digest API

After implementation:

```text
Python 3.13.8: 131 tests, OK
Python 3.14.3: 131 tests, OK
pre-commit (changed files): pass
python -m py_compile: pass
git diff --check: pass
```

## Final-head verification

After merging current `main`, head `7ba3f7f91854563041e235240beca01e3ceab147` passed:

- activation kit: 55/55
- pma-v0 row contract: 2/2
- generic implementation registry: 36/36
- final-component symlink smoke: destination symlink replaced rather than followed; target bytes unchanged; output mode `0600`
- clean worktree and `git diff --check`

## Mutation evidence

Re-run in a detached worktree at `7ba3f7f91854563041e235240beca01e3ceab147`:

| Mutation | Result |
|---|---|
| M0 unmodified control | green |
| disable key sorting | red |
| remove trailing LF | red |
| digest a second path read | red |
| bypass semantic capture validation | red |
| bypass shared writer in capture producer | red |
| leave temp file after failed replace | red |
| parse a second path read while digesting the first | red |

## Non-claims

- atomic replacement is not durable storage; the parent directory is not fsynced
- the caller must keep the parent path stable; concurrent symlink-parent repointing can fail and leave a mode-0600 sibling temp file
- a digest addresses bytes but does not authenticate their producer
- deterministic pretty JSON is not JCS or a general canonical-JSON format
- no schema field, workflow, release, score, status or public projection changes here


