### PR TITLE
feat(conformance): bind run records to the scored capture digest

### DIFF
--- a/.github/workflows/privileged-mcp-action-oci-candidate.yml
+++ b/.github/workflows/privileged-mcp-action-oci-candidate.yml
@@ -109,3 +109,104 @@ jobs:
           path: ${{ runner.temp }}/oci-capture/candidate_capture.v0
           if-no-files-found: error
           retention-days: 7
+
+  score:
+    needs: [capture]
+    if: success()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Check out current main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13.8"
+
+      - name: Require trusted main
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "oci capture must be dispatched from main, got $GITHUB_REF" >&2
+            exit 2
+          fi
+          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
+            echo "checked-out main does not match the workflow source commit" >&2
+            exit 2
+          fi
+
+      - name: Resolve published pack tag
+        id: candidate
+        run: |
+          set -euo pipefail
+          python3 \
+            conformance/privileged-mcp-action-v0/scripts/validate_candidate_release.py \
+            --candidate conformance/privileged-mcp-action-v0/candidate-release.json \
+            --manifest conformance/privileged-mcp-action-v0/MANIFEST.json \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Download attested pack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.candidate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/oci-downloads"
+          gh release download "$TAG" --repo Rul1an/assay \
+            --pattern privileged-mcp-action-v0-clean-room.tar.gz \
+            --pattern SHA256SUMS \
+            --pattern attestation-bundle.json \
+            --dir "$RUNNER_TEMP/oci-downloads"
+          (
+            cd "$RUNNER_TEMP/oci-downloads"
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Verify pack attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.candidate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          source_digest="$(gh api "repos/Rul1an/assay/commits/$TAG" --jq .sha)"
+          [[ "$source_digest" =~ ^[0-9a-f]{40}$ ]] || exit 2
+          gh attestation verify \
+            "$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz" \
+            --repo Rul1an/assay \
+            --bundle "$RUNNER_TEMP/oci-downloads/attestation-bundle.json" \
+            --signer-workflow Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml \
+            --source-digest "$source_digest" \
+            --source-ref refs/heads/main \
+            --deny-self-hosted-runners
+
+      - name: Download candidate capture
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: candidate-capture-v0
+          path: ${{ runner.temp }}/oci-score
+
+      - name: Score candidate capture
+        run: |
+          set -euo pipefail
+          PACK="$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"
+          CAPTURE="$RUNNER_TEMP/oci-score/candidate_capture.v0"
+          OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v0"
+          mkdir -p "$(dirname "$OUTPUT")"
+          python3 conformance/privileged-mcp-action-v0/scripts/score_candidate.py \
+            --pack "$PACK" \
+            --manifest conformance/privileged-mcp-action-v0/MANIFEST.json \
+            --capture "$CAPTURE" \
+            --output "$OUTPUT"
+
+      - name: Upload validated run record
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: candidate-run-record-v0
+          path: ${{ runner.temp }}/oci-score/conformance_run.v0
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/privileged-mcp-action-oci-candidate.yml
+++ b/.github/workflows/privileged-mcp-action-oci-candidate.yml
@@ -194,7 +194,7 @@ jobs:
           set -euo pipefail
           PACK="$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"
           CAPTURE="$RUNNER_TEMP/oci-score/candidate_capture.v0"
-          OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v0"
+          OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v1"
           mkdir -p "$(dirname "$OUTPUT")"
           python3 conformance/privileged-mcp-action-v0/scripts/score_candidate.py \
             --pack "$PACK" \
@@ -206,7 +206,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: candidate-run-record-v0
-          path: ${{ runner.temp }}/oci-score/conformance_run.v0
+          name: candidate-run-record-v1
+          path: ${{ runner.temp }}/oci-score/conformance_run.v1
           if-no-files-found: error
           retention-days: 7

--- a/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
+++ b/conformance/privileged-mcp-action-v0/CONFORMANCE-PROTOCOL.md
@@ -192,6 +192,9 @@ a partial record would publish agreement that was never measured.
 `capture.schema.json` documents the capture format. It carries no expected value,
 no match or mismatch, no count of agreement, no score and no badge.
 
+Historical v0 run records are read with the validator from their exact
+activation-kit tag.
+
 ### What the split does and does not buy
 
 It removes the oracle from the host that runs candidate code. It does not

--- a/conformance/privileged-mcp-action-v0/report.schema.json
+++ b/conformance/privileged-mcp-action-v0/report.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Rul1an/assay/privileged-mcp-action-v0-candidate.1/conformance/privileged-mcp-action-v0/report.schema.json",
+  "$id": "urn:assay:schema:privileged-mcp-action:conformance-run:v1",
   "title": "Privileged MCP Action v0 conformance run",
   "type": "object",
   "additionalProperties": false,
@@ -22,7 +22,7 @@
   ],
   "properties": {
     "schema": {
-      "const": "assay.privileged_mcp_action.conformance_run.v0"
+      "const": "assay.privileged_mcp_action.conformance_run.v1"
     },
     "profile": {
       "const": "privileged-mcp-action/v0"

--- a/conformance/privileged-mcp-action-v0/report.schema.json
+++ b/conformance/privileged-mcp-action-v0/report.schema.json
@@ -7,6 +7,7 @@
   "required": [
     "schema",
     "profile",
+    "suite",
     "source_corpus_digest",
     "rendered_set_digest",
     "pack_sha256",
@@ -16,7 +17,8 @@
     "summary",
     "harness_errors",
     "cases",
-    "non_claims"
+    "non_claims",
+    "capture_sha256"
   ],
   "properties": {
     "schema": {
@@ -24,6 +26,9 @@
     },
     "profile": {
       "const": "privileged-mcp-action/v0"
+    },
+    "suite": {
+      "const": "privileged-mcp-action-v0"
     },
     "source_corpus_digest": {
       "$ref": "#/$defs/sha256"
@@ -163,6 +168,9 @@
           }
         ]
       }
+    },
+    "capture_sha256": {
+      "$ref": "#/$defs/sha256"
     },
     "non_claims": {
       "type": "array",

--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -34,6 +34,7 @@ from capture_candidate import (  # noqa: E402
     sha256,
 )
 from artifact_io import (  # noqa: E402
+    content_sha256,
     render_deterministic_json_bytes,
     write_regular_file_atomically,
 )
@@ -44,7 +45,7 @@ from capture_format import (  # noqa: E402
     CaptureError,
     add_identity_arguments,
     identity_from_args,
-    load_capture,
+    load_capture_with_digest,
     normative_surface,
     review_warnings,
     validate_capture,
@@ -55,6 +56,7 @@ from validate_run_record import (  # noqa: E402
     PROFILE,
     RUN_NON_CLAIMS,
     RUN_SCHEMA,
+    require_run_record_binds_capture,
     validate_run_record,
 )
 
@@ -304,7 +306,7 @@ def main() -> int:
 
         try:
             if args.capture is not None:
-                capture = load_capture(args.capture)
+                capture, digest = load_capture_with_digest(args.capture)
             else:
                 # The oracle is already resident, so this path is for candidates
                 # the operator trusts. capture_candidate.py exists for the ones
@@ -314,6 +316,7 @@ def main() -> int:
                     pack, pack_digest, observations, identity_from_args(args)
                 )
                 validate_capture(capture)
+                digest = content_sha256(render_deterministic_json_bytes(capture))
             require_capture_binds_pack(capture, pack, pack_digest)
         except (CaptureError, OSError) as error:
             print(f"capture does not bind: {error}", file=sys.stderr)
@@ -327,8 +330,11 @@ def main() -> int:
         source_corpus_digest,
         rendered_set_digest,
     )
+    report["suite"] = capture["suite"]
+    report["capture_sha256"] = digest
     try:
         validate_run_record(report)
+        require_run_record_binds_capture(report, digest)
     except (KeyError, TypeError, ValueError) as error:
         print(f"scorer produced an invalid run record: {error}", file=sys.stderr)
         return 2

--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -39,15 +39,11 @@ from artifact_io import (  # noqa: E402
     write_regular_file_atomically,
 )
 from capture_format import (  # noqa: E402
-    STATE_CANDIDATE_ERROR,
-    STATE_CAPTURE_ERROR,
-    STATE_OBSERVED,
     CaptureError,
     add_identity_arguments,
     identity_from_args,
     load_capture_with_digest,
     normative_surface,
-    review_warnings,
     validate_capture,
 )
 from pack_format import ordered_vectors, rewrite_bundle_stream_identity  # noqa: E402
@@ -56,17 +52,12 @@ from validate_run_record import (  # noqa: E402
     PROFILE,
     RUN_NON_CLAIMS,
     RUN_SCHEMA,
+    STATE_TO_STATUS,
     implementation_record,
+    report_case_from_observation,
     require_run_record_binds_capture,
     validate_run_record,
 )
-
-# A capture state names what happened on the capture host; a run-record status
-# names what the run concluded. The two vocabularies are joined in one place.
-STATE_TO_STATUS = {
-    STATE_CANDIDATE_ERROR: "execution_error",
-    STATE_CAPTURE_ERROR: "harness_error",
-}
 
 
 def load_expectations(manifest_path: Path) -> tuple[dict[str, Any], str, str]:
@@ -157,37 +148,10 @@ def score_capture(
         "review_warnings": 0,
     }
     for observation in capture["observations"]:
-        result: dict[str, Any] = {
-            "case_id": observation["case_id"],
-            "input_sha256": observation["input_sha256"],
-        }
-        if observation["state"] != STATE_OBSERVED:
-            status = STATE_TO_STATUS[observation["state"]]
-            result.update(status=status, error=observation["error"])
-            counts[status] += 1
-            cases.append(result)
-            continue
-        observed = observation["observed"]
-        expected = expected_by_hash.get(observation["input_sha256"])
-        if expected is None:
-            result.update(
-                status="harness_error",
-                error="opaque case is absent from canonical expectations",
-            )
-            counts["harness_error"] += 1
-            cases.append(result)
-            continue
-        result.update(
-            status="match" if observed == expected else "mismatch",
-            observed=observed,
-            exit_code=observation["exit_code"],
-            stderr_present=observation["stderr_present"],
-        )
+        result = report_case_from_observation(observation, expected_by_hash)
         counts[result["status"]] += 1
-        warnings = review_warnings(observation)
-        if warnings:
-            result["review_warnings"] = warnings
-            counts["review_warnings"] += len(warnings)
+        warnings = result.get("review_warnings", [])
+        counts["review_warnings"] += len(warnings)
         cases.append(result)
 
     return {
@@ -315,7 +279,7 @@ def main() -> int:
     report["capture_sha256"] = digest
     try:
         validate_run_record(report)
-        require_run_record_binds_capture(report, capture, digest)
+        require_run_record_binds_capture(report, capture, digest, expected_by_hash)
     except (KeyError, TypeError, ValueError) as error:
         print(f"scorer produced an invalid run record: {error}", file=sys.stderr)
         return 2

--- a/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
+++ b/conformance/privileged-mcp-action-v0/scripts/score_candidate.py
@@ -56,6 +56,7 @@ from validate_run_record import (  # noqa: E402
     PROFILE,
     RUN_NON_CLAIMS,
     RUN_SCHEMA,
+    implementation_record,
     require_run_record_binds_capture,
     validate_run_record,
 )
@@ -117,26 +118,6 @@ def require_capture_binds_pack(capture: dict[str, Any], pack: dict[str, Any], pa
             raise CaptureError(
                 f"{case['id']}: capture input digest does not bind this pack"
             )
-
-
-def implementation_record(declared: dict[str, Any]) -> dict[str, Any]:
-    """Carry the capture's declared identity. Shape-validated, never verified.
-
-    `id` and `image` appear only when the capture declared them, so an existing
-    v0 run record with neither stays valid and a run that named no image does
-    not grow a field implying one.
-    """
-    record = {
-        "name": declared["name"],
-        "version": declared["version"],
-        "source": declared["source"],
-        "commit": declared["commit"],
-        "reproduction_mode": declared["reproduction_mode"],
-    }
-    if declared["id"] is not None:
-        record["id"] = declared["id"]
-        record["image"] = declared["image"]
-    return record
 
 
 def score_capture(
@@ -334,7 +315,7 @@ def main() -> int:
     report["capture_sha256"] = digest
     try:
         validate_run_record(report)
-        require_run_record_binds_capture(report, digest)
+        require_run_record_binds_capture(report, capture, digest)
     except (KeyError, TypeError, ValueError) as error:
         print(f"scorer produced an invalid run record: {error}", file=sys.stderr)
         return 2

--- a/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
+++ b/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
@@ -24,6 +24,8 @@ from strict_json import MAX_JSON_DEPTH, load_strict_object  # noqa: E402
 
 RUN_SCHEMA = "assay.privileged_mcp_action.conformance_run.v0"
 PROFILE = "privileged-mcp-action/v0"
+# Captured from the capture document, never reconstructed from PROFILE.
+SUITE = "privileged-mcp-action-v0"
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 # Kept beside the other corpus-shape constants rather than written into the checks, which is how
 # "13" survived in seven separate files after the corpus grew: two scripts, this one's own checks,
@@ -71,6 +73,7 @@ IMPLEMENTATION_BINDING_KEYS = {"id", "image"}
 TOP_LEVEL_KEYS = {
     "schema",
     "profile",
+    "suite",
     "source_corpus_digest",
     "rendered_set_digest",
     "pack_sha256",
@@ -81,12 +84,21 @@ TOP_LEVEL_KEYS = {
     "harness_errors",
     "cases",
     "non_claims",
+    "capture_sha256",
 }
 
 
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise ValueError(message)
+
+
+def require_run_record_binds_capture(report: dict[str, Any], capture_digest: str) -> None:
+    require(bool(SHA256.fullmatch(capture_digest)), "capture digest is malformed")
+    require(
+        report["capture_sha256"] == capture_digest,
+        "capture_sha256 does not address the scored capture bytes",
+    )
 
 
 def load_run_record(path: Path) -> Any:
@@ -157,7 +169,8 @@ def validate_run_record(report: dict[str, Any]) -> None:
     require(set(report) == TOP_LEVEL_KEYS, "run record has missing or surplus fields")
     require(report["schema"] == RUN_SCHEMA, "run record schema mismatch")
     require(report["profile"] == PROFILE, "run record profile mismatch")
-    for field in ("source_corpus_digest", "rendered_set_digest", "pack_sha256"):
+    require(report["suite"] == SUITE, "run record suite mismatch")
+    for field in ("source_corpus_digest", "rendered_set_digest", "pack_sha256", "capture_sha256"):
         require(bool(SHA256.fullmatch(report[field])), f"{field} is malformed")
     require(
         bool(FULL_SHA.fullmatch(report["pack_declared_source_commit"])),

--- a/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
+++ b/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
@@ -93,11 +93,59 @@ def require(condition: bool, message: str) -> None:
         raise ValueError(message)
 
 
-def require_run_record_binds_capture(report: dict[str, Any], capture_digest: str) -> None:
+def implementation_record(declared: dict[str, Any]) -> dict[str, Any]:
+    """Carry the capture's declared identity. Shape-validated, never verified.
+
+    `id` and `image` appear only when the capture declared them, so an existing
+    v0 run record with neither stays valid and a run that named no image does
+    not grow a field implying one.
+    """
+    record = {
+        "name": declared["name"],
+        "version": declared["version"],
+        "source": declared["source"],
+        "commit": declared["commit"],
+        "reproduction_mode": declared["reproduction_mode"],
+    }
+    if declared["id"] is not None:
+        record["id"] = declared["id"]
+        record["image"] = declared["image"]
+    return record
+
+
+def require_run_record_binds_capture(
+    report: dict[str, Any], capture: dict[str, Any], capture_digest: str
+) -> None:
     require(bool(SHA256.fullmatch(capture_digest)), "capture digest is malformed")
     require(
         report["capture_sha256"] == capture_digest,
         "capture_sha256 does not address the scored capture bytes",
+    )
+    require(
+        report["suite"] == capture["suite"],
+        "run record suite does not bind the scored capture",
+    )
+    for field in (
+        "pack_sha256",
+        "source_corpus_digest",
+        "rendered_set_digest",
+        "pack_declared_source_commit",
+    ):
+        require(
+            report[field] == capture[field],
+            f"run record {field} does not bind the scored capture",
+        )
+    require(
+        report["implementation"] == implementation_record(capture["implementation"]),
+        "run record implementation does not bind the scored capture",
+    )
+    require(
+        [(case["case_id"], case["input_sha256"]) for case in report["cases"]]
+        == [
+            (observation["case_id"], observation["input_sha256"])
+            for observation in capture["observations"]
+        ],
+        "run record cases do not bind the scored capture observations in order",
     )
 
 

--- a/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
+++ b/conformance/privileged-mcp-action-v0/scripts/validate_run_record.py
@@ -22,7 +22,7 @@ from implementations import (  # noqa: E402
 from strict_json import MAX_JSON_DEPTH, load_strict_object  # noqa: E402
 
 
-RUN_SCHEMA = "assay.privileged_mcp_action.conformance_run.v0"
+RUN_SCHEMA = "assay.privileged_mcp_action.conformance_run.v1"
 PROFILE = "privileged-mcp-action/v0"
 # Captured from the capture document, never reconstructed from PROFILE.
 SUITE = "privileged-mcp-action-v0"
@@ -96,9 +96,8 @@ def require(condition: bool, message: str) -> None:
 def implementation_record(declared: dict[str, Any]) -> dict[str, Any]:
     """Carry the capture's declared identity. Shape-validated, never verified.
 
-    `id` and `image` appear only when the capture declared them, so an existing
-    v0 run record with neither stays valid and a run that named no image does
-    not grow a field implying one.
+    Optional `id` and `image` follow only the capture; a run that named no
+    image does not grow a field implying one.
     """
     record = {
         "name": declared["name"],
@@ -113,8 +112,55 @@ def implementation_record(declared: dict[str, Any]) -> dict[str, Any]:
     return record
 
 
+# A capture state names what happened on the capture host; a run-record status
+# names what the run concluded. The two vocabularies are joined in one place.
+# Keys are capture_format.STATE_* values, kept as literals so this module does
+# not import capture_format at load time (capture_format imports us).
+STATE_TO_STATUS = {
+    "candidate_error": "execution_error",
+    "capture_error": "harness_error",
+}
+
+
+def report_case_from_observation(
+    observation: dict[str, Any], expected_by_hash: dict[str, Any]
+) -> dict[str, Any]:
+    """Project one capture observation into a run-record case. The only projector."""
+    from capture_format import STATE_OBSERVED, review_warnings
+
+    result: dict[str, Any] = {
+        "case_id": observation["case_id"],
+        "input_sha256": observation["input_sha256"],
+    }
+    if observation["state"] != STATE_OBSERVED:
+        status = STATE_TO_STATUS[observation["state"]]
+        result.update(status=status, error=observation["error"])
+        return result
+    observed = observation["observed"]
+    expected = expected_by_hash.get(observation["input_sha256"])
+    if expected is None:
+        result.update(
+            status="harness_error",
+            error="opaque case is absent from canonical expectations",
+        )
+        return result
+    result.update(
+        status="match" if observed == expected else "mismatch",
+        observed=observed,
+        exit_code=observation["exit_code"],
+        stderr_present=observation["stderr_present"],
+    )
+    warnings = review_warnings(observation)
+    if warnings:
+        result["review_warnings"] = warnings
+    return result
+
+
 def require_run_record_binds_capture(
-    report: dict[str, Any], capture: dict[str, Any], capture_digest: str
+    report: dict[str, Any],
+    capture: dict[str, Any],
+    capture_digest: str,
+    expected_by_hash: dict[str, Any],
 ) -> None:
     require(bool(SHA256.fullmatch(capture_digest)), "capture digest is malformed")
     require(
@@ -139,13 +185,13 @@ def require_run_record_binds_capture(
         report["implementation"] == implementation_record(capture["implementation"]),
         "run record implementation does not bind the scored capture",
     )
+    projected = [
+        report_case_from_observation(obs, expected_by_hash)
+        for obs in capture["observations"]
+    ]
     require(
-        [(case["case_id"], case["input_sha256"]) for case in report["cases"]]
-        == [
-            (observation["case_id"], observation["input_sha256"])
-            for observation in capture["observations"]
-        ],
-        "run record cases do not bind the scored capture observations in order",
+        report["cases"] == projected,
+        "run record cases do not bind the projected capture observations",
     )
 
 
@@ -214,8 +260,8 @@ def validate_normative_surface(value: dict[str, Any]) -> None:
 
 
 def validate_run_record(report: dict[str, Any]) -> None:
+    require(report.get("schema") == RUN_SCHEMA, "unsupported schema")
     require(set(report) == TOP_LEVEL_KEYS, "run record has missing or surplus fields")
-    require(report["schema"] == RUN_SCHEMA, "run record schema mismatch")
     require(report["profile"] == PROFILE, "run record profile mismatch")
     require(report["suite"] == SUITE, "run record suite mismatch")
     for field in ("source_corpus_digest", "rendered_set_digest", "pack_sha256", "capture_sha256"):
@@ -236,9 +282,8 @@ def validate_run_record(report: dict[str, Any]) -> None:
         and set(implementation) <= IMPLEMENTATION_REQUIRED_KEYS | IMPLEMENTATION_BINDING_KEYS,
         "implementation has missing or surplus fields",
     )
-    # `id` and `image` are optional so a v0 record produced before this binding
-    # existed stays valid, and they travel together so a record cannot name a
-    # registry row without naming the image bytes that row addresses.
+    # `id` and `image` are optional and travel together, so a record cannot
+    # name a registry row without naming the image bytes that row addresses.
     binding = set(implementation) & IMPLEMENTATION_BINDING_KEYS
     require(
         binding in (set(), IMPLEMENTATION_BINDING_KEYS),

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -67,7 +67,7 @@ OCI_PYTHON_VERSION = 'python-version: "3.13.8"'
 OCI_SOURCE_DIGEST_SHAPE = '[[ "$source_digest" =~ ^[0-9a-f]{40}$ ]]'
 OCI_SOURCE_DIGEST_GUARD = OCI_SOURCE_DIGEST_SHAPE + " || exit 2"
 OCI_CAPTURE_UPLOAD_PATH = "${{ runner.temp }}/oci-capture/candidate_capture.v0"
-OCI_SCORE_UPLOAD_PATH = "${{ runner.temp }}/oci-score/conformance_run.v0"
+OCI_SCORE_UPLOAD_PATH = "${{ runner.temp }}/oci-score/conformance_run.v1"
 OCI_IMPLEMENTATION_ID_ENV = "IMPLEMENTATION_ID: ${{ inputs.implementation_id }}"
 OCI_IMPLEMENTATION_ID_ARGV = '--implementation-id "$IMPLEMENTATION_ID"'
 OCI_UPLOAD_STEP = "Upload validated capture"
@@ -96,7 +96,7 @@ OCI_SCORE_JOB_KEYS = ("needs", "if", "runs-on", "timeout-minutes", "steps")
 OCI_DOCUMENT_KEYS = ("name", "on", "permissions", "concurrency", "jobs")
 OCI_TAG_BINDING = "TAG: ${{ steps.candidate.outputs.tag }}"
 OCI_ARTIFACT_NAME = "name: candidate-capture-v0"
-OCI_SCORE_ARTIFACT_NAME = "name: candidate-run-record-v0"
+OCI_SCORE_ARTIFACT_NAME = "name: candidate-run-record-v1"
 OCI_SCORE_NEEDS = "needs: [capture]"
 OCI_STEP_KEYS = {
     "Check out current main": ("name", "uses", "with"),
@@ -233,7 +233,7 @@ OCI_SCORE_PINNED_STEP_SEQUENCES = {
         "set -euo pipefail",
         'PACK="$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"',
         'CAPTURE="$RUNNER_TEMP/oci-score/candidate_capture.v0"',
-        'OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v0"',
+        'OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v1"',
         'mkdir -p "$(dirname "$OUTPUT")"',
         f"python3 {OCI_SCORER}"
         ' --pack "$PACK"'
@@ -1660,6 +1660,14 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         target.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
         return target
 
+    def expected_from(self, capture: dict) -> dict:
+        """The expected dict `bound_report` already builds."""
+        return {
+            observation["input_sha256"]: observation["observed"]
+            for observation in capture["observations"]
+            if observation["state"] == capture_format.STATE_OBSERVED
+        }
+
     def bound_report(self, capture: dict, digest: str) -> dict:
         pack = {
             "declared_source_commit": capture["pack_declared_source_commit"],
@@ -1670,11 +1678,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
                 for observation in capture["observations"]
             ],
         }
-        expected = {
-            observation["input_sha256"]: observation["observed"]
-            for observation in capture["observations"]
-            if observation["state"] == capture_format.STATE_OBSERVED
-        }
+        expected = self.expected_from(capture)
         report = score_candidate.score_capture(
             capture,
             pack,
@@ -1806,6 +1810,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
                 validate_run_record.load_run_record(record),
                 document,
                 h1,
+                self.expected_from(document),
             )
         self.assertEqual(record.read_bytes(), original_record)
 
@@ -1872,7 +1877,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             "capture_sha256 does not address the scored capture bytes",
         ):
             validate_run_record.validate_run_record(report)
-            validate_run_record.require_run_record_binds_capture(report, loaded, h1)
+            validate_run_record.require_run_record_binds_capture(report, loaded, h1, self.expected_from(loaded))
         self.assertFalse(output.exists())
 
     def test_unmutated_capture_binds_and_rescore_is_byte_identical(self) -> None:
@@ -1884,6 +1889,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             validate_run_record.load_run_record(first),
             document,
             h0,
+            self.expected_from(document),
         )
         second = self.root / "noop-rescore-second.json"
         first_bytes = first.read_bytes()
@@ -1902,7 +1908,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         self.assertEqual(report["suite"], capture_format.SUITE)
         self.assertEqual(report["capture_sha256"], digest)
         self.assertNotEqual(report["suite"], report["profile"])
-        validate_run_record.require_run_record_binds_capture(report, document, digest)
+        validate_run_record.require_run_record_binds_capture(report, document, digest, self.expected_from(document))
 
     def test_unswapped_scored_report_binds_capture(self) -> None:
         """No-op control: a report scored from the capture must bind it."""
@@ -1911,11 +1917,11 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         report = self.bound_report(capture, digest)
         capture_format.validate_capture(capture)
         validate_run_record.validate_run_record(report)
-        validate_run_record.require_run_record_binds_capture(report, capture, digest)
+        validate_run_record.require_run_record_binds_capture(report, capture, digest, self.expected_from(capture))
         params = list(
             inspect.signature(validate_run_record.require_run_record_binds_capture).parameters
         )
-        self.assertEqual(params, ["report", "capture", "capture_digest"])
+        self.assertEqual(params, ["report", "capture", "capture_digest", "expected_by_hash"])
 
     def test_binder_refuses_swapped_implementation_identity(self) -> None:
         capture_path = self.valid_capture("cross-bind-impl")
@@ -1930,7 +1936,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         capture_format.validate_capture(capture)
         validate_run_record.validate_run_record(swapped)
         with self.assertRaisesRegex(ValueError, "implementation does not bind"):
-            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest, self.expected_from(capture))
         self.assertEqual(capture, original_capture)
         capture_format.validate_capture(capture)
 
@@ -1960,7 +1966,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         capture_format.validate_capture(capture)
         validate_run_record.validate_run_record(swapped)
         with self.assertRaisesRegex(ValueError, "implementation does not bind"):
-            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest, self.expected_from(capture))
         self.assertEqual(capture, original_capture)
         capture_format.validate_capture(capture)
 
@@ -1977,7 +1983,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         capture_format.validate_capture(capture)
         validate_run_record.validate_run_record(swapped)
         with self.assertRaisesRegex(ValueError, "does not bind the scored capture"):
-            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest, self.expected_from(capture))
         self.assertEqual(capture, original_capture)
         capture_format.validate_capture(capture)
 
@@ -1991,9 +1997,172 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         capture_format.validate_capture(capture)
         validate_run_record.validate_run_record(swapped)
         with self.assertRaisesRegex(ValueError, "cases do not bind"):
-            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest, self.expected_from(capture))
         self.assertEqual(capture, original_capture)
         capture_format.validate_capture(capture)
+
+    def test_binder_refuses_swapped_observed_on_match_case(self) -> None:
+        """A match report can keep IDs/digests and still carry a foreign observed."""
+        capture_path = self.valid_capture("cross-bind-observed")
+        capture, digest = capture_format.load_capture_with_digest(capture_path)
+        original_capture = json.loads(json.dumps(capture))
+        report = self.bound_report(capture, digest)
+        swapped = json.loads(json.dumps(report))
+        original_observed = swapped["cases"][0]["observed"]
+        swapped_observed = {"bundle_integrity": "fail"}
+        if original_observed == swapped_observed:
+            swapped_observed = {"bundle_integrity": "pass", "verdict": "invalid"}
+        swapped["cases"][0]["observed"] = swapped_observed
+        self.assertEqual(swapped["capture_sha256"], digest)
+        self.assertEqual(swapped["cases"][0]["case_id"], capture["observations"][0]["case_id"])
+        self.assertEqual(
+            swapped["cases"][0]["input_sha256"],
+            capture["observations"][0]["input_sha256"],
+        )
+        self.assertEqual(swapped["cases"][0]["status"], "match")
+        self.assertNotEqual(swapped["cases"][0]["observed"], original_observed)
+        capture_format.validate_capture(capture)
+        validate_run_record.validate_run_record(swapped)
+        with self.assertRaisesRegex(ValueError, "do not bind"):
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest, self.expected_from(capture))
+        self.assertEqual(capture, original_capture)
+        capture_format.validate_capture(capture)
+
+    def test_binder_refuses_swapped_status_and_error_on_non_observed_case(self) -> None:
+        """candidate_error scores to execution_error; status/error still must bind."""
+        capture_path = self.valid_capture("cross-bind-error-case")
+
+        def as_candidate_error(document):
+            first = document["observations"][0]
+            document["observations"][0] = {
+                "case_id": first["case_id"],
+                "input_sha256": first["input_sha256"],
+                "state": capture_format.STATE_CANDIDATE_ERROR,
+                "error": capture_format.bound_error("candidate failed this case"),
+            }
+
+        rewritten = self.rewrite(
+            capture_path, "cross-bind-error-case-rewritten", as_candidate_error
+        )
+        capture, digest = capture_format.load_capture_with_digest(rewritten)
+        original_capture = json.loads(json.dumps(capture))
+        report = self.bound_report(capture, digest)
+        self.assertEqual(report["cases"][0]["status"], "execution_error")
+        self.assertEqual(report["cases"][0]["error"], "candidate failed this case")
+        swapped = json.loads(json.dumps(report))
+        swapped["cases"][0]["status"] = "harness_error"
+        swapped["cases"][0]["error"] = "swapped harness error"
+        swapped["summary"]["execution_error"] -= 1
+        swapped["summary"]["harness_error"] += 1
+        self.assertEqual(swapped["capture_sha256"], digest)
+        self.assertEqual(swapped["cases"][0]["case_id"], capture["observations"][0]["case_id"])
+        self.assertEqual(
+            swapped["cases"][0]["input_sha256"],
+            capture["observations"][0]["input_sha256"],
+        )
+        capture_format.validate_capture(capture)
+        validate_run_record.validate_run_record(swapped)
+        with self.assertRaisesRegex(ValueError, "do not bind"):
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest, self.expected_from(capture))
+        self.assertEqual(capture, original_capture)
+        capture_format.validate_capture(capture)
+
+    def test_binder_refuses_swapped_exit_code_stderr_or_review_warnings(self) -> None:
+        """exit_code, stderr_present, and capture-derived warnings must bind."""
+        capture_path = self.valid_capture("cross-bind-case-facts")
+
+        def flag_schema_mismatch(document):
+            document["observations"][0]["report_schema_matches"] = False
+
+        warned = self.rewrite(
+            capture_path, "cross-bind-case-facts-warned", flag_schema_mismatch
+        )
+        capture, digest = capture_format.load_capture_with_digest(warned)
+        original_capture = json.loads(json.dumps(capture))
+        self.assertTrue(capture_format.review_warnings(capture["observations"][0]))
+        report = self.bound_report(capture, digest)
+        self.assertTrue(report["cases"][0].get("review_warnings"))
+
+        with self.subTest(field="exit_code_and_stderr_present"):
+            swapped = json.loads(json.dumps(report))
+            swapped["cases"][0]["exit_code"] = swapped["cases"][0]["exit_code"] + 1
+            swapped["cases"][0]["stderr_present"] = not swapped["cases"][0][
+                "stderr_present"
+            ]
+            self.assertEqual(swapped["capture_sha256"], digest)
+            self.assertEqual(
+                swapped["cases"][0]["case_id"],
+                capture["observations"][0]["case_id"],
+            )
+            self.assertEqual(
+                swapped["cases"][0]["input_sha256"],
+                capture["observations"][0]["input_sha256"],
+            )
+            capture_format.validate_capture(capture)
+            validate_run_record.validate_run_record(swapped)
+            with self.assertRaisesRegex(ValueError, "do not bind"):
+                validate_run_record.require_run_record_binds_capture(
+                    swapped, capture, digest, self.expected_from(capture)
+                )
+            self.assertEqual(capture, original_capture)
+
+        with self.subTest(field="review_warnings"):
+            swapped = json.loads(json.dumps(report))
+            warnings = swapped["cases"][0].pop("review_warnings")
+            swapped["summary"]["review_warnings"] -= len(warnings)
+            self.assertEqual(swapped["capture_sha256"], digest)
+            self.assertEqual(
+                swapped["cases"][0]["case_id"],
+                capture["observations"][0]["case_id"],
+            )
+            self.assertEqual(
+                swapped["cases"][0]["input_sha256"],
+                capture["observations"][0]["input_sha256"],
+            )
+            capture_format.validate_capture(capture)
+            validate_run_record.validate_run_record(swapped)
+            with self.assertRaisesRegex(ValueError, "do not bind"):
+                validate_run_record.require_run_record_binds_capture(
+                    swapped, capture, digest, self.expected_from(capture)
+                )
+            self.assertEqual(capture, original_capture)
+        capture_format.validate_capture(capture)
+
+    def test_swapped_observed_does_not_overwrite_prior_output(self) -> None:
+        capture_path = self.valid_capture("prior-output-observed")
+        output = self.root / "prior-output-observed-record.json"
+        prior = b'{"prior":true}\n'
+        output.write_bytes(prior)
+        real_score = score_candidate.score_capture
+
+        def score_then_swap(*args, **kwargs):
+            report = real_score(*args, **kwargs)
+            observed = report["cases"][0]["observed"]
+            swapped_observed = {"bundle_integrity": "fail"}
+            if observed == swapped_observed:
+                swapped_observed = {"bundle_integrity": "pass", "verdict": "invalid"}
+            report["cases"][0]["observed"] = swapped_observed
+            return report
+
+        argv = [
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(self.pack),
+            "--manifest",
+            str(CORPUS_DIR / "MANIFEST.json"),
+            "--capture",
+            str(capture_path),
+            "--output",
+            str(output),
+        ]
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch.object(
+                score_candidate, "score_capture", side_effect=score_then_swap
+            ),
+        ):
+            self.assertEqual(score_candidate.main(), 2)
+        self.assertEqual(output.read_bytes(), prior)
 
     def test_swapped_report_does_not_overwrite_prior_output(self) -> None:
         capture_path = self.valid_capture("prior-output")
@@ -2046,6 +2215,28 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             inspect.getsource(validate_run_record.require_run_record_binds_capture),
         )
 
+    def test_report_case_from_observation_is_one_shared_projection(self) -> None:
+        source = Path(score_candidate.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("def report_case_from_observation", source)
+        self.assertIs(
+            score_candidate.report_case_from_observation,
+            validate_run_record.report_case_from_observation,
+        )
+        self.assertIn(
+            "report_case_from_observation(observation, expected_by_hash)",
+            inspect.getsource(score_candidate.score_capture),
+        )
+        self.assertIn(
+            "report_case_from_observation(obs, expected_by_hash)",
+            inspect.getsource(validate_run_record.require_run_record_binds_capture),
+        )
+        defs = [
+            node.name
+            for node in ast.parse(source).body
+            if isinstance(node, ast.FunctionDef)
+        ]
+        self.assertEqual(defs.count("report_case_from_observation"), 0)
+
     def test_scorer_uses_one_read_digest_and_keeps_the_bind_callsite(self) -> None:
         source = inspect.getsource(score_candidate.main)
         self.assertIn("load_capture_with_digest(", source)
@@ -2053,7 +2244,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         self.assertIn('report["suite"] = capture["suite"]', source)
         self.assertNotIn("PROFILE.replace", source)
         self.assertIn("validate_run_record(", source)
-        self.assertIn("require_run_record_binds_capture(report, capture, digest)", source)
+        self.assertIn("require_run_record_binds_capture(report, capture, digest, expected_by_hash)", source)
         self.assertIn("write_regular_file_atomically(", source)
         self.assertNotIn("write_text", source)
         self.assertIs(
@@ -2074,6 +2265,70 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             schema["properties"]["capture_sha256"]["$ref"],
             "#/$defs/sha256",
         )
+
+    def test_run_record_schema_identity_is_v1(self) -> None:
+        schema = json.loads((CORPUS_DIR / "report.schema.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            schema["$id"],
+            "urn:assay:schema:privileged-mcp-action:conformance-run:v1",
+        )
+        self.assertNotIn("getassay.dev", schema["$id"])
+        self.assertNotIn("githubusercontent.com", schema["$id"])
+        self.assertEqual(
+            schema["properties"]["schema"]["const"],
+            "assay.privileged_mcp_action.conformance_run.v1",
+        )
+        self.assertEqual(
+            validate_run_record.RUN_SCHEMA,
+            "assay.privileged_mcp_action.conformance_run.v1",
+        )
+        self.assertEqual(
+            schema["properties"]["schema"]["const"],
+            validate_run_record.RUN_SCHEMA,
+        )
+        capture = self.valid_capture("schema-v1")
+        output = self.root / "schema-v1-report.json"
+        self.assertEqual(self.score_capture(capture, output).returncode, 0)
+        report = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(report["schema"], validate_run_record.RUN_SCHEMA)
+        self.assertEqual(report["schema"], schema["properties"]["schema"]["const"])
+
+    def test_validator_refuses_canonical_v0_as_unsupported_schema(self) -> None:
+        """A v0 record is refused as unsupported schema, not as a shape error."""
+        capture = self.valid_capture("v0-refusal")
+        output = self.root / "v0-refusal-report.json"
+        self.assertEqual(self.score_capture(capture, output).returncode, 0)
+        report = json.loads(output.read_text(encoding="utf-8"))
+        v0 = json.loads(json.dumps(report))
+        v0["schema"] = "assay.privileged_mcp_action.conformance_run.v0"
+        del v0["suite"]
+        del v0["capture_sha256"]
+        with self.assertRaisesRegex(ValueError, "unsupported schema") as ctx:
+            validate_run_record.validate_run_record(v0)
+        self.assertNotIn("missing or surplus fields", str(ctx.exception))
+
+    def test_profile_remains_privileged_mcp_action_v0(self) -> None:
+        schema = json.loads((CORPUS_DIR / "report.schema.json").read_text(encoding="utf-8"))
+        self.assertEqual(validate_run_record.PROFILE, "privileged-mcp-action/v0")
+        self.assertEqual(
+            schema["properties"]["profile"]["const"],
+            "privileged-mcp-action/v0",
+        )
+        capture = self.valid_capture("profile-v0")
+        output = self.root / "profile-v0-report.json"
+        self.assertEqual(self.score_capture(capture, output).returncode, 0)
+        report = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(report["profile"], "privileged-mcp-action/v0")
+
+    def test_workflow_score_output_is_v1_only(self) -> None:
+        text = OCI_CANDIDATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn('OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v1"', text)
+        self.assertIn("name: candidate-run-record-v1", text)
+        self.assertIn("${{ runner.temp }}/oci-score/conformance_run.v1", text)
+        self.assertNotIn("conformance_run.v0", text)
+        self.assertNotIn("candidate-run-record-v0", text)
+        self.assertIn("name: candidate-capture-v0", text)
+        self.assertIn("candidate_capture.v0", text)
 
     def test_missing_or_duplicated_observation_is_refused_without_a_record(self) -> None:
         capture = self.valid_capture("cardinality")
@@ -3496,7 +3751,7 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
             (
                 "score_artifact_name",
                 f"          {OCI_SCORE_ARTIFACT_NAME}\n",
-                "          name: candidate-run-record-v0-extra\n",
+                "          name: candidate-run-record-v1-extra\n",
                 "missing exact run-record artifact name",
             ),
         )

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -1660,6 +1660,33 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         target.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
         return target
 
+    def bound_report(self, capture: dict, digest: str) -> dict:
+        pack = {
+            "declared_source_commit": capture["pack_declared_source_commit"],
+            "source_corpus_digest": capture["source_corpus_digest"],
+            "rendered_set_digest": capture["rendered_set_digest"],
+            "cases": [
+                {"id": observation["case_id"], "sha256": observation["input_sha256"]}
+                for observation in capture["observations"]
+            ],
+        }
+        expected = {
+            observation["input_sha256"]: observation["observed"]
+            for observation in capture["observations"]
+            if observation["state"] == capture_format.STATE_OBSERVED
+        }
+        report = score_candidate.score_capture(
+            capture,
+            pack,
+            capture["pack_sha256"],
+            expected,
+            pack["source_corpus_digest"],
+            pack["rendered_set_digest"],
+        )
+        report["suite"] = capture["suite"]
+        report["capture_sha256"] = digest
+        return report
+
     def test_capture_observations_runner_is_keyword_only_and_defaults(self) -> None:
         import capture_candidate
 
@@ -1768,7 +1795,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             document["implementation"]["name"] = "mutated implementation"
 
         mutated = self.rewrite(capture, "stale-bind-mutated", rename)
-        _document, h1 = capture_format.load_capture_with_digest(mutated)
+        document, h1 = capture_format.load_capture_with_digest(mutated)
         self.assertNotEqual(h0, h1)
 
         with self.assertRaisesRegex(
@@ -1777,6 +1804,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         ):
             validate_run_record.require_run_record_binds_capture(
                 validate_run_record.load_run_record(record),
+                document,
                 h1,
             )
         self.assertEqual(record.read_bytes(), original_record)
@@ -1844,16 +1872,17 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             "capture_sha256 does not address the scored capture bytes",
         ):
             validate_run_record.validate_run_record(report)
-            validate_run_record.require_run_record_binds_capture(report, h1)
+            validate_run_record.require_run_record_binds_capture(report, loaded, h1)
         self.assertFalse(output.exists())
 
     def test_unmutated_capture_binds_and_rescore_is_byte_identical(self) -> None:
         capture = self.valid_capture("noop-rescore")
         first = self.root / "noop-rescore-first.json"
         self.assertEqual(self.score_capture(capture, first).returncode, 0)
-        h0 = capture_format.load_capture_with_digest(capture)[1]
+        document, h0 = capture_format.load_capture_with_digest(capture)
         validate_run_record.require_run_record_binds_capture(
             validate_run_record.load_run_record(first),
+            document,
             h0,
         )
         second = self.root / "noop-rescore-second.json"
@@ -1873,7 +1902,149 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         self.assertEqual(report["suite"], capture_format.SUITE)
         self.assertEqual(report["capture_sha256"], digest)
         self.assertNotEqual(report["suite"], report["profile"])
-        validate_run_record.require_run_record_binds_capture(report, digest)
+        validate_run_record.require_run_record_binds_capture(report, document, digest)
+
+    def test_unswapped_scored_report_binds_capture(self) -> None:
+        """No-op control: a report scored from the capture must bind it."""
+        capture_path = self.valid_capture("cross-bind-noop")
+        capture, digest = capture_format.load_capture_with_digest(capture_path)
+        report = self.bound_report(capture, digest)
+        capture_format.validate_capture(capture)
+        validate_run_record.validate_run_record(report)
+        validate_run_record.require_run_record_binds_capture(report, capture, digest)
+        params = list(
+            inspect.signature(validate_run_record.require_run_record_binds_capture).parameters
+        )
+        self.assertEqual(params, ["report", "capture", "capture_digest"])
+
+    def test_binder_refuses_swapped_implementation_identity(self) -> None:
+        capture_path = self.valid_capture("cross-bind-impl")
+        capture, digest = capture_format.load_capture_with_digest(capture_path)
+        original_capture = json.loads(json.dumps(capture))
+        report = self.bound_report(capture, digest)
+        swapped = json.loads(json.dumps(report))
+        swapped["implementation"]["name"] = "other implementation"
+        swapped["implementation"]["source"] = "https://example.test/other"
+        swapped["implementation"]["commit"] = "2" * 40
+        swapped["implementation"]["reproduction_mode"] = "from_spec_then_conformance"
+        capture_format.validate_capture(capture)
+        validate_run_record.validate_run_record(swapped)
+        with self.assertRaisesRegex(ValueError, "implementation does not bind"):
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+        self.assertEqual(capture, original_capture)
+        capture_format.validate_capture(capture)
+
+    def test_binder_refuses_swapped_implementation_image(self) -> None:
+        image_a = "ghcr.io/example/verifier@sha256:" + "1" * 64
+        image_b = "ghcr.io/example/other@sha256:" + "a" * 64
+        capture_path = self.root / "capture-cross-bind-image.json"
+        result = self.capture(
+            self.candidate("match"),
+            capture_path,
+            extra=(
+                "--implementation-id",
+                "example-verifier",
+                "--implementation-image",
+                image_a,
+            ),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        capture, digest = capture_format.load_capture_with_digest(capture_path)
+        original_capture = json.loads(json.dumps(capture))
+        report = self.bound_report(capture, digest)
+        self.assertEqual(report["implementation"]["id"], "example-verifier")
+        self.assertEqual(report["implementation"]["image"], image_a)
+        swapped = json.loads(json.dumps(report))
+        swapped["implementation"]["id"] = "other-verifier"
+        swapped["implementation"]["image"] = image_b
+        capture_format.validate_capture(capture)
+        validate_run_record.validate_run_record(swapped)
+        with self.assertRaisesRegex(ValueError, "implementation does not bind"):
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+        self.assertEqual(capture, original_capture)
+        capture_format.validate_capture(capture)
+
+    def test_binder_refuses_swapped_pack_tokens(self) -> None:
+        capture_path = self.valid_capture("cross-bind-pack")
+        capture, digest = capture_format.load_capture_with_digest(capture_path)
+        original_capture = json.loads(json.dumps(capture))
+        report = self.bound_report(capture, digest)
+        swapped = json.loads(json.dumps(report))
+        swapped["pack_sha256"] = "sha256:" + "b" * 64
+        swapped["source_corpus_digest"] = "sha256:" + "c" * 64
+        swapped["rendered_set_digest"] = "sha256:" + "d" * 64
+        swapped["pack_declared_source_commit"] = "e" * 40
+        capture_format.validate_capture(capture)
+        validate_run_record.validate_run_record(swapped)
+        with self.assertRaisesRegex(ValueError, "does not bind the scored capture"):
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+        self.assertEqual(capture, original_capture)
+        capture_format.validate_capture(capture)
+
+    def test_binder_refuses_swapped_case_input_digest(self) -> None:
+        capture_path = self.valid_capture("cross-bind-case")
+        capture, digest = capture_format.load_capture_with_digest(capture_path)
+        original_capture = json.loads(json.dumps(capture))
+        report = self.bound_report(capture, digest)
+        swapped = json.loads(json.dumps(report))
+        swapped["cases"][0]["input_sha256"] = "sha256:" + "f" * 64
+        capture_format.validate_capture(capture)
+        validate_run_record.validate_run_record(swapped)
+        with self.assertRaisesRegex(ValueError, "cases do not bind"):
+            validate_run_record.require_run_record_binds_capture(swapped, capture, digest)
+        self.assertEqual(capture, original_capture)
+        capture_format.validate_capture(capture)
+
+    def test_swapped_report_does_not_overwrite_prior_output(self) -> None:
+        capture_path = self.valid_capture("prior-output")
+        output = self.root / "prior-output-record.json"
+        prior = b'{"prior":true}\n'
+        output.write_bytes(prior)
+        real_score = score_candidate.score_capture
+
+        def score_then_swap(*args, **kwargs):
+            report = real_score(*args, **kwargs)
+            report["implementation"]["name"] = "other implementation"
+            report["implementation"]["source"] = "https://example.test/other"
+            report["implementation"]["commit"] = "2" * 40
+            report["implementation"]["reproduction_mode"] = "from_spec_then_conformance"
+            return report
+
+        argv = [
+            str(SCORE_SCRIPT),
+            "--pack",
+            str(self.pack),
+            "--manifest",
+            str(CORPUS_DIR / "MANIFEST.json"),
+            "--capture",
+            str(capture_path),
+            "--output",
+            str(output),
+        ]
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch.object(
+                score_candidate, "score_capture", side_effect=score_then_swap
+            ),
+        ):
+            self.assertEqual(score_candidate.main(), 2)
+        self.assertEqual(output.read_bytes(), prior)
+
+    def test_implementation_record_is_one_shared_projection(self) -> None:
+        source = Path(score_candidate.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("def implementation_record", source)
+        self.assertIs(
+            score_candidate.implementation_record,
+            validate_run_record.implementation_record,
+        )
+        self.assertIn(
+            'implementation_record(capture["implementation"])',
+            inspect.getsource(score_candidate.score_capture),
+        )
+        self.assertIn(
+            'implementation_record(capture["implementation"])',
+            inspect.getsource(validate_run_record.require_run_record_binds_capture),
+        )
 
     def test_scorer_uses_one_read_digest_and_keeps_the_bind_callsite(self) -> None:
         source = inspect.getsource(score_candidate.main)
@@ -1882,7 +2053,7 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         self.assertIn('report["suite"] = capture["suite"]', source)
         self.assertNotIn("PROFILE.replace", source)
         self.assertIn("validate_run_record(", source)
-        self.assertIn("require_run_record_binds_capture(", source)
+        self.assertIn("require_run_record_binds_capture(report, capture, digest)", source)
         self.assertIn("write_regular_file_atomically(", source)
         self.assertNotIn("write_text", source)
         self.assertIs(

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -2028,9 +2028,54 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         self.assertEqual(capture, original_capture)
         capture_format.validate_capture(capture)
 
-    def test_binder_refuses_swapped_status_and_error_on_non_observed_case(self) -> None:
-        """candidate_error scores to execution_error; status/error still must bind."""
-        capture_path = self.valid_capture("cross-bind-error-case")
+    def test_binder_refuses_swapped_status_on_non_observed_case(self) -> None:
+        """status alone must bind; error stays, summary stays coherent."""
+        capture, digest, original_capture, report = self._non_observed_bound_report(
+            "cross-bind-status-only"
+        )
+        swapped = json.loads(json.dumps(report))
+        swapped["cases"][0]["status"] = "harness_error"
+        swapped["summary"]["execution_error"] -= 1
+        swapped["summary"]["harness_error"] += 1
+        self._assert_case_swap_refused(swapped, capture, digest, original_capture)
+
+    def test_binder_refuses_swapped_error_on_non_observed_case(self) -> None:
+        """error alone must bind; status stays execution_error."""
+        capture, digest, original_capture, report = self._non_observed_bound_report(
+            "cross-bind-error-only"
+        )
+        swapped = json.loads(json.dumps(report))
+        swapped["cases"][0]["error"] = "swapped harness error"
+        self.assertEqual(swapped["cases"][0]["status"], "execution_error")
+        self._assert_case_swap_refused(swapped, capture, digest, original_capture)
+
+    def test_binder_refuses_swapped_exit_code(self) -> None:
+        capture, digest, original_capture, report = self._observed_warned_bound_report(
+            "cross-bind-exit-code"
+        )
+        swapped = json.loads(json.dumps(report))
+        swapped["cases"][0]["exit_code"] = swapped["cases"][0]["exit_code"] + 1
+        self._assert_case_swap_refused(swapped, capture, digest, original_capture)
+
+    def test_binder_refuses_swapped_stderr_present(self) -> None:
+        capture, digest, original_capture, report = self._observed_warned_bound_report(
+            "cross-bind-stderr"
+        )
+        swapped = json.loads(json.dumps(report))
+        swapped["cases"][0]["stderr_present"] = not swapped["cases"][0]["stderr_present"]
+        self._assert_case_swap_refused(swapped, capture, digest, original_capture)
+
+    def test_binder_refuses_swapped_review_warnings(self) -> None:
+        capture, digest, original_capture, report = self._observed_warned_bound_report(
+            "cross-bind-warnings"
+        )
+        swapped = json.loads(json.dumps(report))
+        warnings = swapped["cases"][0].pop("review_warnings")
+        swapped["summary"]["review_warnings"] -= len(warnings)
+        self._assert_case_swap_refused(swapped, capture, digest, original_capture)
+
+    def _non_observed_bound_report(self, name: str):
+        capture_path = self.valid_capture(name)
 
         def as_candidate_error(document):
             first = document["observations"][0]
@@ -2041,21 +2086,34 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
                 "error": capture_format.bound_error("candidate failed this case"),
             }
 
-        rewritten = self.rewrite(
-            capture_path, "cross-bind-error-case-rewritten", as_candidate_error
-        )
+        rewritten = self.rewrite(capture_path, f"{name}-rewritten", as_candidate_error)
         capture, digest = capture_format.load_capture_with_digest(rewritten)
         original_capture = json.loads(json.dumps(capture))
         report = self.bound_report(capture, digest)
         self.assertEqual(report["cases"][0]["status"], "execution_error")
         self.assertEqual(report["cases"][0]["error"], "candidate failed this case")
-        swapped = json.loads(json.dumps(report))
-        swapped["cases"][0]["status"] = "harness_error"
-        swapped["cases"][0]["error"] = "swapped harness error"
-        swapped["summary"]["execution_error"] -= 1
-        swapped["summary"]["harness_error"] += 1
+        return capture, digest, original_capture, report
+
+    def _observed_warned_bound_report(self, name: str):
+        capture_path = self.valid_capture(name)
+
+        def flag_schema_mismatch(document):
+            document["observations"][0]["report_schema_matches"] = False
+
+        warned = self.rewrite(capture_path, f"{name}-warned", flag_schema_mismatch)
+        capture, digest = capture_format.load_capture_with_digest(warned)
+        original_capture = json.loads(json.dumps(capture))
+        self.assertTrue(capture_format.review_warnings(capture["observations"][0]))
+        report = self.bound_report(capture, digest)
+        self.assertTrue(report["cases"][0].get("review_warnings"))
+        return capture, digest, original_capture, report
+
+    def _assert_case_swap_refused(self, swapped, capture, digest, original_capture):
         self.assertEqual(swapped["capture_sha256"], digest)
-        self.assertEqual(swapped["cases"][0]["case_id"], capture["observations"][0]["case_id"])
+        self.assertEqual(
+            swapped["cases"][0]["case_id"],
+            capture["observations"][0]["case_id"],
+        )
         self.assertEqual(
             swapped["cases"][0]["input_sha256"],
             capture["observations"][0]["input_sha256"],
@@ -2063,69 +2121,10 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         capture_format.validate_capture(capture)
         validate_run_record.validate_run_record(swapped)
         with self.assertRaisesRegex(ValueError, "do not bind"):
-            validate_run_record.require_run_record_binds_capture(swapped, capture, digest, self.expected_from(capture))
+            validate_run_record.require_run_record_binds_capture(
+                swapped, capture, digest, self.expected_from(capture)
+            )
         self.assertEqual(capture, original_capture)
-        capture_format.validate_capture(capture)
-
-    def test_binder_refuses_swapped_exit_code_stderr_or_review_warnings(self) -> None:
-        """exit_code, stderr_present, and capture-derived warnings must bind."""
-        capture_path = self.valid_capture("cross-bind-case-facts")
-
-        def flag_schema_mismatch(document):
-            document["observations"][0]["report_schema_matches"] = False
-
-        warned = self.rewrite(
-            capture_path, "cross-bind-case-facts-warned", flag_schema_mismatch
-        )
-        capture, digest = capture_format.load_capture_with_digest(warned)
-        original_capture = json.loads(json.dumps(capture))
-        self.assertTrue(capture_format.review_warnings(capture["observations"][0]))
-        report = self.bound_report(capture, digest)
-        self.assertTrue(report["cases"][0].get("review_warnings"))
-
-        with self.subTest(field="exit_code_and_stderr_present"):
-            swapped = json.loads(json.dumps(report))
-            swapped["cases"][0]["exit_code"] = swapped["cases"][0]["exit_code"] + 1
-            swapped["cases"][0]["stderr_present"] = not swapped["cases"][0][
-                "stderr_present"
-            ]
-            self.assertEqual(swapped["capture_sha256"], digest)
-            self.assertEqual(
-                swapped["cases"][0]["case_id"],
-                capture["observations"][0]["case_id"],
-            )
-            self.assertEqual(
-                swapped["cases"][0]["input_sha256"],
-                capture["observations"][0]["input_sha256"],
-            )
-            capture_format.validate_capture(capture)
-            validate_run_record.validate_run_record(swapped)
-            with self.assertRaisesRegex(ValueError, "do not bind"):
-                validate_run_record.require_run_record_binds_capture(
-                    swapped, capture, digest, self.expected_from(capture)
-                )
-            self.assertEqual(capture, original_capture)
-
-        with self.subTest(field="review_warnings"):
-            swapped = json.loads(json.dumps(report))
-            warnings = swapped["cases"][0].pop("review_warnings")
-            swapped["summary"]["review_warnings"] -= len(warnings)
-            self.assertEqual(swapped["capture_sha256"], digest)
-            self.assertEqual(
-                swapped["cases"][0]["case_id"],
-                capture["observations"][0]["case_id"],
-            )
-            self.assertEqual(
-                swapped["cases"][0]["input_sha256"],
-                capture["observations"][0]["input_sha256"],
-            )
-            capture_format.validate_capture(capture)
-            validate_run_record.validate_run_record(swapped)
-            with self.assertRaisesRegex(ValueError, "do not bind"):
-                validate_run_record.require_run_record_binds_capture(
-                    swapped, capture, digest, self.expected_from(capture)
-                )
-            self.assertEqual(capture, original_capture)
         capture_format.validate_capture(capture)
 
     def test_swapped_observed_does_not_overwrite_prior_output(self) -> None:

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -53,8 +53,12 @@ OCI_WORKFLOW_PATH = ".github/workflows/privileged-mcp-action-oci-candidate.yml"
 OCI_CHECKOUT_PIN = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
 OCI_SETUP_PYTHON_PIN = "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1"
 OCI_UPLOAD_PIN = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+OCI_DOWNLOAD_PIN = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 OCI_EXECUTOR = (
     "conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py"
+)
+OCI_SCORER = (
+    "conformance/privileged-mcp-action-v0/scripts/score_candidate.py"
 )
 OCI_SIGNER_WORKFLOW = (
     "Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml"
@@ -63,9 +67,13 @@ OCI_PYTHON_VERSION = 'python-version: "3.13.8"'
 OCI_SOURCE_DIGEST_SHAPE = '[[ "$source_digest" =~ ^[0-9a-f]{40}$ ]]'
 OCI_SOURCE_DIGEST_GUARD = OCI_SOURCE_DIGEST_SHAPE + " || exit 2"
 OCI_CAPTURE_UPLOAD_PATH = "${{ runner.temp }}/oci-capture/candidate_capture.v0"
+OCI_SCORE_UPLOAD_PATH = "${{ runner.temp }}/oci-score/conformance_run.v0"
 OCI_IMPLEMENTATION_ID_ENV = "IMPLEMENTATION_ID: ${{ inputs.implementation_id }}"
 OCI_IMPLEMENTATION_ID_ARGV = '--implementation-id "$IMPLEMENTATION_ID"'
 OCI_UPLOAD_STEP = "Upload validated capture"
+OCI_SCORE_UPLOAD_STEP = "Upload validated run record"
+OCI_SCORE_DOWNLOAD_STEP = "Download candidate capture"
+OCI_SCORE_STEP = "Score candidate capture"
 USES_SHA_RE = re.compile(r"uses:\s*\S+@([^\s#]+)")
 # Ordered capture-job shape. Env-key sets and the step-name tuple are one table
 # so a skipped setup, extra step, leaked token, or duplicate upload cannot
@@ -82,10 +90,14 @@ OCI_STEP_ENV_KEYS = {
 }
 OCI_CAPTURE_STEP_NAMES = tuple(OCI_STEP_ENV_KEYS)
 OCI_CAPTURE_JOB = "capture"
+OCI_SCORE_JOB = "score"
 OCI_CAPTURE_JOB_KEYS = ("runs-on", "timeout-minutes", "steps")
+OCI_SCORE_JOB_KEYS = ("needs", "if", "runs-on", "timeout-minutes", "steps")
 OCI_DOCUMENT_KEYS = ("name", "on", "permissions", "concurrency", "jobs")
 OCI_TAG_BINDING = "TAG: ${{ steps.candidate.outputs.tag }}"
 OCI_ARTIFACT_NAME = "name: candidate-capture-v0"
+OCI_SCORE_ARTIFACT_NAME = "name: candidate-run-record-v0"
+OCI_SCORE_NEEDS = "needs: [capture]"
 OCI_STEP_KEYS = {
     "Check out current main": ("name", "uses", "with"),
     "Set up Python": ("name", "uses", "with"),
@@ -185,6 +197,49 @@ OCI_PINNED_STEP_SEQUENCES = {
         f" {OCI_IMPLEMENTATION_ID_ARGV}"
         ' --output "$OUTPUT"'
         " --timeout-seconds 30",
+    ),
+}
+OCI_SCORE_STEP_ENV_KEYS = {
+    "Check out current main": frozenset(),
+    "Set up Python": frozenset(),
+    "Require trusted main": frozenset(),
+    "Resolve published pack tag": frozenset(),
+    "Download attested pack": frozenset({"GH_TOKEN", "TAG"}),
+    "Verify pack attestation": frozenset({"GH_TOKEN", "TAG"}),
+    OCI_SCORE_DOWNLOAD_STEP: frozenset(),
+    OCI_SCORE_STEP: frozenset(),
+    OCI_SCORE_UPLOAD_STEP: frozenset(),
+}
+OCI_SCORE_STEP_NAMES = tuple(OCI_SCORE_STEP_ENV_KEYS)
+OCI_SCORE_STEP_KEYS = {
+    "Check out current main": ("name", "uses", "with"),
+    "Set up Python": ("name", "uses", "with"),
+    "Require trusted main": ("name", "run"),
+    "Resolve published pack tag": ("name", "id", "run"),
+    "Download attested pack": ("name", "env", "run"),
+    "Verify pack attestation": ("name", "env", "run"),
+    OCI_SCORE_DOWNLOAD_STEP: ("name", "uses", "with"),
+    OCI_SCORE_STEP: ("name", "run"),
+    OCI_SCORE_UPLOAD_STEP: ("name", "if", "uses", "with"),
+}
+OCI_SCORE_STEP_WITH_KEYS = {
+    "Check out current main": ("persist-credentials", "ref"),
+    "Set up Python": ("python-version",),
+    OCI_SCORE_DOWNLOAD_STEP: ("name", "path"),
+    OCI_SCORE_UPLOAD_STEP: ("name", "path", "if-no-files-found", "retention-days"),
+}
+OCI_SCORE_PINNED_STEP_SEQUENCES = {
+    OCI_SCORE_STEP: (
+        "set -euo pipefail",
+        'PACK="$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"',
+        'CAPTURE="$RUNNER_TEMP/oci-score/candidate_capture.v0"',
+        'OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v0"',
+        'mkdir -p "$(dirname "$OUTPUT")"',
+        f"python3 {OCI_SCORER}"
+        ' --pack "$PACK"'
+        " --manifest conformance/privileged-mcp-action-v0/MANIFEST.json"
+        ' --capture "$CAPTURE"'
+        ' --output "$OUTPUT"',
     ),
 }
 
@@ -1393,6 +1448,7 @@ import artifact_io  # noqa: E402
 import capture_format  # noqa: E402
 import score_candidate  # noqa: E402
 import strict_json  # noqa: E402
+import validate_run_record  # noqa: E402
 
 CAPTURE_SCRIPT = CORPUS_DIR / "scripts" / "capture_candidate.py"
 CAPTURE_SCHEMA_DOC = CORPUS_DIR / "capture.schema.json"
@@ -1456,7 +1512,7 @@ class SharedArtifactIoContractTests(unittest.TestCase):
                 ):
                     inline_pretty_calls.append(f"{path.name}:{node.lineno}")
         self.assertEqual(inline_pretty_calls, [], "inline deterministic renderers drift")
-        self.assertEqual(shared_calls, 6, "the six shipped pretty-JSON sites must delegate")
+        self.assertEqual(shared_calls, 7, "the seven shipped pretty-JSON sites must delegate")
 
     def test_capture_and_record_outputs_use_one_atomic_writer(self) -> None:
         scripts = CORPUS_DIR / "scripts"
@@ -1692,6 +1748,161 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "capture schema mismatch"):
             capture_format.load_capture_with_digest(capture)
+
+    def test_stale_run_record_does_not_bind_mutated_capture_bytes(self) -> None:
+        """Existing R addressed H0; mutated exact-read C' is H1. Bind must refuse.
+
+        Capture files do not declare capture_sha256. Fresh scoring of C' may
+        compute H1 and write a new record; this case is the cross-artifact
+        check: load C' once, compare R's stamped digest to that one-read
+        digest, and write nothing.
+        """
+        capture = self.valid_capture("stale-bind")
+        record = self.root / "stale-bind-record.json"
+        scored = self.score_capture(capture, record)
+        self.assertEqual(scored.returncode, 0, scored.stderr)
+        original_record = record.read_bytes()
+        h0 = capture_format.load_capture_with_digest(capture)[1]
+
+        def rename(document: object) -> None:
+            document["implementation"]["name"] = "mutated implementation"
+
+        mutated = self.rewrite(capture, "stale-bind-mutated", rename)
+        _document, h1 = capture_format.load_capture_with_digest(mutated)
+        self.assertNotEqual(h0, h1)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "capture_sha256 does not address the scored capture bytes",
+        ):
+            validate_run_record.require_run_record_binds_capture(
+                validate_run_record.load_run_record(record),
+                h1,
+            )
+        self.assertEqual(record.read_bytes(), original_record)
+
+    def test_unknown_observation_state_is_refused_without_a_record(self) -> None:
+        capture = self.valid_capture("unknown-state")
+
+        def invent(document: object) -> None:
+            first = document["observations"][0]
+            document["observations"][0] = {
+                "case_id": first["case_id"],
+                "input_sha256": first["input_sha256"],
+                "state": "invented",
+                "error": "unknown observation state",
+            }
+
+        hostile = self.rewrite(capture, "unknown-state", invent)
+        output = self.root / "unknown-state-report.json"
+        result = self.score_capture(hostile, output)
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertFalse(output.exists())
+        self.assertNotIn("Traceback", result.stderr)
+        with self.assertRaises(KeyError):
+            score_candidate.STATE_TO_STATUS["invented"]
+
+    def test_producer_refuses_stale_digest_before_write(self) -> None:
+        """Stamping H0 while the one-read digest is H1 must fail before write."""
+        capture = self.valid_capture("stale-producer")
+        h0 = capture_format.load_capture_with_digest(capture)[1]
+
+        def rename(document: object) -> None:
+            document["implementation"]["name"] = "producer-stale implementation"
+
+        mutated = self.rewrite(capture, "stale-producer-mutated", rename)
+        loaded, h1 = capture_format.load_capture_with_digest(mutated)
+        self.assertNotEqual(h0, h1)
+
+        pack = {
+            "declared_source_commit": loaded["pack_declared_source_commit"],
+            "source_corpus_digest": loaded["source_corpus_digest"],
+            "rendered_set_digest": loaded["rendered_set_digest"],
+            "cases": [
+                {"id": observation["case_id"], "sha256": observation["input_sha256"]}
+                for observation in loaded["observations"]
+            ],
+        }
+        expected = {
+            observation["input_sha256"]: observation["observed"]
+            for observation in loaded["observations"]
+            if observation["state"] == capture_format.STATE_OBSERVED
+        }
+        report = score_candidate.score_capture(
+            loaded,
+            pack,
+            loaded["pack_sha256"],
+            expected,
+            pack["source_corpus_digest"],
+            pack["rendered_set_digest"],
+        )
+        report["suite"] = loaded["suite"]
+        report["capture_sha256"] = h0
+        output = self.root / "stale-producer-record.json"
+        with self.assertRaisesRegex(
+            ValueError,
+            "capture_sha256 does not address the scored capture bytes",
+        ):
+            validate_run_record.validate_run_record(report)
+            validate_run_record.require_run_record_binds_capture(report, h1)
+        self.assertFalse(output.exists())
+
+    def test_unmutated_capture_binds_and_rescore_is_byte_identical(self) -> None:
+        capture = self.valid_capture("noop-rescore")
+        first = self.root / "noop-rescore-first.json"
+        self.assertEqual(self.score_capture(capture, first).returncode, 0)
+        h0 = capture_format.load_capture_with_digest(capture)[1]
+        validate_run_record.require_run_record_binds_capture(
+            validate_run_record.load_run_record(first),
+            h0,
+        )
+        second = self.root / "noop-rescore-second.json"
+        first_bytes = first.read_bytes()
+        self.assertEqual(self.score_capture(capture, second).returncode, 0)
+        self.assertEqual(second.read_bytes(), first_bytes)
+        self.assertEqual(self.score_capture(capture, first).returncode, 0)
+        self.assertEqual(first.read_bytes(), first_bytes)
+
+    def test_scorer_stamps_suite_from_capture_and_one_read_digest(self) -> None:
+        capture = self.valid_capture("stamp-from-capture")
+        output = self.root / "stamp-from-capture-record.json"
+        self.assertEqual(self.score_capture(capture, output).returncode, 0)
+        document, digest = capture_format.load_capture_with_digest(capture)
+        report = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(report["suite"], document["suite"])
+        self.assertEqual(report["suite"], capture_format.SUITE)
+        self.assertEqual(report["capture_sha256"], digest)
+        self.assertNotEqual(report["suite"], report["profile"])
+        validate_run_record.require_run_record_binds_capture(report, digest)
+
+    def test_scorer_uses_one_read_digest_and_keeps_the_bind_callsite(self) -> None:
+        source = inspect.getsource(score_candidate.main)
+        self.assertIn("load_capture_with_digest(", source)
+        self.assertNotRegex(source, r"(?<![_\w])load_capture\(")
+        self.assertIn('report["suite"] = capture["suite"]', source)
+        self.assertNotIn("PROFILE.replace", source)
+        self.assertIn("validate_run_record(", source)
+        self.assertIn("require_run_record_binds_capture(", source)
+        self.assertIn("write_regular_file_atomically(", source)
+        self.assertNotIn("write_text", source)
+        self.assertIs(
+            score_candidate.load_capture_with_digest,
+            capture_format.load_capture_with_digest,
+        )
+
+    def test_run_record_schema_document_requires_suite_and_capture_digest(self) -> None:
+        schema = json.loads((CORPUS_DIR / "report.schema.json").read_text(encoding="utf-8"))
+        self.assertFalse(schema["additionalProperties"])
+        self.assertEqual(set(schema["required"]), validate_run_record.TOP_LEVEL_KEYS)
+        self.assertEqual(schema["properties"]["suite"]["const"], capture_format.SUITE)
+        self.assertEqual(
+            schema["properties"]["suite"]["const"],
+            validate_run_record.SUITE,
+        )
+        self.assertEqual(
+            schema["properties"]["capture_sha256"]["$ref"],
+            "#/$defs/sha256",
+        )
 
     def test_missing_or_duplicated_observation_is_refused_without_a_record(self) -> None:
         capture = self.valid_capture("cardinality")
@@ -2346,6 +2557,18 @@ def _normalized_command_sequence(run_body: str) -> tuple[str, ...]:
     return tuple(commands)
 
 
+def _job_block(text: str, job: str) -> str | None:
+    """Full job mapping, from `  {job}:` through the next sibling job."""
+    marker = f"  {job}:\n"
+    start = text.find(marker)
+    if start < 0:
+        return None
+    rest = text[start + len(marker) :]
+    nxt = re.search(r"(?m)^  [A-Za-z0-9_-]+:", rest)
+    tail = rest if nxt is None else rest[: nxt.start()]
+    return marker + tail
+
+
 def oci_candidate_workflow_problems(
     text: str, *, skip: frozenset[str] = frozenset()
 ) -> list[str]:
@@ -2357,6 +2580,8 @@ def oci_candidate_workflow_problems(
 
     active = _active_lines(text)
     active_text = "\n".join(active)
+    capture_block = _job_block(text, OCI_CAPTURE_JOB)
+    score_block = _job_block(text, OCI_SCORE_JOB)
     on_keys = _top_level_mapping_keys(text, "on")
     if on_keys != ("workflow_dispatch",):
         if "workflow_dispatch" not in on_keys:
@@ -2370,7 +2595,7 @@ def oci_candidate_workflow_problems(
                 problems.append("push trigger")
             else:
                 problems.append(f"extra trigger: {key}")
-    if "runs-on: ubuntu-24.04" not in active_text:
+    if sum(1 for line in active if line == "runs-on: ubuntu-24.04") != 2:
         problems.append("missing ubuntu-24.04")
     if re.search(r"runs-on:\s*.*self-hosted", active_text):
         problems.append("self-hosted runner")
@@ -2388,7 +2613,7 @@ def oci_candidate_workflow_problems(
         problems.append("missing main ref guard")
     if "git rev-parse HEAD" not in active_text or "$GITHUB_SHA" not in active_text:
         problems.append("missing HEAD/SHA guard")
-    if "persist-credentials: false" not in active_text:
+    if sum(1 for line in active if line == "persist-credentials: false") != 2:
         problems.append("missing persist-credentials:false")
     if "candidate-release.json" not in active_text:
         problems.append("missing candidate-release.json")
@@ -2396,8 +2621,10 @@ def oci_candidate_workflow_problems(
         problems.append("missing validate_candidate_release.py")
     if "attestation-bundle.json" not in active_text:
         problems.append("missing attestation-bundle.json")
-    if not any(re.match(r"^(-\s+)?gh attestation verify(\s|\\|$)", line) for line in active):
-        problems.append("missing gh attestation verify")
+    for job_text in (capture_block, score_block):
+        job_active = _active_lines(job_text or "")
+        if not any(re.match(r"^(-\s+)?gh attestation verify(\s|\\|$)", line) for line in job_active):
+            problems.append("missing gh attestation verify")
     if "--bundle" not in active_text:
         problems.append("missing --bundle")
     if f"--signer-workflow {OCI_SIGNER_WORKFLOW}" not in active_text:
@@ -2446,63 +2673,108 @@ def oci_candidate_workflow_problems(
         problems.append("continue-on-error swallows failure")
     if "|| true" in active_text:
         problems.append("|| true swallows failure")
-    for pin, label in (
-        (OCI_CHECKOUT_PIN, "unpinned or wrong checkout"),
-        (OCI_SETUP_PYTHON_PIN, "unpinned or wrong setup-python"),
-        (OCI_UPLOAD_PIN, "unpinned or wrong upload-artifact"),
+    for pin, label, expected in (
+        (OCI_CHECKOUT_PIN, "unpinned or wrong checkout", 2),
+        (OCI_SETUP_PYTHON_PIN, "unpinned or wrong setup-python", 2),
+        (OCI_UPLOAD_PIN, "unpinned or wrong upload-artifact", 2),
+        (OCI_DOWNLOAD_PIN, "unpinned or wrong download-artifact", 1),
     ):
-        if not any(_uses_pin_line(line, pin) for line in active):
+        if sum(1 for line in active if _uses_pin_line(line, pin)) != expected:
             problems.append(label)
-    if OCI_PYTHON_VERSION not in active_text:
+    if sum(1 for line in active if line == OCI_PYTHON_VERSION) != 2:
         problems.append("missing python 3.13.8")
-    upload_steps = [
-        block
-        for block in re.split(r"(?m)^(?=      - )", text)
-        if any(_uses_pin_line(line, OCI_UPLOAD_PIN) for line in _active_lines(block))
-    ]
-    upload_ifs = [
-        line
-        for block in upload_steps
-        for line in _active_lines(block)
-        if line.startswith("if:")
-    ]
-    if not omitted("upload not gated on success") and upload_ifs != ["if: success()"]:
+    upload_ifs = []
+    for block in (
+        _named_step_block(capture_block or "", OCI_UPLOAD_STEP),
+        _named_step_block(score_block or "", OCI_SCORE_UPLOAD_STEP),
+    ):
+        if block is None:
+            upload_ifs.append("<missing-upload>")
+            continue
+        ifs = [line for line in _active_lines(block) if line.startswith("if:")]
+        upload_ifs.extend(ifs or ["<missing-if>"])
+    if not omitted("upload not gated on success") and upload_ifs != ["if: success()", "if: success()"]:
         problems.append("upload not gated on success")
     if "candidate_capture.v0" not in active_text:
         problems.append("missing fixed capture name")
     if OCI_CAPTURE_UPLOAD_PATH not in active_text:
         problems.append("missing exact capture upload path")
-    if "retention-days: 7" not in active_text:
+    if sum(1 for line in active if line == "retention-days: 7") != 2:
         problems.append("missing retention-days: 7")
-    if "if-no-files-found: error" not in active_text:
+    if sum(1 for line in active if line == "if-no-files-found: error") != 2:
         problems.append("missing if-no-files-found:error")
-    if "timeout-minutes: 25" not in active_text:
+    if sum(1 for line in active if line == "timeout-minutes: 25") != 2:
         problems.append("missing timeout-minutes: 25")
     for line in active:
         for match in USES_SHA_RE.finditer(line):
             pin = match.group(1)
             if not re.fullmatch(r"[0-9a-f]{40}", pin):
                 problems.append(f"unpinned uses: {match.group(0)}")
-    for name in _named_step_names(text):
-        if name == OCI_UPLOAD_STEP:
+    for job_text, upload_name in (
+        (capture_block, OCI_UPLOAD_STEP),
+        (score_block, OCI_SCORE_UPLOAD_STEP),
+    ):
+        if job_text is None:
             continue
-        block = _named_step_block(text, name)
-        if (
-            not omitted("conditional step")
-            and block is not None
-            and any(re.match(r"^if:", line) for line in _active_lines(block))
-        ):
-            problems.append(f"conditional step: {name}")
+        for name in _named_step_names(job_text):
+            if name == upload_name:
+                continue
+            block = _named_step_block(job_text, name)
+            if (
+                not omitted("conditional step")
+                and block is not None
+                and any(re.match(r"^if:", line) for line in _active_lines(block))
+            ):
+                problems.append(f"conditional step: {name}")
     for name, allowed in OCI_PINNED_STEP_SEQUENCES.items():
         body = _named_step_run_body(text, name)
         if body is None or _normalized_command_sequence(body) != allowed:
             problems.append(f"unexpected run sequence: {name}")
-    if _top_level_mapping_keys(text, "jobs") != (OCI_CAPTURE_JOB,):
+        if score_block is not None and name in OCI_SCORE_STEP_ENV_KEYS:
+            score_body = _named_step_run_body(score_block, name)
+            if score_body is None or _normalized_command_sequence(score_body) != allowed:
+                problems.append(f"unexpected run sequence: {name}")
+    for name, allowed in OCI_SCORE_PINNED_STEP_SEQUENCES.items():
+        body = _named_step_run_body(score_block or "", name)
+        if body is None or _normalized_command_sequence(body) != allowed:
+            problems.append(f"unexpected run sequence: {name}")
+    if _top_level_mapping_keys(text, "jobs") != (OCI_CAPTURE_JOB, OCI_SCORE_JOB):
         problems.append("unexpected jobs")
     if _job_mapping_keys(text, OCI_CAPTURE_JOB) != OCI_CAPTURE_JOB_KEYS:
         problems.append("unexpected capture job keys")
-    if tuple(_named_step_names(text)) != OCI_CAPTURE_STEP_NAMES:
+    if _job_mapping_keys(text, OCI_SCORE_JOB) != OCI_SCORE_JOB_KEYS:
+        problems.append("unexpected score job keys")
+    score_needs = [
+        raw.strip()
+        for raw in (score_block or "").splitlines()
+        if raw.startswith("    needs:") and not raw.startswith("     ")
+    ]
+    if score_needs != [OCI_SCORE_NEEDS]:
+        problems.append("score job missing needs: capture")
+    score_ifs = [
+        raw.strip()
+        for raw in (score_block or "").splitlines()
+        if raw.startswith("    if:") and not raw.startswith("     ")
+    ]
+    if score_ifs != ["if: success()"]:
+        problems.append("score job not gated on success")
+    if capture_block is None or tuple(_named_step_names(capture_block)) != OCI_CAPTURE_STEP_NAMES:
         problems.append("unexpected step names")
+    if score_block is None or tuple(_named_step_names(score_block)) != OCI_SCORE_STEP_NAMES:
+        problems.append("unexpected step names")
+    score_active = "\n".join(_active_lines(score_block or ""))
+    if "--entrypoint" in score_active:
+        problems.append("score job invokes --entrypoint")
+    if "docker" in score_active:
+        problems.append("score job invokes docker")
+    if OCI_EXECUTOR in score_active:
+        problems.append("score job invokes executor")
+    if OCI_SCORER not in score_active:
+        problems.append("missing score_candidate.py")
+    if "--capture" not in score_active:
+        problems.append("missing --capture")
+    if OCI_SCORE_UPLOAD_PATH not in active_text:
+        problems.append("missing exact run-record upload path")
     if _top_level_mapping_children(text, "permissions") != OCI_TOP_LEVEL_PERMISSIONS:
         problems.append("unexpected top-level permissions")
     if _has_job_level_permissions(text):
@@ -2510,6 +2782,15 @@ def oci_candidate_workflow_problems(
     if not omitted("unexpected env keys"):
         for name, allowed in OCI_STEP_ENV_KEYS.items():
             block = _named_step_block(text, name)
+            actual = (
+                frozenset(_keys_at_indent(block, 10, under="env"))
+                if block is not None
+                else frozenset()
+            )
+            if block is None or actual != allowed:
+                problems.append(f"unexpected env keys: {name}")
+        for name, allowed in OCI_SCORE_STEP_ENV_KEYS.items():
+            block = _named_step_block(score_block or "", name)
             actual = (
                 frozenset(_keys_at_indent(block, 10, under="env"))
                 if block is not None
@@ -2526,6 +2807,11 @@ def oci_candidate_workflow_problems(
             actual = ("name",) + _keys_at_indent(block, 8) if block is not None else ()
             if block is None or actual != allowed:
                 problems.append(f"unexpected step keys: {name}")
+        for name, allowed in OCI_SCORE_STEP_KEYS.items():
+            block = _named_step_block(score_block or "", name)
+            actual = ("name",) + _keys_at_indent(block, 8) if block is not None else ()
+            if block is None or actual != allowed:
+                problems.append(f"unexpected step keys: {name}")
     if not omitted("unexpected with keys"):
         for name, allowed in OCI_STEP_WITH_KEYS.items():
             block = _named_step_block(text, name)
@@ -2534,17 +2820,27 @@ def oci_candidate_workflow_problems(
             )
             if block is None or actual != allowed:
                 problems.append(f"unexpected with keys: {name}")
+        for name, allowed in OCI_SCORE_STEP_WITH_KEYS.items():
+            block = _named_step_block(score_block or "", name)
+            actual = (
+                _keys_at_indent(block, 10, under="with") if block is not None else ()
+            )
+            if block is None or actual != allowed:
+                problems.append(f"unexpected with keys: {name}")
     if not omitted("unexpected TAG bindings"):
-        if sum(1 for line in active if line == OCI_TAG_BINDING) != 2:
+        if sum(1 for line in active if line == OCI_TAG_BINDING) != 4:
             problems.append("unexpected TAG bindings")
     if not omitted("missing exact artifact name"):
-        if sum(1 for line in active if line == OCI_ARTIFACT_NAME) != 1:
+        if sum(1 for line in active if line == OCI_ARTIFACT_NAME) != 2:
             problems.append("missing exact artifact name")
+    if not omitted("missing exact run-record artifact name"):
+        if sum(1 for line in active if line == OCI_SCORE_ARTIFACT_NAME) != 1:
+            problems.append("missing exact run-record artifact name")
     return problems
 
 
 class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
-    """Capture-only trusted-main workflow. Structural; no live dispatch."""
+    """Trusted-main OCI capture then score. Structural; no live dispatch."""
 
     def test_workflow_file_exists(self) -> None:
         self.assertTrue(
@@ -2576,8 +2872,13 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
             (OCI_SETUP_PYTHON_PIN, "unpinned or wrong setup-python"),
             (OCI_PYTHON_VERSION, "missing python 3.13.8"),
             (OCI_CAPTURE_UPLOAD_PATH, "missing exact capture upload path"),
+            (OCI_SCORE_UPLOAD_PATH, "missing exact run-record upload path"),
             ("retention-days: 7", "missing retention-days: 7"),
             ("if: success()", "upload not gated on success"),
+            (OCI_SCORE_NEEDS, "score job missing needs: capture"),
+            (OCI_SCORER, "missing score_candidate.py"),
+            ("--capture", "missing --capture"),
+            (OCI_DOWNLOAD_PIN, "unpinned or wrong download-artifact"),
         )
         for needle, expected in drops:
             with self.subTest(drop=needle):
@@ -2980,6 +3281,62 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                     restored,
                     [],
                     f"{kind} must be [] when {expected!r} is skipped: {restored}",
+                )
+
+        score_mutations = (
+            (
+                "score_needs_dropped",
+                f"    {OCI_SCORE_NEEDS}\n",
+                "",
+                "score job missing needs: capture",
+            ),
+            (
+                "score_if_always",
+                f"    {OCI_SCORE_NEEDS}\n    if: success()\n",
+                f"    {OCI_SCORE_NEEDS}\n    if: always()\n",
+                "score job not gated on success",
+            ),
+            (
+                "score_entrypoint",
+                '            --capture "$CAPTURE" \\\n',
+                '            --entrypoint /bin/true \\\n            --capture "$CAPTURE" \\\n',
+                "score job invokes --entrypoint",
+            ),
+            (
+                "score_docker",
+                f"          python3 {OCI_SCORER} \\\n",
+                "          docker run --rm example \\\n"
+                f"          python3 {OCI_SCORER} \\\n",
+                "score job invokes docker",
+            ),
+            (
+                "score_executor",
+                f"          python3 {OCI_SCORER} \\\n",
+                f"          python3 {OCI_EXECUTOR} \\\n"
+                f"          python3 {OCI_SCORER} \\\n",
+                "score job invokes executor",
+            ),
+            (
+                "score_upload_on_failure",
+                "      - name: Upload validated run record\n        if: success()\n",
+                "      - name: Upload validated run record\n        if: failure()\n",
+                "upload not gated on success",
+            ),
+            (
+                "score_artifact_name",
+                f"          {OCI_SCORE_ARTIFACT_NAME}\n",
+                "          name: candidate-run-record-v0-extra\n",
+                "missing exact run-record artifact name",
+            ),
+        )
+        for kind, needle, replacement, expected in score_mutations:
+            with self.subTest(kind=kind):
+                self.assertIn(needle, text)
+                mutated = text.replace(needle, replacement, 1)
+                problems = oci_candidate_workflow_problems(mutated)
+                self.assertTrue(
+                    any(expected in problem for problem in problems),
+                    f"expected {expected!r} in {problems}",
                 )
 
     def test_conformance_path_filters_include_oci_workflow(self) -> None:


### PR DESCRIPTION
Implements [assay-tunnel-experiments#205](https://github.com/Rul1an/assay-tunnel-experiments/issues/205).

## SHA
- Branch: `ruley/205-trusted-score-run-record`
- Old HEAD: `3f361419d36fd1c7aa2985c4e084986f6328f6ff`
- Merged `origin/main`: `3634550acd898468951a1dcb9410aa52997bbee9`
- New HEAD (merge commit): `edaae242034b321eaf08758b67161ee8c6e6d775`
- Tree: `27452f33cd296064bc145c752f9f11e143d5612e`
- Merge parents: `3f361419d36fd1c7aa2985c4e084986f6328f6ff` + `3634550acd898468951a1dcb9410aa52997bbee9`
- No rebase. Product/schema blobs unchanged vs old HEAD.

## Allowlist
1. `conformance/privileged-mcp-action-v0/scripts/validate_run_record.py`
2. `conformance/privileged-mcp-action-v0/scripts/score_candidate.py`
3. `conformance/privileged-mcp-action-v0/report.schema.json`
4. `conformance/privileged-mcp-action-v0/tests/test_activation_kit.py`
5. `.github/workflows/privileged-mcp-action-oci-candidate.yml`

No capture format, artifact I/O, executor, registry, implementations.json, published_rows, or Rust changes.

## First RED
`CandidateCaptureTests.test_stale_run_record_does_not_bind_mutated_capture_bytes` failed first with:

`AttributeError: module 'validate_run_record' has no attribute 'require_run_record_binds_capture'`

Then the producer stamps `suite` from `capture["suite"]` and `capture_sha256` from the one-read digest, and `require_run_record_binds_capture` refuses H0 vs H1 before the atomic write.

## What this does
- Adds required run-record fields `suite` and `capture_sha256` (`additionalProperties: false`).
- Split path: `load_capture_with_digest` (exact bounded input bytes). Direct path: `content_sha256(render_deterministic_json_bytes(capture))`.
- One oracle: `score_capture` still compares; main stamps then `validate_run_record` + `require_run_record_binds_capture` then `write_regular_file_atomically`.
- Trusted-main OCI workflow gains a `score` job: `needs: [capture]`, `if: success()`, re-downloads the attested pack, re-verifies attestation, downloads `candidate-capture-v0`, scores with `--capture` (not `--entrypoint`), uploads `candidate-run-record-v0` only on success.
- Structural checker now requires the score job and keeps every capture pin fail-closed.

## Non-claims
- A matching run still demonstrates agreement on the pinned corpus only.
- This PR does not register, release, or score a live OCI candidate.
- This PR does not implement #201, does not add a renderer/loader/writer, and does not change capture artifact name/path (`candidate-capture-v0` / `candidate_capture.v0`).
- The scorer still does not verify pack provenance or which image ran.
- No live workflow dispatch was executed.

## Status
Draft only. Do not mark ready. Do not merge. Freeze: no further commits unless asked.