### PR TITLE
fix(release): bound GitHub CLI subprocesses

### DIFF
--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -88,8 +88,23 @@ fake_gh="$tmp/gh"
 cat >"$fake_gh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$$" >"$FAKE_GH_PID_FILE"
-sleep 30 &
-printf '%s\n' "$!" >>"$FAKE_GH_PID_FILE"
+python3 - "$FAKE_GH_PID_FILE" <<'PY' &
+import os
+import signal
+import sys
+import time
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with open(sys.argv[1], "a", encoding="utf-8") as handle:
+    handle.write(f"{os.getpid()}\n")
+os.close(1)
+os.close(2)
+while True:
+    time.sleep(30)
+PY
+while [[ "$(wc -l <"$FAKE_GH_PID_FILE" | tr -d ' ')" -lt 2 ]]; do
+  sleep 0.01
+done
 wait
 SH
 chmod +x "$fake_gh"
@@ -97,17 +112,18 @@ chmod +x "$fake_gh"
 status_file="$tmp/hung-gh.status"
 stderr_file="$tmp/hung-gh.stderr"
 pid_file="$tmp/hung-gh.pid"
+survivor_file="$tmp/hung-gh.survivors"
 FAKE_GH_PID_FILE="$pid_file" \
 ASSAY_RELEASE_GH_TIMEOUT_SECONDS=0.2 \
 GH="$fake_gh" \
-python3 - "$ORACLE" "$status_file" "$stderr_file" "$pid_file" <<'PY'
+python3 - "$ORACLE" "$status_file" "$stderr_file" "$pid_file" "$survivor_file" <<'PY'
 import os
 import pathlib
 import signal
 import subprocess
 import sys
 
-oracle, status_path, stderr_path, pid_path = sys.argv[1:]
+oracle, status_path, stderr_path, pid_path, survivor_path = sys.argv[1:]
 process = subprocess.Popen(
     [oracle, "--self-test"],
     stdout=subprocess.PIPE,
@@ -127,6 +143,26 @@ except subprocess.TimeoutExpired:
         pass
     _, stderr = process.communicate()
     status = 124
+pids = []
+try:
+    pids = [int(pid) for pid in pathlib.Path(pid_path).read_text(encoding="utf-8").splitlines()]
+except (FileNotFoundError, ValueError):
+    pass
+survivors = []
+for pid in pids:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        continue
+    survivors.append(pid)
+pathlib.Path(survivor_path).write_text(
+    "".join(f"{pid}\n" for pid in survivors), encoding="utf-8"
+)
+if pids:
+    try:
+        os.killpg(pids[0], signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 pathlib.Path(status_path).write_text(f"{status}\n", encoding="utf-8")
 pathlib.Path(stderr_path).write_bytes(stderr)
 PY
@@ -134,6 +170,8 @@ PY
   || fail "hung gh was not classified as infrastructure exit 2 (got $(cat "$status_file"))"
 grep -q 'deadline' "$stderr_file" || fail "hung gh diagnostic does not name the deadline"
 [[ -s "$pid_file" ]] || fail "fake gh did not record its pid"
+[[ ! -s "$survivor_file" ]] \
+  || fail "hung gh processes survived verifier timeout: $(tr '\n' ' ' <"$survivor_file")"
 while IFS= read -r pid; do
   if kill -0 "$pid" 2>/dev/null; then
     fail "hung gh process $pid survived verifier timeout"

--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -82,4 +82,76 @@ if grep -Eq '\|[[:space:]]*(python3|"\$PYTHON")[[:space:]].*<<' "$ORACLE"; then
 fi
 grep -q 'bounded_capture' "$ORACLE" || fail "oracle has no bounded JSON capture"
 
+# A stalled GitHub CLI must be bounded by the verifier itself. The outer Python
+# watchdog protects this test from hanging when that inner deadline regresses.
+fake_gh="$tmp/gh"
+cat >"$fake_gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" >"$FAKE_GH_PID_FILE"
+sleep 30 &
+printf '%s\n' "$!" >>"$FAKE_GH_PID_FILE"
+wait
+SH
+chmod +x "$fake_gh"
+
+status_file="$tmp/hung-gh.status"
+stderr_file="$tmp/hung-gh.stderr"
+pid_file="$tmp/hung-gh.pid"
+FAKE_GH_PID_FILE="$pid_file" \
+ASSAY_RELEASE_GH_TIMEOUT_SECONDS=0.2 \
+GH="$fake_gh" \
+python3 - "$ORACLE" "$status_file" "$stderr_file" "$pid_file" <<'PY'
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+
+oracle, status_path, stderr_path, pid_path = sys.argv[1:]
+process = subprocess.Popen(
+    [oracle, "--self-test"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    start_new_session=True,
+)
+try:
+    _, stderr = process.communicate(timeout=2.0)
+    status = process.returncode
+except subprocess.TimeoutExpired:
+    os.killpg(process.pid, signal.SIGKILL)
+    try:
+        pids = pathlib.Path(pid_path).read_text(encoding="utf-8").splitlines()
+        if pids:
+            os.killpg(int(pids[0]), signal.SIGKILL)
+    except (FileNotFoundError, ProcessLookupError, ValueError):
+        pass
+    _, stderr = process.communicate()
+    status = 124
+pathlib.Path(status_path).write_text(f"{status}\n", encoding="utf-8")
+pathlib.Path(stderr_path).write_bytes(stderr)
+PY
+[[ "$(cat "$status_file")" -eq 2 ]] \
+  || fail "hung gh was not classified as infrastructure exit 2 (got $(cat "$status_file"))"
+grep -q 'deadline' "$stderr_file" || fail "hung gh diagnostic does not name the deadline"
+[[ -s "$pid_file" ]] || fail "fake gh did not record its pid"
+while IFS= read -r pid; do
+  if kill -0 "$pid" 2>/dev/null; then
+    fail "hung gh process $pid survived verifier timeout"
+  fi
+done <"$pid_file"
+[[ "$(wc -l <"$pid_file" | tr -d ' ')" -eq 2 ]] \
+  || fail "fake gh did not record both parent and descendant pids"
+
+for invalid_timeout in 0 nan invalid; do
+  status=0
+  diagnostic="$(
+    ASSAY_RELEASE_GH_TIMEOUT_SECONDS="$invalid_timeout" GH="$fake_gh" \
+      "$ORACLE" --self-test 2>&1 >/dev/null
+  )" || status=$?
+  [[ "$status" -eq 2 ]] \
+    || fail "invalid gh deadline '$invalid_timeout' did not fail as infrastructure"
+  printf '%s\n' "$diagnostic" | grep -q 'must be a positive finite number' \
+    || fail "invalid gh deadline '$invalid_timeout' lacks a bounded diagnostic"
+done
+
 printf 'PASS: verify-release offline contract tests\n'

--- a/scripts/ci/verify-release.sh
+++ b/scripts/ci/verify-release.sh
@@ -112,11 +112,18 @@ except subprocess.TimeoutExpired:
     try:
         process.communicate(timeout=0.2)
     except subprocess.TimeoutExpired:
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        process.communicate()
+        pass
+    # The direct child may exit and close its pipes while a TERM-resistant
+    # descendant remains in the session. Always finish cleanup at group scope.
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=0.2)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=0.2)
     raise SystemExit(f"{command[0]} exceeded {timeout:g}s deadline")
 
 if process.returncode:

--- a/scripts/ci/verify-release.sh
+++ b/scripts/ci/verify-release.sh
@@ -72,21 +72,58 @@ bounded_capture() {
   local output="$1"
   shift
   "$PYTHON" - "$output" "$@" <<'PY'
+import math
+import os
 import pathlib
+import signal
 import subprocess
 import sys
 
 output, command = pathlib.Path(sys.argv[1]), sys.argv[2:]
 limit = 1024 * 1024
+raw_timeout = os.environ.get("ASSAY_RELEASE_GH_TIMEOUT_SECONDS", "60")
 try:
-    result = subprocess.run(command, stdout=subprocess.PIPE, check=False)
+    timeout = float(raw_timeout)
+except ValueError:
+    raise SystemExit(
+        "ASSAY_RELEASE_GH_TIMEOUT_SECONDS must be a positive finite number"
+    )
+if not math.isfinite(timeout) or timeout <= 0:
+    raise SystemExit(
+        "ASSAY_RELEASE_GH_TIMEOUT_SECONDS must be a positive finite number"
+    )
+
+try:
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        start_new_session=True,
+    )
 except OSError as error:
     raise SystemExit(f"could not execute {command[0]}: {error}")
-if result.returncode:
-    raise SystemExit(f"{command[0]} exited {result.returncode}")
-if len(result.stdout) > limit:
+
+try:
+    stdout, _ = process.communicate(timeout=timeout)
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.communicate(timeout=0.2)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.communicate()
+    raise SystemExit(f"{command[0]} exceeded {timeout:g}s deadline")
+
+if process.returncode:
+    raise SystemExit(f"{command[0]} exited {process.returncode}")
+if len(stdout) > limit:
     raise SystemExit(f"{command[0]} response exceeds {limit} bytes")
-output.write_bytes(result.stdout)
+output.write_bytes(stdout)
 PY
 }
 


### PR DESCRIPTION
## Summary

- bound every GitHub CLI subprocess in `verify-release.sh` with one validated positive finite deadline
- start each child in its own process group and terminate/reap the full group on expiry
- always finish timeout cleanup with group-wide SIGKILL, even when the direct child exits during the TERM grace period
- classify expiry through the existing infrastructure exit `2` with a bounded deadline diagnostic
- add a Bash 3.2-compatible behavioral harness covering parent and TERM-resistant descendant cleanup

Refs #2562. This is slice 1 of 2; it intentionally does not close the issue.

## Verification

Exact head: `2a1a60bf2eb17c4f1aabe8a74cce0f4a260fef8a`

- RED: current verifier reached the 2-second outer watchdog and returned test sentinel `124`, not infrastructure exit `2`
- review RED: a TERM-resistant descendant that closes stdout/stderr survived while the verifier returned exit `2`
- GREEN: `/bin/bash scripts/ci/test-verify-release.sh` passes on macOS Bash 3.2
- `pre-commit run --files scripts/ci/verify-release.sh scripts/ci/test-verify-release.sh`: pass
- pre-push full hooks, including workspace clippy and cross-target Linux compile: pass
- `git diff --check`: pass

## Mutation evidence

- removing the inner `communicate(timeout=timeout)` reaches the outer watchdog and fails the test
- replacing process-group TERM/KILL with direct-child `process.kill()` reaches the outer watchdog and fails the test
- removing the unconditional group-wide SIGKILL leaves the TERM-resistant descendant alive and fails the survivor assertion
- the outer watchdog cleans nested fake process groups on mutant failure; restored control is green

## Remaining slice

#2562 remains open for pre-materialization combined stdout/stderr accounting. This PR preserves the existing stdout-only 1 MiB post-completion check and inherited stderr behavior so that the streaming-cap change can be reviewed and mutated independently.

## Non-claims

- no claim that GitHub currently hangs or that a released artifact is invalid
- no RSS, kernel-pipe-buffer, escaped-session, or native-Windows process-tree bound
- no change to curl behavior
- this applies ADR-043-style bounded-ingest discipline by analogy; it does not add this release verifier to ADR-043's enumerated evidence entrypoints
