### PR TITLE
fix(monitor): classify missing tracepoint file errors

### DIFF
--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -32,6 +32,10 @@ fn attach_kernel_lacks_point(err: &ProgramError) -> bool {
     // ENOENT=2, EOPNOTSUPP=95 on Linux.
     match err {
         ProgramError::SyscallError(sy) => matches!(sy.io_error.raw_os_error(), Some(2 | 95)),
+        ProgramError::TracePointError(aya::programs::trace_point::TracePointError::FileError {
+            io_error,
+            ..
+        }) => matches!(io_error.raw_os_error(), Some(2 | 95)),
         _ => false,
     }
 }
@@ -703,5 +707,46 @@ impl LinuxMonitor {
             .map_err(|_| MonitorError::ReaderDied)?;
 
         Ok(ReceiverStream::new(rx))
+    }
+}
+
+#[cfg(test)]
+mod attach_error_tests {
+    use super::attach_kernel_lacks_point;
+    use aya::{
+        programs::{trace_point::TracePointError, ProgramError},
+        sys::SyscallError,
+    };
+    use std::io;
+
+    fn syscall_error(errno: i32) -> ProgramError {
+        ProgramError::SyscallError(SyscallError {
+            call: "test_attach",
+            io_error: io::Error::from_raw_os_error(errno),
+        })
+    }
+
+    fn tracepoint_file_error(errno: i32) -> ProgramError {
+        ProgramError::TracePointError(TracePointError::FileError {
+            filename: "/tracefs/events/syscalls/test/id".into(),
+            io_error: io::Error::from_raw_os_error(errno),
+        })
+    }
+
+    #[test]
+    fn missing_tracepoint_classification_covers_both_aya_error_paths() {
+        let cases = [
+            ("syscall ENOENT", syscall_error(2), true),
+            ("syscall EOPNOTSUPP", syscall_error(95), true),
+            ("tracepoint ENOENT", tracepoint_file_error(2), true),
+            ("tracepoint EOPNOTSUPP", tracepoint_file_error(95), true),
+            ("syscall EACCES", syscall_error(13), false),
+            ("tracepoint EACCES", tracepoint_file_error(13), false),
+            ("unrelated program error", ProgramError::NotLoaded, false),
+        ];
+
+        for (name, error, expected) in cases {
+            assert_eq!(attach_kernel_lacks_point(&error), expected, "{name}");
+        }
     }
 }

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -40,6 +40,14 @@ fn attach_kernel_lacks_point(err: &ProgramError) -> bool {
     }
 }
 
+fn classify_send_attach_error(error: ProgramError) -> (SendFault, String) {
+    let kernel_lacks_point = attach_kernel_lacks_point(&error);
+    (
+        SendFault::AttachFailed { kernel_lacks_point },
+        error.to_string(),
+    )
+}
+
 #[cfg(target_os = "linux")]
 fn attach_send_tracepoint(
     bpf: &mut Ebpf,
@@ -55,14 +63,9 @@ fn attach_send_tracepoint(
         .map_err(|error| (SendFault::WrongProgramKind, error.to_string()))?;
     tp.load()
         .map_err(|error| (SendFault::LoadFailed, error.to_string()))?;
-    let link_id = tp.attach(row.tp().0, row.tp().1).map_err(|error| {
-        (
-            SendFault::AttachFailed {
-                kernel_lacks_point: attach_kernel_lacks_point(&error),
-            },
-            error.to_string(),
-        )
-    })?;
+    let link_id = tp
+        .attach(row.tp().0, row.tp().1)
+        .map_err(classify_send_attach_error)?;
     tp.take_link(link_id).map_err(|error| {
         (
             SendFault::AttachFailed {
@@ -712,7 +715,8 @@ impl LinuxMonitor {
 
 #[cfg(test)]
 mod attach_error_tests {
-    use super::attach_kernel_lacks_point;
+    use super::{attach_kernel_lacks_point, classify_send_attach_error};
+    use crate::probes::{send_update, ProbeAttachment, ProbeOutcome};
     use aya::{
         programs::{trace_point::TracePointError, ProgramError},
         sys::SyscallError,
@@ -748,5 +752,46 @@ mod attach_error_tests {
         for (name, error, expected) in cases {
             assert_eq!(attach_kernel_lacks_point(&error), expected, "{name}");
         }
+    }
+
+    #[test]
+    fn send_attach_error_reaches_the_final_probe_outcome() {
+        for (name, error, expected) in [
+            (
+                "missing tracepoint",
+                tracepoint_file_error(2),
+                ProbeOutcome::Unsupported,
+            ),
+            (
+                "permission failure",
+                tracepoint_file_error(13),
+                ProbeOutcome::Failed,
+            ),
+        ] {
+            let (fault, _) = classify_send_attach_error(error);
+            let mut attachment = ProbeAttachment::default();
+            attachment.record_attempt_failure("sys_enter_sendto", send_update(fault));
+            assert_eq!(
+                attachment.outcome("sys_enter_sendto"),
+                Some(expected),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn send_attach_site_delegates_to_the_classification_owner() {
+        let production = include_str!("loader.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production loader source");
+
+        assert_eq!(
+            production
+                .matches(".map_err(classify_send_attach_error)?")
+                .count(),
+            1,
+            "send attach must use the tested classification owner exactly once"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- classify Aya `TracePointError::FileError` with `ENOENT` or `EOPNOTSUPP` as a kernel-unsupported tracepoint
- retain `Failed` semantics for `EACCES` and unrelated attach errors
- route the production attach site through one tested classifier and project its result to the final probe outcome

Closes #2350.

## Verification

Exact head: `dc8cff4bdb808c398e8352ac19b74cb0803c79f8`
Linux host: `assay-bpf-runner`, Ubuntu 24.04 arm64, rustc/cargo 1.96.0.

- initial RED: typed-path test failed at `tracepoint ENOENT` (actual `false`, expected `true`)
- review-fix RED: production-callsite guard found zero uses of the tested classification owner
- GREEN: 3 focused attach-error tests pass
- `cargo test -p assay-monitor`: 57 passed, 1 ignored
- `cargo clippy -p assay-monitor --all-targets -- -D warnings`: pass
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

## Mutation evidence

- hardcoding `kernel_lacks_point: false` at the production attach call makes the callsite-delegation test fail
- classifying every `TracePointError::FileError` as unsupported makes both the EACCES parity row and final `ProbeOutcome::Failed` assertion fail
- restoring the source returns all 3 focused tests to green

## Review disposition

The blocker on the prior head `907d0b3545ad4370251a1d008f8610cd47016ff6` was valid: the helper test did not pin its production caller. This head extracts one `classify_send_attach_error` owner, routes the attach call through it, and pins both the final projection and the callsite.

## Non-claims

- no claim that every kernel exposes these tracepoints
- no exhaustive send or io_uring coverage claim
- no enforcement behavior change
- no live missing-tracepoint attach was exercised; the Linux test constructs the exact typed Aya error variants and verifies their final inventory outcomes
