### PR TITLE
fix(release): cap combined GitHub CLI output while reading

### DIFF
--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -246,6 +246,44 @@ if kill -0 "$(cat "$cap_pid_file")" 2>/dev/null; then
   fail "combined output fake gh survived the size ceiling"
 fi
 
+# Charge before display: the one byte beyond the cap must not reach stderr.
+sink_gh="$tmp/sink-gh"
+cat >"$sink_gh" <<'SH'
+#!/usr/bin/env bash
+exec python3 - <<'PY'
+import sys
+import time
+
+sys.stderr.buffer.write(b"\x01" * (1024 * 1024 + 1))
+sys.stderr.buffer.flush()
+time.sleep(30)
+PY
+SH
+chmod +x "$sink_gh"
+
+sink_stderr_file="$tmp/sink-gh.stderr"
+sink_status=0
+ASSAY_RELEASE_GH_TIMEOUT_SECONDS=2 GH="$sink_gh" \
+  "$ORACLE" --self-test >/dev/null 2>"$sink_stderr_file" || sink_status=$?
+[[ "$sink_status" -eq 2 ]] \
+  || fail "stderr overflow was not infrastructure exit 2 (got $sink_status)"
+grep -q 'combined stdout+stderr' "$sink_stderr_file" \
+  || fail "stderr overflow lacks the size diagnostic"
+if grep -q 'deadline' "$sink_stderr_file"; then
+  fail "stderr overflow reached the command deadline"
+fi
+python3 - "$sink_stderr_file" <<'PY'
+import pathlib
+import sys
+
+visible = pathlib.Path(sys.argv[1]).read_bytes().count(b"\x01")
+limit = 1024 * 1024
+if visible != limit:
+    raise SystemExit(
+        f"overflow bytes reached stderr: expected {limit} visible child bytes, got {visible}"
+    )
+PY
+
 for invalid_timeout in 0 nan invalid; do
   status=0
   diagnostic="$(

--- a/scripts/ci/test-verify-release.sh
+++ b/scripts/ci/test-verify-release.sh
@@ -180,6 +180,72 @@ done <"$pid_file"
 [[ "$(wc -l <"$pid_file" | tr -d ' ')" -eq 2 ]] \
   || fail "fake gh did not record both parent and descendant pids"
 
+# The ceiling applies while reading and across both streams. Each stream stays
+# below 1 MiB, then the fake sleeps so a post-completion check loses to timeout.
+cap_gh="$tmp/cap-gh"
+cat >"$cap_gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$$" >"$FAKE_GH_PID_FILE"
+exec python3 - <<'PY'
+import sys
+import time
+
+sys.stdout.buffer.write(b"o" * (600 * 1024))
+sys.stdout.buffer.flush()
+sys.stderr.buffer.write(b"e" * (600 * 1024))
+sys.stderr.buffer.flush()
+time.sleep(30)
+PY
+SH
+chmod +x "$cap_gh"
+
+cap_status_file="$tmp/cap-gh.status"
+cap_stderr_file="$tmp/cap-gh.stderr"
+cap_pid_file="$tmp/cap-gh.pid"
+FAKE_GH_PID_FILE="$cap_pid_file" \
+ASSAY_RELEASE_GH_TIMEOUT_SECONDS=2 \
+GH="$cap_gh" \
+python3 - "$ORACLE" "$cap_status_file" "$cap_stderr_file" "$cap_pid_file" <<'PY'
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+
+oracle, status_path, stderr_path, pid_path = sys.argv[1:]
+process = subprocess.Popen(
+    [oracle, "--self-test"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    start_new_session=True,
+)
+try:
+    _, stderr = process.communicate(timeout=5.0)
+    status = process.returncode
+except subprocess.TimeoutExpired:
+    os.killpg(process.pid, signal.SIGKILL)
+    _, stderr = process.communicate()
+    status = 124
+pathlib.Path(status_path).write_text(f"{status}\n", encoding="utf-8")
+pathlib.Path(stderr_path).write_bytes(stderr)
+try:
+    fake_pid = int(pathlib.Path(pid_path).read_text(encoding="utf-8").strip())
+    os.killpg(fake_pid, signal.SIGKILL)
+except (FileNotFoundError, ProcessLookupError, ValueError):
+    pass
+PY
+[[ "$(cat "$cap_status_file")" -eq 2 ]] \
+  || fail "combined output overflow was not infrastructure exit 2 (got $(cat "$cap_status_file"))"
+grep -q 'combined stdout+stderr' "$cap_stderr_file" \
+  || fail "combined output overflow lacks the size diagnostic"
+if grep -q 'deadline' "$cap_stderr_file"; then
+  fail "combined output overflow reached the command deadline"
+fi
+[[ -s "$cap_pid_file" ]] || fail "combined output fake gh did not record its pid"
+if kill -0 "$(cat "$cap_pid_file")" 2>/dev/null; then
+  fail "combined output fake gh survived the size ceiling"
+fi
+
 for invalid_timeout in 0 nan invalid; do
   status=0
   diagnostic="$(

--- a/scripts/ci/verify-release.sh
+++ b/scripts/ci/verify-release.sh
@@ -75,9 +75,11 @@ bounded_capture() {
 import math
 import os
 import pathlib
+import selectors
 import signal
 import subprocess
 import sys
+import time
 
 output, command = pathlib.Path(sys.argv[1]), sys.argv[2:]
 limit = 1024 * 1024
@@ -97,24 +99,27 @@ try:
     process = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         start_new_session=True,
     )
 except OSError as error:
     raise SystemExit(f"could not execute {command[0]}: {error}")
 
-try:
-    stdout, _ = process.communicate(timeout=timeout)
-except subprocess.TimeoutExpired:
+
+class CaptureFailure(Exception):
+    pass
+
+
+def stop_process_group():
     try:
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
         pass
     try:
-        process.communicate(timeout=0.2)
+        process.wait(timeout=0.2)
     except subprocess.TimeoutExpired:
         pass
-    # The direct child may exit and close its pipes while a TERM-resistant
-    # descendant remains in the session. Always finish cleanup at group scope.
+    # The direct child may exit while a TERM-resistant descendant remains.
     try:
         os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
@@ -124,12 +129,66 @@ except subprocess.TimeoutExpired:
     except subprocess.TimeoutExpired:
         process.kill()
         process.wait(timeout=0.2)
-    raise SystemExit(f"{command[0]} exceeded {timeout:g}s deadline")
+
+
+stdout = bytearray()
+total = 0
+deadline = time.monotonic() + timeout
+selector = selectors.DefaultSelector()
+streams = ((process.stdout, "stdout"), (process.stderr, "stderr"))
+for pipe, name in streams:
+    os.set_blocking(pipe.fileno(), False)
+    selector.register(pipe, selectors.EVENT_READ, name)
+
+try:
+    while selector.get_map():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise CaptureFailure(f"{command[0]} exceeded {timeout:g}s deadline")
+        events = selector.select(timeout=remaining)
+        if not events:
+            continue
+        for key, _ in events:
+            try:
+                chunk = os.read(key.fd, min(64 * 1024, limit + 1 - total))
+            except BlockingIOError:
+                continue
+            except OSError as error:
+                raise CaptureFailure(f"could not read {command[0]} output: {error}")
+            if not chunk:
+                selector.unregister(key.fileobj)
+                key.fileobj.close()
+                continue
+            next_total = total + len(chunk)
+            if next_total > limit:
+                raise CaptureFailure(
+                    f"{command[0]} response exceeds {limit} combined stdout+stderr bytes"
+                )
+            total = next_total
+            if key.data == "stdout":
+                stdout.extend(chunk)
+            else:
+                sys.stderr.buffer.write(chunk)
+                sys.stderr.buffer.flush()
+
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise CaptureFailure(f"{command[0]} exceeded {timeout:g}s deadline")
+    try:
+        process.wait(timeout=remaining)
+    except subprocess.TimeoutExpired:
+        raise CaptureFailure(f"{command[0]} exceeded {timeout:g}s deadline")
+except CaptureFailure as error:
+    stop_process_group()
+    raise SystemExit(str(error))
+finally:
+    selector.close()
+    for pipe, _ in streams:
+        if not pipe.closed:
+            pipe.close()
 
 if process.returncode:
     raise SystemExit(f"{command[0]} exited {process.returncode}")
-if len(stdout) > limit:
-    raise SystemExit(f"{command[0]} response exceeds {limit} bytes")
 output.write_bytes(stdout)
 PY
 }


### PR DESCRIPTION
## Summary

- read GitHub CLI stdout and stderr concurrently through nonblocking POSIX selectors
- enforce the existing 1 MiB ceiling across both streams before retaining or displaying each chunk
- keep one absolute command deadline and reuse the process-group cleanup landed in #2605
- preserve stderr visibility within the cap and publish stdout only after both EOFs plus exit 0
- add a behavioral combined-stream overflow test that must beat the later sleep/deadline

Closes #2562.

## Verification

Exact head: `f24fbaabe48ef788807f4c3575f5a883cc675b9c`

- RED: 600 KiB stdout + 600 KiB stderr + sleep returned exit `2` with the deadline path; the test failed because no combined-size diagnostic was present
- GREEN: `/bin/bash scripts/ci/test-verify-release.sh` passes on macOS Bash 3.2
- five consecutive focused runs pass with no retained fake process
- `pre-commit run --files scripts/ci/verify-release.sh scripts/ci/test-verify-release.sh`: pass
- pre-push workspace clippy and cross-target Linux compile: pass
- `git diff --check`: pass

## Mutation evidence

- restoring unbounded 64 KiB reads and removing the incremental cap loses the size diagnostic to the deadline; test fails
- charging only stdout lets the two individually sub-cap streams reach the deadline; test fails
- moving the cap check after stderr display exposes byte 1,048,577; the exact sink-boundary assertion fails
- the existing timeout test still kills a TERM-resistant descendant that closes both descriptors
- restored control passes

## Contract

- combined stdout + stderr retained/displayed bytes are capped at 1,048,576
- the overshooting chunk is charged before stdout retention or stderr display and is discarded
- after child exit, both streams are drained to EOF before accepting success
- nonzero exit, timeout, read error, or overflow never writes the output target

## Non-claims

- POSIX-only selector/process-group contract; no native Windows process-tree claim
- no RSS, PID-count, escaped-session, or kernel-pipe-buffer bound
- no change to curl or downstream JSON parser limits
- no claim that GitHub currently hangs or emits oversized responses
- one bounded read chunk may be materialized transiently; it is never retained after exceeding the ceiling

