### PR TITLE
fix(conformance): preserve hosted candidate evidence

### DIFF
--- a/.github/workflows/privileged-mcp-action-oci-candidate.yml
+++ b/.github/workflows/privileged-mcp-action-oci-candidate.yml
@@ -190,20 +190,29 @@ jobs:
           path: ${{ runner.temp }}/oci-score
 
       - name: Score candidate capture
+        id: score
         run: |
           set -euo pipefail
           PACK="$RUNNER_TEMP/oci-downloads/privileged-mcp-action-v0-clean-room.tar.gz"
           CAPTURE="$RUNNER_TEMP/oci-score/candidate_capture.v0"
           OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v1"
           mkdir -p "$(dirname "$OUTPUT")"
+          set +e
           python3 conformance/privileged-mcp-action-v0/scripts/score_candidate.py \
             --pack "$PACK" \
             --manifest conformance/privileged-mcp-action-v0/MANIFEST.json \
             --capture "$CAPTURE" \
             --output "$OUTPUT"
+          rc=$?
+          set -e
+          if [[ "$rc" -eq 0 || "$rc" -eq 1 ]]; then
+            python3 conformance/privileged-mcp-action-v0/scripts/validate_run_record.py "$OUTPUT"
+            echo "upload=yes" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$rc"
 
       - name: Upload validated run record
-        if: success()
+        if: always() && steps.score.outputs.upload == 'yes'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: candidate-run-record-v1

--- a/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py
@@ -213,7 +213,7 @@ def stage_opaque_bundle(source: Path, staging_dir: Path) -> Path:
     data = published_rows.read_regular_file(Path(source), limit=MAX_BUNDLE_BYTES)
     staged = Path(staging_dir) / STAGED_BUNDLE_NAME
     staged.write_bytes(data)
-    staged.chmod(0o400)
+    staged.chmod(0o444)  # runtime UID 65532 reads via other-read; not a security claim
     return staged.resolve()
 
 

--- a/conformance/privileged-mcp-action-v0/tests/fixtures/oci-candidate.c
+++ b/conformance/privileged-mcp-action-v0/tests/fixtures/oci-candidate.c
@@ -1,7 +1,7 @@
 /* Inert local fixture for the bounded OCI executor contract.
  *
  * Built into a FROM scratch image in tests. Not a candidate implementation.
- * Modes are argv[1]: ok (default), sleep, flood, oom.
+ * Modes are argv[1]: ok (default), sleep, flood, oom, read.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,6 +36,27 @@ int main(int argc, char **argv)
                 block[1024 * 1024 - 1] = 1;
             }
         }
+    }
+    if (strcmp(mode, "read") == 0) {
+        FILE *fp = fopen("/input/bundle.tar.gz", "rb");
+        char buf[4096];
+        size_t n;
+
+        if (fp == NULL) {
+            return 1;
+        }
+        while ((n = fread(buf, 1, sizeof(buf), fp)) > 0) {
+            if (fwrite(buf, 1, n, stdout) != n) {
+                fclose(fp);
+                return 1;
+            }
+        }
+        if (ferror(fp)) {
+            fclose(fp);
+            return 1;
+        }
+        fclose(fp);
+        return 0;
     }
     return 2;
 }

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -60,6 +60,10 @@ OCI_EXECUTOR = (
 OCI_SCORER = (
     "conformance/privileged-mcp-action-v0/scripts/score_candidate.py"
 )
+OCI_VALIDATOR = (
+    "conformance/privileged-mcp-action-v0/scripts/validate_run_record.py"
+)
+OCI_SCORE_UPLOAD_IF = "if: always() && steps.score.outputs.upload == 'yes'"
 OCI_SIGNER_WORKFLOW = (
     "Rul1an/assay/.github/workflows/privileged-mcp-action-pack-release.yml"
 )
@@ -219,7 +223,7 @@ OCI_SCORE_STEP_KEYS = {
     "Download attested pack": ("name", "env", "run"),
     "Verify pack attestation": ("name", "env", "run"),
     OCI_SCORE_DOWNLOAD_STEP: ("name", "uses", "with"),
-    OCI_SCORE_STEP: ("name", "run"),
+    OCI_SCORE_STEP: ("name", "id", "run"),
     OCI_SCORE_UPLOAD_STEP: ("name", "if", "uses", "with"),
 }
 OCI_SCORE_STEP_WITH_KEYS = {
@@ -235,11 +239,19 @@ OCI_SCORE_PINNED_STEP_SEQUENCES = {
         'CAPTURE="$RUNNER_TEMP/oci-score/candidate_capture.v0"',
         'OUTPUT="$RUNNER_TEMP/oci-score/conformance_run.v1"',
         'mkdir -p "$(dirname "$OUTPUT")"',
+        "set +e",
         f"python3 {OCI_SCORER}"
         ' --pack "$PACK"'
         " --manifest conformance/privileged-mcp-action-v0/MANIFEST.json"
         ' --capture "$CAPTURE"'
         ' --output "$OUTPUT"',
+        "rc=$?",
+        "set -e",
+        'if [[ "$rc" -eq 0 || "$rc" -eq 1 ]]; then',
+        f'python3 {OCI_VALIDATOR} "$OUTPUT"',
+        'echo "upload=yes" >> "$GITHUB_OUTPUT"',
+        "fi",
+        'exit "$rc"',
     ),
 }
 
@@ -3118,8 +3130,46 @@ def oci_candidate_workflow_problems(
             continue
         ifs = [line for line in _active_lines(block) if line.startswith("if:")]
         upload_ifs.extend(ifs or ["<missing-if>"])
-    if not omitted("upload not gated on success") and upload_ifs != ["if: success()", "if: success()"]:
+    if not omitted("upload not gated on success") and (
+        not upload_ifs or upload_ifs[0] != "if: success()"
+    ):
         problems.append("upload not gated on success")
+    if not omitted("score upload not gated on revalidated output") and (
+        len(upload_ifs) < 2 or upload_ifs[1] != OCI_SCORE_UPLOAD_IF
+    ):
+        problems.append("score upload not gated on revalidated output")
+    score_run = _named_step_run_body(score_block or "", OCI_SCORE_STEP)
+    score_seq = _normalized_command_sequence(score_run or "")
+    validate_idx = next(
+        (i for i, cmd in enumerate(score_seq) if "validate_run_record.py" in cmd),
+        -1,
+    )
+    upload_yes_idxs = [
+        i for i, cmd in enumerate(score_seq) if 'echo "upload=yes"' in cmd
+    ]
+    if not omitted("score sets upload=yes before revalidate"):
+        if any(idx < validate_idx or validate_idx < 0 for idx in upload_yes_idxs):
+            problems.append("score sets upload=yes before revalidate")
+    if not omitted("score uploads stale output on rc 2"):
+        in_01 = False
+        wrote_outside = False
+        saw_01 = False
+        for cmd in score_seq:
+            if 'if [[ "$rc" -eq 0 || "$rc" -eq 1 ]]' in cmd:
+                in_01 = True
+                saw_01 = True
+            elif cmd == "fi":
+                in_01 = False
+            elif 'echo "upload=yes"' in cmd and not in_01:
+                wrote_outside = True
+        if upload_yes_idxs and (wrote_outside or not saw_01):
+            problems.append("score uploads stale output on rc 2")
+    score_step = _named_step_block(score_block or "", OCI_SCORE_STEP)
+    score_ids = [
+        line for line in _active_lines(score_step or "") if line.startswith("id:")
+    ]
+    if not omitted("score step missing id: score") and score_ids != ["id: score"]:
+        problems.append("score step missing id: score")
     if "candidate_capture.v0" not in active_text:
         problems.append("missing fixed capture name")
     if OCI_CAPTURE_UPLOAD_PATH not in active_text:
@@ -3447,6 +3497,7 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
             "Download attested pack",
             "Verify pack attestation",
             "Capture candidate observations",
+            OCI_SCORE_STEP,
         )
         for step in swallow_steps:
             with self.subTest(continue_on_error=step):
@@ -3462,6 +3513,8 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
             "gh release download",
             "gh attestation verify",
             OCI_EXECUTOR,
+            OCI_SCORER,
+            OCI_VALIDATOR,
         )
         for cmd in swallow_commands:
             with self.subTest(or_true=cmd):
@@ -3742,10 +3795,47 @@ class PrivilegedMcpActionOciCandidateWorkflowContract(unittest.TestCase):
                 "score job invokes executor",
             ),
             (
-                "score_upload_on_failure",
+                "score_upload_if_success",
+                "      - name: Upload validated run record\n        "
+                + OCI_SCORE_UPLOAD_IF
+                + "\n",
                 "      - name: Upload validated run record\n        if: success()\n",
-                "      - name: Upload validated run record\n        if: failure()\n",
-                "upload not gated on success",
+                "score upload not gated on revalidated output",
+            ),
+            (
+                "score_upload_if_or_failure",
+                "      - name: Upload validated run record\n        "
+                + OCI_SCORE_UPLOAD_IF
+                + "\n",
+                "      - name: Upload validated run record\n"
+                "        if: success() || failure()\n",
+                "score upload not gated on revalidated output",
+            ),
+            (
+                "score_continue_on_error",
+                f"      - name: {OCI_SCORE_STEP}\n",
+                f"      - name: {OCI_SCORE_STEP}\n        continue-on-error: true\n",
+                "continue-on-error swallows failure",
+            ),
+            (
+                "score_upload_yes_before_revalidate",
+                f'            python3 {OCI_VALIDATOR} "$OUTPUT"\n'
+                '            echo "upload=yes" >> "$GITHUB_OUTPUT"\n',
+                '            echo "upload=yes" >> "$GITHUB_OUTPUT"\n'
+                f'            python3 {OCI_VALIDATOR} "$OUTPUT"\n',
+                "score sets upload=yes before revalidate",
+            ),
+            (
+                "score_upload_yes_on_rc_2",
+                '          if [[ "$rc" -eq 0 || "$rc" -eq 1 ]]; then\n'
+                f'            python3 {OCI_VALIDATOR} "$OUTPUT"\n'
+                '            echo "upload=yes" >> "$GITHUB_OUTPUT"\n'
+                "          fi\n",
+                '          if [[ "$rc" -eq 0 || "$rc" -eq 1 ]]; then\n'
+                f'            python3 {OCI_VALIDATOR} "$OUTPUT"\n'
+                "          fi\n"
+                '          echo "upload=yes" >> "$GITHUB_OUTPUT"\n',
+                "score uploads stale output on rc 2",
             ),
             (
                 "score_artifact_name",

--- a/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
@@ -17,6 +17,7 @@ import inspect
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -70,6 +71,26 @@ ISSUE_203_NON_CLAIMS = (
     "malware safety, supply-chain integrity, conformance, or cleanup "
     "guarantee after host/daemon/SIGKILL failure."
 )
+
+
+
+def _mount_src(mount: str) -> Path:
+    for part in mount.split(","):
+        if part.startswith("src="):
+            return Path(part[4:])
+    raise AssertionError(f"mount lost src=: {mount!r}")
+
+
+def _other_readable_for_runtime(path: Path, runtime_user: str) -> bool:
+    uid_s, gid_s = runtime_user.split(":")
+    uid, gid = int(uid_s), int(gid_s)
+    st = path.stat()
+    mode = stat.S_IMODE(st.st_mode)
+    if st.st_uid == uid:
+        return bool(mode & 0o400)
+    if st.st_gid == gid and mode & 0o040:
+        return True
+    return bool(mode & 0o004)
 
 
 def _require() -> Any:
@@ -950,6 +971,52 @@ class LiveDockerInspect(unittest.TestCase):
         self.assertEqual(result.state, module.STATE_OUTPUT_OVERFLOW)
         self.assertNotIn(result.state, AGREEMENT)
 
+    def test_live_runtime_user_reads_exact_mounted_bundle_bytes(self) -> None:
+        module = _require()
+        assert self.image_ref is not None
+        payload = b"opaque-runtime-read-bytes"
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            bundle = root / "opaque.bundle.tar.gz"
+            bundle.write_bytes(payload)
+            staging = root / "stage"
+            staging.mkdir(mode=0o700)
+            os.chmod(staging, 0o700)
+            argv = module.build_container_create_argv(
+                image=self.image_ref,
+                bundle_path=bundle,
+                container_name=f"assay-oci-live-read-{os.getpid()}",
+                staging_dir=staging,
+                command=("/oci-candidate", "read"),
+            )
+            assert_argv_runtime_user(argv)
+            self.assertEqual(_flag_value(argv, "--user"), module.RUNTIME_USER)
+            mounted = _mount_src(_flag_value(argv, "--mount") or "")
+            self.assertEqual(stat.S_IMODE(mounted.stat().st_mode), 0o444)
+            self.assertEqual(stat.S_IMODE(staging.stat().st_mode), 0o700)
+            self.assertEqual(mounted.read_bytes(), payload)
+            assert self.local_ref is not None
+            live_argv = rewrite_fixture_image_argv(
+                argv, registry_ref=self.image_ref, local_ref=self.local_ref
+            )
+            created = subprocess.run(live_argv, capture_output=True, text=True, check=False)
+            self.assertEqual(created.returncode, 0, created.stderr)
+            container = created.stdout.strip()
+            try:
+                started = subprocess.run(
+                    ["docker", "start", "-a", container],
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(started.returncode, 0, started.stderr)
+                self.assertEqual(started.stdout, payload)
+            finally:
+                subprocess.run(
+                    ["docker", "rm", "--force", "--volumes", container],
+                    capture_output=True,
+                    check=False,
+                )
+
     def test_live_completed_ok_is_not_agreement(self) -> None:
         module = _require()
         assert self.image_ref is not None
@@ -1224,6 +1291,44 @@ class StagedBundleMount(unittest.TestCase):
             staged = module.stage_opaque_bundle(source, Path(raw) / "stage")
             source.write_bytes(b"swapped")
             self.assertEqual(staged.read_bytes(), b"first")
+
+
+    def test_umask_077_keeps_bytes_and_is_readable_for_runtime_user(self) -> None:
+        module = _require()
+        previous = os.umask(0o077)
+        try:
+            with tempfile.TemporaryDirectory() as raw:
+                root = Path(raw)
+                source = root / "input.bundle"
+                payload = b"opaque-umask-077-bytes"
+                source.write_bytes(payload)
+                staging = root / "stage"
+                staging.mkdir(mode=0o700)
+                os.chmod(staging, 0o700)
+                staged = module.stage_opaque_bundle(source, staging)
+                self.assertEqual(staged.read_bytes(), payload)
+                self.assertEqual(stat.S_IMODE(staging.stat().st_mode), 0o700)
+                self.assertEqual(stat.S_IMODE(staged.stat().st_mode), 0o444)
+                self.assertTrue(
+                    _other_readable_for_runtime(staged, module.RUNTIME_USER),
+                    f"{oct(stat.S_IMODE(staged.stat().st_mode))} is not readable "
+                    f"for runtime {module.RUNTIME_USER} without widening host scope",
+                )
+                argv_staging = root / "argv-stage"
+                argv_staging.mkdir(mode=0o700)
+                os.chmod(argv_staging, 0o700)
+                argv = module.build_container_create_argv(
+                    image=DIGEST_IMAGE,
+                    bundle_path=source,
+                    container_name="assay-oci-umask",
+                    staging_dir=argv_staging,
+                )
+                mounted = _mount_src(_flag_value(argv, "--mount") or "")
+                self.assertEqual(stat.S_IMODE(mounted.stat().st_mode), 0o444)
+                self.assertEqual(mounted.read_bytes(), payload)
+                self.assertEqual(stat.S_IMODE(argv_staging.stat().st_mode), 0o700)
+        finally:
+            os.umask(previous)
 
 
 class CandidateOutputHandoff(unittest.TestCase):


### PR DESCRIPTION
Implements the two hosted-path slices needed so a Linux candidate run can leave a reviewable record.

Hosted evidence: main `c2c056b6f6a209fd98413d273fc788a5f67f767c`, run `32544494405` (14x `bundle_integrity=fail`). On native Linux the staged opaque bundle is owner-1000 mode 0600/0400 and unreadable to runtime UID 65532; mode 0444 is readable. The executor previously `chmod` 0400.

1. Staged opaque bundle is 0444 so UID 65532 can read it via other-read. No `chown`. No Docker/runtime policy change. Host staging directory stays 0700; the file bind-mount bypasses parent traversal.
2. Score publishes a valid v1 run record when the scorer exits 0 or 1. Exit 1 (mismatch) still fails the score job. Capture upload stays `if: success()`. Score upload is `if: always() && steps.score.outputs.upload == 'yes'` after revalidating the written file. Exit 2, a missing file, or an invalid file never sets `upload=yes`.

Allowlist (five files):
- `conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py`
- `conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py`
- `conformance/privileged-mcp-action-v0/tests/fixtures/oci-candidate.c`
- `.github/workflows/privileged-mcp-action-oci-candidate.yml`
- `conformance/privileged-mcp-action-v0/tests/test_activation_kit.py`

Non-claims:
- Not #201 and not a security claim. 0444 is runtime readability only.
- Mismatch is still a red score job.
- Capture upload remains success-only.
- `score_candidate.py` is unchanged.

Status: draft. Do not ready or merge.

## Exact-head evidence

Head under review: `08732a75a6c750d1295370594fb2115351e149a8` (tree `a99188f05c44efb9dee7a3ca57936768d53c2eb7`, base `c2c056b6f6a209fd98413d273fc788a5f67f767c`).

Builder RED -> GREEN:
- commit A: old `0400` fails the umask/readability and live UID-65532 read; `0444` passes; mutating back to `0400` fails while the inert `ok` control stays green; executor suite 77/77;
- commit B: old score upload `if: success()` fails the mismatch-artifact contract; the guarded `always()` upload passes after validation while exit 1 remains red; activation-kit suite 85/85.

Independent non-quorum preflight on the exact head in `/private/tmp/assay-pr2591-review`:

```bash
python3 -W error::ResourceWarning -m unittest \
  conformance/privileged-mcp-action-v0/tests/test_activation_kit.py \
  conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py
# Ran 162 tests in 84.470s -- OK

actionlint .github/workflows/privileged-mcp-action-oci-candidate.yml
python3 -m py_compile \
  conformance/privileged-mcp-action-v0/scripts/oci_candidate_executor.py \
  conformance/privileged-mcp-action-v0/tests/test_oci_candidate_executor.py \
  conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
git diff --check c2c056b6...HEAD
```

This preflight is not the review quorum. Cursor is performing the reserved non-building exact-head review. A post-merge hosted dispatch and downloaded-artifact validation remain required before #205 closes.
