### PR TITLE
fix(sandbox): require --enforce-net for --enforcement-health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ All notable changes to this project will be documented in this file.
   (#2245).
 
 ### Fixed
+- `assay sandbox --enforcement-health` now requires `--enforce-net` at clap
+  validation, matching `--probe-enforcement`. The previously accepted combination
+  requested a v1 artifact without requesting its Landlock producer and wrote
+  nothing (#2635).
 - Evidence-vocabulary CI structurally rejects a required command after an
   unconditional `exit`/`return`, or when that command is the skipped operand
   of `false &&` / `true ||`. A short-circuit skip does not make later lines

--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -205,7 +205,8 @@ pub struct SandboxArgs {
 
     /// Write the `assay.enforcement_health.v1` artifact (Landlock TCP-connect domain) to this path.
     /// A requested artifact that cannot be written is a command failure, never a silent absence.
-    #[arg(long = "enforcement-health")]
+    /// Requires --enforce-net: the Landlock v1 producer is reached only on that path.
+    #[arg(long = "enforcement-health", requires = "enforce_net")]
     pub enforcement_health: Option<PathBuf>,
 
     // Six digests -- subject, substrate, corpus, catch policy, observation vocabulary, run entropy

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -399,3 +399,56 @@ fn top_level_failure_funnel_owns_supported_machine_output_commands() {
         "run owns its JSON error renderer and must not be rendered twice"
     );
 }
+
+#[test]
+fn sandbox_enforcement_health_without_enforce_net_is_clap_usage_error() {
+    let missing = Cli::try_parse_from([
+        "assay",
+        "sandbox",
+        "--enforcement-health",
+        "health.json",
+        "--",
+        "true",
+    ]);
+    let err = match missing {
+        Ok(_) => panic!(
+            "sandbox --enforcement-health without --enforce-net must fail clap before execution"
+        ),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("--enforce-net"),
+        "clap must name the missing --enforce-net requirement: {rendered}"
+    );
+}
+
+#[test]
+fn sandbox_enforcement_health_with_enforce_net_still_parses() {
+    // Control: a live parser still accepts the coherent invocation. A dead harness
+    // that always returned Err would make the rejection test look green.
+    let ok = Cli::try_parse_from([
+        "assay",
+        "sandbox",
+        "--enforce",
+        "--enforce-net",
+        "--enforcement-health",
+        "health.json",
+        "--",
+        "true",
+    ])
+    .expect("sandbox --enforce --enforce-net --enforcement-health must still parse");
+    match ok.cmd {
+        Command::Sandbox(args) => {
+            assert!(args.enforce);
+            assert!(args.enforce_net);
+            assert_eq!(
+                args.enforcement_health.as_deref(),
+                Some(std::path::Path::new("health.json"))
+            );
+            assert_eq!(args.command, ["true"]);
+        }
+        _ => panic!("expected sandbox command"),
+    }
+}

--- a/crates/assay-cli/src/enforcement_health_v1.rs
+++ b/crates/assay-cli/src/enforcement_health_v1.rs
@@ -17,10 +17,12 @@
 //! row it produced was false, which is why that list warns that a stale entry is worse than none.
 //!
 //! Honesty rules baked into the shape:
-//! - `status` is `active` or `failed` only. There is no `not_applicable`, and no `absent`: the
-//!   presence of a v1 artifact means Landlock enforcement was requested. A run that does not request
-//!   Landlock enforcement simply writes no v1 artifact (and a requested-but-unwritable artifact must
-//!   be a hard error at the producer, the same rule v0 enforces).
+//! - `status` is `active` or `failed` only. There is no `not_applicable`, and no `absent`.
+//!   Presence of a v1 artifact is producer-reported observation for that episode. Absence of a
+//!   v1 artifact is no artifact and no claim: it cannot prove that enforcement was not requested
+//!   (no output flag, a non-Linux build, or a clap-rejected invocation all produce absence).
+//!   A requested-but-unwritable artifact must be a hard error at the producer. This is not v0
+//!   parity: v0 serializes `absent` inside the artifact; v1 has no such status.
 //! - `probe` is always present and is `null` when no real-block probe was run, so a consumer can
 //!   distinguish "schema knows about probe, none happened" from an older shape that lacked the field.
 //!   `active` without a probe means the ruleset was applied (`no_new_privs` + `restrict_self`
@@ -36,8 +38,9 @@ pub const SCHEMA_V1: &str = "assay.enforcement_health.v1";
 /// IPv4-only, so the transport lives under `probe`, not in the scope string.
 pub const SCOPE_TCP_CONNECT_LANDLOCK_PORT: &str = "tcp_connect_landlock_port";
 
-/// Whether enforcement was active or failed to install. No `not_applicable`; `absent` is modelled by
-/// the artifact not existing (presence means requested).
+/// Whether enforcement was active or failed to install. No `not_applicable` and no `absent`
+/// variant. Artifact absence is no artifact and no claim; it does not prove that enforcement
+/// was not requested.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Status {
@@ -519,8 +522,8 @@ mod tests {
 
     #[test]
     fn v1_status_has_no_not_applicable_or_absent() {
-        // The carrier vocabulary is intentionally only active/failed; absent is "no artifact",
-        // and not_applicable does not exist in v1.
+        // The carrier vocabulary is only active/failed. Missing artifact is no claim, not a
+        // v0-style `absent` / not-requested status. not_applicable does not exist in v1.
         assert!(serde_json::from_str::<Status>("\"active\"").is_ok());
         assert!(serde_json::from_str::<Status>("\"failed\"").is_ok());
         assert!(serde_json::from_str::<Status>("\"absent\"").is_err());


### PR DESCRIPTION
## Summary
- Fail-closed CLI change: `assay sandbox --enforcement-health` now requires `--enforce-net` at clap validation, matching `--probe-enforcement`. The previously accepted combination requested a v1 artifact without requesting its Landlock producer and wrote nothing (#2635).
- v1 docs now treat artifact absence as no artifact/no claim. They no longer imply v0-style `absent` / not-requested parity. Serialized v1 fixtures are unchanged.
- No real `assay sandbox --enforcement-health` caller exists in workflows, scripts, or docs. `project-otel` and `monitor` use a same-named flag on different commands and were not changed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Refactor

Deliberate fail-closed CLI validation: the previously accepted but evidence-empty combination is now a clap usage error.

## Test plan
- [x] RED first: `sandbox_enforcement_health_without_enforce_net_is_clap_usage_error` failed before `requires = "enforce_net"` (invalid invocation parsed as `Ok`).
- [x] Control: `sandbox_enforcement_health_with_enforce_net_still_parses` stays green so a dead harness cannot look like a pass.
- [x] Mutation: scratch-removed `requires` from the sandbox flag only; rejection test failed, control stayed green; restored and both green.
- [x] `cargo test -p assay-cli --bin assay` — 623 passed, 2 ignored
- [x] `cargo test -p assay-cli --test contract_sandbox_policy_load_fail_closed` — 5 passed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p assay-cli --bin assay -- -D warnings`
- [x] `git diff --check`

## Non-claims
Absence is never evidence that enforcement was not requested, that egress did not occur, or that a sandbox was sealed. `status: active` remains producer-reported observation for one Landlock ruleset in one episode. v0 and v1 stay distinct domains. `assay.doctor_report.v0` and `assay.enforcement_health.v0` are unchanged.

Fixes #2635

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `--enforcement-health` now requires `--enforce-net`, preventing invalid enforcement-health artifacts.
  * Clarified that missing enforcement-health artifacts make no enforcement claim.
* **Documentation**
  * Updated changelog and usage documentation to explain the enforcement-health requirements and absence behavior.
* **Tests**
  * Added coverage for valid and invalid enforcement-health command combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->