### PR TITLE
docs(interop): remeasure Vaara decision pairing v1.75

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,11 +125,11 @@ repos:
         files: ^(scripts/(ci/test-generate-product-capabilities|docs/generate-product-capabilities)\.py|docs/data/product-capabilities\.v0\.json|docs/(reference/product-support|generated/product-claim-proof)\.md)$
 
       - id: sep2828-fallback-classifier-self-test
-        name: SEP-2828 fallback classifier self-test
-        entry: python3 scripts/ci/test_classify_sep2828_fallback.py
+        name: SEP-2828 fallback reproduction self-test
+        entry: bash -c 'python3 scripts/ci/test_classify_sep2828_fallback.py && python3 scripts/ci/test_reproduce_sep2828_decision_pairing.py'
         language: system
         pass_filenames: false
-        files: ^(scripts/(ci/test_classify_sep2828_fallback|interop/classify_sep2828_fallback)\.py|scripts/interop/reproduce-sep2828-decision-pairing\.sh|docs/interop/sep2828-decision-pairing-v0\.md|\.pre-commit-config\.yaml)$
+        files: ^(scripts/(ci/(test_classify_sep2828_fallback|test_reproduce_sep2828_decision_pairing|bounded_download)|interop/classify_sep2828_fallback)\.py|scripts/interop/reproduce-sep2828-decision-pairing\.sh|docs/interop/sep2828-decision-pairing-v0\.md|\.pre-commit-config\.yaml)$
 
       - id: docs-generated-drift
         name: Generated docs match their generators

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,6 +124,13 @@ repos:
         pass_filenames: false
         files: ^(scripts/(ci/test-generate-product-capabilities|docs/generate-product-capabilities)\.py|docs/data/product-capabilities\.v0\.json|docs/(reference/product-support|generated/product-claim-proof)\.md)$
 
+      - id: sep2828-fallback-classifier-self-test
+        name: SEP-2828 fallback classifier self-test
+        entry: python3 scripts/ci/test_classify_sep2828_fallback.py
+        language: system
+        pass_filenames: false
+        files: ^(scripts/(ci/test_classify_sep2828_fallback|interop/classify_sep2828_fallback)\.py|scripts/interop/reproduce-sep2828-decision-pairing\.sh|docs/interop/sep2828-decision-pairing-v0\.md|\.pre-commit-config\.yaml)$
+
       - id: docs-generated-drift
         name: Generated docs match their generators
         entry: bash scripts/ci/check-docs-generated-drift.sh

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -16,7 +16,8 @@ scripts/interop/reproduce-sep2828-decision-pairing.sh
 The vectors are published by [vaaraio/vaara](https://github.com/vaaraio/vaara) under
 AGPL-3.0-or-later. The script fetches them at run time and never vendors them into this MIT
 repository. No upstream code is fetched or executed, and every verdict below is computed by
-`assay` from the published JSON wire bytes.
+`assay` from the published JSON wire bytes. Assay computes the individual checks; the local
+fallback classifier applies this record's disposition rule to those check results.
 
 ## Why this record exists
 
@@ -110,7 +111,8 @@ The upstream revision is pinned rather than tracked from `main`, because a recor
 move is not a record. Drift shows up as a fetch failure instead of as a quietly different number.
 `ASSAY_INTEROP_REV` re-runs the comparison against another commit. The script prints the revision
 and the versions of `assay`, `curl` and `python3` it used, and fails closed on a bad fetch or an
-unexpected tool exit rather than reporting either as a comparison result.
+unexpected tool exit rather than reporting either as a comparison result. Every fetched JSON file
+and the fallback report are bounded to 1 MiB before parsing.
 
 The comparison is per check, not per case. Each row above pins the specific check ids that must
 pass and must fail, so a case that reaches the right overall verdict for the wrong reason is

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -71,6 +71,10 @@ Declared rather than left to inference:
   outcome back-links to agree. It does not establish that `_meta.authorization_binding.nonce` was
   observed by the server, equals the back-link nonce, or is fresh or unique. Reported as
   `fallback_server_observation_truth` and `fallback_nonce_freshness_or_uniqueness`.
+- **Fallback call parameters on this upstream shape.** The vector carries top-level `name` and
+  `arguments`; Assay 5.4.0's named projection reads top-level `params` and substitutes JSON `null`
+  when it is absent. This run therefore does not establish that the call name or arguments are
+  bound by Assay's fallback digest. Tracked as [#2595](https://github.com/Rul1an/assay/issues/2595).
 
 ## The case that was not reproduced
 
@@ -95,6 +99,11 @@ The published text names the source fields (`tools/call` name and arguments, plu
 binding block), but it does not define the projected JSON member names and nesting. That shape is
 part of the JCS bytes, so the identifier alone is not enough for an independent implementation to
 reconstruct the same pre-image.
+
+There is also a distinct Assay-side boundary: for this vector's top-level `name`/`arguments` shape,
+Assay's own projection hashes `params: null`. Changing those two upstream fields alone therefore
+does not change Assay's digest. That behavior is not counted as reproduced here and is separated
+from the upstream member-mapping gap above.
 
 That is a general property rather than a complaint about one profile. It was raised on the SCITT
 Canonical Payload Binding draft and resolved by adding an assembled pre-image member-mapping rule:

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -106,8 +106,12 @@ does not change Assay's digest. That behavior is not counted as reproduced here 
 from the upstream member-mapping gap above.
 
 That is a general property rather than a complaint about one profile. It was raised on the SCITT
-Canonical Payload Binding draft and resolved by adding an assembled pre-image member-mapping rule:
+Canonical Payload Binding draft in
 [action-state-group/scitt-payload-binding#5](https://github.com/action-state-group/scitt-payload-binding/issues/5).
+The issue closed after executable vectors and a proposed `member_mapping` landed in
+[PR #16](https://github.com/action-state-group/scitt-payload-binding/pull/16); the normative section
+and registry-template text were deliberately deferred after prerequisite
+[PR #9](https://github.com/action-state-group/scitt-payload-binding/pull/9) closed unmerged.
 Short version: an identifier that travels is necessary but not sufficient. It has to resolve to a
 published pre-image construction, or it names a shape only its author can build.
 

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -15,8 +15,8 @@ scripts/interop/reproduce-sep2828-decision-pairing.sh
 
 The vectors are published by [vaaraio/vaara](https://github.com/vaaraio/vaara) under
 AGPL-3.0-or-later. The script fetches them at run time and never vendors them into this MIT
-repository. No upstream code is fetched or executed, and every verdict below is computed by
-`assay` from the published JSON wire bytes. Assay computes the individual checks; the local
+repository. No upstream code is fetched or executed. Assay computes the individual checks from
+the published JSON wire bytes; the local
 fallback classifier applies this record's disposition rule to those check results.
 
 ## Why this record exists
@@ -105,12 +105,12 @@ artifact is bad rather than that their pre-image is wrong.
 | Assay | `assay-cli` 5.4.0, release profile |
 | Verifier commands | `assay evidence verify-mcp-records`, `assay evidence verify-mcp-supersession` |
 | Upstream vectors | Vaara `v1.75.0`, `tests/vectors/decision_pairing_v0/normative` at `9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b` |
-| Method | upstream JSON fetched and read; no upstream code fetched or executed; all verdicts computed by `assay` |
+| Method | upstream JSON fetched and read; no upstream code fetched or executed; checks computed by `assay`, recorded fallback disposition applied locally |
 
 The upstream revision is pinned rather than tracked from `main`, because a record whose inputs can
 move is not a record. Drift shows up as a fetch failure instead of as a quietly different number.
 `ASSAY_INTEROP_REV` re-runs the comparison against another commit. The script prints the revision
-and the versions of `assay`, `curl` and `python3` it used, and fails closed on a bad fetch or an
+and the versions of `assay` and `python3` it used, and fails closed on a bad fetch or an
 unexpected tool exit rather than reporting either as a comparison result. Every fetched JSON file
 and the fallback report are bounded to 1 MiB before parsing.
 

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -37,7 +37,7 @@ rather than a sentence in a README.
 | `substituted_pairing_nonce` | Check A fails | attestation digest holds, nonce mismatch, pairing refused |
 | `substituted_decision_under_shared_attestation` | Check A holds, Check B fails | back-links match, `outcomeDerived.decisionDigest` does not |
 | `supersession_equal_decidedat_tie` | `ambiguous` | `ambiguous`, reason `supersession_ambiguous_missing_sequence` |
-| `fallback_envelope_binding` | binding holds | named projection is present; both envelope-digest checks fail, see below |
+| `fallback_envelope_binding` | binding holds | unsupported envelope shape is refused (`fallback_projection_missing_params`); no binding digest is published, see below |
 
 Two of these are worth calling out as good corpus design. `substituted_pairing_nonce` and
 `substituted_decision_under_shared_attestation` are the cases that separate an implementation which
@@ -72,9 +72,10 @@ Declared rather than left to inference:
   observed by the server, equals the back-link nonce, or is fresh or unique. Reported as
   `fallback_server_observation_truth` and `fallback_nonce_freshness_or_uniqueness`.
 - **Fallback call parameters on this upstream shape.** The vector carries top-level `name` and
-  `arguments`; Assay 5.4.0's named projection reads top-level `params` and substitutes JSON `null`
-  when it is absent. This run therefore does not establish that the call name or arguments are
-  bound by Assay's fallback digest. Tracked as [#2595](https://github.com/Rul1an/assay/issues/2595).
+  `arguments`. Assay's named projection requires object-valued `params`, so it fails closed on this
+  shape rather than binding a partial pre-image. This run therefore establishes nothing about
+  whether the call name or arguments are bound. The earlier silent-`null` behavior was fixed in
+  [#2596](https://github.com/Rul1an/assay/pull/2596).
 
 ## The case that was not reproduced
 
@@ -88,10 +89,11 @@ silent. Assay computes `assay.fallback_projection.v0`; the vectors carry
 
 Assay does not implement the upstream projection version, and reconstructing it from the published
 specification text turned out not to be possible. The current vector does publish the request
-envelope, decision, and receipt, so this record now executes the case directly. Assay confirms the
-binding block, request nonce, decision/outcome backlink, outcome decision digest, and result
-commitment. It refuses the pair only on the two request-envelope digest checks. The measured
-Assay projection is `assay.fallback_projection.v0`; the decision names
+envelope, decision, and receipt, so this record now executes the case directly. Assay's named
+pre-image does not resolve for this envelope, so no binding digest is published and the dependent
+decision and outcome digest comparisons are omitted. The refusal is the
+`fallback_projection_missing_params` projection-shape check. The measured Assay projection is
+`assay.fallback_projection.v0`; the decision names
 `tools_call_params_plus_meta_authorization_binding_v1`. Those identifiers denote different object
 shapes and therefore different digest pre-images.
 
@@ -99,11 +101,6 @@ The published text names the source fields (`tools/call` name and arguments, plu
 binding block), but it does not define the projected JSON member names and nesting. That shape is
 part of the JCS bytes, so the identifier alone is not enough for an independent implementation to
 reconstruct the same pre-image.
-
-There is also a distinct Assay-side boundary: for this vector's top-level `name`/`arguments` shape,
-Assay's own projection hashes `params: null`. Changing those two upstream fields alone therefore
-does not change Assay's digest. That behavior is not counted as reproduced here and is separated
-from the upstream member-mapping gap above.
 
 That is a general property rather than a complaint about one profile. It was raised on the SCITT
 Canonical Payload Binding draft in
@@ -124,7 +121,7 @@ artifact is bad rather than that their pre-image is wrong.
 
 | | |
 |---|---|
-| Run | 2026-08-23 |
+| Run | 2026-08-24 |
 | Assay | `assay-cli` 5.4.0, release profile |
 | Verifier commands | `assay evidence verify-mcp-records`, `assay evidence verify-mcp-supersession` |
 | Upstream vectors | Vaara `v1.75.0`, `tests/vectors/decision_pairing_v0/normative` at `9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b` |

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -66,6 +66,11 @@ Declared rather than left to inference:
   `ArgsProjection` form is surfaced on the same terms: shown, not checked.
 - **Runtime effect.** A reproduced verdict says the records bind to each other as specified. It
   does not say the recorded action occurred. Reported as `runtime_side_effect_truth`.
+- **Fallback observation and nonce semantics.** In request-envelope mode, Assay checks its selected
+  envelope projection, requires a nonce on the decision back-link, and requires the decision and
+  outcome back-links to agree. It does not establish that `_meta.authorization_binding.nonce` was
+  observed by the server, equals the back-link nonce, or is fresh or unique. Reported as
+  `fallback_server_observation_truth` and `fallback_nonce_freshness_or_uniqueness`.
 
 ## The case that was not reproduced
 
@@ -86,8 +91,13 @@ Assay projection is `assay.fallback_projection.v0`; the decision names
 `tools_call_params_plus_meta_authorization_binding_v1`. Those identifiers denote different object
 shapes and therefore different digest pre-images.
 
-That is a general property rather than a complaint about one profile, and it is raised as such in
-the venue where the rule is being written, on the SCITT Canonical Payload Binding draft:
+The published text names the source fields (`tools/call` name and arguments, plus the authorization
+binding block), but it does not define the projected JSON member names and nesting. That shape is
+part of the JCS bytes, so the identifier alone is not enough for an independent implementation to
+reconstruct the same pre-image.
+
+That is a general property rather than a complaint about one profile. It was raised on the SCITT
+Canonical Payload Binding draft and resolved by adding an assembled pre-image member-mapping rule:
 [action-state-group/scitt-payload-binding#5](https://github.com/action-state-group/scitt-payload-binding/issues/5).
 Short version: an identifier that travels is necessary but not sufficient. It has to resolve to a
 published pre-image construction, or it names a shape only its author can build.

--- a/docs/interop/sep2828-decision-pairing-v0.md
+++ b/docs/interop/sep2828-decision-pairing-v0.md
@@ -15,8 +15,8 @@ scripts/interop/reproduce-sep2828-decision-pairing.sh
 
 The vectors are published by [vaaraio/vaara](https://github.com/vaaraio/vaara) under
 AGPL-3.0-or-later. The script fetches them at run time and never vendors them into this MIT
-repository. Nothing upstream is executed: the upstream checker is read but not run, and every
-verdict below is computed by `assay` from the wire bytes.
+repository. No upstream code is fetched or executed, and every verdict below is computed by
+`assay` from the published JSON wire bytes.
 
 ## Why this record exists
 
@@ -36,7 +36,7 @@ rather than a sentence in a README.
 | `substituted_pairing_nonce` | Check A fails | attestation digest holds, nonce mismatch, pairing refused |
 | `substituted_decision_under_shared_attestation` | Check A holds, Check B fails | back-links match, `outcomeDerived.decisionDigest` does not |
 | `supersession_equal_decidedat_tie` | `ambiguous` | `ambiguous`, reason `supersession_ambiguous_missing_sequence` |
-| `fallback_envelope_binding` | binding holds | not reproduced, see below |
+| `fallback_envelope_binding` | binding holds | named projection is present; both envelope-digest checks fail, see below |
 
 Two of these are worth calling out as good corpus design. `substituted_pairing_nonce` and
 `substituted_decision_under_shared_attestation` are the cases that separate an implementation which
@@ -77,11 +77,13 @@ silent. Assay computes `assay.fallback_projection.v0`; the vectors carry
 `tools_call_params_plus_meta_authorization_binding_v1`.
 
 Assay does not implement the upstream projection version, and reconstructing it from the published
-specification text turned out not to be possible. The text declares the allowlist exactly, the
-`tools/call` `name` and `arguments` plus the named binding block, which fixes *which* fields enter
-the pre-image. It does not fix the *shape* of the object the digest is taken over, and the shape is
-part of the bytes. Five readings of the published prose were tried before the reference checker's
-source settled it.
+specification text turned out not to be possible. The current vector does publish the request
+envelope, decision, and receipt, so this record now executes the case directly. Assay confirms the
+binding block, request nonce, decision/outcome backlink, outcome decision digest, and result
+commitment. It refuses the pair only on the two request-envelope digest checks. The measured
+Assay projection is `assay.fallback_projection.v0`; the decision names
+`tools_call_params_plus_meta_authorization_binding_v1`. Those identifiers denote different object
+shapes and therefore different digest pre-images.
 
 That is a general property rather than a complaint about one profile, and it is raised as such in
 the venue where the rule is being written, on the SCITT Canonical Payload Binding draft:
@@ -98,11 +100,11 @@ artifact is bad rather than that their pre-image is wrong.
 
 | | |
 |---|---|
-| Run | 2026-08-03 |
-| Assay | `assay-cli` 3.37.0, release profile |
+| Run | 2026-08-23 |
+| Assay | `assay-cli` 5.4.0, release profile |
 | Verifier commands | `assay evidence verify-mcp-records`, `assay evidence verify-mcp-supersession` |
-| Upstream vectors | `tests/vectors/decision_pairing_v0/normative` at `519d3df8749bc0adbd79b28d0fb3d19142ababc7` |
-| Method | upstream JSON read; upstream checker read, not executed; all verdicts computed by `assay` |
+| Upstream vectors | Vaara `v1.75.0`, `tests/vectors/decision_pairing_v0/normative` at `9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b` |
+| Method | upstream JSON fetched and read; no upstream code fetched or executed; all verdicts computed by `assay` |
 
 The upstream revision is pinned rather than tracked from `main`, because a record whose inputs can
 move is not a record. Drift shows up as a fetch failure instead of as a quietly different number.
@@ -112,4 +114,6 @@ unexpected tool exit rather than reporting either as a comparison result.
 
 The comparison is per check, not per case. Each row above pins the specific check ids that must
 pass and must fail, so a case that reaches the right overall verdict for the wrong reason is
-reported as a divergence.
+reported as a divergence. The fallback row also pins Assay's binding mode, projection identifier,
+and digest source. A newly reproduced fallback is likewise reported as drift until this record is
+updated; the script cannot silently retain the 6-of-7 result.

--- a/scripts/ci/test_classify_sep2828_fallback.py
+++ b/scripts/ci/test_classify_sep2828_fallback.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CLASSIFIER = ROOT / "scripts" / "interop" / "classify_sep2828_fallback.py"
+
+
+class FallbackClassificationTests(unittest.TestCase):
+    def classify(self, report: dict, decision: dict) -> tuple[int, dict]:
+        self.assertTrue(CLASSIFIER.is_file(), f"missing classifier: {CLASSIFIER}")
+        with tempfile.TemporaryDirectory() as tmp:
+            report_path = Path(tmp) / "report.json"
+            decision_path = Path(tmp) / "decision.json"
+            report_path.write_text(json.dumps(report))
+            decision_path.write_text(json.dumps(decision))
+            completed = subprocess.run(
+                ["python3", str(CLASSIFIER), str(report_path), str(decision_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        return completed.returncode, json.loads(completed.stdout)
+
+    @staticmethod
+    def report(*, ok: bool, false_checks: list[str]) -> dict:
+        required_true = {
+            "fallback_projection_binding_present",
+            "decision_request_envelope_nonce_present",
+            "decision_outcome_backlink_match",
+            "outcome_decision_digest_match",
+            "result_commitment_projection_digest_match",
+        }
+        return {
+            "ok": ok,
+            "binding": {
+                "mode": "request_envelope",
+                "projection": "assay.fallback_projection.v0",
+                "digest_source": "request_envelope_named_projection_jcs",
+            },
+            "checks": [
+                {"id": check_id, "ok": check_id in required_true}
+                for check_id in sorted(required_true | set(false_checks))
+            ],
+        }
+
+    @staticmethod
+    def decision(projection: object = "tools_call_params_plus_meta_authorization_binding_v1") -> dict:
+        return {"backLink": {"fallbackProjection": projection}}
+
+    def test_exact_projection_mismatch_is_documented_non_reproduction(self) -> None:
+        rc, result = self.classify(
+            self.report(
+                ok=False,
+                false_checks=[
+                    "decision_request_envelope_digest_match",
+                    "outcome_request_envelope_digest_match",
+                ],
+            ),
+            self.decision(),
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "documented_non_reproduction")
+        self.assertEqual(result["assay_projection"], "assay.fallback_projection.v0")
+        self.assertEqual(
+            result["upstream_projection"],
+            "tools_call_params_plus_meta_authorization_binding_v1",
+        )
+
+    def test_unexpected_failure_is_a_divergence(self) -> None:
+        rc, result = self.classify(
+            self.report(ok=False, false_checks=["outcome_decision_digest_match"]),
+            self.decision(),
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+    def test_success_is_reported_as_reproduced_drift(self) -> None:
+        rc, result = self.classify(self.report(ok=True, false_checks=[]), self.decision())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "reproduced")
+
+    def test_missing_upstream_projection_is_a_divergence(self) -> None:
+        rc, result = self.classify(
+            self.report(
+                ok=False,
+                false_checks=[
+                    "decision_request_envelope_digest_match",
+                    "outcome_request_envelope_digest_match",
+                ],
+            ),
+            self.decision(None),
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_classify_sep2828_fallback.py
+++ b/scripts/ci/test_classify_sep2828_fallback.py
@@ -45,7 +45,7 @@ class FallbackClassificationTests(unittest.TestCase):
                 "digest_source": "request_envelope_named_projection_jcs",
             },
             "checks": [
-                {"id": check_id, "ok": check_id in required_true}
+                {"id": check_id, "ok": check_id not in false_checks}
                 for check_id in sorted(required_true | set(false_checks))
             ],
         }
@@ -103,6 +103,41 @@ class FallbackClassificationTests(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertEqual(result["classification"], "diverged")
+
+    def test_missing_overall_verdict_is_a_divergence(self) -> None:
+        report = self.report(
+            ok=False,
+            false_checks=[
+                "decision_request_envelope_digest_match",
+                "outcome_request_envelope_digest_match",
+            ],
+        )
+        del report["ok"]
+
+        rc, result = self.classify(report, self.decision())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+    def test_each_binding_field_is_load_bearing(self) -> None:
+        expected_false = [
+            "decision_request_envelope_digest_match",
+            "outcome_request_envelope_digest_match",
+        ]
+        mutations = {
+            "mode": "attestation",
+            "projection": "another.assay.projection.v0",
+            "digest_source": "whole_request_envelope_jcs",
+        }
+        for field, replacement in mutations.items():
+            with self.subTest(field=field):
+                report = self.report(ok=False, false_checks=expected_false)
+                report["binding"][field] = replacement
+
+                rc, result = self.classify(report, self.decision())
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(result["classification"], "diverged")
 
     def test_different_upstream_projection_is_a_divergence(self) -> None:
         rc, result = self.classify(

--- a/scripts/ci/test_classify_sep2828_fallback.py
+++ b/scripts/ci/test_classify_sep2828_fallback.py
@@ -10,17 +10,23 @@ CLASSIFIER = ROOT / "scripts" / "interop" / "classify_sep2828_fallback.py"
 
 
 class FallbackClassificationTests(unittest.TestCase):
+    MAX_REPORT_BYTES = 1024 * 1024
+
     def classify(self, report: dict, decision: dict) -> tuple[int, dict]:
+        return self.classify_raw(json.dumps(report), decision)
+
+    def classify_raw(self, report: str, decision: dict) -> tuple[int, dict | None]:
         self.assertTrue(CLASSIFIER.is_file(), f"missing classifier: {CLASSIFIER}")
         projection = decision.get("backLink", {}).get("fallbackProjection")
         completed = subprocess.run(
             ["python3", str(CLASSIFIER), json.dumps(projection)],
-            input=json.dumps(report),
+            input=report,
             check=False,
             capture_output=True,
             text=True,
         )
-        return completed.returncode, json.loads(completed.stdout)
+        result = json.loads(completed.stdout) if completed.stdout else None
+        return completed.returncode, result
 
     @staticmethod
     def report(*, ok: bool, false_checks: list[str]) -> dict:
@@ -97,6 +103,47 @@ class FallbackClassificationTests(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertEqual(result["classification"], "diverged")
+
+    def test_different_upstream_projection_is_a_divergence(self) -> None:
+        rc, result = self.classify(
+            self.report(
+                ok=False,
+                false_checks=[
+                    "decision_request_envelope_digest_match",
+                    "outcome_request_envelope_digest_match",
+                ],
+            ),
+            self.decision("another_named_projection_v2"),
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+    def test_duplicate_check_id_is_a_divergence(self) -> None:
+        report = self.report(
+            ok=False,
+            false_checks=[
+                "decision_request_envelope_digest_match",
+                "outcome_request_envelope_digest_match",
+            ],
+        )
+        report["checks"].insert(
+            0,
+            {"id": "decision_request_envelope_digest_match", "ok": True},
+        )
+
+        rc, result = self.classify(report, self.decision())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+    def test_oversized_report_fails_closed(self) -> None:
+        oversized = json.dumps({"padding": "x" * self.MAX_REPORT_BYTES})
+
+        rc, result = self.classify_raw(oversized, self.decision())
+
+        self.assertEqual(rc, 2)
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_classify_sep2828_fallback.py
+++ b/scripts/ci/test_classify_sep2828_fallback.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import json
 import subprocess
-import tempfile
 import unittest
 from pathlib import Path
 
@@ -13,17 +12,14 @@ CLASSIFIER = ROOT / "scripts" / "interop" / "classify_sep2828_fallback.py"
 class FallbackClassificationTests(unittest.TestCase):
     def classify(self, report: dict, decision: dict) -> tuple[int, dict]:
         self.assertTrue(CLASSIFIER.is_file(), f"missing classifier: {CLASSIFIER}")
-        with tempfile.TemporaryDirectory() as tmp:
-            report_path = Path(tmp) / "report.json"
-            decision_path = Path(tmp) / "decision.json"
-            report_path.write_text(json.dumps(report))
-            decision_path.write_text(json.dumps(decision))
-            completed = subprocess.run(
-                ["python3", str(CLASSIFIER), str(report_path), str(decision_path)],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
+        projection = decision.get("backLink", {}).get("fallbackProjection")
+        completed = subprocess.run(
+            ["python3", str(CLASSIFIER), json.dumps(projection)],
+            input=json.dumps(report),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
         return completed.returncode, json.loads(completed.stdout)
 
     @staticmethod

--- a/scripts/ci/test_classify_sep2828_fallback.py
+++ b/scripts/ci/test_classify_sep2828_fallback.py
@@ -51,10 +51,41 @@ class FallbackClassificationTests(unittest.TestCase):
         }
 
     @staticmethod
+    def missing_params_report() -> dict:
+        return {
+            "ok": False,
+            "binding": {
+                "mode": "request_envelope",
+                "projection": "assay.fallback_projection.v0",
+                "digest_source": "request_envelope_named_projection_jcs",
+                "digest": None,
+            },
+            "checks": [
+                {"id": "fallback_projection_missing_params", "ok": False},
+                {"id": "decision_request_envelope_nonce_present", "ok": True},
+                {"id": "decision_outcome_backlink_match", "ok": True},
+                {"id": "outcome_decision_digest_match", "ok": True},
+                {"id": "result_commitment_projection_digest_match", "ok": True},
+            ],
+            "claims_not_made": ["fallback_call_parameter_binding"],
+        }
+
+    @staticmethod
     def decision(projection: object = "tools_call_params_plus_meta_authorization_binding_v1") -> dict:
         return {"backLink": {"fallbackProjection": projection}}
 
     def test_exact_projection_mismatch_is_documented_non_reproduction(self) -> None:
+        rc, result = self.classify(self.missing_params_report(), self.decision())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "documented_non_reproduction")
+        self.assertEqual(result["assay_projection"], "assay.fallback_projection.v0")
+        self.assertEqual(
+            result["upstream_projection"],
+            "tools_call_params_plus_meta_authorization_binding_v1",
+        )
+
+    def test_historical_digest_mismatch_shape_is_now_drift(self) -> None:
         rc, result = self.classify(
             self.report(
                 ok=False,
@@ -67,12 +98,82 @@ class FallbackClassificationTests(unittest.TestCase):
         )
 
         self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+    def test_unresolved_projection_must_not_publish_a_digest(self) -> None:
+        for replacement in ("missing", "sha256:unresolved"):
+            with self.subTest(replacement=replacement):
+                report = self.missing_params_report()
+                if replacement == "missing":
+                    del report["binding"]["digest"]
+                else:
+                    report["binding"]["digest"] = replacement
+
+                rc, result = self.classify(report, self.decision())
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(result["classification"], "diverged")
+
+    def test_missing_params_is_the_only_accepted_shape_reason(self) -> None:
+        report = self.missing_params_report()
+        report["checks"][0]["id"] = "fallback_projection_invalid_params"
+
+        rc, result = self.classify(report, self.decision())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+    def test_unresolved_projection_requires_parameter_binding_nonclaim(self) -> None:
+        report = self.missing_params_report()
+        report["claims_not_made"] = []
+
+        rc, result = self.classify(report, self.decision())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result["classification"], "diverged")
+
+    def test_unresolved_projection_omits_checks_that_require_a_resolved_preimage(self) -> None:
+        for check_id in (
+            "fallback_projection_binding_present",
+            "decision_request_envelope_digest_match",
+            "outcome_request_envelope_digest_match",
+        ):
+            with self.subTest(check_id=check_id):
+                report = self.missing_params_report()
+                # Even a green dependent check is drift: it claims a preimage existed.
+                report["checks"].append({"id": check_id, "ok": True})
+
+                rc, result = self.classify(report, self.decision())
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(result["classification"], "diverged")
+
+    def test_each_remaining_pairing_check_is_required(self) -> None:
+        for check_id in (
+            "decision_request_envelope_nonce_present",
+            "decision_outcome_backlink_match",
+            "outcome_decision_digest_match",
+            "result_commitment_projection_digest_match",
+        ):
+            with self.subTest(check_id=check_id):
+                report = self.missing_params_report()
+                report["checks"] = [
+                    check for check in report["checks"] if check["id"] != check_id
+                ]
+
+                rc, result = self.classify(report, self.decision())
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(result["classification"], "diverged")
+
+    def test_check_order_does_not_change_the_classification(self) -> None:
+        report = self.missing_params_report()
+        report["checks"].reverse()
+
+        rc, result = self.classify(report, self.decision())
+
+        self.assertEqual(rc, 0)
         self.assertEqual(result["classification"], "documented_non_reproduction")
-        self.assertEqual(result["assay_projection"], "assay.fallback_projection.v0")
-        self.assertEqual(
-            result["upstream_projection"],
-            "tools_call_params_plus_meta_authorization_binding_v1",
-        )
 
     def test_unexpected_failure_is_a_divergence(self) -> None:
         rc, result = self.classify(
@@ -90,28 +191,13 @@ class FallbackClassificationTests(unittest.TestCase):
         self.assertEqual(result["classification"], "reproduced")
 
     def test_missing_upstream_projection_is_a_divergence(self) -> None:
-        rc, result = self.classify(
-            self.report(
-                ok=False,
-                false_checks=[
-                    "decision_request_envelope_digest_match",
-                    "outcome_request_envelope_digest_match",
-                ],
-            ),
-            self.decision(None),
-        )
+        rc, result = self.classify(self.missing_params_report(), self.decision(None))
 
         self.assertEqual(rc, 0)
         self.assertEqual(result["classification"], "diverged")
 
     def test_missing_overall_verdict_is_a_divergence(self) -> None:
-        report = self.report(
-            ok=False,
-            false_checks=[
-                "decision_request_envelope_digest_match",
-                "outcome_request_envelope_digest_match",
-            ],
-        )
+        report = self.missing_params_report()
         del report["ok"]
 
         rc, result = self.classify(report, self.decision())
@@ -120,10 +206,6 @@ class FallbackClassificationTests(unittest.TestCase):
         self.assertEqual(result["classification"], "diverged")
 
     def test_each_binding_field_is_load_bearing(self) -> None:
-        expected_false = [
-            "decision_request_envelope_digest_match",
-            "outcome_request_envelope_digest_match",
-        ]
         mutations = {
             "mode": "attestation",
             "projection": "another.assay.projection.v0",
@@ -131,7 +213,7 @@ class FallbackClassificationTests(unittest.TestCase):
         }
         for field, replacement in mutations.items():
             with self.subTest(field=field):
-                report = self.report(ok=False, false_checks=expected_false)
+                report = self.missing_params_report()
                 report["binding"][field] = replacement
 
                 rc, result = self.classify(report, self.decision())
@@ -141,13 +223,7 @@ class FallbackClassificationTests(unittest.TestCase):
 
     def test_different_upstream_projection_is_a_divergence(self) -> None:
         rc, result = self.classify(
-            self.report(
-                ok=False,
-                false_checks=[
-                    "decision_request_envelope_digest_match",
-                    "outcome_request_envelope_digest_match",
-                ],
-            ),
+            self.missing_params_report(),
             self.decision("another_named_projection_v2"),
         )
 
@@ -155,22 +231,31 @@ class FallbackClassificationTests(unittest.TestCase):
         self.assertEqual(result["classification"], "diverged")
 
     def test_duplicate_check_id_is_a_divergence(self) -> None:
-        report = self.report(
-            ok=False,
-            false_checks=[
-                "decision_request_envelope_digest_match",
-                "outcome_request_envelope_digest_match",
-            ],
-        )
+        report = self.missing_params_report()
         report["checks"].insert(
             0,
-            {"id": "decision_request_envelope_digest_match", "ok": True},
+            {"id": "fallback_projection_missing_params", "ok": True},
         )
 
         rc, result = self.classify(report, self.decision())
 
         self.assertEqual(rc, 0)
         self.assertEqual(result["classification"], "diverged")
+
+    def test_malformed_extra_check_is_a_divergence(self) -> None:
+        for malformed in (
+            {"id": "extra_without_ok"},
+            {"id": 7, "ok": False},
+            "not-a-check",
+        ):
+            with self.subTest(malformed=malformed):
+                report = self.missing_params_report()
+                report["checks"].append(malformed)
+
+                rc, result = self.classify(report, self.decision())
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(result["classification"], "diverged")
 
     def test_oversized_report_fails_closed(self) -> None:
         oversized = json.dumps({"padding": "x" * self.MAX_REPORT_BYTES})

--- a/scripts/ci/test_reproduce_sep2828_decision_pairing.py
+++ b/scripts/ci/test_reproduce_sep2828_decision_pairing.py
@@ -114,25 +114,33 @@ class ReproductionFunnelTests(unittest.TestCase):
                 }
                 if case == "fallback":
                     required = {
-                        "fallback_projection_binding_present": True,
+                        "fallback_projection_missing_params": False,
                         "decision_request_envelope_nonce_present": True,
                         "decision_outcome_backlink_match": True,
                         "outcome_decision_digest_match": True,
                         "result_commitment_projection_digest_match": True,
-                        "decision_request_envelope_digest_match": False,
-                        "outcome_request_envelope_digest_match": False,
                     }
                     ok = os.environ.get("FAKE_FALLBACK_REPRODUCED") == "1"
                     if ok:
-                        required = {key: True for key in required}
+                        required = {
+                            "fallback_projection_binding_present": True,
+                            "decision_request_envelope_nonce_present": True,
+                            "decision_request_envelope_digest_match": True,
+                            "decision_outcome_backlink_match": True,
+                            "outcome_request_envelope_digest_match": True,
+                            "outcome_decision_digest_match": True,
+                            "result_commitment_projection_digest_match": True,
+                        }
                     report = {
                         "ok": ok,
                         "binding": {
                             "mode": "request_envelope",
                             "projection": "assay.fallback_projection.v0",
                             "digest_source": "request_envelope_named_projection_jcs",
+                            "digest": "sha256:future" if ok else None,
                         },
                         "checks": [{"id": key, "ok": value} for key, value in required.items()],
+                        "claims_not_made": [] if ok else ["fallback_call_parameter_binding"],
                     }
                     if os.environ.get("FAKE_FALLBACK_OMIT_OK") == "1":
                         del report["ok"]
@@ -169,6 +177,10 @@ class ReproductionFunnelTests(unittest.TestCase):
         completed = self.run_script()
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn(
+            "not reproduced (unsupported named-projection envelope shape)",
+            completed.stdout,
+        )
         self.assertIn("reproduced: 6   diverged: 0   documented non-reproduction: 1", completed.stdout)
         invocations = [json.loads(line) for line in self.invocations.read_text().splitlines()]
         fallback = [args for args in invocations if "--request-envelope" in args]

--- a/scripts/ci/test_reproduce_sep2828_decision_pairing.py
+++ b/scripts/ci/test_reproduce_sep2828_decision_pairing.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = Path(
+    os.environ.get(
+        "ASSAY_SEP2828_REPRO_SCRIPT",
+        ROOT / "scripts" / "interop" / "reproduce-sep2828-decision-pairing.sh",
+    )
+)
+
+
+class ReproductionFunnelTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.upstream = self.root / "upstream"
+        self.invocations = self.root / "invocations.jsonl"
+        self.assay = self.root / "assay"
+        self._write_vectors()
+        self._write_fake_assay()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _write(self, case: str, name: str, value: dict) -> None:
+        destination = self.upstream / case / name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(json.dumps(value), encoding="utf-8")
+
+    def _write_vectors(self) -> None:
+        cases = {
+            "valid_pair_allow_executed": (True, True),
+            "decision_only_escalate": (True, False),
+            "substituted_attestation_backlink": (True, True),
+            "substituted_pairing_nonce": (True, True),
+            "substituted_decision_under_shared_attestation": (True, True),
+        }
+        for case, (attestation, receipt) in cases.items():
+            self._write(case, "decision.json", {"case": case})
+            if attestation:
+                self._write(case, "attestation.json", {"case": case})
+            if receipt:
+                self._write(case, "receipt.json", {"case": case})
+        self._write("supersession_equal_decidedat_tie", "decision_a.json", {"case": "supersession"})
+        self._write("supersession_equal_decidedat_tie", "decision_b.json", {"case": "supersession"})
+        self._write("fallback_envelope_binding", "request_envelope.json", {"request": "fallback"})
+        self._write(
+            "fallback_envelope_binding",
+            "decision.json",
+            {
+                "case": "fallback",
+                "backLink": {
+                    "fallbackProjection": "tools_call_params_plus_meta_authorization_binding_v1"
+                },
+            },
+        )
+        self._write("fallback_envelope_binding", "receipt.json", {"case": "fallback"})
+
+    def _write_fake_assay(self) -> None:
+        self.assay.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json, os, pathlib, sys
+
+                args = sys.argv[1:]
+                if args == ["--version"]:
+                    print("assay 5.4.0-test")
+                    raise SystemExit(0)
+                if os.environ.get("FAKE_ASSAY_FAIL") == "1":
+                    raise SystemExit(17)
+                log = pathlib.Path(os.environ["ASSAY_TEST_INVOCATIONS"])
+                with log.open("a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(args) + "\\n")
+                if "verify-mcp-supersession" in args:
+                    print(json.dumps({"groups": [{"verdict": "ambiguous", "reason_code": "supersession_ambiguous_missing_sequence"}]}))
+                    raise SystemExit(0)
+                decision = json.load(open(args[args.index("--decision") + 1], encoding="utf-8"))
+                case = decision["case"]
+                expected = {
+                    "valid_pair_allow_executed": (True, {
+                        "decision_outcome_backlink_match": True,
+                        "outcome_decision_digest_match": True,
+                        "result_commitment_projection_digest_match": True,
+                    }),
+                    "decision_only_escalate": (True, {
+                        "decision_attestation_digest_match": True,
+                        "outcome_absent": True,
+                    }),
+                    "substituted_attestation_backlink": (False, {
+                        "decision_attestation_digest_match": True,
+                        "outcome_attestation_digest_match": False,
+                        "decision_outcome_backlink_match": False,
+                    }),
+                    "substituted_pairing_nonce": (False, {
+                        "outcome_attestation_digest_match": True,
+                        "outcome_attestation_nonce_match": False,
+                        "decision_outcome_backlink_match": False,
+                    }),
+                    "substituted_decision_under_shared_attestation": (False, {
+                        "decision_outcome_backlink_match": True,
+                        "outcome_decision_digest_match": False,
+                    }),
+                }
+                if case == "fallback":
+                    required = {
+                        "fallback_projection_binding_present": True,
+                        "decision_request_envelope_nonce_present": True,
+                        "decision_outcome_backlink_match": True,
+                        "outcome_decision_digest_match": True,
+                        "result_commitment_projection_digest_match": True,
+                        "decision_request_envelope_digest_match": False,
+                        "outcome_request_envelope_digest_match": False,
+                    }
+                    ok = os.environ.get("FAKE_FALLBACK_REPRODUCED") == "1"
+                    if ok:
+                        required = {key: True for key in required}
+                    report = {
+                        "ok": ok,
+                        "binding": {
+                            "mode": "request_envelope",
+                            "projection": "assay.fallback_projection.v0",
+                            "digest_source": "request_envelope_named_projection_jcs",
+                        },
+                        "checks": [{"id": key, "ok": value} for key, value in required.items()],
+                    }
+                    if os.environ.get("FAKE_FALLBACK_OMIT_OK") == "1":
+                        del report["ok"]
+                    print(json.dumps(report))
+                    raise SystemExit(0 if ok else 2)
+                ok, checks = expected[case]
+                print(json.dumps({"ok": ok, "checks": [{"id": key, "ok": value} for key, value in checks.items()]}))
+                raise SystemExit(0 if ok else 2)
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.assay.chmod(0o755)
+
+    def run_script(self, **extra_env: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "ASSAY_INTEROP_UPSTREAM_BASE": self.upstream.as_uri(),
+                "ASSAY_TEST_INVOCATIONS": str(self.invocations),
+                **extra_env,
+            }
+        )
+        return subprocess.run(
+            ["bash", str(SCRIPT), str(self.assay)],
+            cwd=ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_full_funnel_executes_named_fallback_and_records_six_zero_one(self) -> None:
+        completed = self.run_script()
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("reproduced: 6   diverged: 0   documented non-reproduction: 1", completed.stdout)
+        invocations = [json.loads(line) for line in self.invocations.read_text().splitlines()]
+        fallback = [args for args in invocations if "--request-envelope" in args]
+        self.assertEqual(len(fallback), 1)
+        self.assertIn("--fallback-projection", fallback[0])
+        self.assertEqual(fallback[0][fallback[0].index("--fallback-projection") + 1], "named")
+
+    def test_classifier_result_controls_the_final_count(self) -> None:
+        completed = self.run_script(FAKE_FALLBACK_REPRODUCED="1")
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("now reproduced; update the recorded result", completed.stdout)
+
+    def test_missing_fallback_overall_verdict_is_drift(self) -> None:
+        completed = self.run_script(FAKE_FALLBACK_OMIT_OK="1")
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("unexpected fallback failure", completed.stdout)
+
+    def test_pairing_tool_failure_is_setup_failure(self) -> None:
+        completed = self.run_script(FAKE_ASSAY_FAIL="1")
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("assay exited 17", completed.stderr)
+
+    def test_oversized_vector_is_rejected_before_publish(self) -> None:
+        oversized = self.upstream / "valid_pair_allow_executed" / "decision.json"
+        oversized.write_bytes(b"x" * (1024 * 1024 + 1))
+
+        completed = self.run_script()
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("exceeds ceiling", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/interop/classify_sep2828_fallback.py
+++ b/scripts/interop/classify_sep2828_fallback.py
@@ -57,7 +57,8 @@ def classify(report: dict, upstream_projection: object) -> dict:
             binding.get(key) == value for key, value in EXPECTED_BINDING.items()
         )
         exact_mismatch = (
-            exact_binding
+            report.get("ok") is False
+            and exact_binding
             and upstream_projection == EXPECTED_UPSTREAM_PROJECTION
             and upstream_projection != assay_projection
             and not duplicate_check_ids

--- a/scripts/interop/classify_sep2828_fallback.py
+++ b/scripts/interop/classify_sep2828_fallback.py
@@ -3,7 +3,6 @@
 
 import json
 import sys
-from pathlib import Path
 
 
 EXPECTED_FALSE = {
@@ -24,18 +23,16 @@ EXPECTED_BINDING = {
 }
 
 
-def load_object(path: str) -> dict:
-    value = json.loads(Path(path).read_text())
+def load_report() -> dict:
+    value = json.load(sys.stdin)
     if not isinstance(value, dict):
-        raise ValueError(f"{path} must contain a JSON object")
+        raise ValueError("stdin must contain a JSON object")
     return value
 
 
-def classify(report: dict, decision: dict) -> dict:
+def classify(report: dict, upstream_projection: object) -> dict:
     binding = report.get("binding")
     checks_raw = report.get("checks")
-    upstream = decision.get("backLink")
-    upstream_projection = upstream.get("fallbackProjection") if isinstance(upstream, dict) else None
     assay_projection = binding.get("projection") if isinstance(binding, dict) else None
 
     checks = {}
@@ -70,12 +67,13 @@ def classify(report: dict, decision: dict) -> dict:
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
-        print("usage: classify_sep2828_fallback.py REPORT DECISION", file=sys.stderr)
+    if len(sys.argv) != 2:
+        print("usage: classify_sep2828_fallback.py UPSTREAM_PROJECTION_JSON < REPORT", file=sys.stderr)
         return 2
     try:
-        result = classify(load_object(sys.argv[1]), load_object(sys.argv[2]))
-    except (OSError, ValueError, json.JSONDecodeError) as error:
+        upstream_projection = json.loads(sys.argv[1])
+        result = classify(load_report(), upstream_projection)
+    except (ValueError, json.JSONDecodeError) as error:
         print(f"failed to classify fallback result: {error}", file=sys.stderr)
         return 2
     print(json.dumps(result, sort_keys=True, separators=(",", ":")))

--- a/scripts/interop/classify_sep2828_fallback.py
+++ b/scripts/interop/classify_sep2828_fallback.py
@@ -9,6 +9,8 @@ EXPECTED_FALSE = {
     "decision_request_envelope_digest_match",
     "outcome_request_envelope_digest_match",
 }
+EXPECTED_UPSTREAM_PROJECTION = "tools_call_params_plus_meta_authorization_binding_v1"
+MAX_REPORT_BYTES = 1024 * 1024
 REQUIRED_TRUE = {
     "fallback_projection_binding_present",
     "decision_request_envelope_nonce_present",
@@ -24,7 +26,10 @@ EXPECTED_BINDING = {
 
 
 def load_report() -> dict:
-    value = json.load(sys.stdin)
+    raw = sys.stdin.buffer.read(MAX_REPORT_BYTES + 1)
+    if len(raw) > MAX_REPORT_BYTES:
+        raise ValueError(f"stdin exceeds {MAX_REPORT_BYTES} bytes")
+    value = json.loads(raw)
     if not isinstance(value, dict):
         raise ValueError("stdin must contain a JSON object")
     return value
@@ -36,9 +41,12 @@ def classify(report: dict, upstream_projection: object) -> dict:
     assay_projection = binding.get("projection") if isinstance(binding, dict) else None
 
     checks = {}
+    duplicate_check_ids = set()
     if isinstance(checks_raw, list):
         for check in checks_raw:
             if isinstance(check, dict) and isinstance(check.get("id"), str):
+                if check["id"] in checks:
+                    duplicate_check_ids.add(check["id"])
                 checks[check["id"]] = check.get("ok")
     false_checks = sorted(check_id for check_id, ok in checks.items() if ok is False)
 
@@ -50,9 +58,9 @@ def classify(report: dict, upstream_projection: object) -> dict:
         )
         exact_mismatch = (
             exact_binding
-            and isinstance(upstream_projection, str)
-            and upstream_projection
+            and upstream_projection == EXPECTED_UPSTREAM_PROJECTION
             and upstream_projection != assay_projection
+            and not duplicate_check_ids
             and set(false_checks) == EXPECTED_FALSE
             and all(checks.get(check_id) is True for check_id in REQUIRED_TRUE)
         )
@@ -63,6 +71,7 @@ def classify(report: dict, upstream_projection: object) -> dict:
         "assay_projection": assay_projection,
         "upstream_projection": upstream_projection,
         "false_checks": false_checks,
+        "duplicate_check_ids": sorted(duplicate_check_ids),
     }
 
 

--- a/scripts/interop/classify_sep2828_fallback.py
+++ b/scripts/interop/classify_sep2828_fallback.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Classify Assay's measured SEP-2828 fallback result without hiding drift."""
+
+import json
+import sys
+from pathlib import Path
+
+
+EXPECTED_FALSE = {
+    "decision_request_envelope_digest_match",
+    "outcome_request_envelope_digest_match",
+}
+REQUIRED_TRUE = {
+    "fallback_projection_binding_present",
+    "decision_request_envelope_nonce_present",
+    "decision_outcome_backlink_match",
+    "outcome_decision_digest_match",
+    "result_commitment_projection_digest_match",
+}
+EXPECTED_BINDING = {
+    "mode": "request_envelope",
+    "projection": "assay.fallback_projection.v0",
+    "digest_source": "request_envelope_named_projection_jcs",
+}
+
+
+def load_object(path: str) -> dict:
+    value = json.loads(Path(path).read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def classify(report: dict, decision: dict) -> dict:
+    binding = report.get("binding")
+    checks_raw = report.get("checks")
+    upstream = decision.get("backLink")
+    upstream_projection = upstream.get("fallbackProjection") if isinstance(upstream, dict) else None
+    assay_projection = binding.get("projection") if isinstance(binding, dict) else None
+
+    checks = {}
+    if isinstance(checks_raw, list):
+        for check in checks_raw:
+            if isinstance(check, dict) and isinstance(check.get("id"), str):
+                checks[check["id"]] = check.get("ok")
+    false_checks = sorted(check_id for check_id, ok in checks.items() if ok is False)
+
+    if report.get("ok") is True:
+        disposition = "reproduced"
+    else:
+        exact_binding = isinstance(binding, dict) and all(
+            binding.get(key) == value for key, value in EXPECTED_BINDING.items()
+        )
+        exact_mismatch = (
+            exact_binding
+            and isinstance(upstream_projection, str)
+            and upstream_projection
+            and upstream_projection != assay_projection
+            and set(false_checks) == EXPECTED_FALSE
+            and all(checks.get(check_id) is True for check_id in REQUIRED_TRUE)
+        )
+        disposition = "documented_non_reproduction" if exact_mismatch else "diverged"
+
+    return {
+        "classification": disposition,
+        "assay_projection": assay_projection,
+        "upstream_projection": upstream_projection,
+        "false_checks": false_checks,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: classify_sep2828_fallback.py REPORT DECISION", file=sys.stderr)
+        return 2
+    try:
+        result = classify(load_object(sys.argv[1]), load_object(sys.argv[2]))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"failed to classify fallback result: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/interop/classify_sep2828_fallback.py
+++ b/scripts/interop/classify_sep2828_fallback.py
@@ -6,13 +6,17 @@ import sys
 
 
 EXPECTED_FALSE = {
+    "fallback_projection_missing_params",
+}
+FORBIDDEN_UNRESOLVED_CHECKS = {
+    "fallback_projection_binding_present",
     "decision_request_envelope_digest_match",
     "outcome_request_envelope_digest_match",
 }
 EXPECTED_UPSTREAM_PROJECTION = "tools_call_params_plus_meta_authorization_binding_v1"
+REQUIRED_NONCLAIM = "fallback_call_parameter_binding"
 MAX_REPORT_BYTES = 1024 * 1024
 REQUIRED_TRUE = {
-    "fallback_projection_binding_present",
     "decision_request_envelope_nonce_present",
     "decision_outcome_backlink_match",
     "outcome_decision_digest_match",
@@ -38,16 +42,24 @@ def load_report() -> dict:
 def classify(report: dict, upstream_projection: object) -> dict:
     binding = report.get("binding")
     checks_raw = report.get("checks")
+    claims_not_made = report.get("claims_not_made")
     assay_projection = binding.get("projection") if isinstance(binding, dict) else None
 
     checks = {}
     duplicate_check_ids = set()
+    malformed_checks = not isinstance(checks_raw, list)
     if isinstance(checks_raw, list):
         for check in checks_raw:
-            if isinstance(check, dict) and isinstance(check.get("id"), str):
-                if check["id"] in checks:
-                    duplicate_check_ids.add(check["id"])
-                checks[check["id"]] = check.get("ok")
+            if not (
+                isinstance(check, dict)
+                and isinstance(check.get("id"), str)
+                and isinstance(check.get("ok"), bool)
+            ):
+                malformed_checks = True
+                continue
+            if check["id"] in checks:
+                duplicate_check_ids.add(check["id"])
+            checks[check["id"]] = check["ok"]
     false_checks = sorted(check_id for check_id, ok in checks.items() if ok is False)
 
     if report.get("ok") is True:
@@ -56,14 +68,24 @@ def classify(report: dict, upstream_projection: object) -> dict:
         exact_binding = isinstance(binding, dict) and all(
             binding.get(key) == value for key, value in EXPECTED_BINDING.items()
         )
+        unresolved_digest = (
+            isinstance(binding, dict)
+            and "digest" in binding
+            and binding["digest"] is None
+        )
         exact_mismatch = (
             report.get("ok") is False
             and exact_binding
+            and unresolved_digest
             and upstream_projection == EXPECTED_UPSTREAM_PROJECTION
             and upstream_projection != assay_projection
+            and not malformed_checks
             and not duplicate_check_ids
             and set(false_checks) == EXPECTED_FALSE
             and all(checks.get(check_id) is True for check_id in REQUIRED_TRUE)
+            and FORBIDDEN_UNRESOLVED_CHECKS.isdisjoint(checks)
+            and isinstance(claims_not_made, list)
+            and REQUIRED_NONCLAIM in claims_not_made
         )
         disposition = "documented_non_reproduction" if exact_mismatch else "diverged"
 

--- a/scripts/interop/reproduce-sep2828-decision-pairing.sh
+++ b/scripts/interop/reproduce-sep2828-decision-pairing.sh
@@ -22,6 +22,7 @@ REV="${ASSAY_INTEROP_REV:-9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b}"
 UPSTREAM="https://raw.githubusercontent.com/vaaraio/vaara/${REV}/tests/vectors/decision_pairing_v0/normative"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FALLBACK_CLASSIFIER="$SCRIPT_DIR/classify_sep2828_fallback.py"
+MAX_INPUT_BYTES=1048576
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -47,8 +48,12 @@ non_reproduced=0
 
 # A missing or empty fetch is a setup failure, never an absent optional input.
 fetch() { # case, file
-  curl -sfL --max-time 30 "$UPSTREAM/$1/$2" -o "$WORK/$2" || return 1
+  curl -sfL --max-time 30 --max-filesize "$MAX_INPUT_BYTES" \
+    "$UPSTREAM/$1/$2" -o "$WORK/$2" \
+    || die "failed to fetch $1/$2 at $REV within $MAX_INPUT_BYTES bytes"
   [ -s "$WORK/$2" ] || die "empty response for $1/$2 at $REV"
+  [ "$(wc -c <"$WORK/$2")" -le "$MAX_INPUT_BYTES" ] \
+    || die "oversized response for $1/$2 at $REV"
 }
 
 # Runs the verifier and echoes the ids of the checks that passed and failed. Exit code 2 means a

--- a/scripts/interop/reproduce-sep2828-decision-pairing.sh
+++ b/scripts/interop/reproduce-sep2828-decision-pairing.sh
@@ -18,8 +18,10 @@
 set -euo pipefail
 
 ASSAY="${1:-./target/release/assay}"
-REV="${ASSAY_INTEROP_REV:-519d3df8749bc0adbd79b28d0fb3d19142ababc7}"
+REV="${ASSAY_INTEROP_REV:-9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b}"
 UPSTREAM="https://raw.githubusercontent.com/vaaraio/vaara/${REV}/tests/vectors/decision_pairing_v0/normative"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FALLBACK_CLASSIFIER="$SCRIPT_DIR/classify_sep2828_fallback.py"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -29,6 +31,7 @@ die() { echo "$*" >&2; exit 2; }
   || die "assay binary not found at '$ASSAY'. Build it with: cargo build -p assay-cli --release"
 command -v curl >/dev/null 2>&1 || die "curl is required"
 command -v python3 >/dev/null 2>&1 || die "python3 is required"
+[ -f "$FALLBACK_CLASSIFIER" ] || die "fallback classifier not found at '$FALLBACK_CLASSIFIER'"
 
 echo "SEP-2828 decision_pairing_v0, reproduced by Assay as an independent consumer"
 echo "Vectors: vaaraio/vaara (AGPL-3.0-or-later), fetched, not vendored, not executed"
@@ -40,6 +43,7 @@ echo
 
 pass=0
 diverge=0
+non_reproduced=0
 
 # A missing or empty fetch is a setup failure, never an absent optional input.
 fetch() { # case, file
@@ -145,14 +149,44 @@ else
   diverge=$((diverge + 1))
 fi
 
-# The fallback case is a documented non-reproduction: Assay implements its own named projection
-# (assay.fallback_projection.v0) and the upstream projection's pre-image cannot be reconstructed
-# from the published specification text. See docs/interop/sep2828-decision-pairing-v0.md.
-printf '  %-46s not reproduced (upstream projection pre-image, see the record)\n' fallback_envelope_binding
+# The fallback case uses a different named projection in each implementation. Execute it rather
+# than printing a fixed conclusion: only the exact recorded projection mismatch is a documented
+# non-reproduction. A different failure or a new success is drift that must update this record.
+rm -f "$WORK"/*.json
+fetch fallback_envelope_binding request_envelope.json
+fetch fallback_envelope_binding decision.json
+fetch fallback_envelope_binding receipt.json
+fallback_rc=0
+"$ASSAY" evidence verify-mcp-records \
+  --request-envelope "$WORK/request_envelope.json" \
+  --decision "$WORK/decision.json" \
+  --outcome "$WORK/receipt.json" \
+  --fallback-projection named \
+  --format json >"$WORK/fallback_report.json" 2>/dev/null || fallback_rc=$?
+case "$fallback_rc" in 0|2) ;; *) die "assay exited $fallback_rc on fallback_envelope_binding" ;; esac
+fallback_classification="$(python3 "$FALLBACK_CLASSIFIER" \
+  "$WORK/fallback_report.json" "$WORK/decision.json")" \
+  || die "could not classify fallback_envelope_binding"
+fallback_disposition="$(printf '%s' "$fallback_classification" | python3 -c \
+  'import json,sys; print(json.load(sys.stdin)["classification"])')"
+case "$fallback_disposition" in
+  documented_non_reproduction)
+    printf '  %-46s not reproduced (explicit named-projection mismatch)\n' fallback_envelope_binding
+    non_reproduced=$((non_reproduced + 1))
+    ;;
+  reproduced)
+    printf '  %-46s DIVERGES     now reproduced; update the recorded result\n' fallback_envelope_binding
+    diverge=$((diverge + 1))
+    ;;
+  *)
+    printf '  %-46s DIVERGES     unexpected fallback failure\n' fallback_envelope_binding
+    diverge=$((diverge + 1))
+    ;;
+esac
 
 echo
-echo "reproduced: $pass   diverged: $diverge   documented non-reproduction: 1"
-if [ "$diverge" -ne 0 ] || [ "$pass" -ne 6 ]; then
+echo "reproduced: $pass   diverged: $diverge   documented non-reproduction: $non_reproduced"
+if [ "$diverge" -ne 0 ] || [ "$pass" -ne 6 ] || [ "$non_reproduced" -ne 1 ]; then
   echo "Result differs from the recorded 6 of 7. Update docs/interop/sep2828-decision-pairing-v0.md." >&2
   exit 1
 fi

--- a/scripts/interop/reproduce-sep2828-decision-pairing.sh
+++ b/scripts/interop/reproduce-sep2828-decision-pairing.sh
@@ -164,8 +164,13 @@ fallback_rc=0
   --fallback-projection named \
   --format json >"$WORK/fallback_report.json" 2>/dev/null || fallback_rc=$?
 case "$fallback_rc" in 0|2) ;; *) die "assay exited $fallback_rc on fallback_envelope_binding" ;; esac
-fallback_classification="$(python3 "$FALLBACK_CLASSIFIER" \
-  "$WORK/fallback_report.json" "$WORK/decision.json")" \
+upstream_projection_json="$(python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+print(json.dumps(d.get("backLink", {}).get("fallbackProjection"), separators=(",", ":")))
+' <"$WORK/decision.json")" || die "could not read upstream fallback projection"
+fallback_classification="$(python3 "$FALLBACK_CLASSIFIER" "$upstream_projection_json" \
+  <"$WORK/fallback_report.json")" \
   || die "could not classify fallback_envelope_binding"
 fallback_disposition="$(printf '%s' "$fallback_classification" | python3 -c \
   'import json,sys; print(json.load(sys.stdin)["classification"])')"

--- a/scripts/interop/reproduce-sep2828-decision-pairing.sh
+++ b/scripts/interop/reproduce-sep2828-decision-pairing.sh
@@ -19,9 +19,11 @@ set -euo pipefail
 
 ASSAY="${1:-./target/release/assay}"
 REV="${ASSAY_INTEROP_REV:-9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b}"
-UPSTREAM="https://raw.githubusercontent.com/vaaraio/vaara/${REV}/tests/vectors/decision_pairing_v0/normative"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+UPSTREAM="${ASSAY_INTEROP_UPSTREAM_BASE:-https://raw.githubusercontent.com/vaaraio/vaara/${REV}/tests/vectors/decision_pairing_v0/normative}"
 FALLBACK_CLASSIFIER="$SCRIPT_DIR/classify_sep2828_fallback.py"
+BOUNDED_DOWNLOADER_DIR="$REPO_ROOT/scripts/ci"
 MAX_INPUT_BYTES=1048576
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -30,15 +32,16 @@ die() { echo "$*" >&2; exit 2; }
 
 [ -x "$ASSAY" ] || command -v "$ASSAY" >/dev/null 2>&1 \
   || die "assay binary not found at '$ASSAY'. Build it with: cargo build -p assay-cli --release"
-command -v curl >/dev/null 2>&1 || die "curl is required"
 command -v python3 >/dev/null 2>&1 || die "python3 is required"
 [ -f "$FALLBACK_CLASSIFIER" ] || die "fallback classifier not found at '$FALLBACK_CLASSIFIER'"
+[ -f "$BOUNDED_DOWNLOADER_DIR/bounded_download.py" ] \
+  || die "bounded downloader not found at '$BOUNDED_DOWNLOADER_DIR/bounded_download.py'"
 
 echo "SEP-2828 decision_pairing_v0, reproduced by Assay as an independent consumer"
 echo "Vectors: vaaraio/vaara (AGPL-3.0-or-later), fetched, not vendored, not executed"
 echo "Upstream revision: ${REV}"
+echo "Vector base:       ${UPSTREAM}"
 echo "Toolchain:         $("$ASSAY" --version 2>/dev/null || echo 'assay ?')"
-echo "                   $(curl --version 2>/dev/null | head -1 | cut -d' ' -f1-2)"
 echo "                   $(python3 --version 2>&1)"
 echo
 
@@ -48,30 +51,37 @@ non_reproduced=0
 
 # A missing or empty fetch is a setup failure, never an absent optional input.
 fetch() { # case, file
-  curl -sfL --max-time 30 --max-filesize "$MAX_INPUT_BYTES" \
-    "$UPSTREAM/$1/$2" -o "$WORK/$2" \
+  PYTHONPATH="$BOUNDED_DOWNLOADER_DIR${PYTHONPATH:+:$PYTHONPATH}" \
+    python3 - "$UPSTREAM/$1/$2" "$WORK/$2" "$MAX_INPUT_BYTES" <<'PY' \
     || die "failed to fetch $1/$2 at $REV within $MAX_INPUT_BYTES bytes"
-  [ -s "$WORK/$2" ] || die "empty response for $1/$2 at $REV"
-  [ "$(wc -c <"$WORK/$2")" -le "$MAX_INPUT_BYTES" ] \
-    || die "oversized response for $1/$2 at $REV"
+import pathlib
+import sys
+
+from bounded_download import download
+
+try:
+    download(sys.argv[1], pathlib.Path(sys.argv[2]), max_bytes=int(sys.argv[3]))
+except Exception as error:
+    print(f"bounded download failed: {error}", file=sys.stderr)
+    raise SystemExit(1)
+PY
 }
 
 # Runs the verifier and echoes the ids of the checks that passed and failed. Exit code 2 means a
 # case was correctly refused, so only a code outside {0,2} is a tool failure.
-run_pairing() { # case, has_receipt
-  local case="$1" has_receipt="$2" rc=0 out
+run_pairing() { # case, has_receipt, output
+  local case="$1" has_receipt="$2" output="$3" rc=0
   local args=(evidence verify-mcp-records --decision "$WORK/decision.json" --format json)
   if [ -s "$WORK/attestation.json" ]; then
     args=(evidence verify-mcp-records --attestation "$WORK/attestation.json" \
           --decision "$WORK/decision.json" --format json)
   fi
   [ "$has_receipt" = yes ] && args+=(--outcome "$WORK/receipt.json")
-  out="$("$ASSAY" "${args[@]}" 2>/dev/null)" || rc=$?
+  "$ASSAY" "${args[@]}" >"$output" 2>/dev/null || rc=$?
   case "$rc" in
     0|2) ;;
     *) die "assay exited $rc on $case" ;;
   esac
-  printf '%s' "$out"
 }
 
 # Compares against the check ids each upstream case pins, not just the overall boolean, so a case
@@ -105,7 +115,8 @@ case_run() { # case, has_attestation, has_receipt, expect_ok, must_pass, must_fa
   [ "$2" = yes ] && fetch "$1" attestation.json
   fetch "$1" decision.json
   [ "$3" = yes ] && fetch "$1" receipt.json
-  compare "$1" "$(run_pairing "$1" "$3")" "$4" "$5" "$6" "$7"
+  run_pairing "$1" "$3" "$WORK/pairing_report.json"
+  compare "$1" "$(cat "$WORK/pairing_report.json")" "$4" "$5" "$6" "$7"
 }
 
 case_run valid_pair_allow_executed yes yes true \

--- a/scripts/interop/reproduce-sep2828-decision-pairing.sh
+++ b/scripts/interop/reproduce-sep2828-decision-pairing.sh
@@ -192,7 +192,7 @@ fallback_disposition="$(printf '%s' "$fallback_classification" | python3 -c \
   'import json,sys; print(json.load(sys.stdin)["classification"])')"
 case "$fallback_disposition" in
   documented_non_reproduction)
-    printf '  %-46s not reproduced (explicit named-projection mismatch)\n' fallback_envelope_binding
+    printf '  %-46s not reproduced (unsupported named-projection envelope shape)\n' fallback_envelope_binding
     non_reproduced=$((non_reproduced + 1))
     ;;
   reproduced)


### PR DESCRIPTION
## Summary

- refresh the public Vaara `decision_pairing_v0` interop record to Vaara `v1.75.0` (`9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b`)
- execute the seventh fallback case instead of printing a hard-coded non-reproduction
- align the classifier with Assay's merged fail-closed named-projection contract from #2596
- classify only the exact unsupported-envelope result as documented non-reproduction; any malformed, stale, incomplete, or newly successful shape is drift
- keep upstream JSON fetched at run time and execute no upstream code

## Result

Assay `5.4.0` reproduces 6 of 7 normative cases. For the fallback case:

- the pinned Vaara envelope has top-level `name`/`arguments`, while `assay.fallback_projection.v0` requires a top-level `params` object
- Assay refuses that unsupported shape with `ok:false`, `binding.digest:null`, and `fallback_projection_missing_params:false`
- dependent request-envelope digest checks are omitted because no valid named projection was resolved
- nonce, decision/outcome backlink, outcome-decision digest, and result-commitment projection checks remain positive
- `fallback_call_parameter_binding` remains an explicit non-claim
- the aggregate remains: reproduced 6, diverged 0, documented non-reproduction 1

This is an independent-consumer interop record, not a conformance, certification, partnership, runtime-effect, signature, issuer-trust, or upstream-defect claim.

## Exact-Head Evidence

- head: `02ebdf6963778d32d54e5f18301062fac2a1c719`
- worktree: `/Users/roelschuurkes/wt-vaara-v175-interop`
- toolchain: `assay 5.4.0`, Python `3.14.3`
- upstream pin: `vaaraio/vaara@9fefe51a61f16dc13cd64ca8ca4b8792e48fb64b`
- `python3 -m unittest scripts.ci.test_classify_sep2828_fallback scripts.ci.test_reproduce_sep2828_decision_pairing` -> 22/22 pass
- `scripts/interop/reproduce-sep2828-decision-pairing.sh ./target/debug/assay` -> reproduced 6, diverged 0, documented non-reproduction 1
- focused `pre-commit run --files ...` -> all applicable hooks pass
- pre-push hooks -> pass, including workspace clippy with deny warnings and the cross-target Linux compile gate
- `git diff --check` -> clean

## Mutation Evidence

Hermetic detached worktree at the exact head, with green control before and after:

- remove unresolved-digest requirement -> red (2 failures)
- remove forbidden dependent-check guard -> red (3 failures)
- remove required non-claim -> red (1 failure)
- restore the historical two-red-digest false set -> red (3 failures)
- remove required-positive checks -> red (4 failures)
- remove malformed-check guard -> red (3 failures)
- remove duplicate-check guard -> red (1 failure)
- restore stale UX wording -> red (1 failure)
- post-mutation control -> 22/22 pass

## Review Focus

- fail-closed classification of unsupported named-projection shapes
- malformed and duplicate check records cannot become documented non-reproduction
- public prose remains narrower than the measured evidence
- no upstream code or licensed fixture is vendored or executed

