### PR TITLE
fix(policy): type remaining load failure causes

### DIFF
--- a/crates/assay-core/src/mcp/policy/legacy.rs
+++ b/crates/assay-core/src/mcp/policy/legacy.rs
@@ -3,7 +3,11 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 pub(super) fn from_file(path: &Path) -> anyhow::Result<McpPolicy> {
-    let bytes = std::fs::read(path)?;
+    let bytes = std::fs::read(path).map_err(|error| McpPolicyError {
+        kind: McpPolicyErrorKind::Io,
+        source: anyhow::Error::new(error)
+            .context(format!("failed to read policy {}", path.display())),
+    })?;
     McpPolicy::from_slice(&bytes)
 }
 
@@ -70,7 +74,13 @@ pub(super) fn from_slice(bytes: &[u8]) -> anyhow::Result<McpPolicy> {
     // Check for v1 format and warn if necessary
     if is_v1_format(&policy) {
         if std::env::var("ASSAY_STRICT_DEPRECATIONS").ok().as_deref() == Some("1") {
-            anyhow::bail!("Strict mode: v1 policy format (constraints) is not allowed.");
+            return Err(McpPolicyError {
+                kind: McpPolicyErrorKind::StrictDeprecation,
+                source: anyhow::anyhow!(
+                    "Strict mode: v1 policy format (constraints) is not allowed."
+                ),
+            }
+            .into());
         }
         emit_deprecation_warning();
     }

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -8,15 +8,13 @@ mod response;
 mod schema;
 mod types;
 
-/// Typed classification of full-policy parse failures.
+/// Typed classification of full-policy load failures.
 ///
 /// Non-exhaustive so downstream match arms must use a wildcard.
-/// `check_args` maps these to the three fixed `PolicyParseFailure` summaries.
+/// `check_args` maps only parse variants to the fixed `PolicyParseFailure` summaries.
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum McpPolicyErrorKind {
-    /// The policy file could not be read from the supplied path.
-    Io,
     /// YAML decode or UTF-8 failure.
     Syntax {
         line: Option<usize>,
@@ -28,6 +26,8 @@ pub enum McpPolicyErrorKind {
     Structure,
     /// Post-deserialization validation (kill-switch refs, pin hashes) failed.
     Validation,
+    /// The policy file could not be read from the supplied path.
+    Io,
     /// V1 policy input was refused because strict deprecation handling is enabled.
     StrictDeprecation,
 }

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -15,6 +15,8 @@ mod types;
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum McpPolicyErrorKind {
+    /// The policy file could not be read from the supplied path.
+    Io,
     /// YAML decode or UTF-8 failure.
     Syntax {
         line: Option<usize>,
@@ -26,6 +28,8 @@ pub enum McpPolicyErrorKind {
     Structure,
     /// Post-deserialization validation (kill-switch refs, pin hashes) failed.
     Validation,
+    /// V1 policy input was refused because strict deprecation handling is enabled.
+    StrictDeprecation,
 }
 
 /// Wrapper that carries the typed kind alongside the anyhow error chain.
@@ -96,11 +100,17 @@ mod error_source_contract {
             assert!(error.is_parse_failure());
         }
 
-        let validation = McpPolicyError {
-            kind: McpPolicyErrorKind::Validation,
-            source: anyhow::anyhow!("validation failure"),
-        };
-        assert!(!validation.is_parse_failure());
+        for kind in [
+            McpPolicyErrorKind::Io,
+            McpPolicyErrorKind::Validation,
+            McpPolicyErrorKind::StrictDeprecation,
+        ] {
+            let error = McpPolicyError {
+                kind,
+                source: anyhow::anyhow!("non-parse failure"),
+            };
+            assert!(!error.is_parse_failure());
+        }
     }
 }
 

--- a/crates/assay-core/src/mcp/tests.rs
+++ b/crates/assay-core/src/mcp/tests.rs
@@ -94,6 +94,29 @@ fn policy_error_classification_invalid_utf8() {
     );
 }
 
+#[test]
+fn policy_error_classification_io_preserves_path_and_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("missing-policy.yaml");
+
+    let err = McpPolicy::from_file(&path).unwrap_err();
+    let typed = err
+        .downcast_ref::<McpPolicyError>()
+        .expect("file I/O must have a core-owned typed cause");
+
+    assert!(matches!(typed.kind, McpPolicyErrorKind::Io));
+    assert!(!typed.is_parse_failure(), "file I/O is not a parse failure");
+    assert!(
+        err.to_string().contains(&path.display().to_string()),
+        "file-load diagnostic must name the policy path: {err}"
+    );
+    assert!(
+        err.chain()
+            .any(|cause| cause.downcast_ref::<std::io::Error>().is_some()),
+        "file-load error chain must retain std::io::Error: {err:#}"
+    );
+}
+
 // ── Validation kind (gap 4) ──────────────────────────────────────────────
 
 #[test]
@@ -247,8 +270,17 @@ fn policy_file_parser_contract_strict_deprecations_rejects_v1() {
     unsafe { std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1") };
     let err = McpPolicy::from_file(tmp.path());
     assert!(err.is_err(), "strict deprecations must reject v1");
+    let err = err.unwrap_err();
+    let typed = err
+        .downcast_ref::<McpPolicyError>()
+        .expect("strict deprecation refusal must have a core-owned typed cause");
+    assert!(matches!(typed.kind, McpPolicyErrorKind::StrictDeprecation));
     assert!(
-        err.unwrap_err().to_string().contains("Strict mode"),
+        !typed.is_parse_failure(),
+        "strict deprecation refusal is not a parse failure"
+    );
+    assert!(
+        err.to_string().contains("Strict mode"),
         "error must mention Strict mode"
     );
     unsafe { std::env::remove_var("ASSAY_STRICT_DEPRECATIONS") };
@@ -544,14 +576,13 @@ enum ParserOutcome {
 fn classify_policy_err(err: anyhow::Error) -> ParserOutcome {
     if let Some(typed) = err.downcast_ref::<McpPolicyError>() {
         return match typed.kind {
+            McpPolicyErrorKind::Io => panic!("parity fixtures must not produce file I/O errors"),
             McpPolicyErrorKind::Syntax { .. } => ParserOutcome::Syntax,
             McpPolicyErrorKind::RootNotMapping => ParserOutcome::RootNotMapping,
             McpPolicyErrorKind::Structure => ParserOutcome::Structure,
             McpPolicyErrorKind::Validation => ParserOutcome::Validation,
+            McpPolicyErrorKind::StrictDeprecation => ParserOutcome::StrictDeprecation,
         };
-    }
-    if err.to_string().contains("Strict mode") {
-        return ParserOutcome::StrictDeprecation;
     }
     panic!("unclassified policy error: {err}");
 }

--- a/scripts/ci/test-check-mcp-policy-parser-delegation.sh
+++ b/scripts/ci/test-check-mcp-policy-parser-delegation.sh
@@ -93,11 +93,10 @@ mutate_from_file_reparse() {
 import sys
 from pathlib import Path
 p = Path(sys.argv[1]); s = p.read_text()
-old = "let bytes = std::fs::read(path)?;\n    McpPolicy::from_slice(&bytes)"
-new = """let bytes = std::fs::read(path)?;
-    let _ = serde_yaml::from_slice::<serde_yaml::Value>(&bytes);
+old = "    McpPolicy::from_slice(&bytes)"
+new = """    let _ = serde_yaml::from_slice::<serde_yaml::Value>(&bytes);
     McpPolicy::from_slice(&bytes)"""
-assert old in s
+assert s.count(old) == 1
 p.write_text(s.replace(old, new, 1))
 PY
 }


### PR DESCRIPTION
## Summary

- add core-owned `Io` and `StrictDeprecation` policy-load causes without changing public loader signatures
- retain the underlying `std::io::Error` chain and include the policy path in file-read diagnostics
- remove strict-deprecation prose matching from the existing file/slice/string parity classifier
- keep the parser-delegation mutation test valid after the typed I/O wrapper changed the read expression

Closes #2201.

## Contract changes

- `McpPolicyErrorKind` gains two variants; the enum is already `#[non_exhaustive]`
- `McpPolicy::from_file`, `McpPolicy::from_slice`, and `FromStr<Err = anyhow::Error>` are unchanged
- file I/O now downcasts to `McpPolicyError { kind: Io }`; the original `std::io::Error` remains in the error chain
- no CLI reason code, output schema, retry contract, or MCP parse-summary change

## Review packet

- base: `ccd3f99335f40064e22b1cd1feaabee5a9af9653`
- head: `26a4fa55eceffc88496e8e8a44ffc78300f83bd5`
- files: 4, `+65/-15`
- risk: public enum addition, non-breaking by the existing non-exhaustive contract; error downcast behavior intentionally becomes uniformly core-owned

### Validation

```text
cargo test -p assay-core policy_ -- --nocapture       42 relevant tests pass
cargo test -p assay-core                              full crate suite passes
cargo clippy -p assay-core --all-targets -- -D warnings
cargo fmt --all -- --check
RUSTUP_TOOLCHAIN=1.96.0 cargo semver-checks check-release -p assay-core --baseline-rev ccd3f993...  223 pass
git diff --check
bash scripts/ci/test-check-mcp-policy-parser-delegation.sh
external path-dependent consumer crate                  PASS
```

The pre-push hook also passed workspace clippy and the Linux cross-target compile gate.

### Mutation proof

- remove the policy path from the I/O context -> focused test RED
- stringify I/O and drop `std::io::Error` from the chain -> focused test RED
- classify strict deprecation as `Validation` -> focused test RED
- parser-delegation self-test still rejects a deserializer inserted into either delegation hop

### Non-claims

- schema compilation remains a separate stage
- accepted untyped exit-2 CLI paths are unchanged
- no new typed loader API or major-version signature change
- local external-consumer proof is not a replacement for CI semver/public-API gates

