### PR TITLE
chore(ci): lockstep osv-scanner/reporter 2.5.1 with count bind

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -148,61 +148,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import sys
-
-          def vulnerability_count(path):
-              with open(path, "r", encoding="utf-8") as handle:
-                  data = json.load(handle)
-              count = 0
-
-              def walk(value):
-                  nonlocal count
-                  if isinstance(value, dict):
-                      for key, child in value.items():
-                          if key == "vulnerabilities" and isinstance(child, list):
-                              count += len(child)
-                          walk(child)
-                  elif isinstance(value, list):
-                      for item in value:
-                          walk(item)
-
-              walk(data)
-              return count
-
-          def sarif_result_count(path):
-              with open(path, "r", encoding="utf-8") as handle:
-                  data = json.load(handle)
-              count = 0
-              runs = data.get("runs")
-              if not isinstance(runs, list):
-                  print("::error::OSV SARIF is missing a runs list", file=sys.stderr)
-                  sys.exit(1)
-              for run in runs:
-                  if not isinstance(run, dict):
-                      print("::error::OSV SARIF runs[] entry is not an object", file=sys.stderr)
-                      sys.exit(1)
-                  results = run.get("results")
-                  if not isinstance(results, list):
-                      print("::error::OSV SARIF runs[].results is not a list", file=sys.stderr)
-                      sys.exit(1)
-                  count += len(results)
-              return count
-
-          osv_json_vuln_count = vulnerability_count("osv-results.json")
-          osv_sarif_result_count = sarif_result_count("osv-results.sarif")
-          print(f"osv-json-vulnerabilities={osv_json_vuln_count}")
-          print(f"osv-sarif-results={osv_sarif_result_count}")
-          if osv_json_vuln_count != osv_sarif_result_count:
-              print(
-                  "::error::OSV reporter SARIF result count "
-                  f"{osv_sarif_result_count} does not match scanner JSON "
-                  f"vulnerability count {osv_json_vuln_count}",
-                  file=sys.stderr,
-              )
-              sys.exit(1)
-          PY
+          python3 scripts/ci/bind-osv-json-sarif-counts.py osv-results.json osv-results.sarif
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run OSV scanner
         id: osv-scan
-        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
         with:
           scan-args: ${{ steps.osv-targets.outputs.scan_args }}
         continue-on-error: true
@@ -136,13 +136,73 @@ jobs:
           fi
 
       - name: Build advisory SARIF
-        uses: google/osv-scanner-action/osv-reporter-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        uses: google/osv-scanner-action/osv-reporter-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
         with:
           scan-args: |-
             --output=osv-results.sarif
             --new=osv-results.json
             --gh-annotations=false
             --fail-on-vuln=false
+
+      - name: Bind scanner JSON count to reporter SARIF count
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import sys
+
+          def vulnerability_count(path):
+              with open(path, "r", encoding="utf-8") as handle:
+                  data = json.load(handle)
+              count = 0
+
+              def walk(value):
+                  nonlocal count
+                  if isinstance(value, dict):
+                      for key, child in value.items():
+                          if key == "vulnerabilities" and isinstance(child, list):
+                              count += len(child)
+                          walk(child)
+                  elif isinstance(value, list):
+                      for item in value:
+                          walk(item)
+
+              walk(data)
+              return count
+
+          def sarif_result_count(path):
+              with open(path, "r", encoding="utf-8") as handle:
+                  data = json.load(handle)
+              count = 0
+              runs = data.get("runs")
+              if not isinstance(runs, list):
+                  print("::error::OSV SARIF is missing a runs list", file=sys.stderr)
+                  sys.exit(1)
+              for run in runs:
+                  if not isinstance(run, dict):
+                      print("::error::OSV SARIF runs[] entry is not an object", file=sys.stderr)
+                      sys.exit(1)
+                  results = run.get("results")
+                  if not isinstance(results, list):
+                      print("::error::OSV SARIF runs[].results is not a list", file=sys.stderr)
+                      sys.exit(1)
+                  count += len(results)
+              return count
+
+          osv_json_vuln_count = vulnerability_count("osv-results.json")
+          osv_sarif_result_count = sarif_result_count("osv-results.sarif")
+          print(f"osv-json-vulnerabilities={osv_json_vuln_count}")
+          print(f"osv-sarif-results={osv_sarif_result_count}")
+          if osv_json_vuln_count != osv_sarif_result_count:
+              print(
+                  "::error::OSV reporter SARIF result count "
+                  f"{osv_sarif_result_count} does not match scanner JSON "
+                  f"vulnerability count {osv_json_vuln_count}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -148,7 +148,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 scripts/ci/bind-osv-json-sarif-counts.py osv-results.json osv-results.sarif
+          python3 scripts/ci/bind-osv-json-sarif-counts.py
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -90,16 +90,6 @@ jobs:
           scan-args: ${{ steps.osv-targets.outputs.scan_args }}
         continue-on-error: true
 
-      - name: Validate OSV scanner result
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ ! -s osv-results.json ]; then
-            echo "::error::OSV scanner did not produce a JSON result"
-            exit 1
-          fi
-
       - name: Build advisory SARIF
         uses: google/osv-scanner-action/osv-reporter-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
         with:

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -92,46 +92,11 @@ jobs:
 
       - name: Validate OSV scanner result
         shell: bash
-        env:
-          OSV_OUTCOME: ${{ steps.osv-scan.outcome }}
         run: |
           set -euo pipefail
 
           if [ ! -s osv-results.json ]; then
             echo "::error::OSV scanner did not produce a JSON result"
-            exit 1
-          fi
-
-          vuln_count="$(
-            python3 - <<'PY'
-          import json
-          import sys
-
-          with open("osv-results.json", "r", encoding="utf-8") as handle:
-              data = json.load(handle)
-
-          count = 0
-
-          def walk(value):
-              global count
-              if isinstance(value, dict):
-                  for key, child in value.items():
-                      if key == "vulnerabilities" and isinstance(child, list):
-                          count += len(child)
-                      walk(child)
-              elif isinstance(value, list):
-                  for item in value:
-                      walk(item)
-
-          walk(data)
-          print(count)
-          PY
-          )"
-
-          echo "osv-vulnerability-results=$vuln_count"
-
-          if [ "$OSV_OUTCOME" != "success" ] && [ "$vuln_count" -eq 0 ]; then
-            echo "::error::OSV scanner exited non-zero without vulnerability results; treating this as scanner execution failure"
             exit 1
           fi
 
@@ -146,6 +111,8 @@ jobs:
 
       - name: Bind scanner JSON count to reporter SARIF count
         shell: bash
+        env:
+          OSV_OUTCOME: ${{ steps.osv-scan.outcome }}
         run: |
           set -euo pipefail
           python3 scripts/ci/bind-osv-json-sarif-counts.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -367,6 +367,14 @@ repos:
         # no `target/` build it still verifies source and published-release truth independently.
         files: ^(scripts/ci/((check|test-check)-release-surface|read-assay-release-tag)\.sh|\.github/assay-release-tag|Cargo\.toml|README\.md|llms\.txt|docs/(index\.md|getting-started/(index|installation|quickstart|ci-integration)\.md|reference/cli/index\.md|python-sdk/index\.md|use-cases/(air-gapped|ci-gate)\.md|AIcontext/user-flows\.md|migration-v1\.2\.md|guides/editor-mcp-recipe\.md)|\.pre-commit-config\.yaml)$
 
+
+      - id: osv-scanner-scheduled-lockstep
+        name: OSV scanner/reporter lockstep and count bind
+        entry: bash scripts/ci/test-osv-scanner-scheduled-contract.sh
+        language: system
+        pass_filenames: false
+        files: ^(\.github/workflows/osv-scanner-scheduled\.yml|scripts/ci/(check|test)-osv-scanner-scheduled-contract\.(py|sh)|\.pre-commit-config\.yaml)$
+
       - id: workflow-continue-on-error-policy
         name: Workflow continue-on-error policy
         entry: bash scripts/ci/test-check-workflow-continue-on-error.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -373,7 +373,7 @@ repos:
         entry: bash scripts/ci/test-osv-scanner-scheduled-contract.sh
         language: system
         pass_filenames: false
-        files: ^(\.github/workflows/osv-scanner-scheduled\.yml|scripts/ci/(check|test)-osv-scanner-scheduled-contract\.(py|sh)|\.pre-commit-config\.yaml)$
+        files: ^(\.github/workflows/osv-scanner-scheduled\.yml|scripts/ci/(bind-osv-json-sarif-counts\.py|(check|test)-osv-scanner-scheduled-contract\.(py|sh))|\.pre-commit-config\.yaml)$
 
       - id: workflow-continue-on-error-policy
         name: Workflow continue-on-error policy

--- a/scripts/ci/bind-osv-json-sarif-counts.py
+++ b/scripts/ci/bind-osv-json-sarif-counts.py
@@ -3,7 +3,11 @@
 
 One rule, one function: refuse when the JSON `vulnerabilities` walk and the SARIF
 `runs[].results` length disagree, or when either artifact is missing/malformed.
+A second named function owns the scanner outcome gate: non-success plus a zero
+JSON count is an execution failure, not a clean scan.
+
 The scheduled workflow invokes this script; it does not reimplement the walk.
+OSV_OUTCOME must be wired from steps.osv-scan.outcome.
 
 Does not claim live scanner/reporter schema compatibility beyond these two counts.
 """
@@ -11,6 +15,7 @@ Does not claim live scanner/reporter schema compatibility beyond these two count
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -51,6 +56,27 @@ def sarif_result_count(data: Any) -> int:
     return count
 
 
+def read_osv_outcome() -> str:
+    outcome = os.environ.get("OSV_OUTCOME")
+    if outcome is None or outcome == "":
+        print(
+            "::error::OSV_OUTCOME is unset or empty; refusing (wiring hole)",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return outcome
+
+
+def refuse_if_scanner_execution_failed(outcome: str, json_count: int) -> None:
+    """Non-success with zero JSON vulns is a scanner crash, not a clean scan."""
+    if outcome != "success" and json_count == 0:
+        print(
+            "::error::OSV scanner exited non-zero without vulnerability results; treating this as scanner execution failure",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
 def refuse_if_counts_differ(json_count: int, sarif_count: int) -> None:
     """The compare/exit. Mutating this is the false-green hole."""
     if json_count != sarif_count:
@@ -64,6 +90,7 @@ def refuse_if_counts_differ(json_count: int, sarif_count: int) -> None:
 
 
 def bind(json_path: Path, sarif_path: Path) -> None:
+    outcome = read_osv_outcome()
     if not json_path.is_file() or json_path.stat().st_size == 0:
         print(f"::error::OSV JSON result missing: {json_path}", file=sys.stderr)
         raise SystemExit(1)
@@ -88,6 +115,7 @@ def bind(json_path: Path, sarif_path: Path) -> None:
         raise SystemExit(1) from exc
     print(f"osv-json-vulnerabilities={json_count}")
     print(f"osv-sarif-results={sarif_count}")
+    refuse_if_scanner_execution_failed(outcome, json_count)
     refuse_if_counts_differ(json_count, sarif_count)
 
 

--- a/scripts/ci/bind-osv-json-sarif-counts.py
+++ b/scripts/ci/bind-osv-json-sarif-counts.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fail-closed bind of OSV scanner JSON vulnerability count to reporter SARIF results.
+
+One rule, one function: refuse when the JSON `vulnerabilities` walk and the SARIF
+`runs[].results` length disagree, or when either artifact is missing/malformed.
+The scheduled workflow invokes this script; it does not reimplement the walk.
+
+Does not claim live scanner/reporter schema compatibility beyond these two counts.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def vulnerability_count(data: Any) -> int:
+    count = 0
+
+    def walk(value: Any) -> None:
+        nonlocal count
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key == "vulnerabilities" and isinstance(child, list):
+                    count += len(child)
+                walk(child)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    walk(data)
+    return count
+
+
+def sarif_result_count(data: Any) -> int:
+    if not isinstance(data, dict):
+        raise ValueError("OSV SARIF root is not an object")
+    runs = data.get("runs")
+    if not isinstance(runs, list):
+        raise ValueError("OSV SARIF is missing a runs list")
+    count = 0
+    for run in runs:
+        if not isinstance(run, dict):
+            raise ValueError("OSV SARIF runs[] entry is not an object")
+        results = run.get("results")
+        if not isinstance(results, list):
+            raise ValueError("OSV SARIF runs[].results is not a list")
+        count += len(results)
+    return count
+
+
+def refuse_if_counts_differ(json_count: int, sarif_count: int) -> None:
+    """The compare/exit. Mutating this is the false-green hole."""
+    if json_count != sarif_count:
+        print(
+            "::error::OSV reporter SARIF result count "
+            f"{sarif_count} does not match scanner JSON "
+            f"vulnerability count {json_count}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
+def bind(json_path: Path, sarif_path: Path) -> None:
+    if not json_path.is_file() or json_path.stat().st_size == 0:
+        print(f"::error::OSV JSON result missing: {json_path}", file=sys.stderr)
+        raise SystemExit(1)
+    if not sarif_path.is_file() or sarif_path.stat().st_size == 0:
+        print(f"::error::OSV SARIF result missing: {sarif_path}", file=sys.stderr)
+        raise SystemExit(1)
+    try:
+        json_data = json.loads(json_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"::error::OSV JSON is malformed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    try:
+        sarif_data = json.loads(sarif_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"::error::OSV SARIF is malformed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    try:
+        json_count = vulnerability_count(json_data)
+        sarif_count = sarif_result_count(sarif_data)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(f"osv-json-vulnerabilities={json_count}")
+    print(f"osv-sarif-results={sarif_count}")
+    refuse_if_counts_differ(json_count, sarif_count)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 2:
+        print(
+            "usage: bind-osv-json-sarif-counts.py <osv-results.json> <osv-results.sarif>",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        bind(Path(args[0]), Path(args[1]))
+    except SystemExit as exc:
+        code = exc.code
+        return int(code) if isinstance(code, int) else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/bind-osv-json-sarif-counts.py
+++ b/scripts/ci/bind-osv-json-sarif-counts.py
@@ -91,16 +91,12 @@ def bind(json_path: Path, sarif_path: Path) -> None:
     refuse_if_counts_differ(json_count, sarif_count)
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = sys.argv[1:] if argv is None else argv
-    if len(args) != 2:
-        print(
-            "usage: bind-osv-json-sarif-counts.py <osv-results.json> <osv-results.sarif>",
-            file=sys.stderr,
-        )
+def main() -> int:
+    if len(sys.argv) != 1:
+        print("usage: bind-osv-json-sarif-counts.py", file=sys.stderr)
         return 2
     try:
-        bind(Path(args[0]), Path(args[1]))
+        bind(Path("osv-results.json"), Path("osv-results.sarif"))
     except SystemExit as exc:
         code = exc.code
         return int(code) if isinstance(code, int) else 1

--- a/scripts/ci/check-osv-scanner-scheduled-contract.py
+++ b/scripts/ci/check-osv-scanner-scheduled-contract.py
@@ -3,8 +3,9 @@
 
 The reporter fail-opens on unreadable JSON (warn, empty results, exit 0). The
 runtime rule lives in scripts/ci/bind-osv-json-sarif-counts.py. This checker
-only pins that the workflow calls that script with both artifacts, and that
-scanner/reporter share one 40-hex SHA and semver comment.
+only pins that the workflow calls that script with both artifacts, wires
+OSV_OUTCOME from the scanner step, does not walk vulnerabilities itself, and
+that scanner/reporter share one 40-hex SHA and semver comment.
 
 It does not reimplement the count. Does not run the actions.
 """
@@ -17,6 +18,7 @@ from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/osv-scanner-scheduled.yml")
 BIND_SCRIPT = "scripts/ci/bind-osv-json-sarif-counts.py"
+ENV_WIRING = "OSV_OUTCOME: ${{ steps.osv-scan.outcome }}"
 
 USES_RE = re.compile(
     r"^[ \t]*uses:[ \t]+google/osv-scanner-action/"
@@ -28,6 +30,11 @@ USES_RE = re.compile(
 # path args. Filenames are fixed inside the script (cwd osv-results.json/.sarif).
 INVOKE_RE = re.compile(
     r"^[ \t]+(?:run:[ \t]+)?python3[ \t]+scripts/ci/bind-osv-json-sarif-counts\.py[ \t]*$"
+)
+
+INLINE_WALK_TELLS = (
+    'key == "vulnerabilities"',
+    "key == 'vulnerabilities'",
 )
 
 
@@ -84,6 +91,19 @@ def check(text: str) -> list[str]:
             "want exactly one active invocation "
             f"`python3 {BIND_SCRIPT}`, "
             f"found {len(invokes)}"
+        )
+
+    env_lines = [line for line in active_lines if line.strip() == ENV_WIRING]
+    if len(env_lines) != 1:
+        errors.append(
+            "want exactly one active env wiring "
+            f"`{ENV_WIRING}`, found {len(env_lines)}"
+        )
+
+    if any(tell in text for tell in INLINE_WALK_TELLS):
+        errors.append(
+            "workflow still contains an inline vulnerabilities walk; "
+            f"{BIND_SCRIPT} is the only JSON counter"
         )
 
     return errors

--- a/scripts/ci/check-osv-scanner-scheduled-contract.py
+++ b/scripts/ci/check-osv-scanner-scheduled-contract.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Lockstep + count-bind contract for the scheduled OSV scanner/reporter pair.
+
+The reporter fail-opens on unreadable JSON (warn, empty results, exit 0). A
+version-skewed pair can therefore upload an empty SARIF while the scanner JSON
+still lists vulnerabilities. This checker refuses that hole in the workflow
+text: scanner and reporter must share one 40-hex SHA and semver comment, and a
+non-comment bind must compare the JSON vulnerability walk to the SARIF result
+count and exit non-zero on mismatch.
+
+Does not run the actions. Does not claim live 2.5.1 JSON/SARIF compatibility.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/osv-scanner-scheduled.yml")
+
+USES_RE = re.compile(
+    r"^[ \t]*uses:[ \t]+google/osv-scanner-action/"
+    r"(osv-scanner-action|osv-reporter-action)"
+    r"@([0-9a-f]{40})[ \t]+#[ \t]+(v\d+\.\d+\.\d+)[ \t]*$",
+    re.M,
+)
+
+# Distinctive identifiers the bind step must use so a comment or a no-op
+# `if False` cannot satisfy the contract.
+BIND_CONDITION = "osv_json_vuln_count != osv_sarif_result_count"
+JSON_NAME = "osv-results.json"
+SARIF_NAME = "osv-results.sarif"
+
+
+def _active_lines(text: str) -> list[str]:
+    """Lines that are not empty and not full-line comments."""
+    out: list[str] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        out.append(raw)
+    return out
+
+
+def check(text: str) -> list[str]:
+    errors: list[str] = []
+    active = "\n".join(_active_lines(text))
+    uses = USES_RE.findall(text)
+    by_kind: dict[str, list[tuple[str, str]]] = {"osv-scanner-action": [], "osv-reporter-action": []}
+    for kind, sha, tag in uses:
+        # Ignore matches that live on a commented uses line.
+        by_kind[kind].append((sha, tag))
+
+    # Re-scan line by line so a commented uses: is not counted.
+    by_kind = {"osv-scanner-action": [], "osv-reporter-action": []}
+    for line in _active_lines(text):
+        m = USES_RE.match(line)
+        if not m:
+            continue
+        by_kind[m.group(1)].append((m.group(2), m.group(3)))
+
+    for kind in ("osv-scanner-action", "osv-reporter-action"):
+        found = by_kind[kind]
+        if len(found) != 1:
+            errors.append(
+                f"{kind}: want exactly one active SHA-pin uses line, found {len(found)}"
+            )
+    if len(by_kind["osv-scanner-action"]) == 1 and len(by_kind["osv-reporter-action"]) == 1:
+        scan_sha, scan_tag = by_kind["osv-scanner-action"][0]
+        rep_sha, rep_tag = by_kind["osv-reporter-action"][0]
+        if scan_sha != rep_sha or scan_tag != rep_tag:
+            errors.append(
+                "scanner/reporter pin drift: "
+                f"scanner @{scan_sha} #{scan_tag} vs reporter @{rep_sha} #{rep_tag}"
+            )
+
+    if "continue-on-error: true" not in active:
+        errors.append("scanner continue-on-error: true is missing")
+    if "--fail-on-vuln=false" not in active:
+        errors.append("reporter --fail-on-vuln=false is missing")
+    if "category: osv-scanner-non-rust" not in active:
+        errors.append("upload category osv-scanner-non-rust is missing")
+
+    if JSON_NAME not in active or SARIF_NAME not in active:
+        errors.append("workflow no longer names both osv-results.json and osv-results.sarif")
+
+    if BIND_CONDITION not in active:
+        errors.append(
+            "missing fail-closed count bind "
+            f"({BIND_CONDITION} on an active line); "
+            "reporter parse-fail can upload empty SARIF at exit 0"
+        )
+    elif "sys.exit(1)" not in active and "exit 1" not in active:
+        errors.append("count bind has no non-zero exit")
+
+    # The bind must actually read both artifacts, not just mention them in uses/with.
+    bind_reads_json = re.search(
+        r"(?:open|Path|vulnerability_count)\(\s*['\"]osv-results\.json['\"]",
+        active,
+    )
+    bind_reads_sarif = re.search(
+        r"(?:open|Path|sarif_result_count)\(\s*['\"]osv-results\.sarif['\"]",
+        active,
+    )
+    if BIND_CONDITION in active and not (bind_reads_json and bind_reads_sarif):
+        errors.append("count bind does not read both osv-results.json and osv-results.sarif")
+
+    return errors
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else WORKFLOW
+    if not path.is_file():
+        print(f"FAIL: workflow missing: {path}", file=sys.stderr)
+        return 2
+    errors = check(path.read_text(encoding="utf-8"))
+    if errors:
+        print(f"FAIL: {path}", file=sys.stderr)
+        for err in errors:
+            print(f"  {err}", file=sys.stderr)
+        return 1
+    print(f"ok    {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-osv-scanner-scheduled-contract.py
+++ b/scripts/ci/check-osv-scanner-scheduled-contract.py
@@ -24,11 +24,10 @@ USES_RE = re.compile(
     r"@([0-9a-f]{40})[ \t]+#[ \t]+(v\d+\.\d+\.\d+)[ \t]*$",
 )
 
-# Active invocation: the workflow must call the one runtime script with both
-# production filenames. A comment, a different script, or dropped args is drift.
+# Active invocation: the workflow must call the one runtime script with no
+# path args. Filenames are fixed inside the script (cwd osv-results.json/.sarif).
 INVOKE_RE = re.compile(
-    r"^[ \t]+(?:run:[ \t]+)?python3[ \t]+scripts/ci/bind-osv-json-sarif-counts\.py"
-    r"[ \t]+osv-results\.json[ \t]+osv-results\.sarif[ \t]*$"
+    r"^[ \t]+(?:run:[ \t]+)?python3[ \t]+scripts/ci/bind-osv-json-sarif-counts\.py[ \t]*$"
 )
 
 
@@ -83,7 +82,7 @@ def check(text: str) -> list[str]:
     if len(invokes) != 1:
         errors.append(
             "want exactly one active invocation "
-            f"`python3 {BIND_SCRIPT} osv-results.json osv-results.sarif`, "
+            f"`python3 {BIND_SCRIPT}`, "
             f"found {len(invokes)}"
         )
 

--- a/scripts/ci/check-osv-scanner-scheduled-contract.py
+++ b/scripts/ci/check-osv-scanner-scheduled-contract.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
-"""Lockstep + count-bind contract for the scheduled OSV scanner/reporter pair.
+"""Lockstep + bind-invocation contract for the scheduled OSV pair.
 
-The reporter fail-opens on unreadable JSON (warn, empty results, exit 0). A
-version-skewed pair can therefore upload an empty SARIF while the scanner JSON
-still lists vulnerabilities. This checker refuses that hole in the workflow
-text: scanner and reporter must share one 40-hex SHA and semver comment, and a
-non-comment bind must compare the JSON vulnerability walk to the SARIF result
-count and exit non-zero on mismatch.
+The reporter fail-opens on unreadable JSON (warn, empty results, exit 0). The
+runtime rule lives in scripts/ci/bind-osv-json-sarif-counts.py. This checker
+only pins that the workflow calls that script with both artifacts, and that
+scanner/reporter share one 40-hex SHA and semver comment.
 
-Does not run the actions. Does not claim live 2.5.1 JSON/SARIF compatibility.
+It does not reimplement the count. Does not run the actions.
 """
 
 from __future__ import annotations
@@ -18,23 +16,23 @@ import sys
 from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/osv-scanner-scheduled.yml")
+BIND_SCRIPT = "scripts/ci/bind-osv-json-sarif-counts.py"
 
 USES_RE = re.compile(
     r"^[ \t]*uses:[ \t]+google/osv-scanner-action/"
     r"(osv-scanner-action|osv-reporter-action)"
     r"@([0-9a-f]{40})[ \t]+#[ \t]+(v\d+\.\d+\.\d+)[ \t]*$",
-    re.M,
 )
 
-# Distinctive identifiers the bind step must use so a comment or a no-op
-# `if False` cannot satisfy the contract.
-BIND_CONDITION = "osv_json_vuln_count != osv_sarif_result_count"
-JSON_NAME = "osv-results.json"
-SARIF_NAME = "osv-results.sarif"
+# Active invocation: the workflow must call the one runtime script with both
+# production filenames. A comment, a different script, or dropped args is drift.
+INVOKE_RE = re.compile(
+    r"^[ \t]+(?:run:[ \t]+)?python3[ \t]+scripts/ci/bind-osv-json-sarif-counts\.py"
+    r"[ \t]+osv-results\.json[ \t]+osv-results\.sarif[ \t]*$"
+)
 
 
 def _active_lines(text: str) -> list[str]:
-    """Lines that are not empty and not full-line comments."""
     out: list[str] = []
     for raw in text.splitlines():
         stripped = raw.strip()
@@ -46,16 +44,14 @@ def _active_lines(text: str) -> list[str]:
 
 def check(text: str) -> list[str]:
     errors: list[str] = []
-    active = "\n".join(_active_lines(text))
-    uses = USES_RE.findall(text)
-    by_kind: dict[str, list[tuple[str, str]]] = {"osv-scanner-action": [], "osv-reporter-action": []}
-    for kind, sha, tag in uses:
-        # Ignore matches that live on a commented uses line.
-        by_kind[kind].append((sha, tag))
+    active_lines = _active_lines(text)
+    active = "\n".join(active_lines)
 
-    # Re-scan line by line so a commented uses: is not counted.
-    by_kind = {"osv-scanner-action": [], "osv-reporter-action": []}
-    for line in _active_lines(text):
+    by_kind: dict[str, list[tuple[str, str]]] = {
+        "osv-scanner-action": [],
+        "osv-reporter-action": [],
+    }
+    for line in active_lines:
         m = USES_RE.match(line)
         if not m:
             continue
@@ -83,29 +79,13 @@ def check(text: str) -> list[str]:
     if "category: osv-scanner-non-rust" not in active:
         errors.append("upload category osv-scanner-non-rust is missing")
 
-    if JSON_NAME not in active or SARIF_NAME not in active:
-        errors.append("workflow no longer names both osv-results.json and osv-results.sarif")
-
-    if BIND_CONDITION not in active:
+    invokes = [line for line in active_lines if INVOKE_RE.match(line)]
+    if len(invokes) != 1:
         errors.append(
-            "missing fail-closed count bind "
-            f"({BIND_CONDITION} on an active line); "
-            "reporter parse-fail can upload empty SARIF at exit 0"
+            "want exactly one active invocation "
+            f"`python3 {BIND_SCRIPT} osv-results.json osv-results.sarif`, "
+            f"found {len(invokes)}"
         )
-    elif "sys.exit(1)" not in active and "exit 1" not in active:
-        errors.append("count bind has no non-zero exit")
-
-    # The bind must actually read both artifacts, not just mention them in uses/with.
-    bind_reads_json = re.search(
-        r"(?:open|Path|vulnerability_count)\(\s*['\"]osv-results\.json['\"]",
-        active,
-    )
-    bind_reads_sarif = re.search(
-        r"(?:open|Path|sarif_result_count)\(\s*['\"]osv-results\.sarif['\"]",
-        active,
-    )
-    if BIND_CONDITION in active and not (bind_reads_json and bind_reads_sarif):
-        errors.append("count bind does not read both osv-results.json and osv-results.sarif")
 
     return errors
 

--- a/scripts/ci/check-osv-scanner-scheduled-contract.py
+++ b/scripts/ci/check-osv-scanner-scheduled-contract.py
@@ -4,8 +4,9 @@
 The reporter fail-opens on unreadable JSON (warn, empty results, exit 0). The
 runtime rule lives in scripts/ci/bind-osv-json-sarif-counts.py. This checker
 only pins that the workflow calls that script with both artifacts, wires
-OSV_OUTCOME from the scanner step, does not walk vulnerabilities itself, and
-that scanner/reporter share one 40-hex SHA and semver comment.
+OSV_OUTCOME from the scanner step, does not walk vulnerabilities itself, does
+not re-check missing/empty JSON (bind() is the only owner), and that
+scanner/reporter share one 40-hex SHA and semver comment.
 
 It does not reimplement the count. Does not run the actions.
 """
@@ -35,6 +36,14 @@ INVOKE_RE = re.compile(
 INLINE_WALK_TELLS = (
     'key == "vulnerabilities"',
     "key == 'vulnerabilities'",
+)
+
+VALIDATE_STEP_NAME = "Validate OSV scanner result"
+
+# bind() owns missing/empty JSON. Refuse the leftover `[ ! -s osv-results.json ]`
+# and close equivalents (`! -f` / `! -e`) still running in the workflow.
+MISSING_EMPTY_JSON_RE = re.compile(
+    r"""!\s+-[sfe]\s+["']?osv-results\.json["']?"""
 )
 
 
@@ -104,6 +113,19 @@ def check(text: str) -> list[str]:
         errors.append(
             "workflow still contains an inline vulnerabilities walk; "
             f"{BIND_SCRIPT} is the only JSON counter"
+        )
+
+    if VALIDATE_STEP_NAME in active:
+        errors.append(
+            f"leftover step name `{VALIDATE_STEP_NAME}`; "
+            f"missing/empty JSON is owned only by {BIND_SCRIPT} bind()"
+        )
+
+    if MISSING_EMPTY_JSON_RE.search(active):
+        errors.append(
+            "leftover missing/empty JSON check "
+            "(`[ ! -s osv-results.json ]` or equivalent); "
+            f"{BIND_SCRIPT} bind() is the only owner"
         )
 
     return errors

--- a/scripts/ci/check-osv-scanner-scheduled-contract.py
+++ b/scripts/ci/check-osv-scanner-scheduled-contract.py
@@ -91,17 +91,16 @@ def check(text: str) -> list[str]:
 
 
 def main() -> int:
-    path = Path(sys.argv[1]) if len(sys.argv) > 1 else WORKFLOW
-    if not path.is_file():
-        print(f"FAIL: workflow missing: {path}", file=sys.stderr)
+    if not WORKFLOW.is_file():
+        print(f"FAIL: workflow missing: {WORKFLOW}", file=sys.stderr)
         return 2
-    errors = check(path.read_text(encoding="utf-8"))
+    errors = check(WORKFLOW.read_text(encoding="utf-8"))
     if errors:
-        print(f"FAIL: {path}", file=sys.stderr)
+        print(f"FAIL: {WORKFLOW}", file=sys.stderr)
         for err in errors:
             print(f"  {err}", file=sys.stderr)
         return 1
-    print(f"ok    {path}")
+    print(f"ok    {WORKFLOW}")
     return 0
 
 

--- a/scripts/ci/test-osv-scanner-scheduled-contract.sh
+++ b/scripts/ci/test-osv-scanner-scheduled-contract.sh
@@ -2,10 +2,13 @@
 # Mutation + fixture battery for the scheduled OSV lockstep/bind contract.
 #
 # Control must be green. SHA-drift and invocation-bypass must bite the checker.
+# Env-wiring and a restored inline vulnerabilities walk must also bite.
 # The runtime script is executed against synthetic fixtures (scratch only),
 # always via cwd-fixed names with zero CLI path args.
 # A compare/exit mutation on refuse_if_counts_differ must flip mismatch
 # from exit 1 to exit 0, proving the fixture hits that function.
+# A compare/exit mutation on refuse_if_scanner_execution_failed must flip
+# non-success+0+empty-SARIF from exit 1 to exit 0 (crashed scanner hole).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -13,7 +16,9 @@ CHECKER="scripts/ci/check-osv-scanner-scheduled-contract.py"
 BIND="scripts/ci/bind-osv-json-sarif-counts.py"
 WORKFLOW=".github/workflows/osv-scanner-scheduled.yml"
 ACTIVE_INVOKE="python3 scripts/ci/bind-osv-json-sarif-counts.py"
+ENV_WIRING='OSV_OUTCOME: ${{ steps.osv-scan.outcome }}'
 COMPARE_LINE="if json_count != sarif_count:"
+OUTCOME_COMPARE_LINE='if outcome != "success" and json_count == 0:'
 
 [[ -f "${ROOT}/${CHECKER}" ]] || { echo "FAIL: checker missing" >&2; exit 1; }
 [[ -f "${ROOT}/${BIND}" ]] || { echo "FAIL: bind script missing" >&2; exit 1; }
@@ -43,10 +48,12 @@ run_checker() {
 }
 
 # Production CLI is argumentless. Fixtures live in cwd as the fixed names.
+# Extra args after expected are env assignments (OSV_OUTCOME=...).
 run_bind_cwd() {
   local name="$1" case_dir="$2" bind_path="$3" expected="$4"
+  shift 4
   local status=0
-  ( cd "$case_dir" && python3 "$bind_path" ) >"$scratch/$name.log" 2>&1 || status=$?
+  ( cd "$case_dir" && env "$@" python3 "$bind_path" ) >"$scratch/$name.log" 2>&1 || status=$?
   if [[ "$status" -ne "$expected" ]]; then
     cat "$scratch/$name.log" >&2
     echo "FAIL: $name exited $status, wanted $expected" >&2
@@ -104,10 +111,47 @@ p.write_text(text.replace(old, "echo 'bypassed'", 1))
 PY
 run_checker "invoke-bypass-is-refused" "$c" 1
 
+c="$scratch/env-unwired"
+seed "$c"
+python3 - "$c/${WORKFLOW}" "$ENV_WIRING" <<'PY'
+from pathlib import Path
+import sys
+
+p = Path(sys.argv[1])
+old = sys.argv[2]
+text = p.read_text()
+if old not in text:
+    raise SystemExit("env wiring missing from seed; cannot mutate")
+p.write_text(text.replace(old, "OSV_SCAN_RESULT: ${{ steps.osv-scan.outcome }}", 1))
+PY
+run_checker "env-wiring-mutation-is-refused" "$c" 1
+
+c="$scratch/shared-teller"
+seed "$c"
+python3 - "$c/${WORKFLOW}" <<'PY'
+from pathlib import Path
+import sys
+
+p = Path(sys.argv[1])
+text = p.read_text()
+walk = (
+    "          def walk(value):\n"
+    "              if isinstance(value, dict):\n"
+    "                  for key, child in value.items():\n"
+    '                      if key == "vulnerabilities" and isinstance(child, list):\n'
+    "                          pass\n"
+)
+if 'key == "vulnerabilities"' in text:
+    text = text.replace('key == "vulnerabilities"', 'key == "packages"', 1)
+p.write_text(text + "\n" + walk)
+PY
+run_checker "shared-teller-walk-is-refused" "$c" 1
+
 # --- runtime fixtures (scratch only; not added to the repo) ---
 
 ACCEPT_JSON='{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}'
 ACCEPT_SARIF='{"runs": [{"results": [{"ruleId": "OSV-TEST-1"}]}]}'
+EMPTY_JSON='{"results": []}'
 EMPTY_SARIF='{"runs": [{"results": []}]}'
 MISSING_RUNS_SARIF='{"version": "2.1.0"}'
 BAD_JSON='{not-json'
@@ -116,11 +160,16 @@ write_pair "$scratch/fx-accept" "$ACCEPT_JSON" "$ACCEPT_SARIF"
 write_pair "$scratch/fx-mismatch" "$ACCEPT_JSON" "$EMPTY_SARIF"
 write_pair "$scratch/fx-malformed-json" "$BAD_JSON" "$ACCEPT_SARIF"
 write_pair "$scratch/fx-malformed-sarif" "$ACCEPT_JSON" "$MISSING_RUNS_SARIF"
+write_pair "$scratch/fx-empty" "$EMPTY_JSON" "$EMPTY_SARIF"
 
-run_bind_cwd "fixture-acceptance" "$scratch/fx-accept" "${ROOT}/${BIND}" 0
-run_bind_cwd "fixture-mismatch" "$scratch/fx-mismatch" "${ROOT}/${BIND}" 1
-run_bind_cwd "fixture-malformed-json" "$scratch/fx-malformed-json" "${ROOT}/${BIND}" 1
-run_bind_cwd "fixture-malformed-sarif" "$scratch/fx-malformed-sarif" "${ROOT}/${BIND}" 1
+run_bind_cwd "fixture-acceptance" "$scratch/fx-accept" "${ROOT}/${BIND}" 0 OSV_OUTCOME=success
+run_bind_cwd "fixture-mismatch" "$scratch/fx-mismatch" "${ROOT}/${BIND}" 1 OSV_OUTCOME=success
+run_bind_cwd "fixture-malformed-json" "$scratch/fx-malformed-json" "${ROOT}/${BIND}" 1 OSV_OUTCOME=success
+run_bind_cwd "fixture-malformed-sarif" "$scratch/fx-malformed-sarif" "${ROOT}/${BIND}" 1 OSV_OUTCOME=success
+run_bind_cwd "fixture-clean-scan" "$scratch/fx-empty" "${ROOT}/${BIND}" 0 OSV_OUTCOME=success
+run_bind_cwd "fixture-execution-failure" "$scratch/fx-empty" "${ROOT}/${BIND}" 1 OSV_OUTCOME=failure
+run_bind_cwd "fixture-non-success-with-vulns" "$scratch/fx-accept" "${ROOT}/${BIND}" 0 OSV_OUTCOME=failure
+run_bind_cwd "fixture-missing-outcome" "$scratch/fx-accept" "${ROOT}/${BIND}" 1
 
 # --- compare/exit mutation must bite refuse_if_counts_differ ---
 # Same mismatch fixture (cwd-fixed names, zero CLI args).
@@ -138,6 +187,23 @@ if old not in text:
     raise SystemExit("FAIL: compare/exit string missing from bind script; cannot mutate")
 p.write_text(text.replace(old, "if False:", 1))
 PY
-run_bind_cwd "compare-exit-mutation-accepts-mismatch" "$scratch/fx-mismatch" "$mutated" 0
+run_bind_cwd "compare-exit-mutation-accepts-mismatch" "$scratch/fx-mismatch" "$mutated" 0 OSV_OUTCOME=success
 
-printf 'PASS: osv-scanner scheduled lockstep/bind battery (control, sha-drift, invoke-bypass, fixture-acceptance, fixture-mismatch, fixture-malformed-json, fixture-malformed-sarif, compare-exit-mutation)\n'
+# --- outcome-gate mutation: unmutated is 1, mutated is 0 ---
+# Crashed scanner + empty matching artifacts must not go green.
+mutated_outcome="$scratch/mutated-outcome-bind.py"
+cp "${ROOT}/${BIND}" "$mutated_outcome"
+python3 - "$mutated_outcome" "$OUTCOME_COMPARE_LINE" <<'PY'
+from pathlib import Path
+import sys
+
+p = Path(sys.argv[1])
+old = sys.argv[2]
+text = p.read_text()
+if old not in text:
+    raise SystemExit("FAIL: outcome compare/exit string missing from bind script; cannot mutate")
+p.write_text(text.replace(old, "if False:", 1))
+PY
+run_bind_cwd "outcome-gate-mutation-accepts-execution-failure" "$scratch/fx-empty" "$mutated_outcome" 0 OSV_OUTCOME=failure
+
+printf 'PASS: osv-scanner scheduled lockstep/bind battery (control, sha-drift, invoke-bypass, env-wiring-mutation, shared-teller-walk, fixture-acceptance, fixture-mismatch, fixture-malformed-json, fixture-malformed-sarif, fixture-clean-scan, fixture-execution-failure, fixture-non-success-with-vulns, fixture-missing-outcome, compare-exit-mutation, outcome-gate-mutation)\n'

--- a/scripts/ci/test-osv-scanner-scheduled-contract.sh
+++ b/scripts/ci/test-osv-scanner-scheduled-contract.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# Mutation battery for check-osv-scanner-scheduled-contract.py.
+# Mutation + fixture battery for the scheduled OSV lockstep/bind contract.
 #
-# Control must be green. Each mutation must bite. A mutation that passes here
-# means the lockstep/count-bind policy has a hole of that shape.
+# Control must be green. SHA-drift and invocation-bypass must bite the checker.
+# The runtime script is executed against synthetic fixtures (scratch only).
+# A compare/exit mutation on refuse_if_counts_differ must flip mismatch
+# from exit 1 to exit 0, proving the fixture hits that function.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECKER="scripts/ci/check-osv-scanner-scheduled-contract.py"
+BIND="scripts/ci/bind-osv-json-sarif-counts.py"
 WORKFLOW=".github/workflows/osv-scanner-scheduled.yml"
+ACTIVE_INVOKE="python3 scripts/ci/bind-osv-json-sarif-counts.py osv-results.json osv-results.sarif"
+COMPARE_LINE="if json_count != sarif_count:"
+
 [[ -f "${ROOT}/${CHECKER}" ]] || { echo "FAIL: checker missing" >&2; exit 1; }
+[[ -f "${ROOT}/${BIND}" ]] || { echo "FAIL: bind script missing" >&2; exit 1; }
 [[ -f "${ROOT}/${WORKFLOW}" ]] || { echo "FAIL: workflow missing" >&2; exit 1; }
 
 scratch="$(mktemp -d)"
@@ -19,9 +26,10 @@ seed() {
   mkdir -p "$case_root/.github/workflows" "$case_root/scripts/ci"
   cp "${ROOT}/${CHECKER}" "$case_root/${CHECKER}"
   cp "${ROOT}/${WORKFLOW}" "$case_root/${WORKFLOW}"
+  cp "${ROOT}/${BIND}" "$case_root/${BIND}"
 }
 
-run_case() {
+run_checker() {
   local name="$1" case_root="$2" expected="$3"
   local status=0
   ( cd "$case_root" && python3 "$CHECKER" ) >"$scratch/$name.log" 2>&1 || status=$?
@@ -33,20 +41,35 @@ run_case() {
   echo "ok    $name (exit $status)"
 }
 
-# 0. The real tree (copied) is the control.
+run_bind() {
+  local name="$1" bind_path="$2" json_path="$3" sarif_path="$4" expected="$5"
+  local status=0
+  python3 "$bind_path" "$json_path" "$sarif_path" >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+# --- checker cases ---
+
+# 0. Copied real tree is the control.
 c="$scratch/control"
 seed "$c"
-run_case "control-is-green" "$c" 0
+run_checker "control-is-green" "$c" 0
 
-# 1. One SHA rolled back: lockstep hole, the closed Dependabot split.
-c="$scratch/one-sha"
+# 1. SHA-drift: roll back ONLY the reporter 40-hex.
+c="$scratch/sha-drift"
 seed "$c"
 python3 - "$c/${WORKFLOW}" <<'PY'
 from pathlib import Path
-import re, sys
+import re
+import sys
+
 p = Path(sys.argv[1])
 text = p.read_text()
-# Flip the reporter pin only. Keep a well-formed 40-hex so the miss is drift, not parse.
 text, n = re.subn(
     r"(osv-reporter-action@)[0-9a-f]{40}",
     r"\g<1>9a498708959aeaef5ef730655706c5a1df1edbc2",
@@ -57,21 +80,76 @@ if n != 1:
     raise SystemExit("failed to mutate reporter SHA")
 p.write_text(text)
 PY
-run_case "one-sha-rollback-is-refused" "$c" 1
+run_checker "sha-drift-is-refused" "$c" 1
 
-# 2. Count bind bypassed: the silent-empty-SARIF hole.
-c="$scratch/bind-bypass"
+# 2. Invocation-bypass: replace the exact active invocation with a no-op.
+c="$scratch/invoke-bypass"
 seed "$c"
-python3 - "$c/${WORKFLOW}" <<'PY'
+python3 - "$c/${WORKFLOW}" "$ACTIVE_INVOKE" <<'PY'
 from pathlib import Path
 import sys
-p = Path(sys.argv[1])
-text = p.read_text()
-old = "osv_json_vuln_count != osv_sarif_result_count"
-if old not in text:
-    raise SystemExit("bind condition missing from seed; cannot mutate")
-p.write_text(text.replace(old, "False", 1))
-PY
-run_case "count-bind-bypass-is-refused" "$c" 1
 
-printf 'PASS: osv-scanner scheduled lockstep/count-bind mutation battery (3 cases)\n'
+p = Path(sys.argv[1])
+old = sys.argv[2]
+text = p.read_text()
+if old not in text:
+    raise SystemExit("active invocation missing from seed; cannot mutate")
+p.write_text(text.replace(old, "echo 'bypassed'", 1))
+PY
+run_checker "invoke-bypass-is-refused" "$c" 1
+
+# --- runtime fixtures (scratch only; not added to the repo) ---
+
+fx="$scratch/fixtures"
+mkdir -p "$fx"
+
+cat >"$fx/accept.json" <<'JSON'
+{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}
+JSON
+cat >"$fx/accept.sarif" <<'JSON'
+{"runs": [{"results": [{"ruleId": "OSV-TEST-1"}]}]}
+JSON
+
+cat >"$fx/mismatch.json" <<'JSON'
+{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}
+JSON
+cat >"$fx/mismatch.sarif" <<'JSON'
+{"runs": [{"results": []}]}
+JSON
+
+printf '{not-json\n' >"$fx/malformed.json"
+cat >"$fx/ok.sarif" <<'JSON'
+{"runs": [{"results": [{"ruleId": "OSV-TEST-1"}]}]}
+JSON
+
+cat >"$fx/ok.json" <<'JSON'
+{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}
+JSON
+cat >"$fx/malformed.sarif" <<'JSON'
+{"version": "2.1.0"}
+JSON
+
+run_bind "fixture-acceptance" "${ROOT}/${BIND}" "$fx/accept.json" "$fx/accept.sarif" 0
+run_bind "fixture-mismatch" "${ROOT}/${BIND}" "$fx/mismatch.json" "$fx/mismatch.sarif" 1
+run_bind "fixture-malformed-json" "${ROOT}/${BIND}" "$fx/malformed.json" "$fx/ok.sarif" 1
+run_bind "fixture-malformed-sarif" "${ROOT}/${BIND}" "$fx/ok.json" "$fx/malformed.sarif" 1
+
+# --- compare/exit mutation must bite refuse_if_counts_differ ---
+# Same mismatch fixture. Unmutated already refused (exit 1 above).
+# Mutating `if json_count != sarif_count:` -> `if False:` must accept (exit 0).
+mutated="$scratch/mutated-bind.py"
+cp "${ROOT}/${BIND}" "$mutated"
+python3 - "$mutated" "$COMPARE_LINE" <<'PY'
+from pathlib import Path
+import sys
+
+p = Path(sys.argv[1])
+old = sys.argv[2]
+text = p.read_text()
+if old not in text:
+    raise SystemExit("FAIL: compare/exit string missing from bind script; cannot mutate")
+p.write_text(text.replace(old, "if False:", 1))
+PY
+run_bind "compare-exit-mutation-accepts-mismatch" "$mutated" "$fx/mismatch.json" "$fx/mismatch.sarif" 0
+
+printf 'PASS: osv-scanner scheduled lockstep/bind battery (control, sha-drift, invoke-bypass, fixture-acceptance, fixture-mismatch, fixture-malformed-json, fixture-malformed-sarif, compare-exit-mutation)\n'

--- a/scripts/ci/test-osv-scanner-scheduled-contract.sh
+++ b/scripts/ci/test-osv-scanner-scheduled-contract.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Mutation battery for check-osv-scanner-scheduled-contract.py.
+#
+# Control must be green. Each mutation must bite. A mutation that passes here
+# means the lockstep/count-bind policy has a hole of that shape.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="scripts/ci/check-osv-scanner-scheduled-contract.py"
+WORKFLOW=".github/workflows/osv-scanner-scheduled.yml"
+[[ -f "${ROOT}/${CHECKER}" ]] || { echo "FAIL: checker missing" >&2; exit 1; }
+[[ -f "${ROOT}/${WORKFLOW}" ]] || { echo "FAIL: workflow missing" >&2; exit 1; }
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+seed() {
+  local case_root="$1"
+  mkdir -p "$case_root/.github/workflows" "$case_root/scripts/ci"
+  cp "${ROOT}/${CHECKER}" "$case_root/${CHECKER}"
+  cp "${ROOT}/${WORKFLOW}" "$case_root/${WORKFLOW}"
+}
+
+run_case() {
+  local name="$1" case_root="$2" expected="$3"
+  local status=0
+  ( cd "$case_root" && python3 "$CHECKER" ) >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+# 0. The real tree (copied) is the control.
+c="$scratch/control"
+seed "$c"
+run_case "control-is-green" "$c" 0
+
+# 1. One SHA rolled back: lockstep hole, the closed Dependabot split.
+c="$scratch/one-sha"
+seed "$c"
+python3 - "$c/${WORKFLOW}" <<'PY'
+from pathlib import Path
+import re, sys
+p = Path(sys.argv[1])
+text = p.read_text()
+# Flip the reporter pin only. Keep a well-formed 40-hex so the miss is drift, not parse.
+text, n = re.subn(
+    r"(osv-reporter-action@)[0-9a-f]{40}",
+    r"\g<1>9a498708959aeaef5ef730655706c5a1df1edbc2",
+    text,
+    count=1,
+)
+if n != 1:
+    raise SystemExit("failed to mutate reporter SHA")
+p.write_text(text)
+PY
+run_case "one-sha-rollback-is-refused" "$c" 1
+
+# 2. Count bind bypassed: the silent-empty-SARIF hole.
+c="$scratch/bind-bypass"
+seed "$c"
+python3 - "$c/${WORKFLOW}" <<'PY'
+from pathlib import Path
+import sys
+p = Path(sys.argv[1])
+text = p.read_text()
+old = "osv_json_vuln_count != osv_sarif_result_count"
+if old not in text:
+    raise SystemExit("bind condition missing from seed; cannot mutate")
+p.write_text(text.replace(old, "False", 1))
+PY
+run_case "count-bind-bypass-is-refused" "$c" 1
+
+printf 'PASS: osv-scanner scheduled lockstep/count-bind mutation battery (3 cases)\n'

--- a/scripts/ci/test-osv-scanner-scheduled-contract.sh
+++ b/scripts/ci/test-osv-scanner-scheduled-contract.sh
@@ -2,7 +2,8 @@
 # Mutation + fixture battery for the scheduled OSV lockstep/bind contract.
 #
 # Control must be green. SHA-drift and invocation-bypass must bite the checker.
-# The runtime script is executed against synthetic fixtures (scratch only).
+# The runtime script is executed against synthetic fixtures (scratch only),
+# always via cwd-fixed names with zero CLI path args.
 # A compare/exit mutation on refuse_if_counts_differ must flip mismatch
 # from exit 1 to exit 0, proving the fixture hits that function.
 set -euo pipefail
@@ -11,7 +12,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECKER="scripts/ci/check-osv-scanner-scheduled-contract.py"
 BIND="scripts/ci/bind-osv-json-sarif-counts.py"
 WORKFLOW=".github/workflows/osv-scanner-scheduled.yml"
-ACTIVE_INVOKE="python3 scripts/ci/bind-osv-json-sarif-counts.py osv-results.json osv-results.sarif"
+ACTIVE_INVOKE="python3 scripts/ci/bind-osv-json-sarif-counts.py"
 COMPARE_LINE="if json_count != sarif_count:"
 
 [[ -f "${ROOT}/${CHECKER}" ]] || { echo "FAIL: checker missing" >&2; exit 1; }
@@ -41,10 +42,11 @@ run_checker() {
   echo "ok    $name (exit $status)"
 }
 
-run_bind() {
-  local name="$1" bind_path="$2" json_path="$3" sarif_path="$4" expected="$5"
+# Production CLI is argumentless. Fixtures live in cwd as the fixed names.
+run_bind_cwd() {
+  local name="$1" case_dir="$2" bind_path="$3" expected="$4"
   local status=0
-  python3 "$bind_path" "$json_path" "$sarif_path" >"$scratch/$name.log" 2>&1 || status=$?
+  ( cd "$case_dir" && python3 "$bind_path" ) >"$scratch/$name.log" 2>&1 || status=$?
   if [[ "$status" -ne "$expected" ]]; then
     cat "$scratch/$name.log" >&2
     echo "FAIL: $name exited $status, wanted $expected" >&2
@@ -53,14 +55,19 @@ run_bind() {
   echo "ok    $name (exit $status)"
 }
 
+write_pair() {
+  local dest="$1" json_body="$2" sarif_body="$3"
+  mkdir -p "$dest"
+  printf '%s\n' "$json_body" >"$dest/osv-results.json"
+  printf '%s\n' "$sarif_body" >"$dest/osv-results.sarif"
+}
+
 # --- checker cases ---
 
-# 0. Copied real tree is the control.
 c="$scratch/control"
 seed "$c"
 run_checker "control-is-green" "$c" 0
 
-# 1. SHA-drift: roll back ONLY the reporter 40-hex.
 c="$scratch/sha-drift"
 seed "$c"
 python3 - "$c/${WORKFLOW}" <<'PY'
@@ -82,7 +89,6 @@ p.write_text(text)
 PY
 run_checker "sha-drift-is-refused" "$c" 1
 
-# 2. Invocation-bypass: replace the exact active invocation with a no-op.
 c="$scratch/invoke-bypass"
 seed "$c"
 python3 - "$c/${WORKFLOW}" "$ACTIVE_INVOKE" <<'PY'
@@ -100,42 +106,24 @@ run_checker "invoke-bypass-is-refused" "$c" 1
 
 # --- runtime fixtures (scratch only; not added to the repo) ---
 
-fx="$scratch/fixtures"
-mkdir -p "$fx"
+ACCEPT_JSON='{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}'
+ACCEPT_SARIF='{"runs": [{"results": [{"ruleId": "OSV-TEST-1"}]}]}'
+EMPTY_SARIF='{"runs": [{"results": []}]}'
+MISSING_RUNS_SARIF='{"version": "2.1.0"}'
+BAD_JSON='{not-json'
 
-cat >"$fx/accept.json" <<'JSON'
-{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}
-JSON
-cat >"$fx/accept.sarif" <<'JSON'
-{"runs": [{"results": [{"ruleId": "OSV-TEST-1"}]}]}
-JSON
+write_pair "$scratch/fx-accept" "$ACCEPT_JSON" "$ACCEPT_SARIF"
+write_pair "$scratch/fx-mismatch" "$ACCEPT_JSON" "$EMPTY_SARIF"
+write_pair "$scratch/fx-malformed-json" "$BAD_JSON" "$ACCEPT_SARIF"
+write_pair "$scratch/fx-malformed-sarif" "$ACCEPT_JSON" "$MISSING_RUNS_SARIF"
 
-cat >"$fx/mismatch.json" <<'JSON'
-{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}
-JSON
-cat >"$fx/mismatch.sarif" <<'JSON'
-{"runs": [{"results": []}]}
-JSON
-
-printf '{not-json\n' >"$fx/malformed.json"
-cat >"$fx/ok.sarif" <<'JSON'
-{"runs": [{"results": [{"ruleId": "OSV-TEST-1"}]}]}
-JSON
-
-cat >"$fx/ok.json" <<'JSON'
-{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}
-JSON
-cat >"$fx/malformed.sarif" <<'JSON'
-{"version": "2.1.0"}
-JSON
-
-run_bind "fixture-acceptance" "${ROOT}/${BIND}" "$fx/accept.json" "$fx/accept.sarif" 0
-run_bind "fixture-mismatch" "${ROOT}/${BIND}" "$fx/mismatch.json" "$fx/mismatch.sarif" 1
-run_bind "fixture-malformed-json" "${ROOT}/${BIND}" "$fx/malformed.json" "$fx/ok.sarif" 1
-run_bind "fixture-malformed-sarif" "${ROOT}/${BIND}" "$fx/ok.json" "$fx/malformed.sarif" 1
+run_bind_cwd "fixture-acceptance" "$scratch/fx-accept" "${ROOT}/${BIND}" 0
+run_bind_cwd "fixture-mismatch" "$scratch/fx-mismatch" "${ROOT}/${BIND}" 1
+run_bind_cwd "fixture-malformed-json" "$scratch/fx-malformed-json" "${ROOT}/${BIND}" 1
+run_bind_cwd "fixture-malformed-sarif" "$scratch/fx-malformed-sarif" "${ROOT}/${BIND}" 1
 
 # --- compare/exit mutation must bite refuse_if_counts_differ ---
-# Same mismatch fixture. Unmutated already refused (exit 1 above).
+# Same mismatch fixture (cwd-fixed names, zero CLI args).
 # Mutating `if json_count != sarif_count:` -> `if False:` must accept (exit 0).
 mutated="$scratch/mutated-bind.py"
 cp "${ROOT}/${BIND}" "$mutated"
@@ -150,6 +138,6 @@ if old not in text:
     raise SystemExit("FAIL: compare/exit string missing from bind script; cannot mutate")
 p.write_text(text.replace(old, "if False:", 1))
 PY
-run_bind "compare-exit-mutation-accepts-mismatch" "$mutated" "$fx/mismatch.json" "$fx/mismatch.sarif" 0
+run_bind_cwd "compare-exit-mutation-accepts-mismatch" "$scratch/fx-mismatch" "$mutated" 0
 
 printf 'PASS: osv-scanner scheduled lockstep/bind battery (control, sha-drift, invoke-bypass, fixture-acceptance, fixture-mismatch, fixture-malformed-json, fixture-malformed-sarif, compare-exit-mutation)\n'

--- a/scripts/ci/test-osv-scanner-scheduled-contract.sh
+++ b/scripts/ci/test-osv-scanner-scheduled-contract.sh
@@ -3,6 +3,8 @@
 #
 # Control must be green. SHA-drift and invocation-bypass must bite the checker.
 # Env-wiring and a restored inline vulnerabilities walk must also bite.
+# A leftover Validate-step / `! -s osv-results.json` mutation must also bite
+# (bind() is the only missing/empty JSON owner).
 # The runtime script is executed against synthetic fixtures (scratch only),
 # always via cwd-fixed names with zero CLI path args.
 # A compare/exit mutation on refuse_if_counts_differ must flip mismatch
@@ -147,6 +149,35 @@ p.write_text(text + "\n" + walk)
 PY
 run_checker "shared-teller-walk-is-refused" "$c" 1
 
+c="$scratch/leftover-validate"
+seed "$c"
+python3 - "$c/${WORKFLOW}" <<'PY'
+from pathlib import Path
+import sys
+
+p = Path(sys.argv[1])
+text = p.read_text()
+needle = "      - name: Build advisory SARIF\n"
+step = (
+    "      - name: Validate OSV scanner result\n"
+    "        shell: bash\n"
+    "        run: |\n"
+    "          set -euo pipefail\n"
+    "\n"
+    "          if [ ! -s osv-results.json ]; then\n"
+    "            echo \"::error::OSV scanner did not produce a JSON result\"\n"
+    "            exit 1\n"
+    "          fi\n"
+    "\n"
+)
+if needle not in text:
+    raise SystemExit("Build advisory SARIF step missing from seed; cannot mutate")
+if "Validate OSV scanner result" in text:
+    raise SystemExit("Validate step already present; mutation would be a no-op")
+p.write_text(text.replace(needle, step + needle, 1))
+PY
+run_checker "leftover-validate-step-is-refused" "$c" 1
+
 # --- runtime fixtures (scratch only; not added to the repo) ---
 
 ACCEPT_JSON='{"results": [{"vulnerabilities": [{"id": "OSV-TEST-1"}]}]}'
@@ -206,4 +237,4 @@ p.write_text(text.replace(old, "if False:", 1))
 PY
 run_bind_cwd "outcome-gate-mutation-accepts-execution-failure" "$scratch/fx-empty" "$mutated_outcome" 0 OSV_OUTCOME=failure
 
-printf 'PASS: osv-scanner scheduled lockstep/bind battery (control, sha-drift, invoke-bypass, env-wiring-mutation, shared-teller-walk, fixture-acceptance, fixture-mismatch, fixture-malformed-json, fixture-malformed-sarif, fixture-clean-scan, fixture-execution-failure, fixture-non-success-with-vulns, fixture-missing-outcome, compare-exit-mutation, outcome-gate-mutation)\n'
+printf 'PASS: osv-scanner scheduled lockstep/bind battery (control, sha-drift, invoke-bypass, env-wiring-mutation, shared-teller-walk, leftover-validate-step, fixture-acceptance, fixture-mismatch, fixture-malformed-json, fixture-malformed-sarif, fixture-clean-scan, fixture-execution-failure, fixture-non-success-with-vulns, fixture-missing-outcome, compare-exit-mutation, outcome-gate-mutation)\n'


### PR DESCRIPTION
Part of #2474. Supersedes closed Dependabot PRs #2614 and #2615.

## Summary
Bump `google/osv-scanner-action/{osv-scanner-action,osv-reporter-action}` in lockstep from `v2.3.8` (`9a498708959aeaef5ef730655706c5a1df1edbc2`) to `v2.5.1` (`6e4298ebc4db23e847df9b2e2de2939d6f066c67`).

The runtime JSON/SARIF count and scanner-outcome checks live in one argumentless script, `scripts/ci/bind-osv-json-sarif-counts.py`, which reads only cwd `osv-results.json` and `osv-results.sarif`. The workflow no longer reimplements JSON validation or vulnerability counting. The contract checker pins the invocation, `OSV_OUTCOME` wiring, and lockstep SHA/tag.

## Preserved behavior
- `continue-on-error: true` on the scanner step
- `--fail-on-vuln=false` on the reporter
- the existing 16-target manifest list
- upload category `osv-scanner-non-rust`

## Exact-head evidence
Final head: `c4f052dabdb0f23f254a0c3fdd4b1532ea36358c`; base: `40610b441fde086737383fd530a8825d47d66df2`.

- RED then GREEN for the removed duplicate `Validate OSV scanner result` step and for non-success plus zero vulnerabilities.
- Battery: control 0; SHA drift 1; invocation bypass 1; env-wiring 1; shared-teller 1; leftover validation 1; acceptance 0; mismatch 1; malformed JSON/SARIF 1; clean scan 0; execution failure 1; non-success with vulnerabilities 0; missing outcome 1.
- Compare/exit and outcome-gate mutations both make their intended failure fixture falsely pass and are killed by the battery.
- Live `workflow_dispatch`: https://github.com/Rul1an/assay/actions/runs/32825556434, exact head, success.
- Live result: 16 targets; `OSV_OUTCOME=failure` with 286 vulnerability rows; 286 SARIF results; upload succeeded.
- Independent exact-head review: READY with no findings; review record https://github.com/Rul1an/assay/pull/2625#issuecomment-5407544451.

## Non-claims
- The 286/286 match is one live run, not a general scanner/reporter schema-compatibility claim.
- `OSV_OUTCOME=failure` in that run is the scanner's vulnerability-result path under `continue-on-error`, not a demonstrated scanner crash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded scheduled vulnerability scanning and reporting actions.
  * Improved validation to ensure vulnerability counts remain consistent between scan and report results.
  * Added fail-closed handling for missing, malformed, or inconsistent scan data.

* **Tests**
  * Added automated checks for workflow configuration, action version alignment, result binding, and failure scenarios.
  * Added pre-commit validation to detect configuration drift and bypasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->