### PR TITLE
chore(deps): update moka with cache witness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5055,7 +5055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/assay-mcp-server/src/cache.rs
+++ b/crates/assay-mcp-server/src/cache.rs
@@ -41,3 +41,30 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 pub fn key(abs_path: &str, sha: &str) -> String {
     format!("{}:{}", abs_path, sha)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_caches_store_and_retrieve_compiled_values() {
+        let caches = PolicyCaches::new(2);
+
+        let sequence = std::sync::Arc::new(SequencePolicy::Legacy(vec!["deploy".into()]));
+        caches.sequence.insert("sequence".into(), sequence.clone());
+
+        let blocklist = std::sync::Arc::new(vec!["shell".into()]);
+        caches
+            .blocklist
+            .insert("blocklist".into(), blocklist.clone());
+
+        assert!(std::sync::Arc::ptr_eq(
+            &caches.sequence.get("sequence").expect("sequence cached"),
+            &sequence
+        ));
+        assert!(std::sync::Arc::ptr_eq(
+            &caches.blocklist.get("blocklist").expect("blocklist cached"),
+            &blocklist
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- update the root lock from `moka 0.12.15` to `0.12.16`
- accept Cargo's bounded `tempfile 3.27.0 -> getrandom 0.3.4` edge re-resolution
- add a production-path unit witness for both Moka-backed policy caches

## Resolver decision

This update was isolated because targeted Moka resolution changes one shared transitive edge. The committed graph is the stable result of one targeted update:

```bash
cargo update -p moka --precise 0.12.16
```

Exact lock delta:

- remove `moka 0.12.15`
- add `moka 0.12.16`
- change only `tempfile 3.27.0: getrandom 0.4.3 -> 0.3.4`
- retain Assay, `uuid`, and direct consumers on `getrandom 0.4.3`
- no `windows-sys` movement
- no other package additions or removals

## Behavioral proof

The new test constructs `PolicyCaches::new(2)`, inserts real sequence and blocklist values, and retrieves the same `Arc` values through the production Moka caches.

Mutation witness: replacing both production `Cache::new(max_entries)` calls with `Cache::new(0)` makes the focused test fail on the missing sequence entry. The source was restored byte-for-byte before commit.

## Validation

- `cargo test -p assay-mcp-server --locked`
- `cargo clippy -p assay-mcp-server --all-targets --locked -- -D warnings`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo +1.89.0 metadata --locked --format-version 1 --no-deps`
- exact before/after lockgraph assertion
- `cargo tree --locked -i getrandom@0.3.4 --target all`
- `cargo tree --locked -i getrandom@0.4.3 --target all`
- `cargo fmt --all -- --check`
- `cargo deny check`
- `cargo audit --file Cargo.lock`
- pre-commit and pre-push hooks, including workspace clippy and Linux cross-target

## Non-claims

- this does not update `clap`; its Windows resolver churn remains a separate slice
- this does not resolve the fresh Dependabot PRs for `uuid`, `futures`, `rustls-webpki`, or `similar`
- existing allowed RustSec warnings are unchanged
- this is dependency compatibility evidence, not a security certification

Closes no issue; partial progress on #2474.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that compiled policy and blocklist values can be stored and retrieved correctly from the cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->