### PR TITLE
Pin trusted-main OCI capture against runner Python drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,24 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Conformance inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          python3 conformance/registry.py
+          python3 conformance/implementations.py
+          python3 -W error::ResourceWarning conformance/tests/test_implementations.py
+          python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
+          python3 -W error::ResourceWarning conformance/tests/test_registry.py
+          python3 -W error::ResourceWarning conformance/tests/test_run_all.py
+          python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py
+          python3 conformance/run_all.py --require-complete --completion-scope required
+
       - id: detect
         shell: bash
         env:
@@ -149,24 +167,6 @@ jobs:
           bash scripts/ci/check-assay-release-pin.sh --published
           bash scripts/ci/test-ci-hardening-b1.sh
           bash scripts/ci/test-structurizr-export-docker.sh
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.12"
-
-      - name: Conformance inventory
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          python3 conformance/registry.py
-          python3 conformance/implementations.py
-          python3 -W error::ResourceWarning conformance/tests/test_implementations.py
-          python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
-          python3 -W error::ResourceWarning conformance/tests/test_registry.py
-          python3 -W error::ResourceWarning conformance/tests/test_run_all.py
-          python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py
-          python3 conformance/run_all.py --require-complete --completion-scope required
 
       # Stdlib-only. Required CI cannot go green if these tests are deleted;
       # adequacy-drift is not a required context. No conditional or soft-failure settings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           python3 conformance/registry.py
           python3 conformance/implementations.py
           python3 -W error::ResourceWarning conformance/tests/test_implementations.py

--- a/.github/workflows/privileged-mcp-action-conformance.yml
+++ b/.github/workflows/privileged-mcp-action-conformance.yml
@@ -7,6 +7,7 @@ on:
       - ".github/actions/privileged-mcp-action-conformance/**"
       - ".github/workflows/privileged-mcp-action-conformance.yml"
       - ".github/workflows/privileged-mcp-action-pack-release.yml"
+      - ".github/workflows/privileged-mcp-action-oci-candidate.yml"
       - "scripts/ci/check_clean_room_pack_reachable.py"
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - ".github/actions/privileged-mcp-action-conformance/**"
       - ".github/workflows/privileged-mcp-action-conformance.yml"
       - ".github/workflows/privileged-mcp-action-pack-release.yml"
+      - ".github/workflows/privileged-mcp-action-oci-candidate.yml"
       - "scripts/ci/check_clean_room_pack_reachable.py"
   workflow_dispatch:
 

--- a/.github/workflows/privileged-mcp-action-conformance.yml
+++ b/.github/workflows/privileged-mcp-action-conformance.yml
@@ -47,6 +47,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           python3 -m unittest \
             conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \
             conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py

--- a/.github/workflows/privileged-mcp-action-conformance.yml
+++ b/.github/workflows/privileged-mcp-action-conformance.yml
@@ -44,6 +44,7 @@ jobs:
           python-version: "3.13.8"
 
       - name: Run activation-kit contract tests
+        shell: bash
         run: |
           set -euo pipefail
           python3 -m unittest \

--- a/.github/workflows/privileged-mcp-action-oci-candidate.yml
+++ b/.github/workflows/privileged-mcp-action-oci-candidate.yml
@@ -1,0 +1,111 @@
+name: Privileged MCP Action OCI candidate capture
+
+on:
+  workflow_dispatch:
+    inputs:
+      implementation_id:
+        description: Checked-in implementation_id
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: privileged-mcp-action-oci-candidate
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Check out current main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13.8"
+
+      - name: Require trusted main
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "oci capture must be dispatched from main, got $GITHUB_REF" >&2
+            exit 2
+          fi
+          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
+            echo "checked-out main does not match the workflow source commit" >&2
+            exit 2
+          fi
+
+      - name: Resolve published pack tag
+        id: candidate
+        run: |
+          set -euo pipefail
+          python3 \
+            conformance/privileged-mcp-action-v0/scripts/validate_candidate_release.py \
+            --candidate conformance/privileged-mcp-action-v0/candidate-release.json \
+            --manifest conformance/privileged-mcp-action-v0/MANIFEST.json \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Download attested pack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.candidate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/oci-downloads"
+          gh release download "$TAG" --repo Rul1an/assay \
+            --pattern privileged-mcp-action-v0-clean-room.tar.gz \
+            --pattern SHA256SUMS \
+            --pattern attestation-bundle.json \
+            --dir "$RUNNER_TEMP/oci-downloads"
+          (
+            cd "$RUNNER_TEMP/oci-downloads"
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Verify pack attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.candidate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          source_digest="$(gh api "repos/Rul1an/assay/commits/$TAG" --jq .sha)"
+          [[ "$source_digest" =~ ^[0-9a-f]{40}$ ]] || exit 2
+          gh attestation verify \
+            "$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz" \
+            --repo Rul1an/assay \
+            --bundle "$RUNNER_TEMP/oci-downloads/attestation-bundle.json" \
+            --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml \
+            --source-digest "$source_digest" \
+            --source-ref refs/heads/main \
+            --deny-self-hosted-runners
+
+      - name: Capture candidate observations
+        env:
+          IMPLEMENTATION_ID: ${{ inputs.implementation_id }}
+        run: |
+          set -euo pipefail
+          PACK="$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"
+          OUTPUT="$RUNNER_TEMP/oci-capture/candidate_capture.v0"
+          mkdir -p "$(dirname "$OUTPUT")"
+          python3 conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py \
+            --pack "$PACK" \
+            --implementation-id "$IMPLEMENTATION_ID" \
+            --output "$OUTPUT" \
+            --timeout-seconds 30
+
+      - name: Upload validated capture
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: candidate-capture-v0
+          path: ${{ runner.temp }}/oci-capture/candidate_capture.v0
+          if-no-files-found: error
+          retention-days: 7

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -63,6 +63,69 @@ OCI_IMPLEMENTATION_ID_ENV = "IMPLEMENTATION_ID: ${{ inputs.implementation_id }}"
 OCI_IMPLEMENTATION_ID_ARGV = '--implementation-id "$IMPLEMENTATION_ID"'
 USES_SHA_RE = re.compile(r"uses:\s*\S+@([0-9a-f]{40}|[^\s#]+)")
 
+# Normalized `run:` sequences for the named capture steps. Copied from the
+# committed YAML after joining `\` continuations and collapsing whitespace;
+# not a second parser of workflow intent.
+OCI_PINNED_STEP_SEQUENCES = {
+    "Require trusted main": (
+        "set -euo pipefail",
+        'if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then',
+        'echo "oci capture must be dispatched from main, got $GITHUB_REF" >&2',
+        "exit 2",
+        "fi",
+        'if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then',
+        'echo "checked-out main does not match the workflow source commit" >&2',
+        "exit 2",
+        "fi",
+    ),
+    "Resolve published pack tag": (
+        "set -euo pipefail",
+        "python3"
+        " conformance/privileged-mcp-action-v0/scripts/validate_candidate_release.py"
+        " --candidate conformance/privileged-mcp-action-v0/candidate-release.json"
+        " --manifest conformance/privileged-mcp-action-v0/MANIFEST.json"
+        ' --github-output "$GITHUB_OUTPUT"',
+    ),
+    "Download attested pack": (
+        "set -euo pipefail",
+        'mkdir -p "$RUNNER_TEMP/oci-downloads"',
+        'gh release download "$TAG" --repo Rul1an/assay'
+        " --pattern privileged-mcp-action-v0-clean-room.tar.gz"
+        " --pattern SHA256SUMS"
+        " --pattern attestation-bundle.json"
+        ' --dir "$RUNNER_TEMP/oci-downloads"',
+        "(",
+        'cd "$RUNNER_TEMP/oci-downloads"',
+        "sha256sum -c SHA256SUMS",
+        ")",
+    ),
+    "Verify pack attestation": (
+        "set -euo pipefail",
+        'source_digest="$(gh api "repos/Rul1an/assay/commits/$TAG" --jq .sha)"',
+        OCI_SOURCE_DIGEST_GUARD,
+        "gh attestation verify"
+        ' "$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"'
+        " --repo Rul1an/assay"
+        ' --bundle "$RUNNER_TEMP/oci-downloads/attestation-bundle.json"'
+        f" --signer-workflow {OCI_SIGNER_WORKFLOW}"
+        ' --source-digest "$source_digest"'
+        " --source-ref refs/heads/main"
+        " --deny-self-hosted-runners",
+    ),
+    "Capture candidate observations": (
+        "set -euo pipefail",
+        'PACK="$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"',
+        'OUTPUT="$RUNNER_TEMP/oci-capture/candidate_capture.v0"',
+        'mkdir -p "$(dirname "$OUTPUT")"',
+        f"python3 {OCI_EXECUTOR}"
+        ' --pack "$PACK"'
+        f" {OCI_IMPLEMENTATION_ID_ARGV}"
+        ' --output "$OUTPUT"'
+        " --timeout-seconds 30",
+    ),
+}
+
+
 def _head_commit() -> str:
     """Resolve HEAD, the way the conformance and pack-release workflows already do.
 
@@ -2015,6 +2078,49 @@ def _active_lines(text: str) -> list[str]:
     return lines
 
 
+def _named_step_run_body(text: str, name: str) -> str | None:
+    """Literal `run:` body of a named step. None if the step or body is missing."""
+    marker = f"      - name: {name}\n"
+    start = text.find(marker)
+    if start < 0:
+        return None
+    rest = text[start + len(marker) :]
+    nxt = re.search(r"(?m)^      - ", rest)
+    block = rest if nxt is None else rest[: nxt.start()]
+    run_m = re.search(r"(?m)^        run:\s*\|\s*$", block)
+    if run_m is None:
+        return None
+    after = block[run_m.end() :]
+    if after.startswith("\n"):
+        after = after[1:]
+    body: list[str] = []
+    for line in after.splitlines():
+        if line.startswith("          ") or line == "":
+            body.append(line)
+            continue
+        break
+    return "\n".join(body)
+
+
+def _normalized_command_sequence(run_body: str) -> tuple[str, ...]:
+    """Join `\\` continuations, drop comments, collapse insignificant whitespace."""
+    commands: list[str] = []
+    pending: list[str] = []
+    for line in _active_lines(run_body):
+        continued = line.endswith("\\")
+        piece = line[:-1].rstrip() if continued else line
+        if piece:
+            pending.append(piece)
+        if continued:
+            continue
+        if pending:
+            commands.append(re.sub(r"\s+", " ", " ".join(pending)).strip())
+            pending = []
+    if pending:
+        commands.append(re.sub(r"\s+", " ", " ".join(pending)).strip())
+    return tuple(commands)
+
+
 def oci_candidate_workflow_problems(text: str) -> list[str]:
     """Structural pins for the trusted-main OCI capture workflow. One function."""
     problems: list[str] = []
@@ -2156,6 +2262,10 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
             pin = match.group(1)
             if not re.fullmatch(r"[0-9a-f]{40}", pin):
                 problems.append(f"unpinned uses: {match.group(0)}")
+    for name, allowed in OCI_PINNED_STEP_SEQUENCES.items():
+        body = _named_step_run_body(text, name)
+        if body is None or _normalized_command_sequence(body) != allowed:
+            problems.append(f"unexpected run sequence: {name}")
     return problems
 
 
@@ -2341,6 +2451,52 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                 self.assertTrue(
                     any("|| true swallows failure" in problem for problem in problems),
                     f"expected || true in {problems}",
+                )
+        verify_cmd = (
+            "          gh attestation verify \\\n"
+            '            "$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz" \\\n'
+            "            --repo Rul1an/assay \\\n"
+            '            --bundle "$RUNNER_TEMP/oci-downloads/attestation-bundle.json" \\\n'
+            f"            --signer-workflow {OCI_SIGNER_WORKFLOW} \\\n"
+            '            --source-digest "$source_digest" \\\n'
+            "            --source-ref refs/heads/main \\\n"
+            "            --deny-self-hosted-runners"
+        )
+        executor_cmd = (
+            f"          python3 {OCI_EXECUTOR} \\\n"
+            '            --pack "$PACK" \\\n'
+            '            --implementation-id "$IMPLEMENTATION_ID" \\\n'
+            '            --output "$OUTPUT" \\\n'
+            "            --timeout-seconds 30"
+        )
+        reachability = (
+            (
+                "verify_if_false",
+                verify_cmd,
+                f"          if false; then\n{verify_cmd}\n          fi",
+                "unexpected run sequence: Verify pack attestation",
+            ),
+            (
+                "executor_if_false",
+                executor_cmd,
+                f"          if false; then\n{executor_cmd}\n          fi",
+                "unexpected run sequence: Capture candidate observations",
+            ),
+            (
+                "exit_0_before_verify",
+                "          gh attestation verify \\",
+                "          exit 0\n          gh attestation verify \\",
+                "unexpected run sequence: Verify pack attestation",
+            ),
+        )
+        for kind, needle, replacement, expected in reachability:
+            with self.subTest(kind=kind):
+                self.assertIn(needle, text)
+                mutated = text.replace(needle, replacement, 1)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
                 )
 
 

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -2019,96 +2019,104 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
     """Structural pins for the trusted-main OCI capture workflow. One function."""
     problems: list[str] = []
     active = _active_lines(text)
-    if "workflow_dispatch:" not in text:
+    active_text = "\n".join(active)
+    if "workflow_dispatch:" not in active_text:
         problems.append("missing workflow_dispatch")
-    if re.search(r"(?m)^  pull_request", text) or "pull_request_target:" in text:
+    if re.search(r"(?m)^  pull_request", text) or "pull_request_target:" in active_text:
         problems.append("untrusted pull_request trigger")
     if re.search(r"(?m)^  push:", text):
         problems.append("push trigger")
     in_on = False
     for line in text.splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
         if line == "on:":
             in_on = True
             continue
         if not in_on:
             continue
         if line.startswith("  ") and not line.startswith("   "):
-            key = line.strip().split(":", 1)[0]
+            key = stripped.split(":", 1)[0]
             if key != "workflow_dispatch":
                 problems.append(f"extra trigger: {key}")
-        elif line != "" and not line.startswith(" "):
+        elif not line.startswith(" "):
             in_on = False
-    if "runs-on: ubuntu-24.04" not in text:
+    if "runs-on: ubuntu-24.04" not in active_text:
         problems.append("missing ubuntu-24.04")
-    if re.search(r"runs-on:\s*.*self-hosted", text):
+    if re.search(r"runs-on:\s*.*self-hosted", active_text):
         problems.append("self-hosted runner")
     if (
-        re.search(r"(?m)^\s+\S+:\s*write\s*$", text)
-        or "id-token:" in text
-        or "attestations:" in text
+        re.search(r"(?m)^\S+:\s*write\s*$", active_text)
+        or "id-token:" in active_text
+        or "attestations:" in active_text
     ):
         problems.append("excess permissions")
-    if "contents: read" not in text:
+    if "contents: read" not in active_text:
         problems.append("missing contents:read")
-    if "secrets." in text:
+    if "secrets." in active_text:
         problems.append("explicit secrets")
-    if 'if [[ "$GITHUB_REF" != "refs/heads/main" ]]' not in text:
+    if 'if [[ "$GITHUB_REF" != "refs/heads/main" ]]' not in active_text:
         problems.append("missing main ref guard")
-    if 'git rev-parse HEAD' not in text or "$GITHUB_SHA" not in text:
+    if "git rev-parse HEAD" not in active_text or "$GITHUB_SHA" not in active_text:
         problems.append("missing HEAD/SHA guard")
-    if "persist-credentials: false" not in text:
+    if "persist-credentials: false" not in active_text:
         problems.append("missing persist-credentials:false")
-    if "candidate-release.json" not in text:
+    if "candidate-release.json" not in active_text:
         problems.append("missing candidate-release.json")
-    if "validate_candidate_release.py" not in text:
+    if "validate_candidate_release.py" not in active_text:
         problems.append("missing validate_candidate_release.py")
-    if "attestation-bundle.json" not in text:
+    if "attestation-bundle.json" not in active_text:
         problems.append("missing attestation-bundle.json")
     if not any(re.match(r"^(-\s+)?gh attestation verify(\s|\\|$)", line) for line in active):
         problems.append("missing gh attestation verify")
-    if "--bundle" not in text:
+    if "--bundle" not in active_text:
         problems.append("missing --bundle")
-    if f"--signer-workflow {OCI_SIGNER_WORKFLOW}" not in text:
+    if f"--signer-workflow {OCI_SIGNER_WORKFLOW}" not in active_text:
         problems.append("missing or wrong signer-workflow")
-    if "--source-digest" not in text:
+    if "--source-digest" not in active_text:
         problems.append("missing --source-digest")
-    if OCI_SOURCE_DIGEST_SHAPE not in text:
+    if OCI_SOURCE_DIGEST_SHAPE not in active_text:
         problems.append("missing source_digest regex")
-    elif OCI_SOURCE_DIGEST_GUARD not in text:
+    elif OCI_SOURCE_DIGEST_GUARD not in active_text:
         problems.append("source_digest check not fail-closed")
-    if "--source-ref refs/heads/main" not in text:
+    if "--source-ref refs/heads/main" not in active_text:
         problems.append("missing --source-ref")
-    if "--deny-self-hosted-runners" not in text:
+    if "--deny-self-hosted-runners" not in active_text:
         problems.append("missing --deny-self-hosted-runners")
-    if "release_attestation_enforce.sh" in text:
+    if "release_attestation_enforce.sh" in active_text:
         problems.append("software-release verifier used for pack")
     if not any(
         re.match(rf"^(-\s+)?python3\s+{re.escape(OCI_EXECUTOR)}(\s|\\|$)", line)
         for line in active
     ):
         problems.append("missing canonical executor")
-    if "--pack" not in text or "--implementation-id" not in text or "--output" not in text:
+    if (
+        "--pack" not in active_text
+        or "--implementation-id" not in active_text
+        or "--output" not in active_text
+    ):
         problems.append("missing executor argv")
-    if "--timeout-seconds 30" not in text:
+    if "--timeout-seconds 30" not in active_text:
         problems.append("missing --timeout-seconds 30")
-    if "--implementation-image" in text or "--registry" in text:
+    if "--implementation-image" in active_text or "--registry" in active_text:
         problems.append("direct image or registry override")
-    if "python3 - <<" in text:
+    if "python3 - <<" in active_text:
         problems.append("inline Python")
-    if OCI_IMPLEMENTATION_ID_ENV not in text:
+    if OCI_IMPLEMENTATION_ID_ENV not in active_text:
         problems.append("missing implementation_id env binding")
-    if OCI_IMPLEMENTATION_ID_ARGV not in text:
+    if OCI_IMPLEMENTATION_ID_ARGV not in active_text:
         problems.append("implementation_id not quoted argv")
-    for line in text.splitlines():
+    for line in active:
         if "${{ inputs." not in line:
             continue
-        if re.match(r"^\s+[A-Za-z_][A-Za-z0-9_]*:\s*\$\{\{ inputs\.", line):
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*:\s*\$\{\{ inputs\.", line):
             continue
         problems.append("inputs interpolated in run script")
         break
-    if "continue-on-error" in text:
+    if "continue-on-error" in active_text:
         problems.append("continue-on-error swallows failure")
-    if "|| true" in text:
+    if "|| true" in active_text:
         problems.append("|| true swallows failure")
     for pin, label in (
         (OCI_CHECKOUT_PIN, "unpinned or wrong checkout"),
@@ -2117,7 +2125,7 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
     ):
         if not any(re.match(rf"^(-\s+)?uses:\s*{re.escape(pin)}", line) for line in active):
             problems.append(label)
-    if OCI_PYTHON_VERSION not in text:
+    if OCI_PYTHON_VERSION not in active_text:
         problems.append("missing python 3.13.8")
     upload_steps = [
         block
@@ -2133,15 +2141,15 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
         for line in _active_lines(block)
     ):
         problems.append("upload not gated on success")
-    if "candidate_capture.v0" not in text:
+    if "candidate_capture.v0" not in active_text:
         problems.append("missing fixed capture name")
-    if OCI_CAPTURE_UPLOAD_PATH not in text:
+    if OCI_CAPTURE_UPLOAD_PATH not in active_text:
         problems.append("missing exact capture upload path")
-    if "retention-days: 7" not in text:
+    if "retention-days: 7" not in active_text:
         problems.append("missing retention-days: 7")
-    if "if-no-files-found: error" not in text:
+    if "if-no-files-found: error" not in active_text:
         problems.append("missing if-no-files-found:error")
-    if "timeout-minutes: 25" not in text:
+    if "timeout-minutes: 25" not in active_text:
         problems.append("missing timeout-minutes: 25")
     for line in active:
         for match in USES_SHA_RE.finditer(line):
@@ -2190,6 +2198,41 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
         for needle, expected in drops:
             with self.subTest(drop=needle):
                 mutated = text.replace(needle, "")
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
+                )
+        comment_out = (
+            (
+                OCI_SOURCE_DIGEST_GUARD,
+                f"# {OCI_SOURCE_DIGEST_GUARD}",
+                "missing source_digest regex",
+            ),
+            (
+                "--source-ref refs/heads/main",
+                "# --source-ref refs/heads/main",
+                "missing --source-ref",
+            ),
+            (
+                f"--signer-workflow {OCI_SIGNER_WORKFLOW}",
+                f"# --signer-workflow {OCI_SIGNER_WORKFLOW}",
+                "missing or wrong signer-workflow",
+            ),
+            (
+                "--bundle",
+                "# --bundle",
+                "missing --bundle",
+            ),
+            (
+                "contents: read",
+                "# contents: read",
+                "missing contents:read",
+            ),
+        )
+        for needle, replacement, expected in comment_out:
+            with self.subTest(comment_out=expected):
+                mutated = text.replace(needle, replacement)
                 problems = oci_candidate_workflow_problems(mutated)
                 self.assertTrue(
                     any(expected in problem for problem in problems),

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -61,6 +61,7 @@ OCI_SOURCE_DIGEST_GUARD = OCI_SOURCE_DIGEST_SHAPE + " || exit 2"
 OCI_CAPTURE_UPLOAD_PATH = "${{ runner.temp }}/oci-capture/candidate_capture.v0"
 OCI_IMPLEMENTATION_ID_ENV = "IMPLEMENTATION_ID: ${{ inputs.implementation_id }}"
 OCI_IMPLEMENTATION_ID_ARGV = '--implementation-id "$IMPLEMENTATION_ID"'
+OCI_UPLOAD_STEP = "Upload validated capture"
 USES_SHA_RE = re.compile(r"uses:\s*\S+@([0-9a-f]{40}|[^\s#]+)")
 
 # Normalized `run:` sequences for the named capture steps. Copied from the
@@ -2078,15 +2079,33 @@ def _active_lines(text: str) -> list[str]:
     return lines
 
 
-def _named_step_run_body(text: str, name: str) -> str | None:
-    """Literal `run:` body of a named step. None if the step or body is missing."""
+def _named_step_names(text: str) -> list[str]:
+    """Active `- name:` values in document order."""
+    names: list[str] = []
+    for line in _active_lines(text):
+        match = re.match(r"^-\s+name:\s*(.+)$", line)
+        if match:
+            names.append(match.group(1).strip())
+    return names
+
+
+def _named_step_block(text: str, name: str) -> str | None:
+    """Full named step mapping, from `- name:` through the next sibling step."""
     marker = f"      - name: {name}\n"
     start = text.find(marker)
     if start < 0:
         return None
     rest = text[start + len(marker) :]
     nxt = re.search(r"(?m)^      - ", rest)
-    block = rest if nxt is None else rest[: nxt.start()]
+    tail = rest if nxt is None else rest[: nxt.start()]
+    return marker + tail
+
+
+def _named_step_run_body(text: str, name: str) -> str | None:
+    """Literal `run:` body of a named step. None if the step or body is missing."""
+    block = _named_step_block(text, name)
+    if block is None:
+        return None
     run_m = re.search(r"(?m)^        run:\s*\|\s*$", block)
     if run_m is None:
         return None
@@ -2262,6 +2281,14 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
             pin = match.group(1)
             if not re.fullmatch(r"[0-9a-f]{40}", pin):
                 problems.append(f"unpinned uses: {match.group(0)}")
+    for name in _named_step_names(text):
+        if name == OCI_UPLOAD_STEP:
+            continue
+        block = _named_step_block(text, name)
+        if block is not None and any(
+            re.match(r"^if:", line) for line in _active_lines(block)
+        ):
+            problems.append(f"conditional step: {name}")
     for name, allowed in OCI_PINNED_STEP_SEQUENCES.items():
         body = _named_step_run_body(text, name)
         if body is None or _normalized_command_sequence(body) != allowed:
@@ -2493,6 +2520,43 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
             with self.subTest(kind=kind):
                 self.assertIn(needle, text)
                 mutated = text.replace(needle, replacement, 1)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
+                )
+        step_conditionals = (
+            (
+                "checkout_if_false",
+                "Check out current main",
+                "conditional step: Check out current main",
+            ),
+            (
+                "setup_python_if_false",
+                "Set up Python",
+                "conditional step: Set up Python",
+            ),
+            (
+                "trusted_main_if_false",
+                "Require trusted main",
+                "conditional step: Require trusted main",
+            ),
+            (
+                "verify_step_if_false",
+                "Verify pack attestation",
+                "conditional step: Verify pack attestation",
+            ),
+            (
+                "capture_step_if_false",
+                "Capture candidate observations",
+                "conditional step: Capture candidate observations",
+            ),
+        )
+        for kind, step, expected in step_conditionals:
+            with self.subTest(kind=kind):
+                needle = f"      - name: {step}\n"
+                self.assertIn(needle, text)
+                mutated = text.replace(needle, needle + "        if: false\n", 1)
                 problems = oci_candidate_workflow_problems(mutated)
                 self.assertTrue(
                     any(expected in problem for problem in problems),

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -66,7 +66,7 @@ OCI_CAPTURE_UPLOAD_PATH = "${{ runner.temp }}/oci-capture/candidate_capture.v0"
 OCI_IMPLEMENTATION_ID_ENV = "IMPLEMENTATION_ID: ${{ inputs.implementation_id }}"
 OCI_IMPLEMENTATION_ID_ARGV = '--implementation-id "$IMPLEMENTATION_ID"'
 OCI_UPLOAD_STEP = "Upload validated capture"
-USES_SHA_RE = re.compile(r"uses:\s*\S+@([0-9a-f]{40}|[^\s#]+)")
+USES_SHA_RE = re.compile(r"uses:\s*\S+@([^\s#]+)")
 # Ordered capture-job shape. Env-key sets and the step-name tuple are one table
 # so a skipped setup, extra step, leaked token, or duplicate upload cannot
 # look green by matching a looser presence pin.
@@ -2130,6 +2130,11 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         )
 
 
+def _uses_pin_line(line: str, pin: str) -> bool:
+    """True when `uses:` is exactly `pin`, then only whitespace or a comment."""
+    return re.fullmatch(rf"(?:-\s+)?uses:\s*{re.escape(pin)}(?:\s+#.*)?", line) is not None
+
+
 def _active_lines(text: str) -> list[str]:
     """YAML/script lines that can execute. Full-line comments and blanks do not."""
     lines = []
@@ -2352,28 +2357,19 @@ def oci_candidate_workflow_problems(
 
     active = _active_lines(text)
     active_text = "\n".join(active)
-    if "workflow_dispatch:" not in active_text:
-        problems.append("missing workflow_dispatch")
-    if re.search(r"(?m)^  pull_request", text) or "pull_request_target:" in active_text:
-        problems.append("untrusted pull_request trigger")
-    if re.search(r"(?m)^  push:", text):
-        problems.append("push trigger")
-    in_on = False
-    for line in text.splitlines():
-        stripped = line.lstrip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if line == "on:":
-            in_on = True
-            continue
-        if not in_on:
-            continue
-        if line.startswith("  ") and not line.startswith("   "):
-            key = stripped.split(":", 1)[0]
-            if key != "workflow_dispatch":
+    on_keys = _top_level_mapping_keys(text, "on")
+    if on_keys != ("workflow_dispatch",):
+        if "workflow_dispatch" not in on_keys:
+            problems.append("missing workflow_dispatch")
+        for key in on_keys:
+            if key == "workflow_dispatch":
+                continue
+            if key in ("pull_request", "pull_request_target"):
+                problems.append("untrusted pull_request trigger")
+            elif key == "push":
+                problems.append("push trigger")
+            else:
                 problems.append(f"extra trigger: {key}")
-        elif not line.startswith(" "):
-            in_on = False
     if "runs-on: ubuntu-24.04" not in active_text:
         problems.append("missing ubuntu-24.04")
     if re.search(r"runs-on:\s*.*self-hosted", active_text):
@@ -2455,17 +2451,14 @@ def oci_candidate_workflow_problems(
         (OCI_SETUP_PYTHON_PIN, "unpinned or wrong setup-python"),
         (OCI_UPLOAD_PIN, "unpinned or wrong upload-artifact"),
     ):
-        if not any(re.match(rf"^(-\s+)?uses:\s*{re.escape(pin)}", line) for line in active):
+        if not any(_uses_pin_line(line, pin) for line in active):
             problems.append(label)
     if OCI_PYTHON_VERSION not in active_text:
         problems.append("missing python 3.13.8")
     upload_steps = [
         block
         for block in re.split(r"(?m)^(?=      - )", text)
-        if any(
-            re.match(rf"^(-\s+)?uses:\s*{re.escape(OCI_UPLOAD_PIN)}", line)
-            for line in _active_lines(block)
-        )
+        if any(_uses_pin_line(line, OCI_UPLOAD_PIN) for line in _active_lines(block))
     ]
     upload_ifs = [
         line
@@ -2684,6 +2677,9 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
             (OCI_CHECKOUT_PIN, "actions/checkout@v5", "unpinned uses:"),
             (OCI_SETUP_PYTHON_PIN, "actions/setup-python@v6", "unpinned or wrong setup-python"),
             (OCI_PYTHON_VERSION, 'python-version: "3.12.0"', "missing python 3.13.8"),
+            (OCI_CHECKOUT_PIN, f"{OCI_CHECKOUT_PIN}-mutable", "unpinned or wrong checkout"),
+            (OCI_SETUP_PYTHON_PIN, f"{OCI_SETUP_PYTHON_PIN}-mutable", "unpinned or wrong setup-python"),
+            (OCI_UPLOAD_PIN, f"{OCI_UPLOAD_PIN}-mutable", "unpinned or wrong upload-artifact"),
         )
         for needle, replacement, expected in inserts:
             with self.subTest(insert=expected):
@@ -2693,6 +2689,22 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                     any(expected in problem for problem in problems),
                     f"expected {expected!r} in {problems}",
                 )
+        with self.subTest(kind="flow_style_on_pull_request"):
+            block_on = text[text.index("on:\n") : text.index("\npermissions:")]
+            flow_on = (
+                "on: {workflow_dispatch: {inputs: {implementation_id: "
+                "{description: Checked-in implementation_id, required: true, "
+                "type: string}}}, pull_request: {}}"
+            )
+            mutated = text.replace(block_on, flow_on, 1)
+            problems = oci_candidate_workflow_problems(mutated)
+            self.assertTrue(
+                any("unexpected on triggers" in problem or "missing workflow_dispatch" in problem
+                    or "untrusted pull_request" in problem or "extra trigger" in problem
+                    for problem in problems),
+                f"expected trigger guard in {problems}",
+            )
+            self.assertEqual(oci_candidate_workflow_problems(text), [])
         with self.subTest(kind="inputs-in-run"):
             mutated = text.replace(OCI_IMPLEMENTATION_ID_ENV + "\n", "", 1).replace(
                 OCI_IMPLEMENTATION_ID_ARGV,

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -78,6 +78,7 @@ OCI_STEP_ENV_KEYS = {
 }
 OCI_CAPTURE_STEP_NAMES = tuple(OCI_STEP_ENV_KEYS)
 OCI_CAPTURE_JOB = "capture"
+OCI_CAPTURE_JOB_KEYS = ("runs-on", "timeout-minutes", "steps")
 OCI_TOP_LEVEL_PERMISSIONS = ("contents: read",)
 _STEP_FIELD_KEYS = frozenset(
     {
@@ -2160,6 +2161,26 @@ def _has_job_level_permissions(text: str) -> bool:
     return False
 
 
+def _job_mapping_keys(text: str, job: str) -> tuple[str, ...]:
+    """Document-order 4-space keys under the `  {job}:` mapping."""
+    keys: list[str] = []
+    in_job = False
+    for raw in text.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if raw.startswith("  ") and not raw.startswith("   "):
+            in_job = stripped.split(":", 1)[0] == job
+            continue
+        if not in_job:
+            continue
+        if raw.startswith("    ") and not raw.startswith("     "):
+            keys.append(stripped.split(":", 1)[0])
+        elif not raw.startswith(" "):
+            in_job = False
+    return tuple(keys)
+
+
 def _named_step_env_keys(block: str) -> frozenset[str]:
     """Active `env:` mapping keys inside one named step block."""
     keys: set[str] = set()
@@ -2383,6 +2404,8 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
             problems.append(f"unexpected run sequence: {name}")
     if _top_level_mapping_keys(text, "jobs") != (OCI_CAPTURE_JOB,):
         problems.append("unexpected jobs")
+    if _job_mapping_keys(text, OCI_CAPTURE_JOB) != OCI_CAPTURE_JOB_KEYS:
+        problems.append("unexpected capture job keys")
     if tuple(_named_step_names(text)) != OCI_CAPTURE_STEP_NAMES:
         problems.append("unexpected step names")
     if _top_level_mapping_children(text, "permissions") != OCI_TOP_LEVEL_PERMISSIONS:
@@ -2670,7 +2693,13 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                 "job_write_all",
                 capture_job,
                 "  capture:\n    permissions: write-all\n",
-                "job-level permissions",
+                "unexpected capture job keys",
+            ),
+            (
+                "job_env_token",
+                capture_job,
+                "  capture:\n    env:\n      GH_TOKEN: ${{ github.token }}\n",
+                "unexpected capture job keys",
             ),
             (
                 "curl_bash_pre_guard",

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -2554,7 +2554,7 @@ def oci_candidate_workflow_problems(
         if sum(1 for line in active if line == OCI_TAG_BINDING) != 2:
             problems.append("unexpected TAG bindings")
     if not omitted("missing exact artifact name"):
-        if OCI_ARTIFACT_NAME not in active_text:
+        if sum(1 for line in active if line == OCI_ARTIFACT_NAME) != 1:
             problems.append("missing exact artifact name")
     return problems
 
@@ -2902,7 +2902,7 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
             (
                 "artifact_name",
                 f"          {OCI_ARTIFACT_NAME}\n",
-                "          name: leaked-capture\n",
+                "          name: candidate-capture-v0-extra\n",
                 "missing exact artifact name",
             ),
             (

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -2290,23 +2290,6 @@ def _job_mapping_keys(text: str, job: str) -> tuple[str, ...]:
     return tuple(keys)
 
 
-def _named_step_env_keys(block: str) -> frozenset[str]:
-    """Active `env:` mapping keys inside one named step block."""
-    keys: set[str] = set()
-    in_env = False
-    for line in _active_lines(block):
-        key = line.split(":", 1)[0]
-        if key == "env":
-            in_env = True
-            continue
-        if not in_env:
-            continue
-        if key in _STEP_FIELD_KEYS:
-            break
-        keys.add(key)
-    return frozenset(keys)
-
-
 def _named_step_block(text: str, name: str) -> str | None:
     """Full named step mapping, from `- name:` through the next sibling step."""
     marker = f"      - name: {name}\n"
@@ -2463,7 +2446,7 @@ def oci_candidate_workflow_problems(
             continue
         problems.append("inputs interpolated in run script")
         break
-    if "continue-on-error" in active_text:
+    if not omitted("continue-on-error swallows failure") and "continue-on-error" in active_text:
         problems.append("continue-on-error swallows failure")
     if "|| true" in active_text:
         problems.append("|| true swallows failure")
@@ -2511,8 +2494,10 @@ def oci_candidate_workflow_problems(
         if name == OCI_UPLOAD_STEP:
             continue
         block = _named_step_block(text, name)
-        if block is not None and any(
-            re.match(r"^if:", line) for line in _active_lines(block)
+        if (
+            not omitted("conditional step")
+            and block is not None
+            and any(re.match(r"^if:", line) for line in _active_lines(block))
         ):
             problems.append(f"conditional step: {name}")
     for name, allowed in OCI_PINNED_STEP_SEQUENCES.items():
@@ -2529,10 +2514,16 @@ def oci_candidate_workflow_problems(
         problems.append("unexpected top-level permissions")
     if _has_job_level_permissions(text):
         problems.append("job-level permissions")
-    for name, allowed in OCI_STEP_ENV_KEYS.items():
-        block = _named_step_block(text, name)
-        if block is None or _named_step_env_keys(block) != allowed:
-            problems.append(f"unexpected env keys: {name}")
+    if not omitted("unexpected env keys"):
+        for name, allowed in OCI_STEP_ENV_KEYS.items():
+            block = _named_step_block(text, name)
+            actual = (
+                frozenset(_keys_at_indent(block, 10, under="env"))
+                if block is not None
+                else frozenset()
+            )
+            if block is None or actual != allowed:
+                problems.append(f"unexpected env keys: {name}")
     if not omitted("unexpected top-level keys"):
         if _keys_at_indent(text, 0) != OCI_DOCUMENT_KEYS:
             problems.append("unexpected top-level keys")
@@ -2853,6 +2844,17 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                 capture_env + "          GH_TOKEN: ${{ github.token }}\n",
                 "unexpected env keys",
             ),
+            *(
+                (
+                    f"capture_env_break_{field}",
+                    capture_env,
+                    capture_env
+                    + f"          {field}: breakpoint\n"
+                    + "          GH_TOKEN: token-value\n",
+                    "unexpected env keys",
+                )
+                for field in sorted(_STEP_FIELD_KEYS)
+            ),
             (
                 "inline_python_direct",
                 executor_line,
@@ -2860,6 +2862,10 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                 "inline Python",
             ),
         )
+        env_break_extra_skip = {
+            "if": "conditional step",
+            "continue-on-error": "continue-on-error swallows failure",
+        }
         for kind, needle, replacement, expected in shape:
             with self.subTest(kind=kind):
                 self.assertIn(needle, text)
@@ -2869,6 +2875,20 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                     any(expected in problem for problem in problems),
                     f"expected {expected!r} in {problems}",
                 )
+                if kind.startswith("capture_env_break_"):
+                    field = kind.removeprefix("capture_env_break_")
+                    skip = {expected}
+                    extra = env_break_extra_skip.get(field)
+                    if extra:
+                        skip.add(extra)
+                    restored = oci_candidate_workflow_problems(
+                        mutated, skip=frozenset(skip)
+                    )
+                    self.assertEqual(
+                        restored,
+                        [],
+                        f"{kind} must be [] when {sorted(skip)} is skipped: {restored}",
+                    )
         with self.subTest(kind="duplicate_upload_always"):
             mutated = text + (
                 f"\n      - name: {OCI_UPLOAD_STEP}\n"

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -63,6 +63,37 @@ OCI_IMPLEMENTATION_ID_ENV = "IMPLEMENTATION_ID: ${{ inputs.implementation_id }}"
 OCI_IMPLEMENTATION_ID_ARGV = '--implementation-id "$IMPLEMENTATION_ID"'
 OCI_UPLOAD_STEP = "Upload validated capture"
 USES_SHA_RE = re.compile(r"uses:\s*\S+@([0-9a-f]{40}|[^\s#]+)")
+# Ordered capture-job shape. Env-key sets and the step-name tuple are one table
+# so a skipped setup, extra step, leaked token, or duplicate upload cannot
+# look green by matching a looser presence pin.
+OCI_STEP_ENV_KEYS = {
+    "Check out current main": frozenset(),
+    "Set up Python": frozenset(),
+    "Require trusted main": frozenset(),
+    "Resolve published pack tag": frozenset(),
+    "Download attested pack": frozenset({"GH_TOKEN", "TAG"}),
+    "Verify pack attestation": frozenset({"GH_TOKEN", "TAG"}),
+    "Capture candidate observations": frozenset({"IMPLEMENTATION_ID"}),
+    OCI_UPLOAD_STEP: frozenset(),
+}
+OCI_CAPTURE_STEP_NAMES = tuple(OCI_STEP_ENV_KEYS)
+OCI_CAPTURE_JOB = "capture"
+OCI_TOP_LEVEL_PERMISSIONS = ("contents: read",)
+_STEP_FIELD_KEYS = frozenset(
+    {
+        "name",
+        "id",
+        "if",
+        "env",
+        "run",
+        "uses",
+        "with",
+        "shell",
+        "timeout-minutes",
+        "continue-on-error",
+        "working-directory",
+    }
+)
 
 # Normalized `run:` sequences for the named capture steps. Copied from the
 # committed YAML after joining `\` continuations and collapsing whitespace;
@@ -2089,6 +2120,63 @@ def _named_step_names(text: str) -> list[str]:
     return names
 
 
+def _top_level_mapping_children(text: str, header: str) -> tuple[str, ...]:
+    """Active 2-space lines under column-0 `header:`, or a same-line scalar."""
+    children: list[str] = []
+    in_map = False
+    prefix = f"{header}:"
+    for raw in text.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not raw.startswith(" ") and raw.startswith(prefix):
+            in_map = True
+            scalar = raw[len(prefix) :].strip()
+            if scalar:
+                children.append(scalar)
+            continue
+        if not in_map:
+            continue
+        if raw.startswith("  ") and not raw.startswith("   "):
+            children.append(stripped)
+        elif not raw.startswith(" "):
+            in_map = False
+    return tuple(children)
+
+
+def _top_level_mapping_keys(text: str, header: str) -> tuple[str, ...]:
+    """Document-order keys of a column-0 mapping."""
+    return tuple(child.split(":", 1)[0] for child in _top_level_mapping_children(text, header))
+
+
+def _has_job_level_permissions(text: str) -> bool:
+    """True when a job mapping (exactly 4-space keys) declares `permissions:`."""
+    for raw in text.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if raw.startswith("    permissions:") and not raw.startswith("     "):
+            return True
+    return False
+
+
+def _named_step_env_keys(block: str) -> frozenset[str]:
+    """Active `env:` mapping keys inside one named step block."""
+    keys: set[str] = set()
+    in_env = False
+    for line in _active_lines(block):
+        key = line.split(":", 1)[0]
+        if key == "env":
+            in_env = True
+            continue
+        if not in_env:
+            continue
+        if key in _STEP_FIELD_KEYS:
+            break
+        keys.add(key)
+    return frozenset(keys)
+
+
 def _named_step_block(text: str, name: str) -> str | None:
     """Full named step mapping, from `- name:` through the next sibling step."""
     marker = f"      - name: {name}\n"
@@ -2293,6 +2381,18 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
         body = _named_step_run_body(text, name)
         if body is None or _normalized_command_sequence(body) != allowed:
             problems.append(f"unexpected run sequence: {name}")
+    if _top_level_mapping_keys(text, "jobs") != (OCI_CAPTURE_JOB,):
+        problems.append("unexpected jobs")
+    if tuple(_named_step_names(text)) != OCI_CAPTURE_STEP_NAMES:
+        problems.append("unexpected step names")
+    if _top_level_mapping_children(text, "permissions") != OCI_TOP_LEVEL_PERMISSIONS:
+        problems.append("unexpected top-level permissions")
+    if _has_job_level_permissions(text):
+        problems.append("job-level permissions")
+    for name, allowed in OCI_STEP_ENV_KEYS.items():
+        block = _named_step_block(text, name)
+        if block is None or _named_step_env_keys(block) != allowed:
+            problems.append(f"unexpected env keys: {name}")
     return problems
 
 
@@ -2562,6 +2662,55 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                     any(expected in problem for problem in problems),
                     f"expected {expected!r} in {problems}",
                 )
+        capture_job = "  capture:\n"
+        capture_env = "          IMPLEMENTATION_ID: ${{ inputs.implementation_id }}\n"
+        executor_line = f"          python3 {OCI_EXECUTOR} \\\n"
+        shape = (
+            (
+                "job_write_all",
+                capture_job,
+                "  capture:\n    permissions: write-all\n",
+                "job-level permissions",
+            ),
+            (
+                "curl_bash_pre_guard",
+                "    steps:\n",
+                "    steps:\n      - name: Pre-guard\n        run: curl | bash\n",
+                "unexpected step names",
+            ),
+            (
+                "capture_gh_token",
+                capture_env,
+                capture_env + "          GH_TOKEN: ${{ github.token }}\n",
+                "unexpected env keys",
+            ),
+            (
+                "inline_python_direct",
+                executor_line,
+                "          python3 - <<'PY'\n          print(0)\n          PY\n" + executor_line,
+                "inline Python",
+            ),
+        )
+        for kind, needle, replacement, expected in shape:
+            with self.subTest(kind=kind):
+                self.assertIn(needle, text)
+                mutated = text.replace(needle, replacement, 1)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
+                )
+        with self.subTest(kind="duplicate_upload_always"):
+            mutated = text + (
+                f"\n      - name: {OCI_UPLOAD_STEP}\n"
+                "        if: always()\n"
+                f"        uses: {OCI_UPLOAD_PIN}\n"
+            )
+            problems = oci_candidate_workflow_problems(mutated)
+            self.assertTrue(
+                any("unexpected step names" in problem for problem in problems),
+                f"expected unexpected step names in {problems}",
+            )
 
 
 if __name__ == "__main__":

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -2004,9 +2004,21 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         )
 
 
+def _active_lines(text: str) -> list[str]:
+    """YAML/script lines that can execute. Full-line comments and blanks do not."""
+    lines = []
+    for raw in text.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+    return lines
+
+
 def oci_candidate_workflow_problems(text: str) -> list[str]:
     """Structural pins for the trusted-main OCI capture workflow. One function."""
     problems: list[str] = []
+    active = _active_lines(text)
     if "workflow_dispatch:" not in text:
         problems.append("missing workflow_dispatch")
     if re.search(r"(?m)^  pull_request", text) or "pull_request_target:" in text:
@@ -2052,7 +2064,7 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
         problems.append("missing validate_candidate_release.py")
     if "attestation-bundle.json" not in text:
         problems.append("missing attestation-bundle.json")
-    if "gh attestation verify" not in text:
+    if not any(re.match(r"^(-\s+)?gh attestation verify(\s|\\|$)", line) for line in active):
         problems.append("missing gh attestation verify")
     if "--bundle" not in text:
         problems.append("missing --bundle")
@@ -2070,7 +2082,10 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
         problems.append("missing --deny-self-hosted-runners")
     if "release_attestation_enforce.sh" in text:
         problems.append("software-release verifier used for pack")
-    if OCI_EXECUTOR not in text:
+    if not any(
+        re.match(rf"^(-\s+)?python3\s+{re.escape(OCI_EXECUTOR)}(\s|\\|$)", line)
+        for line in active
+    ):
         problems.append("missing canonical executor")
     if "--pack" not in text or "--implementation-id" not in text or "--output" not in text:
         problems.append("missing executor argv")
@@ -2095,15 +2110,28 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
         problems.append("continue-on-error swallows failure")
     if "|| true" in text:
         problems.append("|| true swallows failure")
-    if OCI_CHECKOUT_PIN not in text:
-        problems.append("unpinned or wrong checkout")
-    if OCI_SETUP_PYTHON_PIN not in text:
-        problems.append("unpinned or wrong setup-python")
+    for pin, label in (
+        (OCI_CHECKOUT_PIN, "unpinned or wrong checkout"),
+        (OCI_SETUP_PYTHON_PIN, "unpinned or wrong setup-python"),
+        (OCI_UPLOAD_PIN, "unpinned or wrong upload-artifact"),
+    ):
+        if not any(re.match(rf"^(-\s+)?uses:\s*{re.escape(pin)}", line) for line in active):
+            problems.append(label)
     if OCI_PYTHON_VERSION not in text:
         problems.append("missing python 3.13.8")
-    if OCI_UPLOAD_PIN not in text:
-        problems.append("unpinned or wrong upload-artifact")
-    if "if: success()" not in text:
+    upload_steps = [
+        block
+        for block in re.split(r"(?m)^(?=      - )", text)
+        if any(
+            re.match(rf"^(-\s+)?uses:\s*{re.escape(OCI_UPLOAD_PIN)}", line)
+            for line in _active_lines(block)
+        )
+    ]
+    if not any(
+        re.match(r"^if:\s*success\(\)", line)
+        for block in upload_steps
+        for line in _active_lines(block)
+    ):
         problems.append("upload not gated on success")
     if "candidate_capture.v0" not in text:
         problems.append("missing fixed capture name")
@@ -2115,10 +2143,11 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
         problems.append("missing if-no-files-found:error")
     if "timeout-minutes: 25" not in text:
         problems.append("missing timeout-minutes: 25")
-    for match in USES_SHA_RE.finditer(text):
-        pin = match.group(1)
-        if not re.fullmatch(r"[0-9a-f]{40}", pin):
-            problems.append(f"unpinned uses: {match.group(0)}")
+    for line in active:
+        for match in USES_SHA_RE.finditer(line):
+            pin = match.group(1)
+            if not re.fullmatch(r"[0-9a-f]{40}", pin):
+                problems.append(f"unpinned uses: {match.group(0)}")
     return problems
 
 
@@ -2161,6 +2190,31 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
         for needle, expected in drops:
             with self.subTest(drop=needle):
                 mutated = text.replace(needle, "")
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
+                )
+        decorative = (
+            (
+                "gh attestation verify \\",
+                "echo gh attestation verify \\",
+                "missing gh attestation verify",
+            ),
+            (
+                f"python3 {OCI_EXECUTOR} \\",
+                f"echo python3 {OCI_EXECUTOR} \\",
+                "missing canonical executor",
+            ),
+            (
+                "if: success()",
+                "# if: success()",
+                "upload not gated on success",
+            ),
+        )
+        for needle, replacement, expected in decorative:
+            with self.subTest(decorative=expected):
+                mutated = text.replace(needle, replacement, 1)
                 problems = oci_candidate_workflow_problems(mutated)
                 self.assertTrue(
                     any(expected in problem for problem in problems),

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -46,6 +46,10 @@ RELEASE_WORKFLOW = (
 OCI_CANDIDATE_WORKFLOW = (
     REPO_ROOT / ".github/workflows/privileged-mcp-action-oci-candidate.yml"
 )
+CONFORMANCE_WORKFLOW = (
+    REPO_ROOT / ".github/workflows/privileged-mcp-action-conformance.yml"
+)
+OCI_WORKFLOW_PATH = ".github/workflows/privileged-mcp-action-oci-candidate.yml"
 OCI_CHECKOUT_PIN = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
 OCI_SETUP_PYTHON_PIN = "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1"
 OCI_UPLOAD_PIN = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
@@ -79,6 +83,32 @@ OCI_STEP_ENV_KEYS = {
 OCI_CAPTURE_STEP_NAMES = tuple(OCI_STEP_ENV_KEYS)
 OCI_CAPTURE_JOB = "capture"
 OCI_CAPTURE_JOB_KEYS = ("runs-on", "timeout-minutes", "steps")
+OCI_DOCUMENT_KEYS = ("name", "on", "permissions", "concurrency", "jobs")
+OCI_TAG_BINDING = "TAG: ${{ steps.candidate.outputs.tag }}"
+OCI_ARTIFACT_NAME = "name: candidate-capture-v0"
+OCI_STEP_KEYS = {
+    "Check out current main": ("name", "uses", "with"),
+    "Set up Python": ("name", "uses", "with"),
+    "Require trusted main": ("name", "run"),
+    "Resolve published pack tag": ("name", "id", "run"),
+    "Download attested pack": ("name", "env", "run"),
+    "Verify pack attestation": ("name", "env", "run"),
+    "Capture candidate observations": ("name", "env", "run"),
+    OCI_UPLOAD_STEP: ("name", "if", "uses", "with"),
+}
+OCI_STEP_WITH_KEYS = {
+    "Check out current main": ("persist-credentials", "ref"),
+    "Set up Python": ("python-version",),
+    OCI_UPLOAD_STEP: ("name", "path", "if-no-files-found", "retention-days"),
+}
+CONFORMANCE_REQUIRED_PATHS = (
+    "conformance/privileged-mcp-action-v0/**",
+    ".github/actions/privileged-mcp-action-conformance/**",
+    ".github/workflows/privileged-mcp-action-conformance.yml",
+    ".github/workflows/privileged-mcp-action-pack-release.yml",
+    OCI_WORKFLOW_PATH,
+    "scripts/ci/check_clean_room_pack_reachable.py",
+)
 OCI_TOP_LEVEL_PERMISSIONS = ("contents: read",)
 _STEP_FIELD_KEYS = frozenset(
     {
@@ -2111,6 +2141,85 @@ def _active_lines(text: str) -> list[str]:
     return lines
 
 
+def _keys_at_indent(
+    block: str, indent: int, *, under: str | None = None
+) -> tuple[str, ...]:
+    """Active mapping keys at exactly `indent` spaces. One allowlist extractor.
+
+    `under` limits collection to children of that parent key (parent at indent-2).
+    """
+    keys: list[str] = []
+    parent_indent = indent - 2
+    in_under = under is None
+    key_prefix = " " * indent
+    parent_prefix = " " * parent_indent if parent_indent >= 0 else ""
+    for raw in block.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if under is not None:
+            if parent_indent <= 0:
+                at_parent = not raw.startswith(" ")
+            else:
+                at_parent = raw.startswith(parent_prefix) and not raw.startswith(
+                    parent_prefix + " "
+                )
+            if at_parent:
+                in_under = stripped.split(":", 1)[0] == under
+                continue
+        if not in_under:
+            continue
+        if indent == 0:
+            at_key = not raw.startswith(" ")
+        else:
+            at_key = raw.startswith(key_prefix) and not raw.startswith(key_prefix + " ")
+        if not at_key:
+            continue
+        if stripped.startswith("- "):
+            item = stripped[2:].lstrip()
+            if item.startswith("name:"):
+                keys.append("name")
+            continue
+        keys.append(stripped.split(":", 1)[0])
+    return tuple(keys)
+
+
+def _on_paths(text: str, trigger: str) -> tuple[str, ...]:
+    """Quoted path-filter entries under `on.<trigger>.paths`."""
+    paths: list[str] = []
+    in_on = False
+    in_trigger = False
+    in_paths = False
+    for raw in text.splitlines():
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if raw == "on:":
+            in_on = True
+            in_trigger = False
+            in_paths = False
+            continue
+        if not in_on:
+            continue
+        if not raw.startswith(" "):
+            break
+        if raw.startswith("  ") and not raw.startswith("   "):
+            in_trigger = stripped.split(":", 1)[0] == trigger
+            in_paths = False
+            continue
+        if not in_trigger:
+            continue
+        if raw.startswith("    ") and not raw.startswith("     "):
+            in_paths = stripped.rstrip(":") == "paths" or stripped.split(":", 1)[0] == "paths"
+            continue
+        if in_paths and raw.startswith("      - "):
+            item = stripped[2:].strip()
+            if item.startswith('"') and item.endswith('"'):
+                item = item[1:-1]
+            paths.append(item)
+    return tuple(paths)
+
+
 def _named_step_names(text: str) -> list[str]:
     """Active `- name:` values in document order."""
     names: list[str] = []
@@ -2249,9 +2358,15 @@ def _normalized_command_sequence(run_body: str) -> tuple[str, ...]:
     return tuple(commands)
 
 
-def oci_candidate_workflow_problems(text: str) -> list[str]:
+def oci_candidate_workflow_problems(
+    text: str, *, skip: frozenset[str] = frozenset()
+) -> list[str]:
     """Structural pins for the trusted-main OCI capture workflow. One function."""
     problems: list[str] = []
+
+    def omitted(label: str) -> bool:
+        return any(label == token or label.startswith(token) for token in skip)
+
     active = _active_lines(text)
     active_text = "\n".join(active)
     if "workflow_dispatch:" not in active_text:
@@ -2369,11 +2484,13 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
             for line in _active_lines(block)
         )
     ]
-    if not any(
-        re.match(r"^if:\s*success\(\)", line)
+    upload_ifs = [
+        line
         for block in upload_steps
         for line in _active_lines(block)
-    ):
+        if line.startswith("if:")
+    ]
+    if not omitted("upload not gated on success") and upload_ifs != ["if: success()"]:
         problems.append("upload not gated on success")
     if "candidate_capture.v0" not in active_text:
         problems.append("missing fixed capture name")
@@ -2416,6 +2533,29 @@ def oci_candidate_workflow_problems(text: str) -> list[str]:
         block = _named_step_block(text, name)
         if block is None or _named_step_env_keys(block) != allowed:
             problems.append(f"unexpected env keys: {name}")
+    if not omitted("unexpected top-level keys"):
+        if _keys_at_indent(text, 0) != OCI_DOCUMENT_KEYS:
+            problems.append("unexpected top-level keys")
+    if not omitted("unexpected step keys"):
+        for name, allowed in OCI_STEP_KEYS.items():
+            block = _named_step_block(text, name)
+            actual = ("name",) + _keys_at_indent(block, 8) if block is not None else ()
+            if block is None or actual != allowed:
+                problems.append(f"unexpected step keys: {name}")
+    if not omitted("unexpected with keys"):
+        for name, allowed in OCI_STEP_WITH_KEYS.items():
+            block = _named_step_block(text, name)
+            actual = (
+                _keys_at_indent(block, 10, under="with") if block is not None else ()
+            )
+            if block is None or actual != allowed:
+                problems.append(f"unexpected with keys: {name}")
+    if not omitted("unexpected TAG bindings"):
+        if sum(1 for line in active if line == OCI_TAG_BINDING) != 2:
+            problems.append("unexpected TAG bindings")
+    if not omitted("missing exact artifact name"):
+        if OCI_ARTIFACT_NAME not in active_text:
+            problems.append("missing exact artifact name")
     return problems
 
 
@@ -2740,6 +2880,80 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                 any("unexpected step names" in problem for problem in problems),
                 f"expected unexpected step names in {problems}",
             )
+        allowlist = (
+            (
+                "workflow_env_token",
+                "on:\n",
+                "env:\n  GH_TOKEN: ${{ github.token }}\non:\n",
+                "unexpected top-level keys",
+            ),
+            (
+                "upload_if_or_failure",
+                "        if: success()\n",
+                "        if: success() || failure()\n",
+                "upload not gated on success",
+            ),
+            (
+                "tag_literal",
+                f"          {OCI_TAG_BINDING}\n",
+                "          TAG: privileged-mcp-action-v0-candidate.4\n",
+                "unexpected TAG bindings",
+            ),
+            (
+                "artifact_name",
+                f"          {OCI_ARTIFACT_NAME}\n",
+                "          name: leaked-capture\n",
+                "missing exact artifact name",
+            ),
+            (
+                "capture_working_directory",
+                "      - name: Capture candidate observations\n",
+                "      - name: Capture candidate observations\n"
+                "        working-directory: /tmp\n",
+                "unexpected step keys",
+            ),
+            (
+                "checkout_extra_with",
+                "          persist-credentials: false\n",
+                "          persist-credentials: false\n"
+                "          repository: example/evil\n",
+                "unexpected with keys",
+            ),
+            (
+                "unknown_top_level",
+                "on:\n",
+                "assay-note: ignore\non:\n",
+                "unexpected top-level keys",
+            ),
+            (
+                "unknown_step_timeout",
+                "      - name: Require trusted main\n",
+                "      - name: Require trusted main\n        timeout-minutes: 5\n",
+                "unexpected step keys",
+            ),
+        )
+        for kind, needle, replacement, expected in allowlist:
+            with self.subTest(kind=kind):
+                self.assertIn(needle, text)
+                mutated = text.replace(needle, replacement)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
+                )
+                restored = oci_candidate_workflow_problems(
+                    mutated, skip=frozenset({expected})
+                )
+                self.assertEqual(
+                    restored,
+                    [],
+                    f"{kind} must be [] when {expected!r} is skipped: {restored}",
+                )
+
+    def test_conformance_path_filters_include_oci_workflow(self) -> None:
+        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual(_on_paths(text, "pull_request"), CONFORMANCE_REQUIRED_PATHS)
+        self.assertEqual(_on_paths(text, "push"), CONFORMANCE_REQUIRED_PATHS)
 
 
 if __name__ == "__main__":

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -43,6 +43,25 @@ CANDIDATE_RELEASE = CORPUS_DIR / "candidate-release.json"
 RELEASE_WORKFLOW = (
     REPO_ROOT / ".github/workflows/privileged-mcp-action-pack-release.yml"
 )
+OCI_CANDIDATE_WORKFLOW = (
+    REPO_ROOT / ".github/workflows/privileged-mcp-action-oci-candidate.yml"
+)
+OCI_CHECKOUT_PIN = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
+OCI_SETUP_PYTHON_PIN = "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1"
+OCI_UPLOAD_PIN = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+OCI_EXECUTOR = (
+    "conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py"
+)
+OCI_SIGNER_WORKFLOW = (
+    "Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml"
+)
+OCI_PYTHON_VERSION = 'python-version: "3.13.8"'
+OCI_SOURCE_DIGEST_SHAPE = '[[ "$source_digest" =~ ^[0-9a-f]{40}$ ]]'
+OCI_SOURCE_DIGEST_GUARD = OCI_SOURCE_DIGEST_SHAPE + " || exit 2"
+OCI_CAPTURE_UPLOAD_PATH = "${{ runner.temp }}/oci-capture/candidate_capture.v0"
+OCI_IMPLEMENTATION_ID_ENV = "IMPLEMENTATION_ID: ${{ inputs.implementation_id }}"
+OCI_IMPLEMENTATION_ID_ARGV = '--implementation-id "$IMPLEMENTATION_ID"'
+USES_SHA_RE = re.compile(r"uses:\s*\S+@([0-9a-f]{40}|[^\s#]+)")
 
 def _head_commit() -> str:
     """Resolve HEAD, the way the conformance and pack-release workflows already do.
@@ -1984,6 +2003,248 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             "positive control: the probe must be able to discriminate",
         )
 
+
+def oci_candidate_workflow_problems(text: str) -> list[str]:
+    """Structural pins for the trusted-main OCI capture workflow. One function."""
+    problems: list[str] = []
+    if "workflow_dispatch:" not in text:
+        problems.append("missing workflow_dispatch")
+    if re.search(r"(?m)^  pull_request", text) or "pull_request_target:" in text:
+        problems.append("untrusted pull_request trigger")
+    if re.search(r"(?m)^  push:", text):
+        problems.append("push trigger")
+    in_on = False
+    for line in text.splitlines():
+        if line == "on:":
+            in_on = True
+            continue
+        if not in_on:
+            continue
+        if line.startswith("  ") and not line.startswith("   "):
+            key = line.strip().split(":", 1)[0]
+            if key != "workflow_dispatch":
+                problems.append(f"extra trigger: {key}")
+        elif line != "" and not line.startswith(" "):
+            in_on = False
+    if "runs-on: ubuntu-24.04" not in text:
+        problems.append("missing ubuntu-24.04")
+    if re.search(r"runs-on:\s*.*self-hosted", text):
+        problems.append("self-hosted runner")
+    if (
+        re.search(r"(?m)^\s+\S+:\s*write\s*$", text)
+        or "id-token:" in text
+        or "attestations:" in text
+    ):
+        problems.append("excess permissions")
+    if "contents: read" not in text:
+        problems.append("missing contents:read")
+    if "secrets." in text:
+        problems.append("explicit secrets")
+    if 'if [[ "$GITHUB_REF" != "refs/heads/main" ]]' not in text:
+        problems.append("missing main ref guard")
+    if 'git rev-parse HEAD' not in text or "$GITHUB_SHA" not in text:
+        problems.append("missing HEAD/SHA guard")
+    if "persist-credentials: false" not in text:
+        problems.append("missing persist-credentials:false")
+    if "candidate-release.json" not in text:
+        problems.append("missing candidate-release.json")
+    if "validate_candidate_release.py" not in text:
+        problems.append("missing validate_candidate_release.py")
+    if "attestation-bundle.json" not in text:
+        problems.append("missing attestation-bundle.json")
+    if "gh attestation verify" not in text:
+        problems.append("missing gh attestation verify")
+    if "--bundle" not in text:
+        problems.append("missing --bundle")
+    if f"--signer-workflow {OCI_SIGNER_WORKFLOW}" not in text:
+        problems.append("missing or wrong signer-workflow")
+    if "--source-digest" not in text:
+        problems.append("missing --source-digest")
+    if OCI_SOURCE_DIGEST_SHAPE not in text:
+        problems.append("missing source_digest regex")
+    elif OCI_SOURCE_DIGEST_GUARD not in text:
+        problems.append("source_digest check not fail-closed")
+    if "--source-ref refs/heads/main" not in text:
+        problems.append("missing --source-ref")
+    if "--deny-self-hosted-runners" not in text:
+        problems.append("missing --deny-self-hosted-runners")
+    if "release_attestation_enforce.sh" in text:
+        problems.append("software-release verifier used for pack")
+    if OCI_EXECUTOR not in text:
+        problems.append("missing canonical executor")
+    if "--pack" not in text or "--implementation-id" not in text or "--output" not in text:
+        problems.append("missing executor argv")
+    if "--timeout-seconds 30" not in text:
+        problems.append("missing --timeout-seconds 30")
+    if "--implementation-image" in text or "--registry" in text:
+        problems.append("direct image or registry override")
+    if "python3 - <<" in text:
+        problems.append("inline Python")
+    if OCI_IMPLEMENTATION_ID_ENV not in text:
+        problems.append("missing implementation_id env binding")
+    if OCI_IMPLEMENTATION_ID_ARGV not in text:
+        problems.append("implementation_id not quoted argv")
+    for line in text.splitlines():
+        if "${{ inputs." not in line:
+            continue
+        if re.match(r"^\s+[A-Za-z_][A-Za-z0-9_]*:\s*\$\{\{ inputs\.", line):
+            continue
+        problems.append("inputs interpolated in run script")
+        break
+    if "continue-on-error" in text:
+        problems.append("continue-on-error swallows failure")
+    if "|| true" in text:
+        problems.append("|| true swallows failure")
+    if OCI_CHECKOUT_PIN not in text:
+        problems.append("unpinned or wrong checkout")
+    if OCI_SETUP_PYTHON_PIN not in text:
+        problems.append("unpinned or wrong setup-python")
+    if OCI_PYTHON_VERSION not in text:
+        problems.append("missing python 3.13.8")
+    if OCI_UPLOAD_PIN not in text:
+        problems.append("unpinned or wrong upload-artifact")
+    if "if: success()" not in text:
+        problems.append("upload not gated on success")
+    if "candidate_capture.v0" not in text:
+        problems.append("missing fixed capture name")
+    if OCI_CAPTURE_UPLOAD_PATH not in text:
+        problems.append("missing exact capture upload path")
+    if "retention-days: 7" not in text:
+        problems.append("missing retention-days: 7")
+    if "if-no-files-found: error" not in text:
+        problems.append("missing if-no-files-found:error")
+    if "timeout-minutes: 25" not in text:
+        problems.append("missing timeout-minutes: 25")
+    for match in USES_SHA_RE.finditer(text):
+        pin = match.group(1)
+        if not re.fullmatch(r"[0-9a-f]{40}", pin):
+            problems.append(f"unpinned uses: {match.group(0)}")
+    return problems
+
+
+class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
+    """Capture-only trusted-main workflow. Structural; no live dispatch."""
+
+    def test_workflow_file_exists(self) -> None:
+        self.assertTrue(
+            OCI_CANDIDATE_WORKFLOW.is_file(),
+            f"missing {OCI_CANDIDATE_WORKFLOW}",
+        )
+
+    def test_trusted_main_capture_contract(self) -> None:
+        text = OCI_CANDIDATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual(oci_candidate_workflow_problems(text), [])
+
+    def test_mutations_fail_independently(self) -> None:
+        text = OCI_CANDIDATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual(oci_candidate_workflow_problems(text), [])
+        drops = (
+            ('if [[ "$GITHUB_REF" != "refs/heads/main" ]]', "missing main ref guard"),
+            ("gh attestation verify", "missing gh attestation verify"),
+            ("attestation-bundle.json", "missing attestation-bundle.json"),
+            ("--source-digest", "missing --source-digest"),
+            ("^[0-9a-f]{40}$", "missing source_digest regex"),
+            (" || exit 2", "source_digest check not fail-closed"),
+            ("--source-ref refs/heads/main", "missing --source-ref"),
+            (f"--signer-workflow {OCI_SIGNER_WORKFLOW}", "missing or wrong signer-workflow"),
+            ("--deny-self-hosted-runners", "missing --deny-self-hosted-runners"),
+            (OCI_EXECUTOR, "missing canonical executor"),
+            ("--implementation-id", "missing executor argv"),
+            (OCI_IMPLEMENTATION_ID_ENV, "missing implementation_id env binding"),
+            (OCI_IMPLEMENTATION_ID_ARGV, "implementation_id not quoted argv"),
+            (OCI_SETUP_PYTHON_PIN, "unpinned or wrong setup-python"),
+            (OCI_PYTHON_VERSION, "missing python 3.13.8"),
+            (OCI_CAPTURE_UPLOAD_PATH, "missing exact capture upload path"),
+            ("retention-days: 7", "missing retention-days: 7"),
+            ("if: success()", "upload not gated on success"),
+        )
+        for needle, expected in drops:
+            with self.subTest(drop=needle):
+                mutated = text.replace(needle, "")
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
+                )
+        extra = text + "\n      --implementation-image ghcr.io/example/x@sha256:" + "ab" * 32 + "\n"
+        extra = extra.replace(OCI_EXECUTOR, "python3 -c 'pass'", 1)
+        with self.subTest(kind="inline-and-image"):
+            problems = oci_candidate_workflow_problems(extra)
+            self.assertTrue(any("canonical executor" in p or "inline" in p for p in problems))
+            self.assertTrue(any("image or registry" in p for p in problems))
+        software = text.replace(
+            "gh attestation verify",
+            "bash scripts/ci/release_attestation_enforce.sh",
+            1,
+        )
+        with self.subTest(kind="software-release-verifier"):
+            problems = oci_candidate_workflow_problems(software)
+            self.assertTrue(any("software-release verifier" in p for p in problems))
+        inserts = (
+            ("on:\n", "on:\n  pull_request:\n    branches: [main]\n", "untrusted pull_request trigger"),
+            ("on:\n", "on:\n  schedule:\n    - cron: '0 0 * * *'\n", "extra trigger: schedule"),
+            ("on:\n", "on:\n  repository_dispatch:\n", "extra trigger: repository_dispatch"),
+            ("on:\n", "on:\n  workflow_call:\n", "extra trigger: workflow_call"),
+            ("ubuntu-24.04", "self-hosted", "self-hosted runner"),
+            ("permissions:\n  contents: read\n", "permissions:\n  contents: write\n", "excess permissions"),
+            (
+                "permissions:\n  contents: read\n",
+                "permissions:\n  contents: read\n  packages: write\n",
+                "excess permissions",
+            ),
+            ("permissions:\n", "env:\n  TOKEN: ${{ secrets.FOO }}\npermissions:\n", "explicit secrets"),
+            (OCI_CHECKOUT_PIN, "actions/checkout@v5", "unpinned uses:"),
+            (OCI_SETUP_PYTHON_PIN, "actions/setup-python@v6", "unpinned or wrong setup-python"),
+            (OCI_PYTHON_VERSION, 'python-version: "3.12.0"', "missing python 3.13.8"),
+        )
+        for needle, replacement, expected in inserts:
+            with self.subTest(insert=expected):
+                mutated = text.replace(needle, replacement, 1)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
+                )
+        with self.subTest(kind="inputs-in-run"):
+            mutated = text.replace(OCI_IMPLEMENTATION_ID_ENV + "\n", "", 1).replace(
+                OCI_IMPLEMENTATION_ID_ARGV,
+                "--implementation-id ${{ inputs.implementation_id }}",
+                1,
+            )
+            problems = oci_candidate_workflow_problems(mutated)
+            self.assertTrue(
+                any("inputs interpolated in run script" in problem for problem in problems),
+                f"expected inputs interpolated in {problems}",
+            )
+        swallow_steps = (
+            "Resolve published pack tag",
+            "Download attested pack",
+            "Verify pack attestation",
+            "Capture candidate observations",
+        )
+        for step in swallow_steps:
+            with self.subTest(continue_on_error=step):
+                needle = f"      - name: {step}\n"
+                mutated = text.replace(needle, needle + "        continue-on-error: true\n", 1)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any("continue-on-error swallows failure" in problem for problem in problems),
+                    f"expected continue-on-error in {problems}",
+                )
+        swallow_commands = (
+            "validate_candidate_release.py",
+            "gh release download",
+            "gh attestation verify",
+            OCI_EXECUTOR,
+        )
+        for cmd in swallow_commands:
+            with self.subTest(or_true=cmd):
+                mutated = text.replace(cmd, f"{cmd} || true", 1)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any("|| true swallows failure" in problem for problem in problems),
+                    f"expected || true in {problems}",
+                )
 
 
 if __name__ == "__main__":

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -29,7 +29,6 @@ CORPUS = Path(__file__).resolve().parents[1]
 REPO = CORPUS.parents[1]
 SCRIPTS = CORPUS / "scripts"
 FIXTURE_C = Path(__file__).resolve().parent / "fixtures" / "oci-candidate.c"
-CONFORMANCE_WORKFLOW = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
 
 sys.path.insert(0, str(SCRIPTS))
 sys.path.insert(0, str(REPO / "conformance"))
@@ -715,19 +714,6 @@ class LifecycleClassification(unittest.TestCase):
         execute_src = inspect.getsource(module.execute_candidate)
         self.assertIn("DOCKER_LIFECYCLE_ERRORS", execute_src)
         self.assertNotIn("except (DockerCommandError", execute_src)
-
-
-class ConformanceCiContract(unittest.TestCase):
-    def test_existing_workflow_runs_this_file(self) -> None:
-        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("test_activation_kit.py", text)
-        self.assertIn("test_oci_candidate_executor.py", text)
-        self.assertRegex(
-            text,
-            r"python3 -m unittest \\\n"
-            r"\s+conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
-            r"\s+conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py",
-        )
 
 
 def _docker_info() -> subprocess.CompletedProcess[bytes]:

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -189,6 +190,32 @@ def _direct_mapping(block: str) -> dict[str, str]:
     return entries
 
 
+def _assert_no_workflow_bash_env(text: str) -> None:
+    lines = text.splitlines(keepends=True)
+    env_indexes: list[int] = []
+    for index, raw in enumerate(lines):
+        line = raw.rstrip("\r\n")
+        if not line or line.startswith((" ", "#")):
+            continue
+        match = DIRECT_ENTRY_RE.fullmatch(line)
+        if match is None:
+            continue
+        key = next(match.group(name) for name in ("plain", "single", "double")
+                   if match.group(name) is not None)
+        if key != "env":
+            continue
+        if match.group("value").strip():
+            raise AssertionError("workflow env must use a direct mapping")
+        env_indexes.append(index)
+    if len(env_indexes) > 1:
+        raise AssertionError("workflow has duplicate top-level env mappings")
+    if not env_indexes:
+        return
+    env_block = _indentation_bounded_block(lines, env_indexes[0], 0)
+    if "BASH_ENV" in _direct_mapping(env_block):
+        raise AssertionError("workflow-level BASH_ENV can neutralize hard-run scripts")
+
+
 def _direct_scalar(raw: str) -> str:
     value = raw.strip()
     if re.fullmatch(r"[A-Za-z0-9_.-]+", value):
@@ -212,6 +239,7 @@ def assert_hard_run_command(
     if contract is None:
         raise AssertionError(f"no hard-run contract for {job_name}/{step_name}")
     allowed_job_keys, allowed_step_keys, expected_script = contract
+    _assert_no_workflow_bash_env(text)
 
     job = named_job(text, job_name)
     actual_job_keys = frozenset(_direct_mapping(job))
@@ -479,6 +507,31 @@ class ProductCallsite(unittest.TestCase):
                 )
                 self.assertEqual(completed.returncode, expected)
 
+    def test_bash_env_neutralizes_both_unchanged_hard_scripts(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bash_env = Path(raw) / "bash-env"
+            bash_env.write_text(
+                "test() { return 0; }\npython3() { return 0; }\n",
+                encoding="utf-8",
+            )
+            env = {
+                **os.environ,
+                "BASH_ENV": str(bash_env),
+                "GITHUB_SHA": "0" * 40,
+            }
+            for label, script in (
+                ("inventory", INVENTORY_RUN_SCRIPT),
+                ("activation", ACTIVATION_KIT_RUN_SCRIPT),
+            ):
+                with self.subTest(label=label):
+                    completed = subprocess.run(
+                        ["bash", "-c", "\n".join(script)],
+                        cwd=REPO,
+                        env=env,
+                        check=False,
+                    )
+                    self.assertEqual(completed.returncode, 0)
+
     def test_direct_key_parser_ignores_nested_soft_failure_names(self):
         block = (
             "  scope:\n"
@@ -575,6 +628,22 @@ class ProductCallsite(unittest.TestCase):
         self.assertNotEqual(mutated, text)
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
+
+    def test_activation_workflow_bash_env_fails_closed(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "permissions:\n",
+            "env:\n  BASH_ENV: /tmp/assay-bash-env\n\npermissions:\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+        control = text.replace(
+            "permissions:\n",
+            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n\npermissions:\n",
+            1,
+        )
+        assert_combined_unittest(control)
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -10,6 +10,7 @@ on required_complete, not by mapping 3 to 0.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import re
 import subprocess
@@ -36,6 +37,9 @@ COMBINED_UNITTEST = (
     "          python3 -m unittest \\\n"
     "            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
     "            conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py"
+)
+ACTIVATION_KIT = (
+    REPO / "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
 )
 
 
@@ -78,6 +82,51 @@ def _kit_step(text: str) -> str:
     if step is None:
         raise AssertionError("conformance workflow missing kit contract step")
     return step.group(0)
+
+
+def _load_activation_kit():
+    spec = importlib.util.spec_from_file_location(
+        "pma_activation_kit_required_ci", ACTIVATION_KIT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("activation kit is not loadable")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def assert_oci_candidate_checker(mod) -> None:
+    checker = getattr(mod, "oci_candidate_workflow_problems", None)
+    if not callable(checker):
+        raise AssertionError("oci_candidate_workflow_problems missing")
+    cls = getattr(mod, "PrivilegedMcpActionOciCandidateWorkflowContract", None)
+    if cls is None:
+        raise AssertionError("PrivilegedMcpActionOciCandidateWorkflowContract missing")
+    if not hasattr(cls, "test_mutations_fail_independently"):
+        raise AssertionError("standalone mutation matrix missing")
+    workflow = getattr(mod, "OCI_CANDIDATE_WORKFLOW", None)
+    if workflow is None:
+        raise AssertionError("OCI_CANDIDATE_WORKFLOW missing")
+    text = workflow.read_text(encoding="utf-8")
+    problems = checker(text)
+    if problems:
+        raise AssertionError(f"committed workflow problems: {problems}")
+    executor = getattr(mod, "OCI_EXECUTOR", None)
+    if not executor:
+        raise AssertionError("OCI_EXECUTOR missing")
+    mutations = (
+        ("        if: success()\n", "        if: always()\n", "upload not gated on success"),
+        ("gh attestation verify", "", "missing gh attestation verify"),
+        (f"python3 {executor}", "python3 -c 'pass'", "missing canonical executor"),
+    )
+    for needle, replacement, expected in mutations:
+        mutated = text.replace(needle, replacement, 1)
+        if mutated == text:
+            raise AssertionError(f"mutation needle missing: {needle!r}")
+        got = checker(mutated)
+        if not any(expected in problem for problem in got):
+            raise AssertionError(f"expected {expected!r} in {got}")
+    if checker(text.replace("no-such-token", "no-such-token")):
+        raise AssertionError("no-op control was not green")
 
 
 def assert_combined_unittest(step: str) -> None:
@@ -348,6 +397,24 @@ class ProductCallsite(unittest.TestCase):
         for mutated in mutations:
             with self.assertRaises(AssertionError):
                 assert_combined_unittest(mutated)
+
+    def test_required_ci_invokes_oci_candidate_checker(self):
+        mod = _load_activation_kit()
+        assert_oci_candidate_checker(mod)
+        cls = mod.PrivilegedMcpActionOciCandidateWorkflowContract
+        drops = (
+            (mod, "oci_candidate_workflow_problems"),
+            (mod, "PrivilegedMcpActionOciCandidateWorkflowContract"),
+            (cls, "test_mutations_fail_independently"),
+        )
+        for owner, name in drops:
+            saved = getattr(owner, name)
+            delattr(owner, name)
+            try:
+                with self.assertRaises(AssertionError):
+                    assert_oci_candidate_checker(mod)
+            finally:
+                setattr(owner, name, saved)
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -39,32 +39,51 @@ ACTIVATION_KIT = (
 )
 
 
-def named_step(text: str, name: str) -> str:
+def _indentation_bounded_block(
+        lines: list[str], start: int, block_indent: int) -> str:
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        if line.strip():
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= block_indent:
+                break
+        end += 1
+    return "".join(lines[start:end])
+
+
+def named_job(text: str, name: str) -> str:
     lines = text.splitlines(keepends=True)
-    marker = re.compile(rf"^(?P<indent> +)- name: {re.escape(name)}\s*$")
+    marker = re.compile(rf"^  {re.escape(name)}:\s*$")
     matches = [
         (i, marker.fullmatch(line.rstrip("\r\n")))
         for i, line in enumerate(lines)
     ]
     matches = [(i, match) for i, match in matches if match is not None]
     if len(matches) != 1:
-        raise AssertionError(f"expected one {name!r} step, found {len(matches)}")
+        raise AssertionError(f"expected one {name!r} job, found {len(matches)}")
+    return _indentation_bounded_block(lines, matches[0][0], 2)
+
+
+def named_step(text: str, job_name: str, step_name: str) -> str:
+    lines = named_job(text, job_name).splitlines(keepends=True)
+    marker = re.compile(rf"^(?P<indent> +)- name: {re.escape(step_name)}\s*$")
+    matches = [
+        (i, marker.fullmatch(line.rstrip("\r\n")))
+        for i, line in enumerate(lines)
+    ]
+    matches = [(i, match) for i, match in matches if match is not None]
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected one {step_name!r} step in {job_name!r}, found {len(matches)}")
     start, match = matches[0]
     assert match is not None
-    step_indent = len(match.group("indent"))
-    end = start + 1
-    while end < len(lines):
-        line = lines[end]
-        if line.strip():
-            indent = len(line) - len(line.lstrip(" "))
-            if indent <= step_indent:
-                break
-        end += 1
-    return "".join(lines[start:end])
+    return _indentation_bounded_block(
+        lines, start, len(match.group("indent")))
 
 
 def _inventory_step(text: str) -> str:
-    return named_step(text, "Conformance inventory")
+    return named_step(text, "scope", "Conformance inventory")
 
 
 def _active_run_lines(step: str) -> list[str]:
@@ -91,12 +110,9 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
-def _kit_step(text: str) -> str:
-    return named_step(text, "Run activation-kit contract tests")
-
-
-def assert_hard_run_command(text: str, step_name: str, command: str) -> str:
-    step = named_step(text, step_name)
+def assert_hard_run_command(
+        text: str, job_name: str, step_name: str, command: str) -> str:
+    step = named_step(text, job_name, step_name)
     first = step.splitlines()[0]
     step_indent = len(first) - len(first.lstrip(" "))
     guarded = re.compile(
@@ -166,7 +182,8 @@ def assert_oci_candidate_checker(mod) -> None:
 
 def assert_combined_unittest(text: str) -> None:
     assert_hard_run_command(
-        text, "Run activation-kit contract tests", COMBINED_UNITTEST)
+        text, "activation-kit", "Run activation-kit contract tests",
+        COMBINED_UNITTEST)
 
 
 POLICIES = {
@@ -349,7 +366,7 @@ class ProductCallsite(unittest.TestCase):
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "Conformance inventory", REQUIRED_RUN_ALL)
+            text, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
         lines = _active_run_lines(step)
         self.assertEqual(lines[0], "set -euo pipefail")
         self.assertIn("python3 conformance/registry.py", lines)
@@ -409,21 +426,20 @@ class ProductCallsite(unittest.TestCase):
 
     def test_conformance_combined_unittest_is_a_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
-        step = _kit_step(text)
         assert_combined_unittest(text)
-        assert_combined_unittest(step.replace("no-such-token", "no-such-token"))
+        assert_combined_unittest(text.replace("no-such-token", "no-such-token"))
         name = "      - name: Run activation-kit contract tests\n"
         mutations = (
-            step.replace(COMBINED_UNITTEST, "          true"),
-            step.replace("          python3 -m unittest \\",
+            text.replace(COMBINED_UNITTEST, "          true"),
+            text.replace("          python3 -m unittest \\",
                          "          # python3 -m unittest \\"),
-            step.replace(COMBINED_UNITTEST, "          :"),
-            step.replace("test_activation_kit.py", ""),
-            step.replace("test_oci_candidate_executor.py", ""),
-            step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || true"),
-            step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || :"),
-            step.replace("          set -euo pipefail", "          set +e"),
-            step.replace(name, name + "        continue-on-error: true\n"),
+            text.replace(COMBINED_UNITTEST, "          :"),
+            text.replace("test_activation_kit.py", ""),
+            text.replace("test_oci_candidate_executor.py", ""),
+            text.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || true"),
+            text.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || :"),
+            text.replace("          set -euo pipefail", "          set +e", 1),
+            text.replace(name, name + "        continue-on-error: true\n"),
         )
         for mutated in mutations:
             with self.assertRaises(AssertionError):
@@ -452,6 +468,17 @@ class ProductCallsite(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
+
+    def test_inventory_step_moved_to_conditional_job_fails(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutated = text.replace(step, "", 1)
+        job_start = mutated.index("  ebpf-smoke-ubuntu:\n")
+        insert_at = mutated.index("    steps:\n", job_start) + len("    steps:\n")
+        mutated = mutated[:insert_at] + step + mutated[insert_at:]
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
 
     def test_required_ci_invokes_oci_candidate_checker(self):
         mod = _load_activation_kit()

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -34,6 +34,34 @@ COMBINED_UNITTEST = (
     "            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
     "            conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py"
 )
+INVENTORY_RUN_SCRIPT = (
+    "set -euo pipefail",
+    "python3 conformance/registry.py",
+    "python3 conformance/implementations.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_implementations.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_registry.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_run_all.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py",
+    REQUIRED_RUN_ALL,
+)
+ACTIVATION_KIT_RUN_SCRIPT = (
+    "set -euo pipefail",
+    *(line.strip() for line in COMBINED_UNITTEST.splitlines()),
+)
+HARD_RUN_CONTRACTS = {
+    ("scope", "Conformance inventory"): (
+        frozenset({"name", "runs-on", "timeout-minutes", "permissions",
+                   "outputs", "steps"}),
+        frozenset({"name", "shell", "run"}),
+        INVENTORY_RUN_SCRIPT,
+    ),
+    ("activation-kit", "Run activation-kit contract tests"): (
+        frozenset({"runs-on", "steps"}),
+        frozenset({"name", "run"}),
+        ACTIVATION_KIT_RUN_SCRIPT,
+    ),
+}
 ACTIVATION_KIT = (
     REPO / "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
 )
@@ -110,42 +138,58 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
-def _direct_soft_failure_key(block: str) -> str | None:
+DIRECT_KEY_RE = re.compile(
+    r"^(?:(?P<plain>[A-Za-z0-9_-]+)|'(?P<single>[A-Za-z0-9_-]+)'|"
+    r'"(?P<double>[A-Za-z0-9_-]+)")\s*:')
+
+
+def _direct_mapping_keys(block: str) -> frozenset[str]:
     lines = block.splitlines()
     block_indent = len(lines[0]) - len(lines[0].lstrip(" "))
-    guarded = re.compile(
-        rf"^ {{{block_indent + 2}}}(?P<key>if|continue-on-error)\s*:")
-    for line in lines[1:]:
-        match = guarded.match(line)
-        if match:
-            return match.group("key")
-    return None
+    direct_indent = block_indent + 2
+    keys: set[str] = set()
+    for index, line in enumerate(lines):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if index == 0 and indent == block_indent and line[indent:].startswith("- "):
+            direct = line[indent + 2:]
+        elif indent == direct_indent:
+            direct = line[direct_indent:]
+        else:
+            continue
+        match = DIRECT_KEY_RE.match(direct)
+        if match is None:
+            raise AssertionError(f"unrecognized direct mapping key syntax: {direct!r}")
+        key = next(value for value in match.groupdict().values() if value is not None)
+        if key in keys:
+            raise AssertionError(f"duplicate direct mapping key: {key}")
+        keys.add(key)
+    return frozenset(keys)
 
 
 def assert_hard_run_command(
-        text: str, job_name: str, step_name: str, command: str) -> str:
+        text: str, job_name: str, step_name: str) -> str:
+    contract = HARD_RUN_CONTRACTS.get((job_name, step_name))
+    if contract is None:
+        raise AssertionError(f"no hard-run contract for {job_name}/{step_name}")
+    allowed_job_keys, allowed_step_keys, expected_script = contract
+
     job = named_job(text, job_name)
-    job_key = _direct_soft_failure_key(job)
-    if job_key:
-        raise AssertionError(f"{job_name} job has a direct {job_key} key")
+    unexpected_job_keys = _direct_mapping_keys(job) - allowed_job_keys
+    if unexpected_job_keys:
+        raise AssertionError(
+            f"{job_name} job has unexpected direct keys: {sorted(unexpected_job_keys)}")
 
     step = named_step(text, job_name, step_name)
-    step_key = _direct_soft_failure_key(step)
-    if step_key:
-        raise AssertionError(f"{step_name} has a direct {step_key} key")
+    unexpected_step_keys = _direct_mapping_keys(step) - allowed_step_keys
+    if unexpected_step_keys:
+        raise AssertionError(
+            f"{step_name} has unexpected direct keys: {sorted(unexpected_step_keys)}")
 
-    active = _active_run_lines(step)
-    expected = [line.strip() for line in command.splitlines()]
-    matches = sum(
-        active[i:i + len(expected)] == expected
-        for i in range(len(active) - len(expected) + 1)
-    )
-    if matches != 1:
-        raise AssertionError(f"{step_name} must run the canonical command exactly once")
-    if any(re.search(r"\|\|\s*(?:true|:)(?:\s|$)", line) for line in active):
-        raise AssertionError(f"{step_name} command is neutralized with ||")
-    if any(line == "set +e" or line.startswith("set +e ") for line in active):
-        raise AssertionError(f"{step_name} disables fail-fast shell behavior")
+    active = tuple(_active_run_lines(step))
+    if active != expected_script:
+        raise AssertionError(f"{step_name} run script differs from the canonical script")
     return step
 
 
@@ -196,8 +240,7 @@ def assert_oci_candidate_checker(mod) -> None:
 
 def assert_combined_unittest(text: str) -> None:
     assert_hard_run_command(
-        text, "activation-kit", "Run activation-kit contract tests",
-        COMBINED_UNITTEST)
+        text, "activation-kit", "Run activation-kit contract tests")
 
 
 POLICIES = {
@@ -377,24 +420,31 @@ class ProductCallsite(unittest.TestCase):
     def test_no_separate_inventory_workflow(self):
         self.assertFalse(STANDALONE.exists(), STANDALONE)
 
+    def test_direct_key_parser_ignores_nested_soft_failure_names(self):
+        block = (
+            "  scope:\n"
+            "    \"runs-on\": ubuntu-latest\n"
+            "    outputs:\n"
+            "      if: nested-output\n"
+            "      continue-on-error: nested-output\n"
+            "    'steps': []\n"
+        )
+        self.assertEqual(
+            _direct_mapping_keys(block),
+            frozenset({"runs-on", "outputs", "steps"}),
+        )
+
+    def test_direct_key_parser_fails_closed_on_unrecognized_syntax(self):
+        block = "  scope:\n    ? [if]\n    : false\n"
+        with self.assertRaises(AssertionError):
+            _direct_mapping_keys(block)
+
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
+            text, "scope", "Conformance inventory")
         lines = _active_run_lines(step)
-        self.assertEqual(lines[0], "set -euo pipefail")
-        self.assertIn("python3 conformance/registry.py", lines)
-        self.assertTrue(any("conformance/tests/test_registry.py" in ln for ln in lines))
-        self.assertTrue(any("conformance/tests/test_run_all.py" in ln for ln in lines))
-        self.assertTrue(any("conformance/tests/test_completion_scope.py" in ln for ln in lines))
-        self.assertIn(REQUIRED_RUN_ALL, lines)
-        self.assertEqual(lines.count(REQUIRED_RUN_ALL), 1)
-        self.assertFalse(any("||" in ln for ln in lines if REQUIRED_RUN_ALL in ln))
-        self.assertFalse(any(ln == "set +e" or ln.startswith("set +e ") for ln in lines))
-        self.assertNotIn("|| true", step)
-        self.assertNotIn("|| :", step)
-        self.assertNotIn("continue-on-error", step)
-        self.assertNotRegex(step, r"eq 3|returncode in \(0, 3\)")
+        self.assertEqual(tuple(lines), INVENTORY_RUN_SCRIPT)
 
     def test_commented_or_colon_run_all_line_is_not_an_active_callsite(self):
         step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
@@ -455,9 +505,10 @@ class ProductCallsite(unittest.TestCase):
             text.replace("          set -euo pipefail", "          set +e", 1),
             text.replace(name, name + "        continue-on-error: true\n"),
         )
-        for mutated in mutations:
-            with self.assertRaises(AssertionError):
-                assert_combined_unittest(mutated)
+        for index, mutated in enumerate(mutations):
+            with self.subTest(index=index):
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
 
     def test_conditional_activation_kit_step_fails_the_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
@@ -491,6 +542,44 @@ class ProductCallsite(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
 
+    def test_quoted_activation_kit_job_and_step_keys_fail(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        job = "  activation-kit:\n"
+        step = "      - name: Run activation-kit contract tests\n"
+        mutations = (
+            ("job double if", job,
+             job + "    \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("job single continue", job,
+             job + "    'continue-on-error': true\n"),
+            ("step double if", step,
+             step + "        \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("step single continue", step,
+             step + "        'continue-on-error': true\n"),
+        )
+        for label, needle, replacement in mutations:
+            with self.subTest(label=label):
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(text.replace(needle, replacement, 1))
+
+    def test_shell_neutralizers_fail_the_activation_kit_guard(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutations = (
+            text.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          set +o errexit\n",
+                1,
+            ).replace(COMBINED_UNITTEST, COMBINED_UNITTEST + "\n          true", 1),
+            text.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          python3() { :; }\n",
+                1,
+            ),
+        )
+        for index, mutated in enumerate(mutations):
+            with self.subTest(index=index):
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
+
     def test_relocated_activation_kit_command_fails_the_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
         mutated = text.replace(COMBINED_UNITTEST, "          :", 1).replace(
@@ -513,7 +602,7 @@ class ProductCallsite(unittest.TestCase):
         mutated = mutated[:insert_at] + step + mutated[insert_at:]
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
+                mutated, "scope", "Conformance inventory")
 
     def test_required_ci_invokes_oci_candidate_checker(self):
         mod = _load_activation_kit()

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -25,14 +25,10 @@ import run_all  # noqa: E402
 REPO = Path(__file__).resolve().parents[2]
 CI_YML = REPO / ".github/workflows/ci.yml"
 STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
-INVENTORY_STEP_RE = re.compile(r"(?ms)^      - name: Conformance inventory\n(?:        .+\n)+")
-JOB_KEY_RE = re.compile(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:")
 REQUIRED_RUN_ALL = (
     "python3 conformance/run_all.py --require-complete --completion-scope required"
 )
 CONFORMANCE_YML = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
-KIT_STEP_RE = re.compile(
-    r"(?ms)^      - name: Run activation-kit contract tests\n(?:        .+\n)+")
 COMBINED_UNITTEST = (
     "          python3 -m unittest \\\n"
     "            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
@@ -43,34 +39,52 @@ ACTIVATION_KIT = (
 )
 
 
-def _scope_job(text: str) -> str:
+def named_step(text: str, name: str) -> str:
     lines = text.splitlines(keepends=True)
-    start = next((i for i, line in enumerate(lines) if line.startswith("  scope:")), None)
-    if start is None:
-        raise AssertionError("ci.yml missing scope job")
+    marker = re.compile(rf"^(?P<indent> +)- name: {re.escape(name)}\s*$")
+    matches = [
+        (i, marker.fullmatch(line.rstrip("\r\n")))
+        for i, line in enumerate(lines)
+    ]
+    matches = [(i, match) for i, match in matches if match is not None]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one {name!r} step, found {len(matches)}")
+    start, match = matches[0]
+    assert match is not None
+    step_indent = len(match.group("indent"))
     end = start + 1
-    while end < len(lines) and not JOB_KEY_RE.match(lines[end]):
+    while end < len(lines):
+        line = lines[end]
+        if line.strip():
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= step_indent:
+                break
         end += 1
     return "".join(lines[start:end])
 
 
 def _inventory_step(text: str) -> str:
-    step = INVENTORY_STEP_RE.search(_scope_job(text))
-    if step is None:
-        raise AssertionError("scope job missing Conformance inventory step")
-    return step.group(0)
+    return named_step(text, "Conformance inventory")
 
 
 def _active_run_lines(step: str) -> list[str]:
+    raw_lines = step.splitlines()
+    if not raw_lines:
+        return []
+    step_indent = len(raw_lines[0]) - len(raw_lines[0].lstrip(" "))
+    run_indent = step_indent + 2
+    run_indexes = [
+        i for i, raw in enumerate(raw_lines)
+        if raw == " " * run_indent + "run: |"
+    ]
+    if len(run_indexes) != 1:
+        return []
     lines: list[str] = []
-    in_run = False
-    for raw in step.splitlines():
-        if raw.strip() == "run: |":
-            in_run = True
-            continue
-        if not in_run:
-            continue
+    for raw in raw_lines[run_indexes[0] + 1:]:
         stripped = raw.strip()
+        indent = len(raw) - len(raw.lstrip(" "))
+        if stripped and indent <= run_indent:
+            break
         if not stripped or stripped.startswith("#"):
             continue
         lines.append(stripped)
@@ -78,10 +92,31 @@ def _active_run_lines(step: str) -> list[str]:
 
 
 def _kit_step(text: str) -> str:
-    step = KIT_STEP_RE.search(text)
-    if step is None:
-        raise AssertionError("conformance workflow missing kit contract step")
-    return step.group(0)
+    return named_step(text, "Run activation-kit contract tests")
+
+
+def assert_hard_run_command(text: str, step_name: str, command: str) -> str:
+    step = named_step(text, step_name)
+    first = step.splitlines()[0]
+    step_indent = len(first) - len(first.lstrip(" "))
+    guarded = re.compile(
+        rf"^ {{{step_indent + 2}}}(?:if|continue-on-error)\s*:")
+    if any(guarded.match(line) for line in step.splitlines()[1:]):
+        raise AssertionError(f"{step_name} has a conditional or soft-failure key")
+
+    active = _active_run_lines(step)
+    expected = [line.strip() for line in command.splitlines()]
+    matches = sum(
+        active[i:i + len(expected)] == expected
+        for i in range(len(active) - len(expected) + 1)
+    )
+    if matches != 1:
+        raise AssertionError(f"{step_name} must run the canonical command exactly once")
+    if any(re.search(r"\|\|\s*(?:true|:)(?:\s|$)", line) for line in active):
+        raise AssertionError(f"{step_name} command is neutralized with ||")
+    if any(line == "set +e" or line.startswith("set +e ") for line in active):
+        raise AssertionError(f"{step_name} disables fail-fast shell behavior")
+    return step
 
 
 def _load_activation_kit():
@@ -129,21 +164,9 @@ def assert_oci_candidate_checker(mod) -> None:
         raise AssertionError("no-op control was not green")
 
 
-def assert_combined_unittest(step: str) -> None:
-    if COMBINED_UNITTEST not in step:
-        raise AssertionError("combined unittest command missing")
-    lines = _active_run_lines(step)
-    joined = "\n".join(lines)
-    if "python3 -m unittest" not in joined:
-        raise AssertionError("combined unittest is not active")
-    if "test_activation_kit.py" not in joined:
-        raise AssertionError("activation kit is not active")
-    if "test_oci_candidate_executor.py" not in joined:
-        raise AssertionError("executor kit is not active")
-    if "|| true" in step or "|| :" in step or "continue-on-error" in step:
-        raise AssertionError("combined unittest is neutralized")
-    if any(ln == "set +e" or ln.startswith("set +e ") for ln in lines):
-        raise AssertionError("kit contract step disables -e")
+def assert_combined_unittest(text: str) -> None:
+    assert_hard_run_command(
+        text, "Run activation-kit contract tests", COMBINED_UNITTEST)
 
 
 POLICIES = {
@@ -325,7 +348,8 @@ class ProductCallsite(unittest.TestCase):
 
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
-        step = _inventory_step(text)
+        step = assert_hard_run_command(
+            text, "Conformance inventory", REQUIRED_RUN_ALL)
         lines = _active_run_lines(step)
         self.assertEqual(lines[0], "set -euo pipefail")
         self.assertIn("python3 conformance/registry.py", lines)
@@ -351,7 +375,11 @@ class ProductCallsite(unittest.TestCase):
 
     def test_deleting_the_scope_job_callsite_fails(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = INVENTORY_STEP_RE.sub("", text)
+        mutated = text.replace(
+            "      - name: Conformance inventory\n",
+            "      - name: Deleted conformance inventory\n",
+            1,
+        )
         with self.assertRaises(AssertionError):
             _inventory_step(mutated)
 
@@ -380,8 +408,9 @@ class ProductCallsite(unittest.TestCase):
                              for ln in _active_run_lines(mutated)))
 
     def test_conformance_combined_unittest_is_a_hard_callsite(self):
-        step = _kit_step(CONFORMANCE_YML.read_text(encoding="utf-8"))
-        assert_combined_unittest(step)
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        step = _kit_step(text)
+        assert_combined_unittest(text)
         assert_combined_unittest(step.replace("no-such-token", "no-such-token"))
         name = "      - name: Run activation-kit contract tests\n"
         mutations = (
@@ -392,11 +421,37 @@ class ProductCallsite(unittest.TestCase):
             step.replace("test_activation_kit.py", ""),
             step.replace("test_oci_candidate_executor.py", ""),
             step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || true"),
+            step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || :"),
+            step.replace("          set -euo pipefail", "          set +e"),
             step.replace(name, name + "        continue-on-error: true\n"),
         )
         for mutated in mutations:
             with self.assertRaises(AssertionError):
                 assert_combined_unittest(mutated)
+
+    def test_conditional_activation_kit_step_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "      - name: Run activation-kit contract tests\n",
+            "      - name: Run activation-kit contract tests\n"
+            "        if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+
+    def test_relocated_activation_kit_command_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(COMBINED_UNITTEST, "          :", 1).replace(
+            "      - name: Validate public JSON documents\n",
+            "      - name: Decorative activation-kit note\n"
+            "        run: |\n"
+            f"{COMBINED_UNITTEST}\n\n"
+            "      - name: Validate public JSON documents\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
 
     def test_required_ci_invokes_oci_candidate_checker(self):
         mod = _load_activation_kit()

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import sys
@@ -28,6 +29,7 @@ STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
 REQUIRED_RUN_ALL = (
     "python3 conformance/run_all.py --require-complete --completion-scope required"
 )
+REVISION_WITNESS = 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"'
 CONFORMANCE_YML = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
 COMBINED_UNITTEST = (
     "          python3 -m unittest \\\n"
@@ -36,6 +38,7 @@ COMBINED_UNITTEST = (
 )
 INVENTORY_RUN_SCRIPT = (
     "set -euo pipefail",
+    REVISION_WITNESS,
     "python3 conformance/registry.py",
     "python3 conformance/implementations.py",
     "python3 -W error::ResourceWarning conformance/tests/test_implementations.py",
@@ -47,6 +50,7 @@ INVENTORY_RUN_SCRIPT = (
 )
 ACTIVATION_KIT_RUN_SCRIPT = (
     "set -euo pipefail",
+    REVISION_WITNESS,
     *(line.strip() for line in COMBINED_UNITTEST.splitlines()),
 )
 HARD_RUN_CONTRACTS = {
@@ -459,6 +463,22 @@ class ProductCallsite(unittest.TestCase):
     def test_no_separate_inventory_workflow(self):
         self.assertFalse(STANDALONE.exists(), STANDALONE)
 
+    def test_revision_witness_accepts_head_and_rejects_mismatch(self):
+        head = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=REPO, text=True).strip()
+        for label, sha, expected in (
+            ("actual", head, 0),
+            ("mismatch", "0" * 40, 1),
+        ):
+            with self.subTest(label=label):
+                completed = subprocess.run(
+                    ["bash", "-c", REVISION_WITNESS],
+                    cwd=REPO,
+                    env={**os.environ, "GITHUB_SHA": sha},
+                    check=False,
+                )
+                self.assertEqual(completed.returncode, expected)
+
     def test_direct_key_parser_ignores_nested_soft_failure_names(self):
         block = (
             "  scope:\n"
@@ -548,6 +568,13 @@ class ProductCallsite(unittest.TestCase):
             with self.subTest(index=index):
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(mutated)
+
+    def test_removing_activation_revision_witness_fails(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace("          " + REVISION_WITNESS + "\n", "", 1)
+        self.assertNotEqual(mutated, text)
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -110,15 +110,29 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
+def _direct_soft_failure_key(block: str) -> str | None:
+    lines = block.splitlines()
+    block_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    guarded = re.compile(
+        rf"^ {{{block_indent + 2}}}(?P<key>if|continue-on-error)\s*:")
+    for line in lines[1:]:
+        match = guarded.match(line)
+        if match:
+            return match.group("key")
+    return None
+
+
 def assert_hard_run_command(
         text: str, job_name: str, step_name: str, command: str) -> str:
+    job = named_job(text, job_name)
+    job_key = _direct_soft_failure_key(job)
+    if job_key:
+        raise AssertionError(f"{job_name} job has a direct {job_key} key")
+
     step = named_step(text, job_name, step_name)
-    first = step.splitlines()[0]
-    step_indent = len(first) - len(first.lstrip(" "))
-    guarded = re.compile(
-        rf"^ {{{step_indent + 2}}}(?:if|continue-on-error)\s*:")
-    if any(guarded.match(line) for line in step.splitlines()[1:]):
-        raise AssertionError(f"{step_name} has a conditional or soft-failure key")
+    step_key = _direct_soft_failure_key(step)
+    if step_key:
+        raise AssertionError(f"{step_name} has a direct {step_key} key")
 
     active = _active_run_lines(step)
     expected = [line.strip() for line in command.splitlines()]
@@ -451,6 +465,27 @@ class ProductCallsite(unittest.TestCase):
             "      - name: Run activation-kit contract tests\n",
             "      - name: Run activation-kit contract tests\n"
             "        if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+
+    def test_conditional_activation_kit_job_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  activation-kit:\n",
+            "  activation-kit:\n"
+            "    if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+
+    def test_softened_activation_kit_job_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  activation-kit:\n",
+            "  activation-kit:\n    continue-on-error: true\n",
             1,
         )
         with self.assertRaises(AssertionError):

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -71,6 +71,30 @@ HARD_RUN_CONTRACTS = {
         frozenset(),
     ),
 }
+CHECKOUT_REF = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
+SETUP_PYTHON_REF = (
+    "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1")
+# The trusted prefix prevents earlier steps from changing runner state before the
+# hard call. Pins constrain workflow inputs; they do not attest the runner platform
+# or the implementation and behavior of GitHub-hosted actions.
+TRUSTED_PREFIX_CONTRACTS = {
+    ("scope", "Conformance inventory"): (
+        (frozenset({"uses", "with"}),
+         {"uses": CHECKOUT_REF},
+         {"persist-credentials": "false", "fetch-depth": "0"}),
+        (frozenset({"uses", "with"}),
+         {"uses": SETUP_PYTHON_REF},
+         {"python-version": "3.12"}),
+    ),
+    ("activation-kit", "Run activation-kit contract tests"): (
+        (frozenset({"name", "uses", "with"}),
+         {"name": "Check out source", "uses": CHECKOUT_REF},
+         {"fetch-depth": "0", "persist-credentials": "false"}),
+        (frozenset({"name", "uses", "with"}),
+         {"name": "Set up Python", "uses": SETUP_PYTHON_REF},
+         {"python-version": "3.13.8"}),
+    ),
+}
 ACTIVATION_KIT = (
     REPO / "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
 )
@@ -194,6 +218,112 @@ def _direct_mapping(block: str) -> dict[str, str]:
     return entries
 
 
+def _ordered_job_steps(text: str, job_name: str) -> list[str]:
+    lines = named_job(text, job_name).splitlines(keepends=True)
+    job_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    direct_indent = None
+    steps_index = None
+    for index, raw in enumerate(lines[1:], 1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if direct_indent is None:
+            direct_indent = indent
+        if indent != direct_indent:
+            continue
+        match = DIRECT_ENTRY_RE.fullmatch(raw[direct_indent:].rstrip("\r\n"))
+        if match is None:
+            raise AssertionError("unrecognized direct job key in steps parser")
+        key = next(match.group(name) for name in ("plain", "single", "double")
+                   if match.group(name) is not None)
+        if key == "steps":
+            if match.group("value").strip():
+                raise AssertionError("job steps must use a block sequence")
+            steps_index = index
+            break
+    if steps_index is None or direct_indent is None:
+        raise AssertionError(f"{job_name} job has no direct steps block")
+
+    end = steps_index + 1
+    while end < len(lines):
+        raw = lines[end]
+        if raw.strip():
+            indent = len(raw) - len(raw.lstrip(" "))
+            if indent <= direct_indent:
+                break
+        end += 1
+    step_indent = None
+    starts: list[int] = []
+    for index in range(steps_index + 1, end):
+        raw = lines[index]
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if step_indent is None:
+            step_indent = indent
+        if indent == step_indent:
+            if not raw[step_indent:].startswith("- "):
+                raise AssertionError("unrecognized direct workflow step syntax")
+            starts.append(index)
+        elif indent < step_indent:
+            raise AssertionError("inconsistent workflow step indentation")
+    if not starts:
+        raise AssertionError(f"{job_name} job has no steps")
+    return [
+        "".join(lines[start:starts[index + 1] if index + 1 < len(starts) else end])
+        for index, start in enumerate(starts)
+    ]
+
+
+def _assert_trusted_prefix(text: str, job_name: str, step_name: str) -> None:
+    contracts = TRUSTED_PREFIX_CONTRACTS.get((job_name, step_name))
+    if contracts is None:
+        raise AssertionError(f"no trusted-prefix contract for {job_name}/{step_name}")
+    steps = _ordered_job_steps(text, job_name)
+    target = named_step(text, job_name, step_name)
+    if len(steps) < 3 or steps[2] != target:
+        raise AssertionError(
+            f"{step_name} must be the third step after pinned checkout and setup")
+
+    for step, (expected_keys, expected_values, expected_with) in zip(
+            steps[:2], contracts, strict=True):
+        entries = _direct_mapping(step)
+        actual_keys = frozenset(entries)
+        if actual_keys != expected_keys:
+            raise AssertionError(
+                "trusted action step keys differ: "
+                f"expected {sorted(expected_keys)}, got {sorted(actual_keys)}")
+
+        def direct_value(key: str) -> str:
+            return entries[key].split(" #", 1)[0].strip()
+
+        actual_values = {key: direct_value(key) for key in expected_values}
+        if actual_values != expected_values:
+            raise AssertionError(
+                f"trusted action values differ: expected {expected_values}, "
+                f"got {actual_values}")
+
+        raw_lines = step.splitlines(keepends=True)
+        step_indent = len(raw_lines[0]) - len(raw_lines[0].lstrip(" "))
+        with_indent = step_indent + 2
+        with_indexes = [
+            index for index, raw in enumerate(raw_lines)
+            if raw.rstrip("\r\n") == " " * with_indent + "with:"
+        ]
+        if len(with_indexes) != 1:
+            raise AssertionError("trusted action must have one direct with mapping")
+        with_block = _indentation_bounded_block(
+            raw_lines, with_indexes[0], with_indent)
+        actual_with = {
+            key: _direct_scalar(value)
+            for key, value in _direct_mapping(with_block).items()
+        }
+        if actual_with != expected_with:
+            raise AssertionError(
+                f"trusted action with values differ: expected {expected_with}, "
+                f"got {actual_with}")
+
+
 def _assert_workflow_document(
         text: str,
         expected_keys: frozenset[str],
@@ -264,6 +394,7 @@ def assert_hard_run_command(
         raise AssertionError(
             f"{job_name} job direct keys differ: "
             f"expected {sorted(allowed_job_keys)}, got {sorted(actual_job_keys)}")
+    _assert_trusted_prefix(text, job_name, step_name)
 
     step = named_step(text, job_name, step_name)
     step_entries = _direct_mapping(step)
@@ -329,6 +460,67 @@ def assert_oci_candidate_checker(mod) -> None:
 def assert_combined_unittest(text: str) -> None:
     assert_hard_run_command(
         text, "activation-kit", "Run activation-kit contract tests")
+
+
+TRUSTED_PREFIX_WRITERS = (
+    (
+        "BASH_ENV writer",
+        "      - name: Preload Bash functions\n"
+        "        run: |\n"
+        "          printf '%s\\n' 'test() { return 0; }' "
+        "'python3() { return 0; }' > \"$RUNNER_TEMP/bash-env\"\n"
+        "          echo \"BASH_ENV=$RUNNER_TEMP/bash-env\" >> \"$GITHUB_ENV\"\n\n",
+    ),
+    (
+        "PATH writer",
+        "      - name: Prepend executable path\n"
+        "        run: echo \"$RUNNER_TEMP/bin\" >> \"$GITHUB_PATH\"\n\n",
+    ),
+    (
+        "Git and Python path writer",
+        "      - name: Redirect Git and Python\n"
+        "        run: |\n"
+        "          echo \"GIT_DIR=$RUNNER_TEMP/base.git\" >> \"$GITHUB_ENV\"\n"
+        "          echo \"PYTHONPATH=$RUNNER_TEMP/base\" >> \"$GITHUB_ENV\"\n\n",
+    ),
+)
+
+
+def trusted_prefix_mutations(
+        text: str, target_line: str, checkout: str, setup: str):
+    mutations = [
+        (label, text.replace(target_line, writer + target_line, 1))
+        for label, writer in TRUSTED_PREFIX_WRITERS
+    ]
+    mutations.extend((
+        ("checkout env", text.replace(
+            checkout, checkout.replace(
+                "        with:\n", "        env:\n          EXTRA: value\n        with:\n",
+                1), 1)),
+        ("checkout with", text.replace(
+            checkout, checkout.replace(
+                "          persist-credentials: false\n",
+                "          persist-credentials: false\n          extra: value\n", 1), 1)),
+        ("checkout mutable ref", text.replace(
+            checkout, checkout.replace(CHECKOUT_REF, "actions/checkout@main", 1), 1)),
+        ("setup if", text.replace(
+            setup, setup.replace("        with:\n", "        if: always()\n        with:\n", 1),
+            1)),
+        ("setup continue", text.replace(
+            setup, setup.replace(
+                "        with:\n", "        continue-on-error: true\n        with:\n", 1),
+            1)),
+        ("setup with", text.replace(
+            setup, re.sub(
+                r'(          python-version:.*\n)', r'\1          cache: pip\n',
+                setup, count=1), 1)),
+        ("setup mutable ref", text.replace(
+            setup, setup.replace(SETUP_PYTHON_REF, "actions/setup-python@main", 1), 1)),
+    ))
+    reordered = text.replace(checkout, "__CHECKOUT__", 1)
+    reordered = reordered.replace(setup, checkout, 1).replace("__CHECKOUT__", setup, 1)
+    mutations.append(("reordered prefix", reordered))
+    return mutations
 
 
 POLICIES = {
@@ -665,6 +857,25 @@ class ProductCallsite(unittest.TestCase):
                 self.assertNotEqual(mutated, text)
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(mutated)
+
+    def test_activation_trusted_prefix_fails_closed(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        target = "      - name: Run activation-kit contract tests\n"
+        checkout = named_step(text, "activation-kit", "Check out source")
+        setup = named_step(text, "activation-kit", "Set up Python")
+        for label, mutated in trusted_prefix_mutations(
+                text, target, checkout, setup):
+            with self.subTest(label=label):
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
+
+        target_step = named_step(
+            text, "activation-kit", "Run activation-kit contract tests")
+        post_target = target_step + (
+            "      - name: Harmless post-target control\n"
+            "        run: echo harmless\n\n")
+        assert_combined_unittest(text.replace(target_step, post_target, 1))
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -58,7 +58,7 @@ HARD_RUN_CONTRACTS = {
     ),
     ("activation-kit", "Run activation-kit contract tests"): (
         frozenset({"runs-on", "steps"}),
-        frozenset({"name", "run"}),
+        frozenset({"name", "shell", "run"}),
         ACTIVATION_KIT_RUN_SCRIPT,
     ),
 }
@@ -138,34 +138,68 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
-DIRECT_KEY_RE = re.compile(
+DIRECT_ENTRY_RE = re.compile(
     r"^(?:(?P<plain>[A-Za-z0-9_-]+)|'(?P<single>[A-Za-z0-9_-]+)'|"
-    r'"(?P<double>[A-Za-z0-9_-]+)")\s*:')
+    r'"(?P<double>[A-Za-z0-9_-]+)")\s*:(?P<value>.*)$')
 
 
-def _direct_mapping_keys(block: str) -> frozenset[str]:
+def _direct_mapping(block: str) -> dict[str, str]:
     lines = block.splitlines()
+    if not lines:
+        raise AssertionError("empty mapping block")
     block_indent = len(lines[0]) - len(lines[0].lstrip(" "))
-    direct_indent = block_indent + 2
-    keys: set[str] = set()
+    sequence_item = lines[0][block_indent:].startswith("- ")
+    direct_indent = block_indent + 2 if sequence_item else None
+    if direct_indent is None:
+        for line in lines[1:]:
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            direct_indent = len(line) - len(line.lstrip(" "))
+            if direct_indent <= block_indent:
+                raise AssertionError("mapping block has no indented entry")
+            break
+    if direct_indent is None:
+        raise AssertionError("mapping block has no direct entries")
+
+    entries: dict[str, str] = {}
     for index, line in enumerate(lines):
         if not line.strip() or line.lstrip().startswith("#"):
             continue
         indent = len(line) - len(line.lstrip(" "))
-        if index == 0 and indent == block_indent and line[indent:].startswith("- "):
+        if index == 0 and sequence_item:
             direct = line[indent + 2:]
         elif indent == direct_indent:
             direct = line[direct_indent:]
+        elif block_indent < indent < direct_indent:
+            raise AssertionError("inconsistent direct mapping indentation")
         else:
             continue
-        match = DIRECT_KEY_RE.match(direct)
+        match = DIRECT_ENTRY_RE.fullmatch(direct)
         if match is None:
             raise AssertionError(f"unrecognized direct mapping key syntax: {direct!r}")
-        key = next(value for value in match.groupdict().values() if value is not None)
-        if key in keys:
+        key = next(match.group(name) for name in ("plain", "single", "double")
+                   if match.group(name) is not None)
+        if key in entries:
             raise AssertionError(f"duplicate direct mapping key: {key}")
-        keys.add(key)
-    return frozenset(keys)
+        entries[key] = match.group("value")
+    return entries
+
+
+def _direct_scalar(raw: str) -> str:
+    value = raw.strip()
+    if re.fullmatch(r"[A-Za-z0-9_.-]+", value):
+        return value
+    if re.fullmatch(r"'(?:[^']|'')*'", value):
+        return value[1:-1].replace("''", "'")
+    if value.startswith('"') and value.endswith('"'):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"unsupported direct scalar syntax: {raw!r}") from error
+        if isinstance(parsed, str):
+            return parsed
+    raise AssertionError(f"unsupported direct scalar syntax: {raw!r}")
 
 
 def assert_hard_run_command(
@@ -176,16 +210,21 @@ def assert_hard_run_command(
     allowed_job_keys, allowed_step_keys, expected_script = contract
 
     job = named_job(text, job_name)
-    unexpected_job_keys = _direct_mapping_keys(job) - allowed_job_keys
-    if unexpected_job_keys:
+    actual_job_keys = frozenset(_direct_mapping(job))
+    if actual_job_keys != allowed_job_keys:
         raise AssertionError(
-            f"{job_name} job has unexpected direct keys: {sorted(unexpected_job_keys)}")
+            f"{job_name} job direct keys differ: "
+            f"expected {sorted(allowed_job_keys)}, got {sorted(actual_job_keys)}")
 
     step = named_step(text, job_name, step_name)
-    unexpected_step_keys = _direct_mapping_keys(step) - allowed_step_keys
-    if unexpected_step_keys:
+    step_entries = _direct_mapping(step)
+    actual_step_keys = frozenset(step_entries)
+    if actual_step_keys != allowed_step_keys:
         raise AssertionError(
-            f"{step_name} has unexpected direct keys: {sorted(unexpected_step_keys)}")
+            f"{step_name} direct keys differ: "
+            f"expected {sorted(allowed_step_keys)}, got {sorted(actual_step_keys)}")
+    if _direct_scalar(step_entries["shell"]) != "bash":
+        raise AssertionError(f"{step_name} must use shell: bash")
 
     active = tuple(_active_run_lines(step))
     if active != expected_script:
@@ -430,14 +469,14 @@ class ProductCallsite(unittest.TestCase):
             "    'steps': []\n"
         )
         self.assertEqual(
-            _direct_mapping_keys(block),
+            frozenset(_direct_mapping(block)),
             frozenset({"runs-on", "outputs", "steps"}),
         )
 
     def test_direct_key_parser_fails_closed_on_unrecognized_syntax(self):
         block = "  scope:\n    ? [if]\n    : false\n"
         with self.assertRaises(AssertionError):
-            _direct_mapping_keys(block)
+            _direct_mapping(block)
 
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -509,6 +548,53 @@ class ProductCallsite(unittest.TestCase):
             with self.subTest(index=index):
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(mutated)
+
+    def test_activation_kit_step_uses_explicit_bash(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        step = named_step(
+            text,
+            "activation-kit",
+            "Run activation-kit contract tests",
+        )
+        self.assertIn("        shell: bash\n", step)
+        mutations = (
+            step.replace(
+                "        shell: bash\n",
+                "        shell: bash -c 'true' -- {0}\n",
+                1,
+            ),
+            step.replace("        shell: bash\n", "", 1),
+        )
+        for index, mutated_step in enumerate(mutations):
+            with self.subTest(index=index):
+                self.assertNotEqual(mutated_step, step)
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(text.replace(step, mutated_step, 1))
+
+    def test_explicit_activation_shell_overrides_workflow_default(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "permissions:\n",
+            "defaults:\n"
+            "  run:\n"
+            "    shell: bash -c 'true' -- {0}\n\n"
+            "permissions:\n",
+            1,
+        )
+        self.assertNotEqual(mutated, text)
+        assert_combined_unittest(mutated)
+
+    def test_wider_indented_conditional_activation_job_fails(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        job = named_job(text, "activation-kit")
+        lines = job.splitlines(keepends=True)
+        widened = (
+            lines[0]
+            + "      if: ${{ github.event_name == 'disabled' }}\n"
+            + "".join("  " + line if line.strip() else line for line in lines[1:])
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(text.replace(job, widened, 1))
 
     def test_conditional_activation_kit_step_fails_the_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -60,11 +60,15 @@ HARD_RUN_CONTRACTS = {
                    "outputs", "steps"}),
         frozenset({"name", "shell", "run"}),
         INVENTORY_RUN_SCRIPT,
+        frozenset({"name", "on", "permissions", "env", "jobs"}),
+        frozenset({"ASSAY_PUBLIC_MSRV"}),
     ),
     ("activation-kit", "Run activation-kit contract tests"): (
         frozenset({"runs-on", "steps"}),
         frozenset({"name", "shell", "run"}),
         ACTIVATION_KIT_RUN_SCRIPT,
+        frozenset({"name", "on", "permissions", "concurrency", "jobs"}),
+        frozenset(),
     ),
 }
 ACTIVATION_KIT = (
@@ -190,9 +194,20 @@ def _direct_mapping(block: str) -> dict[str, str]:
     return entries
 
 
-def _assert_no_workflow_bash_env(text: str) -> None:
+def _assert_workflow_document(
+        text: str,
+        expected_keys: frozenset[str],
+        expected_env_keys: frozenset[str]) -> None:
     lines = text.splitlines(keepends=True)
-    env_indexes: list[int] = []
+    document = "document:\n" + "".join(
+        "  " + line if line.strip() else line for line in lines)
+    actual_keys = frozenset(_direct_mapping(document))
+    if actual_keys != expected_keys:
+        raise AssertionError(
+            "workflow top-level keys differ: "
+            f"expected {sorted(expected_keys)}, got {sorted(actual_keys)}")
+
+    env_index = None
     for index, raw in enumerate(lines):
         line = raw.rstrip("\r\n")
         if not line or line.startswith((" ", "#")):
@@ -206,14 +221,15 @@ def _assert_no_workflow_bash_env(text: str) -> None:
             continue
         if match.group("value").strip():
             raise AssertionError("workflow env must use a direct mapping")
-        env_indexes.append(index)
-    if len(env_indexes) > 1:
-        raise AssertionError("workflow has duplicate top-level env mappings")
-    if not env_indexes:
-        return
-    env_block = _indentation_bounded_block(lines, env_indexes[0], 0)
-    if "BASH_ENV" in _direct_mapping(env_block):
-        raise AssertionError("workflow-level BASH_ENV can neutralize hard-run scripts")
+        env_index = index
+    actual_env_keys = frozenset()
+    if env_index is not None:
+        env_block = _indentation_bounded_block(lines, env_index, 0)
+        actual_env_keys = frozenset(_direct_mapping(env_block))
+    if actual_env_keys != expected_env_keys:
+        raise AssertionError(
+            "workflow env keys differ: "
+            f"expected {sorted(expected_env_keys)}, got {sorted(actual_env_keys)}")
 
 
 def _direct_scalar(raw: str) -> str:
@@ -238,8 +254,9 @@ def assert_hard_run_command(
     contract = HARD_RUN_CONTRACTS.get((job_name, step_name))
     if contract is None:
         raise AssertionError(f"no hard-run contract for {job_name}/{step_name}")
-    allowed_job_keys, allowed_step_keys, expected_script = contract
-    _assert_no_workflow_bash_env(text)
+    (allowed_job_keys, allowed_step_keys, expected_script,
+     workflow_keys, workflow_env_keys) = contract
+    _assert_workflow_document(text, workflow_keys, workflow_env_keys)
 
     job = named_job(text, job_name)
     actual_job_keys = frozenset(_direct_mapping(job))
@@ -629,21 +646,25 @@ class ProductCallsite(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
 
-    def test_activation_workflow_bash_env_fails_closed(self):
+    def test_activation_workflow_document_shape_fails_closed(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
-        mutated = text.replace(
-            "permissions:\n",
-            "env:\n  BASH_ENV: /tmp/assay-bash-env\n\npermissions:\n",
-            1,
+        mutations = (
+            ("BASH_ENV", "env:\n  BASH_ENV: /tmp/assay-bash-env\n\n"),
+            ("PATH", "env:\n  PATH: /tmp\n\n"),
+            ("quoted GIT_DIR", "env:\n  'GIT_DIR': /tmp/repo\n\n"),
+            ("unrelated env", "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n\n"),
+            (
+                "defaults working-directory",
+                "defaults:\n  run:\n    working-directory: /tmp\n\n",
+            ),
         )
-        with self.assertRaises(AssertionError):
-            assert_combined_unittest(mutated)
-        control = text.replace(
-            "permissions:\n",
-            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n\npermissions:\n",
-            1,
-        )
-        assert_combined_unittest(control)
+        for label, addition in mutations:
+            with self.subTest(label=label):
+                mutated = text.replace(
+                    "permissions:\n", addition + "permissions:\n", 1)
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
@@ -666,19 +687,6 @@ class ProductCallsite(unittest.TestCase):
                 self.assertNotEqual(mutated_step, step)
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(text.replace(step, mutated_step, 1))
-
-    def test_explicit_activation_shell_overrides_workflow_default(self):
-        text = CONFORMANCE_YML.read_text(encoding="utf-8")
-        mutated = text.replace(
-            "permissions:\n",
-            "defaults:\n"
-            "  run:\n"
-            "    shell: bash -c 'true' -- {0}\n\n"
-            "permissions:\n",
-            1,
-        )
-        self.assertNotEqual(mutated, text)
-        assert_combined_unittest(mutated)
 
     def test_wider_indented_conditional_activation_job_fails(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -29,6 +29,14 @@ JOB_KEY_RE = re.compile(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:")
 REQUIRED_RUN_ALL = (
     "python3 conformance/run_all.py --require-complete --completion-scope required"
 )
+CONFORMANCE_YML = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
+KIT_STEP_RE = re.compile(
+    r"(?ms)^      - name: Run activation-kit contract tests\n(?:        .+\n)+")
+COMBINED_UNITTEST = (
+    "          python3 -m unittest \\\n"
+    "            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
+    "            conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py"
+)
 
 
 def _scope_job(text: str) -> str:
@@ -63,6 +71,30 @@ def _active_run_lines(step: str) -> list[str]:
             continue
         lines.append(stripped)
     return lines
+
+
+def _kit_step(text: str) -> str:
+    step = KIT_STEP_RE.search(text)
+    if step is None:
+        raise AssertionError("conformance workflow missing kit contract step")
+    return step.group(0)
+
+
+def assert_combined_unittest(step: str) -> None:
+    if COMBINED_UNITTEST not in step:
+        raise AssertionError("combined unittest command missing")
+    lines = _active_run_lines(step)
+    joined = "\n".join(lines)
+    if "python3 -m unittest" not in joined:
+        raise AssertionError("combined unittest is not active")
+    if "test_activation_kit.py" not in joined:
+        raise AssertionError("activation kit is not active")
+    if "test_oci_candidate_executor.py" not in joined:
+        raise AssertionError("executor kit is not active")
+    if "|| true" in step or "|| :" in step or "continue-on-error" in step:
+        raise AssertionError("combined unittest is neutralized")
+    if any(ln == "set +e" or ln.startswith("set +e ") for ln in lines):
+        raise AssertionError("kit contract step disables -e")
 
 
 POLICIES = {
@@ -289,6 +321,33 @@ class ProductCallsite(unittest.TestCase):
         source = Path(registry.__file__).read_text(encoding="utf-8")
         self.assertNotRegex(source, r"returncode in \(0, 3\)")
         self.assertNotIn("if completed.returncode in (0, 3)", source)
+
+    def test_deleting_registry_suite_callsite_fails(self):
+        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        self.assertTrue(any("conformance/tests/test_registry.py" in ln
+                            for ln in _active_run_lines(step)))
+        mutated = step.replace("conformance/tests/test_registry.py", "")
+        self.assertFalse(any("conformance/tests/test_registry.py" in ln
+                             for ln in _active_run_lines(mutated)))
+
+    def test_conformance_combined_unittest_is_a_hard_callsite(self):
+        step = _kit_step(CONFORMANCE_YML.read_text(encoding="utf-8"))
+        assert_combined_unittest(step)
+        assert_combined_unittest(step.replace("no-such-token", "no-such-token"))
+        name = "      - name: Run activation-kit contract tests\n"
+        mutations = (
+            step.replace(COMBINED_UNITTEST, "          true"),
+            step.replace("          python3 -m unittest \\",
+                         "          # python3 -m unittest \\"),
+            step.replace(COMBINED_UNITTEST, "          :"),
+            step.replace("test_activation_kit.py", ""),
+            step.replace("test_oci_candidate_executor.py", ""),
+            step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || true"),
+            step.replace(name, name + "        continue-on-error: true\n"),
+        )
+        for mutated in mutations:
+            with self.assertRaises(AssertionError):
+                assert_combined_unittest(mutated)
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_pma_v0_registration.py
+++ b/conformance/tests/test_pma_v0_registration.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-"""#206: one opt-in pma-v0-repro registry row, plus PMA delivery wiring.
+"""#206: one opt-in pma-v0-repro registry row.
 
     python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
 
 A digest addresses bytes. This test does not pull, run, or endorse the image.
 Generic schema rejection lives in test_implementations.py.
-Required CI also pins that privileged-mcp-action-conformance.yml still
-invokes both kit files in one unittest command.
 """
 
 from __future__ import annotations
@@ -37,26 +35,9 @@ CONSENT_URL = (
 ROW_ID = "pma-v0-repro"
 MODEL = "Grok Bot"
 CI_YML = REPO / ".github/workflows/ci.yml"
-CONFORMANCE_WORKFLOW = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
 CI_COMMAND = (
     "python3 -W error::ResourceWarning "
     "conformance/tests/test_pma_v0_registration.py"
-)
-ACTIVATION_KIT = (
-    "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
-)
-EXECUTOR_KIT = (
-    "conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py"
-)
-COMBINED_UNITTEST = (
-    "          python3 -m unittest \\\n"
-    f"            {ACTIVATION_KIT} \\\n"
-    f"            {EXECUTOR_KIT}"
-)
-COMBINED_UNITTEST_RE = re.compile(
-    r"python3 -m unittest \\\n"
-    rf"\s+{re.escape(ACTIVATION_KIT)} \\\n"
-    rf"\s+{re.escape(EXECUTOR_KIT)}"
 )
 INVENTORY_STEP_RE = re.compile(
     r"(?ms)^      - name: Conformance inventory\n(?:        .+\n)+"
@@ -123,47 +104,6 @@ class RequiredCi(unittest.TestCase):
         step = _inventory_step()
         self.assertIn(CI_COMMAND, step)
         self.assertNotIn("continue-on-error", step)
-
-
-class PmaDeliveryWiring(unittest.TestCase):
-    """Required-CI pin of PMA delivery: both kit files in one unittest command."""
-
-    def _assert_combined_command(self, text: str) -> None:
-        self.assertIn("test_activation_kit.py", text)
-        self.assertIn("test_oci_candidate_executor.py", text)
-        self.assertRegex(text, COMBINED_UNITTEST_RE)
-
-    def test_conformance_workflow_runs_both_kit_files(self) -> None:
-        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
-        self._assert_combined_command(text)
-
-    def test_replacing_combined_command_with_true_is_rejected(self) -> None:
-        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn(COMBINED_UNITTEST, text)
-        mutated = text.replace(COMBINED_UNITTEST, "          true", 1)
-        with self.assertRaises(AssertionError):
-            self._assert_combined_command(mutated)
-
-    def test_removing_only_activation_arg_is_rejected(self) -> None:
-        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
-        mutated = text.replace(f"            {ACTIVATION_KIT} \\\n", "", 1)
-        with self.assertRaises(AssertionError):
-            self._assert_combined_command(mutated)
-
-    def test_removing_only_executor_arg_is_rejected(self) -> None:
-        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
-        mutated = text.replace(f"            {EXECUTOR_KIT}\n", "", 1)
-        with self.assertRaises(AssertionError):
-            self._assert_combined_command(mutated)
-
-    def test_reverse_and_noop_remain_green(self) -> None:
-        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
-        self._assert_combined_command(text)
-        mutated = text.replace(COMBINED_UNITTEST, "          true", 1)
-        self.assertNotEqual(mutated, text)
-        with self.assertRaises(AssertionError):
-            self._assert_combined_command(mutated)
-        self._assert_combined_command(text)
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_pma_v0_registration.py
+++ b/conformance/tests/test_pma_v0_registration.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""#206: one opt-in pma-v0-repro registry row.
+"""#206: one opt-in pma-v0-repro registry row, plus PMA delivery wiring.
 
     python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
 
 A digest addresses bytes. This test does not pull, run, or endorse the image.
 Generic schema rejection lives in test_implementations.py.
+Required CI also pins that privileged-mcp-action-conformance.yml still
+invokes both kit files in one unittest command.
 """
 
 from __future__ import annotations
@@ -35,9 +37,26 @@ CONSENT_URL = (
 ROW_ID = "pma-v0-repro"
 MODEL = "Grok Bot"
 CI_YML = REPO / ".github/workflows/ci.yml"
+CONFORMANCE_WORKFLOW = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
 CI_COMMAND = (
     "python3 -W error::ResourceWarning "
     "conformance/tests/test_pma_v0_registration.py"
+)
+ACTIVATION_KIT = (
+    "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
+)
+EXECUTOR_KIT = (
+    "conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py"
+)
+COMBINED_UNITTEST = (
+    "          python3 -m unittest \\\n"
+    f"            {ACTIVATION_KIT} \\\n"
+    f"            {EXECUTOR_KIT}"
+)
+COMBINED_UNITTEST_RE = re.compile(
+    r"python3 -m unittest \\\n"
+    rf"\s+{re.escape(ACTIVATION_KIT)} \\\n"
+    rf"\s+{re.escape(EXECUTOR_KIT)}"
 )
 INVENTORY_STEP_RE = re.compile(
     r"(?ms)^      - name: Conformance inventory\n(?:        .+\n)+"
@@ -104,6 +123,47 @@ class RequiredCi(unittest.TestCase):
         step = _inventory_step()
         self.assertIn(CI_COMMAND, step)
         self.assertNotIn("continue-on-error", step)
+
+
+class PmaDeliveryWiring(unittest.TestCase):
+    """Required-CI pin of PMA delivery: both kit files in one unittest command."""
+
+    def _assert_combined_command(self, text: str) -> None:
+        self.assertIn("test_activation_kit.py", text)
+        self.assertIn("test_oci_candidate_executor.py", text)
+        self.assertRegex(text, COMBINED_UNITTEST_RE)
+
+    def test_conformance_workflow_runs_both_kit_files(self) -> None:
+        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
+        self._assert_combined_command(text)
+
+    def test_replacing_combined_command_with_true_is_rejected(self) -> None:
+        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(COMBINED_UNITTEST, text)
+        mutated = text.replace(COMBINED_UNITTEST, "          true", 1)
+        with self.assertRaises(AssertionError):
+            self._assert_combined_command(mutated)
+
+    def test_removing_only_activation_arg_is_rejected(self) -> None:
+        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
+        mutated = text.replace(f"            {ACTIVATION_KIT} \\\n", "", 1)
+        with self.assertRaises(AssertionError):
+            self._assert_combined_command(mutated)
+
+    def test_removing_only_executor_arg_is_rejected(self) -> None:
+        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
+        mutated = text.replace(f"            {EXECUTOR_KIT}\n", "", 1)
+        with self.assertRaises(AssertionError):
+            self._assert_combined_command(mutated)
+
+    def test_reverse_and_noop_remain_green(self) -> None:
+        text = CONFORMANCE_WORKFLOW.read_text(encoding="utf-8")
+        self._assert_combined_command(text)
+        mutated = text.replace(COMBINED_UNITTEST, "          true", 1)
+        self.assertNotEqual(mutated, text)
+        with self.assertRaises(AssertionError):
+            self._assert_combined_command(mutated)
+        self._assert_combined_command(text)
 
 
 if __name__ == "__main__":

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -377,6 +377,28 @@ class ProductWorkflow(unittest.TestCase):
             assert_hard_run_command(
                 mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
+    def test_conditional_scope_job_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  scope:\n",
+            "  scope:\n    if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+
+    def test_softened_scope_job_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  scope:\n",
+            "  scope:\n    continue-on-error: true\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+
     def test_relocated_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
         mutated = text.replace("          " + RUN_ALL_COMMAND, "          :", 1).replace(

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -27,15 +27,14 @@ sys.path.insert(0, str(REPO / "conformance/tests"))
 
 import registry  # noqa: E402
 import run_all  # noqa: E402
-from test_completion_scope import assert_hard_run_command, named_step  # noqa: E402
+from test_completion_scope import (  # noqa: E402
+    REQUIRED_RUN_ALL,
+    assert_hard_run_command,
+    named_step,
+)
 
 CI_YML = REPO / ".github/workflows/ci.yml"
 STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
-RUN_ALL_COMMAND = (
-    "python3 conformance/run_all.py --require-complete --completion-scope required"
-)
-
-
 POLICIES = ("required", "optional", "external-candidate")
 
 
@@ -326,7 +325,7 @@ class ProductWorkflow(unittest.TestCase):
     def test_scope_job_invokes_require_complete_as_a_hard_check(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+            text, "scope", "Conformance inventory")
         self.assertIn("python3 conformance/registry.py", step)
 
     def test_scope_job_invokes_completion_scope_suite(self):
@@ -365,17 +364,17 @@ class ProductWorkflow(unittest.TestCase):
 
     def test_commented_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace(RUN_ALL_COMMAND, "# " + RUN_ALL_COMMAND, 1)
+        mutated = text.replace(REQUIRED_RUN_ALL, "# " + REQUIRED_RUN_ALL, 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
     def test_softened_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace(RUN_ALL_COMMAND, RUN_ALL_COMMAND + " || true", 1)
+        mutated = text.replace(REQUIRED_RUN_ALL, REQUIRED_RUN_ALL + " || true", 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -386,7 +385,7 @@ class ProductWorkflow(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
     def test_softened_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -397,21 +396,64 @@ class ProductWorkflow(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
+
+    def test_quoted_scope_job_and_inventory_step_keys_fail(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        job = "  scope:\n"
+        step = "      - name: Conformance inventory\n"
+        mutations = (
+            ("job double if", job,
+             job + "    \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("job single continue", job,
+             job + "    'continue-on-error': true\n"),
+            ("step double if", step,
+             step + "        \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("step single continue", step,
+             step + "        'continue-on-error': true\n"),
+        )
+        for label, needle, replacement in mutations:
+            with self.subTest(label=label):
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        text.replace(needle, replacement, 1),
+                        "scope", "Conformance inventory")
+
+    def test_shell_neutralizers_fail_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutations = (
+            step.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          set +o errexit\n",
+                1,
+            ).replace(REQUIRED_RUN_ALL, REQUIRED_RUN_ALL + "\n          true", 1),
+            step.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          python3() { :; }\n",
+                1,
+            ),
+        )
+        for index, mutated_step in enumerate(mutations):
+            with self.subTest(index=index):
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        text.replace(step, mutated_step, 1),
+                        "scope", "Conformance inventory")
 
     def test_relocated_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace("          " + RUN_ALL_COMMAND, "          :", 1).replace(
+        mutated = text.replace("          " + REQUIRED_RUN_ALL, "          :", 1).replace(
             "      - name: Published-numbers projection contract\n",
             "      - name: Decorative completion-scope note\n"
             "        run: |\n"
-            f"          {RUN_ALL_COMMAND}\n\n"
+            f"          {REQUIRED_RUN_ALL}\n\n"
             "      - name: Published-numbers projection contract\n",
             1,
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
 
 class RegistryDoesNotRunAll(unittest.TestCase):

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -24,32 +23,17 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "conformance"))
+sys.path.insert(0, str(REPO / "conformance/tests"))
 
 import registry  # noqa: E402
 import run_all  # noqa: E402
+from test_completion_scope import assert_hard_run_command, named_step  # noqa: E402
 
 CI_YML = REPO / ".github/workflows/ci.yml"
 STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
-INVENTORY_STEP_RE = re.compile(r"(?ms)^      - name: Conformance inventory\n(?:        .+\n)+")
-JOB_KEY_RE = re.compile(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:")
-
-
-def _scope_job(text: str) -> str:
-    lines = text.splitlines(keepends=True)
-    start = next((i for i, line in enumerate(lines) if line.startswith("  scope:")), None)
-    if start is None:
-        raise AssertionError("ci.yml missing scope job")
-    end = start + 1
-    while end < len(lines) and not JOB_KEY_RE.match(lines[end]):
-        end += 1
-    return "".join(lines[start:end])
-
-
-def _inventory_step(text: str) -> str:
-    step = INVENTORY_STEP_RE.search(_scope_job(text))
-    if step is None:
-        raise AssertionError("scope job missing Conformance inventory step")
-    return step.group(0)
+RUN_ALL_COMMAND = (
+    "python3 conformance/run_all.py --require-complete --completion-scope required"
+)
 
 
 POLICIES = ("required", "optional", "external-candidate")
@@ -340,13 +324,14 @@ class ProductWorkflow(unittest.TestCase):
         self.assertFalse(STANDALONE.exists(), STANDALONE)
 
     def test_scope_job_invokes_require_complete_as_a_hard_check(self):
-        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        text = CI_YML.read_text(encoding="utf-8")
+        step = assert_hard_run_command(
+            text, "Conformance inventory", RUN_ALL_COMMAND)
         self.assertIn("python3 conformance/registry.py", step)
-        self.assertIn("conformance/run_all.py --require-complete --completion-scope required", step)
-        self.assertNotIn("continue-on-error", step)
 
     def test_scope_job_invokes_completion_scope_suite(self):
-        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        step = named_step(
+            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
         self.assertIn("conformance/tests/test_completion_scope.py", step)
         mutated = step.replace("conformance/tests/test_completion_scope.py", "")
         self.assertNotEqual(mutated, step)
@@ -355,13 +340,49 @@ class ProductWorkflow(unittest.TestCase):
     def test_deleting_the_scope_job_callsite_fails_this_test(self):
         text = CI_YML.read_text(encoding="utf-8")
         with self.assertRaises(AssertionError):
-            _inventory_step(INVENTORY_STEP_RE.sub("", text))
+            named_step(
+                text.replace(
+                    "      - name: Conformance inventory\n",
+                    "      - name: Deleted conformance inventory\n",
+                    1,
+                ),
+                "Conformance inventory",
+            )
 
     def test_deleting_the_require_complete_callsite_fails_this_test(self):
-        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        step = named_step(
+            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
         mutated = step.replace("--require-complete", "")
         self.assertNotEqual(mutated, step)
         self.assertNotIn("--require-complete", mutated)
+
+    def test_commented_run_all_command_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(RUN_ALL_COMMAND, "# " + RUN_ALL_COMMAND, 1)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+
+    def test_softened_run_all_command_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(RUN_ALL_COMMAND, RUN_ALL_COMMAND + " || true", 1)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+
+    def test_relocated_run_all_command_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace("          " + RUN_ALL_COMMAND, "          :", 1).replace(
+            "      - name: Published-numbers projection contract\n",
+            "      - name: Decorative completion-scope note\n"
+            "        run: |\n"
+            f"          {RUN_ALL_COMMAND}\n\n"
+            "      - name: Published-numbers projection contract\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "Conformance inventory", RUN_ALL_COMMAND)
 
 
 class RegistryDoesNotRunAll(unittest.TestCase):

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -29,6 +29,7 @@ import registry  # noqa: E402
 import run_all  # noqa: E402
 from test_completion_scope import (  # noqa: E402
     REQUIRED_RUN_ALL,
+    REVISION_WITNESS,
     assert_hard_run_command,
     named_job,
     named_step,
@@ -376,6 +377,18 @@ class ProductWorkflow(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
                 mutated, "scope", "Conformance inventory")
+
+    def test_removing_scope_revision_witness_fails(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutated_step = step.replace("          " + REVISION_WITNESS + "\n", "", 1)
+        self.assertNotEqual(mutated_step, step)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace(step, mutated_step, 1),
+                "scope",
+                "Conformance inventory",
+            )
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -390,6 +390,24 @@ class ProductWorkflow(unittest.TestCase):
                 "Conformance inventory",
             )
 
+    def test_scope_workflow_bash_env_fails_closed(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "env:\n",
+            "env:\n  BASH_ENV: /tmp/assay-bash-env\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory")
+        control = text.replace(
+            "env:\n",
+            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n",
+            1,
+        )
+        assert_hard_run_command(
+            control, "scope", "Conformance inventory")
+
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
         mutated = text.replace(

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -30,6 +30,7 @@ import run_all  # noqa: E402
 from test_completion_scope import (  # noqa: E402
     REQUIRED_RUN_ALL,
     assert_hard_run_command,
+    named_job,
     named_step,
 )
 
@@ -397,6 +398,44 @@ class ProductWorkflow(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
                 mutated, "scope", "Conformance inventory")
+
+    def test_wider_indented_conditional_scope_job_fails(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        job = named_job(text, "scope")
+        lines = job.splitlines(keepends=True)
+        widened = (
+            lines[0]
+            + "      if: ${{ github.event_name == 'disabled' }}\n"
+            + "".join("  " + line if line.strip() else line for line in lines[1:])
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace(job, widened, 1),
+                "scope",
+                "Conformance inventory",
+            )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace("    timeout-minutes: 10\n", "", 1),
+                "scope",
+                "Conformance inventory",
+            )
+
+    def test_custom_scope_shell_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutated_step = step.replace(
+            "        shell: bash\n",
+            "        shell: bash -c 'true' -- {0}\n",
+            1,
+        )
+        self.assertNotEqual(mutated_step, step)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace(step, mutated_step, 1),
+                "scope",
+                "Conformance inventory",
+            )
 
     def test_quoted_scope_job_and_inventory_step_keys_fail(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -326,12 +326,15 @@ class ProductWorkflow(unittest.TestCase):
     def test_scope_job_invokes_require_complete_as_a_hard_check(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "Conformance inventory", RUN_ALL_COMMAND)
+            text, "scope", "Conformance inventory", RUN_ALL_COMMAND)
         self.assertIn("python3 conformance/registry.py", step)
 
     def test_scope_job_invokes_completion_scope_suite(self):
         step = named_step(
-            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
+            CI_YML.read_text(encoding="utf-8"),
+            "scope",
+            "Conformance inventory",
+        )
         self.assertIn("conformance/tests/test_completion_scope.py", step)
         mutated = step.replace("conformance/tests/test_completion_scope.py", "")
         self.assertNotEqual(mutated, step)
@@ -346,12 +349,16 @@ class ProductWorkflow(unittest.TestCase):
                     "      - name: Deleted conformance inventory\n",
                     1,
                 ),
+                "scope",
                 "Conformance inventory",
             )
 
     def test_deleting_the_require_complete_callsite_fails_this_test(self):
         step = named_step(
-            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
+            CI_YML.read_text(encoding="utf-8"),
+            "scope",
+            "Conformance inventory",
+        )
         mutated = step.replace("--require-complete", "")
         self.assertNotEqual(mutated, step)
         self.assertNotIn("--require-complete", mutated)
@@ -361,14 +368,14 @@ class ProductWorkflow(unittest.TestCase):
         mutated = text.replace(RUN_ALL_COMMAND, "# " + RUN_ALL_COMMAND, 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
     def test_softened_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
         mutated = text.replace(RUN_ALL_COMMAND, RUN_ALL_COMMAND + " || true", 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
     def test_relocated_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -382,7 +389,7 @@ class ProductWorkflow(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
 
 class RegistryDoesNotRunAll(unittest.TestCase):

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -345,6 +345,13 @@ class ProductWorkflow(unittest.TestCase):
         self.assertIn("conformance/run_all.py --require-complete --completion-scope required", step)
         self.assertNotIn("continue-on-error", step)
 
+    def test_scope_job_invokes_completion_scope_suite(self):
+        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        self.assertIn("conformance/tests/test_completion_scope.py", step)
+        mutated = step.replace("conformance/tests/test_completion_scope.py", "")
+        self.assertNotEqual(mutated, step)
+        self.assertNotIn("conformance/tests/test_completion_scope.py", mutated)
+
     def test_deleting_the_scope_job_callsite_fails_this_test(self):
         text = CI_YML.read_text(encoding="utf-8")
         with self.assertRaises(AssertionError):

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -390,23 +390,37 @@ class ProductWorkflow(unittest.TestCase):
                 "Conformance inventory",
             )
 
-    def test_scope_workflow_bash_env_fails_closed(self):
+    def test_scope_workflow_document_shape_fails_closed(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace(
-            "env:\n",
-            "env:\n  BASH_ENV: /tmp/assay-bash-env\n",
+        env_mutations = (
+            ("BASH_ENV", "  BASH_ENV: /tmp/assay-bash-env\n"),
+            ("PATH", "  PATH: /tmp\n"),
+            ("quoted GIT_DIR", "  'GIT_DIR': /tmp/repo\n"),
+            ("unrelated env", "  UNRELATED_WORKFLOW_ENV: allowed\n"),
+        )
+        for label, addition in env_mutations:
+            with self.subTest(label=label):
+                mutated = text.replace("env:\n", "env:\n" + addition, 1)
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        mutated, "scope", "Conformance inventory")
+        defaults = text.replace(
+            "permissions: {}\n",
+            "defaults:\n  run:\n    working-directory: /tmp\n\npermissions: {}\n",
             1,
         )
+        self.assertNotEqual(defaults, text)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory")
-        control = text.replace(
-            "env:\n",
-            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n",
+                defaults, "scope", "Conformance inventory")
+        value_change = text.replace(
+            '  ASSAY_PUBLIC_MSRV: "1.89.0"\n',
+            '  ASSAY_PUBLIC_MSRV: "9.99.0"\n',
             1,
         )
+        self.assertNotEqual(value_change, text)
         assert_hard_run_command(
-            control, "scope", "Conformance inventory")
+            value_change, "scope", "Conformance inventory")
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -33,6 +33,7 @@ from test_completion_scope import (  # noqa: E402
     assert_hard_run_command,
     named_job,
     named_step,
+    trusted_prefix_mutations,
 )
 
 CI_YML = REPO / ".github/workflows/ci.yml"
@@ -421,6 +422,34 @@ class ProductWorkflow(unittest.TestCase):
         self.assertNotEqual(value_change, text)
         assert_hard_run_command(
             value_change, "scope", "Conformance inventory")
+
+    def test_scope_trusted_prefix_fails_closed(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        target = "      - name: Conformance inventory\n"
+        checkout = (
+            "      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0\n"
+            "        with:\n"
+            "          persist-credentials: false\n"
+            "          fetch-depth: 0\n\n")
+        setup = (
+            "      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0\n"
+            "        with:\n"
+            "          python-version: \"3.12\"\n\n")
+        for label, mutated in trusted_prefix_mutations(
+                text, target, checkout, setup):
+            with self.subTest(label=label):
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        mutated, "scope", "Conformance inventory")
+
+        target_step = named_step(text, "scope", "Conformance inventory")
+        post_target = target_step + (
+            "      - name: Harmless post-target control\n"
+            "        run: echo harmless\n\n")
+        assert_hard_run_command(
+            text.replace(target_step, post_target, 1),
+            "scope", "Conformance inventory")
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")


### PR DESCRIPTION
## Description

Trusted-main OCI capture is a `workflow_dispatch`-only job on hosted `ubuntu-24.04`. It checks out the dispatch SHA, pins Python 3.13.8, validates the candidate-release contract, downloads the attested pack, fail-closes if `source_digest` is not a 40-hex SHA, verifies the pack against the pack-release signer workflow, and writes `candidate_capture.v0` through the checked-in executor. `implementation_id` enters only via `env:` and quoted argv.

The structural contract has three allowlist layers that share one indent-key extractor. Upload `if:` is exact equality `if: success()`. Exactly two active TAG bindings come from the candidate-release resolver. Artifact name is one active line equal to `name: candidate-capture-v0`. A step-field name inside `env:` is an env key, not a parser stop.

Action pins use one exact `uses` helper: the 40-hex token ends before only whitespace or a comment. The same helper detects the upload step. `USES_SHA_RE` reads the full ref token. `on:` must be block-style with exactly `("workflow_dispatch",)` via the existing top-level mapping helper.

Required CI (`test_completion_scope.py::ProductCallsite`) imports and calls the existing `oci_candidate_workflow_problems()` against the committed workflow and a small dangerous-mutation table. The registry↔completion_scope 2-cycle remains the base inventory pin.

PR #2586 (exact-head READY and green on `44e80f227882c8a0a74c8756a485ef80b5bb2f42`) was fast-forwarded into this branch. That stacked slice adds the shared hard-run contract for the required inventory and activation-kit funnels, including the consumed-revision witness. No merge commit, rebase, or squash.

**HEAD:** `44e80f227882c8a0a74c8756a485ef80b5bb2f42`

Measurement provenance: worktree `/Users/roelschuurkes/wt-cursor-204-trusted-main-oci-capture`, SHA `44e80f227882c8a0a74c8756a485ef80b5bb2f42`, tree `ec10219eebba8bbc949c4558724f1882773f15bb`.

Prior review and CI on `2bce5f1ecf24021f3754b9976399b2ea768660c6`, `1592a66cccf81f714ca762be35ac8b3db2b647d9`, and older SHAs are obsolete for this head. Only this exact HEAD is under review.

This branch is frozen for that review. No further commits unless the human asks.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Verification (original #2585 slice)

Measured in worktree `/Users/roelschuurkes/wt-cursor-204-trusted-main-oci-capture` on `2bce5f1ecf24021f3754b9976399b2ea768660c6` (ancestor of this HEAD; not the review SHA):

- Focused OCI workflow contract: **4/4**
- Focused `test_completion_scope.py`: **24/24**
- Activation kit: **59/59**
- Executor: **75/75**
- Combined activation+executor: **134/134**
- `py_compile`, `git diff --check`, `check-yaml`, `actionlint`: clean
- Production OCI workflow bytes unchanged on that slice
- Before fix: suffix `-mutable` on checkout/setup-python/upload-artifact and flow-style `on` with extra `pull_request` each returned `[]` (actionlint-clean)
- After fix: suffix checkout → `unpinned or wrong checkout`; setup-python → `unpinned or wrong setup-python`; upload-artifact → `unpinned or wrong upload-artifact`; flow-style `on` → `missing workflow_dispatch` / `extra trigger` from the shared `on` keys rule; reverse/no-op `[]`
- Required-CI witness: committed workflow `[]`; `if: always()` → `upload not gated on success`; drop `gh attestation verify` → `missing gh attestation verify`; executor bypass → `missing canonical executor`; deleting the checker, contract class, or standalone mutation matrix fails `ProductCallsite`

## Verification (stacked guard, PR #2586)

Integrated by fast-forward only. Evidence is bound to `44e80f227882c8a0a74c8756a485ef80b5bb2f42` (tree `ec10219eebba8bbc949c4558724f1882773f15bb`):

- Independent exact-head READY: https://github.com/Rul1an/assay/pull/2586#issuecomment-5375713136
- Hosted checks on that SHA were green or skipped; `lane-check/proof` reported no delegated proof required
- #2586 merged at 2026-08-21T21:45:42Z after the owner-branch fast-forward

That READY covers the stacked hard-run funnel on this SHA. It is not a review of the full #2585-vs-`main` diff.

## Review ask

Please run exact-head CI and an independent Claude (non-building) review of the **full** #2585-vs-`main` diff on **this SHA** `44e80f227882c8a0a74c8756a485ef80b5bb2f42`. Those are requested, not claimed done. The branch is frozen for that review.

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Non-claims
- A hosted VM is ephemeral compute. That is not kernel-proof and does not establish a runtime isolation claim.
- Attestation binds the downloaded pack to the pack-release workflow and the trusted-main source digest. It does not attest an image publisher.
- This change makes no malware, authenticity, or conformance claim about a candidate.
- Capture is not a scorer verdict. The workflow writes observations only.

## Write-set
This HEAD vs `main`:
- `.github/workflows/ci.yml`
- `.github/workflows/privileged-mcp-action-conformance.yml`
- `.github/workflows/privileged-mcp-action-oci-candidate.yml`
- `conformance/privileged-mcp-action-v0/tests/test_activation_kit.py`
- `conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py`
- `conformance/tests/test_completion_scope.py`
- `conformance/tests/test_registry.py`