### PR TITLE
test(conformance): close hard-run guard funnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,24 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Conformance inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          python3 conformance/registry.py
+          python3 conformance/implementations.py
+          python3 -W error::ResourceWarning conformance/tests/test_implementations.py
+          python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
+          python3 -W error::ResourceWarning conformance/tests/test_registry.py
+          python3 -W error::ResourceWarning conformance/tests/test_run_all.py
+          python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py
+          python3 conformance/run_all.py --require-complete --completion-scope required
+
       - id: detect
         shell: bash
         env:
@@ -149,24 +167,6 @@ jobs:
           bash scripts/ci/check-assay-release-pin.sh --published
           bash scripts/ci/test-ci-hardening-b1.sh
           bash scripts/ci/test-structurizr-export-docker.sh
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.12"
-
-      - name: Conformance inventory
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          python3 conformance/registry.py
-          python3 conformance/implementations.py
-          python3 -W error::ResourceWarning conformance/tests/test_implementations.py
-          python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py
-          python3 -W error::ResourceWarning conformance/tests/test_registry.py
-          python3 -W error::ResourceWarning conformance/tests/test_run_all.py
-          python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py
-          python3 conformance/run_all.py --require-complete --completion-scope required
 
       # Stdlib-only. Required CI cannot go green if these tests are deleted;
       # adequacy-drift is not a required context. No conditional or soft-failure settings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           python3 conformance/registry.py
           python3 conformance/implementations.py
           python3 -W error::ResourceWarning conformance/tests/test_implementations.py

--- a/.github/workflows/privileged-mcp-action-conformance.yml
+++ b/.github/workflows/privileged-mcp-action-conformance.yml
@@ -47,6 +47,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           python3 -m unittest \
             conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \
             conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py

--- a/.github/workflows/privileged-mcp-action-conformance.yml
+++ b/.github/workflows/privileged-mcp-action-conformance.yml
@@ -44,6 +44,7 @@ jobs:
           python-version: "3.13.8"
 
       - name: Run activation-kit contract tests
+        shell: bash
         run: |
           set -euo pipefail
           python3 -m unittest \

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -189,6 +190,32 @@ def _direct_mapping(block: str) -> dict[str, str]:
     return entries
 
 
+def _assert_no_workflow_bash_env(text: str) -> None:
+    lines = text.splitlines(keepends=True)
+    env_indexes: list[int] = []
+    for index, raw in enumerate(lines):
+        line = raw.rstrip("\r\n")
+        if not line or line.startswith((" ", "#")):
+            continue
+        match = DIRECT_ENTRY_RE.fullmatch(line)
+        if match is None:
+            continue
+        key = next(match.group(name) for name in ("plain", "single", "double")
+                   if match.group(name) is not None)
+        if key != "env":
+            continue
+        if match.group("value").strip():
+            raise AssertionError("workflow env must use a direct mapping")
+        env_indexes.append(index)
+    if len(env_indexes) > 1:
+        raise AssertionError("workflow has duplicate top-level env mappings")
+    if not env_indexes:
+        return
+    env_block = _indentation_bounded_block(lines, env_indexes[0], 0)
+    if "BASH_ENV" in _direct_mapping(env_block):
+        raise AssertionError("workflow-level BASH_ENV can neutralize hard-run scripts")
+
+
 def _direct_scalar(raw: str) -> str:
     value = raw.strip()
     if re.fullmatch(r"[A-Za-z0-9_.-]+", value):
@@ -212,6 +239,7 @@ def assert_hard_run_command(
     if contract is None:
         raise AssertionError(f"no hard-run contract for {job_name}/{step_name}")
     allowed_job_keys, allowed_step_keys, expected_script = contract
+    _assert_no_workflow_bash_env(text)
 
     job = named_job(text, job_name)
     actual_job_keys = frozenset(_direct_mapping(job))
@@ -479,6 +507,31 @@ class ProductCallsite(unittest.TestCase):
                 )
                 self.assertEqual(completed.returncode, expected)
 
+    def test_bash_env_neutralizes_both_unchanged_hard_scripts(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bash_env = Path(raw) / "bash-env"
+            bash_env.write_text(
+                "test() { return 0; }\npython3() { return 0; }\n",
+                encoding="utf-8",
+            )
+            env = {
+                **os.environ,
+                "BASH_ENV": str(bash_env),
+                "GITHUB_SHA": "0" * 40,
+            }
+            for label, script in (
+                ("inventory", INVENTORY_RUN_SCRIPT),
+                ("activation", ACTIVATION_KIT_RUN_SCRIPT),
+            ):
+                with self.subTest(label=label):
+                    completed = subprocess.run(
+                        ["bash", "-c", "\n".join(script)],
+                        cwd=REPO,
+                        env=env,
+                        check=False,
+                    )
+                    self.assertEqual(completed.returncode, 0)
+
     def test_direct_key_parser_ignores_nested_soft_failure_names(self):
         block = (
             "  scope:\n"
@@ -575,6 +628,22 @@ class ProductCallsite(unittest.TestCase):
         self.assertNotEqual(mutated, text)
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
+
+    def test_activation_workflow_bash_env_fails_closed(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "permissions:\n",
+            "env:\n  BASH_ENV: /tmp/assay-bash-env\n\npermissions:\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+        control = text.replace(
+            "permissions:\n",
+            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n\npermissions:\n",
+            1,
+        )
+        assert_combined_unittest(control)
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -39,32 +39,51 @@ ACTIVATION_KIT = (
 )
 
 
-def named_step(text: str, name: str) -> str:
+def _indentation_bounded_block(
+        lines: list[str], start: int, block_indent: int) -> str:
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        if line.strip():
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= block_indent:
+                break
+        end += 1
+    return "".join(lines[start:end])
+
+
+def named_job(text: str, name: str) -> str:
     lines = text.splitlines(keepends=True)
-    marker = re.compile(rf"^(?P<indent> +)- name: {re.escape(name)}\s*$")
+    marker = re.compile(rf"^  {re.escape(name)}:\s*$")
     matches = [
         (i, marker.fullmatch(line.rstrip("\r\n")))
         for i, line in enumerate(lines)
     ]
     matches = [(i, match) for i, match in matches if match is not None]
     if len(matches) != 1:
-        raise AssertionError(f"expected one {name!r} step, found {len(matches)}")
+        raise AssertionError(f"expected one {name!r} job, found {len(matches)}")
+    return _indentation_bounded_block(lines, matches[0][0], 2)
+
+
+def named_step(text: str, job_name: str, step_name: str) -> str:
+    lines = named_job(text, job_name).splitlines(keepends=True)
+    marker = re.compile(rf"^(?P<indent> +)- name: {re.escape(step_name)}\s*$")
+    matches = [
+        (i, marker.fullmatch(line.rstrip("\r\n")))
+        for i, line in enumerate(lines)
+    ]
+    matches = [(i, match) for i, match in matches if match is not None]
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected one {step_name!r} step in {job_name!r}, found {len(matches)}")
     start, match = matches[0]
     assert match is not None
-    step_indent = len(match.group("indent"))
-    end = start + 1
-    while end < len(lines):
-        line = lines[end]
-        if line.strip():
-            indent = len(line) - len(line.lstrip(" "))
-            if indent <= step_indent:
-                break
-        end += 1
-    return "".join(lines[start:end])
+    return _indentation_bounded_block(
+        lines, start, len(match.group("indent")))
 
 
 def _inventory_step(text: str) -> str:
-    return named_step(text, "Conformance inventory")
+    return named_step(text, "scope", "Conformance inventory")
 
 
 def _active_run_lines(step: str) -> list[str]:
@@ -91,12 +110,9 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
-def _kit_step(text: str) -> str:
-    return named_step(text, "Run activation-kit contract tests")
-
-
-def assert_hard_run_command(text: str, step_name: str, command: str) -> str:
-    step = named_step(text, step_name)
+def assert_hard_run_command(
+        text: str, job_name: str, step_name: str, command: str) -> str:
+    step = named_step(text, job_name, step_name)
     first = step.splitlines()[0]
     step_indent = len(first) - len(first.lstrip(" "))
     guarded = re.compile(
@@ -166,7 +182,8 @@ def assert_oci_candidate_checker(mod) -> None:
 
 def assert_combined_unittest(text: str) -> None:
     assert_hard_run_command(
-        text, "Run activation-kit contract tests", COMBINED_UNITTEST)
+        text, "activation-kit", "Run activation-kit contract tests",
+        COMBINED_UNITTEST)
 
 
 POLICIES = {
@@ -349,7 +366,7 @@ class ProductCallsite(unittest.TestCase):
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "Conformance inventory", REQUIRED_RUN_ALL)
+            text, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
         lines = _active_run_lines(step)
         self.assertEqual(lines[0], "set -euo pipefail")
         self.assertIn("python3 conformance/registry.py", lines)
@@ -409,21 +426,20 @@ class ProductCallsite(unittest.TestCase):
 
     def test_conformance_combined_unittest_is_a_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
-        step = _kit_step(text)
         assert_combined_unittest(text)
-        assert_combined_unittest(step.replace("no-such-token", "no-such-token"))
+        assert_combined_unittest(text.replace("no-such-token", "no-such-token"))
         name = "      - name: Run activation-kit contract tests\n"
         mutations = (
-            step.replace(COMBINED_UNITTEST, "          true"),
-            step.replace("          python3 -m unittest \\",
+            text.replace(COMBINED_UNITTEST, "          true"),
+            text.replace("          python3 -m unittest \\",
                          "          # python3 -m unittest \\"),
-            step.replace(COMBINED_UNITTEST, "          :"),
-            step.replace("test_activation_kit.py", ""),
-            step.replace("test_oci_candidate_executor.py", ""),
-            step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || true"),
-            step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || :"),
-            step.replace("          set -euo pipefail", "          set +e"),
-            step.replace(name, name + "        continue-on-error: true\n"),
+            text.replace(COMBINED_UNITTEST, "          :"),
+            text.replace("test_activation_kit.py", ""),
+            text.replace("test_oci_candidate_executor.py", ""),
+            text.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || true"),
+            text.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || :"),
+            text.replace("          set -euo pipefail", "          set +e", 1),
+            text.replace(name, name + "        continue-on-error: true\n"),
         )
         for mutated in mutations:
             with self.assertRaises(AssertionError):
@@ -452,6 +468,17 @@ class ProductCallsite(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
+
+    def test_inventory_step_moved_to_conditional_job_fails(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutated = text.replace(step, "", 1)
+        job_start = mutated.index("  ebpf-smoke-ubuntu:\n")
+        insert_at = mutated.index("    steps:\n", job_start) + len("    steps:\n")
+        mutated = mutated[:insert_at] + step + mutated[insert_at:]
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
 
     def test_required_ci_invokes_oci_candidate_checker(self):
         mod = _load_activation_kit()

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -34,6 +34,34 @@ COMBINED_UNITTEST = (
     "            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
     "            conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py"
 )
+INVENTORY_RUN_SCRIPT = (
+    "set -euo pipefail",
+    "python3 conformance/registry.py",
+    "python3 conformance/implementations.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_implementations.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_registry.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_run_all.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py",
+    REQUIRED_RUN_ALL,
+)
+ACTIVATION_KIT_RUN_SCRIPT = (
+    "set -euo pipefail",
+    *(line.strip() for line in COMBINED_UNITTEST.splitlines()),
+)
+HARD_RUN_CONTRACTS = {
+    ("scope", "Conformance inventory"): (
+        frozenset({"name", "runs-on", "timeout-minutes", "permissions",
+                   "outputs", "steps"}),
+        frozenset({"name", "shell", "run"}),
+        INVENTORY_RUN_SCRIPT,
+    ),
+    ("activation-kit", "Run activation-kit contract tests"): (
+        frozenset({"runs-on", "steps"}),
+        frozenset({"name", "run"}),
+        ACTIVATION_KIT_RUN_SCRIPT,
+    ),
+}
 ACTIVATION_KIT = (
     REPO / "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
 )
@@ -110,42 +138,58 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
-def _direct_soft_failure_key(block: str) -> str | None:
+DIRECT_KEY_RE = re.compile(
+    r"^(?:(?P<plain>[A-Za-z0-9_-]+)|'(?P<single>[A-Za-z0-9_-]+)'|"
+    r'"(?P<double>[A-Za-z0-9_-]+)")\s*:')
+
+
+def _direct_mapping_keys(block: str) -> frozenset[str]:
     lines = block.splitlines()
     block_indent = len(lines[0]) - len(lines[0].lstrip(" "))
-    guarded = re.compile(
-        rf"^ {{{block_indent + 2}}}(?P<key>if|continue-on-error)\s*:")
-    for line in lines[1:]:
-        match = guarded.match(line)
-        if match:
-            return match.group("key")
-    return None
+    direct_indent = block_indent + 2
+    keys: set[str] = set()
+    for index, line in enumerate(lines):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if index == 0 and indent == block_indent and line[indent:].startswith("- "):
+            direct = line[indent + 2:]
+        elif indent == direct_indent:
+            direct = line[direct_indent:]
+        else:
+            continue
+        match = DIRECT_KEY_RE.match(direct)
+        if match is None:
+            raise AssertionError(f"unrecognized direct mapping key syntax: {direct!r}")
+        key = next(value for value in match.groupdict().values() if value is not None)
+        if key in keys:
+            raise AssertionError(f"duplicate direct mapping key: {key}")
+        keys.add(key)
+    return frozenset(keys)
 
 
 def assert_hard_run_command(
-        text: str, job_name: str, step_name: str, command: str) -> str:
+        text: str, job_name: str, step_name: str) -> str:
+    contract = HARD_RUN_CONTRACTS.get((job_name, step_name))
+    if contract is None:
+        raise AssertionError(f"no hard-run contract for {job_name}/{step_name}")
+    allowed_job_keys, allowed_step_keys, expected_script = contract
+
     job = named_job(text, job_name)
-    job_key = _direct_soft_failure_key(job)
-    if job_key:
-        raise AssertionError(f"{job_name} job has a direct {job_key} key")
+    unexpected_job_keys = _direct_mapping_keys(job) - allowed_job_keys
+    if unexpected_job_keys:
+        raise AssertionError(
+            f"{job_name} job has unexpected direct keys: {sorted(unexpected_job_keys)}")
 
     step = named_step(text, job_name, step_name)
-    step_key = _direct_soft_failure_key(step)
-    if step_key:
-        raise AssertionError(f"{step_name} has a direct {step_key} key")
+    unexpected_step_keys = _direct_mapping_keys(step) - allowed_step_keys
+    if unexpected_step_keys:
+        raise AssertionError(
+            f"{step_name} has unexpected direct keys: {sorted(unexpected_step_keys)}")
 
-    active = _active_run_lines(step)
-    expected = [line.strip() for line in command.splitlines()]
-    matches = sum(
-        active[i:i + len(expected)] == expected
-        for i in range(len(active) - len(expected) + 1)
-    )
-    if matches != 1:
-        raise AssertionError(f"{step_name} must run the canonical command exactly once")
-    if any(re.search(r"\|\|\s*(?:true|:)(?:\s|$)", line) for line in active):
-        raise AssertionError(f"{step_name} command is neutralized with ||")
-    if any(line == "set +e" or line.startswith("set +e ") for line in active):
-        raise AssertionError(f"{step_name} disables fail-fast shell behavior")
+    active = tuple(_active_run_lines(step))
+    if active != expected_script:
+        raise AssertionError(f"{step_name} run script differs from the canonical script")
     return step
 
 
@@ -196,8 +240,7 @@ def assert_oci_candidate_checker(mod) -> None:
 
 def assert_combined_unittest(text: str) -> None:
     assert_hard_run_command(
-        text, "activation-kit", "Run activation-kit contract tests",
-        COMBINED_UNITTEST)
+        text, "activation-kit", "Run activation-kit contract tests")
 
 
 POLICIES = {
@@ -377,24 +420,31 @@ class ProductCallsite(unittest.TestCase):
     def test_no_separate_inventory_workflow(self):
         self.assertFalse(STANDALONE.exists(), STANDALONE)
 
+    def test_direct_key_parser_ignores_nested_soft_failure_names(self):
+        block = (
+            "  scope:\n"
+            "    \"runs-on\": ubuntu-latest\n"
+            "    outputs:\n"
+            "      if: nested-output\n"
+            "      continue-on-error: nested-output\n"
+            "    'steps': []\n"
+        )
+        self.assertEqual(
+            _direct_mapping_keys(block),
+            frozenset({"runs-on", "outputs", "steps"}),
+        )
+
+    def test_direct_key_parser_fails_closed_on_unrecognized_syntax(self):
+        block = "  scope:\n    ? [if]\n    : false\n"
+        with self.assertRaises(AssertionError):
+            _direct_mapping_keys(block)
+
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
+            text, "scope", "Conformance inventory")
         lines = _active_run_lines(step)
-        self.assertEqual(lines[0], "set -euo pipefail")
-        self.assertIn("python3 conformance/registry.py", lines)
-        self.assertTrue(any("conformance/tests/test_registry.py" in ln for ln in lines))
-        self.assertTrue(any("conformance/tests/test_run_all.py" in ln for ln in lines))
-        self.assertTrue(any("conformance/tests/test_completion_scope.py" in ln for ln in lines))
-        self.assertIn(REQUIRED_RUN_ALL, lines)
-        self.assertEqual(lines.count(REQUIRED_RUN_ALL), 1)
-        self.assertFalse(any("||" in ln for ln in lines if REQUIRED_RUN_ALL in ln))
-        self.assertFalse(any(ln == "set +e" or ln.startswith("set +e ") for ln in lines))
-        self.assertNotIn("|| true", step)
-        self.assertNotIn("|| :", step)
-        self.assertNotIn("continue-on-error", step)
-        self.assertNotRegex(step, r"eq 3|returncode in \(0, 3\)")
+        self.assertEqual(tuple(lines), INVENTORY_RUN_SCRIPT)
 
     def test_commented_or_colon_run_all_line_is_not_an_active_callsite(self):
         step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
@@ -455,9 +505,10 @@ class ProductCallsite(unittest.TestCase):
             text.replace("          set -euo pipefail", "          set +e", 1),
             text.replace(name, name + "        continue-on-error: true\n"),
         )
-        for mutated in mutations:
-            with self.assertRaises(AssertionError):
-                assert_combined_unittest(mutated)
+        for index, mutated in enumerate(mutations):
+            with self.subTest(index=index):
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
 
     def test_conditional_activation_kit_step_fails_the_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
@@ -491,6 +542,44 @@ class ProductCallsite(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
 
+    def test_quoted_activation_kit_job_and_step_keys_fail(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        job = "  activation-kit:\n"
+        step = "      - name: Run activation-kit contract tests\n"
+        mutations = (
+            ("job double if", job,
+             job + "    \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("job single continue", job,
+             job + "    'continue-on-error': true\n"),
+            ("step double if", step,
+             step + "        \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("step single continue", step,
+             step + "        'continue-on-error': true\n"),
+        )
+        for label, needle, replacement in mutations:
+            with self.subTest(label=label):
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(text.replace(needle, replacement, 1))
+
+    def test_shell_neutralizers_fail_the_activation_kit_guard(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutations = (
+            text.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          set +o errexit\n",
+                1,
+            ).replace(COMBINED_UNITTEST, COMBINED_UNITTEST + "\n          true", 1),
+            text.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          python3() { :; }\n",
+                1,
+            ),
+        )
+        for index, mutated in enumerate(mutations):
+            with self.subTest(index=index):
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
+
     def test_relocated_activation_kit_command_fails_the_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
         mutated = text.replace(COMBINED_UNITTEST, "          :", 1).replace(
@@ -513,7 +602,7 @@ class ProductCallsite(unittest.TestCase):
         mutated = mutated[:insert_at] + step + mutated[insert_at:]
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", REQUIRED_RUN_ALL)
+                mutated, "scope", "Conformance inventory")
 
     def test_required_ci_invokes_oci_candidate_checker(self):
         mod = _load_activation_kit()

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -25,14 +25,10 @@ import run_all  # noqa: E402
 REPO = Path(__file__).resolve().parents[2]
 CI_YML = REPO / ".github/workflows/ci.yml"
 STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
-INVENTORY_STEP_RE = re.compile(r"(?ms)^      - name: Conformance inventory\n(?:        .+\n)+")
-JOB_KEY_RE = re.compile(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:")
 REQUIRED_RUN_ALL = (
     "python3 conformance/run_all.py --require-complete --completion-scope required"
 )
 CONFORMANCE_YML = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
-KIT_STEP_RE = re.compile(
-    r"(?ms)^      - name: Run activation-kit contract tests\n(?:        .+\n)+")
 COMBINED_UNITTEST = (
     "          python3 -m unittest \\\n"
     "            conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \\\n"
@@ -43,34 +39,52 @@ ACTIVATION_KIT = (
 )
 
 
-def _scope_job(text: str) -> str:
+def named_step(text: str, name: str) -> str:
     lines = text.splitlines(keepends=True)
-    start = next((i for i, line in enumerate(lines) if line.startswith("  scope:")), None)
-    if start is None:
-        raise AssertionError("ci.yml missing scope job")
+    marker = re.compile(rf"^(?P<indent> +)- name: {re.escape(name)}\s*$")
+    matches = [
+        (i, marker.fullmatch(line.rstrip("\r\n")))
+        for i, line in enumerate(lines)
+    ]
+    matches = [(i, match) for i, match in matches if match is not None]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one {name!r} step, found {len(matches)}")
+    start, match = matches[0]
+    assert match is not None
+    step_indent = len(match.group("indent"))
     end = start + 1
-    while end < len(lines) and not JOB_KEY_RE.match(lines[end]):
+    while end < len(lines):
+        line = lines[end]
+        if line.strip():
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= step_indent:
+                break
         end += 1
     return "".join(lines[start:end])
 
 
 def _inventory_step(text: str) -> str:
-    step = INVENTORY_STEP_RE.search(_scope_job(text))
-    if step is None:
-        raise AssertionError("scope job missing Conformance inventory step")
-    return step.group(0)
+    return named_step(text, "Conformance inventory")
 
 
 def _active_run_lines(step: str) -> list[str]:
+    raw_lines = step.splitlines()
+    if not raw_lines:
+        return []
+    step_indent = len(raw_lines[0]) - len(raw_lines[0].lstrip(" "))
+    run_indent = step_indent + 2
+    run_indexes = [
+        i for i, raw in enumerate(raw_lines)
+        if raw == " " * run_indent + "run: |"
+    ]
+    if len(run_indexes) != 1:
+        return []
     lines: list[str] = []
-    in_run = False
-    for raw in step.splitlines():
-        if raw.strip() == "run: |":
-            in_run = True
-            continue
-        if not in_run:
-            continue
+    for raw in raw_lines[run_indexes[0] + 1:]:
         stripped = raw.strip()
+        indent = len(raw) - len(raw.lstrip(" "))
+        if stripped and indent <= run_indent:
+            break
         if not stripped or stripped.startswith("#"):
             continue
         lines.append(stripped)
@@ -78,10 +92,31 @@ def _active_run_lines(step: str) -> list[str]:
 
 
 def _kit_step(text: str) -> str:
-    step = KIT_STEP_RE.search(text)
-    if step is None:
-        raise AssertionError("conformance workflow missing kit contract step")
-    return step.group(0)
+    return named_step(text, "Run activation-kit contract tests")
+
+
+def assert_hard_run_command(text: str, step_name: str, command: str) -> str:
+    step = named_step(text, step_name)
+    first = step.splitlines()[0]
+    step_indent = len(first) - len(first.lstrip(" "))
+    guarded = re.compile(
+        rf"^ {{{step_indent + 2}}}(?:if|continue-on-error)\s*:")
+    if any(guarded.match(line) for line in step.splitlines()[1:]):
+        raise AssertionError(f"{step_name} has a conditional or soft-failure key")
+
+    active = _active_run_lines(step)
+    expected = [line.strip() for line in command.splitlines()]
+    matches = sum(
+        active[i:i + len(expected)] == expected
+        for i in range(len(active) - len(expected) + 1)
+    )
+    if matches != 1:
+        raise AssertionError(f"{step_name} must run the canonical command exactly once")
+    if any(re.search(r"\|\|\s*(?:true|:)(?:\s|$)", line) for line in active):
+        raise AssertionError(f"{step_name} command is neutralized with ||")
+    if any(line == "set +e" or line.startswith("set +e ") for line in active):
+        raise AssertionError(f"{step_name} disables fail-fast shell behavior")
+    return step
 
 
 def _load_activation_kit():
@@ -129,21 +164,9 @@ def assert_oci_candidate_checker(mod) -> None:
         raise AssertionError("no-op control was not green")
 
 
-def assert_combined_unittest(step: str) -> None:
-    if COMBINED_UNITTEST not in step:
-        raise AssertionError("combined unittest command missing")
-    lines = _active_run_lines(step)
-    joined = "\n".join(lines)
-    if "python3 -m unittest" not in joined:
-        raise AssertionError("combined unittest is not active")
-    if "test_activation_kit.py" not in joined:
-        raise AssertionError("activation kit is not active")
-    if "test_oci_candidate_executor.py" not in joined:
-        raise AssertionError("executor kit is not active")
-    if "|| true" in step or "|| :" in step or "continue-on-error" in step:
-        raise AssertionError("combined unittest is neutralized")
-    if any(ln == "set +e" or ln.startswith("set +e ") for ln in lines):
-        raise AssertionError("kit contract step disables -e")
+def assert_combined_unittest(text: str) -> None:
+    assert_hard_run_command(
+        text, "Run activation-kit contract tests", COMBINED_UNITTEST)
 
 
 POLICIES = {
@@ -325,7 +348,8 @@ class ProductCallsite(unittest.TestCase):
 
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
-        step = _inventory_step(text)
+        step = assert_hard_run_command(
+            text, "Conformance inventory", REQUIRED_RUN_ALL)
         lines = _active_run_lines(step)
         self.assertEqual(lines[0], "set -euo pipefail")
         self.assertIn("python3 conformance/registry.py", lines)
@@ -351,7 +375,11 @@ class ProductCallsite(unittest.TestCase):
 
     def test_deleting_the_scope_job_callsite_fails(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = INVENTORY_STEP_RE.sub("", text)
+        mutated = text.replace(
+            "      - name: Conformance inventory\n",
+            "      - name: Deleted conformance inventory\n",
+            1,
+        )
         with self.assertRaises(AssertionError):
             _inventory_step(mutated)
 
@@ -380,8 +408,9 @@ class ProductCallsite(unittest.TestCase):
                              for ln in _active_run_lines(mutated)))
 
     def test_conformance_combined_unittest_is_a_hard_callsite(self):
-        step = _kit_step(CONFORMANCE_YML.read_text(encoding="utf-8"))
-        assert_combined_unittest(step)
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        step = _kit_step(text)
+        assert_combined_unittest(text)
         assert_combined_unittest(step.replace("no-such-token", "no-such-token"))
         name = "      - name: Run activation-kit contract tests\n"
         mutations = (
@@ -392,11 +421,37 @@ class ProductCallsite(unittest.TestCase):
             step.replace("test_activation_kit.py", ""),
             step.replace("test_oci_candidate_executor.py", ""),
             step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || true"),
+            step.replace(COMBINED_UNITTEST, COMBINED_UNITTEST + " || :"),
+            step.replace("          set -euo pipefail", "          set +e"),
             step.replace(name, name + "        continue-on-error: true\n"),
         )
         for mutated in mutations:
             with self.assertRaises(AssertionError):
                 assert_combined_unittest(mutated)
+
+    def test_conditional_activation_kit_step_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "      - name: Run activation-kit contract tests\n",
+            "      - name: Run activation-kit contract tests\n"
+            "        if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+
+    def test_relocated_activation_kit_command_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(COMBINED_UNITTEST, "          :", 1).replace(
+            "      - name: Validate public JSON documents\n",
+            "      - name: Decorative activation-kit note\n"
+            "        run: |\n"
+            f"{COMBINED_UNITTEST}\n\n"
+            "      - name: Validate public JSON documents\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
 
     def test_required_ci_invokes_oci_candidate_checker(self):
         mod = _load_activation_kit()

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import sys
@@ -28,6 +29,7 @@ STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
 REQUIRED_RUN_ALL = (
     "python3 conformance/run_all.py --require-complete --completion-scope required"
 )
+REVISION_WITNESS = 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"'
 CONFORMANCE_YML = REPO / ".github/workflows/privileged-mcp-action-conformance.yml"
 COMBINED_UNITTEST = (
     "          python3 -m unittest \\\n"
@@ -36,6 +38,7 @@ COMBINED_UNITTEST = (
 )
 INVENTORY_RUN_SCRIPT = (
     "set -euo pipefail",
+    REVISION_WITNESS,
     "python3 conformance/registry.py",
     "python3 conformance/implementations.py",
     "python3 -W error::ResourceWarning conformance/tests/test_implementations.py",
@@ -47,6 +50,7 @@ INVENTORY_RUN_SCRIPT = (
 )
 ACTIVATION_KIT_RUN_SCRIPT = (
     "set -euo pipefail",
+    REVISION_WITNESS,
     *(line.strip() for line in COMBINED_UNITTEST.splitlines()),
 )
 HARD_RUN_CONTRACTS = {
@@ -459,6 +463,22 @@ class ProductCallsite(unittest.TestCase):
     def test_no_separate_inventory_workflow(self):
         self.assertFalse(STANDALONE.exists(), STANDALONE)
 
+    def test_revision_witness_accepts_head_and_rejects_mismatch(self):
+        head = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=REPO, text=True).strip()
+        for label, sha, expected in (
+            ("actual", head, 0),
+            ("mismatch", "0" * 40, 1),
+        ):
+            with self.subTest(label=label):
+                completed = subprocess.run(
+                    ["bash", "-c", REVISION_WITNESS],
+                    cwd=REPO,
+                    env={**os.environ, "GITHUB_SHA": sha},
+                    check=False,
+                )
+                self.assertEqual(completed.returncode, expected)
+
     def test_direct_key_parser_ignores_nested_soft_failure_names(self):
         block = (
             "  scope:\n"
@@ -548,6 +568,13 @@ class ProductCallsite(unittest.TestCase):
             with self.subTest(index=index):
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(mutated)
+
+    def test_removing_activation_revision_witness_fails(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace("          " + REVISION_WITNESS + "\n", "", 1)
+        self.assertNotEqual(mutated, text)
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -110,15 +110,29 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
+def _direct_soft_failure_key(block: str) -> str | None:
+    lines = block.splitlines()
+    block_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    guarded = re.compile(
+        rf"^ {{{block_indent + 2}}}(?P<key>if|continue-on-error)\s*:")
+    for line in lines[1:]:
+        match = guarded.match(line)
+        if match:
+            return match.group("key")
+    return None
+
+
 def assert_hard_run_command(
         text: str, job_name: str, step_name: str, command: str) -> str:
+    job = named_job(text, job_name)
+    job_key = _direct_soft_failure_key(job)
+    if job_key:
+        raise AssertionError(f"{job_name} job has a direct {job_key} key")
+
     step = named_step(text, job_name, step_name)
-    first = step.splitlines()[0]
-    step_indent = len(first) - len(first.lstrip(" "))
-    guarded = re.compile(
-        rf"^ {{{step_indent + 2}}}(?:if|continue-on-error)\s*:")
-    if any(guarded.match(line) for line in step.splitlines()[1:]):
-        raise AssertionError(f"{step_name} has a conditional or soft-failure key")
+    step_key = _direct_soft_failure_key(step)
+    if step_key:
+        raise AssertionError(f"{step_name} has a direct {step_key} key")
 
     active = _active_run_lines(step)
     expected = [line.strip() for line in command.splitlines()]
@@ -451,6 +465,27 @@ class ProductCallsite(unittest.TestCase):
             "      - name: Run activation-kit contract tests\n",
             "      - name: Run activation-kit contract tests\n"
             "        if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+
+    def test_conditional_activation_kit_job_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  activation-kit:\n",
+            "  activation-kit:\n"
+            "    if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(mutated)
+
+    def test_softened_activation_kit_job_fails_the_hard_callsite(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  activation-kit:\n",
+            "  activation-kit:\n    continue-on-error: true\n",
             1,
         )
         with self.assertRaises(AssertionError):

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -71,6 +71,30 @@ HARD_RUN_CONTRACTS = {
         frozenset(),
     ),
 }
+CHECKOUT_REF = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
+SETUP_PYTHON_REF = (
+    "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1")
+# The trusted prefix prevents earlier steps from changing runner state before the
+# hard call. Pins constrain workflow inputs; they do not attest the runner platform
+# or the implementation and behavior of GitHub-hosted actions.
+TRUSTED_PREFIX_CONTRACTS = {
+    ("scope", "Conformance inventory"): (
+        (frozenset({"uses", "with"}),
+         {"uses": CHECKOUT_REF},
+         {"persist-credentials": "false", "fetch-depth": "0"}),
+        (frozenset({"uses", "with"}),
+         {"uses": SETUP_PYTHON_REF},
+         {"python-version": "3.12"}),
+    ),
+    ("activation-kit", "Run activation-kit contract tests"): (
+        (frozenset({"name", "uses", "with"}),
+         {"name": "Check out source", "uses": CHECKOUT_REF},
+         {"fetch-depth": "0", "persist-credentials": "false"}),
+        (frozenset({"name", "uses", "with"}),
+         {"name": "Set up Python", "uses": SETUP_PYTHON_REF},
+         {"python-version": "3.13.8"}),
+    ),
+}
 ACTIVATION_KIT = (
     REPO / "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
 )
@@ -194,6 +218,112 @@ def _direct_mapping(block: str) -> dict[str, str]:
     return entries
 
 
+def _ordered_job_steps(text: str, job_name: str) -> list[str]:
+    lines = named_job(text, job_name).splitlines(keepends=True)
+    job_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    direct_indent = None
+    steps_index = None
+    for index, raw in enumerate(lines[1:], 1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if direct_indent is None:
+            direct_indent = indent
+        if indent != direct_indent:
+            continue
+        match = DIRECT_ENTRY_RE.fullmatch(raw[direct_indent:].rstrip("\r\n"))
+        if match is None:
+            raise AssertionError("unrecognized direct job key in steps parser")
+        key = next(match.group(name) for name in ("plain", "single", "double")
+                   if match.group(name) is not None)
+        if key == "steps":
+            if match.group("value").strip():
+                raise AssertionError("job steps must use a block sequence")
+            steps_index = index
+            break
+    if steps_index is None or direct_indent is None:
+        raise AssertionError(f"{job_name} job has no direct steps block")
+
+    end = steps_index + 1
+    while end < len(lines):
+        raw = lines[end]
+        if raw.strip():
+            indent = len(raw) - len(raw.lstrip(" "))
+            if indent <= direct_indent:
+                break
+        end += 1
+    step_indent = None
+    starts: list[int] = []
+    for index in range(steps_index + 1, end):
+        raw = lines[index]
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if step_indent is None:
+            step_indent = indent
+        if indent == step_indent:
+            if not raw[step_indent:].startswith("- "):
+                raise AssertionError("unrecognized direct workflow step syntax")
+            starts.append(index)
+        elif indent < step_indent:
+            raise AssertionError("inconsistent workflow step indentation")
+    if not starts:
+        raise AssertionError(f"{job_name} job has no steps")
+    return [
+        "".join(lines[start:starts[index + 1] if index + 1 < len(starts) else end])
+        for index, start in enumerate(starts)
+    ]
+
+
+def _assert_trusted_prefix(text: str, job_name: str, step_name: str) -> None:
+    contracts = TRUSTED_PREFIX_CONTRACTS.get((job_name, step_name))
+    if contracts is None:
+        raise AssertionError(f"no trusted-prefix contract for {job_name}/{step_name}")
+    steps = _ordered_job_steps(text, job_name)
+    target = named_step(text, job_name, step_name)
+    if len(steps) < 3 or steps[2] != target:
+        raise AssertionError(
+            f"{step_name} must be the third step after pinned checkout and setup")
+
+    for step, (expected_keys, expected_values, expected_with) in zip(
+            steps[:2], contracts, strict=True):
+        entries = _direct_mapping(step)
+        actual_keys = frozenset(entries)
+        if actual_keys != expected_keys:
+            raise AssertionError(
+                "trusted action step keys differ: "
+                f"expected {sorted(expected_keys)}, got {sorted(actual_keys)}")
+
+        def direct_value(key: str) -> str:
+            return entries[key].split(" #", 1)[0].strip()
+
+        actual_values = {key: direct_value(key) for key in expected_values}
+        if actual_values != expected_values:
+            raise AssertionError(
+                f"trusted action values differ: expected {expected_values}, "
+                f"got {actual_values}")
+
+        raw_lines = step.splitlines(keepends=True)
+        step_indent = len(raw_lines[0]) - len(raw_lines[0].lstrip(" "))
+        with_indent = step_indent + 2
+        with_indexes = [
+            index for index, raw in enumerate(raw_lines)
+            if raw.rstrip("\r\n") == " " * with_indent + "with:"
+        ]
+        if len(with_indexes) != 1:
+            raise AssertionError("trusted action must have one direct with mapping")
+        with_block = _indentation_bounded_block(
+            raw_lines, with_indexes[0], with_indent)
+        actual_with = {
+            key: _direct_scalar(value)
+            for key, value in _direct_mapping(with_block).items()
+        }
+        if actual_with != expected_with:
+            raise AssertionError(
+                f"trusted action with values differ: expected {expected_with}, "
+                f"got {actual_with}")
+
+
 def _assert_workflow_document(
         text: str,
         expected_keys: frozenset[str],
@@ -264,6 +394,7 @@ def assert_hard_run_command(
         raise AssertionError(
             f"{job_name} job direct keys differ: "
             f"expected {sorted(allowed_job_keys)}, got {sorted(actual_job_keys)}")
+    _assert_trusted_prefix(text, job_name, step_name)
 
     step = named_step(text, job_name, step_name)
     step_entries = _direct_mapping(step)
@@ -329,6 +460,67 @@ def assert_oci_candidate_checker(mod) -> None:
 def assert_combined_unittest(text: str) -> None:
     assert_hard_run_command(
         text, "activation-kit", "Run activation-kit contract tests")
+
+
+TRUSTED_PREFIX_WRITERS = (
+    (
+        "BASH_ENV writer",
+        "      - name: Preload Bash functions\n"
+        "        run: |\n"
+        "          printf '%s\\n' 'test() { return 0; }' "
+        "'python3() { return 0; }' > \"$RUNNER_TEMP/bash-env\"\n"
+        "          echo \"BASH_ENV=$RUNNER_TEMP/bash-env\" >> \"$GITHUB_ENV\"\n\n",
+    ),
+    (
+        "PATH writer",
+        "      - name: Prepend executable path\n"
+        "        run: echo \"$RUNNER_TEMP/bin\" >> \"$GITHUB_PATH\"\n\n",
+    ),
+    (
+        "Git and Python path writer",
+        "      - name: Redirect Git and Python\n"
+        "        run: |\n"
+        "          echo \"GIT_DIR=$RUNNER_TEMP/base.git\" >> \"$GITHUB_ENV\"\n"
+        "          echo \"PYTHONPATH=$RUNNER_TEMP/base\" >> \"$GITHUB_ENV\"\n\n",
+    ),
+)
+
+
+def trusted_prefix_mutations(
+        text: str, target_line: str, checkout: str, setup: str):
+    mutations = [
+        (label, text.replace(target_line, writer + target_line, 1))
+        for label, writer in TRUSTED_PREFIX_WRITERS
+    ]
+    mutations.extend((
+        ("checkout env", text.replace(
+            checkout, checkout.replace(
+                "        with:\n", "        env:\n          EXTRA: value\n        with:\n",
+                1), 1)),
+        ("checkout with", text.replace(
+            checkout, checkout.replace(
+                "          persist-credentials: false\n",
+                "          persist-credentials: false\n          extra: value\n", 1), 1)),
+        ("checkout mutable ref", text.replace(
+            checkout, checkout.replace(CHECKOUT_REF, "actions/checkout@main", 1), 1)),
+        ("setup if", text.replace(
+            setup, setup.replace("        with:\n", "        if: always()\n        with:\n", 1),
+            1)),
+        ("setup continue", text.replace(
+            setup, setup.replace(
+                "        with:\n", "        continue-on-error: true\n        with:\n", 1),
+            1)),
+        ("setup with", text.replace(
+            setup, re.sub(
+                r'(          python-version:.*\n)', r'\1          cache: pip\n',
+                setup, count=1), 1)),
+        ("setup mutable ref", text.replace(
+            setup, setup.replace(SETUP_PYTHON_REF, "actions/setup-python@main", 1), 1)),
+    ))
+    reordered = text.replace(checkout, "__CHECKOUT__", 1)
+    reordered = reordered.replace(setup, checkout, 1).replace("__CHECKOUT__", setup, 1)
+    mutations.append(("reordered prefix", reordered))
+    return mutations
 
 
 POLICIES = {
@@ -665,6 +857,25 @@ class ProductCallsite(unittest.TestCase):
                 self.assertNotEqual(mutated, text)
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(mutated)
+
+    def test_activation_trusted_prefix_fails_closed(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        target = "      - name: Run activation-kit contract tests\n"
+        checkout = named_step(text, "activation-kit", "Check out source")
+        setup = named_step(text, "activation-kit", "Set up Python")
+        for label, mutated in trusted_prefix_mutations(
+                text, target, checkout, setup):
+            with self.subTest(label=label):
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
+
+        target_step = named_step(
+            text, "activation-kit", "Run activation-kit contract tests")
+        post_target = target_step + (
+            "      - name: Harmless post-target control\n"
+            "        run: echo harmless\n\n")
+        assert_combined_unittest(text.replace(target_step, post_target, 1))
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -58,7 +58,7 @@ HARD_RUN_CONTRACTS = {
     ),
     ("activation-kit", "Run activation-kit contract tests"): (
         frozenset({"runs-on", "steps"}),
-        frozenset({"name", "run"}),
+        frozenset({"name", "shell", "run"}),
         ACTIVATION_KIT_RUN_SCRIPT,
     ),
 }
@@ -138,34 +138,68 @@ def _active_run_lines(step: str) -> list[str]:
     return lines
 
 
-DIRECT_KEY_RE = re.compile(
+DIRECT_ENTRY_RE = re.compile(
     r"^(?:(?P<plain>[A-Za-z0-9_-]+)|'(?P<single>[A-Za-z0-9_-]+)'|"
-    r'"(?P<double>[A-Za-z0-9_-]+)")\s*:')
+    r'"(?P<double>[A-Za-z0-9_-]+)")\s*:(?P<value>.*)$')
 
 
-def _direct_mapping_keys(block: str) -> frozenset[str]:
+def _direct_mapping(block: str) -> dict[str, str]:
     lines = block.splitlines()
+    if not lines:
+        raise AssertionError("empty mapping block")
     block_indent = len(lines[0]) - len(lines[0].lstrip(" "))
-    direct_indent = block_indent + 2
-    keys: set[str] = set()
+    sequence_item = lines[0][block_indent:].startswith("- ")
+    direct_indent = block_indent + 2 if sequence_item else None
+    if direct_indent is None:
+        for line in lines[1:]:
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            direct_indent = len(line) - len(line.lstrip(" "))
+            if direct_indent <= block_indent:
+                raise AssertionError("mapping block has no indented entry")
+            break
+    if direct_indent is None:
+        raise AssertionError("mapping block has no direct entries")
+
+    entries: dict[str, str] = {}
     for index, line in enumerate(lines):
         if not line.strip() or line.lstrip().startswith("#"):
             continue
         indent = len(line) - len(line.lstrip(" "))
-        if index == 0 and indent == block_indent and line[indent:].startswith("- "):
+        if index == 0 and sequence_item:
             direct = line[indent + 2:]
         elif indent == direct_indent:
             direct = line[direct_indent:]
+        elif block_indent < indent < direct_indent:
+            raise AssertionError("inconsistent direct mapping indentation")
         else:
             continue
-        match = DIRECT_KEY_RE.match(direct)
+        match = DIRECT_ENTRY_RE.fullmatch(direct)
         if match is None:
             raise AssertionError(f"unrecognized direct mapping key syntax: {direct!r}")
-        key = next(value for value in match.groupdict().values() if value is not None)
-        if key in keys:
+        key = next(match.group(name) for name in ("plain", "single", "double")
+                   if match.group(name) is not None)
+        if key in entries:
             raise AssertionError(f"duplicate direct mapping key: {key}")
-        keys.add(key)
-    return frozenset(keys)
+        entries[key] = match.group("value")
+    return entries
+
+
+def _direct_scalar(raw: str) -> str:
+    value = raw.strip()
+    if re.fullmatch(r"[A-Za-z0-9_.-]+", value):
+        return value
+    if re.fullmatch(r"'(?:[^']|'')*'", value):
+        return value[1:-1].replace("''", "'")
+    if value.startswith('"') and value.endswith('"'):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"unsupported direct scalar syntax: {raw!r}") from error
+        if isinstance(parsed, str):
+            return parsed
+    raise AssertionError(f"unsupported direct scalar syntax: {raw!r}")
 
 
 def assert_hard_run_command(
@@ -176,16 +210,21 @@ def assert_hard_run_command(
     allowed_job_keys, allowed_step_keys, expected_script = contract
 
     job = named_job(text, job_name)
-    unexpected_job_keys = _direct_mapping_keys(job) - allowed_job_keys
-    if unexpected_job_keys:
+    actual_job_keys = frozenset(_direct_mapping(job))
+    if actual_job_keys != allowed_job_keys:
         raise AssertionError(
-            f"{job_name} job has unexpected direct keys: {sorted(unexpected_job_keys)}")
+            f"{job_name} job direct keys differ: "
+            f"expected {sorted(allowed_job_keys)}, got {sorted(actual_job_keys)}")
 
     step = named_step(text, job_name, step_name)
-    unexpected_step_keys = _direct_mapping_keys(step) - allowed_step_keys
-    if unexpected_step_keys:
+    step_entries = _direct_mapping(step)
+    actual_step_keys = frozenset(step_entries)
+    if actual_step_keys != allowed_step_keys:
         raise AssertionError(
-            f"{step_name} has unexpected direct keys: {sorted(unexpected_step_keys)}")
+            f"{step_name} direct keys differ: "
+            f"expected {sorted(allowed_step_keys)}, got {sorted(actual_step_keys)}")
+    if _direct_scalar(step_entries["shell"]) != "bash":
+        raise AssertionError(f"{step_name} must use shell: bash")
 
     active = tuple(_active_run_lines(step))
     if active != expected_script:
@@ -430,14 +469,14 @@ class ProductCallsite(unittest.TestCase):
             "    'steps': []\n"
         )
         self.assertEqual(
-            _direct_mapping_keys(block),
+            frozenset(_direct_mapping(block)),
             frozenset({"runs-on", "outputs", "steps"}),
         )
 
     def test_direct_key_parser_fails_closed_on_unrecognized_syntax(self):
         block = "  scope:\n    ? [if]\n    : false\n"
         with self.assertRaises(AssertionError):
-            _direct_mapping_keys(block)
+            _direct_mapping(block)
 
     def test_scope_job_invokes_both_flags_and_does_not_map_3_to_0(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -509,6 +548,53 @@ class ProductCallsite(unittest.TestCase):
             with self.subTest(index=index):
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(mutated)
+
+    def test_activation_kit_step_uses_explicit_bash(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        step = named_step(
+            text,
+            "activation-kit",
+            "Run activation-kit contract tests",
+        )
+        self.assertIn("        shell: bash\n", step)
+        mutations = (
+            step.replace(
+                "        shell: bash\n",
+                "        shell: bash -c 'true' -- {0}\n",
+                1,
+            ),
+            step.replace("        shell: bash\n", "", 1),
+        )
+        for index, mutated_step in enumerate(mutations):
+            with self.subTest(index=index):
+                self.assertNotEqual(mutated_step, step)
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(text.replace(step, mutated_step, 1))
+
+    def test_explicit_activation_shell_overrides_workflow_default(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "permissions:\n",
+            "defaults:\n"
+            "  run:\n"
+            "    shell: bash -c 'true' -- {0}\n\n"
+            "permissions:\n",
+            1,
+        )
+        self.assertNotEqual(mutated, text)
+        assert_combined_unittest(mutated)
+
+    def test_wider_indented_conditional_activation_job_fails(self):
+        text = CONFORMANCE_YML.read_text(encoding="utf-8")
+        job = named_job(text, "activation-kit")
+        lines = job.splitlines(keepends=True)
+        widened = (
+            lines[0]
+            + "      if: ${{ github.event_name == 'disabled' }}\n"
+            + "".join("  " + line if line.strip() else line for line in lines[1:])
+        )
+        with self.assertRaises(AssertionError):
+            assert_combined_unittest(text.replace(job, widened, 1))
 
     def test_conditional_activation_kit_step_fails_the_hard_callsite(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -60,11 +60,15 @@ HARD_RUN_CONTRACTS = {
                    "outputs", "steps"}),
         frozenset({"name", "shell", "run"}),
         INVENTORY_RUN_SCRIPT,
+        frozenset({"name", "on", "permissions", "env", "jobs"}),
+        frozenset({"ASSAY_PUBLIC_MSRV"}),
     ),
     ("activation-kit", "Run activation-kit contract tests"): (
         frozenset({"runs-on", "steps"}),
         frozenset({"name", "shell", "run"}),
         ACTIVATION_KIT_RUN_SCRIPT,
+        frozenset({"name", "on", "permissions", "concurrency", "jobs"}),
+        frozenset(),
     ),
 }
 ACTIVATION_KIT = (
@@ -190,9 +194,20 @@ def _direct_mapping(block: str) -> dict[str, str]:
     return entries
 
 
-def _assert_no_workflow_bash_env(text: str) -> None:
+def _assert_workflow_document(
+        text: str,
+        expected_keys: frozenset[str],
+        expected_env_keys: frozenset[str]) -> None:
     lines = text.splitlines(keepends=True)
-    env_indexes: list[int] = []
+    document = "document:\n" + "".join(
+        "  " + line if line.strip() else line for line in lines)
+    actual_keys = frozenset(_direct_mapping(document))
+    if actual_keys != expected_keys:
+        raise AssertionError(
+            "workflow top-level keys differ: "
+            f"expected {sorted(expected_keys)}, got {sorted(actual_keys)}")
+
+    env_index = None
     for index, raw in enumerate(lines):
         line = raw.rstrip("\r\n")
         if not line or line.startswith((" ", "#")):
@@ -206,14 +221,15 @@ def _assert_no_workflow_bash_env(text: str) -> None:
             continue
         if match.group("value").strip():
             raise AssertionError("workflow env must use a direct mapping")
-        env_indexes.append(index)
-    if len(env_indexes) > 1:
-        raise AssertionError("workflow has duplicate top-level env mappings")
-    if not env_indexes:
-        return
-    env_block = _indentation_bounded_block(lines, env_indexes[0], 0)
-    if "BASH_ENV" in _direct_mapping(env_block):
-        raise AssertionError("workflow-level BASH_ENV can neutralize hard-run scripts")
+        env_index = index
+    actual_env_keys = frozenset()
+    if env_index is not None:
+        env_block = _indentation_bounded_block(lines, env_index, 0)
+        actual_env_keys = frozenset(_direct_mapping(env_block))
+    if actual_env_keys != expected_env_keys:
+        raise AssertionError(
+            "workflow env keys differ: "
+            f"expected {sorted(expected_env_keys)}, got {sorted(actual_env_keys)}")
 
 
 def _direct_scalar(raw: str) -> str:
@@ -238,8 +254,9 @@ def assert_hard_run_command(
     contract = HARD_RUN_CONTRACTS.get((job_name, step_name))
     if contract is None:
         raise AssertionError(f"no hard-run contract for {job_name}/{step_name}")
-    allowed_job_keys, allowed_step_keys, expected_script = contract
-    _assert_no_workflow_bash_env(text)
+    (allowed_job_keys, allowed_step_keys, expected_script,
+     workflow_keys, workflow_env_keys) = contract
+    _assert_workflow_document(text, workflow_keys, workflow_env_keys)
 
     job = named_job(text, job_name)
     actual_job_keys = frozenset(_direct_mapping(job))
@@ -629,21 +646,25 @@ class ProductCallsite(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
 
-    def test_activation_workflow_bash_env_fails_closed(self):
+    def test_activation_workflow_document_shape_fails_closed(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
-        mutated = text.replace(
-            "permissions:\n",
-            "env:\n  BASH_ENV: /tmp/assay-bash-env\n\npermissions:\n",
-            1,
+        mutations = (
+            ("BASH_ENV", "env:\n  BASH_ENV: /tmp/assay-bash-env\n\n"),
+            ("PATH", "env:\n  PATH: /tmp\n\n"),
+            ("quoted GIT_DIR", "env:\n  'GIT_DIR': /tmp/repo\n\n"),
+            ("unrelated env", "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n\n"),
+            (
+                "defaults working-directory",
+                "defaults:\n  run:\n    working-directory: /tmp\n\n",
+            ),
         )
-        with self.assertRaises(AssertionError):
-            assert_combined_unittest(mutated)
-        control = text.replace(
-            "permissions:\n",
-            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n\npermissions:\n",
-            1,
-        )
-        assert_combined_unittest(control)
+        for label, addition in mutations:
+            with self.subTest(label=label):
+                mutated = text.replace(
+                    "permissions:\n", addition + "permissions:\n", 1)
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_combined_unittest(mutated)
 
     def test_activation_kit_step_uses_explicit_bash(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")
@@ -666,19 +687,6 @@ class ProductCallsite(unittest.TestCase):
                 self.assertNotEqual(mutated_step, step)
                 with self.assertRaises(AssertionError):
                     assert_combined_unittest(text.replace(step, mutated_step, 1))
-
-    def test_explicit_activation_shell_overrides_workflow_default(self):
-        text = CONFORMANCE_YML.read_text(encoding="utf-8")
-        mutated = text.replace(
-            "permissions:\n",
-            "defaults:\n"
-            "  run:\n"
-            "    shell: bash -c 'true' -- {0}\n\n"
-            "permissions:\n",
-            1,
-        )
-        self.assertNotEqual(mutated, text)
-        assert_combined_unittest(mutated)
 
     def test_wider_indented_conditional_activation_job_fails(self):
         text = CONFORMANCE_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -377,6 +377,28 @@ class ProductWorkflow(unittest.TestCase):
             assert_hard_run_command(
                 mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
+    def test_conditional_scope_job_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  scope:\n",
+            "  scope:\n    if: ${{ github.event_name == 'disabled' }}\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+
+    def test_softened_scope_job_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  scope:\n",
+            "  scope:\n    continue-on-error: true\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+
     def test_relocated_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
         mutated = text.replace("          " + RUN_ALL_COMMAND, "          :", 1).replace(

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -27,15 +27,14 @@ sys.path.insert(0, str(REPO / "conformance/tests"))
 
 import registry  # noqa: E402
 import run_all  # noqa: E402
-from test_completion_scope import assert_hard_run_command, named_step  # noqa: E402
+from test_completion_scope import (  # noqa: E402
+    REQUIRED_RUN_ALL,
+    assert_hard_run_command,
+    named_step,
+)
 
 CI_YML = REPO / ".github/workflows/ci.yml"
 STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
-RUN_ALL_COMMAND = (
-    "python3 conformance/run_all.py --require-complete --completion-scope required"
-)
-
-
 POLICIES = ("required", "optional", "external-candidate")
 
 
@@ -326,7 +325,7 @@ class ProductWorkflow(unittest.TestCase):
     def test_scope_job_invokes_require_complete_as_a_hard_check(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+            text, "scope", "Conformance inventory")
         self.assertIn("python3 conformance/registry.py", step)
 
     def test_scope_job_invokes_completion_scope_suite(self):
@@ -365,17 +364,17 @@ class ProductWorkflow(unittest.TestCase):
 
     def test_commented_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace(RUN_ALL_COMMAND, "# " + RUN_ALL_COMMAND, 1)
+        mutated = text.replace(REQUIRED_RUN_ALL, "# " + REQUIRED_RUN_ALL, 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
     def test_softened_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace(RUN_ALL_COMMAND, RUN_ALL_COMMAND + " || true", 1)
+        mutated = text.replace(REQUIRED_RUN_ALL, REQUIRED_RUN_ALL + " || true", 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -386,7 +385,7 @@ class ProductWorkflow(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
     def test_softened_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -397,21 +396,64 @@ class ProductWorkflow(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
+
+    def test_quoted_scope_job_and_inventory_step_keys_fail(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        job = "  scope:\n"
+        step = "      - name: Conformance inventory\n"
+        mutations = (
+            ("job double if", job,
+             job + "    \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("job single continue", job,
+             job + "    'continue-on-error': true\n"),
+            ("step double if", step,
+             step + "        \"if\": ${{ github.event_name == 'disabled' }}\n"),
+            ("step single continue", step,
+             step + "        'continue-on-error': true\n"),
+        )
+        for label, needle, replacement in mutations:
+            with self.subTest(label=label):
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        text.replace(needle, replacement, 1),
+                        "scope", "Conformance inventory")
+
+    def test_shell_neutralizers_fail_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutations = (
+            step.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          set +o errexit\n",
+                1,
+            ).replace(REQUIRED_RUN_ALL, REQUIRED_RUN_ALL + "\n          true", 1),
+            step.replace(
+                "          set -euo pipefail\n",
+                "          set -euo pipefail\n          python3() { :; }\n",
+                1,
+            ),
+        )
+        for index, mutated_step in enumerate(mutations):
+            with self.subTest(index=index):
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        text.replace(step, mutated_step, 1),
+                        "scope", "Conformance inventory")
 
     def test_relocated_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace("          " + RUN_ALL_COMMAND, "          :", 1).replace(
+        mutated = text.replace("          " + REQUIRED_RUN_ALL, "          :", 1).replace(
             "      - name: Published-numbers projection contract\n",
             "      - name: Decorative completion-scope note\n"
             "        run: |\n"
-            f"          {RUN_ALL_COMMAND}\n\n"
+            f"          {REQUIRED_RUN_ALL}\n\n"
             "      - name: Published-numbers projection contract\n",
             1,
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory")
 
 
 class RegistryDoesNotRunAll(unittest.TestCase):

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -24,32 +23,17 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "conformance"))
+sys.path.insert(0, str(REPO / "conformance/tests"))
 
 import registry  # noqa: E402
 import run_all  # noqa: E402
+from test_completion_scope import assert_hard_run_command, named_step  # noqa: E402
 
 CI_YML = REPO / ".github/workflows/ci.yml"
 STANDALONE = REPO / ".github/workflows/conformance-inventory.yml"
-INVENTORY_STEP_RE = re.compile(r"(?ms)^      - name: Conformance inventory\n(?:        .+\n)+")
-JOB_KEY_RE = re.compile(r"^  [A-Za-z0-9_][A-Za-z0-9_-]*:")
-
-
-def _scope_job(text: str) -> str:
-    lines = text.splitlines(keepends=True)
-    start = next((i for i, line in enumerate(lines) if line.startswith("  scope:")), None)
-    if start is None:
-        raise AssertionError("ci.yml missing scope job")
-    end = start + 1
-    while end < len(lines) and not JOB_KEY_RE.match(lines[end]):
-        end += 1
-    return "".join(lines[start:end])
-
-
-def _inventory_step(text: str) -> str:
-    step = INVENTORY_STEP_RE.search(_scope_job(text))
-    if step is None:
-        raise AssertionError("scope job missing Conformance inventory step")
-    return step.group(0)
+RUN_ALL_COMMAND = (
+    "python3 conformance/run_all.py --require-complete --completion-scope required"
+)
 
 
 POLICIES = ("required", "optional", "external-candidate")
@@ -340,13 +324,14 @@ class ProductWorkflow(unittest.TestCase):
         self.assertFalse(STANDALONE.exists(), STANDALONE)
 
     def test_scope_job_invokes_require_complete_as_a_hard_check(self):
-        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        text = CI_YML.read_text(encoding="utf-8")
+        step = assert_hard_run_command(
+            text, "Conformance inventory", RUN_ALL_COMMAND)
         self.assertIn("python3 conformance/registry.py", step)
-        self.assertIn("conformance/run_all.py --require-complete --completion-scope required", step)
-        self.assertNotIn("continue-on-error", step)
 
     def test_scope_job_invokes_completion_scope_suite(self):
-        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        step = named_step(
+            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
         self.assertIn("conformance/tests/test_completion_scope.py", step)
         mutated = step.replace("conformance/tests/test_completion_scope.py", "")
         self.assertNotEqual(mutated, step)
@@ -355,13 +340,49 @@ class ProductWorkflow(unittest.TestCase):
     def test_deleting_the_scope_job_callsite_fails_this_test(self):
         text = CI_YML.read_text(encoding="utf-8")
         with self.assertRaises(AssertionError):
-            _inventory_step(INVENTORY_STEP_RE.sub("", text))
+            named_step(
+                text.replace(
+                    "      - name: Conformance inventory\n",
+                    "      - name: Deleted conformance inventory\n",
+                    1,
+                ),
+                "Conformance inventory",
+            )
 
     def test_deleting_the_require_complete_callsite_fails_this_test(self):
-        step = _inventory_step(CI_YML.read_text(encoding="utf-8"))
+        step = named_step(
+            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
         mutated = step.replace("--require-complete", "")
         self.assertNotEqual(mutated, step)
         self.assertNotIn("--require-complete", mutated)
+
+    def test_commented_run_all_command_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(RUN_ALL_COMMAND, "# " + RUN_ALL_COMMAND, 1)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+
+    def test_softened_run_all_command_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(RUN_ALL_COMMAND, RUN_ALL_COMMAND + " || true", 1)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+
+    def test_relocated_run_all_command_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace("          " + RUN_ALL_COMMAND, "          :", 1).replace(
+            "      - name: Published-numbers projection contract\n",
+            "      - name: Decorative completion-scope note\n"
+            "        run: |\n"
+            f"          {RUN_ALL_COMMAND}\n\n"
+            "      - name: Published-numbers projection contract\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "Conformance inventory", RUN_ALL_COMMAND)
 
 
 class RegistryDoesNotRunAll(unittest.TestCase):

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -29,6 +29,7 @@ import registry  # noqa: E402
 import run_all  # noqa: E402
 from test_completion_scope import (  # noqa: E402
     REQUIRED_RUN_ALL,
+    REVISION_WITNESS,
     assert_hard_run_command,
     named_job,
     named_step,
@@ -376,6 +377,18 @@ class ProductWorkflow(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
                 mutated, "scope", "Conformance inventory")
+
+    def test_removing_scope_revision_witness_fails(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutated_step = step.replace("          " + REVISION_WITNESS + "\n", "", 1)
+        self.assertNotEqual(mutated_step, step)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace(step, mutated_step, 1),
+                "scope",
+                "Conformance inventory",
+            )
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -390,6 +390,24 @@ class ProductWorkflow(unittest.TestCase):
                 "Conformance inventory",
             )
 
+    def test_scope_workflow_bash_env_fails_closed(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "env:\n",
+            "env:\n  BASH_ENV: /tmp/assay-bash-env\n",
+            1,
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                mutated, "scope", "Conformance inventory")
+        control = text.replace(
+            "env:\n",
+            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n",
+            1,
+        )
+        assert_hard_run_command(
+            control, "scope", "Conformance inventory")
+
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
         mutated = text.replace(

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -30,6 +30,7 @@ import run_all  # noqa: E402
 from test_completion_scope import (  # noqa: E402
     REQUIRED_RUN_ALL,
     assert_hard_run_command,
+    named_job,
     named_step,
 )
 
@@ -397,6 +398,44 @@ class ProductWorkflow(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
                 mutated, "scope", "Conformance inventory")
+
+    def test_wider_indented_conditional_scope_job_fails(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        job = named_job(text, "scope")
+        lines = job.splitlines(keepends=True)
+        widened = (
+            lines[0]
+            + "      if: ${{ github.event_name == 'disabled' }}\n"
+            + "".join("  " + line if line.strip() else line for line in lines[1:])
+        )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace(job, widened, 1),
+                "scope",
+                "Conformance inventory",
+            )
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace("    timeout-minutes: 10\n", "", 1),
+                "scope",
+                "Conformance inventory",
+            )
+
+    def test_custom_scope_shell_fails_the_inventory_guard(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        step = named_step(text, "scope", "Conformance inventory")
+        mutated_step = step.replace(
+            "        shell: bash\n",
+            "        shell: bash -c 'true' -- {0}\n",
+            1,
+        )
+        self.assertNotEqual(mutated_step, step)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_command(
+                text.replace(step, mutated_step, 1),
+                "scope",
+                "Conformance inventory",
+            )
 
     def test_quoted_scope_job_and_inventory_step_keys_fail(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -326,12 +326,15 @@ class ProductWorkflow(unittest.TestCase):
     def test_scope_job_invokes_require_complete_as_a_hard_check(self):
         text = CI_YML.read_text(encoding="utf-8")
         step = assert_hard_run_command(
-            text, "Conformance inventory", RUN_ALL_COMMAND)
+            text, "scope", "Conformance inventory", RUN_ALL_COMMAND)
         self.assertIn("python3 conformance/registry.py", step)
 
     def test_scope_job_invokes_completion_scope_suite(self):
         step = named_step(
-            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
+            CI_YML.read_text(encoding="utf-8"),
+            "scope",
+            "Conformance inventory",
+        )
         self.assertIn("conformance/tests/test_completion_scope.py", step)
         mutated = step.replace("conformance/tests/test_completion_scope.py", "")
         self.assertNotEqual(mutated, step)
@@ -346,12 +349,16 @@ class ProductWorkflow(unittest.TestCase):
                     "      - name: Deleted conformance inventory\n",
                     1,
                 ),
+                "scope",
                 "Conformance inventory",
             )
 
     def test_deleting_the_require_complete_callsite_fails_this_test(self):
         step = named_step(
-            CI_YML.read_text(encoding="utf-8"), "Conformance inventory")
+            CI_YML.read_text(encoding="utf-8"),
+            "scope",
+            "Conformance inventory",
+        )
         mutated = step.replace("--require-complete", "")
         self.assertNotEqual(mutated, step)
         self.assertNotIn("--require-complete", mutated)
@@ -361,14 +368,14 @@ class ProductWorkflow(unittest.TestCase):
         mutated = text.replace(RUN_ALL_COMMAND, "# " + RUN_ALL_COMMAND, 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
     def test_softened_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
         mutated = text.replace(RUN_ALL_COMMAND, RUN_ALL_COMMAND + " || true", 1)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
     def test_relocated_run_all_command_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")
@@ -382,7 +389,7 @@ class ProductWorkflow(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "Conformance inventory", RUN_ALL_COMMAND)
+                mutated, "scope", "Conformance inventory", RUN_ALL_COMMAND)
 
 
 class RegistryDoesNotRunAll(unittest.TestCase):

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -390,23 +390,37 @@ class ProductWorkflow(unittest.TestCase):
                 "Conformance inventory",
             )
 
-    def test_scope_workflow_bash_env_fails_closed(self):
+    def test_scope_workflow_document_shape_fails_closed(self):
         text = CI_YML.read_text(encoding="utf-8")
-        mutated = text.replace(
-            "env:\n",
-            "env:\n  BASH_ENV: /tmp/assay-bash-env\n",
+        env_mutations = (
+            ("BASH_ENV", "  BASH_ENV: /tmp/assay-bash-env\n"),
+            ("PATH", "  PATH: /tmp\n"),
+            ("quoted GIT_DIR", "  'GIT_DIR': /tmp/repo\n"),
+            ("unrelated env", "  UNRELATED_WORKFLOW_ENV: allowed\n"),
+        )
+        for label, addition in env_mutations:
+            with self.subTest(label=label):
+                mutated = text.replace("env:\n", "env:\n" + addition, 1)
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        mutated, "scope", "Conformance inventory")
+        defaults = text.replace(
+            "permissions: {}\n",
+            "defaults:\n  run:\n    working-directory: /tmp\n\npermissions: {}\n",
             1,
         )
+        self.assertNotEqual(defaults, text)
         with self.assertRaises(AssertionError):
             assert_hard_run_command(
-                mutated, "scope", "Conformance inventory")
-        control = text.replace(
-            "env:\n",
-            "env:\n  UNRELATED_WORKFLOW_ENV: allowed\n",
+                defaults, "scope", "Conformance inventory")
+        value_change = text.replace(
+            '  ASSAY_PUBLIC_MSRV: "1.89.0"\n',
+            '  ASSAY_PUBLIC_MSRV: "9.99.0"\n',
             1,
         )
+        self.assertNotEqual(value_change, text)
         assert_hard_run_command(
-            control, "scope", "Conformance inventory")
+            value_change, "scope", "Conformance inventory")
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_registry.py
+++ b/conformance/tests/test_registry.py
@@ -33,6 +33,7 @@ from test_completion_scope import (  # noqa: E402
     assert_hard_run_command,
     named_job,
     named_step,
+    trusted_prefix_mutations,
 )
 
 CI_YML = REPO / ".github/workflows/ci.yml"
@@ -421,6 +422,34 @@ class ProductWorkflow(unittest.TestCase):
         self.assertNotEqual(value_change, text)
         assert_hard_run_command(
             value_change, "scope", "Conformance inventory")
+
+    def test_scope_trusted_prefix_fails_closed(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        target = "      - name: Conformance inventory\n"
+        checkout = (
+            "      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0\n"
+            "        with:\n"
+            "          persist-credentials: false\n"
+            "          fetch-depth: 0\n\n")
+        setup = (
+            "      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0\n"
+            "        with:\n"
+            "          python-version: \"3.12\"\n\n")
+        for label, mutated in trusted_prefix_mutations(
+                text, target, checkout, setup):
+            with self.subTest(label=label):
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_hard_run_command(
+                        mutated, "scope", "Conformance inventory")
+
+        target_step = named_step(text, "scope", "Conformance inventory")
+        post_target = target_step + (
+            "      - name: Harmless post-target control\n"
+            "        run: echo harmless\n\n")
+        assert_hard_run_command(
+            text.replace(target_step, post_target, 1),
+            "scope", "Conformance inventory")
 
     def test_conditional_scope_job_fails_the_inventory_guard(self):
         text = CI_YML.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- replace two independent DOTALL workflow-step regexes with one indentation-bounded parser and shared hard-funnel validator
- bind each protected target to an exact trusted three-step prefix: pinned checkout, pinned setup-python, then the exact hard-run step
- pin workflow, job, action-step, target-step, `with`, shell, and complete active-script contracts without shell-command denylists
- move only the existing CI setup-python and Conformance inventory steps so the inventory target immediately follows its trusted setup prefix

## Stack

- base branch: `cursor/204-trusted-main-oci-capture`
- base / merge-base: `2bce5f1ecf24021f3754b9976399b2ea768660c6`
- current head: `44e80f227882c8a0a74c8756a485ef80b5bb2f42`
- this closes the guard false-greens before PR #2585 receives a new final-head review

## RED -> GREEN

The trusted-prefix RED reproduction initially produced 20 expected failures across the two protected workflows. The completed matrix adds setup `with` mutations and proves 22 valid-YAML/actionlint-clean mutations are rejected:

- pre-target writers for `BASH_ENV`, `GITHUB_PATH`, and combined `GIT_DIR`/`PYTHONPATH`
- checkout extra `env`, extra `with`, and mutable action ref
- setup-python `if`, `continue-on-error`, extra `with`, and mutable action ref
- checkout/setup reordering

Canonical/no-op workflows and one harmless post-target insertion per workflow remain green. Removing the single `_assert_trusted_prefix` call makes all six representative pre-target writer mutations green, establishing ownership of the new failures.

The earlier mutation set remains covered: command commenting/replacement/softening/relocation; step and job `if`/`continue-on-error`; cross-job relocation; quoted direct keys; shell neutralization; wider indentation; explicit Bash; exact scripts; consumed-revision witnesses; and closed document-level keys/env sets.

## Verification on `44e80f227882c8a0a74c8756a485ef80b5bb2f42`

```text
focused trusted-prefix guards: 2/2
completion-scope suite: 40/40
registry suite: 42/42
activation-kit + OCI suites: 134/134
22 trusted-prefix mutations + 2 post-target controls + 2 canonical workflows: actionlint with shellcheck + Ruby Psych pass
reverse removal of trusted-prefix assertion: 6/6 representative writer mutations accepted
py_compile: pass
git diff --check: pass
pre-push hooks including actionlint, required-CI contracts, workspace clippy, and cross-target compile: pass
```

## Scope

Changed only:

- `.github/workflows/ci.yml` (reorder the existing pinned setup-python and Conformance inventory steps into the trusted prefix; existing revision witness retained)
- `.github/workflows/privileged-mcp-action-conformance.yml` (explicit `shell: bash` and revision witness from prior closure commits; no change in the trusted-prefix correction)
- `conformance/tests/test_completion_scope.py`
- `conformance/tests/test_registry.py`

No capture, scoring, record, publication, or candidate behavior changes. Post-target workflow siblings remain unconstrained by this rule.

## Review history

Independent reviews on earlier heads found whole-step cross-job relocation, job-level conditions/soft failure, quoted-key bypass, shell neutralization, stale/base checkout source, workflow-level shell state, and an under-scoped document-level denylist. Each earlier review is invalid for this head.

The latest review on `cbed3179284752e4fa9f71a4be7b93d0984322d5` proved that unchecked pre-target siblings could write `BASH_ENV`, `PATH`, `GIT_DIR`, or `PYTHONPATH` through runner command files. This head replaces implicit trust in those siblings with one shared exact ordered-prefix contract for both funnels.

## Non-claims

- pinned action refs constrain workflow inputs; they do not attest the runner platform or the implementation/behavior of GitHub-hosted actions
- this PR does not prove OCI capture correctness
- this PR does not add trusted scoring, a portable run record, or public projection
- GitHub CI and a fresh independent final-head review must both be green before landing
