### PR TITLE
chore(ci): lock upload-sarif workflows to CodeQL 4.37.8

### DIFF
--- a/.github/workflows/assay-security.yml
+++ b/.github/workflows/assay-security.yml
@@ -62,7 +62,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         if: always() && hashFiles('results.sarif') != ''
         with:
           sarif_file: results.sarif

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -30,7 +30,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: scorecard.sarif
           category: openssf-scorecard

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -108,7 +108,7 @@ jobs:
           python3 scripts/ci/bind-osv-json-sarif-counts.py
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: osv-results.sarif
           category: osv-scanner-non-rust

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -380,7 +380,7 @@ repos:
         entry: bash scripts/ci/test-codeql-upload-sarif-lockstep.sh
         language: system
         pass_filenames: false
-        files: ^(\.github/workflows/(assay-security|openssf-scorecard|osv-scanner-scheduled)\.yml|scripts/ci/(check-codeql-upload-sarif-lockstep\.py|test-codeql-upload-sarif-lockstep\.sh)|\.pre-commit-config\.yaml)$
+        files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-codeql-upload-sarif-lockstep\.py|test-codeql-upload-sarif-lockstep\.sh)|\.pre-commit-config\.yaml)$
 
       - id: workflow-continue-on-error-policy
         name: Workflow continue-on-error policy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -375,6 +375,13 @@ repos:
         pass_filenames: false
         files: ^(\.github/workflows/osv-scanner-scheduled\.yml|scripts/ci/(bind-osv-json-sarif-counts\.py|(check|test)-osv-scanner-scheduled-contract\.(py|sh))|\.pre-commit-config\.yaml)$
 
+      - id: codeql-upload-sarif-lockstep
+        name: CodeQL upload-sarif workflow pin lockstep
+        entry: bash scripts/ci/test-codeql-upload-sarif-lockstep.sh
+        language: system
+        pass_filenames: false
+        files: ^(\.github/workflows/(assay-security|openssf-scorecard|osv-scanner-scheduled)\.yml|scripts/ci/(check-codeql-upload-sarif-lockstep\.py|test-codeql-upload-sarif-lockstep\.sh)|\.pre-commit-config\.yaml)$
+
       - id: workflow-continue-on-error-policy
         name: Workflow continue-on-error policy
         entry: bash scripts/ci/test-check-workflow-continue-on-error.sh

--- a/scripts/ci/check-codeql-upload-sarif-lockstep.py
+++ b/scripts/ci/check-codeql-upload-sarif-lockstep.py
@@ -15,10 +15,15 @@ WORKFLOWS = (
     Path(".github/workflows/osv-scanner-scheduled.yml"),
 )
 WORKFLOW_DIR = Path(".github/workflows")
-UPLOAD_PREFIX = "uses: github/codeql-action/upload-sarif@"
 USES_RE = re.compile(
-    r"^[ \t]*uses:[ \t]+github/codeql-action/upload-sarif@"
-    r"([0-9a-f]{40})[ \t]+#[ \t]+(v\d+\.\d+\.\d+)[ \t]*$"
+    r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+"
+    r"(?P<quote>['\"]?)github/codeql-action/upload-sarif@"
+    r"(?P<sha>[0-9a-f]{40})(?P=quote)[ \t]+"
+    r"#[ \t]+(?P<tag>v\d+\.\d+\.\d+)[ \t]*$"
+)
+ACTIVE_UPLOAD_RE = re.compile(
+    r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+['\"]?"
+    r"github/codeql-action/upload-sarif@"
 )
 
 
@@ -30,7 +35,7 @@ def active_upload_pins(text: str) -> list[tuple[str, str]]:
             continue
         match = USES_RE.match(line)
         if match:
-            pins.append((match.group(1), match.group(2)))
+            pins.append((match.group("sha"), match.group("tag")))
     return pins
 
 
@@ -39,7 +44,7 @@ def has_active_upload_callsite(text: str) -> bool:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
-        if stripped.removeprefix("- ").startswith(UPLOAD_PREFIX):
+        if ACTIVE_UPLOAD_RE.match(line):
             return True
     return False
 

--- a/scripts/ci/check-codeql-upload-sarif-lockstep.py
+++ b/scripts/ci/check-codeql-upload-sarif-lockstep.py
@@ -15,18 +15,13 @@ WORKFLOWS = (
     Path(".github/workflows/osv-scanner-scheduled.yml"),
 )
 WORKFLOW_DIR = Path(".github/workflows")
+UPLOAD_ACTION = "github/codeql-action/upload-sarif@"
 USES_RE = re.compile(
     r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+"
     r"(?P<quote>['\"]?)github/codeql-action/upload-sarif@"
     r"(?P<sha>[0-9a-f]{40})(?P=quote)[ \t]+"
     r"#[ \t]+(?P<tag>v\d+\.\d+\.\d+)[ \t]*$"
 )
-ACTIVE_UPLOAD_RE = re.compile(
-    r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+['\"]?"
-    r"github/codeql-action/upload-sarif@"
-)
-
-
 def active_upload_pins(text: str) -> list[tuple[str, str]]:
     pins: list[tuple[str, str]] = []
     for line in text.splitlines():
@@ -40,13 +35,14 @@ def active_upload_pins(text: str) -> list[tuple[str, str]]:
 
 
 def has_active_upload_callsite(text: str) -> bool:
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if ACTIVE_UPLOAD_RE.match(line):
-            return True
-    return False
+    return active_upload_references(text) > 0
+
+
+def active_upload_references(text: str) -> int:
+    active_text = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+    return active_text.count(UPLOAD_ACTION)
 
 
 def check() -> list[str]:
@@ -66,7 +62,14 @@ def check() -> list[str]:
         if not workflow.is_file():
             errors.append(f"workflow missing: {workflow}")
             continue
-        pins = active_upload_pins(workflow.read_text(encoding="utf-8"))
+        text = workflow.read_text(encoding="utf-8")
+        pins = active_upload_pins(text)
+        references = active_upload_references(text)
+        if references != len(pins):
+            errors.append(
+                f"{workflow}: found {references} upload-sarif reference(s), "
+                f"but only {len(pins)} canonical pin(s)"
+            )
         if len(pins) != 1:
             errors.append(
                 f"{workflow}: want exactly one active upload-sarif SHA pin, found {len(pins)}"

--- a/scripts/ci/check-codeql-upload-sarif-lockstep.py
+++ b/scripts/ci/check-codeql-upload-sarif-lockstep.py
@@ -16,6 +16,9 @@ WORKFLOWS = (
 )
 WORKFLOW_DIR = Path(".github/workflows")
 UPLOAD_ACTION = "github/codeql-action/upload-sarif@"
+YAML_HEX_ESCAPE_RE = re.compile(
+    r"\\(?:x([0-9a-fA-F]{2})|u([0-9a-fA-F]{4})|U([0-9a-fA-F]{8}))"
+)
 USES_RE = re.compile(
     r"^[ \t]*(?:-[ \t]+)?uses:[ \t]+"
     r"(?P<quote>['\"]?)github/codeql-action/upload-sarif@"
@@ -42,7 +45,20 @@ def active_upload_references(text: str) -> int:
     active_text = "\n".join(
         line for line in text.splitlines() if not line.lstrip().startswith("#")
     )
-    return active_text.count(UPLOAD_ACTION)
+
+    def decode_hex_escape(match: re.Match[str]) -> str:
+        codepoint = next(group for group in match.groups() if group is not None)
+        try:
+            return chr(int(codepoint, 16))
+        except ValueError:
+            return "\N{REPLACEMENT CHARACTER}"
+
+    # GitHub resolves repository names case-insensitively, and YAML double-quoted
+    # scalars decode hexadecimal escapes and escaped line breaks before dispatch.
+    normalized = re.sub(r"\\\r?\n[ \t]*", "", active_text)
+    normalized = YAML_HEX_ESCAPE_RE.sub(decode_hex_escape, normalized)
+    normalized = normalized.casefold()
+    return normalized.count(UPLOAD_ACTION)
 
 
 def check() -> list[str]:

--- a/scripts/ci/check-codeql-upload-sarif-lockstep.py
+++ b/scripts/ci/check-codeql-upload-sarif-lockstep.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Pin Assay's three organization-CI upload-sarif callsites in lockstep."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+EXPECTED_SHA = "db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+EXPECTED_TAG = "v4.37.8"
+WORKFLOWS = (
+    Path(".github/workflows/assay-security.yml"),
+    Path(".github/workflows/openssf-scorecard.yml"),
+    Path(".github/workflows/osv-scanner-scheduled.yml"),
+)
+WORKFLOW_DIR = Path(".github/workflows")
+UPLOAD_PREFIX = "uses: github/codeql-action/upload-sarif@"
+USES_RE = re.compile(
+    r"^[ \t]*uses:[ \t]+github/codeql-action/upload-sarif@"
+    r"([0-9a-f]{40})[ \t]+#[ \t]+(v\d+\.\d+\.\d+)[ \t]*$"
+)
+
+
+def active_upload_pins(text: str) -> list[tuple[str, str]]:
+    pins: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = USES_RE.match(line)
+        if match:
+            pins.append((match.group(1), match.group(2)))
+    return pins
+
+
+def has_active_upload_callsite(text: str) -> bool:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.removeprefix("- ").startswith(UPLOAD_PREFIX):
+            return True
+    return False
+
+
+def check() -> list[str]:
+    errors: list[str] = []
+    expected = (EXPECTED_SHA, EXPECTED_TAG)
+    expected_paths = set(WORKFLOWS)
+
+    discovered: set[Path] = set()
+    for pattern in ("*.yml", "*.yaml"):
+        for workflow in WORKFLOW_DIR.glob(pattern):
+            if has_active_upload_callsite(workflow.read_text(encoding="utf-8")):
+                discovered.add(workflow)
+    for workflow in sorted(discovered - expected_paths):
+        errors.append(f"unexpected upload-sarif workflow callsite: {workflow}")
+
+    for workflow in WORKFLOWS:
+        if not workflow.is_file():
+            errors.append(f"workflow missing: {workflow}")
+            continue
+        pins = active_upload_pins(workflow.read_text(encoding="utf-8"))
+        if len(pins) != 1:
+            errors.append(
+                f"{workflow}: want exactly one active upload-sarif SHA pin, found {len(pins)}"
+            )
+        elif pins[0] != expected:
+            errors.append(
+                f"{workflow}: pin @{pins[0][0]} # {pins[0][1]}, "
+                f"want @{EXPECTED_SHA} # {EXPECTED_TAG}"
+            )
+    return errors
+
+
+def main() -> int:
+    errors = check()
+    if errors:
+        print("FAIL: CodeQL upload-sarif workflow pins", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+    print(
+        f"ok    {len(WORKFLOWS)} CodeQL upload-sarif callsites "
+        f"@{EXPECTED_SHA} # {EXPECTED_TAG}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test-codeql-upload-sarif-lockstep.sh
+++ b/scripts/ci/test-codeql-upload-sarif-lockstep.sh
@@ -217,4 +217,70 @@ jobs:
 YAML
 run_case folded-scalar-foreign-workflow-is-refused "$case_root" 1
 
+case_root="$scratch/unicode-escaped-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/unicode-escaped-upload.yml" <<'YAML'
+name: Mutated Unicode-escaped CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "github/codeql-action/upload-sarif\u0040db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+YAML
+run_case unicode-escaped-action-is-refused "$case_root" 1
+
+case_root="$scratch/hex-escaped-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/hex-escaped-upload.yml" <<'YAML'
+name: Mutated hex-escaped CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "github/codeql-action/upload-sarif\x40db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+YAML
+run_case hex-escaped-action-is-refused "$case_root" 1
+
+case_root="$scratch/case-variant-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/case-variant-upload.yml" <<'YAML'
+name: Mutated case-variant CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHub/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+YAML
+run_case case-variant-action-is-refused "$case_root" 1
+
+case_root="$scratch/unicode-escaped-identity"
+seed "$case_root"
+cat >"$case_root/.github/workflows/unicode-identity-upload.yml" <<'YAML'
+name: Mutated Unicode-escaped CodeQL identity
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "\u0067ithub/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+YAML
+run_case unicode-escaped-identity-is-refused "$case_root" 1
+
+case_root="$scratch/escaped-line-break-action"
+seed "$case_root"
+cat >"$case_root/.github/workflows/escaped-break-upload.yml" <<'YAML'
+name: Mutated escaped-line-break CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "github/codeql-action/upload-\
+          sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28"
+YAML
+run_case escaped-line-break-action-is-refused "$case_root" 1
+
 printf 'PASS: CodeQL upload-sarif lockstep battery\n'

--- a/scripts/ci/test-codeql-upload-sarif-lockstep.sh
+++ b/scripts/ci/test-codeql-upload-sarif-lockstep.sh
@@ -164,4 +164,57 @@ jobs:
 YAML
 run_case quoted-foreign-workflow-callsite-is-refused "$case_root" 1
 
+case_root="$scratch/flow-mapping-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/flow-upload.yml" <<'YAML'
+name: Mutated flow-mapping CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - {uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28}
+YAML
+run_case flow-mapping-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-key-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/quoted-key-upload.yml" <<'YAML'
+name: Mutated quoted-key CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - "uses": github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+YAML
+run_case quoted-key-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/spaced-colon-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/spaced-colon-upload.yml" <<'YAML'
+name: Mutated spaced-colon CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses : github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+YAML
+run_case spaced-colon-foreign-workflow-is-refused "$case_root" 1
+
+case_root="$scratch/folded-scalar-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/folded-upload.yml" <<'YAML'
+name: Mutated folded-scalar CodeQL upload
+on: workflow_dispatch
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: >-
+          github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+YAML
+run_case folded-scalar-foreign-workflow-is-refused "$case_root" 1
+
 printf 'PASS: CodeQL upload-sarif lockstep battery\n'

--- a/scripts/ci/test-codeql-upload-sarif-lockstep.sh
+++ b/scripts/ci/test-codeql-upload-sarif-lockstep.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Mutation battery for the closed three-workflow CodeQL upload-sarif pin set.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="scripts/ci/check-codeql-upload-sarif-lockstep.py"
+WORKFLOWS=(
+  .github/workflows/assay-security.yml
+  .github/workflows/openssf-scorecard.yml
+  .github/workflows/osv-scanner-scheduled.yml
+)
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+seed() {
+  local dest="$1" path
+  mkdir -p "$dest/scripts/ci" "$dest/.github/workflows"
+  cp "$ROOT/$CHECKER" "$dest/$CHECKER"
+  for path in "${WORKFLOWS[@]}"; do
+    cp "$ROOT/$path" "$dest/$path"
+  done
+}
+
+run_case() {
+  local name="$1" root="$2" expected="$3" status=0
+  (cd "$root" && python3 "$CHECKER") >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
+}
+
+mutate_once() {
+  local path="$1" old="$2" new="$3"
+  python3 - "$path" "$old" "$new" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+old, new = sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+if text.count(old) != 1:
+    raise SystemExit(f"mutation subject count is {text.count(old)}, want 1: {old}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+}
+
+case_root="$scratch/control"
+seed "$case_root"
+run_case control-is-green "$case_root" 0
+
+case_root="$scratch/one-laggard"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/openssf-scorecard.yml" \
+  "db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28" \
+  "d1ba80a13dd99fba24a470575428917156a28b43"
+run_case one-laggard-is-refused "$case_root" 1
+
+case_root="$scratch/tag-drift"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/assay-security.yml" \
+  "# v4.37.8" \
+  "# v4.37.5"
+run_case tag-drift-is-refused "$case_root" 1
+
+case_root="$scratch/invoke-bypass"
+seed "$case_root"
+mutate_once \
+  "$case_root/.github/workflows/osv-scanner-scheduled.yml" \
+  "uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8" \
+  "run: echo bypassed-upload"
+run_case invoke-bypass-is-refused "$case_root" 1
+
+case_root="$scratch/extra-callsite"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/assay-security.yml" <<'YAML'
+
+# Mutation: a second active upload is outside the closed one-callsite contract.
+uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+YAML
+run_case extra-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/fourth-upload.yml" <<'YAML'
+name: Mutated fourth CodeQL upload
+jobs:
+  upload:
+    steps:
+      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+YAML
+run_case foreign-workflow-callsite-is-refused "$case_root" 1
+
+printf 'PASS: CodeQL upload-sarif lockstep battery\n'

--- a/scripts/ci/test-codeql-upload-sarif-lockstep.sh
+++ b/scripts/ci/test-codeql-upload-sarif-lockstep.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECKER="scripts/ci/check-codeql-upload-sarif-lockstep.py"
+PRECOMMIT=".pre-commit-config.yaml"
 WORKFLOWS=(
   .github/workflows/assay-security.yml
   .github/workflows/openssf-scorecard.yml
@@ -17,9 +18,47 @@ seed() {
   local dest="$1" path
   mkdir -p "$dest/scripts/ci" "$dest/.github/workflows"
   cp "$ROOT/$CHECKER" "$dest/$CHECKER"
+  cp "$ROOT/$PRECOMMIT" "$dest/$PRECOMMIT"
   for path in "${WORKFLOWS[@]}"; do
     cp "$ROOT/$path" "$dest/$path"
   done
+}
+
+check_hook_scope() {
+  local root="$1"
+  python3 - "$root/$PRECOMMIT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+block = text.split("- id: codeql-upload-sarif-lockstep", 1)[1].split("\n      - id:", 1)[0]
+match = re.search(r"^[ \t]*files:[ \t]*(.+)$", block, re.MULTILINE)
+if match is None:
+    raise SystemExit("CodeQL lockstep hook has no files selector")
+pattern = match.group(1).strip()
+required = (
+    ".github/workflows/fourth-upload.yml",
+    ".github/workflows/fourth-upload.yaml",
+    "scripts/ci/check-codeql-upload-sarif-lockstep.py",
+    "scripts/ci/test-codeql-upload-sarif-lockstep.sh",
+    ".pre-commit-config.yaml",
+)
+missing = [path for path in required if re.search(pattern, path) is None]
+if missing:
+    raise SystemExit(f"CodeQL lockstep hook does not trigger for: {', '.join(missing)}")
+PY
+}
+
+run_hook_scope_case() {
+  local name="$1" root="$2" expected="$3" status=0
+  check_hook_scope "$root" >"$scratch/$name.log" 2>&1 || status=$?
+  if [[ "$status" -ne "$expected" ]]; then
+    cat "$scratch/$name.log" >&2
+    echo "FAIL: $name exited $status, wanted $expected" >&2
+    exit 1
+  fi
+  echo "ok    $name (exit $status)"
 }
 
 run_case() {
@@ -51,6 +90,15 @@ PY
 case_root="$scratch/control"
 seed "$case_root"
 run_case control-is-green "$case_root" 0
+run_hook_scope_case hook-scope-covers-all-workflows "$case_root" 0
+
+case_root="$scratch/narrow-hook-scope"
+seed "$case_root"
+mutate_once \
+  "$case_root/$PRECOMMIT" \
+  'files: ^(\.github/workflows/.*\.ya?ml|scripts/ci/(check-codeql-upload-sarif-lockstep\.py|test-codeql-upload-sarif-lockstep\.sh)|\.pre-commit-config\.yaml)$' \
+  'files: ^(\.github/workflows/(assay-security|openssf-scorecard|osv-scanner-scheduled)\.yml|scripts/ci/(check-codeql-upload-sarif-lockstep\.py|test-codeql-upload-sarif-lockstep\.sh)|\.pre-commit-config\.yaml)$'
+run_hook_scope_case narrow-hook-scope-is-refused "$case_root" 1
 
 case_root="$scratch/one-laggard"
 seed "$case_root"
@@ -85,6 +133,15 @@ uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
 YAML
 run_case extra-callsite-is-refused "$case_root" 1
 
+case_root="$scratch/quoted-duplicate"
+seed "$case_root"
+cat >>"$case_root/.github/workflows/assay-security.yml" <<'YAML'
+
+# Mutation: quoted uses values are valid workflow YAML and remain active.
+uses: "github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28" # v4.37.8
+YAML
+run_case quoted-duplicate-is-refused "$case_root" 1
+
 case_root="$scratch/foreign-workflow"
 seed "$case_root"
 cat >"$case_root/.github/workflows/fourth-upload.yml" <<'YAML'
@@ -95,5 +152,16 @@ jobs:
       - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
 YAML
 run_case foreign-workflow-callsite-is-refused "$case_root" 1
+
+case_root="$scratch/quoted-foreign-workflow"
+seed "$case_root"
+cat >"$case_root/.github/workflows/quoted-upload.yaml" <<'YAML'
+name: Mutated quoted CodeQL upload
+jobs:
+  upload:
+    steps:
+      - uses: 'github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28' # v4.37.8
+YAML
+run_case quoted-foreign-workflow-callsite-is-refused "$case_root" 1
 
 printf 'PASS: CodeQL upload-sarif lockstep battery\n'


### PR DESCRIPTION
Part of #2474. Supersedes Dependabot #2613, which targets stale v4.37.7.

## Summary
- update the three Assay organization-CI `github/codeql-action/upload-sarif` callsites from v4.37.5 to v4.37.8
- pin the annotated tag's peeled commit `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28`
- add a closed-set lockstep checker and mutation battery

## RED -> GREEN
RED on base: all three existing v4.37.5 pins were rejected and the control battery exited 1.

Further RED phases closed two false-greens:
- a fourth workflow with an upload-sarif callsite initially passed
- valid single- or double-quoted `uses:` values initially bypassed callsite discovery
- flow mappings, quoted keys, spaced key colons, and folded scalars initially bypassed the line parser
- the pre-commit hook initially did not run for a newly added fourth workflow
- YAML hex/Unicode escapes, escaped line breaks, and case-variant repository identities initially bypassed raw-source inventory

GREEN at `389d84c715b98d9e00dac3c9a260fe56ff445f8d`:
- exact one-callsite/one-SHA/one-semver contract across assay-security, OpenSSF Scorecard, and scheduled OSV
- inventory of active `.github/workflows/*.{yml,yaml}` callsites, including quoted YAML values
- hook activation for every workflow `.yml`/`.yaml`
- mutations killed: one laggard SHA, tag drift, invocation bypass, duplicate callsite, quoted duplicate, fourth workflow, quoted fourth workflow, flow mapping, quoted key, spaced key colon, folded scalar, Unicode/hex escape, escaped identity letter, escaped line break, case variant, narrowed hook selector
- `pre-commit run --all-files`, actionlint, shellcheck, workflow continue-on-error policy, and `git diff --check` pass

## Scope boundary
This PR does not update `assay-action/action.yml`, the CLI-generated workflow in `templates.rs`, examples, or docs. Those are separate customer/template/documentation distributions with different current pins and contracts.

## Live proof required
The PR-triggered `MCP Security (Assay) / security-check` upload step must succeed on the final head. Scorecard and scheduled OSV upload execution are not claimed by that one PR run; their pin shape is covered by the closed-set contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated security workflow scanning components to a newer version.
  * Added safeguards to ensure security scanning configurations remain consistent across workflows.

* **Chores**
  * Added automated checks and tests to detect configuration drift or unexpected security scanning changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->