### PR TITLE
ci(actions): pin Swatinem/rust-cache to v2.9.2

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -27,6 +27,6 @@ runs:
         components: ${{ inputs.components }}
 
     - name: Cache cargo
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:
         workspaces: ${{ inputs.cache-workspaces }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
         with:
           toolchain: ${{ env.ASSAY_PUBLIC_MSRV }}
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: public-msrv-${{ env.ASSAY_PUBLIC_MSRV }}
       - name: Test MSRV package selection
@@ -541,7 +541,7 @@ jobs:
           persist-credentials: false
       - name: Swatinem/rust-cache
         id: rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install Linux deps (for build scripts)
         shell: bash
         run: |
@@ -675,7 +675,7 @@ jobs:
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: |
             . -> target

--- a/.github/workflows/host-capability-proof.yml
+++ b/.github/workflows/host-capability-proof.yml
@@ -75,7 +75,7 @@ jobs:
           toolchain: ${{ steps.rust-toolchain.outputs.channel }}
 
       - name: Restore bounded Rust build cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           # Never let cache cleanup or restore mutate rustup/cargo shims on the persistent host.
           cache-bin: false

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -289,7 +289,7 @@ jobs:
           scripts/ci/install-ebpf-toolchain.sh
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -471,7 +471,7 @@ repos:
         entry: bash scripts/ci/test-setup-rust-composite-contract.sh
         language: system
         pass_filenames: false
-        files: ^(\.github/actions/setup-rust/action\.yml|scripts/ci/test-setup-rust-composite-contract\.sh|\.pre-commit-config\.yaml|\.github/workflows/[^/]+\.ya?ml)$
+        files: ^(\.github/actions/setup-rust/action\.yml|scripts/ci/test-setup-rust-composite-contract\.sh|scripts/ci/test-host-capability-proof-contract\.sh|\.pre-commit-config\.yaml|\.github/workflows/[^/]+\.ya?ml)$
 
       - id: s1b-coverage-gate-contract
         name: S1b send-matrix coverage-gate contract

--- a/scripts/ci/test-host-capability-proof-contract.sh
+++ b/scripts/ci/test-host-capability-proof-contract.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOW="${1:-${ROOT}/.github/workflows/host-capability-proof.yml}"
-CACHE_PIN="c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+CACHE_PIN="6323deb102c322ba6fcbdcafc7e3dddab59af2b6"
 TOOLCHAIN_PIN="29eef336d9b2848a0b548edc03f92a220660cdb8"
 
 validate() {

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -820,6 +820,7 @@ if files_line is None:
 expected = (
     r"^(\.github/actions/setup-rust/action\.yml|"
     r"scripts/ci/test-setup-rust-composite-contract\.sh|"
+    r"scripts/ci/test-host-capability-proof-contract\.sh|"
     r"\.pre-commit-config\.yaml|"
     r"\.github/workflows/[^/]+\.ya?ml)$")
 if files_line != expected:
@@ -830,6 +831,7 @@ missed = [s for s in (
     ".github/workflows/demo.yml", ".github/workflows/docs-auto-update.yml",
     ".github/workflows/parity.yml", ".github/workflows/release.yml",
     ".github/workflows/ci.yml", ".github/workflows/kernel-matrix.yml",
+    "scripts/ci/test-host-capability-proof-contract.sh",
 ) if not cre.search(s)]
 if missed:
     raise SystemExit(f"pre-commit files regex must match exception workflows; missed {missed}")

--- a/scripts/ci/test-setup-rust-composite-contract.sh
+++ b/scripts/ci/test-setup-rust-composite-contract.sh
@@ -23,7 +23,7 @@ SPLIT_WAVE0="${ROOT}/.github/workflows/split-wave0-gates.yml"
 CI_YML="${ROOT}/.github/workflows/ci.yml"
 KERNEL_MATRIX="${ROOT}/.github/workflows/kernel-matrix.yml"
 TOOLCHAIN_REF="dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
-CACHE_REF="Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+CACHE_REF="Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "ok   $*"; }
@@ -685,7 +685,56 @@ from pathlib import Path
 
 root = Path(sys.argv[1])
 TC = "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8"
-RC = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+RC = "Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6"
+
+# CACHE_REF (composite uses:) and RC (workflow-direct uses:) are independent
+# literals today. A slice can update one pin + its production side and leave
+# the other green. Align them, and align CACHE_PIN, then inventory every
+# production uses: Swatinem/rust-cache@SHA (comments are not invocations).
+_src = (root / "scripts/ci/test-setup-rust-composite-contract.sh").read_text(encoding="utf-8")
+_m_ref = re.search(r'(?m)^CACHE_REF="Swatinem/rust-cache@([0-9a-f]{40})"$', _src)
+if not _m_ref:
+    raise SystemExit("CACHE_REF pin missing or not a 40-char SHA")
+_cache_ref_sha = _m_ref.group(1)
+_rc_sha = RC.rsplit("@", 1)[-1]
+if _cache_ref_sha != _rc_sha:
+    raise SystemExit(f"CACHE_REF SHA {_cache_ref_sha} != RC SHA {_rc_sha}")
+_host = (root / "scripts/ci/test-host-capability-proof-contract.sh").read_text(encoding="utf-8")
+_m_pin = re.search(r'(?m)^CACHE_PIN="([0-9a-f]{40})"$', _host)
+if not _m_pin:
+    raise SystemExit("CACHE_PIN pin missing or not a 40-char SHA")
+if _m_pin.group(1) != _rc_sha:
+    raise SystemExit(f"CACHE_PIN {_m_pin.group(1)} != RC SHA {_rc_sha}")
+
+_PROD_USES = re.compile(
+    r"^[ \t]*(?:-[ \t]+)?uses:\s*(?:'|\")?"
+    r"Swatinem/rust-cache@([0-9a-f]{40})"
+)
+_prod_files = (
+    root / ".github/actions/setup-rust/action.yml",
+    root / ".github/workflows/ci.yml",
+    root / ".github/workflows/host-capability-proof.yml",
+    root / ".github/workflows/kernel-matrix.yml",
+)
+_found = []
+for _path in _prod_files:
+    _body = _path.read_text(encoding="utf-8")
+    for _lineno, _line in enumerate(_body.splitlines(), 1):
+        _mm = _PROD_USES.search(_line)
+        if _mm:
+            _found.append((str(_path.relative_to(root)), _lineno, _mm.group(1)))
+if len(_found) != 6:
+    raise SystemExit(
+        f"expected 6 production rust-cache uses: lines, found {len(_found)}: {_found}"
+    )
+_lag = [f for f in _found if f[2] != _rc_sha]
+if _lag:
+    raise SystemExit(f"production rust-cache uses: SHA lagged expected {_rc_sha}: {_lag}")
+print(
+    f"ok   CACHE_REF/RC/CACHE_PIN SHA aligned ({_rc_sha}); "
+    f"6 production rust-cache uses: pins match"
+)
+
 
 def jobs_by_id(text: str) -> dict[str, str]:
     return {j: b for j, b in re.findall(


### PR DESCRIPTION
Refs #2474.

Pin every production `Swatinem/rust-cache` use from v2.9.1 (`c19371144df3bb44fab255c43d04cbc2ab54d1c4`) to peeled v2.9.2 commit `6323deb102c322ba6fcbdcafc7e3dddab59af2b6`. One owner test holds `CACHE_REF` / `RC` / `CACHE_PIN` parity plus the exact-six production-use inventory. Host-capability contract keeps only its own `CACHE_PIN` and workflow. Owner pre-commit selector now also matches `scripts/ci/test-host-capability-proof-contract.sh` so a `CACHE_PIN`-only edit cannot skip that rule.

`origin/main` at `cdc2e338da10412a0faf549742a1d8a72c59d1ab` was merged conflict-free (no rebase). Both contract guards and the five mutations / no-op control were re-run on the post-merge head.

## Head
- Branch: `ruley/2474-rust-cache-2.9.2`
- Exact HEAD: `4b1167f2e5af0ab4e87426005ecacf1f98528323`
- Base: `cdc2e338da10412a0faf549742a1d8a72c59d1ab`

## Files
- `.github/actions/setup-rust/action.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/host-capability-proof.yml`
- `.github/workflows/kernel-matrix.yml`
- `scripts/ci/test-setup-rust-composite-contract.sh`
- `scripts/ci/test-host-capability-proof-contract.sh`
- `.pre-commit-config.yaml` (selector only: add host-contract path to `setup-rust-composite-contract-self-test.files`)

## Nonclaims
- No cache-hit or performance claim.
- No delegated proof.
- No other action bump.
- No `Cargo.lock` change.
- `gates=none` expected.
- Do not merge from this PR body.