### PR TITLE
test(cli): follow JSON writers to inventory rows (#2555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to this project will be documented in this file.
   `evidence lint` (SARIF, not the run-report `sarif` row), `evidence list` (`list_all` vs
   `list_for_run`), and `assay profile update` (`ASSAY_PROFILE_PERF_JSON`, not `profile show`).
   Fourteen files were opted out after reading the emit path. The command-tree walk admits one
-  safe ASCII component at a time, rejects symlinks fail-closed, and never uses `DirEntry::path()`.
-  No schema, runtime, or CLI output changed (#2555).
+  safe ASCII component at a time, rejects a symlink root and nested symlinks fail-closed, and
+  never uses `DirEntry::path()`. No schema, runtime, or CLI output changed (#2555).
 - `capture_candidate.py` records a candidate's observations over the opaque cases and
   writes `assay.privileged_mcp_action.candidate_capture.v0`. It takes no manifest and no
   expectations, so a candidate that escapes its process bounds finds no answers on that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- The CLI JSON identity guard now follows writers to rows as well as rows to writers. Every
+  production file under `cli/commands` that serializes JSON through the six issue idioms must be
+  named by a `cli-documents` writer/namer, an `unnamed-documents` producer, or an explicit
+  stale-checked opt-out. Nineteen previously unrecorded CLI JSON emits were added as unnamed
+  document rows without changing production commands, including the second emit forms in
+  `evidence lint` (SARIF, not the run-report `sarif` row), `evidence list` (`list_all` vs
+  `list_for_run`), and `assay profile update` (`ASSAY_PROFILE_PERF_JSON`, not `profile show`).
+  Fourteen files were opted out after reading the emit path. No schema, runtime, or CLI output
+  changed (#2555).
 - `capture_candidate.py` records a candidate's observations over the opaque cases and
   writes `assay.privileged_mcp_action.candidate_capture.v0`. It takes no manifest and no
   expectations, so a candidate that escapes its process bounds finds no answers on that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ All notable changes to this project will be documented in this file.
   document rows without changing production commands, including the second emit forms in
   `evidence lint` (SARIF, not the run-report `sarif` row), `evidence list` (`list_all` vs
   `list_for_run`), and `assay profile update` (`ASSAY_PROFILE_PERF_JSON`, not `profile show`).
-  Fourteen files were opted out after reading the emit path. No schema, runtime, or CLI output
-  changed (#2555).
+  Fourteen files were opted out after reading the emit path. The command-tree walk admits one
+  safe ASCII component at a time, rejects symlinks fail-closed, and never uses `DirEntry::path()`.
+  No schema, runtime, or CLI output changed (#2555).
 - `capture_candidate.py` records a candidate's observations over the opaque cases and
   writes `assay.privileged_mcp_action.candidate_capture.v0`. It takes no manifest and no
   expectations, so a candidate that escapes its process bounds finds no answers on that

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -5,7 +5,7 @@
 //! emitter could arrive and no record would notice, which is how two counts of that set were
 //! published and withdrawn before this guard existed.
 //!
-//! Three properties, and the third is the one that matters:
+//! Four properties, and the third and fourth are the ones that matter:
 //!
 //! 1. Every identity string in production source is recorded, in the block that says what it is.
 //!    The two blocks are a partition, so "in neither" is a failure rather than a silence.
@@ -16,6 +16,11 @@
 //!    window, soak, `Baseline`, `HygieneReport`, both `run.json` writers, the sim-run report and
 //!    SARIF have zero identity constants between them. A pin built from a source scan alone
 //!    satisfies (1) and (2) while omitting every document #2485 has to migrate, and stays green.
+//! 4. The inventory follows rows to writers *and* writers to rows. A production file under
+//!    `cli/commands` that serializes JSON through the issue idioms must be named by a
+//!    `cli-documents` writer/namer, an `unnamed-documents` producer, or (once classified) an
+//!    explicit opt-out. The older one-way check is how `assay.runner.observation_health.v0`
+//!    shipped unrecorded.
 //!
 //! The inventory is never generated — not in CI and not locally-then-committed. This test reads it
 //! and never writes it.
@@ -143,14 +148,18 @@ fn find_test_mod(src: &str) -> Option<(usize, usize)> {
         let attr = from + rel;
         let after = &src[attr + ATTR.len()..];
         let trimmed = after.trim_start();
-        if let Some(tail) = trimmed.strip_prefix("mod ") {
+        // Visibility prefixes are the same ones `bare_mod_name` already accepts for `mod name;`.
+        // `#[cfg(test)] pub(crate) mod tests { … }` is still a test module; matching only
+        // `mod ` left `skill_supply_chain.rs` looking like a production serializer.
+        if let Some(tail) = module_after_visibility(trimmed) {
             if let Some(brace) = tail.find('{') {
                 if tail[..brace]
                     .trim()
                     .chars()
                     .all(|c| c.is_alphanumeric() || c == '_')
                 {
-                    let consumed = after.len() - trimmed.len() + "mod ".len() + brace + 1;
+                    let prefix_len = trimmed.len() - tail.len();
+                    let consumed = after.len() - trimmed.len() + prefix_len + brace + 1;
                     return Some((attr, attr + ATTR.len() + consumed));
                 }
             }
@@ -308,13 +317,17 @@ fn declared_modules(src: &str) -> Vec<String> {
     src.lines().filter_map(bare_mod_name).collect()
 }
 
+/// Remainder after an optional visibility prefix and `mod `, if this text introduces a module.
+fn module_after_visibility(src: &str) -> Option<&str> {
+    src.strip_prefix("mod ")
+        .or_else(|| src.strip_prefix("pub mod "))
+        .or_else(|| src.strip_prefix("pub(crate) mod "))
+        .or_else(|| src.strip_prefix("pub(super) mod "))
+}
+
 fn bare_mod_name(line: &str) -> Option<String> {
     let line = line.trim();
-    let rest = line
-        .strip_prefix("mod ")
-        .or_else(|| line.strip_prefix("pub mod "))
-        .or_else(|| line.strip_prefix("pub(crate) mod "))
-        .or_else(|| line.strip_prefix("pub(super) mod "))?;
+    let rest = module_after_visibility(line)?;
     let name = rest.strip_suffix(';')?;
     name.chars()
         .all(|c| c.is_alphanumeric() || c == '_')
@@ -589,16 +602,35 @@ fn every_production_identity_is_classified() {
 #[test]
 fn documents_without_an_identity_are_recorded_and_still_exist() {
     const REQUIRED: &[&str] = &[
+        "aee_landlock_seal",
         "baseline",
         "baseline_diff",
+        "calibration_report",
+        "coverage_legacy",
         "coverage_report",
         "discover_inventory",
+        "evidence_attest_dsse",
+        "evidence_diff",
+        "evidence_lint",
+        "evidence_lint_sarif",
+        "evidence_list",
+        "evidence_list_for_run",
+        "evidence_show",
+        "evidence_store_status",
+        "explain_report",
+        "generated_policy",
         "hygiene_report",
+        "mcp_config_path",
+        "profile_file",
+        "profile_perf",
+        "profile_show",
         "run_json_extended",
         "run_json_minimal",
         "sarif",
         "session_state_window",
+        "signed_tool",
         "sim_run_report",
+        "skill_supply_chain_cdx",
         "soak_report",
         "trust_basis_generate",
     ];
@@ -1002,4 +1034,296 @@ fn published_symbols(path: &str) -> BTreeSet<String> {
         }
     }
     names
+}
+
+/// Command files whose JSON emit is the converse of `documents_are_bound_to_a_writer`.
+const COMMANDS_DIR: &str = "crates/assay-cli/src/cli/commands";
+
+/// Idioms that mean a command file serializes JSON.
+///
+/// Deliberately not `WRITERS`: that list includes `println!` and filesystem helpers that 110
+/// command files hit without emitting a document. This converse detector is the issue's
+/// six serializers, matched as those exact substrings after test-module bodies are gone.
+const JSON_SERIALIZER_IDIOMS: &[&str] = &[
+    "write_stdout_json",
+    "to_string_pretty",
+    "to_vec_pretty",
+    "to_writer",
+    "serde_json::to_string(",
+    "serde_json::to_vec(",
+];
+
+/// `true` for a file whose path is an external `tests.rs` module under `COMMANDS_DIR`.
+///
+/// Path-suffix, not basename: `attest.rs` and `livekit_tool_action.rs` must not match, and a
+/// `tests.rs` sitting anywhere else in the crate is out of scope.
+fn is_external_tests_rs(rel: &str) -> bool {
+    rel.starts_with(COMMANDS_DIR)
+        && rel.ends_with("/tests.rs")
+        && rel.as_bytes().get(COMMANDS_DIR.len()) == Some(&b'/')
+}
+
+fn posix_rel(path: &std::path::Path, root: &std::path::Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_str()
+        .unwrap_or_else(|| panic!("{} is not utf-8", path.display()))
+        .replace('\\', "/")
+}
+
+fn command_rs_files() -> Vec<PathBuf> {
+    let base = workspace_root().join(COMMANDS_DIR);
+    let mut stack = vec![base];
+    let mut files = Vec::new();
+    while let Some(path) = stack.pop() {
+        let entries = std::fs::read_dir(&path)
+            .unwrap_or_else(|e| panic!("unreadable command directory {}: {e}", path.display()));
+        for entry in entries {
+            let p = entry.expect("dir entry").path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                files.push(p);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+fn source_has_json_serializer(src: &str) -> bool {
+    JSON_SERIALIZER_IDIOMS
+        .iter()
+        .any(|idiom| src.contains(idiom))
+}
+
+/// Production command files that serialize JSON, as exact workspace-relative POSIX paths.
+fn json_serializing_command_files() -> BTreeSet<String> {
+    let root = workspace_root();
+    let test_only = test_only_files();
+    let mut found = BTreeSet::new();
+    for path in command_rs_files() {
+        let rel = posix_rel(&path, &root);
+        if is_external_tests_rs(&rel) {
+            continue;
+        }
+        if test_only.contains(&path) {
+            continue;
+        }
+        let src = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("unreadable production command file {rel}: {e}"));
+        let src = strip_comments(&strip_test_modules_at(&src, &rel));
+        if source_has_json_serializer(&src) {
+            found.insert(rel);
+        }
+    }
+    found
+}
+
+/// Exact command-tree paths named by a `cli-documents` writer/namer or an `unnamed-documents`
+/// producer. Basename matching is not a fallback: a row that says `lint.rs` does not cover
+/// `crates/assay-cli/src/cli/commands/evidence/lint.rs`.
+fn is_command_tree_path(path: &str) -> bool {
+    path.starts_with(COMMANDS_DIR) && path.as_bytes().get(COMMANDS_DIR.len()) == Some(&b'/')
+}
+
+fn command_paths_named_by_inventory_rows() -> BTreeSet<String> {
+    let mut named = BTreeSet::new();
+    for (writer, namer) in document_rows().into_values() {
+        if is_command_tree_path(&writer) {
+            named.insert(writer);
+        }
+        if is_command_tree_path(&namer) {
+            named.insert(namer);
+        }
+    }
+    for line in recorded("unnamed-documents") {
+        let parts: Vec<&str> = line.split('|').map(str::trim).collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "{INVENTORY}: `unnamed-documents` row is not `key | producer | token`: {line:?}"
+        );
+        let producer = parts[1];
+        if is_command_tree_path(producer) {
+            named.insert(producer.to_string());
+        }
+    }
+    named
+}
+
+/// Exact command-tree paths opted out of being document producers, with a non-empty motive.
+///
+/// The motive is a reviewable declaration of the emit or helper role, not proof. An unreadable
+/// inventory or an unparsable `json-writer-opt-outs` block fails in `recorded` before this runs.
+fn json_writer_opt_outs() -> BTreeMap<String, String> {
+    let mut rows = BTreeMap::new();
+    for line in recorded("json-writer-opt-outs") {
+        let (path, motive) = line.split_once('|').unwrap_or_else(|| {
+            panic!("{INVENTORY}: `json-writer-opt-outs` row is not `path | motive`: {line:?}")
+        });
+        let (path, motive) = (path.trim(), motive.trim());
+        assert!(
+            is_command_tree_path(path),
+            "{INVENTORY}: opt-out path must be the exact command-tree path, not a basename: {path:?}"
+        );
+        assert!(
+            !motive.is_empty(),
+            "{INVENTORY}: opt-out {path:?} has an empty motive; name the emit or helper role"
+        );
+        assert!(
+            rows.insert(path.to_string(), motive.to_string()).is_none(),
+            "{INVENTORY}: `json-writer-opt-outs` records {path:?} twice"
+        );
+    }
+    rows
+}
+
+/// Every production command file that serializes JSON is named by a document row or an opt-out.
+///
+/// The older guard only followed rows to writers. A file that writes JSON without being named
+/// stayed green — which is how `assay.runner.observation_health.v0` shipped unrecorded.
+#[test]
+fn json_serializing_command_files_are_named_by_a_row() {
+    let writers = json_serializing_command_files();
+    assert!(
+        !writers.is_empty(),
+        "collected no JSON-serializing command files; the scan shape moved"
+    );
+    let named = command_paths_named_by_inventory_rows();
+    let opt_outs = json_writer_opt_outs();
+    let opted: BTreeSet<String> = opt_outs.keys().cloned().collect();
+
+    let also_named: Vec<_> = opted.intersection(&named).cloned().collect();
+    assert!(
+        also_named.is_empty(),
+        "{INVENTORY}: these opt-outs are already named by a `cli-documents` writer/namer or \
+         `unnamed-documents` producer, so the opt-out is stale:\n  {}",
+        also_named.join("\n  ")
+    );
+
+    let missing: Vec<_> = opted
+        .iter()
+        .filter(|path| !workspace_root().join(path).is_file())
+        .cloned()
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "{INVENTORY}: these opt-out paths do not exist:\n  {}",
+        missing.join("\n  ")
+    );
+
+    let no_longer_serialize: Vec<_> = opted.difference(&writers).cloned().collect();
+    assert!(
+        no_longer_serialize.is_empty(),
+        "{INVENTORY}: these opt-outs no longer serialize JSON through the converse idioms:\n  {}",
+        no_longer_serialize.join("\n  ")
+    );
+
+    let accounted: BTreeSet<String> = named.union(&opted).cloned().collect();
+    let unaccounted: Vec<String> = writers.difference(&accounted).cloned().collect();
+    assert!(
+        unaccounted.is_empty(),
+        "these production command files serialize JSON and are named by no `cli-documents` \
+         writer/namer, no `unnamed-documents` producer, and no `json-writer-opt-outs` row:\n  {}",
+        unaccounted.join("\n  ")
+    );
+}
+
+/// `*/tests.rs` under the command tree is excluded by a path rule, not because those files
+/// happen to lack serializers. Several of them serialize today; leaking them into the candidate
+/// set is a failure of the rule, not of the inventory.
+#[test]
+fn external_tests_rs_serializers_are_not_candidates() {
+    let root = workspace_root();
+    let mut tests_rs_with_idioms = Vec::new();
+    for path in command_rs_files() {
+        let rel = posix_rel(&path, &root);
+        if !is_external_tests_rs(&rel) {
+            continue;
+        }
+        let src =
+            std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("unreadable {rel}: {e}"));
+        if source_has_json_serializer(&src) {
+            tests_rs_with_idioms.push(rel);
+        }
+    }
+    assert!(
+        !tests_rs_with_idioms.is_empty(),
+        "no `*/tests.rs` under {COMMANDS_DIR} currently contains a serializer idiom; the \
+         exclusion would be an omission rather than a tested rule"
+    );
+    let candidates = json_serializing_command_files();
+    let leaked: Vec<_> = tests_rs_with_idioms
+        .into_iter()
+        .filter(|rel| candidates.contains(rel))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "external `*/tests.rs` files leaked into writer candidates: {leaked:?}"
+    );
+}
+
+/// Inline `#[cfg(test)] mod` bodies are stripped before the idiom scan. Files whose only
+/// serializer sits in that body are not candidates; if the stripper stopped running they would
+/// appear as unaccounted production writers.
+#[test]
+fn inline_cfg_test_module_serializers_are_not_candidates() {
+    let root = workspace_root();
+    let test_only = test_only_files();
+    let mut inline_only = Vec::new();
+    for path in command_rs_files() {
+        let rel = posix_rel(&path, &root);
+        if is_external_tests_rs(&rel) || test_only.contains(&path) {
+            continue;
+        }
+        let src =
+            std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("unreadable {rel}: {e}"));
+        let with_tests = strip_comments(&src);
+        let without_tests = strip_comments(&strip_test_modules_at(&src, &rel));
+        if source_has_json_serializer(&with_tests) && !source_has_json_serializer(&without_tests) {
+            inline_only.push(rel);
+        }
+    }
+    assert!(
+        !inline_only.is_empty(),
+        "no production command file currently keeps its serializer only inside an inline \
+         `#[cfg(test)] mod`; the exclusion would be an omission rather than a tested rule"
+    );
+    let candidates = json_serializing_command_files();
+    let leaked: Vec<_> = inline_only
+        .into_iter()
+        .filter(|rel| candidates.contains(rel))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "inline `#[cfg(test)]` serializers leaked into writer candidates: {leaked:?}"
+    );
+}
+
+#[test]
+fn external_tests_rs_rule_is_a_commands_path_suffix() {
+    assert!(is_external_tests_rs(
+        "crates/assay-cli/src/cli/commands/replay/tests.rs"
+    ));
+    assert!(!is_external_tests_rs(
+        "crates/assay-cli/src/cli/commands/evidence/attest.rs"
+    ));
+    assert!(!is_external_tests_rs(
+        "crates/assay-core/src/report/tests.rs"
+    ));
+    assert!(!is_external_tests_rs(
+        "crates/assay-cli/src/cli/commands/tests_helpers.rs"
+    ));
+}
+
+#[test]
+fn strip_test_modules_removes_pub_crate_mod() {
+    let src = "fn prod() {}\n#[cfg(test)]\npub(crate) mod tests {\n    let _ = serde_json::to_string(&1);\n}\n";
+    let stripped = strip_test_modules_at(src, "fixture");
+    assert!(
+        !stripped.contains("serde_json::to_string("),
+        "visibility-prefixed test modules must strip like bare `mod tests`"
+    );
+    assert!(stripped.contains("fn prod"));
 }

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -1179,12 +1179,12 @@ fn json_writer_opt_outs() -> BTreeMap<String, String> {
     rows
 }
 
-/// Every production command file that serializes JSON is named by a document row or an opt-out.
+/// Every production command file that serializes JSON is accounted for: a document row or an opt-out.
 ///
 /// The older guard only followed rows to writers. A file that writes JSON without being named
 /// stayed green — which is how `assay.runner.observation_health.v0` shipped unrecorded.
 #[test]
-fn json_serializing_command_files_are_named_by_a_row() {
+fn json_serializing_command_files_are_accounted_for() {
     let writers = json_serializing_command_files();
     assert!(
         !writers.is_empty(),

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -1094,8 +1094,21 @@ fn safe_component(name: &std::ffi::OsStr) -> Option<String> {
 ///
 /// Uses `DirEntry::file_type()` (does not follow) and never `DirEntry::path()`. A symlink is a
 /// hard failure, not a skip: skipping would leave a serializer on the other side of the link
-/// unaccounted without anyone noticing.
+/// unaccounted without anyone noticing. The walk root is checked with `symlink_metadata` before
+/// the first `read_dir`, because `read_dir` follows a symlink root and would inventory its target.
 fn collect_rs_under(root: &Path) -> Vec<PathBuf> {
+    let meta = std::fs::symlink_metadata(root)
+        .unwrap_or_else(|e| panic!("unreadable command tree root {}: {e}", root.display()));
+    assert!(
+        !meta.file_type().is_symlink(),
+        "command tree root must not be a symlink: {}",
+        root.display()
+    );
+    assert!(
+        meta.is_dir(),
+        "command tree root must be a real directory: {}",
+        root.display()
+    );
     let mut stack = vec![root.to_path_buf()];
     let mut files = Vec::new();
     while let Some(dir) = stack.pop() {
@@ -1456,5 +1469,22 @@ fn command_tree_walk_rejects_symlinks_fail_closed() {
     assert!(
         result.is_err(),
         "a symlink in the command tree must fail closed, not be followed or skipped"
+    );
+}
+
+/// `read_dir` follows a symlink root. The walk must refuse before the first listing, so a
+/// replaced `cli/commands` link cannot inventory a tree outside that directory.
+#[cfg(unix)]
+#[test]
+fn command_tree_walk_rejects_symlink_root_fail_closed() {
+    let holder = tempfile::tempdir().expect("holder");
+    let outside = tempfile::tempdir().expect("outside");
+    std::fs::write(outside.path().join("escaped.rs"), "fn x() {}\n").expect("escaped.rs");
+    let commands = holder.path().join("commands");
+    std::os::unix::fs::symlink(outside.path(), &commands).expect("root symlink");
+    let result = std::panic::catch_unwind(|| collect_rs_under(&commands));
+    assert!(
+        result.is_err(),
+        "a symlink supplied as the walk root must fail closed, not be followed"
     );
 }

--- a/crates/assay-cli/tests/cli_json_identities.rs
+++ b/crates/assay-cli/tests/cli_json_identities.rs
@@ -26,7 +26,7 @@
 //! and never writes it.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const INVENTORY: &str = "docs/architecture/CLI-JSON-IDENTITIES.md";
 
@@ -1071,24 +1071,75 @@ fn posix_rel(path: &std::path::Path, root: &std::path::Path) -> String {
         .replace('\\', "/")
 }
 
-fn command_rs_files() -> Vec<PathBuf> {
-    let base = workspace_root().join(COMMANDS_DIR);
-    let mut stack = vec![base];
+/// One path component, admitted only if it is an ordinary name.
+///
+/// `read_dir` entries are untrusted input to a static analyser, and a symlink away from being
+/// untrusted in fact. The first fix would canonicalise `DirEntry::path()` and then require
+/// containment; CodeQL still flags that, which is fair: it is a check applied after an arbitrary
+/// path exists. This admits the component instead, so a traversal cannot be spelled. `.`, `..`,
+/// separators, and anything not in the allowed set are refused, and every path below is built
+/// from the walk root plus admitted names. Same rule `error_enums_non_exhaustive.rs` and
+/// `validate_baseline_key()` apply.
+fn safe_component(name: &std::ffi::OsStr) -> Option<String> {
+    let s = name.to_str()?;
+    let ordinary = !s.is_empty()
+        && s != "."
+        && s != ".."
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    ordinary.then(|| s.to_string())
+}
+
+/// Rust files under `root`, walked by admitting one component at a time.
+///
+/// Uses `DirEntry::file_type()` (does not follow) and never `DirEntry::path()`. A symlink is a
+/// hard failure, not a skip: skipping would leave a serializer on the other side of the link
+/// unaccounted without anyone noticing.
+fn collect_rs_under(root: &Path) -> Vec<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
     let mut files = Vec::new();
-    while let Some(path) = stack.pop() {
-        let entries = std::fs::read_dir(&path)
-            .unwrap_or_else(|e| panic!("unreadable command directory {}: {e}", path.display()));
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("unreadable command directory {}: {e}", dir.display()));
         for entry in entries {
-            let p = entry.expect("dir entry").path();
-            if p.is_dir() {
+            let entry = entry.expect("dir entry");
+            let file_type = entry
+                .file_type()
+                .unwrap_or_else(|e| panic!("unreadable file type in {}: {e}", dir.display()));
+            assert!(
+                !file_type.is_symlink(),
+                "command tree must not contain symlinks: {} / {:?}",
+                dir.display(),
+                entry.file_name()
+            );
+            let Some(name) = safe_component(&entry.file_name()) else {
+                panic!(
+                    "command tree path component is not an ordinary ASCII name: {:?}",
+                    entry.file_name()
+                );
+            };
+            let p = dir.join(&name);
+            assert!(
+                p.starts_with(root),
+                "joined path {} escaped walk root {}",
+                p.display(),
+                root.display()
+            );
+            if file_type.is_dir() {
                 stack.push(p);
-            } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+            } else if file_type.is_file() && name.ends_with(".rs") {
                 files.push(p);
+            } else if !file_type.is_file() {
+                panic!("command tree entry is not a regular file or directory: {name}");
             }
         }
     }
     files.sort();
     files
+}
+
+fn command_rs_files() -> Vec<PathBuf> {
+    collect_rs_under(&workspace_root().join(COMMANDS_DIR))
 }
 
 fn source_has_json_serializer(src: &str) -> bool {
@@ -1326,4 +1377,84 @@ fn strip_test_modules_removes_pub_crate_mod() {
         "visibility-prefixed test modules must strip like bare `mod tests`"
     );
     assert!(stripped.contains("fn prod"));
+}
+
+/// The component allowlist, which is the load-bearing half of the command-tree walk.
+#[test]
+fn command_tree_component_rule_refuses_anything_that_could_leave_the_directory() {
+    use std::ffi::OsStr;
+    for ok in ["mod.rs", "lint.rs", "skill_supply_chain.rs", "a.b-c_1"] {
+        assert_eq!(
+            safe_component(OsStr::new(ok)).as_deref(),
+            Some(ok),
+            "{ok} is an ordinary name"
+        );
+    }
+    for bad in ["", ".", "..", "../etc", "a/b", "a\\b", "a b", "naïve"] {
+        assert_eq!(
+            safe_component(OsStr::new(bad)),
+            None,
+            "{bad:?} must not be admitted as a component"
+        );
+    }
+}
+
+/// A newly added `.rs` file under the walk root is collected. The converse detector's
+/// unaccounted assertion is this property on the live tree: an unreferenced serializer file
+/// must appear, not be skipped because the walker only knows inventory paths.
+#[test]
+fn command_tree_walk_collects_a_new_unreferenced_rs_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let nested = dir.path().join("evidence");
+    std::fs::create_dir(&nested).expect("nested dir");
+    std::fs::write(dir.path().join("mod.rs"), "fn g() {}\n").expect("mod.rs");
+    std::fs::write(
+        nested.join("unreferenced.rs"),
+        "fn f() { let _ = serde_json::to_string(&1); }\n",
+    )
+    .expect("unreferenced.rs");
+    let files = collect_rs_under(dir.path());
+    let names: Vec<String> = files
+        .iter()
+        .map(|p| {
+            p.strip_prefix(dir.path())
+                .expect("under root")
+                .to_str()
+                .expect("utf-8")
+                .replace('\\', "/")
+        })
+        .collect();
+    assert!(
+        names.contains(&"mod.rs".to_string()),
+        "existing file must remain visible: {names:?}"
+    );
+    assert!(
+        names.contains(&"evidence/unreferenced.rs".to_string()),
+        "a newly added command file must be collected so the converse detector can fail it: {names:?}"
+    );
+    let with_idiom: Vec<_> = files
+        .iter()
+        .filter(|p| source_has_json_serializer(&std::fs::read_to_string(p).expect("read fixture")))
+        .collect();
+    assert_eq!(
+        with_idiom.len(),
+        1,
+        "the new file is the serializer the inventory has not named"
+    );
+}
+
+/// `DirEntry::path()` then `is_dir()` follows a symlink. The walk must refuse the link
+/// before a path is constructed, so a link cannot take the scan outside the root.
+#[cfg(unix)]
+#[test]
+fn command_tree_walk_rejects_symlinks_fail_closed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("outside");
+    std::fs::write(dir.path().join("ok.rs"), "fn x() {}\n").expect("ok.rs");
+    std::os::unix::fs::symlink(outside.path(), dir.path().join("escape")).expect("symlink");
+    let result = std::panic::catch_unwind(|| collect_rs_under(dir.path()));
+    assert!(
+        result.is_err(),
+        "a symlink in the command tree must fail closed, not be followed or skipped"
+    );
 }

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -152,8 +152,9 @@ assay.tool_decision_truth.v0 | `assay mcp --tool-decision-truth-out` DOES append
 ## Machine-checked: documents with no identity at all
 
 These are the rows a source scan structurally cannot produce, because **none of them has a dotted
-identity constant** — measured, all twelve. A pin built only from identity strings would satisfy every
-other check in the guard while omitting every document #2485 has to migrate. They are therefore
+identity constant**. Twelve were measured from identity-less producers; nineteen more were added when
+#2555 followed writers to rows. A pin built only from identity strings would satisfy every other
+check in the guard while omitting every document #2485 has to migrate. They are therefore
 *required* rows: a missing one fails the build even though there is nothing in the source to collect.
 
 Each row is `key | producer path | token`, and the test asserts the producer file exists and still
@@ -173,6 +174,25 @@ session_state_window | crates/assay-cli/src/cli/commands/session_state_window.rs
 sim_run_report | crates/assay-cli/src/cli/commands/sim.rs | to_string_pretty
 soak_report | crates/assay-cli/src/cli/commands/sim/soak/report.rs | soak-report-v1
 trust_basis_generate | crates/assay-cli/src/cli/commands/trust_basis.rs | generate_trust_basis
+aee_landlock_seal | crates/assay-cli/src/cli/commands/sandbox/child.rs | maybe_emit_aee_seal
+calibration_report | crates/assay-cli/src/cli/commands/calibrate.rs | to_string_pretty(&report)
+coverage_legacy | crates/assay-cli/src/cli/commands/coverage/legacy.rs | LegacyOutputFormat::Json
+evidence_attest_dsse | crates/assay-cli/src/cli/commands/evidence/attest.rs | sign_statement
+evidence_diff | crates/assay-cli/src/cli/commands/evidence/diff.rs | DiffCliDocument
+evidence_lint | crates/assay-cli/src/cli/commands/evidence/lint.rs | LintFormat::Json
+evidence_lint_sarif | crates/assay-cli/src/cli/commands/evidence/lint.rs | LintFormat::Sarif
+evidence_list | crates/assay-cli/src/cli/commands/evidence/list.rs | list_all
+evidence_list_for_run | crates/assay-cli/src/cli/commands/evidence/list.rs | list_for_run
+evidence_show | crates/assay-cli/src/cli/commands/evidence/mod.rs | "verify_mode"
+evidence_store_status | crates/assay-cli/src/cli/commands/evidence/store_status.rs | StatusFormat::Json
+explain_report | crates/assay-cli/src/cli/commands/explain.rs | ExplainFormat::Json
+generated_policy | crates/assay-cli/src/cli/commands/generate/model.rs | PolicyOutputFormat::Json
+mcp_config_path | crates/assay-cli/src/cli/commands/config_path.rs | "generated_server"
+profile_file | crates/assay-cli/src/cli/commands/profile_types.rs | save_profile
+profile_perf | crates/assay-cli/src/cli/commands/profile_next/mod.rs | ASSAY_PROFILE_PERF_JSON
+profile_show | crates/assay-cli/src/cli/commands/profile_next/mod.rs | ProfileShowFormat::Json
+signed_tool | crates/assay-cli/src/cli/commands/tool/sign.rs | sign_tool
+skill_supply_chain_cdx | crates/assay-cli/src/cli/commands/evidence/project_skill_bom.rs | project_bom
 ```
 
 | key | version field | class | note |
@@ -189,12 +209,67 @@ trust_basis_generate | crates/assay-cli/src/cli/commands/trust_basis.rs | genera
 | `discover_inventory` | none | (d) | `assay mcp discover --format json`; **not** `assay.mcp_server_inventory.v0` |
 | `trust_basis_generate` | none | (d) | `assay trust-basis generate` writes canonical JSON; the `assert` report is a separate, named document |
 | `soak_report` | string `soak-report-v1` + `report_version` | (b) | closed schema, validated on emit |
+| `aee_landlock_seal` | DSSE payload type `application/vnd.assay.aee-landlock-seal.v1+json` | (g) | `assay sandbox --aee-seal`; foreign envelope, not an `assay.*` document identity |
+| `calibration_report` | integer `schema_version` on the core model | (c) | `assay calibrate --out`; minting an identity is a #2485 review |
+| `coverage_legacy` | none | (d) | `assay coverage` legacy `--format json`; **not** `coverage_report_v1` |
+| `evidence_attest_dsse` | in-toto/DSSE envelope | (g) | `assay evidence attest`; foreign envelope, integers stay under #2552 |
+| `evidence_diff` | none | (d) | `assay evidence diff --format json` prints `DiffCliDocument` |
+| `evidence_lint` | none | (d) | `assay evidence lint --format json`; **not** the SARIF emit |
+| `evidence_lint_sarif` | SARIF `2.1.0` | (g) | `assay evidence lint --format sarif` via `to_sarif_with_options`; **not** the `sarif` row, whose producer is `assay-core` run-report SARIF |
+| `evidence_list` | none | (d) | `assay evidence list --format json` without `--run-id` (`list_all`) |
+| `evidence_list_for_run` | none | (d) | `assay evidence list --run-id --format json` (`list_for_run`); different object keys than `evidence_list` |
+| `evidence_show` | none | (d) | `assay evidence show --format json` prints manifest + events |
+| `evidence_store_status` | none | (d) | `assay evidence store-status --format json` |
+| `explain_report` | none | (d) | `assay explain --format json` |
+| `generated_policy` | none | (d) | `assay generate --format json` writes a policy, not an `assay.*` document |
+| `mcp_config_path` | none | (d) | `assay mcp config-path` JSON object |
+| `profile_file` | none | (d) | `save_profile` writes a Profile JSON file |
+| `profile_perf` | none | (d) | `ASSAY_PROFILE_PERF_JSON` sidecar from `assay profile update`; **not** `profile_show` |
+| `profile_show` | none | (d) | `assay profile show --format json`; **not** the perf sidecar |
+| `signed_tool` | none | (d) | `assay mcp tool sign` writes a signed tool definition |
+| `skill_supply_chain_cdx` | CycloneDX 1.6 | (g) | `assay evidence project-skill-bom`; foreign identity, do not mint `assay.*` |
 
 Three of these rows — `baseline_diff`, `discover_inventory` and `trust_basis_generate` — came from
 an independent read, not from the author of this file. Two separately written inventories both
 missed them. That is the argument for the required-rows check stated as evidence rather than as
 principle: the documents a scan cannot see are also the ones a single careful reader does not think
 of, and there is no instrument that fixes that.
+
+Nineteen of the rows above were not on that first measured twelve. They were found by reading the
+emit path of each unaccounted serializer on `1c560a912`, which is #2555: the file writes JSON, so
+the inventory has to say what that JSON is. No production command changed. Adding the row does not
+prove the classification; it records that a document was shipped unnamed. The converse detector is
+still file-level, so several of these keys share a producer; the extra rows exist so a second emit
+form in that file is not hidden behind the first.
+
+## Machine-checked: JSON-serializing command files that are not document producers
+
+A production file under `crates/assay-cli/src/cli/commands` that serializes JSON through
+`write_stdout_json`, `to_string_pretty`, `to_vec_pretty`, `to_writer`, `serde_json::to_string(`, or
+`serde_json::to_vec(` — after inline `#[cfg(test)]` modules and external `*/tests.rs` files are
+removed — must be named by a `cli-documents` writer/namer, an `unnamed-documents` producer, or
+listed here with a non-empty motive that names the emit or helper role. Paths are the exact
+workspace-relative POSIX path; a basename does not match. A stale opt-out (missing path, file that
+no longer serializes, or path already named by a document row) is a failure. The motive is a
+reviewable declaration, not mechanical proof.
+
+<!-- machine-checked: json-writer-opt-outs -->
+```text
+crates/assay-cli/src/cli/commands/ci.rs | stdout helper: write_stdout_json of render_summary_json for already-recorded assay.run_summary.v1 (writer is assay-core report/summary/writer.rs)
+crates/assay-cli/src/cli/commands/coverage/io.rs | emit helper: to_vec_pretty of coverage_report_v1 whose unnamed producer is coverage/report.rs
+crates/assay-cli/src/cli/commands/evidence/adapt_skill_scan.rs | second emit: write_stdout_json of an augmented assay.skill_supply_chain.v0 carrier; the cli-documents writer is skill_supply_chain_capture.rs
+crates/assay-cli/src/cli/commands/evidence/explore.rs | TUI helper: to_string_pretty of event.payload for the detail pane, not a CLI document
+crates/assay-cli/src/cli/commands/evidence/livekit_tool_action/canonical.rs | hash helper: serde_json::to_string of keys and strings while building canonical JSON for a digest, not a CLI document
+crates/assay-cli/src/cli/commands/import.rs | NDJSON helper: serde_json::to_string of each TraceEvent into a .trace.jsonl file; no line is a top-level document
+crates/assay-cli/src/cli/commands/mcp/coverage_input.rs | NDJSON helper: serde_json::to_string of one {tool, tool_classes} object per line as coverage_report_v1 input
+crates/assay-cli/src/cli/commands/replay/fs_ops.rs | config helper: to_string_pretty rewriting settings.seed in an existing JSON config
+crates/assay-cli/src/cli/commands/replay/provenance.rs | rewrite helper: to_string_pretty annotating provenance onto an existing run.json
+crates/assay-cli/src/cli/commands/run.rs | stdout helper: write_stdout_json of render_json for already-recorded assay.run_report.v1 (writer is assay-core report/json.rs)
+crates/assay-cli/src/cli/commands/sandbox/profile.rs | digest helper: serde_json::to_string of a degradation record as hasher input, not a CLI document
+crates/assay-cli/src/cli/commands/sim/soak/mod.rs | emit helper: to_string_pretty of soak-report-v1 whose unnamed producer is sim/soak/report.rs
+crates/assay-cli/src/cli/commands/trace.rs | NDJSON helper: serde_json::to_string of each ingested V2 event to --out-trace; no line is a top-level document
+crates/assay-cli/src/cli/commands/trace/import_mcp.rs | NDJSON helper: serde_json::to_string of each TraceEvent to --out-trace; no line is a top-level document
+```
 
 ## What this guard cannot do, stated plainly
 
@@ -228,15 +303,12 @@ of, and there is no instrument that fixes that.
   A file emitting through some route still not on the list is invisible to
   `documents_are_bound_to_a_writer`.
 
-- **The guard follows rows to writers, never writers to rows.** A document row must name a file that
-  writes; a file that writes need not be named by any row. That is the hole
-  `assay.runner.observation_health.v0` fell through. Measured on this head: **31 production files
-  under `cli/commands` serialize JSON and are named by no row.** Some of them almost certainly emit
-  documents — `evidence lint`, `evidence diff`, `evidence list`, `store-status`, `explain`, `import`,
-  `trace`. Closing this means requiring every JSON-serializing command file to be named by a row or
-  to carry an explicit opt-out, and triaging those 31. It is tracked separately rather than answered
-  here, because thirty-one classifications written in one sitting is the failure this file exists to
-  record.
+- **The converse detector is file-level, not dataflow, and its idiom list is not `WRITERS`.** A
+  command file that serializes through `println!` or a filesystem helper not on the six issue
+  idioms stays invisible. A second writer of an already-recorded identity is an opt-out, not a
+  second `cli-documents` row, because that block is keyed by identity. `import` and `trace` write
+  NDJSON; they are opted out for the same reason `assay.tool_decision_truth.v0` is not a document.
+  Classifications cite the emit path and remain reviewable declarations.
 - **Twenty-one of the non-document rows are declared in dependency crates and their emit paths were
   not opened.** They are classified from the declaring module. That is a weaker basis than the rows
   whose producer I read, and three such judgements have already been wrong today.
@@ -248,8 +320,8 @@ of, and there is no instrument that fixes that.
   revision of this file and the guard was green without it. A **sixth** crate is now caught:
   `every_production_identity_is_classified` also collects `pub const` identities from every crate
   `assay-cli` depends on, and `DEPENDENCY_CRATES` is pinned against `assay-cli/Cargo.toml` so the
-  list cannot drift away from the manifest. What that rule does *not* catch is a new command file in
-  a crate already scanned — `evidence lint` and `evidence diff` are that class, and it is #2555.
+  list cannot drift away from the manifest. A new JSON-serializing command file in a crate already
+  scanned is #2555's converse rule.
 - **`describe ⊆ pin` is one-directional.** `BINDING_ROWS` is seven clap paths and omits the run
   report and run summary. Forcing `describe` to grow is a product decision, not bookkeeping.
 

--- a/docs/architecture/CLI-JSON-IDENTITIES.md
+++ b/docs/architecture/CLI-JSON-IDENTITIES.md
@@ -251,7 +251,8 @@ removed — must be named by a `cli-documents` writer/namer, an `unnamed-documen
 listed here with a non-empty motive that names the emit or helper role. Paths are the exact
 workspace-relative POSIX path; a basename does not match. A stale opt-out (missing path, file that
 no longer serializes, or path already named by a document row) is a failure. The motive is a
-reviewable declaration, not mechanical proof.
+reviewable declaration, not mechanical proof. The machine block is a `text` fence of
+`path | motive` lines — pipe-delimited text, not JSON.
 
 <!-- machine-checked: json-writer-opt-outs -->
 ```text


### PR DESCRIPTION
## ADR Boundary Slice

- Canonical ledger: no programme is active
- Slice: #2555 writers-to-rows converse for CLI JSON command files
- Builder: Cursor (`cursor/2555-json-writers-to-rows`)
- Reviewers: Ruley reserved as independent exact-head reviewer; Codex validator only. Ruley remains stopped until this head is the one under review.
- Final head SHA: `c39f9bb6ed9acc49e53764c8ae7ce16d796f6c90` (worktree `/Users/roelschuurkes/wt-2555-json-writers-to-rows`)
- ADR invariants affected: none. Inventory/test/CHANGELOG only. No evidence ingestion, verification, or MCP authorization change.

Closes #2555.

## Behavior

Every production `.rs` file under `crates/assay-cli/src/cli/commands` that, after stripping inline `#[cfg(test)]` modules (including `pub(crate) mod`) and excluding external `*/tests.rs` by an explicit path rule, contains one of `write_stdout_json`, `to_string_pretty`, `to_vec_pretty`, `to_writer`, `serde_json::to_string(`, `serde_json::to_vec(` must be named by an exact POSIX path in a `cli-documents` writer/namer, an `unnamed-documents` producer, or a `json-writer-opt-outs` row with a non-empty motive. Stale opt-outs (missing path, no longer serializes, or already named by a document row) and an unreadable/unparsable machine block fail hard. Basename matching is not used. `println!` and the broader `WRITERS` list are not the converse detector.

The command-tree walk checks `symlink_metadata` on the root before the first `read_dir` and fail-closes unless that root is a real directory and not a symlink. Nested entries admit one safe ASCII component from `DirEntry::file_name()` before joining under the walk root, use `file_type()` without following, and reject nested symlinks fail-closed. It does not call `DirEntry::path()` and does not canonicalise after an arbitrary path exists.

## Classification (emit path, not filename)

RED on base `1c560a912b80121d4a14f62b0e163805ef75c89b` measured **31** unaccounted command files.

GREEN triage of those 31:

- **19 unnamed-document rows** added (no production code). Shared producers get one row per emit form so a second document in the same file is not hidden:
  - `evidence_lint` (`LintFormat::Json`) and `evidence_lint_sarif` (`LintFormat::Sarif`). Lint SARIF is **not** bound to the existing `sarif` row: that row's producer is `assay-core/src/report/sarif.rs` (run-report SARIF), a different emit.
  - `evidence_list` (`list_all`) and `evidence_list_for_run` (`list_for_run`): two JSON objects with different keys.
  - `profile_show` (`ProfileShowFormat::Json`) and `profile_perf` (`ASSAY_PROFILE_PERF_JSON`). `profile_next/mod.rs` has no other JSON serializer after those two; `save_profile` lives on `profile_types.rs` (`profile_file`).
- **14 opt-outs** after reading the emit/helper role (second writers, NDJSON, hash/TUI/config helpers).
- **1** (`evidence/skill_supply_chain.rs`) left the candidate set because `#[cfg(test)] pub(crate) mod tests` is now stripped like bare `mod tests`.

**Finding:** those 19 rows record previously unregistered CLI JSON emits. Adding a row does not prove the classification. `adapt_skill_scan.rs` remains a second writer of already-recorded `assay.skill_supply_chain.v0` (opt-out; the pin still names `skill_supply_chain_capture.rs`).

## Non-Claims

- [x] No scalar trust score or whole-action verdict
- [x] No generic identity, delegation, federation, HTTP/OAuth, or broad MCP scan
- [x] No provider-outcome, compliance, certification, partnership, or safe-agent claim
- No dataflow proof or correctness of classifications; opt-out motives and unnamed-row notes are reviewable declarations
- No coverage of `println!`, other crates, or new serializer idioms
- No schema, runtime, or CLI output change
- The converse detector stays file-level; extra unnamed keys on one producer are the manual triage of visible emit forms, not a machine check that each form still serializes
- No CodeQL query suppression; the walk is the fix

## Test Evidence

### RED

`cargo test -p assay-cli --test cli_json_identities json_serializing_command_files_are_accounted_for`

Originally measured on base `1c560a912b80121d4a14f62b0e163805ef75c89b` (parent of first GREEN `9d7c29e6d`) **before** the rename on `fd936ad4b`; at that measurement the test was still named `json_serializing_command_files_are_named_by_a_row`. Same converse detector, **no** opt-outs / new unnamed rows. Failed with the 31-file unaccounted set (same list as #2555 on this head). Exclusion tests for `*/tests.rs` and inline `#[cfg(test)]` were already green.

CodeQL required check failed HIGH `rust/path-injection` on `fd936ad4b` at `crates/assay-cli/tests/cli_json_identities.rs:1083` (`DirEntry::path()` then `is_dir()` / recursive stack).

Root-symlink follow: `command_tree_walk_rejects_symlink_root_fail_closed` (holder/commands → outside tempdir) failed on `1afb7eaaaee82992f0e9e5377e87e25e4bbd1bcf` with rc 101 because `collect_rs_under` returned normally. Nested-entry symlink rejection did not cover a symlink supplied as the walk root.

### GREEN

- `cargo test -p assay-cli --test cli_json_identities` — 14 passed (final SHA `c39f9bb6ed9acc49e53764c8ae7ce16d796f6c90`, worktree `/Users/roelschuurkes/wt-2555-json-writers-to-rows`). First GREEN was `9d7c29e6db347259f87b6609d77b84994e53b040` before the test rename; `fd936ad4b` was the rename/docs polish; `1afb7eaaa` closed nested `DirEntry::path()` but still followed a symlink root. Final GREEN is this head.
- `cargo fmt --all -- --check`
- `cargo clippy -p assay-cli --tests -- -D warnings`
- `git diff --check`
- Public strings inspected (CHANGELOG + inventory). No production command files changed.

### Mutations (scratch copies; control green; branch restored clean)

- Remove one opt-out (`ci.rs`) → RED (unaccounted)
- Add a new production command `.rs` with `serde_json::to_string(` → RED (unaccounted); now also pinned as `command_tree_walk_collects_a_new_unreferenced_rs_file`
- Stale one opt-out path (`ci_stale.rs`) → RED (path does not exist)
- Remove converse idiom `write_stdout_json` (unique for `ci.rs` / `run.rs`) → RED (opt-out no longer serializes)
- Add `*/tests.rs` with serializer → GREEN
- Serializer only in inline `#[cfg(test)] mod` → GREEN
- Unparsable `json-writer-opt-outs` fence (` ```json ` instead of ` ```text `) → RED (`recorded` fail-closed)
- Unsafe path component (`.`, `..`, separators, non-ASCII) → refused by `safe_component` (`command_tree_component_rule_refuses_anything_that_could_leave_the_directory`)
- Nested symlink entry → panic fail-closed (`command_tree_walk_rejects_symlinks_fail_closed`, unix)
- Symlink supplied as walk root (`holder/commands` → outside) → panic fail-closed (`command_tree_walk_rejects_symlink_root_fail_closed`, unix); RED on `1afb7eaaa`, GREEN on this head

## Review Quorum

- [ ] One non-building agent review (Ruley; exact head `c39f9bb6ed9acc49e53764c8ae7ce16d796f6c90`). Ruley remains stopped. Reviews of `fd936ad4b` or `1afb7eaaa` are invalid on this push.
- [ ] Every actionable finding is fixed or has a technical disposition
- [ ] Any delegated proof targets this exact head SHA

Optional automated reviews can add evidence, but do not count toward or block quorum.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Unreleased changelog entry covering expanded CLI JSON identity documentation.
  * Updated architecture documentation with additional JSON output records and explicit classifications.

* **Tests**
  * Expanded validation to ensure CLI JSON producers are fully inventoried.
  * Added checks for command paths, symlinks, unsafe path components, test-only files, and approved opt-outs.
  * Production commands, schemas, runtime behavior, and CLI output remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->