### PR TITLE
chore(deps): update futures to 0.3.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,9 +1982,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1997,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2007,15 +2007,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2024,38 +2024,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",


### PR DESCRIPTION
## Summary

- update the nine `futures` lockfile packages from 0.3.33 to 0.3.34
- accept the matching `futures-macro` migration from `syn 2.0.117` to `syn 3.0.3`
- preserve the 623-package resolved graph with no unrelated package movement

Supersedes #2617 and advances #2474.

## Contract and risk

This is a lockfile-only compatibility slice. Assay directly uses `StreamExt`/`TryStreamExt` in bounded object-store reads and monitoring paths. No public API, CLI, schema, workflow, or source behavior is changed.

Upstream 0.3.34 also fixes cloned `FuturesUnordered` waker identity. Assay has no direct production `FuturesUnordered` use, so this PR does not claim to reproduce that upstream bugfix.

## Verification

Measured on commit `ebf9e6c85ef1c4587f8d0ee94fee876a56da6168` in `/Users/roelschuurkes/wt-codex-2474-futures-034` with Rust/Cargo 1.96.0 unless noted.

### Characterization before and after update

- `cargo test -p assay-evidence a_stalled_ -- --nocapture`: 2 passed
- `cargo test -p assay-evidence a_slow_but_progressing_transfer_is_not_a_stall -- --nocapture`: 1 passed
- `cargo test -p assay-evidence an_endless_stream_of_empty_chunks_is_refused_by_the_chunk_count -- --nocapture`: 1 passed

The same counts passed before and after the lockfile update. An earlier `--exact` invocation matched zero tests and is explicitly discarded as evidence.

### Production-path mutation

Temporarily changed the bounded object-store idle-timeout branch from returning `IdleTimeout` to `break`:

- stalled-stream test: failed, exit 101
- slow-progress test: passed
- empty-chunk ceiling test: passed

The mutation was restored with an inverse patch; the stalled test then passed. This proves the focused failure-path witness reaches the production timeout decision rather than only a test helper.

### Full local gates

- `cargo test -p assay-evidence -p assay-cli`: passed; CLI unit suite 621 passed, 2 ignored, all affected integration/doc tests passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy -p assay-evidence -p assay-cli --all-targets -- -D warnings`: passed
- `cargo +1.89.0 metadata --locked --no-deps --format-version 1`: passed
- `cargo +1.96.0 metadata --locked --no-deps --format-version 1`: passed
- `cargo deny check`: passed
- `cargo audit`: passed with the four existing allowed warnings, no new advisory introduced
- `pre-commit run --files Cargo.lock`: passed
- `pre-commit run --hook-stage pre-push --files Cargo.lock`: passed, including workspace clippy and Linux cross-target compile gate
- `git diff --check`: passed

## Non-claims

- No direct Assay production path exercises the upstream `FuturesUnordered` cloned-waker fix.
- No live remote object store was used; coverage is the bounded-stream production implementation with deterministic test streams.
- Existing allowed RustSec warnings are not remediated by this update.
