### PR TITLE
test(deps): guard doctor diff across similar 3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,9 +4839,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
 dependencies = [
  "bstr",
 ]

--- a/crates/assay-cli/tests/doctor_fix_e2e.rs
+++ b/crates/assay-cli/tests/doctor_fix_e2e.rs
@@ -81,13 +81,14 @@ fn doctor_fix_parse_error_dry_run_exits_nonzero_and_does_not_write() {
 
     fs::write(
         &config,
-        "version: 1\nsuite: doctor-fix\nmodel: trace\nresponse_format: text\ntests:\n  - id: t1\n    input:\n      prompt: \"hello\"\n    expected:\n      type: must_contain\n      must_contain: [\"hello\"]\n",
+        "version: 1\nsuite: doctor-fix\nmodel: trace\nsettngs: {}\ntests:\n  - id: t1\n    input:\n      prompt: \"hello\"\n    expected:\n      type: must_contain\n      must_contain: [\"hello\"]\n",
     )
     .expect("write invalid eval config");
     let before = fs::read_to_string(&config).expect("read before");
 
     let mut cmd = Command::cargo_bin("assay").expect("cargo bin");
-    cmd.current_dir(temp.path())
+    let assert = cmd
+        .current_dir(temp.path())
         .arg("doctor")
         .arg("--config")
         .arg(&config)
@@ -96,6 +97,41 @@ fn doctor_fix_parse_error_dry_run_exits_nonzero_and_does_not_write() {
         .arg("--yes")
         .assert()
         .failure();
+
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let path = config.display();
+    let misspelled_line = before.lines().nth(3).expect("fixture has misspelled key");
+    assert!(
+        stdout.contains(&format!("--- {path} (dry-run) patch=rename_config_key ---")),
+        "dry-run output must identify the file and patch; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("--- {path}\n+++ {path}\n")),
+        "dry-run output must contain unified-diff file headers; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.lines().any(|line| line.starts_with("@@ ")),
+        "dry-run output must contain a unified-diff hunk; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line == format!("-{misspelled_line}"))
+            && stdout.lines().any(|line| line == "+settings: {}"),
+        "dry-run output must show the old key removed and replacement added; stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout
+            .lines()
+            .any(|line| line == format!("+{misspelled_line}"))
+            && !stdout.lines().any(|line| line == "-settings: {}"),
+        "dry-run output must preserve diff direction; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--- end ---\nDry run complete. 1 fix(es) previewed."),
+        "dry-run output must close the preview before its summary; stdout:\n{stdout}"
+    );
 
     let after = fs::read_to_string(&config).expect("read after");
     assert_eq!(


### PR DESCRIPTION
## Summary

- bump `similar` from 3.1.1 to 3.2.0 with a lock delta byte-identical to Dependabot #2612
- repair the existing doctor parse-error fixture so it actually reaches the auto-fix and unified-diff path
- pin only semantic dry-run output: file/patch frame, unified headers/hunk, removal/addition direction, closing marker, and no disk write

## Why

`similar` 3.2.0 intentionally changes the default Myers heuristic toward Git-style bounded, non-minimal splits. Assay accepts that presentation improvement instead of pinning legacy `RawMyers`; no consumer parses hunk ranges or byte-exact diff output.

The pre-existing E2E used `response_format`, for which doctor found no safe replacement. It therefore exited before `TextDiff::from_lines` and could stay green if the production diff direction was broken. The replacement fixture uses the auto-fixable `settngs -> settings` path.

Supersedes #2612. Part of #2474 dependency hygiene.

## Review packet

- Base: `61f449a440364455a0d663f20ff549ff3dbdd58a`
- Head: `cbdf8d3931be4cd4305cd3ad56d08a5813f12804`
- Scope: `Cargo.lock` and `crates/assay-cli/tests/doctor_fix_e2e.rs`
- Public contract: no schema/exit-code change; semantic human diff direction and frame are now guarded
- Risk: user-visible CLI presentation dependency; no security/auth/evidence-boundary change

## Verification

- `cargo test -p assay-cli` — pass
- `cargo test -p assay-cli --test doctor_fix_e2e` — 4/4 pass
- `cargo clippy -p assay-cli --all-targets -- -D warnings` — pass
- `cargo clippy -p assay-cli --test doctor_fix_e2e -- -D warnings` — pass after final test cleanup
- `cargo +1.89.0 metadata --locked --format-version 1 --no-deps` — pass
- `cargo +1.96.0 metadata --locked --format-version 1 --no-deps` — pass
- `cargo deny check advisories licenses bans sources` — pass
- `cargo audit --file Cargo.lock` — pass with four existing allowed warnings
- `pre-commit run --files Cargo.lock crates/assay-cli/tests/doctor_fix_e2e.rs` — pass
- `pre-commit run --hook-stage pre-push --files Cargo.lock crates/assay-cli/tests/doctor_fix_e2e.rs` — pass, including workspace clippy and Linux cross-target compile
- `git diff --check` — pass

## Mutation proof

On both 3.1.1 and 3.2.0, changing only:

```rust
TextDiff::from_lines(before, after)
```

to:

```rust
TextDiff::from_lines(after, before)
```

made `doctor_fix_parse_error_dry_run_exits_nonzero_and_does_not_write` fail with exit 101 because the removed/added lines were reversed. The unmutated control passed before and after the dependency update.

## Non-claims

- no byte-stability claim for hunk ranges, context grouping, or blank-line layout
- no claim that every `assay fix --dry-run` path is covered; `fix.rs` has a separate duplicate emitter not changed here
- no new RustSec remediation; the four allowed audit warnings predate this lock delta


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for configuration repair dry runs.
  - Verified that invalid configuration keys produce a non-writing preview with a correctly formatted unified diff.
  - Confirmed the preview shows the expected file changes, correction direction, and completion summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->