### PR TITLE
fix(evidence): fail closed on incomplete named projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ All notable changes to this project will be documented in this file.
   (#2245).
 
 ### Fixed
+- Named MCP request-envelope projection now fails closed when `params` is missing or is not a JSON
+  object. These cases report stable `fallback_projection_missing_params` or
+  `fallback_projection_invalid_params` checks, exit `2`, and serialize `binding.digest` as `null`
+  instead of publishing a digest over synthetic or unsupported input (#2595).
 - `assay init` stdout contract tests now separately pin the deterministic empty-project prefix
   and the ordered `--from-trace` closing block (#2254).
 - Published-release golden path and `examples/privileged-action-gate/run.sh` verify the

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -37,11 +37,11 @@ pub struct McpExecutionRecordArgs {
 
     /// For the no-attestation fallback, how the request-envelope binding digest is computed.
     /// `whole-envelope` (default) is the legacy compatibility mode: it digests the full JCS envelope.
-    /// `named` is the named fallback projection mode: it digests only the `tools/call` params plus the
-    /// `_meta.authorization_binding` block, so transport-local or observation-local `_meta` fields a
-    /// gateway/provider can legitimately add or strip do not change the digest. Named mode is
-    /// allowlist + fail-closed: if the binding block cannot be resolved the fallback case is
-    /// non-conformant rather than silently hashing the whole envelope. Ignored for the SEP-2787 path.
+    /// `named` is the named fallback projection mode: it requires object-valued `params` and digests
+    /// only those params plus the `_meta.authorization_binding` block, so transport-local or
+    /// observation-local `_meta` fields a gateway/provider can legitimately add or strip do not
+    /// change the digest. Named mode is allowlist + fail-closed: an incomplete preimage is
+    /// non-conformant rather than silently hashing synthetic input. Ignored for the SEP-2787 path.
     #[arg(long, value_enum, default_value_t = FallbackProjection::WholeEnvelope)]
     pub fallback_projection: FallbackProjection,
 
@@ -110,13 +110,13 @@ enum BindingInput {
 
 struct BindingExpectation {
     mode: &'static str,
-    digest: String,
+    digest: Option<String>,
     digest_source: &'static str,
     projection: Option<&'static str>,
-    /// `Some(false)` when named projection was requested but the binding block could not be resolved
-    /// (fail-closed); `None` when not applicable (whole-envelope / attestation).
-    binding_block_present: Option<bool>,
-    /// Stable reason code for the named-projection fail-closed case (None when present / N/A).
+    /// `Some(false)` when named projection was requested but its complete preimage could not be
+    /// resolved (fail-closed); `None` when not applicable (whole-envelope / attestation).
+    named_projection_ready: Option<bool>,
+    /// Stable reason code for the named-projection fail-closed case (None when ready / N/A).
     named_fail_code: Option<&'static str>,
     nonce: Option<String>,
     nonce_source: &'static str,
@@ -140,19 +140,19 @@ fn build_report(
     // non-conformant, never a silent fall-back to hashing the whole envelope. The check id is the
     // stable reason code (invalid `_meta` vs missing `authorization_binding`).
     match (
-        expectation.binding_block_present,
+        expectation.named_projection_ready,
         expectation.named_fail_code,
     ) {
         (Some(true), _) => checks.push(CheckReport {
             id: "fallback_projection_binding_present",
             ok: true,
-            detail: "named fallback projection binding block present".to_string(),
+            detail: "named fallback projection preimage is complete".to_string(),
         }),
         (Some(false), Some(code)) => checks.push(CheckReport {
             id: code,
             ok: false,
-            detail: "named fallback projection requested but the binding block could not be \
-                     resolved; failing closed instead of hashing the whole envelope"
+            detail: "named fallback projection requested but its preimage could not be resolved; \
+                     failing closed without publishing a binding digest"
                 .to_string(),
         }),
         _ => {}
@@ -254,6 +254,12 @@ fn claims_not_made(expectation: &BindingExpectation) -> Vec<&'static str> {
     if expectation.mode == "request_envelope" {
         claims.push("fallback_server_observation_truth");
         claims.push("fallback_nonce_freshness_or_uniqueness");
+    }
+    if matches!(
+        expectation.named_fail_code,
+        Some("fallback_projection_missing_params" | "fallback_projection_invalid_params")
+    ) {
+        claims.push("fallback_call_parameter_binding");
     }
     claims
 }
@@ -395,10 +401,10 @@ fn binding_expectation(
     match binding_input {
         BindingInput::Attestation(attestation) => Ok(BindingExpectation {
             mode: "sep2787_attestation",
-            digest: jcs_digest(attestation).context("failed to digest attestation")?,
+            digest: Some(jcs_digest(attestation).context("failed to digest attestation")?),
             digest_source: "sep2787_attestation_jcs",
             projection: None,
-            binding_block_present: None,
+            named_projection_ready: None,
             named_fail_code: None,
             nonce: string_at(attestation, &["issuerAsserted", "nonce"]),
             nonce_source: "issuerAsserted.nonce",
@@ -406,53 +412,42 @@ fn binding_expectation(
         BindingInput::RequestEnvelope(request_envelope) => match fallback_projection {
             FallbackProjection::WholeEnvelope => Ok(BindingExpectation {
                 mode: "request_envelope",
-                digest: jcs_digest(request_envelope)
-                    .context("failed to digest request envelope")?,
+                digest: Some(
+                    jcs_digest(request_envelope).context("failed to digest request envelope")?,
+                ),
                 digest_source: "request_envelope_jcs",
                 projection: None,
-                binding_block_present: None,
+                named_projection_ready: None,
                 named_fail_code: None,
                 nonce: decision_backlink.attestation_nonce.clone(),
                 nonce_source: "record_backlink_consistency",
             }),
             FallbackProjection::Named => {
-                // Allowlist: the preimage is exactly the named params plus the whole named binding
-                // block, everything else under _meta is excluded by construction. Fail-closed with a
-                // stable reason when the binding cannot be resolved — never hash the whole envelope.
-                // `_meta` absent or not an object -> invalid_meta; object but no binding -> missing.
-                let meta = request_envelope.get("_meta");
-                let (named_fail_code, binding): (Option<&'static str>, Option<&Value>) = match meta
-                {
-                    None => (Some("fallback_projection_invalid_meta"), None),
-                    Some(m) if !m.is_object() => (Some("fallback_projection_invalid_meta"), None),
-                    Some(m) => match m.get("authorization_binding") {
-                        Some(b) => (None, Some(b)),
-                        None => (
-                            Some("fallback_projection_missing_authorization_binding"),
-                            None,
-                        ),
-                    },
-                };
-                let digest = match binding {
-                    Some(binding) => {
-                        // The whole authorization_binding object is bound (bind-all); any field
-                        // inside it is part of the preimage. The projection id is bound too.
+                let resolved = resolve_named_projection(request_envelope);
+                let (digest, named_fail_code) = match resolved {
+                    Ok((params, binding)) => {
                         let projected = serde_json::json!({
                             "projection": FALLBACK_PROJECTION_V0,
-                            "params": request_envelope.get("params").unwrap_or(&Value::Null),
+                            "params": params,
                             "binding": binding,
                         });
-                        jcs_digest(&projected)
-                            .context("failed to digest named fallback projection")?
+                        (
+                            Some(
+                                jcs_digest(&projected)
+                                    .context("failed to digest named fallback projection")?,
+                            ),
+                            None,
+                        )
                     }
-                    None => "sha256:unresolved-binding-block".to_string(),
+                    Err(code) => (None, Some(code)),
                 };
+                let named_projection_ready = digest.is_some();
                 Ok(BindingExpectation {
                     mode: "request_envelope",
                     digest,
                     digest_source: "request_envelope_named_projection_jcs",
                     projection: Some(FALLBACK_PROJECTION_V0),
-                    binding_block_present: Some(binding.is_some()),
+                    named_projection_ready: Some(named_projection_ready),
                     named_fail_code,
                     nonce: decision_backlink.attestation_nonce.clone(),
                     nonce_source: "record_backlink_consistency",
@@ -462,13 +457,37 @@ fn binding_expectation(
     }
 }
 
+/// Resolve the complete v0 preimage once so validation and digest construction cannot drift.
+fn resolve_named_projection(
+    request_envelope: &Value,
+) -> std::result::Result<(&Value, &Value), &'static str> {
+    let params = request_envelope
+        .get("params")
+        .ok_or("fallback_projection_missing_params")?;
+    if !params.is_object() {
+        return Err("fallback_projection_invalid_params");
+    }
+
+    let meta = request_envelope
+        .get("_meta")
+        .filter(|meta| meta.is_object())
+        .ok_or("fallback_projection_invalid_meta")?;
+    let binding = meta
+        .get("authorization_binding")
+        .ok_or("fallback_projection_missing_authorization_binding")?;
+    Ok((params, binding))
+}
+
 fn attestation_report(
     binding_input: &BindingInput,
     expectation: &BindingExpectation,
 ) -> Option<AttestationReport> {
     match binding_input {
         BindingInput::Attestation(_) => Some(AttestationReport {
-            digest: expectation.digest.clone(),
+            digest: expectation
+                .digest
+                .clone()
+                .expect("attestation binding always has a digest"),
             nonce: expectation.nonce.clone(),
         }),
         BindingInput::RequestEnvelope(_) => None,
@@ -485,7 +504,7 @@ fn push_decision_binding_checks(
             checks.push(check_eq(
                 "decision_attestation_digest_match",
                 decision_backlink.attestation_digest.as_deref(),
-                Some(expectation.digest.as_str()),
+                expectation.digest.as_deref(),
                 "decision backLink.attestationDigest matches SEP-2787 JCS digest",
             ));
             checks.push(check_eq(
@@ -496,12 +515,14 @@ fn push_decision_binding_checks(
             ));
         }
         "request_envelope" => {
-            checks.push(check_eq(
-                "decision_request_envelope_digest_match",
-                decision_backlink.attestation_digest.as_deref(),
-                Some(expectation.digest.as_str()),
-                "decision backLink.attestationDigest matches request-envelope JCS digest",
-            ));
+            if let Some(digest) = expectation.digest.as_deref() {
+                checks.push(check_eq(
+                    "decision_request_envelope_digest_match",
+                    decision_backlink.attestation_digest.as_deref(),
+                    Some(digest),
+                    "decision backLink.attestationDigest matches request-envelope JCS digest",
+                ));
+            }
             checks.push(check_present(
                 "decision_request_envelope_nonce_present",
                 decision_backlink.attestation_nonce.as_deref(),
@@ -522,7 +543,7 @@ fn push_outcome_binding_checks(
             checks.push(check_eq(
                 "outcome_attestation_digest_match",
                 outcome_backlink.attestation_digest.as_deref(),
-                Some(expectation.digest.as_str()),
+                expectation.digest.as_deref(),
                 "outcome backLink.attestationDigest matches SEP-2787 JCS digest",
             ));
             checks.push(check_eq(
@@ -533,12 +554,14 @@ fn push_outcome_binding_checks(
             ));
         }
         "request_envelope" => {
-            checks.push(check_eq(
-                "outcome_request_envelope_digest_match",
-                outcome_backlink.attestation_digest.as_deref(),
-                Some(expectation.digest.as_str()),
-                "outcome backLink.attestationDigest matches request-envelope JCS digest",
-            ));
+            if let Some(digest) = expectation.digest.as_deref() {
+                checks.push(check_eq(
+                    "outcome_request_envelope_digest_match",
+                    outcome_backlink.attestation_digest.as_deref(),
+                    Some(digest),
+                    "outcome backLink.attestationDigest matches request-envelope JCS digest",
+                ));
+            }
         }
         _ => unreachable!("unknown binding mode"),
     }

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records/report.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records/report.rs
@@ -29,7 +29,7 @@ pub(super) struct AttestationReport {
 #[derive(Debug, Serialize)]
 pub(super) struct BindingReport {
     pub(super) mode: &'static str,
-    pub(super) digest: String,
+    pub(super) digest: Option<String>,
     pub(super) digest_source: &'static str,
     pub(super) projection: Option<&'static str>,
     pub(super) nonce: Option<String>,
@@ -87,7 +87,10 @@ pub(super) fn print_table_report(report: &PairingReport) {
     println!("OK:               {}", if report.ok { "yes" } else { "no" });
     println!("Role:             {}", report.verification_scope.role);
     println!("Binding:          {}", report.binding.mode);
-    println!("Binding digest:   {}", report.binding.digest);
+    println!(
+        "Binding digest:   {}",
+        report.binding.digest.as_deref().unwrap_or("-")
+    );
     println!(
         "Binding nonce:    {}",
         report.binding.nonce.as_deref().unwrap_or("-")

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records/named_projection.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records/named_projection.rs
@@ -33,6 +33,215 @@ fn sample_binding() -> Value {
     serde_json::json!({ "tenant": "acme", "resource": "provider/customer/cus_123" })
 }
 
+fn verify_named_json(envelope: Value, decision_digest: &str) -> (i32, Value) {
+    let dir = tempdir().unwrap();
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope.to_string()).unwrap();
+    fs::write(&decision, decision_json(decision_digest)).unwrap();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let report = serde_json::from_slice(&output.stdout).unwrap();
+    (output.status.code().unwrap(), report)
+}
+
+#[test]
+fn fallback_named_projection_missing_params_fails_closed_without_a_digest() {
+    let binding = sample_binding();
+    let envelope = serde_json::json!({
+        "name": "provider.lookup",
+        "arguments": { "customer": "cus_123" },
+        "_meta": { "authorization_binding": binding },
+    });
+    // This is the digest the old implementation produced after silently substituting null.
+    let historical_null_digest = named_digest(&Value::Null, &sample_binding());
+
+    let (exit, report) = verify_named_json(envelope, &historical_null_digest);
+
+    assert_eq!(exit, 2);
+    assert_eq!(report["ok"], false);
+    assert!(report["binding"]["digest"].is_null());
+    assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+        check["id"] == "fallback_projection_missing_params" && check["ok"] == false
+    }));
+    assert!(report["claims_not_made"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|claim| claim == "fallback_call_parameter_binding"));
+}
+
+#[test]
+fn fallback_named_projection_rejects_non_object_params() {
+    let binding = sample_binding();
+
+    for invalid_params in [
+        Value::Null,
+        serde_json::json!("provider.lookup"),
+        serde_json::json!(["provider.lookup"]),
+    ] {
+        let envelope = serde_json::json!({
+            "params": invalid_params,
+            "_meta": { "authorization_binding": binding },
+        });
+        let historical_digest = named_digest(&envelope["params"], &sample_binding());
+
+        let (exit, report) = verify_named_json(envelope, &historical_digest);
+
+        assert_eq!(exit, 2, "invalid params: {}", invalid_params);
+        assert_eq!(report["ok"], false, "invalid params: {}", invalid_params);
+        assert!(
+            report["binding"]["digest"].is_null(),
+            "invalid params: {}",
+            invalid_params
+        );
+        assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+            check["id"] == "fallback_projection_invalid_params" && check["ok"] == false
+        }));
+    }
+}
+
+#[test]
+fn fallback_named_projection_params_error_precedes_meta_error() {
+    let envelope = serde_json::json!({
+        "name": "provider.lookup",
+        "arguments": {},
+        "_meta": "not-an-object",
+    });
+
+    let (exit, report) = verify_named_json(envelope, "sha256:not-used");
+
+    assert_eq!(exit, 2);
+    assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+        check["id"] == "fallback_projection_missing_params" && check["ok"] == false
+    }));
+    assert!(!report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|check| check["id"] == "fallback_projection_invalid_meta"));
+    assert!(!report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|check| check["id"] == "decision_request_envelope_digest_match"));
+}
+
+#[test]
+fn fallback_named_projection_accepts_empty_object_params_without_failure_nonclaim() {
+    let params = serde_json::json!({});
+    let binding = sample_binding();
+    let envelope: Value =
+        serde_json::from_str(&named_envelope(&params, Some(&binding), &[])).unwrap();
+    let digest = named_digest(&params, &binding);
+
+    let (exit, report) = verify_named_json(envelope, &digest);
+
+    assert_eq!(exit, 0);
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["binding"]["digest"], digest);
+    assert!(!report["claims_not_made"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|claim| claim == "fallback_call_parameter_binding"));
+    assert!(!report["checks"].as_array().unwrap().iter().any(|check| {
+        matches!(
+            check["id"].as_str(),
+            Some("fallback_projection_missing_params" | "fallback_projection_invalid_params")
+        )
+    }));
+}
+
+#[test]
+fn whole_envelope_mode_still_accepts_an_envelope_without_params() {
+    let dir = tempdir().unwrap();
+    let envelope = serde_json::json!({
+        "name": "provider.lookup",
+        "arguments": { "customer": "cus_123" },
+        "_meta": { "authorization_binding": sample_binding() },
+    });
+    let digest = jcs_digest_value(&envelope);
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope.to_string()).unwrap();
+    fs::write(&decision, decision_json(&digest)).unwrap();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["binding"]["digest"], digest);
+    assert_eq!(report["binding"]["projection"], Value::Null);
+}
+
+#[test]
+fn fallback_named_projection_failure_table_has_no_pseudo_digest() {
+    let dir = tempdir().unwrap();
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(
+        &env_path,
+        serde_json::json!({
+            "name": "provider.lookup",
+            "_meta": { "authorization_binding": sample_binding() },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(&decision, decision_json("sha256:not-used")).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("OK:               no"))
+        .stdout(predicate::str::contains("Binding digest:   -"))
+        .stdout(predicate::str::contains(
+            "fallback_projection_missing_params",
+        ))
+        .stdout(predicate::str::contains("sha256:unresolved").not());
+}
+
 #[test]
 fn fallback_named_projection_excludes_nonbinding_meta() {
     let dir = tempdir().unwrap();
@@ -142,63 +351,36 @@ fn fallback_named_projection_same_digest_for_different_nonbinding_meta() {
 
 #[test]
 fn fallback_named_projection_fails_closed_when_binding_block_absent() {
-    let dir = tempdir().unwrap();
     let params = sample_params();
-    // Envelope with NO _meta.authorization_binding.
-    let envelope = named_envelope(&params, None, &[("progress_token", serde_json::json!("p"))]);
+    let envelope: Value = serde_json::from_str(&named_envelope(
+        &params,
+        None,
+        &[("progress_token", serde_json::json!("p"))],
+    ))
+    .unwrap();
     let digest = named_digest(&params, &sample_binding());
-    let env_path = dir.path().join("request-envelope.json");
-    let decision = dir.path().join("decision.json");
-    fs::write(&env_path, envelope).unwrap();
-    fs::write(&decision, decision_json(&digest)).unwrap();
 
-    Command::cargo_bin("assay")
-        .unwrap()
-        .args([
-            "evidence",
-            "verify-mcp-records",
-            "--request-envelope",
-            env_path.to_str().unwrap(),
-            "--decision",
-            decision.to_str().unwrap(),
-            "--fallback-projection",
-            "named",
-        ])
-        .assert()
-        .code(2)
-        .stdout(predicate::str::contains(
-            "fallback_projection_missing_authorization_binding",
-        ))
-        .stdout(predicate::str::contains("failing closed"));
+    let (exit, report) = verify_named_json(envelope, &digest);
+
+    assert_eq!(exit, 2);
+    assert!(report["binding"]["digest"].is_null());
+    assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+        check["id"] == "fallback_projection_missing_authorization_binding" && check["ok"] == false
+    }));
 }
 
 #[test]
 fn fallback_named_projection_invalid_meta_fails_closed() {
-    let dir = tempdir().unwrap();
-    // `_meta` present but not an object -> invalid, distinct reason code from a missing binding.
-    let envelope =
-        serde_json::json!({ "params": sample_params(), "_meta": "not-an-object" }).to_string();
+    let envelope = serde_json::json!({ "params": sample_params(), "_meta": "not-an-object" });
     let digest = named_digest(&sample_params(), &sample_binding());
-    let env_path = dir.path().join("request-envelope.json");
-    let decision = dir.path().join("decision.json");
-    fs::write(&env_path, envelope).unwrap();
-    fs::write(&decision, decision_json(&digest)).unwrap();
 
-    Command::cargo_bin("assay")
-        .unwrap()
-        .args([
-            "evidence",
-            "verify-mcp-records",
-            "--request-envelope",
-            env_path.to_str().unwrap(),
-            "--decision",
-            decision.to_str().unwrap(),
-            "--fallback-projection",
-            "named",
-        ])
-        .assert()
-        .code(2)
-        .stdout(predicate::str::contains("fallback_projection_invalid_meta"));
+    let (exit, report) = verify_named_json(envelope, &digest);
+
+    assert_eq!(exit, 2);
+    assert!(report["binding"]["digest"].is_null());
+    assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+        check["id"] == "fallback_projection_invalid_meta" && check["ok"] == false
+    }));
 }
 
 #[test]
@@ -311,7 +493,7 @@ fn fallback_named_projection_breaks_on_changed_binding_block() {
 }
 
 #[test]
-fn fallback_named_projection_breaks_on_changed_bound_param() {
+fn fallback_named_projection_breaks_on_changed_bound_arguments() {
     let dir = tempdir().unwrap();
     let binding = sample_binding();
     // Decision binds the ORIGINAL params; the envelope carries DIFFERENT params.
@@ -342,4 +524,23 @@ fn fallback_named_projection_breaks_on_changed_bound_param() {
             "decision_request_envelope_digest_match",
         ))
         .stdout(predicate::str::contains("fail mismatch"));
+}
+
+#[test]
+fn fallback_named_projection_breaks_on_changed_bound_name() {
+    let binding = sample_binding();
+    let digest = named_digest(&sample_params(), &binding);
+    let other_params = serde_json::json!({
+        "name": "tools/list",
+        "arguments": { "processInstanceKey": "2251799813685249" }
+    });
+    let envelope: Value =
+        serde_json::from_str(&named_envelope(&other_params, Some(&binding), &[])).unwrap();
+
+    let (exit, report) = verify_named_json(envelope, &digest);
+
+    assert_eq!(exit, 2);
+    assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+        check["id"] == "decision_request_envelope_digest_match" && check["ok"] == false
+    }));
 }

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records/named_projection.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records/named_projection.rs
@@ -113,6 +113,16 @@ fn fallback_named_projection_rejects_non_object_params() {
         assert!(report["checks"].as_array().unwrap().iter().any(|check| {
             check["id"] == "fallback_projection_invalid_params" && check["ok"] == false
         }));
+        assert!(!report["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check["id"] == "decision_request_envelope_digest_match"));
+        assert!(report["claims_not_made"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|claim| claim == "fallback_call_parameter_binding"));
     }
 }
 

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records/named_projection.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records/named_projection.rs
@@ -493,54 +493,36 @@ fn fallback_named_projection_breaks_on_changed_binding_block() {
 }
 
 #[test]
-fn fallback_named_projection_breaks_on_changed_bound_arguments() {
-    let dir = tempdir().unwrap();
+fn fallback_named_projection_binds_changed_arguments() {
     let binding = sample_binding();
-    // Decision binds the ORIGINAL params; the envelope carries DIFFERENT params.
-    let digest = named_digest(&sample_params(), &binding);
+    let original_digest = named_digest(&sample_params(), &binding);
     let other_params =
         serde_json::json!({ "name": "tools/call", "arguments": { "processInstanceKey": "9999" } });
-    let envelope = named_envelope(&other_params, Some(&binding), &[]);
-    let env_path = dir.path().join("request-envelope.json");
-    let decision = dir.path().join("decision.json");
-    fs::write(&env_path, envelope).unwrap();
-    fs::write(&decision, decision_json(&digest)).unwrap();
+    let changed_digest = named_digest(&other_params, &binding);
+    let envelope: Value =
+        serde_json::from_str(&named_envelope(&other_params, Some(&binding), &[])).unwrap();
 
-    Command::cargo_bin("assay")
-        .unwrap()
-        .args([
-            "evidence",
-            "verify-mcp-records",
-            "--request-envelope",
-            env_path.to_str().unwrap(),
-            "--decision",
-            decision.to_str().unwrap(),
-            "--fallback-projection",
-            "named",
-        ])
-        .assert()
-        .code(2)
-        .stdout(predicate::str::contains(
-            "decision_request_envelope_digest_match",
-        ))
-        .stdout(predicate::str::contains("fail mismatch"));
+    assert_ne!(changed_digest, original_digest);
+    let (exit, report) = verify_named_json(envelope, &changed_digest);
+    assert_eq!(exit, 0);
+    assert_eq!(report["binding"]["digest"], changed_digest);
 }
 
 #[test]
-fn fallback_named_projection_breaks_on_changed_bound_name() {
+fn fallback_named_projection_binds_changed_name() {
     let binding = sample_binding();
-    let digest = named_digest(&sample_params(), &binding);
+    let original_digest = named_digest(&sample_params(), &binding);
     let other_params = serde_json::json!({
         "name": "tools/list",
         "arguments": { "processInstanceKey": "2251799813685249" }
     });
+    let changed_digest = named_digest(&other_params, &binding);
     let envelope: Value =
         serde_json::from_str(&named_envelope(&other_params, Some(&binding), &[])).unwrap();
 
-    let (exit, report) = verify_named_json(envelope, &digest);
+    assert_ne!(changed_digest, original_digest);
+    let (exit, report) = verify_named_json(envelope, &changed_digest);
 
-    assert_eq!(exit, 2);
-    assert!(report["checks"].as_array().unwrap().iter().any(|check| {
-        check["id"] == "decision_request_envelope_digest_match" && check["ok"] == false
-    }));
+    assert_eq!(exit, 0);
+    assert_eq!(report["binding"]["digest"], changed_digest);
 }

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -97,9 +97,14 @@ computes the binding digest, checks the decision and optional outcome
 `backLink` fields, verifies the outcome's `decisionDigest` commitment to the
 full signed decision record, and verifies the narrow decision/outcome enum
 surface. In SEP-2787 mode the binding digest is the attestation JCS digest and
-the nonce comes from `issuerAsserted.nonce`. In request-envelope mode the
-binding digest is the JCS digest of the supplied envelope, while the nonce is
-only checked for decision/outcome record consistency.
+the nonce comes from `issuerAsserted.nonce`. Request-envelope mode defaults to
+`--fallback-projection whole-envelope`, which digests the supplied envelope.
+With `--fallback-projection named`, `params` must be a present JSON object and
+the digest binds only `{projection, params, binding}`, where `binding` is
+`_meta.authorization_binding`. Missing or non-object `params` fails closed with
+exit `2`, a stable `fallback_projection_*_params` check id, and
+`binding.digest: null`. The nonce is only checked for decision/outcome record
+consistency in either request-envelope mode.
 
 The command is deliberately not an MCP proxy, issuer, policy engine, or runtime
 truth oracle. It does not verify signatures, establish issuer key trust, prove

--- a/docs/reference/cli/mcp-execution-record-fallback-plan.md
+++ b/docs/reference/cli/mcp-execution-record-fallback-plan.md
@@ -1,8 +1,7 @@
 # MCP Execution Record Fallback Binding Plan
 
-> **Status:** docs-first slice plan. This page scopes the next
-> `assay evidence verify-mcp-records` capability after Check B support.
-> It is not a shipped CLI contract yet. The slice adds a no-attestation
+> **Status:** shipped CLI behavior plus retained design rationale. This page documents
+> `assay evidence verify-mcp-records` after Check B support. The command includes a no-attestation
 > request-envelope fallback path for SEP-2828-style execution records,
 > while preserving Assay's current boundary as an independent consumer
 > verifier. It does not add signature verification, issuer trust,
@@ -238,7 +237,11 @@ Everything else under `_meta` is excluded by construction. The rules, in code an
   preimage; unrelated `_meta` (progress tokens, trace context, other SEP blocks) is excluded, so two
   views that differ only in non-binding `_meta` produce the same digest.
 - **Fail-closed.** If `_meta.authorization_binding` is absent, the fallback case is non-conformant
-  (`fallback_binding_block_present` fails, exit `2`) rather than silently hashing the whole envelope.
+  (`fallback_projection_missing_authorization_binding`, exit `2`) rather than silently hashing the
+  whole envelope. The same rule applies when the named preimage is incomplete: `params` must be a
+  present JSON object. Missing `params` reports `fallback_projection_missing_params`; null, array,
+  or scalar `params` reports `fallback_projection_invalid_params`. These failures publish
+  `binding.digest: null`, not a digest over synthetic input.
 - **Self-describing version.** The report carries `binding.projection = "assay.fallback_projection.v0"`.
   This tracks the in-progress SEP-2828 fallback-binding discussion; a rename or rule change is an
   explicit version bump, never a silent reinterpretation.
@@ -247,6 +250,8 @@ Everything else under `_meta` is excluded by construction. The rules, in code an
 
 - The named field set (`params` + `_meta.authorization_binding`) is a proposed shape tracking the
   upstream discussion, not a finalized SEP contract; it is versioned so it can change explicitly.
+- A flat object with top-level `name` and `arguments` is not silently reinterpreted as v0 `params`.
+  Supporting that shape requires a separately named projection and an addressable preimage contract.
 - Matching the named projection digest does not prove the server observed the envelope honestly, nor
   that the omitted `_meta` was irrelevant to anything other than the binding.
 - `whole-envelope` mode remains for interop with current external fixtures that bind the full envelope.
@@ -256,8 +261,10 @@ Everything else under `_meta` is excluded by construction. The rules, in code an
 Stable, machine-readable reason codes (CI consumers key on these, not on prose `detail`):
 
 - fallback (named mode, in `verify-mcp-records` check ids): `fallback_projection_binding_present`,
+  `fallback_projection_missing_params`, `fallback_projection_invalid_params`,
   `fallback_projection_missing_authorization_binding`, `fallback_projection_invalid_meta`; a digest
-  mismatch surfaces through the existing `decision_request_envelope_digest_match` check.
+  mismatch surfaces through the existing `decision_request_envelope_digest_match` check. Missing or
+  invalid `params` additionally declares `fallback_call_parameter_binding` in `claims_not_made`.
 - supersession (`verify-mcp-supersession` `groups[].reason_code`):
   `supersession_resolved_single`, `supersession_resolved_latest_decided_at`,
   `supersession_resolved_sequence`, `supersession_ambiguous_missing_sequence`,

--- a/docs/reference/cli/mcp-execution-record-fallback-plan.md
+++ b/docs/reference/cli/mcp-execution-record-fallback-plan.md
@@ -275,10 +275,10 @@ Pinned semantics:
 - **Projection id is bound.** The named projection digest is `sha256(jcs({projection, params, binding}))`,
   so the projection id is part of the preimage; changing it changes the digest. A rename or rule change
   is an explicit version bump.
-- **Bind-all inside the binding block.** Extra non-binding `_meta` fields are excluded from the digest,
-  but the `authorization_binding` object is included as a whole — there is no allowlist *inside* the
-  binding block, so any field within it is bound. (A closed schema for `authorization_binding` is a
-  possible later policy step, not part of this hardening.)
+- **Bind-all inside the binding value.** Extra non-binding `_meta` fields are excluded from the digest,
+  but the `authorization_binding` JSON value is included as a whole — there is no allowlist inside it.
+  When the value is an object, every field within it is therefore bound. A closed schema for
+  `authorization_binding` is a possible later policy step, not part of this hardening.
 - **`whole-envelope` is legacy compatibility.** `named` is the mode used for the `_meta`
   authorization-binding allowlist behavior. The default is unchanged here.
 - **Asserted sequence ordering.** `sequence` is read from the canonical `decisionDerived` content.

--- a/docs/reference/cli/mcp-execution-record-fallback-plan.md
+++ b/docs/reference/cli/mcp-execution-record-fallback-plan.md
@@ -265,6 +265,8 @@ Stable, machine-readable reason codes (CI consumers key on these, not on prose `
   `fallback_projection_missing_authorization_binding`, `fallback_projection_invalid_meta`; a digest
   mismatch surfaces through the existing `decision_request_envelope_digest_match` check. Missing or
   invalid `params` additionally declares `fallback_call_parameter_binding` in `claims_not_made`.
+  When the named preimage cannot be resolved, Assay omits dependent decision/outcome digest-match
+  checks because no expected digest exists; the stable projection-shape check is the primary failure.
 - supersession (`verify-mcp-supersession` `groups[].reason_code`):
   `supersession_resolved_single`, `supersession_resolved_latest_decided_at`,
   `supersession_resolved_sequence`, `supersession_ambiguous_missing_sequence`,


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: none; `AGENTS.md` states no programme is active
- Slice: #2595 named fallback projection fail-closed hardening
- Builder: Codex
- Reviewers: Cursor, Claude Desktop, and Ruley advisory reviews; fresh independent non-building Codex subagent READY at the exact final head
- Final head SHA: `f8a131c308c4d77a1001461b540497d01e01f0e7`
- ADR invariants affected: hostile evidence inputs, fail-closed unsupported boundaries, absence-of-evidence honesty, explicit non-claims

## Behavior

`assay.fallback_projection.v0` now requires a present object-valued `params` member. Missing `params` reports `fallback_projection_missing_params`; null, scalar, or array values report `fallback_projection_invalid_params`. Both paths exit `2`, set `ok: false`, publish `binding.digest: null`, add the conditional `fallback_call_parameter_binding` non-claim, and suppress dependent digest comparisons.

Valid v0 inputs retain their exact digest. Default `whole-envelope` behavior remains unchanged. Flat top-level `name`/`arguments` is not silently adopted; supporting another shape requires a separately named projection and addressable preimage contract.

Closes #2595.

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim

This change does not judge another implementation or establish a new external projection contract. It does not verify signatures, issuer trust, policy correctness, runtime effects, or honest server observation.

## Test Evidence

### RED

On the pre-change tree, this command ran 10 focused tests; 8 passed and the two new behavior tests failed because the CLI returned exit `0` instead of `2`:

```bash
cargo test -p assay-cli --test evidence_test fallback_named_projection_ -- --nocapture
```

Failing tests:

- `fallback_named_projection_missing_params_fails_closed_without_a_digest`
- `fallback_named_projection_rejects_non_object_params`

### GREEN

Measured in `/Users/roelschuurkes/wt-2595-fail-closed` at exact SHA `f8a131c308c4d77a1001461b540497d01e01f0e7`, rustc/cargo `1.96.0`:

```bash
cargo test -p assay-cli --test evidence_test fallback_named_projection_ -- --nocapture
# 14 passed

cargo test -p assay-cli
# pass

cargo clippy -p assay-cli --all-targets -- -D warnings
# pass

cargo fmt --all -- --check
# pass

git diff --check
# pass; worktree clean
```

Seven bypass mutations were run against committed production code and each was killed with a clean post-mutation control:

1. restore missing `params` -> synthetic `null`
2. accept array-valued `params`
3. drop `name` from the bound preimage
4. publish a pseudo digest for unresolved input
5. keep the reason but mark its check `ok: true`
6. omit the invalid-params conditional non-claim
7. emit a dependent digest comparison without a resolved preimage

Ruley also re-ran the live JSON/table matrix on this head: missing and invalid `params` exit `2` with null/no digest, valid name and arguments independently move the digest, and whole-envelope remains successful.

## Review Quorum

- [x] One non-building agent review: READY at `f8a131c308c4d77a1001461b540497d01e01f0e7`
- [x] Every advisory actionable finding is fixed or has a technical disposition
- [x] Delegated proof not required for this scope; `lane-check/proof` reports that explicitly on the exact head

Optional automated reviews can add evidence, but do not count toward or block quorum.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP named fallback verification now fails closed when request parameters are missing or invalid.
  * Invalid inputs return clear error checks, exit with status 2, and no longer generate misleading digests.
  * Reports now indicate when a binding digest is unavailable.

* **Documentation**
  * Updated CLI reference materials to document named fallback projection requirements, error handling, and digest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->