### PR TITLE
docs(conformance): record historical v0 schema identity

### DIFF
--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -36,8 +36,9 @@ identity resolved to two different schema resources. The declared `$id` was:
 Interpret a historical v0 run record with the schema and validator from its exact candidate tag;
 do not dereference the `candidate.1` `$id` and assume those bytes describe a `candidate.3` or
 `candidate.4` record. Candidate tags and their assets remain immutable. The portable successor is
-`urn:assay:schema:privileged-mcp-action:conformance-run:v1`. This mapping documents the collision; it
-does not retroactively repair the identity of any v0 schema resource or run record.
+[`urn:assay:schema:privileged-mcp-action:conformance-run:v1`](report.schema.json). This mapping
+documents the collision; it does not retroactively repair the identity of any v0 schema resource or
+run record.
 
 ## What reproducing this corpus can and cannot distinguish
 

--- a/conformance/privileged-mcp-action-v0/ERRATA.md
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md
@@ -19,6 +19,26 @@ Recorded 2026-08-19. **No vector, expectation or digest is changed by this file.
 corpus whose digest is its identity does not get edited; it gets an erratum, and a later corpus
 gets the fix.
 
+## Historical v0 run-schema identity
+
+The four published candidate tags declared the same canonical schema identity even though that
+identity resolved to two different schema resources. The declared `$id` was:
+
+`https://raw.githubusercontent.com/Rul1an/assay/privileged-mcp-action-v0-candidate.1/conformance/privileged-mcp-action-v0/report.schema.json`
+
+| candidate tag | cases | `report.schema.json` SHA-256 |
+|---|---:|---|
+| `candidate.1` | 13 | `ebbee1990a7206cfe5ea7c23f54079f6eeb0b263cf750fb57a77b50b0f72aa9b` |
+| `candidate.2` | 13 | `ebbee1990a7206cfe5ea7c23f54079f6eeb0b263cf750fb57a77b50b0f72aa9b` |
+| `candidate.3` | 14 | `571e35aed92ae0c23f78c81021cb1c604f307f1e9dd4700a6aedc884d6be0d16` |
+| `candidate.4` | 14 | `571e35aed92ae0c23f78c81021cb1c604f307f1e9dd4700a6aedc884d6be0d16` |
+
+Interpret a historical v0 run record with the schema and validator from its exact candidate tag;
+do not dereference the `candidate.1` `$id` and assume those bytes describe a `candidate.3` or
+`candidate.4` record. Candidate tags and their assets remain immutable. The portable successor is
+`urn:assay:schema:privileged-mcp-action:conformance-run:v1`. This mapping documents the collision; it
+does not retroactively repair the identity of any v0 schema resource or run record.
+
 ## What reproducing this corpus can and cannot distinguish
 
 Reproducing all fourteen outcomes **can distinguish an implementation on at most five of the

--- a/conformance/privileged-mcp-action-v0/ERRATA.md.in
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md.in
@@ -36,8 +36,9 @@ identity resolved to two different schema resources. The declared `$id` was:
 Interpret a historical v0 run record with the schema and validator from its exact candidate tag;
 do not dereference the `candidate.1` `$id` and assume those bytes describe a `candidate.3` or
 `candidate.4` record. Candidate tags and their assets remain immutable. The portable successor is
-`urn:assay:schema:privileged-mcp-action:conformance-run:v1`. This mapping documents the collision; it
-does not retroactively repair the identity of any v0 schema resource or run record.
+[`urn:assay:schema:privileged-mcp-action:conformance-run:v1`](report.schema.json). This mapping
+documents the collision; it does not retroactively repair the identity of any v0 schema resource or
+run record.
 
 ## What reproducing this corpus can and cannot distinguish
 

--- a/conformance/privileged-mcp-action-v0/ERRATA.md.in
+++ b/conformance/privileged-mcp-action-v0/ERRATA.md.in
@@ -19,6 +19,26 @@ Recorded 2026-08-19. **No vector, expectation or digest is changed by this file.
 corpus whose digest is its identity does not get edited; it gets an erratum, and a later corpus
 gets the fix.
 
+## Historical v0 run-schema identity
+
+The four published candidate tags declared the same canonical schema identity even though that
+identity resolved to two different schema resources. The declared `$id` was:
+
+`https://raw.githubusercontent.com/Rul1an/assay/privileged-mcp-action-v0-candidate.1/conformance/privileged-mcp-action-v0/report.schema.json`
+
+| candidate tag | cases | `report.schema.json` SHA-256 |
+|---|---:|---|
+| `candidate.1` | 13 | `ebbee1990a7206cfe5ea7c23f54079f6eeb0b263cf750fb57a77b50b0f72aa9b` |
+| `candidate.2` | 13 | `ebbee1990a7206cfe5ea7c23f54079f6eeb0b263cf750fb57a77b50b0f72aa9b` |
+| `candidate.3` | 14 | `571e35aed92ae0c23f78c81021cb1c604f307f1e9dd4700a6aedc884d6be0d16` |
+| `candidate.4` | 14 | `571e35aed92ae0c23f78c81021cb1c604f307f1e9dd4700a6aedc884d6be0d16` |
+
+Interpret a historical v0 run record with the schema and validator from its exact candidate tag;
+do not dereference the `candidate.1` `$id` and assume those bytes describe a `candidate.3` or
+`candidate.4` record. Candidate tags and their assets remain immutable. The portable successor is
+`urn:assay:schema:privileged-mcp-action:conformance-run:v1`. This mapping documents the collision; it
+does not retroactively repair the identity of any v0 schema resource or run record.
+
 ## What reproducing this corpus can and cannot distinguish
 
 Reproducing all fourteen outcomes **can distinguish an implementation on at most five of the

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -2327,7 +2327,8 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
             self.assertIn("schema and validator from its exact candidate tag", errata)
             self.assertIn("Candidate tags and their assets remain immutable", errata)
             self.assertIn(
-                "urn:assay:schema:privileged-mcp-action:conformance-run:v1",
+                "[`urn:assay:schema:privileged-mcp-action:conformance-run:v1`]"
+                "(report.schema.json)",
                 errata,
             )
             self.assertIn("does not retroactively repair", errata)

--- a/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
+++ b/conformance/privileged-mcp-action-v0/tests/test_activation_kit.py
@@ -2304,6 +2304,34 @@ class CandidateCaptureTests(CandidateHarness, unittest.TestCase):
         self.assertEqual(report["schema"], validate_run_record.RUN_SCHEMA)
         self.assertEqual(report["schema"], schema["properties"]["schema"]["const"])
 
+    def test_historical_v0_schema_identity_is_reserved_and_documented(self) -> None:
+        historical_id = (
+            "https://raw.githubusercontent.com/Rul1an/assay/"
+            "privileged-mcp-action-v0-candidate.1/"
+            "conformance/privileged-mcp-action-v0/report.schema.json"
+        )
+        schema = json.loads((CORPUS_DIR / "report.schema.json").read_text(encoding="utf-8"))
+        self.assertNotEqual(schema["$id"], historical_id)
+
+        expected_rows = (
+            "| `candidate.1` | 13 | `ebbee1990a7206cfe5ea7c23f54079f6eeb0b263cf750fb57a77b50b0f72aa9b` |",
+            "| `candidate.2` | 13 | `ebbee1990a7206cfe5ea7c23f54079f6eeb0b263cf750fb57a77b50b0f72aa9b` |",
+            "| `candidate.3` | 14 | `571e35aed92ae0c23f78c81021cb1c604f307f1e9dd4700a6aedc884d6be0d16` |",
+            "| `candidate.4` | 14 | `571e35aed92ae0c23f78c81021cb1c604f307f1e9dd4700a6aedc884d6be0d16` |",
+        )
+        for path in (CORPUS_DIR / "ERRATA.md.in", CORPUS_DIR / "ERRATA.md"):
+            errata = path.read_text(encoding="utf-8")
+            self.assertIn(historical_id, errata)
+            for row in expected_rows:
+                self.assertIn(row, errata)
+            self.assertIn("schema and validator from its exact candidate tag", errata)
+            self.assertIn("Candidate tags and their assets remain immutable", errata)
+            self.assertIn(
+                "urn:assay:schema:privileged-mcp-action:conformance-run:v1",
+                errata,
+            )
+            self.assertIn("does not retroactively repair", errata)
+
     def test_validator_refuses_canonical_v0_as_unsupported_schema(self) -> None:
         """A v0 record is refused as unsupported schema, not as a shape error."""
         capture = self.valid_capture("v0-refusal")


### PR DESCRIPTION
## Summary

- document the two historical v0 run-schema resources published under one candidate.1 `$id`
- map candidate.1-.4 to exact schema SHA-256 and case count
- require historical v0 interpretation against the schema and validator from the exact candidate tag
- reserve the historical `$id` against reuse by the portable v1 schema

Closes #2589.

## Contract

- Candidate tags and assets remain immutable.
- The portable successor remains `urn:assay:schema:privileged-mcp-action:conformance-run:v1`.
- The erratum records the collision; it does not retroactively repair v0 resources or assert that external v0 run records exist.

## RED -> GREEN

- RED: the new contract test failed because the erratum did not contain the historical `$id` or tag mapping.
- GREEN: the generated and source errata both carry the mapping and the current schema uses the v1 URN.
- Mutation: replacing the v1 `$id` with the historical candidate.1 URL fails exactly at the reserved-identity assertion; the restored control is green.

## Validation

Measured on committed head `0e27853cb211fc6736b7be367410e75a93dd0a21` in `/Users/roelschuurkes/wt-codex-2589-schema-identity-erratum`.

- `python3 conformance/adequacy/project_published_numbers.py --check --repo .`
- `python3 conformance/adequacy/check_published_numbers.py`
- `python3 conformance/tests/test_published_numbers_guard.py` (41/41)
- `python3 conformance/privileged-mcp-action-v0/tests/test_activation_kit.py` (86/86)
- `python3 conformance/tests/test_completion_scope.py` (44/44)
- `pre-commit run --files <three changed paths>`
- `git diff --check`

## Local infrastructure limit

The combined OCI suite reached 154 tests but failed its live Docker setup because Docker Desktop was unavailable. This is not reported as a pass. Hosted CI must supply the live OCI integration result on the final head.
