### PR TITLE
fix(ci): pin required aggregator scheduling from the host check

### DIFF
--- a/.github/workflows/host-capability-check.yml
+++ b/.github/workflows/host-capability-check.yml
@@ -61,3 +61,9 @@ jobs:
             fi
           fi
           python3 scripts/ci/assay_host_capability_check.py --pr "$PR_NUMBER"
+
+      - name: Verify required CI aggregator scheduling
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check-conformance-inventory-callsite.py --required-aggregator-schedule

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -149,6 +149,7 @@ HOST_SCHEDULE_RUN_SCRIPT = (
     "set -euo pipefail",
     "python3 scripts/ci/check-conformance-inventory-callsite.py --required-aggregator-schedule",
 )
+HOST_FORBIDDEN_JOB_KEYS = frozenset({"if", "needs"})
 
 
 def _indentation_bounded_block(
@@ -489,6 +490,11 @@ def assert_required_aggregator_schedule(text: str) -> None:
 
 
 def assert_host_schedule_invocation(text: str) -> str:
+    job = named_job(text, HOST_SCHEDULE_JOB)
+    forbidden = frozenset(_direct_mapping(job)) & HOST_FORBIDDEN_JOB_KEYS
+    if forbidden:
+        raise AssertionError(
+            f"{HOST_SCHEDULE_JOB} job must not set {sorted(forbidden)}")
     step = named_step(text, HOST_SCHEDULE_JOB, HOST_SCHEDULE_STEP)
     _assert_hard_run_step(
         step,
@@ -1150,6 +1156,28 @@ class ProductCallsite(unittest.TestCase):
                 self.assertNotEqual(mutated, text)
                 with self.assertRaises(AssertionError):
                     assert_required_aggregator_schedule(mutated)
+
+    def test_host_schedule_job_rejects_if_and_needs(self):
+        text = (REPO / ".github/workflows/host-capability-check.yml").read_text(
+            encoding="utf-8")
+        assert_host_schedule_invocation(text)
+        needle = (
+            "  check:\n"
+            "    name: host-capability-check\n"
+            "    runs-on: ubuntu-latest\n"
+            "    timeout-minutes: 10\n"
+            "    steps:\n"
+        )
+        for key_line in ("if: false", "needs: [ci]"):
+            with self.subTest(key_line=key_line):
+                mutated = text.replace(
+                    needle,
+                    needle.replace("    steps:\n", f"    {key_line}\n    steps:\n"),
+                    1,
+                )
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_host_schedule_invocation(mutated)
 
     def test_hard_run_successor_ignores_blank_and_comment_only_lines(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -1161,20 +1161,11 @@ class ProductCallsite(unittest.TestCase):
         text = (REPO / ".github/workflows/host-capability-check.yml").read_text(
             encoding="utf-8")
         assert_host_schedule_invocation(text)
-        needle = (
-            "  check:\n"
-            "    name: host-capability-check\n"
-            "    runs-on: ubuntu-latest\n"
-            "    timeout-minutes: 10\n"
-            "    steps:\n"
-        )
+        needle = "    name: host-capability-check\n"
+        self.assertEqual(text.count(needle), 1)
         for key_line in ("if: false", "needs: [ci]"):
             with self.subTest(key_line=key_line):
-                mutated = text.replace(
-                    needle,
-                    needle.replace("    steps:\n", f"    {key_line}\n    steps:\n"),
-                    1,
-                )
+                mutated = text.replace(needle, needle + f"    {key_line}\n", 1)
                 self.assertNotEqual(mutated, text)
                 with self.assertRaises(AssertionError):
                     assert_host_schedule_invocation(mutated)

--- a/conformance/tests/test_completion_scope.py
+++ b/conformance/tests/test_completion_scope.py
@@ -141,6 +141,14 @@ HARD_RUN_ENV_CONTRACTS = {
         "GH_TOKEN": "${{ github.token }}",
     },
 }
+REQUIRED_AGGREGATOR_JOB = "ci"
+REQUIRED_AGGREGATOR_IF = "always()"
+HOST_SCHEDULE_JOB = "check"
+HOST_SCHEDULE_STEP = "Verify required CI aggregator scheduling"
+HOST_SCHEDULE_RUN_SCRIPT = (
+    "set -euo pipefail",
+    "python3 scripts/ci/check-conformance-inventory-callsite.py --required-aggregator-schedule",
+)
 
 
 def _indentation_bounded_block(
@@ -313,8 +321,8 @@ def _ordered_job_steps(text: str, job_name: str) -> list[str]:
     if not starts:
         raise AssertionError(f"{job_name} job has no steps")
     return [
-        "".join(lines[start:starts[index + 1] if index + 1 < len(starts) else end])
-        for index, start in enumerate(starts)
+        _indentation_bounded_block(lines, start, step_indent)
+        for start in starts
     ]
 
 
@@ -470,6 +478,28 @@ def _assert_hard_run_step(
         raise AssertionError(f"{step_name} run script differs from the canonical script")
 
 
+def assert_required_aggregator_schedule(text: str) -> None:
+    job = named_job(text, REQUIRED_AGGREGATOR_JOB)
+    entries = _direct_mapping(job)
+    actual = entries["if"].strip() if "if" in entries else ""
+    if actual != REQUIRED_AGGREGATOR_IF:
+        raise AssertionError(
+            f"{REQUIRED_AGGREGATOR_JOB} job if differs: "
+            f"expected {REQUIRED_AGGREGATOR_IF}, got {actual or '<missing>'}")
+
+
+def assert_host_schedule_invocation(text: str) -> str:
+    step = named_step(text, HOST_SCHEDULE_JOB, HOST_SCHEDULE_STEP)
+    _assert_hard_run_step(
+        step,
+        HOST_SCHEDULE_JOB,
+        HOST_SCHEDULE_STEP,
+        frozenset({"name", "shell", "run"}),
+        HOST_SCHEDULE_RUN_SCRIPT,
+    )
+    return step
+
+
 def assert_hard_run_command(
         text: str, job_name: str, step_name: str) -> str:
     contract = HARD_RUN_CONTRACTS.get((job_name, step_name))
@@ -478,6 +508,8 @@ def assert_hard_run_command(
     (allowed_job_keys, allowed_step_keys, expected_script,
      workflow_keys, workflow_env_keys) = contract
     _assert_workflow_document(text, workflow_keys, workflow_env_keys)
+    if job_name == REQUIRED_AGGREGATOR_JOB:
+        assert_required_aggregator_schedule(text)
 
     job = named_job(text, job_name)
     actual_job_keys = frozenset(_direct_mapping(job))
@@ -1096,6 +1128,59 @@ class ProductCallsite(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             assert_combined_unittest(mutated)
+
+    def test_required_aggregator_schedule_is_always(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        assert_required_aggregator_schedule(text)
+        needle = (
+            "  ci:\n"
+            "    name: CI\n"
+            "    runs-on: ubuntu-latest\n"
+            "    timeout-minutes: 10\n"
+            "    if: always()\n"
+        )
+        mutations = (
+            needle.replace("    if: always()\n", "    if: false\n"),
+            needle.replace("    if: always()\n", ""),
+            needle.replace("    if: always()\n", "    if: success()\n"),
+        )
+        for replacement in mutations:
+            with self.subTest(replacement=replacement):
+                mutated = text.replace(needle, replacement, 1)
+                self.assertNotEqual(mutated, text)
+                with self.assertRaises(AssertionError):
+                    assert_required_aggregator_schedule(mutated)
+
+    def test_hard_run_successor_ignores_blank_and_comment_only_lines(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        finale = "      - name: Verify this gate waits on every gating job\n"
+        for insert in (
+            "\n",
+            "      # comment-only documentation\n",
+            "\n      # comment-only documentation\n\n",
+        ):
+            with self.subTest(insert=insert):
+                mutated = text.replace(finale, insert + finale, 1)
+                self.assertNotEqual(mutated, text)
+                assert_hard_run_successor(
+                    mutated,
+                    "ci",
+                    "Verify CI hardening contracts",
+                    "Verify this gate waits on every gating job",
+                )
+
+    def test_hard_run_successor_rejects_intervening_executable_step(self):
+        text = CI_YML.read_text(encoding="utf-8")
+        finale = "      - name: Verify this gate waits on every gating job\n"
+        mutated = text.replace(finale, TRUSTED_PREFIX_WRITERS[0][1] + finale, 1)
+        self.assertNotEqual(mutated, text)
+        with self.assertRaises(AssertionError):
+            assert_hard_run_successor(
+                mutated,
+                "ci",
+                "Verify CI hardening contracts",
+                "Verify this gate waits on every gating job",
+            )
 
     def test_inventory_step_moved_to_conditional_job_fails(self):
         text = CI_YML.read_text(encoding="utf-8")

--- a/scripts/ci/check-conformance-inventory-callsite.py
+++ b/scripts/ci/check-conformance-inventory-callsite.py
@@ -3,17 +3,22 @@
 
 The inventory tests already encode this contract, but they execute inside the
 step they guard. Required CI therefore invokes this module from the later
-hardening step and again from the final required CI job. This file does not
+hardening step and again from the final required CI job. The required
+aggregator scheduling condition (`jobs.ci.if: always()`) is checked from the
+already-required host-capability-check workflow; a checker inside `jobs.ci`
+cannot prove that its own parent job was scheduled. This file does not
 parse workflow YAML; it calls assert_hard_run_command / assert_hard_run_successor
+/ assert_required_aggregator_schedule / assert_host_schedule_invocation
 and the shared indentation/direct-key helpers.
 Canonical CI always reads the committed CI_YML. Tests inject text at the
 function seam.
 
 Hardening and finale own each other under a single-mutation contract: changing
-only one root must turn the remaining caller red. Deleting or neutralizing
-both mutual roots in the same rewrite is outside that contract. Hosted CI
-then has no remaining in-repo caller, so this is not absolute protection
-against a fully rewritten workflow.
+only one root must turn the remaining caller red. The host workflow pins the
+aggregator `if: always()` value and the CI job pins that host invocation.
+Deleting or neutralizing both mutual roots in the same rewrite is outside
+that contract. Hosted CI then has no remaining in-repo caller, so this is
+not absolute protection against a fully rewritten workflow.
 """
 
 from __future__ import annotations
@@ -27,14 +32,18 @@ sys.path.insert(0, str(REPO / "conformance/tests"))
 from test_completion_scope import (  # noqa: E402
     assert_hard_run_command,
     assert_hard_run_successor,
+    assert_host_schedule_invocation,
+    assert_required_aggregator_schedule,
 )
 
 CI_YML = REPO / ".github/workflows/ci.yml"
+HOST_YML = REPO / ".github/workflows/host-capability-check.yml"
 JOB = "scope"
 INVENTORY_STEP = "Conformance inventory"
 HARDENING_JOB = "ci"
 HARDENING_STEP = "Verify CI hardening contracts"
 FINALE_STEP = "Verify this gate waits on every gating job"
+SCHEDULE_FLAG = "--required-aggregator-schedule"
 
 
 def conformance_inventory_callsite_problems(text: str) -> list[str]:
@@ -61,15 +70,39 @@ def hardening_guard_callsite_problems(text: str) -> list[str]:
     return problems
 
 
+def required_aggregator_schedule_problems(text: str) -> list[str]:
+    try:
+        assert_required_aggregator_schedule(text)
+    except AssertionError as exc:
+        message = str(exc).strip() or "required aggregator schedule failed"
+        return [message]
+    return []
+
+
+def host_schedule_callsite_problems(text: str) -> list[str]:
+    try:
+        assert_host_schedule_invocation(text)
+    except AssertionError as exc:
+        message = str(exc).strip() or "host scheduling callsite failed"
+        return [message]
+    return []
+
+
 def main() -> int:
-    if len(sys.argv) != 1:
+    args = sys.argv[1:]
+    if args and args != [SCHEDULE_FLAG]:
         print("FAIL: this checker reads only the committed CI_YML", file=sys.stderr)
         return 2
     text = CI_YML.read_text(encoding="utf-8")
-    problems = (
-        conformance_inventory_callsite_problems(text)
-        + hardening_guard_callsite_problems(text)
-    )
+    if args == [SCHEDULE_FLAG]:
+        problems = required_aggregator_schedule_problems(text)
+    else:
+        problems = (
+            conformance_inventory_callsite_problems(text)
+            + hardening_guard_callsite_problems(text)
+            + required_aggregator_schedule_problems(text)
+            + host_schedule_callsite_problems(HOST_YML.read_text(encoding="utf-8"))
+        )
     if problems:
         for problem in problems:
             print(f"FAIL: {problem}", file=sys.stderr)

--- a/scripts/ci/check-conformance-inventory-callsite.py
+++ b/scripts/ci/check-conformance-inventory-callsite.py
@@ -14,11 +14,11 @@ Canonical CI always reads the committed CI_YML. Tests inject text at the
 function seam.
 
 Hardening and finale own each other under a single-mutation contract: changing
-only one root must turn the remaining caller red. The host workflow pins the
-aggregator `if: always()` value and the CI job pins that host invocation.
-Deleting or neutralizing both mutual roots in the same rewrite is outside
-that contract. Hosted CI then has no remaining in-repo caller, so this is
-not absolute protection against a fully rewritten workflow.
+only one root must turn the remaining caller red. The host job is the
+scheduling root only because it has no if/needs; the CI checker pins that
+absence. Simultaneous mutation of both required roots (jobs.ci.if and the
+host check job if/needs) is outside repo-local enforcement. This is not
+self-enforcement against coordinated workflow edits.
 """
 
 from __future__ import annotations

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -9,10 +9,12 @@ checker and the workflow calls that invoke it. The live workflow is never
 written. Command literals here are an independent oracle, not an import.
 
 Hardening and finale check each other under a single-mutation contract:
-changing only one root must turn the remaining caller red. Deleting or
-neutralizing both mutual roots in the same rewrite is outside that
-contract and is not a hosted-CI proof. This is not absolute protection
-against a fully rewritten workflow.
+changing only one root must turn the remaining caller red. The host job
+is used as the scheduling root only because it has no if/needs; the CI
+root pins that absence. Simultaneous mutation of both required roots
+(jobs.ci.if and the host check job if/needs) is outside repo-local
+enforcement. This is not self-enforcement against coordinated workflow
+edits, and not a hosted-CI proof.
 """
 
 from __future__ import annotations
@@ -399,6 +401,32 @@ def neutralize_host_schedule_command(text: str, mode: str) -> str:
     if mutated == text:
         raise AssertionError(f"{mode} mutation of host scheduling command was a no-op")
     return mutated
+
+
+HOST_JOB_BLOCK = (
+    "  check:\n"
+    "    name: host-capability-check\n"
+    "    runs-on: ubuntu-latest\n"
+    "    timeout-minutes: 10\n"
+    "    steps:\n"
+)
+
+
+def add_host_job_key(text: str, key_line: str) -> str:
+    if HOST_JOB_BLOCK not in text:
+        raise AssertionError("canonical host check job block missing")
+    replacement = HOST_JOB_BLOCK.replace(
+        "    steps:\n", f"    {key_line}\n    steps:\n")
+    mutated = text.replace(HOST_JOB_BLOCK, replacement, 1)
+    if mutated == text:
+        raise AssertionError(f"host job {key_line!r} mutation was a no-op")
+    return mutated
+
+
+HOST_JOB_MUTATIONS = (
+    ("host_job_if_false", lambda text: add_host_job_key(text, "if: false")),
+    ("host_job_needs", lambda text: add_host_job_key(text, "needs: [ci]")),
+)
 
 
 HOST_SCHEDULE_MUTATIONS = (
@@ -835,6 +863,24 @@ class ConformanceInventoryCallsite(unittest.TestCase):
                 self.assertTrue(
                     self.host_fn(mutated),
                     f"{label} must fail the host scheduling callsite pin",
+                )
+                self.assertNotEqual(
+                    run_checker_main(self.checker, self.live, host_text=mutated),
+                    0,
+                    f"{label} must fail checker main()",
+                )
+        self.assertEqual(self.host_fn(self.host_live), [])
+        self.assertEqual(run_checker_main(self.checker, self.live), 0)
+
+    def test_host_job_if_or_needs_fails_the_ci_root(self) -> None:
+        self.assertEqual(self.host_fn(self.host_live), [])
+        self.assertEqual(run_checker_main(self.checker, self.live), 0)
+        for label, mutate in HOST_JOB_MUTATIONS:
+            with self.subTest(label=label):
+                mutated = mutate(self.host_live)
+                self.assertTrue(
+                    self.host_fn(mutated),
+                    f"{label} must fail the CI-root host-job pin",
                 )
                 self.assertNotEqual(
                     run_checker_main(self.checker, self.live, host_text=mutated),

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -403,21 +403,13 @@ def neutralize_host_schedule_command(text: str, mode: str) -> str:
     return mutated
 
 
-HOST_JOB_BLOCK = (
-    "  check:\n"
-    "    name: host-capability-check\n"
-    "    runs-on: ubuntu-latest\n"
-    "    timeout-minutes: 10\n"
-    "    steps:\n"
-)
+HOST_JOB_NAME = "    name: host-capability-check\n"
 
 
 def add_host_job_key(text: str, key_line: str) -> str:
-    if HOST_JOB_BLOCK not in text:
-        raise AssertionError("canonical host check job block missing")
-    replacement = HOST_JOB_BLOCK.replace(
-        "    steps:\n", f"    {key_line}\n    steps:\n")
-    mutated = text.replace(HOST_JOB_BLOCK, replacement, 1)
+    if text.count(HOST_JOB_NAME) != 1:
+        raise AssertionError("expected one host-capability-check job name")
+    mutated = text.replace(HOST_JOB_NAME, HOST_JOB_NAME + f"    {key_line}\n", 1)
     if mutated == text:
         raise AssertionError(f"host job {key_line!r} mutation was a no-op")
     return mutated
@@ -871,6 +863,21 @@ class ConformanceInventoryCallsite(unittest.TestCase):
                 )
         self.assertEqual(self.host_fn(self.host_live), [])
         self.assertEqual(run_checker_main(self.checker, self.live), 0)
+
+    def test_parent_host_job_if_false_after_name_fails_the_ci_root(self) -> None:
+        mutated = add_host_job_key(self.host_live, "if: false")
+        self.assertIn(
+            "    name: host-capability-check\n    if: false\n", mutated)
+        self.assertTrue(
+            self.host_fn(mutated),
+            "job-level if: false after the host job name must fail the CI-root pin",
+        )
+        self.assertNotEqual(
+            run_checker_main(self.checker, self.live, host_text=mutated),
+            0,
+            "job-level if: false must fail checker main()",
+        )
+        self.assertEqual(self.host_fn(self.host_live), [])
 
     def test_host_job_if_or_needs_fails_the_ci_root(self) -> None:
         self.assertEqual(self.host_fn(self.host_live), [])

--- a/scripts/ci/test-conformance-inventory-callsite.py
+++ b/scripts/ci/test-conformance-inventory-callsite.py
@@ -38,12 +38,27 @@ from test_completion_scope import (  # noqa: E402
 CHECKER_PATH = REPO / "scripts/ci/check-conformance-inventory-callsite.py"
 B1_PATH = REPO / "scripts/ci/test-ci-hardening-b1.sh"
 CI_YML = REPO / ".github/workflows/ci.yml"
+HOST_YML = REPO / ".github/workflows/host-capability-check.yml"
 JOB = "scope"
 INVENTORY_STEP = "Conformance inventory"
 HARDENING_STEP = "Verify CI hardening contracts"
 FINALE_JOB = "ci"
 FINALE_STEP = "Verify this gate waits on every gating job"
 FINALE_CHECKER = "python3 scripts/ci/check-conformance-inventory-callsite.py"
+HOST_JOB = "check"
+HOST_STEP = "Verify required CI aggregator scheduling"
+# Independent of the checker module and of HOST_SCHEDULE_RUN_SCRIPT.
+HOST_SCHEDULE_COMMANDS = (
+    "set -euo pipefail",
+    "python3 scripts/ci/check-conformance-inventory-callsite.py --required-aggregator-schedule",
+)
+CI_JOB_IF_BLOCK = (
+    "  ci:\n"
+    "    name: CI\n"
+    "    runs-on: ubuntu-latest\n"
+    "    timeout-minutes: 10\n"
+    "    if: always()\n"
+)
 
 # Independent oracle. Do not import the completion-scope run-script tuple.
 REQUIRED_INVENTORY_COMMANDS = (
@@ -96,13 +111,19 @@ def load_checker():
     spec.loader.exec_module(module)
     problems_fn = getattr(module, "conformance_inventory_callsite_problems", None)
     guards_fn = getattr(module, "hardening_guard_callsite_problems", None)
+    schedule_fn = getattr(module, "required_aggregator_schedule_problems", None)
+    host_fn = getattr(module, "host_schedule_callsite_problems", None)
     if not callable(problems_fn):
         raise AssertionError("conformance_inventory_callsite_problems missing")
     if not callable(guards_fn):
         raise AssertionError("hardening_guard_callsite_problems missing")
+    if not callable(schedule_fn):
+        raise AssertionError("required_aggregator_schedule_problems missing")
+    if not callable(host_fn):
+        raise AssertionError("host_schedule_callsite_problems missing")
     if not callable(getattr(module, "main", None)):
         raise AssertionError("checker main missing")
-    return module, problems_fn, guards_fn
+    return module, problems_fn, guards_fn, schedule_fn, host_fn
 
 
 def sha256_text(text: str) -> str:
@@ -282,6 +303,115 @@ def bash_env_before_hardening(text: str) -> str:
     return mutated
 
 
+def mutate_ci_job_if(text: str, value: str | None) -> str:
+    if CI_JOB_IF_BLOCK not in text:
+        raise AssertionError("canonical ci job if: always() block missing")
+    if value is None:
+        replacement = (
+            "  ci:\n"
+            "    name: CI\n"
+            "    runs-on: ubuntu-latest\n"
+            "    timeout-minutes: 10\n"
+        )
+    else:
+        replacement = CI_JOB_IF_BLOCK.replace("    if: always()\n", f"    if: {value}\n")
+    mutated = text.replace(CI_JOB_IF_BLOCK, replacement, 1)
+    if mutated == text:
+        raise AssertionError(f"ci job if mutation {value!r} was a no-op")
+    return mutated
+
+
+def comment_between_hardening_and_finale(text: str) -> str:
+    needle = finale_heading(text)
+    mutated = text.replace(
+        needle,
+        "      # documentation-only line between hardening and finale\n" + needle,
+        1,
+    )
+    if mutated == text:
+        raise AssertionError("comment-between-steps mutation was a no-op")
+    return mutated
+
+
+def blank_between_hardening_and_finale(text: str) -> str:
+    needle = finale_heading(text)
+    mutated = text.replace(needle, "\n" + needle, 1)
+    if mutated == text:
+        raise AssertionError("blank-between-steps mutation was a no-op")
+    return mutated
+
+
+def intervening_step_between_hardening_and_finale(text: str) -> str:
+    needle = finale_heading(text)
+    writer = TRUSTED_PREFIX_WRITERS[0][1]
+    mutated = text.replace(needle, writer + needle, 1)
+    if mutated == text:
+        raise AssertionError("intervening-step mutation was a no-op")
+    return mutated
+
+
+def host_heading(text: str) -> str:
+    heading = f"      - name: {HOST_STEP}\n"
+    if heading not in text:
+        raise AssertionError("host scheduling step heading missing")
+    return heading
+
+
+def delete_host_schedule_step(text: str) -> str:
+    step = named_step(text, HOST_JOB, HOST_STEP)
+    mutated = text.replace(step, "", 1)
+    if mutated == text or f"      - name: {HOST_STEP}\n" in mutated:
+        raise AssertionError("delete-host-schedule mutation was a no-op")
+    return mutated
+
+
+def rename_host_schedule_step(text: str) -> str:
+    mutated = text.replace(
+        host_heading(text),
+        "      - name: Verify required CI aggregator schedule\n",
+        1,
+    )
+    if mutated == text:
+        raise AssertionError("rename-host-schedule mutation was a no-op")
+    return mutated
+
+
+def false_if_host_schedule_step(text: str) -> str:
+    needle = host_heading(text)
+    mutated = text.replace(needle, needle + "        if: false\n", 1)
+    if mutated == text:
+        raise AssertionError("if:false host-schedule mutation was a no-op")
+    return mutated
+
+
+def neutralize_host_schedule_command(text: str, mode: str) -> str:
+    command = HOST_SCHEDULE_COMMANDS[1]
+    needle = f"          {command}\n"
+    if needle not in text:
+        raise AssertionError("host scheduling command missing")
+    if mode == "remove":
+        replacement = ""
+    elif mode == "comment":
+        replacement = f"          # {command}\n"
+    else:
+        raise AssertionError(f"unknown neutralize mode {mode!r}")
+    mutated = text.replace(needle, replacement, 1)
+    if mutated == text:
+        raise AssertionError(f"{mode} mutation of host scheduling command was a no-op")
+    return mutated
+
+
+HOST_SCHEDULE_MUTATIONS = (
+    ("delete_host_schedule_step", delete_host_schedule_step),
+    ("rename_host_schedule_step", rename_host_schedule_step),
+    ("false_if_host_schedule_step", false_if_host_schedule_step),
+    ("comment_host_schedule_command",
+     lambda text: neutralize_host_schedule_command(text, "comment")),
+    ("remove_host_schedule_command",
+     lambda text: neutralize_host_schedule_command(text, "remove")),
+)
+
+
 def neutralize_finale_checker(text: str) -> str:
     step = named_step(text, FINALE_JOB, FINALE_STEP)
     needle = f"          {FINALE_CHECKER}\n"
@@ -382,18 +512,27 @@ def rebind_hardening_gh_token(text: str) -> str:
     return mutated
 
 
-def run_checker_main(module, workflow_text: str) -> int:
+def run_checker_main(
+        module, workflow_text: str, *args: str, host_text: str | None = None) -> int:
     original = module.CI_YML
+    original_host = getattr(module, "HOST_YML", None)
     original_argv = sys.argv
+    if host_text is None:
+        host_text = HOST_YML.read_text(encoding="utf-8")
     with tempfile.TemporaryDirectory() as tmp:
         scratch = Path(tmp) / "ci.yml"
         scratch.write_text(workflow_text, encoding="utf-8")
+        host_scratch = Path(tmp) / "host.yml"
+        host_scratch.write_text(host_text, encoding="utf-8")
         module.CI_YML = scratch
-        sys.argv = [str(CHECKER_PATH)]
+        module.HOST_YML = host_scratch
+        sys.argv = [str(CHECKER_PATH), *args]
         try:
             return module.main()
         finally:
             module.CI_YML = original
+            if original_host is not None:
+                module.HOST_YML = original_host
             sys.argv = original_argv
 
 
@@ -425,15 +564,22 @@ class ConformanceInventoryCallsite(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.live = CI_YML.read_text(encoding="utf-8")
         cls.live_digest = sha256_text(cls.live)
-        module, problems_fn, guards_fn = load_checker()
+        module, problems_fn, guards_fn, schedule_fn, host_fn = load_checker()
         cls.checker = module
         cls.problems_fn = staticmethod(problems_fn)
         cls.guards_fn = staticmethod(guards_fn)
+        cls.schedule_fn = staticmethod(schedule_fn)
+        cls.host_fn = staticmethod(host_fn)
+        cls.host_live = HOST_YML.read_text(encoding="utf-8")
+        cls.host_digest = sha256_text(cls.host_live)
 
     def tearDown(self) -> None:
         current = CI_YML.read_text(encoding="utf-8")
         self.assertEqual(sha256_text(current), self.live_digest)
         self.assertEqual(current, self.live)
+        host = HOST_YML.read_text(encoding="utf-8")
+        self.assertEqual(sha256_text(host), self.host_digest)
+        self.assertEqual(host, self.host_live)
 
     def test_command_table_is_not_an_import_of_the_completion_scope_tuple(self) -> None:
         imported = [
@@ -450,11 +596,15 @@ class ConformanceInventoryCallsite(unittest.TestCase):
     def test_pristine_workflow_is_green(self) -> None:
         self.assertEqual(self.problems_fn(self.live), [])
         self.assertEqual(self.guards_fn(self.live), [])
+        self.assertEqual(self.schedule_fn(self.live), [])
+        self.assertEqual(self.host_fn(self.host_live), [])
         step = named_step(self.live, FINALE_JOB, HARDENING_STEP)
         self.assertEqual(tuple(_active_run_lines(step)), HARDENING_STEP_COMMANDS)
         self.assertIn(HARDENING_ENV_BLOCK, step)
         finale = named_step(self.live, FINALE_JOB, FINALE_STEP)
         self.assertEqual(tuple(_active_run_lines(finale)), FINALE_STEP_COMMANDS)
+        host = named_step(self.host_live, HOST_JOB, HOST_STEP)
+        self.assertEqual(tuple(_active_run_lines(host)), HOST_SCHEDULE_COMMANDS)
 
     def test_live_inventory_step_matches_independent_literals(self) -> None:
         step = named_step(self.live, JOB, INVENTORY_STEP)
@@ -610,6 +760,7 @@ class ConformanceInventoryCallsite(unittest.TestCase):
             ("inventory_delete", delete_step),
             ("hardening_delete", delete_hardening_step),
             ("finale_if_false", false_if_finale),
+            ("ci_if_false", lambda text: mutate_ci_job_if(text, "false")),
         )
         for label, mutate in mutations:
             with self.subTest(label=label):
@@ -646,6 +797,74 @@ class ConformanceInventoryCallsite(unittest.TestCase):
             0,
             "live main() must stay red on the same mutated workflow",
         )
+
+    def test_ci_aggregator_if_mutations_fail_the_host_root(self) -> None:
+        self.assertEqual(self.schedule_fn(self.live), [])
+        self.assertEqual(
+            run_checker_main(
+                self.checker, self.live, "--required-aggregator-schedule"),
+            0,
+        )
+        mutations = (
+            ("if_false", lambda text: mutate_ci_job_if(text, "false")),
+            ("if_missing", lambda text: mutate_ci_job_if(text, None)),
+            ("if_success", lambda text: mutate_ci_job_if(text, "success()")),
+        )
+        for label, mutate in mutations:
+            with self.subTest(label=label):
+                mutated = mutate(self.live)
+                self.assertEqual(self.problems_fn(mutated), [])
+                self.assertTrue(
+                    self.schedule_fn(mutated),
+                    f"{label} must fail the host-root schedule pin",
+                )
+                self.assertNotEqual(
+                    run_checker_main(
+                        self.checker, mutated, "--required-aggregator-schedule"),
+                    0,
+                    f"{label} must fail checker --required-aggregator-schedule",
+                )
+        self.assertEqual(self.schedule_fn(self.live), [])
+
+    def test_host_schedule_invocation_mutations_fail(self) -> None:
+        self.assertEqual(self.host_fn(self.host_live), [])
+        self.assertEqual(run_checker_main(self.checker, self.live), 0)
+        for label, mutate in HOST_SCHEDULE_MUTATIONS:
+            with self.subTest(label=label):
+                mutated = mutate(self.host_live)
+                self.assertTrue(
+                    self.host_fn(mutated),
+                    f"{label} must fail the host scheduling callsite pin",
+                )
+                self.assertNotEqual(
+                    run_checker_main(self.checker, self.live, host_text=mutated),
+                    0,
+                    f"{label} must fail checker main()",
+                )
+        self.assertEqual(self.host_fn(self.host_live), [])
+        self.assertEqual(run_checker_main(self.checker, self.live), 0)
+
+    def test_blank_or_comment_between_hardening_and_finale_stays_green(self) -> None:
+        self.assertEqual(self.guards_fn(self.live), [])
+        for label, mutate in (
+            ("blank", blank_between_hardening_and_finale),
+            ("comment", comment_between_hardening_and_finale),
+        ):
+            with self.subTest(label=label):
+                self.assertEqual(
+                    self.guards_fn(mutate(self.live)),
+                    [],
+                    f"{label} lines must not break hardening/finale successor identity",
+                )
+        self.assertEqual(self.guards_fn(self.live), [])
+
+    def test_intervening_executable_step_still_fails_successor(self) -> None:
+        self.assertEqual(self.guards_fn(self.live), [])
+        self.assertTrue(
+            self.guards_fn(intervening_step_between_hardening_and_finale(self.live)),
+            "an intervening executable step must still fail successor identity",
+        )
+        self.assertEqual(self.guards_fn(self.live), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the post-merge #2588 audit finding: changing only `jobs.ci.if` from `always()` to `false` left the in-job checker and B1 green, and GitHub reports a conditionally skipped required job as Success.

- Pin `jobs.ci.if == always()` with the existing `named_job` / `_direct_mapping` helpers.
- Run that pin from `host-capability-check` only because that required job has no `if`/`needs`.
- From the CI root, reject `if` or `needs` on the host `check` job. The focused reproduction inserts `if: false` immediately after `name: host-capability-check` (parent job, not step-level `if`). This is not a host-job `if: always()` pin.
- Ignore blank/comment-only lines between hardening and finale for successor identity; an intervening executable/state-writing step still fails.

Exact head: `5209492d15e428b4aacc173079cf9130fca6bc70`
Base: `c61fbd20862587815999ee655ef077cb617fd1a7`
Worktree: `/Users/roelschuurkes/wt-cursor-210-required-ci-scheduling-root`

Write-set:

- `.github/workflows/host-capability-check.yml`
- `conformance/tests/test_completion_scope.py`
- `scripts/ci/check-conformance-inventory-callsite.py`
- `scripts/ci/test-conformance-inventory-callsite.py`

Host workflow remains `pull_request` only, read-only permissions, pinned checkout, no `pull_request_target`, and no new required context.

## Test plan

- [x] RED on `d130691ce`: job-level `if: false` after `name: host-capability-check` left `host_schedule_callsite_problems` empty; `false_if_host_schedule_step` only covered step-level `if`
- [x] Focused suite 22/22, including that exact parent-job insertion, host-job `needs`, and existing domain-specific mutations
- [x] Blank/comment-only successor stays green; intervening executable step stays red
- [x] completion-scope 44/44; B1 PASS
- [x] `py_compile`, `git diff --check`
- [ ] Exact-head hosted `CI` and `host-capability-check`
- [ ] Independent non-building review of this SHA

## Non-claims

- This closes the demonstrated single parent-job scheduling mutation (`jobs.ci.if`).
- Simultaneous mutation of both required roots (`jobs.ci.if` and the host `check` job `if`/`needs`) is outside repo-local enforcement.
- This is not self-enforcement against coordinated two-file workflow edits.
- It does not make in-repo guards immutable or prove hosted-runner honesty.

Draft. Not ready. Not merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation that required CI aggregation and host scheduling workflows run under the correct conditions.
  * Added a dedicated validation mode for checking required aggregator scheduling.
* **Bug Fixes**
  * Improved detection of invalid workflow conditions, dependencies, command changes, and step ordering.
* **Tests**
  * Expanded coverage for CI and host workflow scheduling, ordering rules, and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->