### PR TITLE
chore(deps): synchronize uuid 1.24.1 locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5545,9 +5545,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2621,7 +2621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",
@@ -2856,9 +2856,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",


### PR DESCRIPTION
## Summary

- synchronize root and fuzz lockfiles on `uuid 1.24.1`
- preserve the root `uuid -> getrandom 0.4.3` edge
- accept the one Cargo-selected fuzz edge change `tempfile 3.27.0: getrandom 0.4.3 -> 0.3.4`

## Why

Follow-up batch from #2474. Dependabot PR #2618 was closed because its title advertised 1.24.1 while its actual fuzz lock selected 1.25.0. This slice regenerates both locks from current main at one explicit version.

## Resolver proof

Base: `d68ca5f2ac3d05e9d820c8b22e3ec3ceaf8d1317`

- root removed/added package records: only `uuid 1.24.0 -> 1.24.1`
- root shared package-record changes: none
- fuzz removed/added package records: only `uuid 1.24.0 -> 1.24.1`
- fuzz shared package-record changes: only `tempfile 3.27.0` changing its getrandom edge
- no `windows-sys` movement
- Cargo 1.89 and 1.96 accept both lockfiles

## Behavioral proof

- `redaction_key::tests::generated_keys_differ`: 1 test executed and passed
- mutation replacing both production `Uuid::new_v4()` calls with `Uuid::nil()`: same test failed with exit 101 on equal zero keys
- `cargo test -p assay-runner-core --locked`: 116 tests passed
- affected clippy `-D warnings`, fmt, metadata, cargo-deny, cargo-audit, pre-commit and full pre-push hooks: passed

## Nonclaims

A locally built nightly `bundle_reader` fuzz target did not return within a 30-second outer bound even for an empty direct input. This is recorded separately as a pre-existing harness/portability finding; it is not reported as a UUID failure or as a passing fuzz smoke. Hosted fuzz CI on this exact head remains required.

No claim about UUID parsing behavior is made; Assay's production UUID use in this slice is random v4 key/run generation.
