### PR TITLE
feat(conformance): project reviewed run records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
           python3 -W error::ResourceWarning conformance/tests/test_completion_scope.py
           python3 conformance/run_all.py --require-complete --completion-scope required
 
+      - name: Public-run projection
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -W error::ResourceWarning conformance/tests/test_public_runs.py
+          python3 conformance/project_public_runs.py --check
+
       - id: detect
         shell: bash
         env:

--- a/conformance/IMPLEMENTATIONS.md
+++ b/conformance/IMPLEMENTATIONS.md
@@ -1,0 +1,11 @@
+# Public implementation runs
+
+This page lists reviewed, digest-addressed `conformance_run.v1` records.
+It is not a leaderboard, badge, certification, or trust score.
+
+A digest addresses bytes. It does not authenticate a publisher.
+A match is agreement on the pinned corpus only.
+
+| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error |
+|---|---|---|---|---|---|---|---|---|
+| pma-v0-repro | privileged-mcp-action-v0 | sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27 | ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493 | c226a34f3cea50a114607c35f0976048ff3cab2b | 14 | 0 | 0 | 0 |

--- a/conformance/IMPLEMENTATIONS.md
+++ b/conformance/IMPLEMENTATIONS.md
@@ -5,6 +5,8 @@ It is not a leaderboard, badge, certification, or trust score.
 
 A digest addresses bytes. It does not authenticate a publisher.
 A match is agreement on the pinned corpus only.
+Corpus agreement does not prove implementation independence.
+reproduction_mode, image, and identity are publisher-declared and bound; they are not attested or verified.
 
 To add a reviewed row, write it to `public-runs.json` and the digest-named file under `public-runs/`, then run `python3 conformance/project_public_runs.py --check`.
 

--- a/conformance/IMPLEMENTATIONS.md
+++ b/conformance/IMPLEMENTATIONS.md
@@ -8,6 +8,6 @@ A match is agreement on the pinned corpus only.
 
 To add a reviewed row, write it to `public-runs.json` and the digest-named file under `public-runs/`, then run `python3 conformance/project_public_runs.py --check`.
 
-| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error | review_warnings |
-|---|---|---|---|---|---|---|---|---|---|
-| pma-v0-repro | privileged-mcp-action-v0 | [sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27](public-runs/9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27) | ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493 | c226a34f3cea50a114607c35f0976048ff3cab2b | 14 | 0 | 0 | 0 | 0 |
+| implementation | suite | record | image | commit | reproduction_mode | match | mismatch | execution_error | harness_error | review_warnings |
+|---|---|---|---|---|---|---|---|---|---|---|
+| pma-v0-repro | privileged-mcp-action-v0 | [sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27](public-runs/9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27) | ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493 | c226a34f3cea50a114607c35f0976048ff3cab2b | other_disclosed | 14 | 0 | 0 | 0 | 0 |

--- a/conformance/IMPLEMENTATIONS.md
+++ b/conformance/IMPLEMENTATIONS.md
@@ -6,6 +6,8 @@ It is not a leaderboard, badge, certification, or trust score.
 A digest addresses bytes. It does not authenticate a publisher.
 A match is agreement on the pinned corpus only.
 
-| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error |
-|---|---|---|---|---|---|---|---|---|
-| pma-v0-repro | privileged-mcp-action-v0 | sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27 | ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493 | c226a34f3cea50a114607c35f0976048ff3cab2b | 14 | 0 | 0 | 0 |
+To add a reviewed row, write it to `public-runs.json` and the digest-named file under `public-runs/`, then run `python3 conformance/project_public_runs.py --check`.
+
+| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error | review_warnings |
+|---|---|---|---|---|---|---|---|---|---|
+| pma-v0-repro | privileged-mcp-action-v0 | [sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27](public-runs/9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27) | ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493 | c226a34f3cea50a114607c35f0976048ff3cab2b | 14 | 0 | 0 | 0 | 0 |

--- a/conformance/IMPLEMENTATIONS.md.in
+++ b/conformance/IMPLEMENTATIONS.md.in
@@ -8,6 +8,6 @@ A match is agreement on the pinned corpus only.
 
 To add a reviewed row, write it to `public-runs.json` and the digest-named file under `public-runs/`, then run `python3 conformance/project_public_runs.py --check`.
 
-| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error | review_warnings |
-|---|---|---|---|---|---|---|---|---|---|
+| implementation | suite | record | image | commit | reproduction_mode | match | mismatch | execution_error | harness_error | review_warnings |
+|---|---|---|---|---|---|---|---|---|---|---|
 {{public_runs_table}}

--- a/conformance/IMPLEMENTATIONS.md.in
+++ b/conformance/IMPLEMENTATIONS.md.in
@@ -5,6 +5,8 @@ It is not a leaderboard, badge, certification, or trust score.
 
 A digest addresses bytes. It does not authenticate a publisher.
 A match is agreement on the pinned corpus only.
+Corpus agreement does not prove implementation independence.
+reproduction_mode, image, and identity are publisher-declared and bound; they are not attested or verified.
 
 To add a reviewed row, write it to `public-runs.json` and the digest-named file under `public-runs/`, then run `python3 conformance/project_public_runs.py --check`.
 

--- a/conformance/IMPLEMENTATIONS.md.in
+++ b/conformance/IMPLEMENTATIONS.md.in
@@ -6,6 +6,8 @@ It is not a leaderboard, badge, certification, or trust score.
 A digest addresses bytes. It does not authenticate a publisher.
 A match is agreement on the pinned corpus only.
 
-| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error |
-|---|---|---|---|---|---|---|---|---|
+To add a reviewed row, write it to `public-runs.json` and the digest-named file under `public-runs/`, then run `python3 conformance/project_public_runs.py --check`.
+
+| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error | review_warnings |
+|---|---|---|---|---|---|---|---|---|---|
 {{public_runs_table}}

--- a/conformance/IMPLEMENTATIONS.md.in
+++ b/conformance/IMPLEMENTATIONS.md.in
@@ -1,0 +1,11 @@
+# Public implementation runs
+
+This page lists reviewed, digest-addressed `conformance_run.v1` records.
+It is not a leaderboard, badge, certification, or trust score.
+
+A digest addresses bytes. It does not authenticate a publisher.
+A match is agreement on the pinned corpus only.
+
+| implementation | suite | record | image | commit | match | mismatch | execution_error | harness_error |
+|---|---|---|---|---|---|---|---|---|
+{{public_runs_table}}

--- a/conformance/project_public_runs.py
+++ b/conformance/project_public_runs.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Project reviewed, digest-addressed run records into IMPLEMENTATIONS.md."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "conformance"))
+sys.path.insert(0, str(REPO / "conformance/adequacy"))
+sys.path.insert(0, str(REPO / "conformance/privileged-mcp-action-v0/scripts"))
+
+import published_rows  # noqa: E402
+from implementations import ImplementationRegistryError, load_implementations  # noqa: E402
+from artifact_io import content_sha256  # noqa: E402
+from strict_json import parse_strict_object  # noqa: E402
+from validate_run_record import MAX_RUN_RECORD_BYTES, validate_run_record  # noqa: E402
+
+INDEX_SCHEMA = "assay.conformance.public_runs.v0"
+INDEX_FIELDS = ("schema", "runs")
+RUN_FIELDS = (
+    "implementation_id",
+    "suite",
+    "record_sha256",
+    "image",
+    "source",
+    "commit",
+)
+MAX_INDEX_BYTES = 64 * 1024
+MAX_TEMPLATE_BYTES = 1024 * 1024
+SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+TABLE_TOKEN = "{{public_runs_table}}"
+
+
+def _digest(data: bytes) -> str:
+    return content_sha256(data)
+
+
+def index_path(repo: Path) -> Path:
+    return repo / "conformance/public-runs.json"
+
+
+def records_dir(repo: Path) -> Path:
+    return repo / "conformance/public-runs"
+
+
+def record_path(repo: Path, digest: str) -> Path:
+    if not SHA256.fullmatch(digest):
+        raise ValueError("record_sha256 must be a sha256 content address")
+    return records_dir(repo) / digest.removeprefix("sha256:")
+
+
+def sort_publication_rows(rows: list[dict]) -> list[dict]:
+    return sorted(rows, key=lambda row: (row["implementation_id"], row["record_sha256"]))
+
+
+def _registry_by_id(repo: Path) -> dict[str, dict]:
+    try:
+        document = load_implementations(repo / "conformance/implementations.json")
+    except ImplementationRegistryError as exc:
+        raise ValueError("implementation registry rejected: %s" % exc) from exc
+    return {row["id"]: row for row in document["implementations"]}
+
+
+def _load_index(repo: Path) -> list[dict]:
+    data = published_rows.read_regular_file(index_path(repo), MAX_INDEX_BYTES)
+    document = published_rows.parse_json_object(data, "public-runs index")
+    extra = set(document) - set(INDEX_FIELDS)
+    missing = [field for field in INDEX_FIELDS if field not in document]
+    if extra or missing:
+        raise ValueError("public-runs index has missing or surplus fields")
+    if document["schema"] != INDEX_SCHEMA:
+        raise ValueError("unsupported public-runs schema")
+    runs = document["runs"]
+    if not isinstance(runs, list):
+        raise ValueError("public-runs runs must be a list")
+    seen: set[str] = set()
+    clean: list[dict] = []
+    for row in runs:
+        if not isinstance(row, dict) or set(row) != set(RUN_FIELDS):
+            raise ValueError("public-runs row has missing or surplus fields")
+        ident = row["implementation_id"]
+        if not isinstance(ident, str) or ident in seen:
+            raise ValueError("duplicate public-run identity: %s" % ident)
+        seen.add(ident)
+        if not SHA256.fullmatch(row["record_sha256"]):
+            raise ValueError("record_sha256 must be a sha256 content address")
+        clean.append(row)
+    return clean
+
+
+def _listed_record_names(repo: Path) -> set[str]:
+    directory = records_dir(repo)
+    if not directory.exists():
+        return set()
+    if not directory.is_dir() or directory.is_symlink():
+        raise ValueError("%s is not a regular directory" % directory)
+    names: set[str] = set()
+    for entry in directory.iterdir():
+        if entry.name.startswith("."):
+            continue
+        if entry.is_symlink() or not entry.is_file() or not HEX64.fullmatch(entry.name):
+            raise ValueError("surplus record %s" % entry.name)
+        names.add(entry.name)
+    return names
+
+
+def _bind_row(row: dict, report: dict, registry: dict[str, dict]) -> None:
+    implementation = report["implementation"]
+    if "id" not in implementation or "image" not in implementation:
+        raise ValueError("publication requires implementation id and image")
+    registered = registry.get(row["implementation_id"])
+    if registered is None:
+        raise ValueError("implementation_id mismatch: unknown %s" % row["implementation_id"])
+    checks = (
+        ("implementation_id", row["implementation_id"], implementation["id"], registered["id"]),
+        ("suite", row["suite"], report["suite"], registered["suite"]),
+        ("image", row["image"], implementation["image"], registered["image"]),
+        ("source", row["source"], implementation["source"], registered["source"]),
+        ("commit", row["commit"], implementation["commit"], registered["commit"]),
+    )
+    for name, indexed, recorded, expected in checks:
+        if not indexed == recorded == expected:
+            raise ValueError("%s mismatch" % name)
+
+
+def load_publication(repo: Path) -> list[dict]:
+    rows = _load_index(repo)
+    present = _listed_record_names(repo)
+    expected = {row["record_sha256"].removeprefix("sha256:") for row in rows}
+    missing = expected - present
+    surplus = present - expected
+    if missing:
+        raise ValueError("missing record %s" % sorted(missing)[0])
+    if surplus:
+        raise ValueError("surplus record %s" % sorted(surplus)[0])
+    registry = _registry_by_id(repo)
+    loaded: list[dict] = []
+    for row in rows:
+        path = record_path(repo, row["record_sha256"])
+        data = published_rows.read_regular_file(path, MAX_RUN_RECORD_BYTES)
+        digest = _digest(data)
+        if digest != row["record_sha256"]:
+            raise ValueError("record digest mismatch: %s" % digest)
+        report = parse_strict_object(data, label="run record")
+        validate_run_record(report)
+        _bind_row(row, report, registry)
+        loaded.append(
+            {
+                "implementation_id": row["implementation_id"],
+                "suite": row["suite"],
+                "record_sha256": row["record_sha256"],
+                "image": row["image"],
+                "source": row["source"],
+                "commit": row["commit"],
+                "summary": report["summary"],
+            }
+        )
+    return sort_publication_rows(loaded)
+
+
+def render_table(rows: list[dict]) -> str:
+    lines = []
+    for row in rows:
+        summary = row["summary"]
+        lines.append(
+            "| %s | %s | %s | %s | %s | %s | %s | %s | %s |"
+            % (
+                row["implementation_id"],
+                row["suite"],
+                row["record_sha256"],
+                row["image"],
+                row["commit"],
+                summary["match"],
+                summary["mismatch"],
+                summary["execution_error"],
+                summary["harness_error"],
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_document(repo: Path, rows: list[dict]) -> str:
+    template = repo / "conformance/IMPLEMENTATIONS.md.in"
+    source = published_rows.read_regular_file(template, MAX_TEMPLATE_BYTES).decode("utf-8")
+    if source.count(TABLE_TOKEN) != 1:
+        raise ValueError("IMPLEMENTATIONS.md.in must contain exactly one table token")
+    rendered = source.replace(TABLE_TOKEN, render_table(rows))
+    if "{{" in rendered or "}}" in rendered:
+        raise ValueError("template carries an unresolved or malformed token")
+    return rendered
+
+
+def projection_findings(repo: Path) -> list[str]:
+    try:
+        rows = load_publication(repo)
+        expected = render_document(repo, rows)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        return [str(exc)]
+    output = repo / "conformance/IMPLEMENTATIONS.md"
+    try:
+        actual = published_rows.read_regular_file(output, MAX_TEMPLATE_BYTES).decode("utf-8")
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        return [str(exc)]
+    if actual != expected:
+        return ["conformance/IMPLEMENTATIONS.md differs from its fresh deterministic projection"]
+    return []
+
+
+def write_document(repo: Path) -> None:
+    rendered = render_document(repo, load_publication(repo))
+    output = repo / "conformance/IMPLEMENTATIONS.md"
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output.parent,
+            prefix=output.name + ".",
+            delete=False,
+        ) as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, output)
+        temporary = None
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--repo", type=Path, default=REPO)
+    args = parser.parse_args(argv)
+    try:
+        if args.check:
+            findings = projection_findings(args.repo)
+            if findings:
+                for finding in findings:
+                    print(finding, file=sys.stderr)
+                return 1
+        else:
+            write_document(args.repo)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        print("public-run projection failed: %s" % exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/project_public_runs.py
+++ b/conformance/project_public_runs.py
@@ -91,17 +91,21 @@ def _load_index(repo: Path) -> list[dict]:
     runs = document["runs"]
     if not isinstance(runs, list):
         raise ValueError("public-runs runs must be a list")
-    seen: set[str] = set()
+    seen: set[tuple[str, str]] = set()
     clean: list[dict] = []
     for row in runs:
         if not isinstance(row, dict) or set(row) != set(RUN_FIELDS):
             raise ValueError("public-runs row has missing or surplus fields")
         ident = row["implementation_id"]
-        if not isinstance(ident, str) or ident in seen:
-            raise ValueError("duplicate public-run identity: %s" % ident)
-        seen.add(ident)
-        if not SHA256.fullmatch(row["record_sha256"]):
+        digest = row["record_sha256"]
+        if not isinstance(ident, str):
+            raise ValueError("implementation_id must be a string")
+        if not SHA256.fullmatch(digest):
             raise ValueError("record_sha256 must be a sha256 content address")
+        key = (ident, digest)
+        if key in seen:
+            raise ValueError("duplicate public-run identity: %s %s" % key)
+        seen.add(key)
         clean.append(row)
     return clean
 

--- a/conformance/project_public_runs.py
+++ b/conformance/project_public_runs.py
@@ -60,6 +60,16 @@ def sort_publication_rows(rows: list[dict]) -> list[dict]:
     return sorted(rows, key=lambda row: (row["implementation_id"], row["record_sha256"]))
 
 
+def escape_markdown_cell(value: object) -> str:
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
 def _registry_by_id(repo: Path) -> dict[str, dict]:
     try:
         document = load_implementations(repo / "conformance/implementations.json")
@@ -169,18 +179,24 @@ def render_table(rows: list[dict]) -> str:
     lines = []
     for row in rows:
         summary = row["summary"]
+        digest = row["record_sha256"]
+        record_cell = "[%s](%s)" % (
+            escape_markdown_cell(digest),
+            escape_markdown_cell("public-runs/" + digest.removeprefix("sha256:")),
+        )
         lines.append(
-            "| %s | %s | %s | %s | %s | %s | %s | %s | %s |"
+            "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |"
             % (
-                row["implementation_id"],
-                row["suite"],
-                row["record_sha256"],
-                row["image"],
-                row["commit"],
-                summary["match"],
-                summary["mismatch"],
-                summary["execution_error"],
-                summary["harness_error"],
+                escape_markdown_cell(row["implementation_id"]),
+                escape_markdown_cell(row["suite"]),
+                record_cell,
+                escape_markdown_cell(row["image"]),
+                escape_markdown_cell(row["commit"]),
+                escape_markdown_cell(summary["match"]),
+                escape_markdown_cell(summary["mismatch"]),
+                escape_markdown_cell(summary["execution_error"]),
+                escape_markdown_cell(summary["harness_error"]),
+                escape_markdown_cell(summary["review_warnings"]),
             )
         )
     return "\n".join(lines)
@@ -225,10 +241,10 @@ def write_document(repo: Path) -> None:
             prefix=output.name + ".",
             delete=False,
         ) as handle:
+            temporary = Path(handle.name)
             handle.write(rendered)
             handle.flush()
             os.fsync(handle.fileno())
-            temporary = Path(handle.name)
         os.chmod(temporary, 0o644)
         os.replace(temporary, output)
         temporary = None

--- a/conformance/project_public_runs.py
+++ b/conformance/project_public_runs.py
@@ -30,6 +30,7 @@ RUN_FIELDS = (
     "image",
     "source",
     "commit",
+    "reproduction_mode",
 )
 MAX_INDEX_BYTES = 64 * 1024
 MAX_TEMPLATE_BYTES = 1024 * 1024
@@ -134,6 +135,12 @@ def _bind_row(row: dict, report: dict, registry: dict[str, dict]) -> None:
         ("image", row["image"], implementation["image"], registered["image"]),
         ("source", row["source"], implementation["source"], registered["source"]),
         ("commit", row["commit"], implementation["commit"], registered["commit"]),
+        (
+            "reproduction_mode",
+            row["reproduction_mode"],
+            implementation["reproduction_mode"],
+            registered["reproduction_mode"],
+        ),
     )
     for name, indexed, recorded, expected in checks:
         if not indexed == recorded == expected:
@@ -169,6 +176,7 @@ def load_publication(repo: Path) -> list[dict]:
                 "image": row["image"],
                 "source": row["source"],
                 "commit": row["commit"],
+                "reproduction_mode": row["reproduction_mode"],
                 "summary": report["summary"],
             }
         )
@@ -185,13 +193,14 @@ def render_table(rows: list[dict]) -> str:
             escape_markdown_cell("public-runs/" + digest.removeprefix("sha256:")),
         )
         lines.append(
-            "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |"
+            "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |"
             % (
                 escape_markdown_cell(row["implementation_id"]),
                 escape_markdown_cell(row["suite"]),
                 record_cell,
                 escape_markdown_cell(row["image"]),
                 escape_markdown_cell(row["commit"]),
+                escape_markdown_cell(row["reproduction_mode"]),
                 escape_markdown_cell(summary["match"]),
                 escape_markdown_cell(summary["mismatch"]),
                 escape_markdown_cell(summary["execution_error"]),

--- a/conformance/project_public_runs.py
+++ b/conformance/project_public_runs.py
@@ -250,6 +250,7 @@ def write_document(repo: Path) -> None:
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
+            newline="\n",
             dir=output.parent,
             prefix=output.name + ".",
             delete=False,

--- a/conformance/public-runs.json
+++ b/conformance/public-runs.json
@@ -1,0 +1,13 @@
+{
+  "schema": "assay.conformance.public_runs.v0",
+  "runs": [
+    {
+      "implementation_id": "pma-v0-repro",
+      "suite": "privileged-mcp-action-v0",
+      "record_sha256": "sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27",
+      "image": "ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493",
+      "source": "https://github.com/Rul1an/pma-v0-repro",
+      "commit": "c226a34f3cea50a114607c35f0976048ff3cab2b"
+    }
+  ]
+}

--- a/conformance/public-runs.json
+++ b/conformance/public-runs.json
@@ -7,7 +7,8 @@
       "record_sha256": "sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27",
       "image": "ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493",
       "source": "https://github.com/Rul1an/pma-v0-repro",
-      "commit": "c226a34f3cea50a114607c35f0976048ff3cab2b"
+      "commit": "c226a34f3cea50a114607c35f0976048ff3cab2b",
+      "reproduction_mode": "other_disclosed"
     }
   ]
 }

--- a/conformance/public-runs/9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27
+++ b/conformance/public-runs/9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27
@@ -1,0 +1,267 @@
+{
+  "capture_sha256": "sha256:3980810946a51c7fbc708f365991997636a9888a84c96a896dd6ea11173611d7",
+  "cases": [
+    {
+      "case_id": "case-001",
+      "exit_code": 0,
+      "input_sha256": "sha256:0066a1d32a5d87b8c9de8b4c6c54e7baed4fe5185369b9b146faa4ef46ccc442",
+      "observed": {
+        "bundle_integrity": "pass",
+        "claims": {
+          "caller_visible_denial": {
+            "status": "incomplete"
+          },
+          "external_side_effect": {
+            "status": "incomplete"
+          },
+          "policy_decision_recorded": {
+            "source_class": "producer_reported",
+            "status": "confirmed"
+          },
+          "upstream_delivery": {
+            "status": "incomplete"
+          }
+        },
+        "verdict": "valid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-002",
+      "exit_code": 0,
+      "input_sha256": "sha256:d22bcd852850d5b92490cebeccf8fec934da9fa3464cee5aa7d8c1a9b11a70da",
+      "observed": {
+        "bundle_integrity": "pass",
+        "claims": {
+          "caller_visible_denial": {
+            "source_class": "producer_reported",
+            "status": "refuted"
+          },
+          "external_side_effect": {
+            "status": "incomplete"
+          },
+          "policy_decision_recorded": {
+            "source_class": "producer_reported",
+            "status": "confirmed"
+          },
+          "upstream_delivery": {
+            "status": "incomplete"
+          }
+        },
+        "verdict": "valid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-003",
+      "exit_code": 0,
+      "input_sha256": "sha256:0592a8a6f4a0047f6f3502e6b10dddc77b00409d047cdffa3c0b3d6a7d88359f",
+      "observed": {
+        "bundle_integrity": "pass",
+        "verdict": "invalid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-004",
+      "exit_code": 0,
+      "input_sha256": "sha256:a179f445e622107d18fa3f18d7765205f8dc6ec5ebae7f8f8803ae5c431955aa",
+      "observed": {
+        "bundle_integrity": "pass",
+        "claims": {
+          "caller_visible_denial": {
+            "source_class": "producer_reported",
+            "status": "confirmed"
+          },
+          "external_side_effect": {
+            "status": "incomplete"
+          },
+          "policy_decision_recorded": {
+            "source_class": "producer_reported",
+            "status": "confirmed"
+          },
+          "upstream_delivery": {
+            "status": "incomplete"
+          }
+        },
+        "verdict": "valid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-005",
+      "exit_code": 0,
+      "input_sha256": "sha256:1963a5ec5a7a9c681fc931f481facd287037ea66305790a391deb6839f2d4831",
+      "observed": {
+        "bundle_integrity": "fail"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-006",
+      "exit_code": 0,
+      "input_sha256": "sha256:676f8792f4826e14425b3008f765e61d87e34e4a7a8b896143ba3fc85532fab8",
+      "observed": {
+        "bundle_integrity": "pass",
+        "claims": {
+          "caller_visible_denial": {
+            "status": "incomplete"
+          },
+          "external_side_effect": {
+            "status": "incomplete"
+          },
+          "policy_decision_recorded": {
+            "source_class": "producer_reported",
+            "status": "confirmed"
+          },
+          "upstream_delivery": {
+            "status": "incomplete"
+          }
+        },
+        "verdict": "valid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-007",
+      "exit_code": 0,
+      "input_sha256": "sha256:c49c3b502716625868cb8fb2bf768758f965a3bb77ab5f777f8bef334392d9d6",
+      "observed": {
+        "bundle_integrity": "pass",
+        "verdict": "invalid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-008",
+      "exit_code": 0,
+      "input_sha256": "sha256:b546b655645e16743b69db0b3dbeca63fb928111de9fd811369dffd8fba825a5",
+      "observed": {
+        "bundle_integrity": "pass",
+        "verdict": "invalid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-009",
+      "exit_code": 0,
+      "input_sha256": "sha256:e76d15edeb1e095d4c3aeef15f86053bdb4034c46d403e8c35c78378517b1ff9",
+      "observed": {
+        "bundle_integrity": "pass",
+        "verdict": "invalid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-010",
+      "exit_code": 0,
+      "input_sha256": "sha256:bee21b4a71053f0942788680e61d15a047ef39f5c28d14e84e12cb22f825b54f",
+      "observed": {
+        "bundle_integrity": "pass",
+        "verdict": "invalid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-011",
+      "exit_code": 0,
+      "input_sha256": "sha256:7f39cb84904b62b8cccc1fd60869d2e8cecdee359eedc0c61417a0397113b1f7",
+      "observed": {
+        "bundle_integrity": "pass",
+        "verdict": "invalid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-012",
+      "exit_code": 0,
+      "input_sha256": "sha256:1ae4201ae3040f6878fcdaf7f5ba8ad68f40fedfc7be4e165be29944dd29981f",
+      "observed": {
+        "bundle_integrity": "pass",
+        "claims": {
+          "caller_visible_denial": {
+            "status": "incomplete"
+          },
+          "external_side_effect": {
+            "status": "incomplete"
+          },
+          "policy_decision_recorded": {
+            "source_class": "producer_reported",
+            "status": "confirmed"
+          },
+          "upstream_delivery": {
+            "status": "incomplete"
+          }
+        },
+        "verdict": "valid"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-013",
+      "exit_code": 0,
+      "input_sha256": "sha256:b7b20aeaf194aaa45700b71c5ffdbd6ae2ce8c28796ab0f383c5d83441822998",
+      "observed": {
+        "bundle_integrity": "fail"
+      },
+      "status": "match",
+      "stderr_present": false
+    },
+    {
+      "case_id": "case-014",
+      "exit_code": 0,
+      "input_sha256": "sha256:571a15cb9a77dc41fda4a5001e9d7c6c99443db9154c707ffa77ce4de92243b1",
+      "observed": {
+        "bundle_integrity": "pass",
+        "verdict": "invalid"
+      },
+      "status": "match",
+      "stderr_present": false
+    }
+  ],
+  "harness_errors": [],
+  "implementation": {
+    "commit": "c226a34f3cea50a114607c35f0976048ff3cab2b",
+    "id": "pma-v0-repro",
+    "image": "ghcr.io/rul1an/pma-v0-repro@sha256:88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493",
+    "name": "pma-v0-repro privileged-mcp-action/v0 verifier",
+    "reproduction_mode": "other_disclosed",
+    "source": "https://github.com/Rul1an/pma-v0-repro",
+    "version": null
+  },
+  "non_claims": [
+    "a matching run demonstrates agreement on the pinned corpus only",
+    "a matching run does not establish implementation independence",
+    "the scorer records but does not verify the pack's declared source commit",
+    "the scorer does not assess security, compliance, or provider outcomes",
+    "candidate process limits are operational bounds, not a sandbox"
+  ],
+  "pack_declared_source_commit": "0c055ead5a2661569d544df4a0df40df90b98e18",
+  "pack_provenance_verification": "not_performed_by_scorer",
+  "pack_sha256": "sha256:4a3d5a713d424b37eb77ab238e73582e3dd26d42f8b656d0a6216c2993909b72",
+  "profile": "privileged-mcp-action/v0",
+  "rendered_set_digest": "sha256:b2f715408c82346b0928852f0bc6cb11c17dd7e3233395316d764b282080a05c",
+  "schema": "assay.privileged_mcp_action.conformance_run.v1",
+  "source_corpus_digest": "sha256:cb58ce91863f52e0568742b977f0642158453ec11bbcd25821f9171dccd03342",
+  "suite": "privileged-mcp-action-v0",
+  "summary": {
+    "execution_error": 0,
+    "harness_error": 0,
+    "match": 14,
+    "mismatch": 0,
+    "review_warnings": 0,
+    "total": 14
+  }
+}

--- a/conformance/tests/test_public_runs.py
+++ b/conformance/tests/test_public_runs.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Public-run projection contract. First RED is a stored-record byte flip.
+
+    python3 -W error::ResourceWarning conformance/tests/test_public_runs.py
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "conformance"))
+sys.path.insert(0, str(REPO / "conformance/adequacy"))
+sys.path.insert(0, str(REPO / "conformance/privileged-mcp-action-v0/scripts"))
+
+HOSTED_SHA256 = (
+    "9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27"
+)
+HOSTED_DIGEST = "sha256:" + HOSTED_SHA256
+COPIED = (
+    "conformance/public-runs.json",
+    "conformance/IMPLEMENTATIONS.md.in",
+    "conformance/IMPLEMENTATIONS.md",
+    "conformance/implementations.json",
+    f"conformance/public-runs/{HOSTED_SHA256}",
+)
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+@contextlib.contextmanager
+def sandbox():
+    import project_public_runs as project
+
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        for rel in COPIED:
+            dst = root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO / rel, dst)
+        saved = project.REPO
+        project.REPO = root
+        try:
+            yield root, project
+        finally:
+            project.REPO = saved
+
+
+def run_check(project, repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(REPO / "conformance/project_public_runs.py"), "--check", "--repo", str(repo)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class PublicRunProjection(unittest.TestCase):
+    def test_record_byte_flip_fails_check_and_preserves_markdown(self) -> None:
+        with sandbox() as (root, project):
+            markdown = root / "conformance/IMPLEMENTATIONS.md"
+            before = markdown.read_bytes()
+            record = root / "conformance/public-runs" / HOSTED_SHA256
+            data = bytearray(record.read_bytes())
+            data[0] ^= 0x01
+            record.write_bytes(bytes(data))
+            findings = project.projection_findings(root)
+            self.assertTrue(findings, "byte-flipped record must fail --check")
+            self.assertTrue(
+                any("digest" in item or "sha256" in item for item in findings),
+                findings,
+            )
+            self.assertEqual(markdown.read_bytes(), before)
+            completed = run_check(project, root)
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertEqual(markdown.read_bytes(), before)
+
+    def test_pristine_tree_is_green(self) -> None:
+        import project_public_runs as project
+
+        self.assertEqual(project.projection_findings(REPO), [])
+        completed = run_check(project, REPO)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_hosted_record_is_the_exact_validated_bytes(self) -> None:
+        import project_public_runs as project
+        import validate_run_record
+
+        path = REPO / "conformance/public-runs" / HOSTED_SHA256
+        data = path.read_bytes()
+        self.assertEqual(_sha256(data), HOSTED_DIGEST)
+        self.assertEqual(len(data), 8102)
+        report = validate_run_record.load_run_record(path)
+        validate_run_record.validate_run_record(report)
+        self.assertEqual(report["implementation"]["id"], "pma-v0-repro")
+
+    def test_sorts_by_identity_and_digest_never_score(self) -> None:
+        import project_public_runs as project
+
+        low_score_first = {
+            "implementation_id": "aaa",
+            "record_sha256": "sha256:" + ("ab" * 32),
+            "summary": {"match": 0, "mismatch": 14, "execution_error": 0, "harness_error": 0},
+        }
+        high_score_second = {
+            "implementation_id": "bbb",
+            "record_sha256": "sha256:" + ("01" * 32),
+            "summary": {"match": 14, "mismatch": 0, "execution_error": 0, "harness_error": 0},
+        }
+        ordered = project.sort_publication_rows([high_score_second, low_score_first])
+        self.assertEqual(
+            [row["implementation_id"] for row in ordered],
+            ["aaa", "bbb"],
+        )
+        source = ast.parse((REPO / "conformance/project_public_runs.py").read_text(encoding="utf-8"))
+        names = {node.id for node in ast.walk(source) if isinstance(node, ast.Name)}
+        self.assertIn("sort_publication_rows", names)
+        self.assertNotIn("score_percent", ast.dump(source))
+
+    def test_reuses_canonical_loader_validator_and_registry(self) -> None:
+        source = (REPO / "conformance/project_public_runs.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        names = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+        attrs = {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+        self.assertIn("validate_run_record", names | attrs)
+        self.assertIn("load_implementations", names | attrs)
+        self.assertIn("read_regular_file", names | attrs)
+        self.assertIn("parse_json_object", names | attrs)
+        self.assertNotIn("json.loads", source.replace("parse_json_object", ""))
+
+
+class PublicRunMutations(unittest.TestCase):
+    def test_duplicate_identity_fails_closed(self) -> None:
+        with sandbox() as (root, project):
+            index = json.loads((root / "conformance/public-runs.json").read_text())
+            index["runs"].append(index["runs"][0])
+            (root / "conformance/public-runs.json").write_text(json.dumps(index) + "\n")
+            findings = project.projection_findings(root)
+            self.assertTrue(any("duplicate" in item for item in findings), findings)
+
+    def test_missing_and_surplus_record_fail_closed(self) -> None:
+        with sandbox() as (root, project):
+            extra = root / "conformance/public-runs" / ("cd" * 32)
+            extra.write_bytes(b'{"schema":"x"}')
+            findings = project.projection_findings(root)
+            self.assertTrue(any("surplus" in item for item in findings), findings)
+            extra.unlink()
+            (root / "conformance/public-runs" / HOSTED_SHA256).unlink()
+            findings = project.projection_findings(root)
+            self.assertTrue(any("missing" in item for item in findings), findings)
+
+    def test_v0_and_unknown_schema_fail_closed(self) -> None:
+        with sandbox() as (root, project):
+            record = root / "conformance/public-runs" / HOSTED_SHA256
+            payload = json.loads(record.read_text())
+            payload["schema"] = "assay.privileged_mcp_action.conformance_run.v0"
+            mutated = json.dumps(payload, indent=2, sort_keys=True).encode() + b"\n"
+            record.write_bytes(mutated)
+            index = json.loads((root / "conformance/public-runs.json").read_text())
+            index["runs"][0]["record_sha256"] = _sha256(mutated)
+            (root / "conformance/public-runs.json").write_text(json.dumps(index) + "\n")
+            record.rename(root / "conformance/public-runs" / hashlib.sha256(mutated).hexdigest())
+            findings = project.projection_findings(root)
+            self.assertTrue(any("unsupported schema" in item for item in findings), findings)
+
+    def test_identity_image_source_commit_mismatch_fails_closed(self) -> None:
+        with sandbox() as (root, project):
+            index = json.loads((root / "conformance/public-runs.json").read_text())
+            for field, value in (
+                ("implementation_id", "not-pma-v0-repro"),
+                ("image", "ghcr.io/example/x@sha256:" + ("ab" * 32)),
+                ("source", "https://example.invalid/other"),
+                ("commit", "0" * 40),
+            ):
+                mutated = json.loads(json.dumps(index))
+                mutated["runs"][0][field] = value
+                (root / "conformance/public-runs.json").write_text(json.dumps(mutated) + "\n")
+                findings = project.projection_findings(root)
+                self.assertTrue(any("mismatch" in item for item in findings), findings)
+
+    def test_stale_generated_markdown_fails_without_write(self) -> None:
+        with sandbox() as (root, project):
+            markdown = root / "conformance/IMPLEMENTATIONS.md"
+            before = markdown.read_bytes()
+            markdown.write_bytes(before + b"\n# stale\n")
+            findings = project.projection_findings(root)
+            self.assertTrue(any("IMPLEMENTATIONS.md" in item for item in findings), findings)
+            completed = run_check(project, root)
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertEqual(markdown.read_bytes(), before + b"\n# stale\n")
+
+    def test_validator_bypass_is_visible(self) -> None:
+        with sandbox() as (root, project):
+            with mock.patch.object(project, "validate_run_record", side_effect=AssertionError("bypass")):
+                with self.assertRaises(AssertionError):
+                    project.load_publication(root)
+
+    def test_hostile_index_inputs_fail_before_render(self) -> None:
+        with sandbox() as (root, project):
+            index = root / "conformance/public-runs.json"
+            markdown = root / "conformance/IMPLEMENTATIONS.md"
+            before = markdown.read_bytes()
+            index.write_bytes(b'{"schema":1e999}\n')
+            with self.assertRaises(ValueError):
+                project.load_publication(root)
+            self.assertEqual(markdown.read_bytes(), before)
+            index.write_bytes(b'{"schema":"x","schema":"y"}\n')
+            with self.assertRaises(ValueError):
+                project.load_publication(root)
+            huge = root / "huge.json"
+            huge.write_bytes(b"{" + (b"a" * (project.MAX_INDEX_BYTES + 1)) + b"}")
+            with self.assertRaises(ValueError):
+                project.published_rows.read_regular_file(huge, project.MAX_INDEX_BYTES)
+            if hasattr(os, "mkfifo"):
+                fifo = root / "fifo.json"
+                os.mkfifo(fifo)
+                with self.assertRaises(ValueError):
+                    project.published_rows.read_regular_file(fifo, project.MAX_INDEX_BYTES)
+            link = root / "link.json"
+            link.symlink_to(root / "conformance/public-runs.json")
+            with self.assertRaises(ValueError):
+                project.published_rows.read_regular_file(link, project.MAX_INDEX_BYTES)
+
+    def test_check_does_not_write(self) -> None:
+        with sandbox() as (root, project):
+            markdown = root / "conformance/IMPLEMENTATIONS.md"
+            markdown.write_bytes(b"wrong\n")
+            stamp = markdown.stat()
+            completed = run_check(project, root)
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertEqual(markdown.stat().st_mtime_ns, stamp.st_mtime_ns)
+            self.assertEqual(markdown.read_bytes(), b"wrong\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/tests/test_public_runs.py
+++ b/conformance/tests/test_public_runs.py
@@ -211,6 +211,11 @@ class PublicRunMutations(unittest.TestCase):
             digests = [row["record_sha256"] for row in rows]
             self.assertEqual(set(digests), {HOSTED_DIGEST, "sha256:" + digest})
             self.assertEqual(digests, sorted(digests))
+            document = project.render_document(root, rows)
+            data_rows = [line for line in document.splitlines() if "pma-v0-repro" in line]
+            self.assertEqual(len(data_rows), 2)
+            self.assertIn("[sha256:%s](public-runs/%s)" % (HOSTED_SHA256, HOSTED_SHA256), document)
+            self.assertIn("[sha256:%s](public-runs/%s)" % (digest, digest), document)
 
     def test_missing_and_surplus_record_fail_closed(self) -> None:
         with sandbox() as (root, project):
@@ -435,6 +440,41 @@ class PublicRunMutations(unittest.TestCase):
             cells = _table_cells(next(line for line in document.splitlines() if "pma-v0-repro" in line))
             self.assertEqual(len(cells), 11)
             self.assertEqual(cells[5], "other_disclosed")
+
+    def test_missing_registry_row_fails_unknown(self) -> None:
+        with sandbox() as (root, project):
+            def rename_registry(registry: dict) -> None:
+                registry["implementations"][0]["id"] = "not-pma-v0-repro"
+
+            _rebind_record(root, lambda _payload: None, mutate_registry=rename_registry)
+            with self.assertRaises(ValueError) as ctx:
+                project.load_publication(root)
+            self.assertIn("unknown", str(ctx.exception))
+
+    def test_oversize_digest_named_record_fails_before_parse(self) -> None:
+        with sandbox() as (root, project):
+            markdown = root / "conformance/IMPLEMENTATIONS.md"
+            before = markdown.read_bytes()
+            huge = b"{" + (b"a" * 4194303) + b"}"
+            self.assertEqual(len(huge), 4194305)
+            digest = hashlib.sha256(huge).hexdigest()
+            (root / "conformance/public-runs" / HOSTED_SHA256).unlink()
+            (root / "conformance/public-runs" / digest).write_bytes(huge)
+            index_path = root / "conformance/public-runs.json"
+            index = json.loads(index_path.read_text())
+            index["runs"][0]["record_sha256"] = "sha256:" + digest
+            index_path.write_text(json.dumps(index) + "\n")
+            with self.assertRaises(ValueError) as ctx:
+                project.load_publication(root)
+            self.assertIn("exceeds", str(ctx.exception))
+            self.assertEqual(markdown.read_bytes(), before)
+
+    def test_public_non_claims_name_binding_without_attestation(self) -> None:
+        with sandbox() as (root, project):
+            document = project.render_document(root, project.load_publication(root))
+            self.assertIn("does not prove implementation independence", document)
+            self.assertIn("publisher-declared and bound", document)
+            self.assertIn("not attested or verified", document)
 
     def test_record_digest_links_to_stored_bytes_and_names_opt_in(self) -> None:
         with sandbox() as (root, project):

--- a/conformance/tests/test_public_runs.py
+++ b/conformance/tests/test_public_runs.py
@@ -68,6 +68,37 @@ def run_check(project, repo: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _table_cells(row: str) -> list[str]:
+    body = row.strip()
+    if body.startswith("|"):
+        body = body[1:]
+    if body.endswith("|"):
+        body = body[:-1]
+    return [cell.strip() for cell in body.split(" | ")]
+
+
+def _rebind_record(root: Path, mutate_payload, mutate_index=None, mutate_registry=None) -> str:
+    record = root / "conformance/public-runs" / HOSTED_SHA256
+    payload = json.loads(record.read_text())
+    mutate_payload(payload)
+    mutated = json.dumps(payload, indent=2, sort_keys=True).encode() + b"\n"
+    digest = hashlib.sha256(mutated).hexdigest()
+    record.unlink()
+    (root / "conformance/public-runs" / digest).write_bytes(mutated)
+    index_path = root / "conformance/public-runs.json"
+    index = json.loads(index_path.read_text())
+    index["runs"][0]["record_sha256"] = "sha256:" + digest
+    if mutate_index is not None:
+        mutate_index(index)
+    index_path.write_text(json.dumps(index) + "\n")
+    if mutate_registry is not None:
+        registry_path = root / "conformance/implementations.json"
+        registry = json.loads(registry_path.read_text())
+        mutate_registry(registry)
+        registry_path.write_text(json.dumps(registry) + "\n")
+    return digest
+
+
 class PublicRunProjection(unittest.TestCase):
     def test_record_byte_flip_fails_check_and_preserves_markdown(self) -> None:
         with sandbox() as (root, project):
@@ -208,7 +239,7 @@ class PublicRunMutations(unittest.TestCase):
                 with self.assertRaises(AssertionError):
                     project.load_publication(root)
 
-    def test_hostile_index_inputs_fail_before_render(self) -> None:
+    def test_index_path_hostile_inputs_fail_before_render(self) -> None:
         with sandbox() as (root, project):
             index = root / "conformance/public-runs.json"
             markdown = root / "conformance/IMPLEMENTATIONS.md"
@@ -220,19 +251,127 @@ class PublicRunMutations(unittest.TestCase):
             index.write_bytes(b'{"schema":"x","schema":"y"}\n')
             with self.assertRaises(ValueError):
                 project.load_publication(root)
-            huge = root / "huge.json"
-            huge.write_bytes(b"{" + (b"a" * (project.MAX_INDEX_BYTES + 1)) + b"}")
+            shutil.copy2(REPO / "conformance/public-runs.json", index)
+            hidden = root / "hidden-index.json"
+            shutil.copy2(index, hidden)
+            index.unlink()
+            index.symlink_to(hidden)
             with self.assertRaises(ValueError):
-                project.published_rows.read_regular_file(huge, project.MAX_INDEX_BYTES)
+                project.load_publication(root)
+            index.unlink()
+            shutil.copy2(REPO / "conformance/public-runs.json", index)
             if hasattr(os, "mkfifo"):
-                fifo = root / "fifo.json"
-                os.mkfifo(fifo)
+                index.unlink()
+                os.mkfifo(index)
                 with self.assertRaises(ValueError):
-                    project.published_rows.read_regular_file(fifo, project.MAX_INDEX_BYTES)
-            link = root / "link.json"
-            link.symlink_to(root / "conformance/public-runs.json")
-            with self.assertRaises(ValueError):
-                project.published_rows.read_regular_file(link, project.MAX_INDEX_BYTES)
+                    project.load_publication(root)
+                index.unlink()
+                shutil.copy2(REPO / "conformance/public-runs.json", index)
+            index.write_bytes(b"{" + (b"a" * 65535) + b"}")
+            with self.assertRaises(ValueError) as oversize:
+                project.load_publication(root)
+            self.assertIn("exceeds", str(oversize.exception))
+
+    def test_write_document_replaces_with_exact_render_bytes(self) -> None:
+        with sandbox() as (root, project):
+            markdown = root / "conformance/IMPLEMENTATIONS.md"
+            markdown.write_bytes(b"stale-prior-bytes\n")
+            project.write_document(root)
+            expected = project.render_document(root, project.load_publication(root)).encode("utf-8")
+            self.assertEqual(markdown.read_bytes(), expected)
+
+    def test_write_document_failures_keep_prior_bytes_and_clean_temp(self) -> None:
+        with sandbox() as (root, project):
+            markdown = root / "conformance/IMPLEMENTATIONS.md"
+            prior = b"keep-these-bytes\n"
+            markdown.write_bytes(prior)
+
+            real_named = tempfile.NamedTemporaryFile
+
+            def leaking_write(*args, **kwargs):
+                handle = real_named(*args, **kwargs)
+                handle.write = lambda _data: (_ for _ in ()).throw(OSError("injected write failure"))
+                return handle
+
+            with mock.patch.object(project.tempfile, "NamedTemporaryFile", side_effect=leaking_write):
+                with self.assertRaises(OSError):
+                    project.write_document(root)
+            self.assertEqual(markdown.read_bytes(), prior)
+            leftovers = [
+                path.name
+                for path in (root / "conformance").iterdir()
+                if path.name.startswith("IMPLEMENTATIONS.md.") and path.name != "IMPLEMENTATIONS.md.in"
+            ]
+            self.assertEqual(leftovers, [])
+
+            markdown.write_bytes(prior)
+            with mock.patch.object(project.os, "replace", side_effect=OSError("injected replace failure")):
+                with self.assertRaises(OSError):
+                    project.write_document(root)
+            self.assertEqual(markdown.read_bytes(), prior)
+            leftovers = [
+                path.name
+                for path in (root / "conformance").iterdir()
+                if path.name.startswith("IMPLEMENTATIONS.md.") and path.name != "IMPLEMENTATIONS.md.in"
+            ]
+            self.assertEqual(leftovers, [])
+
+    def test_valid_review_warnings_are_projected(self) -> None:
+        with sandbox() as (root, project):
+            import validate_run_record
+
+            def add_warning(payload: dict) -> None:
+                payload["cases"][0]["review_warnings"] = ["one typed warning"]
+                payload["summary"]["review_warnings"] = 1
+
+            digest = _rebind_record(root, add_warning)
+            report = validate_run_record.load_run_record(root / "conformance/public-runs" / digest)
+            validate_run_record.validate_run_record(report)
+            self.assertEqual(report["summary"]["review_warnings"], 1)
+            rows = project.load_publication(root)
+            self.assertEqual(rows[0]["summary"]["review_warnings"], 1)
+            document = project.render_document(root, rows)
+            self.assertIn("| review_warnings |", document)
+            row = next(line for line in document.splitlines() if "pma-v0-repro" in line)
+            cells = _table_cells(row)
+            self.assertEqual(len(cells), 10)
+            self.assertEqual(cells[-1], "1")
+
+    def test_bound_image_markup_stays_one_cell(self) -> None:
+        with sandbox() as (root, project):
+            image = (
+                "ghcr.io/rul1an/pma|<v0>@sha256:"
+                "88a5ef285a80dc0caeb2b11093eba79f8f08c870b549cafc395aa77ee5ffc493"
+            )
+
+            def set_image(payload: dict) -> None:
+                payload["implementation"]["image"] = image
+
+            def set_index_image(index: dict) -> None:
+                index["runs"][0]["image"] = image
+
+            def set_registry_image(registry: dict) -> None:
+                registry["implementations"][0]["image"] = image
+
+            _rebind_record(root, set_image, set_index_image, set_registry_image)
+            rows = project.load_publication(root)
+            table = project.render_table(rows)
+            cells = _table_cells(table.splitlines()[0])
+            self.assertEqual(len(cells), 10)
+            self.assertIn("\\|", cells[3])
+            self.assertIn("&lt;", cells[3])
+            self.assertIn("&gt;", cells[3])
+            self.assertEqual(project.escape_markdown_cell("a|b<c>d"), "a\\|b&lt;c&gt;d")
+
+    def test_record_digest_links_to_stored_bytes_and_names_opt_in(self) -> None:
+        with sandbox() as (root, project):
+            rows = project.load_publication(root)
+            document = project.render_document(root, rows)
+            self.assertIn(
+                "[sha256:%s](public-runs/%s)" % (HOSTED_SHA256, HOSTED_SHA256),
+                document,
+            )
+            self.assertIn("python3 conformance/project_public_runs.py --check", document)
 
     def test_check_does_not_write(self) -> None:
         with sandbox() as (root, project):

--- a/conformance/tests/test_public_runs.py
+++ b/conformance/tests/test_public_runs.py
@@ -334,7 +334,7 @@ class PublicRunMutations(unittest.TestCase):
             self.assertIn("| review_warnings |", document)
             row = next(line for line in document.splitlines() if "pma-v0-repro" in line)
             cells = _table_cells(row)
-            self.assertEqual(len(cells), 10)
+            self.assertEqual(len(cells), 11)
             self.assertEqual(cells[-1], "1")
 
     def test_bound_image_markup_stays_one_cell(self) -> None:
@@ -357,11 +357,37 @@ class PublicRunMutations(unittest.TestCase):
             rows = project.load_publication(root)
             table = project.render_table(rows)
             cells = _table_cells(table.splitlines()[0])
-            self.assertEqual(len(cells), 10)
+            self.assertEqual(len(cells), 11)
             self.assertIn("\\|", cells[3])
             self.assertIn("&lt;", cells[3])
             self.assertIn("&gt;", cells[3])
             self.assertEqual(project.escape_markdown_cell("a|b<c>d"), "a\\|b&lt;c&gt;d")
+
+    def test_valid_reproduction_mode_swap_fails_closed(self) -> None:
+        with sandbox() as (root, project):
+            import validate_run_record
+
+            def swap_mode(payload: dict) -> None:
+                self.assertEqual(payload["implementation"]["reproduction_mode"], "other_disclosed")
+                payload["implementation"]["reproduction_mode"] = "blind_from_spec"
+
+            digest = _rebind_record(root, swap_mode)
+            report = validate_run_record.load_run_record(root / "conformance/public-runs" / digest)
+            validate_run_record.validate_run_record(report)
+            self.assertEqual(report["implementation"]["reproduction_mode"], "blind_from_spec")
+            registry = json.loads((root / "conformance/implementations.json").read_text())
+            self.assertEqual(registry["implementations"][0]["reproduction_mode"], "other_disclosed")
+            with self.assertRaises(ValueError) as ctx:
+                project.load_publication(root)
+            self.assertIn("reproduction_mode", str(ctx.exception))
+
+    def test_reproduction_mode_is_projected(self) -> None:
+        with sandbox() as (root, project):
+            document = project.render_document(root, project.load_publication(root))
+            self.assertIn("| reproduction_mode |", document)
+            cells = _table_cells(next(line for line in document.splitlines() if "pma-v0-repro" in line))
+            self.assertEqual(len(cells), 11)
+            self.assertEqual(cells[5], "other_disclosed")
 
     def test_record_digest_links_to_stored_bytes_and_names_opt_in(self) -> None:
         with sandbox() as (root, project):

--- a/conformance/tests/test_public_runs.py
+++ b/conformance/tests/test_public_runs.py
@@ -181,6 +181,36 @@ class PublicRunMutations(unittest.TestCase):
             (root / "conformance/public-runs.json").write_text(json.dumps(index) + "\n")
             findings = project.projection_findings(root)
             self.assertTrue(any("duplicate" in item for item in findings), findings)
+            self.assertTrue(any(HOSTED_SHA256 in item for item in findings), findings)
+
+    def test_same_implementation_two_digests_are_kept_and_sorted(self) -> None:
+        with sandbox() as (root, project):
+            import validate_run_record
+
+            record = root / "conformance/public-runs" / HOSTED_SHA256
+            payload = json.loads(record.read_text())
+            payload["cases"][0]["review_warnings"] = ["one typed warning"]
+            payload["summary"]["review_warnings"] = 1
+            mutated = json.dumps(payload, indent=2, sort_keys=True).encode() + b"\n"
+            digest = hashlib.sha256(mutated).hexdigest()
+            (root / "conformance/public-runs" / digest).write_bytes(mutated)
+            report = validate_run_record.load_run_record(root / "conformance/public-runs" / digest)
+            validate_run_record.validate_run_record(report)
+            index_path = root / "conformance/public-runs.json"
+            index = json.loads(index_path.read_text())
+            second = dict(index["runs"][0])
+            second["record_sha256"] = "sha256:" + digest
+            index["runs"] = [second, index["runs"][0]]
+            index_path.write_text(json.dumps(index) + "\n")
+            try:
+                rows = project.load_publication(root)
+            except ValueError as exc:
+                self.fail("same implementation with two digests must load, got %s" % exc)
+            self.assertEqual(len(rows), 2)
+            self.assertEqual({row["implementation_id"] for row in rows}, {"pma-v0-repro"})
+            digests = [row["record_sha256"] for row in rows]
+            self.assertEqual(set(digests), {HOSTED_DIGEST, "sha256:" + digest})
+            self.assertEqual(digests, sorted(digests))
 
     def test_missing_and_surplus_record_fail_closed(self) -> None:
         with sandbox() as (root, project):

--- a/conformance/tests/test_public_runs.py
+++ b/conformance/tests/test_public_runs.py
@@ -308,7 +308,24 @@ class PublicRunMutations(unittest.TestCase):
             markdown.write_bytes(b"stale-prior-bytes\n")
             project.write_document(root)
             expected = project.render_document(root, project.load_publication(root)).encode("utf-8")
+            self.assertNotIn(b"\r\n", expected)
+            self.assertIn(b"\n", expected)
             self.assertEqual(markdown.read_bytes(), expected)
+            tree = ast.parse((REPO / "conformance/project_public_runs.py").read_text(encoding="utf-8"))
+            write_fn = next(
+                node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "write_document"
+            )
+            named = [
+                node
+                for node in ast.walk(write_fn)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "NamedTemporaryFile"
+            ]
+            self.assertEqual(len(named), 1)
+            newline = next((kw.value for kw in named[0].keywords if kw.arg == "newline"), None)
+            self.assertIsNotNone(newline)
+            self.assertEqual(ast.literal_eval(newline), "\n")
 
     def test_write_document_failures_keep_prior_bytes_and_clean_temp(self) -> None:
         with sandbox() as (root, project):


### PR DESCRIPTION
## Summary
- Typed loader + digest-addressed store for opt-in `public-runs.json` rows. Record path is the SHA-256 hex only. Bytes are hashed before parse, then passed through existing `published_rows`, `validate_run_record`, and `load_implementations`.
- Deterministic `IMPLEMENTATIONS.md.in` → `IMPLEMENTATIONS.md` projector with `--check` that never writes. Publication identity and sort key are `(implementation_id, record_sha256)` so a correction can append without rewriting historical bytes.
- Registry, record, and index must agree on identity, image, source, commit, and `reproduction_mode`. The table projects those bound values plus typed `review_warnings`.
- Consumes hosted run-record artifact `9468514238` from run [`32546006900`](https://github.com/Rul1an/assay/actions/runs/32546006900) (8102 bytes, `sha256:9275ac65b1f2dde89299fcc811c733096b3b5683cb5ed15a8f32560d4580ae27`), revalidated locally before the index row was added.
- Invoked from a sibling step on the existing required `scope` job. No new required context. Does not touch the #210 inventory-callsite pin files.

Implements [assay-tunnel-experiments#201](https://github.com/Rul1an/assay-tunnel-experiments/issues/201).

Exact head: `cef9d29a7a0fe5a08d3f06d3a5ea4125fce301b1`
Base: `a63a97c16615c181b65aaf6fdf0eed0fc5270ad0`

## RED → GREEN
1. First RED: `project_public_runs` missing (`ModuleNotFoundError`, 13 errors).
2. Preflight closures: hostile index on the production path; exact writer bytes + LF; typed `review_warnings`; Markdown escape; `reproduction_mode` bind; append-only digest tuple.
3. Audit-property RED on `13eb7623f`:
   - B1: rename the registry row via `_rebind_record`; `load_publication` must say `unknown`. Record-derived fallback: `ValueError not raised`.
   - H1: two valid digests must render two digest-links. `render_table` drop-last-row: `1 != 2`.
   - H2: public page omitted corpus-independence and declared-but-unattested binding.
   - M1: digest-named 4194305-byte record must fail with `exceeds` before parse. `path.read_bytes()`: JSON parse error instead.
4. GREEN on this head: focused `conformance/tests/test_public_runs.py` 24/24; `--check` exit 0; `git diff --check` clean; affected Python suite 188/188; B1/H1/M1 mutations red.

## Mutations
- Record byte flip with stale index digest: `--check` red; `IMPLEMENTATIONS.md` bytes unchanged.
- Duplicate `(implementation_id, record_sha256)` tuple; two different digests for one implementation stay and sort.
- Missing/surplus record; v0 schema after digest rebind; identity/image/source/commit/`reproduction_mode` mismatch; missing registry row is `unknown`.
- Hostile index on `public-runs.json` (FIFO/symlink/literal 65537/dup-key/nonfinite); digest-named record over 4MiB fails before parse.
- Stale generated markdown; `validate_run_record` bypass; `--check` does not write; writer exact bytes and LF.
- Sort-by-score: `sort_publication_rows` is identity/digest only; projector source has no `score_percent`.

## Test plan
- [x] `python3 -W error::ResourceWarning conformance/tests/test_public_runs.py` (24/24)
- [x] `python3 conformance/project_public_runs.py --check`
- [x] `git diff --check`
- [x] affected Python suite (`test_public_runs`, `test_completion_scope`, `test_implementations`, `test_pma_v0_registration`, `test_published_rows`, `test_registry`) 188/188
- [ ] GitHub Actions on this head
- [ ] Independent exact-head review of `cef9d29a7` (review on `13eb7623f` does not carry)

## Non-claims
Not a leaderboard, badge, certification, trust score, or implementation-independence proof. A digest addresses bytes, not a publisher. A match is agreement on the pinned corpus only. `reproduction_mode`, image, and identity are publisher-declared and bound; they are not attested or verified. Append-only is a reviewed repository-delta property, not a fact of one checkout. No latest/supersedes semantics. This draft does not merge itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public conformance run record covering 14 privileged MCP action cases, with complete provenance and aggregate results.
  - Added validation and deterministic projection of reviewed public run records into implementation documentation.
  - Added CI validation to ensure the public-run projection remains current and conformant.

- **Documentation**
  - Added a public implementation-runs page explaining record scope, limitations, review requirements, and reproduction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->