### PR TITLE
fix(ci): pin conformance inventory callsite from the later hardening root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1064,6 +1064,7 @@ jobs:
           python3 scripts/ci/test-conformance-inventory-callsite.py
 
       - name: Verify this gate waits on every gating job
+        shell: bash
         run: |
           python3 scripts/ci/check-ci-gate-coverage.py
           python3 scripts/ci/check-conformance-inventory-callsite.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
           bash scripts/ci/check-assay-release-pin.sh --published
           bash scripts/ci/test-ci-hardening-b1.sh
           bash scripts/ci/test-structurizr-export-docker.sh
+          python3 scripts/ci/check-conformance-inventory-callsite.py
+          python3 scripts/ci/test-conformance-inventory-callsite.py
 
       # Stdlib-only. Required CI cannot go green if these tests are deleted;
       # adequacy-drift is not a required context. No conditional or soft-failure settings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1054,6 +1054,8 @@ jobs:
 
       - name: Verify CI hardening contracts
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           bash scripts/ci/test-check-assay-release-pin.sh
@@ -1066,6 +1068,7 @@ jobs:
       - name: Verify this gate waits on every gating job
         shell: bash
         run: |
+          set -euo pipefail
           python3 scripts/ci/check-ci-gate-coverage.py
           python3 scripts/ci/check-conformance-inventory-callsite.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,19 +157,6 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Verify CI hardening contracts
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          bash scripts/ci/test-check-assay-release-pin.sh
-          bash scripts/ci/check-assay-release-pin.sh --published
-          bash scripts/ci/test-ci-hardening-b1.sh
-          bash scripts/ci/test-structurizr-export-docker.sh
-          python3 scripts/ci/check-conformance-inventory-callsite.py
-          python3 scripts/ci/test-conformance-inventory-callsite.py
-
       # Stdlib-only. Required CI cannot go green if these tests are deleted;
       # adequacy-drift is not a required context. No conditional or soft-failure settings.
       # After setup-python so this uses the pinned 3.12, not the runner default.
@@ -1060,8 +1047,26 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify CI hardening contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/test-check-assay-release-pin.sh
+          bash scripts/ci/check-assay-release-pin.sh --published
+          bash scripts/ci/test-ci-hardening-b1.sh
+          bash scripts/ci/test-structurizr-export-docker.sh
+          python3 scripts/ci/check-conformance-inventory-callsite.py
+          python3 scripts/ci/test-conformance-inventory-callsite.py
+
       - name: Verify this gate waits on every gating job
-        run: python3 scripts/ci/check-ci-gate-coverage.py
+        run: |
+          python3 scripts/ci/check-ci-gate-coverage.py
+          python3 scripts/ci/check-conformance-inventory-callsite.py
 
       - name: Evaluate required job results
         env:

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -49,6 +49,15 @@ INVENTORY_RUN_SCRIPT = (
     "python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py",
     REQUIRED_RUN_ALL,
 )
+HARDENING_RUN_SCRIPT = (
+    "set -euo pipefail",
+    "bash scripts/ci/test-check-assay-release-pin.sh",
+    "bash scripts/ci/check-assay-release-pin.sh --published",
+    "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-structurizr-export-docker.sh",
+    "python3 scripts/ci/check-conformance-inventory-callsite.py",
+    "python3 scripts/ci/test-conformance-inventory-callsite.py",
+)
 ACTIVATION_KIT_RUN_SCRIPT = (
     "set -euo pipefail",
     REVISION_WITNESS,
@@ -69,6 +78,14 @@ HARD_RUN_CONTRACTS = {
         ACTIVATION_KIT_RUN_SCRIPT,
         frozenset({"name", "on", "permissions", "concurrency", "jobs"}),
         frozenset(),
+    ),
+    ("ci", "Verify CI hardening contracts"): (
+        frozenset({"name", "runs-on", "timeout-minutes", "if", "needs",
+                   "permissions", "steps"}),
+        frozenset({"name", "shell", "run"}),
+        HARDENING_RUN_SCRIPT,
+        frozenset({"name", "on", "permissions", "env", "jobs"}),
+        frozenset({"ASSAY_PUBLIC_MSRV"}),
     ),
 }
 CHECKOUT_REF = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
@@ -93,6 +110,14 @@ TRUSTED_PREFIX_CONTRACTS = {
         (frozenset({"name", "uses", "with"}),
          {"name": "Set up Python", "uses": SETUP_PYTHON_REF},
          {"python-version": "3.13.8"}),
+    ),
+    ("ci", "Verify CI hardening contracts"): (
+        (frozenset({"uses", "with"}),
+         {"uses": CHECKOUT_REF},
+         {"persist-credentials": "false"}),
+        (frozenset({"uses", "with"}),
+         {"uses": SETUP_PYTHON_REF},
+         {"python-version": "3.12"}),
     ),
 }
 ACTIVATION_KIT = (

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -59,6 +59,7 @@ HARDENING_RUN_SCRIPT = (
     "python3 scripts/ci/test-conformance-inventory-callsite.py",
 )
 FINALE_RUN_SCRIPT = (
+    "set -euo pipefail",
     "python3 scripts/ci/check-ci-gate-coverage.py",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
 )
@@ -86,7 +87,7 @@ HARD_RUN_CONTRACTS = {
     ("ci", "Verify CI hardening contracts"): (
         frozenset({"name", "runs-on", "timeout-minutes", "if", "needs",
                    "permissions", "steps"}),
-        frozenset({"name", "shell", "run"}),
+        frozenset({"name", "shell", "env", "run"}),
         HARDENING_RUN_SCRIPT,
         frozenset({"name", "on", "permissions", "env", "jobs"}),
         frozenset({"ASSAY_PUBLIC_MSRV"}),
@@ -135,6 +136,11 @@ TRUSTED_PREFIX_CONTRACTS = {
 ACTIVATION_KIT = (
     REPO / "conformance/privileged-mcp-action-v0/tests/test_activation_kit.py"
 )
+HARD_RUN_ENV_CONTRACTS = {
+    ("ci", "Verify CI hardening contracts"): {
+        "GH_TOKEN": "${{ github.token }}",
+    },
+}
 
 
 def _indentation_bounded_block(
@@ -416,8 +422,36 @@ def _direct_scalar(raw: str) -> str:
     raise AssertionError(f"unsupported direct scalar syntax: {raw!r}")
 
 
+def _assert_hard_run_env(
+        step: str, job_name: str, step_name: str) -> None:
+    expected = HARD_RUN_ENV_CONTRACTS.get((job_name, step_name))
+    raw_lines = step.splitlines(keepends=True)
+    step_indent = len(raw_lines[0]) - len(raw_lines[0].lstrip(" "))
+    env_indent = step_indent + 2
+    env_indexes = [
+        index for index, raw in enumerate(raw_lines)
+        if raw.rstrip("\r\n") == " " * env_indent + "env:"
+    ]
+    if expected is None:
+        if env_indexes:
+            raise AssertionError(f"{step_name} must not set env")
+        return
+    if len(env_indexes) != 1:
+        raise AssertionError(f"{step_name} must have one direct env mapping")
+    env_block = _indentation_bounded_block(
+        raw_lines, env_indexes[0], env_indent)
+    actual = {
+        key: value.strip()
+        for key, value in _direct_mapping(env_block).items()
+    }
+    if actual != expected:
+        raise AssertionError(
+            f"{step_name} env mapping differs: expected {expected}, got {actual}")
+
+
 def _assert_hard_run_step(
         step: str,
+        job_name: str,
         step_name: str,
         allowed_step_keys: frozenset[str],
         expected_script: tuple[str, ...]) -> None:
@@ -429,6 +463,7 @@ def _assert_hard_run_step(
             f"expected {sorted(allowed_step_keys)}, got {sorted(actual_step_keys)}")
     if _direct_scalar(step_entries["shell"]) != "bash":
         raise AssertionError(f"{step_name} must use shell: bash")
+    _assert_hard_run_env(step, job_name, step_name)
 
     active = tuple(_active_run_lines(step))
     if active != expected_script:
@@ -453,7 +488,8 @@ def assert_hard_run_command(
     _assert_trusted_prefix(text, job_name, step_name)
 
     step = named_step(text, job_name, step_name)
-    _assert_hard_run_step(step, step_name, allowed_step_keys, expected_script)
+    _assert_hard_run_step(
+        step, job_name, step_name, allowed_step_keys, expected_script)
     return step
 
 
@@ -474,7 +510,8 @@ def assert_hard_run_successor(
     if index + 1 >= len(steps) or steps[index + 1] != step:
         raise AssertionError(
             f"{successor} must immediately follow {predecessor}")
-    _assert_hard_run_step(step, successor, allowed_step_keys, expected_script)
+    _assert_hard_run_step(
+        step, job_name, successor, allowed_step_keys, expected_script)
     return step
 
 

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -58,6 +58,10 @@ HARDENING_RUN_SCRIPT = (
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",
 )
+FINALE_RUN_SCRIPT = (
+    "python3 scripts/ci/check-ci-gate-coverage.py",
+    "python3 scripts/ci/check-conformance-inventory-callsite.py",
+)
 ACTIVATION_KIT_RUN_SCRIPT = (
     "set -euo pipefail",
     REVISION_WITNESS,
@@ -84,6 +88,14 @@ HARD_RUN_CONTRACTS = {
                    "permissions", "steps"}),
         frozenset({"name", "shell", "run"}),
         HARDENING_RUN_SCRIPT,
+        frozenset({"name", "on", "permissions", "env", "jobs"}),
+        frozenset({"ASSAY_PUBLIC_MSRV"}),
+    ),
+    ("ci", "Verify this gate waits on every gating job"): (
+        frozenset({"name", "runs-on", "timeout-minutes", "if", "needs",
+                   "permissions", "steps"}),
+        frozenset({"name", "shell", "run"}),
+        FINALE_RUN_SCRIPT,
         frozenset({"name", "on", "permissions", "env", "jobs"}),
         frozenset({"ASSAY_PUBLIC_MSRV"}),
     ),
@@ -404,6 +416,25 @@ def _direct_scalar(raw: str) -> str:
     raise AssertionError(f"unsupported direct scalar syntax: {raw!r}")
 
 
+def _assert_hard_run_step(
+        step: str,
+        step_name: str,
+        allowed_step_keys: frozenset[str],
+        expected_script: tuple[str, ...]) -> None:
+    step_entries = _direct_mapping(step)
+    actual_step_keys = frozenset(step_entries)
+    if actual_step_keys != allowed_step_keys:
+        raise AssertionError(
+            f"{step_name} direct keys differ: "
+            f"expected {sorted(allowed_step_keys)}, got {sorted(actual_step_keys)}")
+    if _direct_scalar(step_entries["shell"]) != "bash":
+        raise AssertionError(f"{step_name} must use shell: bash")
+
+    active = tuple(_active_run_lines(step))
+    if active != expected_script:
+        raise AssertionError(f"{step_name} run script differs from the canonical script")
+
+
 def assert_hard_run_command(
         text: str, job_name: str, step_name: str) -> str:
     contract = HARD_RUN_CONTRACTS.get((job_name, step_name))
@@ -422,18 +453,28 @@ def assert_hard_run_command(
     _assert_trusted_prefix(text, job_name, step_name)
 
     step = named_step(text, job_name, step_name)
-    step_entries = _direct_mapping(step)
-    actual_step_keys = frozenset(step_entries)
-    if actual_step_keys != allowed_step_keys:
-        raise AssertionError(
-            f"{step_name} direct keys differ: "
-            f"expected {sorted(allowed_step_keys)}, got {sorted(actual_step_keys)}")
-    if _direct_scalar(step_entries["shell"]) != "bash":
-        raise AssertionError(f"{step_name} must use shell: bash")
+    _assert_hard_run_step(step, step_name, allowed_step_keys, expected_script)
+    return step
 
-    active = tuple(_active_run_lines(step))
-    if active != expected_script:
-        raise AssertionError(f"{step_name} run script differs from the canonical script")
+
+def assert_hard_run_successor(
+        text: str, job_name: str, predecessor: str, successor: str) -> str:
+    contract = HARD_RUN_CONTRACTS.get((job_name, successor))
+    if contract is None:
+        raise AssertionError(f"no hard-run contract for {job_name}/{successor}")
+    allowed_step_keys, expected_script = contract[1], contract[2]
+    steps = _ordered_job_steps(text, job_name)
+    before = named_step(text, job_name, predecessor)
+    step = named_step(text, job_name, successor)
+    try:
+        index = steps.index(before)
+    except ValueError as error:
+        raise AssertionError(
+            f"{predecessor} is not a direct step in {job_name}") from error
+    if index + 1 >= len(steps) or steps[index + 1] != step:
+        raise AssertionError(
+            f"{successor} must immediately follow {predecessor}")
+    _assert_hard_run_step(step, successor, allowed_step_keys, expected_script)
     return step
 
 

--- a/scripts/ci/check-conformance-inventory-callsite.py
+++ b/scripts/ci/check-conformance-inventory-callsite.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""External required-CI pin for the Conformance inventory callsite.
+
+The inventory tests already encode this contract, but they execute inside the
+step they guard. Required CI therefore invokes the same rule from the later
+hardening root. This file does not parse workflow YAML; it calls
+assert_hard_run_command.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "conformance/tests"))
+
+from test_completion_scope import assert_hard_run_command  # noqa: E402
+
+CI_YML = REPO / ".github/workflows/ci.yml"
+JOB = "scope"
+STEP = "Conformance inventory"
+
+
+def conformance_inventory_callsite_problems(text: str) -> list[str]:
+    try:
+        assert_hard_run_command(text, JOB, STEP)
+    except AssertionError as exc:
+        message = str(exc).strip() or "conformance inventory callsite contract failed"
+        return [message]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    path = Path(args[0]) if args else CI_YML
+    problems = conformance_inventory_callsite_problems(
+        path.read_text(encoding="utf-8"))
+    if problems:
+        for problem in problems:
+            print(f"FAIL: {problem}", file=sys.stderr)
+        return 1
+    print("ok   conformance inventory callsite")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-conformance-inventory-callsite.py
+++ b/scripts/ci/check-conformance-inventory-callsite.py
@@ -3,8 +3,9 @@
 
 The inventory tests already encode this contract, but they execute inside the
 step they guard. Required CI therefore invokes this module from the later
-hardening step. This file does not parse workflow YAML; it calls
-assert_hard_run_command and named_step/_active_run_lines.
+hardening step and again from the final required CI job. This file does not
+parse workflow YAML; it calls assert_hard_run_command and
+named_step/_active_run_lines.
 Canonical CI always reads the committed CI_YML. Tests inject text at the
 function seam.
 """
@@ -26,11 +27,10 @@ from test_completion_scope import (  # noqa: E402
 CI_YML = REPO / ".github/workflows/ci.yml"
 JOB = "scope"
 INVENTORY_STEP = "Conformance inventory"
+HARDENING_JOB = "ci"
 HARDENING_STEP = "Verify CI hardening contracts"
-HARDENING_GUARD_COMMANDS = (
-    "python3 scripts/ci/check-conformance-inventory-callsite.py",
-    "python3 scripts/ci/test-conformance-inventory-callsite.py",
-)
+FINALE_STEP = "Verify this gate waits on every gating job"
+FINALE_CHECKER = "python3 scripts/ci/check-conformance-inventory-callsite.py"
 
 
 def conformance_inventory_callsite_problems(text: str) -> list[str]:
@@ -44,16 +44,19 @@ def conformance_inventory_callsite_problems(text: str) -> list[str]:
 
 def hardening_guard_callsite_problems(text: str) -> list[str]:
     try:
-        step = named_step(text, JOB, HARDENING_STEP)
+        assert_hard_run_command(text, HARDENING_JOB, HARDENING_STEP)
     except AssertionError as exc:
-        message = str(exc).strip() or "hardening step missing"
-        return [message]
-    active = _active_run_lines(step)
-    return [
-        f"hardening step missing active {command}"
-        for command in HARDENING_GUARD_COMMANDS
-        if command not in active
-    ]
+        problems = [str(exc).strip() or "hardening hard-run contract failed"]
+    else:
+        problems = []
+    try:
+        step = named_step(text, HARDENING_JOB, FINALE_STEP)
+    except AssertionError as exc:
+        problems.append(str(exc).strip() or "finale CI checker step missing")
+        return problems
+    if FINALE_CHECKER not in _active_run_lines(step):
+        problems.append("finale CI missing active hardening-step checker")
+    return problems
 
 
 def main() -> int:

--- a/scripts/ci/check-conformance-inventory-callsite.py
+++ b/scripts/ci/check-conformance-inventory-callsite.py
@@ -2,9 +2,11 @@
 """External required-CI pin for the Conformance inventory callsite.
 
 The inventory tests already encode this contract, but they execute inside the
-step they guard. Required CI therefore invokes the same rule from the later
-hardening root. This file does not parse workflow YAML; it calls
-assert_hard_run_command.
+step they guard. Required CI therefore invokes this module from the later
+hardening step. This file does not parse workflow YAML; it calls
+assert_hard_run_command and named_step/_active_run_lines.
+Canonical CI always reads the committed CI_YML. Tests inject text at the
+function seam.
 """
 
 from __future__ import annotations
@@ -15,27 +17,54 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "conformance/tests"))
 
-from test_completion_scope import assert_hard_run_command  # noqa: E402
+from test_completion_scope import (  # noqa: E402
+    _active_run_lines,
+    assert_hard_run_command,
+    named_step,
+)
 
 CI_YML = REPO / ".github/workflows/ci.yml"
 JOB = "scope"
-STEP = "Conformance inventory"
+INVENTORY_STEP = "Conformance inventory"
+HARDENING_STEP = "Verify CI hardening contracts"
+HARDENING_GUARD_COMMANDS = (
+    "python3 scripts/ci/check-conformance-inventory-callsite.py",
+    "python3 scripts/ci/test-conformance-inventory-callsite.py",
+)
 
 
 def conformance_inventory_callsite_problems(text: str) -> list[str]:
     try:
-        assert_hard_run_command(text, JOB, STEP)
+        assert_hard_run_command(text, JOB, INVENTORY_STEP)
     except AssertionError as exc:
         message = str(exc).strip() or "conformance inventory callsite contract failed"
         return [message]
     return []
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = list(sys.argv[1:] if argv is None else argv)
-    path = Path(args[0]) if args else CI_YML
-    problems = conformance_inventory_callsite_problems(
-        path.read_text(encoding="utf-8"))
+def hardening_guard_callsite_problems(text: str) -> list[str]:
+    try:
+        step = named_step(text, JOB, HARDENING_STEP)
+    except AssertionError as exc:
+        message = str(exc).strip() or "hardening step missing"
+        return [message]
+    active = _active_run_lines(step)
+    return [
+        f"hardening step missing active {command}"
+        for command in HARDENING_GUARD_COMMANDS
+        if command not in active
+    ]
+
+
+def main() -> int:
+    if len(sys.argv) != 1:
+        print("FAIL: this checker reads only the committed CI_YML", file=sys.stderr)
+        return 2
+    text = CI_YML.read_text(encoding="utf-8")
+    problems = (
+        conformance_inventory_callsite_problems(text)
+        + hardening_guard_callsite_problems(text)
+    )
     if problems:
         for problem in problems:
             print(f"FAIL: {problem}", file=sys.stderr)

--- a/scripts/ci/check-conformance-inventory-callsite.py
+++ b/scripts/ci/check-conformance-inventory-callsite.py
@@ -4,10 +4,16 @@
 The inventory tests already encode this contract, but they execute inside the
 step they guard. Required CI therefore invokes this module from the later
 hardening step and again from the final required CI job. This file does not
-parse workflow YAML; it calls assert_hard_run_command and
-named_step/_active_run_lines.
+parse workflow YAML; it calls assert_hard_run_command / assert_hard_run_successor
+and the shared indentation/direct-key helpers.
 Canonical CI always reads the committed CI_YML. Tests inject text at the
 function seam.
+
+Hardening and finale own each other under a single-mutation contract: changing
+only one root must turn the remaining caller red. Deleting or neutralizing
+both mutual roots in the same rewrite is outside that contract. Hosted CI
+then has no remaining in-repo caller, so this is not absolute protection
+against a fully rewritten workflow.
 """
 
 from __future__ import annotations
@@ -19,9 +25,8 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "conformance/tests"))
 
 from test_completion_scope import (  # noqa: E402
-    _active_run_lines,
     assert_hard_run_command,
-    named_step,
+    assert_hard_run_successor,
 )
 
 CI_YML = REPO / ".github/workflows/ci.yml"
@@ -30,7 +35,6 @@ INVENTORY_STEP = "Conformance inventory"
 HARDENING_JOB = "ci"
 HARDENING_STEP = "Verify CI hardening contracts"
 FINALE_STEP = "Verify this gate waits on every gating job"
-FINALE_CHECKER = "python3 scripts/ci/check-conformance-inventory-callsite.py"
 
 
 def conformance_inventory_callsite_problems(text: str) -> list[str]:
@@ -50,12 +54,10 @@ def hardening_guard_callsite_problems(text: str) -> list[str]:
     else:
         problems = []
     try:
-        step = named_step(text, HARDENING_JOB, FINALE_STEP)
+        assert_hard_run_successor(
+            text, HARDENING_JOB, HARDENING_STEP, FINALE_STEP)
     except AssertionError as exc:
-        problems.append(str(exc).strip() or "finale CI checker step missing")
-        return problems
-    if FINALE_CHECKER not in _active_run_lines(step):
-        problems.append("finale CI missing active hardening-step checker")
+        problems.append(str(exc).strip() or "finale hard-run successor failed")
     return problems
 
 

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -563,31 +563,27 @@ fi
 
 echo "== required CI workflow actively runs both hardening contracts =="
 # Without a workflow invocation, every GitHub check can stay green while these
-# regressions return. The scope job is always required by the CI aggregator.
+# regressions return. The final CI job is the required aggregator.
 if python3 - "${CI_WF}" <<'PY'
 import re
 import sys
 
 text = open(sys.argv[1]).read()
-match = re.search(r"(?ms)^  scope:\n(.*?)(?=^  [a-zA-Z][\w-]*:|\Z)", text)
+match = re.search(r"(?ms)^  ci:\n(.*?)(?=^  [a-zA-Z][\w-]*:|\Z)", text)
 if not match:
-    sys.exit("scope job missing from ci.yml")
+    sys.exit("ci job missing from ci.yml")
 section = match.group(1)
 # Reject if/continue-on-error on the hardening step itself.
 heading = "      - name: Verify CI hardening contracts\n"
 start = section.find(heading)
 if start < 0:
-    sys.exit("scope job missing 'Verify CI hardening contracts' step")
+    sys.exit("ci job missing 'Verify CI hardening contracts' step")
 rest = section[start + len(heading):]
 nxt = re.search(r"(?m)^      - ", rest)
 body = rest if nxt is None else rest[:nxt.start()]
 for forbidden in ("if:", "continue-on-error:"):
     if re.search(rf"(?m)^        {re.escape(forbidden)}", body):
         sys.exit(f"hardening step must not use {forbidden}")
-required_env = ("GH_TOKEN: ${{ github.token }}",)
-missing_env = [entry for entry in required_env if entry not in body]
-if missing_env:
-    sys.exit("hardening step environment missing: " + ", ".join(missing_env))
 run_at = body.find("        run: |\n")
 if run_at < 0:
     sys.exit("hardening step missing run script")
@@ -612,9 +608,9 @@ if active != list(required):
 sys.exit(0)
 PY
 then
-  ok "ci.yml scope job actively runs both hardening contract scripts"
+  ok "ci.yml ci job actively runs both hardening contract scripts"
 else
-  fail "ci.yml does not actively invoke both hardening contracts in the scope job"
+  fail "ci.yml does not actively invoke both hardening contracts in the ci job"
 fi
 
 echo "== required CI workflow actively runs evidence-vocabulary self-test and live checker =="

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -598,6 +598,8 @@ required = (
     "bash scripts/ci/check-assay-release-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
     "bash scripts/ci/test-structurizr-export-docker.sh",
+    "python3 scripts/ci/check-conformance-inventory-callsite.py",
+    "python3 scripts/ci/test-conformance-inventory-callsite.py",
 )
 missing = [cmd for cmd in required if cmd not in active]
 if missing:
@@ -701,21 +703,6 @@ then
   ok "ci.yml scope job actively runs the published-numbers projection contract"
 else
   fail "ci.yml does not actively invoke the published-numbers projection contract"
-fi
-
-echo "== required CI pins the conformance inventory callsite from outside its step =="
-# The inventory tests already encode this contract, but they execute inside the
-# step they guard. Deleting that step would leave required CI green unless this
-# later root calls the same rule.
-if python3 "${ROOT}/scripts/ci/check-conformance-inventory-callsite.py"; then
-  ok "live conformance inventory callsite matches the hard-run contract"
-else
-  fail "live conformance inventory callsite failed the later required-CI checker"
-fi
-if python3 "${ROOT}/scripts/ci/test-conformance-inventory-callsite.py"; then
-  ok "conformance inventory callsite mutations fail independently"
-else
-  fail "conformance inventory callsite mutation contract failed"
 fi
 
 if [[ "${failures}" -ne 0 ]]; then

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -703,6 +703,21 @@ else
   fail "ci.yml does not actively invoke the published-numbers projection contract"
 fi
 
+echo "== required CI pins the conformance inventory callsite from outside its step =="
+# The inventory tests already encode this contract, but they execute inside the
+# step they guard. Deleting that step would leave required CI green unless this
+# later root calls the same rule.
+if python3 "${ROOT}/scripts/ci/check-conformance-inventory-callsite.py"; then
+  ok "live conformance inventory callsite matches the hard-run contract"
+else
+  fail "live conformance inventory callsite failed the later required-CI checker"
+fi
+if python3 "${ROOT}/scripts/ci/test-conformance-inventory-callsite.py"; then
+  ok "conformance inventory callsite mutations fail independently"
+else
+  fail "conformance inventory callsite mutation contract failed"
+fi
+
 if [[ "${failures}" -ne 0 ]]; then
   echo "ci-hardening-b1 contract: ${failures} failure(s)" >&2
   exit 1

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -584,6 +584,10 @@ body = rest if nxt is None else rest[:nxt.start()]
 for forbidden in ("if:", "continue-on-error:"):
     if re.search(rf"(?m)^        {re.escape(forbidden)}", body):
         sys.exit(f"hardening step must not use {forbidden}")
+required_env = ("GH_TOKEN: ${{ github.token }}",)
+missing_env = [entry for entry in required_env if entry not in body]
+if missing_env:
+    sys.exit("hardening step environment missing: " + ", ".join(missing_env))
 run_at = body.find("        run: |\n")
 if run_at < 0:
     sys.exit("hardening step missing run script")

--- a/scripts/ci/test-ci-hardening-b1.sh
+++ b/scripts/ci/test-ci-hardening-b1.sh
@@ -574,13 +574,13 @@ if not match:
     sys.exit("scope job missing from ci.yml")
 section = match.group(1)
 # Reject if/continue-on-error on the hardening step itself.
-step = re.search(
-    r"(?ms)^      - name: Verify CI hardening contracts\n(?P<body>(?:        .+\n)+)",
-    section,
-)
-if not step:
+heading = "      - name: Verify CI hardening contracts\n"
+start = section.find(heading)
+if start < 0:
     sys.exit("scope job missing 'Verify CI hardening contracts' step")
-body = step.group("body")
+rest = section[start + len(heading):]
+nxt = re.search(r"(?m)^      - ", rest)
+body = rest if nxt is None else rest[:nxt.start()]
 for forbidden in ("if:", "continue-on-error:"):
     if re.search(rf"(?m)^        {re.escape(forbidden)}", body):
         sys.exit(f"hardening step must not use {forbidden}")
@@ -588,12 +588,17 @@ required_env = ("GH_TOKEN: ${{ github.token }}",)
 missing_env = [entry for entry in required_env if entry not in body]
 if missing_env:
     sys.exit("hardening step environment missing: " + ", ".join(missing_env))
+run_at = body.find("        run: |\n")
+if run_at < 0:
+    sys.exit("hardening step missing run script")
+script = body[run_at + len("        run: |\n"):]
 active = [
     line.strip()
-    for line in body.splitlines()
+    for line in script.splitlines()
     if line.startswith("          ") and not line.lstrip().startswith("#")
 ]
 required = (
+    "set -euo pipefail",
     "bash scripts/ci/test-check-assay-release-pin.sh",
     "bash scripts/ci/check-assay-release-pin.sh --published",
     "bash scripts/ci/test-ci-hardening-b1.sh",
@@ -601,9 +606,9 @@ required = (
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",
 )
-missing = [cmd for cmd in required if cmd not in active]
-if missing:
-    sys.exit("active commands missing: " + ", ".join(missing))
+if active != list(required):
+    sys.exit("active hardening step body must be exactly %r, got %r" %
+             (list(required), active))
 sys.exit(0)
 PY
 then

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -22,13 +22,21 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "conformance/tests"))
 
-from test_completion_scope import _active_run_lines, named_step  # noqa: E402
+from test_completion_scope import (  # noqa: E402
+    TRUSTED_PREFIX_WRITERS,
+    _active_run_lines,
+    named_step,
+)
 
 CHECKER_PATH = REPO / "scripts/ci/check-conformance-inventory-callsite.py"
 B1_PATH = REPO / "scripts/ci/test-ci-hardening-b1.sh"
 CI_YML = REPO / ".github/workflows/ci.yml"
 JOB = "scope"
 INVENTORY_STEP = "Conformance inventory"
+HARDENING_STEP = "Verify CI hardening contracts"
+FINALE_JOB = "ci"
+FINALE_STEP = "Verify this gate waits on every gating job"
+FINALE_CHECKER = "python3 scripts/ci/check-conformance-inventory-callsite.py"
 
 # Independent oracle. Do not import the completion-scope run-script tuple.
 REQUIRED_INVENTORY_COMMANDS = (
@@ -194,6 +202,87 @@ STRUCTURAL_MUTATIONS = (
 )
 
 
+def hardening_heading(text: str) -> str:
+    heading = f"      - name: {HARDENING_STEP}\n"
+    if heading not in text:
+        raise AssertionError("hardening step heading missing")
+    return heading
+
+
+def delete_hardening_step(text: str) -> str:
+    for job in (FINALE_JOB, JOB):
+        try:
+            step = named_step(text, job, HARDENING_STEP)
+        except AssertionError:
+            continue
+        mutated = text.replace(step, "", 1)
+        if mutated == text or f"      - name: {HARDENING_STEP}\n" in mutated:
+            raise AssertionError("delete-hardening mutation was a no-op")
+        return mutated
+    raise AssertionError("hardening step missing")
+
+
+def rename_hardening_step(text: str) -> str:
+    mutated = text.replace(
+        hardening_heading(text),
+        "      - name: Verify CI hardening contract\n",
+        1,
+    )
+    if mutated == text:
+        raise AssertionError("rename-hardening mutation was a no-op")
+    return mutated
+
+
+def false_if_hardening(text: str) -> str:
+    needle = hardening_heading(text)
+    mutated = text.replace(needle, needle + "        if: false\n", 1)
+    if mutated == text:
+        raise AssertionError("if:false hardening mutation was a no-op")
+    return mutated
+
+
+def hostile_hardening_shell(text: str) -> str:
+    needle = hardening_heading(text) + "        shell: bash\n"
+    mutated = text.replace(
+        needle,
+        hardening_heading(text) + '        shell: bash -c "exit 0" {0}\n',
+        1,
+    )
+    if mutated == text:
+        raise AssertionError("hostile-shell mutation was a no-op")
+    return mutated
+
+
+def bash_env_before_hardening(text: str) -> str:
+    needle = hardening_heading(text)
+    writer = TRUSTED_PREFIX_WRITERS[0][1]
+    mutated = text.replace(needle, writer + needle, 1)
+    if mutated == text:
+        raise AssertionError("BASH_ENV writer mutation was a no-op")
+    return mutated
+
+
+def neutralize_finale_checker(text: str) -> str:
+    step = named_step(text, FINALE_JOB, FINALE_STEP)
+    needle = f"          {FINALE_CHECKER}\n"
+    if needle not in step:
+        raise AssertionError("finale checker callsite missing")
+    mutated_step = step.replace(needle, "", 1)
+    mutated = text.replace(step, mutated_step, 1)
+    if mutated == text:
+        raise AssertionError("finale-checker neutralization was a no-op")
+    return mutated
+
+
+HARDENING_EXECUTION_MUTATIONS = (
+    ("delete_hardening_step", delete_hardening_step),
+    ("rename_hardening_step", rename_hardening_step),
+    ("false_if_hardening", false_if_hardening),
+    ("hostile_hardening_shell", hostile_hardening_shell),
+    ("bash_env_before_hardening", bash_env_before_hardening),
+)
+
+
 class ConformanceInventoryCallsite(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -221,7 +310,7 @@ class ConformanceInventoryCallsite(unittest.TestCase):
     def test_pristine_workflow_is_green(self) -> None:
         self.assertEqual(self.problems_fn(self.live), [])
         self.assertEqual(self.guards_fn(self.live), [])
-        step = named_step(self.live, JOB, "Verify CI hardening contracts")
+        step = named_step(self.live, FINALE_JOB, HARDENING_STEP)
         self.assertEqual(tuple(_active_run_lines(step)), HARDENING_STEP_COMMANDS)
 
     def test_live_inventory_step_matches_independent_literals(self) -> None:
@@ -292,6 +381,22 @@ class ConformanceInventoryCallsite(unittest.TestCase):
                     f"{label} must fail the B1 hardening-step pin",
                 )
         self.assertEqual(b1_hardening_pin_rc(self.live), 0)
+
+    def test_hardening_execution_removal_fails_the_required_root(self) -> None:
+        self.assertEqual(self.guards_fn(self.live), [])
+        for label, mutate in HARDENING_EXECUTION_MUTATIONS:
+            with self.subTest(label=label):
+                problems = self.guards_fn(mutate(self.live))
+                self.assertTrue(
+                    problems,
+                    f"{label} must fail the hardening hard-run contract",
+                )
+        self.assertEqual(self.guards_fn(self.live), [])
+
+    def test_finale_ci_invokes_the_hardening_checker(self) -> None:
+        step = named_step(self.live, FINALE_JOB, FINALE_STEP)
+        self.assertIn(FINALE_CHECKER, _active_run_lines(step))
+        self.assertTrue(self.guards_fn(neutralize_finale_checker(self.live)))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -100,7 +100,9 @@ def load_checker():
         raise AssertionError("conformance_inventory_callsite_problems missing")
     if not callable(guards_fn):
         raise AssertionError("hardening_guard_callsite_problems missing")
-    return problems_fn, guards_fn
+    if not callable(getattr(module, "main", None)):
+        raise AssertionError("checker main missing")
+    return module, problems_fn, guards_fn
 
 
 def sha256_text(text: str) -> str:
@@ -380,6 +382,21 @@ def rebind_hardening_gh_token(text: str) -> str:
     return mutated
 
 
+def run_checker_main(module, workflow_text: str) -> int:
+    original = module.CI_YML
+    original_argv = sys.argv
+    with tempfile.TemporaryDirectory() as tmp:
+        scratch = Path(tmp) / "ci.yml"
+        scratch.write_text(workflow_text, encoding="utf-8")
+        module.CI_YML = scratch
+        sys.argv = [str(CHECKER_PATH)]
+        try:
+            return module.main()
+        finally:
+            module.CI_YML = original
+            sys.argv = original_argv
+
+
 def run_live_finale_step(workflow_text: str, *, fail_first: bool) -> int:
     script = "\n".join(_active_run_lines(named_step(
         workflow_text, FINALE_JOB, FINALE_STEP)))
@@ -408,7 +425,8 @@ class ConformanceInventoryCallsite(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.live = CI_YML.read_text(encoding="utf-8")
         cls.live_digest = sha256_text(cls.live)
-        problems_fn, guards_fn = load_checker()
+        module, problems_fn, guards_fn = load_checker()
+        cls.checker = module
         cls.problems_fn = staticmethod(problems_fn)
         cls.guards_fn = staticmethod(guards_fn)
 
@@ -585,6 +603,49 @@ class ConformanceInventoryCallsite(unittest.TestCase):
                     tuple(_active_run_lines(finale)),
                     FINALE_STEP_COMMANDS,
                 )
+
+    def test_main_fails_closed_on_mutated_workflows(self) -> None:
+        self.assertEqual(run_checker_main(self.checker, self.live), 0)
+        mutations = (
+            ("inventory_delete", delete_step),
+            ("hardening_delete", delete_hardening_step),
+            ("finale_if_false", false_if_finale),
+        )
+        for label, mutate in mutations:
+            with self.subTest(label=label):
+                self.assertNotEqual(
+                    run_checker_main(self.checker, mutate(self.live)),
+                    0,
+                    f"{label} must fail checker main()",
+                )
+        self.assertEqual(run_checker_main(self.checker, self.live), 0)
+
+    def test_neutralizing_main_failure_branch_is_visible(self) -> None:
+        source = CHECKER_PATH.read_text(encoding="utf-8")
+        needle = "    if problems:\n"
+        self.assertIn(needle, source)
+        self.assertNotIn("    if False and problems:\n", source)
+        disabled = source.replace(needle, "    if False and problems:\n", 1)
+        mutated_workflow = delete_step(self.live)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "checker.py"
+            path.write_text(disabled, encoding="utf-8")
+            spec = importlib.util.spec_from_file_location(
+                "disabled_inventory_callsite", path)
+            if spec is None or spec.loader is None:
+                raise AssertionError("disabled checker is not loadable")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            self.assertEqual(
+                run_checker_main(module, mutated_workflow),
+                0,
+                "the reported if False and problems mutation must skip main failure",
+            )
+        self.assertNotEqual(
+            run_checker_main(self.checker, mutated_workflow),
+            0,
+            "live main() must stay red on the same mutated workflow",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -45,6 +47,16 @@ HARDENING_GUARD_COMMANDS = (
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",
 )
+# Independent of the checker module. B1 keeps its own copy of this sequence.
+HARDENING_STEP_COMMANDS = (
+    "set -euo pipefail",
+    "bash scripts/ci/test-check-assay-release-pin.sh",
+    "bash scripts/ci/check-assay-release-pin.sh --published",
+    "bash scripts/ci/test-ci-hardening-b1.sh",
+    "bash scripts/ci/test-structurizr-export-docker.sh",
+    "python3 scripts/ci/check-conformance-inventory-callsite.py",
+    "python3 scripts/ci/test-conformance-inventory-callsite.py",
+)
 
 
 def load_checker():
@@ -67,6 +79,52 @@ def load_checker():
 
 def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def b1_hardening_pin_rc(workflow_text: str) -> int:
+    source = B1_PATH.read_text(encoding="utf-8")
+    marker = 'echo "== required CI workflow actively runs both hardening contracts =="'
+    start = source.index(marker)
+    py_start = source.index("import re\n", start)
+    py_end = source.index("\nPY\n", py_start)
+    scratch = Path(tempfile.mkdtemp()) / "ci.yml"
+    scratch.write_text(workflow_text, encoding="utf-8")
+    completed = subprocess.run(
+        [sys.executable, "-c", source[py_start:py_end], str(scratch)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode
+
+
+def early_exit_0(text: str) -> str:
+    needle = "          bash scripts/ci/test-ci-hardening-b1.sh\n"
+    mutated = text.replace(needle, needle + "          exit 0\n", 1)
+    if mutated == text:
+        raise AssertionError("early exit 0 mutation was a no-op")
+    return mutated
+
+
+def swap_hardening_guards(text: str) -> str:
+    first = "          python3 scripts/ci/check-conformance-inventory-callsite.py\n"
+    second = "          python3 scripts/ci/test-conformance-inventory-callsite.py\n"
+    if first not in text or second not in text:
+        raise AssertionError("guard swap targets missing")
+    mutated = text.replace(first, "__SWAP_A__\n", 1)
+    mutated = mutated.replace(second, first, 1)
+    mutated = mutated.replace("__SWAP_A__\n", second, 1)
+    if mutated == text:
+        raise AssertionError("guard swap mutation was a no-op")
+    return mutated
+
+
+def extra_hardening_command(text: str) -> str:
+    needle = "          python3 scripts/ci/check-conformance-inventory-callsite.py\n"
+    mutated = text.replace(needle, needle + "          echo extra-active\n", 1)
+    if mutated == text:
+        raise AssertionError("extra-command mutation was a no-op")
+    return mutated
 
 
 def neutralize(text: str, command: str, mode: str) -> str:
@@ -162,6 +220,8 @@ class ConformanceInventoryCallsite(unittest.TestCase):
     def test_pristine_workflow_is_green(self) -> None:
         self.assertEqual(self.problems_fn(self.live), [])
         self.assertEqual(self.guards_fn(self.live), [])
+        step = named_step(self.live, JOB, "Verify CI hardening contracts")
+        self.assertEqual(tuple(_active_run_lines(step)), HARDENING_STEP_COMMANDS)
 
     def test_live_inventory_step_matches_independent_literals(self) -> None:
         step = named_step(self.live, JOB, INVENTORY_STEP)
@@ -201,16 +261,36 @@ class ConformanceInventoryCallsite(unittest.TestCase):
                     )
         self.assertEqual(self.guards_fn(self.live), [])
 
-    def test_b1_pins_the_exact_hardening_guard_commands(self) -> None:
+    def test_b1_pins_the_exact_hardening_step_sequence(self) -> None:
         text = B1_PATH.read_text(encoding="utf-8")
-        active = [
-            line
-            for line in text.splitlines()
-            if line.strip() and not line.lstrip().startswith("#")
-        ]
-        joined = "\n".join(active)
-        for command in HARDENING_GUARD_COMMANDS:
-            self.assertIn(f'"{command}"', joined)
+        marker = 'echo "== required CI workflow actively runs both hardening contracts =="'
+        start = text.index(marker)
+        py_start = text.index("import re\n", start)
+        py_end = text.index("\nPY\n", py_start)
+        block = text[py_start:py_end]
+        self.assertIn("if active != list(required):", block)
+        self.assertNotIn(
+            "missing = [cmd for cmd in required if cmd not in active]",
+            block,
+        )
+        for command in HARDENING_STEP_COMMANDS:
+            self.assertIn(f'"{command}"', block)
+
+    def test_hardening_step_sequence_mutations_fail_b1(self) -> None:
+        self.assertEqual(b1_hardening_pin_rc(self.live), 0)
+        mutations = (
+            ("early_exit_0", early_exit_0),
+            ("swap_guards", swap_hardening_guards),
+            ("extra_command", extra_hardening_command),
+        )
+        for label, mutate in mutations:
+            with self.subTest(label=label):
+                self.assertNotEqual(
+                    b1_hardening_pin_rc(mutate(self.live)),
+                    0,
+                    f"{label} must fail the B1 hardening-step pin",
+                )
+        self.assertEqual(b1_hardening_pin_rc(self.live), 0)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Mutations for the external Conformance inventory callsite pin.
+
+    python3 scripts/ci/test-conformance-inventory-callsite.py
+
+The inventory tests already encode this contract, but they execute inside the
+step they guard. These mutations therefore target the later required-CI
+checker, not the in-step suite. The live workflow file is never written.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "conformance/tests"))
+
+from test_completion_scope import (  # noqa: E402
+    INVENTORY_RUN_SCRIPT,
+    REQUIRED_RUN_ALL,
+    named_step,
+)
+
+CHECKER_PATH = REPO / "scripts/ci/check-conformance-inventory-callsite.py"
+B1_PATH = REPO / "scripts/ci/test-ci-hardening-b1.sh"
+CI_YML = REPO / ".github/workflows/ci.yml"
+JOB = "scope"
+STEP = "Conformance inventory"
+CHECKER_PATH_TOKEN = "scripts/ci/check-conformance-inventory-callsite.py"
+TEST_PATH_TOKEN = "scripts/ci/test-conformance-inventory-callsite.py"
+
+
+def load_checker():
+    if not CHECKER_PATH.is_file():
+        raise AssertionError(f"missing checker {CHECKER_PATH}")
+    spec = importlib.util.spec_from_file_location(
+        "conformance_inventory_callsite", CHECKER_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError("checker is not loadable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    checker = getattr(module, "conformance_inventory_callsite_problems", None)
+    if not callable(checker):
+        raise AssertionError("conformance_inventory_callsite_problems missing")
+    return checker
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def delete_step(text: str) -> str:
+    step = named_step(text, JOB, STEP)
+    mutated = text.replace(step, "", 1)
+    if mutated == text or f"      - name: {STEP}\n" in mutated:
+        raise AssertionError("delete-step mutation was a no-op")
+    return mutated
+
+
+def rename_step(text: str) -> str:
+    mutated = text.replace(
+        f"      - name: {STEP}\n",
+        "      - name: Inventory conformance\n",
+        1,
+    )
+    if mutated == text:
+        raise AssertionError("rename mutation was a no-op")
+    return mutated
+
+
+def false_if(text: str) -> str:
+    needle = f"      - name: {STEP}\n"
+    mutated = text.replace(needle, needle + "        if: false\n", 1)
+    if mutated == text:
+        raise AssertionError("if:false mutation was a no-op")
+    return mutated
+
+
+def comment_live_commands(text: str) -> str:
+    mutated = text
+    for command in INVENTORY_RUN_SCRIPT[1:]:
+        needle = f"          {command}\n"
+        if needle not in mutated:
+            raise AssertionError(f"missing live command {command!r}")
+        mutated = mutated.replace(needle, f"          # {command}\n", 1)
+    if mutated == text:
+        raise AssertionError("comment mutation was a no-op")
+    return mutated
+
+
+def colon_one_command(text: str) -> str:
+    needle = f"          {REQUIRED_RUN_ALL}\n"
+    mutated = text.replace(needle, "          :\n", 1)
+    if mutated == text:
+        raise AssertionError("colon mutation was a no-op")
+    return mutated
+
+
+def reorder_one_command(text: str) -> str:
+    first = "          python3 conformance/registry.py\n"
+    second = "          python3 conformance/implementations.py\n"
+    if first not in text or second not in text:
+        raise AssertionError("reorder targets missing")
+    mutated = text.replace(first, "__SWAP_A__\n", 1)
+    mutated = mutated.replace(second, first, 1)
+    mutated = mutated.replace("__SWAP_A__\n", second, 1)
+    if mutated == text:
+        raise AssertionError("reorder mutation was a no-op")
+    return mutated
+
+
+MUTATIONS = (
+    ("delete_step", delete_step),
+    ("rename_step", rename_step),
+    ("false_if", false_if),
+    ("comment_live_commands", comment_live_commands),
+    ("colon_one_command", colon_one_command),
+    ("reorder_one_command", reorder_one_command),
+)
+
+
+class ConformanceInventoryCallsite(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.live = CI_YML.read_text(encoding="utf-8")
+        cls.live_digest = sha256_text(cls.live)
+        cls.problems_fn = staticmethod(load_checker())
+
+    def tearDown(self) -> None:
+        current = CI_YML.read_text(encoding="utf-8")
+        self.assertEqual(sha256_text(current), self.live_digest)
+        self.assertEqual(current, self.live)
+
+    def test_pristine_workflow_is_green(self) -> None:
+        self.assertEqual(self.problems_fn(self.live), [])
+
+    def test_each_mutation_fails_independently(self) -> None:
+        self.assertEqual(self.problems_fn(self.live), [])
+        for label, mutate in MUTATIONS:
+            with self.subTest(label=label):
+                mutated = mutate(self.live)
+                self.assertNotEqual(mutated, self.live)
+                problems = self.problems_fn(mutated)
+                self.assertTrue(
+                    problems,
+                    f"{label} must fail the later required-CI checker",
+                )
+        self.assertEqual(self.problems_fn(self.live), [])
+
+    def test_b1_actively_invokes_checker_and_mutations(self) -> None:
+        text = B1_PATH.read_text(encoding="utf-8")
+        active = [
+            line
+            for line in text.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        joined = "\n".join(active)
+        self.assertIn(CHECKER_PATH_TOKEN, joined)
+        self.assertIn(TEST_PATH_TOKEN, joined)
+        self.assertTrue(
+            any("python3" in line and CHECKER_PATH_TOKEN in line for line in active),
+            "B1 must actively invoke the live callsite checker",
+        )
+        self.assertTrue(
+            any("python3" in line and TEST_PATH_TOKEN in line for line in active),
+            "B1 must actively invoke the callsite mutation tests",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -5,7 +5,8 @@
 
 The inventory tests already encode this contract, but they execute inside the
 step they guard. These mutations therefore target the later required-CI
-checker, not the in-step suite. The live workflow file is never written.
+checker and the workflow calls that invoke it. The live workflow is never
+written. Command literals here are an independent oracle, not an import.
 """
 
 from __future__ import annotations
@@ -19,19 +20,31 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "conformance/tests"))
 
-from test_completion_scope import (  # noqa: E402
-    INVENTORY_RUN_SCRIPT,
-    REQUIRED_RUN_ALL,
-    named_step,
-)
+from test_completion_scope import _active_run_lines, named_step  # noqa: E402
 
 CHECKER_PATH = REPO / "scripts/ci/check-conformance-inventory-callsite.py"
 B1_PATH = REPO / "scripts/ci/test-ci-hardening-b1.sh"
 CI_YML = REPO / ".github/workflows/ci.yml"
 JOB = "scope"
-STEP = "Conformance inventory"
-CHECKER_PATH_TOKEN = "scripts/ci/check-conformance-inventory-callsite.py"
-TEST_PATH_TOKEN = "scripts/ci/test-conformance-inventory-callsite.py"
+INVENTORY_STEP = "Conformance inventory"
+
+# Independent oracle. Do not import the completion-scope run-script tuple.
+REQUIRED_INVENTORY_COMMANDS = (
+    "set -euo pipefail",
+    'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+    "python3 conformance/registry.py",
+    "python3 conformance/implementations.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_implementations.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_pma_v0_registration.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_registry.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_run_all.py",
+    "python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py",
+    "python3 conformance/run_all.py --require-complete --completion-scope required",
+)
+HARDENING_GUARD_COMMANDS = (
+    "python3 scripts/ci/check-conformance-inventory-callsite.py",
+    "python3 scripts/ci/test-conformance-inventory-callsite.py",
+)
 
 
 def load_checker():
@@ -43,27 +56,48 @@ def load_checker():
         raise AssertionError("checker is not loadable")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    checker = getattr(module, "conformance_inventory_callsite_problems", None)
-    if not callable(checker):
+    problems_fn = getattr(module, "conformance_inventory_callsite_problems", None)
+    guards_fn = getattr(module, "hardening_guard_callsite_problems", None)
+    if not callable(problems_fn):
         raise AssertionError("conformance_inventory_callsite_problems missing")
-    return checker
+    if not callable(guards_fn):
+        raise AssertionError("hardening_guard_callsite_problems missing")
+    return problems_fn, guards_fn
 
 
 def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def neutralize(text: str, command: str, mode: str) -> str:
+    needle = f"          {command}\n"
+    if needle not in text:
+        raise AssertionError(f"missing live command {command!r}")
+    if mode == "remove":
+        replacement = ""
+    elif mode == "comment":
+        replacement = f"          # {command}\n"
+    elif mode == "colon":
+        replacement = "          :\n"
+    else:
+        raise AssertionError(f"unknown neutralize mode {mode!r}")
+    mutated = text.replace(needle, replacement, 1)
+    if mutated == text:
+        raise AssertionError(f"{mode} mutation of {command!r} was a no-op")
+    return mutated
+
+
 def delete_step(text: str) -> str:
-    step = named_step(text, JOB, STEP)
+    step = named_step(text, JOB, INVENTORY_STEP)
     mutated = text.replace(step, "", 1)
-    if mutated == text or f"      - name: {STEP}\n" in mutated:
+    if mutated == text or f"      - name: {INVENTORY_STEP}\n" in mutated:
         raise AssertionError("delete-step mutation was a no-op")
     return mutated
 
 
 def rename_step(text: str) -> str:
     mutated = text.replace(
-        f"      - name: {STEP}\n",
+        f"      - name: {INVENTORY_STEP}\n",
         "      - name: Inventory conformance\n",
         1,
     )
@@ -73,30 +107,10 @@ def rename_step(text: str) -> str:
 
 
 def false_if(text: str) -> str:
-    needle = f"      - name: {STEP}\n"
+    needle = f"      - name: {INVENTORY_STEP}\n"
     mutated = text.replace(needle, needle + "        if: false\n", 1)
     if mutated == text:
         raise AssertionError("if:false mutation was a no-op")
-    return mutated
-
-
-def comment_live_commands(text: str) -> str:
-    mutated = text
-    for command in INVENTORY_RUN_SCRIPT[1:]:
-        needle = f"          {command}\n"
-        if needle not in mutated:
-            raise AssertionError(f"missing live command {command!r}")
-        mutated = mutated.replace(needle, f"          # {command}\n", 1)
-    if mutated == text:
-        raise AssertionError("comment mutation was a no-op")
-    return mutated
-
-
-def colon_one_command(text: str) -> str:
-    needle = f"          {REQUIRED_RUN_ALL}\n"
-    mutated = text.replace(needle, "          :\n", 1)
-    if mutated == text:
-        raise AssertionError("colon mutation was a no-op")
     return mutated
 
 
@@ -113,12 +127,10 @@ def reorder_one_command(text: str) -> str:
     return mutated
 
 
-MUTATIONS = (
+STRUCTURAL_MUTATIONS = (
     ("delete_step", delete_step),
     ("rename_step", rename_step),
     ("false_if", false_if),
-    ("comment_live_commands", comment_live_commands),
-    ("colon_one_command", colon_one_command),
     ("reorder_one_command", reorder_one_command),
 )
 
@@ -128,30 +140,68 @@ class ConformanceInventoryCallsite(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.live = CI_YML.read_text(encoding="utf-8")
         cls.live_digest = sha256_text(cls.live)
-        cls.problems_fn = staticmethod(load_checker())
+        problems_fn, guards_fn = load_checker()
+        cls.problems_fn = staticmethod(problems_fn)
+        cls.guards_fn = staticmethod(guards_fn)
 
     def tearDown(self) -> None:
         current = CI_YML.read_text(encoding="utf-8")
         self.assertEqual(sha256_text(current), self.live_digest)
         self.assertEqual(current, self.live)
 
+    def test_command_table_is_not_an_import_of_the_completion_scope_tuple(self) -> None:
+        imported = [
+            line
+            for line in Path(__file__).read_text(encoding="utf-8").splitlines()
+            if "import" in line and "test_completion_scope" in line
+        ]
+        joined = "\n".join(imported)
+        self.assertNotIn("INVENTORY_" + "RUN_SCRIPT", joined)
+        self.assertNotIn("REQUIRED_" + "RUN_ALL", joined)
+
     def test_pristine_workflow_is_green(self) -> None:
         self.assertEqual(self.problems_fn(self.live), [])
+        self.assertEqual(self.guards_fn(self.live), [])
 
-    def test_each_mutation_fails_independently(self) -> None:
+    def test_live_inventory_step_matches_independent_literals(self) -> None:
+        step = named_step(self.live, JOB, INVENTORY_STEP)
+        self.assertEqual(tuple(_active_run_lines(step)), REQUIRED_INVENTORY_COMMANDS)
+
+    def test_structural_mutations_fail_independently(self) -> None:
         self.assertEqual(self.problems_fn(self.live), [])
-        for label, mutate in MUTATIONS:
+        for label, mutate in STRUCTURAL_MUTATIONS:
             with self.subTest(label=label):
-                mutated = mutate(self.live)
-                self.assertNotEqual(mutated, self.live)
-                problems = self.problems_fn(mutated)
-                self.assertTrue(
-                    problems,
-                    f"{label} must fail the later required-CI checker",
-                )
+                problems = self.problems_fn(mutate(self.live))
+                self.assertTrue(problems, f"{label} must fail the later checker")
         self.assertEqual(self.problems_fn(self.live), [])
 
-    def test_b1_actively_invokes_checker_and_mutations(self) -> None:
+    def test_each_required_command_neutralization_fails(self) -> None:
+        self.assertEqual(self.problems_fn(self.live), [])
+        for command in REQUIRED_INVENTORY_COMMANDS:
+            for mode in ("remove", "comment", "colon"):
+                with self.subTest(command=command, mode=mode):
+                    problems = self.problems_fn(
+                        neutralize(self.live, command, mode))
+                    self.assertTrue(
+                        problems,
+                        f"{mode} {command!r} must fail the later checker",
+                    )
+        self.assertEqual(self.problems_fn(self.live), [])
+
+    def test_hardening_guard_call_neutralization_fails(self) -> None:
+        self.assertEqual(self.guards_fn(self.live), [])
+        for command in HARDENING_GUARD_COMMANDS:
+            for mode in ("remove", "comment", "colon"):
+                with self.subTest(command=command, mode=mode):
+                    problems = self.guards_fn(
+                        neutralize(self.live, command, mode))
+                    self.assertTrue(
+                        problems,
+                        f"{mode} {command!r} must fail the workflow-call pin",
+                    )
+        self.assertEqual(self.guards_fn(self.live), [])
+
+    def test_b1_pins_the_exact_hardening_guard_commands(self) -> None:
         text = B1_PATH.read_text(encoding="utf-8")
         active = [
             line
@@ -159,16 +209,8 @@ class ConformanceInventoryCallsite(unittest.TestCase):
             if line.strip() and not line.lstrip().startswith("#")
         ]
         joined = "\n".join(active)
-        self.assertIn(CHECKER_PATH_TOKEN, joined)
-        self.assertIn(TEST_PATH_TOKEN, joined)
-        self.assertTrue(
-            any("python3" in line and CHECKER_PATH_TOKEN in line for line in active),
-            "B1 must actively invoke the live callsite checker",
-        )
-        self.assertTrue(
-            any("python3" in line and TEST_PATH_TOKEN in line for line in active),
-            "B1 must actively invoke the callsite mutation tests",
-        )
+        for command in HARDENING_GUARD_COMMANDS:
+            self.assertIn(f'"{command}"', joined)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -87,14 +87,15 @@ def b1_hardening_pin_rc(workflow_text: str) -> int:
     start = source.index(marker)
     py_start = source.index("import re\n", start)
     py_end = source.index("\nPY\n", py_start)
-    scratch = Path(tempfile.mkdtemp()) / "ci.yml"
-    scratch.write_text(workflow_text, encoding="utf-8")
-    completed = subprocess.run(
-        [sys.executable, "-c", source[py_start:py_end], str(scratch)],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    with tempfile.TemporaryDirectory() as tmp:
+        scratch = Path(tmp) / "ci.yml"
+        scratch.write_text(workflow_text, encoding="utf-8")
+        completed = subprocess.run(
+            [sys.executable, "-c", source[py_start:py_end], str(scratch)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
     return completed.returncode
 
 

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -74,8 +74,14 @@ HARDENING_STEP_COMMANDS = (
 )
 # Independent of the checker module and of FINALE_RUN_SCRIPT.
 FINALE_STEP_COMMANDS = (
+    "set -euo pipefail",
     "python3 scripts/ci/check-ci-gate-coverage.py",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
+)
+HARDENING_GH_TOKEN = "GH_TOKEN: ${{ github.token }}"
+HARDENING_ENV_BLOCK = (
+    "        env:\n"
+    f"          {HARDENING_GH_TOKEN}\n"
 )
 
 
@@ -348,6 +354,55 @@ FINALE_EXECUTION_MUTATIONS = (
 )
 
 
+def drop_hardening_gh_token(text: str) -> str:
+    step = named_step(text, FINALE_JOB, HARDENING_STEP)
+    if HARDENING_ENV_BLOCK not in step:
+        raise AssertionError("hardening GH_TOKEN env block missing")
+    mutated_step = step.replace(HARDENING_ENV_BLOCK, "", 1)
+    mutated = text.replace(step, mutated_step, 1)
+    if mutated == text:
+        raise AssertionError("drop-GH_TOKEN mutation was a no-op")
+    return mutated
+
+
+def rebind_hardening_gh_token(text: str) -> str:
+    step = named_step(text, FINALE_JOB, HARDENING_STEP)
+    if HARDENING_GH_TOKEN not in step:
+        raise AssertionError("hardening GH_TOKEN binding missing")
+    mutated_step = step.replace(
+        HARDENING_GH_TOKEN,
+        "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+        1,
+    )
+    mutated = text.replace(step, mutated_step, 1)
+    if mutated == text:
+        raise AssertionError("rebind-GH_TOKEN mutation was a no-op")
+    return mutated
+
+
+def run_live_finale_step(workflow_text: str, *, fail_first: bool) -> int:
+    script = "\n".join(_active_run_lines(named_step(
+        workflow_text, FINALE_JOB, FINALE_STEP)))
+    if fail_first:
+        script = (
+            "python3() {\n"
+            "  if [ \"$1\" = \"scripts/ci/check-ci-gate-coverage.py\" ]; then\n"
+            "    return 2\n"
+            "  fi\n"
+            "  command python3 \"$@\"\n"
+            "}\n"
+            + script
+        )
+    completed = subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode
+
+
 class ConformanceInventoryCallsite(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -379,6 +434,7 @@ class ConformanceInventoryCallsite(unittest.TestCase):
         self.assertEqual(self.guards_fn(self.live), [])
         step = named_step(self.live, FINALE_JOB, HARDENING_STEP)
         self.assertEqual(tuple(_active_run_lines(step)), HARDENING_STEP_COMMANDS)
+        self.assertIn(HARDENING_ENV_BLOCK, step)
         finale = named_step(self.live, FINALE_JOB, FINALE_STEP)
         self.assertEqual(tuple(_active_run_lines(finale)), FINALE_STEP_COMMANDS)
 
@@ -434,6 +490,7 @@ class ConformanceInventoryCallsite(unittest.TestCase):
         )
         for command in HARDENING_STEP_COMMANDS:
             self.assertIn(f'"{command}"', block)
+        self.assertIn(HARDENING_GH_TOKEN, block)
 
     def test_hardening_step_sequence_mutations_fail_b1(self) -> None:
         self.assertEqual(b1_hardening_pin_rc(self.live), 0)
@@ -477,6 +534,35 @@ class ConformanceInventoryCallsite(unittest.TestCase):
                     f"{label} must fail the finale hard-run contract",
                 )
         self.assertEqual(self.guards_fn(self.live), [])
+
+    def test_hardening_gh_token_binding_mutations_fail(self) -> None:
+        self.assertEqual(self.guards_fn(self.live), [])
+        for label, mutate in (
+            ("drop_hardening_gh_token", drop_hardening_gh_token),
+            ("rebind_hardening_gh_token", rebind_hardening_gh_token),
+        ):
+            with self.subTest(label=label):
+                problems = self.guards_fn(mutate(self.live))
+                self.assertTrue(
+                    problems,
+                    f"{label} must fail the exact GH_TOKEN env pin",
+                )
+        self.assertEqual(self.guards_fn(self.live), [])
+
+    def test_finale_first_checker_failure_fails_the_real_step(self) -> None:
+        second = subprocess.run(
+            [sys.executable, str(CHECKER_PATH)],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertNotEqual(
+            run_live_finale_step(self.live, fail_first=True),
+            0,
+            "first-checker failure must fail the live finale step",
+        )
 
     def test_single_mutation_ownership_is_mutual(self) -> None:
         for label, mutate in FINALE_EXECUTION_MUTATIONS:

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -7,6 +7,12 @@ The inventory tests already encode this contract, but they execute inside the
 step they guard. These mutations therefore target the later required-CI
 checker and the workflow calls that invoke it. The live workflow is never
 written. Command literals here are an independent oracle, not an import.
+
+Hardening and finale check each other under a single-mutation contract:
+changing only one root must turn the remaining caller red. Deleting or
+neutralizing both mutual roots in the same rewrite is outside that
+contract and is not a hosted-CI proof. This is not absolute protection
+against a fully rewritten workflow.
 """
 
 from __future__ import annotations
@@ -25,6 +31,7 @@ sys.path.insert(0, str(REPO / "conformance/tests"))
 from test_completion_scope import (  # noqa: E402
     TRUSTED_PREFIX_WRITERS,
     _active_run_lines,
+    assert_hard_run_command,
     named_step,
 )
 
@@ -64,6 +71,11 @@ HARDENING_STEP_COMMANDS = (
     "bash scripts/ci/test-structurizr-export-docker.sh",
     "python3 scripts/ci/check-conformance-inventory-callsite.py",
     "python3 scripts/ci/test-conformance-inventory-callsite.py",
+)
+# Independent of the checker module and of FINALE_RUN_SCRIPT.
+FINALE_STEP_COMMANDS = (
+    "python3 scripts/ci/check-ci-gate-coverage.py",
+    "python3 scripts/ci/check-conformance-inventory-callsite.py",
 )
 
 
@@ -283,6 +295,59 @@ HARDENING_EXECUTION_MUTATIONS = (
 )
 
 
+def finale_heading(text: str) -> str:
+    heading = f"      - name: {FINALE_STEP}\n"
+    if heading not in text:
+        raise AssertionError("finale step heading missing")
+    return heading
+
+
+def false_if_finale(text: str) -> str:
+    needle = finale_heading(text)
+    mutated = text.replace(needle, needle + "        if: false\n", 1)
+    if mutated == text:
+        raise AssertionError("if:false finale mutation was a no-op")
+    return mutated
+
+
+def hostile_finale_shell(text: str) -> str:
+    heading = finale_heading(text)
+    bash = heading + "        shell: bash\n"
+    hostile = heading + '        shell: bash -c "exit 0" {0}\n'
+    if bash in text:
+        mutated = text.replace(bash, hostile, 1)
+    else:
+        mutated = text.replace(heading, hostile, 1)
+    if mutated == text:
+        raise AssertionError("hostile-finale-shell mutation was a no-op")
+    return mutated
+
+
+def continue_on_error_finale(text: str) -> str:
+    needle = finale_heading(text)
+    mutated = text.replace(needle, needle + "        continue-on-error: true\n", 1)
+    if mutated == text:
+        raise AssertionError("continue-on-error finale mutation was a no-op")
+    return mutated
+
+
+def bash_env_between_hardening_and_finale(text: str) -> str:
+    needle = finale_heading(text)
+    writer = TRUSTED_PREFIX_WRITERS[0][1]
+    mutated = text.replace(needle, writer + needle, 1)
+    if mutated == text:
+        raise AssertionError("inter-step BASH_ENV writer mutation was a no-op")
+    return mutated
+
+
+FINALE_EXECUTION_MUTATIONS = (
+    ("false_if_finale", false_if_finale),
+    ("hostile_finale_shell", hostile_finale_shell),
+    ("continue_on_error_finale", continue_on_error_finale),
+    ("bash_env_between_hardening_and_finale", bash_env_between_hardening_and_finale),
+)
+
+
 class ConformanceInventoryCallsite(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -306,12 +371,16 @@ class ConformanceInventoryCallsite(unittest.TestCase):
         joined = "\n".join(imported)
         self.assertNotIn("INVENTORY_" + "RUN_SCRIPT", joined)
         self.assertNotIn("REQUIRED_" + "RUN_ALL", joined)
+        self.assertNotIn("HARDENING_" + "RUN_SCRIPT", joined)
+        self.assertNotIn("FINALE_" + "RUN_SCRIPT", joined)
 
     def test_pristine_workflow_is_green(self) -> None:
         self.assertEqual(self.problems_fn(self.live), [])
         self.assertEqual(self.guards_fn(self.live), [])
         step = named_step(self.live, FINALE_JOB, HARDENING_STEP)
         self.assertEqual(tuple(_active_run_lines(step)), HARDENING_STEP_COMMANDS)
+        finale = named_step(self.live, FINALE_JOB, FINALE_STEP)
+        self.assertEqual(tuple(_active_run_lines(finale)), FINALE_STEP_COMMANDS)
 
     def test_live_inventory_step_matches_independent_literals(self) -> None:
         step = named_step(self.live, JOB, INVENTORY_STEP)
@@ -395,8 +464,41 @@ class ConformanceInventoryCallsite(unittest.TestCase):
 
     def test_finale_ci_invokes_the_hardening_checker(self) -> None:
         step = named_step(self.live, FINALE_JOB, FINALE_STEP)
-        self.assertIn(FINALE_CHECKER, _active_run_lines(step))
+        self.assertEqual(tuple(_active_run_lines(step)), FINALE_STEP_COMMANDS)
         self.assertTrue(self.guards_fn(neutralize_finale_checker(self.live)))
+
+    def test_finale_execution_removal_fails_the_hardening_root(self) -> None:
+        self.assertEqual(self.guards_fn(self.live), [])
+        for label, mutate in FINALE_EXECUTION_MUTATIONS:
+            with self.subTest(label=label):
+                problems = self.guards_fn(mutate(self.live))
+                self.assertTrue(
+                    problems,
+                    f"{label} must fail the finale hard-run contract",
+                )
+        self.assertEqual(self.guards_fn(self.live), [])
+
+    def test_single_mutation_ownership_is_mutual(self) -> None:
+        for label, mutate in FINALE_EXECUTION_MUTATIONS:
+            with self.subTest(direction="finale-only", label=label):
+                mutated = mutate(self.live)
+                assert_hard_run_command(mutated, FINALE_JOB, HARDENING_STEP)
+                self.assertTrue(
+                    self.guards_fn(mutated),
+                    f"{label} must fail finale ownership while hardening stays green",
+                )
+        for label, mutate in HARDENING_EXECUTION_MUTATIONS:
+            with self.subTest(direction="hardening-only", label=label):
+                mutated = mutate(self.live)
+                self.assertTrue(
+                    self.guards_fn(mutated),
+                    f"{label} must fail hardening ownership",
+                )
+                finale = named_step(mutated, FINALE_JOB, FINALE_STEP)
+                self.assertEqual(
+                    tuple(_active_run_lines(finale)),
+                    FINALE_STEP_COMMANDS,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Required `CI` pins the conformance-inventory callsite with the same hard-run contract as inventory, from the final required `ci` job.
- Hardening and finale own each other under a single-mutation contract: exact direct keys, `shell: bash`, trusted prefix, exact ordered run, and no intervening state-writer.
- The hardening step restores `env.GH_TOKEN: ${{ github.token }}` and pins that exact mapping so the hosted `--published` check can authenticate.
- The finale step starts with `set -euo pipefail`, so a failing first checker cannot be hidden by a later green command.
- Checker `main()` is now executed against mutated temporary `CI_YML` copies, so neutralizing `if problems:` cannot leave the suite green.
- Dual-root deletion/neutralization in one rewrite is outside this in-repo single-mutation contract.

Implements private slice [Rul1an/assay-tunnel-experiments#210](https://github.com/Rul1an/assay-tunnel-experiments/issues/210) under #191/#190.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Exact Head
- Branch: `cursor/210-conformance-inventory-callsite`
- Head: `e1f2d85f511110a1b173b70a11c38ea462cc4c39`
- Base: `489e672d16b81da368e4a462ac29ac1ad69aa9e8`
- Worktree: `/Users/roelschuurkes/wt-cursor-210-conformance-inventory`

## RED -> GREEN
First RED on base: deleting the complete `Conformance inventory` step left later required-CI roots green.

Later independent reviews reproduced further false-greens, closed on this head:
- deleting, renaming, or `if: false` on the hardening step;
- hostile `shell: bash -c "exit 0" {0}` and preceding `BASH_ENV` writers;
- the same class of escapes on the finale checker step, including `continue-on-error: true`;
- missing or rebound `GH_TOKEN` on the hardening step;
- a failing first finale checker with a later green command, which returned bash 0 without `set -euo pipefail`;
- `if problems:` rewritten to `if False and problems:`, which left helper-only tests and B1 green because `main()` was only run against the pristine workflow.

## Verification
Measured on exact head `e1f2d85f511110a1b173b70a11c38ea462cc4c39`:
- [x] focused mutation suite: 16/16
- [x] `bash scripts/ci/test-ci-hardening-b1.sh`
- [x] completion-scope suite: 40/40
- [x] `py_compile` and `git diff --check`

First RED on `23e0e2bbb449d127bc2e84792536d11f65452783`: with `if False and problems:`, `main()` returned 0 for inventory-delete, hardening-delete, and finale `if: false`. After the pin, the same mutation is red via `test_main_fails_closed_on_mutated_workflows` and `test_neutralizing_main_failure_branch_is_visible`.

## Files
- `.github/workflows/ci.yml`
- `conformance/tests/test_completion_scope.py`
- `scripts/ci/check-conformance-inventory-callsite.py`
- `scripts/ci/test-conformance-inventory-callsite.py`
- `scripts/ci/test-ci-hardening-b1.sh`

## Checklist
- [x] My code follows the code style of this project.
- [x] I have added tests covering the changed contract.
- [x] Public strings and scope were inspected.

## Non-claims
This proves required CI invokes the exact pinned conformance-inventory hardening sequence, that one mutation of either mutual root turns the remaining caller red, and that checker `main()` fails closed on mutated workflow text. It does not prove the tests are complete, the corpus is adequate, a candidate is conformant, GitHub-hosted infrastructure is honest, or that a rewrite deleting both mutual roots is caught.

Draft until an independent non-building review records a verdict on this exact head.

Made with [Cursor](https://cursor.com)
