### PR TITLE
chore(deps): lock clap 4.6.6 via two-pass resolver (#2474)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1789,7 +1789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3924,7 +3924,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4412,7 +4412,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4470,7 +4470,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5059,7 +5059,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5843,7 +5843,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5992,15 +5992,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6032,28 +6023,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6078,12 +6052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6094,12 +6062,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6114,22 +6076,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6144,12 +6094,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6160,12 +6104,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6180,12 +6118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6196,12 +6128,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wiremock"


### PR DESCRIPTION
## Summary

- Part of #2474
- One generated lockfile: `clap` / `clap_builder` 4.6.5 → 4.6.6 via two-pass `cargo +1.96.0 update -p clap --precise 4.6.6` to a byte-identical fixed point. No invented guard. No source, test, docs, fuzz lock, or workflow edits.

## SHAs

- Base (`origin/main`): `7507899f4f62c9098791e022d478549e608ecde8`
- Head (`ruley/2474-clap-466`): `879f8d5b6b28622daec4c13bacb567c120230bd1`

## Resolver RED/GREEN

Lock SHA256 (sha256sum Cargo.lock):

| pass | SHA256 | note |
| --- | --- | --- |
| orig | `a56b2afcfd653282cfef5000514932c10c162f86fc419023a18944fde5ed00e6` | clap/clap_builder 4.6.5 |
| pass1 | `e371838b356f8a87fbe94e95903c19a132e8befab96792d7d4872a8a6a178978` | clap/clap_builder 4.6.6 + windows-sys retargets |
| pass2 | `87444c4d465e25d1bb0d68578e662a7428f1f936b13d856d862007682378be48` | stale unused Windows family dropped |
| pass3 | `87444c4d465e25d1bb0d68578e662a7428f1f936b13d856d862007682378be48` | byte-identical to pass2 (fixed point) |

### pass1 package/edge delta (vs orig)

Packages:
- − clap 4.6.5, clap_builder 4.6.5
- + clap 4.6.6, clap_builder 4.6.6

Edges (windows-sys retargets only; crate versions unchanged):
- anstyle-query 1.1.5, anstyle-wincon 3.0.11, dirs-sys 0.5.0, nu-ansi-term 0.50.3, socket2 0.6.3, termina 0.3.3: windows-sys 0.61.2 → 0.60.2
- errno 0.3.14, rustix 1.1.4, rustls-platform-verifier 0.6.2, tempfile 3.27.0, winapi-util 0.1.11: windows-sys 0.61.2 → 0.52.0

No getrandom / tempfile / aws-lc / rustls *version* move. tempfile and rustls-platform-verifier only retargeted their windows-sys edge.

### pass2 package/edge delta (vs pass1)

Packages removed (stale unused Windows resolver family):
- windows-sys 0.60.2
- windows-targets 0.53.5
- windows_aarch64_gnullvm 0.53.1
- windows_aarch64_msvc 0.53.1
- windows_i686_gnu 0.53.1
- windows_i686_gnullvm 0.53.1
- windows_i686_msvc 0.53.1
- windows_x86_64_gnu 0.53.1
- windows_x86_64_gnullvm 0.53.1
- windows_x86_64_msvc 0.53.1

Edges:
- anstyle-query 1.1.5, anstyle-wincon 3.0.11, dirs-sys 0.5.0, nu-ansi-term 0.50.3, socket2 0.6.3, termina 0.3.3: windows-sys 0.60.2 → 0.61.2
- quinn-udp 0.5.14: windows-sys 0.60.2 → 0.52.0
- windows-targets 0.52.6: `windows_i686_gnullvm 0.52.6` → `windows_i686_gnullvm` (only one version remains)

### pass3

Identical `cargo +1.96.0 update -p clap --precise 4.6.6` produced a byte-identical Cargo.lock (fixed point).

## Mutation (scratch only; writer tree never dirtied)

- Control (scratch, pre-mutation): `mcp_group_accepts_canonical_paths_and_legacy_shims_are_removed` and `mcp_group_is_visible_and_legacy_flat_commands_are_hidden` GREEN.
- Mutation: add `#[command(name="mcp-x")]` to `Command::Mcp` in a scratch copy at `/tmp/scratch-2474-clap-466-mut` only.
- Expected RED, observed RED:
  - unit args witness: `assertion failed: visible.contains(&"mcp".to_string())`
  - grouping witness: `assertion failed: mcp_help.status.success()` (`assay mcp --help` became unrecognized; tip: `mcp-x`)
- Restore: deleted scratch; `cargo +1.96.0 clean -p assay-cli` then same tests GREEN on the writer tree. Binary help shows `mcp` again.

This proves the witness bites. It does **not** claim 4.6.6 changed parser behavior.

## Windows

Hosted `Build + Test (windows-latest)` succeeded on exact head `879f8d5b6b28622daec4c13bacb567c120230bd1`:
https://github.com/Rul1an/assay/actions/runs/32854395810/job/97822943563

Assay-Runner Spike Delegated `gates=all` run 32854601199 succeeded on the same SHA (all gates, proof pack, attestation, upload, cleanup):
https://github.com/Rul1an/assay/actions/runs/32854601199

Proof pointer: https://github.com/Rul1an/assay/pull/2630#issuecomment-5411294135

## Nonclaims

- No new Clap API coverage. v4.6.6 only adds `Command::get_overridden_usage`; Assay has no callsite. Claim compatibility / no regression, not new-API coverage.
- Hosted `windows-latest` Build + Test and delegated `gates=all` succeeded on this head; that is those two jobs, not a broader Windows-runtime or other-OS claim.
- No security fix.
- No other dependency compatibility.

## Verify (writer tree, final lock)

- `cargo +1.89.0 metadata --locked --no-deps` → 0
- `cargo +1.96.0 metadata --locked --no-deps` → 0
- `cargo +1.96.0 tree --locked -i clap@4.6.6` → 0
- `cargo +1.89.0 tree --locked -i clap@4.6.6` → 0
- `cargo +1.96.0 test -p assay-cli --test mcp_command_grouping_test --test policy_command_grouping_test --test format_value_parser --test contract_docs_generate_explain --test doctor_argument_contract` → 0
- `cargo +1.96.0 test -p assay-cli --bin assay -- mcp_group cli_debug_assert visible_top_level` → 0
- `cargo +1.96.0 fmt --all -- --check` → 0
- `cargo +1.96.0 clippy -p assay-cli --tests -- -D warnings` → 0
- `cargo-deny check advisories bans licenses sources` → 0
- `bash scripts/ci/cargo-audit-with-isolated-db.sh` → 0 (4 pre-existing allowed warnings; none clap)
- `git diff --check -- Cargo.lock` → 0
