### PR TITLE
chore(deps): update rustls-webpki to 0.103.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,9 +670,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -681,14 +681,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4480,9 +4481,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- update `rustls-webpki` from 0.103.13 to 0.103.15
- accept the resolver-required `aws-lc-rs` 1.18.0 / `aws-lc-sys` 0.44.0 closure
- preserve the unrelated `tempfile -> getrandom 0.3.4` edge

Part of #2474. Supersedes Dependabot PR #2616, which stopped at 0.103.14.

## Lockfile closure

Only `Cargo.lock` changes:

- `rustls-webpki` 0.103.13 -> 0.103.15
- `aws-lc-rs` 1.16.2 -> 1.18.0
- `aws-lc-sys` 0.39.1 -> 0.44.0
- add the resolver-required `pkg-config` edge for `aws-lc-sys`

Cargo 1.89 and 1.96 both accept the resulting lockfile with `--locked` and leave it byte-identical.

## Verification

Measured at `c5d143ac429c20d09918b226d0a448db6fe5282e` in `/Users/roelschuurkes/wt-2474-rustls-webpki-10315`:

- pre-update control: `cargo test -p assay-registry sigstore_offline` -> 13/13
- post-update focused test: 13/13
- real Fulcio chain integration: 4/4
- full `assay-registry` suite: 286 unit tests plus all integration suites
- `cargo clippy -p assay-registry --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo deny check`
- `cargo audit` (no new advisory failure; existing allowed warnings only)
- full pre-commit and pre-push gates

Production-path mutation: a scratch-only bypass returning `Verified` before `EndEntityCert::verify_for_usage` made the focused suite exit 101 with 8 failures, including unrelated root, expiry, not-yet-valid, missing/wrong intermediate, missing EKU, bundled-byte verdict, and unsupported signature. The clean control remained 13/13.

## Risk and non-claims

- This verifies Assay's ring-backed offline Fulcio verification path and hosted platform integration.
- This does not claim FIPS behavior, ML-DSA support, every `aws-lc-rs` backend, or a general TLS compatibility result.
- Hosted Linux, macOS, Windows, required CI, delegated proof, and exact-head independent review remain merge gates.
