### PR TITLE
ci: require exact-head review record on main

### DIFF
--- a/.github/rulesets/main-required-ci-contexts.json
+++ b/.github/rulesets/main-required-ci-contexts.json
@@ -28,6 +28,10 @@
           {
             "context": "host-capability-check",
             "integration_id": 15368
+          },
+          {
+            "context": "review-record-check",
+            "integration_id": 15368
           }
         ]
       }

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -444,6 +444,7 @@ Currently required live branch-protection contexts:
 - `CI`
 - `host-capability-check`
 - `lane-check/proof` (commit status posted by `scripts/ci/assay_runner_lane_check.py`)
+- `review-record-check`
 <!-- required-contexts:end (scripts/ci/check-required-contexts.py reads the entries between
      the "Currently required" line above and this marker; keep it after the last entry) -->
 
@@ -478,7 +479,7 @@ Checked-in ruleset activation lives at
 
 Import note: the checked-in ruleset is config-as-code only until imported in
 GitHub settings, which makes it an importable description of the required set that
-nothing reconciles against reality. It therefore carries exactly the three contexts
+nothing reconciles against reality. It therefore carries exactly the four contexts
 above that are live, and no proposals: a proposal that ships inside an importable
 artifact gets promoted by whoever imports it, without the review it is waiting for.
 Importing the ruleset as checked in neither weakens nor widens the existing

--- a/docs/BRANCH-PROTECTION-SETUP.md
+++ b/docs/BRANCH-PROTECTION-SETUP.md
@@ -12,8 +12,9 @@ that protection in sync (UI or `gh` CLI).
 
 - **Require a pull request** before merging (no direct pushes to main).
 - **Required approvals:** at least 1–2.
-- **Required status checks:** `CI`, `host-capability-check`, and the commit
-  status `lane-check/proof` (pinned to the GitHub Actions app; observed live on
+- **Required status checks:** `CI`, `host-capability-check`,
+  `review-record-check`, and the commit status `lane-check/proof` (pinned to
+  the GitHub Actions app; observed live on
   2026-07-27, issue #1869 migration). The `lane-check` Actions job still runs
   and reports, but is informational: the proof status is posted on the exact PR
   head and refreshes on a same-head delegated proof, which the check-run cannot.
@@ -42,8 +43,9 @@ Ensure `.github/CODEOWNERS` exists and lists the right owners (see repo root).
 4. Enable:
    - Require a pull request before merging.
    - Require approvals (set number, e.g. 1).
-   - Require status checks: add `CI`, `host-capability-check`, and
-     `lane-check/proof` (or the exact context names your workflows expose;
+   - Require status checks: add `CI`, `host-capability-check`,
+     `review-record-check`, and `lane-check/proof` (or the exact context names
+     your workflows expose;
      check **Settings → Branches → Branch protection** or the Ruleset UI for the
      list of available checks).
    - Require branches to be up to date before merging.
@@ -63,6 +65,7 @@ Ensure `.github/CODEOWNERS` exists and lists the right owners (see repo root).
 | `lane-check/proof` | commit status posted by `scripts/ci/assay_runner_lane_check.py` (runs in `.github/workflows/assay-runner-lane-check.yml`) |
 | `lane-check` | `.github/workflows/assay-runner-lane-check.yml` (informational since the #1869 migration) |
 | `host-capability-check` | `.github/workflows/host-capability-check.yml` |
+| `review-record-check` | `.github/workflows/review-record-check.yml` |
 | `Smoke Install (E2E)` | `.github/workflows/smoke-install.yml` |
 | `assay-action-contract-tests` | `.github/workflows/action-tests.yml` |
 | `MCP Security (Assay)` | `.github/workflows/assay-security.yml` |
@@ -80,6 +83,7 @@ Use **`CI`** (not `CIExpected` or any other variant). No workflow in this repo r
 | **CI** | Build, test, clippy, cargo-deny, cargo-audit, eBPF smoke | **Essential** — new deps must not break build or tests. | **Essential** — same. |
 | **lane-check/proof** | Commit status confirming runner-sensitive PRs carry the delegated proof for the exact head. | Required but normally quick/no-op unless the classifier says proof is needed. | Required; becomes load-bearing for runner/evidence-sensitive changes. A same-head delegated proof refreshes it without a manual rerun. |
 | **host-capability-check** | Confirms whether the PR requires host-capability proof before privileged runner evidence is trusted. | Required but normally quick/no-op for ordinary dependency updates. | Required; becomes load-bearing for host/kernel/runner capability-sensitive changes. |
+| **review-record-check** | Requires a public non-building review record bound to the current PR head. | Required; dependency automation still needs an independent exact-head record. | Required; a later push invalidates the prior record until a new review is posted. |
 | **Smoke Install (E2E)** | Build from source, run assay, JUnit | Redundant with CI (CI already builds and tests). | Useful — verifies install path. |
 | **assay-action-contract-tests** | Tests GitHub Action in `assay-action/` | Not needed — Cargo.toml/Cargo.lock don't touch the action. | **Essential** if PR touches `assay-action/` or workflows. |
 | **MCP Security (Assay)** | Install assay, run validate with demo config | Redundant with CI for deps-only (CI validates the binary). | Useful — sanity check for security workflow. |
@@ -105,9 +109,9 @@ Until then the gate runs, reports on every PR, and is a review obligation like
 Smoke Install and MCP Security: if a PR moves a published number, its green tick
 is the thing to look for before merging.
 
-**Current recommendation:** Keep **`CI`, `lane-check/proof`, and
-`host-capability-check`** required. `CI` is the universal build/security gate;
-`lane-check/proof` and `host-capability-check` are quick for ordinary PRs but
+**Current recommendation:** Keep **`CI`, `lane-check/proof`,
+`host-capability-check`, and `review-record-check`** required. `CI` is the
+universal build/security gate; `lane-check/proof` and `host-capability-check` are quick for ordinary PRs but
 preserve the runner/evidence proof boundary when a PR touches sensitive paths. Smoke
 Install, assay-action-contract-tests, and MCP Security still run and appear on
 the PR; they are not required to merge. If you merge changes to `assay-action/`
@@ -131,7 +135,7 @@ gh api repos/OWNER/REPO/branches/main/protection -X PUT \
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["CI", "host-capability-check", "lane-check/proof"]
+    "contexts": ["CI", "host-capability-check", "lane-check/proof", "review-record-check"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": {
@@ -226,8 +230,8 @@ See `docs/REVIEWER-PACK.md` (sectie 3, “Environments & approvals”) and the c
 ## Checklist
 
 - [x] Branch protection or ruleset on `main` with: require PR, approvals, status checks, up to date, no force-push.
-- [x] Required status checks: `CI`, `host-capability-check`, and
-  `lane-check/proof` (see "Required checks: when each is needed" above;
+- [x] Required status checks: `CI`, `host-capability-check`,
+  `lane-check/proof`, and `review-record-check` (see "Required checks: when each is needed" above;
   add Smoke Install / contract tests / MCP Security / Kernel Matrix only when
   stricter gates are intentionally needed).
 - [x] CODEOWNERS in place; “Require review from Code Owners” enabled.
@@ -242,10 +246,10 @@ If a PR shows a required check **CIExpected** that never completes, branch prote
 **Fix:** In **Settings → Branches → Branch protection rule for `main`**, under
 "Require status checks", remove **CIExpected** and add **CI** (from
 `.github/workflows/ci.yml`) plus the current required live contexts
-`host-capability-check` and `lane-check/proof`. Save.
+`host-capability-check`, `lane-check/proof`, and `review-record-check`. Save.
 
 **Via API:** Inspect with `gh api repos/OWNER/REPO/branches/main/protection`.
 Ensure `required_status_checks.contexts` contains `CI`, `host-capability-check`,
-and `lane-check/proof`, and does not contain `CIExpected` or the retired bare
+`lane-check/proof`, and `review-record-check`, and does not contain `CIExpected` or the retired bare
 `lane-check`. Re-apply using the JSON in Option B above with
-`"contexts": ["CI", "host-capability-check", "lane-check/proof"]`.
+`"contexts": ["CI", "host-capability-check", "lane-check/proof", "review-record-check"]`.

--- a/docs/reference/review-record.md
+++ b/docs/reference/review-record.md
@@ -63,7 +63,7 @@ pages (200 comments) with `comments_limit`. A comments-API failure is
 `comments_api_failure`. The pre-commit hook is
 `assay-review-record-self-test`.
 
-## Advisory workflow
+## Required workflow
 
 `.github/workflows/review-record-check.yml` runs for `opened`, `reopened`,
 `synchronize`, and `ready_for_review` pull-request events. It checks out the

--- a/docs/reference/review-record.md
+++ b/docs/reference/review-record.md
@@ -3,8 +3,9 @@
 Assay #2561. A merge to `main` still needs the AGENTS.md non-building
 exact-head review. This page documents the **public, machine-readable
 record** and the checker that proves one exists for a named head. Slice B
-adds the advisory `review-record-check` GitHub Actions job. It is deliberately
-not a required branch-protection context yet.
+added the `review-record-check` GitHub Actions job. Slice C makes that stable
+context required by classic branch protection after the workflow proved both
+a missing-record failure and a current-record success on the same PR head.
 
 ## What to post
 
@@ -78,15 +79,18 @@ record. A later push triggers `synchronize`; the old record is stale and the
 new head needs a new independent review record before a rerun can pass.
 
 The workflow structure is cross-pinned from the existing required CI and
-host-capability roots. That makes a single changed root detectable, but does
-not turn this advisory job into merge enforcement.
+host-capability roots. Classic branch protection requires its stable
+`review-record-check` context, and
+`.github/rulesets/main-required-ci-contexts.json` records that expected live
+set. The scheduled reconciliation workflow detects drift between that file and
+the live protection rule.
 
 ## Non-claims
 
 The record is not cryptographic agent identity, intellectual adequacy, review
-quality, an approval count, or AGENTS carry-forward. Slice B does not change
-branch protection, support merge queues, write comments or statuses, or use a
-write token. API failure is a failed check, not evidence that the review was
-defective. A base checkout protects the executed repository code, not the
-PR-supplied workflow definition. Coordinated mutation of the workflow,
-checker, and both required roots is outside repo-local enforcement.
+quality, an approval count, or AGENTS carry-forward. The workflow does not
+support merge queues, write comments or statuses, or use a write token. API
+failure is a failed required check, not evidence that the review was defective.
+A base checkout protects the executed repository code, not the PR-supplied
+workflow definition. Coordinated mutation of the workflow, checker, both
+required roots, and live protection is outside repo-local enforcement.


### PR DESCRIPTION
## Summary

- add `review-record-check` to the checked-in required-context set
- update the three public contract projections that name or explain that set
- keep the workflow/checker unchanged; enforcement is classic branch protection

## Why

PR #2600 proved the advisory workflow on one exact head in both directions:

- missing current record on `synchronize` -> failure
- current independent record on `ready_for_review` -> success

Slice C makes that stable context merge-enforcing without adding a second checker or identity claim.

## Review packet

- Base: `b32a9165a13a1937099d02baac859629bb8e0ce8`
- Head: `2b4404165d5728094b873ae690e09f9809869583`
- Scope: four config/docs files; no workflow, checker, Rust, schema, or runtime changes
- Contract change: required contexts become `CI`, `host-capability-check`, `lane-check/proof`, `review-record-check`
- RED: live reconciliation exits 1 because current branch protection lacks `review-record-check`
- GREEN target: exact same reconciliation exits 0 after the reviewed PR head is green and live protection is updated
- Risk: repository-wide merge enforcement; staged while no other PRs are open
- Non-claims: record existence does not prove cryptographic identity, review quality, approval, or AGENTS carry-forward

## Validation

```text
python3 scripts/ci/check-required-contexts.py
required-contexts=passed

python3 scripts/ci/check-required-contexts.py --self-test
check-required-contexts self-test=passed

python3 scripts/ci/check-required-contexts.py --live-response < /tmp/assay-2561-live-before.json
required-contexts-live=drift
missing review-record-check
exit 1

python3 scripts/ci/check-ci-gate-coverage.py
ci-gate-coverage=passed

bash scripts/ci/test-ci-programme-truth.sh
PASS: ci programme truth

pre-commit run --files <four paths>
all applicable hooks passed
```

Draft until independent exact-head review, live context success, and branch-protection reconciliation are complete.


## Review delta

The first exact-head review on `98ed9df878ff6ac8968d240565a9c2d0ec95995d` identified one stale public heading. Commit `2b4404165d5728094b873ae690e09f9809869583` changes only `## Advisory workflow` to `## Required workflow`; the prior review and record are intentionally stale and a fresh exact-head review is required.
