### PR TITLE
fix(describe): fail closed on run output ownership

### DIFF
--- a/crates/assay-cli/src/cli/commands/describe/bindings.rs
+++ b/crates/assay-cli/src/cli/commands/describe/bindings.rs
@@ -5,6 +5,8 @@ use crate::cli::commands::evidence::schema::{
 use crate::cli::commands::init_report::INIT_REPORT_SCHEMA;
 use crate::cli::commands::validate::VALIDATE_REPORT_SCHEMA;
 use crate::diagnostics::report::DOCTOR_REPORT_SCHEMA;
+use assay_core::report::json::RUN_REPORT_SCHEMA;
+use assay_core::report::summary::SUMMARY_SCHEMA;
 
 /// One shipping identity owned by a clap path. The identity field is the
 /// existing constant, not a second string.
@@ -26,6 +28,14 @@ pub(super) const BINDING_ROWS: &[IdentityBinding] = &[
     IdentityBinding {
         path: "init",
         identity: INIT_REPORT_SCHEMA,
+    },
+    IdentityBinding {
+        path: "run",
+        identity: RUN_REPORT_SCHEMA,
+    },
+    IdentityBinding {
+        path: "run",
+        identity: SUMMARY_SCHEMA,
     },
     IdentityBinding {
         path: "validate",

--- a/crates/assay-cli/tests/cli_describe_contract.rs
+++ b/crates/assay-cli/tests/cli_describe_contract.rs
@@ -8,6 +8,8 @@
 #[allow(dead_code)]
 mod bounded_process;
 
+use assay_core::report::json::RUN_REPORT_SCHEMA;
+use assay_core::report::summary::SUMMARY_SCHEMA;
 use bounded_process::{run_bounded, GOLDEN_PATH_LIMITS};
 use serde_json::Value;
 use std::fs;
@@ -181,5 +183,28 @@ fn describe_parent_listing_includes_child_identities() {
     assert!(
         listed.contains(&list_schema.as_str()),
         "parent listing must include a child identity that exists in code; identities={listed:?}"
+    );
+}
+
+#[test]
+fn describe_run_lists_both_shipping_identities() {
+    let output = describe(&["run"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        exit_code(&output),
+        0,
+        "assay describe run must descend; stderr={stderr}"
+    );
+
+    let document = sole_report(&output);
+    assert_eq!(document["path"], Value::Array(vec!["run".into()]));
+
+    let mut listed = identities(&document);
+    listed.sort_unstable();
+    let mut expected = vec![RUN_REPORT_SCHEMA, SUMMARY_SCHEMA];
+    expected.sort_unstable();
+    assert_eq!(
+        listed, expected,
+        "run must publish both shipping output identities"
     );
 }

--- a/scripts/ci/cli_describe_contract.py
+++ b/scripts/ci/cli_describe_contract.py
@@ -20,15 +20,19 @@ BINDING_RE = re.compile(
     re.MULTILINE,
 )
 BINDINGS_REL = Path("crates/assay-cli/src/cli/commands/describe/bindings.rs")
-CLI_SRC_REL = Path("crates/assay-cli/src")
+SOURCE_RELS = (Path("crates/assay-cli/src"), Path("crates/assay-core/src"))
+REQUIRED_COMMAND_OWNERS = {
+    "run": ("RUN_REPORT_SCHEMA", "SUMMARY_SCHEMA"),
+}
 
 
-def shipping_constants(src_root: Path) -> dict[str, str]:
+def shipping_constants(repo: Path) -> dict[str, str]:
     found: dict[str, str] = {}
-    for path in src_root.rglob("*.rs"):
-        text = path.read_text(encoding="utf-8")
-        for match in CONST_RE.finditer(text):
-            found[match.group(1)] = match.group(2)
+    for relative in SOURCE_RELS:
+        for path in (repo / relative).rglob("*.rs"):
+            text = path.read_text(encoding="utf-8")
+            for match in CONST_RE.finditer(text):
+                found[match.group(1)] = match.group(2)
     return found
 
 
@@ -54,6 +58,16 @@ def belongs_on_node(binding_path: str, node_path: str) -> bool:
     return rest.startswith("/") and "/" not in rest[1:]
 
 
+def required_owner_rows(constants: dict[str, str]) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    for path, names in REQUIRED_COMMAND_OWNERS.items():
+        for name in names:
+            if name not in constants:
+                raise SystemExit(f"required command owner {path} references unknown constant {name}")
+            rows.append((path, constants[name]))
+    return rows
+
+
 def node_path(listing: dict) -> str:
     path = listing.get("path")
     if not isinstance(path, list) or not all(isinstance(part, str) for part in path):
@@ -70,8 +84,18 @@ def old_guard(listing: dict) -> list[str]:
     return problems
 
 
-def new_guard(listing: dict, rows: list[tuple[str, str]]) -> list[str]:
+def new_guard(
+    listing: dict,
+    rows: list[tuple[str, str]],
+    required_rows: list[tuple[str, str]],
+) -> list[str]:
     problems = old_guard(listing)
+    row_set = set(rows)
+    for path, identity in required_rows:
+        if (path, identity) not in row_set:
+            problems.append(
+                f"required command owner {path} omitted shipping identity {identity}"
+            )
     identities = listing.get("identities")
     if not isinstance(identities, list) or not all(isinstance(item, str) for item in identities):
         problems.append("describe listing is missing an identities array")
@@ -105,10 +129,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--listing", type=Path, required=True)
     parser.add_argument("--guard", choices=("old", "new"), required=True)
     args = parser.parse_args(argv)
-    constants = shipping_constants(args.repo / CLI_SRC_REL)
-    rows = binding_rows(args.repo, constants)
     listing = load_listing(args.listing)
-    problems = old_guard(listing) if args.guard == "old" else new_guard(listing, rows)
+    if args.guard == "old":
+        problems = old_guard(listing)
+    else:
+        constants = shipping_constants(args.repo)
+        rows = binding_rows(args.repo, constants)
+        problems = new_guard(listing, rows, required_owner_rows(constants))
     for problem in problems:
         print(problem, file=sys.stderr)
     return 1 if problems else 0

--- a/scripts/ci/test-cli-describe-contract.sh
+++ b/scripts/ci/test-cli-describe-contract.sh
@@ -19,6 +19,63 @@ fail() {
 [[ -f "$CHECKER" ]] || fail "checker missing: $CHECKER"
 [[ -f "$BINDINGS" ]] || fail "bindings missing: $BINDINGS"
 
+for omitted in RUN_REPORT_SCHEMA SUMMARY_SCHEMA; do
+  MUTANT_REPO="${SCRATCH}/owner-omission-${omitted}"
+  mkdir -p "${MUTANT_REPO}/crates/assay-cli"
+  cp -R "${ROOT}/crates/assay-cli/src" "${MUTANT_REPO}/crates/assay-cli/src"
+  mkdir -p "${MUTANT_REPO}/crates/assay-core"
+  cp -R "${ROOT}/crates/assay-core/src" "${MUTANT_REPO}/crates/assay-core/src"
+  RUN_LISTING="${SCRATCH}/run-${omitted}.json"
+  python3 - "$CHECKER" "${MUTANT_REPO}/${BINDINGS#"${ROOT}/"}" \
+    "$MUTANT_REPO" "$RUN_LISTING" "$omitted" <<'PY' \
+    || fail "could not seed run owner omission for ${omitted}"
+import importlib.util
+import json
+import pathlib
+import re
+import sys
+
+spec = importlib.util.spec_from_file_location("cli_describe_contract", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+path = pathlib.Path(sys.argv[2])
+text = path.read_text(encoding="utf-8")
+pattern = re.compile(
+    r'\s*IdentityBinding \{\s*path: "run",\s*identity: '
+    + re.escape(sys.argv[5])
+    + r',\s*\},'
+)
+mutated, count = pattern.subn("", text)
+if count != 1:
+    raise SystemExit(f"expected one {sys.argv[5]} binding, removed {count}")
+path.write_text(mutated, encoding="utf-8")
+repo = pathlib.Path(sys.argv[3])
+constants = mod.shipping_constants(repo)
+rows = mod.binding_rows(repo, constants)
+identities = [identity for owner, identity in rows if owner == "run"]
+pathlib.Path(sys.argv[4]).write_text(
+    json.dumps(
+        {
+            "schema": "assay.cli.describe.v0",
+            "path": ["run"],
+            "commands": [],
+            "identities": identities,
+        }
+    ),
+    encoding="utf-8",
+)
+PY
+
+  owner_exit=0
+  python3 "$CHECKER" --repo "$MUTANT_REPO" --listing "$RUN_LISTING" --guard new \
+    >/dev/null 2>"$SCRATCH/owner-${omitted}.err" || owner_exit=$?
+  [[ "$owner_exit" -ne 0 ]] \
+    || fail "new guard stayed green when run lost ${omitted}"
+  grep -F "required command owner run omitted shipping identity" \
+    "$SCRATCH/owner-${omitted}.err" >/dev/null \
+    || fail "new guard did not name ${omitted}: $(cat "$SCRATCH/owner-${omitted}.err")"
+done
+
 DOCTOR_SCHEMA="$(
   python3 - "$DOCTOR_SRC" <<'PY'
 import re, sys


### PR DESCRIPTION
## Summary

- publish the two shipping `assay run` JSON identities through `assay describe run`
- bind those identities directly to `assay-core` constants, without copied schema strings
- add an independent CI owner pin so deleting a binding cannot make runtime output and its checker drift empty together
- preserve the existing doctor-listing omission control

Closes #2178.

## Contract

`assay describe run` now lists exactly:

- `assay.run_report.v1`
- `assay.run_summary.v1`

This changes introspection output only. It does not change either run-output schema or validate emitted run documents.

## RED -> GREEN

RED on base `e523f793d10cb965c21b728f6c4af9260052ace5`:

```text
left: []
right: ["assay.run_report.v1", "assay.run_summary.v1"]
```

A second RED removed both required owner bindings in a scratch repo; the old checker stayed green.

GREEN at `7144771531aed5a1139d5751157651ad427feafb`:

```text
cargo test -p assay-cli --test cli_describe_contract
19 passed; 1 ignored

bash scripts/ci/test-cli-describe-contract.sh
identity omission old_guard_exit=0 new_guard_exit=1
ok: cli describe contract
```

## Mutation Evidence

- remove only `RUN_REPORT_SCHEMA` from the run owner bindings -> new guard rejects and names the missing owner contract
- remove only `SUMMARY_SCHEMA` -> same rejection
- remove the doctor identity from a listing while its binding remains -> old guard accepts, new guard rejects

The run-listing mutants are generated from the mutated binding rows, matching the false-clean path this change closes.

## Verification

- `cargo test -p assay-cli --test cli_describe_contract -- --nocapture`
- `cargo test -p assay-cli describe:: -- --nocapture`
- `bash scripts/ci/test-cli-describe-contract.sh`
- `shellcheck scripts/ci/test-cli-describe-contract.sh`
- `python3 -m py_compile scripts/ci/cli_describe_contract.py`
- `cargo fmt --all -- --check`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `git diff --check`

## Non-claims

- does not validate the contents of `assay run` output
- does not enumerate or independently pin every CLI output identity
- does not change run/summary schemas, exit codes, or serialization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `assay describe run` command now publishes both run-report and summary identities.

* **Bug Fixes**
  * Improved validation ensures required report and command ownership identities are present and correctly mapped.

* **Tests**
  * Added contract coverage for the run description and its published identities.
  * Added CI checks to detect missing report identity bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->